### PR TITLE
chore: ignore local MCP-fleet dev overlay files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ venv/
 *.pem
 *.key
 
+# local dev overlay: Google Workspace MCP server fleet (deployment-specific, not core)
+compose.override.yml
+mcp-fleet.env
+
 # Editor
 .vscode/
 .idea/


### PR DESCRIPTION
`compose.override.yml` and `mcp-fleet.env` are deployment-specific local dev overlay files for running a Google Workspace MCP server fleet alongside aios. They're not part of the core repo, so this adds them to `.gitignore` to keep `git status` clean for anyone running a local fleet.

One-line change; no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)