### PR TITLE
feat(vaults): interactive OAuth Connect for vault credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,27 @@ OPENAI_API_KEY=
 
 # Optional: Tavily key for web_fetch / web_search built-in tools.
 AIOS_TAVILY_API_KEY=
+
+# ── Interactive MCP OAuth "Connect" provider apps ─────────────────────
+#
+# Lets end users one-click-connect MCP servers that DON'T support dynamic
+# client registration (Google, Microsoft, Slack, …) without pasting any
+# credentials — the way Claude Managed Agents does. For each such provider you
+# register ONE OAuth app and list it here; AIOS uses it automatically when a
+# server's OAuth issuer/host matches `match`.
+#
+# Servers that DO support dynamic registration (Notion, Linear, …) need no
+# config — they already one-click.
+#
+# One-time setup per provider, e.g. Google:
+#   1. Google Cloud Console → APIs & Services → Credentials → Create OAuth
+#      client ID → Web application.
+#   2. Authorized redirect URI: <console_url>/api/auth/mcp-oauth/callback
+#      (dev: http://localhost:3100/api/auth/mcp-oauth/callback).
+#   3. Copy the client ID + secret into the JSON below. `match` is the OAuth
+#      issuer host (Google = accounts.google.com). `scope` is optional — set it
+#      if the provider requires scopes its MCP server doesn't advertise.
+#
+# JSON list of {match, client_id, client_secret?, token_endpoint_auth_method?, scope?}:
+# AIOS_OAUTH_PROVIDER_APPS=[{"match":"accounts.google.com","client_id":"...apps.googleusercontent.com","client_secret":"...","scope":"https://www.googleapis.com/auth/calendar"}]
+AIOS_OAUTH_PROVIDER_APPS=

--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,10 @@ AIOS_TAVILY_API_KEY=
 #      issuer host (Google = accounts.google.com). `scope` is optional — set it
 #      if the provider requires scopes its MCP server doesn't advertise.
 #
-# JSON list of {match, client_id, client_secret?, token_endpoint_auth_method?, scope?}:
-# AIOS_OAUTH_PROVIDER_APPS=[{"match":"accounts.google.com","client_id":"...apps.googleusercontent.com","client_secret":"...","scope":"https://www.googleapis.com/auth/calendar"}]
+# Google note: to get a REFRESH token (so AIOS can keep the credential alive),
+# Google requires authorize_params {"access_type":"offline","prompt":"consent"}.
+# Standard providers issue refresh tokens without this.
+#
+# JSON list of {match, client_id, client_secret?, token_endpoint_auth_method?, scope?, authorize_params?}:
+# AIOS_OAUTH_PROVIDER_APPS=[{"match":"accounts.google.com","client_id":"...apps.googleusercontent.com","client_secret":"...","scope":"https://www.googleapis.com/auth/calendar","authorize_params":{"access_type":"offline","prompt":"consent"}}]
 AIOS_OAUTH_PROVIDER_APPS=

--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,22 @@ AIOS_TAVILY_API_KEY=
 # Google requires authorize_params {"access_type":"offline","prompt":"consent"}.
 # Standard providers issue refresh tokens without this.
 #
-# JSON list of {match, client_id, client_secret?, token_endpoint_auth_method?, scope?, authorize_params?}:
-# AIOS_OAUTH_PROVIDER_APPS=[{"match":"accounts.google.com","client_id":"...apps.googleusercontent.com","client_secret":"...","scope":"https://www.googleapis.com/auth/calendar","authorize_params":{"access_type":"offline","prompt":"consent"}}]
+# token_endpoint_hosts: hosts (besides `match`) the operator client_secret may
+# be sent to. Required when the provider issues tokens from a different apex than
+# it authorizes at — Google authorizes at accounts.google.com but issues tokens
+# at oauth2.googleapis.com, so list ["oauth2.googleapis.com"]. The secret is sent
+# to the discovered token endpoint ONLY if its host is `match` (or a sub-host) or
+# listed here — closing client_secret exfiltration via spoofed discovery metadata.
+#
+# JSON list of {match, client_id, client_secret?, token_endpoint_auth_method?, token_endpoint_hosts?, scope?, authorize_params?}:
+# AIOS_OAUTH_PROVIDER_APPS=[{"match":"accounts.google.com","client_id":"...apps.googleusercontent.com","client_secret":"...","token_endpoint_hosts":["oauth2.googleapis.com"],"scope":"https://www.googleapis.com/auth/calendar","authorize_params":{"access_type":"offline","prompt":"consent"}}]
 AIOS_OAUTH_PROVIDER_APPS=
+
+# Interactive OAuth — DEV-ONLY SSRF bypass.
+# Comma-separated host[:port] allowlist that lets the "Connect" flow reach an
+# MCP fleet served over plain http on internal hosts (e.g. a self-hosted Google
+# Workspace MCP at workspace-mcp:8000). Bypasses the https requirement and the
+# private-range block for the listed hosts ONLY. Leave EMPTY in production (prod
+# MCP servers are https); any value there re-opens SSRF to internal hosts.
+# AIOS_OAUTH_ALLOW_INSECURE_HOSTS=workspace-mcp,workspace-mcp:8000
+AIOS_OAUTH_ALLOW_INSECURE_HOSTS=

--- a/migrations/versions/0061_oauth_flows.py
+++ b/migrations/versions/0061_oauth_flows.py
@@ -1,0 +1,65 @@
+"""Interactive OAuth flow state for vault-credential "Connect".
+
+The console's "Connect" UX lets a user authorize an MCP server interactively:
+the server initiates an OAuth 2.0 authorization-code flow (optionally with
+Dynamic Client Registration + PKCE), redirects the user to sign in at the
+provider, then exchanges the returned code for tokens and stores them as an
+``oauth2_refresh`` vault credential.
+
+That flow spans two HTTP requests (start → user consents at the provider →
+complete), so the transient state must live server-side between them. Each
+row holds the random ``state`` (CSRF), the ``redirect_uri`` (which MUST be
+byte-identical across registration, /authorize and the token exchange — so it
+is persisted and reused on complete, never re-accepted from the client), and
+an encrypted blob carrying the PKCE ``code_verifier``, the (possibly
+dynamically-registered) client_id/secret, and the resolved endpoints. The blob
+is encrypted with the same per-account subkey as vault credentials because it
+contains the code_verifier and an optional client_secret.
+
+Rows are single-use (deleted on complete) and short-lived (``expires_at`` ~10
+min); ``start`` opportunistically prunes expired rows so the table stays small
+without a separate janitor.
+
+Revision ID: 0061
+Revises: 0060
+Create Date: 2026-06-02
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0061"
+down_revision: str = "0060"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(r"""
+        CREATE TABLE oauth_flows (
+            id            text PRIMARY KEY,
+            account_id    text NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+            vault_id      text NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+            target_url    text NOT NULL,
+            state         text NOT NULL,
+            redirect_uri  text NOT NULL,
+            ciphertext    bytea NOT NULL,
+            nonce         bytea NOT NULL,
+            created_at    timestamptz NOT NULL DEFAULT now(),
+            expires_at    timestamptz NOT NULL,
+            UNIQUE (account_id, state)
+        )
+    """)
+    # The complete-flow lookup is keyed by (account_id, vault_id, state); the
+    # UNIQUE(account_id, state) above already covers it. This index serves the
+    # expiry prune (DELETE ... WHERE expires_at < now()).
+    op.execute("""
+        CREATE INDEX oauth_flows_expires_at ON oauth_flows (expires_at)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS oauth_flows")

--- a/openapi.json
+++ b/openapi.json
@@ -4290,6 +4290,144 @@
         }
       }
     },
+    "/v1/vaults/{vault_id}/credentials/oauth/start": {
+      "post": {
+        "tags": [
+          "vaults"
+        ],
+        "summary": "Start Credential Oauth",
+        "description": "Begin an interactive OAuth \"Connect\" flow for an MCP server.\n\nDiscovers the target's OAuth metadata, registers a client (RFC 7591\nDynamic Client Registration) or uses a caller-supplied ``client_id`` /\n``client_secret`` for servers without DCR, generates PKCE + a CSRF\n``state``, and returns the provider ``authorization_url`` to redirect the\nuser to. The token fields are obtained from the provider \u2014 the caller does\nnot supply them. Complete the flow with the returned ``state`` + the\nauthorization ``code`` via ``complete_vault_credential_oauth``.",
+        "operationId": "start_vault_credential_oauth",
+        "parameters": [
+          {
+            "name": "vault_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Vault Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OAuthStartRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthStartResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/vaults/{vault_id}/credentials/oauth/complete": {
+      "post": {
+        "tags": [
+          "vaults"
+        ],
+        "summary": "Complete Credential Oauth",
+        "description": "Finish an interactive OAuth flow: exchange the code and store the credential.\n\nValidates the ``state`` against the in-progress flow, exchanges the\nauthorization ``code`` for tokens, and stores them as an ``oauth2_refresh``\ncredential (creating a new one, or rotating an existing credential for the\nsame ``target_url``). Secrets are encrypted at rest and never returned.",
+        "operationId": "complete_vault_credential_oauth",
+        "parameters": [
+          {
+            "name": "vault_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Vault Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OAuthCompleteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VaultCredential"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/vaults/{vault_id}/credentials/{credential_id}": {
       "get": {
         "tags": [
@@ -11008,6 +11146,137 @@
           "plaintext_key"
         ],
         "title": "MintKeyResponse"
+      },
+      "OAuthCompleteRequest": {
+        "properties": {
+          "state": {
+            "type": "string",
+            "minLength": 1,
+            "title": "State"
+          },
+          "code": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Code"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "state",
+          "code"
+        ],
+        "title": "OAuthCompleteRequest",
+        "description": "Finish an interactive OAuth flow: exchange the returned code for tokens.\n\nThe ``state`` correlates back to the in-progress flow (and guards CSRF);\n``code`` is the authorization code the provider returned to the callback."
+      },
+      "OAuthStartRequest": {
+        "properties": {
+          "target_url": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Target Url"
+          },
+          "redirect_uri": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Redirect Uri"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scope"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Secret"
+          },
+          "token_endpoint_auth_method": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "client_secret_basic",
+                  "client_secret_post"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token Endpoint Auth Method"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "target_url",
+          "redirect_uri"
+        ],
+        "title": "OAuthStartRequest",
+        "description": "Begin an interactive OAuth authorization-code flow for an MCP server.\n\nWith the token fields left blank, the server discovers the target's OAuth\nmetadata, registers a client (RFC 7591 Dynamic Client Registration) or uses\nthe supplied ``client_id``/``client_secret``, and returns an\n``authorization_url`` to redirect the user to. The ``redirect_uri`` is the\nconsole's callback and is reused verbatim on completion."
+      },
+      "OAuthStartResponse": {
+        "properties": {
+          "flow_id": {
+            "type": "string",
+            "title": "Flow Id"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          },
+          "authorization_url": {
+            "type": "string",
+            "title": "Authorization Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "flow_id",
+          "state",
+          "authorization_url"
+        ],
+        "title": "OAuthStartResponse",
+        "description": "The authorization URL to redirect the user to, plus the flow's CSRF state."
       },
       "RecentChat": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/complete_vault_credential_oauth.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/complete_vault_credential_oauth.py
@@ -1,0 +1,241 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.o_auth_complete_request import OAuthCompleteRequest
+from ...models.vault_credential import VaultCredential
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    body: OAuthCompleteRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/vaults/{vault_id}/credentials/oauth/complete".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | VaultCredential | None:
+    if response.status_code == 201:
+        response_201 = VaultCredential.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | VaultCredential]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthCompleteRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Complete Credential Oauth
+
+     Finish an interactive OAuth flow: exchange the code and store the credential.
+
+    Validates the ``state`` against the in-progress flow, exchanges the
+    authorization ``code`` for tokens, and stores them as an ``oauth2_refresh``
+    credential (creating a new one, or rotating an existing credential for the
+    same ``target_url``). Secrets are encrypted at rest and never returned.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthCompleteRequest): Finish an interactive OAuth flow: exchange the returned code
+            for tokens.
+
+            The ``state`` correlates back to the in-progress flow (and guards CSRF);
+            ``code`` is the authorization code the provider returned to the callback.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthCompleteRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Complete Credential Oauth
+
+     Finish an interactive OAuth flow: exchange the code and store the credential.
+
+    Validates the ``state`` against the in-progress flow, exchanges the
+    authorization ``code`` for tokens, and stores them as an ``oauth2_refresh``
+    credential (creating a new one, or rotating an existing credential for the
+    same ``target_url``). Secrets are encrypted at rest and never returned.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthCompleteRequest): Finish an interactive OAuth flow: exchange the returned code
+            for tokens.
+
+            The ``state`` correlates back to the in-progress flow (and guards CSRF);
+            ``code`` is the authorization code the provider returned to the callback.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthCompleteRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | VaultCredential]:
+    """Complete Credential Oauth
+
+     Finish an interactive OAuth flow: exchange the code and store the credential.
+
+    Validates the ``state`` against the in-progress flow, exchanges the
+    authorization ``code`` for tokens, and stores them as an ``oauth2_refresh``
+    credential (creating a new one, or rotating an existing credential for the
+    same ``target_url``). Secrets are encrypted at rest and never returned.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthCompleteRequest): Finish an interactive OAuth flow: exchange the returned code
+            for tokens.
+
+            The ``state`` correlates back to the in-progress flow (and guards CSRF);
+            ``code`` is the authorization code the provider returned to the callback.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | VaultCredential]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthCompleteRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | VaultCredential | None:
+    """Complete Credential Oauth
+
+     Finish an interactive OAuth flow: exchange the code and store the credential.
+
+    Validates the ``state`` against the in-progress flow, exchanges the
+    authorization ``code`` for tokens, and stores them as an ``oauth2_refresh``
+    credential (creating a new one, or rotating an existing credential for the
+    same ``target_url``). Secrets are encrypted at rest and never returned.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthCompleteRequest): Finish an interactive OAuth flow: exchange the returned code
+            for tokens.
+
+            The ``state`` correlates back to the in-progress flow (and guards CSRF);
+            ``code`` is the authorization code the provider returned to the callback.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | VaultCredential
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/start_vault_credential_oauth.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/start_vault_credential_oauth.py
@@ -1,0 +1,265 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.o_auth_start_request import OAuthStartRequest
+from ...models.o_auth_start_response import OAuthStartResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    vault_id: str,
+    *,
+    body: OAuthStartRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/vaults/{vault_id}/credentials/oauth/start".format(
+            vault_id=quote(str(vault_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | OAuthStartResponse | None:
+    if response.status_code == 200:
+        response_200 = OAuthStartResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | OAuthStartResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthStartRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | OAuthStartResponse]:
+    r"""Start Credential Oauth
+
+     Begin an interactive OAuth \"Connect\" flow for an MCP server.
+
+    Discovers the target's OAuth metadata, registers a client (RFC 7591
+    Dynamic Client Registration) or uses a caller-supplied ``client_id`` /
+    ``client_secret`` for servers without DCR, generates PKCE + a CSRF
+    ``state``, and returns the provider ``authorization_url`` to redirect the
+    user to. The token fields are obtained from the provider — the caller does
+    not supply them. Complete the flow with the returned ``state`` + the
+    authorization ``code`` via ``complete_vault_credential_oauth``.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthStartRequest): Begin an interactive OAuth authorization-code flow for an MCP
+            server.
+
+            With the token fields left blank, the server discovers the target's OAuth
+            metadata, registers a client (RFC 7591 Dynamic Client Registration) or uses
+            the supplied ``client_id``/``client_secret``, and returns an
+            ``authorization_url`` to redirect the user to. The ``redirect_uri`` is the
+            console's callback and is reused verbatim on completion.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | OAuthStartResponse]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthStartRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | OAuthStartResponse | None:
+    r"""Start Credential Oauth
+
+     Begin an interactive OAuth \"Connect\" flow for an MCP server.
+
+    Discovers the target's OAuth metadata, registers a client (RFC 7591
+    Dynamic Client Registration) or uses a caller-supplied ``client_id`` /
+    ``client_secret`` for servers without DCR, generates PKCE + a CSRF
+    ``state``, and returns the provider ``authorization_url`` to redirect the
+    user to. The token fields are obtained from the provider — the caller does
+    not supply them. Complete the flow with the returned ``state`` + the
+    authorization ``code`` via ``complete_vault_credential_oauth``.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthStartRequest): Begin an interactive OAuth authorization-code flow for an MCP
+            server.
+
+            With the token fields left blank, the server discovers the target's OAuth
+            metadata, registers a client (RFC 7591 Dynamic Client Registration) or uses
+            the supplied ``client_id``/``client_secret``, and returns an
+            ``authorization_url`` to redirect the user to. The ``redirect_uri`` is the
+            console's callback and is reused verbatim on completion.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | OAuthStartResponse
+    """
+
+    return sync_detailed(
+        vault_id=vault_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthStartRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | OAuthStartResponse]:
+    r"""Start Credential Oauth
+
+     Begin an interactive OAuth \"Connect\" flow for an MCP server.
+
+    Discovers the target's OAuth metadata, registers a client (RFC 7591
+    Dynamic Client Registration) or uses a caller-supplied ``client_id`` /
+    ``client_secret`` for servers without DCR, generates PKCE + a CSRF
+    ``state``, and returns the provider ``authorization_url`` to redirect the
+    user to. The token fields are obtained from the provider — the caller does
+    not supply them. Complete the flow with the returned ``state`` + the
+    authorization ``code`` via ``complete_vault_credential_oauth``.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthStartRequest): Begin an interactive OAuth authorization-code flow for an MCP
+            server.
+
+            With the token fields left blank, the server discovers the target's OAuth
+            metadata, registers a client (RFC 7591 Dynamic Client Registration) or uses
+            the supplied ``client_id``/``client_secret``, and returns an
+            ``authorization_url`` to redirect the user to. The ``redirect_uri`` is the
+            console's callback and is reused verbatim on completion.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | OAuthStartResponse]
+    """
+
+    kwargs = _get_kwargs(
+        vault_id=vault_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    vault_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: OAuthStartRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | OAuthStartResponse | None:
+    r"""Start Credential Oauth
+
+     Begin an interactive OAuth \"Connect\" flow for an MCP server.
+
+    Discovers the target's OAuth metadata, registers a client (RFC 7591
+    Dynamic Client Registration) or uses a caller-supplied ``client_id`` /
+    ``client_secret`` for servers without DCR, generates PKCE + a CSRF
+    ``state``, and returns the provider ``authorization_url`` to redirect the
+    user to. The token fields are obtained from the provider — the caller does
+    not supply them. Complete the flow with the returned ``state`` + the
+    authorization ``code`` via ``complete_vault_credential_oauth``.
+
+    Args:
+        vault_id (str):
+        authorization (None | str | Unset):
+        body (OAuthStartRequest): Begin an interactive OAuth authorization-code flow for an MCP
+            server.
+
+            With the token fields left blank, the server discovers the target's OAuth
+            metadata, registers a client (RFC 7591 Dynamic Client Registration) or uses
+            the supplied ``client_id``/``client_secret``, and returns an
+            ``authorization_url`` to redirect the user to. The ``redirect_uri`` is the
+            console's callback and is reused verbatim on completion.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | OAuthStartResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            vault_id=vault_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -116,6 +116,12 @@ from .mint_account_request import MintAccountRequest
 from .mint_account_response import MintAccountResponse
 from .mint_key_request import MintKeyRequest
 from .mint_key_response import MintKeyResponse
+from .o_auth_complete_request import OAuthCompleteRequest
+from .o_auth_start_request import OAuthStartRequest
+from .o_auth_start_request_token_endpoint_auth_method_type_0 import (
+    OAuthStartRequestTokenEndpointAuthMethodType0,
+)
+from .o_auth_start_response import OAuthStartResponse
 from .post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle import (
     PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle,
 )
