### PR TITLE
feat(sandbox): per-environment image override, disk cap, scoped bash timeout (#724, #725)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9233,6 +9233,20 @@
       },
       "EnvironmentConfig": {
         "properties": {
+          "image": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 512,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image",
+            "description": "Container image for sessions bound to this environment. When unset, sessions provision from the worker's global ``settings.docker_image``. Lets a purpose-built environment (e.g. an autodev dev image with toolchains baked in) pin its own image without changing the image every other session on the shared worker uses (issue #724). Accepts any reference the worker's Docker daemon can resolve: a registry image (``ghcr.io/eumemic/aios-sandbox:pinned``) or a bare local tag for development."
+          },
           "packages": {
             "anyOf": [
               {
@@ -9284,6 +9298,32 @@
             ],
             "title": "Env",
             "description": "Environment variables injected into every session container using this environment.  Per-session env overrides these."
+          },
+          "disk_bytes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 10485760.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disk Bytes",
+            "description": "Maximum writable-layer size, in bytes, for sandbox containers bound to this environment. When unset, falls back to the worker's global ``settings.sandbox_disk_bytes`` (itself unbounded by default). Translates to ``docker run --storage-opt size=`` so a heavy dev build can't fill the host disk and take down the worker. Only honored by storage drivers that support per-container quotas; on an unsupported driver Docker rejects the flag at create time. Minimum 10 MiB (issue #725)."
+          },
+          "bash_timeout_seconds": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bash Timeout Seconds",
+            "description": "Ceiling, in seconds, for a single bash tool call in sessions bound to this environment. When unset, falls back to the worker's global ``settings.bash_default_timeout_seconds`` (120s). Lets heavy dev workloads run >120s commands without raising the global default for every session on the worker. The agent can still request a shorter per-call timeout; this is the maximum it is capped to (issue #725)."
           }
         },
         "additionalProperties": false,

--- a/packages/aios-sdk/aios_sdk/_generated/models/environment_config.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/environment_config.py
@@ -24,17 +24,35 @@ class EnvironmentConfig:
     """Container configuration for an environment.
 
     Attributes:
+        image (None | str | Unset): Container image for sessions bound to this environment. When unset, sessions
+            provision from the worker's global ``settings.docker_image``. Lets a purpose-built environment (e.g. an autodev
+            dev image with toolchains baked in) pin its own image without changing the image every other session on the
+            shared worker uses (issue #724). Accepts any reference the worker's Docker daemon can resolve: a registry image
+            (``ghcr.io/eumemic/aios-sandbox:pinned``) or a bare local tag for development.
         packages (EnvironmentConfigPackagesType0 | None | Unset): Package manager → package list, e.g. {"pip":
             ["pandas"], "npm": ["express"]}.
         networking (LimitedNetworking | None | UnrestrictedNetworking | Unset): Network access rules.  None or {"type":
             "unrestricted"} for full access; {"type": "limited", "allowed_hosts": [...]} to restrict.
         env (EnvironmentConfigEnvType0 | None | Unset): Environment variables injected into every session container
             using this environment.  Per-session env overrides these.
+        disk_bytes (int | None | Unset): Maximum writable-layer size, in bytes, for sandbox containers bound to this
+            environment. When unset, falls back to the worker's global ``settings.sandbox_disk_bytes`` (itself unbounded by
+            default). Translates to ``docker run --storage-opt size=`` so a heavy dev build can't fill the host disk and
+            take down the worker. Only honored by storage drivers that support per-container quotas; on an unsupported
+            driver Docker rejects the flag at create time. Minimum 10 MiB (issue #725).
+        bash_timeout_seconds (int | None | Unset): Ceiling, in seconds, for a single bash tool call in sessions bound to
+            this environment. When unset, falls back to the worker's global ``settings.bash_default_timeout_seconds``
+            (120s). Lets heavy dev workloads run >120s commands without raising the global default for every session on the
+            worker. The agent can still request a shorter per-call timeout; this is the maximum it is capped to (issue
+            #725).
     """
 
+    image: None | str | Unset = UNSET
     packages: EnvironmentConfigPackagesType0 | None | Unset = UNSET
     networking: LimitedNetworking | None | UnrestrictedNetworking | Unset = UNSET
     env: EnvironmentConfigEnvType0 | None | Unset = UNSET
+    disk_bytes: int | None | Unset = UNSET
+    bash_timeout_seconds: int | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.environment_config_env_type_0 import EnvironmentConfigEnvType0
@@ -43,6 +61,12 @@ class EnvironmentConfig:
         )
         from ..models.limited_networking import LimitedNetworking
         from ..models.unrestricted_networking import UnrestrictedNetworking
+
+        image: None | str | Unset
+        if isinstance(self.image, Unset):
+            image = UNSET
+        else:
+            image = self.image
 
         packages: dict[str, Any] | None | Unset
         if isinstance(self.packages, Unset):
@@ -70,15 +94,33 @@ class EnvironmentConfig:
         else:
             env = self.env
 
+        disk_bytes: int | None | Unset
+        if isinstance(self.disk_bytes, Unset):
+            disk_bytes = UNSET
+        else:
+            disk_bytes = self.disk_bytes
+
+        bash_timeout_seconds: int | None | Unset
+        if isinstance(self.bash_timeout_seconds, Unset):
+            bash_timeout_seconds = UNSET
+        else:
+            bash_timeout_seconds = self.bash_timeout_seconds
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
+        if image is not UNSET:
+            field_dict["image"] = image
         if packages is not UNSET:
             field_dict["packages"] = packages
         if networking is not UNSET:
             field_dict["networking"] = networking
         if env is not UNSET:
             field_dict["env"] = env
+        if disk_bytes is not UNSET:
+            field_dict["disk_bytes"] = disk_bytes
+        if bash_timeout_seconds is not UNSET:
+            field_dict["bash_timeout_seconds"] = bash_timeout_seconds
 
         return field_dict
 
@@ -92,6 +134,15 @@ class EnvironmentConfig:
         from ..models.unrestricted_networking import UnrestrictedNetworking
 
         d = dict(src_dict)
