### PR TITLE
feat(harness): inject current time into the per-step context tail

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 import litellm
 
 from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT
+from aios.harness.time_block import TIME_BLOCK_PREFIX
 
 # Anthropic rejects empty text blocks that some OpenRouter models emit on
 # tool-call-only turns; modify_params tells LiteLLM to sanitize them.
@@ -226,10 +227,10 @@ def inject_cache_breakpoints(
     1. **System message** — cache-stable across steps.
     2. **Last tool definition** — cache-stable while tools don't change.
     3. **Last stable conversation message** — the last event-sourced
-       message, skipping the trailing channels tail block (which
-       mutates every step: unread counts, previews) and any
-       empty-assistant separator inserted before it by
-       :func:`separate_adjacent_user_messages`.
+       message, skipping the trailing ephemeral tail blocks (the
+       current-time line and the channels listing, both of which mutate
+       every step) and any empty-assistant separator inserted before them
+       by :func:`separate_adjacent_user_messages`.
 
     Skipping the tail is load-bearing: with the breakpoint on the tail
     itself, the conversation prefix never gets its own cache entry and
@@ -261,6 +262,9 @@ def _last_stable_message_index(messages: list[dict[str, Any]]) -> int | None:
     * The channels tail block — identified by its content signature
       ``━━━ Channels ━━━`` (always the last user-role message when
       present).
+    * The current-time tail block — identified by
+      :data:`~aios.harness.time_block.TIME_BLOCK_PREFIX`; appended every
+      step and mutates with the clock.
     * Any role-transition separator — inserted by
       :func:`~aios.harness.context.separate_adjacent_user_messages` to
       defeat Anthropic's adjacent-user-merge; carries only a
@@ -271,7 +275,7 @@ def _last_stable_message_index(messages: list[dict[str, Any]]) -> int | None:
     """
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
-        if _is_tail_block(msg) or _is_separator_placeholder(msg):
+        if _is_tail_block(msg) or _is_time_block(msg) or _is_separator_placeholder(msg):
             continue
         return i
     return None
@@ -295,6 +299,29 @@ def _is_tail_block(msg: dict[str, Any]) -> bool:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text")
                 if isinstance(text, str) and text.startswith("━━━ Channels ━━━"):
+                    return True
+    return False
+
+
+def _is_time_block(msg: dict[str, Any]) -> bool:
+    """Detect the current-time tail block by its leading marker.
+
+    Mirrors :func:`_is_tail_block`: a user-role message whose content
+    begins with :data:`~aios.harness.time_block.TIME_BLOCK_PREFIX`.  Like
+    the channels tail, the time block mutates every step (the clock ticks),
+    so the breakpoint walker must skip it to keep the conversation prefix
+    cache-stable.
+    """
+    if msg.get("role") != "user":
+        return False
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content.startswith(TIME_BLOCK_PREFIX)
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str) and text.startswith(TIME_BLOCK_PREFIX):
                     return True
     return False
 

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -26,6 +26,7 @@ work to honor the "byte-identical" promise.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from aios.harness._text import join_blocks
@@ -34,6 +35,7 @@ from aios.harness.context import (
     separate_adjacent_user_messages,
     stub_missing_reasoning_content,
 )
+from aios.harness.time_block import TIME_BLOCK_MAX_LOCAL, build_time_block
 from aios.tools.registry import to_openai_tools
 
 if TYPE_CHECKING:
@@ -214,7 +216,7 @@ async def compute_step_prelude(
         system_prompt=system_prompt,
         tools=tools,
         skill_versions=skill_versions,
-        tail_block_upper_bound_local=max_tail_block_local(channels),
+        tail_block_upper_bound_local=max_tail_block_local(channels) + TIME_BLOCK_MAX_LOCAL,
     )
 
 
@@ -274,6 +276,7 @@ async def compose_step_context(
     prelude: StepPrelude,
     events: list[Event],
     in_flight_tool_call_ids: frozenset[str] = frozenset(),
+    now: datetime | None = None,
 ) -> StepContext:
     """Compose the chat-completions payload for a step.
 
@@ -314,9 +317,13 @@ async def compose_step_context(
         in_flight_tool_call_ids=in_flight_tool_call_ids,
     )
 
-    # Tail block lives *after* build_messages so its per-step mutations
-    # (unread counts, previews) don't bust the prefix cache.  Paradigm
-    # prose stays in the cache-stable system prompt above.
+    # Tail blocks live *after* build_messages so their per-step mutations
+    # (the current time; unread counts, previews) don't bust the prefix
+    # cache.  Cache-stable prose stays in the system prompt above.
+    #
+    # Current-time block first, so the channels listing stays the literal
+    # tail that the focal-paradigm prose refers to.
+    ctx.messages.append(build_time_block(now if now is not None else datetime.now(UTC)))
     tail = build_channels_tail_block(channels, events, session.focal_channel)
     if tail is not None:
         ctx.messages.append(tail)

--- a/src/aios/harness/time_block.py
+++ b/src/aios/harness/time_block.py
@@ -1,0 +1,65 @@
+"""Per-step current-time tail block.
+
+A long-lived agent needs to know what "now" is to reason about dates and
+times — scheduling reminders, answering "what's today", stamping notes —
+without guessing (models routinely hallucinate the date) or paying a tool
+round-trip just to read a clock.
+
+The harness injects the current UTC time as an *ephemeral tail message*:
+appended AFTER :func:`~aios.harness.context.build_messages`, exactly like the
+channels tail block, so its per-step value never mutates the cache-stable
+prompt prefix. Conversion to the user's local timezone is the agent's job
+(the timezone lives in the agent's instructions/memory, not here), so this
+block stays a single, locale-free UTC line.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from aios.harness.tokens import approx_tokens
+
+# Stable leading marker, shared between the producer (:func:`build_time_block`)
+# and the cache-breakpoint recognizer (``_is_time_block`` in completion.py) so
+# the two can never drift — the same producer/recognizer coupling the channels
+# tail (``━━━ Channels ━━━``) and the separator placeholder already rely on.
+# It also frames the line as harness metadata so the model never reads this
+# user-role message as something the human said — load-bearing on no-channels
+# sessions, where no other framing prose is present.
+TIME_BLOCK_PREFIX = "[current time] "
+
+
+def build_time_block(now: datetime) -> dict[str, Any]:
+    """Ephemeral tail message stating the current UTC time.
+
+    Rendered as a user-role message (matching the channels tail) and appended
+    after ``build_messages``. Two safety properties, both shared with the
+    channels tail and both load-bearing:
+
+    * Cache-safe — completion.py's breakpoint walker skips it (via
+      :data:`TIME_BLOCK_PREFIX`), so its per-step mutation never anchors the
+      conversation cache breakpoint.
+    * Unambiguous — the ``[current time]`` marker + the explicit disclaimer
+      keep the model from attributing this to the human.
+
+    Includes the weekday because relative reasoning ("next Thursday") needs it.
+    """
+    return {
+        "role": "user",
+        "content": (
+            f"{TIME_BLOCK_PREFIX}{now:%Y-%m-%d %H:%M:%S} UTC ({now:%A}) "
+            "— system clock, not a message from anyone."
+        ),
+    }
+
+
+# Worst-case local-token cost of :func:`build_time_block`. The date/time
+# portion is fixed-width; only the weekday name varies (6 to 9 chars), so the
+# fattest of any 7 consecutive days is an exact upper bound. Reserved from
+# the window budget alongside ``max_tail_block_local`` so the composed
+# payload never exceeds ``window_max``.
+TIME_BLOCK_MAX_LOCAL: int = max(
+    approx_tokens([build_time_block(datetime(2026, 1, day, 23, 59, 59, tzinfo=UTC))])
+    for day in range(1, 8)
+)

--- a/tests/unit/test_time_block.py
+++ b/tests/unit/test_time_block.py
@@ -1,0 +1,31 @@
+"""Tests for the per-step current-time tail block."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from aios.harness.time_block import TIME_BLOCK_MAX_LOCAL, TIME_BLOCK_PREFIX, build_time_block
+from aios.harness.tokens import approx_tokens
+
+
+def test_build_time_block_shape_and_format() -> None:
+    now = datetime(2026, 6, 6, 19, 5, 49, tzinfo=UTC)  # a Saturday
+    block = build_time_block(now)
+    # Mirrors the channels tail: a user-role message appended after
+    # build_messages (so it never enters the cache-stable prefix).
+    assert block["role"] == "user"
+    assert block["content"] == (
+        "[current time] 2026-06-06 19:05:49 UTC (Saturday) "
+        "— system clock, not a message from anyone."
+    )
+    # The leading marker the cache-breakpoint recognizer keys off.
+    assert block["content"].startswith(TIME_BLOCK_PREFIX)
+
+
+def test_time_block_max_local_is_a_true_upper_bound() -> None:
+    # The reserved window budget must never be exceeded by the real block,
+    # whatever the weekday — otherwise the composed payload could overshoot
+    # window_max. March 2026 spans every weekday several times over.
+    for day in range(1, 32):
+        now = datetime(2026, 3, day, 23, 59, 59, tzinfo=UTC)
+        assert approx_tokens([build_time_block(now)]) <= TIME_BLOCK_MAX_LOCAL

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from aios.harness.completion import (
@@ -9,6 +10,7 @@ from aios.harness.completion import (
     _normalize_usage,
     inject_cache_breakpoints,
 )
+from aios.harness.time_block import build_time_block
 
 # Model string that LiteLLM routes through the Anthropic provider — used to
 # exercise the branch of inject_cache_breakpoints that actually mutates
@@ -255,6 +257,52 @@ class TestInjectCacheBreakpoints:
         # Separator stays bare; tail stays bare.
         assert msgs[2] == {"role": "assistant", "content": "."}
         assert msgs[3]["content"] == tail["content"]
+
+    def test_skips_time_block_no_channels(self) -> None:
+        """The current-time tail block is appended every step and mutates
+        with the clock, exactly like the channels tail.  On a no-channels
+        session it is the literal last message, so the breakpoint must skip
+        it and land on the last stable event — otherwise the conversation
+        prefix re-caches every step.
+        """
+        time_block = build_time_block(datetime(2026, 6, 6, 19, 5, 49, tzinfo=UTC))
+        msgs = [
+            _msg("system", "sys"),
+            _msg("user", "hi there"),
+            _msg("assistant", "hello"),
+            time_block,
+        ]
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
+        # Last stable message (the assistant), not the mutating time block.
+        assert msgs[2]["content"] == [
+            {"type": "text", "text": "hello", "cache_control": _CACHE_CONTROL}
+        ]
+        # Time block stays un-annotated.
+        assert msgs[3]["content"] == time_block["content"]
+
+    def test_skips_both_time_block_and_channels_tail(self) -> None:
+        """Both ephemeral tails (current-time then channels listing) plus the
+        adjacency separator between them must be skipped; the breakpoint
+        lands on the last stable event-sourced message.
+        """
+        time_block = build_time_block(datetime(2026, 6, 6, 19, 5, 49, tzinfo=UTC))
+        channels_tail = _msg("user", "━━━ Channels ━━━\n▸ channel_id=x (focal)")
+        separator = {"role": "assistant", "content": "."}
+        msgs = [
+            _msg("system", "sys"),
+            _msg("assistant", "hello"),
+            time_block,
+            separator,
+            channels_tail,
+        ]
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
+        # Breakpoint on the last stable event (the assistant).
+        assert msgs[1]["content"] == [
+            {"type": "text", "text": "hello", "cache_control": _CACHE_CONTROL}
+        ]
+        # Both ephemeral tails stay un-annotated.
+        assert msgs[2]["content"] == time_block["content"]
+        assert msgs[4]["content"] == channels_tail["content"]
 
     def test_tail_only_context_falls_back_to_system_and_tool(self) -> None:
         """Degenerate case: only system + tail.  No stable conversation


### PR DESCRIPTION
## What

Inject the current UTC time into the per-step context as an ephemeral tail message, so a long-lived agent always knows "now" without guessing or paying a `bash date` round-trip.

## Why

The harness never told the model the current time. Agents routinely hallucinate the date when scheduling reminders, answering "what's today", or stamping notes; the only workaround was instructing the agent to shell out to `date`, which costs a tool round-trip and relies on the model remembering to make it.

## How

`build_time_block(now)` returns a user-role message `[current time] <YYYY-MM-DD HH:MM:SS> UTC (<Weekday>) — system clock, not a message from anyone.`, appended in `compose_step_context` **after** `build_messages` — exactly like the existing channels tail block — so it never enters the cache-stable prompt prefix.

Two properties mirror the channels tail and are both load-bearing:

- **Cache-safe.** The cache-breakpoint walker (`_last_stable_message_index`) places the conversation breakpoint by walking backward, skipping per-step-mutating tails. A new ephemeral tail the walker *doesn't* recognize would capture the breakpoint and force the conversation prefix to re-cache every step — the exact pathology the existing tail-skip prevents. Added an `_is_time_block` recognizer to the skip set, keyed off a shared `TIME_BLOCK_PREFIX` constant so producer and recognizer can't drift (same coupling the channels tail and the separator placeholder already rely on).
- **Unambiguous.** The `[current time]` marker plus the disclaimer keep the model from reading this user-role message as something the human said — load-bearing on no-channels sessions, which have no other framing prose.

The block's fixed worst-case token cost (`TIME_BLOCK_MAX_LOCAL`) is reserved from the window budget alongside `max_tail_block_local`, so the composed payload never exceeds `window_max`.

## Tests

- `test_time_block.py` — content format + the token upper-bound invariant.
- `test_usage.py` — cache-breakpoint placement with the time block present (channels on **and** off): the breakpoint lands on the last event-sourced message and both ephemeral tails stay un-annotated.

`uv run mypy src`, `ruff check` / `ruff format --check`, and the full `tests/unit` suite (1750 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