@@ -330,6 +336,10 @@ __all__ = (
     "MintAccountResponse",
     "MintKeyRequest",
     "MintKeyResponse",
+    "OAuthCompleteRequest",
+    "OAuthStartRequest",
+    "OAuthStartRequestTokenEndpointAuthMethodType0",
+    "OAuthStartResponse",
     "PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle",
     "RecentChat",
     "RuntimeLifecycleRequest",

--- a/packages/aios-sdk/aios_sdk/_generated/models/o_auth_complete_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/o_auth_complete_request.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="OAuthCompleteRequest")
+
+
+@_attrs_define
+class OAuthCompleteRequest:
+    """Finish an interactive OAuth flow: exchange the returned code for tokens.
+
+    The ``state`` correlates back to the in-progress flow (and guards CSRF);
+    ``code`` is the authorization code the provider returned to the callback.
+
+        Attributes:
+            state (str):
+            code (str):
+    """
+
+    state: str
+    code: str
+
+    def to_dict(self) -> dict[str, Any]:
+        state = self.state
+
+        code = self.code
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "state": state,
+                "code": code,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        state = d.pop("state")
+
+        code = d.pop("code")
+
+        o_auth_complete_request = cls(
+            state=state,
+            code=code,
+        )
+
+        return o_auth_complete_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/o_auth_start_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/o_auth_start_request.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..models.o_auth_start_request_token_endpoint_auth_method_type_0 import (
+    OAuthStartRequestTokenEndpointAuthMethodType0,
+)
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="OAuthStartRequest")
+
+
+@_attrs_define
+class OAuthStartRequest:
+    """Begin an interactive OAuth authorization-code flow for an MCP server.
+
+    With the token fields left blank, the server discovers the target's OAuth
+    metadata, registers a client (RFC 7591 Dynamic Client Registration) or uses
+    the supplied ``client_id``/``client_secret``, and returns an
+    ``authorization_url`` to redirect the user to. The ``redirect_uri`` is the
+    console's callback and is reused verbatim on completion.
+
+        Attributes:
+            target_url (str):
+            redirect_uri (str):
+            display_name (None | str | Unset):
+            scope (None | str | Unset):
+            client_id (None | str | Unset):
+            client_secret (None | str | Unset):
+            token_endpoint_auth_method (None | OAuthStartRequestTokenEndpointAuthMethodType0 | Unset):
+    """
+
+    target_url: str
+    redirect_uri: str
+    display_name: None | str | Unset = UNSET
+    scope: None | str | Unset = UNSET
+    client_id: None | str | Unset = UNSET
+    client_secret: None | str | Unset = UNSET
+    token_endpoint_auth_method: (
+        None | OAuthStartRequestTokenEndpointAuthMethodType0 | Unset
+    ) = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        target_url = self.target_url
+
+        redirect_uri = self.redirect_uri
+
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
+        else:
+            display_name = self.display_name
+
+        scope: None | str | Unset
+        if isinstance(self.scope, Unset):
+            scope = UNSET
+        else:
+            scope = self.scope
+
+        client_id: None | str | Unset
+        if isinstance(self.client_id, Unset):
+            client_id = UNSET
+        else:
+            client_id = self.client_id
+
+        client_secret: None | str | Unset
+        if isinstance(self.client_secret, Unset):
+            client_secret = UNSET
+        else:
+            client_secret = self.client_secret
+
+        token_endpoint_auth_method: None | str | Unset
+        if isinstance(self.token_endpoint_auth_method, Unset):
+            token_endpoint_auth_method = UNSET
+        elif isinstance(
+            self.token_endpoint_auth_method,
+            OAuthStartRequestTokenEndpointAuthMethodType0,
+        ):
+            token_endpoint_auth_method = self.token_endpoint_auth_method.value
+        else:
+            token_endpoint_auth_method = self.token_endpoint_auth_method
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "target_url": target_url,
+                "redirect_uri": redirect_uri,
+            }
+        )
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if scope is not UNSET:
+            field_dict["scope"] = scope
+        if client_id is not UNSET:
+            field_dict["client_id"] = client_id
+        if client_secret is not UNSET:
+            field_dict["client_secret"] = client_secret
+        if token_endpoint_auth_method is not UNSET:
+            field_dict["token_endpoint_auth_method"] = token_endpoint_auth_method
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        target_url = d.pop("target_url")
+
+        redirect_uri = d.pop("redirect_uri")
+
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        def _parse_scope(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        scope = _parse_scope(d.pop("scope", UNSET))
+
+        def _parse_client_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        client_id = _parse_client_id(d.pop("client_id", UNSET))
+
+        def _parse_client_secret(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        client_secret = _parse_client_secret(d.pop("client_secret", UNSET))
+
+        def _parse_token_endpoint_auth_method(
+            data: object,
+        ) -> None | OAuthStartRequestTokenEndpointAuthMethodType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                token_endpoint_auth_method_type_0 = (
+                    OAuthStartRequestTokenEndpointAuthMethodType0(data)
+                )
+
+                return token_endpoint_auth_method_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(
+                None | OAuthStartRequestTokenEndpointAuthMethodType0 | Unset, data
+            )
+
+        token_endpoint_auth_method = _parse_token_endpoint_auth_method(
+            d.pop("token_endpoint_auth_method", UNSET)
+        )
+
+        o_auth_start_request = cls(
+            target_url=target_url,
+            redirect_uri=redirect_uri,
+            display_name=display_name,
+            scope=scope,
+            client_id=client_id,
+            client_secret=client_secret,
+            token_endpoint_auth_method=token_endpoint_auth_method,
+        )
+
+        return o_auth_start_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/o_auth_start_request_token_endpoint_auth_method_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/o_auth_start_request_token_endpoint_auth_method_type_0.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class OAuthStartRequestTokenEndpointAuthMethodType0(str, Enum):
+    CLIENT_SECRET_BASIC = "client_secret_basic"
+    CLIENT_SECRET_POST = "client_secret_post"
+    NONE = "none"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/o_auth_start_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/o_auth_start_response.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="OAuthStartResponse")
+
+
+@_attrs_define
+class OAuthStartResponse:
+    """The authorization URL to redirect the user to, plus the flow's CSRF state.
+
+    Attributes:
+        flow_id (str):
+        state (str):
+        authorization_url (str):
+    """
+
+    flow_id: str
+    state: str
+    authorization_url: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        flow_id = self.flow_id
+
+        state = self.state
+
+        authorization_url = self.authorization_url
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "flow_id": flow_id,
+                "state": state,
+                "authorization_url": authorization_url,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        flow_id = d.pop("flow_id")
+
+        state = d.pop("state")
+
+        authorization_url = d.pop("authorization_url")
+
+        o_auth_start_response = cls(
+            flow_id=flow_id,
+            state=state,
+            authorization_url=authorization_url,
+        )
+
+        o_auth_start_response.additional_properties = d
+        return o_auth_start_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/scripts/regen-client.sh
+++ b/scripts/regen-client.sh
@@ -30,5 +30,10 @@ OUT="packages/aios-sdk/aios_sdk/_generated"
 mkdir -p "$OUT"
 rsync -a --delete --exclude=".ruff_cache" "$WORK/" "$OUT/"
 
+# ``rsync -a`` propagates the mktemp source dir's 0700 perms onto $OUT, which
+# makes the tree unreadable by the non-root user in the runtime image (Docker
+# COPY preserves perms). Normalize to world-readable (dirs 755, files 644).
+chmod -R u=rwX,go=rX "$OUT"
+
 py_count=$(find "$OUT" -name '*.py' | wc -l | awk '{print $1}')
 echo "regenerated $OUT/ ($py_count py files)"

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -9,6 +9,9 @@ from fastapi import APIRouter, Query, status
 from aios.api.deps import AccountIdDep, CryptoBoxDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.vaults import (
+    OAuthCompleteRequest,
+    OAuthStartRequest,
+    OAuthStartResponse,
     Vault,
     VaultCreate,
     VaultCredential,
@@ -16,6 +19,7 @@ from aios.models.vaults import (
     VaultCredentialUpdate,
     VaultUpdate,
 )
+from aios.services import vault_oauth as oauth_service
 from aios.services import vaults as service
 
 router = APIRouter(prefix="/v1/vaults", tags=["vaults"])
@@ -129,6 +133,56 @@ async def create_credential(
     archive the existing one and create a new credential at the new URL.
     """
     return await service.create_vault_credential(
+        pool, crypto_box, vault_id=vault_id, body=body, account_id=account_id
+    )
+
+
+@router.post(
+    "/{vault_id}/credentials/oauth/start",
+    operation_id="start_vault_credential_oauth",
+)
+async def start_credential_oauth(
+    vault_id: str,
+    body: OAuthStartRequest,
+    pool: PoolDep,
+    crypto_box: CryptoBoxDep,
+    account_id: AccountIdDep,
+) -> OAuthStartResponse:
+    """Begin an interactive OAuth "Connect" flow for an MCP server.
+
+    Discovers the target's OAuth metadata, registers a client (RFC 7591
+    Dynamic Client Registration) or uses a caller-supplied ``client_id`` /
+    ``client_secret`` for servers without DCR, generates PKCE + a CSRF
+    ``state``, and returns the provider ``authorization_url`` to redirect the
+    user to. The token fields are obtained from the provider — the caller does
+    not supply them. Complete the flow with the returned ``state`` + the
+    authorization ``code`` via ``complete_vault_credential_oauth``.
+    """
+    return await oauth_service.start_oauth_flow(
+        pool, crypto_box, vault_id=vault_id, body=body, account_id=account_id
+    )
+
+
+@router.post(
+    "/{vault_id}/credentials/oauth/complete",
+    operation_id="complete_vault_credential_oauth",
+    status_code=status.HTTP_201_CREATED,
+)
+async def complete_credential_oauth(
+    vault_id: str,
+    body: OAuthCompleteRequest,
+    pool: PoolDep,
+    crypto_box: CryptoBoxDep,
+    account_id: AccountIdDep,
+) -> VaultCredential:
+    """Finish an interactive OAuth flow: exchange the code and store the credential.
+
+    Validates the ``state`` against the in-progress flow, exchanges the
+    authorization ``code`` for tokens, and stores them as an ``oauth2_refresh``
+    credential (creating a new one, or rotating an existing credential for the
+    same ``target_url``). Secrets are encrypted at rest and never returned.
+    """
+    return await oauth_service.complete_oauth_flow(
         pool, crypto_box, vault_id=vault_id, body=body, account_id=account_id
     )
 

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -68,6 +68,19 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
         "and only callable while the accounts table is empty. Operator runs "
         "this via curl during initial install, not via day-to-day CLI."
     ),
+    # ── Interactive (browser-redirect) OAuth ─────────────────────────
+    # The vault-credential "Connect" flow returns an authorization URL for the
+    # user to sign in at the provider, then exchanges the returned code. It is
+    # inherently browser-interactive (driven by the console), not a CLI flow —
+    # operators use `aios vaults credentials create` for the paste-tokens path.
+    "start_vault_credential_oauth": (
+        "Interactive OAuth: returns a provider authorization URL for a browser "
+        "redirect; driven by the console, not the CLI."
+    ),
+    "complete_vault_credential_oauth": (
+        "Interactive OAuth: exchanges a browser-redirect authorization code; "
+        "driven by the console, not the CLI."
+    ),
 }
 
 NEEDS_CLI_TRACKED: dict[str, str] = {

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -14,6 +14,8 @@ from typing import Literal
 from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from aios.models.vaults import OAuthProviderApp
+
 # Hardcoded mirror of ``aios.harness.loop._JOB_TIMEOUT_S`` (300.0). We
 # don't import it because ``aios.harness.loop`` itself imports config
 # at module load — a top-level import here would risk a cycle, and a
@@ -70,6 +72,19 @@ class Settings(BaseSettings):
         description="Unlocks ``POST /v1/accounts/bootstrap`` while the ``accounts`` table "
         "has no root row; the endpoint is 404 once a root exists. Generate with "
         "``openssl rand -base64 32``.",
+    )
+
+    # ── interactive OAuth (vault credential "Connect") ─────────────────────
+    oauth_provider_apps: list[OAuthProviderApp] = Field(
+        default_factory=list,
+        description="Operator-registered OAuth client apps for MCP providers that don't "
+        "support Dynamic Client Registration (Google, Microsoft, Slack, …). When a "
+        "server's discovered OAuth issuer/host matches an app's ``match``, the interactive "
+        "Connect flow uses that app so end users sign in without supplying any credentials. "
+        "Set ``AIOS_OAUTH_PROVIDER_APPS`` to a JSON list of "
+        "{match, client_id, client_secret?, token_endpoint_auth_method?, scope?}. Register "
+        "each app with the provider using the console callback "
+        "``<console_url>/api/auth/mcp-oauth/callback`` as the redirect URI.",
     )
 
     # ── database (required) ────────────────────────────────────────────────

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -82,9 +82,20 @@ class Settings(BaseSettings):
         "server's discovered OAuth issuer/host matches an app's ``match``, the interactive "
         "Connect flow uses that app so end users sign in without supplying any credentials. "
         "Set ``AIOS_OAUTH_PROVIDER_APPS`` to a JSON list of "
-        "{match, client_id, client_secret?, token_endpoint_auth_method?, scope?}. Register "
+        "{match, client_id, client_secret?, token_endpoint_auth_method?, "
+        "token_endpoint_hosts?, scope?, authorize_params?}. Register "
         "each app with the provider using the console callback "
         "``<console_url>/api/auth/mcp-oauth/callback`` as the redirect URI.",
+    )
+    oauth_allow_insecure_hosts: str = Field(
+        default="",
+        description="DEV-ONLY comma-separated host[:port] allowlist that bypasses the "
+        "interactive-Connect SSRF guard (https requirement + private-range block) for "
+        "the listed hosts. Lets a self-hosted MCP fleet reachable only over plain http "
+        "on an internal host (e.g. ``workspace-mcp:8000``) be connected from dev. Leave "
+        "empty in production (prod MCP servers are https), where any value would re-open "
+        "SSRF to internal hosts. Plain comma string (not JSON) so the natural ``.env`` "
+        "format ``host-a,host-b:8000`` parses without brackets.",
     )
 
     # ── database (required) ────────────────────────────────────────────────
@@ -270,6 +281,11 @@ class Settings(BaseSettings):
 
     # ── observability ──────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
+
+    @property
+    def oauth_allow_insecure_host_set(self) -> frozenset[str]:
+        """Parsed ``oauth_allow_insecure_hosts`` as a set of host[:port] entries."""
+        return frozenset(h.strip() for h in self.oauth_allow_insecure_hosts.split(",") if h.strip())
 
     @model_validator(mode="after")
     def _require_absolute_workspace_root(self) -> Settings:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -44,6 +44,7 @@ from aios.ids import (
     MEMORY,
     MEMORY_STORE,
     MEMORY_VERSION,
+    OAUTH_FLOW,
     RUNTIME_TOKEN,
     SCHEDULED_TASK,
     SESSION,
@@ -2898,6 +2899,84 @@ async def lock_oauth_credential_for_refresh(
         return None
     blob = EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"]))
     return str(row["id"]), blob
+
+
+# ── interactive OAuth flow state (vault credential "Connect") ────────────────
+
+
+async def insert_oauth_flow(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    vault_id: str,
+    target_url: str,
+    state: str,
+    redirect_uri: str,
+    blob: EncryptedBlob,
+    expires_at: datetime,
+) -> str:
+    """Persist an in-progress OAuth flow; returns the new flow id.
+
+    The encrypted ``blob`` carries the PKCE code_verifier, resolved endpoints,
+    and any client_id/secret — see :func:`get_oauth_flow_for_complete`.
+    """
+    new_id = make_id(OAUTH_FLOW)
+    await conn.execute(
+        """
+        INSERT INTO oauth_flows (
+            id, account_id, vault_id, target_url, state, redirect_uri,
+            ciphertext, nonce, expires_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        """,
+        new_id,
+        account_id,
+        vault_id,
+        target_url,
+        state,
+        redirect_uri,
+        blob.ciphertext,
+        blob.nonce,
+        expires_at,
+    )
+    return new_id
+
+
+async def get_oauth_flow_for_complete(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    vault_id: str,
+    state: str,
+) -> tuple[str, str, str, EncryptedBlob] | None:
+    """``SELECT FOR UPDATE`` the live (not-expired) flow for this state.
+
+    Returns ``(flow_id, target_url, redirect_uri, EncryptedBlob)`` or ``None``
+    if no matching non-expired flow exists. Caller owns the transaction and
+    deletes the row via :func:`delete_oauth_flow` after a successful exchange.
+    """
+    row = await conn.fetchrow(
+        "SELECT id, target_url, redirect_uri, ciphertext, nonce FROM oauth_flows "
+        "WHERE account_id = $1 AND vault_id = $2 AND state = $3 AND expires_at > now() "
+        "FOR UPDATE",
+        account_id,
+        vault_id,
+        state,
+    )
+    if row is None:
+        return None
+    blob = EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"]))
+    return str(row["id"]), str(row["target_url"]), str(row["redirect_uri"]), blob
+
+
+async def delete_oauth_flow(conn: asyncpg.Connection[Any], flow_id: str) -> None:
+    """Delete a (single-use) OAuth flow row after the token exchange."""
+    await conn.execute("DELETE FROM oauth_flows WHERE id = $1", flow_id)
+
+
+async def delete_expired_oauth_flows(conn: asyncpg.Connection[Any]) -> None:
+    """Prune expired flow rows. Called opportunistically on ``start``."""
+    await conn.execute("DELETE FROM oauth_flows WHERE expires_at < now()")
 
 
 async def get_vault_credential_with_blob(

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -2853,6 +2853,31 @@ async def insert_vault_credential(
     return _row_to_vault_credential(row)
 
 
+async def get_active_credential_by_target_url(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    vault_id: str,
+    target_url: str,
+) -> VaultCredential | None:
+    """The active (non-archived) credential for ``(vault_id, target_url)``, if any.
+
+    Used by the interactive OAuth completion to decide between creating a new
+    credential and rotating the existing one (the ``(vault_id, target_url)``
+    active-row unique index allows only one). Returns metadata only.
+    """
+    row = await conn.fetchrow(
+        "SELECT * FROM vault_credentials "
+        "WHERE vault_id = $1 AND target_url = $2 AND account_id = $3 AND archived_at IS NULL",
+        vault_id,
+        target_url,
+        account_id,
+    )
+    if row is None:
+        return None
+    return _row_to_vault_credential(row)
+
+
 async def get_vault_credential(
     conn: asyncpg.Connection[Any],
     vault_id: str,

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -151,6 +151,21 @@ class OAuthRefreshError(AiosError):
     status_code = 502
 
 
+class OAuthFlowError(AiosError):
+    """Raised when an interactive OAuth "Connect" flow fails.
+
+    Covers the start phase (OAuth metadata discovery found nothing, the server
+    requires a pre-registered client but none was supplied, dynamic client
+    registration was rejected) and the complete phase (unknown/expired
+    ``state``, the token endpoint returned a non-2xx response, or the response
+    was missing ``access_token``). Distinct from :class:`OAuthRefreshError`,
+    which covers refreshing an already-stored credential.
+    """
+
+    error_type = "oauth_flow_error"
+    status_code = 502
+
+
 class ManagementCallTimeoutError(AiosError):
     """Management call exceeded its per-method timeout.
 

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -47,6 +47,10 @@ MANAGEMENT_CALL: Final = "mgmt"
 ACCOUNT: Final = "acc"
 ACCOUNT_KEY: Final = "acckey"
 SCHEDULED_TASK: Final = "sched"
+# Short-lived server-side state for an in-progress interactive OAuth
+# authorization-code flow (vault credential "Connect"). Rows are pruned on
+# expiry — see ``oauth_flows`` (migration 0061).
+OAUTH_FLOW: Final = "oaf"
 
 _PREFIXES: Final = frozenset(
     {
@@ -71,6 +75,7 @@ _PREFIXES: Final = frozenset(
         ACCOUNT,
         ACCOUNT_KEY,
         SCHEDULED_TASK,
+        OAUTH_FLOW,
     }
 )
 

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 from contextlib import AsyncExitStack
 from typing import Any, assert_never
@@ -29,11 +30,71 @@ from mcp.types import InitializeResult
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.logging import get_logger
+from aios.mcp.pool import HttpErrorSink
 from aios.mcp.schema import make_function_tool
 from aios.models.vaults import AuthType
 from aios.services.vaults import is_expiring, refresh_credential
 
 log = get_logger("aios.mcp.client")
+
+
+class _McpHttpError(Exception):
+    """A tool call hit an HTTP error response (e.g. 403) on the MCP transport.
+
+    Carries the server's status + body so the caller can surface the real,
+    actionable message instead of a generic timeout.
+    """
+
+    def __init__(self, status: int | None, body: str) -> None:
+        self.status = status
+        self.body = body
+        super().__init__(f"HTTP {status}")
+
+
+async def _call_tool_fast(
+    session: ClientSession,
+    tool_name: str,
+    arguments: dict[str, Any],
+    meta: dict[str, Any] | None,
+    sink: HttpErrorSink | None,
+    timeout_s: float,
+) -> Any:
+    """Invoke a tool, but fail fast with the server's message if its transport
+    reports an HTTP error.
+
+    The streamable-http client traps an error response (e.g. a 403) inside a
+    suspended task group, so ``call_tool`` would otherwise hang until
+    ``timeout`` and surface a bare ``TimeoutError``. We race the call against
+    the transport's :class:`HttpErrorSink` so a captured 4xx/5xx aborts the
+    wait immediately and is re-raised as :class:`_McpHttpError`.
+    """
+    if sink is not None:
+        sink.reset()
+    call_task: asyncio.Task[Any] = asyncio.ensure_future(
+        session.call_tool(tool_name, arguments, meta=meta)
+    )
+    waiters: set[asyncio.Future[Any]] = {call_task}
+    err_task: asyncio.Task[bool] | None = None
+    if sink is not None:
+        err_task = asyncio.ensure_future(sink.event.wait())
+        waiters.add(err_task)
+    try:
+        done, _pending = await asyncio.wait(
+            waiters, timeout=timeout_s, return_when=asyncio.FIRST_COMPLETED
+        )
+    finally:
+        if err_task is not None and not err_task.done():
+            err_task.cancel()
+    if call_task in done:
+        return call_task.result()  # re-raises the underlying call error, if any
+    # The call didn't finish: an HTTP error was captured, or we timed out.
+    call_task.cancel()
+    with contextlib.suppress(BaseException):
+        await call_task
+    if sink is not None and sink.event.is_set():
+        raise _McpHttpError(sink.status, sink.body)
+    raise TimeoutError(f"tool call exceeded {timeout_s:.0f}s")
+
 
 MAX_TOOLS_PER_SERVER = 128
 
@@ -268,9 +329,13 @@ async def call_mcp_tool(
         if _pool is not None:
             try:
                 session, _ = await _pool.get_or_connect(url, vault_id, headers)
-                result = await asyncio.wait_for(
-                    session.call_tool(tool_name, arguments, meta=meta),
-                    timeout=_TOOL_CALL_TIMEOUT_S,
+                result = await _call_tool_fast(
+                    session,
+                    tool_name,
+                    arguments,
+                    meta,
+                    _pool.error_sink(url, vault_id),
+                    _TOOL_CALL_TIMEOUT_S,
                 )
             except Exception:
                 # Don't retry any call_tool failure: by the time the
@@ -289,13 +354,22 @@ async def call_mcp_tool(
         else:
             async with AsyncExitStack() as stack:
                 session, _ = await _open_session(url, headers, stack)
-                result = await asyncio.wait_for(
-                    session.call_tool(tool_name, arguments, meta=meta),
-                    timeout=_TOOL_CALL_TIMEOUT_S,
+                result = await _call_tool_fast(
+                    session, tool_name, arguments, meta, None, _TOOL_CALL_TIMEOUT_S
                 )
 
         return shape_call_result(result)
 
+    except _McpHttpError as err:
+        # The MCP server returned an HTTP error (e.g. 403 "API not enabled").
+        # Surface its actual message so the model/operator can act on it,
+        # rather than a generic timeout.
+        log.warning("mcp.call_http_error", url=url, tool_name=tool_name, status=err.status)
+        detail = err.body.strip() or f"HTTP {err.status}"
+        return {
+            "error": f"MCP server returned HTTP {err.status}: {detail}",
+            "code": "transport_error",
+        }
     except Exception as err:
         log.warning(
             "mcp.call_failed",

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -254,14 +254,31 @@ async def discover_mcp_tools(
     _pool = runtime.mcp_session_pool
 
     if _pool is not None:
-        # Pool path: reuse cached session; on failure evict + retry once.
+        # Pool path: check out a session; on a transport/protocol error discard
+        # it and retry once with a fresh one. Always release-or-discard so the
+        # per-key cap slot is freed.
+        entry = await _pool.acquire(url, vault_id, headers)
         try:
-            session, init_result = await _pool.get_or_connect(url, vault_id, headers)
-            result = await session.list_tools()
+            result = await entry.session.list_tools()
         except Exception:
-            _pool.evict(url, vault_id)
-            session, init_result = await _pool.get_or_connect(url, vault_id, headers)
-            result = await session.list_tools()
+            await asyncio.shield(_pool.discard(url, vault_id, entry))
+            entry = await _pool.acquire(url, vault_id, headers)
+            try:
+                result = await entry.session.list_tools()
+            except BaseException:
+                await asyncio.shield(_pool.discard(url, vault_id, entry))
+                raise
+            else:
+                await asyncio.shield(_pool.release(url, vault_id, entry))
+        except BaseException:
+            # CancelledError etc. — don't retry (a re-acquire mid-cancellation
+            # would spawn an owner task that's never tracked, leaking it); just
+            # discard the checked-out entry and propagate.
+            await asyncio.shield(_pool.discard(url, vault_id, entry))
+            raise
+        else:
+            await asyncio.shield(_pool.release(url, vault_id, entry))
+        init_result = entry.init_result
     else:
         # Fallback: fresh connection per call (API process, tests).
         async with AsyncExitStack() as stack:
@@ -327,30 +344,36 @@ async def call_mcp_tool(
         _pool = runtime.mcp_session_pool
 
         if _pool is not None:
+            entry = await _pool.acquire(url, vault_id, headers)
             try:
-                session, _ = await _pool.get_or_connect(url, vault_id, headers)
                 result = await _call_tool_fast(
-                    session,
+                    entry.session,
                     tool_name,
                     arguments,
                     meta,
-                    _pool.error_sink(url, vault_id),
+                    entry.error_sink,
                     _TOOL_CALL_TIMEOUT_S,
                 )
-            except Exception:
-                # Don't retry any call_tool failure: by the time the
-                # exception surfaces here, the request may already
-                # have reached the server and been processed —
-                # whether it was a timeout firing mid-response-read,
-                # a broken pipe, a TCP reset, or an HTTP/2 GOAWAY.
-                # A retry would duplicate the side effect — e.g.
-                # ``signal_send`` / ``telegram_send`` delivering the
-                # same message twice.  Evict so the next caller
-                # doesn't reuse the same session; surface the error
-                # so the model can decide whether to retry through
-                # the session log.
-                _pool.evict(url, vault_id)
+            except _McpHttpError:
+                # Benign application-level HTTP error (e.g. 403 "API not
+                # enabled") — the transport/session is healthy, so return it to
+                # idle for reuse rather than tearing it down and re-handshaking.
+                # shield so a second cancellation can't strand the entry checked
+                # out (leaking a per-key cap slot).
+                await asyncio.shield(_pool.release(url, vault_id, entry))
                 raise
+            except BaseException:
+                # Transport failure or cancellation — the session may be broken.
+                # Discard so the next caller doesn't reuse it. Don't retry: by
+                # the time the error surfaces the request may already have
+                # reached the server (timeout mid-response-read, broken pipe, TCP
+                # reset, HTTP/2 GOAWAY), so a retry could duplicate a side effect
+                # — e.g. ``signal_send`` delivering the same message twice.
+                # Surface the error so the model can retry through the session log.
+                await asyncio.shield(_pool.discard(url, vault_id, entry))
+                raise
+            else:
+                await asyncio.shield(_pool.release(url, vault_id, entry))
         else:
             async with AsyncExitStack() as stack:
                 session, _ = await _open_session(url, headers, stack)

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -32,7 +32,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import time
+from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
@@ -52,6 +54,54 @@ _MCP_HTTPX_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10
 type _PoolKey = tuple[str, str | None]
 
 
+@dataclass
+class HttpErrorSink:
+    """Captures the most recent 4xx/5xx HTTP response seen on a pooled MCP
+    transport.
+
+    The streamable-http client raises the HTTP error inside a long-lived anyio
+    task group that stays suspended while the pooled session is parked, so a
+    failed ``call_tool`` would otherwise hang until the tool-call timeout and
+    surface a bare ``TimeoutError`` — losing the server's actual message. This
+    sink lets the caller observe the error response immediately (via ``event``)
+    and report it (``status`` + ``body``).
+    """
+
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+    status: int | None = None
+    body: str = ""
+
+    def reset(self) -> None:
+        self.event.clear()
+        self.status = None
+        self.body = ""
+
+    def record(self, status: int, body: str) -> None:
+        self.status = status
+        self.body = body
+        self.event.set()
+
+
+def _make_error_hook(sink: HttpErrorSink) -> Callable[[httpx.Response], Awaitable[None]]:
+    """httpx response hook that records error responses into ``sink``.
+
+    Only reads the body for 4xx/5xx (error JSON, never an SSE stream), so
+    success-path streaming responses are untouched.
+    """
+
+    async def _hook(response: httpx.Response) -> None:
+        if response.status_code < 400 or sink.event.is_set():
+            return
+        try:
+            await response.aread()
+            body = response.text[:800]
+        except Exception:
+            body = ""
+        sink.record(response.status_code, body)
+
+    return _hook
+
+
 class _Entry:
     """A single pooled MCP session with its associated owner task.
 
@@ -69,11 +119,15 @@ class _Entry:
         shutdown: asyncio.Event,
         owner_task: asyncio.Task[None],
         last_used: float,
+        error_sink: HttpErrorSink,
     ) -> None:
         self.session = session
         self.init_result = init_result
         self._shutdown = shutdown
         self._owner_task = owner_task
+        # Records error responses on this session's transport so a failed
+        # call_tool can fail fast with the server's message (see HttpErrorSink).
+        self.error_sink = error_sink
         # monotonic() of the last get_or_connect that returned this
         # entry. Reaper keys off this, NOT owner-task liveness: the
         # task parks on `await shutdown.wait()` for the entry's whole
@@ -135,13 +189,18 @@ class McpSessionPool:
         """
         ready = asyncio.Event()
         shutdown = asyncio.Event()
+        sink = HttpErrorSink()
         result: dict[str, Any] = {}
 
         async def _own() -> None:
             try:
                 async with AsyncExitStack() as stack:
                     http_client: Any = await stack.enter_async_context(
-                        httpx.AsyncClient(headers=headers, timeout=_MCP_HTTPX_TIMEOUT)
+                        httpx.AsyncClient(
+                            headers=headers,
+                            timeout=_MCP_HTTPX_TIMEOUT,
+                            event_hooks={"response": [_make_error_hook(sink)]},
+                        )
                     )
                     read_stream, write_stream, _ = await stack.enter_async_context(
                         streamable_http_client(url, http_client=http_client)
@@ -168,7 +227,7 @@ class McpSessionPool:
             await task
             # Defensive — unreachable in practice.
             raise RuntimeError("mcp pool owner task signalled ready but produced no session")
-        return _Entry(result["session"], result["init"], shutdown, task, time.monotonic())
+        return _Entry(result["session"], result["init"], shutdown, task, time.monotonic(), sink)
 
     async def get_or_connect(
         self, url: str, vault_id: str | None, headers: dict[str, str]
@@ -207,6 +266,15 @@ class McpSessionPool:
             log.info("mcp_pool.connected", url=url)
 
         return entry.session, entry.init_result
+
+    def error_sink(self, url: str, vault_id: str | None) -> HttpErrorSink | None:
+        """The error sink for a connected entry (or ``None`` if not connected).
+
+        Lets the caller observe an error response on the pooled transport and
+        fail fast instead of hanging to the tool-call timeout.
+        """
+        entry = self._entries.get((url, vault_id))
+        return entry.error_sink if entry is not None else None
 
     def evict(self, url: str, vault_id: str | None) -> None:
         """Drop a cache entry and close it in the background.

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -1,21 +1,33 @@
-"""Worker-scoped MCP session pool.
+"""Worker-scoped MCP session pool — per-call session checkout.
 
-Holds a persistent ``ClientSession`` per ``(url, vault_id)`` key (stable
-across OAuth token rotation — see :func:`get_or_connect` and #459) so
-tool discovery and invocation can reuse an already-initialized MCP
-connection instead of opening a fresh one on every call.
+Holds initialized ``ClientSession`` instances per ``(url, vault_id)`` key
+(stable across OAuth token rotation — see :meth:`acquire` and #459) so tool
+discovery and invocation can reuse an already-initialized MCP connection
+instead of opening a fresh one on every call.
+
+Checkout model: each tool call :meth:`acquire`\\ s an entry for **exclusive**
+use and :meth:`release`\\ s (healthy) or :meth:`discard`\\ s (broken) it when
+done. Because an entry — and its :class:`HttpErrorSink` — is never shared
+while checked out, two concurrent calls to the same server can't cross-attribute
+each other's HTTP errors (the bug a single shared session caused). Released
+entries return to a per-key idle pool and are reused on the next acquire (warm
+reuse); a fresh session is opened only when none are idle.
 
 Pool lifecycle:
 
 - Created at worker startup, stashed on :mod:`aios.harness.runtime`.
-- :meth:`get_or_connect` lazily opens and initializes a session on first
-  use. A per-key ``asyncio.Lock`` prevents thundering-herd
-  double-initialization.
-- Callers evict on first failure; the next :meth:`get_or_connect`
-  re-opens. Eviction drops the reference without attempting to close the
-  broken session — closing a half-dead stack may hang.
-- :meth:`close_all` is called from ``worker_main``'s ``finally`` at
-  shutdown to tear everything down.
+- :meth:`acquire` pops an idle entry or opens one. At most
+  ``MAX_SESSIONS_PER_KEY`` live sessions exist per key — beyond the cap the
+  caller waits on a per-key :class:`asyncio.Condition` until a release/discard
+  frees a slot. The Condition is held across the open so the cap is strict.
+- :meth:`release` returns a healthy session to idle; :meth:`discard` drops a
+  broken one (fire-and-forget close). A benign HTTP error (e.g. 403) releases —
+  the transport is fine; only transport failures discard.
+- The idle reaper closes sessions idle longer than the TTL (idle entries only —
+  an in-use entry is by definition active).
+- :meth:`close_all` is called from ``worker_main``'s ``finally`` at shutdown and
+  closes **both** idle and in-use sessions (in-use owner tasks must receive the
+  shutdown signal or they leak).
 
 Owner-task model (#425): each entry's ``AsyncExitStack`` lives inside a
 dedicated long-lived task. The task opens the contexts, signals the
@@ -50,6 +62,13 @@ log = get_logger("aios.mcp.pool")
 # pooled sessions share a connection-level timeout so a stalled MCP server
 # can't keep the worker on a dead socket indefinitely.
 _MCP_HTTPX_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=10.0, pool=10.0)
+
+# Cap on live sessions per ``(url, vault_id)``. Bounds session/connection growth
+# under a model that fires many concurrent calls at one server; at the cap an
+# ``acquire`` waits for a release rather than opening unboundedly. A session is
+# created only when in-use < cap and none are idle, so the total live count never
+# exceeds the peak concurrent in-use count, which is bounded by this value.
+MAX_SESSIONS_PER_KEY = 8
 
 type _PoolKey = tuple[str, str | None]
 
@@ -128,10 +147,12 @@ class _Entry:
         # Records error responses on this session's transport so a failed
         # call_tool can fail fast with the server's message (see HttpErrorSink).
         self.error_sink = error_sink
-        # monotonic() of the last get_or_connect that returned this
-        # entry. Reaper keys off this, NOT owner-task liveness: the
-        # task parks on `await shutdown.wait()` for the entry's whole
-        # life, so liveness is a useless staleness signal.
+        # monotonic() stamped each time this entry is released back to idle.
+        # The reaper keys off this, NOT owner-task liveness: the task parks on
+        # `await shutdown.wait()` for the entry's whole life, so liveness is a
+        # useless staleness signal. Only idle entries are reaped (an in-use
+        # entry is by definition active), so last_used is the time the entry
+        # last finished a checkout.
         #
         # Post-#459 the pool keys on (url, vault_id), stable across
         # OAuth refresh. The reaper's remaining job is the cold-entry
@@ -155,28 +176,46 @@ class _Entry:
 
 
 class McpSessionPool:
-    """Worker-scoped pool of persistent MCP ``ClientSession`` instances.
+    """Worker-scoped pool of MCP ``ClientSession`` instances, checked out per call.
 
-    Single-event-loop — no thread-safety concerns. Concurrent async tasks
-    calling the same key serialise through a per-key ``asyncio.Lock``.
+    Single-event-loop — no thread-safety concerns. A per-key ``asyncio.Condition``
+    guards the idle/in-use sets and blocks acquires at the per-key cap.
     """
 
     def __init__(self) -> None:
-        self._entries: dict[_PoolKey, _Entry] = {}
-        self._locks: dict[_PoolKey, asyncio.Lock] = {}
+        # Idle (available) and in-use (checked out) entries per key. The cap is
+        # on in-use count; idle entries are reused before a new one is opened.
+        self._idle: dict[_PoolKey, list[_Entry]] = {}
+        self._in_use: dict[_PoolKey, set[_Entry]] = {}
+        self._conditions: dict[_PoolKey, asyncio.Condition] = {}
+        self._closed = False
         self._reaper_task: asyncio.Task[None] | None = None
-        # Strong refs for evict()'s fire-and-forget close tasks. asyncio
+        # Strong refs for discard()'s fire-and-forget close tasks. asyncio
         # only weak-refs tasks, so without this the task can be GC'd
         # before close() unwinds the owner task's contexts — defeating
         # the leak fix.
-        self._evict_close_tasks: set[asyncio.Task[None]] = set()
+        self._close_tasks: set[asyncio.Task[None]] = set()
 
-    def _lock_for(self, key: _PoolKey) -> asyncio.Lock:
-        lock = self._locks.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._locks[key] = lock
-        return lock
+    def _condition_for(self, key: _PoolKey) -> asyncio.Condition:
+        cond = self._conditions.get(key)
+        if cond is None:
+            cond = asyncio.Condition()
+            self._conditions[key] = cond
+        return cond
+
+    def _drop_in_use(self, key: _PoolKey, entry: _Entry) -> None:
+        """Remove ``entry`` from the in-use set, deleting the set once it empties.
+
+        Mirrors acquire's idle-list cleanup so a key whose last in-flight entry
+        is released/discarded doesn't leave a ghost empty set behind. Caller
+        holds the key's Condition.
+        """
+        in_use = self._in_use.get(key)
+        if in_use is None:
+            return
+        in_use.discard(entry)
+        if not in_use:
+            del self._in_use[key]
 
     async def _open_entry(self, url: str, headers: dict[str, str]) -> _Entry:
         """Open a fresh session inside a dedicated long-lived owner task.
@@ -229,101 +268,113 @@ class McpSessionPool:
             raise RuntimeError("mcp pool owner task signalled ready but produced no session")
         return _Entry(result["session"], result["init"], shutdown, task, time.monotonic(), sink)
 
-    async def get_or_connect(
-        self, url: str, vault_id: str | None, headers: dict[str, str]
-    ) -> tuple[ClientSession, InitializeResult]:
-        """Return a cached session, opening a fresh one if none exists.
+    async def acquire(self, url: str, vault_id: str | None, headers: dict[str, str]) -> _Entry:
+        """Check out an entry for **exclusive** use; caller must release/discard it.
 
         Keyed on ``(url, vault_id)`` — stable across OAuth token rotation
         because ``vault_id`` is the row id of the ``vault_credentials``
         entry that ``refresh_credential`` updates in place (see #459).
         ``vault_id`` is ``None`` for the no-credential case (an
         unauthenticated MCP server); all such callers on the same URL
-        share one entry, which is safe because no auth identity is
-        being keyed on.
+        share one key, which is safe because no auth identity is keyed on.
 
-        Double-checked locking: the fast unsynchronised check avoids
-        lock contention on the common (already-connected) path; the
-        slow path acquires the per-key lock and re-checks before
-        opening.
+        Reuses an idle entry if one exists; otherwise opens a fresh one when
+        under the per-key cap; otherwise waits on the per-key Condition for a
+        release/discard to free a slot. The Condition is held across the open so
+        the cap is strict (no thundering-herd over-open). An ``_open_entry``
+        failure propagates out, releasing the Condition; no slot is consumed and
+        no waiter is notified — the next waiter to wake simply retries.
+        """
+        if self._closed:
+            raise RuntimeError("McpSessionPool is closed")
+        key: _PoolKey = (url, vault_id)
+        cond = self._condition_for(key)
+        async with cond:
+            while True:
+                idle = self._idle.get(key)
+                if idle:
+                    entry = idle.pop()
+                    if not idle:
+                        del self._idle[key]
+                    self._in_use.setdefault(key, set()).add(entry)
+                    return entry
+                if len(self._in_use.get(key, set())) < MAX_SESSIONS_PER_KEY:
+                    log.info("mcp_pool.connecting", url=url)
+                    entry = await self._open_entry(url, headers)
+                    self._in_use.setdefault(key, set()).add(entry)
+                    log.info("mcp_pool.connected", url=url)
+                    return entry
+                await cond.wait()
+
+    async def release(self, url: str, vault_id: str | None, entry: _Entry) -> None:
+        """Return a healthy entry to the idle pool for reuse.
+
+        Called when the session is fine — a successful call, or a benign
+        application-level HTTP error (the transport is unaffected). Stamps
+        ``last_used`` (the reaper's staleness signal) and notifies one waiter
+        that a slot is free.
+        """
+        entry.last_used = time.monotonic()
+        key: _PoolKey = (url, vault_id)
+        cond = self._condition_for(key)
+        async with cond:
+            self._drop_in_use(key, entry)
+            self._idle.setdefault(key, []).append(entry)
+            cond.notify()
+
+    async def discard(self, url: str, vault_id: str | None, entry: _Entry) -> None:
+        """Drop a broken entry and close it in the background.
+
+        Called when the session may be broken (transport failure, cancellation).
+        The caller can't block on close (the owner task may wait up to the httpx
+        read timeout before unwinding), so the close is fire-and-forget. Skipping
+        close entirely would strand the owner task + httpx client + SSE stream —
+        the same leak the idle reaper exists to prevent. Frees the in-use slot
+        and notifies one waiter.
         """
         key: _PoolKey = (url, vault_id)
-
-        entry = self._entries.get(key)
-        if entry is not None:
-            entry.last_used = time.monotonic()
-            return entry.session, entry.init_result
-
-        async with self._lock_for(key):
-            entry = self._entries.get(key)
-            if entry is not None:
-                entry.last_used = time.monotonic()
-                return entry.session, entry.init_result
-
-            log.info("mcp_pool.connecting", url=url)
-            entry = await self._open_entry(url, headers)
-            self._entries[key] = entry
-            log.info("mcp_pool.connected", url=url)
-
-        return entry.session, entry.init_result
-
-    def error_sink(self, url: str, vault_id: str | None) -> HttpErrorSink | None:
-        """The error sink for a connected entry (or ``None`` if not connected).
-
-        Lets the caller observe an error response on the pooled transport and
-        fail fast instead of hanging to the tool-call timeout.
-        """
-        entry = self._entries.get((url, vault_id))
-        return entry.error_sink if entry is not None else None
-
-    def evict(self, url: str, vault_id: str | None) -> None:
-        """Drop a cache entry and close it in the background.
-
-        Called when a cached session has been found to be broken. The
-        caller is on a retry path and can't block on close (the owner
-        task may wait up to the httpx read timeout before unwinding), so
-        the close is fire-and-forget. Skipping close entirely would
-        strand the owner task + httpx client + SSE stream — same leak
-        shape the idle reaper exists to prevent, except evict pops the
-        entry from ``_entries`` so the reaper can't reach it.
-        """
-        key: _PoolKey = (url, vault_id)
-        entry = self._entries.pop(key, None)
-        if entry is None:
-            return
-        task = asyncio.create_task(entry.close(), name=f"mcp-pool-evict:{url}")
-        self._evict_close_tasks.add(task)
-        task.add_done_callback(self._evict_close_tasks.discard)
-        log.info("mcp_pool.evicted", url=url)
+        cond = self._condition_for(key)
+        async with cond:
+            self._drop_in_use(key, entry)
+            cond.notify()
+        task = asyncio.create_task(entry.close(), name=f"mcp-pool-discard:{url}")
+        self._close_tasks.add(task)
+        task.add_done_callback(self._close_tasks.discard)
+        log.info("mcp_pool.discarded", url=url)
 
     async def _reap_idle_once(self, *, idle_timeout: float, now: float) -> None:
-        """Close entries idle longer than ``idle_timeout`` seconds.
+        """Close idle entries unused longer than ``idle_timeout`` seconds.
 
-        Keyed on ``_Entry.last_used``, not owner-task liveness — see
-        :class:`_Entry`. Reclamation goes through ``_Entry.close()``
-        (same path as :meth:`close_all`), NOT a bare ``pop``: dropping
-        the reference alone strands the owner task, httpx client and SSE
-        stream — exactly the leak this reaps.
+        Idle entries only — an in-use (checked-out) entry is by definition
+        active. Keyed on ``_Entry.last_used`` (stamped at :meth:`release`).
+        Reclamation goes through ``_Entry.close()`` (same path as
+        :meth:`close_all`), NOT a bare ``remove``: dropping the reference alone
+        strands the owner task, httpx client and SSE stream — exactly the leak
+        this reaps. No notify after close: reaping an idle entry doesn't free an
+        in-use slot, so no capped waiter is unblocked by it.
         """
-        stale = [k for k, e in self._entries.items() if now - e.last_used > idle_timeout]
-        for key in stale:
-            async with self._lock_for(key):
-                # Re-check under the lock: a concurrent get_or_connect
-                # warm hit (pool.py:193-196) bumps entry.last_used
-                # synchronously without acquiring the lock, so a freshen
-                # can race between the scan above and this iteration.
-                # Without the re-check, the reaper would close a session
-                # actively held by a caller — same shape as the
-                # SandboxRegistry reaper TOCTOU fixed in #654. evict()
-                # is also lockless and can drop the entry between scan
-                # and lock-acquire (the get() returning None handles
-                # that).
-                entry = self._entries.get(key)
-                if entry is None or now - entry.last_used <= idle_timeout:
+        if self._closed:
+            return
+        stale = [
+            (key, entry)
+            for key, entries in self._idle.items()
+            for entry in entries
+            if now - entry.last_used > idle_timeout
+        ]
+        for key, entry in stale:
+            async with self._condition_for(key):
+                # Re-check under the lock: acquire() may have popped this entry
+                # (warm reuse) between the scan and here, or release() may have
+                # refreshed its last_used — same TOCTOU shape as the
+                # SandboxRegistry reaper fixed in #654.
+                idle = self._idle.get(key)
+                if idle is None or entry not in idle or now - entry.last_used <= idle_timeout:
                     continue
-                del self._entries[key]
-                log.info("mcp_pool.idle_close", url=key[0])
-                await entry.close()
+                idle.remove(entry)
+                if not idle:
+                    del self._idle[key]
+            log.info("mcp_pool.idle_close", url=key[0])
+            await entry.close()
 
     async def _reap_idle_loop(self, idle_timeout: float, interval: float = 60.0) -> None:
         """Background loop: close pooled sessions idle > idle_timeout.
@@ -360,10 +411,19 @@ class McpSessionPool:
             self._reaper_task = None
 
     async def close_all(self) -> None:
-        """Tear down all pooled sessions. Called at worker shutdown."""
-        entries = list(self._entries.values())
-        self._entries.clear()
-        self._locks.clear()
+        """Tear down all sessions — idle AND in-use. Called at worker shutdown.
+
+        In-use entries must be closed too: their owner tasks are parked on the
+        shutdown event and would leak otherwise (setting it unwinds the
+        AsyncExitStack, cancelling any in-flight transport task). ``_closed`` is
+        set first so no new session is acquired during or after teardown.
+        """
+        self._closed = True
+        entries = [e for entries in self._idle.values() for e in entries]
+        entries += [e for entries in self._in_use.values() for e in entries]
+        self._idle.clear()
+        self._in_use.clear()
+        self._conditions.clear()
         if not entries:
             return
         log.info("mcp_pool.close_all", count=len(entries))

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -158,3 +158,52 @@ class VaultCredential(BaseModel):
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None
+
+
+# ── Interactive OAuth "Connect" flow ────────────────────────────────────────
+
+
+class OAuthStartRequest(BaseModel):
+    """Begin an interactive OAuth authorization-code flow for an MCP server.
+
+    With the token fields left blank, the server discovers the target's OAuth
+    metadata, registers a client (RFC 7591 Dynamic Client Registration) or uses
+    the supplied ``client_id``/``client_secret``, and returns an
+    ``authorization_url`` to redirect the user to. The ``redirect_uri`` is the
+    console's callback and is reused verbatim on completion.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_url: str = Field(min_length=1)
+    redirect_uri: str = Field(min_length=1)
+    display_name: str | None = Field(default=None, max_length=128)
+    scope: str | None = None
+    # For MCP servers that do NOT support Dynamic Client Registration: a
+    # pre-registered OAuth client. Omit for DCR-capable servers.
+    client_id: str | None = None
+    client_secret: SecretStr | None = None
+    token_endpoint_auth_method: (
+        Literal["none", "client_secret_basic", "client_secret_post"] | None
+    ) = None
+
+
+class OAuthStartResponse(BaseModel):
+    """The authorization URL to redirect the user to, plus the flow's CSRF state."""
+
+    flow_id: str
+    state: str
+    authorization_url: str
+
+
+class OAuthCompleteRequest(BaseModel):
+    """Finish an interactive OAuth flow: exchange the returned code for tokens.
+
+    The ``state`` correlates back to the in-progress flow (and guards CSRF);
+    ``code`` is the authorization code the provider returned to the callback.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    state: str = Field(min_length=1)
+    code: str = Field(min_length=1)

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
 AuthType = Literal["bearer_header", "oauth2_refresh", "basic", "custom_header"]
 
@@ -232,6 +232,18 @@ class OAuthProviderApp(BaseModel):
     token_endpoint_auth_method: Literal["none", "client_secret_basic", "client_secret_post"] = (
         "client_secret_post"
     )
+    token_endpoint_hosts: list[str] = Field(
+        default_factory=list,
+        description="Token-endpoint hostnames trusted for this app, beyond ``match``. "
+        "Required when the provider issues tokens from a different host than it "
+        "authorizes at — e.g. Google authorizes at accounts.google.com but issues "
+        "tokens at oauth2.googleapis.com, so set "
+        "token_endpoint_hosts=['oauth2.googleapis.com']. The operator's client_secret "
+        "is sent to the discovered token endpoint only if its host is ``match`` (or a "
+        "sub-host) or appears here — closing the exfiltration where attacker metadata "
+        "selects this app via a spoofed issuer/authorization host but points the token "
+        "endpoint elsewhere.",
+    )
     scope: str | None = Field(
         default=None,
         description="Override the discovered scope (some providers, e.g. Google, "
@@ -243,3 +255,18 @@ class OAuthProviderApp(BaseModel):
         "quirks live here — e.g. Google needs {'access_type': 'offline', 'prompt': "
         "'consent'} to return a refresh token (standard providers issue one without).",
     )
+
+    @model_validator(mode="after")
+    def _require_secret_for_confidential_method(self) -> OAuthProviderApp:
+        """A confidential client-auth method needs a secret — fail fast at config
+        load rather than silently POSTing an empty secret (and storing the
+        credential as a public ``none`` client) at the user's first Connect."""
+        if (
+            self.token_endpoint_auth_method in ("client_secret_basic", "client_secret_post")
+            and not self.client_secret
+        ):
+            raise ValueError(
+                f"token_endpoint_auth_method={self.token_endpoint_auth_method!r} "
+                "requires client_secret"
+            )
+        return self

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -207,3 +207,33 @@ class OAuthCompleteRequest(BaseModel):
 
     state: str = Field(min_length=1)
     code: str = Field(min_length=1)
+
+
+class OAuthProviderApp(BaseModel):
+    """An operator-registered OAuth client app for a provider that does NOT
+    support Dynamic Client Registration (Google, Microsoft, Slack, …).
+
+    When the interactive Connect flow discovers a server whose OAuth issuer /
+    authorization host / target URL host matches ``match``, it uses this app's
+    ``client_id`` / ``client_secret`` instead of registering a client — so end
+    users sign in without supplying any credentials (the CMA model). Configured
+    by the operator via the ``AIOS_OAUTH_PROVIDER_APPS`` JSON env var.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    match: str = Field(
+        min_length=1,
+        description="Host (or host suffix) to match against the discovered OAuth "
+        "issuer, authorization endpoint, or target URL — e.g. 'accounts.google.com'.",
+    )
+    client_id: str = Field(min_length=1)
+    client_secret: SecretStr | None = None
+    token_endpoint_auth_method: Literal["none", "client_secret_basic", "client_secret_post"] = (
+        "client_secret_post"
+    )
+    scope: str | None = Field(
+        default=None,
+        description="Override the discovered scope (some providers, e.g. Google, "
+        "require specific scopes the MCP server may not advertise).",
+    )

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -237,3 +237,9 @@ class OAuthProviderApp(BaseModel):
         description="Override the discovered scope (some providers, e.g. Google, "
         "require specific scopes the MCP server may not advertise).",
     )
+    authorize_params: dict[str, str] = Field(
+        default_factory=dict,
+        description="Extra query params to add to the authorization URL. Provider "
+        "quirks live here — e.g. Google needs {'access_type': 'offline', 'prompt': "
+        "'consent'} to return a refresh token (standard providers issue one without).",
+    )

--- a/src/aios/services/vault_oauth.py
+++ b/src/aios/services/vault_oauth.py
@@ -21,8 +21,7 @@ via :func:`aios.services.vaults.build_token_endpoint_post`.
 
 from __future__ import annotations
 
-import ipaddress
-import os
+import asyncio
 import secrets
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
@@ -75,6 +74,7 @@ from aios.services.vaults import (
     create_vault_credential,
     update_vault_credential,
 )
+from aios.tools.url_safety import is_safe_url
 
 log = get_logger("aios.services.vault_oauth")
 
@@ -85,45 +85,53 @@ OAUTH_FLOW_TTL_SECONDS = 600
 # Generous per-call HTTP timeout — OAuth providers vary widely.
 _OAUTH_HTTP_TIMEOUT_SECONDS = 30
 
-# Comma-separated host[:port] allowlist that bypasses the https/private-range
-# SSRF guard. Test-only: the local mock provider runs on 127.0.0.1:<port>.
-_ALLOW_INSECURE_ENV = "AIOS_OAUTH_ALLOW_INSECURE_HOSTS"
-
 
 # ── SSRF guard ───────────────────────────────────────────────────────────────
 
 
-def _guard_target_url(url: str) -> None:
-    """Reject target URLs that could drive server-side requests at internal hosts.
+async def _guard_url(url: str, *, allow_insecure: frozenset[str], label: str) -> None:
+    """Reject a server-side-fetched URL that could reach an internal host.
 
-    Requires https and blocks loopback/private/link-local/reserved IP literals
-    and ``localhost``. A test-only env allowlist (``AIOS_OAUTH_ALLOW_INSECURE_HOSTS``)
-    permits the local mock provider.
+    Operator-allowlisted hosts (dev only — ``Settings.oauth_allow_insecure_hosts``)
+    bypass the check so a self-hosted MCP fleet on plain http can be connected
+    in dev. Otherwise requires https and delegates to the shared
+    :func:`aios.tools.url_safety.is_safe_url`, which resolves DNS and blocks
+    private/CGNAT/loopback/link-local/cloud-metadata addresses — the same guard
+    ``web_fetch``/``http_request`` use, so the policy can't drift. ``is_safe_url``
+    is blocking (``getaddrinfo``), so it runs in a worker thread.
     """
     parsed = urlparse(url)
-    host = parsed.hostname or ""
-    allow = {h.strip() for h in os.environ.get(_ALLOW_INSECURE_ENV, "").split(",") if h.strip()}
-    if host in allow or parsed.netloc in allow:
+    host = (parsed.hostname or "").lower()
+    if host in allow_insecure or parsed.netloc.lower() in allow_insecure:
         return
     if parsed.scheme != "https":
+        raise OAuthFlowError(f"{label} must use https", detail={label: url})
+    if not await asyncio.to_thread(is_safe_url, url):
+        raise OAuthFlowError(f"{label} host is not allowed", detail={label: url})
+
+
+def _assert_token_endpoint_bound(app: OAuthProviderApp, metadata: OAuthMetadata) -> None:
+    """Refuse to use the operator client unless the discovered token endpoint
+    belongs to ``app``.
+
+    The operator's confidential ``client_secret`` is POSTed to the discovered
+    ``token_endpoint`` at completion. ``_match_provider_app`` selects the app on
+    the issuer / authorization-endpoint / target host, all of which come from
+    the (untrusted) target's discovery metadata. Without this check an attacker
+    could serve metadata advertising ``accounts.google.com`` as the issuer (to
+    select the operator's Google app) while pointing ``token_endpoint`` at a host
+    they control, exfiltrating the secret. Bind it: the token host must be
+    ``match`` (or a sub-host) or one of ``token_endpoint_hosts`` (e.g. Google
+    issues at ``oauth2.googleapis.com``, a different apex than the authorize
+    host).
+    """
+    allowed = {_norm_host(app.match)}
+    allowed.update(_norm_host(h) for h in app.token_endpoint_hosts if h.strip())
+    token_host = _host(str(metadata.token_endpoint))
+    if not token_host or not _host_covered_by(token_host, allowed):
         raise OAuthFlowError(
-            "target_url must use https",
-            detail={"target_url": url},
-        )
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        # A hostname, not an IP literal — block obvious loopback names.
-        if host == "localhost" or host.endswith(".localhost"):
-            raise OAuthFlowError(
-                "target_url host is not allowed",
-                detail={"target_url": url},
-            ) from None
-        return
-    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
-        raise OAuthFlowError(
-            "target_url host is not allowed",
-            detail={"target_url": url},
+            "discovered token endpoint is not trusted for this operator app",
+            detail={"token_endpoint": str(metadata.token_endpoint), "match": app.match},
         )
 
 
@@ -134,6 +142,23 @@ def _origin(url: str) -> str:
 
 def _host(url: str | None) -> str:
     return (urlparse(url).hostname or "").lower() if url else ""
+
+
+def _norm_host(value: str) -> str:
+    """Normalize a host / ``match`` pattern for comparison (lowercase, no leading dot)."""
+    return value.strip().lower().lstrip(".")
+
+
+def _host_covered_by(host: str, patterns: set[str]) -> bool:
+    """True if ``host`` equals or is a dotted sub-host of any pattern.
+
+    Single source of the provider-app host-match rule, shared by the app
+    *selection* path (:func:`_match_provider_app`) and the secret-binding path
+    (:func:`_assert_token_endpoint_bound`) so a future tightening can't make the
+    two security checks drift. ``patterns`` must be pre-normalized via
+    :func:`_norm_host`.
+    """
+    return any(host == p or host.endswith("." + p) for p in patterns)
 
 
 def _match_provider_app(
@@ -152,10 +177,10 @@ def _match_provider_app(
     }
     hosts.discard("")
     for app in apps:
-        m = app.match.strip().lower().lstrip(".")
+        m = _norm_host(app.match)
         if not m:
             continue
-        if any(h == m or h.endswith("." + m) for h in hosts):
+        if any(_host_covered_by(h, {m}) for h in hosts):
             return app
     return None
 
@@ -220,8 +245,10 @@ async def start_oauth_flow(
     ``Settings.oauth_provider_apps``) for servers without DCR → Dynamic Client
     Registration → otherwise an error asking for client credentials.
     """
-    apps = provider_apps if provider_apps is not None else get_settings().oauth_provider_apps
-    _guard_target_url(body.target_url)
+    settings = get_settings()
+    apps = provider_apps if provider_apps is not None else settings.oauth_provider_apps
+    allow_insecure = settings.oauth_allow_insecure_host_set
+    await _guard_url(body.target_url, allow_insecure=allow_insecure, label="target_url")
 
     # Ownership check (raises NotFoundError if the vault isn't this account's)
     # and opportunistic prune of expired flows.
@@ -229,19 +256,35 @@ async def start_oauth_flow(
         await queries.get_vault(conn, vault_id, account_id=account_id)
         await queries.delete_expired_oauth_flows(conn)
 
+    # follow_redirects is OFF: is_safe_url validates the literal host, but a 3xx
+    # to an internal host would bypass it (the redirect target is never guarded).
+    # RFC 9728/8414 discovery hits well-known paths directly, so no redirect is
+    # needed for a spec-compliant provider.
     async with httpx.AsyncClient(
-        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS, follow_redirects=True
+        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS, follow_redirects=False
     ) as client:
         prm = await _discover_protected_resource(client, body.target_url)
         auth_server_url = (
             str(prm.authorization_servers[0]) if prm and prm.authorization_servers else None
         )
+        # The authorization server is discovered from the target's (untrusted)
+        # metadata, then fetched server-side — guard it before the fetch.
+        if auth_server_url:
+            await _guard_url(
+                auth_server_url, allow_insecure=allow_insecure, label="authorization_server"
+            )
         metadata = await _discover_auth_server(client, auth_server_url, body.target_url)
         if metadata is None:
             raise OAuthFlowError(
                 "could not discover OAuth metadata for this server",
                 detail={"target_url": body.target_url},
             )
+
+        # The token endpoint is persisted verbatim and POSTed at completion —
+        # guard the discovered value now so the SSRF check covers that use.
+        await _guard_url(
+            str(metadata.token_endpoint), allow_insecure=allow_insecure, label="token_endpoint"
+        )
 
         scope = body.scope or get_client_metadata_scopes(None, prm, metadata)
         # RFC 8707 resource indicator: the MCP server's canonical URI.
@@ -263,7 +306,10 @@ async def start_oauth_flow(
             )
         elif provider_app:
             # Operator-registered app for this provider — the user supplies
-            # nothing (the CMA model for non-DCR providers like Google).
+            # nothing (the CMA model for non-DCR providers like Google). Bind
+            # the secret to the discovered token endpoint before using it, so
+            # spoofed issuer/authz metadata can't redirect it to an attacker.
+            _assert_token_endpoint_bound(provider_app, metadata)
             client_id = provider_app.client_id
             client_secret = (
                 provider_app.client_secret.get_secret_value()
@@ -275,6 +321,12 @@ async def start_oauth_flow(
                 scope = provider_app.scope
         elif metadata.registration_endpoint:
             # Dynamic Client Registration (RFC 7591) — public client + PKCE.
+            # The registration endpoint is fetched server-side; guard it.
+            await _guard_url(
+                str(metadata.registration_endpoint),
+                allow_insecure=allow_insecure,
+                label="registration_endpoint",
+            )
             client_metadata = OAuthClientMetadata(
                 redirect_uris=[AnyUrl(body.redirect_uri)],
                 grant_types=["authorization_code", "refresh_token"],
@@ -411,7 +463,12 @@ async def _exchange_code(
         endpoint_auth["client_secret"] = str(secret)
     post_kwargs = build_token_endpoint_post(body, client_id=client_id, endpoint_auth=endpoint_auth)
 
-    async with httpx.AsyncClient(timeout=_OAUTH_HTTP_TIMEOUT_SECONDS) as client:
+    # follow_redirects OFF: the token_endpoint was SSRF-guarded at start and is
+    # stored encrypted, but a token-exchange POST should never be redirected
+    # anyway — a 3xx here can only point somewhere we didn't validate.
+    async with httpx.AsyncClient(
+        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS, follow_redirects=False
+    ) as client:
         try:
             resp = await client.post(token_endpoint, **post_kwargs)
             resp.raise_for_status()
@@ -430,41 +487,25 @@ async def _exchange_code(
             ) from exc
 
 
-async def complete_oauth_flow(
+async def _store_oauth_credential(
     pool: asyncpg.Pool[Any],
     crypto_box: CryptoBox,
     *,
     account_id: str,
     vault_id: str,
-    body: OAuthCompleteRequest,
+    target_url: str,
+    token: OAuthToken,
+    flow_payload: dict[str, Any],
+    existing: VaultCredential | None,
 ) -> VaultCredential:
-    """Finish an interactive flow: exchange the code and store the credential.
+    """Create or rotate the ``oauth2_refresh`` credential for ``target_url``.
 
-    Claims the flow (lock + decrypt + delete — single-use, anti-replay),
-    exchanges the code for tokens, then stores them as an ``oauth2_refresh``
-    credential — creating a new one or **rotating** an existing credential for
-    the same ``(vault_id, target_url)`` (the active-row unique index allows only
-    one), so re-connecting an already-connected server doesn't 409 after the
-    user already consented at the provider.
+    ``existing`` is the active credential observed before the exchange (already
+    confirmed by the caller to be ``oauth2_refresh`` or ``None``). On a create
+    that loses a race with a concurrent completion, the active-row unique index
+    is the serialization point: catch the conflict, re-read, and rotate — so a
+    double-submit doesn't 409 the user after they consented.
     """
-    # Phase 1: claim the flow under a row lock; single-use.
-    async with pool.acquire() as conn, conn.transaction():
-        flow = await queries.get_oauth_flow_for_complete(
-            conn, account_id=account_id, vault_id=vault_id, state=body.state
-        )
-        if flow is None:
-            raise ValidationError(
-                "unknown or expired OAuth flow",
-                detail={"state": body.state},
-            )
-        flow_id, target_url, redirect_uri, blob = flow
-        flow_payload = crypto_box.derive_account_subkey(account_id).decrypt_dict(blob)
-        await queries.delete_oauth_flow(conn, flow_id)
-
-    # Phase 2: token exchange (network; no locks held).
-    token = await _exchange_code(flow_payload, redirect_uri=redirect_uri, code=body.code)
-
-    # Phase 3: persist as an oauth2_refresh credential (create or rotate).
     expires_at = (
         datetime.now(UTC) + timedelta(seconds=token.expires_in) if token.expires_in else None
     )
@@ -487,11 +528,6 @@ async def complete_oauth_flow(
     if token.refresh_token:
         secret_fields["refresh_token"] = SecretStr(token.refresh_token)
 
-    async with pool.acquire() as conn:
-        existing = await queries.get_active_credential_by_target_url(
-            conn, account_id=account_id, vault_id=vault_id, target_url=target_url
-        )
-
     if existing is None:
         create_body = VaultCredentialCreate(
             target_url=target_url,
@@ -499,12 +535,81 @@ async def complete_oauth_flow(
             display_name=display_name,
             **secret_fields,
         )
-        cred = await create_vault_credential(
-            pool, crypto_box, account_id=account_id, vault_id=vault_id, body=create_body
+        try:
+            return await create_vault_credential(
+                pool, crypto_box, account_id=account_id, vault_id=vault_id, body=create_body
+            )
+        except ConflictError:
+            # Lost a race with a concurrent completion for the same target_url —
+            # the active-row unique index serialized us. Re-read and rotate.
+            async with pool.acquire() as conn:
+                raced = await queries.get_active_credential_by_target_url(
+                    conn, account_id=account_id, vault_id=vault_id, target_url=target_url
+                )
+            if raced is None or raced.auth_type != "oauth2_refresh":
+                raise
+            existing = raced
+
+    # Rotate. Omit fields the exchange didn't return (e.g. no new refresh_token)
+    # so they're preserved — EXCEPT expires_at, which is written even when None
+    # so a token that came back without expires_in clears the prior (now-stale,
+    # possibly-past) value instead of inheriting it. Inheriting a past expires_at
+    # would make is_expiring() perpetually true and force a refresh before every
+    # call (a hard failure when the provider issued no refresh_token).
+    update_fields = {k: v for k, v in secret_fields.items() if v is not None or k == "expires_at"}
+    if display_name:
+        update_fields["display_name"] = display_name
+    return await update_vault_credential(
+        pool,
+        crypto_box,
+        account_id=account_id,
+        vault_id=vault_id,
+        credential_id=existing.id,
+        body=VaultCredentialUpdate(**update_fields),
+    )
+
+
+async def complete_oauth_flow(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    *,
+    account_id: str,
+    vault_id: str,
+    body: OAuthCompleteRequest,
+) -> VaultCredential:
+    """Finish an interactive flow: exchange the code and store the credential.
+
+    Reads the flow under a row lock and decrypts it, rejects a conflicting
+    ``auth_type`` at the target URL *before* burning the single-use code,
+    exchanges the code for tokens, then stores them as an ``oauth2_refresh``
+    credential — creating one or **rotating** the existing credential for the
+    same ``(vault_id, target_url)`` — and finally deletes the flow row. The flow
+    is consumed only on success: a transient exchange failure leaves it reusable
+    within its TTL instead of forcing the user to re-consent from scratch.
+    """
+    # Read + decrypt the flow under a row lock. NOT deleted yet — single-use is
+    # enforced by deleting on success (below), so a transient exchange failure
+    # doesn't burn the flow + auth code.
+    async with pool.acquire() as conn, conn.transaction():
+        flow = await queries.get_oauth_flow_for_complete(
+            conn, account_id=account_id, vault_id=vault_id, state=body.state
         )
-    elif existing.auth_type != "oauth2_refresh":
-        # A different auth_type already occupies this target_url; auth_type is
-        # immutable, so refuse rather than silently producing a broken hybrid.
+        if flow is None:
+            raise ValidationError(
+                "unknown or expired OAuth flow",
+                detail={"state": body.state},
+            )
+        flow_id, target_url, redirect_uri, blob = flow
+        flow_payload = crypto_box.derive_account_subkey(account_id).decrypt_dict(blob)
+
+    # Reject a different auth_type at this target_url BEFORE the exchange burns
+    # the single-use code (auth_type is immutable — an OAuth connect can't
+    # overwrite e.g. a bearer credential, so don't waste the user's consent).
+    async with pool.acquire() as conn:
+        existing = await queries.get_active_credential_by_target_url(
+            conn, account_id=account_id, vault_id=vault_id, target_url=target_url
+        )
+    if existing is not None and existing.auth_type != "oauth2_refresh":
         raise ConflictError(
             f"an active {existing.auth_type} credential already exists for {target_url}; "
             "archive it before connecting via OAuth",
@@ -514,26 +619,32 @@ async def complete_oauth_flow(
                 "auth_type": existing.auth_type,
             },
         )
-    else:
-        # Rotate the existing credential. Omit fields the exchange didn't return
-        # (e.g. no new refresh_token) so they're preserved, not unset.
-        update_fields = {k: v for k, v in secret_fields.items() if v is not None}
-        if display_name:
-            update_fields["display_name"] = display_name
-        cred = await update_vault_credential(
-            pool,
-            crypto_box,
-            account_id=account_id,
-            vault_id=vault_id,
-            credential_id=existing.id,
-            body=VaultCredentialUpdate(**update_fields),
-        )
+
+    # Token exchange (network; no locks held; flow row intact for retry on a
+    # transient failure).
+    token = await _exchange_code(flow_payload, redirect_uri=redirect_uri, code=body.code)
+
+    # Store as an oauth2_refresh credential (create or rotate), then consume the
+    # flow — single-use is enforced on success.
+    cred = await _store_oauth_credential(
+        pool,
+        crypto_box,
+        account_id=account_id,
+        vault_id=vault_id,
+        target_url=target_url,
+        token=token,
+        flow_payload=flow_payload,
+        existing=existing,
+    )
+
+    async with pool.acquire() as conn:
+        await queries.delete_oauth_flow(conn, flow_id)
 
     log.info(
         "vault.oauth_flow_completed",
         vault_id=vault_id,
         target_url=target_url,
         credential_id=cred.id,
-        rotated=bool(existing is not None),
+        rotated=existing is not None,
     )
     return cred

--- a/src/aios/services/vault_oauth.py
+++ b/src/aios/services/vault_oauth.py
@@ -318,6 +318,11 @@ async def start_oauth_flow(
         auth_params["scope"] = scope
     if resource:
         auth_params["resource"] = resource
+    # Provider-specific extras (e.g. Google needs access_type=offline +
+    # prompt=consent to return a refresh token). Standard params win on conflict.
+    if provider_app and provider_app.authorize_params:
+        for k, v in provider_app.authorize_params.items():
+            auth_params.setdefault(k, v)
     authorization_url = f"{metadata.authorization_endpoint}?{urlencode(auth_params)}"
 
     # Persist the flow state, encrypted under the per-account subkey (it carries

--- a/src/aios/services/vault_oauth.py
+++ b/src/aios/services/vault_oauth.py
@@ -30,6 +30,7 @@ from urllib.parse import urlencode, urlparse
 
 import asyncpg
 import httpx
+from mcp.client.auth import OAuthTokenError
 from mcp.client.auth.oauth2 import PKCEParameters
 from mcp.client.auth.utils import (
     build_oauth_authorization_server_metadata_discovery_urls,
@@ -40,19 +41,37 @@ from mcp.client.auth.utils import (
     handle_auth_metadata_response,
     handle_protected_resource_response,
     handle_registration_response,
+    handle_token_response_scopes,
 )
 from mcp.shared.auth import (
     OAuthClientMetadata,
     OAuthMetadata,
+    OAuthToken,
     ProtectedResourceMetadata,
 )
-from pydantic import AnyUrl
+from pydantic import AnyUrl, SecretStr
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
-from aios.errors import OAuthFlowError
+from aios.errors import ConflictError, OAuthFlowError, ValidationError
 from aios.logging import get_logger
-from aios.models.vaults import OAuthStartRequest, OAuthStartResponse
+from aios.models.vaults import (
+    OAuthCompleteRequest,
+    OAuthStartRequest,
+    OAuthStartResponse,
+    TokenEndpointAuth,
+    TokenEndpointAuthBasic,
+    TokenEndpointAuthNone,
+    TokenEndpointAuthPost,
+    VaultCredential,
+    VaultCredentialCreate,
+    VaultCredentialUpdate,
+)
+from aios.services.vaults import (
+    build_token_endpoint_post,
+    create_vault_credential,
+    update_vault_credential,
+)
 
 log = get_logger("aios.services.vault_oauth")
 
@@ -290,3 +309,175 @@ async def start_oauth_flow(
         registered=bool(not body.client_id),
     )
     return OAuthStartResponse(flow_id=flow_id, state=state, authorization_url=authorization_url)
+
+
+# ── complete ─────────────────────────────────────────────────────────────────
+
+
+def _token_endpoint_auth_model(method: str, client_secret: str | None) -> TokenEndpointAuth:
+    """Reconstruct the typed token_endpoint_auth from the stored flow fields."""
+    if method == "client_secret_basic" and client_secret:
+        return TokenEndpointAuthBasic(
+            method="client_secret_basic", client_secret=SecretStr(client_secret)
+        )
+    if method == "client_secret_post" and client_secret:
+        return TokenEndpointAuthPost(
+            method="client_secret_post", client_secret=SecretStr(client_secret)
+        )
+    return TokenEndpointAuthNone(method="none")
+
+
+async def _exchange_code(
+    flow_payload: dict[str, Any], *, redirect_uri: str, code: str
+) -> OAuthToken:
+    """Exchange the authorization code for tokens at the stored token endpoint.
+
+    Reuses the same client-auth handling as the refresh path. The
+    ``redirect_uri`` is the one persisted at start (byte-identical to the one
+    registered and sent to /authorize).
+    """
+    token_endpoint = str(flow_payload["token_endpoint"])
+    client_id = str(flow_payload["client_id"])
+    body: dict[str, str] = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": str(flow_payload["code_verifier"]),
+    }
+    resource = flow_payload.get("resource")
+    if resource:
+        body["resource"] = str(resource)
+    endpoint_auth: dict[str, str] = {
+        "method": str(flow_payload.get("token_endpoint_auth_method", "none"))
+    }
+    secret = flow_payload.get("client_secret")
+    if secret:
+        endpoint_auth["client_secret"] = str(secret)
+    post_kwargs = build_token_endpoint_post(body, client_id=client_id, endpoint_auth=endpoint_auth)
+
+    async with httpx.AsyncClient(timeout=_OAUTH_HTTP_TIMEOUT_SECONDS) as client:
+        try:
+            resp = await client.post(token_endpoint, **post_kwargs)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            log.warning("vault.oauth_exchange_http_error", token_endpoint=token_endpoint)
+            raise OAuthFlowError(
+                "OAuth token exchange failed",
+                detail={"token_endpoint": token_endpoint},
+            ) from exc
+        try:
+            return await handle_token_response_scopes(resp)
+        except OAuthTokenError as exc:
+            raise OAuthFlowError(
+                "OAuth token endpoint returned an invalid response",
+                detail={"token_endpoint": token_endpoint},
+            ) from exc
+
+
+async def complete_oauth_flow(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    *,
+    account_id: str,
+    vault_id: str,
+    body: OAuthCompleteRequest,
+) -> VaultCredential:
+    """Finish an interactive flow: exchange the code and store the credential.
+
+    Claims the flow (lock + decrypt + delete — single-use, anti-replay),
+    exchanges the code for tokens, then stores them as an ``oauth2_refresh``
+    credential — creating a new one or **rotating** an existing credential for
+    the same ``(vault_id, target_url)`` (the active-row unique index allows only
+    one), so re-connecting an already-connected server doesn't 409 after the
+    user already consented at the provider.
+    """
+    # Phase 1: claim the flow under a row lock; single-use.
+    async with pool.acquire() as conn, conn.transaction():
+        flow = await queries.get_oauth_flow_for_complete(
+            conn, account_id=account_id, vault_id=vault_id, state=body.state
+        )
+        if flow is None:
+            raise ValidationError(
+                "unknown or expired OAuth flow",
+                detail={"state": body.state},
+            )
+        flow_id, target_url, redirect_uri, blob = flow
+        flow_payload = crypto_box.derive_account_subkey(account_id).decrypt_dict(blob)
+        await queries.delete_oauth_flow(conn, flow_id)
+
+    # Phase 2: token exchange (network; no locks held).
+    token = await _exchange_code(flow_payload, redirect_uri=redirect_uri, code=body.code)
+
+    # Phase 3: persist as an oauth2_refresh credential (create or rotate).
+    expires_at = (
+        datetime.now(UTC) + timedelta(seconds=token.expires_in) if token.expires_in else None
+    )
+    client_secret = flow_payload.get("client_secret")
+    endpoint_auth = _token_endpoint_auth_model(
+        str(flow_payload.get("token_endpoint_auth_method", "none")),
+        str(client_secret) if client_secret else None,
+    )
+    display_name = flow_payload.get("display_name")
+
+    secret_fields: dict[str, Any] = {
+        "access_token": SecretStr(token.access_token),
+        "token_endpoint": str(flow_payload["token_endpoint"]),
+        "client_id": str(flow_payload["client_id"]),
+        "token_endpoint_auth": endpoint_auth,
+        "scope": token.scope or flow_payload.get("scope"),
+        "resource": flow_payload.get("resource"),
+        "expires_at": expires_at,
+    }
+    if token.refresh_token:
+        secret_fields["refresh_token"] = SecretStr(token.refresh_token)
+
+    async with pool.acquire() as conn:
+        existing = await queries.get_active_credential_by_target_url(
+            conn, account_id=account_id, vault_id=vault_id, target_url=target_url
+        )
+
+    if existing is None:
+        create_body = VaultCredentialCreate(
+            target_url=target_url,
+            auth_type="oauth2_refresh",
+            display_name=display_name,
+            **secret_fields,
+        )
+        cred = await create_vault_credential(
+            pool, crypto_box, account_id=account_id, vault_id=vault_id, body=create_body
+        )
+    elif existing.auth_type != "oauth2_refresh":
+        # A different auth_type already occupies this target_url; auth_type is
+        # immutable, so refuse rather than silently producing a broken hybrid.
+        raise ConflictError(
+            f"an active {existing.auth_type} credential already exists for {target_url}; "
+            "archive it before connecting via OAuth",
+            detail={
+                "vault_id": vault_id,
+                "target_url": target_url,
+                "auth_type": existing.auth_type,
+            },
+        )
+    else:
+        # Rotate the existing credential. Omit fields the exchange didn't return
+        # (e.g. no new refresh_token) so they're preserved, not unset.
+        update_fields = {k: v for k, v in secret_fields.items() if v is not None}
+        if display_name:
+            update_fields["display_name"] = display_name
+        cred = await update_vault_credential(
+            pool,
+            crypto_box,
+            account_id=account_id,
+            vault_id=vault_id,
+            credential_id=existing.id,
+            body=VaultCredentialUpdate(**update_fields),
+        )
+
+    log.info(
+        "vault.oauth_flow_completed",
+        vault_id=vault_id,
+        target_url=target_url,
+        credential_id=cred.id,
+        rotated=bool(existing is not None),
+    )
+    return cred

--- a/src/aios/services/vault_oauth.py
+++ b/src/aios/services/vault_oauth.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import ipaddress
 import os
 import secrets
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlencode, urlparse
@@ -51,12 +52,14 @@ from mcp.shared.auth import (
 )
 from pydantic import AnyUrl, SecretStr
 
+from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.errors import ConflictError, OAuthFlowError, ValidationError
 from aios.logging import get_logger
 from aios.models.vaults import (
     OAuthCompleteRequest,
+    OAuthProviderApp,
     OAuthStartRequest,
     OAuthStartResponse,
     TokenEndpointAuth,
@@ -129,6 +132,34 @@ def _origin(url: str) -> str:
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
+def _host(url: str | None) -> str:
+    return (urlparse(url).hostname or "").lower() if url else ""
+
+
+def _match_provider_app(
+    apps: Sequence[OAuthProviderApp], metadata: OAuthMetadata, target_url: str
+) -> OAuthProviderApp | None:
+    """The operator-configured app whose ``match`` host covers this server.
+
+    Matches against the discovered OAuth issuer, authorization endpoint, or the
+    target URL host — so e.g. ``accounts.google.com`` covers every Google MCP
+    server. Exact host or dotted-suffix match.
+    """
+    hosts = {
+        _host(str(metadata.issuer)),
+        _host(str(metadata.authorization_endpoint)),
+        _host(target_url),
+    }
+    hosts.discard("")
+    for app in apps:
+        m = app.match.strip().lower().lstrip(".")
+        if not m:
+            continue
+        if any(h == m or h.endswith("." + m) for h in hosts):
+            return app
+    return None
+
+
 # ── metadata discovery ───────────────────────────────────────────────────────
 
 
@@ -176,13 +207,20 @@ async def start_oauth_flow(
     account_id: str,
     vault_id: str,
     body: OAuthStartRequest,
+    provider_apps: Sequence[OAuthProviderApp] | None = None,
 ) -> OAuthStartResponse:
     """Begin an interactive authorization-code flow and return the authorize URL.
 
     Verifies vault ownership, discovers the target's OAuth metadata, obtains a
-    client (caller-supplied or via DCR), generates PKCE + state, persists the
-    encrypted flow (TTL ~10 min), and returns the provider authorization URL.
+    client, generates PKCE + state, persists the encrypted flow (TTL ~10 min),
+    and returns the provider authorization URL.
+
+    The client is resolved in priority order: a caller-supplied ``client_id`` →
+    an operator-configured provider app (``provider_apps``, default
+    ``Settings.oauth_provider_apps``) for servers without DCR → Dynamic Client
+    Registration → otherwise an error asking for client credentials.
     """
+    apps = provider_apps if provider_apps is not None else get_settings().oauth_provider_apps
     _guard_target_url(body.target_url)
 
     # Ownership check (raises NotFoundError if the vault isn't this account's)
@@ -215,6 +253,7 @@ async def start_oauth_flow(
         client_id: str
         client_secret: str | None
         method: str
+        provider_app = _match_provider_app(apps, metadata, body.target_url)
         if body.client_id:
             # Caller supplied a pre-registered client (server without DCR).
             client_id = body.client_id
@@ -222,6 +261,18 @@ async def start_oauth_flow(
             method = body.token_endpoint_auth_method or (
                 "client_secret_post" if client_secret else "none"
             )
+        elif provider_app:
+            # Operator-registered app for this provider — the user supplies
+            # nothing (the CMA model for non-DCR providers like Google).
+            client_id = provider_app.client_id
+            client_secret = (
+                provider_app.client_secret.get_secret_value()
+                if provider_app.client_secret
+                else None
+            )
+            method = provider_app.token_endpoint_auth_method
+            if provider_app.scope:
+                scope = provider_app.scope
         elif metadata.registration_endpoint:
             # Dynamic Client Registration (RFC 7591) — public client + PKCE.
             client_metadata = OAuthClientMetadata(

--- a/src/aios/services/vault_oauth.py
+++ b/src/aios/services/vault_oauth.py
@@ -1,0 +1,292 @@
+"""Interactive OAuth "Connect" flow for vault credentials.
+
+This is the server-side half of the console's one-click "Connect": instead of
+pasting tokens, the user authorizes an MCP server interactively. The flow spans
+two calls:
+
+* :func:`start_oauth_flow` — discover the target's OAuth metadata (RFC 9728
+  protected-resource → RFC 8414 authorization-server), register a client
+  (RFC 7591 Dynamic Client Registration) or use a caller-supplied client,
+  generate PKCE (RFC 7636) + a CSRF ``state``, persist the encrypted flow, and
+  return the provider's authorization URL to redirect the user to.
+* :func:`complete_oauth_flow` — (see below) exchange the returned code for
+  tokens and store them as an ``oauth2_refresh`` credential.
+
+It reuses the MCP SDK's standalone request-builders/response-handlers
+(``mcp.client.auth.utils``) and data models (``mcp.shared.auth``) rather than
+its inline ``OAuthClientProvider``, which is coupled to a live transport. The
+token-endpoint client-auth (none/basic/post) is shared with the refresh path
+via :func:`aios.services.vaults.build_token_endpoint_post`.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlencode, urlparse
+
+import asyncpg
+import httpx
+from mcp.client.auth.oauth2 import PKCEParameters
+from mcp.client.auth.utils import (
+    build_oauth_authorization_server_metadata_discovery_urls,
+    build_protected_resource_metadata_discovery_urls,
+    create_client_registration_request,
+    create_oauth_metadata_request,
+    get_client_metadata_scopes,
+    handle_auth_metadata_response,
+    handle_protected_resource_response,
+    handle_registration_response,
+)
+from mcp.shared.auth import (
+    OAuthClientMetadata,
+    OAuthMetadata,
+    ProtectedResourceMetadata,
+)
+from pydantic import AnyUrl
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries
+from aios.errors import OAuthFlowError
+from aios.logging import get_logger
+from aios.models.vaults import OAuthStartRequest, OAuthStartResponse
+
+log = get_logger("aios.services.vault_oauth")
+
+# In-progress flows are short-lived: the user signs in at the provider then
+# returns. Ten minutes is generous headroom for a manual sign-in.
+OAUTH_FLOW_TTL_SECONDS = 600
+
+# Generous per-call HTTP timeout — OAuth providers vary widely.
+_OAUTH_HTTP_TIMEOUT_SECONDS = 30
+
+# Comma-separated host[:port] allowlist that bypasses the https/private-range
+# SSRF guard. Test-only: the local mock provider runs on 127.0.0.1:<port>.
+_ALLOW_INSECURE_ENV = "AIOS_OAUTH_ALLOW_INSECURE_HOSTS"
+
+
+# ── SSRF guard ───────────────────────────────────────────────────────────────
+
+
+def _guard_target_url(url: str) -> None:
+    """Reject target URLs that could drive server-side requests at internal hosts.
+
+    Requires https and blocks loopback/private/link-local/reserved IP literals
+    and ``localhost``. A test-only env allowlist (``AIOS_OAUTH_ALLOW_INSECURE_HOSTS``)
+    permits the local mock provider.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    allow = {h.strip() for h in os.environ.get(_ALLOW_INSECURE_ENV, "").split(",") if h.strip()}
+    if host in allow or parsed.netloc in allow:
+        return
+    if parsed.scheme != "https":
+        raise OAuthFlowError(
+            "target_url must use https",
+            detail={"target_url": url},
+        )
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # A hostname, not an IP literal — block obvious loopback names.
+        if host == "localhost" or host.endswith(".localhost"):
+            raise OAuthFlowError(
+                "target_url host is not allowed",
+                detail={"target_url": url},
+            ) from None
+        return
+    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
+        raise OAuthFlowError(
+            "target_url host is not allowed",
+            detail={"target_url": url},
+        )
+
+
+def _origin(url: str) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+# ── metadata discovery ───────────────────────────────────────────────────────
+
+
+async def _discover_protected_resource(
+    client: httpx.AsyncClient, server_url: str
+) -> ProtectedResourceMetadata | None:
+    """Try the RFC 9728 protected-resource well-known URLs in priority order."""
+    for url in build_protected_resource_metadata_discovery_urls(None, server_url):
+        try:
+            resp = await client.send(create_oauth_metadata_request(url))
+        except httpx.HTTPError:
+            continue
+        prm = await handle_protected_resource_response(resp)
+        if prm is not None:
+            return prm
+    return None
+
+
+async def _discover_auth_server(
+    client: httpx.AsyncClient, auth_server_url: str | None, server_url: str
+) -> OAuthMetadata | None:
+    """Try the RFC 8414 / OIDC authorization-server metadata URLs in order."""
+    for url in build_oauth_authorization_server_metadata_discovery_urls(
+        auth_server_url, server_url
+    ):
+        try:
+            resp = await client.send(create_oauth_metadata_request(url))
+        except httpx.HTTPError:
+            continue
+        should_continue, metadata = await handle_auth_metadata_response(resp)
+        if metadata is not None:
+            return metadata
+        if not should_continue:
+            break
+    return None
+
+
+# ── start ────────────────────────────────────────────────────────────────────
+
+
+async def start_oauth_flow(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    *,
+    account_id: str,
+    vault_id: str,
+    body: OAuthStartRequest,
+) -> OAuthStartResponse:
+    """Begin an interactive authorization-code flow and return the authorize URL.
+
+    Verifies vault ownership, discovers the target's OAuth metadata, obtains a
+    client (caller-supplied or via DCR), generates PKCE + state, persists the
+    encrypted flow (TTL ~10 min), and returns the provider authorization URL.
+    """
+    _guard_target_url(body.target_url)
+
+    # Ownership check (raises NotFoundError if the vault isn't this account's)
+    # and opportunistic prune of expired flows.
+    async with pool.acquire() as conn:
+        await queries.get_vault(conn, vault_id, account_id=account_id)
+        await queries.delete_expired_oauth_flows(conn)
+
+    async with httpx.AsyncClient(
+        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS, follow_redirects=True
+    ) as client:
+        prm = await _discover_protected_resource(client, body.target_url)
+        auth_server_url = (
+            str(prm.authorization_servers[0]) if prm and prm.authorization_servers else None
+        )
+        metadata = await _discover_auth_server(client, auth_server_url, body.target_url)
+        if metadata is None:
+            raise OAuthFlowError(
+                "could not discover OAuth metadata for this server",
+                detail={"target_url": body.target_url},
+            )
+
+        scope = body.scope or get_client_metadata_scopes(None, prm, metadata)
+        # RFC 8707 resource indicator: the MCP server's canonical URI.
+        resource = str(prm.resource) if prm else body.target_url
+
+        # Resolved client identity. ``method`` is stored as a plain string and
+        # interpreted by ``build_token_endpoint_post`` (anything other than
+        # client_secret_basic/post behaves as a public "none" client).
+        client_id: str
+        client_secret: str | None
+        method: str
+        if body.client_id:
+            # Caller supplied a pre-registered client (server without DCR).
+            client_id = body.client_id
+            client_secret = body.client_secret.get_secret_value() if body.client_secret else None
+            method = body.token_endpoint_auth_method or (
+                "client_secret_post" if client_secret else "none"
+            )
+        elif metadata.registration_endpoint:
+            # Dynamic Client Registration (RFC 7591) — public client + PKCE.
+            client_metadata = OAuthClientMetadata(
+                redirect_uris=[AnyUrl(body.redirect_uri)],
+                grant_types=["authorization_code", "refresh_token"],
+                response_types=["code"],
+                token_endpoint_auth_method="none",
+                scope=scope,
+            )
+            reg_resp = await client.send(
+                create_client_registration_request(
+                    metadata, client_metadata, _origin(auth_server_url or body.target_url)
+                )
+            )
+            client_info = await handle_registration_response(reg_resp)
+            if not client_info.client_id:
+                raise OAuthFlowError(
+                    "dynamic client registration returned no client_id",
+                    detail={"target_url": body.target_url},
+                )
+            client_id = client_info.client_id
+            client_secret = client_info.client_secret
+            method = client_info.token_endpoint_auth_method or "none"
+        else:
+            raise OAuthFlowError(
+                "this MCP server does not support automatic client registration; "
+                "provide an OAuth client ID (and secret) under OAuth client credentials",
+                detail={"target_url": body.target_url},
+            )
+
+    pkce = PKCEParameters.generate()
+    state = secrets.token_urlsafe(32)
+
+    auth_params: dict[str, str] = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": body.redirect_uri,
+        "state": state,
+        "code_challenge": pkce.code_challenge,
+        "code_challenge_method": "S256",
+    }
+    if scope:
+        auth_params["scope"] = scope
+    if resource:
+        auth_params["resource"] = resource
+    authorization_url = f"{metadata.authorization_endpoint}?{urlencode(auth_params)}"
+
+    # Persist the flow state, encrypted under the per-account subkey (it carries
+    # the PKCE code_verifier and possibly a client_secret).
+    flow_payload: dict[str, Any] = {
+        "code_verifier": pkce.code_verifier,
+        "client_id": client_id,
+        "token_endpoint": str(metadata.token_endpoint),
+        "token_endpoint_auth_method": method,
+    }
+    if client_secret:
+        flow_payload["client_secret"] = client_secret
+    if scope:
+        flow_payload["scope"] = scope
+    if resource:
+        flow_payload["resource"] = resource
+    if body.display_name:
+        flow_payload["display_name"] = body.display_name
+
+    blob = crypto_box.derive_account_subkey(account_id).encrypt_dict(flow_payload)
+    expires_at = datetime.now(UTC) + timedelta(seconds=OAUTH_FLOW_TTL_SECONDS)
+
+    async with pool.acquire() as conn:
+        flow_id = await queries.insert_oauth_flow(
+            conn,
+            account_id=account_id,
+            vault_id=vault_id,
+            target_url=body.target_url,
+            state=state,
+            redirect_uri=body.redirect_uri,
+            blob=blob,
+            expires_at=expires_at,
+        )
+
+    log.info(
+        "vault.oauth_flow_started",
+        flow_id=flow_id,
+        vault_id=vault_id,
+        target_url=body.target_url,
+        registered=bool(not body.client_id),
+    )
+    return OAuthStartResponse(flow_id=flow_id, state=state, authorization_url=authorization_url)

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -88,6 +88,33 @@ def _serialize_token_endpoint_auth(v: TokenEndpointAuth) -> dict[str, str]:
     return {"method": v.method, "client_secret": v.client_secret.get_secret_value()}
 
 
+def build_token_endpoint_post(
+    body: dict[str, str],
+    *,
+    client_id: str,
+    endpoint_auth: dict[str, str] | None,
+) -> dict[str, Any]:
+    """Apply the configured token-endpoint client-auth method to an OAuth POST.
+
+    Mutates ``body`` in place (``client_id`` is always added — it identifies the
+    public client; ``client_secret`` is added for the ``client_secret_post``
+    method) and returns the kwargs for ``httpx.AsyncClient.post`` (``data``,
+    plus ``auth`` for ``client_secret_basic``). Shared by the refresh path
+    (:func:`refresh_credential`) and the authorization-code exchange
+    (:mod:`aios.services.vault_oauth`) so the two never drift.
+    """
+    auth = endpoint_auth or {"method": "none"}
+    method = auth.get("method", "none")
+    body["client_id"] = client_id
+    post_kwargs: dict[str, Any] = {"data": body}
+    if method == "client_secret_basic":
+        post_kwargs["auth"] = httpx.BasicAuth(client_id, auth.get("client_secret", ""))
+    elif method == "client_secret_post":
+        body["client_secret"] = auth.get("client_secret", "")
+    # method == "none" → nothing extra; client_id alone identifies the public client.
+    return post_kwargs
+
+
 def is_expiring(payload: dict[str, Any], skew: int = REFRESH_SKEW_SECONDS) -> bool:
     """Return True if the token's ``expires_at`` is within ``skew`` seconds of now.
 
@@ -168,24 +195,24 @@ async def refresh_credential(
                 },
             )
 
-        # Build the POST per the configured token_endpoint_auth method.
-        endpoint_auth = payload.get("token_endpoint_auth") or {"method": "none"}
-        method = endpoint_auth.get("method", "none")
+        # Build the refresh POST. Client-auth handling (none/basic/post) is
+        # shared with the authorization-code exchange via
+        # ``build_token_endpoint_post`` so the two paths can't drift.
         body: dict[str, str] = {
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
-            "client_id": client_id,
         }
-        post_kwargs: dict[str, Any] = {"data": body}
-        if method == "client_secret_basic":
-            post_kwargs["auth"] = httpx.BasicAuth(client_id, endpoint_auth.get("client_secret", ""))
-        elif method == "client_secret_post":
-            body["client_secret"] = endpoint_auth.get("client_secret", "")
-        # method == "none" → nothing extra; client_id alone identifies the public client.
-
         scope = payload.get("scope")
         if scope:
             body["scope"] = scope
+        # RFC 8707: some providers bind the refresh to the same resource the
+        # tokens were minted for; include it when the credential stored one.
+        resource = payload.get("resource")
+        if resource:
+            body["resource"] = resource
+        post_kwargs = build_token_endpoint_post(
+            body, client_id=client_id, endpoint_auth=payload.get("token_endpoint_auth")
+        )
 
         try:
             async with httpx.AsyncClient(timeout=_REFRESH_HTTP_TIMEOUT_SECONDS) as client:

--- a/tests/e2e/test_vault_oauth.py
+++ b/tests/e2e/test_vault_oauth.py
@@ -21,7 +21,12 @@ from pydantic import SecretStr
 
 from aios.crypto.vault import EncryptedBlob
 from aios.errors import ConflictError, OAuthFlowError, ValidationError
-from aios.models.vaults import OAuthCompleteRequest, OAuthStartRequest, VaultCredentialCreate
+from aios.models.vaults import (
+    OAuthCompleteRequest,
+    OAuthProviderApp,
+    OAuthStartRequest,
+    VaultCredentialCreate,
+)
 from aios.services import vault_oauth as svc
 from aios.services import vaults as vaults_svc
 
@@ -197,7 +202,59 @@ class TestStart:
                 account_id=ACCOUNT_ID,
                 vault_id=vault_id,
                 body=OAuthStartRequest(target_url=TARGET_URL, redirect_uri=REDIRECT_URI),
+                provider_apps=[],
             )
+
+    async def test_uses_configured_provider_app_when_no_dcr(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        """An operator-registered app lets a non-DCR server connect with no user
+        credentials — the CMA model for Google/Microsoft/etc."""
+        vault_id = await _vault(pool, "oauth-provider-app")
+        app = OAuthProviderApp(
+            match="auth.example.com",
+            client_id="operator-client",
+            client_secret=SecretStr("operator-secret"),
+            token_endpoint_auth_method="client_secret_post",
+            scope="calendar.read",
+        )
+        with _patched_provider(registration=False):
+            res = await svc.start_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthStartRequest(target_url=TARGET_URL, redirect_uri=REDIRECT_URI),
+                provider_apps=[app],
+            )
+        q = parse_qs(urlparse(res.authorization_url).query)
+        assert q["client_id"] == ["operator-client"]
+        assert q["scope"] == ["calendar.read"]  # provider-app scope override
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT ciphertext, nonce FROM oauth_flows WHERE state = $1", res.state
+            )
+        payload = _decrypt_flow(
+            crypto_box,
+            EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"])),
+        )
+        assert payload["client_id"] == "operator-client"
+        assert payload["client_secret"] == "operator-secret"
+
+        # Complete exchanges the code using the operator app (client_secret_post).
+        token_calls: list[dict[str, Any]] = []
+        with _patched_provider(registration=False, token_calls=token_calls):
+            cred = await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=res.state, code="code-app"),
+            )
+        assert cred.auth_type == "oauth2_refresh"
+        assert token_calls[0]["client_id"] == "operator-client"
+        assert token_calls[0]["client_secret"] == "operator-secret"
 
 
 class TestComplete:

--- a/tests/e2e/test_vault_oauth.py
+++ b/tests/e2e/test_vault_oauth.py
@@ -10,6 +10,7 @@ the authorization-code token exchange end-to-end without a browser or network.
 from __future__ import annotations
 
 import json as _json
+import os
 from contextlib import contextmanager
 from typing import Any
 from unittest.mock import patch
@@ -54,7 +55,13 @@ def crypto_box(aios_env: dict[str, str]) -> Any:
     return CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
 
 
-def _make_handler(*, registration: bool = True, token_calls: list[dict[str, Any]] | None = None):
+def _make_handler(
+    *,
+    registration: bool = True,
+    token_calls: list[dict[str, Any]] | None = None,
+    token_expires_in: int | None = 3600,
+    token_status: int = 200,
+):
     """A MockTransport handler emulating a spec-compliant MCP OAuth provider."""
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -96,16 +103,17 @@ def _make_handler(*, registration: bool = True, token_calls: list[dict[str, Any]
         if path.endswith("/token"):
             if token_calls is not None:
                 token_calls.append(dict(httpx.QueryParams(request.read().decode())))
-            return httpx.Response(
-                200,
-                json={
-                    "access_token": "at-xyz",
-                    "refresh_token": "rt-xyz",
-                    "token_type": "Bearer",
-                    "expires_in": 3600,
-                    "scope": "read write",
-                },
-            )
+            if token_status != 200:
+                return httpx.Response(token_status, json={"error": "server_error"})
+            tok: dict[str, Any] = {
+                "access_token": "at-xyz",
+                "refresh_token": "rt-xyz",
+                "token_type": "Bearer",
+                "scope": "read write",
+            }
+            if token_expires_in is not None:
+                tok["expires_in"] = token_expires_in
+            return httpx.Response(200, json=tok)
         return httpx.Response(404, json={"error": "not found"})
 
     return handler
@@ -123,8 +131,22 @@ def _patched_provider(**kwargs: Any):
     def factory(*_a: Any, **_k: Any) -> httpx.AsyncClient:
         return _REAL_ASYNC_CLIENT(transport=httpx.MockTransport(handler))
 
-    with patch("aios.services.vault_oauth.httpx.AsyncClient", factory):
-        yield
+    from aios.config import get_settings
+
+    # The mock hosts don't resolve in DNS, so the real is_safe_url SSRF guard
+    # would block them. Allowlist them (the same dev mechanism that reaches an
+    # internal http MCP fleet) so these tests exercise the flow logic, not the
+    # guard — the guard itself is covered by tests/unit/test_vault_oauth_guard.py.
+    with patch.dict(
+        os.environ,
+        {"AIOS_OAUTH_ALLOW_INSECURE_HOSTS": "mock-mcp.example.com,auth.example.com"},
+    ):
+        get_settings.cache_clear()
+        try:
+            with patch("aios.services.vault_oauth.httpx.AsyncClient", factory):
+                yield
+        finally:
+            get_settings.cache_clear()
 
 
 async def _vault(pool: Any, name: str) -> str:
@@ -134,6 +156,19 @@ async def _vault(pool: Any, name: str) -> str:
 
 def _decrypt_flow(crypto_box: Any, blob: EncryptedBlob) -> dict[str, Any]:
     return crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt_dict(blob)
+
+
+async def _cred_payload(pool: Any, crypto_box: Any, cred_id: str) -> dict[str, Any]:
+    """Decrypt a stored credential's secret payload."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT ciphertext, nonce FROM vault_credentials WHERE id = $1", cred_id
+        )
+    return _json.loads(
+        crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt(
+            EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"]))
+        )
+    )
 
 
 class TestStart:
@@ -341,6 +376,70 @@ class TestComplete:
         assert second.id == first.id, "re-connect should rotate the same credential row"
         creds = await vaults_svc.list_vault_credentials(pool, vault_id, account_id=ACCOUNT_ID)
         assert len([c for c in creds if c.target_url == TARGET_URL]) == 1
+
+    async def test_rotate_clears_expires_at_when_token_omits_expires_in(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        """A re-connect whose token response omits expires_in must CLEAR the
+        prior expires_at, not inherit it — otherwise is_expiring() stays True
+        forever and forces a refresh before every call."""
+        vault_id = await _vault(pool, "oauth-rotate-exp")
+        # First connect: token carries expires_in -> expires_at is stored.
+        state1 = await self._start(pool, crypto_box, vault_id)
+        with _patched_provider():
+            first = await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state1, code="code-1"),
+            )
+        assert "expires_at" in await _cred_payload(pool, crypto_box, first.id)
+
+        # Re-connect; this time the token response omits expires_in.
+        state2 = await self._start(pool, crypto_box, vault_id)
+        with _patched_provider(token_expires_in=None):
+            second = await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state2, code="code-2"),
+            )
+        assert second.id == first.id
+        payload = await _cred_payload(pool, crypto_box, second.id)
+        assert "expires_at" not in payload, "stale expires_at must be cleared on rotate"
+        assert payload["access_token"] == "at-xyz"
+
+    async def test_transient_exchange_failure_preserves_flow(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        """A transient token-exchange failure must leave the flow row intact so
+        the user can retry within its TTL instead of re-consenting from scratch."""
+        vault_id = await _vault(pool, "oauth-transient")
+        state = await self._start(pool, crypto_box, vault_id)
+        with _patched_provider(token_status=500), pytest.raises(OAuthFlowError):
+            await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state, code="code-fail"),
+            )
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow("SELECT 1 FROM oauth_flows WHERE state = $1", state)
+        assert row is not None, "a transient exchange failure must leave the flow for retry"
+
+        # Retry against a healthy token endpoint succeeds.
+        with _patched_provider():
+            cred = await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state, code="code-ok"),
+            )
+        assert cred.auth_type == "oauth2_refresh"
 
     async def test_rejects_different_auth_type_at_same_url(
         self, pool: Any, crypto_box: Any

--- a/tests/e2e/test_vault_oauth.py
+++ b/tests/e2e/test_vault_oauth.py
@@ -1,0 +1,321 @@
+"""E2E tests for the interactive OAuth "Connect" flow (services.vault_oauth).
+
+Real testcontainer Postgres + a mocked OAuth/MCP provider. The provider is an
+``httpx.MockTransport`` patched onto ``aios.services.vault_oauth.httpx.AsyncClient``
+so the real MCP SDK request-builders/response-handlers run against it — exercising
+discovery (RFC 9728 → RFC 8414), Dynamic Client Registration (RFC 7591), PKCE, and
+the authorization-code token exchange end-to-end without a browser or network.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from aios.crypto.vault import EncryptedBlob
+from aios.errors import ConflictError, OAuthFlowError, ValidationError
+from aios.models.vaults import OAuthCompleteRequest, OAuthStartRequest, VaultCredentialCreate
+from aios.services import vault_oauth as svc
+from aios.services import vaults as vaults_svc
+
+ACCOUNT_ID = "acc_test_stub"
+TARGET_URL = "https://mock-mcp.example.com/mcp"
+REDIRECT_URI = "https://console.example.com/api/auth/mcp-oauth/callback"
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> Any:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+def crypto_box(aios_env: dict[str, str]) -> Any:
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    return CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+
+
+def _make_handler(*, registration: bool = True, token_calls: list[dict[str, Any]] | None = None):
+    """A MockTransport handler emulating a spec-compliant MCP OAuth provider."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if "/.well-known/oauth-protected-resource" in path:
+            return httpx.Response(
+                200,
+                json={
+                    "resource": TARGET_URL,
+                    "authorization_servers": ["https://auth.example.com"],
+                    "scopes_supported": ["read", "write"],
+                },
+            )
+        if (
+            "/.well-known/oauth-authorization-server" in path
+            or "/.well-known/openid-configuration" in path
+        ):
+            metadata: dict[str, Any] = {
+                "issuer": "https://auth.example.com",
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+                "scopes_supported": ["read", "write"],
+                "response_types_supported": ["code"],
+            }
+            if registration:
+                metadata["registration_endpoint"] = "https://auth.example.com/register"
+            return httpx.Response(200, json=metadata)
+        if path.endswith("/register"):
+            return httpx.Response(
+                201,
+                json={
+                    "client_id": "dyn-client-123",
+                    "redirect_uris": [REDIRECT_URI],
+                    "token_endpoint_auth_method": "none",
+                    "grant_types": ["authorization_code", "refresh_token"],
+                    "response_types": ["code"],
+                },
+            )
+        if path.endswith("/token"):
+            if token_calls is not None:
+                token_calls.append(dict(httpx.QueryParams(request.read().decode())))
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "at-xyz",
+                    "refresh_token": "rt-xyz",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "read write",
+                },
+            )
+        return httpx.Response(404, json={"error": "not found"})
+
+    return handler
+
+
+# Captured before any patching — the factory uses the real class so patching
+# `vault_oauth.httpx.AsyncClient` (the shared module attribute) doesn't recurse.
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+@contextmanager
+def _patched_provider(**kwargs: Any):
+    handler = _make_handler(**kwargs)
+
+    def factory(*_a: Any, **_k: Any) -> httpx.AsyncClient:
+        return _REAL_ASYNC_CLIENT(transport=httpx.MockTransport(handler))
+
+    with patch("aios.services.vault_oauth.httpx.AsyncClient", factory):
+        yield
+
+
+async def _vault(pool: Any, name: str) -> str:
+    v = await vaults_svc.create_vault(pool, display_name=name, metadata={}, account_id=ACCOUNT_ID)
+    return str(v.id)
+
+
+def _decrypt_flow(crypto_box: Any, blob: EncryptedBlob) -> dict[str, Any]:
+    return crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt_dict(blob)
+
+
+class TestStart:
+    async def test_builds_authorize_url_and_persists_encrypted_flow(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        vault_id = await _vault(pool, "oauth-start")
+        with _patched_provider():
+            res = await svc.start_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthStartRequest(target_url=TARGET_URL, redirect_uri=REDIRECT_URI),
+            )
+
+        parsed = urlparse(res.authorization_url)
+        assert (
+            f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+            == "https://auth.example.com/authorize"
+        )
+        q = parse_qs(parsed.query)
+        assert q["response_type"] == ["code"]
+        assert q["client_id"] == ["dyn-client-123"]
+        assert q["redirect_uri"] == [REDIRECT_URI]
+        assert q["state"] == [res.state]
+        assert q["code_challenge_method"] == ["S256"]
+        assert q["code_challenge"][0]
+        assert q["resource"] == [TARGET_URL]
+        assert q["scope"] == ["read write"]
+
+        # The flow row exists and decrypts to the PKCE verifier + registered client.
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT ciphertext, nonce, redirect_uri, target_url FROM oauth_flows WHERE state = $1",
+                res.state,
+            )
+        assert row is not None
+        assert row["redirect_uri"] == REDIRECT_URI
+        payload = _decrypt_flow(
+            crypto_box,
+            EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"])),
+        )
+        assert payload["client_id"] == "dyn-client-123"
+        assert payload["token_endpoint"] == "https://auth.example.com/token"
+        assert len(payload["code_verifier"]) >= 43
+
+    async def test_rejects_insecure_target(self, pool: Any, crypto_box: Any) -> None:
+        vault_id = await _vault(pool, "oauth-ssrf")
+        for bad in ("http://mcp.example.com/mcp", "https://localhost/mcp", "https://127.0.0.1/mcp"):
+            with pytest.raises(OAuthFlowError):
+                await svc.start_oauth_flow(
+                    pool,
+                    crypto_box,
+                    account_id=ACCOUNT_ID,
+                    vault_id=vault_id,
+                    body=OAuthStartRequest(target_url=bad, redirect_uri=REDIRECT_URI),
+                )
+
+    async def test_requires_client_when_no_dcr(self, pool: Any, crypto_box: Any) -> None:
+        vault_id = await _vault(pool, "oauth-nodcr")
+        with _patched_provider(registration=False), pytest.raises(OAuthFlowError):
+            await svc.start_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthStartRequest(target_url=TARGET_URL, redirect_uri=REDIRECT_URI),
+            )
+
+
+class TestComplete:
+    async def _start(self, pool: Any, crypto_box: Any, vault_id: str) -> str:
+        with _patched_provider():
+            res = await svc.start_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthStartRequest(
+                    target_url=TARGET_URL, redirect_uri=REDIRECT_URI, display_name="My Notion"
+                ),
+            )
+        return res.state
+
+    async def test_creates_oauth_credential(self, pool: Any, crypto_box: Any) -> None:
+        vault_id = await _vault(pool, "oauth-complete")
+        state = await self._start(pool, crypto_box, vault_id)
+
+        token_calls: list[dict[str, Any]] = []
+        with _patched_provider(token_calls=token_calls):
+            cred = await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state, code="auth-code-1"),
+            )
+
+        assert cred.auth_type == "oauth2_refresh"
+        assert cred.display_name == "My Notion"
+        assert cred.target_url == TARGET_URL
+        # The exchange POST carried the auth-code grant + PKCE verifier.
+        assert token_calls and token_calls[0]["grant_type"] == "authorization_code"
+        assert token_calls[0]["code"] == "auth-code-1"
+        assert token_calls[0]["redirect_uri"] == REDIRECT_URI
+        assert token_calls[0]["code_verifier"]
+
+        # Stored payload decrypts to the exchanged tokens.
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT ciphertext, nonce FROM vault_credentials WHERE id = $1", cred.id
+            )
+            flow_left = await conn.fetchrow("SELECT 1 FROM oauth_flows WHERE state = $1", state)
+        payload = _json.loads(
+            crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt(
+                EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"]))
+            )
+        )
+        assert payload["access_token"] == "at-xyz"
+        assert payload["refresh_token"] == "rt-xyz"
+        assert payload["client_id"] == "dyn-client-123"
+        assert payload["token_endpoint"] == "https://auth.example.com/token"
+        assert flow_left is None, "flow row should be deleted (single-use)"
+
+    async def test_rotates_existing_credential_without_conflict(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        vault_id = await _vault(pool, "oauth-rotate")
+        # First connect.
+        state1 = await self._start(pool, crypto_box, vault_id)
+        with _patched_provider():
+            first = await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state1, code="code-1"),
+            )
+        # Second connect to the same target_url must rotate, not 409.
+        state2 = await self._start(pool, crypto_box, vault_id)
+        with _patched_provider():
+            second = await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state2, code="code-2"),
+            )
+        assert second.id == first.id, "re-connect should rotate the same credential row"
+        creds = await vaults_svc.list_vault_credentials(pool, vault_id, account_id=ACCOUNT_ID)
+        assert len([c for c in creds if c.target_url == TARGET_URL]) == 1
+
+    async def test_rejects_different_auth_type_at_same_url(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        vault_id = await _vault(pool, "oauth-collide")
+        # A bearer credential already occupies this target_url.
+        await vaults_svc.create_vault_credential(
+            pool,
+            crypto_box,
+            account_id=ACCOUNT_ID,
+            vault_id=vault_id,
+            body=VaultCredentialCreate(
+                target_url=TARGET_URL,
+                auth_type="bearer_header",
+                token=SecretStr("tok"),
+            ),
+        )
+        state = await self._start(pool, crypto_box, vault_id)
+
+        with _patched_provider(), pytest.raises(ConflictError):
+            await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state=state, code="code-x"),
+            )
+
+    async def test_rejects_unknown_state(self, pool: Any, crypto_box: Any) -> None:
+        vault_id = await _vault(pool, "oauth-badstate")
+        with pytest.raises(ValidationError):
+            await svc.complete_oauth_flow(
+                pool,
+                crypto_box,
+                account_id=ACCOUNT_ID,
+                vault_id=vault_id,
+                body=OAuthCompleteRequest(state="nope", code="code"),
+            )

--- a/tests/e2e/test_vault_oauth.py
+++ b/tests/e2e/test_vault_oauth.py
@@ -217,6 +217,7 @@ class TestStart:
             client_secret=SecretStr("operator-secret"),
             token_endpoint_auth_method="client_secret_post",
             scope="calendar.read",
+            authorize_params={"access_type": "offline", "prompt": "consent"},
         )
         with _patched_provider(registration=False):
             res = await svc.start_oauth_flow(
@@ -230,6 +231,8 @@ class TestStart:
         q = parse_qs(urlparse(res.authorization_url).query)
         assert q["client_id"] == ["operator-client"]
         assert q["scope"] == ["calendar.read"]  # provider-app scope override
+        assert q["access_type"] == ["offline"]  # provider-app authorize_params
+        assert q["prompt"] == ["consent"]
 
         async with pool.acquire() as conn:
             row = await conn.fetchrow(

--- a/tests/unit/test_mcp_call_fast_fail.py
+++ b/tests/unit/test_mcp_call_fast_fail.py
@@ -1,0 +1,70 @@
+"""Unit tests for the MCP tool-call fast-fail path (services don't hang on a
+403/5xx; the server's message is surfaced instead of a generic timeout)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from aios.mcp.client import _call_tool_fast, _McpHttpError
+from aios.mcp.pool import HttpErrorSink, _make_error_hook
+
+
+class _FakeSession:
+    def __init__(self, *, hang: bool) -> None:
+        self._hang = hang
+        self.result = object()
+
+    async def call_tool(self, name: str, args: dict[str, Any], *, meta: Any = None) -> Any:
+        if self._hang:
+            await asyncio.Event().wait()  # never resolves
+        return self.result
+
+
+async def test_returns_result_on_success() -> None:
+    sess = _FakeSession(hang=False)
+    out = await _call_tool_fast(sess, "t", {}, None, HttpErrorSink(), 5.0)  # type: ignore[arg-type]
+    assert out is sess.result
+
+
+async def test_fast_fails_with_http_error_before_timeout() -> None:
+    sess = _FakeSession(hang=True)
+    sink = HttpErrorSink()
+
+    async def fire() -> None:
+        await asyncio.sleep(0.05)
+        sink.record(403, "Calendar MCP API ... is disabled. Enable it by visiting ...")
+
+    fired = asyncio.create_task(fire())
+    started = time.monotonic()
+    # A long timeout — the call must abort on the sink signal, not wait it out.
+    with pytest.raises(_McpHttpError) as exc:
+        await _call_tool_fast(sess, "t", {}, None, sink, 30.0)  # type: ignore[arg-type]
+    assert time.monotonic() - started < 2.0
+    assert exc.value.status == 403
+    assert "is disabled" in exc.value.body
+    await fired
+
+
+async def test_times_out_without_a_signal() -> None:
+    sess = _FakeSession(hang=True)
+    with pytest.raises(TimeoutError):
+        await _call_tool_fast(sess, "t", {}, None, HttpErrorSink(), 0.2)  # type: ignore[arg-type]
+
+
+async def test_error_hook_records_4xx_only() -> None:
+    sink = HttpErrorSink()
+    hook = _make_error_hook(sink)
+
+    import httpx
+
+    await hook(httpx.Response(200, text="ok"))
+    assert not sink.event.is_set()  # success responses are ignored
+
+    await hook(httpx.Response(403, text='{"error":"nope"}'))
+    assert sink.event.is_set()
+    assert sink.status == 403
+    assert "nope" in sink.body

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -1,4 +1,4 @@
-"""Unit tests for the MCP session pool.
+"""Unit tests for the MCP session pool (per-call checkout model).
 
 All MCP SDK and httpx interactions are mocked. No network calls.
 """
@@ -12,10 +12,13 @@ from collections.abc import Iterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from aios.harness import runtime
 from aios.mcp.pool import McpSessionPool
+
+URL = "https://m.example/"
 
 # ── helpers ────────────────────────────────────────────────────────────────
 
@@ -55,12 +58,17 @@ def _session_ctx_seq(sessions: list[AsyncMock]) -> MagicMock:
     return cls
 
 
-# ── McpSessionPool ─────────────────────────────────────────────────────────
+def _live_count(pool: McpSessionPool, key: tuple[str, str | None]) -> int:
+    return len(pool._idle.get(key, [])) + len(pool._in_use.get(key, set()))
+
+
+# ── McpSessionPool (checkout model) ─────────────────────────────────────────
 
 
 class TestMcpSessionPool:
-    async def test_pool_hit_reuses_session(self) -> None:
-        """Two calls with same key → only one ``initialize()`` happens."""
+    async def test_warm_reuse_after_release(self) -> None:
+        """acquire → release → acquire returns the SAME session (idle reuse);
+        ``initialize`` runs only once."""
         session = _make_mock_session()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
@@ -68,35 +76,72 @@ class TestMcpSessionPool:
         ):
             pool = McpSessionPool()
             headers = {"Authorization": "Bearer tok"}
-            s1, _ = await pool.get_or_connect("https://m.example/", "v", headers)
-            s2, _ = await pool.get_or_connect("https://m.example/", "v", headers)
+            e1 = await pool.acquire(URL, "v", headers)
+            await pool.release(URL, "v", e1)
+            # release moves the entry to idle and cleans up the empty in-use set.
+            assert (URL, "v") not in pool._in_use
+            assert pool._idle[(URL, "v")] == [e1]
+            e2 = await pool.acquire(URL, "v", headers)
 
-        assert s1 is s2
+        assert e1 is e2
+        assert e1.session is e2.session
         session.initialize.assert_awaited_once()
 
-    async def test_pool_miss_different_vault_ids(self) -> None:
-        """Different vault_ids on the same URL → two separate sessions
-        (the multi-tenant safety surface: per-account vaults yield
-        per-account pool entries even when sharing an MCP URL)."""
+    async def test_different_vault_ids_get_distinct_sessions(self) -> None:
+        """Different vault_ids on the same URL → separate sessions (the
+        multi-tenant safety surface)."""
         s_a, s_b = _make_mock_session(), _make_mock_session()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
             pool = McpSessionPool()
-            r1, _ = await pool.get_or_connect(
-                "https://m.example/", "vault_a", {"Authorization": "Bearer t1"}
-            )
-            r2, _ = await pool.get_or_connect(
-                "https://m.example/", "vault_b", {"Authorization": "Bearer t2"}
-            )
+            e1 = await pool.acquire(URL, "vault_a", {"Authorization": "Bearer t1"})
+            e2 = await pool.acquire(URL, "vault_b", {"Authorization": "Bearer t2"})
 
-        assert r1 is not r2
+        assert e1.session is not e2.session
         assert s_a.initialize.await_count == 1
         assert s_b.initialize.await_count == 1
 
-    async def test_evict_causes_reconnect(self) -> None:
-        """After eviction, next ``get_or_connect`` opens a new session."""
+    async def test_concurrent_acquires_same_key_get_isolated_entries_and_sinks(self) -> None:
+        """Two simultaneous checkouts of the same key get DISTINCT entries and
+        DISTINCT HttpErrorSinks, and an HTTP error captured by one entry's
+        transport hook never touches the other's sink — the core regression for
+        the shared-sink cross-talk bug (#3)."""
+        captured_hooks: list[Any] = []
+
+        def fake_client(*_a: Any, **k: Any) -> MagicMock:
+            captured_hooks.append(k["event_hooks"]["response"][0])
+            m = MagicMock()
+            m.__aenter__ = AsyncMock(return_value=m)
+            m.__aexit__ = AsyncMock(return_value=False)
+            return m
+
+        s1, s2 = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.httpx.AsyncClient", fake_client),
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s1, s2])),
+        ):
+            pool = McpSessionPool()
+            e1 = await pool.acquire(URL, "v", {})
+            e2 = await pool.acquire(URL, "v", {})  # e1 still in use → distinct entry
+
+            assert e1 is not e2
+            assert e1.error_sink is not e2.error_sink
+
+            # Fire a 4xx through entry1's transport response hook only.
+            resp = httpx.Response(403, text="forbidden", request=httpx.Request("POST", URL))
+            await captured_hooks[0](resp)
+
+        assert e1.error_sink.event.is_set()
+        assert e1.error_sink.status == 403
+        assert not e2.error_sink.event.is_set(), "entry2's sink must be untouched"
+
+    async def test_discard_causes_reconnect_and_closes_entry(self) -> None:
+        """discard drops a broken entry (closing it via _Entry.close so the owner
+        task + httpx client + SSE stream are released) and the next acquire opens
+        a fresh session."""
         s_a, s_b = _make_mock_session(), _make_mock_session()
         headers = {"Authorization": "Bearer tok"}
         with (
@@ -104,336 +149,226 @@ class TestMcpSessionPool:
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
             pool = McpSessionPool()
-            r1, _ = await pool.get_or_connect("https://m.example/", "v", headers)
-            pool.evict("https://m.example/", "v")
-            r2, _ = await pool.get_or_connect("https://m.example/", "v", headers)
-
-        assert r1 is not r2
-
-    async def test_evict_closes_evicted_entry(self) -> None:
-        """``evict`` must reclaim the entry, not just drop the reference.
-
-        The idle reaper's docstring spells out the leak shape: dropping a
-        reference without going through ``_Entry.close()`` strands the
-        owner task, the httpx client, and the SSE stream — exactly what
-        the reaper exists to prevent. The reaper iterates ``_entries``,
-        so an evicted entry (popped from the map) is invisible to it
-        and the leak survives until process exit. Every transient MCP
-        failure produces one such evict, so over a long-running worker
-        the leak is unbounded.
-        """
-        url = "https://m.example/"
-        headers = {"Authorization": "Bearer tok"}
-        with (
-            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
-            patch("aios.mcp.pool.ClientSession", _session_ctx(_make_mock_session())),
-        ):
-            pool = McpSessionPool()
-            await pool.get_or_connect(url, "v", headers)
-            entry = pool._entries[(url, "v")]
-
-            closed = False
-            orig_close = entry.close
-
-            async def _tracked() -> None:
-                nonlocal closed
-                closed = True
-                await orig_close()
-
-            entry.close = _tracked  # type: ignore[method-assign]
-
-            pool.evict(url, "v")
-            # Allow any background close task scheduled by evict to run.
+            e1 = await pool.acquire(URL, "v", headers)
+            await pool.discard(URL, "v", e1)
+            # Let the fire-and-forget close task run.
             await asyncio.sleep(0)
             await asyncio.sleep(0)
+            assert e1._owner_task.done(), "discard must close the entry's owner task"
+            # discard removes the entry AND cleans up the now-empty in-use set
+            # (no ghost keys accumulating across tenant churn).
+            assert (URL, "v") not in pool._in_use
 
-        assert closed, (
-            "evict must close the entry through _Entry.close() to release "
-            "the owner task + httpx client + SSE stream; a bare pop strands "
-            "them for the worker's lifetime"
-        )
-        assert entry._owner_task.done(), (
-            "the owner task must exit after evict; while parked on "
-            "shutdown.wait() it holds the httpx client and SSE stream open"
-        )
+            e2 = await pool.acquire(URL, "v", headers)
 
-    async def test_thundering_herd_single_initialize(self) -> None:
-        """N concurrent ``get_or_connect`` calls → exactly one ``initialize()``."""
-        session = _make_mock_session()
+        assert e1.session is not e2.session
 
-        init_count = 0
-
-        async def slow_init() -> MagicMock:
-            nonlocal init_count
-            init_count += 1
-            # Yield to let other concurrent callers pile up on the lock.
-            await asyncio.sleep(0)
-            return MagicMock()
-
-        session.initialize = AsyncMock(side_effect=slow_init)
-
-        with (
-            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
-            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
-        ):
-            pool = McpSessionPool()
-            headers = {"Authorization": "Bearer tok"}
-            results = await asyncio.gather(
-                *[pool.get_or_connect("https://m.example/", "v", headers) for _ in range(8)]
-            )
-
-        assert init_count == 1
-        first = results[0][0]
-        for session_got, _ in results:
-            assert session_got is first
-
-    async def test_close_all_closes_entries(self) -> None:
-        """``close_all`` tears down every pooled entry and clears the map."""
+    async def test_http_error_releases_not_discards(self) -> None:
+        """Finding #9 at the pool layer: a healthy session returned via release
+        is reused (not torn down) — the owner task stays alive."""
         session = _make_mock_session()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
             pool = McpSessionPool()
-            await pool.get_or_connect("https://a.example/", "vault_a", {"Authorization": "A"})
-            await pool.get_or_connect("https://b.example/", "vault_b", {"Authorization": "B"})
+            e1 = await pool.acquire(URL, "v", {})
+            await pool.release(URL, "v", e1)  # the call_mcp_tool _McpHttpError path
+            assert not e1._owner_task.done(), "release must NOT close the session"
+            e2 = await pool.acquire(URL, "v", {})
 
-            close_calls: list[str] = []
-            for key, entry in pool._entries.items():
-                url = key[0]
-                orig = entry.close
+        assert e2 is e1
+        session.initialize.assert_awaited_once()
 
-                async def _tracked(u: str = url, o: Any = orig) -> None:
-                    close_calls.append(u)
-                    await o()
+    async def test_concurrent_acquires_open_distinct_sessions_up_to_cap(self) -> None:
+        """N concurrent checkouts of a cold key open N distinct sessions (no
+        shared state) — replaces the old shared-session 'single initialize'
+        guarantee, which was the bug."""
+        sessions = [_make_mock_session() for _ in range(8)]
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq(sessions)),
+        ):
+            pool = McpSessionPool()
+            entries = await asyncio.gather(*[pool.acquire(URL, "v", {}) for _ in range(8)])
 
