### PR TITLE
fix(harness): confirmed-tool dispatch hardening — window-edge (#737), awaiting (#741), sweep-predicate unification

### DIFF
--- a/migrations/versions/0065_tool_confirmed_allow_index.py
+++ b/migrations/versions/0065_tool_confirmed_allow_index.py
@@ -1,0 +1,53 @@
+"""Partial index on operator-confirmed (allow) tool-confirmation lifecycle
+events, keyed by ``(session_id, tool_call_id)``.
+
+Two readers resolve the same "confirmed ``allow`` whose ``tool_call`` has no
+``tool_result``" predicate and both benefit:
+
+* ``sweep.CONFIRMED_ROWS_SQL`` (``find_sessions_needing_inference`` case (c))
+  scans confirmed-allow lifecycle rows **cross-session** every sweep pass to
+  decide which sessions need a dispatch step — previously unindexed for this
+  predicate (only the wide ``events_session_seq_idx`` applied).
+* ``queries.list_confirmed_unresolved_tool_calls`` resolves the dispatchable
+  ``tool_call`` dicts for one session on **every** inference step; without this
+  index it would scan all of a long session's lifecycle rows per step.
+
+Confirmed-allow events are rare relative to total events (one per operator
+``allow`` of an ``always_ask`` tool), so this is a small partial index. The
+companion result-existence check reuses ``events_tool_result_idx`` (migration
+0023) and the parent-assistant lookup reuses ``events_assistant_tool_calls_idx``.
+
+Built with ``CREATE INDEX CONCURRENTLY`` (outside a transaction via
+``autocommit_block``) so it never takes an ACCESS EXCLUSIVE lock on the
+live-written ``events`` table — same pattern as migrations 0023 / 0062.
+
+Revision ID: 0065
+Revises: 0064
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0065"
+down_revision: str = "0064"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_tool_confirmed_allow_idx "
+            "ON events (session_id, (data->>'tool_call_id')) "
+            "WHERE kind = 'lifecycle' "
+            "AND data->>'event' = 'tool_confirmed' "
+            "AND data->>'result' = 'allow'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_tool_confirmed_allow_idx")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1962,21 +1962,24 @@ async def find_tool_confirmed_event(
     return _row_to_event(row) if row is not None else None
 
 
-async def lookup_tool_name_by_call_id(
+async def lookup_tool_call_by_call_id(
     conn: asyncpg.Connection[Any],
     session_id: str,
     tool_call_id: str,
     *,
     account_id: str,
-) -> str | None:
-    """Return the function name of the matching ``tool_call`` on the parent
-    assistant event, or None if no parent is found.
+) -> dict[str, Any] | None:
+    """Return the full ``tool_call`` dict (id / type / function) from the
+    parent assistant event whose ``tool_calls`` array contains
+    ``tool_call_id``, or None if no parent is found.
 
-    Used by the custom tool-result handler to stamp a ``name`` field on
-    the tool-role event it appends, so ``_derive_tool_name`` populates
-    the ``tool_name`` column (issue #133, migration 0022).  Mirrors the
-    parent-assistant lookup in ``_derive_event_channel`` — same ``@>``
-    predicate, same partial index (``events_assistant_tool_calls_idx``).
+    Unwindowed by construction — scans the whole log via the
+    ``events_assistant_tool_calls_idx`` partial index (the same ``@>``
+    predicate as the parent-assistant lookup in ``_derive_event_channel``).
+    This is the dispatch source for a confirmed ``always_ask`` tool whose
+    parent assistant may have scrolled out of the token window (#737); a
+    windowed read would detect the confirmation yet fail to find the call.
+    The name-only sibling :func:`lookup_tool_name_by_call_id` delegates here.
     """
     raw = await conn.fetchval(
         "SELECT data->'tool_calls' FROM events "
@@ -1998,14 +2001,34 @@ async def lookup_tool_name_by_call_id(
     if not isinstance(tool_calls, list):
         return None
     for tc in tool_calls:
-        if not isinstance(tc, dict) or tc.get("id") != tool_call_id:
-            continue
-        function = tc.get("function")
-        if not isinstance(function, dict):
-            return None
-        name = function.get("name")
-        return name if isinstance(name, str) else None
+        if isinstance(tc, dict) and tc.get("id") == tool_call_id:
+            return tc
     return None
+
+
+async def lookup_tool_name_by_call_id(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    tool_call_id: str,
+    *,
+    account_id: str,
+) -> str | None:
+    """Return the function name of the matching ``tool_call`` on the parent
+    assistant event, or None if no parent is found.
+
+    Used by the custom tool-result handler to stamp a ``name`` field on
+    the tool-role event it appends, so ``_derive_tool_name`` populates
+    the ``tool_name`` column (issue #133, migration 0022).  Delegates to
+    :func:`lookup_tool_call_by_call_id` and extracts the name.
+    """
+    tc = await lookup_tool_call_by_call_id(conn, session_id, tool_call_id, account_id=account_id)
+    if tc is None:
+        return None
+    function = tc.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    return name if isinstance(name, str) else None
 
 
 async def append_event(

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1962,24 +1962,21 @@ async def find_tool_confirmed_event(
     return _row_to_event(row) if row is not None else None
 
 
-async def lookup_tool_call_by_call_id(
+async def lookup_tool_name_by_call_id(
     conn: asyncpg.Connection[Any],
     session_id: str,
     tool_call_id: str,
     *,
     account_id: str,
-) -> dict[str, Any] | None:
-    """Return the full ``tool_call`` dict (id / type / function) from the
-    parent assistant event whose ``tool_calls`` array contains
-    ``tool_call_id``, or None if no parent is found.
+) -> str | None:
+    """Return the function name of the matching ``tool_call`` on the parent
+    assistant event, or None if no parent is found.
 
-    Unwindowed by construction — scans the whole log via the
-    ``events_assistant_tool_calls_idx`` partial index (the same ``@>``
-    predicate as the parent-assistant lookup in ``_derive_event_channel``).
-    This is the dispatch source for a confirmed ``always_ask`` tool whose
-    parent assistant may have scrolled out of the token window (#737); a
-    windowed read would detect the confirmation yet fail to find the call.
-    The name-only sibling :func:`lookup_tool_name_by_call_id` delegates here.
+    Used by the custom tool-result handler to stamp a ``name`` field on
+    the tool-role event it appends, so ``_derive_tool_name`` populates
+    the ``tool_name`` column (issue #133, migration 0022).  Mirrors the
+    parent-assistant lookup in ``_derive_event_channel`` — same ``@>``
+    predicate, same partial index (``events_assistant_tool_calls_idx``).
     """
     raw = await conn.fetchval(
         "SELECT data->'tool_calls' FROM events "
@@ -2001,34 +1998,91 @@ async def lookup_tool_call_by_call_id(
     if not isinstance(tool_calls, list):
         return None
     for tc in tool_calls:
-        if isinstance(tc, dict) and tc.get("id") == tool_call_id:
-            return tc
+        if not isinstance(tc, dict) or tc.get("id") != tool_call_id:
+            continue
+        function = tc.get("function")
+        if not isinstance(function, dict):
+            return None
+        name = function.get("name")
+        return name if isinstance(name, str) else None
     return None
 
 
-async def lookup_tool_name_by_call_id(
+async def list_confirmed_unresolved_tool_calls(
     conn: asyncpg.Connection[Any],
     session_id: str,
-    tool_call_id: str,
     *,
     account_id: str,
-) -> str | None:
-    """Return the function name of the matching ``tool_call`` on the parent
-    assistant event, or None if no parent is found.
+) -> list[dict[str, Any]]:
+    """Return the dispatchable ``tool_call`` dicts for a session: those
+    operator-confirmed (``tool_confirmed``/``allow``) whose ``tool_call_id``
+    has no paired ``tool_result`` yet, in chronological (parent-assistant
+    ``seq``) order.
 
-    Used by the custom tool-result handler to stamp a ``name`` field on
-    the tool-role event it appends, so ``_derive_tool_name`` populates
-    the ``tool_name`` column (issue #133, migration 0022).  Delegates to
-    :func:`lookup_tool_call_by_call_id` and extracts the name.
+    This is the dispatch-side resolver of the SAME predicate the sweep uses to
+    wake the session for case (c) — ``sweep.CONFIRMED_ROWS_SQL``: a
+    ``tool_confirmed``/``allow`` lifecycle event whose ``tool_call_id`` has no
+    ``role='tool'`` result.  Detection (the sweep, cross-session, projecting
+    only ``session_id``) and dispatch (here, per-session, projecting the
+    ``tool_call`` dicts) therefore agree by construction; re-resolving per step
+    is load-bearing against the wake→step TOCTOU window.
+
+    Unwindowed and unbounded — keyed on ``tool_call_id`` via the
+    ``events_tool_confirmed_allow_idx`` partial index (migration 0065), so a
+    confirmed tool whose parent assistant has scrolled out of the token window,
+    or simply isn't the latest assistant, is still recovered (#737).  The
+    ``NOT EXISTS`` result guard means one whose result has itself scrolled out
+    is not re-dispatched (no duplicate ``tool_result``; CLAUDE.md invariant
+    #4).  The parent-assistant join reuses ``events_assistant_tool_calls_idx``;
+    the result check reuses ``events_tool_result_idx``.
     """
-    tc = await lookup_tool_call_by_call_id(conn, session_id, tool_call_id, account_id=account_id)
-    if tc is None:
-        return None
-    function = tc.get("function")
-    if not isinstance(function, dict):
-        return None
-    name = function.get("name")
-    return name if isinstance(name, str) else None
+    rows = await conn.fetch(
+        """
+        SELECT a.seq AS asst_seq,
+               lc.data->>'tool_call_id' AS tool_call_id,
+               a.data->'tool_calls' AS tool_calls
+          FROM events lc
+          JOIN events a
+            ON a.session_id = lc.session_id
+           AND a.account_id = lc.account_id
+           AND a.kind = 'message'
+           AND a.role = 'assistant'
+           AND a.data ? 'tool_calls'
+           AND a.data->'tool_calls' @> jsonb_build_array(
+                 jsonb_build_object('id', lc.data->>'tool_call_id'))
+         WHERE lc.session_id = $1
+           AND lc.account_id = $2
+           AND lc.kind = 'lifecycle'
+           AND lc.data->>'event' = 'tool_confirmed'
+           AND lc.data->>'result' = 'allow'
+           AND NOT EXISTS (
+               SELECT 1 FROM events tr
+                WHERE tr.session_id = lc.session_id
+                  AND tr.account_id = lc.account_id
+                  AND tr.kind = 'message'
+                  AND tr.role = 'tool'
+                  AND tr.data->>'tool_call_id' = lc.data->>'tool_call_id'
+           )
+         ORDER BY a.seq ASC
+        """,
+        session_id,
+        account_id,
+    )
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        tool_call_id: str = row["tool_call_id"]
+        if tool_call_id in seen:
+            continue
+        tool_calls = parse_jsonb(row["tool_calls"])
+        if not isinstance(tool_calls, list):
+            continue
+        for tc in tool_calls:
+            if isinstance(tc, dict) and tc.get("id") == tool_call_id:
+                seen.add(tool_call_id)
+                out.append(tc)
+                break
+    return out
 
 
 async def append_event(
@@ -2208,10 +2262,12 @@ async def list_pending_calls_for_connector(
     """Pending custom tool calls across every active connection of ``connector`` type.
 
     Used by the runtime SSE at subscribe-time backfill.  A "pending"
-    call is a tool_call on the latest assistant message of a bound
-    session whose ``function.name`` is in ``connector.tools_schema``
-    and has no paired tool_result event yet.  No dependency on
-    ``stop_reason`` — the source of truth is the event log.
+    call is a tool_call on ANY assistant message of a bound session
+    whose ``function.name`` is in ``connector.tools_schema`` and has no
+    paired tool_result event yet — not just the latest assistant turn, so
+    a custom call left pending while the model emitted a later turn is
+    still surfaced for execution (the connector-side facet of #741).  No
+    dependency on ``stop_reason`` — the source of truth is the event log.
 
     Each emitted record carries ``connection_id`` so the runtime can
     fan out to the right per-connection worker.
@@ -2283,9 +2339,7 @@ async def list_pending_calls_for_connector(
         )
         workspace_path_by_session[row["session_id"]] = row["workspace_path"]
 
-    raw_by_sid = await _latest_unresolved_tool_calls(
-        conn, list(by_session.keys()), account_id=account_id
-    )
+    raw_by_sid = await _unresolved_tool_calls(conn, list(by_session.keys()), account_id=account_id)
     out: list[dict[str, Any]] = []
     for sid, calls in raw_by_sid.items():
         workspace_path = workspace_path_by_session[sid]
@@ -2347,7 +2401,7 @@ async def list_pending_calls_for_session_and_connection(
     if not name_set:
         return []
 
-    raw_by_sid = await _latest_unresolved_tool_calls(conn, [session_id], account_id=account_id)
+    raw_by_sid = await _unresolved_tool_calls(conn, [session_id], account_id=account_id)
     focal = conn_row["focal_channel"]
     workspace_path = conn_row["workspace_path"]
     out: list[dict[str, Any]] = []
@@ -2370,14 +2424,23 @@ async def list_pending_calls_for_session_and_connection(
     return out
 
 
-async def _latest_unresolved_tool_calls(
+async def _unresolved_tool_calls(
     conn: asyncpg.Connection[Any],
     session_ids: list[str],
     *,
     account_id: str,
 ) -> dict[str, list[dict[str, Any]]]:
-    """Return ``{session_id: [tool_call_dict]}`` for the latest assistant's
-    tool_calls (per session) that have no paired tool_result event.
+    """Return ``{session_id: [tool_call_dict]}`` for EVERY assistant's
+    tool_calls (per session) that have no paired tool_result event, in
+    chronological (seq-ascending) order.
+
+    Spans all assistant turns, not just the latest: an ``always_ask``
+    tool_call on an earlier assistant can stay unresolved while a later
+    assistant emits other tool_calls (e.g. the model reacts to an impatient
+    user message before the operator confirms).  Restricting to the latest
+    assistant (a ``DISTINCT ON (session_id) ... ORDER BY seq DESC``) hid such
+    still-pending calls from ``Session.awaiting`` — the read-model sibling of
+    the dispatch-side window-edge bug #737 (#741).
 
     Pending-ness is purely an event-log property — the session row's
     ``status`` and ``stop_reason`` are irrelevant. Tool_call dicts are
@@ -2392,7 +2455,7 @@ async def _latest_unresolved_tool_calls(
     # falls back to the wider ``events_session_seq_idx``.
     asst_rows = await conn.fetch(
         """
-        SELECT DISTINCT ON (session_id) session_id, data
+        SELECT session_id, data
           FROM events
          WHERE session_id = ANY($1::text[])
            AND account_id = $2
@@ -2402,7 +2465,7 @@ async def _latest_unresolved_tool_calls(
            AND jsonb_array_length(
                  COALESCE(NULLIF(data->'tool_calls','null'::jsonb), '[]'::jsonb)
                ) > 0
-         ORDER BY session_id, seq DESC
+         ORDER BY session_id, seq ASC
         """,
         session_ids,
         account_id,
@@ -2415,13 +2478,9 @@ async def _latest_unresolved_tool_calls(
         sid: str = row["session_id"]
         data = parse_jsonb(row["data"])
         completed: set[str] = results_by_sid.get(sid, set())
-        unresolved = [
-            tc
-            for tc in (data.get("tool_calls") or [])
-            if tc.get("id") and tc["id"] not in completed
-        ]
-        if unresolved:
-            out[sid] = unresolved
+        for tc in data.get("tool_calls") or []:
+            if tc.get("id") and tc["id"] not in completed:
+                out.setdefault(sid, []).append(tc)
     return out
 
 
@@ -2458,17 +2517,19 @@ async def list_unresolved_tool_calls_batch(
     *,
     account_id: str,
 ) -> dict[str, list[dict[str, Any]]]:
-    """For each session, return the latest assistant's tool_calls that
-    have no paired tool_result, annotated with allow-lifecycle presence.
+    """For each session, return every assistant's tool_calls that have no
+    paired tool_result, annotated with allow-lifecycle presence.
 
-    Used by :func:`services.sessions.compute_awaiting` to build the
+    Spans all assistant turns, not just the latest, so a tool_call left
+    unresolved on an earlier turn still appears in ``Session.awaiting``
+    (#741).  Used by :func:`services.sessions.compute_awaiting` to build the
     ``Session.awaiting`` derived view. Returned dicts have keys
     ``tool_call_id``, ``name``, ``arguments``, ``has_allow_lifecycle``
     — the caller classifies kind / needs_confirm using ``agent`` (and
     the tool's ``classify_permission`` for arg-aware routes like
     ``http_request``).
     """
-    raw = await _latest_unresolved_tool_calls(conn, session_ids, account_id=account_id)
+    raw = await _unresolved_tool_calls(conn, session_ids, account_id=account_id)
     if not raw:
         return {}
     allow_rows = await conn.fetch(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -785,65 +785,30 @@ async def _dispatch_confirmed_tools(
     Returns the original tool call dicts ready for ``launch_tool_calls``,
     or an empty list if nothing to dispatch.
 
-    Both halves are UNWINDOWED, and must agree:
-
-    - Detection: the ``tool_confirmed`` lifecycle tail, read newest-first
-      so a fresh confirmation isn't missed behind 200 ancient
-      ``turn_ended`` rows on a long session (#155).
-    - Dispatch: each confirmed tool_call is resolved from the log by
-      ``tool_call_id`` (:func:`sessions_service.resolve_confirmed_dispatchable`),
-      independent of the token window.  An earlier version sourced the
-      dispatchable calls from the windowed message slice, so a confirmed
-      ``always_ask`` tool whose parent assistant had scrolled past
-      ``window_max`` was detected-as-confirmed yet never found to
-      dispatch — the #155 symptom reachable via the window edge (#737).
+    Resolution is UNWINDOWED and mirrors the sweep's case-(c) wake predicate
+    (``sweep.CONFIRMED_ROWS_SQL``): a ``tool_confirmed``/``allow`` lifecycle
+    event whose ``tool_call_id`` has no ``tool_result``.  Sourcing the
+    dispatchable calls from the windowed message slice — as an earlier version
+    did — dropped a confirmed ``always_ask`` tool whose parent assistant had
+    scrolled past ``window_max`` (#737, the window-edge sibling of the
+    lifecycle-``LIMIT`` bug #155).  Detection (the sweep) and dispatch (here)
+    now resolve the identical predicate, so they can't disagree at any edge.
 
     Skips ``tool_call_id``s whose asyncio task is still in flight per
-    *task_registry*: procrastinate releases the per-session lock when
-    step N's job body returns, but the fire-and-forget tool task
-    outlives the body — any wake firing step N+1 before the task
-    appends its result would otherwise re-launch the same tool and
-    write a second ``tool_result`` event (violates CLAUDE.md
-    invariant #4).  ``resolve_confirmed_dispatchable`` applies the
-    complementary already-has-a-result guard.
+    *task_registry*: procrastinate releases the per-session lock when step N's
+    job body returns, but the fire-and-forget tool task outlives the body —
+    any wake firing step N+1 before the task appends its result would otherwise
+    re-launch the same tool and write a second ``tool_result`` event (violates
+    CLAUDE.md invariant #4).  ``list_confirmed_unresolved_tool_calls`` applies
+    the complementary already-has-a-result guard.
     """
-    # Read the recent tail newest-first; the default ASC scan would read
-    # the oldest 200 lifecycle events and miss any fresh tool_confirmed.
-    lifecycle_events = await sessions_service.read_events(
-        pool,
-        session_id,
-        kind="lifecycle",
-        newest_first=True,
-        limit=200,
-        account_id=account_id,
+    dispatchable = await sessions_service.list_confirmed_unresolved_tool_calls(
+        pool, session_id, account_id=account_id
     )
-    # Confirmed (allow) tool_call_ids, de-duplicated but order-preserving
-    # so dispatch order is deterministic.
-    seen: set[str] = set()
-    confirmed: list[str] = []
-    for e in lifecycle_events:
-        if e.data.get("event") == "tool_confirmed" and e.data.get("result") == "allow":
-            tcid = e.data.get("tool_call_id")
-            if tcid and tcid not in seen:
-                seen.add(tcid)
-                confirmed.append(tcid)
-    if not confirmed:
+    if not dispatchable:
         return []
-
     in_flight = task_registry.in_flight_tool_call_ids(session_id)
-    candidates = [tcid for tcid in confirmed if tcid not in in_flight]
-    if not candidates:
-        return []
-
-    # Resolve each confirmed-and-not-in-flight id to its dispatchable
-    # tool_call dict from the unwindowed log, dropping any that already
-    # have a result.
-    return await sessions_service.resolve_confirmed_dispatchable(
-        pool,
-        session_id,
-        tool_call_ids=candidates,
-        account_id=account_id,
-    )
+    return [tc for tc in dispatchable if tc.get("id") not in in_flight]
 
 
 async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str) -> float | None:

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -281,7 +281,6 @@ async def _run_session_step_body(
     pending = await _dispatch_confirmed_tools(
         pool,
         session_id,
-        events,
         account_id=account_id,
         task_registry=task_registry,
     )
@@ -777,7 +776,6 @@ async def discover_session_mcp_tools(
 async def _dispatch_confirmed_tools(
     pool: Any,
     session_id: str,
-    message_events: list[Any],
     *,
     account_id: str,
     task_registry: TaskRegistry,
@@ -787,44 +785,29 @@ async def _dispatch_confirmed_tools(
     Returns the original tool call dicts ready for ``launch_tool_calls``,
     or an empty list if nothing to dispatch.
 
+    Both halves are UNWINDOWED, and must agree:
+
+    - Detection: the ``tool_confirmed`` lifecycle tail, read newest-first
+      so a fresh confirmation isn't missed behind 200 ancient
+      ``turn_ended`` rows on a long session (#155).
+    - Dispatch: each confirmed tool_call is resolved from the log by
+      ``tool_call_id`` (:func:`sessions_service.resolve_confirmed_dispatchable`),
+      independent of the token window.  An earlier version sourced the
+      dispatchable calls from the windowed message slice, so a confirmed
+      ``always_ask`` tool whose parent assistant had scrolled past
+      ``window_max`` was detected-as-confirmed yet never found to
+      dispatch — the #155 symptom reachable via the window edge (#737).
+
     Skips ``tool_call_id``s whose asyncio task is still in flight per
     *task_registry*: procrastinate releases the per-session lock when
     step N's job body returns, but the fire-and-forget tool task
     outlives the body — any wake firing step N+1 before the task
     appends its result would otherwise re-launch the same tool and
     write a second ``tool_result`` event (violates CLAUDE.md
-    invariant #4).
+    invariant #4).  ``resolve_confirmed_dispatchable`` applies the
+    complementary already-has-a-result guard.
     """
-    # Collect tool_calls from EVERY assistant message, not just the
-    # latest.  An always_ask tool_call in turn A1 can outlive A1 if
-    # the model emits a later assistant A2 (e.g., reacting to an
-    # impatient user message that lifts the session out of
-    # ``requires_action``).  Stopping at A2 would silently drop A1's
-    # operator-confirmed dispatch — ghost-repair then papers over
-    # with a synthetic "did not run" error (per the two-branch recovery
-    # in ``sweep.find_and_repair_ghosts``, see #685), even though the
-    # operator did allow the tool; the dispatch was lost.  Filtering by
-    # ``completed`` / ``in_flight`` below correctly excludes anything
-    # already handled.
-    asst_tool_calls: list[dict[str, Any]] = []
-    for e in message_events:
-        if e.kind == "message" and e.data.get("role") == "assistant":
-            tcs = e.data.get("tool_calls")
-            if tcs:
-                asst_tool_calls.extend(tcs)
-
-    if not asst_tool_calls:
-        return []
-
-    # Build set of tool_call_ids that already have a tool-role result.
-    completed: set[str] = set()
-    for e in message_events:
-        if e.kind == "message" and e.data.get("role") == "tool":
-            tcid = e.data.get("tool_call_id")
-            if tcid:
-                completed.add(tcid)
-
-    # Read the recent tail; on long sessions the default ASC scan would read
+    # Read the recent tail newest-first; the default ASC scan would read
     # the oldest 200 lifecycle events and miss any fresh tool_confirmed.
     lifecycle_events = await sessions_service.read_events(
         pool,
@@ -834,22 +817,33 @@ async def _dispatch_confirmed_tools(
         limit=200,
         account_id=account_id,
     )
-    confirmed: set[str] = set()
+    # Confirmed (allow) tool_call_ids, de-duplicated but order-preserving
+    # so dispatch order is deterministic.
+    seen: set[str] = set()
+    confirmed: list[str] = []
     for e in lifecycle_events:
         if e.data.get("event") == "tool_confirmed" and e.data.get("result") == "allow":
             tcid = e.data.get("tool_call_id")
-            if tcid:
-                confirmed.add(tcid)
+            if tcid and tcid not in seen:
+                seen.add(tcid)
+                confirmed.append(tcid)
+    if not confirmed:
+        return []
 
     in_flight = task_registry.in_flight_tool_call_ids(session_id)
-    pending = [
-        tc
-        for tc in asst_tool_calls
-        if tc.get("id") in confirmed
-        and tc.get("id") not in completed
-        and tc.get("id") not in in_flight
-    ]
-    return pending
+    candidates = [tcid for tcid in confirmed if tcid not in in_flight]
+    if not candidates:
+        return []
+
+    # Resolve each confirmed-and-not-in-flight id to its dispatchable
+    # tool_call dict from the unwindowed log, dropping any that already
+    # have a result.
+    return await sessions_service.resolve_confirmed_dispatchable(
+        pool,
+        session_id,
+        tool_call_ids=candidates,
+        account_id=account_id,
+    )
 
 
 async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str) -> float | None:

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -121,6 +121,12 @@ CANDIDATE_ROWS_SQL = """
        {scope_clause}
 """
 
+# Cross-session detection of confirmed-but-unresolved tools, for the wake
+# decision (case (c)).  The dispatch-side counterpart that resolves these same
+# confirmed-allow, result-less tool_calls into the actual tool_call dicts to
+# launch is ``queries.list_confirmed_unresolved_tool_calls`` (per-session) —
+# keep the predicate (``tool_confirmed``/``allow`` ∧ no ``role='tool'`` result)
+# in sync.  Both are served by ``events_tool_confirmed_allow_idx`` (0065).
 CONFIRMED_ROWS_SQL = """
     SELECT DISTINCT lc.session_id
       FROM events lc

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -564,6 +564,48 @@ async def read_events(
         )
 
 
+async def resolve_confirmed_dispatchable(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    *,
+    tool_call_ids: list[str],
+    account_id: str,
+) -> list[dict[str, Any]]:
+    """Resolve confirmed-but-unresolved tool_calls to their dispatchable
+    tool_call dicts, sourced from the UNWINDOWED log.
+
+    For each ``tool_call_id`` (an operator-confirmed ``always_ask`` tool),
+    returns the parent assistant's tool_call dict — UNLESS the call already
+    has a ``tool_result``.  Both the result check (:func:`find_tool_result_event`)
+    and the parent lookup (:func:`lookup_tool_call_by_call_id`) are
+    unwindowed point-lookups keyed on ``tool_call_id``, so:
+
+    - a confirmed tool whose parent assistant has scrolled past
+      ``window_max`` is still recovered and dispatched (#737), and
+    - a confirmed tool whose ``tool_result`` has itself scrolled out is
+      NOT re-dispatched — no duplicate ``tool_result`` (CLAUDE.md
+      invariant #4).
+
+    Order-preserving over ``tool_call_ids``.  O(len(tool_call_ids)) indexed
+    lookups, not a full-log scan — the caller passes only the small set of
+    confirmed-and-not-in-flight ids from the lifecycle tail.
+    """
+    dispatchable: list[dict[str, Any]] = []
+    async with pool.acquire() as conn:
+        for tool_call_id in tool_call_ids:
+            existing = await queries.find_tool_result_event(
+                conn, session_id, tool_call_id, account_id=account_id
+            )
+            if existing is not None:
+                continue
+            tool_call = await queries.lookup_tool_call_by_call_id(
+                conn, session_id, tool_call_id, account_id=account_id
+            )
+            if tool_call is not None:
+                dispatchable.append(tool_call)
+    return dispatchable
+
+
 async def get_event(
     pool: asyncpg.Pool[Any], session_id: str, event_id: str, *, account_id: str
 ) -> Event:

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -564,46 +564,25 @@ async def read_events(
         )
 
 
-async def resolve_confirmed_dispatchable(
+async def list_confirmed_unresolved_tool_calls(
     pool: asyncpg.Pool[Any],
     session_id: str,
     *,
-    tool_call_ids: list[str],
     account_id: str,
 ) -> list[dict[str, Any]]:
-    """Resolve confirmed-but-unresolved tool_calls to their dispatchable
-    tool_call dicts, sourced from the UNWINDOWED log.
+    """Dispatchable ``tool_call`` dicts for operator-confirmed tools in a
+    session that have no result yet, sourced unwindowed from the log.
 
-    For each ``tool_call_id`` (an operator-confirmed ``always_ask`` tool),
-    returns the parent assistant's tool_call dict — UNLESS the call already
-    has a ``tool_result``.  Both the result check (:func:`find_tool_result_event`)
-    and the parent lookup (:func:`lookup_tool_call_by_call_id`) are
-    unwindowed point-lookups keyed on ``tool_call_id``, so:
-
-    - a confirmed tool whose parent assistant has scrolled past
-      ``window_max`` is still recovered and dispatched (#737), and
-    - a confirmed tool whose ``tool_result`` has itself scrolled out is
-      NOT re-dispatched — no duplicate ``tool_result`` (CLAUDE.md
-      invariant #4).
-
-    Order-preserving over ``tool_call_ids``.  O(len(tool_call_ids)) indexed
-    lookups, not a full-log scan — the caller passes only the small set of
-    confirmed-and-not-in-flight ids from the lifecycle tail.
+    One indexed query (see :func:`queries.list_confirmed_unresolved_tool_calls`)
+    that mirrors the sweep's case-(c) wake predicate, so a confirmed
+    ``always_ask`` tool whose parent assistant has scrolled out of the token
+    window (#737) — or simply isn't the latest assistant — is still recovered,
+    and one that already has a result is not re-dispatched (invariant #4).
     """
-    dispatchable: list[dict[str, Any]] = []
     async with pool.acquire() as conn:
-        for tool_call_id in tool_call_ids:
-            existing = await queries.find_tool_result_event(
-                conn, session_id, tool_call_id, account_id=account_id
-            )
-            if existing is not None:
-                continue
-            tool_call = await queries.lookup_tool_call_by_call_id(
-                conn, session_id, tool_call_id, account_id=account_id
-            )
-            if tool_call is not None:
-                dispatchable.append(tool_call)
-    return dispatchable
+        return await queries.list_confirmed_unresolved_tool_calls(
+            conn, session_id, account_id=account_id
+        )
 
 
 async def get_event(

--- a/tests/integration/test_awaiting_spans_all_assistants.py
+++ b/tests/integration/test_awaiting_spans_all_assistants.py
@@ -1,0 +1,118 @@
+"""Integration test for #741: ``Session.awaiting`` must surface unresolved
+tool_calls from EVERY assistant turn, not just the latest.
+
+``_unresolved_tool_calls`` (backing ``list_unresolved_tool_calls_batch`` →
+``compute_awaiting`` → ``Session.awaiting``) previously used
+``SELECT DISTINCT ON (session_id) ... ORDER BY seq DESC`` — the single latest
+assistant message with non-empty tool_calls.  A tool_call on an EARLIER
+assistant whose result hasn't landed was invisible to ``awaiting`` whenever a
+LATER assistant also emitted tool_calls.  Sibling of #737 on the read-model
+side: after #737 dispatch runs such a tool, but the awaiting view couldn't see
+it.
+
+Reachable scenario (the one #737 documents): A1 emits an ``always_ask``
+tool_call X; before the operator confirms, an impatient user lifts the session
+out of ``requires_action``; the model emits A2 with a different tool_call Z.
+A2 is now the latest assistant-with-tool_calls, so ``awaiting`` reported only Z
+and omitted the still-pending X.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.agents import ToolSpec
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+def _assistant(tool_call_id: str, name: str = "bash") -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": tool_call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+        ],
+    }
+
+
+@pytest.fixture
+async def session_with_two_assistant_turns(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a session whose log is:
+    A1(tool_call tc_X) → user → A2(tool_call tc_Z), with NO tool_result for
+    either.  ``tc_X`` is the earlier, non-latest unresolved tool_call.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_awaiting_all_assistants"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, $2)",
+                account_id,
+                "awaiting-all-assistants-test",
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool,
+            account_id=account_id,
+            prefix="awaiting-all-assistants",
+            tools=[ToolSpec(type="bash")],
+        )
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data=_assistant("tc_X"),
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data={"role": "user", "content": "are you still there?"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session.id,
+                kind="message",
+                data=_assistant("tc_Z"),
+            )
+        yield pool, account_id, session.id
+    finally:
+        await pool.close()
+
+
+class TestAwaitingSpansAllAssistants:
+    async def test_unresolved_from_earlier_assistant_is_surfaced(
+        self,
+        session_with_two_assistant_turns: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """#741: an unresolved tool_call on a non-latest assistant must appear
+        in the unresolved batch, not be hidden by a later assistant turn."""
+        pool, account_id, session_id = session_with_two_assistant_turns
+        async with pool.acquire() as conn:
+            unresolved = await queries.list_unresolved_tool_calls_batch(
+                conn, [session_id], account_id=account_id
+            )
+        tcids = {e["tool_call_id"] for e in unresolved.get(session_id, [])}
+        assert tcids == {"tc_X", "tc_Z"}, (
+            "Session.awaiting missed tc_X (on the earlier assistant A1) because "
+            "the unresolved-tool_calls query only inspected the latest assistant "
+            "turn (#741, sibling of #737)"
+        )

--- a/tests/integration/test_confirmed_unresolved_dispatch.py
+++ b/tests/integration/test_confirmed_unresolved_dispatch.py
@@ -1,0 +1,138 @@
+"""Integration test for ``queries.list_confirmed_unresolved_tool_calls`` — the
+unwindowed dispatch-side resolver introduced for #737 (and unified with the
+sweep's case-(c) wake predicate, ``sweep.CONFIRMED_ROWS_SQL``).
+
+Exercises the three filters against real Postgres (so the JSONB ``@>`` join,
+the ``NOT EXISTS`` result guard, and the ``events_tool_confirmed_allow_idx``
+partial index from migration 0065 are all genuinely in play):
+
+* confirmed (allow) ∧ no result ∧ parent is a NON-latest assistant  → returned
+  (the #737 window-edge / non-latest-assistant case the resolver must recover);
+* confirmed (allow) ∧ a tool_result already exists                  → excluded
+  (no re-dispatch — CLAUDE.md invariant #4);
+* an unconfirmed tool_call (no ``tool_confirmed allow``)            → excluded.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.agents import ToolSpec
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+def _assistant(tool_call_ids: list[str], name: str = "bash") -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": tcid,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+            for tcid in tool_call_ids
+        ],
+    }
+
+
+def _allow(tool_call_id: str) -> dict[str, Any]:
+    return {"event": "tool_confirmed", "result": "allow", "tool_call_id": tool_call_id}
+
+
+@pytest.fixture
+async def session_with_mixed_confirmations(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a session whose log is:
+
+    A1[tc_pending, tc_unconfirmed] → user → A2[tc_resolved],
+    then allow(tc_pending), allow(tc_resolved), tool_result(tc_resolved).
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_confirmed_unresolved_dispatch"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, $2)",
+                account_id,
+                "confirmed-unresolved-dispatch-test",
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool,
+            account_id=account_id,
+            prefix="confirmed-unresolved-dispatch",
+            tools=[ToolSpec(type="bash")],
+        )
+        sid = session.id
+
+        async def append(kind: str, data: dict[str, Any]) -> None:
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn, account_id=account_id, session_id=sid, kind=kind, data=data
+                )
+
+        # A1 carries the pending tool (later confirmed, never resolved) plus an
+        # unconfirmed tool; A2 is the LATEST assistant and carries the resolved
+        # tool — so the pending tool's parent is deliberately not the latest.
+        await append("message", _assistant(["tc_pending", "tc_unconfirmed"]))
+        await append("message", {"role": "user", "content": "are you still there?"})
+        await append("message", _assistant(["tc_resolved"]))
+        await append("lifecycle", _allow("tc_pending"))
+        await append("lifecycle", _allow("tc_resolved"))
+        await append(
+            "message",
+            {
+                "role": "tool",
+                "tool_call_id": "tc_resolved",
+                "content": "done",
+                "name": "bash",
+            },
+        )
+        yield pool, account_id, sid
+    finally:
+        await pool.close()
+
+
+class TestListConfirmedUnresolvedToolCalls:
+    async def test_only_confirmed_unresolved_are_returned(
+        self,
+        session_with_mixed_confirmations: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = session_with_mixed_confirmations
+        async with pool.acquire() as conn:
+            dispatchable = await queries.list_confirmed_unresolved_tool_calls(
+                conn, session_id, account_id=account_id
+            )
+
+        ids = [tc["id"] for tc in dispatchable]
+        assert ids == ["tc_pending"], (
+            "expected only the confirmed-and-unresolved tool_call (on the "
+            "non-latest assistant A1); got "
+            f"{ids} — tc_resolved has a result (invariant #4) and tc_unconfirmed "
+            "was never allowed"
+        )
+        # Full dispatchable dict, ready for ``launch_tool_calls``.
+        assert dispatchable[0]["function"]["name"] == "bash"
+
+    async def test_account_scoped(
+        self,
+        session_with_mixed_confirmations: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A different account sees nothing for the same session id (tenant
+        isolation — the resolver filters ``account_id``)."""
+        pool, _account_id, session_id = session_with_mixed_confirmations
+        async with pool.acquire() as conn:
+            dispatchable = await queries.list_confirmed_unresolved_tool_calls(
+                conn, session_id, account_id="acc_someone_else"
+            )
+        assert dispatchable == []

--- a/tests/unit/test_dispatch_confirmed_tools.py
+++ b/tests/unit/test_dispatch_confirmed_tools.py
@@ -1,23 +1,26 @@
-"""Unit tests for ``_dispatch_confirmed_tools`` tool-confirmation lookup."""
+"""Unit tests for confirmed-tool dispatch.
+
+Two layers:
+
+* ``_dispatch_confirmed_tools`` (harness) — orchestration: detect
+  confirmations from the unwindowed lifecycle tail, drop in-flight ids,
+  delegate dispatch resolution.
+* ``resolve_confirmed_dispatchable`` (service) — the unwindowed resolver
+  that recovers each confirmed tool_call by ``tool_call_id`` from the log,
+  independent of the token window.  This is the heart of the #737 fix.
+"""
 
 from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aios.harness.loop import _dispatch_confirmed_tools
 from aios.harness.task_registry import TaskRegistry
-
-
-def _assistant_with_tool_calls(tool_call_ids: list[str]) -> SimpleNamespace:
-    return SimpleNamespace(
-        kind="message",
-        data={
-            "role": "assistant",
-            "tool_calls": [{"id": tcid, "type": "function"} for tcid in tool_call_ids],
-        },
-    )
+from aios.services import sessions as sessions_service
+from tests.unit.conftest import fake_pool_yielding_conn
 
 
 def _confirmed(tool_call_id: str, result: str = "allow") -> SimpleNamespace:
@@ -26,133 +29,249 @@ def _confirmed(tool_call_id: str, result: str = "allow") -> SimpleNamespace:
     )
 
 
+def _tool_call(tool_call_id: str, name: str = "bash") -> dict[str, Any]:
+    return {
+        "id": tool_call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": "{}"},
+    }
+
+
 class TestDispatchConfirmedTools:
-    async def test_returns_empty_when_no_assistant_tool_calls(self) -> None:
+    """Orchestration: lifecycle-tail detection + in-flight filter, then
+    delegate dispatch resolution to the unwindowed resolver."""
+
+    async def test_returns_empty_when_no_confirmations(self) -> None:
         pool = MagicMock()
-        with patch(
-            "aios.harness.loop.sessions_service.read_events",
-            AsyncMock(return_value=[]),
-        ):
-            assert (
-                await _dispatch_confirmed_tools(
-                    pool,
-                    "sess_x",
-                    [],
-                    account_id="acc_test_stub",
-                    task_registry=TaskRegistry(),
-                )
-                == []
-            )
-
-    async def test_returns_confirmed_but_not_completed(self) -> None:
-        """Baseline: a confirmed tool call with no tool result is pending."""
-        msg_events = [_assistant_with_tool_calls(["tc1"])]
-        pool = MagicMock()
-        with patch(
-            "aios.harness.loop.sessions_service.read_events",
-            AsyncMock(return_value=[_confirmed("tc1")]),
-        ):
-            pending = await _dispatch_confirmed_tools(
-                pool,
-                "sess_x",
-                msg_events,
-                account_id="acc_test_stub",
-                task_registry=TaskRegistry(),
-            )
-        assert [tc["id"] for tc in pending] == ["tc1"]
-
-    async def test_reads_lifecycle_tail_newest_first(self) -> None:
-        """Regression for #155: default ASC + LIMIT 200 scan drops recent
-        ``tool_confirmed`` events on long sessions (bulk are ancient
-        ``turn_ended``). The user clicks allow but the confirmation is
-        invisible to the dispatch sweep.
-        """
-        msg_events = [_assistant_with_tool_calls(["tc1"])]
-        mock_read = AsyncMock(return_value=[_confirmed("tc1")])
-        pool = MagicMock()
-        with patch("aios.harness.loop.sessions_service.read_events", mock_read):
-            pending = await _dispatch_confirmed_tools(
-                pool,
-                "sess_x",
-                msg_events,
-                account_id="acc_test_stub",
-                task_registry=TaskRegistry(),
-            )
-        assert [tc["id"] for tc in pending] == ["tc1"]
-        assert mock_read.call_args.kwargs["newest_first"] is True
-
-    async def test_dispatches_confirmed_from_older_assistant(self) -> None:
-        """Confirmed tool calls from older assistant turns must still be
-        dispatched, even when a later assistant turn carries different
-        tool_calls.
-
-        Reachable scenario: the model emits assistant message A1 with an
-        ``always_ask`` tool_call X.  Operator hasn't confirmed yet.  The
-        user — impatient — sends another message.  ``append_event`` lifts
-        idle to pending; the step fires; the model sees X as a synthetic
-        pending result and emits assistant message A2 with a NEW tool_call
-        Z (e.g., a search to gather context for the reply, or a new
-        ``always_allow`` action).  Z runs, lands its tool_result.  THEN
-        the operator finally confirms X.
-
-        Pre-fix ``_dispatch_confirmed_tools`` walked reversed events and
-        broke at the first assistant with non-empty tool_calls — A2's
-        ``[Z]``.  The dispatch filter checked ``confirmed={X}`` against
-        ``[Z]`` and returned ``[]``.  X is silently dropped; ghost-repair
-        eventually papers over with a synthetic "did not run" error (per
-        the two-branch recovery in ``sweep.find_and_repair_ghosts`` — see
-        #685), because the operator DID allow X; only the dispatch was
-        lost."""
-        msg_events = [
-            _assistant_with_tool_calls(["tc_X"]),  # older A1 with the confirmed tool
-            SimpleNamespace(
-                kind="message",
-                data={"role": "user", "content": "are you still there?"},
+        resolve = AsyncMock(return_value=[])
+        with (
+            patch(
+                "aios.harness.loop.sessions_service.read_events",
+                AsyncMock(return_value=[]),
             ),
-            _assistant_with_tool_calls(["tc_Z"]),  # newer A2 with a DIFFERENT tool_call
-            SimpleNamespace(
-                kind="message",
-                data={"role": "tool", "tool_call_id": "tc_Z", "content": "z done"},
+            patch(
+                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
+                resolve,
             ),
-        ]
-        pool = MagicMock()
-        with patch(
-            "aios.harness.loop.sessions_service.read_events",
-            AsyncMock(return_value=[_confirmed("tc_X")]),
         ):
             pending = await _dispatch_confirmed_tools(
-                pool,
-                "sess_x",
-                msg_events,
-                account_id="acc_test_stub",
-                task_registry=TaskRegistry(),
-            )
-        assert [tc["id"] for tc in pending] == ["tc_X"], (
-            "operator-confirmed tool_call from an older assistant turn was "
-            "dropped because _dispatch_confirmed_tools broke at the first "
-            "assistant-with-tool_calls it found, ignoring earlier turns"
-        )
-
-    async def test_skips_tool_call_with_in_flight_task(self) -> None:
-        """An in-flight task in ``task_registry`` blocks re-dispatch — without
-        this guard, a wake firing step N+1 before the task appended its
-        result would launch a second asyncio task for the same
-        ``tool_call_id`` (violates CLAUDE.md invariant #4).
-        """
-        msg_events = [_assistant_with_tool_calls(["tc1"])]
-        pool = MagicMock()
-        registry = TaskRegistry()
-        in_flight: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        registry.add("sess_x", "tc1", in_flight)  # type: ignore[arg-type]
-        with patch(
-            "aios.harness.loop.sessions_service.read_events",
-            AsyncMock(return_value=[_confirmed("tc1")]),
-        ):
-            pending = await _dispatch_confirmed_tools(
-                pool,
-                "sess_x",
-                msg_events,
-                account_id="acc_test_stub",
-                task_registry=registry,
+                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
             )
         assert pending == []
+        resolve.assert_not_awaited()
+
+    async def test_returns_confirmed_dispatchable(self) -> None:
+        """A confirmed tool with no result is resolved and returned."""
+        pool = MagicMock()
+        resolve = AsyncMock(return_value=[_tool_call("tc1")])
+        with (
+            patch(
+                "aios.harness.loop.sessions_service.read_events",
+                AsyncMock(return_value=[_confirmed("tc1")]),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
+                resolve,
+            ),
+        ):
+            pending = await _dispatch_confirmed_tools(
+                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
+            )
+        assert [tc["id"] for tc in pending] == ["tc1"]
+        assert resolve.await_args.kwargs["tool_call_ids"] == ["tc1"]
+
+    async def test_reads_lifecycle_tail_newest_first(self) -> None:
+        """Regression for #155: the lifecycle tail must be read newest-first
+        so a fresh ``tool_confirmed`` isn't hidden behind 200 ancient
+        ``turn_ended`` rows on a long session."""
+        pool = MagicMock()
+        mock_read = AsyncMock(return_value=[_confirmed("tc1")])
+        with (
+            patch("aios.harness.loop.sessions_service.read_events", mock_read),
+            patch(
+                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
+                AsyncMock(return_value=[_tool_call("tc1")]),
+            ),
+        ):
+            await _dispatch_confirmed_tools(
+                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
+            )
+        assert mock_read.call_args.kwargs["newest_first"] is True
+
+    async def test_skips_in_flight_before_resolving(self) -> None:
+        """An in-flight task blocks re-dispatch — and short-circuits before
+        the resolver runs (no redundant DB work, no second asyncio task for
+        the same tool_call_id; CLAUDE.md invariant #4)."""
+        pool = MagicMock()
+        registry = TaskRegistry()
+        fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        registry.add("sess_x", "tc1", fut)  # type: ignore[arg-type]
+        resolve = AsyncMock(return_value=[])
+        with (
+            patch(
+                "aios.harness.loop.sessions_service.read_events",
+                AsyncMock(return_value=[_confirmed("tc1")]),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
+                resolve,
+            ),
+        ):
+            pending = await _dispatch_confirmed_tools(
+                pool, "sess_x", account_id="acc_test_stub", task_registry=registry
+            )
+        assert pending == []
+        resolve.assert_not_awaited()
+
+    async def test_dedupes_confirmed_ids_preserving_order(self) -> None:
+        """Multiple allow events for the same id collapse to one candidate;
+        order follows first appearance in the (newest-first) tail."""
+        pool = MagicMock()
+        resolve = AsyncMock(return_value=[])
+        with (
+            patch(
+                "aios.harness.loop.sessions_service.read_events",
+                AsyncMock(
+                    return_value=[
+                        _confirmed("tc2"),
+                        _confirmed("tc1"),
+                        _confirmed("tc2"),  # duplicate
+                    ]
+                ),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
+                resolve,
+            ),
+        ):
+            await _dispatch_confirmed_tools(
+                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
+            )
+        assert resolve.await_args.kwargs["tool_call_ids"] == ["tc2", "tc1"]
+
+    async def test_dispatches_confirmed_when_parent_scrolled_out_of_window(self) -> None:
+        """End-to-end regression for #737: a confirmed ``always_ask`` tool
+        whose parent assistant has scrolled out of the token window is still
+        dispatched.
+
+        Exercises the REAL resolver (only the DB queries are mocked), so a
+        regression that re-sources dispatch from the windowed message slice —
+        which by construction lacks the scrolled-out parent — would surface
+        here as an empty dispatch.  ``lookup_tool_call_by_call_id`` returning
+        the call models 'parent gone from the window but still in the log';
+        the operator's allow is visible via the unwindowed lifecycle tail."""
+        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
+        with (
+            patch(
+                "aios.harness.loop.sessions_service.read_events",
+                AsyncMock(return_value=[_confirmed("tc_X")]),
+            ),
+            patch(
+                "aios.services.sessions.queries.find_tool_result_event",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
+                AsyncMock(return_value=_tool_call("tc_X")),
+            ),
+        ):
+            pending = await _dispatch_confirmed_tools(
+                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
+            )
+        assert [tc["id"] for tc in pending] == ["tc_X"], (
+            "confirmed always_ask tool_call whose parent assistant scrolled "
+            "out of the token window was never dispatched (#737)"
+        )
+
+
+class TestResolveConfirmedDispatchable:
+    """The unwindowed resolver — the heart of the #737 fix.
+
+    Dispatch is sourced by ``tool_call_id`` from the full log, NOT from the
+    token-windowed slice, so a confirmed ``always_ask`` tool whose parent
+    assistant has scrolled past ``window_max`` is still recovered."""
+
+    async def test_recovers_parent_tool_call_unwindowed(self) -> None:
+        """Regression for #737: a confirmed tool whose parent assistant has
+        scrolled out of the token window is recovered via the unwindowed
+        parent-by-tool_call_id lookup and returned for dispatch.
+
+        ``lookup_tool_call_by_call_id`` returning the call models 'A1 is
+        gone from the window but still in the log'; ``find_tool_result_event``
+        returning None models 'no result yet'.  Pre-fix, dispatch read the
+        windowed slice (which lacks A1) and returned nothing."""
+        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
+        with (
+            patch(
+                "aios.services.sessions.queries.find_tool_result_event",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
+                AsyncMock(return_value=_tool_call("tc_X")),
+            ),
+        ):
+            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
+                pool, "sess_x", tool_call_ids=["tc_X"], account_id="acc_test_stub"
+            )
+        assert [tc["id"] for tc in dispatchable] == ["tc_X"]
+
+    async def test_skips_when_result_already_exists(self) -> None:
+        """A confirmed id whose ``tool_result`` exists in the log (even if it
+        scrolled out of the window) is NOT re-dispatched — no duplicate
+        ``tool_result`` (CLAUDE.md invariant #4).  The parent lookup is not
+        even reached."""
+        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
+        lookup = AsyncMock(return_value=_tool_call("tc_X"))
+        with (
+            patch(
+                "aios.services.sessions.queries.find_tool_result_event",
+                AsyncMock(return_value=SimpleNamespace(data={})),
+            ),
+            patch("aios.services.sessions.queries.lookup_tool_call_by_call_id", lookup),
+        ):
+            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
+                pool, "sess_x", tool_call_ids=["tc_X"], account_id="acc_test_stub"
+            )
+        assert dispatchable == []
+        lookup.assert_not_awaited()
+
+    async def test_skips_when_no_parent_found(self) -> None:
+        """No parent assistant for the id (should not happen in practice) →
+        nothing to dispatch, no crash."""
+        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
+        with (
+            patch(
+                "aios.services.sessions.queries.find_tool_result_event",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
+                pool, "sess_x", tool_call_ids=["tc_missing"], account_id="acc_test_stub"
+            )
+        assert dispatchable == []
+
+    async def test_resolves_multiple_in_order(self) -> None:
+        """Several confirmed ids resolve to their calls, order preserved."""
+        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
+        with (
+            patch(
+                "aios.services.sessions.queries.find_tool_result_event",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
+                AsyncMock(side_effect=[_tool_call("tc_a"), _tool_call("tc_b")]),
+            ),
+        ):
+            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
+                pool,
+                "sess_x",
+                tool_call_ids=["tc_a", "tc_b"],
+                account_id="acc_test_stub",
+            )
+        assert [tc["id"] for tc in dispatchable] == ["tc_a", "tc_b"]

--- a/tests/unit/test_dispatch_confirmed_tools.py
+++ b/tests/unit/test_dispatch_confirmed_tools.py
@@ -1,32 +1,21 @@
-"""Unit tests for confirmed-tool dispatch.
+"""Unit tests for ``_dispatch_confirmed_tools`` — the harness orchestration
+that filters in-flight tools out of the unwindowed confirmed-unresolved set
+resolved by ``sessions_service.list_confirmed_unresolved_tool_calls``.
 
-Two layers:
-
-* ``_dispatch_confirmed_tools`` (harness) — orchestration: detect
-  confirmations from the unwindowed lifecycle tail, drop in-flight ids,
-  delegate dispatch resolution.
-* ``resolve_confirmed_dispatchable`` (service) — the unwindowed resolver
-  that recovers each confirmed tool_call by ``tool_call_id`` from the log,
-  independent of the token window.  This is the heart of the #737 fix.
+The resolver's SQL — which mirrors the sweep's case-(c) predicate and recovers
+the parent ``tool_call`` regardless of window position or which assistant turn
+carries it — is covered by the integration test
+``tests/integration/test_confirmed_unresolved_dispatch.py``.
 """
 
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aios.harness.loop import _dispatch_confirmed_tools
 from aios.harness.task_registry import TaskRegistry
-from aios.services import sessions as sessions_service
-from tests.unit.conftest import fake_pool_yielding_conn
-
-
-def _confirmed(tool_call_id: str, result: str = "allow") -> SimpleNamespace:
-    return SimpleNamespace(
-        data={"event": "tool_confirmed", "result": result, "tool_call_id": tool_call_id}
-    )
 
 
 def _tool_call(tool_call_id: str, name: str = "bash") -> dict[str, Any]:
@@ -38,240 +27,44 @@ def _tool_call(tool_call_id: str, name: str = "bash") -> dict[str, Any]:
 
 
 class TestDispatchConfirmedTools:
-    """Orchestration: lifecycle-tail detection + in-flight filter, then
-    delegate dispatch resolution to the unwindowed resolver."""
-
-    async def test_returns_empty_when_no_confirmations(self) -> None:
+    async def test_returns_empty_when_none_unresolved(self) -> None:
         pool = MagicMock()
-        resolve = AsyncMock(return_value=[])
-        with (
-            patch(
-                "aios.harness.loop.sessions_service.read_events",
-                AsyncMock(return_value=[]),
-            ),
-            patch(
-                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
-                resolve,
-            ),
+        with patch(
+            "aios.harness.loop.sessions_service.list_confirmed_unresolved_tool_calls",
+            AsyncMock(return_value=[]),
         ):
             pending = await _dispatch_confirmed_tools(
                 pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
             )
         assert pending == []
-        resolve.assert_not_awaited()
 
-    async def test_returns_confirmed_dispatchable(self) -> None:
-        """A confirmed tool with no result is resolved and returned."""
+    async def test_returns_unwindowed_dispatchable(self) -> None:
+        """The confirmed-unresolved tool_calls from the resolver are returned
+        as-is when nothing is in flight — independent of window position or
+        which assistant turn carries them (#737)."""
         pool = MagicMock()
-        resolve = AsyncMock(return_value=[_tool_call("tc1")])
-        with (
-            patch(
-                "aios.harness.loop.sessions_service.read_events",
-                AsyncMock(return_value=[_confirmed("tc1")]),
-            ),
-            patch(
-                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
-                resolve,
-            ),
+        with patch(
+            "aios.harness.loop.sessions_service.list_confirmed_unresolved_tool_calls",
+            AsyncMock(return_value=[_tool_call("tc_X"), _tool_call("tc_Y")]),
         ):
             pending = await _dispatch_confirmed_tools(
                 pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
             )
-        assert [tc["id"] for tc in pending] == ["tc1"]
-        assert resolve.await_args.kwargs["tool_call_ids"] == ["tc1"]
+        assert [tc["id"] for tc in pending] == ["tc_X", "tc_Y"]
 
-    async def test_reads_lifecycle_tail_newest_first(self) -> None:
-        """Regression for #155: the lifecycle tail must be read newest-first
-        so a fresh ``tool_confirmed`` isn't hidden behind 200 ancient
-        ``turn_ended`` rows on a long session."""
-        pool = MagicMock()
-        mock_read = AsyncMock(return_value=[_confirmed("tc1")])
-        with (
-            patch("aios.harness.loop.sessions_service.read_events", mock_read),
-            patch(
-                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
-                AsyncMock(return_value=[_tool_call("tc1")]),
-            ),
-        ):
-            await _dispatch_confirmed_tools(
-                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
-            )
-        assert mock_read.call_args.kwargs["newest_first"] is True
-
-    async def test_skips_in_flight_before_resolving(self) -> None:
-        """An in-flight task blocks re-dispatch — and short-circuits before
-        the resolver runs (no redundant DB work, no second asyncio task for
-        the same tool_call_id; CLAUDE.md invariant #4)."""
+    async def test_skips_in_flight(self) -> None:
+        """An in-flight task blocks re-dispatch of the same tool_call_id — no
+        second asyncio task, no duplicate ``tool_result`` (CLAUDE.md
+        invariant #4)."""
         pool = MagicMock()
         registry = TaskRegistry()
         fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        registry.add("sess_x", "tc1", fut)  # type: ignore[arg-type]
-        resolve = AsyncMock(return_value=[])
-        with (
-            patch(
-                "aios.harness.loop.sessions_service.read_events",
-                AsyncMock(return_value=[_confirmed("tc1")]),
-            ),
-            patch(
-                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
-                resolve,
-            ),
+        registry.add("sess_x", "tc_X", fut)  # type: ignore[arg-type]
+        with patch(
+            "aios.harness.loop.sessions_service.list_confirmed_unresolved_tool_calls",
+            AsyncMock(return_value=[_tool_call("tc_X"), _tool_call("tc_Y")]),
         ):
             pending = await _dispatch_confirmed_tools(
                 pool, "sess_x", account_id="acc_test_stub", task_registry=registry
             )
-        assert pending == []
-        resolve.assert_not_awaited()
-
-    async def test_dedupes_confirmed_ids_preserving_order(self) -> None:
-        """Multiple allow events for the same id collapse to one candidate;
-        order follows first appearance in the (newest-first) tail."""
-        pool = MagicMock()
-        resolve = AsyncMock(return_value=[])
-        with (
-            patch(
-                "aios.harness.loop.sessions_service.read_events",
-                AsyncMock(
-                    return_value=[
-                        _confirmed("tc2"),
-                        _confirmed("tc1"),
-                        _confirmed("tc2"),  # duplicate
-                    ]
-                ),
-            ),
-            patch(
-                "aios.harness.loop.sessions_service.resolve_confirmed_dispatchable",
-                resolve,
-            ),
-        ):
-            await _dispatch_confirmed_tools(
-                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
-            )
-        assert resolve.await_args.kwargs["tool_call_ids"] == ["tc2", "tc1"]
-
-    async def test_dispatches_confirmed_when_parent_scrolled_out_of_window(self) -> None:
-        """End-to-end regression for #737: a confirmed ``always_ask`` tool
-        whose parent assistant has scrolled out of the token window is still
-        dispatched.
-
-        Exercises the REAL resolver (only the DB queries are mocked), so a
-        regression that re-sources dispatch from the windowed message slice —
-        which by construction lacks the scrolled-out parent — would surface
-        here as an empty dispatch.  ``lookup_tool_call_by_call_id`` returning
-        the call models 'parent gone from the window but still in the log';
-        the operator's allow is visible via the unwindowed lifecycle tail."""
-        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
-        with (
-            patch(
-                "aios.harness.loop.sessions_service.read_events",
-                AsyncMock(return_value=[_confirmed("tc_X")]),
-            ),
-            patch(
-                "aios.services.sessions.queries.find_tool_result_event",
-                AsyncMock(return_value=None),
-            ),
-            patch(
-                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
-                AsyncMock(return_value=_tool_call("tc_X")),
-            ),
-        ):
-            pending = await _dispatch_confirmed_tools(
-                pool, "sess_x", account_id="acc_test_stub", task_registry=TaskRegistry()
-            )
-        assert [tc["id"] for tc in pending] == ["tc_X"], (
-            "confirmed always_ask tool_call whose parent assistant scrolled "
-            "out of the token window was never dispatched (#737)"
-        )
-
-
-class TestResolveConfirmedDispatchable:
-    """The unwindowed resolver — the heart of the #737 fix.
-
-    Dispatch is sourced by ``tool_call_id`` from the full log, NOT from the
-    token-windowed slice, so a confirmed ``always_ask`` tool whose parent
-    assistant has scrolled past ``window_max`` is still recovered."""
-
-    async def test_recovers_parent_tool_call_unwindowed(self) -> None:
-        """Regression for #737: a confirmed tool whose parent assistant has
-        scrolled out of the token window is recovered via the unwindowed
-        parent-by-tool_call_id lookup and returned for dispatch.
-
-        ``lookup_tool_call_by_call_id`` returning the call models 'A1 is
-        gone from the window but still in the log'; ``find_tool_result_event``
-        returning None models 'no result yet'.  Pre-fix, dispatch read the
-        windowed slice (which lacks A1) and returned nothing."""
-        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
-        with (
-            patch(
-                "aios.services.sessions.queries.find_tool_result_event",
-                AsyncMock(return_value=None),
-            ),
-            patch(
-                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
-                AsyncMock(return_value=_tool_call("tc_X")),
-            ),
-        ):
-            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
-                pool, "sess_x", tool_call_ids=["tc_X"], account_id="acc_test_stub"
-            )
-        assert [tc["id"] for tc in dispatchable] == ["tc_X"]
-
-    async def test_skips_when_result_already_exists(self) -> None:
-        """A confirmed id whose ``tool_result`` exists in the log (even if it
-        scrolled out of the window) is NOT re-dispatched — no duplicate
-        ``tool_result`` (CLAUDE.md invariant #4).  The parent lookup is not
-        even reached."""
-        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
-        lookup = AsyncMock(return_value=_tool_call("tc_X"))
-        with (
-            patch(
-                "aios.services.sessions.queries.find_tool_result_event",
-                AsyncMock(return_value=SimpleNamespace(data={})),
-            ),
-            patch("aios.services.sessions.queries.lookup_tool_call_by_call_id", lookup),
-        ):
-            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
-                pool, "sess_x", tool_call_ids=["tc_X"], account_id="acc_test_stub"
-            )
-        assert dispatchable == []
-        lookup.assert_not_awaited()
-
-    async def test_skips_when_no_parent_found(self) -> None:
-        """No parent assistant for the id (should not happen in practice) →
-        nothing to dispatch, no crash."""
-        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
-        with (
-            patch(
-                "aios.services.sessions.queries.find_tool_result_event",
-                AsyncMock(return_value=None),
-            ),
-            patch(
-                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
-                AsyncMock(return_value=None),
-            ),
-        ):
-            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
-                pool, "sess_x", tool_call_ids=["tc_missing"], account_id="acc_test_stub"
-            )
-        assert dispatchable == []
-
-    async def test_resolves_multiple_in_order(self) -> None:
-        """Several confirmed ids resolve to their calls, order preserved."""
-        pool = cast("Any", fake_pool_yielding_conn(MagicMock()))
-        with (
-            patch(
-                "aios.services.sessions.queries.find_tool_result_event",
-                AsyncMock(return_value=None),
-            ),
-            patch(
-                "aios.services.sessions.queries.lookup_tool_call_by_call_id",
-                AsyncMock(side_effect=[_tool_call("tc_a"), _tool_call("tc_b")]),
-            ),
-        ):
-            dispatchable = await sessions_service.resolve_confirmed_dispatchable(
-                pool,
-                "sess_x",
-                tool_call_ids=["tc_a", "tc_b"],
-                account_id="acc_test_stub",
-            )
-        assert [tc["id"] for tc in dispatchable] == ["tc_a", "tc_b"]
+        assert [tc["id"] for tc in pending] == ["tc_Y"]

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,15 +26,16 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0064``."""
+    """The migration ladder has exactly one head: ``0065``."""
     script = _script_directory()
-    assert script.get_heads() == ["0064"]
+    assert script.get_heads() == ["0065"]
 
 
 def test_chain_is_linear_0054_to_0060() -> None:
     """``0054 -> … -> 0060 -> 0061`` is a plain linear chain."""
     script = _script_directory()
 
+    rev_0065 = script.get_revision("0065")
     rev_0064 = script.get_revision("0064")
     rev_0063 = script.get_revision("0063")
     rev_0062 = script.get_revision("0062")
@@ -46,6 +47,7 @@ def test_chain_is_linear_0054_to_0060() -> None:
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0065.down_revision == "0064"
     assert rev_0064.down_revision == "0063"
     assert rev_0063.down_revision == "0062"
     assert rev_0062.down_revision == "0061"


### PR DESCRIPTION
Hardens the confirmed-tool dispatch + unresolved-tool_calls machinery. Three related fixes, all repro-first with deterministic tests.

## 1. #737 — confirmed tool dropped at the window edge (commit 1)

`_dispatch_confirmed_tools` detected confirmations from the *unwindowed* lifecycle tail but sourced the dispatchable `tool_calls` from the token-**windowed** message slice. A confirmed `always_ask` tool whose parent assistant had scrolled past `window_max` was seen-as-confirmed yet **never found-to-dispatch** → the tool never ran and the session re-woke every sweep with no progress (the #155 symptom via the window edge). Root cause: detection unwindowed, dispatch windowed — they disagreed at the edge.

## 2. #741 — `Session.awaiting` (and connector backfill) latest-assistant-only (commit 2)

`_latest_unresolved_tool_calls` sourced unresolved tool_calls from `DISTINCT ON (session_id) ORDER BY seq DESC` — only the latest assistant turn. A tool_call left unresolved on an *earlier* assistant (model emitted a later turn before the operator confirmed / before a custom result landed) was invisible to `Session.awaiting`. The same function backs the **connector SSE pending-call backfill** (`list_pending_calls_for_connector`), so a pending *custom* call on a non-latest assistant was likewise silently dropped by the runtime → a ghost. Now spans **all** assistants (`_unresolved_tool_calls`).

## 3. Unify dispatch with the sweep's wake predicate (commit 2)

The sweep's `CONFIRMED_ROWS_SQL` (case (c)) already computes "confirmed `allow` ∧ no `tool_result`" to wake the session; commit 1's dispatch re-derived it per-tcid from a bounded newest-200 lifecycle tail — a duplicated predicate that could disagree at the 200-row edge. Replaced with a single unwindowed `queries.list_confirmed_unresolved_tool_calls` mirroring that predicate and returning the dispatchable dicts. Detection and dispatch now resolve the **identical** condition and can't disagree at any edge; `_dispatch_confirmed_tools` collapses to "resolve, then drop in-flight."

New partial index `events_tool_confirmed_allow_idx` (**migration 0065**) keeps the unwindowed per-step resolver cheap **and** covers the previously-unindexed cross-session `CONFIRMED_ROWS_SQL`. Supersedes the per-tcid `resolve_confirmed_dispatchable` + `lookup_tool_call_by_call_id` (removed); `lookup_tool_name_by_call_id` reverts to standalone.

## Test plan

- [x] Type-checker (`mypy src`) — clean
- [x] Linter + format — clean
- [x] Unit suite — **1744 passed** (incl. #737 RED→GREEN at the orchestration layer, migration-chain single-head)
- [x] Integration (real Postgres) — **152 passed**, incl. deterministic repros that fail pre-fix: `test_awaiting_spans_all_assistants` (#741), `test_confirmed_unresolved_dispatch` (resolver's three filters + account scoping), and the existing 14 tool-confirmation tests
- [x] `alembic heads` — single head `0065`
- [ ] CI runs the full e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #737
Closes #741