### PR TITLE
feat(sessions): derive last_event_at from the newest event in list_sessions

### DIFF
--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -130,13 +130,18 @@ async def _list_scoped[T](
     limit: int = 50,
     after: str | None = None,
     filters: list[tuple[str, Any]] | None = None,
+    extra_select: str | None = None,
 ) -> list[T]:
     """Keyset-paginated SELECT scoped by ``account_id`` + ``archived_at IS NULL``.
 
     ``filters`` is a list of ``(column, value)`` equality predicates;
     entries whose ``value`` is ``None`` are skipped (mirrors the per-arg
     ``if x is not None`` guards in the originals).  ``column`` names are
-    static literals from this module — never user input."""
+    static literals from this module — never user input.
+
+    ``extra_select`` is an optional SQL expression (a static literal from
+    this module, never user input) appended to the projection — e.g. a
+    correlated subquery that derives a column the base table doesn't store."""
     args: list[Any] = [account_id]
     where = ["archived_at IS NULL", "account_id = $1"]
     for column, value in filters or []:
@@ -148,7 +153,8 @@ async def _list_scoped[T](
         args.append(after)
         where.append(f"id < ${len(args)}")
     args.append(limit)
-    sql = f"SELECT * FROM {table} WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ${len(args)}"
+    select = f"{table}.*" + (f", {extra_select}" if extra_select else "")
+    sql = f"SELECT {select} FROM {table} WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ${len(args)}"
     return [row(r) for r in await conn.fetch(sql, *args)]
 
 
@@ -801,6 +807,9 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         archived_at=row["archived_at"],
         focal_channel=row["focal_channel"],
         focal_locked=row["focal_locked"],
+        # Present only when the query derives it (list_sessions); other callers
+        # (single read, INSERT ... RETURNING) leave it None.
+        last_event_at=row.get("last_event_at"),
     )
 
 
@@ -993,6 +1002,14 @@ async def list_sessions(
         limit=limit,
         after=after,
         filters=[("agent_id", agent_id), ("status", status)],
+        # Derive last-activity = timestamp of the session's newest event.
+        # ``ORDER BY seq DESC LIMIT 1`` rides the (session_id, seq) index, so
+        # it's O(log n) even for huge sessions (unlike MAX(created_at), which
+        # has no supporting index).
+        extra_select=(
+            "(SELECT e.created_at FROM events e WHERE e.session_id = sessions.id "
+            "ORDER BY e.seq DESC LIMIT 1) AS last_event_at"
+        ),
     )
 
 

--- a/tests/integration/test_list_sessions_last_event_at.py
+++ b/tests/integration/test_list_sessions_last_event_at.py
@@ -1,0 +1,67 @@
+"""Integration test: ``list_sessions`` derives ``last_event_at`` from the
+session's newest event (a correlated subquery in ``_list_scoped``).
+
+Before this, ``last_event_at`` was never populated on reads, so the console's
+Sessions "Last activity" column fell back to ``created_at`` for every row.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+class TestListSessionsLastEventAt:
+    async def test_last_event_at_tracks_newest_event(
+        self, migrated_db_url: str, _reset_db_state: None
+    ) -> None:
+        pool: asyncpg.Pool[Any] = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                    "VALUES ('acc_lea', NULL, TRUE, 'last-event-at-test')"
+                )
+            _agent, _env, session = await seed_agent_env_session(
+                pool, account_id="acc_lea", prefix="lea"
+            )
+
+            # No events yet → the subquery yields NULL → None.
+            async with pool.acquire() as conn:
+                sessions = await queries.list_sessions(conn, account_id="acc_lea")
+            s = next(x for x in sessions if x.id == session.id)
+            assert s.last_event_at is None
+
+            # After appending events, last_event_at = the newest event's time,
+            # which is strictly after the session's created_at.
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn,
+                    account_id="acc_lea",
+                    session_id=session.id,
+                    kind="message",
+                    data={"role": "user", "content": "hi"},
+                )
+                await queries.append_event(
+                    conn,
+                    account_id="acc_lea",
+                    session_id=session.id,
+                    kind="message",
+                    data={"role": "assistant", "content": "yo"},
+                )
+
+            async with pool.acquire() as conn:
+                sessions = await queries.list_sessions(conn, account_id="acc_lea")
+            s = next(x for x in sessions if x.id == session.id)
+            assert s.last_event_at is not None
+            assert s.last_event_at >= s.created_at
+        finally:
+            await pool.close()


### PR DESCRIPTION
The `Session` model has a `last_event_at` field that was **never populated on reads**, so the console's Sessions "Last activity" column fell back to `created_at` for every row (round-3 console feedback R3-P1).

Populate it via a correlated subquery added as an optional `extra_select` on `_list_scoped`, wired through `list_sessions`:
```sql
(SELECT created_at FROM events WHERE session_id = sessions.id ORDER BY seq DESC LIMIT 1) AS last_event_at
```
`ORDER BY seq DESC LIMIT 1` rides the existing `(session_id, seq)` index — O(log n) even for the 275k-event session (vs `MAX(created_at)`, which has no supporting index). `_row_to_session` reads it defensively (`row.get`) so the single-read and `INSERT … RETURNING` callers are unaffected (stay `None`). No schema/OpenAPI change (the field already existed).

**Verified:** ruff + mypy clean; full test suite (1682) green; new `tests/integration/test_list_sessions_last_event_at.py` covers null-when-empty + tracks-newest-event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)