-                entry.close = _tracked  # type: ignore[method-assign]
+        assert len({id(e) for e in entries}) == 8
+        assert all(s.initialize.await_count == 1 for s in sessions)
+
+    async def test_cap_blocks_then_release_unblocks_waiter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """At MAX_SESSIONS_PER_KEY the next acquire waits; a release unblocks it
+        and hands back the freed (warm) entry."""
+        monkeypatch.setattr("aios.mcp.pool.MAX_SESSIONS_PER_KEY", 2)
+        sessions = [_make_mock_session() for _ in range(3)]
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq(sessions)),
+        ):
+            pool = McpSessionPool()
+            e1 = await pool.acquire(URL, "v", {})
+            await pool.acquire(URL, "v", {})  # now at cap (2 in use)
+
+            waiter = asyncio.create_task(pool.acquire(URL, "v", {}))
+            await asyncio.sleep(0)
+            assert not waiter.done(), "third acquire must block at the cap"
+
+            await pool.release(URL, "v", e1)
+            e3 = await asyncio.wait_for(waiter, timeout=1.0)
+
+        assert e3 is e1, "the freed (idle) entry should be reused by the waiter"
+        # Only two sessions ever opened — the cap held.
+        assert sessions[2].initialize.await_count == 0
+
+    async def test_acquire_after_close_raises(self) -> None:
+        """close_all latches the pool closed; a later acquire fails loudly
+        rather than silently opening a session that never gets torn down."""
+        pool = McpSessionPool()
+        await pool.close_all()
+        with pytest.raises(RuntimeError):
+            await pool.acquire(URL, "v", {})
+
+    async def test_close_all_closes_idle_and_in_use(self) -> None:
+        """close_all tears down BOTH released (idle) and checked-out (in-use)
+        entries — an in-use owner task would otherwise leak at shutdown."""
+        s_idle, s_in_use = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_idle, s_in_use])),
+        ):
+            pool = McpSessionPool()
+            e_idle = await pool.acquire(URL, "a", {})
+            await pool.release(URL, "a", e_idle)  # → idle
+            e_in_use = await pool.acquire(URL, "b", {})  # stays in use
 
             await pool.close_all()
 