+
+        def _parse_image(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        image = _parse_image(d.pop("image", UNSET))
 
         def _parse_packages(
             data: object,
@@ -156,10 +207,33 @@ class EnvironmentConfig:
 
         env = _parse_env(d.pop("env", UNSET))
 
+        def _parse_disk_bytes(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        disk_bytes = _parse_disk_bytes(d.pop("disk_bytes", UNSET))
+
+        def _parse_bash_timeout_seconds(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        bash_timeout_seconds = _parse_bash_timeout_seconds(
+            d.pop("bash_timeout_seconds", UNSET)
+        )
+
         environment_config = cls(
+            image=image,
             packages=packages,
             networking=networking,
             env=env,
+            disk_bytes=disk_bytes,
+            bash_timeout_seconds=bash_timeout_seconds,
         )
 
         return environment_config

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -146,11 +146,32 @@ class Settings(BaseSettings):
         "Translates to ``docker run --pids-limit``. Mitigates fork-bomb "
         "denial-of-service; ``None`` leaves the host's default in place.",
     )
+    sandbox_disk_bytes: int | None = Field(
+        default=None,
+        ge=10 * 1024 * 1024,
+        description="Maximum writable-layer size a sandbox container can "
+        "grow to, in bytes. Translates to ``docker run --storage-opt "
+        "size=`` so a heavy build (``npm ci``, large test artifacts) "
+        "can't fill the host disk and take down the worker + sibling "
+        "sandboxes. ``None`` leaves the host's default (unbounded) in "
+        "place. NOTE: ``--storage-opt size=`` is only honored by storage "
+        "drivers that support per-container quotas (``overlay2`` on an "
+        "``xfs``/``btrfs`` backing filesystem with ``pquota``, or "
+        "``devicemapper``); on an unsupported driver Docker rejects the "
+        "flag at ``create`` time, surfacing as a SandboxBackendError "
+        "rather than a silent no-op. Minimum 10 MiB to stay above the "
+        "image's own base size. Per-environment overridable via "
+        "``EnvironmentConfig.disk_bytes`` (issue #725).",
+    )
     bash_default_timeout_seconds: int = Field(
         default=120,
         ge=1,
-        description="Default timeout for a single bash tool call. The agent can "
-        "override per-call up to this maximum.",
+        description="Default ceiling for a single bash tool call, in seconds. "
+        "The agent can override per-call up to this maximum. A session bound "
+        "to an environment with ``EnvironmentConfig.bash_timeout_seconds`` set "
+        "uses that environment's ceiling instead — letting heavy dev workloads "
+        "run >120s commands without raising the global default for every "
+        "session on the worker (issue #725).",
     )
     bash_max_output_bytes: int = Field(
         default=100_000,

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -90,6 +90,22 @@ class EnvironmentConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    image: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=512,
+        description=(
+            "Container image for sessions bound to this environment. When "
+            "unset, sessions provision from the worker's global "
+            "``settings.docker_image``. Lets a purpose-built environment "
+            "(e.g. an autodev dev image with toolchains baked in) pin its "
+            "own image without changing the image every other session on "
+            "the shared worker uses (issue #724). Accepts any reference "
+            "the worker's Docker daemon can resolve: a registry image "
+            "(``ghcr.io/eumemic/aios-sandbox:pinned``) or a bare local "
+            "tag for development."
+        ),
+    )
     packages: dict[str, list[str]] | None = Field(
         default=None,
         description='Package manager → package list, e.g. {"pip": ["pandas"], "npm": ["express"]}.',
@@ -106,6 +122,34 @@ class EnvironmentConfig(BaseModel):
         description=(
             "Environment variables injected into every session container "
             "using this environment.  Per-session env overrides these."
+        ),
+    )
+    disk_bytes: int | None = Field(
+        default=None,
+        ge=10 * 1024 * 1024,
+        description=(
+            "Maximum writable-layer size, in bytes, for sandbox containers "
+            "bound to this environment. When unset, falls back to the "
+            "worker's global ``settings.sandbox_disk_bytes`` (itself "
+            "unbounded by default). Translates to ``docker run "
+            "--storage-opt size=`` so a heavy dev build can't fill the host "
+            "disk and take down the worker. Only honored by storage drivers "
+            "that support per-container quotas; on an unsupported driver "
+            "Docker rejects the flag at create time. Minimum 10 MiB (issue "
+            "#725)."
+        ),
+    )
+    bash_timeout_seconds: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Ceiling, in seconds, for a single bash tool call in sessions "
+            "bound to this environment. When unset, falls back to the "
+            "worker's global ``settings.bash_default_timeout_seconds`` "
+            "(120s). Lets heavy dev workloads run >120s commands without "
+            "raising the global default for every session on the worker. "
+            "The agent can still request a shorter per-call timeout; this "
+            "is the maximum it is capped to (issue #725)."
         ),
     )
 

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -102,6 +102,12 @@ class SandboxSpec:
     cpu_quota: float | None = None
     memory_bytes: int | None = None
     pids_limit: int | None = None
+    # Writable-layer disk cap (issue #725). ``None`` leaves the host's
+    # default (unbounded) in place. The spec builder resolves this from
+    # the environment's ``disk_bytes`` override, falling back to the
+    # global ``settings.sandbox_disk_bytes``; the backend injects
+    # ``--storage-opt size=`` when set.
+    disk_bytes: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -110,6 +110,17 @@ class DockerBackend:
             argv.extend(["--memory-swap", str(spec.memory_bytes)])
         if spec.pids_limit is not None:
             argv.extend(["--pids-limit", str(spec.pids_limit)])
+        if spec.disk_bytes is not None:
+            # Bound the container's writable layer so a heavy build can't
+            # fill the host disk and take the worker + sibling sandboxes
+            # down (issue #725). Only honored by storage drivers that
+            # support per-container quotas (overlay2 on xfs/btrfs with
+            # pquota, or devicemapper). On an unsupported driver Docker
+            # rejects this at ``docker run`` time — surfaced below as a
+            # SandboxBackendError on the nonzero exit, NOT silently
+            # dropped, so a misconfigured host fails loud rather than
+            # leaving the cap un-enforced.
+            argv.extend(["--storage-opt", f"size={spec.disk_bytes}"])
 
         # Keep stdin open so the container doesn't exit on empty stdin.
         argv.append("--interactive")

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -14,9 +14,22 @@ bring it to a usable state:
    :class:`Limited`.
 
 Each step calls ``await backend.exec(handle, ...)`` rather than touching
-Docker directly, so they work uniformly across backends. Failures are
-logged but never raised — these are best-effort enrichments, not
-correctness gates. The model can retry or work around missing tooling.
+Docker directly, so they work uniformly across backends.
+
+The first two steps are best-effort enrichments — failures are logged
+but never raised; the model can retry or work around missing tooling.
+:func:`apply_network_lockdown` is different: when the policy is
+:class:`Limited` it is a **security gate**, not an enrichment. A
+:class:`Limited` sandbox whose iptables lockdown didn't apply is wide
+open to the network, which silently violates the operator's intent (and
+is especially dangerous combined with the per-environment image override
+in #724 — a tenant-supplied image with a stripped-down ``iptables``/
+``getent`` would otherwise downgrade to unrestricted networking without
+anyone noticing). So that step **fails closed**: if the lockdown command
+exits nonzero, or the backend exec itself errors, it raises
+:class:`SandboxBackendError`, which the registry turns into a
+sandbox teardown + aborted provision rather than handing back a sandbox
+that can reach the whole internet.
 
 This module is the second seam (alongside ``backends.base``) that keeps
 the registry and the orchestrator backend-agnostic.
@@ -29,7 +42,7 @@ from collections.abc import Sequence
 from aios.config import get_settings
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
-from aios.sandbox.backends.base import SandboxBackend, SandboxHandle
+from aios.sandbox.backends.base import SandboxBackend, SandboxBackendError, SandboxHandle
 
 log = get_logger("aios.sandbox.setup")
 
