### PR TITLE
fix(sandbox): evict stale sandbox on session resource mutation

### DIFF
--- a/migrations/versions/0077_sessions_spec_version.py
+++ b/migrations/versions/0077_sessions_spec_version.py
@@ -1,0 +1,87 @@
+"""Sessions ``spec_version`` + bump triggers for sandbox staleness probe (#713).
+
+The worker's :class:`aios.sandbox.registry.SandboxRegistry` caches a live
+:class:`SandboxHandle` per session across steps. When a session-scoped
+resource changes between steps, the cached sandbox no longer reflects
+:func:`aios.sandbox.spec.build_spec_from_session` and must be recycled.
+The write-path eviction (Layer 1) is a no-op in the API process (the
+registry global is worker-only) and invisible to direct-SQL mutations,
+so we add a version probe (Layer 2): a monotonically-incrementing
+``sessions.spec_version`` the registry stamps onto each cached handle and
+re-reads on a warm hit, recycling on mismatch.
+
+Only the tables that actually feed ``build_spec_from_session`` get a bump
+trigger:
+
+- ``session_memory_stores`` — drives the ``/mnt/memory/*`` bind mounts.
+- ``session_github_repositories`` — drives the cloned working-tree mounts.
+
+``session_scheduled_tasks`` (read per-turn by the scheduled-task runner,
+never by the spec builder) and ``session_vaults`` / connection bindings
+(reach the agent via the MCP pool / per-step tool provider, not the
+sandbox spec) deliberately get NO bump trigger. This Layer1/Layer2
+asymmetry is intentional — Layer 1 still evicts on vault/connection
+binding changes as defense-in-depth, but Layer 2 only fires on changes
+that genuinely alter the sandbox spec. We do NOT touch migration 0059's
+``notify_scheduled_tasks_due`` / ``session_scheduled_tasks_notify``
+trigger; the two coexist on different tables.
+
+``set_session_resources`` (DELETE-all + re-INSERT N) bumps
+``spec_version`` by N+M within a single transaction — that's fine: the
+registry only ever compares the version for inequality, never for an
+exact delta.
+
+Revision ID: 0077
+Revises: 0076
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0077"
+down_revision: str = "0076"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN spec_version integer NOT NULL DEFAULT 0")
+    op.execute(r"""
+        CREATE OR REPLACE FUNCTION bump_session_spec_version() RETURNS TRIGGER AS $$
+        BEGIN
+            UPDATE sessions
+               SET spec_version = spec_version + 1
+             WHERE id = COALESCE(NEW.session_id, OLD.session_id);
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+    """)
+    op.execute("""
+        CREATE TRIGGER session_memory_stores_bump_spec_version
+        AFTER INSERT OR UPDATE OR DELETE ON session_memory_stores
+        FOR EACH ROW
+        EXECUTE FUNCTION bump_session_spec_version()
+    """)
+    op.execute("""
+        CREATE TRIGGER session_github_repositories_bump_spec_version
+        AFTER INSERT OR UPDATE OR DELETE ON session_github_repositories
+        FOR EACH ROW
+        EXECUTE FUNCTION bump_session_spec_version()
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP TRIGGER IF EXISTS session_github_repositories_bump_spec_version "
+        "ON session_github_repositories"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS session_memory_stores_bump_spec_version "
+        "ON session_memory_stores"
+    )
+    op.execute("DROP FUNCTION IF EXISTS bump_session_spec_version()")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS spec_version")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1372,10 +1372,17 @@ async def get_session_provisioning(
     session_id: str,
     *,
     account_id: str,
-) -> tuple[str, dict[str, str]]:
-    """Return ``(workspace_volume_path, env)`` for provisioning a session's container."""
+) -> tuple[str, dict[str, str], int]:
+    """Return ``(workspace_volume_path, env, spec_version)`` for provisioning
+    a session's container.
+
+    ``spec_version`` (issue #713) is the snapshot the backend stamps onto
+    the :class:`SandboxHandle` so the registry can detect drift on a warm
+    hit and recycle the cached sandbox.
+    """
     row = await conn.fetchrow(
-        "SELECT workspace_volume_path, env FROM sessions WHERE id = $1 AND account_id = $2",
+        "SELECT workspace_volume_path, env, spec_version "
+        "FROM sessions WHERE id = $1 AND account_id = $2",
         session_id,
         account_id,
     )