-        assert len(close_calls) == 2
-        assert len(pool._entries) == 0
+        assert e_idle._owner_task.done()
+        assert e_in_use._owner_task.done()
+        assert not pool._idle and not pool._in_use
 
     async def test_close_all_empty_pool(self) -> None:
-        """``close_all`` on an empty pool is a no-op."""
+        """close_all on an empty pool is a no-op."""
         pool = McpSessionPool()
         await pool.close_all()
-        assert len(pool._entries) == 0
+        assert not pool._idle and not pool._in_use
 
-    async def test_idle_reaper_closes_cold_entry(self) -> None:
-        """A cold pool entry must be reclaimed via ``_Entry.close()``.
-
-        Post-#459 re-key, the reaper guards the cold-entry vector: a
-        ``(url, vault_id)`` whose tenant never returns. A bare ``pop``
-        would leave the owner task + httpx + SSE stream dangling —
-        exactly the leak this defends against.
-        """
-        s_cold, s_warm = _make_mock_session(), _make_mock_session()
+    async def test_idle_reaper_closes_idle_skips_in_use(self) -> None:
+        """The reaper closes a stale IDLE entry but never an in-use one (an
+        in-use entry is by definition active)."""
+        s1, s2 = _make_mock_session(), _make_mock_session()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
-            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_cold, s_warm])),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s1, s2])),
         ):
             pool = McpSessionPool()
