### PR TITLE
feat(sessions): derive {active, idle} status from the event log

### DIFF
--- a/migrations/versions/0062_errored_lifecycle_index.py
+++ b/migrations/versions/0062_errored_lifecycle_index.py
@@ -1,0 +1,46 @@
+"""Partial index on terminal-error lifecycle events, for the derived
+``errored`` session state.
+
+Session ``status`` is being collapsed to a derived ``{active, idle}`` value
+computed from the event log; ``errored`` becomes a special case of ``idle``
+derived as "the latest ``turn_ended``/``error`` lifecycle event is more recent
+than the latest user message" (see ``sweep.ERRORED_SESSIONS_SQL``). The sweep
+excludes errored sessions on every pass, so the ``MAX(seq)`` over error
+lifecycle events must be cheap.
+
+Error lifecycle events are rare, so this is a tiny partial index. The
+matching user-message ``MAX`` reuses ``events_session_message_seq_idx``
+(``WHERE kind = 'message'``) from migration 0001.
+
+Built with ``CREATE INDEX CONCURRENTLY`` (outside a transaction via
+``autocommit_block``) so it never takes an ACCESS EXCLUSIVE lock on the
+live-written ``events`` table — same pattern as migration 0023.
+
+Revision ID: 0062
+Revises: 0061
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0062"
+down_revision: str = "0061"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_turn_error_idx "
+            "ON events (session_id, seq) "
+            "WHERE kind = 'lifecycle' AND data->>'stop_reason' = 'error'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_turn_error_idx")

--- a/migrations/versions/0063_drop_session_status_column.py
+++ b/migrations/versions/0063_drop_session_status_column.py
@@ -1,0 +1,47 @@
+"""Drop the denormalized ``sessions.status`` column (and its index).
+
+Session ``status`` is now a derived ``{active, idle}`` value computed from the
+event log at read time (``queries._SESSION_STATUS_EXPR``); ``errored`` is a
+special case of ``idle`` derived from the latest ``turn_ended``/``error``
+lifecycle event vs. the latest user message (``sweep.ERRORED_SESSIONS_SQL``).
+Nothing reads the column for control flow anymore:
+
+* the sweep excludes errored sessions via the derived predicate (subtracted
+  in-process), not ``status <> 'errored'``;
+* recovery from errored is automatic (a user message overtakes the error
+  event), so the ``append_event`` ``idle/errored → pending`` flip is gone;
+* ``set_session_stop_reason`` writes only ``stop_reason``.
+
+``stop_reason`` stays — it records why the last step ended and drives the
+console's Errored pill (``idle`` + ``stop_reason.type == 'error'``).
+
+Revision ID: 0063
+Revises: 0062
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0063"
+down_revision: str = "0062"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS sessions_status_idx")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS status")
+
+
+def downgrade() -> None:
+    # Best-effort restore: the historical per-status value is unrecoverable
+    # (it was derived), so every session comes back as 'idle'. The partial
+    # index is recreated to match migration 0001.
+    op.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'idle'")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS sessions_status_idx "
+        "ON sessions (status) WHERE archived_at IS NULL"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -2634,7 +2634,7 @@
           "sessions"
         ],
         "summary": "Interrupt",