@@ -1383,7 +1390,29 @@ async def get_session_provisioning(
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
     raw_env = row["env"]
     env: dict[str, str] = parse_jsonb(raw_env)
-    return row["workspace_volume_path"], env
+    return row["workspace_volume_path"], env, row["spec_version"]
+
+
+async def get_session_spec_version(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+) -> int:
+    """Return the session's current ``spec_version`` (issue #713).
+
+    Used by the registry's warm-hit staleness probe to compare the live
+    value against the snapshot stamped onto the cached
+    :class:`SandboxHandle`.
+    """
+    row = await conn.fetchrow(
+        "SELECT spec_version FROM sessions WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
+    )
+    if row is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    return int(row["spec_version"])
 
 
 async def list_sessions(

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1393,28 +1393,6 @@ async def get_session_provisioning(
     return row["workspace_volume_path"], env, row["spec_version"]
 
 
-async def get_session_spec_version(
-    conn: asyncpg.Connection[Any],
-    session_id: str,
-    *,
-    account_id: str,
-) -> int:
-    """Return the session's current ``spec_version`` (issue #713).
-
-    Used by the registry's warm-hit staleness probe to compare the live
-    value against the snapshot stamped onto the cached
-    :class:`SandboxHandle`.
-    """
-    row = await conn.fetchrow(
-        "SELECT spec_version FROM sessions WHERE id = $1 AND account_id = $2",
-        session_id,
-        account_id,
-    )
-    if row is None:
-        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
-    return int(row["spec_version"])
-
-
 async def list_sessions(
     conn: asyncpg.Connection[Any],
     *,
@@ -7203,6 +7181,26 @@ async def unscoped_live_session_account_id(
         session_id,
     )
     return account_id
+
+
+async def unscoped_get_session_spec_version(conn: asyncpg.Connection[Any], session_id: str) -> int:
+    """Return the session's current ``spec_version`` (issue #713).
+
+    Used by the registry's warm-hit staleness probe to compare the live
+    value against the snapshot stamped onto the cached
+    :class:`SandboxHandle`. Unscoped for the same reason as the account-id
+    bootstrap above: the probe runs worker-internal, keyed only by the
+    session_id the worker already holds — deriving ``account_id`` from the
+    row just to filter the same row by it would cost a second round-trip
+    on every warm tool call for no added protection.
+    """
+    row = await conn.fetchrow(
+        "SELECT spec_version FROM sessions WHERE id = $1",
+        session_id,
+    )
+    if row is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    return int(row["spec_version"])
 
 
 # ─── account management (#367 PR 7) ───────────────────────────────────────────

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -83,6 +83,11 @@ class SandboxSpec:
     populated ``extra_mounts``; the backend stamps it onto the handle
     it returns so the registry's drift detector can compare it against
     the current echo set on each step.
+
+    ``spec_version`` is the ``sessions.spec_version`` snapshot at build
+    time (issue #713). The backend copies it onto the handle so the
+    registry can re-read the current version on a warm hit and recycle
+    the sandbox when a session-scoped resource changed between steps.
     """
 
     session_id: str
@@ -95,6 +100,11 @@ class SandboxSpec:
     host_gateway_alias: str | None
     image: str
     mount_snapshot: frozenset[tuple[str, ...]] = frozenset()
+    # ``sessions.spec_version`` snapshot at build time (issue #713). Bumped
+    # by Postgres triggers on the resource tables that feed this spec
+    # (``session_memory_stores`` / ``session_github_repositories``); the
+    # registry's warm-hit probe compares it against the current value.
+    spec_version: int = 0
     # Per-sandbox resource caps (multi-tenancy hardening — #367 PR 9).
     # ``None`` leaves the host's default in place. The spec builder
     # populates these from the AIOS_SANDBOX_* settings; the backend
@@ -123,12 +133,20 @@ class SandboxHandle:
     have changed since the sandbox was provisioned (e.g. a memory store
     was attached or detached) — see
     :meth:`SandboxRegistry.release_if_mounts_changed`.
+
+    ``spec_version`` is the provision-time snapshot of
+    ``sessions.spec_version`` (issue #713). The registry's staleness
+    probe re-reads the current version on a warm hit and recycles the
+    cached sandbox when it has drifted past this snapshot — catching the
+    API-process and direct-SQL mutation gaps the write-path eviction
+    can't see.
     """
 
     session_id: str
     sandbox_id: str
     workspace_path: Path
     mount_snapshot: frozenset[tuple[str, ...]] = frozenset()
+    spec_version: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -150,6 +150,7 @@ class DockerBackend:
             sandbox_id=container_id,
             workspace_path=spec.workspace.host_path,
             mount_snapshot=spec.mount_snapshot,
+            spec_version=spec.spec_version,
         )
 
     async def exec(

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -31,6 +31,7 @@ import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
+from aios.db import queries
 from aios.logging import get_logger
 from aios.sandbox.backends.base import CommandResult, SandboxBackend, SandboxHandle
 from aios.sandbox.git_proxy import GitProxy
@@ -107,6 +108,19 @@ class SandboxRegistry:
         resources are recycled and a fresh sandbox provisioned under the
         per-session lock.
 
+        A second warm-hit probe re-reads ``sessions.spec_version`` and
+        recycles the (still-alive) sandbox when it has drifted past the
+        snapshot stamped on the handle (issue #713). A memory store or
+        github repo attached/detached between steps bumps ``spec_version``
+        via a Postgres trigger; the next step would otherwise reuse a
+        sandbox whose mounts no longer match
+        :func:`build_spec_from_session`. The version probe only runs when
+        a ``pool`` is supplied (the cold-start span path already passes
+        one) and is best-effort — a transient DB error returns the live
+        handle rather than churning a healthy sandbox. A drifted version
+        falls through to the same stale-handle recycle path as a dead
+        liveness probe.
+
         Best-effort, not a hard guarantee. The probe runs lock-free, so a
         container can still die between the probe and the caller's use,
         and a concurrent ``release``/reaper (which DO hold the per-session
@@ -118,8 +132,15 @@ class SandboxRegistry:
         """
         handle = self._handles.get(session_id)
         if handle is not None and await self._backend.is_alive(handle):
-            self._last_used[session_id] = time.monotonic()
-            return handle
+            if pool is None or not await self._spec_version_changed(session_id, handle, pool):
+                self._last_used[session_id] = time.monotonic()
+                return handle
+            log.info(
+                "sandbox.spec_version_drift_recycling",
+                session_id=session_id,
+                container_id=handle.sandbox_id[:12],
+                handle_spec_version=handle.spec_version,
+            )
 
         # ``handle`` is the dead reference we just probed (or None on a cold
         # miss). Capture it: under the lock, a *different* cached handle means
@@ -152,6 +173,36 @@ class SandboxRegistry:
             self._handles[session_id] = handle
             self._last_used[session_id] = time.monotonic()
             return handle
+
+    async def _spec_version_changed(
+        self, session_id: str, handle: SandboxHandle, pool: asyncpg.Pool[Any]
+    ) -> bool:
+        """Return True iff ``sessions.spec_version`` drifted past the handle's
+        snapshot (issue #713).
+
+        Best-effort: any exception (transient DB error, session vanished)
+        returns ``False`` so a healthy sandbox isn't recycled over a blip.
+        The deferred ``sessions`` import matches the cycle-avoidance pattern
+        in :meth:`_provision_with_span` (the runtime module lists this
+        module under ``TYPE_CHECKING``); ``queries`` is imported at module
+        top, same as :mod:`aios.sandbox.spec`.
+        """
+        from aios.services import sessions as sessions_service
+
+        try:
+            account_id = await sessions_service.load_session_account_id(pool, session_id)
+            async with pool.acquire() as conn:
+                current = await queries.get_session_spec_version(
+                    conn, session_id, account_id=account_id
+                )
+        except Exception as err:
+            log.warning(
+                "sandbox.spec_version_probe_failed",
+                session_id=session_id,
+                error=str(err),
+            )
+            return False
+        return current != handle.spec_version
 
     async def _provision_with_span(
         self, session_id: str, *, pool: asyncpg.Pool[Any] | None

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -118,8 +118,10 @@ class SandboxRegistry:
         a ``pool`` is supplied (the cold-start span path already passes
         one) and is best-effort — a transient DB error returns the live
         handle rather than churning a healthy sandbox. A drifted version
-        falls through to the same stale-handle recycle path as a dead
-        liveness probe.
+        triggers a recycle: the alive container is explicitly destroyed
+        via ``_destroy_quietly`` before re-provisioning so it doesn't
+        run until the next worker restart the way a dead-container evict
+        would.
 
         Best-effort, not a hard guarantee. The probe runs lock-free, so a
         container can still die between the probe and the caller's use,
@@ -131,10 +133,12 @@ class SandboxRegistry:
         not every TOCTOU window.
         """
         handle = self._handles.get(session_id)
+        spec_version_drifted = False
         if handle is not None and await self._backend.is_alive(handle):
             if pool is None or not await self._spec_version_changed(session_id, handle, pool):
                 self._last_used[session_id] = time.monotonic()
                 return handle
+            spec_version_drifted = True
             log.info(
                 "sandbox.spec_version_drift_recycling",
                 session_id=session_id,
@@ -142,12 +146,13 @@ class SandboxRegistry:
                 handle_spec_version=handle.spec_version,
             )
 
-        # ``handle`` is the dead reference we just probed (or None on a cold
-        # miss). Capture it: under the lock, a *different* cached handle means
-        # a concurrent caller already recycled+reprovisioned while we waited,
-        # and we trust theirs without a second probe (they validated it micro-
-        # seconds ago via backend.create). Only when the cached handle is still
-        # the same dead one do we recycle it.
+        # ``handle`` is the dead or spec-version-drifted reference we just
+        # probed (or None on a cold miss). Capture it: under the lock, a
+        # *different* cached handle means a concurrent caller already
+        # recycled+reprovisioned while we waited, and we trust theirs without
+        # a second probe (they validated it micro-seconds ago via
+        # backend.create). Only when the cached handle is still the same one
+        # do we recycle it.
         stale = handle
         async with self._lock_for(session_id):
             current = self._handles.get(session_id)
@@ -155,20 +160,31 @@ class SandboxRegistry:
                 self._last_used[session_id] = time.monotonic()
                 return current
             if current is not None:
-                log.warning(
-                    "sandbox.stale_handle_recycling",
-                    session_id=session_id,
-                    container_id=current.sandbox_id[:12],
-                )
-                # Recycle the dead container's host-side resources (proxy,
-                # broker secret) but DELIBERATELY keep the session-level
-                # runtime caches: we're mid-step and about to hand a fresh
-                # sandbox back to the same step. ``_session_memory_mounts``
-                # in particular is consumed by the bash memory-reconcile that
-                # runs right after this returns (bash.py snapshots it *after*
-                # get_or_provision); clearing it here would make the before/
-                # after diff empty and silently drop the step's memory writes.
-                self.evict(session_id, unload_session_caches=False)
+                if spec_version_drifted:
+                    # Container is still alive — must destroy it, not just
+                    # evict (evict drops the cache entry but skips
+                    # backend.destroy, which is correct for dead containers
+                    # but would leak a live one). _destroy_quietly is
+                    # best-effort so a Docker hiccup doesn't block
+                    # re-provisioning (#713).
+                    self.evict(session_id, unload_session_caches=False)
+                    await self._destroy_quietly(current, session_id)
+                else:
+                    log.warning(
+                        "sandbox.stale_handle_recycling",
+                        session_id=session_id,
+                        container_id=current.sandbox_id[:12],
+                    )
+                    # Recycle the dead container's host-side resources (proxy,
+                    # broker secret) but DELIBERATELY keep the session-level
+                    # runtime caches: we're mid-step and about to hand a fresh
+                    # sandbox back to the same step. ``_session_memory_mounts``
+                    # in particular is consumed by the bash memory-reconcile
+                    # that runs right after this returns (bash.py snapshots it
+                    # *after* get_or_provision); clearing it here would make
+                    # the before/after diff empty and silently drop the step's
+                    # memory writes.
+                    self.evict(session_id, unload_session_caches=False)
             handle = await self._provision_with_span(session_id, pool=pool)
             self._handles[session_id] = handle
             self._last_used[session_id] = time.monotonic()

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -198,19 +198,12 @@ class SandboxRegistry:
 
         Best-effort: any exception (transient DB error, session vanished)
         returns ``False`` so a healthy sandbox isn't recycled over a blip.
-        The deferred ``sessions`` import matches the cycle-avoidance pattern
-        in :meth:`_provision_with_span` (the runtime module lists this
-        module under ``TYPE_CHECKING``); ``queries`` is imported at module
-        top, same as :mod:`aios.sandbox.spec`.
+        One unscoped round-trip — this runs on every warm hit (every tool
+        call reusing a live sandbox), so it must stay a single query.
         """
-        from aios.services import sessions as sessions_service
-
         try:
-            account_id = await sessions_service.load_session_account_id(pool, session_id)
             async with pool.acquire() as conn:
-                current = await queries.get_session_spec_version(
-                    conn, session_id, account_id=account_id
-                )
+                current = await queries.unscoped_get_session_spec_version(conn, session_id)
         except Exception as err:
             log.warning(
                 "sandbox.spec_version_probe_failed",

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -189,8 +189,9 @@ async def resolve_bash_timeout_ceiling(session_id: str) -> int:
 
 async def _load_session_provisioning(
     session_id: str, *, account_id: str
-) -> tuple[str, dict[str, str]]:
-    """Load workspace path and env from the session row in one query."""
+) -> tuple[str, dict[str, str], int]:
+    """Load workspace path, env, and ``spec_version`` from the session row
+    in one query (issue #713 adds ``spec_version`` to the tuple)."""
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
@@ -360,7 +361,9 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
 
     settings = get_settings()
     account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
-    raw_path, session_env = await _load_session_provisioning(session_id, account_id=account_id)
+    raw_path, session_env, spec_version = await _load_session_provisioning(
+        session_id, account_id=account_id
+    )
     # Re-validate at the bind-mount boundary: ``validate_workspace_path``
     # also runs at session-create time, but a symlink swap on any
     # directory component of ``raw_path`` between then and now would
@@ -421,6 +424,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             tool_broker_url=tool_broker_url,
             tool_broker_secret=tool_broker_secret,
             tool_socket_host_path=tool_socket_host_path,
+            spec_version=spec_version,
         )
     except BaseException:
         # Both proxies hold worker-process state (ports, token maps,
@@ -456,6 +460,7 @@ def _assemble_plan(
     tool_broker_secret: str,
     tool_socket_host_path: Path | None = None,
     disk_bytes: int | None = None,
+    spec_version: int = 0,
 ) -> ProvisioningPlan:
     """Pure assembly of the plan from already-materialized inputs.
 
@@ -579,6 +584,10 @@ def _assemble_plan(
         host_gateway_alias=None if is_running_in_container() else WORKER_NETWORK_ALIAS,
         image=image,
         mount_snapshot=snapshot,
+        # Provision-time ``sessions.spec_version`` snapshot (issue #713):
+        # the backend copies it onto the handle so the registry's warm-hit
+        # probe can detect a between-steps resource mutation and recycle.
+        spec_version=spec_version,
         # Resource caps come from deployment-wide settings (multi-tenancy
         # hardening — #367 PR 9). A future revision will let an account
         # override these via the management API; the spec-layer plumbing

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -29,6 +29,7 @@ from aios.models.connections import (
     ConnectionMode,
     RecentChat,
 )
+from aios.services.sessions import _evict_sandbox_for_resource_change
 
 
 def _encrypt_secrets(
@@ -239,6 +240,11 @@ async def attach_connection(
             event="added",
             account_id=account_id,
         )
+    # Connection session-bindings don't feed the sandbox spec (they reach
+    # the agent via the per-step tool provider, not build_spec_from_session);
+    # eviction is defense-in-depth so the next step re-reads cleanly (#713).
+    # Post-commit, worker-only — no-op from the API process.
+    _evict_sandbox_for_resource_change(session_id)
     return connection
 
 
@@ -250,12 +256,20 @@ async def detach_connection(
 
     Refuses (404 / 409) if the connection is missing, archived, or not
     in single_session mode.
+
+    Evicts the previously-bound session's sandbox (#713) so a step that
+    was about to provision against the now-removed binding re-reads the
+    spec. The archived binding row carries the ``session_id``; we recover
+    it from ``_archive_binding_or_raise`` and evict post-commit.
     """
     async with pool.acquire() as conn:
-        await _archive_binding_or_raise(
+        archived = await _archive_binding_or_raise(
             conn, connection_id, expected_mode="single_session", account_id=account_id
         )
-        return await queries.get_connection(conn, connection_id, account_id=account_id)
+        connection = await queries.get_connection(conn, connection_id, account_id=account_id)
+    if archived.session_id is not None:
+        _evict_sandbox_for_resource_change(archived.session_id)
+    return connection
 
 
 async def configure_per_chat(
@@ -270,6 +284,10 @@ async def configure_per_chat(
     and the ``insert_binding`` — that race would otherwise leave an
     archived connection with an active binding (the
     ``bindings.connection_id`` FK accepts archived rows).
+
+    No sandbox eviction (#713): per_chat mode binds a session *template*,
+    not a live session — there is no provisioned sandbox to recycle.
+    Sessions spawned per-chat cold-start from the template at spawn time.
     """
     async with pool.acquire() as conn, conn.transaction():
         locked = await conn.fetchrow(
@@ -305,6 +323,9 @@ async def unconfigure_connection(
 
     Refuses (404 / 409) if the connection is missing, archived, or not
     in per_chat mode.
+
+    No sandbox eviction (#713): a per_chat binding targets a session
+    *template*, never a live session — no provisioned sandbox to recycle.
     """
     async with pool.acquire() as conn:
         await _archive_binding_or_raise(
@@ -319,8 +340,11 @@ async def _archive_binding_or_raise(
     *,
     account_id: str,
     expected_mode: BindingMode,
-) -> None:
+) -> queries.ActiveBinding:
     """Archive the connection's active binding, raising on a mode mismatch.
+
+    Returns the now-archived binding so callers can recover its
+    ``session_id`` (e.g. for sandbox eviction, #713).
 
     Happy path is a single mode-guarded UPDATE-RETURNING.  On miss we
     follow up with a connection read to diagnose: NotFound > archived
@@ -330,7 +354,7 @@ async def _archive_binding_or_raise(
         conn, connection_id, expected_mode=expected_mode, account_id=account_id
     )
     if archived is not None:
-        return
+        return archived
     existing = await queries.get_connection(conn, connection_id, account_id=account_id)
     if existing.archived_at is not None:
         raise ConflictError(

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -67,6 +67,14 @@ async def attach_to_session(
     Caller controls the transaction so a failed attach rolls back the
     earlier session insert (paired flow with
     :func:`aios.services.memory_stores.attach_to_session`).
+
+    Conn-scoped (mid-transaction): does NOT evict the session's sandbox.
+    Github attachments feed build_spec_from_session, so eviction IS
+    required — but it must fire AFTER the parent transaction commits, so
+    :func:`aios.services.sessions.update_session` owns the post-commit
+    eviction hook (#713). Layer 2's ``spec_version`` trigger on
+    ``session_github_repositories`` is the direct-SQL / API-process
+    safety net behind it.
     """
     if not resources:
         return
@@ -108,6 +116,9 @@ async def set_session_resources(
     after the DB swap commits — the per-session ``.git/config`` carries
     the embedded auth token, so leaving them on disk after detach would
     be a slow plaintext-token leak.
+
+    Conn-scoped: sandbox eviction is fired post-commit by
+    :func:`aios.services.sessions.update_session`, not here (#713).
     """
     async with conn.transaction():
         old_ids = await _list_attached_resource_ids(conn, session_id, account_id=account_id)
@@ -121,7 +132,11 @@ async def detach_all_from_session(
 ) -> None:
     """Detach every github_repository from a session and clean up the
     working trees. Used by the full-list-replace path when the new
-    resource list contains no github entries."""
+    resource list contains no github entries.
+
+    Conn-scoped: sandbox eviction is fired post-commit by
+    :func:`aios.services.sessions.update_session`, not here (#713).
+    """
     async with conn.transaction():
         old_ids = await _list_attached_resource_ids(conn, session_id, account_id=account_id)
         await queries.delete_session_github_repos(conn, session_id, account_id=account_id)
@@ -171,6 +186,13 @@ async def rotate_token(
     both fields atomically.  Token-only callers leave ``identity``
     unset and the stored ``git_user_name`` / ``git_user_email`` survive
     the rotation.
+
+    In-place rotation does NOT call the sandbox-eviction hook (#713): the
+    UPDATE bumps the github echo's ``updated_at``, which is part of the
+    ``mount_snapshot`` key (see
+    :func:`aios.sandbox.spec.mount_snapshot_from_echoes`), so the
+    per-step :meth:`SandboxRegistry.release_if_mounts_changed` already
+    recycles the sandbox on the next step.
     """
     blob = _encrypt_token(crypto_box, new_token, account_id=account_id)
     async with pool.acquire() as conn, conn.transaction():

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -129,10 +129,13 @@ async def set_session_resources(
 
 async def detach_all_from_session(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
-) -> None:
+) -> bool:
     """Detach every github_repository from a session and clean up the
     working trees. Used by the full-list-replace path when the new
     resource list contains no github entries.
+
+    Returns whether any attachment was actually removed, so the caller
+    can skip the Layer 1 eviction when there was nothing to detach (#713).
 
     Conn-scoped: sandbox eviction is fired post-commit by
     :func:`aios.services.sessions.update_session`, not here (#713).
@@ -141,6 +144,7 @@ async def detach_all_from_session(
         old_ids = await _list_attached_resource_ids(conn, session_id, account_id=account_id)
         await queries.delete_session_github_repos(conn, session_id, account_id=account_id)
     _purge_working_trees(session_id, old_ids)
+    return bool(old_ids)
 
 
 async def list_session_echoes(

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -107,7 +107,7 @@ async def set_session_resources(
     crypto_box: CryptoBox,
     *,
     account_id: str,
-) -> None:
+) -> bool:
     """Replace attached repositories atomically.
 
     A failed attach rolls back the delete (parent transaction is the
@@ -117,6 +117,12 @@ async def set_session_resources(
     the embedded auth token, so leaving them on disk after detach would
     be a slow plaintext-token leak.
 
+    Always returns True (the changed signal, mirroring the memory-store
+    sibling): a github re-PUT is never idempotent — the incoming
+    ``authorization_token`` is re-encrypted (fresh ciphertext, new
+    ``updated_at``), and ``updated_at`` is deliberately part of the mount
+    snapshot so token rotation reaches the sandbox.
+
     Conn-scoped: sandbox eviction is fired post-commit by
     :func:`aios.services.sessions.update_session`, not here (#713).
     """
@@ -125,6 +131,7 @@ async def set_session_resources(
         await queries.delete_session_github_repos(conn, session_id, account_id=account_id)
         await attach_to_session(conn, session_id, resources, crypto_box, account_id=account_id)
     _purge_working_trees(session_id, old_ids)
+    return True
 
 
 async def detach_all_from_session(

--- a/src/aios/services/memory_stores.py
+++ b/src/aios/services/memory_stores.py
@@ -394,14 +394,30 @@ async def set_session_resources(
     resources: list[MemoryStoreResource],
     *,
     account_id: str,
-) -> None:
+) -> bool:
     """Replace attached stores atomically. A failed attach rolls back the delete.
+
+    Returns whether the attachments changed. An incoming list that matches
+    the current rows is a complete no-op — zero rows touched, so Layer 2's
+    ``spec_version`` trigger stays quiet and the caller skips the Layer 1
+    eviction: an idempotent re-PUT must not recycle the sandbox (#713).
+    The skip also means a re-PUT does not re-snapshot ``name_at_attach``
+    from the parent store, matching the documented echo semantics
+    (snapshots don't follow renames).
 
     Conn-scoped: sandbox eviction is fired post-commit by
     :func:`aios.services.sessions.update_session`, not here (#713).
     """
+    current = await queries.list_session_memory_store_echoes(
+        conn, session_id, account_id=account_id
+    )
+    if [(e.memory_store_id, e.access, e.instructions) for e in current] == [
+        (r.memory_store_id, r.access, r.instructions) for r in resources
+    ]:
+        return False
     async with conn.transaction():
         await conn.execute("DELETE FROM session_memory_stores WHERE session_id = $1", session_id)
         await queries.attach_memory_stores_to_session(
             conn, session_id, resources, account_id=account_id
         )
+    return True

--- a/src/aios/services/memory_stores.py
+++ b/src/aios/services/memory_stores.py
@@ -375,6 +375,13 @@ async def attach_to_session(
 
     Used by the sessions service so that session insert + memory-store
     attaches commit atomically.
+
+    Conn-scoped: does NOT evict the session's sandbox. Memory stores feed
+    build_spec_from_session, so eviction is required — but it must fire
+    AFTER the parent transaction commits, so
+    :func:`aios.services.sessions.update_session` owns the post-commit
+    eviction hook (#713). Layer 2's ``spec_version`` trigger on
+    ``session_memory_stores`` is the direct-SQL / API-process safety net.
     """
     await queries.attach_memory_stores_to_session(
         conn, session_id, resources, account_id=account_id
@@ -388,7 +395,11 @@ async def set_session_resources(
     *,
     account_id: str,
 ) -> None:
-    """Replace attached stores atomically. A failed attach rolls back the delete."""
+    """Replace attached stores atomically. A failed attach rolls back the delete.
+
+    Conn-scoped: sandbox eviction is fired post-commit by
+    :func:`aios.services.sessions.update_session`, not here (#713).
+    """
     async with conn.transaction():
         await conn.execute("DELETE FROM session_memory_stores WHERE session_id = $1", session_id)
         await queries.attach_memory_stores_to_session(

--- a/src/aios/services/scheduled_tasks.py
+++ b/src/aios/services/scheduled_tasks.py
@@ -7,6 +7,12 @@ granular add/remove/update/list operations to the API + tool layers.
 
 Deliberately no whole-list-replace primitive; per #270, the only
 mutation surface is granular ops.
+
+Scheduled tasks do NOT feed :func:`aios.sandbox.spec.build_spec_from_session`
+(the scheduled-task runner reads them per-turn), so mutations here force
+no sandbox eviction and get no Layer 2 ``spec_version`` trigger (#713).
+The existing NOTIFY trigger on ``session_scheduled_tasks`` (migration 0059)
+is untouched.
 """
 
 from __future__ import annotations

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -991,14 +991,9 @@ async def update_session(
                 assert crypto_box is not None, (
                     "API surface requires CryptoBox when attaching github_repository"
                 )
-                await github_repo_service.set_session_resources(
+                changed |= await github_repo_service.set_session_resources(
                     conn, session_id, github_resources, crypto_box, account_id=account_id
                 )
-                # A github re-PUT is never idempotent: the incoming
-                # authorization_token is re-encrypted (fresh ciphertext, new
-                # updated_at), and updated_at is deliberately part of the
-                # mount snapshot so token rotation reaches the sandbox.
-                changed = True
             else:
                 changed |= await github_repo_service.detach_all_from_session(
                     conn, session_id, account_id=account_id

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -120,6 +120,33 @@ async def _batch_list_all_echoes(
     return {sid: [*memory_map[sid], *github_map[sid]] for sid in session_ids}
 
 
+def _evict_sandbox_for_resource_change(session_id: str) -> None:
+    """Force a fresh sandbox provision after a session-scoped resource
+    mutation commits (#713).
+
+    No-op in the API process (the registry global is worker-only); the
+    worker process recycles so the NEXT step re-reads build_spec_from_session.
+    unload_session_caches=False: a between-steps mutation re-provisions
+    cleanly on the next step.
+
+    Memory-store and github-repository bindings feed build_spec_from_session
+    and MUST evict. Vault session-bindings do NOT feed the sandbox spec (they
+    reach the agent via the MCP pool, keyed on (url, vault_id)); we evict
+    anyway as defense-in-depth so 'any session-resource mutation forces a
+    clean re-read' holds — harmless, one extra cold-start. In-place vault
+    credential rotation (refresh_credential / ciphertext overwrite) does NOT
+    evict: the pool keys on (url, vault_id) and a rotation overwrites the row
+    contents, so the stable key already serves the new secret. Layer 2's
+    spec_version triggers are deliberately NOT placed on vault/connection
+    tables (they don't change the spec) — this Layer1/Layer2 asymmetry is
+    intentional.
+    """
+    from aios.harness import runtime
+
+    if runtime.sandbox_registry is not None:
+        runtime.sandbox_registry.evict(session_id, unload_session_caches=False)
+
+
 async def create_session(
     pool: asyncpg.Pool[Any],
     *,
@@ -158,6 +185,10 @@ async def create_session(
     """
     if workspace_path is not None:
         validate_workspace_path(workspace_path, account_id)
+    # No sandbox eviction here (#713): a brand-new session has no cached
+    # sandbox to recycle — its first step cold-starts from the freshly
+    # written spec. Eviction is only meaningful for mutations to an
+    # already-provisioned session (see update_session / connections).
     async with pool.acquire() as conn, conn.transaction():
         session = await queries.insert_session(
             conn,
@@ -964,13 +995,22 @@ async def update_session(
         vids = await queries.get_session_vault_ids(conn, session_id, account_id=account_id)
         echoes = await _list_all_echoes(conn, session_id, account_id=account_id)
         task_echoes = await queries.list_scheduled_tasks(conn, session_id, account_id=account_id)
-        return session.model_copy(
+        result = session.model_copy(
             update={
                 "vault_ids": vids,
                 "resources": echoes,
                 "scheduled_tasks": task_echoes,
             }
         )
+
+    # Eviction fires AFTER the transaction commits — recycling mid-transaction
+    # could re-provision against an uncommitted spec (#713). A resource or
+    # vault-binding change forces the worker to re-read build_spec_from_session
+    # on the next step; no-op in the API process (registry global is
+    # worker-only).
+    if vault_ids is not None or resources is not None:
+        _evict_sandbox_for_resource_change(session_id)
+    return result
 
 
 # ─── tool confirmations ────────────────────────────────────────────────────

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -971,14 +971,20 @@ async def update_session(
             metadata=metadata,
             account_id=account_id,
         )
+        changed = False
         if vault_ids is not None:
-            await queries.set_session_vaults(conn, session_id, vault_ids, account_id=account_id)
+            old_vault_ids = await queries.get_session_vault_ids(
+                conn, session_id, account_id=account_id
+            )
+            if vault_ids != old_vault_ids:
+                await queries.set_session_vaults(conn, session_id, vault_ids, account_id=account_id)
+                changed = True
         if resources is not None:
             # Wire-level semantics is full-list-replace across all
             # resource types, so an incoming list that omits a type
             # detaches every existing attachment of that type.
             memory_resources, github_resources = split_resources_by_type(resources)
-            await memory_service.set_session_resources(
+            changed |= await memory_service.set_session_resources(
                 conn, session_id, memory_resources, account_id=account_id
             )
             if github_resources:
@@ -988,8 +994,13 @@ async def update_session(
                 await github_repo_service.set_session_resources(
                     conn, session_id, github_resources, crypto_box, account_id=account_id
                 )
+                # A github re-PUT is never idempotent: the incoming
+                # authorization_token is re-encrypted (fresh ciphertext, new
+                # updated_at), and updated_at is deliberately part of the
+                # mount snapshot so token rotation reaches the sandbox.
+                changed = True
             else:
-                await github_repo_service.detach_all_from_session(
+                changed |= await github_repo_service.detach_all_from_session(
                     conn, session_id, account_id=account_id
                 )
         vids = await queries.get_session_vault_ids(conn, session_id, account_id=account_id)
@@ -1007,8 +1018,9 @@ async def update_session(
     # could re-provision against an uncommitted spec (#713). A resource or
     # vault-binding change forces the worker to re-read build_spec_from_session
     # on the next step; no-op in the API process (registry global is
-    # worker-only).
-    if vault_ids is not None or resources is not None:
+    # worker-only). An idempotent re-PUT (same vaults, same resources) writes
+    # nothing and must not recycle the sandbox.
+    if changed:
         _evict_sandbox_for_resource_change(session_id)
     return result
 

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -4,6 +4,18 @@ Vaults are named collections of encrypted credentials for authenticated
 outbound services (MCP servers, HTTP APIs). The CryptoBox handles
 encryption/decryption; the service layer validates auth-type-specific
 fields and enforces limits.
+
+Sandbox eviction (#713): session-BINDING changes (which vaults a session
+can reach) flow through :func:`aios.db.queries.set_session_vaults` from
+:func:`aios.services.sessions.update_session`, which fires the post-commit
+sandbox-eviction hook as defense-in-depth. The in-place credential
+mutations here (:func:`refresh_credential`, :func:`update_vault_credential`,
+:func:`create_vault_credential`, and credential archive/delete) do NOT
+evict any sandbox: the MCP pool keys on ``(url, vault_id)`` and a rotation
+overwrites the row contents under that stable key, so the existing key
+already serves the new secret. Vault tables are also deliberately excluded
+from Layer 2's ``spec_version`` triggers — they don't change the sandbox
+spec.
 """
 
 from __future__ import annotations

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -31,6 +31,7 @@ def make_handle(
     sandbox_id: str = "abc123def456abc123def456",
     workspace_path: Path | None = None,
     mount_snapshot: frozenset[tuple[str, ...]] = frozenset(),
+    spec_version: int = 0,
 ) -> SandboxHandle:
     """Construct a :class:`SandboxHandle` with sensible defaults for tests."""
     return SandboxHandle(
@@ -38,6 +39,7 @@ def make_handle(
         sandbox_id=sandbox_id,
         workspace_path=workspace_path or Path("/tmp/aios-test-workspace"),
         mount_snapshot=mount_snapshot,
+        spec_version=spec_version,
     )
 
 
@@ -73,6 +75,7 @@ class FakeBackend:
             sandbox_id=self.next_handle_id,
             workspace_path=spec.workspace.host_path,
             mount_snapshot=spec.mount_snapshot,
+            spec_version=spec.spec_version,
         )
 
     async def is_alive(self, handle: SandboxHandle) -> bool:

--- a/tests/integration/test_session_resource_eviction.py
+++ b/tests/integration/test_session_resource_eviction.py
@@ -244,9 +244,7 @@ async def test_update_session_idempotent_memory_resources_does_not_evict(
         pool, session_id, account_id=_ACCOUNT_ID, resources=resources
     )
     async with pool.acquire() as conn:
-        version_before = await queries.get_session_spec_version(
-            conn, session_id, account_id=_ACCOUNT_ID
-        )
+        version_before = await queries.unscoped_get_session_spec_version(conn, session_id)
     spy = _install_spy(monkeypatch)
 
     await sessions_service.update_session(
@@ -255,9 +253,7 @@ async def test_update_session_idempotent_memory_resources_does_not_evict(
 
     spy.evict.assert_not_called()
     async with pool.acquire() as conn:
-        version_after = await queries.get_session_spec_version(
-            conn, session_id, account_id=_ACCOUNT_ID
-        )
+        version_after = await queries.unscoped_get_session_spec_version(conn, session_id)
     assert version_after == version_before
 
 

--- a/tests/integration/test_session_resource_eviction.py
+++ b/tests/integration/test_session_resource_eviction.py
@@ -21,6 +21,9 @@ Coverage:
   defense-in-depth (they do NOT feed the spec, but Layer 1 evicts on any
   session-resource mutation).
 - a title-only ``update_session`` and ``create_session`` do NOT evict.
+- an idempotent re-PUT (same memory resources, same vault ids, or an
+  empty list on an empty session) writes nothing: no eviction AND no
+  ``spec_version`` bump, so neither layer recycles the sandbox.
 - connection attach/detach evict the bound session (defense-in-depth).
 - in-place vault credential rotation does NOT evict (the MCP pool keys on
   ``(url, vault_id)`` and the row contents are overwritten in place).
@@ -213,6 +216,81 @@ async def test_create_session_does_not_evict(
         ],
         crypto_box=crypto_box,
     )
+
+    spy.evict.assert_not_called()
+
+
+async def test_update_session_idempotent_memory_resources_does_not_evict(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A re-PUT of the current resource list writes nothing: no Layer-1
+    eviction and no Layer-2 ``spec_version`` bump (the triggers fire per
+    affected row, and a no-op touches zero rows). Companion to the e2e
+    ``test_idempotent_update_does_not_recycle``."""
+    pool, session_id, _crypto_box = env
+    store = await memory_stores_service.create_store(
+        pool, account_id=_ACCOUNT_ID, name="idem-notes", description="d", metadata={}
+    )
+    resources = [
+        MemoryStoreResource(
+            type="memory_store",
+            memory_store_id=store.id,
+            access="read_write",
+            instructions="keep",
+        )
+    ]
+    await sessions_service.update_session(
+        pool, session_id, account_id=_ACCOUNT_ID, resources=resources
+    )
+    async with pool.acquire() as conn:
+        version_before = await queries.get_session_spec_version(
+            conn, session_id, account_id=_ACCOUNT_ID
+        )
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.update_session(
+        pool, session_id, account_id=_ACCOUNT_ID, resources=resources
+    )
+
+    spy.evict.assert_not_called()
+    async with pool.acquire() as conn:
+        version_after = await queries.get_session_spec_version(
+            conn, session_id, account_id=_ACCOUNT_ID
+        )
+    assert version_after == version_before
+
+
+async def test_update_session_idempotent_vault_binding_does_not_evict(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool, session_id, _crypto_box = env
+    vault = await vaults_service.create_vault(
+        pool, account_id=_ACCOUNT_ID, display_name="idem-creds", metadata={}
+    )
+    await sessions_service.update_session(
+        pool, session_id, account_id=_ACCOUNT_ID, vault_ids=[vault.id]
+    )
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.update_session(
+        pool, session_id, account_id=_ACCOUNT_ID, vault_ids=[vault.id]
+    )
+
+    spy.evict.assert_not_called()
+
+
+async def test_update_session_empty_resources_on_empty_session_does_not_evict(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``resources=[]`` against a session with no attachments detaches
+    nothing — no eviction."""
+    pool, session_id, _crypto_box = env
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.update_session(pool, session_id, account_id=_ACCOUNT_ID, resources=[])
 
     spy.evict.assert_not_called()
 

--- a/tests/integration/test_session_resource_eviction.py
+++ b/tests/integration/test_session_resource_eviction.py
@@ -1,0 +1,296 @@
+"""Integration tests for Layer-1 write-path sandbox eviction (#713).
+
+When a session-scoped resource that feeds
+:func:`aios.sandbox.spec.build_spec_from_session` is mutated, the worker
+must force the next step to re-provision a fresh sandbox. The mechanism
+is :func:`aios.services.sessions._evict_sandbox_for_resource_change`,
+which calls ``runtime.sandbox_registry.evict(session_id,
+unload_session_caches=False)`` AFTER the mutation transaction commits.
+
+``runtime.sandbox_registry`` is populated only in the WORKER process, so
+the helper is a real eviction in-worker and a safe no-op from an API
+route (where the global is ``None``). These tests stand in a spy for the
+registry global to assert the eviction fires for the right mutations and
+stays silent for the ones that don't touch the spec.
+
+Coverage:
+
+- memory-store and github-repository resource changes via
+  ``update_session`` evict (they feed the spec).
+- vault session-BINDING changes via ``update_session`` evict as
+  defense-in-depth (they do NOT feed the spec, but Layer 1 evicts on any
+  session-resource mutation).
+- a title-only ``update_session`` and ``create_session`` do NOT evict.
+- connection attach/detach evict the bound session (defense-in-depth).
+- in-place vault credential rotation does NOT evict (the MCP pool keys on
+  ``(url, vault_id)`` and the row contents are overwritten in place).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import asyncpg
+import pytest
+from pydantic import SecretStr
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.harness import runtime
+from aios.models.github_repositories import GithubRepositoryResource
+from aios.models.memory_stores import MemoryStoreResource
+from aios.models.vaults import VaultCredentialCreate
+from aios.services import connections as connections_service
+from aios.services import memory_stores as memory_stores_service
+from aios.services import sessions as sessions_service
+from aios.services import vaults as vaults_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT_ID = "acc_evict"
+
+
+@pytest.fixture
+async def env(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, CryptoBox]]:
+    """Yield ``(pool, session_id, crypto_box)`` for a freshly-seeded session."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    crypto_box = CryptoBox(os.urandom(32))
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ($1, NULL, TRUE, 'evict-test')
+                """,
+                _ACCOUNT_ID,
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id=_ACCOUNT_ID, prefix="evict"
+        )
+        yield pool, session.id, crypto_box
+    finally:
+        await pool.close()
+
+
+def _install_spy(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stand a spy in for the worker-only registry global.
+
+    ``evict`` is a SYNCHRONOUS method, so the spy uses a plain
+    ``MagicMock`` (not ``AsyncMock``) — the production helper must not
+    await it.
+    """
+    spy = MagicMock()
+    monkeypatch.setattr(runtime, "sandbox_registry", spy)
+    return spy
+
+
+# ── update_session: resources that feed the spec ────────────────────────────
+
+
+async def test_update_session_memory_resources_evicts(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool, session_id, _crypto_box = env
+    store = await memory_stores_service.create_store(
+        pool, account_id=_ACCOUNT_ID, name="notes", description="d", metadata={}
+    )
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.update_session(
+        pool,
+        session_id,
+        account_id=_ACCOUNT_ID,
+        resources=[
+            MemoryStoreResource(
+                type="memory_store",
+                memory_store_id=store.id,
+                access="read_write",
+                instructions="",
+            )
+        ],
+    )
+
+    spy.evict.assert_called_once_with(session_id, unload_session_caches=False)
+
+
+async def test_update_session_github_resources_evicts(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool, session_id, crypto_box = env
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.update_session(
+        pool,
+        session_id,
+        account_id=_ACCOUNT_ID,
+        resources=[
+            GithubRepositoryResource(
+                type="github_repository",
+                url="https://github.com/example/repo.git",
+                mount_path="/mnt/repo",
+                authorization_token=SecretStr("ghp_fake_token"),
+                git_user_name="u",
+                git_user_email="u@example.com",
+            )
+        ],
+        crypto_box=crypto_box,
+    )
+
+    spy.evict.assert_called_once_with(session_id, unload_session_caches=False)
+
+
+async def test_update_session_vault_binding_evicts(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Vault session-bindings don't feed the spec, but Layer 1 evicts on
+    any session-resource mutation as defense-in-depth."""
+    pool, session_id, _crypto_box = env
+    vault = await vaults_service.create_vault(
+        pool, account_id=_ACCOUNT_ID, display_name="creds", metadata={}
+    )
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.update_session(
+        pool, session_id, account_id=_ACCOUNT_ID, vault_ids=[vault.id]
+    )
+
+    spy.evict.assert_called_once_with(session_id, unload_session_caches=False)
+
+
+# ── update_session / create_session: no resource change ─────────────────────
+
+
+async def test_update_session_no_resource_or_vault_change_does_not_evict(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool, session_id, _crypto_box = env
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.update_session(pool, session_id, account_id=_ACCOUNT_ID, title="renamed")
+
+    spy.evict.assert_not_called()
+
+
+async def test_create_session_does_not_evict(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A brand-new session has no cached sandbox to recycle."""
+    pool, _session_id, crypto_box = env
+    agent, environment, _seed = await seed_agent_env_session(
+        pool, account_id=_ACCOUNT_ID, prefix="evict-create"
+    )
+    store = await memory_stores_service.create_store(
+        pool, account_id=_ACCOUNT_ID, name="cs-notes", description="d", metadata={}
+    )
+    spy = _install_spy(monkeypatch)
+
+    await sessions_service.create_session(
+        pool,
+        account_id=_ACCOUNT_ID,
+        agent_id=agent.id,
+        environment_id=environment.id,
+        title="fresh",
+        metadata={},
+        resources=[
+            MemoryStoreResource(
+                type="memory_store",
+                memory_store_id=store.id,
+                access="read_write",
+                instructions="",
+            )
+        ],
+        crypto_box=crypto_box,
+    )
+
+    spy.evict.assert_not_called()
+
+
+# ── connections: session-binding changes ────────────────────────────────────
+
+
+async def test_connection_attach_evicts(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool, session_id, _crypto_box = env
+    async with pool.acquire() as conn:
+        connection = await queries.insert_connection(
+            conn,
+            connector="echo",
+            external_account_id="acct-attach",
+            metadata={},
+            account_id=_ACCOUNT_ID,
+        )
+    spy = _install_spy(monkeypatch)
+
+    await connections_service.attach_connection(
+        pool, connection.id, session_id=session_id, account_id=_ACCOUNT_ID
+    )
+
+    spy.evict.assert_called_once_with(session_id, unload_session_caches=False)
+
+
+async def test_connection_detach_evicts(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool, session_id, _crypto_box = env
+    async with pool.acquire() as conn:
+        connection = await queries.insert_connection(
+            conn,
+            connector="echo",
+            external_account_id="acct-detach",
+            metadata={},
+            account_id=_ACCOUNT_ID,
+        )
+    # Attach without the spy so only the detach is observed.
+    await connections_service.attach_connection(
+        pool, connection.id, session_id=session_id, account_id=_ACCOUNT_ID
+    )
+    spy = _install_spy(monkeypatch)
+
+    await connections_service.detach_connection(pool, connection.id, account_id=_ACCOUNT_ID)
+
+    spy.evict.assert_called_once_with(session_id, unload_session_caches=False)
+
+
+# ── vaults: in-place credential rotation must NOT evict ─────────────────────
+
+
+async def test_vault_credential_rotation_does_not_evict(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Creating/rotating a credential inside a vault overwrites the row the
+    MCP pool already keys on ``(url, vault_id)``; no sandbox eviction."""
+    pool, _session_id, crypto_box = env
+    vault = await vaults_service.create_vault(
+        pool, account_id=_ACCOUNT_ID, display_name="creds", metadata={}
+    )
+    spy = _install_spy(monkeypatch)
+
+    await vaults_service.create_vault_credential(
+        pool,
+        crypto_box,
+        account_id=_ACCOUNT_ID,
+        vault_id=vault.id,
+        body=VaultCredentialCreate(
+            target_url="https://mcp.example.com",
+            auth_type="bearer_header",
+            token=SecretStr("secret-token"),
+        ),
+    )
+
+    spy.evict.assert_not_called()

--- a/tests/integration/test_spec_version_triggers.py
+++ b/tests/integration/test_spec_version_triggers.py
@@ -1,0 +1,257 @@
+"""Integration tests for the ``sessions.spec_version`` bump triggers (#713).
+
+Migration 0077 stamps an integer ``spec_version`` on ``sessions`` and
+installs AFTER INSERT/UPDATE/DELETE triggers on the two resource tables
+that actually feed :func:`aios.sandbox.spec.build_spec_from_session` —
+``session_memory_stores`` and ``session_github_repositories``. Every
+mutation of those tables bumps the owning session's ``spec_version`` so
+the worker's :class:`aios.sandbox.registry.SandboxRegistry` can detect
+drift on a warm hit and recycle the cached sandbox.
+
+Tables that do NOT feed the sandbox spec
+(``session_scheduled_tasks``, ``session_vaults``) deliberately have no
+bump trigger; two negative tests pin that exclusion and prove no
+conflict with migration 0059's NOTIFY trigger on scheduled tasks.
+
+The tests poke the resource tables with raw SQL so each OLD/NEW path of
+the trigger is exercised directly, independent of service-layer logic.
+Account-scoped parent rows (memory store, vault) are seeded through the
+service layer so the column shapes stay correct as the schema evolves.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.services import memory_stores as memory_stores_service
+from aios.services import vaults as vaults_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT_ID = "acc_spec_version"
+
+
+@pytest.fixture
+async def pool_and_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str]]:
+    """Yield ``(pool, session_id)`` for a freshly-seeded session."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ($1, NULL, TRUE, 'spec-version-test')
+                """,
+                _ACCOUNT_ID,
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id=_ACCOUNT_ID, prefix="spec-version"
+        )
+        yield pool, session.id
+    finally:
+        await pool.close()
+
+
+async def _spec_version(pool: asyncpg.Pool[Any], session_id: str) -> int:
+    async with pool.acquire() as conn:
+        value = await conn.fetchval("SELECT spec_version FROM sessions WHERE id = $1", session_id)
+    assert value is not None
+    return int(value)
+
+
+async def _attach_memory_store(pool: asyncpg.Pool[Any], session_id: str, store_id: str) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO session_memory_stores
+                (session_id, memory_store_id, rank, access,
+                 name_at_attach, description_at_attach, account_id)
+            VALUES ($1, $2, 0, 'read_write', 'notes', 'spec-version store', $3)
+            """,
+            session_id,
+            store_id,
+            _ACCOUNT_ID,
+        )
+
+
+# ── memory store triggers ───────────────────────────────────────────────────
+
+
+async def test_memory_store_attach_bumps_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    pool, session_id = pool_and_session
+    store = await memory_stores_service.create_store(
+        pool, account_id=_ACCOUNT_ID, name="notes", description="d", metadata={}
+    )
+    before = await _spec_version(pool, session_id)
+
+    await _attach_memory_store(pool, session_id, store.id)
+
+    assert await _spec_version(pool, session_id) == before + 1
+
+
+async def test_memory_store_delete_bumps_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """DELETE exercises the ``OLD.session_id`` COALESCE branch."""
+    pool, session_id = pool_and_session
+    store = await memory_stores_service.create_store(
+        pool, account_id=_ACCOUNT_ID, name="notes", description="d", metadata={}
+    )
+    await _attach_memory_store(pool, session_id, store.id)
+    before = await _spec_version(pool, session_id)
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "DELETE FROM session_memory_stores WHERE session_id = $1 AND memory_store_id = $2",
+            session_id,
+            store.id,
+        )
+
+    assert await _spec_version(pool, session_id) == before + 1
+
+
+async def test_memory_store_update_bumps_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    pool, session_id = pool_and_session
+    store = await memory_stores_service.create_store(
+        pool, account_id=_ACCOUNT_ID, name="notes", description="d", metadata={}
+    )
+    await _attach_memory_store(pool, session_id, store.id)
+    before = await _spec_version(pool, session_id)
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE session_memory_stores SET access = 'read_only' "
+            "WHERE session_id = $1 AND memory_store_id = $2",
+            session_id,
+            store.id,
+        )
+
+    assert await _spec_version(pool, session_id) == before + 1
+
+
+# ── github repository triggers ──────────────────────────────────────────────
+
+
+async def _attach_github_repo(
+    pool: asyncpg.Pool[Any], session_id: str, *, mount_path: str = "/mnt/repo"
+) -> str:
+    repo_id = f"ghrepo_spec_version_{mount_path.strip('/').replace('/', '_')}"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO session_github_repositories
+                (id, session_id, rank, repo_url, mount_path, ciphertext, nonce, account_id)
+            VALUES ($1, $2, 0, 'https://github.com/example/repo.git', $3,
+                    '\\x00'::bytea, '\\x00'::bytea, $4)
+            """,
+            repo_id,
+            session_id,
+            mount_path,
+            _ACCOUNT_ID,
+        )
+    return repo_id
+
+
+async def test_github_repo_attach_bumps_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    pool, session_id = pool_and_session
+    before = await _spec_version(pool, session_id)
+
+    await _attach_github_repo(pool, session_id)
+
+    assert await _spec_version(pool, session_id) == before + 1
+
+
+async def test_github_repo_delete_bumps_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """DELETE exercises the ``OLD.session_id`` COALESCE branch."""
+    pool, session_id = pool_and_session
+    repo_id = await _attach_github_repo(pool, session_id)
+    before = await _spec_version(pool, session_id)
+
+    async with pool.acquire() as conn:
+        await conn.execute("DELETE FROM session_github_repositories WHERE id = $1", repo_id)
+
+    assert await _spec_version(pool, session_id) == before + 1
+
+
+async def test_github_repo_update_bumps_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    pool, session_id = pool_and_session
+    repo_id = await _attach_github_repo(pool, session_id)
+    before = await _spec_version(pool, session_id)
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE session_github_repositories SET mount_path = '/mnt/moved' WHERE id = $1",
+            repo_id,
+        )
+
+    assert await _spec_version(pool, session_id) == before + 1
+
+
+# ── exclusions: tables that don't feed build_spec_from_session ──────────────
+
+
+async def test_scheduled_task_insert_does_not_bump_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """Scheduled tasks are read per-turn by the runner, not via
+    build_spec_from_session — no bump trigger. Also proves migration
+    0077 didn't collide with 0059's NOTIFY trigger on the same table."""
+    pool, session_id = pool_and_session
+    before = await _spec_version(pool, session_id)
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO session_scheduled_tasks
+                (id, session_id, account_id, name, schedule, command, enabled,
+                 timeout_seconds, max_output_bytes, metadata)
+            VALUES ('sched_spec_version_01', $1, $2, 'noop', '* * * * *', 'echo hi',
+                    TRUE, 60, 65536, '{}'::jsonb)
+            """,
+            session_id,
+            _ACCOUNT_ID,
+        )
+
+    assert await _spec_version(pool, session_id) == before
+
+
+async def test_vault_binding_insert_does_not_bump_spec_version(
+    pool_and_session: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """Vault session-bindings reach the agent via the MCP pool, not the
+    sandbox spec — deliberately no bump trigger (Layer 1 still evicts as
+    defense-in-depth; Layer 2 stays silent here by design)."""
+    pool, session_id = pool_and_session
+    vault = await vaults_service.create_vault(
+        pool, account_id=_ACCOUNT_ID, display_name="creds", metadata={}
+    )
+    before = await _spec_version(pool, session_id)
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO session_vaults (session_id, vault_id, rank, account_id) "
+            "VALUES ($1, $2, 0, $3)",
+            session_id,
+            vault.id,
+            _ACCOUNT_ID,
+        )
+
+    assert await _spec_version(pool, session_id) == before

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -117,7 +117,8 @@ def _patch_build_spec_deps(
         ),
         patch(
             "aios.sandbox.spec._load_session_provisioning",
-            AsyncMock(return_value=("/tmp/w", {})),
+            # (workspace_path, env, spec_version) since #713.
+            AsyncMock(return_value=("/tmp/w", {}, 0)),
         ),
         # ``build_spec_from_session`` imports these function-locally from
         # ``aios.sandbox.volumes`` (deferred import to avoid a cycle), so

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0076``."""
+    """The migration ladder has exactly one head: ``0077``."""
     script = _script_directory()
-    assert script.get_heads() == ["0076"]
+    assert script.get_heads() == ["0077"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_sandbox_provision_span.py
+++ b/tests/unit/test_sandbox_provision_span.py
@@ -81,11 +81,7 @@ class TestSandboxProvisionSpan:
         with (
             patch("aios.services.sessions.append_event", append_event),
             patch(
-                "aios.services.sessions.load_session_account_id",
-                AsyncMock(return_value="acct_x"),
-            ),
-            patch(
-                "aios.sandbox.registry.queries.get_session_spec_version",
+                "aios.sandbox.registry.queries.unscoped_get_session_spec_version",
                 AsyncMock(return_value=0),
             ),
         ):

--- a/tests/unit/test_sandbox_provision_span.py
+++ b/tests/unit/test_sandbox_provision_span.py
@@ -71,12 +71,24 @@ class TestSandboxProvisionSpan:
     async def test_warm_hit_emits_no_span(self) -> None:
         backend = FakeBackend()
         registry = SandboxRegistry(backend=backend)
-        cached = make_handle(sandbox_id="warmcache_id")
+        cached = make_handle(sandbox_id="warmcache_id", spec_version=0)
         registry._handles["sess_01TEST"] = cached
         pool = MagicMock()
         append_event = AsyncMock()
 
-        with patch("aios.services.sessions.append_event", append_event):
+        # The warm path now also probes ``sessions.spec_version`` (#713);
+        # report no drift so the cached handle is returned without a span.
+        with (
+            patch("aios.services.sessions.append_event", append_event),
+            patch(
+                "aios.services.sessions.load_session_account_id",
+                AsyncMock(return_value="acct_x"),
+            ),
+            patch(
+                "aios.sandbox.registry.queries.get_session_spec_version",
+                AsyncMock(return_value=0),
+            ),
+        ):
             result = await registry.get_or_provision("sess_01TEST", pool=pool)
 
         assert result is cached

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -695,16 +695,17 @@ class TestSpecVersionDrift:
 
         with (
             patch(
-                "aios.sandbox.registry.queries.get_session_spec_version",
+                "aios.sandbox.registry.queries.unscoped_get_session_spec_version",
                 AsyncMock(return_value=2),
             ),
+            # The recycle path re-provisions via the span wrapper, which
+            # looks up the account and appends a sandbox_provision span
+            # pair; stub both so the MagicMock pool isn't driven through
+            # real SQL.
             patch(
                 "aios.services.sessions.load_session_account_id",
                 AsyncMock(return_value="acct_x"),
             ),
-            # The recycle path re-provisions via the span wrapper, which
-            # appends a sandbox_provision span pair; stub the event append
-            # so the MagicMock pool isn't driven through real SQL.
             patch("aios.services.sessions.append_event", AsyncMock()),
             patch(
                 "aios.sandbox.registry.build_spec_from_session",
@@ -733,15 +734,9 @@ class TestSpecVersionDrift:
         registry = SandboxRegistry(backend=backend)
         cached = _seed_versioned(registry, "sess_X", spec_version=3)
 
-        with (
-            patch(
-                "aios.sandbox.registry.queries.get_session_spec_version",
-                AsyncMock(return_value=3),
-            ),
-            patch(
-                "aios.services.sessions.load_session_account_id",
-                AsyncMock(return_value="acct_x"),
-            ),
+        with patch(
+            "aios.sandbox.registry.queries.unscoped_get_session_spec_version",
+            AsyncMock(return_value=3),
         ):
             result = await registry.get_or_provision("sess_X", pool=cast(Any, MagicMock()))
 
@@ -757,7 +752,9 @@ class TestSpecVersionDrift:
         cached = _seed_versioned(registry, "sess_X", spec_version=1)
 
         version_query = AsyncMock(return_value=99)
-        with patch("aios.sandbox.registry.queries.get_session_spec_version", version_query):
+        with patch(
+            "aios.sandbox.registry.queries.unscoped_get_session_spec_version", version_query
+        ):
             result = await registry.get_or_provision("sess_X")
 
         assert result is cached
@@ -770,15 +767,9 @@ class TestSpecVersionDrift:
         registry = SandboxRegistry(backend=backend)
         cached = _seed_versioned(registry, "sess_X", spec_version=1)
 
-        with (
-            patch(
-                "aios.sandbox.registry.queries.get_session_spec_version",
-                AsyncMock(side_effect=RuntimeError("db hiccup")),
-            ),
-            patch(
-                "aios.services.sessions.load_session_account_id",
-                AsyncMock(return_value="acct_x"),
-            ),
+        with patch(
+            "aios.sandbox.registry.queries.unscoped_get_session_spec_version",
+            AsyncMock(side_effect=RuntimeError("db hiccup")),
         ):
             result = await registry.get_or_provision("sess_X", pool=cast(Any, MagicMock()))
 

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -720,9 +720,12 @@ class TestSpecVersionDrift:
         assert result.sandbox_id == "fresh_sandbox_id"
         create_calls = [c for c in backend.calls if c[0] == "create"]
         assert len(create_calls) == 1, "spec-version drift must re-provision exactly once"
-        # The dead-but-alive handle's host resources were recycled via evict.
+        # The alive-but-drifted container must be destroyed (not just evicted):
+        # evict() skips backend.destroy (designed for dead containers), but a
+        # spec-version drift recycles a LIVE container — not destroying it would
+        # leave it running until the next worker restart (#713 fix).
         destroys = [c for c in backend.calls if c[0] == "destroy"]
-        assert destroys == [], "evict() drops the cache entry without backend.destroy"
+        assert len(destroys) == 1, "spec-version drift must backend.destroy the live old container"
 
     async def test_warm_hit_returns_handle_when_spec_version_matches(self) -> None:
         """Live handle, current spec_version == snapshot ⇒ cached returned."""

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -657,3 +657,159 @@ class TestStaleHandleDetection:
         assert len(create_calls) == 1, (
             f"expected exactly one re-provision; got {len(create_calls)} (calls={backend.calls})"
         )
+
+
+def _seed_versioned(
+    registry: SandboxRegistry, session_id: str, *, spec_version: int
+) -> SandboxHandle:
+    """Seed a live cached handle stamped with ``spec_version`` (#713)."""
+    handle = make_handle(session_id=session_id, spec_version=spec_version)
+    registry._handles[session_id] = handle
+    registry._last_used[session_id] = 0.0
+    return handle
+
+
+class TestSpecVersionDrift:
+    """``get_or_provision`` recycles a live cached sandbox when the
+    session's ``spec_version`` has drifted past the snapshot stamped on
+    the handle (#713).
+
+    The version probe is the API-process / direct-SQL safety net behind
+    the worker-only write-path eviction: a memory store or github repo
+    attached/detached between steps bumps ``sessions.spec_version`` via a
+    Postgres trigger, and the next warm hit notices the mismatch and
+    re-provisions even though the cached container is still alive.
+
+    The probe only runs when ``get_or_provision`` is passed a ``pool``
+    (the cold-start span path already passes one); without a pool the
+    version check is skipped so the existing lock/liveness tests keep
+    their no-DB behavior. All tests patch the registry's provisioning
+    helpers so the cold path runs without DB or Docker.
+    """
+
+    async def test_warm_hit_recycles_when_spec_version_changed(self) -> None:
+        """Live handle, current spec_version > snapshot ⇒ recycle."""
+        backend = FakeBackend(next_handle_id="fresh_sandbox_id")
+        registry = SandboxRegistry(backend=backend)
+        stale = _seed_versioned(registry, "sess_X", spec_version=1)
+
+        with (
+            patch(
+                "aios.sandbox.registry.queries.get_session_spec_version",
+                AsyncMock(return_value=2),
+            ),
+            patch(
+                "aios.services.sessions.load_session_account_id",
+                AsyncMock(return_value="acct_x"),
+            ),
+            # The recycle path re-provisions via the span wrapper, which
+            # appends a sandbox_provision span pair; stub the event append
+            # so the MagicMock pool isn't driven through real SQL.
+            patch("aios.services.sessions.append_event", AsyncMock()),
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=_provisioning_plan("sess_X")),
+            ),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+        ):
+            result = await registry.get_or_provision("sess_X", pool=cast(Any, MagicMock()))
+
+        assert result is not stale
+        assert result.sandbox_id == "fresh_sandbox_id"
+        create_calls = [c for c in backend.calls if c[0] == "create"]
+        assert len(create_calls) == 1, "spec-version drift must re-provision exactly once"
+        # The dead-but-alive handle's host resources were recycled via evict.
+        destroys = [c for c in backend.calls if c[0] == "destroy"]
+        assert destroys == [], "evict() drops the cache entry without backend.destroy"
+
+    async def test_warm_hit_returns_handle_when_spec_version_matches(self) -> None:
+        """Live handle, current spec_version == snapshot ⇒ cached returned."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        cached = _seed_versioned(registry, "sess_X", spec_version=3)
+
+        with (
+            patch(
+                "aios.sandbox.registry.queries.get_session_spec_version",
+                AsyncMock(return_value=3),
+            ),
+            patch(
+                "aios.services.sessions.load_session_account_id",
+                AsyncMock(return_value="acct_x"),
+            ),
+        ):
+            result = await registry.get_or_provision("sess_X", pool=cast(Any, MagicMock()))
+
+        assert result is cached
+        assert not any(c[0] == "create" for c in backend.calls), (
+            "matching spec_version must not re-provision"
+        )
+
+    async def test_warm_hit_without_pool_skips_version_check(self) -> None:
+        """No pool ⇒ the version query is never called; cached handle returned."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        cached = _seed_versioned(registry, "sess_X", spec_version=1)
+
+        version_query = AsyncMock(return_value=99)
+        with patch("aios.sandbox.registry.queries.get_session_spec_version", version_query):
+            result = await registry.get_or_provision("sess_X")
+
+        assert result is cached
+        version_query.assert_not_awaited()
+        assert not any(c[0] == "create" for c in backend.calls)
+
+    async def test_spec_version_probe_failure_does_not_recycle(self) -> None:
+        """A transient version-read error must not churn a healthy sandbox."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        cached = _seed_versioned(registry, "sess_X", spec_version=1)
+
+        with (
+            patch(
+                "aios.sandbox.registry.queries.get_session_spec_version",
+                AsyncMock(side_effect=RuntimeError("db hiccup")),
+            ),
+            patch(
+                "aios.services.sessions.load_session_account_id",
+                AsyncMock(return_value="acct_x"),
+            ),
+        ):
+            result = await registry.get_or_provision("sess_X", pool=cast(Any, MagicMock()))
+
+        assert result is cached, "a failed probe must return the live cached handle"
+        assert not any(c[0] == "create" for c in backend.calls)
+
+    async def test_handle_carries_spec_version_from_spec(self) -> None:
+        """Cold provision stamps the plan's spec_version onto the cached handle."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        plan = _provisioning_plan("sess_X")
+        # Rebuild the spec with a non-default spec_version to prove the
+        # backend copies it through to the handle.
+        from dataclasses import replace
+
+        plan = ProvisioningPlan(
+            spec=replace(plan.spec, spec_version=7),
+            env_config=plan.env_config,
+            memory_echoes=plan.memory_echoes,
+            github_echoes=plan.github_echoes,
+            git_proxy=plan.git_proxy,
+        )
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=plan),
+            ),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+        ):
+            await registry.get_or_provision("sess_X")
+
+        handle = registry.peek("sess_X")
+        assert handle is not None
+        assert handle.spec_version == 7


### PR DESCRIPTION
## Problem

Session-scoped resources (memory stores, GitHub repos, vault bindings, connections) feed `build_spec_from_session` at provision time. `SandboxRegistry.get_or_provision` returned the cached sandbox handle as long as `backend.is_alive` succeeded, so mutating a resource row had zero effect on the running sandbox until the next natural recycle (idle timeout, container exit, or manual eviction). No error was raised — the operator and agent both had to guess whether the change had taken effect.

This was security-sensitive for credential/binding removals: a revoked credential stayed reachable from the sandbox until recycle. Real incident: a repo added mid-session via SQL took ~1 hour to appear in the agent's sandbox.

## Fix

Two complementary layers, matching aios's two-process architecture.

### Layer 1 — write-path eviction (API/worker process)

After a session-scoped resource mutation commits, the service calls `SandboxRegistry.evict(session_id, unload_session_caches=False)`. The registry global lives only in the worker process (it is `None` in the API process), so this is an immediate eviction for worker-initiated mutations and a safe no-op from API routes. Wired post-commit in:

- `sessions.update_session` — when `resources` or `vault_ids` actually change (see "Idempotent re-PUTs" below)
- `connections.attach_connection` / `detach_connection`

### Layer 2 — spec version probe (cross-process mechanism)

A new `sessions.spec_version` column is bumped by Postgres `AFTER INSERT/UPDATE/DELETE` triggers (migration **0077**) on the two tables that actually feed `build_spec_from_session`: `session_memory_stores` and `session_github_repositories`.

The registry stamps the provision-time version onto each `SandboxHandle` and re-reads the current version on warm cache hits (one unscoped query per warm hit), recycling on drift. This closes the gaps Layer 1 cannot reach: API-process callers, direct-SQL mutations (operator backfills, migrations), and any path that bypasses the service layer entirely.

Best-effort: a transient DB error during the probe skips the check rather than recycling a healthy sandbox. The check is also skipped when no pool is passed, preserving cold-start behavior.

### Idempotent re-PUTs write nothing

A re-PUT of the current state must not recycle the container (issue #198 contract, pinned by the e2e test `TestMountUpdateRecyclesContainer::test_idempotent_update_does_not_recycle`). Conditioning only the Layer-1 eviction would be theater — the full-list-replace swap (DELETE-all + re-INSERT) would still fire the Layer-2 triggers and force a recycle at the next warm hit. The root fix makes the idempotent path write nothing:

- `memory_stores.set_session_resources` compares the incoming `(memory_store_id, access, instructions)` list against current rows and skips all DML on equality. Zero rows touched ⇒ the row-level triggers stay quiet ⇒ both layers observe "no change" by construction.
- `update_session` compares `vault_ids` against current bindings before writing.
- A non-empty github re-PUT is deliberately **always** a change: the incoming `authorization_token` is re-encrypted (fresh ciphertext, new `updated_at`) and `updated_at` is part of the mount snapshot, so token rotation must reach the sandbox.
- Every resource service reports a changed signal; `update_session` evicts only when something actually changed.

## Scope decisions

- Triggers are placed **only** on tables that feed the sandbox spec. `session_scheduled_tasks` (read per-turn by the runner, not at provision), `session_vaults`, and connection binding tables are excluded — bumping `spec_version` there would force pointless sandbox recycles for changes the sandbox never observes.
- Layer 1 still evicts for vault-binding and connection changes as documented defense-in-depth (harmless extra cold-start). The asymmetry — Layer 1 evicts, Layer 2 does not bump — is intentional for those resources.
- In-place vault credential rotation does **not** evict: the MCP pool keys on `(url, vault_id)` and rotation overwrites the row contents, so the stable key already serves the new secret. Only session-to-vault binding changes are the gap this PR closes.
- Eviction fires strictly post-commit to avoid recycling against an uncommitted spec under a concurrent provision.
- The warm-hit probe is a single **unscoped** query (`unscoped_get_session_spec_version`), homed with the worker's other unscoped bootstrap helpers — deriving `account_id` from the sessions row just to filter the same row by it would cost a second round-trip per tool call for no added protection.
- `spec_version` is internal and not exposed on the public `Session` model, so no OpenAPI/SDK regeneration is needed.

## Reviewer note

`connections._archive_binding_or_raise` return type changed from `None` to `queries.ActiveBinding` so `detach_connection` can recover the bound `session_id` to evict. The underlying query already returned this row, so the change is purely additive.

## Tests

- `tests/integration/test_spec_version_triggers.py` — triggers bump `spec_version` on memory-store and GitHub-repo INSERT/UPDATE/DELETE; do not bump on scheduled-task or vault-binding writes (verifies trigger scope and no conflict with the existing scheduled-tasks NOTIFY trigger).
- `tests/integration/test_session_resource_eviction.py` — per-site eviction coverage: memory/GitHub/vault-binding update evicts; title-only update and session create do not evict; connection attach/detach evict; in-place credential rotation does not evict; **idempotent memory re-PUT neither evicts nor bumps `spec_version`; idempotent vault re-PUT does not evict; `resources=[]` on an empty session does not evict**.
- `tests/unit/test_sandbox_registry.py` (`TestSpecVersionDrift`) — warm hit recycles on version mismatch, returns cached handle on match, skips check without a pool, does not recycle on probe failure, handle carries `spec_version` from the spec.
- e2e `TestMountUpdateRecyclesContainer` (pre-existing, master) — attach/detach via update recycle; idempotent update does not.

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)