-            url = "https://m.example/"
-            await pool.get_or_connect(url, "vault_cold", {"Authorization": "Bearer A"})
-            await pool.get_or_connect(url, "vault_warm", {"Authorization": "Bearer B"})
-            assert len(pool._entries) == 2
-
-            # Locate each entry by the session it wraps (keying-agnostic
-            # so this test stays a pure reaper-mechanism test).
-            key_cold = next(k for k, e in pool._entries.items() if e.session is s_cold)
-            key_warm = next(k for k, e in pool._entries.items() if e.session is s_warm)
-
-            closed: list[tuple[str, str | None]] = []
-            for key, entry in pool._entries.items():
-                orig = entry.close
-
-                async def _tracked(k: tuple[str, str | None] = key, o: Any = orig) -> None:
-                    closed.append(k)
-                    await o()
-
-                entry.close = _tracked  # type: ignore[method-assign]
-
-            # Cold tenant idle since t=1000; warm tenant freshly used at t=9000.
-            pool._entries[key_cold].last_used = 1000.0
-            pool._entries[key_warm].last_used = 9000.0
+            e1 = await pool.acquire(URL, "v", {})
+            e2 = await pool.acquire(URL, "v", {})  # two distinct in-use entries
+            await pool.release(URL, "v", e1)  # e1 → idle, e2 stays in use
+            e1.last_used = 1000.0
+            e2.last_used = 1000.0  # also old, but in-use → protected
 
             await pool._reap_idle_once(idle_timeout=300.0, now=9100.0)
 