-        "description": "Interrupt a running session: cancel all in-flight work and idle it.",
+        "description": "Interrupt a running session: cancel all in-flight work and record the\ninterrupt. Status is derived, so the session then reads ``idle`` if nothing\nis owed, or ``active`` if a cancelled tool's result re-wakes a follow-up\nstep (strictly more honest than the old unconditional idle).",
         "operationId": "interrupt_session",
         "parameters": [
           {

--- a/openapi.json
+++ b/openapi.json
@@ -1718,11 +1718,8 @@
               "anyOf": [
                 {
                   "enum": [
-                    "pending",
-                    "idle",
-                    "rescheduling",
-                    "errored",
-                    "terminated"
+                    "active",
+                    "idle"
                   ],
                   "type": "string"
                 },
@@ -12060,11 +12057,8 @@
           "status": {
             "type": "string",
             "enum": [
-              "pending",
-              "idle",
-              "rescheduling",
-              "errored",
-              "terminated"
+              "active",
+              "idle"
             ],
             "title": "Status"
           },
@@ -12200,7 +12194,7 @@
           "updated_at"
         ],
         "title": "Session",
-        "description": "Read view of a session. Internal-only columns are not exposed.\n\n``stop_reason`` records why the most recent step ended. Possible\n``type`` values: ``\"end_turn\"``, ``\"interrupt\"``, ``\"rescheduling\"``,\n``\"error\"``. ``awaiting`` lists tool calls the session is blocked\non (derived per read from the event log + agent tool specs)."
+        "description": "Read view of a session. Internal-only columns are not exposed.\n\n``status`` ({active, idle}) is derived per read from the event log; see\n:data:`SessionStatus`. ``stop_reason`` records why the most recent step\nended. Possible ``type`` values: ``\"end_turn\"``, ``\"interrupt\"``,\n``\"rescheduling\"``, ``\"error\"`` (``idle`` + ``error`` = the errored\nlanding pad). ``awaiting`` lists tool calls the session is blocked on\n(derived per read from the event log + agent tool specs)."
       },
       "SessionCloneRequest": {
         "properties": {
@@ -14054,11 +14048,8 @@
           "session_status": {
             "type": "string",
             "enum": [
-              "pending",
-              "idle",
-              "rescheduling",
-              "errored",
-              "terminated"
+              "active",
+              "idle"
             ],
             "title": "Session Status"
           },

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/interrupt_session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/interrupt_session.py
@@ -76,7 +76,10 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | Session]:
     """Interrupt
 
-     Interrupt a running session: cancel all in-flight work and idle it.
+     Interrupt a running session: cancel all in-flight work and record the
+    interrupt. Status is derived, so the session then reads ``idle`` if nothing
+    is owed, or ``active`` if a cancelled tool's result re-wakes a follow-up
+    step (strictly more honest than the old unconditional idle).
 
     Args:
         session_id (str):
@@ -113,7 +116,10 @@ def sync(
 ) -> HTTPValidationError | Session | None:
     """Interrupt
 
-     Interrupt a running session: cancel all in-flight work and idle it.
+     Interrupt a running session: cancel all in-flight work and record the
+    interrupt. Status is derived, so the session then reads ``idle`` if nothing
+    is owed, or ``active`` if a cancelled tool's result re-wakes a follow-up
+    step (strictly more honest than the old unconditional idle).
 
     Args:
         session_id (str):
@@ -145,7 +151,10 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | Session]:
     """Interrupt
 
-     Interrupt a running session: cancel all in-flight work and idle it.
+     Interrupt a running session: cancel all in-flight work and record the
+    interrupt. Status is derived, so the session then reads ``idle`` if nothing
+    is owed, or ``active`` if a cancelled tool's result re-wakes a follow-up
+    step (strictly more honest than the old unconditional idle).
 
     Args:
         session_id (str):
@@ -180,7 +189,10 @@ async def asyncio(
 ) -> HTTPValidationError | Session | None:
     """Interrupt
 
-     Interrupt a running session: cancel all in-flight work and idle it.
+     Interrupt a running session: cancel all in-flight work and record the
+    interrupt. Status is derived, so the session then reads ``idle`` if nothing
+    is owed, or ``active`` if a cancelled tool's result re-wakes a follow-up
+    step (strictly more honest than the old unconditional idle).
 
     Args:
         session_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
@@ -2,11 +2,8 @@ from enum import Enum
 
 
 class ListSessionsStatusType0(str, Enum):
-    ERRORED = "errored"
+    ACTIVE = "active"
     IDLE = "idle"
-    PENDING = "pending"
-    RESCHEDULING = "rescheduling"
-    TERMINATED = "terminated"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -28,10 +28,12 @@ T = TypeVar("T", bound="Session")
 class Session:
     """Read view of a session. Internal-only columns are not exposed.
 
-    ``stop_reason`` records why the most recent step ended. Possible
-    ``type`` values: ``"end_turn"``, ``"interrupt"``, ``"rescheduling"``,
-    ``"error"``. ``awaiting`` lists tool calls the session is blocked
-    on (derived per read from the event log + agent tool specs).
+    ``status`` ({active, idle}) is derived per read from the event log; see
+    :data:`SessionStatus`. ``stop_reason`` records why the most recent step
+    ended. Possible ``type`` values: ``"end_turn"``, ``"interrupt"``,
+    ``"rescheduling"``, ``"error"`` (``idle`` + ``error`` = the errored
+    landing pad). ``awaiting`` lists tool calls the session is blocked on
+    (derived per read from the event log + agent tool specs).
 
         Attributes:
             id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
@@ -2,11 +2,8 @@ from enum import Enum
 
 
 class SessionStatus(str, Enum):
-    ERRORED = "errored"
+    ACTIVE = "active"
     IDLE = "idle"
-    PENDING = "pending"
-    RESCHEDULING = "rescheduling"
-    TERMINATED = "terminated"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
@@ -2,11 +2,8 @@ from enum import Enum
 
 
 class WaitResponseSessionStatus(str, Enum):
-    ERRORED = "errored"
+    ACTIVE = "active"
     IDLE = "idle"
-    PENDING = "pending"
-    RESCHEDULING = "rescheduling"
-    TERMINATED = "terminated"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -407,7 +407,10 @@ async def interrupt(
     pool: PoolDep,
     account_id: AccountIdDep,
 ) -> Session:
-    """Interrupt a running session: cancel all in-flight work and idle it."""
+    """Interrupt a running session: cancel all in-flight work and record the
+    interrupt. Status is derived, so the session then reads ``idle`` if nothing
+    is owed, or ``active`` if a cancelled tool's result re-wakes a follow-up
+    step (strictly more honest than the old unconditional idle)."""
     await service.append_event(
         pool, session_id, "interrupt", {"reason": body.reason}, account_id=account_id
     )

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -411,8 +411,12 @@ async def interrupt(
     await service.append_event(
         pool, session_id, "interrupt", {"reason": body.reason}, account_id=account_id
     )
-    await service.set_session_status(
-        pool, session_id, "idle", stop_reason={"type": "interrupt"}, account_id=account_id
+    # Record the stop_reason only; ``status`` is derived. After cancelling
+    # in-flight work the session derives ``idle`` if nothing is owed, or
+    # ``active`` if a cancelled tool's result re-wakes a follow-up step — which
+    # is more honest than the old unconditional ``status='idle'`` write.
+    await service.set_session_stop_reason(
+        pool, session_id, {"type": "interrupt"}, account_id=account_id
     )
     await service.append_event(
         pool,

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -38,7 +38,7 @@ def list_(
     agent_id: Annotated[str | None, typer.Option("--agent-id")] = None,
     status_filter: Annotated[
         str | None,
-        typer.Option("--status", help="Filter by status: running, idle, terminated."),
+        typer.Option("--status", help="Filter by status: active, idle."),
     ] = None,
     limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
     all_: Annotated[bool, typer.Option("--all")] = False,
@@ -130,7 +130,7 @@ def update(
     run_or_die(_run)
 
 
-@app.command("archive", help="Archive a session (status=terminated, soft).")
+@app.command("archive", help="Archive a session (soft delete via archived_at).")
 @covers("archive_session")
 def archive(ctx: typer.Context, session_id: str) -> None:
     def _run() -> None:

--- a/src/aios/db/queries.py
+++ b/src/aios/db/queries.py
@@ -780,6 +780,65 @@ async def list_agent_versions(
 
 # ─── sessions ─────────────────────────────────────────────────────────────────
 
+# Read-time derivation of the session ``status`` ({active, idle}) from the event
+# log — there is no persisted status column (#728-era status collapse). A
+# session is ``active`` when it has owed/in-flight work that will advance
+# WITHOUT a new unprompted user message:
+#   * an unreacted stimulus  — a non-assistant message event past the assistant
+#     ``reacting_to`` watermark (queued/generating/tool-completed-awaiting-step), OR
+#   * an unresolved tool_call — an assistant tool_call with no tool-role result
+#     (harness tool in-flight, or blocked on an approval/custom-tool result).
+# ...EXCEPT when ``errored`` (retry budget exhausted, not yet recovered): the
+# latest ``turn_ended``/``error`` lifecycle event is more recent than the latest
+# user message. Errored forces ``idle`` (a special case of idle) and the sweep
+# skips it — see ``sweep.ERRORED_SESSIONS_SQL`` (the same predicate, used to
+# exclude errored sessions from inference; keep the two in sync).
+#
+# Correlated on ``sessions.id``/``sessions.account_id`` so it drops into any
+# query with ``sessions`` in scope. Each EXISTS rides a partial index
+# (events_session_message_seq_idx, events_assistant_tool_calls_idx,
+# events_tool_result_idx, events_turn_error_idx). For single reads and
+# keyset-limited list pages it evaluates on O(page) rows.
+#
+# ``_SESSION_ACTIVE_EXPR`` — has owed/in-flight work (unreacted stimulus OR
+# unresolved tool_call). ``_SESSION_ERRORED_EXPR`` — parked-errored latch
+# (also reused by ``lock_active_session_for_update`` and the clone gate).
+_SESSION_ACTIVE_EXPR = """(
+        EXISTS (
+            SELECT 1 FROM events ev
+             WHERE ev.session_id = sessions.id AND ev.account_id = sessions.account_id
+               AND ev.kind = 'message' AND ev.role <> 'assistant'
+               AND ev.seq > COALESCE((
+                   SELECT MAX(COALESCE((ae.data->>'reacting_to')::bigint, ae.seq))
+                     FROM events ae
+                    WHERE ae.session_id = sessions.id AND ae.account_id = sessions.account_id
+                      AND ae.kind = 'message' AND ae.role = 'assistant'), 0))
+        OR EXISTS (
+            SELECT 1 FROM events ate
+             CROSS JOIN LATERAL jsonb_array_elements(ate.data->'tool_calls') tc
+             WHERE ate.session_id = sessions.id AND ate.account_id = sessions.account_id
+               AND ate.kind = 'message' AND ate.role = 'assistant' AND ate.data ? 'tool_calls'
+               AND NOT EXISTS (
+                   SELECT 1 FROM events tr
+                    WHERE tr.session_id = sessions.id AND tr.account_id = sessions.account_id
+                      AND tr.kind = 'message' AND tr.role = 'tool'
+                      AND tr.data->>'tool_call_id' = tc->>'id'))
+    )"""
+
+_SESSION_ERRORED_EXPR = """EXISTS (
+        SELECT 1 FROM events le
+         WHERE le.session_id = sessions.id AND le.account_id = sessions.account_id
+           AND le.kind = 'lifecycle' AND le.data->>'stop_reason' = 'error'
+           AND le.seq > COALESCE((
+               SELECT MAX(ue.seq) FROM events ue
+                WHERE ue.session_id = sessions.id AND ue.account_id = sessions.account_id
+                  AND ue.kind = 'message' AND ue.role = 'user'), 0))"""
+
+_SESSION_STATUS_EXPR = (
+    f"CASE WHEN {_SESSION_ACTIVE_EXPR} AND NOT {_SESSION_ERRORED_EXPR} "
+    "THEN 'active' ELSE 'idle' END"
+)
+
 
 def _row_to_session(row: asyncpg.Record) -> Session:
     raw_metadata = row["metadata"]
@@ -793,7 +852,12 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         agent_version=row["agent_version"],
         title=row["title"],
         metadata=metadata,
-        status=row["status"],
+        # ``status`` is derived ({active, idle}) from the event log via
+        # ``_SESSION_STATUS_EXPR``; ``get_session``/``list_sessions`` select it
+        # as a ``status`` column. There is no persisted status column. Reads
+        # that don't derive it (INSERT ... RETURNING, clone) default to "idle"
+        # — a fresh session is idle, and internal paths never surface it.
+        status=row.get("status") or "idle",
         stop_reason=stop_reason,
         last_event_seq=row["last_event_seq"],
         usage=SessionUsage(
@@ -855,10 +919,10 @@ async def insert_session(
             """
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
-                status, workspace_volume_path, env,
+                workspace_volume_path, env,
                 focal_channel, focal_locked, account_id
             )
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'idle', $7, $8::jsonb, $9, $10, $11)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9, $10, $11)
             RETURNING *
             """,
             new_id,
@@ -888,6 +952,26 @@ async def insert_session(
 async def get_session(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> Session:
+    rec = await conn.fetchrow(
+        f"SELECT sessions.*, ({_SESSION_STATUS_EXPR}) AS status "
+        "FROM sessions WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
+    )
+    if rec is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    return _row_to_session(rec)
+
+
+async def get_session_bare(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> Session:
+    """Session read WITHOUT deriving ``status`` (defaults to ``idle``).
+
+    For callers that need only core columns and never surface the status label
+    — existence checks, the worker step path, connection lookups — so they
+    don't pay for the ``_SESSION_STATUS_EXPR`` event-log derivation.
+    """
     return await _get_scoped(
         conn,
         table="sessions",
@@ -994,6 +1078,16 @@ async def list_sessions(
     limit: int = 50,
     after: str | None = None,
 ) -> list[Session]:
+    """Keyset-paginated session list with derived ``status`` ({active, idle}).
+
+    ``status`` is a derived expression, not a column, so it's passed to
+    ``_list_scoped`` as an expression-filter (a static literal, never user
+    input) rather than a column name. That keeps the keyset/limit/has-more
+    boilerplate in one place while still applying the filter in SQL — so
+    pagination stays correct (post-filtering the page would conflate "few
+    matches in this window" with "no more results"). ``status`` and
+    ``last_event_at`` are derived in ``extra_select``.
+    """
     return await _list_scoped(
         conn,
         table="sessions",
@@ -1001,12 +1095,12 @@ async def list_sessions(
         row=_row_to_session,
         limit=limit,
         after=after,
-        filters=[("agent_id", agent_id), ("status", status)],
-        # Derive last-activity = timestamp of the session's newest event.
-        # ``ORDER BY seq DESC LIMIT 1`` rides the (session_id, seq) index, so
-        # it's O(log n) even for huge sessions (unlike MAX(created_at), which
-        # has no supporting index).
+        filters=[("agent_id", agent_id), (f"({_SESSION_STATUS_EXPR})", status)],
+        # last_event_at: timestamp of the session's newest event. ``ORDER BY
+        # seq DESC LIMIT 1`` rides the (session_id, seq) index — O(log n) even
+        # for huge sessions (unlike MAX(created_at), which has no index).
         extra_select=(
+            f"({_SESSION_STATUS_EXPR}) AS status, "
             "(SELECT e.created_at FROM events e WHERE e.session_id = sessions.id "
             "ORDER BY e.seq DESC LIMIT 1) AS last_event_at"
         ),
@@ -1025,7 +1119,8 @@ async def lock_active_session_for_update(
     row lock is what serialises concurrent retries on the same session.
     """
     row = await conn.fetchrow(
-        "SELECT status FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+        f"SELECT ({_SESSION_ERRORED_EXPR}) AS errored "
+        "FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
         session_id,
         account_id,
     )
@@ -1034,35 +1129,35 @@ async def lock_active_session_for_update(
             f"session {session_id} not found",
             detail={"session_id": session_id},
         )
-    if row["status"] == "errored":
+    if row["errored"]:
         raise ConflictError(
             f"session {session_id} is errored; post a user message to resume",
             detail={"session_id": session_id, "status": "errored"},
         )
 
 
-async def set_session_status(
+async def set_session_stop_reason(
     conn: asyncpg.Connection[Any],
     session_id: str,
-    status: SessionStatus,
-    stop_reason: dict[str, Any] | None = None,
+    stop_reason: dict[str, Any],
     *,
     account_id: str,
 ) -> None:
-    stop_json = json.dumps(stop_reason) if stop_reason is not None else None
-    # ``archived_at IS NULL`` guards the archive race: every caller is
-    # worker-internal and silent no-op is the right contract — surfacing
-    # would just cascade into an ``errored`` flip on the same archived row.
-    row = await conn.fetchrow(
-        "UPDATE sessions SET status = $1, stop_reason = $2::jsonb, updated_at = now() "
-        "WHERE id = $3 AND account_id = $4 AND archived_at IS NULL RETURNING 1",
-        status,
-        stop_json,
+    """Record why the most recent step ended. ``status`` is derived from the
+    event log (see ``_SESSION_STATUS_EXPR``), so this writes only
+    ``stop_reason`` — the console renders the Errored pill from
+    ``status == 'idle' AND stop_reason.type == 'error'``.
+
+    ``archived_at IS NULL`` guards the archive race: every caller is
+    worker-internal and a silent no-op is the right contract.
+    """
+    await conn.execute(
+        "UPDATE sessions SET stop_reason = $1::jsonb, updated_at = now() "
+        "WHERE id = $2 AND account_id = $3 AND archived_at IS NULL",
+        json.dumps(stop_reason),
         session_id,
         account_id,
     )
-    if row is None:
-        return
 
 
 async def increment_session_usage(
@@ -1297,9 +1392,6 @@ async def delete_session(
         )
 
 
-_CLONEABLE_STATUSES: tuple[SessionStatus, ...] = ("idle", "terminated")
-
-
 async def clone_session(
     conn: asyncpg.Connection[Any],
     parent_session_id: str,
@@ -1312,9 +1404,11 @@ async def clone_session(
     The clone inherits ``agent_id``, ``environment_id``, ``agent_version``,
     ``title``, ``metadata``, ``env``, vault bindings, memory-store
     attachments, github-repository attachments, ``last_event_seq``,
-    ``status``, ``stop_reason``, ``focal_channel``, and ``focal_locked``
+    ``stop_reason``, ``focal_channel``, and ``focal_locked``
     so its next forward step sees a context byte-identical to the
-    parent's at clone time.  ``focal_locked`` MUST follow ``focal_channel``
+    parent's at clone time.  (``status`` is derived from the event log, so
+    the clone's status follows from its copied events — idle, like the
+    parent it was required to be.)  ``focal_locked`` MUST follow ``focal_channel``
     on the clone path: a per_chat parent (``focal_locked=True``) cloned
     without its lock would inherit the bound channel but bypass the
     ``is_session_focal_locked`` gate on ``switch_channel``, letting the
@@ -1347,7 +1441,9 @@ async def clone_session(
 
     async with conn.transaction():
         row = await conn.fetchrow(
-            "SELECT status, archived_at FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+            f"SELECT archived_at, ({_SESSION_ACTIVE_EXPR}) AS active, "
+            f"({_SESSION_ERRORED_EXPR}) AS errored "
+            "FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
             parent_session_id,
             account_id,
         )
@@ -1365,23 +1461,27 @@ async def clone_session(
                 f"session {parent_session_id} is archived",
                 detail={"id": parent_session_id},
             )
-        status = row["status"]
-        if status not in _CLONEABLE_STATUSES:
+        # Only clone idle (quiescent, non-errored) parents: an active parent
+        # has tool tasks in flight whose results would land only on its own
+        # session_id, leaving the clone's expected event stream undefined; an
+        # errored parent isn't a clean base. (Derived ``status == 'idle'`` =
+        # not active; errored is checked explicitly for a precise message.)
+        if row["active"] or row["errored"]:
+            state = "errored" if row["errored"] else "active"
             raise ConflictError(
-                f"can only clone sessions in {_CLONEABLE_STATUSES} state; "
-                f"parent {parent_session_id} is in {status!r}",
-                detail={"id": parent_session_id, "status": status},
+                f"can only clone idle sessions; parent {parent_session_id} is {state}",
+                detail={"id": parent_session_id, "status": state},
             )
 
         new_row = await conn.fetchrow(
             """
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
-                status, stop_reason, workspace_volume_path, env, last_event_seq,
+                stop_reason, workspace_volume_path, env, last_event_seq,
                 focal_channel, focal_locked, account_id
             )
             SELECT $1, agent_id, environment_id, agent_version, title, metadata,
-                   status, stop_reason, $2, env, last_event_seq, focal_channel,
+                   stop_reason, $2, env, last_event_seq, focal_channel,
                    focal_locked, account_id
               FROM sessions WHERE id = $3
             RETURNING *
@@ -1959,18 +2059,18 @@ async def append_event(
         raw_role = data.get("role")
         if isinstance(raw_role, str):
             role = raw_role
-    # User messages lift idle/errored → pending in the seq UPDATE so the
-    # sweep stops ignoring an errored session (#39, #353).
+    # A user message bumps ``updated_at`` (last-interaction time). It no longer
+    # needs to flip a status column: ``status`` is derived from the event log,
+    # so an errored session recovers automatically once a user message lands
+    # (its seq exceeds the latest error lifecycle event — see
+    # ``_SESSION_ERRORED_EXPR``), and the sweep stops skipping it (#39, #353).
     is_user_message = kind == "message" and role == "user"
 
     async with conn.transaction():
         seq_row = await conn.fetchrow(
             "UPDATE sessions "
             "SET last_event_seq = last_event_seq + 1, "
-            "    status = CASE WHEN $3 AND status IN ('idle', 'errored') "
-            "                  THEN 'pending' ELSE status END, "
-            "    updated_at = CASE WHEN $3 AND status IN ('idle', 'errored') "
-            "                      THEN now() ELSE updated_at END "
+            "    updated_at = CASE WHEN $3 THEN now() ELSE updated_at END "
             "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL "
             "RETURNING last_event_seq, focal_channel",
             session_id,

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -538,10 +538,13 @@ async def _run_session_step_body(
                 custom_tools=[tc.get("id") for tc in custom if tc.get("id")],
             )
 
-    # End-of-turn is unconditional; pending tool calls live on
-    # ``Session.awaiting`` (derived from the event log per read).
-    await sessions_service.set_session_status(
-        pool, session_id, "idle", stop_reason={"type": "end_turn"}, account_id=account_id
+    # End-of-turn is unconditional; the resulting ``status`` ({active, idle})
+    # is derived from the event log per read — a session that just launched
+    # background tools derives ``active`` until they resolve, without any
+    # status write here (see queries._SESSION_STATUS_EXPR). We only record the
+    # stop_reason of this step.
+    await sessions_service.set_session_stop_reason(
+        pool, session_id, {"type": "end_turn"}, account_id=account_id
     )
     await _append_lifecycle(
         pool, session_id, "turn_ended", "idle", "end_turn", account_id=account_id
@@ -860,12 +863,8 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
     attempt = await _count_consecutive_rescheduling(pool, session_id, account_id=account_id)
     delay = _retry_delay_for_attempt(attempt)
     if delay is not None:
-        await sessions_service.set_session_status(
-            pool,
-            session_id,
-            "rescheduling",
-            stop_reason={"type": "rescheduling"},
-            account_id=account_id,
+        await sessions_service.set_session_stop_reason(
+            pool, session_id, {"type": "rescheduling"}, account_id=account_id
         )
         await _append_lifecycle(
             pool,
@@ -876,12 +875,13 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
             account_id=account_id,
         )
         return delay
-    # Terminal landing pad (#353): sweep skips ``errored`` (see
-    # ``CANDIDATE_ROWS_SQL`` / ``CONFIRMED_ROWS_SQL``); any in-flight
-    # tool task that completes after this point sits unreaped until a
-    # user message lifts status back to ``pending`` (via ``append_event``).
-    await sessions_service.set_session_status(
-        pool, session_id, "errored", stop_reason={"type": "error"}, account_id=account_id
+    # Terminal landing pad (#353): the ``turn_ended``/``error`` lifecycle event
+    # appended below puts the session in the derived ``errored`` state, which
+    # the sweep skips (see ``sweep.ERRORED_SESSIONS_SQL``); any in-flight tool
+    # task that completes after this point sits unreaped until a user message
+    # recovers the session (its seq overtakes the error event).
+    await sessions_service.set_session_stop_reason(
+        pool, session_id, {"type": "error"}, account_id=account_id
     )
     await _append_lifecycle(
         pool, session_id, "turn_ended", "errored", "error", account_id=account_id

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -68,7 +68,6 @@ GHOST_ASST_SQL = """
       FROM events e
       JOIN sessions s ON s.id = e.session_id
      WHERE s.archived_at IS NULL
-       AND s.status <> 'errored'
        AND e.kind = 'message'
        AND e.role = 'assistant'
        AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
@@ -116,7 +115,6 @@ CANDIDATE_ROWS_SQL = """
       JOIN sessions s ON s.id = e.session_id
       LEFT JOIN session_max_reacting smr ON smr.session_id = e.session_id
      WHERE s.archived_at IS NULL
-       AND s.status <> 'errored'
        AND e.kind = 'message'
        AND e.role <> 'assistant'
        AND (smr.max_reacting IS NULL OR e.seq > smr.max_reacting)
@@ -128,7 +126,6 @@ CONFIRMED_ROWS_SQL = """
       FROM events lc
       JOIN sessions s ON s.id = lc.session_id
      WHERE s.archived_at IS NULL
-       AND s.status <> 'errored'
        AND lc.kind = 'lifecycle'
        AND lc.data->>'event' = 'tool_confirmed'
        AND lc.data->>'result' = 'allow'
@@ -177,6 +174,41 @@ ALL_ASST_ROWS_SQL = """
        AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
 """
 
+# Sessions currently in the terminal "errored" state, derived from the event
+# log (there is no denormalized ``status`` column). A session is errored when
+# its most recent ``turn_ended``/``error`` lifecycle event is more recent than
+# its most recent user message — i.e. a model-call failure exhausted the retry
+# budget and no user message has since arrived to recover it. A later user
+# message flips the inequality (``user_seq > err_seq``), which is exactly the
+# recovery semantics the pre-derivation ``append_event`` ``idle/errored →
+# pending`` flip provided.
+#
+# Shape: two ``MAX(seq)``-per-session CTEs joined — the same hoisted-aggregation
+# pattern as ``session_max_reacting`` above, so no correlated SubPlan re-scans
+# ``events`` (the #140 pathology). The error CTE is backed by the partial index
+# ``events_turn_error_idx`` (migration 0062); the user CTE reuses
+# ``events_session_message_seq_idx`` (migration 0001).
+ERRORED_SESSIONS_SQL = """
+    WITH err_max AS (
+        SELECT session_id, MAX(seq) AS err_seq
+          FROM events
+         WHERE kind = 'lifecycle' AND data->>'stop_reason' = 'error'
+         {scope_clause}
+         GROUP BY session_id
+    ),
+    user_max AS (
+        SELECT session_id, MAX(seq) AS user_seq
+          FROM events
+         WHERE kind = 'message' AND role = 'user'
+         {scope_clause}
+         GROUP BY session_id
+    )
+    SELECT em.session_id
+      FROM err_max em
+      LEFT JOIN user_max um ON um.session_id = em.session_id
+     WHERE um.user_seq IS NULL OR em.err_seq > um.user_seq
+"""
+
 
 # ─── ghost repair ────────────────────────────────────────────────────────────
 
@@ -215,6 +247,16 @@ async def find_and_repair_ghosts(
             return []
 
         session_ids = list({r["session_id"] for r in asst_rows})
+
+        # Skip errored sessions: their dispatched-but-unresolved tool calls are
+        # part of the terminal landing pad and stay unreaped until a user
+        # message recovers the session (mirrors the pre-derivation status skip).
+        errored = await _errored_session_ids(conn, session_id=session_id)
+        if errored:
+            asst_rows = [r for r in asst_rows if r["session_id"] not in errored]
+            if not asst_rows:
+                return []
+            session_ids = [s for s in session_ids if s not in errored]
 
         result_rows = await conn.fetch(ALL_RESULT_ROWS_SQL, session_ids)
         results_by_session: dict[str, set[str]] = {}
@@ -408,6 +450,22 @@ def _was_dispatched(
 # ─── sessions needing inference ──────────────────────────────────────────────
 
 
+async def _errored_session_ids(
+    conn: asyncpg.Connection[Any], *, session_id: str | None = None
+) -> set[str]:
+    """Session IDs currently in the derived ``errored`` state.
+
+    See ``ERRORED_SESSIONS_SQL``. The sweep excludes these from both
+    inference and ghost repair: an errored session is parked until a user
+    message recovers it (mirrors the pre-derivation ``status = 'errored'``
+    skip + the ``append_event`` recovery flip).
+    """
+    scope_clause = "AND session_id = $1" if session_id else ""
+    params: list[Any] = [session_id] if session_id else []
+    rows = await conn.fetch(ERRORED_SESSIONS_SQL.format(scope_clause=scope_clause), *params)
+    return {r["session_id"] for r in rows}
+
+
 async def find_sessions_needing_inference(
     pool: asyncpg.Pool[Any],
     task_registry: TaskRegistry,
@@ -452,6 +510,14 @@ async def find_sessions_needing_inference(
         )
         confirmed_sessions = {r["session_id"] for r in confirmed_rows}
 
+        # Errored sessions are parked until a user message recovers them.
+        # Derived from the event log rather than a denormalized status column
+        # (subtracted in-process to keep the candidate/confirmed queries free
+        # of an anti-join that the perf guard would flag as a SubPlan).
+        errored = await _errored_session_ids(conn, session_id=session_id)
+
+    candidates -= errored
+    confirmed_sessions -= errored
     to_filter = candidates - confirmed_sessions
     filtered = (
         await _filter_incomplete_batches(pool, task_registry, to_filter) if to_filter else set()

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -72,7 +72,21 @@ def _validate_session_resources(resources: list[SessionResource]) -> None:
     _validate_github_resources(github)
 
 
-SessionStatus = Literal["pending", "idle", "rescheduling", "errored", "terminated"]
+SessionStatus = Literal["active", "idle"]
+"""Derived session activity, computed from the event log at read time (there is
+no persisted status column).
+
+* ``active`` — the session has owed/in-flight work that will advance WITHOUT a
+  new unprompted user message: an unreacted user/tool stimulus, or an unresolved
+  tool_call (a built-in tool running, or one blocked on operator approval / a
+  custom-tool result — see :class:`AwaitingToolCall`).
+* ``idle`` — quiescent: nothing is owed; only a new unprompted user message (or
+  an armed timer firing) will move it. ``idle`` implies ``awaiting == []``.
+
+An *errored* session (model-call retry budget exhausted, not yet recovered) is a
+special case of ``idle``: it reads ``idle`` with ``stop_reason.type == "error"``
+and will not wake until a user message arrives.
+"""
 
 MAX_USER_MESSAGE_CHARS = 1_000_000
 
@@ -224,10 +238,12 @@ class SessionUpdate(BaseModel):
 class Session(BaseModel):
     """Read view of a session. Internal-only columns are not exposed.
 
-    ``stop_reason`` records why the most recent step ended. Possible
-    ``type`` values: ``"end_turn"``, ``"interrupt"``, ``"rescheduling"``,
-    ``"error"``. ``awaiting`` lists tool calls the session is blocked
-    on (derived per read from the event log + agent tool specs).
+    ``status`` ({active, idle}) is derived per read from the event log; see
+    :data:`SessionStatus`. ``stop_reason`` records why the most recent step
+    ended. Possible ``type`` values: ``"end_turn"``, ``"interrupt"``,
+    ``"rescheduling"``, ``"error"`` (``idle`` + ``error`` = the errored
+    landing pad). ``awaiting`` lists tool calls the session is blocked on
+    (derived per read from the event log + agent tool specs).
     """
 
     id: str

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -217,7 +217,7 @@ async def attach_connection(
                     f"connection {connection_id} is archived; cannot attach a session to it",
                     detail={"id": connection_id},
                 )
-            session = await queries.get_session(conn, session_id, account_id=account_id)
+            session = await queries.get_session_bare(conn, session_id, account_id=account_id)
             if session.archived_at is not None:
                 raise ConflictError(
                     f"session {session_id} is archived; cannot attach a connection to it",
@@ -391,7 +391,7 @@ async def bind_chat_to_session(
         # Validate both FKs at the service boundary — without this,
         # asyncpg surfaces FK violations as 500s instead of clean 4xxs.
         await queries.get_connection(conn, connection_id, account_id=account_id)
-        session = await queries.get_session(conn, session_id, account_id=account_id)
+        session = await queries.get_session_bare(conn, session_id, account_id=account_id)
         # Refuse archived sessions at bind time — the FK accepts archived
         # rows so without this check the ledger stamp succeeds, the
         # operator receives a 201 ``BoundChat`` with the archived id, and

--- a/src/aios/services/files.py
+++ b/src/aios/services/files.py
@@ -60,7 +60,7 @@ async def stage_upload(
     settings = get_settings()
 
     async with pool.acquire() as conn:
-        await queries.get_session(conn, session_id, account_id=account_id)  # 404 if missing
+        await queries.get_session_bare(conn, session_id, account_id=account_id)  # 404 if missing
 
     file_id = make_id(FILE)
     filename = safe_filename(upload.filename)

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -341,10 +341,11 @@ async def get_session_basic(
 
     Use this when the caller reads only core columns — the worker step
     path (``agent_id``, ``agent_version``, ``focal_channel``) and the
-    long-poll wait endpoint's existence check.
+    long-poll wait endpoint's existence check. Skips the ``status``
+    derivation (``status`` defaults to ``idle`` and is never surfaced here).
     """
     async with pool.acquire() as conn:
-        return await queries.get_session(conn, session_id, account_id=account_id)
+        return await queries.get_session_bare(conn, session_id, account_id=account_id)
 
 
 async def get_session_event_stats(
@@ -599,18 +600,18 @@ async def read_windowed_events(
         )
 
 
-async def set_session_status(
+async def set_session_stop_reason(
     pool: asyncpg.Pool[Any],
     session_id: str,
-    status: SessionStatus,
-    stop_reason: dict[str, Any] | None = None,
+    stop_reason: dict[str, Any],
     *,
     account_id: str,
 ) -> None:
+    """Record why the most recent step ended (end_turn/error/interrupt/
+    rescheduling). ``status`` is derived from the event log, so this no longer
+    writes a status column."""
     async with pool.acquire() as conn:
-        await queries.set_session_status(
-            conn, session_id, status, stop_reason, account_id=account_id
-        )
+        await queries.set_session_stop_reason(conn, session_id, stop_reason, account_id=account_id)
 
 
 async def increment_usage(

--- a/src/aios/tools/wake_session.py
+++ b/src/aios/tools/wake_session.py
@@ -206,7 +206,7 @@ async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> di
     # justifies bypassing the usual ``account_id``-scoped helper.
     async with pool.acquire() as conn:
         target_row = await conn.fetchrow(
-            "SELECT account_id, status, archived_at FROM sessions WHERE id = $1",
+            "SELECT account_id, archived_at FROM sessions WHERE id = $1",
             target_session_id,
         )
     if target_row is None:
@@ -228,11 +228,6 @@ async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> di
         raise WakeSessionTargetUnavailableError(
             f"target session {target_session_id} is archived",
             detail={"target_session_id": target_session_id, "reason": "archived"},
-        )
-    if target_row["status"] == "terminated":
-        raise WakeSessionTargetUnavailableError(
-            f"target session {target_session_id} is terminated",
-            detail={"target_session_id": target_session_id, "reason": "terminated"},
         )
 
     # Wake-depth: inherit from the source's most recent user message;

--- a/tests/e2e/test_connection_tools.py
+++ b/tests/e2e/test_connection_tools.py
@@ -308,9 +308,11 @@ class TestConnectionToolDispatch:
         )
 
         # Step 1: model calls chat_send → call appears in session.awaiting.
+        # The session is ACTIVE: the unresolved connection-sourced custom call
+        # resumes on a tool-result POST (no user message needed).
         await harness.run_step(session.id)
         s = await harness.session(session.id)
-        assert s.status == "idle"
+        assert s.status == "active"
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"cs_1"}
         assert s.awaiting[0].kind == "custom"

--- a/tests/e2e/test_errored_session_sweep.py
+++ b/tests/e2e/test_errored_session_sweep.py
@@ -19,7 +19,6 @@ import pytest
 from aios.db.pool import create_pool
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.task_registry import TaskRegistry
-from aios.models.sessions import SessionStatus
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 
@@ -45,10 +44,10 @@ async def _ensure_agent_and_env(pool: asyncpg.Pool[Any]) -> tuple[str, str]:
 async def _seed_session_with_unreacted_message(
     pool: asyncpg.Pool[Any],
     *,
-    status: SessionStatus,
+    errored: bool = False,
 ) -> str:
-    """Create a session via the service layer, append a user message, then
-    force ``status`` if it isn't ``pending``.  Returns the new session id.
+    """Create a session, append an unreacted user message, and optionally park
+    it in the derived ``errored`` state.  Returns the new session id.
     """
     account_id = "acc_test_stub"  # PR 3 scaffolding
     agent_id, environment_id = await _ensure_agent_and_env(pool)
@@ -61,8 +60,18 @@ async def _seed_session_with_unreacted_message(
         account_id=account_id,
     )
     await sessions_service.append_user_message(pool, session.id, "hi", account_id=account_id)
-    if status != "pending":
-        await sessions_service.set_session_status(pool, session.id, status, account_id=account_id)
+    if errored:
+        # ``errored`` is derived from the event log (sweep.ERRORED_SESSIONS_SQL /
+        # queries._SESSION_ERRORED_EXPR): a ``turn_ended``/``error`` lifecycle
+        # event more recent than the last user message. Append the same event
+        # ``loop._apply_retry_or_failure`` writes so the derived exclusion fires.
+        await sessions_service.append_event(
+            pool,
+            session.id,
+            "lifecycle",
+            {"event": "turn_ended", "status": "errored", "stop_reason": "error"},
+            account_id=account_id,
+        )
     return session.id
 
 
@@ -81,7 +90,7 @@ class TestErroredSessionSweepFilter:
         self, db_pool: asyncpg.Pool[Any]
     ) -> None:
         """The exhaustion landing pad: errored + unreacted user msg ⇒ skipped."""
-        sid = await _seed_session_with_unreacted_message(db_pool, status="errored")
+        sid = await _seed_session_with_unreacted_message(db_pool, errored=True)
 
         result = await find_sessions_needing_inference(db_pool, TaskRegistry(), session_id=sid)
 
@@ -89,28 +98,35 @@ class TestErroredSessionSweepFilter:
             "Errored sessions must not be re-woken by the sweep — that's the regression #353 fixes."
         )
 
-    async def test_pending_session_still_picked_up(self, db_pool: asyncpg.Pool[Any]) -> None:
-        """Sanity: a pending session with an unreacted user msg is still found."""
-        sid = await _seed_session_with_unreacted_message(db_pool, status="pending")
+    async def test_active_session_still_picked_up(self, db_pool: asyncpg.Pool[Any]) -> None:
+        """Sanity: a non-errored session with an unreacted user msg is found."""
+        sid = await _seed_session_with_unreacted_message(db_pool, errored=False)
 
         result = await find_sessions_needing_inference(db_pool, TaskRegistry(), session_id=sid)
 
         assert sid in result
 
-    async def test_user_message_flips_errored_to_pending(self, db_pool: asyncpg.Pool[Any]) -> None:
-        """``append_user_message`` is the operator-recovery escape hatch:
-        it must un-park an ``errored`` session by flipping status to ``pending``.
+    async def test_user_message_recovers_errored_session(self, db_pool: asyncpg.Pool[Any]) -> None:
+        """A new user message is the operator-recovery escape hatch: its seq
+        overtakes the error lifecycle event, so the session stops deriving
+        ``errored`` and the sweep picks it up again — no status flip needed.
         """
         account_id = "acc_test_stub"  # PR 3 scaffolding
-        sid = await _seed_session_with_unreacted_message(db_pool, status="errored")
+        sid = await _seed_session_with_unreacted_message(db_pool, errored=True)
+
+        # Parked: the sweep skips it.
+        assert (
+            await find_sessions_needing_inference(db_pool, TaskRegistry(), session_id=sid) == set()
+        )
 
         await sessions_service.append_user_message(
             db_pool, sid, "please try again", account_id=account_id
         )
 
-        async with db_pool.acquire() as conn:
-            status = await conn.fetchval("SELECT status FROM sessions WHERE id = $1", sid)
-        assert status == "pending", (
-            "A new user message must clear the errored marker so the next "
+        # Recovered: the new user message is more recent than the error event,
+        # so the session is no longer derived-errored and the sweep finds it.
+        result = await find_sessions_needing_inference(db_pool, TaskRegistry(), session_id=sid)
+        assert sid in result, (
+            "A new user message must recover an errored session so the next "
             "wake actually runs — otherwise recovery requires manual DB poking."
         )

--- a/tests/e2e/test_litellm_502_recovery.py
+++ b/tests/e2e/test_litellm_502_recovery.py
@@ -57,7 +57,10 @@ class TestLiteLLMBadGatewayRecovery:
 
             await harness.run_step(session.id)
             s_after_first = await harness.session(session.id)
-            assert s_after_first.status == "rescheduling"
+            # Retry pending (unreacted user message + rescheduling stop_reason)
+            # derives ``active`` — rescheduling folded into active.
+            assert s_after_first.status == "active"
+            assert s_after_first.stop_reason == {"type": "rescheduling"}
 
             await harness.run_step(session.id)
             s_after_second = await harness.session(session.id)

--- a/tests/e2e/test_session_clone.py
+++ b/tests/e2e/test_session_clone.py
@@ -88,11 +88,17 @@ async def parent_session_id(pool: Any) -> str:
         metadata={"k": "v"},
         account_id=account_id,
     )
-    # Append a couple of events so we can verify the copy.
+    # Append a user message and an assistant reply that reacts to it, so the
+    # parent is idle (no unreacted stimulus — clone requires an idle parent)
+    # and there are >=2 events to verify the copy.
     await sessions_svc.append_user_message(pool, session.id, "first", account_id=account_id)
-    await sessions_svc.append_user_message(pool, session.id, "second", account_id=account_id)
-    # The append flips status to pending; tests that need idle reset it.
-    await sessions_svc.set_session_status(pool, session.id, "idle", account_id=account_id)
+    await sessions_svc.append_event(
+        pool,
+        session.id,
+        "message",
+        {"role": "assistant", "content": "ack", "reacting_to": 1},
+        account_id=account_id,
+    )
     return session.id
 
 
@@ -166,30 +172,20 @@ class TestCloneBasic:
 
 
 class TestCloneRefusal:
-    async def test_refuses_pending_parent(
+    async def test_refuses_active_parent(
         self, http_client: httpx.AsyncClient, pool: Any, parent_session_id: str
     ) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.services import sessions as sessions_svc
 
-        await sessions_svc.set_session_status(
-            pool, parent_session_id, "pending", account_id=account_id
+        # An unreacted user message makes the parent derive ``active`` — clone
+        # refuses non-idle parents (their in-flight/owed work would leave the
+        # clone's expected event stream undefined).
+        await sessions_svc.append_user_message(
+            pool, parent_session_id, "more", account_id=account_id
         )
         r = await http_client.post(f"/v1/sessions/{parent_session_id}/clone", json={})
         assert r.status_code == 409, r.text
-
-    async def test_allowed_when_terminated(
-        self, http_client: httpx.AsyncClient, pool: Any, parent_session_id: str
-    ) -> None:
-        account_id = "acc_test_stub"  # PR 3 scaffolding
-        from aios.services import sessions as sessions_svc
-
-        await sessions_svc.set_session_status(
-            pool, parent_session_id, "terminated", account_id=account_id
-        )
-        r = await http_client.post(f"/v1/sessions/{parent_session_id}/clone", json={})
-        assert r.status_code == 201, r.text
-        assert r.json()["status"] == "terminated"
 
     async def test_404_on_missing_parent(self, http_client: httpx.AsyncClient) -> None:
         r = await http_client.post(

--- a/tests/e2e/test_session_status_pending.py
+++ b/tests/e2e/test_session_status_pending.py
@@ -1,4 +1,5 @@
-"""E2E tests for the ``pending`` session status (issue #39)."""
+"""E2E tests for the derived ``active`` session status (issue #39): a user
+message gives an idle session owed work, so it derives ``active``."""
 
 from __future__ import annotations
 
@@ -85,10 +86,13 @@ async def idle_session_id(pool: Any) -> str:
     return session.id
 
 
-class TestPendingStatus:
-    async def test_post_message_flips_idle_to_pending(
+class TestActiveStatus:
+    async def test_post_message_makes_session_active(
         self, http_client: httpx.AsyncClient, idle_session_id: str
     ) -> None:
+        """An unprompted user message gives the session owed work, so its
+        derived status flips ``idle → active`` (#39 orchestrators need to
+        distinguish a session that will run from one that's truly done)."""
         r = await http_client.get(f"/v1/sessions/{idle_session_id}")
         assert r.json()["status"] == "idle"
 
@@ -99,27 +103,33 @@ class TestPendingStatus:
         assert r.status_code == 201, r.text
 
         r = await http_client.get(f"/v1/sessions/{idle_session_id}")
-        assert r.json()["status"] == "pending"
+        assert r.json()["status"] == "active"
 
-    async def test_rescheduling_status_not_clobbered(
+    async def test_armed_schedule_wake_stays_idle(
         self, http_client: httpx.AsyncClient, pool: Any, idle_session_id: str
     ) -> None:
-        account_id = "acc_test_stub"  # PR 3 scaffolding
-        from aios.services import sessions as sessions_svc
+        """Quiescent between fires: a session with an armed future wake (a
+        pending scheduled task) but no in-flight or unreacted work derives
+        ``idle``. The scheduled task is a row, not an event, so it adds no
+        unreacted stimulus — the timer only matters when it actually fires."""
+        from datetime import UTC, datetime, timedelta
 
-        await sessions_svc.set_session_status(
+        from aios.models.scheduled_tasks import ScheduledTaskCreate
+        from aios.services import scheduled_tasks as scheduled_tasks_svc
+
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        await scheduled_tasks_svc.add_task(
             pool,
             idle_session_id,
-            "rescheduling",
-            stop_reason={"type": "rescheduling"},
+            ScheduledTaskCreate(
+                name=f"wake-{_uniq()}",
+                fire_at=datetime.now(UTC) + timedelta(hours=1),
+                command="echo hi",
+                timeout_seconds=30,
+            ),
             account_id=account_id,
         )
 
-        r = await http_client.post(
-            f"/v1/sessions/{idle_session_id}/messages",
-            json={"content": "ping"},
-        )
-        assert r.status_code == 201, r.text
-
         r = await http_client.get(f"/v1/sessions/{idle_session_id}")
-        assert r.json()["status"] == "rescheduling"
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "idle"

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -447,17 +447,18 @@ class TestBatchGating:
 @needs_docker
 class TestSessionStatus:
     async def test_status_transitions(self, harness: Harness) -> None:
-        """Session status should go pending → running → idle across a step.
+        """Derived status goes active → idle across a step.
 
-        ``harness.start`` appends a user message, which flips the newly
-        created session from ``idle`` to ``pending`` (issue #39 —
-        orchestrators need to distinguish "queued" from "turn finished").
+        ``harness.start`` appends a user message, giving the session owed
+        work, so it derives ``active`` (issue #39 — orchestrators need to
+        distinguish "will run" from "turn finished"). Once the model replies
+        with no pending work, it derives ``idle``.
         """
         harness.script_model([assistant("Hi!")])
         session = await harness.start("hello")
 
         s = await harness.session(session.id)
-        assert s.status == "pending"
+        assert s.status == "active"
 
         await harness.run_until_idle(session.id)
 
@@ -1128,9 +1129,11 @@ class TestCustomTools:
         # Run one step — model calls custom tool
         await harness.run_step(session.id)
 
-        # Session ends turn cleanly; custom tool is observable via awaiting
+        # Turn ends (stop_reason=end_turn) but the session is ACTIVE: the custom
+        # tool call is unresolved and resumes on a result POST (no user message
+        # needed), so status != idle. It's observable via awaiting.
         s = await harness.session(session.id)
-        assert s.status == "idle"
+        assert s.status == "active"
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"call_w1"}
         assert s.awaiting[0].kind == "custom"
@@ -1288,9 +1291,11 @@ class TestCustomTools:
         await harness.run_step(session.id)
         await harness.wait_for_tools(session.id)
 
-        # Custom tool is awaiting external execution; built-in already completed
+        # Custom tool is awaiting external execution (built-in already
+        # completed) → session is ACTIVE: the unresolved custom call resumes on
+        # a result POST without a user message.
         s = await harness.session(session.id)
-        assert s.status == "idle"
+        assert s.status == "active"
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"call_lookup"}
 
@@ -1366,8 +1371,10 @@ class TestPermissionPolicies:
         )
         await harness.run_step(session.id)
 
+        # always_ask tool pending confirmation → session is ACTIVE: it resumes
+        # on an operator confirmation (no user message needed).
         s = await harness.session(session.id)
-        assert s.status == "idle"
+        assert s.status == "active"
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"call_ask1"}
         assert s.awaiting[0].kind == "builtin"
@@ -1508,9 +1515,10 @@ class TestPermissionPolicies:
         await harness.run_step(session.id)
         await harness.wait_for_tools(session.id)
 
-        # glob should have executed; grep is awaiting confirmation
+        # glob should have executed; grep is awaiting confirmation → session is
+        # ACTIVE (resumes on the operator confirmation, no user message needed).
         s = await harness.session(session.id)
-        assert s.status == "idle"
+        assert s.status == "active"
         assert s.stop_reason == {"type": "end_turn"}
         assert {a.tool_call_id for a in s.awaiting} == {"call_slow"}
         assert s.awaiting[0].kind == "builtin"

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -47,6 +47,21 @@ _N_SESSIONS = 3
 _N_ASSISTANT_PER = 400
 _N_UNREACTED_PER = 30
 
+# Tool-call-heavy sessions. The sess_perf_* sessions carry no tool_calls, so the
+# expensive branch of ``_SESSION_ACTIVE_EXPR`` — the CROSS JOIN LATERAL over
+# ``tool_calls`` + the NOT EXISTS anti-join over tool results — never runs on
+# them (the OR short-circuits on the unreacted-stimulus branch). These sessions
+# are fully resolved AND fully reacted (a final assistant message reacts to the
+# tail), so the active derivation can't short-circuit: it must scan every
+# tool_call and confirm each has a result. That full-scan worst case is what the
+# read-time budget test guards — a missing index / quadratic re-scan here would
+# blow the buffer budget (the per-row-correlated active expr can't be locked
+# structurally with ``find_subplans_over_events`` the way the sweep's bulk CTE
+# queries are: its SubPlans over events are inherent and keyset+LIMIT-bounded).
+_N_TC_SESSIONS = 3
+_N_TC_ASST_PER = 30  # assistant messages carrying tool_calls
+_N_TC_PER_ASST = 4  # tool_calls per assistant message
+
 
 async def _seed_pathological(pool: asyncpg.Pool[Any]) -> list[str]:
     """Seed the shape that triggers the pre-#140 correlated-subquery
@@ -131,6 +146,78 @@ async def _seed_pathological(pool: asyncpg.Pool[Any]) -> list[str]:
                     )
                 )
                 seq += 1
+            await conn.executemany(
+                "INSERT INTO events (id, session_id, seq, kind, data, role, account_id) "
+                "VALUES ($1, $2, $3, $4, $5::jsonb, $6, 'acc_test_stub') "
+                "ON CONFLICT (id) DO NOTHING",
+                rows,
+            )
+
+        # Tool-call-heavy sessions (see module comment): fully resolved + fully
+        # reacted, so the active derivation runs its tool_call branch to
+        # completion (no short-circuit) and the session still derives idle.
+        for t in range(_N_TC_SESSIONS):
+            tsid = f"sess_tc_{t:03d}"
+            await conn.execute(
+                "INSERT INTO sessions (id, agent_id, environment_id, workspace_volume_path, account_id) "
+                "VALUES ($1, 'agt_perf', 'env_perf', '/tmp/ws_' || $1, 'acc_test_stub') "
+                "ON CONFLICT (id) DO NOTHING",
+                tsid,
+            )
+            rows = []
+            seq = 1
+            for i in range(_N_TC_ASST_PER):
+                tcids = [f"tc_{tsid}_{i}_{k}" for k in range(_N_TC_PER_ASST)]
+                rows.append(
+                    (
+                        f"ev_a_{tsid}_{i}",
+                        tsid,
+                        seq,
+                        "message",
+                        json.dumps(
+                            {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": tc,
+                                        "type": "function",
+                                        "function": {"name": "bash", "arguments": "{}"},
+                                    }
+                                    for tc in tcids
+                                ],
+                                "reacting_to": seq - 1,
+                            }
+                        ),
+                        "assistant",
+                    )
+                )
+                seq += 1
+                for tc in tcids:
+                    rows.append(
+                        (
+                            f"ev_t_{tsid}_{i}_{tc}",
+                            tsid,
+                            seq,
+                            "message",
+                            json.dumps({"role": "tool", "tool_call_id": tc, "content": "ok"}),
+                            "tool",
+                        )
+                    )
+                    seq += 1
+            # Final assistant message reacts to every tool result, so there is no
+            # unreacted stimulus — the active OR can't short-circuit and must
+            # evaluate the (fully-resolved) tool_call branch.
+            rows.append(
+                (
+                    f"ev_a_{tsid}_final",
+                    tsid,
+                    seq,
+                    "message",
+                    json.dumps({"role": "assistant", "content": "done", "reacting_to": seq - 1}),
+                    "assistant",
+                )
+            )
             await conn.executemany(
                 "INSERT INTO events (id, session_id, seq, kind, data, role, account_id) "
                 "VALUES ($1, $2, $3, $4, $5::jsonb, $6, 'acc_test_stub') "
@@ -256,9 +343,15 @@ class TestSweepQueryBudget:
     ) -> None:
         """The read-time ``status`` derivation (``_SESSION_STATUS_EXPR``) runs
         per returned row on ``list_sessions``/``get_session``. Keyset + LIMIT
-        bound it to the page, so on the pathological fixture (3 sessions, ~830
-        events each) it must stay cheap — guard against an accidental
-        O(events^2) plan (e.g. a cross-join in the correlated subqueries)."""
+        bound it to the page, so it must stay cheap — guard against an accidental
+        O(events^2) plan (e.g. a cross-join in the correlated subqueries).
+
+        Crucially this also exercises the *expensive* branch: the ``sess_tc_*``
+        sessions are fully resolved + fully reacted, so the active expression
+        can't short-circuit and runs its CROSS JOIN LATERAL over ``tool_calls``
+        + NOT EXISTS anti-join over results to completion on every row. A
+        quadratic re-scan there would blow this budget — so this assertion is
+        the N+1 lock for ``_SESSION_ACTIVE_EXPR``'s tool_call branch."""
         list_sql = (
             f"SELECT sessions.*, ({_SESSION_STATUS_EXPR}) AS status, "
             "(SELECT e.created_at FROM events e WHERE e.session_id = sessions.id "

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -28,7 +28,13 @@ from typing import Any
 import asyncpg
 import pytest
 
-from aios.harness.sweep import CANDIDATE_ROWS_SQL, GHOST_SPAN_START_SQL, UNREACTED_ROWS_SQL
+from aios.db.queries import _SESSION_STATUS_EXPR
+from aios.harness.sweep import (
+    CANDIDATE_ROWS_SQL,
+    ERRORED_SESSIONS_SQL,
+    GHOST_SPAN_START_SQL,
+    UNREACTED_ROWS_SQL,
+)
 from tests.conftest import needs_docker
 from tests.support import find_subplans_over_events
 
@@ -70,8 +76,8 @@ async def _seed_pathological(pool: asyncpg.Pool[Any]) -> list[str]:
         for sid in session_ids:
             await conn.execute(
                 """
-                INSERT INTO sessions (id, agent_id, environment_id, status, workspace_volume_path, account_id)
-                VALUES ($1, 'agt_perf', 'env_perf', 'idle', '/tmp/ws_' || $1, 'acc_test_stub')
+                INSERT INTO sessions (id, agent_id, environment_id, workspace_volume_path, account_id)
+                VALUES ($1, 'agt_perf', 'env_perf', '/tmp/ws_' || $1, 'acc_test_stub')
                 ON CONFLICT (id) DO NOTHING
                 """,
                 sid,
@@ -191,6 +197,19 @@ class TestNoCorrelatedSubplanOverEvents:
             f"{len(found)} correlated subplan(s) over events. Same CTE fix applies."
         )
 
+    async def test_errored_sessions_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
+        """``ERRORED_SESSIONS_SQL`` derives the parked-errored set the sweep
+        subtracts on every pass (replacing the old ``status = 'errored'``
+        column filter). Lock its two-MAX-CTE shape so it can't regress into a
+        correlated subquery over ``events``."""
+        plan = await _explain(seeded_pool, ERRORED_SESSIONS_SQL.format(scope_clause=""))
+        found = find_subplans_over_events(plan)
+        assert not found, (
+            f"N+1 regression in errored-session derivation: "
+            f"{len(found)} correlated subplan(s) over events. This query must "
+            f"hoist MAX(seq) per session via CTEs (see session_max_reacting)."
+        )
+
     async def test_span_start_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
         """``GHOST_SPAN_START_SQL`` drives the two-branch ghost-recovery
         synthesis (#685).  Lock its single-pass shape so a future
@@ -231,6 +250,32 @@ class TestSweepQueryBudget:
         # Fixture seeds ~2600 events; linear-scan cost is ~2.6k hits. We
         # allow generous headroom; the pre-fix path burnt ~1.8M here.
         assert hits < 50_000, f"candidate_rows uses {hits} buffer hits — N+1 regression?"
+
+    async def test_list_sessions_status_derivation_budget(
+        self, seeded_pool: asyncpg.Pool[Any]
+    ) -> None:
+        """The read-time ``status`` derivation (``_SESSION_STATUS_EXPR``) runs
+        per returned row on ``list_sessions``/``get_session``. Keyset + LIMIT
+        bound it to the page, so on the pathological fixture (3 sessions, ~830
+        events each) it must stay cheap — guard against an accidental
+        O(events^2) plan (e.g. a cross-join in the correlated subqueries)."""
+        list_sql = (
+            f"SELECT sessions.*, ({_SESSION_STATUS_EXPR}) AS status, "
+            "(SELECT e.created_at FROM events e WHERE e.session_id = sessions.id "
+            "ORDER BY e.seq DESC LIMIT 1) AS last_event_at "
+            "FROM sessions WHERE sessions.archived_at IS NULL "
+            "AND sessions.account_id = $1 ORDER BY sessions.id DESC LIMIT 50"
+        )
+        async with seeded_pool.acquire() as conn:
+            result = await conn.fetchval(
+                f"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {list_sql}", "acc_test_stub"
+            )
+        if isinstance(result, str):
+            result = json.loads(result)
+        hits = _total_buffer_hits(result[0]["Plan"])
+        assert hits < 50_000, (
+            f"list_sessions status derivation uses {hits} buffer hits — correlated-subquery blowup?"
+        )
 
 
 def _total_buffer_hits(plan_node: dict[str, Any]) -> int:

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -106,7 +106,7 @@ class TestWaitEndpoint:
             e["kind"] == "message" and e["data"].get("content") == "hello" for e in body["events"]
         )
         assert body["next_after"] == body["events"][-1]["seq"]
-        assert body["session_status"] in {"pending", "idle"}
+        assert body["session_status"] in {"active", "idle"}
 
     async def test_empty_after_timeout(
         self, http_client: httpx.AsyncClient, session_id: str

--- a/tests/integration/test_set_session_status_archived.py
+++ b/tests/integration/test_set_session_status_archived.py
@@ -1,5 +1,6 @@
-"""Integration test: ``set_session_status`` must not rewrite an
-archived session's row."""
+"""Integration test: ``set_session_stop_reason`` must not rewrite an
+archived session's row (status is derived now; ``stop_reason`` is the only
+mutable column it writes)."""
 
 from __future__ import annotations
 
@@ -11,6 +12,7 @@ import pytest
 
 from aios.db import queries
 from aios.db.pool import create_pool
+from aios.db.queries import parse_jsonb
 from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
@@ -20,9 +22,9 @@ pytestmark = pytest.mark.integration
 async def archived_marked_session(
     migrated_db_url: str, _reset_db_state: None
 ) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
-    """Yield ``(pool, account_id, session_id)`` for a session pinned
-    to ``rescheduling`` then archived — gives the post-call read a
-    distinctive expected ``status`` value."""
+    """Yield ``(pool, account_id, session_id)`` for a session whose
+    ``stop_reason`` is pinned to a distinctive value, then archived — giving
+    the post-call read a known expected ``stop_reason``."""
     pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
     try:
         async with pool.acquire() as conn:
@@ -36,57 +38,52 @@ async def archived_marked_session(
             pool, account_id="acc_sss_arch", prefix="sss-arch"
         )
         async with pool.acquire() as conn:
-            await queries.set_session_status(
-                conn, session.id, "rescheduling", None, account_id="acc_sss_arch"
+            await queries.set_session_stop_reason(
+                conn, session.id, {"type": "rescheduling"}, account_id="acc_sss_arch"
             )
             archived = await queries.archive_session(conn, session.id, account_id="acc_sss_arch")
         assert archived.archived_at is not None
-        assert archived.status == "rescheduling"
+        assert archived.stop_reason == {"type": "rescheduling"}
         yield pool, "acc_sss_arch", session.id
     finally:
         await pool.close()
 
 
-async def test_set_session_status_refuses_archived_silently(
+async def test_set_session_stop_reason_refuses_archived_silently(
     archived_marked_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
     pool, account_id, session_id = archived_marked_session
 
     async with pool.acquire() as conn:
-        await queries.set_session_status(
-            conn, session_id, "idle", {"type": "interrupt"}, account_id=account_id
+        await queries.set_session_stop_reason(
+            conn, session_id, {"type": "interrupt"}, account_id=account_id
         )
 
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
-            "SELECT status, stop_reason, archived_at FROM sessions WHERE id = $1",
+            "SELECT stop_reason, archived_at FROM sessions WHERE id = $1",
             session_id,
         )
     assert row is not None
-    assert row["status"] == "rescheduling", (
-        f"archived row was rewritten: status is {row['status']!r}, expected 'rescheduling'."
+    assert parse_jsonb(row["stop_reason"]) == {"type": "rescheduling"}, (
+        f"archived row was rewritten: stop_reason is {row['stop_reason']!r}."
     )
-    assert row["stop_reason"] is None
     assert row["archived_at"] is not None
 
 
-async def test_set_session_status_no_rewrite_on_archived(
+async def test_set_session_stop_reason_no_rewrite_on_archived(
     archived_marked_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
-    """The no-row UPDATE on an archived session must not bump
-    ``updated_at`` (and therefore must not have written anything)."""
+    """The no-row UPDATE on an archived session must not bump ``updated_at``
+    (and therefore must not have written anything)."""
     pool, account_id, session_id = archived_marked_session
 
     async with pool.acquire() as conn:
         pre_updated_at = await conn.fetchval(
             "SELECT updated_at FROM sessions WHERE id = $1", session_id
         )
-        await queries.set_session_status(
-            conn,
-            session_id,
-            "idle",
-            {"type": "end_turn"},
-            account_id=account_id,
+        await queries.set_session_stop_reason(
+            conn, session_id, {"type": "end_turn"}, account_id=account_id
         )
         post_updated_at = await conn.fetchval(
             "SELECT updated_at FROM sessions WHERE id = $1", session_id

--- a/tests/integration/test_tool_actions_on_errored.py
+++ b/tests/integration/test_tool_actions_on_errored.py
@@ -60,8 +60,18 @@ async def errored_session_with_tool_call(
                 },
                 account_id="acc_err_tool",
             )
-            await queries.set_session_status(
-                conn, session.id, "errored", {"type": "error"}, account_id="acc_err_tool"
+            # Park the session in the derived ``errored`` state: a
+            # ``turn_ended``/``error`` lifecycle event with no later user
+            # message (see queries._SESSION_ERRORED_EXPR / sweep).
+            await queries.append_event(
+                conn,
+                session_id=session.id,
+                kind="lifecycle",
+                data={"event": "turn_ended", "status": "errored", "stop_reason": "error"},
+                account_id="acc_err_tool",
+            )
+            await queries.set_session_stop_reason(
+                conn, session.id, {"type": "error"}, account_id="acc_err_tool"
             )
         yield pool, "acc_err_tool", session.id
     finally:
@@ -141,13 +151,14 @@ async def test_confirm_tool_deny_rejects_errored_session(
 async def test_ghost_repair_skips_errored_session(
     errored_session_with_tool_call: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
-    """Without the ``GHOST_ASST_SQL`` filter, ghost-repair would trip
-    the new operator-facing ConflictError on every errored session and
-    abort the sweep loop."""
+    """Ghost-repair must skip derived-errored sessions; otherwise it would
+    trip the operator-facing ConflictError on every errored session and abort
+    the sweep loop."""
     pool, _account_id, session_id = errored_session_with_tool_call
 
     repaired = await find_and_repair_ghosts(pool, TaskRegistry(), session_id=session_id)
     assert repaired == [], (
         f"ghost-repair attempted on an errored session (got {repaired}); "
-        f"GHOST_ASST_SQL is missing the ``s.status <> 'errored'`` filter."
+        f"find_and_repair_ghosts is missing the derived-errored exclusion "
+        f"(_errored_session_ids)."
     )

--- a/tests/integration/test_wake_session.py
+++ b/tests/integration/test_wake_session.py
@@ -197,27 +197,6 @@ class TestWakeSessionIntegration:
             )
         patched_defer_wake.assert_not_awaited()
 
-    async def test_terminated_target_rejected(
-        self,
-        pool_with_runtime: asyncpg.Pool[Any],
-        patched_defer_wake: AsyncMock,
-    ) -> None:
-        pool = pool_with_runtime
-        await _seed_account(pool, "acc_wake_term", "wake-test-terminated")
-        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_term", prefix="src")
-        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_term", prefix="dst")
-        async with pool.acquire() as conn:
-            await queries.set_session_status(
-                conn, target.id, "terminated", None, account_id="acc_wake_term"
-            )
-
-        with pytest.raises(WakeSessionTargetUnavailableError, match="terminated"):
-            await wake_session_handler(
-                source.id,
-                {"target_session_id": target.id, "prompt": "into the void"},
-            )
-        patched_defer_wake.assert_not_awaited()
-
     async def test_wake_depth_inherits_then_caps(
         self,
         pool_with_runtime: asyncpg.Pool[Any],

--- a/tests/unit/test_files_service.py
+++ b/tests/unit/test_files_service.py
@@ -37,18 +37,18 @@ class _FakeUpload:
 
 
 def _patch_session_get(session_id: str = "sess_x") -> Any:
-    """Patch ``queries.get_session`` to return a stub session row."""
+    """Patch ``queries.get_session_bare`` to return a stub session row."""
     stub = MagicMock()
     stub.id = session_id
     return patch(
-        "aios.services.files.queries.get_session",
+        "aios.services.files.queries.get_session_bare",
         AsyncMock(return_value=stub),
     )
 
 
 def _patch_session_not_found() -> Any:
     return patch(
-        "aios.services.files.queries.get_session",
+        "aios.services.files.queries.get_session_bare",
         AsyncMock(side_effect=NotFoundError("session sess_x not found", detail={"id": "sess_x"})),
     )
 

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -197,9 +197,9 @@ def mock_step_dependencies() -> Any:
             ),
         ),
         patch(
-            "aios.harness.loop.sessions_service.set_session_status",
+            "aios.harness.loop.sessions_service.set_session_stop_reason",
             AsyncMock(),
-        ) as set_status,
+        ) as set_stop_reason,
         patch(
             "aios.harness.loop.sessions_service.append_event",
             AsyncMock(return_value=start_event),
@@ -214,7 +214,7 @@ def mock_step_dependencies() -> Any:
         ) as defer_wake_mock,
     ):
         yield SimpleNamespace(
-            set_status=set_status,
+            set_stop_reason=set_stop_reason,
             append_event=append_event,
             defer_wake=defer_wake_mock,
         )
@@ -233,20 +233,26 @@ class TestRunSessionStepOnModelError:
         mock_step_dependencies.defer_wake.assert_awaited_once_with(
             ANY, "sess_x", cause="reschedule", delay_seconds=2, account_id=ANY
         )
-        status_calls = [call.args[2] for call in mock_step_dependencies.set_status.call_args_list]
-        assert "rescheduling" in status_calls
-        assert "idle" not in status_calls
+        # ``set_session_stop_reason(pool, session_id, stop_reason)`` — status is
+        # derived now, so the rescheduling state is recorded only via stop_reason
+        # (and the turn_ended/rescheduling lifecycle event).
+        stop_reasons = [
+            call.args[2] for call in mock_step_dependencies.set_stop_reason.call_args_list
+        ]
+        assert {"type": "rescheduling"} in stop_reasons
+        assert {"type": "end_turn"} not in stop_reasons
 
-    async def test_exhausted_budget_sets_errored_status_without_raising(
+    async def test_exhausted_budget_records_error_stop_reason_without_raising(
         self, mock_step_dependencies: Any
     ) -> None:
-        """Budget exhaustion parks the session in ``errored`` status (#353).
+        """Budget exhaustion parks the session in the derived ``errored`` state
+        (#353) — recorded as ``stop_reason={"type": "error"}`` plus the
+        ``turn_ended``/``error`` lifecycle event the sweep keys off.
 
-        After the fix, the inner model-call handler returns ``None`` instead of
-        re-raising, so ``run_session_step`` completes cleanly. The outer
-        ``harness_error`` handler never fires for model-call errors, preventing
-        an extra unintended ``_apply_retry_or_failure`` call that would
-        flip the session from ``errored`` back to ``rescheduling``.
+        The inner model-call handler returns ``None`` instead of re-raising, so
+        ``run_session_step`` completes cleanly; the outer ``harness_error``
+        handler never fires for model-call errors, preventing an extra
+        ``_apply_retry_or_failure`` call that would re-record ``rescheduling``.
         """
         with patch(
             "aios.harness.loop._count_consecutive_rescheduling",
@@ -255,12 +261,8 @@ class TestRunSessionStepOnModelError:
             await run_session_step("sess_x")  # must NOT raise
 
         mock_step_dependencies.defer_wake.assert_not_awaited()
-        statuses = [call.args[2] for call in mock_step_dependencies.set_status.call_args_list]
-        assert "errored" in statuses
-        assert "idle" not in statuses
-        errored_call = next(
-            call
-            for call in mock_step_dependencies.set_status.call_args_list
-            if call.args[2] == "errored"
-        )
-        assert errored_call.kwargs["stop_reason"] == {"type": "error"}
+        stop_reasons = [
+            call.args[2] for call in mock_step_dependencies.set_stop_reason.call_args_list
+        ]
+        assert {"type": "error"} in stop_reasons
+        assert {"type": "end_turn"} not in stop_reasons

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,15 +26,17 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0061``."""
+    """The migration ladder has exactly one head: ``0063``."""
     script = _script_directory()
-    assert script.get_heads() == ["0061"]
+    assert script.get_heads() == ["0063"]
 
 
 def test_chain_is_linear_0054_to_0060() -> None:
     """``0054 -> … -> 0060 -> 0061`` is a plain linear chain."""
     script = _script_directory()
 
+    rev_0063 = script.get_revision("0063")
+    rev_0062 = script.get_revision("0062")
     rev_0061 = script.get_revision("0061")
     rev_0060 = script.get_revision("0060")
     rev_0059 = script.get_revision("0059")
@@ -43,6 +45,8 @@ def test_chain_is_linear_0054_to_0060() -> None:
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0063.down_revision == "0062"
+    assert rev_0062.down_revision == "0061"
     assert rev_0061.down_revision == "0060"
     assert rev_0060.down_revision == "0059"
     assert rev_0059.down_revision == "0058"

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -198,7 +198,7 @@ class TestEntrySweepSpan:
                     )
                 ),
             ),
-            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
             patch(
                 "aios.harness.loop.sessions_service.append_event",
                 AsyncMock(return_value=start_event),

--- a/tests/unit/test_sweep_isolation.py
+++ b/tests/unit/test_sweep_isolation.py
@@ -66,14 +66,15 @@ async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> No
         {"session_id": "sess_a", "tools": "[]"},
         {"session_id": "sess_b", "tools": "[]"},
     ]
-    # find_and_repair_ghosts issues five ``conn.fetch`` calls in order:
-    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents,
-    # GHOST_SPAN_START_SQL.  The empty span result means both ghosts hit
+    # find_and_repair_ghosts issues six ``conn.fetch`` calls in order:
+    # GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
+    # GHOST_LIFECYCLE_SQL, agents, GHOST_SPAN_START_SQL.  The empty errored
+    # and span results mean no session is parked-errored and both ghosts hit
     # the "never started" branch of the recovery synthesis (#685) — which
     # is fine for this test, which only cares that per-ghost failures
     # don't abort the batch.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, []])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, []])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock(side_effect=[RuntimeError("first ghost db blip"), None])
@@ -131,11 +132,11 @@ async def test_ghost_repair_branch_may_have_completed(monkeypatch: Any) -> None:
     span_rows = [
         {"session_id": "sess_a", "tool_call_id": "tc_a"},
     ]
-    # find_and_repair_ghosts now issues five ``conn.fetch`` calls in order:
-    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents,
-    # GHOST_SPAN_START_SQL.
+    # find_and_repair_ghosts now issues six ``conn.fetch`` calls in order:
+    # GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
+    # GHOST_LIFECYCLE_SQL, agents, GHOST_SPAN_START_SQL.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, span_rows])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, span_rows])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock(return_value=None)
@@ -178,8 +179,10 @@ async def test_ghost_repair_branch_did_not_run(monkeypatch: Any) -> None:
     ]
     # NO span for tc_a → routes the synthesis to the "did not run" branch.
     span_rows: list[dict[str, Any]] = []
+    # Six fetches: GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
+    # GHOST_LIFECYCLE_SQL, agents, GHOST_SPAN_START_SQL.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, span_rows])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, span_rows])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock(return_value=None)

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -248,7 +248,7 @@ class TestStepStartEndSpans:
                     )
                 ),
             ),
-            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
             patch("aios.harness.loop.sessions_service.append_event", append_event),
             patch(
                 "aios.harness.loop.stream_litellm",
@@ -345,7 +345,7 @@ class TestStepStartEndSpans:
                     )
                 ),
             ),
-            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
             patch(
                 "aios.harness.loop.sessions_service.append_event",
                 AsyncMock(return_value=start_event),
@@ -442,7 +442,7 @@ class TestStepStartEndSpans:
                     )
                 ),
             ),
-            patch("aios.harness.loop.sessions_service.set_session_status", AsyncMock()),
+            patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
             patch("aios.harness.loop.sessions_service.append_event", append_event),
             patch(
                 "aios.harness.loop.stream_litellm",

--- a/tests/unit/test_wake_session_handler.py
+++ b/tests/unit/test_wake_session_handler.py
@@ -162,28 +162,8 @@ class TestWakeSessionHandlerPermission:
                 {"target_session_id": "sess_01TARGET", "prompt": "hi"},
             )
 
-    async def test_terminated_target_rejects(self, monkeypatch: Any, install_pool: Any) -> None:
-        install_pool(
-            _make_pool(
-                target_row={
-                    "account_id": "acc_test_stub",
-                    "status": "terminated",
-                    "archived_at": None,
-                },
-                depth=0,
-                recent_wakes=0,
-            )
-        )
-        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
-        with pytest.raises(WakeSessionTargetUnavailableError, match="terminated"):
-            await wake_session_handler(
-                "sess_01SOURCE",
-                {"target_session_id": "sess_01TARGET", "prompt": "hi"},
-            )
-
     async def test_errored_target_allowed(self, monkeypatch: Any, install_pool: Any) -> None:
-        """Errored isn't a terminal state — a wake re-promotes it to pending."""
+        """Errored isn't a terminal state — a wake's user message recovers it."""
         install_pool(
             _make_pool(
                 target_row={


### PR DESCRIPTION
## What

Collapse the denormalized 5-value session status enum
(`pending`/`idle`/`rescheduling`/`errored`/`terminated`) into a **derived binary
`{active, idle}`** computed from the event log at read time, and drop the
persisted `sessions.status` column entirely.

## Why

`status` was set to `"idle"` unconditionally at the end of every step
(`loop.py`), so a session read `idle` while it was generating, while its
background tools ran, and while it was blocked on an approval — a lossy union of
unrelated conditions that almost never reflected real activity (the console had
to kludge `pending`→"Active" and `isRunning = pending||rescheduling`). The sweep
never relied on the column for control flow anyway: it keys off the
`reacting_to` watermark + unresolved tool_calls and only excluded `errored`.

## Semantics (`queries._SESSION_STATUS_EXPR`)

- **`active`** = unreacted stimulus **OR** an unresolved tool_call — owed/in-flight
  work that advances *without* a new unprompted user message (queued, generating,
  tools running, or blocked on approval / a custom-tool result). Subsumes the old
  `pending` + `rescheduling`.
- **`idle`** = quiescent; nothing owed. `idle ⟹ awaiting == []`. An armed
  `schedule_wake`/cron is a row, not an event, so a session stays `idle` between
  fires ("quiescent between fires").
- **`errored`** = derived (latest `turn_ended`/`error` lifecycle event newer than
  the latest user message); forces `idle`, skipped by the sweep, and **recovers
  automatically** when a user message's seq overtakes the error event — so the
  `append_event` `idle/errored → pending` CASE flip is gone. A special case of
  idle: `idle` + `stop_reason.type == "error"`.

`status` and `awaiting` now compose: a session blocked on an operator approval is
`active` with non-empty `awaiting`, not a third status.

## Mechanics

- **sweep.py**: `status <> 'errored'` → a derived-errored exclusion (two
  `MAX`-per-session CTEs, same hoisted-aggregation shape as `session_max_reacting`
  — no correlated subplan over `events`), subtracted in-process in
  `find_sessions_needing_inference` and `find_and_repair_ghosts`.
- **queries.py**: `get_session`/`list_sessions` select the derived status inline
  (`list_sessions` reuses `_list_scoped`, passing the status filter as an
  expression-filter so keyset pagination stays correct). `get_session_bare` (no
  derivation) for callers that never surface the label (worker step, existence
  checks, connection lookups). `set_session_status` → `set_session_stop_reason`.
- **interrupt/rescheduling** stop writing status (derive correctly);
  **terminated** removed from the enum (the `terminated` *lifecycle-event*
  stream-end sentinel is preserved). Clone gate: cloneable iff the parent is idle.
- Migrations **0062** (partial index `events_turn_error_idx`) and **0063** (drop
  `sessions.status` + `sessions_status_idx`). `openapi.json` + `aios-sdk`
  regenerated.

## Test plan

- `uv run mypy src` · `ruff check`/`format` clean.
- **1710 unit** + **618 e2e/integration** pass.
- `test_sweep_perf` extended: guards the derived-errored sweep query *and* the
  read-time list derivation against correlated-subplan / buffer-budget
  regressions.
- New coverage: derived `active` during owed work; `idle` only when nothing owed;
  derived `errored` + automatic recovery via a user message; armed `schedule_wake`
  reads `idle`. The 5 "idle-with-awaiting" tests now correctly assert `active`.

## Coordinated change

Console binding: eumemic/aios-console#15 (separate PR — `isRunning` now keys on
`status === "active"`; Errored pill derived from `idle` + `stop_reason.error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