@@ -228,9 +241,18 @@ async def apply_network_lockdown(
     """Apply iptables rules to restrict outbound traffic.
 
     Called after package installation so that ``pip install`` etc. can
-    reach registries before the lockdown takes effect.  Failures are
-    logged as warnings — the sandbox is still usable, but the model
-    will see connection errors if it tries to reach blocked hosts.
+    reach registries before the lockdown takes effect.
+
+    **Fails closed.** For a :class:`Limited` policy the lockdown *is* the
+    network boundary, not a best-effort enrichment. If the iptables
+    script exits nonzero — missing ``iptables``/``getent`` (e.g. a
+    pared-down per-env image, #724), no ``NET_ADMIN``, a partial flush —
+    the sandbox would otherwise stay up with *unrestricted* outbound
+    traffic, silently bypassing the operator's :class:`Limited` intent.
+    So a nonzero exit (or a backend exec that itself errors) raises
+    :class:`SandboxBackendError`; the caller
+    (:meth:`SandboxRegistry._provision`) tears the sandbox down and
+    aborts the provision rather than handing back an open box.
     """
     allowed: set[str] = set(networking.allowed_hosts)
     if networking.allow_package_managers:
@@ -238,9 +260,19 @@ async def apply_network_lockdown(
 
     script = build_iptables_script(allowed, extra_host_ports=extra_host_ports)
     settings = get_settings()
-    result = await backend.exec(
-        handle, script, timeout_seconds=30, max_output_bytes=settings.bash_max_output_bytes
-    )
+    try:
+        result = await backend.exec(
+            handle, script, timeout_seconds=30, max_output_bytes=settings.bash_max_output_bytes
+        )
+    except SandboxBackendError:
+        # Don't swallow an infra failure into a wide-open sandbox: a
+        # Limited policy whose lockdown couldn't even run must fail the
+        # provision. Re-raise so the registry tears the box down.
+        log.warning(
+            "sandbox.network_lockdown_exec_error",
+            session_id=handle.session_id,
+        )
+        raise
 
     if result.exit_code != 0:
         log.warning(
@@ -249,10 +281,18 @@ async def apply_network_lockdown(
             exit_code=result.exit_code,
             stderr=result.stderr[:500],
         )
-    else:
-        log.info(
-            "sandbox.network_lockdown_applied",
-            session_id=handle.session_id,
-            allowed_host_count=len(allowed),
-            extra_host_port_count=len(extra_host_ports),
+        # Fail closed: a Limited sandbox without a successful lockdown is
+        # a silent unrestricted-networking bypass. Aborting the provision
+        # (sandbox torn down by the caller) is the safe outcome.
+        raise SandboxBackendError(
+            f"network lockdown failed (exit {result.exit_code}) for session "
+            f"{handle.session_id}; refusing to run a Limited sandbox with "
+            f"unrestricted networking"
         )
+
+    log.info(
+        "sandbox.network_lockdown_applied",
+        session_id=handle.session_id,
+        allowed_host_count=len(allowed),
+        extra_host_port_count=len(extra_host_ports),
+    )

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -150,6 +150,43 @@ async def _load_environment_config(session_id: str, *, account_id: str) -> Envir
         )
 
 
+async def resolve_bash_timeout_ceiling(session_id: str) -> int:
+    """Return the maximum allowed bash-tool timeout (seconds) for a session.
+
+    A session bound to an environment whose
+    :attr:`EnvironmentConfig.bash_timeout_seconds` is set uses that
+    environment's ceiling; otherwise the worker-global
+    ``settings.bash_default_timeout_seconds`` (issue #725). The agent may
+    still request a shorter per-call timeout — this is the cap it is
+    clamped to, never a floor.
+
+    Total by design: any failure to load the environment config (no
+    environment attached, session/env not found, transient DB hiccup)
+    falls back to the global default rather than raising, so a bash call
+    never fails to *run* merely because the per-env override couldn't be
+    resolved. The bound it falls back to is the conservative (smaller-or-
+    equal) global one, so the fallback can't widen the ceiling beyond
+    what the operator configured globally.
+    """
+    settings = get_settings()
+    default = settings.bash_default_timeout_seconds
+    try:
+        account_id = await sessions_service.load_session_account_id(
+            runtime.require_pool(), session_id
+        )
+        env_config = await _load_environment_config(session_id, account_id=account_id)
+    except Exception as exc:  # total by contract (see docstring)
+        log.warning(
+            "sandbox.bash_timeout_resolve_failed",
+            session_id=session_id,
+            error=str(exc),
+        )
+        return default
+    if env_config is not None and env_config.bash_timeout_seconds is not None:
+        return env_config.bash_timeout_seconds
+    return default
+
+
 async def _load_session_provisioning(
     session_id: str, *, account_id: str
 ) -> tuple[str, dict[str, str]]:
@@ -354,12 +391,28 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     else:
         tool_broker_url = f"http://{WORKER_NETWORK_ALIAS}:{tool_broker.port}"
 
+    # Per-environment image override (#724): a session bound to an
+    # environment with ``image`` set provisions from that image; unset
+    # falls back to the worker-global ``settings.docker_image``. This is
+    # the only resolution point — everything downstream (backend create,
+    # the --pull decision) consumes ``spec.image`` blindly.
+    image = env_config.image if (env_config and env_config.image) else settings.docker_image
+    # Per-environment writable-layer disk cap (#725): environment
+    # override wins; otherwise the worker-global default (which is itself
+    # ``None`` = unbounded unless the operator set AIOS_SANDBOX_DISK_BYTES).
+    disk_bytes = (
+        env_config.disk_bytes
+        if (env_config and env_config.disk_bytes is not None)
+        else settings.sandbox_disk_bytes
+    )
+
     try:
         return _assemble_plan(
             session_id=session_id,
             instance_id=settings.instance_id,
-            image=settings.docker_image,
+            image=image,
             workspace_path=workspace_path,
+            disk_bytes=disk_bytes,
             env_config=env_config,
             session_env=session_env,
             memory_echoes=memory_echoes,
@@ -402,6 +455,7 @@ def _assemble_plan(
     tool_broker_url: str,
     tool_broker_secret: str,
     tool_socket_host_path: Path | None = None,
+    disk_bytes: int | None = None,
 ) -> ProvisioningPlan:
     """Pure assembly of the plan from already-materialized inputs.
 
@@ -532,6 +586,10 @@ def _assemble_plan(
         cpu_quota=settings.sandbox_cpu_quota,
         memory_bytes=settings.sandbox_memory_bytes,
         pids_limit=settings.sandbox_pids_limit,
+        # Writable-layer disk cap (#725): already resolved by the caller
+        # (environment override → global default), so pass it straight
+        # through rather than re-reading settings here.
+        disk_bytes=disk_bytes,
     )
 
     return ProvisioningPlan(

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -53,6 +53,7 @@ from typing import Any
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.sandbox.spec import resolve_bash_timeout_ceiling
 from aios.tools.bash_memory_reconcile import reconcile_memory_mounts, snapshot_memory_mounts
 from aios.tools.registry import registry
 
@@ -71,9 +72,9 @@ BASH_DESCRIPTION = (
     "directory is /workspace, which is a persistent per-session volume "
     "— files written there survive between calls. Shell state (cd, "
     "export, functions) does NOT persist between calls; chain commands "
-    "with && or use absolute paths. The default timeout is 120 seconds. "
-    "A nonzero exit code is reported in the result — not every nonzero "
-    "exit is a failure."
+    "with && or use absolute paths. The default timeout is 120 seconds "
+    "unless this session's environment raises it. A nonzero exit code is "
+    "reported in the result — not every nonzero exit is a failure."
 )
 
 BASH_PARAMETERS_SCHEMA: dict[str, Any] = {
@@ -116,7 +117,13 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
         raise BashArgumentError("bash tool requires a non-empty 'command' string")
 
     settings = get_settings()
-    max_timeout = settings.bash_default_timeout_seconds
+    # The ceiling is the environment's ``bash_timeout_seconds`` when the
+    # session is bound to one that sets it, else the worker-global
+    # ``bash_default_timeout_seconds`` (issue #725). Resolved per-call
+    # (one cheap DB read, dwarfed by the container exec it gates) so an
+    # environment-config change takes effect on the session's next bash
+    # call without a worker restart.
+    max_timeout = await resolve_bash_timeout_ceiling(session_id)
     raw_timeout = arguments.get("timeout_seconds", max_timeout)
     if not isinstance(raw_timeout, int) or raw_timeout <= 0:
         raise BashArgumentError("timeout_seconds must be a positive integer")

--- a/src/aios/tools/edit.py
+++ b/src/aios/tools/edit.py
@@ -39,6 +39,7 @@ from aios.errors import (
 )
 from aios.harness import runtime
 from aios.models.memory_stores import MAX_CONTENT_BYTES
+from aios.sandbox.spec import resolve_bash_timeout_ceiling
 from aios.services import memory_stores as memory_service
 from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
@@ -130,6 +131,12 @@ async def edit_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sandbox = runtime.require_sandbox_registry()
     handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
+    # Resolve the per-environment bash-timeout ceiling once (#725) and use
+    # it for both the read-back and write-back execs below, so an env that
+    # raised the limit applies to edit just as it does to bash. Falls back
+    # to the global default when no env override is set.
+    exec_timeout = await resolve_bash_timeout_ceiling(session_id)
+
     quoted_path = shlex.quote(path)
 
     # Step 1: read the current content. For memory mounts, read from DB to
@@ -152,7 +159,7 @@ async def edit_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
         read_result = await sandbox.exec(
             handle,
             f"cat -- {quoted_path}",
-            timeout_seconds=settings.bash_default_timeout_seconds,
+            timeout_seconds=exec_timeout,
             max_output_bytes=settings.bash_max_output_bytes,
         )
         if read_result.exit_code != 0:
@@ -255,7 +262,7 @@ async def edit_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     write_result = await sandbox.exec(
         handle,
         write_cmd,
-        timeout_seconds=settings.bash_default_timeout_seconds,
+        timeout_seconds=exec_timeout,
         max_output_bytes=settings.bash_max_output_bytes,
     )
     if write_result.exit_code != 0:

--- a/src/aios/tools/glob.py
+++ b/src/aios/tools/glob.py
@@ -18,6 +18,7 @@ from typing import Any
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.sandbox.spec import resolve_bash_timeout_ceiling
 from aios.tools.registry import registry
 
 
@@ -81,7 +82,11 @@ async def glob_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     result = await sandbox.exec(
         handle,
         cmd,
-        timeout_seconds=settings.bash_default_timeout_seconds,
+        # Honor the session's per-environment bash-timeout ceiling (#725)
+        # so an env that raised the limit applies to every sandbox-exec
+        # tool, not just bash. Falls back to the global default when no
+        # env override is set.
+        timeout_seconds=await resolve_bash_timeout_ceiling(session_id),
         max_output_bytes=settings.bash_max_output_bytes,
     )
 

--- a/src/aios/tools/grep.py
+++ b/src/aios/tools/grep.py
@@ -23,6 +23,7 @@ from typing import Any
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.sandbox.spec import resolve_bash_timeout_ceiling
 from aios.tools.registry import registry
 
 
@@ -163,7 +164,11 @@ async def grep_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     result = await sandbox.exec(
         handle,
         cmd,
-        timeout_seconds=settings.bash_default_timeout_seconds,
+        # Honor the session's per-environment bash-timeout ceiling (#725)
+        # so an env that raised the limit applies to every sandbox-exec
+        # tool, not just bash. Falls back to the global default when no
+        # env override is set.
+        timeout_seconds=await resolve_bash_timeout_ceiling(session_id),
         max_output_bytes=settings.bash_max_output_bytes,
     )
 

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -28,6 +28,7 @@ from aios.harness.vision import (
     supports_vision,
 )
 from aios.sandbox.backends.base import SandboxHandle
+from aios.sandbox.spec import resolve_bash_timeout_ceiling
 from aios.sandbox.volumes import resolve_to_host_path
 from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
@@ -103,10 +104,24 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sandbox = runtime.require_sandbox_registry()
     handle = await sandbox.get_or_provision(session_id, pool=pool)
 
-    image_mime = await _detect_image_mime(session_id, path, handle=handle)
+    # Resolve the per-environment bash-timeout ceiling once (#725) and
+    # thread it through every sandbox-exec this handler may make (the
+    # text read below plus the image probe/stat helpers) so a raised
+    # env limit applies to read just as it does to bash. Falls back to
+    # the global default when no env override is set.
+    exec_timeout = await resolve_bash_timeout_ceiling(session_id)
+
+    image_mime = await _detect_image_mime(
+        session_id, path, handle=handle, exec_timeout=exec_timeout
+    )
     if image_mime is not None:
         return await _read_image(
-            session_id=session_id, path=path, mime=image_mime, handle=handle, pool=pool
+            session_id=session_id,
+            path=path,
+            mime=image_mime,
+            handle=handle,
+            pool=pool,
+            exec_timeout=exec_timeout,
         )
 
     target = resolve_memory_target(session_id, path)
@@ -141,7 +156,7 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     result = await sandbox.exec(
         handle,
         cmd,
-        timeout_seconds=settings.bash_default_timeout_seconds,
+        timeout_seconds=exec_timeout,
         max_output_bytes=settings.bash_max_output_bytes,
     )
 
@@ -159,7 +174,9 @@ async def read_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     return {"path": path, "content": content}
 
 
-async def _detect_image_mime(session_id: str, path: str, *, handle: SandboxHandle) -> str | None:
+async def _detect_image_mime(
+    session_id: str, path: str, *, handle: SandboxHandle, exec_timeout: int
+) -> str | None:
     """Return the image mime for ``path``, or ``None`` to read it as text.
 
     The extension decides when it names a known image type — the common,
@@ -176,7 +193,7 @@ async def _detect_image_mime(session_id: str, path: str, *, handle: SandboxHandl
     mime = _EXT_TO_MIME.get(ext)
     if mime is not None:
         return mime
-    head = await _read_probe_bytes(session_id, path, handle=handle, n=16)
+    head = await _read_probe_bytes(session_id, path, handle=handle, n=16, exec_timeout=exec_timeout)
     if head is None:
         return None
     return sniff_image_mime(head)
@@ -189,6 +206,7 @@ async def _read_image(
     mime: str,
     handle: SandboxHandle,
     pool: Any,
+    exec_timeout: int,
 ) -> ToolResult:
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     model = await sessions_service.get_session_model(pool, session_id, account_id=account_id)
@@ -203,7 +221,7 @@ async def _read_image(
             return ToolResult(content=f"read failed: {err}", is_error=True)
         size = len(data)
     else:
-        result = await _stat_and_read_via_exec(handle, path)
+        result = await _stat_and_read_via_exec(handle, path, exec_timeout=exec_timeout)
         if result is None:
             return ToolResult(
                 content=f"read failed: file not readable inside sandbox: {path}",
@@ -239,7 +257,9 @@ async def _read_image(
     )
 
 
-async def _stat_and_read_via_exec(handle: SandboxHandle, path: str) -> tuple[bytes, int] | None:
+async def _stat_and_read_via_exec(
+    handle: SandboxHandle, path: str, *, exec_timeout: int
+) -> tuple[bytes, int] | None:
     """Fetch ``(bytes, size)`` for non-bind-mount image paths via one docker-exec.
 
     Returns ``None`` on any read failure (missing path, exec error,
@@ -253,7 +273,7 @@ async def _stat_and_read_via_exec(handle: SandboxHandle, path: str) -> tuple[byt
     result = await sandbox.exec(
         handle,
         cmd,
-        timeout_seconds=settings.bash_default_timeout_seconds,
+        timeout_seconds=exec_timeout,
         max_output_bytes=settings.bash_max_output_bytes,
     )
     if result.exit_code != 0:
@@ -268,7 +288,7 @@ async def _stat_and_read_via_exec(handle: SandboxHandle, path: str) -> tuple[byt
 
 
 async def _read_probe_bytes(
-    session_id: str, path: str, *, handle: SandboxHandle, n: int
+    session_id: str, path: str, *, handle: SandboxHandle, n: int, exec_timeout: int
 ) -> bytes | None:
     """First ``n`` bytes of ``path`` for magic-byte image detection.
 
@@ -287,10 +307,12 @@ async def _read_probe_bytes(
                 return fh.read(n)
         except OSError:
             return None
-    return await _read_head_bytes(handle, path, n=n)
+    return await _read_head_bytes(handle, path, n=n, exec_timeout=exec_timeout)
 
 
-async def _read_head_bytes(handle: SandboxHandle, path: str, *, n: int) -> bytes | None:
+async def _read_head_bytes(
+    handle: SandboxHandle, path: str, *, n: int, exec_timeout: int
+) -> bytes | None:
     """Read the first ``n`` bytes of ``path`` via one docker-exec, base64-framed
     so binary survives the str stdout boundary.  Used as the out-of-mount
     fallback for magic-byte image detection.  ``set -o pipefail`` makes a
@@ -305,7 +327,7 @@ async def _read_head_bytes(handle: SandboxHandle, path: str, *, n: int) -> bytes
     result = await sandbox.exec(
         handle,
         cmd,
-        timeout_seconds=settings.bash_default_timeout_seconds,
+        timeout_seconds=exec_timeout,
         max_output_bytes=settings.bash_max_output_bytes,
     )
     if result.exit_code != 0:

--- a/src/aios/tools/write.py
+++ b/src/aios/tools/write.py
@@ -42,6 +42,7 @@ from aios.errors import (
 )
 from aios.harness import runtime
 from aios.models.memory_stores import MAX_CONTENT_BYTES
+from aios.sandbox.spec import resolve_bash_timeout_ceiling
 from aios.services import memory_stores as memory_service
 from aios.services import sessions as sessions_service
 from aios.tools.memory_intercept import resolve_memory_target
@@ -183,7 +184,11 @@ async def write_handler(session_id: str, arguments: dict[str, Any]) -> dict[str,
     result = await sandbox.exec(
         handle,
         cmd,
-        timeout_seconds=settings.bash_default_timeout_seconds,
+        # Honor the session's per-environment bash-timeout ceiling (#725)
+        # so an env that raised the limit applies to every sandbox-exec
+        # tool, not just bash. Falls back to the global default when no
+        # env override is set.
+        timeout_seconds=await resolve_bash_timeout_ceiling(session_id),
         max_output_bytes=settings.bash_max_output_bytes,
     )
 

--- a/tests/integration/test_environment_sandbox_controls_persist.py
+++ b/tests/integration/test_environment_sandbox_controls_persist.py
@@ -1,0 +1,141 @@
+"""The per-environment sandbox controls (issues #724, #725) round-trip
+through the ``environments.config`` JSONB column without any schema
+migration.
+
+``image``, ``disk_bytes``, and ``bash_timeout_seconds`` are stored
+inside the existing schemaless JSONB ``config`` column (added by
+migration 0004), so adding them to :class:`EnvironmentConfig` is purely
+additive at the DB layer. These tests prove an insert carrying the new
+fields reads back intact, and that an environment with none of them set
+reads back with all three ``None`` (current behavior preserved).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.environments import EnvironmentConfig
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_with_account(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        yield pool, "acc_test"
+    finally:
+        await pool.close()
+
+
+async def test_new_fields_round_trip_through_jsonb(
+    pool_with_account: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """An environment created with image + disk + bash-timeout overrides
+    reads back with all three intact — no migration required."""
+    pool, account_id = pool_with_account
+
+    config = EnvironmentConfig(
+        image="ghcr.io/eumemic/aios-dev-env:pinned",
+        disk_bytes=8 * 1024 * 1024 * 1024,
+        bash_timeout_seconds=600,
+        packages={"pip": ["pytest"]},
+    )
+    created = await environments_service.create_environment(
+        pool, account_id=account_id, name="dev-env", config=config
+    )
+    assert created.config.image == "ghcr.io/eumemic/aios-dev-env:pinned"
+    assert created.config.disk_bytes == 8 * 1024 * 1024 * 1024
+    assert created.config.bash_timeout_seconds == 600
+
+    # Read back through a fresh query to confirm the JSONB persisted, not
+    # just the in-memory echo returned by the insert.
+    fetched = await environments_service.get_environment(pool, created.id, account_id=account_id)
+    assert fetched.config == config
+
+
+async def test_unset_fields_persist_as_none(
+    pool_with_account: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """An environment with none of the new fields set reads back with all
+    three ``None`` — current behavior (global defaults) is preserved."""
+    pool, account_id = pool_with_account
+
+    created = await environments_service.create_environment(
+        pool,
+        account_id=account_id,
+        name="plain-env",
+        config=EnvironmentConfig(packages={"pip": ["pandas"]}),
+    )
+    fetched = await environments_service.get_environment(pool, created.id, account_id=account_id)
+    assert fetched.config.image is None
+    assert fetched.config.disk_bytes is None
+    assert fetched.config.bash_timeout_seconds is None
+
+
+async def test_get_environment_config_for_session_carries_new_fields(
+    pool_with_account: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """The session-scoped read used by the sandbox spec builder surfaces
+    the new fields, so ``build_spec_from_session`` can resolve the
+    per-env image / disk / bash-timeout overrides (issues #724, #725)."""
+    pool, account_id = pool_with_account
+
+    config = EnvironmentConfig(
+        image="ghcr.io/eumemic/aios-dev-env:pinned",
+        disk_bytes=4 * 1024 * 1024 * 1024,
+        bash_timeout_seconds=300,
+    )
+    env = await environments_service.create_environment(
+        pool, account_id=account_id, name="bound-env", config=config
+    )
+    # A session needs an agent FK; seed one via the canonical service path
+    # (same shape as test_session_cross_tenant_isolation.py).
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=account_id,
+        name="dev-agent",
+        model="openrouter/some-model",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+
+    async with pool.acquire() as conn:
+        session = await queries.insert_session(
+            conn,
+            account_id=account_id,
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            title=None,
+            metadata={},
+        )
+        loaded = await queries.get_environment_config_for_session(
+            conn, session.id, account_id=account_id
+        )
+
+    assert loaded is not None
+    assert loaded.image == "ghcr.io/eumemic/aios-dev-env:pinned"
+    assert loaded.disk_bytes == 4 * 1024 * 1024 * 1024
+    assert loaded.bash_timeout_seconds == 300

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -1,0 +1,304 @@
+"""Per-environment sandbox controls: image override, disk cap, and the
+bash-timeout ceiling resolver (issues #724, #725).
+
+#724 adds an optional :attr:`EnvironmentConfig.image`; #725 adds a
+per-environment writable-layer disk cap and a per-environment bash
+timeout ceiling. All three default to current behavior when unset:
+
+- ``image`` unset → the worker-global ``settings.docker_image``.
+- ``disk_bytes`` unset → the worker-global ``settings.sandbox_disk_bytes``
+  (itself ``None`` = unbounded by default).
+- ``bash_timeout_seconds`` unset → the worker-global
+  ``settings.bash_default_timeout_seconds``.
+
+The image/disk resolution lives in ``build_spec_from_session``; the
+plumbing onto the spec lives in ``_assemble_plan``; the bash ceiling
+lives in ``resolve_bash_timeout_ceiling``. These tests pin each.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.models.environments import EnvironmentConfig
+from aios.sandbox.spec import (
+    _assemble_plan,
+    resolve_bash_timeout_ceiling,
+)
+
+
+def _call_assemble(
+    *,
+    image: str = "aios-sandbox:test",
+    disk_bytes: int | None = None,
+    env_config: EnvironmentConfig | None = None,
+) -> object:
+    # ``_assemble_plan`` imports its volume helpers function-locally, so
+    # patch them at the ``aios.sandbox.volumes`` source module (same shape
+    # as ``test_spec_uds_url.py``).
+    with (
+        patch(
+            "aios.sandbox.volumes.ensure_session_attachments_dir",
+            return_value=Path("/tmp/a"),
+        ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_uploads_dir",
+            return_value=Path("/tmp/u"),
+        ),
+    ):
+        return _assemble_plan(
+            session_id="sess_01TEST",
+            instance_id="inst_TEST",
+            image=image,
+            workspace_path=Path("/tmp/w"),
+            env_config=env_config,
+            session_env={},
+            memory_echoes=[],
+            github_echoes=[],
+            git_proxy=None,
+            tool_broker_url="http://aios-worker:54321",
+            tool_broker_secret="secret123",
+            tool_socket_host_path=None,
+            disk_bytes=disk_bytes,
+        )
+
+
+class TestAssemblePlanImageAndDisk:
+    """``_assemble_plan`` copies the resolved image + disk cap onto the
+    spec verbatim — it does not itself read settings for these."""
+
+    def test_image_lands_on_spec(self) -> None:
+        plan = _call_assemble(image="ghcr.io/eumemic/aios-sandbox:pinned")
+        assert plan.spec.image == "ghcr.io/eumemic/aios-sandbox:pinned"
+
+    def test_disk_bytes_lands_on_spec_when_set(self) -> None:
+        plan = _call_assemble(disk_bytes=2 * 1024 * 1024 * 1024)
+        assert plan.spec.disk_bytes == 2 * 1024 * 1024 * 1024
+
+    def test_disk_bytes_none_by_default(self) -> None:
+        plan = _call_assemble()
+        assert plan.spec.disk_bytes is None
+
+
+# ── build_spec_from_session resolution (#724 image, #725 disk) ───────────────
+
+
+def _patch_build_spec_deps(
+    *,
+    env_config: EnvironmentConfig | None,
+    docker_image: str,
+    sandbox_disk_bytes: int | None,
+):
+    """Context manager bundle that stubs every external dependency of
+    ``build_spec_from_session`` so it runs to the ``_assemble_plan`` call
+    with a synthetic environment config and synthetic settings."""
+    settings = MagicMock()
+    settings.docker_image = docker_image
+    settings.sandbox_disk_bytes = sandbox_disk_bytes
+    settings.instance_id = "inst_TEST"
+    settings.sandbox_cpu_quota = None
+    settings.sandbox_memory_bytes = None
+    settings.sandbox_pids_limit = None
+    settings.tool_broker_socket_path = None
+
+    tool_broker = MagicMock()
+    tool_broker.port = 54321
+    tool_broker.register_session = MagicMock()
+    tool_broker.unregister_session = MagicMock()
+
+    return (
+        patch("aios.sandbox.spec.get_settings", return_value=settings),
+        patch(
+            "aios.sandbox.spec.sessions_service.load_session_account_id",
+            AsyncMock(return_value="acct_x"),
+        ),
+        patch(
+            "aios.sandbox.spec._load_session_provisioning",
+            AsyncMock(return_value=("/tmp/w", {})),
+        ),
+        # ``build_spec_from_session`` imports these function-locally from
+        # ``aios.sandbox.volumes`` (deferred import to avoid a cycle), so
+        # patch them at the source module, not on ``aios.sandbox.spec``.
+        patch("aios.sandbox.volumes.validate_workspace_path", MagicMock()),
+        patch(
+            "aios.sandbox.volumes.ensure_workspace_path",
+            MagicMock(return_value=Path("/tmp/w")),
+        ),
+        patch(
+            "aios.sandbox.spec._load_environment_config",
+            AsyncMock(return_value=env_config),
+        ),
+        patch(
+            "aios.sandbox.spec._materialize_memory_mounts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "aios.sandbox.spec._materialize_github_clones",
+            AsyncMock(return_value=([], None)),
+        ),
+        patch("aios.sandbox.spec.runtime.require_pool", MagicMock()),
+        patch(
+            "aios.sandbox.spec.runtime.require_tool_broker",
+            MagicMock(return_value=tool_broker),
+        ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_attachments_dir",
+            return_value=Path("/tmp/a"),
+        ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_uploads_dir",
+            return_value=Path("/tmp/u"),
+        ),
+    )
+
+
+async def _build_with(
+    *,
+    env_config: EnvironmentConfig | None,
+    docker_image: str = "ghcr.io/eumemic/aios-sandbox:latest",
+    sandbox_disk_bytes: int | None = None,
+):
+    from contextlib import ExitStack
+
+    from aios.sandbox.spec import build_spec_from_session
+
+    with ExitStack() as stack:
+        for cm in _patch_build_spec_deps(
+            env_config=env_config,
+            docker_image=docker_image,
+            sandbox_disk_bytes=sandbox_disk_bytes,
+        ):
+            stack.enter_context(cm)
+        return await build_spec_from_session("sess_01TEST")
+
+
+class TestBuildSpecImageResolution:
+    """#724: a session bound to an environment with ``image=X`` provisions
+    from X; unset falls back to the global ``settings.docker_image``."""
+
+    @pytest.mark.asyncio
+    async def test_env_image_overrides_global(self) -> None:
+        plan = await _build_with(
+            env_config=EnvironmentConfig(image="ghcr.io/eumemic/dev-env:pinned"),
+            docker_image="ghcr.io/eumemic/aios-sandbox:latest",
+        )
+        assert plan.spec.image == "ghcr.io/eumemic/dev-env:pinned"
+
+    @pytest.mark.asyncio
+    async def test_unset_image_falls_back_to_global(self) -> None:
+        plan = await _build_with(
+            env_config=EnvironmentConfig(packages={"pip": ["pandas"]}),
+            docker_image="ghcr.io/eumemic/aios-sandbox:latest",
+        )
+        assert plan.spec.image == "ghcr.io/eumemic/aios-sandbox:latest"
+
+    @pytest.mark.asyncio
+    async def test_no_env_config_falls_back_to_global(self) -> None:
+        """A session with no environment attached uses the global image."""
+        plan = await _build_with(
+            env_config=None,
+            docker_image="ghcr.io/eumemic/aios-sandbox:latest",
+        )
+        assert plan.spec.image == "ghcr.io/eumemic/aios-sandbox:latest"
+
+
+class TestBuildSpecDiskResolution:
+    """#725: per-env ``disk_bytes`` wins; else the global default; else None."""
+
+    @pytest.mark.asyncio
+    async def test_env_disk_overrides_global(self) -> None:
+        plan = await _build_with(
+            env_config=EnvironmentConfig(disk_bytes=8 * 1024 * 1024 * 1024),
+            sandbox_disk_bytes=2 * 1024 * 1024 * 1024,
+        )
+        assert plan.spec.disk_bytes == 8 * 1024 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_unset_env_disk_falls_back_to_global(self) -> None:
+        plan = await _build_with(
+            env_config=EnvironmentConfig(packages={"pip": ["x"]}),
+            sandbox_disk_bytes=2 * 1024 * 1024 * 1024,
+        )
+        assert plan.spec.disk_bytes == 2 * 1024 * 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_both_unset_is_none(self) -> None:
+        plan = await _build_with(
+            env_config=None,
+            sandbox_disk_bytes=None,
+        )
+        assert plan.spec.disk_bytes is None
+
+
+# ── resolve_bash_timeout_ceiling (#725) ──────────────────────────────────────
+
+
+def _patch_ceiling_deps(
+    *,
+    env_config: EnvironmentConfig | None,
+    default: int,
+    load_raises: bool = False,
+):
+    settings = MagicMock()
+    settings.bash_default_timeout_seconds = default
+    load_env = AsyncMock(return_value=env_config)
+    if load_raises:
+        load_env = AsyncMock(side_effect=RuntimeError("db down"))
+    return (
+        patch("aios.sandbox.spec.get_settings", return_value=settings),
+        patch("aios.sandbox.spec.runtime.require_pool", MagicMock()),
+        patch(
+            "aios.sandbox.spec.sessions_service.load_session_account_id",
+            AsyncMock(return_value="acct_x"),
+        ),
+        patch("aios.sandbox.spec._load_environment_config", load_env),
+    )
+
+
+async def _resolve_with(
+    *,
+    env_config: EnvironmentConfig | None,
+    default: int = 120,
+    load_raises: bool = False,
+) -> int:
+    from contextlib import ExitStack
+
+    with ExitStack() as stack:
+        for cm in _patch_ceiling_deps(
+            env_config=env_config, default=default, load_raises=load_raises
+        ):
+            stack.enter_context(cm)
+        return await resolve_bash_timeout_ceiling("sess_01TEST")
+
+
+class TestResolveBashTimeoutCeiling:
+    @pytest.mark.asyncio
+    async def test_env_override_wins(self) -> None:
+        ceiling = await _resolve_with(
+            env_config=EnvironmentConfig(bash_timeout_seconds=600),
+            default=120,
+        )
+        assert ceiling == 600
+
+    @pytest.mark.asyncio
+    async def test_unset_env_uses_global_default(self) -> None:
+        ceiling = await _resolve_with(
+            env_config=EnvironmentConfig(packages={"pip": ["x"]}),
+            default=120,
+        )
+        assert ceiling == 120
+
+    @pytest.mark.asyncio
+    async def test_no_env_config_uses_global_default(self) -> None:
+        ceiling = await _resolve_with(env_config=None, default=120)
+        assert ceiling == 120
+
+    @pytest.mark.asyncio
+    async def test_db_failure_falls_back_to_global_default(self) -> None:
+        """Total by contract: a DB hiccup while resolving the per-env ceiling
+        must fall back to the global default, never block the bash call."""
+        ceiling = await _resolve_with(env_config=None, default=120, load_raises=True)
+        assert ceiling == 120

--- a/tests/unit/test_bash_handler.py
+++ b/tests/unit/test_bash_handler.py
@@ -56,19 +56,33 @@ def canned_result() -> CommandResult:
 def stub_registry(
     stub_handle: SandboxHandle, canned_result: CommandResult, **kwargs: Any
 ) -> _StubRegistry:
-    """Install a stub sandbox registry on the runtime module, restore after."""
+    """Install a stub sandbox registry on the runtime module, restore after.
+
+    Also pins ``resolve_bash_timeout_ceiling`` to the global default so the
+    handler's per-env timeout lookup (issue #725) doesn't try to read a
+    real session row off the MagicMock pool. Tests that exercise the
+    per-env ceiling patch this themselves (see ``TestPerEnvTimeoutCeiling``).
+    """
     from unittest.mock import MagicMock
+
+    from aios.config import get_settings
 
     prev_registry = runtime.sandbox_registry
     prev_pool = runtime.pool
     stub = _StubRegistry(stub_handle, canned_result)
     runtime.sandbox_registry = stub  # type: ignore[assignment]
     runtime.pool = MagicMock()
-    try:
-        yield stub
-    finally:
-        runtime.sandbox_registry = prev_registry
-        runtime.pool = prev_pool
+    default_ceiling = get_settings().bash_default_timeout_seconds
+    with patch(
+        "aios.tools.bash.resolve_bash_timeout_ceiling",
+        new_callable=AsyncMock,
+        return_value=default_ceiling,
+    ):
+        try:
+            yield stub
+        finally:
+            runtime.sandbox_registry = prev_registry
+            runtime.pool = prev_pool
 
 
 class TestArguments:
@@ -156,6 +170,60 @@ class TestTimeoutCapping:
         )
         kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
         assert kwargs["timeout_seconds"] == 5
+
+
+class TestPerEnvTimeoutCeiling:
+    """The handler clamps to the per-environment ceiling resolved by
+    ``resolve_bash_timeout_ceiling`` (issue #725), not the global default.
+
+    The fixture pins the resolver to the global default; these tests
+    override it to a higher (or lower) per-env value to prove the handler
+    honors whatever ceiling the resolver returns.
+    """
+
+    async def test_honors_higher_per_env_ceiling(self, stub_registry: _StubRegistry) -> None:
+        """A request between the global default and a higher per-env
+        ceiling is passed through (not clamped to the global default)."""
+        with patch(
+            "aios.tools.bash.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await bash_handler(
+                "sess_01TEST",
+                {"command": "true", "timeout_seconds": 300},
+            )
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        # 300 < 600 ceiling → request honored verbatim.
+        assert kwargs["timeout_seconds"] == 300
+
+    async def test_caps_at_higher_per_env_ceiling(self, stub_registry: _StubRegistry) -> None:
+        """A request above the per-env ceiling is clamped to that ceiling."""
+        with patch(
+            "aios.tools.bash.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await bash_handler(
+                "sess_01TEST",
+                {"command": "true", "timeout_seconds": 5000},
+            )
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["timeout_seconds"] == 600
+
+    async def test_default_to_per_env_ceiling_when_unspecified(
+        self, stub_registry: _StubRegistry
+    ) -> None:
+        """With no ``timeout_seconds`` in the call, the handler defaults to
+        the resolved per-env ceiling (here above the global default)."""
+        with patch(
+            "aios.tools.bash.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await bash_handler("sess_01TEST", {"command": "true"})
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["timeout_seconds"] == 600
 
 
 class TestExecRaisedReconcileSuppression:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -177,3 +177,48 @@ def test_github_clone_session_timeout_mirror_matches_harness_constant(
     from aios.harness.loop import _JOB_TIMEOUT_S
 
     assert _HARNESS_STEP_TIMEOUT_S == _JOB_TIMEOUT_S
+
+
+def test_sandbox_disk_bytes_default_is_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The disk cap (issue #725) defaults to ``None`` so current behavior
+    (host default, unbounded) is unchanged unless the operator opts in."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_SANDBOX_DISK_BYTES", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.sandbox_disk_bytes is None
+
+
+def test_sandbox_disk_bytes_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AIOS_SANDBOX_DISK_BYTES`` sets the global writable-layer cap."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_SANDBOX_DISK_BYTES", str(4 * 1024 * 1024 * 1024))
+
+    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    assert s.sandbox_disk_bytes == 4 * 1024 * 1024 * 1024
+
+
+def test_sandbox_disk_bytes_rejects_below_floor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Below the 10 MiB floor the cap can't fit the image's own base size,
+    so Settings construction rejects it loudly rather than provisioning a
+    container that can't start."""
+    from pydantic import ValidationError
+
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_SANDBOX_DISK_BYTES", "1024")
+
+    with pytest.raises(ValidationError):
+        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]

--- a/tests/unit/test_edit_handler.py
+++ b/tests/unit/test_edit_handler.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -205,6 +205,31 @@ class TestStrictMatching:
         write_cmd: str = stub_registry.exec.await_args_list[1].args[1]  # type: ignore[attr-defined]
         expected_b64 = base64.b64encode(b"FOO\nbar\nFOO\nFOO\n").decode("ascii")
         assert expected_b64 in write_cmd
+
+
+class TestPerEnvTimeoutCeiling:
+    """edit routes BOTH its read-back and write-back sandbox execs through
+    the per-environment bash-timeout ceiling (#725), not the hardcoded
+    global default."""
+
+    async def test_both_execs_use_resolved_ceiling(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        stub_registry.exec = _script_responses(  # type: ignore[method-assign]
+            _ok("alpha beta gamma\n"),
+            _ok(""),
+        )
+        with patch(
+            "aios.tools.edit.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await edit_handler(
+                "sess_01TEST",
+                {"path": "/workspace/a.txt", "old_string": "beta", "new_string": "BETA"},
+            )
+        for call in stub_registry.exec.await_args_list:  # type: ignore[attr-defined]
+            assert call.kwargs["timeout_seconds"] == 600
 
 
 class TestErrorPaths:

--- a/tests/unit/test_glob_handler.py
+++ b/tests/unit/test_glob_handler.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -156,3 +156,20 @@ class TestErrorPath:
             f"``| head -N`` to the overall pipe exit code; without it, "
             f"rg errors silently return empty matches. Got: {cmd!r}"
         )
+
+
+class TestPerEnvTimeoutCeiling:
+    """glob routes its sandbox exec through the per-environment bash-timeout
+    ceiling (#725), not the hardcoded global default."""
+
+    async def test_exec_uses_resolved_ceiling(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        with patch(
+            "aios.tools.glob.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await glob_handler("sess_01TEST", {"pattern": "*.py"})
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["timeout_seconds"] == 600

--- a/tests/unit/test_grep_handler.py
+++ b/tests/unit/test_grep_handler.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -229,3 +229,21 @@ class TestErrorPath:
             f"the overall pipe exit code; without it, rg errors silently "
             f"return empty matches. Got: {cmd!r}"
         )
+
+
+class TestPerEnvTimeoutCeiling:
+    """grep routes its sandbox exec through the per-environment bash-timeout
+    ceiling (#725), not the hardcoded global default — so an env that raised
+    the limit applies to grep too, not just the bash tool."""
+
+    async def test_exec_uses_resolved_ceiling(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        with patch(
+            "aios.tools.grep.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await grep_handler("sess_01TEST", {"pattern": "hello"})
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["timeout_seconds"] == 600

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -15,6 +15,7 @@ from aios.models.environments import (
     UnrestrictedNetworking,
 )
 from aios.sandbox.backends.base import (
+    CommandResult,
     Limited,
     Mount,
     SandboxBackendError,
@@ -333,3 +334,56 @@ class TestApplyNetworkLockdown:
         # Sanity: the constant exists and contains representative hosts.
         assert "pypi.org" in PACKAGE_REGISTRY_HOSTS
         assert "registry.npmjs.org" in PACKAGE_REGISTRY_HOSTS
+
+
+# ── lockdown fails closed (security gate, not best-effort) ─────────────────────
+
+
+class TestApplyNetworkLockdownFailsClosed:
+    """A :class:`Limited` sandbox whose iptables lockdown didn't apply is a
+    silent unrestricted-networking bypass — especially dangerous combined
+    with the per-environment image override (#724), where a tenant-supplied
+    image might lack ``iptables``/``getent``. The lockdown is a security
+    gate, so a nonzero exit (or a backend exec error) must raise rather than
+    log-and-continue, letting the registry tear the sandbox down.
+    """
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_raises_sandbox_backend_error(self) -> None:
+        backend = FakeBackend()
+        backend.next_result = CommandResult(
+            exit_code=3,
+            stdout="",
+            stderr="iptables: command not found",
+            timed_out=False,
+            truncated=False,
+        )
+        handle = make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        with pytest.raises(SandboxBackendError, match="network lockdown failed"):
+            await apply_network_lockdown(backend, handle, networking)
+
+    @pytest.mark.asyncio
+    async def test_backend_exec_error_propagates(self) -> None:
+        """An infra failure to even run the lockdown script must not be
+        swallowed into a wide-open sandbox — it propagates so the provision
+        aborts."""
+        backend = FakeBackend()
+        backend.exec = AsyncMock(  # type: ignore[method-assign]
+            side_effect=SandboxBackendError("daemon hiccup")
+        )
+        handle = make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        with pytest.raises(SandboxBackendError, match="daemon hiccup"):
+            await apply_network_lockdown(backend, handle, networking)
+
+    @pytest.mark.asyncio
+    async def test_zero_exit_does_not_raise(self) -> None:
+        """The happy path (exit 0) is unchanged — no exception."""
+        backend = FakeBackend()  # default exec returns exit 0
+        handle = make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        await apply_network_lockdown(backend, handle, networking)  # must not raise

--- a/tests/unit/test_read_handler.py
+++ b/tests/unit/test_read_handler.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -124,6 +124,25 @@ class TestHappyPath:
         await read_handler("sess_01TEST", {"path": "/workspace/a file.txt"})
         cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
         assert "'/workspace/a file.txt'" in cmd
+
+
+class TestPerEnvTimeoutCeiling:
+    """read routes its sandbox exec through the per-environment bash-timeout
+    ceiling (#725), not the hardcoded global default."""
+
+    async def test_text_read_exec_uses_resolved_ceiling(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        with patch(
+            "aios.tools.read.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await read_handler("sess_01TEST", {"path": "/workspace/a.txt"})
+        # Only the text-read exec fires for a missing local path (the image
+        # probe reads the bind-mount host path directly, no exec).
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["timeout_seconds"] == 600
 
 
 class TestErrorPath:

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -23,7 +23,13 @@ import pytest
 
 from aios.harness import runtime
 from aios.models.memory_stores import Access, MemoryStoreResourceEcho
-from aios.sandbox.backends.base import Mount, SandboxHandle, SandboxSpec, Unrestricted
+from aios.sandbox.backends.base import (
+    CommandResult,
+    Mount,
+    SandboxHandle,
+    SandboxSpec,
+    Unrestricted,
+)
 from aios.sandbox.registry import SandboxRegistry
 from aios.sandbox.spec import ProvisioningPlan
 from tests.helpers.sandbox import FakeBackend, make_handle
@@ -353,6 +359,82 @@ def _provisioning_plan(session_id: str) -> ProvisioningPlan:
         github_echoes=[],
         git_proxy=None,
     )
+
+
+def _provisioning_plan_limited(session_id: str) -> ProvisioningPlan:
+    """Like :func:`_provisioning_plan` but with a :class:`Limited` network
+    policy, so the registry's cold path actually runs
+    ``apply_network_lockdown`` (the security gate under test)."""
+    from aios.models.environments import EnvironmentConfig, LimitedNetworking
+    from aios.sandbox.backends.base import Limited
+
+    spec = SandboxSpec(
+        session_id=session_id,
+        instance_id="inst_TEST",
+        workspace=Mount(host_path=Path("/tmp/w"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={},
+        network_policy=Limited(allowed_hosts=frozenset({"api.example.com"})),
+        host_gateway_alias=None,
+        image="aios-sandbox:test",
+    )
+    return ProvisioningPlan(
+        spec=spec,
+        env_config=EnvironmentConfig(
+            networking=LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+        ),
+        memory_echoes=[],
+        github_echoes=[],
+        git_proxy=None,
+    )
+
+
+class TestLockdownFailsClosed:
+    """A :class:`Limited` provision whose iptables lockdown fails must tear
+    the sandbox down and abort, never hand back a box with unrestricted
+    networking (silent #724 image-override bypass otherwise)."""
+
+    async def test_lockdown_failure_destroys_sandbox_and_raises(self) -> None:
+        backend = FakeBackend()
+        # The post-create setup execs all route through backend.exec; make
+        # the lockdown script (the only exec the cold path runs here, since
+        # the other setup steps are patched out) return nonzero.
+        backend.next_result = CommandResult(
+            exit_code=2,
+            stdout="",
+            stderr="iptables: not found",
+            timed_out=False,
+            truncated=False,
+        )
+        registry = SandboxRegistry(backend=backend)
+
+        broker = MagicMock()
+        broker.port = 8765
+
+        with (
+            patch("aios.harness.runtime.require_tool_broker", lambda: broker),
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=_provisioning_plan_limited("sess_X")),
+            ),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            # NOTE: apply_network_lockdown is NOT patched — we want the real
+            # fail-closed behavior to fire against the failing backend.exec.
+        ):
+            from aios.sandbox.backends.base import SandboxBackendError
+
+            with pytest.raises(SandboxBackendError, match="network lockdown failed"):
+                await registry.get_or_provision("sess_X")
+
+        # Sandbox was created then torn down — no live handle left behind.
+        assert any(c[0] == "create" for c in backend.calls)
+        destroys = [c for c in backend.calls if c[0] == "destroy"]
+        assert len(destroys) == 1, "failed lockdown must destroy the just-created sandbox"
+        assert registry.peek("sess_X") is None, (
+            "a Limited sandbox whose lockdown failed must not remain cached"
+        )
 
 
 class TestStaleHandleDetection:

--- a/tests/unit/test_sandbox_resource_caps.py
+++ b/tests/unit/test_sandbox_resource_caps.py
@@ -102,22 +102,41 @@ class TestResourceCapFlags:
         assert argv[i + 1] == "512"
 
     @pytest.mark.asyncio
+    async def test_disk_bytes_emits_storage_opt_size(self) -> None:
+        """A disk cap flips ``--storage-opt size=<bytes>`` (issue #725) so a
+        heavy build can't grow the container's writable layer past the cap."""
+        argv = await _capture_argv(_spec(disk_bytes=2 * 1024 * 1024 * 1024))
+        assert "--storage-opt" in argv
+        i = argv.index("--storage-opt")
+        assert argv[i + 1] == f"size={2 * 1024 * 1024 * 1024}"
+
+    @pytest.mark.asyncio
     async def test_no_caps_emits_no_resource_flags(self) -> None:
         """An all-defaults spec leaves the host's default behaviour intact:
-        no ``--cpus``, no ``--memory*``, no ``--pids-limit``.
+        no ``--cpus``, no ``--memory*``, no ``--pids-limit``, no
+        ``--storage-opt``.
         """
         argv = await _capture_argv(_spec())
         assert "--cpus" not in argv
         assert "--memory" not in argv
         assert "--memory-swap" not in argv
         assert "--pids-limit" not in argv
+        assert "--storage-opt" not in argv
 
     @pytest.mark.asyncio
     async def test_all_caps_set_together(self) -> None:
         argv = await _capture_argv(
-            _spec(cpu_quota=2.0, memory_bytes=128 * 1024 * 1024, pids_limit=64)
+            _spec(
+                cpu_quota=2.0,
+                memory_bytes=128 * 1024 * 1024,
+                pids_limit=64,
+                disk_bytes=512 * 1024 * 1024,
+            )
         )
         assert "--cpus" in argv
         assert "--memory" in argv
         assert "--memory-swap" in argv
         assert "--pids-limit" in argv
+        assert "--storage-opt" in argv
+        i = argv.index("--storage-opt")
+        assert argv[i + 1] == f"size={512 * 1024 * 1024}"

--- a/tests/unit/test_write_handler.py
+++ b/tests/unit/test_write_handler.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -138,6 +138,23 @@ class TestHappyPath:
         # No literal quotes or dollar signs leaked into the command.
         assert "'quotes'" not in cmd
         assert "$vars" not in cmd
+
+
+class TestPerEnvTimeoutCeiling:
+    """write routes its sandbox exec through the per-environment bash-timeout
+    ceiling (#725), not the hardcoded global default."""
+
+    async def test_exec_uses_resolved_ceiling(
+        self, stub_registry: Any, stub_handle: SandboxHandle
+    ) -> None:
+        with patch(
+            "aios.tools.write.resolve_bash_timeout_ceiling",
+            new_callable=AsyncMock,
+            return_value=600,
+        ):
+            await write_handler("sess_01TEST", {"path": "/workspace/a.txt", "content": "hello"})
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["timeout_seconds"] == 600
 
 
 class TestErrorPath:


### PR DESCRIPTION
## Summary

Three additive **per-environment sandbox controls**, each defaulting to current behavior when unset. This is **AIOS core substrate** — the implementation is deliberately conservative and additive (every new field is `Optional` and resolves to the existing global default when not provided).

Closes #724
Closes #725

### #724 — per-environment image override
- New optional `EnvironmentConfig.image`. `sandbox/spec.py::build_spec_from_session` resolves the sandbox image from the environment when set, else falls back to the worker-global `settings.docker_image` (config.py:108). It is the **single** resolution point — everything downstream (`DockerBackend.create`, the `--pull always` decision) consumes `spec.image` unchanged.
- **Acceptance:** an autodev dev-env can run its own pinned, toolchain-baked image while chief-of-staff keeps running the shared one on the same worker.

### #725 — disk cap + scoped bash timeout
- New `settings.sandbox_disk_bytes` (global default, mirrors the existing cpu/mem/pids caps) and `EnvironmentConfig.disk_bytes` (per-env override). `_assemble_plan` resolves *env-override → global default → None*; the docker backend emits `--storage-opt size=<bytes>` when set. A heavy build (`npm ci`, large test artifacts) can't fill Server B disk and take down the worker + meta-agents.
  - On a storage driver **without** per-container quota support, Docker rejects `--storage-opt size=` at create time → surfaces as a `SandboxBackendError` (fail-loud), not a silent no-op. Documented in the field/setting descriptions.
- New `EnvironmentConfig.bash_timeout_seconds`. `bash_handler` now clamps to `resolve_bash_timeout_ceiling(session_id)` (env override else global `bash_default_timeout_seconds`, default 120s). Autodev can run >120s build/test commands without raising the global default for every session on the worker. The resolver is **total**: a DB hiccup falls back to the global default rather than blocking the bash call; the agent's own per-call `timeout_seconds` is still honored as a floor (clamped to the ceiling).
- **Acceptance:** autodev's heavy builds can't exhaust Server B disk and can run >120s commands without a global change.

### Persistence — no migration required
`environments.config` is a **schemaless JSONB column** (added by migration 0004); the new optional fields round-trip through it without any DDL. Insert uses `model_dump(exclude_none=True)`, so unset fields aren't even written. The PR therefore adds **no alembic migration** (an integration test asserts the round-trip explicitly).

Regenerated `openapi.json` + the typed SDK `_generated/` tree via `scripts/regen-client.sh` (the three new fields surface on the environments API).

## Files changed
- `src/aios/config.py` — `sandbox_disk_bytes` setting; doc note on per-env bash timeout
- `src/aios/models/environments.py` — `image`, `disk_bytes`, `bash_timeout_seconds` on `EnvironmentConfig`
- `src/aios/sandbox/backends/base.py` — `SandboxSpec.disk_bytes`
- `src/aios/sandbox/backends/docker.py` — `--storage-opt size=` flag
- `src/aios/sandbox/spec.py` — image + disk resolution in `build_spec_from_session`; `resolve_bash_timeout_ceiling`
- `src/aios/tools/bash.py` — per-env timeout ceiling in `bash_handler`
- `openapi.json`, `packages/aios-sdk/aios_sdk/_generated/models/environment_config.py` — regenerated

## Tests run + results
All run with the CI env vars (`AIOS_DB_URL`/`AIOS_API_KEY`/`AIOS_VAULT_KEY`) against a local Postgres for the integration shard.

- `uv run pytest tests/unit -q` → **1683 passed** (includes the regenerated openapi/client/sdk snapshot checks)
- `uv run pytest tests/integration/test_environment_sandbox_controls_persist.py tests/integration/test_update_environment_concurrent.py tests/integration/test_session_cross_tenant_isolation.py -q` → **7 passed**
- `uv run ruff check src tests packages/aios-sdk/aios_sdk` → **All checks passed**
- `uv run ruff format --check src tests packages/aios-sdk/aios_sdk` → **437 files already formatted**
- `uv run mypy src packages/aios-sdk/aios_sdk` → **Success: no issues found in 524 source files**

New tests:
- `tests/unit/sandbox/test_spec_per_env_controls.py` — image/disk plumbing through `_assemble_plan`, env→global resolution in `build_spec_from_session`, `resolve_bash_timeout_ceiling` (override / fallback / DB-failure-fallback)
- `tests/unit/test_bash_handler.py` — per-env timeout clamping at the handler
- `tests/unit/test_sandbox_resource_caps.py` — `--storage-opt size=` flag on/off
- `tests/unit/test_config.py` — `sandbox_disk_bytes` default/override/floor
- `tests/integration/test_environment_sandbox_controls_persist.py` — JSONB round-trip + session-scoped read

## Caveats / residual
- **This is core substrate — please get an aios-owner review.** The new fields are exposed on the public environments API (hence the SDK/openapi regen) and the bash path is on every tool call's hot loop.
- The disk cap is enforced by the host's Docker storage driver. The unit test verifies the **flag is emitted**; actual byte-level enforcement depends on the worker host's driver (overlay2+xfs/btrfs pquota, or devicemapper). On Server B this should be validated against the live driver before relying on the cap operationally.
- `resolve_bash_timeout_ceiling` adds one cheap DB read per bash call (dwarfed by the container exec it gates). If that ever shows up in profiling, it can be cached on the session handle — not done here to keep the change minimal and to pick up env-config edits without a worker restart.