-        assert closed == [key_cold], (
-            f"idle reaper must close exactly the cold entry via the clean "
-            f"_Entry.close() path; closed={closed!r}"
-        )
-        assert key_cold not in pool._entries
-        assert key_warm in pool._entries
+        assert e1._owner_task.done(), "stale idle entry must be reaped"
+        assert not e2._owner_task.done(), "in-use entry must never be reaped"
 
-    async def test_idle_reaper_skips_entry_freshened_during_close_of_another(self) -> None:
-        """The reaper must not close an entry whose ``last_used`` was
-        freshened by a concurrent ``get_or_connect`` between the scan
-        and the actual close.
+    async def test_idle_reaper_skips_entry_popped_during_close_of_another(self) -> None:
+        """TOCTOU: while the reaper awaits one stale entry's close(), a
+        concurrent acquire pops a different idle entry. The reaper's re-check
+        under the lock must see it gone and skip it (mirrors #654)."""
+        park = asyncio.Event()
+        cont = asyncio.Event()
+        closed: list[Any] = []
 
-        Scenario: two pool entries (``vault_a``, ``vault_b``) both land
-        in the ``stale`` snapshot. While the reaper is awaiting
-        ``entry_a.close()``, a tool task warm-hits
-        ``get_or_connect(url, vault_b, ...)``, which bumps
-        ``entry_b.last_used`` to ``time.monotonic()``. The reaper must
-        NOT proceed to close ``entry_b`` — the entry is no longer idle.
-
-        Pre-fix, the reaper acted on the stale ``stale`` snapshot
-        without re-checking ``last_used`` under the per-key lock, so it
-        would close an entry actively held by a caller. Same failure
-        class as the SandboxRegistry reaper TOCTOU fixed in #654 — the
-        warm path (pool.py:193-196) takes no lock.
-        """
-        park_a = asyncio.Event()
-        continue_a = asyncio.Event()
-        closed: list[tuple[str, str | None]] = []
-
-        s_a, s_b = _make_mock_session(), _make_mock_session()
+        s1, s2 = _make_mock_session(), _make_mock_session()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
-            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s1, s2])),
         ):
             pool = McpSessionPool()
-            url = "https://m.example/"
-            await pool.get_or_connect(url, "vault_a", {"Authorization": "Bearer A"})
-            await pool.get_or_connect(url, "vault_b", {"Authorization": "Bearer B"})
-            assert len(pool._entries) == 2
+            e1 = await pool.acquire(URL, "v", {})
+            e2 = await pool.acquire(URL, "v", {})
+            # Release in order so the idle list is [e1, e2]; pop() returns e2.
+            await pool.release(URL, "v", e1)
+            await pool.release(URL, "v", e2)
 
-            key_a = next(k for k, e in pool._entries.items() if e.session is s_a)
-            key_b = next(k for k, e in pool._entries.items() if e.session is s_b)
-            entry_a = pool._entries[key_a]
-            entry_b = pool._entries[key_b]
-            orig_close_a = entry_a.close
-            orig_close_b = entry_b.close
+            orig1 = e1.close
 
-            async def _close_a() -> None:
-                closed.append(key_a)
-                park_a.set()
-                await continue_a.wait()
-                await orig_close_a()
+            async def _close1() -> None:
+                closed.append(e1)
+                park.set()
+                await cont.wait()
+                await orig1()
 
-            async def _close_b() -> None:
-                closed.append(key_b)
-                await orig_close_b()
+            orig2 = e2.close
 
-            entry_a.close = _close_a  # type: ignore[method-assign]
-            entry_b.close = _close_b  # type: ignore[method-assign]
+            async def _close2() -> None:
+                closed.append(e2)
+                await orig2()
 
-            # Use a single reference time so the reaper's ``now`` snapshot
-            # and ``get_or_connect``'s warm-hit (which bumps last_used to
-            # the real ``time.monotonic()``) live in the same clock frame.
-            # The fake-time pattern at line 256-261 only works because
-            # that test doesn't exercise a live warm-hit.
+            e1.close = _close1  # type: ignore[method-assign]
+            e2.close = _close2  # type: ignore[method-assign]
+
             t0 = time.monotonic()
-            entry_a.last_used = t0 - 1000.0
-            entry_b.last_used = t0 - 1000.0
+            e1.last_used = t0 - 1000.0
+            e2.last_used = t0 - 1000.0
 
-            # Insertion order pins key_a as the first iteration → reaper
-            # parks inside _close_a, yielding control to the test.
-            reap_task = asyncio.create_task(pool._reap_idle_once(idle_timeout=300.0, now=t0))
+            reap = asyncio.create_task(pool._reap_idle_once(idle_timeout=300.0, now=t0))
             try:
-                await asyncio.wait_for(park_a.wait(), timeout=1.0)
-                # Reaper is parked inside entry_a.close(). Warm-hit
-                # vault_b — last_used is bumped to time.monotonic(), so
-                # the re-check at entry_b's iteration sees a fresh value.
-                returned_session, _ = await pool.get_or_connect(
-                    url, "vault_b", {"Authorization": "Bearer B"}
-                )
-                assert returned_session is s_b
-                continue_a.set()
-                await asyncio.wait_for(reap_task, timeout=1.0)
+                await asyncio.wait_for(park.wait(), timeout=1.0)
+                # Reaper parked inside e1.close(). Acquire pops an idle entry (e2).
+                popped = await pool.acquire(URL, "v", {})
+                assert popped is e2
+                cont.set()
+                await asyncio.wait_for(reap, timeout=1.0)
             finally:
-                if not reap_task.done():
-                    reap_task.cancel()
+                if not reap.done():
+                    reap.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
-                        await reap_task
+                        await reap
 
-        assert key_b not in closed, (
-            f"reaper closed vault_b's session despite a concurrent "
-            f"get_or_connect freshening entry_b.last_used. The reaper "
-            f"must re-check idleness under the per-key lock before "
-            f"calling close(). closed={closed!r}"
-        )
-        assert key_b in pool._entries, "vault_b's entry must remain in the pool"
+        assert e2 not in closed, "reaper must not close an entry a concurrent acquire popped"
 
-    async def test_oauth_refresh_does_not_orphan_entry(self) -> None:
-        """A token rotation on the same vault must reuse the pool key.
-
-        Pre-#459 the pool keyed on ``(url, sha256(headers))``, so a
-        rotated bearer produced a second key while the predecessor
-        ``_Entry`` lingered. Keyed on ``(url, vault_id)``, rotation hits
-        the same key and ``len(_entries)`` stays put.
-        """
-        s_old, s_new = _make_mock_session(), _make_mock_session()
+    async def test_oauth_refresh_reuses_key_no_orphan(self) -> None:
+        """A token rotation on the same vault reuses the (url, vault_id) key —
+        no orphaned second entry (the #459 invariant)."""
+        session = _make_mock_session()
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
-            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_old, s_new])),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
             pool = McpSessionPool()
-            url = "https://m.example/"
-            # Same vault (identity), two bearer values — the exact shape
-            # an OAuth refresh produces at the inbound boundary.
-            await pool.get_or_connect(url, "vault_a", {"Authorization": "Bearer old"})
-            await pool.get_or_connect(url, "vault_a", {"Authorization": "Bearer new"})
+            e1 = await pool.acquire(URL, "vault_a", {"Authorization": "Bearer old"})
+            await pool.release(URL, "vault_a", e1)
+            e2 = await pool.acquire(URL, "vault_a", {"Authorization": "Bearer new"})
 
-        assert len(pool._entries) == 1, (
-            f"a token refresh of the same vault must NOT orphan an entry; "
-            f"got len(_entries)={len(pool._entries)} (pre-fix the rotated "
-            f"bearer produced a second key while the predecessor lingered)"
-        )
+        assert e2 is e1
+        assert _live_count(pool, (URL, "vault_a")) == 1
 
-    async def test_cross_tenant_refresh_does_not_disturb_other_tenant(self) -> None:
-        """Multi-tenant invariant the #459 re-key is built on.
-
-        ``vault_id`` is account-filtered at the query layer
-        (``resolve_session_credential(..., account_id=...)``), so two
-        tenants sharing an MCP URL hold independent entries and one's
-        refresh reuses its OWN entry without disturbing the other.
-        Pre-fix the rotation would open a third entry under a new
-        headers_hash (orphaning A's first entry); post-fix it reuses
-        A's stable ``(url, vault_id)`` key.
-        """
-        # Exactly 2 sessions: A's, B's. Pre-fix A's rotation pulls a
-        # third → StopIteration; post-fix it reuses A's cached entry.
+    async def test_cross_tenant_isolation(self) -> None:
+        """Two tenants sharing an MCP URL hold independent entries; one's
+        rotation reuses its OWN entry without disturbing the other."""
         s_a, s_b = _make_mock_session(), _make_mock_session()
+        url = "https://shared.example/"
         with (
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
             pool = McpSessionPool()
-            url = "https://shared.example/"
-            sess_a1, _ = await pool.get_or_connect(url, "vault_A", {"Authorization": "Bearer tokA"})
-            sess_b1, _ = await pool.get_or_connect(url, "vault_B", {"Authorization": "Bearer tokB"})
-            # A rotates: must reuse A's cached entry (no new open).
-            sess_a2, _ = await pool.get_or_connect(
-                url, "vault_A", {"Authorization": "Bearer tokA_v2"}
-            )
+            a1 = await pool.acquire(url, "vault_A", {"Authorization": "Bearer tokA"})
+            b1 = await pool.acquire(url, "vault_B", {"Authorization": "Bearer tokB"})
+            await pool.release(url, "vault_A", a1)
+            a2 = await pool.acquire(url, "vault_A", {"Authorization": "Bearer tokA_v2"})
 
-        assert len(pool._entries) == 2, (
-            f"A's refresh must reuse A's entry, not orphan a third; "
-            f"got len(_entries)={len(pool._entries)}"
-        )
-        assert sess_a2 is sess_a1, "A's session must be reused across rotation"
-        assert sess_b1 is not sess_a1, "tenants must hold distinct entries"
+        assert a2 is a1, "A's session is reused across rotation"
+        assert b1.session is not a1.session, "tenants hold distinct entries"
 
     async def test_contexts_exit_in_same_task_they_entered(self) -> None:
-        """Cross-task close — regression for #425.
-
-        Pre-fix, the pool held an ``AsyncExitStack`` on whatever task
-        first opened the entry. ``close_all`` called ``stack.aclose()``
-        from a different task and anyio's ``streamable_http_client``
-        raised ``RuntimeError: Attempted to exit cancel scope in a
-        different task than it was entered in``. The exception was
-        swallowed by ``close_all``'s try/except but logged a warning.
-
-        ``close_all`` still swallows post-fix (defensively, for unrelated
-        teardown failures), so this test instead checks the more
-        specific invariant: the transport's ``__aenter__`` and
-        ``__aexit__`` run in the SAME task. With the owner-task model
-        that's guaranteed; with the legacy stack-on-_Entry model it
-        wasn't.
-        """
+        """Cross-task close — regression for #425. The transport's __aenter__ and
+        __aexit__ must run in the SAME task (the owner-task model guarantees it;
+        the legacy stack-on-_Entry model did not)."""
         entered_in: dict[str, asyncio.Task[Any] | None] = {"open": None, "close": None}
 
         def _task_recording_transport() -> MagicMock:
@@ -458,7 +393,7 @@ class TestMcpSessionPool:
             pool = McpSessionPool()
 
             async def opener() -> None:
-                await pool.get_or_connect("https://m.example/", "v", {"Authorization": "tok"})
+                await pool.acquire(URL, "v", {"Authorization": "tok"})
 
             await asyncio.create_task(opener())
 
@@ -469,9 +404,6 @@ class TestMcpSessionPool:
 
         assert entered_in["open"] is not None
         assert entered_in["close"] is not None
-        # The invariant: contexts exit in the same task that entered them.
-        # Pre-fix this would have failed because __aexit__ ran in the
-        # closer task while __aenter__ ran in the opener task.
         assert entered_in["open"] is entered_in["close"]
 
 
@@ -490,7 +422,8 @@ def restore_runtime_pool() -> Iterator[None]:
 
 class TestDiscoverMcpToolsWithPool:
     async def test_uses_pool_when_set(self, restore_runtime_pool: None) -> None:
-        """Pool path: ``initialize`` called once even across two discovers."""
+        """Pool path: ``initialize`` called once even across two discovers
+        (the second reuses the released idle session)."""
         from aios.mcp.client import discover_mcp_tools
 
         session = _make_mock_session()
@@ -499,15 +432,15 @@ class TestDiscoverMcpToolsWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
-            await discover_mcp_tools("https://m.example/", "v", {}, "srv")
-            await discover_mcp_tools("https://m.example/", "v", {}, "srv")
+            await discover_mcp_tools(URL, "v", {}, "srv")
+            await discover_mcp_tools(URL, "v", {}, "srv")
 
         session.initialize.assert_awaited_once()
 
-    async def test_evicts_and_retries_on_list_tools_failure(
+    async def test_discards_and_retries_on_list_tools_failure(
         self, restore_runtime_pool: None
     ) -> None:
-        """First ``list_tools`` raises → pool evicts, second succeeds."""
+        """First ``list_tools`` raises → pool discards, second succeeds."""
         from aios.mcp.client import discover_mcp_tools
 
         s_a, s_b = _make_mock_session(), _make_mock_session()
@@ -519,7 +452,7 @@ class TestDiscoverMcpToolsWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
         ):
-            tools, _ = await discover_mcp_tools("https://m.example/", "v", {}, "srv")
+            tools, _ = await discover_mcp_tools(URL, "v", {}, "srv")
 
         assert tools == []
         assert s_a.initialize.await_count == 1
@@ -535,7 +468,7 @@ class TestDiscoverMcpToolsWithPool:
             patch("aios.mcp.client.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.client.ClientSession", _session_ctx(session)),
         ):
-            tools, _ = await discover_mcp_tools("https://m.example/", "v", {}, "srv")
+            tools, _ = await discover_mcp_tools(URL, "v", {}, "srv")
 
         assert tools == []
         session.initialize.assert_awaited_once()
@@ -543,7 +476,8 @@ class TestDiscoverMcpToolsWithPool:
 
 class TestCallMcpToolWithPool:
     async def test_uses_pool_when_set(self, restore_runtime_pool: None) -> None:
-        """Pool path: ``initialize`` called once even across two tool calls."""
+        """Pool path: ``initialize`` called once even across two tool calls
+        (the second reuses the released idle session)."""
         from aios.mcp.client import call_mcp_tool
 
         session = _make_mock_session()
@@ -554,17 +488,16 @@ class TestCallMcpToolWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
-            await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
-            await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
+            await call_mcp_tool(URL, "v", {}, "do_thing", {})
+            await call_mcp_tool(URL, "v", {}, "do_thing", {})
 
         session.initialize.assert_awaited_once()
 
     async def test_does_not_retry_on_call_tool_failure(self, restore_runtime_pool: None) -> None:
-        """A non-timeout transport failure (broken pipe, TCP reset,
-        HTTP/2 GOAWAY) may have landed after the server already
-        processed the request — retrying would duplicate the side
-        effect, just like the timeout case.  The wrapper evicts and
-        surfaces the error; the model decides whether to retry."""
+        """A transport failure (broken pipe, TCP reset, HTTP/2 GOAWAY) may have
+        landed after the server processed the request — retrying would duplicate
+        the side effect. The wrapper discards and surfaces the error; the model
+        decides whether to retry."""
         from aios.mcp.client import call_mcp_tool
 
         s_a = _make_mock_session()
@@ -575,7 +508,7 @@ class TestCallMcpToolWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(s_a)),
         ):
-            result = await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
+            result = await call_mcp_tool(URL, "v", {}, "do_thing", {})
 
         assert result.get("code") == "transport_error"
         assert s_a.call_tool.await_count == 1
@@ -583,16 +516,12 @@ class TestCallMcpToolWithPool:
     async def test_does_not_retry_call_tool_on_timeout(
         self, restore_runtime_pool: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A timeout in ``call_tool`` may mean the request reached the server
-        and was processed; retrying would duplicate the side effect. For
-        connector-provided tools like ``signal_send``/``telegram_send``
-        that's a duplicate user-visible message. The wrapper must NOT
-        retry on ``asyncio.TimeoutError`` — evict + surface the error
-        so the model decides whether to retry."""
+        """A timeout in ``call_tool`` may mean the request reached the server;
+        retrying would duplicate the side effect (e.g. a duplicate
+        ``signal_send``). The wrapper must NOT retry — discard + surface."""
         from aios.mcp import client as mcp_client
         from aios.mcp.client import call_mcp_tool
 
-        # Shrink the timeout so the test runs fast.
         monkeypatch.setattr(mcp_client, "_TOOL_CALL_TIMEOUT_S", 0.05)
 
         s_a = _make_mock_session()
@@ -608,9 +537,7 @@ class TestCallMcpToolWithPool:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(s_a)),
         ):
-            result = await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
+            result = await call_mcp_tool(URL, "v", {}, "do_thing", {})
 
-        # The wrapper returns a transport-error envelope on timeout.
         assert result.get("code") == "transport_error"
-        # And crucially, ``call_tool`` was invoked EXACTLY ONCE — no retry.
         assert s_a.call_tool.await_count == 1

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,15 +26,16 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0060``."""
+    """The migration ladder has exactly one head: ``0061``."""
     script = _script_directory()
-    assert script.get_heads() == ["0060"]
+    assert script.get_heads() == ["0061"]
 
 
 def test_chain_is_linear_0054_to_0060() -> None:
-    """``0054 -> 0055 -> 0056 -> 0057 -> 0058 -> 0059 -> 0060`` is a plain linear chain."""
+    """``0054 -> … -> 0060 -> 0061`` is a plain linear chain."""
     script = _script_directory()
 
+    rev_0061 = script.get_revision("0061")
     rev_0060 = script.get_revision("0060")
     rev_0059 = script.get_revision("0059")
     rev_0058 = script.get_revision("0058")
@@ -42,6 +43,7 @@ def test_chain_is_linear_0054_to_0060() -> None:
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0061.down_revision == "0060"
     assert rev_0060.down_revision == "0059"
     assert rev_0059.down_revision == "0058"
     assert rev_0058.down_revision == "0057"
@@ -50,7 +52,7 @@ def test_chain_is_linear_0054_to_0060() -> None:
     assert rev_0055.down_revision == "0054"
 
     # A tuple/list down_revision would mean a merge/branch point.
-    for rev in (rev_0060, rev_0059, rev_0058, rev_0057, rev_0056, rev_0055):
+    for rev in (rev_0061, rev_0060, rev_0059, rev_0058, rev_0057, rev_0056, rev_0055):
         assert isinstance(rev.down_revision, str)
 
 

--- a/tests/unit/test_vault_oauth_guard.py
+++ b/tests/unit/test_vault_oauth_guard.py
@@ -1,0 +1,154 @@
+"""Unit tests for the interactive-OAuth SSRF guard, the operator client_secret
+endpoint-binding, and the provider-app secret/method validator.
+
+These cover the security-critical pure functions in ``services.vault_oauth`` and
+the ``OAuthProviderApp`` model without a DB or network — the end-to-end flow is
+exercised in ``tests/e2e/test_vault_oauth.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.shared.auth import OAuthMetadata
+from pydantic import SecretStr, ValidationError
+
+from aios.errors import OAuthFlowError
+from aios.models.vaults import OAuthProviderApp
+from aios.services.vault_oauth import _assert_token_endpoint_bound, _guard_url
+
+
+def _metadata(
+    token_endpoint: str,
+    *,
+    issuer: str = "https://accounts.google.com",
+    authz: str = "https://accounts.google.com/o/oauth2/v2/auth",
+) -> OAuthMetadata:
+    return OAuthMetadata.model_validate(
+        {
+            "issuer": issuer,
+            "authorization_endpoint": authz,
+            "token_endpoint": token_endpoint,
+            "response_types_supported": ["code"],
+        }
+    )
+
+
+def _app(match: str, token_endpoint_hosts: tuple[str, ...] = ()) -> OAuthProviderApp:
+    return OAuthProviderApp(
+        match=match,
+        client_id="cid",
+        client_secret=SecretStr("sec"),
+        token_endpoint_hosts=list(token_endpoint_hosts),
+    )
+
+
+# ── SSRF guard (_guard_url) ──────────────────────────────────────────────────
+
+
+class TestGuardUrl:
+    async def test_requires_https(self) -> None:
+        with pytest.raises(OAuthFlowError):
+            await _guard_url(
+                "http://mcp.example.com/x", allow_insecure=frozenset(), label="target_url"
+            )
+
+    async def test_blocks_loopback_via_is_safe_url(self) -> None:
+        with pytest.raises(OAuthFlowError):
+            await _guard_url(
+                "https://127.0.0.1/mcp", allow_insecure=frozenset(), label="token_endpoint"
+            )
+
+    async def test_allowlist_bypasses_https_and_private_block(self) -> None:
+        # Host form and host:port form both bypass (matches the dev fleet config).
+        await _guard_url(
+            "http://workspace-mcp/mcp",
+            allow_insecure=frozenset({"workspace-mcp"}),
+            label="target_url",
+        )
+        await _guard_url(
+            "http://workspace-mcp:8000/mcp",
+            allow_insecure=frozenset({"workspace-mcp:8000"}),
+            label="target_url",
+        )
+
+    async def test_error_carries_label(self) -> None:
+        with pytest.raises(OAuthFlowError) as ei:
+            await _guard_url(
+                "http://x.example/y", allow_insecure=frozenset(), label="registration_endpoint"
+            )
+        assert "registration_endpoint" in str(ei.value)
+
+
+# ── operator client_secret endpoint-binding ─────────────────────────────────
+
+
+class TestTokenEndpointBinding:
+    def test_google_split_apex_passes_with_token_hosts(self) -> None:
+        # Google authorizes at accounts.google.com but issues tokens at
+        # oauth2.googleapis.com — only allowed when listed in token_endpoint_hosts.
+        app = _app("accounts.google.com", ("oauth2.googleapis.com",))
+        _assert_token_endpoint_bound(app, _metadata("https://oauth2.googleapis.com/token"))
+
+    def test_google_split_apex_rejected_without_token_hosts(self) -> None:
+        app = _app("accounts.google.com")
+        with pytest.raises(OAuthFlowError):
+            _assert_token_endpoint_bound(app, _metadata("https://oauth2.googleapis.com/token"))
+
+    def test_subhost_of_match_passes(self) -> None:
+        app = _app("accounts.google.com")
+        _assert_token_endpoint_bound(app, _metadata("https://sso.accounts.google.com/token"))
+
+    def test_exact_match_passes(self) -> None:
+        app = _app("auth.example.com")
+        _assert_token_endpoint_bound(
+            app,
+            _metadata(
+                "https://auth.example.com/token",
+                issuer="https://auth.example.com",
+                authz="https://auth.example.com/authorize",
+            ),
+        )
+
+    def test_attacker_token_endpoint_rejected(self) -> None:
+        # Spoofed issuer/authz = accounts.google.com selects the operator app,
+        # but token_endpoint points at an attacker host -> refuse (would leak the
+        # operator client_secret).
+        app = _app("accounts.google.com", ("oauth2.googleapis.com",))
+        with pytest.raises(OAuthFlowError):
+            _assert_token_endpoint_bound(app, _metadata("https://attacker.example/token"))
+
+
+# ── provider-app secret/method validator (#6) ───────────────────────────────
+
+
+class TestProviderAppValidator:
+    def test_client_secret_post_requires_secret(self) -> None:
+        with pytest.raises(ValidationError):
+            OAuthProviderApp(
+                match="accounts.google.com",
+                client_id="cid",
+                token_endpoint_auth_method="client_secret_post",
+            )
+
+    def test_client_secret_basic_requires_secret(self) -> None:
+        with pytest.raises(ValidationError):
+            OAuthProviderApp(
+                match="accounts.google.com",
+                client_id="cid",
+                token_endpoint_auth_method="client_secret_basic",
+            )
+
+    def test_none_method_allows_missing_secret(self) -> None:
+        app = OAuthProviderApp(
+            match="accounts.google.com", client_id="cid", token_endpoint_auth_method="none"
+        )
+        assert app.client_secret is None
+
+    def test_confidential_method_with_secret_ok(self) -> None:
+        app = OAuthProviderApp(
+            match="accounts.google.com",
+            client_id="cid",
+            client_secret=SecretStr("s"),
+            token_endpoint_auth_method="client_secret_post",
+        )
+        assert app.token_endpoint_auth_method == "client_secret_post"


### PR DESCRIPTION
## What

Adds the server-side half of the console's one-click **OAuth "Connect"** for vault credentials: instead of pasting tokens, a user authorizes an MCP server interactively (RFC 9728 → 8414 discovery, RFC 7591 DCR or an operator-configured provider app, PKCE), and the runtime stores the resulting `oauth2_refresh` credential.

- `POST /v1/vaults/{id}/credentials/oauth/{start,complete}` (+ typed SDK, openapi).
- Operator-configured **provider apps** (`AIOS_OAUTH_PROVIDER_APPS`) for branded providers that don't support DCR (Google, Microsoft, …) — the CMA model.
- `authorize_params` for provider quirks (Google needs `access_type=offline`+`prompt=consent` for a refresh token).

Plus the earlier MCP fast-fail fix (surface a server's 4xx immediately instead of a 120s hang).

## Security & correctness hardening

The final commit addresses **10 medium-and-above findings** from an extra-high-effort review (design + implementation both adversarially verified by multi-agent workflows):

**Security**
- 🔴 **client_secret exfiltration** — bind the operator secret to the discovered token endpoint (`token_endpoint_hosts` allowlist, fail-closed). Spoofed issuer/authz metadata can no longer redirect the secret to an attacker host.
- 🟠 **SSRF** — `_guard_url` reuses the hardened, DNS-resolving `is_safe_url` on the target *and every* server-side-fetched discovered endpoint; clients no longer follow redirects.
- 🟡 dev-only insecure-host allowlist moved from `os.environ` → a documented `Settings` field (empty in prod).
- 🟡 provider-app config rejects a confidential auth method without a secret at load time.

**`complete_oauth_flow`**
- 🟡 delete the single-use flow on **success only** (transient exchange failure → retryable).
- 🟡 detect a conflicting `auth_type` **before** burning the code.
- 🟡 concurrent double-complete rotates (reacts to the active-row unique index) instead of 409-ing.
- 🟡 clear a stale `expires_at` on rotate when the token omits `expires_in` (preserving a not-re-issued refresh token).

**MCP pool**
- 🟠 per-call **session checkout** (isolated session + `HttpErrorSink` per call) eliminates concurrent-call error cross-talk; bounded by `MAX_SESSIONS_PER_KEY`.
- 🟡 a benign 4xx **releases** the healthy session; only transport failures discard.

## Tests
`mypy` ✓ · `ruff` ✓ · **1663 unit** ✓ · **46 e2e** ✓. New unit suite for the guard/binding/validator; e2e for rotate-clears-`expires_at` and transient-failure-preserves-flow; full pool test rewrite for the checkout model (isolation, cap, reaper, `_closed`).

## ⚠️ Deploy note
The secret-binding fix is fail-closed: before promoting, the prod `aios-oauth-provider-apps` secret must add `"token_endpoint_hosts":["oauth2.googleapis.com"]` to the Google entry, or Google Connect will fail ("discovered token endpoint is not trusted for this operator app").

## Known follow-up (out of scope here)
The SSRF guard is flow-local. `refresh_credential` re-POSTs to a stored `token_endpoint`, and the credential-create API accepts an arbitrary `token_endpoint`, with no `is_safe_url` check — a tenant could store an internal URL and have the worker hit it on refresh. Same severity class as the SSRF fix above; warrants a focused follow-up that adds a shared, allowlist-aware write-time guard (it interacts with the dev `workspace-mcp` fleet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)