### PR TITLE
feat(workflows): Block 2 — agent invocation via invoke_session (request/response, parallel/pipeline, totality caps)

### DIFF
--- a/migrations/versions/0065_wf_run_environment.py
+++ b/migrations/versions/0065_wf_run_environment.py
@@ -1,0 +1,35 @@
+"""Workflows Block 2: bind a workflow run to an environment.
+
+`agent : session :: workflow : run` — sessions bind to environments, so runs
+bind to environments. A run's ``agent()`` children spawn into ``run.environment_id``
+(inheriting it, the way a session inherits the environment chosen at creation).
+The environment is chosen at run-creation time (data + API level), not baked into
+the immutable workflow definition.
+
+``wf_runs`` has no run-creation surface yet (Block 1 shipped the runtime core,
+not the HTTP/CLI), so the table is empty and ``NOT NULL`` with no default is safe.
+
+Revision ID: 0065
+Revises: 0064
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0065"
+down_revision: str = "0064"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE wf_runs ADD COLUMN environment_id text NOT NULL REFERENCES environments(id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE wf_runs DROP COLUMN IF EXISTS environment_id")

--- a/migrations/versions/0066_wf_run_environment.py
+++ b/migrations/versions/0066_wf_run_environment.py
@@ -9,8 +9,8 @@ the immutable workflow definition.
 ``wf_runs`` has no run-creation surface yet (Block 1 shipped the runtime core,
 not the HTTP/CLI), so the table is empty and ``NOT NULL`` with no default is safe.
 
-Revision ID: 0065
-Revises: 0064
+Revision ID: 0066
+Revises: 0065
 """
 
 from __future__ import annotations
@@ -19,8 +19,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0065"
-down_revision: str = "0064"
+revision: str = "0066"
+down_revision: str = "0065"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/0067_workflow_child_done_index.py
+++ b/migrations/versions/0067_workflow_child_done_index.py
@@ -1,22 +1,17 @@
-"""Partial index on the ``workflow_child_done`` completion marker.
+"""Partial index on the workflow child's request-response event.
 
-A workflow agent child signals logical completion by appending a single
-``workflow_child_done`` lifecycle event (see ``tools/workflow_completion.py``).
-Three readers resolve that exact predicate and all benefit:
+A workflow agent child answers its request with a single ``workflow_child_done``
+lifecycle event (see ``tools/workflow_completion.py`` /
+``queries.write_response_if_absent``). ``queries.read_workflow_child_done`` reads
+that one event on every parent run-step harvest to resolve the ``agent()`` call;
+this partial index keeps that a point lookup instead of a per-wake history scan.
+The same index serves ``write_response_if_absent``'s exactly-once absent-recheck.
 
-* ``sweep.COMPLETED_CHILD_SESSIONS_SQL`` (``find_sessions_needing_inference``)
-  scans marker rows **cross-session** every sweep pass to subtract soft-terminal
-  children from the wake set — previously unindexed for this predicate.
-* the in-worker workflow-child reaper's candidate query (Block 2.F) selects
-  marker-present children to archive.
-* ``queries.read_workflow_child_done`` reads one child's marker on every parent
-  run-step harvest.
-
-Markers are rare relative to total events (one per finished workflow child), so
-this is a small partial index. Built with ``CREATE INDEX CONCURRENTLY`` (outside
-a transaction via ``autocommit_block``) so it never takes an ACCESS EXCLUSIVE
-lock on the live-written ``events`` table — same pattern as migrations 0023 /
-0062 / 0065.
+Responses are rare relative to total events (one per finished child), so this is a
+small partial index. Built with ``CREATE INDEX CONCURRENTLY`` (outside a
+transaction via ``autocommit_block``) so it never takes an ACCESS EXCLUSIVE lock
+on the live-written ``events`` table — same pattern as migrations 0023 / 0062 /
+0065.
 
 Revision ID: 0067
 Revises: 0066

--- a/migrations/versions/0067_workflow_child_done_index.py
+++ b/migrations/versions/0067_workflow_child_done_index.py
@@ -1,0 +1,48 @@
+"""Partial index on the ``workflow_child_done`` completion marker.
+
+A workflow agent child signals logical completion by appending a single
+``workflow_child_done`` lifecycle event (see ``tools/workflow_completion.py``).
+Three readers resolve that exact predicate and all benefit:
+
+* ``sweep.COMPLETED_CHILD_SESSIONS_SQL`` (``find_sessions_needing_inference``)
+  scans marker rows **cross-session** every sweep pass to subtract soft-terminal
+  children from the wake set — previously unindexed for this predicate.
+* the in-worker workflow-child reaper's candidate query (Block 2.F) selects
+  marker-present children to archive.
+* ``queries.read_workflow_child_done`` reads one child's marker on every parent
+  run-step harvest.
+
+Markers are rare relative to total events (one per finished workflow child), so
+this is a small partial index. Built with ``CREATE INDEX CONCURRENTLY`` (outside
+a transaction via ``autocommit_block``) so it never takes an ACCESS EXCLUSIVE
+lock on the live-written ``events`` table — same pattern as migrations 0023 /
+0062 / 0065.
+
+Revision ID: 0067
+Revises: 0066
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0067"
+down_revision: str = "0066"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_workflow_child_done_idx "
+            "ON events (session_id) "
+            "WHERE kind = 'lifecycle' AND data->>'event' = 'workflow_child_done'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_workflow_child_done_idx")

--- a/migrations/versions/0067_workflow_child_done_index.py
+++ b/migrations/versions/0067_workflow_child_done_index.py
@@ -1,17 +1,16 @@
-"""Partial index on the workflow child's request-response event.
+"""Partial index on the workflow child's completion event (superseded by 0068).
 
-A workflow agent child answers its request with a single ``workflow_child_done``
-lifecycle event (see ``tools/workflow_completion.py`` /
-``queries.write_response_if_absent``). ``queries.read_workflow_child_done`` reads
-that one event on every parent run-step harvest to resolve the ``agent()`` call;
-this partial index keeps that a point lookup instead of a per-wake history scan.
-The same index serves ``write_response_if_absent``'s exactly-once absent-recheck.
+Historical: when this revision shipped, a workflow child answered its request with
+a ``workflow_child_done`` lifecycle event, and this index made the harvest's read a
+point lookup. R4 later renamed that event to ``request_response``; **migration 0068
+drops this index and creates ``events_request_response_idx`` in its place**, so on a
+fresh database the index built here lives only until 0068 runs. This body is left
+as-shipped (it still builds the old index) so 0068 can transition every database
+uniformly — see 0068 for the rationale.
 
-Responses are rare relative to total events (one per finished child), so this is a
-small partial index. Built with ``CREATE INDEX CONCURRENTLY`` (outside a
-transaction via ``autocommit_block``) so it never takes an ACCESS EXCLUSIVE lock
-on the live-written ``events`` table — same pattern as migrations 0023 / 0062 /
-0065.
+Built with ``CREATE INDEX CONCURRENTLY`` (outside a transaction via
+``autocommit_block``) so it never takes an ACCESS EXCLUSIVE lock on the
+live-written ``events`` table — same pattern as migrations 0023 / 0062 / 0065.
 
 Revision ID: 0067
 Revises: 0066

--- a/migrations/versions/0068_request_response_index_transition.py
+++ b/migrations/versions/0068_request_response_index_transition.py
@@ -1,0 +1,53 @@
+"""Transition the request-response partial index across the event rename.
+
+Block-2 R1 (revision 0067, committed earlier on this branch) created
+``events_workflow_child_done_idx`` keyed on the ``workflow_child_done`` lifecycle
+event. R4 renamed that event to ``request_response`` and reworked the index to
+``events_request_response_idx`` on ``(session_id, (data->>'request_id'))``.
+
+A fresh database gets the new index directly from 0067 (its file now creates it),
+so for that DB this revision is a no-op. But a database that applied the *original*
+0067 records ``alembic_version = 0067`` and would never pick up the rename — it
+would keep the now-dead ``workflow_child_done`` index and miss the new one. This
+revision makes the transition robust for both: drop the old index if present, and
+create the new one if absent. Both statements are idempotent, so it is safe on a
+fresh DB too.
+
+``CREATE``/``DROP INDEX CONCURRENTLY`` run outside a transaction via
+``autocommit_block`` so they never take an ACCESS EXCLUSIVE lock on the
+live-written ``events`` table (same pattern as 0023 / 0062 / 0065 / 0067).
+
+Revision ID: 0068
+Revises: 0067
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0068"
+down_revision: str = "0067"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_workflow_child_done_idx")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_request_response_idx "
+            "ON events (session_id, (data->>'request_id')) "
+            "WHERE kind = 'lifecycle' AND data->>'event' = 'request_response'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_request_response_idx")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_workflow_child_done_idx "
+            "ON events (session_id) "
+            "WHERE kind = 'lifecycle' AND data->>'event' = 'workflow_child_done'"
+        )

--- a/migrations/versions/0068_request_response_index_transition.py
+++ b/migrations/versions/0068_request_response_index_transition.py
@@ -1,17 +1,14 @@
 """Transition the request-response partial index across the event rename.
 
-Block-2 R1 (revision 0067, committed earlier on this branch) created
-``events_workflow_child_done_idx`` keyed on the ``workflow_child_done`` lifecycle
-event. R4 renamed that event to ``request_response`` and reworked the index to
-``events_request_response_idx`` on ``(session_id, (data->>'request_id'))``.
-
-A fresh database gets the new index directly from 0067 (its file now creates it),
-so for that DB this revision is a no-op. But a database that applied the *original*
-0067 records ``alembic_version = 0067`` and would never pick up the rename — it
-would keep the now-dead ``workflow_child_done`` index and miss the new one. This
-revision makes the transition robust for both: drop the old index if present, and
-create the new one if absent. Both statements are idempotent, so it is safe on a
-fresh DB too.
+Block-2 R1 (revision 0067) created ``events_workflow_child_done_idx`` keyed on the
+``workflow_child_done`` lifecycle event. R4 renamed that event to
+``request_response`` and reworked the index to ``events_request_response_idx`` on
+``(session_id, (data->>'request_id'))``. 0067's own body was left untouched (it
+still creates the old index), so this revision does the whole transition for EVERY
+database — fresh or already stamped at 0067: drop the old index if present, create
+the new one if absent. On a fresh DB the chain runs 0067 (old index) → 0068 (drop
+it, create new); on a DB that applied the original 0067, only 0068 runs and flips
+it. Both statements are idempotent, so re-running is safe.
 
 ``CREATE``/``DROP INDEX CONCURRENTLY`` run outside a transaction via
 ``autocommit_block`` so they never take an ACCESS EXCLUSIVE lock on the

--- a/openapi.json
+++ b/openapi.json
@@ -12175,6 +12175,26 @@
             "title": "Focal Locked",
             "default": false
           },
+          "origin": {
+            "type": "string",
+            "enum": [
+              "foreground",
+              "background"
+            ],
+            "title": "Origin",
+            "default": "foreground"
+          },
+          "parent_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Run Id"
+          },
           "last_event_at": {
             "anyOf": [
               {

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -154,6 +154,7 @@ from .session_create_env import SessionCreateEnv
 from .session_create_metadata import SessionCreateMetadata
 from .session_interrupt_request import SessionInterruptRequest
 from .session_metadata import SessionMetadata
+from .session_origin import SessionOrigin
 from .session_status import SessionStatus
 from .session_stop_reason_type_0 import SessionStopReasonType0
 from .session_template import SessionTemplate
@@ -368,6 +369,7 @@ __all__ = (
     "SessionCreateMetadata",
     "SessionInterruptRequest",
     "SessionMetadata",
+    "SessionOrigin",
     "SessionStatus",
     "SessionStopReasonType0",
     "SessionTemplate",

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -8,6 +8,7 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..models.session_origin import SessionOrigin
 from ..models.session_status import SessionStatus
 from ..types import UNSET, Unset
 
@@ -55,6 +56,8 @@ class Session:
             archived_at (datetime.datetime | None | Unset):
             focal_channel (None | str | Unset):
             focal_locked (bool | Unset):  Default: False.
+            origin (SessionOrigin | Unset):  Default: SessionOrigin.FOREGROUND.
+            parent_run_id (None | str | Unset):
             last_event_at (datetime.datetime | None | Unset):
             total_events (int | Unset):  Default: 0.
     """
@@ -80,6 +83,8 @@ class Session:
     archived_at: datetime.datetime | None | Unset = UNSET
     focal_channel: None | str | Unset = UNSET
     focal_locked: bool | Unset = False
+    origin: SessionOrigin | Unset = SessionOrigin.FOREGROUND
+    parent_run_id: None | str | Unset = UNSET
     last_event_at: datetime.datetime | None | Unset = UNSET
     total_events: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -166,6 +171,16 @@ class Session:
 
         focal_locked = self.focal_locked
 
+        origin: str | Unset = UNSET
+        if not isinstance(self.origin, Unset):
+            origin = self.origin.value
+
+        parent_run_id: None | str | Unset
+        if isinstance(self.parent_run_id, Unset):
+            parent_run_id = UNSET
+        else:
+            parent_run_id = self.parent_run_id
+
         last_event_at: None | str | Unset
         if isinstance(self.last_event_at, Unset):
             last_event_at = UNSET
@@ -209,6 +224,10 @@ class Session:
             field_dict["focal_channel"] = focal_channel
         if focal_locked is not UNSET:
             field_dict["focal_locked"] = focal_locked
+        if origin is not UNSET:
+            field_dict["origin"] = origin
+        if parent_run_id is not UNSET:
+            field_dict["parent_run_id"] = parent_run_id
         if last_event_at is not UNSET:
             field_dict["last_event_at"] = last_event_at
         if total_events is not UNSET:
@@ -360,6 +379,22 @@ class Session:
 
         focal_locked = d.pop("focal_locked", UNSET)
 
+        _origin = d.pop("origin", UNSET)
+        origin: SessionOrigin | Unset
+        if isinstance(_origin, Unset):
+            origin = UNSET
+        else:
+            origin = SessionOrigin(_origin)
+
+        def _parse_parent_run_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        parent_run_id = _parse_parent_run_id(d.pop("parent_run_id", UNSET))
+
         def _parse_last_event_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -399,6 +434,8 @@ class Session:
             archived_at=archived_at,
             focal_channel=focal_channel,
             focal_locked=focal_locked,
+            origin=origin,
+            parent_run_id=parent_run_id,
             last_event_at=last_event_at,
             total_events=total_events,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_origin.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_origin.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class SessionOrigin(str, Enum):
+    BACKGROUND = "background"
+    FOREGROUND = "foreground"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -300,6 +300,32 @@ class Settings(BaseSettings):
         "reminders.",
     )
 
+    # ── workflows ──────────────────────────────────────────────────────────
+    workflow_max_agent_calls: int = Field(
+        default=1000,
+        ge=1,
+        description="Per-run lifetime ceiling on the number of ``agent()`` "
+        "children a workflow may spawn. Counted from the run's ``call_started`` "
+        "journal (monotonic), checked before each step's spawns: a step that "
+        "would push the total past the cap errors the run (``too_many_agents``) "
+        "before spawning any of that step's new children. Bounds a runaway "
+        "script that spawns children in an unbounded loop. The per-call "
+        "single-``parallel()`` fan-out width is bounded separately, in the "
+        "host (``wf_script_host.MAX_PARALLEL_FANOUT``).",
+    )
+    workflow_agent_deadline_seconds: float = Field(
+        default=60 * 60,  # 1 hour
+        gt=0,
+        description="Wall-clock budget for a single ``agent()`` call, measured "
+        "from its ``call_started``. A child that never goes idle (e.g. loops on "
+        "tools forever) never trips the quiescence nudge, so without this its "
+        "caller would suspend forever; past the deadline the harvest writes a "
+        "``timeout`` error response (exactly-once), resolving the call as a "
+        "catchable ``AgentError`` and keeping the run total. Generous by default "
+        "— a child doing real model+tool work can legitimately run for minutes; "
+        "this is the never-resolves backstop, not a tight SLA.",
+    )
+
     # ── observability ──────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
 

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1117,6 +1117,51 @@ async def count_request_nudges(
     return n or 0
 
 
+async def derive_response(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
+) -> dict[str, Any] | None:
+    """A request's **terminal outcome**, or ``None`` if it is still pending.
+
+    The single resolver the run harvest asks "what became of this ``agent()``?" — a
+    pure, monotonic function of the target's state (the dual of Block-0's
+    ``_SESSION_STATUS_EXPR``):
+
+    * a **written response** (``return``/``error``, model-failure, or the no_return
+      backstop) → that outcome;
+    * else, if the target is **gone** (archived or deleted before answering, so it
+      can never respond) → a Failed ``child_gone`` outcome;
+    * else → ``None`` (alive and unanswered — still pending).
+
+    The response and the liveness are read in **one query / one snapshot**, so a
+    response always dominates "gone" even if the target is archived the instant
+    after answering — there is no read-between-reads window. Each branch is
+    terminal-or-pending and never reverts (a response is permanent; gone is
+    permanent), so the harvest can journal the returned dict as the ``call_result``
+    payload directly.
+    """
+    row = await conn.fetchrow(
+        "SELECT (SELECT data FROM events e WHERE e.session_id = $1 AND e.account_id = $2 "
+        "        AND e.kind = 'lifecycle' AND e.data->>'event' = 'request_response' "
+        "        AND e.data->>'request_id' = $3 ORDER BY e.seq DESC LIMIT 1) AS response, "
+        "       EXISTS (SELECT 1 FROM sessions s WHERE s.id = $1 AND s.account_id = $2 "
+        "               AND s.archived_at IS NULL) AS live",
+        session_id,
+        account_id,
+        request_id,
+    )
+    assert row is not None
+    if row["response"] is not None:
+        response = parse_jsonb(row["response"])
+        return {
+            "result": response.get("result"),
+            "is_error": bool(response.get("is_error")),
+            "error": response.get("error"),
+        }
+    if not row["live"]:
+        return {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
+    return None
+
+
 async def derive_session_status(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> str:
@@ -6861,6 +6906,24 @@ async def unscoped_get_session_account_id(conn: asyncpg.Connection[Any], session
     if row is None:
         raise NotFoundError(f"session {session_id} not found", detail={"session_id": session_id})
     return cast("str", row["account_id"])
+
+
+async def unscoped_live_session_account_id(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> str | None:
+    """``account_id`` for a **live** session (exists and not archived), else ``None``.
+
+    The ``run_session_step`` entry guard uses this so a wake for a session that has
+    been archived or deleted is an idempotent no-op — mirroring
+    ``run_workflow_step``'s terminal early-return. Without it a stray wake (e.g. the
+    sweep racing an operator archive, or a reclaim) would reach ``append_event``'s
+    archived guard and crash the job.
+    """
+    account_id: str | None = await conn.fetchval(
+        "SELECT account_id FROM sessions WHERE id = $1 AND archived_at IS NULL",
+        session_id,
+    )
+    return account_id
 
 
 # ─── account management (#367 PR 7) ───────────────────────────────────────────

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1071,7 +1071,10 @@ async def read_workflow_child_done(
     row = await conn.fetchrow(
         "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
         "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done' "
-        "ORDER BY seq LIMIT 1",
+        # DESC: the marker is the child's terminal event — walk the (session_id,
+        # seq) index from the newest row so we stop at the first match, not scan
+        # the whole history forward on every parent wake.
+        "ORDER BY seq DESC LIMIT 1",
         session_id,
         account_id,
     )

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1063,22 +1063,91 @@ async def set_session_archived(
 async def read_workflow_child_done(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> dict[str, Any] | None:
-    """The child's ``workflow_child_done`` marker payload, or ``None`` if absent.
+    """The child's request **response** (`workflow_child_done`), or ``None`` if the
+    request is still open.
 
-    The single explicit completion signal the run-step harvest reads (§3.3/§3.5)
-    — never inferred from idle. ``data`` is ``{event, is_error, result}``.
+    The single explicit response a workflow child gives its request (`return`/
+    `error`) — never inferred from idle. The run-step harvest reads it to resolve
+    the `agent()` call. ``data`` is ``{event, request_id, is_error, result, error}``.
+    Exactly one exists per request (see :func:`write_response_if_absent`), so the
+    ``LIMIT 1`` is unambiguous; the ``seq DESC`` index walk just stops at the first
+    (only) match instead of scanning history forward on every parent wake.
     """
     row = await conn.fetchrow(
         "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
         "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done' "
-        # DESC: the marker is the child's terminal event — walk the (session_id,
-        # seq) index from the newest row so we stop at the first match, not scan
-        # the whole history forward on every parent wake.
         "ORDER BY seq DESC LIMIT 1",
         session_id,
         account_id,
     )
     return parse_jsonb(row["data"]) if row is not None else None
+
+
+async def get_open_request_id(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> str | None:
+    """The ``request_id`` of the session's open request, or ``None`` if it has none.
+
+    A request is a user message stamped ``metadata.request.request_id`` (see
+    ``create_child_session`` / `invoke_session`). v1 injects exactly one per child,
+    so this returns that one; multi-request `invoke_session` will refine "open" to
+    "no response yet" and let `return`/`error` name an explicit ``request_id``.
+    """
+    request_id: str | None = await conn.fetchval(
+        "SELECT data->'metadata'->'request'->>'request_id' FROM events "
+        "WHERE session_id = $1 AND account_id = $2 AND kind = 'message' AND role = 'user' "
+        "AND data->'metadata'->'request'->>'request_id' IS NOT NULL "
+        "ORDER BY seq ASC LIMIT 1",
+        session_id,
+        account_id,
+    )
+    return request_id
+
+
+async def write_response_if_absent(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    request_id: str,
+    is_error: bool,
+    result: Any,
+    error: dict[str, Any] | None,
+) -> bool:
+    """Write a workflow child's request response, **exactly once** (first-writer-wins).
+
+    A child answers its request via `return`/`error`; the harness model-failure path
+    and the totality backstop can also produce a response. All of them must yield
+    **exactly one** response — `return`+`error` in the same assistant batch, a model
+    double-call, or a `return` racing the no_return backstop must not double-write.
+    ``FOR UPDATE`` on the session row + an absent-recheck makes the first writer win;
+    the rest no-op. Returns ``True`` iff this call wrote the response.
+
+    (v1 has one open request per child, so the guard is per-child; the ``request_id``
+    is carried on the event for the multi-request `invoke_session` case.)
+    """
+    async with conn.transaction():
+        await conn.execute(
+            "SELECT 1 FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",
+            session_id,
+            account_id,
+        )
+        if await read_workflow_child_done(conn, session_id, account_id=account_id) is not None:
+            return False
+        await append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="lifecycle",
+            data={
+                "event": "workflow_child_done",
+                "request_id": request_id,
+                "is_error": is_error,
+                "result": result,
+                "error": error,
+            },
+        )
+    return True
 
 
 async def get_session(

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1043,23 +1043,6 @@ async def get_session_workflow_context(
     return (row["account_id"], row["parent_run_id"]) if row is not None else None
 
 
-async def set_session_archived(
-    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
-) -> None:
-    """Idempotently soft-archive a session (no-op if already archived).
-
-    Unlike :func:`archive_session` this never raises ``NotFound`` — used by the
-    workflow completion tools (self-archive on ``return``) and run-termination
-    teardown, where a double-archive is benign.
-    """
-    await conn.execute(
-        "UPDATE sessions SET archived_at = now() "
-        "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL",
-        session_id,
-        account_id,
-    )
-
-
 async def read_workflow_child_done(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> dict[str, Any] | None:
@@ -1069,9 +1052,9 @@ async def read_workflow_child_done(
     The single explicit response a workflow child gives its request (`return`/
     `error`) — never inferred from idle. The run-step harvest reads it to resolve
     the `agent()` call. ``data`` is ``{event, request_id, is_error, result, error}``.
-    Exactly one exists per request (see :func:`write_response_if_absent`), so the
-    ``LIMIT 1`` is unambiguous; the ``seq DESC`` index walk just stops at the first
-    (only) match instead of scanning history forward on every parent wake.
+    Exactly one exists per request (see :func:`write_response_if_absent`), so
+    ``LIMIT 1`` returns it directly; the ``events_workflow_child_done_idx`` partial
+    index (0067) keeps this a point lookup rather than a per-wake history scan.
     """
     row = await conn.fetchrow(
         "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -871,6 +871,11 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         archived_at=row["archived_at"],
         focal_channel=row["focal_channel"],
         focal_locked=row["focal_locked"],
+        # Soft reads: present in every ``SELECT *`` / ``RETURNING *`` feeder
+        # (the worker step's ``get_session_bare`` is one), default for the few
+        # explicit-column reads that don't select them.
+        origin=row.get("origin") or "foreground",
+        parent_run_id=row.get("parent_run_id"),
         # Present only when the query derives it (list_sessions); other callers
         # (single read, INSERT ... RETURNING) leave it None.
         last_event_at=row.get("last_event_at"),
@@ -947,6 +952,58 @@ async def insert_session(
         ) from exc
     assert row is not None
     return _row_to_session(row)
+
+
+async def insert_child_session(
+    conn: asyncpg.Connection[Any],
+    *,
+    session_id: str,
+    account_id: str,
+    agent_id: str,
+    environment_id: str,
+    agent_version: int,
+    parent_run_id: str,
+) -> Session | None:
+    """Insert a workflow ``agent()`` child under a deterministic ``session_id``.
+
+    ``INSERT ... ON CONFLICT (id) DO NOTHING RETURNING *`` — returns the new
+    :class:`Session` on first spawn, or ``None`` on conflict (a replay found the
+    existing row, so the caller harvests instead of re-spawning). ``origin`` is
+    ``'background'`` and ``agent_version`` is the **pinned** int resolved at
+    spawn (never ``None`` — a child must not track "latest"). v1 children carry
+    no vaults/resources/scheduled-tasks; the caller delivers the agent input in
+    the same transaction.
+    """
+    from aios.config import get_settings
+
+    workspace_path = str(get_settings().workspace_root / account_id / session_id)
+    try:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO sessions (
+                id, agent_id, environment_id, agent_version, title, metadata,
+                workspace_volume_path, env, focal_channel, focal_locked,
+                account_id, parent_run_id, origin
+            )
+            VALUES ($1, $2, $3, $4, NULL, '{}'::jsonb, $5, '{}'::jsonb,
+                    NULL, FALSE, $6, $7, 'background')
+            ON CONFLICT (id) DO NOTHING
+            RETURNING *
+            """,
+            session_id,
+            agent_id,
+            environment_id,
+            agent_version,
+            workspace_path,
+            account_id,
+            parent_run_id,
+        )
+    except asyncpg.ForeignKeyViolationError as exc:
+        raise NotFoundError(
+            "agent or environment not found",
+            detail={"agent_id": agent_id, "environment_id": environment_id},
+        ) from exc
+    return _row_to_session(row) if row is not None else None
 
 
 async def get_session(

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1043,48 +1043,96 @@ async def get_session_workflow_context(
     return (row["account_id"], row["parent_run_id"]) if row is not None else None
 
 
-async def read_workflow_child_done(
-    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+async def read_request_response(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
 ) -> dict[str, Any] | None:
-    """The child's request **response** (`workflow_child_done`), or ``None`` if the
-    request is still open.
+    """A specific request's **response** (`request_response` event), or ``None`` if
+    the request is still open.
 
-    The single explicit response a workflow child gives its request (`return`/
-    `error`) — never inferred from idle. The run-step harvest reads it to resolve
+    The single explicit response a session gives a request it was invoked with —
+    a `return`/`error` from the model, the harness erroring path, or the no_return
+    backstop — never inferred from idle. The run-step harvest reads it to resolve
     the `agent()` call. ``data`` is ``{event, request_id, is_error, result, error}``.
     Exactly one exists per request (see :func:`write_response_if_absent`), so
-    ``LIMIT 1`` returns it directly; the ``events_workflow_child_done_idx`` partial
+    ``LIMIT 1`` returns it directly; the ``events_request_response_idx`` partial
     index (0067) keeps this a point lookup rather than a per-wake history scan.
     """
     row = await conn.fetchrow(
         "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
-        "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done' "
-        "ORDER BY seq DESC LIMIT 1",
+        "AND kind = 'lifecycle' AND data->>'event' = 'request_response' "
+        "AND data->>'request_id' = $3 ORDER BY seq DESC LIMIT 1",
         session_id,
         account_id,
+        request_id,
     )
     return parse_jsonb(row["data"]) if row is not None else None
 
 
-async def get_open_request_id(
+async def get_open_request_ids(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
-) -> str | None:
-    """The ``request_id`` of the session's open request, or ``None`` if it has none.
+) -> list[str]:
+    """The ``request_id``s of the session's still-open requests, oldest first.
 
     A request is a user message stamped ``metadata.request.request_id`` (see
-    ``create_child_session`` / `invoke_session`). v1 injects exactly one per child,
-    so this returns that one; multi-request `invoke_session` will refine "open" to
-    "no response yet" and let `return`/`error` name an explicit ``request_id``.
+    ``create_child_session`` / `invoke_session`); it is *open* until a
+    ``request_response`` event answers it. Returns the asked-minus-answered set, so
+    an ordinary session (no requests) returns ``[]`` and the quiescence guard
+    no-ops for it. v1 injects one request per child, so this is ``[]`` or one id;
+    the set shape is ready for multi-request `invoke_session`.
     """
-    request_id: str | None = await conn.fetchval(
-        "SELECT data->'metadata'->'request'->>'request_id' FROM events "
-        "WHERE session_id = $1 AND account_id = $2 AND kind = 'message' AND role = 'user' "
-        "AND data->'metadata'->'request'->>'request_id' IS NOT NULL "
-        "ORDER BY seq ASC LIMIT 1",
+    rows: list[asyncpg.Record] = await conn.fetch(
+        "SELECT req.data->'metadata'->'request'->>'request_id' AS rid FROM events req "
+        "WHERE req.session_id = $1 AND req.account_id = $2 "
+        "AND req.kind = 'message' AND req.role = 'user' "
+        "AND req.data->'metadata'->'request'->>'request_id' IS NOT NULL "
+        "AND NOT EXISTS (SELECT 1 FROM events resp "
+        "    WHERE resp.session_id = $1 AND resp.account_id = $2 "
+        "    AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
+        "    AND resp.data->>'request_id' = req.data->'metadata'->'request'->>'request_id') "
+        "ORDER BY req.seq ASC",
         session_id,
         account_id,
     )
-    return request_id
+    return [r["rid"] for r in rows]
+
+
+async def count_request_nudges(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
+) -> int:
+    """How many times this request has been nudged — the count of nudge user
+    messages whose ``metadata.nudged_request_ids`` include it.
+
+    The per-request retry budget is *derived* from the log, not stored — so it is
+    crash-safe and needs no counter to keep in sync (the same stance as
+    ``_count_consecutive_rescheduling`` for model-error backoff).
+    """
+    n: int | None = await conn.fetchval(
+        "SELECT count(*) FROM events WHERE session_id = $1 AND account_id = $2 "
+        "AND kind = 'message' AND role = 'user' "
+        "AND data->'metadata'->'nudged_request_ids' @> to_jsonb($3::text)",
+        session_id,
+        account_id,
+        request_id,
+    )
+    return n or 0
+
+
+async def derive_session_status(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> str:
+    """The session's derived ``{active, idle}`` status via the single
+    ``_SESSION_STATUS_EXPR`` source of truth.
+
+    The quiescence guard calls this in the same transaction as the just-appended
+    assistant event — so it sees that event — to decide whether the session would
+    now go idle while still owing a request response.
+    """
+    status: str | None = await conn.fetchval(
+        f"SELECT ({_SESSION_STATUS_EXPR}) FROM sessions WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
+    )
+    return status or "idle"
 
 
 async def write_response_if_absent(
@@ -1097,17 +1145,17 @@ async def write_response_if_absent(
     result: Any,
     error: dict[str, Any] | None,
 ) -> bool:
-    """Write a workflow child's request response, **exactly once** (first-writer-wins).
+    """Write a request's response, **exactly once per request** (first-writer-wins).
 
-    A child answers its request via `return`/`error`; concurrent or repeated calls
-    (`return`+`error` in one assistant batch, a model double-call) must still yield
-    **exactly one** response. ``FOR UPDATE`` on the session row + an absent-recheck
-    makes the first writer win; the rest no-op. Returns ``True`` iff this call wrote
-    the response. (Later writers — the model-failure path and the totality backstop —
-    will reuse this same guard so they never clobber a real response.)
+    A session answers a request via `return`/`error`; concurrent or repeated writes
+    for the same ``request_id`` (`return`+`error` in one assistant batch, a model
+    double-call, a late `return` racing the model-failure path or the no_return
+    backstop) must still yield **exactly one** response. ``FOR UPDATE`` on the
+    session row + a per-``request_id`` absent-recheck makes the first writer win;
+    the rest no-op. Returns ``True`` iff this call wrote the response.
 
-    v1 has one open request per child, so the guard is per-child; the ``request_id``
-    is carried on the event for the multi-request `invoke_session` case.
+    The guard is per ``request_id``, so a session with several open requests can
+    answer each independently without clobbering the others.
     """
     async with conn.transaction():
         await conn.execute(
@@ -1115,7 +1163,12 @@ async def write_response_if_absent(
             session_id,
             account_id,
         )
-        if await read_workflow_child_done(conn, session_id, account_id=account_id) is not None:
+        if (
+            await read_request_response(
+                conn, session_id, account_id=account_id, request_id=request_id
+            )
+            is not None
+        ):
             return False
         await append_event(
             conn,
@@ -1123,7 +1176,7 @@ async def write_response_if_absent(
             session_id=session_id,
             kind="lifecycle",
             data={
-                "event": "workflow_child_done",
+                "event": "request_response",
                 "request_id": request_id,
                 "is_error": is_error,
                 "result": result,

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1099,15 +1099,15 @@ async def write_response_if_absent(
 ) -> bool:
     """Write a workflow child's request response, **exactly once** (first-writer-wins).
 
-    A child answers its request via `return`/`error`; the harness model-failure path
-    and the totality backstop can also produce a response. All of them must yield
-    **exactly one** response — `return`+`error` in the same assistant batch, a model
-    double-call, or a `return` racing the no_return backstop must not double-write.
-    ``FOR UPDATE`` on the session row + an absent-recheck makes the first writer win;
-    the rest no-op. Returns ``True`` iff this call wrote the response.
+    A child answers its request via `return`/`error`; concurrent or repeated calls
+    (`return`+`error` in one assistant batch, a model double-call) must still yield
+    **exactly one** response. ``FOR UPDATE`` on the session row + an absent-recheck
+    makes the first writer win; the rest no-op. Returns ``True`` iff this call wrote
+    the response. (Later writers — the model-failure path and the totality backstop —
+    will reuse this same guard so they never clobber a real response.)
 
-    (v1 has one open request per child, so the guard is per-child; the ``request_id``
-    is carried on the event for the multi-request `invoke_session` case.)
+    v1 has one open request per child, so the guard is per-child; the ``request_id``
+    is carried on the event for the multi-request `invoke_session` case.
     """
     async with conn.transaction():
         await conn.execute(

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -527,6 +527,24 @@ async def get_agent(conn: asyncpg.Connection[Any], agent_id: str, *, account_id:
     )
 
 
+async def get_agent_head_version(
+    conn: asyncpg.Connection[Any], agent_id: str, *, account_id: str
+) -> int:
+    """The agent's current head ``version`` as a scalar — no full-row hydration.
+
+    Used to pin a workflow child's ``agent_version`` at spawn (the spawn path
+    needs only the int, not the parsed Agent). Raises ``NotFoundError`` if the
+    agent is absent, mirroring :func:`get_agent`. (Distinct from
+    :func:`get_agent_version`, which fetches one historical ``AgentVersion`` row.)
+    """
+    version = await conn.fetchval(
+        "SELECT version FROM agents WHERE id = $1 AND account_id = $2", agent_id, account_id
+    )
+    if version is None:
+        raise NotFoundError(f"agent {agent_id} not found", detail={"id": agent_id})
+    return int(version)
+
+
 async def list_agents(
     conn: asyncpg.Connection[Any],
     *,
@@ -882,6 +900,18 @@ def _row_to_session(row: asyncpg.Record) -> Session:
     )
 
 
+def _default_workspace_path(account_id: str, session_id: str) -> str:
+    """Per-tenant default workspace dir ``workspace_root/{account_id}/{session_id}``.
+
+    The #367 isolation convention (a stray bind-mount can't reach across tenants;
+    per-tenant quotas/backups scope to one dir) — one source of truth for the
+    session-insert paths.
+    """
+    from aios.config import get_settings
+
+    return str(get_settings().workspace_root / account_id / session_id)
+
+
 async def insert_session(
     conn: asyncpg.Connection[Any],
     *,
@@ -910,15 +940,9 @@ async def insert_session(
     ``focal_locked=True`` to start life locked on the spawning
     chat's channel.
     """
-    from aios.config import get_settings
-
     new_id = make_id(SESSION)
     if workspace_path is None:
-        # Per-tenant subdir (#367 follow-up): each account's sessions
-        # live under ``workspace_root/{account_id}/{session_id}`` so a
-        # stray bind-mount can't reach across tenants, and so per-tenant
-        # disk quotas / backups can scope to one directory.
-        workspace_path = str(get_settings().workspace_root / account_id / new_id)
+        workspace_path = _default_workspace_path(account_id, new_id)
     try:
         row = await conn.fetchrow(
             """
@@ -974,9 +998,7 @@ async def insert_child_session(
     no vaults/resources/scheduled-tasks; the caller delivers the agent input in
     the same transaction.
     """
-    from aios.config import get_settings
-
-    workspace_path = str(get_settings().workspace_root / account_id / session_id)
+    workspace_path = _default_workspace_path(account_id, session_id)
     try:
         row = await conn.fetchrow(
             """
@@ -1536,15 +1558,9 @@ async def clone_session(
     The clone primitive locks the parent row for the copy, so concurrent
     appenders serialize behind it and the copied seq range is gapless.
     """
-    from aios.config import get_settings
-
     new_id = make_id(SESSION)
     if workspace_path is None:
-        # Per-tenant subdir (#367 follow-up): each account's sessions
-        # live under ``workspace_root/{account_id}/{session_id}`` so a
-        # stray bind-mount can't reach across tenants, and so per-tenant
-        # disk quotas / backups can scope to one directory.
-        workspace_path = str(get_settings().workspace_root / account_id / new_id)
+        workspace_path = _default_workspace_path(account_id, new_id)
 
     async with conn.transaction():
         row = await conn.fetchrow(

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1046,16 +1046,20 @@ async def get_session_workflow_context(
 async def read_request_response(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
 ) -> dict[str, Any] | None:
-    """A specific request's **response** (`request_response` event), or ``None`` if
-    the request is still open.
+    """A specific request's written **response** (`request_response` event), or
+    ``None`` if none has been written.
 
-    The single explicit response a session gives a request it was invoked with —
-    a `return`/`error` from the model, the harness erroring path, or the no_return
-    backstop — never inferred from idle. The run-step harvest reads it to resolve
-    the `agent()` call. ``data`` is ``{event, request_id, is_error, result, error}``.
-    Exactly one exists per request (see :func:`write_response_if_absent`), so
-    ``LIMIT 1`` returns it directly; the ``events_request_response_idx`` partial
-    index (0067) keeps this a point lookup rather than a per-wake history scan.
+    The response-only primitive: it reflects only an explicit `return`/`error`,
+    harness-erroring, or no_return write — NOT liveness. It backs
+    :func:`write_response_if_absent`'s exactly-once absent-recheck (its only caller);
+    the run-step harvest instead uses :func:`derive_response`, which additionally
+    folds in `child_gone` liveness. Keeping this response-only is load-bearing — a
+    liveness check here would make the recheck treat a never-answered gone session
+    as already-answered and suppress the totality write. ``data`` is
+    ``{event, request_id, is_error, result, error}``. Exactly one exists per request
+    (see :func:`write_response_if_absent`), so ``LIMIT 1`` returns it directly; the
+    ``events_request_response_idx`` partial index (mig 0068) keeps this a point
+    lookup rather than a per-wake history scan.
     """
     row = await conn.fetchrow(
         "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1006,6 +1006,56 @@ async def insert_child_session(
     return _row_to_session(row) if row is not None else None
 
 
+async def get_session_workflow_context(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> tuple[str, str | None] | None:
+    """``(account_id, parent_run_id)`` for a session, or ``None`` if it's absent.
+
+    Unscoped (internal/trusted — the ``return``/``error`` completion tools run
+    inside the child's own dispatch and need the parent run to wake). A non-null
+    ``parent_run_id`` is what marks the session a workflow child.
+    """
+    row = await conn.fetchrow(
+        "SELECT account_id, parent_run_id FROM sessions WHERE id = $1", session_id
+    )
+    return (row["account_id"], row["parent_run_id"]) if row is not None else None
+
+
+async def set_session_archived(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> None:
+    """Idempotently soft-archive a session (no-op if already archived).
+
+    Unlike :func:`archive_session` this never raises ``NotFound`` — used by the
+    workflow completion tools (self-archive on ``return``) and run-termination
+    teardown, where a double-archive is benign.
+    """
+    await conn.execute(
+        "UPDATE sessions SET archived_at = now() "
+        "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL",
+        session_id,
+        account_id,
+    )
+
+
+async def read_workflow_child_done(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> dict[str, Any] | None:
+    """The child's ``workflow_child_done`` marker payload, or ``None`` if absent.
+
+    The single explicit completion signal the run-step harvest reads (§3.3/§3.5)
+    — never inferred from idle. ``data`` is ``{event, is_error, result}``.
+    """
+    row = await conn.fetchrow(
+        "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
+        "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done' "
+        "ORDER BY seq LIMIT 1",
+        session_id,
+        account_id,
+    )
+    return parse_jsonb(row["data"]) if row is not None else None
+
+
 async def get_session(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> Session:

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -53,6 +53,7 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         id=row["id"],
         workflow_id=row["workflow_id"],
         account_id=row["account_id"],
+        environment_id=row["environment_id"],
         parent_run_id=row["parent_run_id"],
         script=row["script"],
         script_sha=row["script_sha"],
@@ -150,6 +151,7 @@ async def insert_wf_run(
     *,
     account_id: str,
     workflow_id: str,
+    environment_id: str,
     script: str,
     script_sha: str,
     input: Any = None,
@@ -161,13 +163,15 @@ async def insert_wf_run(
         row = await conn.fetchrow(
             """
             INSERT INTO wf_runs
-                (id, workflow_id, account_id, parent_run_id, script, script_sha, status, input)
-            VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7::jsonb)
+                (id, workflow_id, account_id, environment_id, parent_run_id,
+                 script, script_sha, status, input)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8::jsonb)
             RETURNING *
             """,
             new_id,
             workflow_id,
             account_id,
+            environment_id,
             parent_run_id,
             script,
             script_sha,
@@ -175,7 +179,8 @@ async def insert_wf_run(
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
-            f"workflow {workflow_id} not found", detail={"workflow_id": workflow_id}
+            f"workflow {workflow_id} or environment {environment_id} not found",
+            detail={"workflow_id": workflow_id, "environment_id": environment_id},
         ) from exc
     assert row is not None
     return _row_to_wf_run(row)

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -333,6 +333,17 @@ def render_user_event(
     metadata = event_data.get("metadata")
     metadata = metadata if isinstance(metadata, dict) else None
 
+    # A request injected via invoke_session (e.g. a workflow agent child's first
+    # message) carries metadata.request.request_id. return/error require that id, so
+    # surface it on the rendered message — this is where the model reads what to echo
+    # back. Deterministic function of the event, so the context stays monotonic.
+    request = metadata.get("request") if metadata else None
+    if isinstance(request, dict) and isinstance(request.get("request_id"), str):
+        rid = request["request_id"]
+        marker = f"[request_id: {rid} — reply with return/error using this request_id]"
+        existing = msg.get("content") or ""
+        msg["content"] = f"{marker}\n{existing}" if existing else marker
+
     if orig_channel is None:
         return msg
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -42,6 +42,7 @@ from aios.models.agents import (
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 from aios.services.wake import defer_wake
+from aios.tools.workflow_completion import respond_to_request
 
 if TYPE_CHECKING:
     import asyncpg
@@ -838,6 +839,14 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
     )
     await _append_lifecycle(
         pool, session_id, "turn_ended", "errored", "error", account_id=account_id
+    )
+    # A workflow child whose model errored past its retry budget can no longer
+    # answer the request it was invoked with. Respond on its behalf with a
+    # monotonic error so the invoking run resolves (and can raise AgentError)
+    # instead of hanging forever on a dead child. No-op for any session that isn't
+    # a workflow child owing an open request.
+    await respond_to_request(
+        pool, session_id, is_error=True, result=None, error={"kind": "child_errored"}
     )
     return None
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -41,8 +41,8 @@ from aios.models.agents import (
 )
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
-from aios.services.wake import defer_wake
-from aios.tools.workflow_completion import respond_to_request
+from aios.services.wake import defer_run_wake, defer_wake
+from aios.tools.workflow_completion import fail_all_open_requests
 
 if TYPE_CHECKING:
     import asyncpg
@@ -466,11 +466,27 @@ async def _run_session_step_body(
     # wake. ``find_sessions_needing_inference`` uses it as the watermark.
     assistant_msg["reacting_to"] = step_ctx.reacting_to
 
-    # Append assistant message to the session log (unfenced — procrastinate
-    # lock provides mutual exclusion).
-    await sessions_service.append_event(
-        pool, session_id, "message", assistant_msg, account_id=account_id
+    # Append assistant message to the session log (unfenced — procrastinate lock
+    # provides mutual exclusion) and, in the SAME transaction, enforce request
+    # totality: if this tool-call-free turn would leave the session idle while it
+    # owes a request response, a nudge (or a no_return error once the budget is
+    # spent) is written atomically with the idling event — so no reader ever
+    # observes the session idle with an open request. A strict no-op for any
+    # session that owes nothing (the common case).
+    (
+        nudged,
+        autoerrored,
+        caller_run_id,
+    ) = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, session_id, assistant_msg, account_id=account_id
     )
+    if nudged:
+        # The nudge is a fresh user message (delay-less, like any user-message wake,
+        # so — unlike the retry deferral — it has no queue-latency window to land in);
+        # wake promptly to give the model another turn to answer.
+        await defer_wake(pool, session_id, account_id=account_id, cause="request_nudge")
+    if autoerrored and caller_run_id is not None:
+        await defer_run_wake(caller_run_id)
 
     # Partition tool calls into dispatch buckets. Immediate builtin/MCP
     # launch now; ``needs_confirm`` and ``custom`` sit unresolved in the
@@ -841,12 +857,12 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
         pool, session_id, "turn_ended", "errored", "error", account_id=account_id
     )
     # A workflow child whose model errored past its retry budget can no longer
-    # answer the request it was invoked with. Respond on its behalf with a
-    # monotonic error so the invoking run resolves (and can raise AgentError)
+    # answer the requests it was invoked with. Error every one on its behalf with a
+    # monotonic response so each invoking run resolves (and can raise AgentError)
     # instead of hanging forever on a dead child. No-op for any session that isn't
-    # a workflow child owing an open request.
-    await respond_to_request(
-        pool, session_id, is_error=True, result=None, error={"kind": "child_errored"}
+    # a workflow child owing open requests.
+    await fail_all_open_requests(
+        pool, session_id, account_id=account_id, error={"kind": "child_errored"}
     )
     return None
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -561,17 +561,10 @@ def _switch_channel_tool_spec() -> dict[str, Any]:
     to list it in their ``tools`` declaration — it's focal-machinery
     scope, not agent scope.
     """
+    from aios.tools.registry import openai_tool_entry
     from aios.tools.registry import registry as tool_registry
 
-    tool = tool_registry.get("switch_channel")
-    return {
-        "type": "function",
-        "function": {
-            "name": tool.name,
-            "description": tool.description,
-            "parameters": tool.parameters_schema,
-        },
-    }
+    return openai_tool_entry(tool_registry.get("switch_channel"))
 
 
 async def _dump_context_if_enabled(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -23,7 +23,7 @@ watermark and proceeds.
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
@@ -70,6 +70,25 @@ def _retry_delay_for_attempt(attempt: int) -> float | None:
     if attempt >= len(_RETRY_BACKOFF_SECONDS):
         return None
     return _RETRY_BACKOFF_SECONDS[attempt]
+
+
+class _StepResult(NamedTuple):
+    """What a step asks ``run_session_step`` to defer **after** ``step_end``.
+
+    Every wake a step provokes is deferred here, never inside the body, so its
+    ``wake_deferred`` span lands in step N+1's window — the "all wake_deferred since
+    the previous step_end" pairing rule the profiler relies on (#132).
+
+    * ``retry_delay`` — a model-error backoff reschedule (``defer_wake``).
+    * ``nudge_session`` — the quiescence guard nudged an owed request; re-wake the
+      session so the model gets another turn (``defer_wake``).
+    * ``autoerror_caller_run_id`` — the guard auto-errored a request past its budget;
+      wake that caller run to harvest the ``no_return`` (``defer_run_wake``).
+    """
+
+    retry_delay: float | None = None
+    nudge_session: bool = False
+    autoerror_caller_run_id: str | None = None
 
 
 async def refresh_session_mount_state(
@@ -128,10 +147,10 @@ async def run_session_step(
     current_task = asyncio.current_task()
     assert current_task is not None
     task_registry.register_step(session_id, current_task)
-    retry_delay: float | None = None
+    result = _StepResult()
     try:
         try:
-            retry_delay = await asyncio.wait_for(
+            result = await asyncio.wait_for(
                 _run_session_step_body(
                     pool,
                     task_registry,
@@ -146,7 +165,9 @@ async def run_session_step(
             # fire. Force a reschedulable error state so the next wake can
             # proceed (matches what the body's litellm-error handler does).
             log.exception("step.job_timeout", session_id=session_id, timeout=_JOB_TIMEOUT_S)
-            retry_delay = await _handle_step_timeout(pool, session_id, account_id=account_id)
+            result = _StepResult(
+                retry_delay=await _handle_step_timeout(pool, session_id, account_id=account_id)
+            )
         except Exception:
             # Unexpected harness error (not a model/tool error — those are caught
             # inside _run_session_step_body). Emit a span so the event log has a
@@ -160,8 +181,9 @@ async def run_session_step(
                 {"event": "harness_error", "is_error": True},
                 account_id=account_id,
             )
-            retry_delay = await _apply_retry_or_failure(pool, session_id, account_id=account_id)
-            if retry_delay is None:
+            delay = await _apply_retry_or_failure(pool, session_id, account_id=account_id)
+            result = _StepResult(retry_delay=delay)
+            if delay is None:
                 raise
     finally:
         task_registry.unregister_step(session_id)
@@ -173,16 +195,24 @@ async def run_session_step(
             account_id=account_id,
         )
 
-    # Fire retry deferral AFTER ``step_end`` so its ``wake_deferred`` lands
-    # in step N+1's temporal window, not step N's. Under the "all
-    # wake_deferred since previous step_end" pairing rule, emitting
-    # inside the body would make the reschedule invisible to the next
-    # step's queue-latency calculation — the one path where delay is
-    # a known quantity (the retry backoff).
-    if retry_delay is not None:
+    # Every wake fires AFTER ``step_end`` so its ``wake_deferred`` span lands in
+    # step N+1's temporal window, not step N's — the "all wake_deferred since the
+    # previous step_end" pairing rule the profiler keys off (#132). Emitting inside
+    # the body would mis-attribute the gap. ``reschedule`` carries a known backoff
+    # delay; the ``request_nudge`` re-wakes the session for another answer turn; the
+    # auto-error wakes the caller run to harvest the ``no_return``.
+    if result.retry_delay is not None:
         await defer_wake(
-            pool, session_id, cause="reschedule", delay_seconds=retry_delay, account_id=account_id
+            pool,
+            session_id,
+            cause="reschedule",
+            delay_seconds=result.retry_delay,
+            account_id=account_id,
         )
+    if result.nudge_session:
+        await defer_wake(pool, session_id, cause="request_nudge", account_id=account_id)
+    if result.autoerror_caller_run_id is not None:
+        await defer_run_wake(result.autoerror_caller_run_id)
 
 
 async def _run_session_step_body(
@@ -192,12 +222,11 @@ async def _run_session_step_body(
     *,
     cause: str,
     account_id: str,
-) -> float | None:
-    """Returns the retry backoff delay when the model errored and the
-    outer function should defer a ``cause="reschedule"`` wake after
-    ``step_end``; ``None`` otherwise.  Keeping the actual ``defer_wake``
-    call outside the body is what makes the reschedule's
-    ``wake_deferred`` land in the next step's temporal window."""
+) -> _StepResult:
+    """Returns the wakes ``run_session_step`` should defer **after** ``step_end``
+    (see :class:`_StepResult`): a model-error backoff reschedule, and/or the
+    quiescence guard's nudge / auto-error wakes. Keeping every ``defer_wake`` out of
+    the body is what makes each ``wake_deferred`` land in the next step's window."""
     # Sweep-based guard: does this session actually need work?
     # Prevents wasted DB/model calls from stale or duplicate wakes.
     #
@@ -231,7 +260,7 @@ async def _run_session_step_body(
         )
     if session_id not in needs:
         log.debug("step.early_out", session_id=session_id, cause=cause)
-        return None
+        return _StepResult()
 
     session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
 
@@ -304,7 +333,7 @@ async def _run_session_step_body(
             session_id=session_id,
             count=len(pending),
         )
-        return None
+        return _StepResult()
 
     # Span the remainder of the prologue so "why is the step slow?"
     # can separate context-build cost from model-call cost (issue #78).
@@ -421,7 +450,9 @@ async def _run_session_step_body(
             },
             account_id=account_id,
         )
-        return await _apply_retry_or_failure(pool, session_id, account_id=account_id)
+        return _StepResult(
+            retry_delay=await _apply_retry_or_failure(pool, session_id, account_id=account_id)
+        )
 
     # ``local_tokens`` costs the full payload (messages + tools) so it
     # matches what the provider counts.  The error branch above stays
@@ -473,6 +504,10 @@ async def _run_session_step_body(
     # spent) is written atomically with the idling event — so no reader ever
     # observes the session idle with an open request. A strict no-op for any
     # session that owes nothing (the common case).
+    # The resulting wakes (nudge → re-wake the session; auto-error → wake the
+    # caller run) are deferred by run_session_step AFTER step_end via _StepResult,
+    # so their wake_deferred spans land in the next step's window (see the §wakes
+    # block in run_session_step).
     (
         nudged,
         autoerrored,
@@ -480,13 +515,6 @@ async def _run_session_step_body(
     ) = await sessions_service.append_assistant_and_guard_quiescence(
         pool, session_id, assistant_msg, account_id=account_id
     )
-    if nudged:
-        # The nudge is a fresh user message (delay-less, like any user-message wake,
-        # so — unlike the retry deferral — it has no queue-latency window to land in);
-        # wake promptly to give the model another turn to answer.
-        await defer_wake(pool, session_id, account_id=account_id, cause="request_nudge")
-    if autoerrored and caller_run_id is not None:
-        await defer_run_wake(caller_run_id)
 
     # Partition tool calls into dispatch buckets. Immediate builtin/MCP
     # launch now; ``needs_confirm`` and ``custom`` sit unresolved in the
@@ -567,7 +595,11 @@ async def _run_session_step_body(
         pool, session_id, "turn_ended", "idle", "end_turn", account_id=account_id
     )
     log.info("step.turn_ended", session_id=session_id, cause=cause)
-    return None
+    # Hand the quiescence guard's wakes to run_session_step to defer after step_end.
+    return _StepResult(
+        nudge_session=nudged,
+        autoerror_caller_run_id=caller_run_id if autoerrored else None,
+    )
 
 
 def _switch_channel_tool_spec() -> dict[str, Any]:
@@ -850,19 +882,24 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
     # the sweep skips (see ``sweep.ERRORED_SESSIONS_SQL``); any in-flight tool
     # task that completes after this point sits unreaped until a user message
     # recovers the session (its seq overtakes the error event).
+    #
+    # A workflow child whose model errored past its retry budget can no longer
+    # answer the requests it was invoked with. Error every one on its behalf with a
+    # monotonic response so each invoking run resolves (and can raise AgentError)
+    # instead of hanging forever on a dead child (no-op for a non-child / nothing
+    # owed). This MUST land BEFORE the error latch below: the latch makes the sweep
+    # skip the session, so a crash after latching-but-before-responding would strand
+    # the child errored-and-unanswered, with no path to ever resolve its callers.
+    # Responses-before-latch means a crash leaves the child un-latched (recoverable —
+    # the sweep re-wakes it, it re-errors, and the now-written responses no-op).
+    await fail_all_open_requests(
+        pool, session_id, account_id=account_id, error={"kind": "child_errored"}
+    )
     await sessions_service.set_session_stop_reason(
         pool, session_id, {"type": "error"}, account_id=account_id
     )
     await _append_lifecycle(
         pool, session_id, "turn_ended", "errored", "error", account_id=account_id
-    )
-    # A workflow child whose model errored past its retry budget can no longer
-    # answer the requests it was invoked with. Error every one on its behalf with a
-    # monotonic response so each invoking run resolves (and can raise AgentError)
-    # instead of hanging forever on a dead child. No-op for any session that isn't
-    # a workflow child owing open requests.
-    await fail_all_open_requests(
-        pool, session_id, account_id=account_id, error={"kind": "child_errored"}
     )
     return None
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -515,12 +515,12 @@ async def _run_session_step_body(
     # caller run) are deferred by run_session_step AFTER step_end via _StepResult,
     # so their wake_deferred spans land in the next step's window (see the §wakes
     # block in run_session_step).
-    (
-        nudged,
-        autoerrored,
-        caller_run_id,
-    ) = await sessions_service.append_assistant_and_guard_quiescence(
-        pool, session_id, assistant_msg, account_id=account_id
+    nudged, autoerror_caller_run_id = await sessions_service.append_assistant_and_guard_quiescence(
+        pool,
+        session_id,
+        assistant_msg,
+        account_id=account_id,
+        parent_run_id=session.parent_run_id,
     )
 
     # Partition tool calls into dispatch buckets. Immediate builtin/MCP
@@ -605,7 +605,7 @@ async def _run_session_step_body(
     # Hand the quiescence guard's wakes to run_session_step to defer after step_end.
     return _StepResult(
         nudge_session=nudged,
-        autoerror_caller_run_id=caller_run_id if autoerrored else None,
+        autoerror_caller_run_id=autoerror_caller_run_id,
     )
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -128,8 +128,15 @@ async def run_session_step(
     ``lock`` parameter guarantees only one step runs per session at a
     time.
     """
-    account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     pool = runtime.require_pool()
+    # Entry guard (mirrors run_workflow_step's terminal early-return): a wake for a
+    # session that has been archived or deleted is an idempotent no-op. Without it
+    # the unconditional step_start append below would hit append_event's archived
+    # guard and fail the job — e.g. a sweep wake racing an operator archive, or a
+    # workflow child reclaimed after answering.
+    account_id = await sessions_service.load_live_session_account_id(pool, session_id)
+    if account_id is None:
+        return
     task_registry = runtime.require_task_registry()
 
     # Outermost span pair: brackets the entire step (issue #131).  Emitted

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -171,6 +171,12 @@ async def compute_step_prelude(
     # focal attention; inject it whenever the session has bound channels.
     if channels:
         tools.append(_switch_channel_tool_spec())
+    # return/error are a workflow agent child's only way to finish — injected
+    # only for a background child of a run (§3.5), never a foreground session.
+    if session.origin == "background" and session.parent_run_id is not None:
+        from aios.tools.workflow_completion import workflow_completion_tool_specs
+
+        tools.extend(workflow_completion_tool_specs())
 
     mcp_servers_block = ""
     if agent.mcp_servers:

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -215,6 +215,23 @@ ERRORED_SESSIONS_SQL = """
      WHERE um.user_seq IS NULL OR em.err_seq > um.user_seq
 """
 
+# Workflow children that have signalled logical completion (a ``workflow_child_done``
+# marker). They are **soft-terminal**: their unreacted ``tool_result`` (the
+# ``return``/``error`` call's own, plus any sibling tool results) must NOT trigger
+# another model step — that would waste an inference and let a confused child emit
+# a second ``return`` (a duplicate marker). The physical archive is the in-worker
+# workflow-child reaper's job, once the child is provably quiescent; until then this
+# keeps the finished child out of the wake set. Subtracted in-process (like
+# ``errored``) so the candidate/confirmed queries stay free of an anti-join the
+# perf guard flags as a SubPlan. Backed by ``events_workflow_child_done_idx`` (0067).
+COMPLETED_CHILD_SESSIONS_SQL = """
+    SELECT DISTINCT session_id
+      FROM events
+     WHERE kind = 'lifecycle'
+       AND data->>'event' = 'workflow_child_done'
+       {scope_clause}
+"""
+
 
 # ─── ghost repair ────────────────────────────────────────────────────────────
 
@@ -472,6 +489,23 @@ async def _errored_session_ids(
     return {r["session_id"] for r in rows}
 
 
+async def _completed_child_session_ids(
+    conn: asyncpg.Connection[Any], *, session_id: str | None = None
+) -> set[str]:
+    """Session IDs of workflow children that have signalled logical completion.
+
+    See ``COMPLETED_CHILD_SESSIONS_SQL``. A child with a ``workflow_child_done``
+    marker is soft-terminal — the sweep excludes it from inference so its
+    post-``return`` tool_result never triggers another model step (the physical
+    archive is the in-worker reaper's job). Subtracted in-process, mirroring
+    :func:`_errored_session_ids`.
+    """
+    scope_clause = "AND session_id = $1" if session_id else ""
+    params: list[Any] = [session_id] if session_id else []
+    rows = await conn.fetch(COMPLETED_CHILD_SESSIONS_SQL.format(scope_clause=scope_clause), *params)
+    return {r["session_id"] for r in rows}
+
+
 async def find_sessions_needing_inference(
     pool: asyncpg.Pool[Any],
     task_registry: TaskRegistry,
@@ -521,9 +555,14 @@ async def find_sessions_needing_inference(
         # (subtracted in-process to keep the candidate/confirmed queries free
         # of an anti-join that the perf guard would flag as a SubPlan).
         errored = await _errored_session_ids(conn, session_id=session_id)
+        # Workflow children that already signalled completion are soft-terminal:
+        # exclude them so a returned child isn't re-woken (no wasted model step,
+        # no duplicate ``return``). Same in-process-subtraction rationale as
+        # ``errored``. Physical archive is the in-worker reaper's job.
+        completed = await _completed_child_session_ids(conn, session_id=session_id)
 
-    candidates -= errored
-    confirmed_sessions -= errored
+    candidates -= errored | completed
+    confirmed_sessions -= errored | completed
     to_filter = candidates - confirmed_sessions
     filtered = (
         await _filter_incomplete_batches(pool, task_registry, to_filter) if to_filter else set()

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -215,24 +215,6 @@ ERRORED_SESSIONS_SQL = """
      WHERE um.user_seq IS NULL OR em.err_seq > um.user_seq
 """
 
-# Workflow children that have signalled logical completion (a ``workflow_child_done``
-# marker). They are **soft-terminal**: their unreacted ``tool_result`` (the
-# ``return``/``error`` call's own, plus any sibling tool results) must NOT trigger
-# another model step — that would waste an inference and let a confused child emit
-# a second ``return`` (a duplicate marker). The physical archive is the in-worker
-# workflow-child reaper's job, once the child is provably quiescent; until then this
-# keeps the finished child out of the wake set. Subtracted in-process (like
-# ``errored``) so the candidate/confirmed queries stay free of an anti-join the
-# perf guard flags as a SubPlan. Backed by ``events_workflow_child_done_idx`` (0067).
-COMPLETED_CHILD_SESSIONS_SQL = """
-    SELECT DISTINCT session_id
-      FROM events
-     WHERE kind = 'lifecycle'
-       AND data->>'event' = 'workflow_child_done'
-       {scope_clause}
-"""
-
-
 # ─── ghost repair ────────────────────────────────────────────────────────────
 
 
@@ -489,23 +471,6 @@ async def _errored_session_ids(
     return {r["session_id"] for r in rows}
 
 
-async def _completed_child_session_ids(
-    conn: asyncpg.Connection[Any], *, session_id: str | None = None
-) -> set[str]:
-    """Session IDs of workflow children that have signalled logical completion.
-
-    See ``COMPLETED_CHILD_SESSIONS_SQL``. A child with a ``workflow_child_done``
-    marker is soft-terminal — the sweep excludes it from inference so its
-    post-``return`` tool_result never triggers another model step (the physical
-    archive is the in-worker reaper's job). Subtracted in-process, mirroring
-    :func:`_errored_session_ids`.
-    """
-    scope_clause = "AND session_id = $1" if session_id else ""
-    params: list[Any] = [session_id] if session_id else []
-    rows = await conn.fetch(COMPLETED_CHILD_SESSIONS_SQL.format(scope_clause=scope_clause), *params)
-    return {r["session_id"] for r in rows}
-
-
 async def find_sessions_needing_inference(
     pool: asyncpg.Pool[Any],
     task_registry: TaskRegistry,
@@ -555,14 +520,9 @@ async def find_sessions_needing_inference(
         # (subtracted in-process to keep the candidate/confirmed queries free
         # of an anti-join that the perf guard would flag as a SubPlan).
         errored = await _errored_session_ids(conn, session_id=session_id)
-        # Workflow children that already signalled completion are soft-terminal:
-        # exclude them so a returned child isn't re-woken (no wasted model step,
-        # no duplicate ``return``). Same in-process-subtraction rationale as
-        # ``errored``. Physical archive is the in-worker reaper's job.
-        completed = await _completed_child_session_ids(conn, session_id=session_id)
 
-    candidates -= errored | completed
-    confirmed_sessions -= errored | completed
+    candidates -= errored
+    confirmed_sessions -= errored
     to_filter = candidates - confirmed_sessions
     filtered = (
         await _filter_incomplete_batches(pool, task_registry, to_filter) if to_filter else set()

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -90,14 +90,26 @@ _PREFIXES: Final = frozenset(
 )
 
 
-def make_id(prefix: str) -> str:
-    """Generate a fresh prefixed ULID id for ``prefix``.
+def make_id(prefix: str, *, body: bytes | None = None) -> str:
+    """Generate a prefixed ULID id for ``prefix``.
+
+    With no ``body``, returns a fresh random, time-ordered ULID. ``body``
+    (exactly 16 bytes) forces a **deterministic** ULID — Crockford-base32
+    encoded to the same 26-char body ``split_id`` accepts. Used for
+    content-addressed ids (e.g. a workflow's deterministic child session id
+    folded from ``(run_id, call_key)``) so a replayed spawn reproduces the
+    same id rather than minting a duplicate.
 
     Raises ``ValueError`` if ``prefix`` isn't one of the canonical aios
-    resource prefixes — this catches typos before they reach the DB.
+    resource prefixes (catches typos before they reach the DB), or if ``body``
+    is given but isn't exactly 16 bytes.
     """
     if prefix not in _PREFIXES:
         raise ValueError(f"unknown id prefix {prefix!r}; expected one of {sorted(_PREFIXES)}")
+    if body is not None:
+        if len(body) != 16:
+            raise ValueError(f"deterministic id body must be exactly 16 bytes, got {len(body)}")
+        return f"{prefix}_{ULID(body)}"
     return f"{prefix}_{ULID()}"
 
 

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -88,6 +88,13 @@ special case of ``idle``: it reads ``idle`` with ``stop_reason.type == "error"``
 and will not wake until a user message arrives.
 """
 
+
+SessionOrigin = Literal["foreground", "background"]
+"""How the session was created. ``foreground`` (default) — by the API/UI/a
+connector. ``background`` — spawned by a workflow run's ``agent()`` (carries a
+``parent_run_id``); the completion tools (``return``/``error``) are injected only
+into background children, and the totality backstop supervises them."""
+
 MAX_USER_MESSAGE_CHARS = 1_000_000
 
 
@@ -265,6 +272,8 @@ class Session(BaseModel):
     archived_at: datetime | None = None
     focal_channel: str | None = None
     focal_locked: bool = False
+    origin: SessionOrigin = "foreground"
+    parent_run_id: str | None = None  # set for a workflow-spawned (background) child
     last_event_at: datetime | None = None
     total_events: int = 0
 

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -49,6 +49,7 @@ class WfRun(BaseModel):
     id: str
     workflow_id: str
     account_id: str
+    environment_id: str  # the run binds to an environment; agent() children inherit it
     parent_run_id: str | None = None
     script: str
     script_sha: str

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -237,19 +237,23 @@ async def create_child_session(
     environment_id: str,
     agent_version: int,
     parent_run_id: str,
+    request_id: str,
     input: Any,
 ) -> bool:
-    """Idempotently spawn a workflow ``agent()`` child under a deterministic id.
+    """Idempotently spawn a workflow ``agent()`` child and inject the first request.
+
+    `invoke_agent` = create_session + invoke_session: the child's first user
+    message **is a request** — its content is ``input``, and ``metadata.request``
+    carries ``{request_id, caller}`` so the target can correlate its response and
+    the caller (the run) can be resumed. The child must answer this request via
+    ``return``/``error`` (exactly once) — it is otherwise an ordinary user message
+    (the model sees only the content; metadata is stripped at render time).
 
     One transaction: insert the child row (``ON CONFLICT (id) DO NOTHING``) and,
-    **only on a real insert**, deliver ``input`` as the child's first user
-    message — without a stimulus the child would be born-idle (the loop ends
-    every turn idle, so nothing wakes it and the totality backstop would
-    spuriously flag it ``no_return``). Atomic, so a crash can never leave a child
-    row without its input.
-
-    Returns ``True`` if a row was created (first spawn), ``False`` on conflict (a
-    replay found the existing row → the caller harvests instead of re-spawning).
+    **only on a real insert**, deliver the request — without a stimulus the child
+    would be born-idle. Atomic, so a crash can never leave a child row without its
+    request. Returns ``True`` on first spawn, ``False`` on conflict (replay → the
+    caller harvests the response instead of re-spawning).
     """
     content = input if isinstance(input, str) else json.dumps(input)
     async with pool.acquire() as conn, conn.transaction():
@@ -263,13 +267,22 @@ async def create_child_session(
             parent_run_id=parent_run_id,
         )
         if child is None:
-            return False  # replay: row exists — do NOT re-deliver input
+            return False  # replay: row exists — do NOT re-deliver the request
         await queries.append_event(
             conn,
             account_id=account_id,
             session_id=session_id,
             kind="message",
-            data={"role": "user", "content": content},
+            data={
+                "role": "user",
+                "content": content,
+                "metadata": {
+                    "request": {
+                        "request_id": request_id,
+                        "caller": {"kind": "run", "id": parent_run_id},
+                    }
+                },
+            },
         )
         return True
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -246,8 +246,9 @@ async def create_child_session(
     message **is a request** — its content is ``input``, and ``metadata.request``
     carries ``{request_id, caller}`` so the target can correlate its response and
     the caller (the run) can be resumed. The child must answer this request via
-    ``return``/``error`` (exactly once) — it is otherwise an ordinary user message
-    (the model sees only the content; metadata is stripped at render time).
+    ``return``/``error`` (exactly once); the ``request_id`` is surfaced to the model
+    as a render-time marker on the message (see ``render_user_event``) so it knows
+    which id to echo back.
 
     One transaction: insert the child row (``ON CONFLICT (id) DO NOTHING``) and,
     **only on a real insert**, deliver the request — without a stimulus the child
@@ -510,6 +511,108 @@ async def append_event(
         return await queries.append_event(
             conn, session_id=session_id, kind=kind, data=data, account_id=account_id
         )
+
+
+# A session gets this many nudges to answer an owed request before the harness
+# answers it on the model's behalf with a ``no_return`` error. Derived per request
+# from the count of nudge messages (see ``queries.count_request_nudges``).
+REQUEST_NUDGE_BUDGET = 3
+
+
+def _nudge_content(request_ids: list[str]) -> str:
+    ids = ", ".join(request_ids)
+    return (
+        f"You still owe a response to these request(s): {ids}. Answer each one with "
+        "return(request_id, value) if you have a result, or error(request_id, message) "
+        "if you can't complete it — you must answer before you can finish."
+    )
+
+
+async def append_assistant_and_guard_quiescence(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    assistant_msg: dict[str, Any],
+    *,
+    account_id: str,
+) -> tuple[bool, bool, str | None]:
+    """Append the model's assistant message and, **atomically**, enforce the
+    request-totality invariant: a session may not go idle while it owes a response.
+
+    In one transaction: append the assistant message; if the session would now be
+    idle (the model produced a tool-call-free turn — ``derive_session_status``
+    reads the just-appended event) and it still owes request responses, then for
+    each open request either append a **nudge** (a user message that re-triggers
+    inference, so the session stays active) when under
+    :data:`REQUEST_NUDGE_BUDGET`, or write its **no_return** error response when the
+    budget is spent. Because the nudge commits in the same transaction as the
+    idling assistant event, no reader can ever observe the session idle while a
+    request is open — the invariant holds at write time, with no sweep backstop.
+
+    Returns ``(nudged, autoerrored, caller_run_id)``; the caller (the harness loop)
+    does the post-commit wakes — ``defer_wake(session)`` if nudged,
+    ``defer_run_wake(caller_run_id)`` if autoerrored. A strict no-op
+    ``(False, False, None)`` for any session with no open requests, i.e. every
+    ordinary session — the open-request query is the gate.
+    """
+    nudged = False
+    autoerrored = False
+    caller_run_id: str | None = None
+    async with pool.acquire() as conn, conn.transaction():
+        await queries.append_event(
+            conn, session_id=session_id, kind="message", data=assistant_msg, account_id=account_id
+        )
+        # Gates, cheapest first (this runs on EVERY end-of-turn append):
+        #   1. tool calls present → unresolved tool_call → active by construction
+        #      (the tools haven't run yet), so it can't be idle — settle in memory,
+        #      no query.
+        #   2. nothing owed → the common case for every ordinary session → one
+        #      indexed anti-join.
+        #   3. only now pay the multi-EXISTS idleness derivation (the same
+        #      _SESSION_STATUS_EXPR every external reader uses), and only for a
+        #      session that actually owes a response — it could still be active via
+        #      a user message that arrived during inference.
+        if assistant_msg.get("tool_calls"):
+            return (False, False, None)
+        open_ids = await queries.get_open_request_ids(conn, session_id, account_id=account_id)
+        if not open_ids:
+            return (False, False, None)  # ordinary session, or every request answered
+        if await queries.derive_session_status(conn, session_id, account_id=account_id) != "idle":
+            return (False, False, None)
+        to_nudge: list[str] = []
+        for request_id in open_ids:
+            nudges = await queries.count_request_nudges(
+                conn, session_id, account_id=account_id, request_id=request_id
+            )
+            if nudges >= REQUEST_NUDGE_BUDGET:
+                if await queries.write_response_if_absent(
+                    conn,
+                    session_id,
+                    account_id=account_id,
+                    request_id=request_id,
+                    is_error=True,
+                    result=None,
+                    error={"kind": "no_return"},
+                ):
+                    autoerrored = True
+            else:
+                to_nudge.append(request_id)
+        if to_nudge:
+            await queries.append_event(
+                conn,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "user",
+                    "content": _nudge_content(to_nudge),
+                    "metadata": {"nudged_request_ids": to_nudge},
+                },
+                account_id=account_id,
+            )
+            nudged = True
+        if autoerrored:
+            ctx = await queries.get_session_workflow_context(conn, session_id)
+            caller_run_id = ctx[1] if ctx is not None else None
+    return (nudged, autoerrored, caller_run_id)
 
 
 async def append_tool_result(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -228,6 +228,52 @@ async def create_session(
         return session
 
 
+async def create_child_session(
+    pool: asyncpg.Pool[Any],
+    *,
+    session_id: str,
+    account_id: str,
+    agent_id: str,
+    environment_id: str,
+    agent_version: int,
+    parent_run_id: str,
+    input: Any,
+) -> bool:
+    """Idempotently spawn a workflow ``agent()`` child under a deterministic id.
+
+    One transaction: insert the child row (``ON CONFLICT (id) DO NOTHING``) and,
+    **only on a real insert**, deliver ``input`` as the child's first user
+    message — without a stimulus the child would be born-idle (the loop ends
+    every turn idle, so nothing wakes it and the totality backstop would
+    spuriously flag it ``no_return``). Atomic, so a crash can never leave a child
+    row without its input.
+
+    Returns ``True`` if a row was created (first spawn), ``False`` on conflict (a
+    replay found the existing row → the caller harvests instead of re-spawning).
+    """
+    content = input if isinstance(input, str) else json.dumps(input)
+    async with pool.acquire() as conn, conn.transaction():
+        child = await queries.insert_child_session(
+            conn,
+            session_id=session_id,
+            account_id=account_id,
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=agent_version,
+            parent_run_id=parent_run_id,
+        )
+        if child is None:
+            return False  # replay: row exists — do NOT re-deliver input
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "user", "content": content},
+        )
+        return True
+
+
 def _classify_awaiting(
     tc: dict[str, Any],
     agent: Agent | AgentVersion,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -542,50 +542,52 @@ async def append_assistant_and_guard_quiescence(
     assistant_msg: dict[str, Any],
     *,
     account_id: str,
-) -> tuple[bool, bool, str | None]:
+    parent_run_id: str | None,
+) -> tuple[bool, str | None]:
     """Append the model's assistant message and, **atomically**, enforce the
     request-totality invariant: a session may not go idle while it owes a response.
 
-    In one transaction: append the assistant message; if the session would now be
-    idle (the model produced a tool-call-free turn — ``derive_session_status``
+    Only a workflow child (``parent_run_id`` set) can ever owe a request, so for any
+    other session this is a plain assistant append — the totality machinery (and its
+    per-turn open-request scan) is skipped entirely.
+
+    For a workflow child, in one transaction: append the assistant message; if the
+    session would now be idle (a tool-call-free turn — ``derive_session_status``
     reads the just-appended event) and it still owes request responses, then for
     each open request either append a **nudge** (a user message that re-triggers
-    inference, so the session stays active) when under
-    :data:`REQUEST_NUDGE_BUDGET`, or write its **no_return** error response when the
-    budget is spent. Because the nudge commits in the same transaction as the
-    idling assistant event, no reader can ever observe the session idle while a
-    request is open — the invariant holds at write time, with no sweep backstop.
+    inference, so the session stays active) when under :data:`REQUEST_NUDGE_BUDGET`,
+    or write its **no_return** error response when the budget is spent. Because the
+    nudge commits in the same transaction as the idling assistant event, no reader
+    can ever observe the session idle while a request is open — the invariant holds
+    at write time, with no sweep backstop.
 
-    Returns ``(nudged, autoerrored, caller_run_id)``; the caller (the harness loop)
-    does the post-commit wakes — ``defer_wake(session)`` if nudged,
-    ``defer_run_wake(caller_run_id)`` if autoerrored. A strict no-op
-    ``(False, False, None)`` for any session with no open requests, i.e. every
-    ordinary session — the open-request query is the gate.
+    Returns ``(nudged, autoerror_caller_run_id)``; the caller (the harness loop) does
+    the post-commit wakes — ``defer_wake(session)`` if nudged,
+    ``defer_run_wake(run_id)`` if a run id is returned (a request was auto-errored
+    and its caller run must harvest the no_return). The run id is the child's
+    ``parent_run_id`` — the single caller of every request in v1.
     """
     nudged = False
-    autoerrored = False
-    caller_run_id: str | None = None
+    autoerror_caller_run_id: str | None = None
     async with pool.acquire() as conn, conn.transaction():
         await queries.append_event(
             conn, session_id=session_id, kind="message", data=assistant_msg, account_id=account_id
         )
         # Gates, cheapest first (this runs on EVERY end-of-turn append):
-        #   1. tool calls present → unresolved tool_call → active by construction
-        #      (the tools haven't run yet), so it can't be idle — settle in memory,
-        #      no query.
-        #   2. nothing owed → the common case for every ordinary session → one
-        #      indexed anti-join.
-        #   3. only now pay the multi-EXISTS idleness derivation (the same
-        #      _SESSION_STATUS_EXPR every external reader uses), and only for a
-        #      session that actually owes a response — it could still be active via
-        #      a user message that arrived during inference.
-        if assistant_msg.get("tool_calls"):
-            return (False, False, None)
+        #   1. not a workflow child → cannot owe a request → plain append, done.
+        #   2. tool calls present → unresolved tool_call → active by construction
+        #      (the tools haven't run yet), so it can't be idle — settle in memory.
+        #   3. nothing owed → every request already answered → one indexed anti-join.
+        #   4. only now pay the multi-EXISTS idleness derivation (the same
+        #      _SESSION_STATUS_EXPR every external reader uses) — it could still be
+        #      active via a user message that arrived during inference.
+        if parent_run_id is None or assistant_msg.get("tool_calls"):
+            return (False, None)
         open_ids = await queries.get_open_request_ids(conn, session_id, account_id=account_id)
         if not open_ids:
-            return (False, False, None)  # ordinary session, or every request answered
+            return (False, None)  # every request answered
         if await queries.derive_session_status(conn, session_id, account_id=account_id) != "idle":
-            return (False, False, None)
+            return (False, None)
         to_nudge: list[str] = []
         for request_id in open_ids:
             nudges = await queries.count_request_nudges(
@@ -601,7 +603,7 @@ async def append_assistant_and_guard_quiescence(
                     result=None,
                     error={"kind": "no_return"},
                 ):
-                    autoerrored = True
+                    autoerror_caller_run_id = parent_run_id
             else:
                 to_nudge.append(request_id)
         if to_nudge:
@@ -617,10 +619,7 @@ async def append_assistant_and_guard_quiescence(
                 account_id=account_id,
             )
             nudged = True
-        if autoerrored:
-            ctx = await queries.get_session_workflow_context(conn, session_id)
-            caller_run_id = ctx[1] if ctx is not None else None
-    return (nudged, autoerrored, caller_run_id)
+    return (nudged, autoerror_caller_run_id)
 
 
 async def append_tool_result(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -57,6 +57,14 @@ async def load_session_account_id(pool: asyncpg.Pool[Any], session_id: str) -> s
         return await queries.unscoped_get_session_account_id(conn, session_id)
 
 
+async def load_live_session_account_id(pool: asyncpg.Pool[Any], session_id: str) -> str | None:
+    """``account_id`` for a live session (exists + not archived), or ``None`` if it
+    has been archived/deleted — the ``run_session_step`` entry guard, so a wake for
+    a gone session is an idempotent no-op rather than a crash."""
+    async with pool.acquire() as conn:
+        return await queries.unscoped_live_session_account_id(conn, session_id)
+
+
 async def load_session_workspace_path(
     pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
 ) -> Path:

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -36,4 +36,5 @@ from aios.tools import wake_self as _wake_self  # noqa: F401
 from aios.tools import wake_session as _wake_session  # noqa: F401
 from aios.tools import web_fetch as _web_fetch  # noqa: F401
 from aios.tools import web_search as _web_search  # noqa: F401
+from aios.tools import workflow_completion as _workflow_completion  # noqa: F401
 from aios.tools import write as _write  # noqa: F401

--- a/src/aios/tools/registry.py
+++ b/src/aios/tools/registry.py
@@ -170,6 +170,23 @@ class ToolRegistry:
 registry = ToolRegistry()
 
 
+def openai_tool_entry(tool: ToolDefinition) -> dict[str, Any]:
+    """The chat-completions ``tools`` entry for a registered built-in.
+
+    One source of truth for the registry → OpenAI tool-spec shape, shared by
+    :func:`to_openai_tools` and the injected built-ins (``switch_channel`` and
+    the workflow ``return``/``error`` completion tools).
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters_schema,
+        },
+    }
+
+
 def to_openai_tools(agent_tools: list[AgentToolSpec]) -> list[dict[str, Any]]:
     """Translate an agent's declared tools into the OpenAI ``tools`` param.
 
@@ -221,16 +238,7 @@ def to_openai_tools(agent_tools: list[AgentToolSpec]) -> list[dict[str, Any]]:
             effective = entry.transport or tool.transport
             if effective == "cli":
                 continue
-            result.append(
-                {
-                    "type": "function",
-                    "function": {
-                        "name": tool.name,
-                        "description": tool.description,
-                        "parameters": tool.parameters_schema,
-                    },
-                }
-            )
+            result.append(openai_tool_entry(tool))
     return result
 
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -2,12 +2,21 @@
 explicit way to finish (completion is NEVER inferred from idle — §3.5).
 
 Injected ONLY into a workflow child (``origin='background'`` with a
-``parent_run_id``; see ``compute_step_prelude``). The handler is the completion
-writer: it appends the single ``workflow_child_done`` marker on the child,
-soft-archives the child (making it genuinely terminal via ``archived_at``, not
-``status``), and wakes the parent run to harvest the marker. The child's result
-lives in the marker, so no signal row is needed — the parent's harvest reads
-markers, and the periodic ``wf_runs`` sweep is the lost-wake backstop.
+``parent_run_id``; see ``compute_step_prelude``). Termination is **two-phase**:
+
+* **Logical completion = the marker.** The handler writes the single
+  ``workflow_child_done`` marker on the child and wakes the parent run to harvest
+  it. The result lives in the marker, so no signal row is needed — the parent's
+  harvest reads markers, and the periodic ``wf_runs`` sweep is the lost-wake
+  backstop.
+* **Physical reap = ``archived_at``,** done LATER by the in-worker workflow-child
+  reaper once the child is provably quiescent — NOT here. Archive must be a
+  session's last write, yet this handler runs mid tool-lifecycle (the
+  ``tool_result`` append follows it) and sibling tools in the same assistant
+  batch may still be in flight; archiving here would crash those concurrent
+  appends against the ``archived_at IS NULL`` guard in ``append_event``. The
+  marker also makes the child soft-terminal in ``find_sessions_needing_inference``
+  so it is not re-woken for a wasteful extra model step in the meantime.
 """
 
 from __future__ import annotations
@@ -61,21 +70,23 @@ async def _finish(
         account_id, parent_run_id = ctx
         if parent_run_id is None:
             return _NOT_A_CHILD  # fail closed — never signal a NULL parent run
-        async with conn.transaction():
-            await queries.append_event(
-                conn,
-                account_id=account_id,
-                session_id=session_id,
-                kind="lifecycle",
-                data={
-                    "event": "workflow_child_done",
-                    "is_error": is_error,
-                    "result": result,
-                    "error": error,
-                },
-            )
-            await queries.set_session_archived(conn, session_id, account_id=account_id)
-    # After commit: wake the parent run to harvest the marker. The periodic
+        # Logical completion only: write the marker, do NOT archive (the reaper
+        # archives once the child is quiescent — see the module docstring). The
+        # child is not yet archived here, so this append + the tool_result append
+        # that follows both succeed.
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="lifecycle",
+            data={
+                "event": "workflow_child_done",
+                "is_error": is_error,
+                "result": result,
+                "error": error,
+            },
+        )
+    # After the marker commits: wake the parent run to harvest it. The periodic
     # wf_runs sweep is the durable backstop if this wake is lost.
     await defer_run_wake(parent_run_id)
     return {"status": "errored" if is_error else "returned"}

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -56,6 +56,7 @@ _ERROR_SCHEMA: dict[str, Any] = {
 _NOT_A_CHILD = ToolResult(
     content="return/error is only available to a workflow agent child", is_error=True
 )
+_NO_OPEN_REQUEST = ToolResult(content="there is no open request to answer", is_error=True)
 
 
 async def _finish(
@@ -71,7 +72,7 @@ async def _finish(
             return _NOT_A_CHILD  # fail closed — never signal a NULL parent run
         request_id = await queries.get_open_request_id(conn, session_id, account_id=account_id)
         if request_id is None:
-            return _NOT_A_CHILD  # no open request to answer
+            return _NO_OPEN_REQUEST  # a child, but its request is already answered / absent
         # Respond to the request — exactly once (first-writer-wins). NOT archive,
         # NOT terminate: responding resumes the caller; the child carries on (a
         # fresh agent() child simply has nothing else to do and quiesces; run-end

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -1,15 +1,22 @@
-"""The ``return`` / ``error`` tools — a workflow agent child's **response** to the
+"""The **response edge** of `invoke_session` — a workflow child answering the
 request it was invoked with (a response is NEVER inferred from idle).
 
-Injected ONLY into a workflow child (``origin='background'`` with a
-``parent_run_id``; see ``compute_step_prelude``). A child is spawned with a
-**request** (its first user message, stamped ``metadata.request``); ``return``/
-``error`` answer it. The handler:
+A child is spawned with a **request** (its first user message, stamped
+``metadata.request``; see ``create_child_session``). Exactly one response is ever
+captured for it, by whichever of these writes first:
 
-* writes the request's response **exactly once** (``write_response_if_absent`` —
-  first-writer-wins, so a ``return``+``error`` batch, a model double-call, or a
-  ``return`` racing the totality backstop all collapse to one response), and
-* wakes the caller (the run) to harvest it.
+* the ``return`` / ``error`` tools (the model's own answer — injected ONLY into a
+  workflow child, ``origin='background'`` with a ``parent_run_id``; see
+  ``compute_step_prelude``),
+* the harness erroring path (``harness/loop.py`` answers on the child's behalf
+  when its model fails past the retry budget — it can no longer respond itself),
+* the run's totality backstop (R4).
+
+All three funnel through :func:`respond_to_request`, which writes the response
+**exactly once** (``write_response_if_absent`` — first-writer-wins, so a
+``return``+``error`` batch, a model double-call, a model-failure racing a late
+``return``, or the backstop racing any of them all collapse to one response) and
+wakes the caller (the run) to harvest it.
 
 It does **not** archive or terminate the child. Responding resumes the caller
 regardless of the child's subsequent fate; the child carries on (a fresh
@@ -59,24 +66,34 @@ _NOT_A_CHILD = ToolResult(
 _NO_OPEN_REQUEST = ToolResult(content="there is no open request to answer", is_error=True)
 
 
-async def _finish(
-    session_id: str, *, is_error: bool, result: Any, error: dict[str, Any] | None
-) -> dict[str, Any] | ToolResult:
-    pool = runtime.require_pool()
+async def respond_to_request(
+    pool: Any, session_id: str, *, is_error: bool, result: Any, error: dict[str, Any] | None
+) -> str:
+    """Write a session's request response and wake its caller — the shared core
+    behind every `invoke_session` response (``return``/``error``, the harness
+    erroring path, the totality backstop).
+
+    Responding does **not** archive or terminate the target; it resumes the caller
+    regardless of the target's fate. The response is captured **exactly once**
+    (``write_response_if_absent`` — first-writer-wins); the caller is woken only
+    when this call actually wrote (a duplicate is a no-op — the first response
+    already woke it; the periodic ``wf_runs`` sweep is the lost-wake backstop).
+
+    Returns one of ``responded`` | ``duplicate`` | ``not_a_child`` |
+    ``no_open_request`` so callers can shape their own result (the tools surface an
+    error to the model; the harness erroring path no-ops on anything but a child
+    that owes a response).
+    """
     async with pool.acquire() as conn:
         ctx = await queries.get_session_workflow_context(conn, session_id)
         if ctx is None:
-            return _NOT_A_CHILD
+            return "not_a_child"
         account_id, parent_run_id = ctx
         if parent_run_id is None:
-            return _NOT_A_CHILD  # fail closed — never signal a NULL parent run
+            return "not_a_child"  # fail closed — never signal a NULL parent run
         request_id = await queries.get_open_request_id(conn, session_id, account_id=account_id)
         if request_id is None:
-            return _NO_OPEN_REQUEST  # a child, but its request is already answered / absent
-        # Respond to the request — exactly once (first-writer-wins). NOT archive,
-        # NOT terminate: responding resumes the caller; the child carries on (a
-        # fresh agent() child simply has nothing else to do and quiesces; run-end
-        # reclaim archives it). The response is the durable record the harvest reads.
+            return "no_open_request"  # a child, but its request is already answered / absent
         wrote = await queries.write_response_if_absent(
             conn,
             session_id,
@@ -86,11 +103,22 @@ async def _finish(
             result=result,
             error=error,
         )
-    # Wake the caller to harvest the response only when we actually wrote it; a
-    # duplicate response (the request was already answered) is a no-op — the first
-    # response already woke the caller. The periodic wf_runs sweep is the backstop.
     if wrote:
         await defer_run_wake(parent_run_id)
+    return "responded" if wrote else "duplicate"
+
+
+async def _finish(
+    session_id: str, *, is_error: bool, result: Any, error: dict[str, Any] | None
+) -> dict[str, Any] | ToolResult:
+    status = await respond_to_request(
+        runtime.require_pool(), session_id, is_error=is_error, result=result, error=error
+    )
+    if status == "not_a_child":
+        return _NOT_A_CHILD
+    if status == "no_open_request":
+        return _NO_OPEN_REQUEST
+    # responded | duplicate — either way the request now has exactly one response.
     return {"status": "errored" if is_error else "returned"}
 
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -7,16 +7,18 @@ captured for it, by whichever of these writes first:
 
 * the ``return`` / ``error`` tools (the model's own answer — injected ONLY into a
   workflow child, ``origin='background'`` with a ``parent_run_id``; see
-  ``compute_step_prelude``),
-* the harness erroring path (``harness/loop.py`` answers on the child's behalf
-  when its model fails past the retry budget — it can no longer respond itself),
-* the run's totality backstop (R4).
+  ``compute_step_prelude``) and the harness erroring path
+  (``fail_all_open_requests``, when the model fails past its retry budget) both go
+  through :func:`respond_to_request`,
+* the run's totality backstop (``services.sessions`` quiescence guard) writes
+  ``write_response_if_absent`` directly — it runs inside the guard's open
+  transaction, so it can't acquire its own connection.
 
-All three funnel through :func:`respond_to_request`, which writes the response
-**exactly once** (``write_response_if_absent`` — first-writer-wins, so a
+The common, load-bearing seam is therefore ``write_response_if_absent`` (the
+exactly-once, first-writer-wins guard), not :func:`respond_to_request`: a
 ``return``+``error`` batch, a model double-call, a model-failure racing a late
-``return``, or the backstop racing any of them all collapse to one response) and
-wakes the caller (the run) to harvest it.
+``return``, or the backstop racing any of them all collapse to one response there.
+:func:`respond_to_request` adds the caller-wake on top for the pool-level callers.
 
 It does **not** archive or terminate the child. Responding resumes the caller
 regardless of the child's subsequent fate; the child carries on (a fresh
@@ -38,51 +40,68 @@ RETURN_TOOL_NAME = "return"
 ERROR_TOOL_NAME = "error"
 
 RETURN_DESCRIPTION = (
-    "Finish this task and return a value to the workflow that spawned you. Call "
-    "this exactly once when your work is done; `value` is the result the workflow "
-    "receives. After calling it you are finished — do not keep working."
+    "Answer a request you were given with a successful result. `request_id` is the "
+    "id shown with the request you're answering; `value` is the result the caller "
+    "receives. Answer each open request exactly once."
 )
 ERROR_DESCRIPTION = (
-    "Finish this task as a failure. Call this when you cannot complete the task; "
-    "`message` explains why. The workflow receives an errored result."
+    "Answer a request you were given with a failure. `request_id` is the id shown "
+    "with the request you're answering; `message` explains why you couldn't "
+    "complete it. Answer each open request exactly once."
 )
 
+_REQUEST_ID_PROP = {"type": "string", "description": "the id of the request you're answering"}
 _RETURN_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "properties": {"value": {"description": "the result returned to the workflow (any JSON)"}},
-    "required": ["value"],
+    "properties": {
+        "request_id": _REQUEST_ID_PROP,
+        "value": {"description": "the result returned to the caller (any JSON)"},
+    },
+    "required": ["request_id", "value"],
     "additionalProperties": False,
 }
 _ERROR_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "properties": {"message": {"type": "string", "description": "why the task failed"}},
-    "required": ["message"],
+    "properties": {
+        "request_id": _REQUEST_ID_PROP,
+        "message": {"type": "string", "description": "why the request failed"},
+    },
+    "required": ["request_id", "message"],
     "additionalProperties": False,
 }
 
 _NOT_A_CHILD = ToolResult(
     content="return/error is only available to a workflow agent child", is_error=True
 )
-_NO_OPEN_REQUEST = ToolResult(content="there is no open request to answer", is_error=True)
+_UNKNOWN_REQUEST = ToolResult(
+    content="no open request with that request_id — answer a request using the request_id "
+    "shown in its message",
+    is_error=True,
+)
 
 
 async def respond_to_request(
-    pool: Any, session_id: str, *, is_error: bool, result: Any, error: dict[str, Any] | None
+    pool: Any,
+    session_id: str,
+    *,
+    request_id: str,
+    is_error: bool,
+    result: Any,
+    error: dict[str, Any] | None,
 ) -> str:
-    """Write a session's request response and wake its caller — the shared core
-    behind every `invoke_session` response (``return``/``error``, the harness
-    erroring path, the totality backstop).
+    """Write one request's response and wake its caller — the shared core behind
+    every `invoke_session` response (``return``/``error``, the harness erroring
+    path, the no_return backstop).
 
     Responding does **not** archive or terminate the target; it resumes the caller
-    regardless of the target's fate. The response is captured **exactly once**
-    (``write_response_if_absent`` — first-writer-wins); the caller is woken only
-    when this call actually wrote (a duplicate is a no-op — the first response
+    regardless of the target's fate. The response is captured **exactly once per
+    request** (``write_response_if_absent`` — first-writer-wins); the caller is woken
+    only when this call actually wrote (a duplicate is a no-op — the first response
     already woke it; the periodic ``wf_runs`` sweep is the lost-wake backstop).
 
     Returns one of ``responded`` | ``duplicate`` | ``not_a_child`` |
-    ``no_open_request`` so callers can shape their own result (the tools surface an
-    error to the model; the harness erroring path no-ops on anything but a child
-    that owes a response).
+    ``unknown_request`` (the ``request_id`` isn't an open request of this session)
+    so callers can shape their own result.
     """
     async with pool.acquire() as conn:
         ctx = await queries.get_session_workflow_context(conn, session_id)
@@ -91,9 +110,10 @@ async def respond_to_request(
         account_id, parent_run_id = ctx
         if parent_run_id is None:
             return "not_a_child"  # fail closed — never signal a NULL parent run
-        request_id = await queries.get_open_request_id(conn, session_id, account_id=account_id)
-        if request_id is None:
-            return "no_open_request"  # a child, but its request is already answered / absent
+        if request_id not in await queries.get_open_request_ids(
+            conn, session_id, account_id=account_id
+        ):
+            return "unknown_request"  # already answered, never asked, or a typo from the model
         wrote = await queries.write_response_if_absent(
             conn,
             session_id,
@@ -108,27 +128,65 @@ async def respond_to_request(
     return "responded" if wrote else "duplicate"
 
 
+async def fail_all_open_requests(
+    pool: Any, session_id: str, *, account_id: str, error: dict[str, Any]
+) -> None:
+    """Error **every** still-open request on a session that can no longer answer
+    them — the harness erroring path, where the model failed past its retry budget,
+    so a dead child must not leave its callers hung.
+
+    Each request is funnelled through :func:`respond_to_request` (the pool-level
+    response edge), so the child-ness / fail-closed / wake logic lives in exactly
+    one place. A no-op for any session that owes nothing — its open set is empty,
+    including every non-child session.
+    """
+    async with pool.acquire() as conn:
+        open_ids = await queries.get_open_request_ids(conn, session_id, account_id=account_id)
+    for request_id in open_ids:
+        await respond_to_request(
+            pool, session_id, request_id=request_id, is_error=True, result=None, error=error
+        )
+
+
 async def _finish(
-    session_id: str, *, is_error: bool, result: Any, error: dict[str, Any] | None
+    session_id: str, *, request_id: Any, is_error: bool, result: Any, error: dict[str, Any] | None
 ) -> dict[str, Any] | ToolResult:
+    # ``request_id`` is model-supplied (possibly missing or wrong-typed); a value
+    # that isn't an open request resolves to ``unknown_request`` → a tool error the
+    # model self-corrects from.
     status = await respond_to_request(
-        runtime.require_pool(), session_id, is_error=is_error, result=result, error=error
+        runtime.require_pool(),
+        session_id,
+        request_id=request_id,
+        is_error=is_error,
+        result=result,
+        error=error,
     )
     if status == "not_a_child":
         return _NOT_A_CHILD
-    if status == "no_open_request":
-        return _NO_OPEN_REQUEST
+    if status == "unknown_request":
+        return _UNKNOWN_REQUEST
     # responded | duplicate — either way the request now has exactly one response.
     return {"status": "errored" if is_error else "returned"}
 
 
 async def return_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:
-    return await _finish(session_id, is_error=False, result=arguments.get("value"), error=None)
+    return await _finish(
+        session_id,
+        request_id=arguments.get("request_id"),
+        is_error=False,
+        result=arguments.get("value"),
+        error=None,
+    )
 
 
 async def error_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:
     return await _finish(
-        session_id, is_error=True, result=None, error={"message": arguments.get("message")}
+        session_id,
+        request_id=arguments.get("request_id"),
+        is_error=True,
+        result=None,
+        error={"message": arguments.get("message")},
     )
 
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -1,0 +1,128 @@
+"""The ``return`` / ``error`` completion tools — a workflow agent child's only,
+explicit way to finish (completion is NEVER inferred from idle — §3.5).
+
+Injected ONLY into a workflow child (``origin='background'`` with a
+``parent_run_id``; see ``compute_step_prelude``). The handler is the completion
+writer: it appends the single ``workflow_child_done`` marker on the child,
+soft-archives the child (making it genuinely terminal via ``archived_at``, not
+``status``), and wakes the parent run to harvest the marker. The child's result
+lives in the marker, so no signal row is needed — the parent's harvest reads
+markers, and the periodic ``wf_runs`` sweep is the lost-wake backstop.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.db import queries
+from aios.harness import runtime
+from aios.services.wake import defer_run_wake
+from aios.tools.registry import ToolResult, registry
+
+RETURN_TOOL_NAME = "return"
+ERROR_TOOL_NAME = "error"
+
+RETURN_DESCRIPTION = (
+    "Finish this task and return a value to the workflow that spawned you. Call "
+    "this exactly once when your work is done; `value` is the result the workflow "
+    "receives. After calling it you are finished — do not keep working."
+)
+ERROR_DESCRIPTION = (
+    "Finish this task as a failure. Call this when you cannot complete the task; "
+    "`message` explains why. The workflow receives an errored result."
+)
+
+_RETURN_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"value": {"description": "the result returned to the workflow (any JSON)"}},
+    "required": ["value"],
+    "additionalProperties": False,
+}
+_ERROR_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"message": {"type": "string", "description": "why the task failed"}},
+    "required": ["message"],
+    "additionalProperties": False,
+}
+
+_NOT_A_CHILD = ToolResult(
+    content="return/error is only available to a workflow agent child", is_error=True
+)
+
+
+async def _finish(
+    session_id: str, *, is_error: bool, result: Any, error: dict[str, Any] | None
+) -> dict[str, Any] | ToolResult:
+    pool = runtime.require_pool()
+    async with pool.acquire() as conn:
+        ctx = await queries.get_session_workflow_context(conn, session_id)
+    if ctx is None:
+        return _NOT_A_CHILD
+    account_id, parent_run_id = ctx
+    if parent_run_id is None:
+        return _NOT_A_CHILD  # fail closed — never signal a NULL parent run
+
+    async with pool.acquire() as conn, conn.transaction():
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="lifecycle",
+            data={
+                "event": "workflow_child_done",
+                "is_error": is_error,
+                "result": result,
+                "error": error,
+            },
+        )
+        await queries.set_session_archived(conn, session_id, account_id=account_id)
+    # After commit: wake the parent run to harvest the marker. The periodic
+    # wf_runs sweep is the durable backstop if this wake is lost.
+    await defer_run_wake(parent_run_id)
+    return {"status": "errored" if is_error else "returned"}
+
+
+async def return_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:
+    return await _finish(session_id, is_error=False, result=arguments.get("value"), error=None)
+
+
+async def error_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:
+    return await _finish(
+        session_id, is_error=True, result=None, error={"message": arguments.get("message")}
+    )
+
+
+def workflow_completion_tool_specs() -> list[dict[str, Any]]:
+    """The chat-completions tool entries for ``return``/``error`` — injected into
+    a workflow child's tool list by ``compute_step_prelude``."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters_schema,
+            },
+        }
+        for tool in (registry.get(RETURN_TOOL_NAME), registry.get(ERROR_TOOL_NAME))
+    ]
+
+
+def _register() -> None:
+    registry.register(
+        name=RETURN_TOOL_NAME,
+        description=RETURN_DESCRIPTION,
+        parameters_schema=_RETURN_SCHEMA,
+        handler=return_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name=ERROR_TOOL_NAME,
+        description=ERROR_DESCRIPTION,
+        parameters_schema=_ERROR_SCHEMA,
+        handler=error_handler,
+        transport="agent_tool",
+    )
+
+
+_register()

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -17,7 +17,7 @@ from typing import Any
 from aios.db import queries
 from aios.harness import runtime
 from aios.services.wake import defer_run_wake
-from aios.tools.registry import ToolResult, registry
+from aios.tools.registry import ToolResult, openai_tool_entry, registry
 
 RETURN_TOOL_NAME = "return"
 ERROR_TOOL_NAME = "error"
@@ -56,26 +56,25 @@ async def _finish(
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
         ctx = await queries.get_session_workflow_context(conn, session_id)
-    if ctx is None:
-        return _NOT_A_CHILD
-    account_id, parent_run_id = ctx
-    if parent_run_id is None:
-        return _NOT_A_CHILD  # fail closed — never signal a NULL parent run
-
-    async with pool.acquire() as conn, conn.transaction():
-        await queries.append_event(
-            conn,
-            account_id=account_id,
-            session_id=session_id,
-            kind="lifecycle",
-            data={
-                "event": "workflow_child_done",
-                "is_error": is_error,
-                "result": result,
-                "error": error,
-            },
-        )
-        await queries.set_session_archived(conn, session_id, account_id=account_id)
+        if ctx is None:
+            return _NOT_A_CHILD
+        account_id, parent_run_id = ctx
+        if parent_run_id is None:
+            return _NOT_A_CHILD  # fail closed — never signal a NULL parent run
+        async with conn.transaction():
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={
+                    "event": "workflow_child_done",
+                    "is_error": is_error,
+                    "result": result,
+                    "error": error,
+                },
+            )
+            await queries.set_session_archived(conn, session_id, account_id=account_id)
     # After commit: wake the parent run to harvest the marker. The periodic
     # wf_runs sweep is the durable backstop if this wake is lost.
     await defer_run_wake(parent_run_id)
@@ -95,17 +94,7 @@ async def error_handler(session_id: str, arguments: dict[str, Any]) -> dict[str,
 def workflow_completion_tool_specs() -> list[dict[str, Any]]:
     """The chat-completions tool entries for ``return``/``error`` — injected into
     a workflow child's tool list by ``compute_step_prelude``."""
-    return [
-        {
-            "type": "function",
-            "function": {
-                "name": tool.name,
-                "description": tool.description,
-                "parameters": tool.parameters_schema,
-            },
-        }
-        for tool in (registry.get(RETURN_TOOL_NAME), registry.get(ERROR_TOOL_NAME))
-    ]
+    return [openai_tool_entry(registry.get(name)) for name in (RETURN_TOOL_NAME, ERROR_TOOL_NAME)]
 
 
 def _register() -> None:

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -1,22 +1,21 @@
-"""The ``return`` / ``error`` completion tools — a workflow agent child's only,
-explicit way to finish (completion is NEVER inferred from idle — §3.5).
+"""The ``return`` / ``error`` tools — a workflow agent child's **response** to the
+request it was invoked with (a response is NEVER inferred from idle).
 
 Injected ONLY into a workflow child (``origin='background'`` with a
-``parent_run_id``; see ``compute_step_prelude``). Termination is **two-phase**:
+``parent_run_id``; see ``compute_step_prelude``). A child is spawned with a
+**request** (its first user message, stamped ``metadata.request``); ``return``/
+``error`` answer it. The handler:
 
-* **Logical completion = the marker.** The handler writes the single
-  ``workflow_child_done`` marker on the child and wakes the parent run to harvest
-  it. The result lives in the marker, so no signal row is needed — the parent's
-  harvest reads markers, and the periodic ``wf_runs`` sweep is the lost-wake
-  backstop.
-* **Physical reap = ``archived_at``,** done LATER by the in-worker workflow-child
-  reaper once the child is provably quiescent — NOT here. Archive must be a
-  session's last write, yet this handler runs mid tool-lifecycle (the
-  ``tool_result`` append follows it) and sibling tools in the same assistant
-  batch may still be in flight; archiving here would crash those concurrent
-  appends against the ``archived_at IS NULL`` guard in ``append_event``. The
-  marker also makes the child soft-terminal in ``find_sessions_needing_inference``
-  so it is not re-woken for a wasteful extra model step in the meantime.
+* writes the request's response **exactly once** (``write_response_if_absent`` —
+  first-writer-wins, so a ``return``+``error`` batch, a model double-call, or a
+  ``return`` racing the totality backstop all collapse to one response), and
+* wakes the caller (the run) to harvest it.
+
+It does **not** archive or terminate the child. Responding resumes the caller
+regardless of the child's subsequent fate; the child carries on (a fresh
+``agent()`` child has nothing else to do, so it quiesces, and run-end reclaim
+archives it — off the correctness path). The response is the durable record the
+caller's harvest reads; the periodic ``wf_runs`` sweep is the lost-wake backstop.
 """
 
 from __future__ import annotations
@@ -70,25 +69,27 @@ async def _finish(
         account_id, parent_run_id = ctx
         if parent_run_id is None:
             return _NOT_A_CHILD  # fail closed — never signal a NULL parent run
-        # Logical completion only: write the marker, do NOT archive (the reaper
-        # archives once the child is quiescent — see the module docstring). The
-        # child is not yet archived here, so this append + the tool_result append
-        # that follows both succeed.
-        await queries.append_event(
+        request_id = await queries.get_open_request_id(conn, session_id, account_id=account_id)
+        if request_id is None:
+            return _NOT_A_CHILD  # no open request to answer
+        # Respond to the request — exactly once (first-writer-wins). NOT archive,
+        # NOT terminate: responding resumes the caller; the child carries on (a
+        # fresh agent() child simply has nothing else to do and quiesces; run-end
+        # reclaim archives it). The response is the durable record the harvest reads.
+        wrote = await queries.write_response_if_absent(
             conn,
+            session_id,
             account_id=account_id,
-            session_id=session_id,
-            kind="lifecycle",
-            data={
-                "event": "workflow_child_done",
-                "is_error": is_error,
-                "result": result,
-                "error": error,
-            },
+            request_id=request_id,
+            is_error=is_error,
+            result=result,
+            error=error,
         )
-    # After the marker commits: wake the parent run to harvest it. The periodic
-    # wf_runs sweep is the durable backstop if this wake is lost.
-    await defer_run_wake(parent_run_id)
+    # Wake the caller to harvest the response only when we actually wrote it; a
+    # duplicate response (the request was already answered) is a no-op — the first
+    # response already woke the caller. The periodic wf_runs sweep is the backstop.
+    if wrote:
+        await defer_run_wake(parent_run_id)
     return {"status": "errored" if is_error else "returned"}
 
 

--- a/src/aios/workflows/_protocol.py
+++ b/src/aios/workflows/_protocol.py
@@ -5,10 +5,12 @@ Wire format: a 4-byte big-endian length prefix followed by that many bytes of
 UTF-8 JSON. Stdlib-only — imported by the credential-free child, so it must never
 pull in anything from ``aios.harness``/``aios.db``/``aios.crypto``.
 
-Block 1 message flow (the child emits at most one frontier, then a terminal):
+Message flow (the child emits zero or more frontier capabilities, then a terminal;
+a single-coroutine run emits at most one, a ``parallel``/``pipeline`` fan-out emits
+one EMIT per open branch capability before the terminal):
 
     parent → child:  INIT {source, input, memo}
-    child  → parent: [EMIT {capability_id, call_key, spec}]
+    child  → parent: EMIT {capability_id, call_key, spec} *  (zero or more)
                      then exactly one of SUSPENDED | RETURNED {value} | RAISED {repr, traceback}
 """
 

--- a/src/aios/workflows/child_id.py
+++ b/src/aios/workflows/child_id.py
@@ -1,0 +1,30 @@
+"""Deterministic child-session id for a workflow ``agent()`` spawn.
+
+The child id is a pure function of ``(run_id, call_key)`` so a replayed spawn
+reproduces the *same* id — the basis of idempotent ``create_child_session`` +
+harvest-on-reattach (a crash between the row insert and ``call_started`` is
+recovered by recomputing the same id, finding the existing row, and harvesting
+instead of double-spawning).
+
+The seed folds the **full** ``call_key`` string (``"sha:<hex>#<ordinal>"``), NOT
+the content hash — so N identical siblings (``parallel([agent("ping")]*3)`` →
+keys ``…#0/#1/#2``) get THREE distinct child ids. Folding the content hash alone
+would collapse them to one child (the rev-1 regression).
+
+Parent-side only: the step computes this at spawn and journals it into
+``call_started``; harvest reads it back from the journal and never recomputes.
+Kept out of :mod:`aios.workflows.determinism` so that module stays stdlib-only
+for the credential-free host.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from aios.ids import SESSION, make_id
+
+
+def child_session_id(run_id: str, call_key: str) -> str:
+    """``sess_<ulid>`` deterministically derived from ``(run_id, call_key)``."""
+    seed = hashlib.sha256(f"{run_id}:{call_key}".encode()).digest()
+    return make_id(SESSION, body=seed[:16])

--- a/src/aios/workflows/child_id.py
+++ b/src/aios/workflows/child_id.py
@@ -6,10 +6,13 @@ harvest-on-reattach (a crash between the row insert and ``call_started`` is
 recovered by recomputing the same id, finding the existing row, and harvesting
 instead of double-spawning).
 
-The seed folds the **full** ``call_key`` string (``"sha:<hex>#<ordinal>"``), NOT
-the content hash — so N identical siblings (``parallel([agent("ping")]*3)`` →
-keys ``…#0/#1/#2``) get THREE distinct child ids. Folding the content hash alone
-would collapse them to one child (the rev-1 regression).
+The seed folds the **full** ``call_key`` string, NOT the content hash — so N
+identical siblings (``parallel([agent("ping")]*3)`` → keys ``…#0/#1/#2``) get
+THREE distinct child ids. Folding the content hash alone would collapse them to
+one child (the rev-1 regression). A bare call_key is ``"sha:<hex>#<ordinal>"``;
+a key reached inside a ``parallel`` branch additionally carries that branch's
+deterministic path prefix (e.g. ``"0.0/sha:<hex>#<ordinal>"``). Either way the
+**whole** string is folded opaquely, so distinct branches/ordinals → distinct ids.
 
 Parent-side only: the step computes this at spawn and journals it into
 ``call_started``; harvest reads it back from the journal and never recomputes.

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -45,6 +45,7 @@ DEFAULT_ADDRESS_SPACE_BYTES: int | None = 4 * 1024**3
 HostOutcomeKind = Literal["suspended", "returned", "raised"]
 HostErrorKind = Literal[
     "author_exception",
+    "too_wide_fanout",  # a single parallel()/pipeline() exceeded MAX_PARALLEL_FANOUT
     "script_host_crash",
     "script_host_timeout",
     "script_host_spawn_failed",
@@ -148,7 +149,9 @@ def _outcome_from_frames(
         kind="raised",
         emitted=emitted,
         error_repr=terminal.get("repr"),
-        error_kind="author_exception",
+        # The host stamps a specific kind on structural failures it detects itself
+        # (e.g. the fan-out cap); an uncaught author exception carries none → generic.
+        error_kind=terminal.get("kind") or "author_exception",
         stderr=stderr,
     )
 

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -84,7 +84,9 @@ _CHILD_ENV_ALLOWLIST: frozenset[str] = frozenset(
 @dataclass(frozen=True)
 class EmittedCapability:
     capability_id: str
-    call_key: str  # "sha:<hex>#<ordinal>" — content_hash + ordinal are derivable from this
+    # "sha:<hex>#<ordinal>", optionally prefixed by a parallel branch path
+    # ("0.0/sha:<hex>#<ordinal>"). Treated as an opaque, deterministic key.
+    call_key: str
     spec: Any
 
 

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -22,12 +22,15 @@ async def create_run(
     *,
     account_id: str,
     workflow_id: str,
+    environment_id: str,
     input: Any = None,
 ) -> WfRun:
     """Create a run that snapshots the workflow's current script, then wake it.
 
     The run carries its own immutable ``script`` (+ ``script_sha``), so every
     wake execs exactly that source regardless of later edits to the workflow.
+    ``environment_id`` binds the run (and the sessions its ``agent()`` children
+    spawn into) to an environment — chosen at run-creation time, like a session's.
     """
     async with pool.acquire() as conn:
         workflow = await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
@@ -36,6 +39,7 @@ async def create_run(
             conn,
             account_id=account_id,
             workflow_id=workflow_id,
+            environment_id=environment_id,
             script=workflow.script,
             script_sha=script_sha,
             input=input,

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -27,7 +27,7 @@ One wake:
 from __future__ import annotations
 
 import secrets
-from typing import Any
+from typing import Any, NamedTuple
 
 import asyncpg
 
@@ -174,8 +174,11 @@ async def run_workflow_step(run_id: str) -> None:
                 if cap.call_key in signals:
                     needs_rewake = True
             elif cap.capability_id == "agent":
-                if await _open_agent_capability(conn, pool, run, cap):
+                spawn = await _open_agent_capability(conn, pool, run, cap)
+                if spawn.rejected:
                     return  # the frontier was terminally rejected (bad call) — run errored
+                if spawn.needs_rewake:
+                    needs_rewake = True  # C1'/C4: harvest the already-present marker next step
             else:
                 # parallel/pipeline reach the step as their `agent` leaves (B2.G);
                 # any other capability id is unknown.
@@ -195,21 +198,35 @@ async def run_workflow_step(run_id: str) -> None:
         await defer_run_wake(run_id)
 
 
+class _SpawnResult(NamedTuple):
+    """Outcome of opening one ``agent()`` frontier."""
+
+    rejected: bool  # the call was terminally rejected (run errored) — stop the step
+    needs_rewake: bool  # a re-attached child already has its marker — self-wake to harvest
+
+
 async def _open_agent_capability(
     conn: asyncpg.Connection[Any],
     pool: asyncpg.Pool[Any],
     run: WfRun,
     cap: EmittedCapability,
-) -> bool:
+) -> _SpawnResult:
     """Spawn (or, on replay/C1', re-attach) the ``agent()`` child for a frontier,
     then journal ``call_started{child_session_id, child_agent_version}``.
 
     Idempotent + crash-safe: the child id is deterministic, ``create_child_session``
     is ``ON CONFLICT`` (delivers the input atomically with the row on first spawn),
-    ``call_started`` dedups on the memo, and ``defer_wake`` dedups on its queueing
-    lock. On replay the child id already exists → re-attach, journaling the *row's*
-    pinned version (not a re-resolved one). Returns ``True`` iff the call was
-    terminally rejected (the run was errored — the caller should stop the step).
+    ``call_started`` dedups on the memo. On replay the child id already exists →
+    re-attach, journaling the *row's* pinned version (not a re-resolved one).
+
+    Returns ``rejected=True`` iff the call was terminally rejected (the run was
+    errored — the caller should stop the step). ``defer_wake`` fires **only on
+    first spawn** (``created``): on a re-attach the child is already sweep-wakeable
+    via its own first user message and may even be terminal, so appending a wake
+    span to it would crash. ``needs_rewake=True`` asks the caller for a self-wake
+    when a re-attached child *already* has its completion marker (C1'/C4: it
+    finished before this wake journaled ``call_started``, so the pre-replay harvest
+    — which only sees inflight ``call_started`` events — missed it).
     """
     account_id = run.account_id
     spec = cap.spec if isinstance(cap.spec, dict) else {}
@@ -221,7 +238,7 @@ async def _open_agent_capability(
             is_error=True,
             error_kind="not_implemented",
         )
-        return True
+        return _SpawnResult(rejected=True, needs_rewake=False)
     agent_id = spec.get("agent_id")
     if not isinstance(agent_id, str):
         await _complete_run(
@@ -231,7 +248,7 @@ async def _open_agent_capability(
             is_error=True,
             error_kind="bad_agent_call",
         )
-        return True
+        return _SpawnResult(rejected=True, needs_rewake=False)
 
     child_id = child_session_id(run.id, cap.call_key)
     try:
@@ -244,7 +261,7 @@ async def _open_agent_capability(
             is_error=True,
             error_kind="agent_not_found",
         )
-        return True
+        return _SpawnResult(rejected=True, needs_rewake=False)
 
     created = await create_child_session(
         pool,
@@ -259,11 +276,18 @@ async def _open_agent_capability(
     # On replay the row already carries its first-spawn version — journal THAT, so
     # call_started.child_agent_version always matches the version the child runs under.
     child_version: int | None
+    needs_rewake = False
     if created:
         child_version = pinned
     else:
         child = await db_queries.get_session_bare(conn, child_id, account_id=account_id)
         child_version = child.agent_version
+        # C1'/C4: the child finished before we journaled call_started, so the
+        # pre-replay harvest (which only scans inflight call_started events) could
+        # not have seen its marker. Ask for a self-wake so the next step harvests
+        # it now, rather than waiting up to one periodic run-sweep tick.
+        marker = await db_queries.read_workflow_child_done(conn, child_id, account_id=account_id)
+        needs_rewake = marker is not None
     await wf_queries.append_run_event(
         conn,
         account_id=account_id,
@@ -276,10 +300,13 @@ async def _open_agent_capability(
             "child_agent_version": child_version,
         },
     )
-    # Prompt wake of the child; the session sweep is the durable backstop (the
-    # child's first user message makes it is-wakeable regardless).
-    await defer_wake(pool, child_id, account_id=account_id, cause="workflow_child_spawn")
-    return False
+    # Prompt wake of the child ONLY on first spawn. On a re-attach the child is
+    # already sweep-wakeable via its own first user message (delivered with the
+    # row) and may already be terminal — appending a wake span to an archived
+    # child would crash on append_event's archived guard.
+    if created:
+        await defer_wake(pool, child_id, account_id=account_id, cause="workflow_child_spawn")
+    return _SpawnResult(rejected=False, needs_rewake=needs_rewake)
 
 
 async def _complete_run(

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -98,20 +98,16 @@ async def run_workflow_step(run_id: str) -> None:
         for call_key, cap_payload in list(inflight.items()):
             if cap_payload.get("capability") == "agent":
                 # The child was invoked with request_id = call_key (the agent() call
-                # IS the request), so its response is read under that same id.
-                marker = await db_queries.read_request_response(
+                # IS the request), so its outcome is derived under that same id.
+                resolved = await db_queries.derive_response(
                     conn,
                     cap_payload["child_session_id"],
                     account_id=account_id,
                     request_id=call_key,
                 )
-                if marker is None:
-                    continue  # child not done yet — stay suspended
-                result_payload = {
-                    "result": marker.get("result"),
-                    "is_error": bool(marker.get("is_error")),
-                    "error": marker.get("error"),
-                }
+                if resolved is None:
+                    continue  # still pending — stay suspended
+                result_payload = resolved
             else:  # gate: the resume value lives in the signal
                 sig = signals.get(call_key)
                 if sig is None:
@@ -299,14 +295,18 @@ async def _open_agent_capability(
     else:
         child = await db_queries.get_session_bare(conn, child_id, account_id=account_id)
         child_version = child.agent_version
-        # C1'/C4: the child finished before we journaled call_started, so the
-        # pre-replay harvest (which only scans inflight call_started events) could
-        # not have seen its marker. Ask for a self-wake so the next step harvests
-        # it now, rather than waiting up to one periodic run-sweep tick.
-        marker = await db_queries.read_request_response(
-            conn, child_id, account_id=account_id, request_id=cap.call_key
+        # C1'/C4: the child reached a terminal outcome before we journaled
+        # call_started, so the pre-replay harvest (which only scans inflight
+        # call_started events) could not have seen it. Ask for a self-wake so the
+        # next step harvests it now, rather than waiting one periodic sweep tick.
+        # Routed through the same derive_response seam as the harvest, so an already-
+        # gone child (not just an answered one) triggers the prompt re-wake too.
+        needs_rewake = (
+            await db_queries.derive_response(
+                conn, child_id, account_id=account_id, request_id=cap.call_key
+            )
+            is not None
         )
-        needs_rewake = marker is not None
     await wf_queries.append_run_event(
         conn,
         account_id=account_id,
@@ -336,7 +336,18 @@ async def _complete_run(
     is_error: bool,
     error_kind: str | None = None,
 ) -> None:
-    """Append ``run_completed`` + flip status (+ store output) atomically."""
+    """Append ``run_completed`` + flip status (+ store output) atomically.
+
+    Child reclaim (archiving the run's spawned children) is deliberately NOT done
+    here: at run-completion the just-answered child is still finishing its own step
+    (it wrote its response and woke us *before* appending its tool_result), so
+    archiving it now would race that in-flight append into ``append_event``'s
+    archived guard. Safe reclaim is quiescence-gated — a child archives only once it
+    is genuinely idle — which is the deferred ``schedule-archival-on-quiescence``
+    mechanism. Until then a finished child lingers idle (harmless; no sandbox until
+    used). The run's correctness never depended on reclaim. The
+    ``run_session_step`` archived-guard makes that future reclaim crash-free.
+    """
     payload: dict[str, Any] = {"output": output, "is_error": is_error}
     if error_kind is not None:
         payload["error"] = {"kind": error_kind}

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -10,9 +10,9 @@ One wake:
    and ``inflight`` (opened-but-unresolved capabilities) from the log.
 2. On the first wake, append ``run_started`` and flip to ``running``.
 3. **Pre-replay harvest**: for any inflight capability now done — a gate with a
-   delivered resume signal, or an agent child with a ``workflow_child_done``
-   marker — journal its ``call_result`` and fold it into ``memo`` so replay sees
-   a maximal memo and fast-forwards past it.
+   delivered resume signal, or an agent child with a ``request_response`` for the
+   call's request — journal its ``call_result`` and fold it into ``memo`` so replay
+   sees a maximal memo and fast-forwards past it.
 4. Drive one wake of the pinned script in the credential-free subprocess.
 5. Raised → ``errored`` (except a transient ``script_host_spawn_failed``, which
    re-raises so the sweep retries — an infra hiccup must not terminally error the
@@ -97,8 +97,13 @@ async def run_workflow_step(run_id: str) -> None:
         # marker — and fold its result into memo so replay fast-forwards past it.
         for call_key, cap_payload in list(inflight.items()):
             if cap_payload.get("capability") == "agent":
-                marker = await db_queries.read_workflow_child_done(
-                    conn, cap_payload["child_session_id"], account_id=account_id
+                # The child was invoked with request_id = call_key (the agent() call
+                # IS the request), so its response is read under that same id.
+                marker = await db_queries.read_request_response(
+                    conn,
+                    cap_payload["child_session_id"],
+                    account_id=account_id,
+                    request_id=call_key,
                 )
                 if marker is None:
                     continue  # child not done yet — stay suspended
@@ -298,7 +303,9 @@ async def _open_agent_capability(
         # pre-replay harvest (which only scans inflight call_started events) could
         # not have seen its marker. Ask for a self-wake so the next step harvests
         # it now, rather than waiting up to one periodic run-sweep tick.
-        marker = await db_queries.read_workflow_child_done(conn, child_id, account_id=account_id)
+        marker = await db_queries.read_request_response(
+            conn, child_id, account_id=account_id, request_id=cap.call_key
+        )
         needs_rewake = marker is not None
     await wf_queries.append_run_event(
         conn,

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -235,7 +235,7 @@ async def _open_agent_capability(
 
     child_id = child_session_id(run.id, cap.call_key)
     try:
-        pinned = (await db_queries.get_agent(conn, agent_id, account_id=account_id)).version
+        pinned = await db_queries.get_agent_head_version(conn, agent_id, account_id=account_id)
     except NotFoundError:
         await _complete_run(
             conn,
@@ -258,13 +258,12 @@ async def _open_agent_capability(
     )
     # On replay the row already carries its first-spawn version — journal THAT, so
     # call_started.child_agent_version always matches the version the child runs under.
-    child_version = (
-        pinned
-        if created
-        else (
-            await db_queries.get_session_bare(conn, child_id, account_id=account_id)
-        ).agent_version
-    )
+    child_version: int | None
+    if created:
+        child_version = pinned
+    else:
+        child = await db_queries.get_session_bare(conn, child_id, account_id=account_id)
+        child_version = child.agent_version
     await wf_queries.append_run_event(
         conn,
         account_id=account_id,

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -271,6 +271,7 @@ async def _open_agent_capability(
         environment_id=run.environment_id,
         agent_version=pinned,
         parent_run_id=run.id,
+        request_id=cap.call_key,  # the agent() call IS the request the child must answer
         input=spec.get("input"),
     )
     # On replay the row already carries its first-spawn version — journal THAT, so

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -26,17 +26,20 @@ One wake:
 
 from __future__ import annotations
 
+import contextlib
 import secrets
+from datetime import UTC, datetime, timedelta
 from typing import Any, NamedTuple
 
 import asyncpg
 
+from aios.config import get_settings
 from aios.db import queries as db_queries
 from aios.db.queries import workflows as wf_queries
 from aios.errors import NotFoundError
 from aios.harness import runtime
 from aios.logging import get_logger
-from aios.models.workflows import WfRun
+from aios.models.workflows import WfRun, WfRunEvent
 from aios.services.sessions import create_child_session
 from aios.services.wake import defer_run_wake, defer_wake
 from aios.workflows.child_id import child_session_id
@@ -58,6 +61,53 @@ def _memo_outcome(call_result_payload: dict[str, Any]) -> dict[str, Any]:
     return {"ok": call_result_payload.get("result")}
 
 
+async def _resolve_agent_call(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    child_id: str,
+    request_id: str,
+    started_at: datetime,
+    now: datetime,
+    deadline: timedelta,
+) -> dict[str, Any] | None:
+    """The outcome of one inflight ``agent()`` call, or ``None`` if it is still
+    pending and within its wall-clock deadline.
+
+    ``derive_response`` returns the child's written response or a ``child_gone``
+    outcome, else ``None`` (live and unanswered). A still-pending call past its
+    deadline is force-resolved with a ``timeout`` error response (H3): a child that
+    never goes idle — e.g. it loops on tools forever — never trips R4's quiescence
+    nudge, so without this its caller would suspend forever. The write is
+    exactly-once and we re-derive, so a real response that raced in wins; and a child
+    archived/deleted in the derive→write window surfaces as ``child_gone`` on the
+    re-derive (``write_response_if_absent`` raises ``NotFoundError`` against the gone
+    row — the same graceful resolution the non-timeout harvest path gives a gone
+    child, never a crash)."""
+    resolved = await db_queries.derive_response(
+        conn, child_id, account_id=account_id, request_id=request_id
+    )
+    if resolved is not None:
+        return resolved
+    if now - started_at < deadline:
+        return None  # pending, within deadline
+    with contextlib.suppress(NotFoundError):
+        await db_queries.write_response_if_absent(
+            conn,
+            child_id,
+            account_id=account_id,
+            request_id=request_id,
+            is_error=True,
+            result=None,
+            error={"kind": "timeout"},
+        )
+    resolved = await db_queries.derive_response(
+        conn, child_id, account_id=account_id, request_id=request_id
+    )
+    assert resolved is not None  # a response now exists (timeout/child) or child_gone
+    return resolved
+
+
 async def run_workflow_step(run_id: str) -> None:
     pool = runtime.require_pool()
 
@@ -74,10 +124,11 @@ async def run_workflow_step(run_id: str) -> None:
             for e in events
             if e.type == "call_result" and e.call_key is not None
         }
-        # call_key -> call_started payload (capability + child_session_id), so the
-        # harvest can read a gate's signal or an agent child's marker.
-        inflight: dict[str, dict[str, Any]] = {
-            e.call_key: e.payload
+        # call_key -> the call_started event, so the harvest can read a gate's signal
+        # or an agent child's response, and measure an agent call's age against its
+        # wall-clock deadline (off the event's created_at).
+        inflight: dict[str, WfRunEvent] = {
+            e.call_key: e
             for e in events
             if e.type == "call_started" and e.call_key is not None and e.call_key not in memo
         }
@@ -93,21 +144,27 @@ async def run_workflow_step(run_id: str) -> None:
             await wf_queries.set_run_status(conn, run_id, "running", account_id=account_id)
 
         # Pre-replay harvest: resolve any inflight capability that is now done — a
-        # gate with a delivered resume signal, or an agent child with a completion
-        # marker — and fold its result into memo so replay fast-forwards past it.
-        for call_key, cap_payload in list(inflight.items()):
+        # gate with a delivered resume signal, or an agent child with a response (or a
+        # past-deadline timeout) — and fold its result into memo so replay
+        # fast-forwards past it.
+        now = datetime.now(UTC)
+        agent_deadline = timedelta(seconds=get_settings().workflow_agent_deadline_seconds)
+        for call_key, cap_event in list(inflight.items()):
+            cap_payload = cap_event.payload
             if cap_payload.get("capability") == "agent":
                 # The child was invoked with request_id = call_key (the agent() call
                 # IS the request), so its outcome is derived under that same id.
-                resolved = await db_queries.derive_response(
+                result_payload = await _resolve_agent_call(
                     conn,
-                    cap_payload["child_session_id"],
                     account_id=account_id,
+                    child_id=cap_payload["child_session_id"],
                     request_id=call_key,
+                    started_at=cap_event.created_at,
+                    now=now,
+                    deadline=agent_deadline,
                 )
-                if resolved is None:
-                    continue  # still pending — stay suspended
-                result_payload = resolved
+                if result_payload is None:
+                    continue  # still pending, within deadline — stay suspended
             else:  # gate: the resume value lives in the signal
                 sig = signals.get(call_key)
                 if sig is None:
@@ -163,6 +220,38 @@ async def run_workflow_step(run_id: str) -> None:
 
         if outcome.kind == "returned":
             await _complete_run(conn, run, output=outcome.value, is_error=False)
+            return
+
+        # Lifetime agent-call cap (H1): bound a runaway that spawns children in an
+        # unbounded loop. Counted from the monotonic call_started journal plus this
+        # step's new agent frontier, checked BEFORE any spawn so an over-cap step
+        # errors atomically — never leaving a partial fan-out of orphan children.
+        # (A single parallel()'s width is bounded separately in the host.) Gated on
+        # there BEING new spawns: a harvest-only re-suspend (no new agents) must never
+        # error — else lowering the cap mid-flight would retroactively kill a run whose
+        # children are already all inflight, orphaning them. H1 blocks NEW spawns only.
+        new_agent_caps = [
+            cap
+            for cap in outcome.emitted
+            if cap.capability_id == "agent"
+            and cap.call_key not in memo
+            and cap.call_key not in inflight
+        ]
+        prior_agent_calls = sum(
+            1 for e in events if e.type == "call_started" and e.payload.get("capability") == "agent"
+        )
+        max_agent_calls = get_settings().workflow_max_agent_calls
+        if new_agent_caps and prior_agent_calls + len(new_agent_caps) > max_agent_calls:
+            await _complete_run(
+                conn,
+                run,
+                output=(
+                    f"workflow exceeded the {max_agent_calls}-agent call cap "
+                    f"({prior_agent_calls} started, {len(new_agent_caps)} more requested)"
+                ),
+                is_error=True,
+                error_kind="too_many_agents",
+            )
             return
 
         # Suspended: open any *new* frontier capability, then park.

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -47,6 +47,17 @@ log = get_logger("aios.workflows.step")
 _TERMINAL = ("completed", "errored")
 
 
+def _memo_outcome(call_result_payload: dict[str, Any]) -> dict[str, Any]:
+    """Map a ``call_result`` payload to the host memo's tagged outcome: a value the
+    driver fast-forwards into the await (``{"ok": value}``), or an error it throws
+    there as ``AgentError`` (``{"error": {...}}``). The discriminated union lets the
+    host tell "the agent answered" from "the agent failed" even when the answer is
+    itself a dict — the real value always nests one level under ``"ok"``."""
+    if call_result_payload.get("is_error"):
+        return {"error": call_result_payload.get("error")}
+    return {"ok": call_result_payload.get("result")}
+
+
 async def run_workflow_step(run_id: str) -> None:
     pool = runtime.require_pool()
 
@@ -59,7 +70,7 @@ async def run_workflow_step(run_id: str) -> None:
         events = await wf_queries.list_run_events(conn, run_id)
         signals = {s.call_key: s for s in await wf_queries.list_run_signals(conn, run_id)}
         memo: dict[str, Any] = {
-            e.call_key: e.payload.get("result")
+            e.call_key: _memo_outcome(e.payload)
             for e in events
             if e.type == "call_result" and e.call_key is not None
         }
@@ -109,9 +120,9 @@ async def run_workflow_step(run_id: str) -> None:
                 call_key=call_key,
                 payload=result_payload,
             )
-            # memo carries the bare result the host fast-forwards into the await;
-            # wrapping an errored agent result in AgentResult is B2.G.
-            memo[call_key] = result_payload["result"]
+            # memo carries the host's tagged outcome (R3): an `{ok}` value to
+            # fast-forward into the await, or an `{error}` to throw as AgentError.
+            memo[call_key] = _memo_outcome(result_payload)
             del inflight[call_key]
 
     # Drive one wake in the credential-free subprocess (no DB conn held).

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -17,9 +17,10 @@ One wake:
    re-raises so the sweep retries — an infra hiccup must not terminally error the
    run). On a *real* replay (returned/suspended) a replay-prefix check fails
    closed on divergence. Returned → ``run_completed`` + ``completed`` (one txn).
-   Suspended → open any *new* frontier capability (a gate gets a nonce +
-   ``call_started``) and park as ``suspended``; the run re-wakes on the next
-   signal or sweep.
+   Suspended → open each *new* frontier capability and park as ``suspended``: a
+   gate gets a nonce; an ``agent`` spawns a deterministic, idempotent child
+   session, delivers its input, and journals ``call_started``. The run re-wakes
+   on the next signal / child completion or the periodic sweep.
 """
 
 from __future__ import annotations
@@ -29,12 +30,16 @@ from typing import Any
 
 import asyncpg
 
+from aios.db import queries as db_queries
 from aios.db.queries import workflows as wf_queries
+from aios.errors import NotFoundError
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.models.workflows import WfRun
-from aios.services.wake import defer_run_wake
-from aios.workflows.host_launcher import run_script_host
+from aios.services.sessions import create_child_session
+from aios.services.wake import defer_run_wake, defer_wake
+from aios.workflows.child_id import child_session_id
+from aios.workflows.host_launcher import EmittedCapability, run_script_host
 
 log = get_logger("aios.workflows.step")
 
@@ -148,12 +153,16 @@ async def run_workflow_step(run_id: str) -> None:
                 # opened gate promptly instead of waiting for the periodic sweep.
                 if cap.call_key in signals:
                     needs_rewake = True
+            elif cap.capability_id == "agent":
+                if await _open_agent_capability(conn, pool, run, cap):
+                    return  # the frontier was terminally rejected (bad call) — run errored
             else:
-                # agent / parallel / pipeline are not openable in Block 1.
+                # parallel/pipeline reach the step as their `agent` leaves (B2.G);
+                # any other capability id is unknown.
                 await _complete_run(
                     conn,
                     run,
-                    output=f"capability {cap.capability_id!r} is not supported yet (lands in Block 2)",
+                    output=f"capability {cap.capability_id!r} is not supported yet",
                     is_error=True,
                     error_kind="not_implemented",
                 )
@@ -164,6 +173,94 @@ async def run_workflow_step(run_id: str) -> None:
     # harvests an already-delivered resume for a gate opened this wake.
     if needs_rewake:
         await defer_run_wake(run_id)
+
+
+async def _open_agent_capability(
+    conn: asyncpg.Connection[Any],
+    pool: asyncpg.Pool[Any],
+    run: WfRun,
+    cap: EmittedCapability,
+) -> bool:
+    """Spawn (or, on replay/C1', re-attach) the ``agent()`` child for a frontier,
+    then journal ``call_started{child_session_id, child_agent_version}``.
+
+    Idempotent + crash-safe: the child id is deterministic, ``create_child_session``
+    is ``ON CONFLICT`` (delivers the input atomically with the row on first spawn),
+    ``call_started`` dedups on the memo, and ``defer_wake`` dedups on its queueing
+    lock. On replay the child id already exists → re-attach, journaling the *row's*
+    pinned version (not a re-resolved one). Returns ``True`` iff the call was
+    terminally rejected (the run was errored — the caller should stop the step).
+    """
+    account_id = run.account_id
+    spec = cap.spec if isinstance(cap.spec, dict) else {}
+    if spec.get("output_schema") is not None:
+        await _complete_run(
+            conn,
+            run,
+            output="agent() output_schema is not supported in v1 (lands in Block 3)",
+            is_error=True,
+            error_kind="not_implemented",
+        )
+        return True
+    agent_id = spec.get("agent_id")
+    if not isinstance(agent_id, str):
+        await _complete_run(
+            conn,
+            run,
+            output=f"agent() requires a string agent_id, got {agent_id!r}",
+            is_error=True,
+            error_kind="bad_agent_call",
+        )
+        return True
+
+    child_id = child_session_id(run.id, cap.call_key)
+    try:
+        pinned = (await db_queries.get_agent(conn, agent_id, account_id=account_id)).version
+    except NotFoundError:
+        await _complete_run(
+            conn,
+            run,
+            output=f"agent {agent_id!r} not found",
+            is_error=True,
+            error_kind="agent_not_found",
+        )
+        return True
+
+    created = await create_child_session(
+        pool,
+        session_id=child_id,
+        account_id=account_id,
+        agent_id=agent_id,
+        environment_id=run.environment_id,
+        agent_version=pinned,
+        parent_run_id=run.id,
+        input=spec.get("input"),
+    )
+    # On replay the row already carries its first-spawn version — journal THAT, so
+    # call_started.child_agent_version always matches the version the child runs under.
+    child_version = (
+        pinned
+        if created
+        else (
+            await db_queries.get_session_bare(conn, child_id, account_id=account_id)
+        ).agent_version
+    )
+    await wf_queries.append_run_event(
+        conn,
+        account_id=account_id,
+        run_id=run.id,
+        type="call_started",
+        call_key=cap.call_key,
+        payload={
+            "capability": "agent",
+            "child_session_id": child_id,
+            "child_agent_version": child_version,
+        },
+    )
+    # Prompt wake of the child; the session sweep is the durable backstop (the
+    # child's first user message makes it is-wakeable regardless).
+    await defer_wake(pool, child_id, account_id=account_id, cause="workflow_child_spawn")
+    return False
 
 
 async def _complete_run(

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -9,9 +9,10 @@ One wake:
 1. Load the run + its journal + its signals; rebuild ``memo`` (resolved results)
    and ``inflight`` (opened-but-unresolved capabilities) from the log.
 2. On the first wake, append ``run_started`` and flip to ``running``.
-3. **Pre-replay harvest**: for any inflight capability that now has a signal,
-   journal its ``call_result`` and fold it into ``memo`` — so replay sees a
-   maximal memo and fast-forwards past it.
+3. **Pre-replay harvest**: for any inflight capability now done — a gate with a
+   delivered resume signal, or an agent child with a ``workflow_child_done``
+   marker — journal its ``call_result`` and fold it into ``memo`` so replay sees
+   a maximal memo and fast-forwards past it.
 4. Drive one wake of the pinned script in the credential-free subprocess.
 5. Raised → ``errored`` (except a transient ``script_host_spawn_failed``, which
    re-raises so the sweep retries — an infra hiccup must not terminally error the
@@ -62,8 +63,10 @@ async def run_workflow_step(run_id: str) -> None:
             for e in events
             if e.type == "call_result" and e.call_key is not None
         }
-        inflight: set[str] = {
-            e.call_key
+        # call_key -> call_started payload (capability + child_session_id), so the
+        # harvest can read a gate's signal or an agent child's marker.
+        inflight: dict[str, dict[str, Any]] = {
+            e.call_key: e.payload
             for e in events
             if e.type == "call_started" and e.call_key is not None and e.call_key not in memo
         }
@@ -78,21 +81,38 @@ async def run_workflow_step(run_id: str) -> None:
             )
             await wf_queries.set_run_status(conn, run_id, "running", account_id=account_id)
 
-        # Pre-replay harvest: resolve any inflight capability that has a signal.
-        for call_key in list(inflight):
-            sig = signals.get(call_key)
-            if sig is None:
-                continue
+        # Pre-replay harvest: resolve any inflight capability that is now done — a
+        # gate with a delivered resume signal, or an agent child with a completion
+        # marker — and fold its result into memo so replay fast-forwards past it.
+        for call_key, cap_payload in list(inflight.items()):
+            if cap_payload.get("capability") == "agent":
+                marker = await db_queries.read_workflow_child_done(
+                    conn, cap_payload["child_session_id"], account_id=account_id
+                )
+                if marker is None:
+                    continue  # child not done yet — stay suspended
+                result_payload = {
+                    "result": marker.get("result"),
+                    "is_error": bool(marker.get("is_error")),
+                    "error": marker.get("error"),
+                }
+            else:  # gate: the resume value lives in the signal
+                sig = signals.get(call_key)
+                if sig is None:
+                    continue
+                result_payload = {"result": sig.result, "is_error": False}
             await wf_queries.append_run_event(
                 conn,
                 account_id=account_id,
                 run_id=run_id,
                 type="call_result",
                 call_key=call_key,
-                payload={"result": sig.result, "is_error": False},
+                payload=result_payload,
             )
-            memo[call_key] = sig.result
-            inflight.discard(call_key)
+            # memo carries the bare result the host fast-forwards into the await;
+            # wrapping an errored agent result in AgentResult is B2.G.
+            memo[call_key] = result_payload["result"]
+            del inflight[call_key]
 
     # Drive one wake in the credential-free subprocess (no DB conn held).
     outcome = await run_script_host(source=run.script, input=run.input, memo=memo)

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -47,6 +47,28 @@ class WorkflowScriptError(Exception):
     """The author script has the wrong shape (no ``async def main(input)``)."""
 
 
+class AgentError(Exception):
+    """A spawned ``agent()`` failed to return a value.
+
+    Raised at the ``await agent(...)`` site in the author script — the driver
+    ``coro.throw``s it when the call's journaled outcome is an error. So an author
+    can ``try/except AgentError`` and continue, or let it propagate to fail the run
+    (the bubble). ``kind`` distinguishes the failure mode: ``None`` for an explicit
+    ``error()`` from the child, ``"child_errored"`` for a model failure,
+    ``"no_return"`` for no response (see :class:`AgentNoReturnError`).
+    """
+
+    def __init__(self, message: str, *, kind: str | None = None) -> None:
+        super().__init__(message)
+        self.kind = kind
+
+
+class AgentNoReturnError(AgentError):
+    """An ``agent()`` whose child went idle without ever responding (the totality
+    backstop). A subtype of :class:`AgentError`, so a blanket ``except AgentError``
+    catches it too; catch it explicitly to treat "no response" differently."""
+
+
 # ─── the capability awaitables (author-facing API) ───────────────────────────
 
 
@@ -191,6 +213,10 @@ def _build_coroutine(source: str, input_value: Any) -> Any:
         "parallel": parallel,
         "pipeline": pipeline,
         "log": log,
+        # The agent() failure type lives with its capability in the author API
+        # (not SAFE_BUILTINS), so `try/except AgentError` resolves it as a global.
+        "AgentError": AgentError,
+        "AgentNoReturnError": AgentNoReturnError,
     }
     code = compile(source, "<workflow>", "exec")
     exec(code, namespace)
@@ -211,21 +237,43 @@ def _emit_raised(emit: Any, exc: BaseException) -> None:
     emit({"type": RAISED, "repr": _exc_repr(exc), "traceback": traceback.format_exc()})
 
 
+_AGENT_ERROR_DEFAULT_MESSAGES: dict[str | None, str] = {
+    "child_errored": "the agent errored before responding to the request",
+    "no_return": "the agent went idle without responding to the request",
+}
+
+
+def _agent_error_from(error_info: Any) -> AgentError:
+    """Build the ``AgentError`` to throw at an ``await agent(...)`` from a memo
+    outcome's ``error`` payload (``{kind?, message?}``). ``no_return`` maps to the
+    :class:`AgentNoReturnError` subtype; everything else to the base class."""
+    info = error_info if isinstance(error_info, dict) else {}
+    kind = info.get("kind")
+    message = info.get("message") or _AGENT_ERROR_DEFAULT_MESSAGES.get(kind, "the agent failed")
+    if kind == "no_return":
+        return AgentNoReturnError(message, kind=kind)
+    return AgentError(message, kind=kind)
+
+
 # ─── the manual .send() driver ───────────────────────────────────────────────
 
 
 def _drive(coro: Any, memo: dict[str, Any], emit: Any) -> None:
     keyer = CallKeyer()
     to_send: Any = None
+    to_throw: BaseException | None = None
     while True:
         try:
-            yielded = coro.send(to_send)
+            # A journaled error outcome is delivered as a throw AT the await, so the
+            # author's try/except sees it; everything else is a plain resume value.
+            yielded = coro.throw(to_throw) if to_throw is not None else coro.send(to_send)
         except StopIteration as stop:
             emit({"type": RETURNED, "value": stop.value})
             return
         except BaseException as exc:
             _emit_raised(emit, exc)
             return
+        to_send, to_throw = None, None
         if not isinstance(yielded, _Yield):
             emit(
                 {
@@ -241,7 +289,14 @@ def _drive(coro: Any, memo: dict[str, Any], emit: Any) -> None:
             _emit_raised(emit, exc)
             return
         if call_key in memo:
-            to_send = memo[call_key]  # FAST-FORWARD a journaled result
+            # FAST-FORWARD a journaled outcome: an `{ok: value}` resumes the await
+            # with the value; an `{error: {...}}` throws AgentError at it (catchable
+            # by the author, else it propagates and fails the run).
+            outcome = memo[call_key]
+            if isinstance(outcome, dict) and "error" in outcome:
+                to_throw = _agent_error_from(outcome["error"])
+            else:
+                to_send = outcome["ok"]
             continue
         # FRONTIER: emit it and suspend (suspension is the absence of a resume).
         # content_hash + ordinal are recoverable from call_key, so the frame

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -77,7 +77,7 @@ def gate(spec: Any = None) -> _Capability:
 
 
 def agent(agent_id: str, input: Any = None, output_schema: Any = None) -> _Capability:
-    """Invoke an agent (a child session). Block 2 — the parent rejects it for now."""
+    """Invoke an agent: the parent spawns a child session and awaits its result."""
     return _Capability(
         "agent", {"agent_id": agent_id, "input": input, "output_schema": output_schema}
     )

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -240,6 +240,7 @@ def _emit_raised(emit: Any, exc: BaseException) -> None:
 _AGENT_ERROR_DEFAULT_MESSAGES: dict[str | None, str] = {
     "child_errored": "the agent errored before responding to the request",
     "no_return": "the agent went idle without responding to the request",
+    "child_gone": "the agent was archived or deleted before responding to the request",
 }
 
 

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -55,6 +55,7 @@ class AgentError(Exception):
     can ``try/except AgentError`` and continue, or let it propagate to fail the run
     (the bubble). ``kind`` distinguishes the failure mode: ``None`` for an explicit
     ``error()`` from the child, ``"child_errored"`` for a model failure,
+    ``"child_gone"`` if the child was archived/deleted before answering, and
     ``"no_return"`` for no response (see :class:`AgentNoReturnError`).
     """
 

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -18,8 +18,10 @@ reaches only this credential-free process. ``SAFE_BUILTINS`` and the absence of
 ``__import__`` are determinism/footgun aids, **not** the security boundary.
 
 ``gate()`` and ``agent()`` are real capabilities (for ``agent()`` the parent spawns
-a child session and harvests its completion marker); ``parallel()``/``pipeline()``
-still raise until Block 2.G.
+a child session and harvests its completion marker). ``parallel()``/``pipeline()``
+fan a run out across concurrent branches, scheduled cooperatively by the driver:
+each branch keys its own capabilities (so every ``call_key`` is deterministic across
+replays), and the whole live frontier is emitted at once when the run suspends.
 """
 
 from __future__ import annotations
@@ -95,6 +97,28 @@ class _Capability:
         return result
 
 
+class _ParallelYield:
+    """The value ``await parallel(...)`` yields up to the driver: the set of branch
+    coroutines to run concurrently. The driver returns a results list (one per
+    branch, in order; ``None`` for a branch that raised)."""
+
+    __slots__ = ("branches",)
+
+    def __init__(self, branches: list[Any]) -> None:
+        self.branches = branches
+
+
+class _ParallelAwait:
+    __slots__ = ("_branches",)
+
+    def __init__(self, branches: list[Any]) -> None:
+        self._branches = branches
+
+    def __await__(self) -> Any:
+        results = yield _ParallelYield(self._branches)
+        return results
+
+
 def gate(spec: Any = None) -> _Capability:
     """Suspend until an external resume delivers a value for this gate."""
     return _Capability("gate", spec)
@@ -117,14 +141,45 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
     )
 
 
-def parallel(_thunks: Any) -> Any:
-    # Message is run-visible (folded into the run's errored output), so it carries
-    # no dev-world block label — only a stable runtime concept the author can act on.
-    raise NotImplementedError("parallel() is not supported yet")
+async def _branch(thunk: Any) -> Any:
+    """Run one parallel branch: call the thunk, await whatever it returns. Wrapping
+    it in a coroutine lets the driver schedule a uniform set of branches and lets a
+    raising thunk/await surface as this branch's exception (→ None in the barrier)."""
+    return await thunk()
 
 
-def pipeline(_items: Any, *_stages: Any) -> Any:
-    raise NotImplementedError("pipeline() is not supported yet")
+def parallel(thunks: Any) -> _ParallelAwait:
+    """Run ``thunks`` concurrently and return a list of their results, one per thunk
+    in order. Each thunk takes no args and returns an awaitable (e.g.
+    ``lambda: agent('a', x)``). The barrier tolerates a *failed agent*: a branch
+    whose ``agent()`` raises :class:`AgentError` (uncaught) yields ``None`` in its
+    slot — so inspect the results for ``None``. Any *other* exception out of a branch
+    (an author bug — ``KeyError``, ``TypeError``, …) is **not** absorbed: it fails the
+    whole run loudly (fail-hard). The children fan out as a single frontier, so all
+    run at once."""
+    return _ParallelAwait([_branch(t) for t in thunks])
+
+
+def _pipeline_thunk(item: Any, stages: tuple[Any, ...]) -> Any:
+    async def run() -> Any:
+        value = item
+        for stage in stages:
+            produced = stage(value)
+            value = await produced if hasattr(produced, "__await__") else produced
+        return value
+
+    return run
+
+
+def pipeline(items: Any, *stages: Any) -> _ParallelAwait:
+    """Run each item through ``stages`` independently and concurrently — each item's
+    chain advances on its own, with no barrier between stages. Returns a list of
+    final values, one per item in order (``None`` for an item whose chain failed with
+    an :class:`AgentError`; any other exception fails the whole run, per
+    :func:`parallel`). Each stage is ``stage(value) -> awaitable | value``; a
+    non-awaitable return is used as-is (a sync transform). Composition over
+    :func:`parallel`."""
+    return parallel([_pipeline_thunk(item, stages) for item in items])
 
 
 def log(*args: Any) -> None:
@@ -234,8 +289,15 @@ def _exc_repr(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
+def _emit_error(emit: Any, repr_: str, tb: str = "") -> None:
+    """Emit the host's single error terminal (``RAISED``). The sole shape for every
+    failure the driver reports — an escaped exception or a driver-detected invariant
+    breach — so the parent always parses one frame layout."""
+    emit({"type": RAISED, "repr": repr_, "traceback": tb})
+
+
 def _emit_raised(emit: Any, exc: BaseException) -> None:
-    emit({"type": RAISED, "repr": _exc_repr(exc), "traceback": traceback.format_exc()})
+    _emit_error(emit, _exc_repr(exc), traceback.format_exc())
 
 
 _AGENT_ERROR_DEFAULT_MESSAGES: dict[str | None, str] = {
@@ -257,52 +319,191 @@ def _agent_error_from(error_info: Any) -> AgentError:
     return AgentError(message, kind=kind)
 
 
-# ─── the manual .send() driver ───────────────────────────────────────────────
+# ─── the manual .send() driver (a deterministic cooperative scheduler) ────────
 
 
-def _drive(coro: Any, memo: dict[str, Any], emit: Any) -> None:
-    keyer = CallKeyer()
-    to_send: Any = None
-    to_throw: BaseException | None = None
+class _Branch:
+    """One coroutine the scheduler is driving — the root ``main``, or a ``parallel``
+    sub-branch. ``send``/``throw`` is its pending resume; ``blocked`` means it is
+    waiting (on a frontier capability, or on its parallel children to finish);
+    ``join``/``index`` say which ``parallel`` result slot it fills when it ends.
+
+    ``keyer``/``path`` make ``call_key``s **branch-local**: each branch numbers its
+    own capabilities (per-content-hash ordinals from its own ``CallKeyer``), and the
+    ``path`` — a deterministic prefix derived from the parallel structure (root is
+    ``""``, a sub-branch is ``"{parent_path}{kth_parallel}.{i}/"``) — disambiguates
+    the same content hash across branches. Without this, ordinals would be assigned
+    in *sweep* order, which is memo-dependent, so two same-hash branches of unequal
+    depth would swap keys across replays. ``n_parallels`` counts the child-spawning
+    (non-empty) parallels this branch has opened, to number their children's paths
+    deterministically — an empty ``parallel([])`` resolves to ``[]`` inline and is
+    not numbered (its emptiness is structural, so this stays replay-stable)."""
+
+    __slots__ = (
+        "blocked",
+        "coro",
+        "done",
+        "index",
+        "join",
+        "keyer",
+        "n_parallels",
+        "path",
+        "send",
+        "throw",
+    )
+
+    def __init__(
+        self,
+        coro: Any,
+        *,
+        path: str,
+        join: _Join | None = None,
+        index: int = -1,
+    ) -> None:
+        self.coro = coro
+        self.send: Any = None
+        self.throw: BaseException | None = None
+        self.blocked = False
+        self.done = False
+        self.join = join
+        self.index = index
+        self.path = path
+        self.keyer = CallKeyer()
+        self.n_parallels = 0
+
+
+class _Join:
+    """A ``parallel`` barrier: the parent branch is unblocked with ``results`` once
+    all of its child branches have finished (each filling its slot; ``None`` on a
+    raised child — the barrier never fails as a whole)."""
+
+    __slots__ = ("parent", "remaining", "results")
+
+    def __init__(self, parent: _Branch, n: int) -> None:
+        self.parent = parent
+        self.results: list[Any] = [None] * n
+        self.remaining = n
+
+
+def _drive(root_coro: Any, memo: dict[str, Any], emit: Any) -> None:
+    """Drive one wake of the author script. A single coroutine is the common case;
+    ``parallel``/``pipeline`` introduce concurrent branches, which this schedules
+    cooperatively in a fixed (creation-order) sweep — so the capability emission
+    order, and thus every ``call_key``, is deterministic across replays."""
+    root = _Branch(root_coro, path="")  # root keys are unprefixed (back-compatible)
+    branches: list[_Branch] = [root]
+    frontier: dict[str, _Yield] = {}
+
+    def _finish(branch: _Branch, result: Any) -> None:
+        # Feed a finished sub-branch's result into its parallel join. Only ever called
+        # for a non-root branch, which always carries a join (root is handled inline
+        # by the caller and never reaches here). A raised branch passes result=None
+        # (the barrier); a returned branch passes its value.
+        branch.done = True
+        join = branch.join
+        assert join is not None  # non-root ⇒ join present, by construction
+        join.results[branch.index] = result
+        join.remaining -= 1
+        if join.remaining == 0:
+            join.parent.send = join.results
+            join.parent.blocked = False
+
     while True:
-        try:
-            # A journaled error outcome is delivered as a throw AT the await, so the
-            # author's try/except sees it; everything else is a plain resume value.
-            yielded = coro.throw(to_throw) if to_throw is not None else coro.send(to_send)
-        except StopIteration as stop:
-            emit({"type": RETURNED, "value": stop.value})
-            return
-        except BaseException as exc:
-            _emit_raised(emit, exc)
-            return
-        to_send, to_throw = None, None
-        if not isinstance(yielded, _Yield):
-            emit(
-                {
-                    "type": RAISED,
-                    "repr": f"workflow awaited a non-capability value: {type(yielded).__name__}",
-                    "traceback": "",
-                }
-            )
-            return
-        try:
-            call_key = keyer.next(yielded.capability_id, yielded.spec)
-        except BaseException as exc:
-            _emit_raised(emit, exc)
-            return
-        if call_key in memo:
-            # FAST-FORWARD a journaled outcome: an `{ok: value}` resumes the await
-            # with the value; an `{error: {...}}` throws AgentError at it (catchable
-            # by the author, else it propagates and fails the run).
-            outcome = memo[call_key]
-            if isinstance(outcome, dict) and "error" in outcome:
-                to_throw = _agent_error_from(outcome["error"])
+        progressed = False
+        for branch in list(branches):  # snapshot: parallel appends sub-branches mid-sweep
+            if branch.done or branch.blocked:
+                continue
+            try:
+                # A journaled error outcome is delivered as a throw AT the await, so
+                # the author's try/except sees it; everything else is a resume value.
+                if branch.throw is not None:
+                    yielded = branch.coro.throw(branch.throw)
+                else:
+                    yielded = branch.coro.send(branch.send)
+            except StopIteration as stop:
+                progressed = True
+                if branch is root:
+                    emit({"type": RETURNED, "value": stop.value})
+                    return
+                _finish(branch, stop.value)
+                continue
+            except BaseException as exc:
+                progressed = True
+                # The barrier absorbs a *failed agent* — any AgentError reaching a
+                # sub-branch — as a None slot; that is the point of parallel. Matching
+                # by type (not by provenance) means an author who lets an AgentError
+                # escape a branch, even one they raised directly, opts that branch into
+                # the same None: AgentError IS the agent-failure signal. Any OTHER
+                # exception (a KeyError in the branch's own glue, a root error) is an
+                # author bug → fail the whole run loudly (fail-hard), never a silent None.
+                if branch is root or not isinstance(exc, AgentError):
+                    _emit_raised(emit, exc)
+                    return
+                _finish(branch, None)  # barrier: a failed agent → None slot
+                continue
+            branch.send = None
+            branch.throw = None
+            progressed = True
+
+            if isinstance(yielded, _ParallelYield):
+                if not yielded.branches:
+                    branch.send = []  # empty parallel resumes immediately with []
+                    continue
+                join = _Join(branch, len(yielded.branches))
+                branch.blocked = True  # unblocks when its children all finish
+                # Children's paths are deterministic — "{parent}{kth_parallel}.{i}/"
+                # — so their call_keys are stable across replays regardless of the
+                # sweep/emission order.
+                for i, child in enumerate(yielded.branches):
+                    child_path = f"{branch.path}{branch.n_parallels}.{i}/"
+                    branches.append(_Branch(child, path=child_path, join=join, index=i))
+                branch.n_parallels += 1
+                continue
+
+            if not isinstance(yielded, _Yield):
+                # Awaiting a non-capability value is an author bug in ANY branch →
+                # fail the run loudly (fail-hard), never a silent None slot.
+                _emit_error(
+                    emit, f"workflow awaited a non-capability value: {type(yielded).__name__}"
+                )
+                return
+
+            # A capability (agent/gate). The call_key is branch-local: the branch's
+            # own per-content-hash ordinal, prefixed by its deterministic path. A bad
+            # input raises here (in the driver, not the coro) — a deterministic author
+            # error, so fail the whole run loudly rather than None-ing the branch.
+            try:
+                call_key = branch.path + branch.keyer.next(yielded.capability_id, yielded.spec)
+            except BaseException as exc:
+                _emit_raised(emit, exc)
+                return
+            if call_key in memo:
+                # FAST-FORWARD a journaled outcome: `{ok}` resumes with the value,
+                # `{error}` throws AgentError at the await (catchable by the author).
+                outcome = memo[call_key]
+                if isinstance(outcome, dict) and "error" in outcome:
+                    branch.throw = _agent_error_from(outcome["error"])
+                else:
+                    branch.send = outcome["ok"]
             else:
-                to_send = outcome["ok"]
-            continue
-        # FRONTIER: emit it and suspend (suspension is the absence of a resume).
-        # content_hash + ordinal are recoverable from call_key, so the frame
-        # carries only what the parent can't derive.
+                branch.blocked = True  # awaits this frontier capability's resolution
+                frontier[call_key] = yielded
+
+        if not progressed:
+            break
+
+    # No branch can advance and root has not returned → suspend on the frontier (the
+    # whole set of unresolved capabilities, fanned out at once for parallel). The
+    # frontier is non-empty here by construction: a stuck branch is blocked on a join
+    # or a frontier capability, and a join only stays blocked while some child is
+    # itself unfinished — which recurses down to a frontier-blocked leaf — so at least
+    # one capability is always open. The empty case is thus unreachable; assert it
+    # loudly rather than emit a frontier-less SUSPENDED that would park the run forever
+    # (a silent hang is the one failure mode fail-hard must never produce).
+    if not frontier:
+        _emit_error(emit, "workflow deadlocked with no frontier")
+        return
+    for call_key, yielded in frontier.items():
         emit(
             {
                 "type": EMIT,
@@ -311,8 +512,7 @@ def _drive(coro: Any, memo: dict[str, Any], emit: Any) -> None:
                 "spec": yielded.spec,
             }
         )
-        emit({"type": SUSPENDED})
-        return
+    emit({"type": SUSPENDED})
 
 
 def _apply_resource_limits() -> None:

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -57,8 +57,10 @@ class AgentError(Exception):
     can ``try/except AgentError`` and continue, or let it propagate to fail the run
     (the bubble). ``kind`` distinguishes the failure mode: ``None`` for an explicit
     ``error()`` from the child, ``"child_errored"`` for a model failure,
-    ``"child_gone"`` if the child was archived/deleted before answering, and
-    ``"no_return"`` for no response (see :class:`AgentNoReturnError`).
+    ``"child_gone"`` if the child was archived/deleted before answering,
+    ``"timeout"`` if the call outran its wall-clock budget without responding, and
+    ``"no_return"`` for an idle-without-responding child (see
+    :class:`AgentNoReturnError`).
     """
 
     def __init__(self, message: str, *, kind: str | None = None) -> None:
@@ -289,11 +291,13 @@ def _exc_repr(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
-def _emit_error(emit: Any, repr_: str, tb: str = "") -> None:
+def _emit_error(emit: Any, repr_: str, tb: str = "", *, kind: str | None = None) -> None:
     """Emit the host's single error terminal (``RAISED``). The sole shape for every
     failure the driver reports — an escaped exception or a driver-detected invariant
-    breach — so the parent always parses one frame layout."""
-    emit({"type": RAISED, "repr": repr_, "traceback": tb})
+    breach — so the parent always parses one frame layout. ``kind`` lets the host
+    label a structural failure it detects itself (e.g. the fan-out cap) so the parent
+    sees a specific ``error_kind``; an uncaught author exception carries none."""
+    emit({"type": RAISED, "repr": repr_, "traceback": tb, "kind": kind})
 
 
 def _emit_raised(emit: Any, exc: BaseException) -> None:
@@ -304,6 +308,7 @@ _AGENT_ERROR_DEFAULT_MESSAGES: dict[str | None, str] = {
     "child_errored": "the agent errored before responding to the request",
     "no_return": "the agent went idle without responding to the request",
     "child_gone": "the agent was archived or deleted before responding to the request",
+    "timeout": "the agent did not respond within its wall-clock deadline",
 }
 
 
@@ -320,6 +325,13 @@ def _agent_error_from(error_info: Any) -> AgentError:
 
 
 # ─── the manual .send() driver (a deterministic cooperative scheduler) ────────
+
+# Width ceiling for a single ``parallel()``/``pipeline()`` fan-out: the run RAISES
+# before spawning any of an over-wide fan-out's children. A host-side CONSTANT (not
+# config) so it is identical across replays — the decision to RAISE is a pure
+# function of the script. The lifetime total across all calls is bounded separately,
+# parent-side, by ``Settings.workflow_max_agent_calls``.
+MAX_PARALLEL_FANOUT = 1000
 
 
 class _Branch:
@@ -449,6 +461,16 @@ def _drive(root_coro: Any, memo: dict[str, Any], emit: Any) -> None:
                 if not yielded.branches:
                     branch.send = []  # empty parallel resumes immediately with []
                     continue
+                if len(yielded.branches) > MAX_PARALLEL_FANOUT:
+                    # Fail before spawning any child — a deterministic, structural
+                    # (memo-independent) limit, so it RAISES identically on replay.
+                    _emit_error(
+                        emit,
+                        f"parallel() fan-out of {len(yielded.branches)} exceeds the "
+                        f"{MAX_PARALLEL_FANOUT} cap",
+                        kind="too_wide_fanout",
+                    )
+                    return
                 join = _Join(branch, len(yielded.branches))
                 branch.blocked = True  # unblocks when its children all finish
                 # Children's paths are deterministic — "{parent}{kth_parallel}.{i}/"

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -17,8 +17,9 @@ interpreter that never imports them, even a full sandbox escape in author code
 reaches only this credential-free process. ``SAFE_BUILTINS`` and the absence of
 ``__import__`` are determinism/footgun aids, **not** the security boundary.
 
-Block 1: ``gate()`` is a real capability; ``agent()`` emits a frontier the parent
-rejects (Block 2); ``parallel()``/``pipeline()`` raise (Block 2).
+``gate()`` and ``agent()`` are real capabilities (for ``agent()`` the parent spawns
+a child session and harvests its completion marker); ``parallel()``/``pipeline()``
+still raise until Block 2.G.
 """
 
 from __future__ import annotations
@@ -76,8 +77,18 @@ def gate(spec: Any = None) -> _Capability:
     return _Capability("gate", spec)
 
 
-def agent(agent_id: str, input: Any = None, output_schema: Any = None) -> _Capability:
-    """Invoke an agent: the parent spawns a child session and awaits its result."""
+def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
+    """Invoke an agent: spawn a child session with ``input`` as its first user
+    message and await its ``return``/``error`` result.
+
+    ``input`` is **required and must not be None** — the child needs a real first
+    message to act on (a child born with no user message would sit idle forever and
+    poison the totality backstop). Pass a ``str`` (delivered verbatim) or any
+    JSON-serialisable value (delivered as canonical JSON). The error surfaces as a
+    normal exception in the author's script, so a bad call fails the run loudly.
+    """
+    if input is None:
+        raise ValueError("agent() requires a non-None input (the child's first message)")
     return _Capability(
         "agent", {"agent_id": agent_id, "input": input, "output_schema": output_schema}
     )

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -95,11 +95,13 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
 
 
 def parallel(_thunks: Any) -> Any:
-    raise NotImplementedError("parallel() lands in Block 2")
+    # Message is run-visible (folded into the run's errored output), so it carries
+    # no dev-world block label — only a stable runtime concept the author can act on.
+    raise NotImplementedError("parallel() is not supported yet")
 
 
 def pipeline(_items: Any, *_stages: Any) -> Any:
-    raise NotImplementedError("pipeline() lands in Block 2")
+    raise NotImplementedError("pipeline() is not supported yet")
 
 
 def log(*args: Any) -> None:

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -80,6 +80,18 @@ async def test_agent_emits_a_frontier_for_block2() -> None:
     assert out.emitted[0].capability_id == "agent"
 
 
+async def test_agent_requires_non_none_input() -> None:
+    # input is required: a child born with no first user message would sit idle
+    # forever. A bad call raises in the author's script → terminal RAISED.
+    missing = await _run("async def main(input):\n    return await agent('a1')")
+    assert missing.kind == "raised"
+    assert "input" in (missing.error_repr or "")  # TypeError: missing required 'input'
+
+    explicit_none = await _run("async def main(input):\n    return await agent('a1', None)")
+    assert explicit_none.kind == "raised"
+    assert "non-None input" in (explicit_none.error_repr or "")
+
+
 async def test_bad_capability_input_is_raised() -> None:
     out = await _run(
         "async def main(input):\n    return await gate({'t': 1.5})"

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -160,6 +160,173 @@ async def test_missing_main_is_raised() -> None:
     assert "main(input)" in (out.error_repr or "")
 
 
+# ─── parallel / pipeline (B2.G — the concurrent scheduler) ───────────────────
+
+_PARALLEL_SRC = (
+    "async def main(input):\n"
+    "    return await parallel([lambda: agent('a', '1'), lambda: agent('b', '2')])"
+)
+
+
+async def test_parallel_emits_all_branches_as_one_frontier() -> None:
+    """parallel fans its branches out as a single frontier — all children at once,
+    not one at a time."""
+    out = await _run(_PARALLEL_SRC)
+    assert out.kind == "suspended"
+    assert len(out.emitted) == 2
+    assert {e.capability_id for e in out.emitted} == {"agent"}
+    assert len({e.call_key for e in out.emitted}) == 2  # distinct keys
+
+
+async def test_parallel_collects_results_in_order() -> None:
+    """With every branch memoized, parallel fast-forwards to a results list in
+    thunk order."""
+    first = await _run(_PARALLEL_SRC)
+    k0, k1 = (e.call_key for e in first.emitted)
+    out = await _run(_PARALLEL_SRC, memo={k0: {"ok": "r1"}, k1: {"ok": "r2"}})
+    assert out.kind == "returned"
+    assert out.value == ["r1", "r2"]
+
+
+async def test_parallel_barrier_is_none_on_error() -> None:
+    """A branch whose agent errored (and which doesn't catch it) yields None in its
+    slot; the barrier itself still returns."""
+    first = await _run(_PARALLEL_SRC)
+    k0, k1 = (e.call_key for e in first.emitted)
+    out = await _run(
+        _PARALLEL_SRC, memo={k0: {"ok": "r1"}, k1: {"error": {"kind": "child_errored"}}}
+    )
+    assert out.kind == "returned"
+    assert out.value == ["r1", None]
+
+
+async def test_parallel_branch_can_catch_agent_error() -> None:
+    """The AgentError is thrown into the right branch's coroutine, so a branch can
+    try/except it and substitute its own value."""
+    src = (
+        "async def main(input):\n"
+        "    async def safe():\n"
+        "        try:\n"
+        "            return await agent('a', '1')\n"
+        "        except AgentError:\n"
+        "            return 'fallback'\n"
+        "    return await parallel([safe, lambda: agent('b', '2')])"
+    )
+    first = await _run(src)
+    k0, k1 = (e.call_key for e in first.emitted)
+    out = await _run(src, memo={k0: {"error": {"kind": "child_errored"}}, k1: {"ok": "r2"}})
+    assert out.kind == "returned"
+    assert out.value == ["fallback", "r2"]
+
+
+async def test_parallel_non_agent_error_fails_the_run() -> None:
+    """Fail-hard: the barrier absorbs ONLY an agent failure (AgentError). Any OTHER
+    exception out of a branch — an author bug — fails the WHOLE run loudly, never a
+    silent None slot. This is the barrier's most load-bearing property."""
+    src = (
+        "async def main(input):\n"
+        "    async def boom():\n"
+        "        raise ValueError('author bug in a branch')\n"
+        "    return await parallel([boom, lambda: agent('b', '2')])"
+    )
+    out = await _run(src)
+    assert out.kind == "raised"
+    assert out.error_repr is not None
+    assert "ValueError" in out.error_repr
+    assert "author bug in a branch" in out.error_repr
+
+
+async def test_parallel_absorbs_author_raised_agent_error() -> None:
+    """AgentError is the agent-failure signal, matched by type: a branch that lets an
+    AgentError escape — even one the author raised directly, not from an agent() —
+    becomes a None slot, exactly like an agent() that errored. (Counterpart to
+    test_parallel_non_agent_error_fails_the_run: AgentError → None, anything else →
+    fail-hard.)"""
+    src = (
+        "async def main(input):\n"
+        "    async def manual():\n"
+        "        raise AgentError('treat as a failed agent')\n"
+        "    return await parallel([manual, lambda: agent('b', '2')])"
+    )
+    first = await _run(src)
+    assert first.kind == "suspended"
+    key = next(e.call_key for e in first.emitted if e.capability_id == "agent")
+    out = await _run(src, memo={key: {"ok": "rb"}})
+    assert out.kind == "returned"
+    assert out.value == [None, "rb"]
+
+
+async def test_empty_parallel_returns_empty_list() -> None:
+    out = await _run("async def main(input):\n    return await parallel([])")
+    assert out.kind == "returned"
+    assert out.value == []
+
+
+async def test_pipeline_runs_each_item_through_stages() -> None:
+    """pipeline threads each item through stages (a sync transform then an agent
+    leaf) independently; all items fan out at once."""
+    src = (
+        "async def main(input):\n"
+        "    return await pipeline([1, 10], lambda x: x + 1, lambda x: agent('s', x))"
+    )
+    first = await _run(src)
+    assert first.kind == "suspended"
+    assert len(first.emitted) == 2  # one agent leaf per item, post sync stage
+    k0, k1 = (e.call_key for e in first.emitted)
+    out = await _run(src, memo={k0: {"ok": "a"}, k1: {"ok": "b"}})
+    assert out.kind == "returned"
+    assert out.value == ["a", "b"]
+
+
+async def test_parallel_call_keys_are_replay_stable() -> None:
+    """The scheduler's fixed creation-order sweep makes the per-branch call_keys
+    identical across drives — the basis of replay-with-memo for parallel."""
+    first = await _run(_PARALLEL_SRC)
+    second = await _run(_PARALLEL_SRC)
+    assert [e.call_key for e in first.emitted] == [e.call_key for e in second.emitted]
+
+
+async def test_parallel_keys_are_branch_local_under_asymmetric_depth() -> None:
+    """Determinism regression: two branches share a content hash but have different
+    prerequisite depth (b0 awaits a gate first, b1 calls the agent directly). Keys
+    are branch-LOCAL (prefixed by the branch path), so a partial-memo replay where
+    b0 fast-forwards its gate and reaches the shared agent never steals b1's key —
+    each branch keeps its own child, no result swap. (A global emission-order keyer
+    would swap ordinals here.)"""
+    src = (
+        "async def main(input):\n"
+        "    async def b0():\n"
+        "        await gate('g')\n"
+        "        return await agent('p', 'x')\n"
+        "    async def b1():\n"
+        "        return await agent('p', 'x')\n"
+        "    return await parallel([b0, b1])"
+    )
+    # Drive 1 (empty memo): b0 blocks on its gate; b1 emits the shared agent.
+    first = await _run(src)
+    assert first.kind == "suspended"
+    gate_key = next(e.call_key for e in first.emitted if e.capability_id == "gate")
+    b1_agent_key = next(e.call_key for e in first.emitted if e.capability_id == "agent")
+
+    # Drive 2 (gate resolved, b1's agent answered): b0 fast-forwards its gate and
+    # reaches the shared agent — under its OWN branch path, a key distinct from b1's.
+    second = await _run(src, memo={gate_key: {"ok": "g"}, b1_agent_key: {"ok": "rb1"}})
+    assert second.kind == "suspended"
+    new_keys = [e.call_key for e in second.emitted]
+    assert b1_agent_key not in new_keys  # b1's key stayed memoized, not re-stolen
+    assert len(new_keys) == 1  # only b0's own agent key
+    b0_agent_key = new_keys[0]
+    assert b0_agent_key != b1_agent_key  # branch-local — no ordinal swap
+
+    # Drive 3: resolve b0's agent too → results correctly bound to their branches.
+    out = await _run(
+        src,
+        memo={gate_key: {"ok": "g"}, b1_agent_key: {"ok": "rb1"}, b0_agent_key: {"ok": "rb0"}},
+    )
+    assert out.kind == "returned"
+    assert out.value == ["rb0", "rb1"]
+
+
 # ─── isolation (B1.1 — security-critical) ────────────────────────────────────
 
 

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 
 from aios.workflows.host_launcher import HostOutcome, run_script_host
+from aios.workflows.wf_script_host import MAX_PARALLEL_FANOUT
 
 
 async def _run(
@@ -260,6 +261,36 @@ async def test_empty_parallel_returns_empty_list() -> None:
     out = await _run("async def main(input):\n    return await parallel([])")
     assert out.kind == "returned"
     assert out.value == []
+
+
+async def test_parallel_fanout_over_cap_raises_before_spawning() -> None:
+    """A single parallel() wider than MAX_PARALLEL_FANOUT fails the run in the host —
+    deterministically, before any child capability is emitted (none to spawn). The
+    lifetime total across calls is bounded separately, parent-side."""
+    n = MAX_PARALLEL_FANOUT + 1
+    src = (
+        "async def main(input):\n"
+        f"    return await parallel([(lambda: agent('a', 'x')) for _ in range({n})])"
+    )
+    out = await _run(src)
+    assert out.kind == "raised"
+    assert out.error_kind == "too_wide_fanout"  # a distinct, machine-parseable kind
+    assert out.error_repr is not None
+    assert "fan-out" in out.error_repr and str(n) in out.error_repr
+    assert out.emitted == []  # nothing to spawn — failed before opening the frontier
+
+
+async def test_parallel_fanout_at_cap_is_allowed() -> None:
+    """Exactly MAX_PARALLEL_FANOUT branches is within the cap: the run suspends on the
+    full frontier rather than raising (the boundary is strict ``>``)."""
+    n = MAX_PARALLEL_FANOUT
+    src = (
+        "async def main(input):\n"
+        f"    return await parallel([(lambda: agent('a', str(i))) for i in range({n})])"
+    )
+    out = await _run(src)
+    assert out.kind == "suspended"
+    assert len(out.emitted) == n
 
 
 async def test_pipeline_runs_each_item_through_stages() -> None:

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -48,11 +48,65 @@ async def test_memoized_result_fast_forwards() -> None:
     src = "async def main(input):\n    r = await gate({'q': 'ok?'})\n    return {'answer': r}"
     first = await _run(src)
     key = first.emitted[0].call_key
-    # Replay with the gate resolved → fast-forward past it to completion.
-    second = await _run(src, memo={key: "yes"})
+    # Replay with the gate resolved → fast-forward past it. The memo entry is the
+    # tagged outcome {"ok": value}; the driver unwraps it into the await (R3).
+    second = await _run(src, memo={key: {"ok": "yes"}})
     assert second.kind == "returned"
     assert second.value == {"answer": "yes"}
     assert second.emitted == []
+
+
+async def test_memoized_error_outcome_throws_agent_error() -> None:
+    """An {"error"} memo outcome is thrown at the await as AgentError; uncaught, it
+    propagates out of main and terminates the run (the bubble)."""
+    src = "async def main(input):\n    return await agent('a1', 'go')"
+    first = await _run(src)
+    key = first.emitted[0].call_key
+    out = await _run(src, memo={key: {"error": {"message": "boom"}}})
+    assert out.kind == "raised"
+    assert "AgentError: boom" in (out.error_repr or "")
+
+
+async def test_memoized_error_outcome_is_catchable() -> None:
+    """The headline: the author can try/except AgentError and carry on. `kind`
+    surfaces the failure mode (here a model failure)."""
+    src = (
+        "async def main(input):\n"
+        "    try:\n"
+        "        await agent('a1', 'go')\n"
+        "    except AgentError as e:\n"
+        "        return {'caught': True, 'kind': e.kind}\n"
+        "    return {'caught': False}"
+    )
+    first = await _run(src)
+    key = first.emitted[0].call_key
+    out = await _run(src, memo={key: {"error": {"kind": "child_errored"}}})
+    assert out.kind == "returned"
+    assert out.value == {"caught": True, "kind": "child_errored"}
+
+
+async def test_no_return_outcome_raises_agent_no_return_subtype() -> None:
+    """A no_return outcome raises AgentNoReturnError — caught by a blanket
+    `except AgentError` (it is a subtype) and directly as the subtype."""
+    catch_base = (
+        "async def main(input):\n"
+        "    try:\n"
+        "        await agent('a1', 'go')\n"
+        "    except AgentError as e:\n"
+        "        return isinstance(e, AgentNoReturnError)"
+    )
+    first = await _run(catch_base)
+    key = first.emitted[0].call_key
+    out = await _run(catch_base, memo={key: {"error": {"kind": "no_return"}}})
+    assert out.kind == "returned"
+    assert out.value is True  # caught as AgentError, and it IS the no-return subtype
+
+    catch_subtype = catch_base.replace("except AgentError as e", "except AgentNoReturnError")
+    catch_subtype = catch_subtype.replace(
+        "return isinstance(e, AgentNoReturnError)", "return 'caught-subtype'"
+    )
+    out2 = await _run(catch_subtype, memo={key: {"error": {"kind": "no_return"}}})
+    assert out2.kind == "returned" and out2.value == "caught-subtype"
 
 
 async def test_suspend_does_not_run_post_await_body() -> None:

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -20,12 +20,16 @@ from aios.errors import ConflictError
 async def wf_conn(
     migrated_db_url: str, _reset_db_state: None
 ) -> AsyncIterator[asyncpg.Connection[Any]]:
-    """A conn with a single root tenant ``acc_root`` (workflows FK ``accounts``)."""
+    """A conn with a single root tenant ``acc_root`` + env ``env_root``."""
     conn = await asyncpg.connect(migrated_db_url)
     try:
         await conn.execute(
             "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
             "VALUES ('acc_root', NULL, TRUE, 'tenant-root')"
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, name, config, account_id) "
+            "VALUES ('env_root', 'wf-env', '{}'::jsonb, 'acc_root')"
         )
         yield conn
     finally:
@@ -40,6 +44,7 @@ async def _seed_run(conn: asyncpg.Connection[Any]) -> str:
         conn,
         account_id="acc_root",
         workflow_id=wf.id,
+        environment_id="env_root",
         script=wf.script,
         script_sha="deadbeef",
     )
@@ -72,10 +77,16 @@ async def test_insert_run_snapshots_script(wf_conn: asyncpg.Connection[Any]) -> 
         wf_conn, account_id="acc_root", name="demo", script="SRC-V1"
     )
     run = await wf_queries.insert_wf_run(
-        wf_conn, account_id="acc_root", workflow_id=wf.id, script=wf.script, script_sha="sha-v1"
+        wf_conn,
+        account_id="acc_root",
+        workflow_id=wf.id,
+        environment_id="env_root",
+        script=wf.script,
+        script_sha="sha-v1",
     )
     assert run.id.startswith("wfr_")
     assert run.status == "pending"
+    assert run.environment_id == "env_root"
     assert run.script == "SRC-V1"
     assert run.script_sha == "sha-v1"
     assert run.last_event_seq == 0

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -101,6 +101,23 @@ async def wf_agent_id(wf_runtime: asyncpg.Pool[Any]) -> str:
     return agent.id
 
 
+async def _spawn_child(pool: asyncpg.Pool[Any], agent_id: str, ordinal: str) -> tuple[str, str]:
+    """Make a run + idempotently spawn one child for ``ordinal``; return (run_id, cid)."""
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    cid = child_session_id(run_id, ordinal)
+    await sessions_service.create_child_session(
+        pool,
+        session_id=cid,
+        account_id="acc_wf",
+        agent_id=agent_id,
+        environment_id="env_wf",
+        agent_version=1,
+        parent_run_id=run_id,
+        input="hi",
+    )
+    return run_id, cid
+
+
 # ─── B2.B — child create (idempotent) + session read-model ───────────────────
 
 
@@ -148,18 +165,7 @@ async def test_child_session_origin_and_parent_round_trip(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     pool = wf_runtime
-    run_id = await _make_run(pool, "async def main(input):\n    return 1")
-    cid = child_session_id(run_id, "sha:y#0")
-    await sessions_service.create_child_session(
-        pool,
-        session_id=cid,
-        account_id="acc_wf",
-        agent_id=wf_agent_id,
-        environment_id="env_wf",
-        agent_version=1,
-        parent_run_id=run_id,
-        input="hi",
-    )
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:y#0")
     child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
     assert child.origin == "background"
     assert child.parent_run_id == run_id
@@ -311,22 +317,6 @@ async def test_agent_not_found_errors_the_run(wf_runtime: asyncpg.Pool[Any]) -> 
 
 
 # ─── B2.D — return()/error() completion tools + injection gate ────────────────
-
-
-async def _spawn_child(pool: asyncpg.Pool[Any], agent_id: str, ordinal: str) -> tuple[str, str]:
-    run_id = await _make_run(pool, "async def main(input):\n    return 1")
-    cid = child_session_id(run_id, ordinal)
-    await sessions_service.create_child_session(
-        pool,
-        session_id=cid,
-        account_id="acc_wf",
-        agent_id=agent_id,
-        environment_id="env_wf",
-        agent_version=1,
-        parent_run_id=run_id,
-        input="hi",
-    )
-    return run_id, cid
 
 
 async def test_completion_tools_injected_only_for_children(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -447,6 +447,82 @@ async def test_return_from_non_child_fails_closed(
     assert marker is None
 
 
+# ─── B2.E — harvest the child marker (spawn -> return -> complete) ────────────
+
+
+async def _child_id_of(pool: asyncpg.Pool[Any], run_id: str) -> str:
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+    return next(e.payload["child_session_id"] for e in events if e.type == "call_started")
+
+
+async def test_agent_round_trip_harvest_completes_run(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    child_id = await _child_id_of(pool, run_id)
+
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(child_id, {"value": "child-result"})
+
+    await run_workflow_step(run_id)  # harvest marker -> call_result -> replay -> complete
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "completed" and run.output == "done"
+    assert [e.type for e in events] == [
+        "run_started",
+        "call_started",
+        "call_result",
+        "run_completed",
+    ]
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["is_error"] is False and cr.payload["result"] == "child-result"
+
+
+async def test_agent_error_surfaces_in_call_result(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    child_id = await _child_id_of(pool, run_id)
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.error_handler(child_id, {"message": "boom"})
+
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["is_error"] is True and cr.payload["error"] == {"message": "boom"}
+    # an errored child does NOT auto-raise — the run continues (§3.7).
+    assert run is not None and run.status == "completed" and run.output == "done"
+
+
+async def test_agent_stays_suspended_until_marker(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    await run_workflow_step(run_id)  # marker absent -> stays suspended, no call_result
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "suspended"
+    assert not any(e.type == "call_result" for e in events)
+
+
 # ─── crash-safety + divergence (B1.6 + B1.7) ─────────────────────────────────
 
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1047,6 +1047,78 @@ async def test_operator_deleted_child_resolves_run_as_child_gone(
     assert run is not None and run.status == "completed" and run.output == "child_gone"
 
 
+# ─── G — parallel() spawns a child fan-out and collects results ───────────────
+
+
+async def _children_of(pool: asyncpg.Pool[Any], run_id: str) -> list[str]:
+    """All agent children a run has spawned, in call_started (emission) order."""
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+    return [e.payload["child_session_id"] for e in events if e.type == "call_started"]
+
+
+async def test_parallel_spawns_fanout_and_collects_results_in_order(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """parallel() over two agent() calls spawns BOTH children in one step (a single
+    frontier), then a later step harvests both and the run completes with the
+    results in thunk order."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        f"    return await parallel([lambda: agent({wf_agent_id!r}, 'a'),"
+        f" lambda: agent({wf_agent_id!r}, 'b')])\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # drive parallel -> spawn both children + suspend
+    children = await _children_of(pool, run_id)
+    assert len(children) == 2  # fanned out at once
+
+    for cid, value in zip(children, ["ra", "rb"], strict=True):
+        rid = await _open_request_id(pool, cid)
+        with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+            await workflow_completion.return_handler(cid, {"request_id": rid, "value": value})
+
+    await run_workflow_step(run_id)  # harvest both -> replay past parallel -> complete
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == ["ra", "rb"]  # branch order preserved
+
+
+async def test_parallel_barrier_yields_none_for_an_errored_child(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """An errored branch (uncaught) contributes None to the results list; the other
+    branch's value is unaffected and the run completes."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        f"    return await parallel([lambda: agent({wf_agent_id!r}, 'a'),"
+        f" lambda: agent({wf_agent_id!r}, 'b')])\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    children = await _children_of(pool, run_id)
+    rid0 = await _open_request_id(pool, children[0])
+    rid1 = await _open_request_id(pool, children[1])
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(children[0], {"request_id": rid0, "value": "ok"})
+        await workflow_completion.error_handler(
+            children[1], {"request_id": rid1, "message": "nope"}
+        )
+
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == ["ok", None]  # the errored branch → None, barrier still returns
+
+
 async def test_agent_stays_suspended_until_marker(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1119,6 +1119,265 @@ async def test_parallel_barrier_yields_none_for_an_errored_child(
     assert run.output == ["ok", None]  # the errored branch → None, barrier still returns
 
 
+# ─── H — runaway caps + the per-call wall-clock deadline ──────────────────────
+
+
+async def test_lifetime_agent_cap_errors_atomically_before_spawning(
+    monkeypatch: pytest.MonkeyPatch, wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A fan-out that would push the run past its lifetime agent-call cap errors
+    BEFORE spawning any of that step's children — no partial fan-out of orphans."""
+    from aios.config import get_settings
+
+    capped = get_settings().model_copy(update={"workflow_max_agent_calls": 2})
+    monkeypatch.setattr("aios.workflows.step.get_settings", lambda: capped)
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(3)])\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # 3 > cap 2 → error, nothing spawned
+
+    assert await _children_of(pool, run_id) == []  # no call_started journaled
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+        # the invariant at its real surface: no child session rows exist for the run
+        orphans = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert orphans == 0  # atomic: no partial fan-out of orphan children
+    assert run is not None and run.status == "errored"
+    assert events[-1].type == "run_completed"
+    assert events[-1].payload["error"]["kind"] == "too_many_agents"
+    assert "2-agent call cap" in events[-1].payload["output"]
+
+
+async def test_agent_cap_at_boundary_is_allowed(
+    monkeypatch: pytest.MonkeyPatch, wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """Exactly at the cap is allowed: a fan-out of N with cap N spawns all N children
+    and suspends (the boundary is strict ``>``, mirroring H2's at-cap host test)."""
+    from aios.config import get_settings
+
+    capped = get_settings().model_copy(update={"workflow_max_agent_calls": 3})
+    monkeypatch.setattr("aios.workflows.step.get_settings", lambda: capped)
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(3)])\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # 3 == cap 3 → allowed
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "suspended"
+    assert len(await _children_of(pool, run_id)) == 3  # all spawned
+
+
+async def test_lowering_cap_mid_flight_does_not_kill_a_harvest_only_step(
+    monkeypatch: pytest.MonkeyPatch, wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """H1 gates NEW spawns only: a harvest-only re-suspend (no new agents) must never
+    error, even after the cap is lowered below the already-spawned count — otherwise a
+    config reduction would retroactively kill in-flight runs and orphan their
+    children."""
+    from aios.config import get_settings
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(2)])\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn 2 under the default (high) cap
+    children = await _children_of(pool, run_id)
+    assert len(children) == 2
+
+    # Now lower the cap below the 2 already-spawned, and resolve only one child so the
+    # next step is harvest-only (the other stays inflight → zero new agent caps).
+    capped = get_settings().model_copy(update={"workflow_max_agent_calls": 1})
+    monkeypatch.setattr("aios.workflows.step.get_settings", lambda: capped)
+    rid0 = await _open_request_id(pool, children[0])
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(children[0], {"request_id": rid0, "value": "r0"})
+
+    await run_workflow_step(run_id)  # harvest child0; child1 inflight; new_agent_caps == []
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "suspended"  # NOT errored — no new spawns
+
+
+async def test_agent_call_times_out_when_child_never_responds(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A child that never responds past its wall-clock deadline resolves the agent()
+    call as a catchable AgentError(timeout) — totality even for a child that never
+    goes idle (so the quiescence nudge never fires). The child is NOT terminated:
+    the timeout writes a response, it doesn't end the target (responding ≠ ending)."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentError as e:\n"
+        "        return {'timed_out': e.kind}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    child_id = await _child_id_of(pool, run_id)
+    rid = await _open_request_id(pool, child_id)
+
+    # Age the call_started past the (default 1h) deadline — deterministic, no sleep.
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_run_events SET created_at = created_at - interval '2 hours' "
+            "WHERE run_id = $1 AND type = 'call_started'",
+            run_id,
+        )
+
+    await run_workflow_step(run_id)  # harvest: past deadline → timeout response → resolve
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        resp = await db_queries.read_request_response(
+            conn, child_id, account_id="acc_wf", request_id=rid
+        )
+        child = await db_queries.get_session_bare(conn, child_id, account_id="acc_wf")
+    assert run is not None and run.status == "completed"
+    assert run.output == {"timed_out": "timeout"}
+    assert resp is not None and resp["is_error"] is True and resp["error"] == {"kind": "timeout"}
+    assert child.archived_at is None  # left running — responding ≠ terminating
+
+
+async def test_past_deadline_child_that_already_responded_keeps_its_real_response(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A child that answered before the deadline harvest keeps its real value: the
+    harvest's first derive_response is non-None, so the timeout branch is never
+    entered and no clobbering timeout is written (the deadline never overrides an
+    existing response)."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentError as e:\n"
+        "        return {'timed_out': e.kind}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    child_id = await _child_id_of(pool, run_id)
+    rid = await _open_request_id(pool, child_id)
+
+    # The child answers for real, THEN we also age the call past the deadline.
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(child_id, {"request_id": rid, "value": "real"})
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_run_events SET created_at = created_at - interval '2 hours' "
+            "WHERE run_id = $1 AND type = 'call_started'",
+            run_id,
+        )
+
+    await run_workflow_step(run_id)  # derive_response already non-None → no timeout written
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        resp = await db_queries.read_request_response(
+            conn, child_id, account_id="acc_wf", request_id=rid
+        )
+    assert run is not None and run.status == "completed" and run.output == "real"
+    assert resp is not None and resp["is_error"] is False and resp["result"] == "real"
+
+
+async def test_past_deadline_gone_child_resolves_as_child_gone_not_timeout(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A child that is BOTH archived AND past its deadline resolves as child_gone, not
+    timeout: derive_response folds in liveness, so a gone child returns non-None
+    before the deadline branch — and even a child archived in the derive→write window
+    surfaces as child_gone (write_response_if_absent's NotFoundError is absorbed, no
+    crash)."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentError as e:\n"
+        "        return {'kind': e.kind}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    child_id = await _child_id_of(pool, run_id)
+
+    # Archive the child (it never answered) AND age the call past the deadline.
+    async with pool.acquire() as conn:
+        await db_queries.archive_session(conn, child_id, account_id="acc_wf")
+        await conn.execute(
+            "UPDATE wf_run_events SET created_at = created_at - interval '2 hours' "
+            "WHERE run_id = $1 AND type = 'call_started'",
+            run_id,
+        )
+
+    await run_workflow_step(run_id)  # gone wins over the deadline — no timeout, no crash
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == {"kind": "child_gone"}
+
+
+async def test_child_archived_in_timeout_write_window_resolves_as_child_gone(
+    monkeypatch: pytest.MonkeyPatch, wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The narrow TOCTOU the H3 timeout guards against: a child live at the harvest's
+    derive (None) but archived before the timeout write. write_response_if_absent
+    raises NotFoundError against the gone row; the helper absorbs it and the re-derive
+    resolves the call as child_gone — never a step crash."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentError as e:\n"
+        "        return {'kind': e.kind}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn the child
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_run_events SET created_at = created_at - interval '2 hours' "
+            "WHERE run_id = $1 AND type = 'call_started'",
+            run_id,
+        )
+
+    # Inject the race: the first derive observes the child live (returns None) but
+    # archives it in the same breath, so the subsequent timeout write hits a gone row.
+    real_derive = db_queries.derive_response
+    calls = {"n": 0}
+
+    async def racing_derive(conn: Any, sid: str, *, account_id: str, request_id: str) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            await db_queries.archive_session(conn, sid, account_id=account_id)
+            return None  # "live at the snapshot" — but now archived under us
+        return await real_derive(conn, sid, account_id=account_id, request_id=request_id)
+
+    monkeypatch.setattr(db_queries, "derive_response", racing_derive)
+    await run_workflow_step(run_id)  # must NOT crash on the gone-row write
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == {"kind": "child_gone"}  # resolved gracefully, no crash
+
+
 async def test_agent_stays_suspended_until_marker(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -391,13 +391,12 @@ async def _check_completion_injection(
     assert "return" not in fg_tools and "error" not in fg_tools
 
 
-async def test_return_writes_marker_and_wakes_parent_without_archiving(
+async def test_return_writes_response_and_wakes_caller_without_archiving(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
-    """Two-phase termination: the handler writes the marker + wakes the parent but
-    does NOT archive. Archive must be a session's last write, yet this handler runs
-    mid tool-lifecycle (the tool_result append follows); physical reap is the
-    in-worker reaper's job once the child is quiescent."""
+    """return() writes the request's response + wakes the caller, but does NOT
+    archive the child — responding is not terminating. Reclamation is run-end
+    (off the correctness path), so right after responding the child is unarchived."""
     from aios.tools import workflow_completion
 
     pool = wf_runtime
@@ -408,11 +407,11 @@ async def test_return_writes_marker_and_wakes_parent_without_archiving(
     wake.assert_awaited_once_with(run_id)
 
     async with pool.acquire() as conn:
-        marker = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
-    assert marker is not None
-    assert marker["is_error"] is False and marker["result"] == {"answer": 42}
+        response = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
+    assert response is not None
+    assert response["is_error"] is False and response["result"] == {"answer": 42}
     child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
-    assert child.archived_at is None  # NOT archived by the handler — the reaper does that
+    assert child.archived_at is None  # NOT archived by the handler — run-end reclaim does that
 
 
 async def test_error_marker_carries_message(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock
 import asyncpg
 import pytest
 
+from aios.db import queries as db_queries
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.harness import runtime
@@ -307,6 +308,143 @@ async def test_agent_not_found_errors_the_run(wf_runtime: asyncpg.Pool[Any]) -> 
     assert run is not None and run.status == "errored"
     assert events[-1].type == "run_completed"
     assert events[-1].payload["error"]["kind"] == "agent_not_found"
+
+
+# ─── B2.D — return()/error() completion tools + injection gate ────────────────
+
+
+async def _spawn_child(pool: asyncpg.Pool[Any], agent_id: str, ordinal: str) -> tuple[str, str]:
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    cid = child_session_id(run_id, ordinal)
+    await sessions_service.create_child_session(
+        pool,
+        session_id=cid,
+        account_id="acc_wf",
+        agent_id=agent_id,
+        environment_id="env_wf",
+        agent_version=1,
+        parent_run_id=run_id,
+        input="hi",
+    )
+    return run_id, cid
+
+
+async def test_completion_tools_injected_only_for_children(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    from aios.harness.step_context import compute_step_prelude
+
+    pool = wf_runtime
+    # compute_step_prelude asks the tool provider for connection tools; stub it.
+    prev_tp = runtime.tool_provider
+    tp = mock.Mock()
+    tp.list_tools_for_session = AsyncMock(return_value=[])
+    runtime.tool_provider = tp
+    try:
+        await _check_completion_injection(pool, wf_agent_id, compute_step_prelude)
+    finally:
+        runtime.tool_provider = prev_tp
+
+
+async def _check_completion_injection(
+    pool: asyncpg.Pool[Any], wf_agent_id: str, compute_step_prelude: Any
+) -> None:
+    _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:d1#0")
+    child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
+    child_agent = await agents_service.load_for_session(pool, child, account_id="acc_wf")
+    child_prelude = await compute_step_prelude(
+        pool,
+        cid,
+        account_id="acc_wf",
+        session=child,
+        agent=child_agent,
+        channels=[],
+        memory_store_echoes=[],
+    )
+    child_tools = {t["function"]["name"] for t in child_prelude.tools}
+    assert {"return", "error"} <= child_tools
+
+    fg = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )
+    fg_session = await sessions_service.get_session_basic(pool, fg.id, account_id="acc_wf")
+    fg_agent = await agents_service.load_for_session(pool, fg_session, account_id="acc_wf")
+    fg_prelude = await compute_step_prelude(
+        pool,
+        fg.id,
+        account_id="acc_wf",
+        session=fg_session,
+        agent=fg_agent,
+        channels=[],
+        memory_store_echoes=[],
+    )
+    fg_tools = {t["function"]["name"] for t in fg_prelude.tools}
+    assert "return" not in fg_tools and "error" not in fg_tools
+
+
+async def test_return_writes_marker_archives_and_wakes_parent(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:d2#0")
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
+        res = await workflow_completion.return_handler(cid, {"value": {"answer": 42}})
+    assert res == {"status": "returned"}
+    wake.assert_awaited_once_with(run_id)
+
+    async with pool.acquire() as conn:
+        marker = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
+    assert marker is not None
+    assert marker["is_error"] is False and marker["result"] == {"answer": 42}
+    child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
+    assert child.archived_at is not None  # self-archived — genuinely terminal
+
+
+async def test_error_marker_carries_message(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:d2e#0")
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        res = await workflow_completion.error_handler(cid, {"message": "nope"})
+    assert res == {"status": "errored"}
+    async with pool.acquire() as conn:
+        marker = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
+    assert marker is not None and marker["is_error"] is True
+    assert marker["error"] == {"message": "nope"}
+
+
+async def test_return_from_non_child_fails_closed(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    from aios.tools import workflow_completion
+    from aios.tools.registry import ToolResult
+
+    pool = wf_runtime
+    fg = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
+        res = await workflow_completion.return_handler(fg.id, {"value": 1})
+    assert isinstance(res, ToolResult) and res.is_error
+    wake.assert_not_awaited()  # never signal a NULL parent run
+    async with pool.acquire() as conn:
+        marker = await db_queries.read_workflow_child_done(conn, fg.id, account_id="acc_wf")
+    assert marker is None
 
 
 # ─── crash-safety + divergence (B1.6 + B1.7) ─────────────────────────────────

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -113,6 +113,7 @@ async def _spawn_child(pool: asyncpg.Pool[Any], agent_id: str, ordinal: str) -> 
         environment_id="env_wf",
         agent_version=1,
         parent_run_id=run_id,
+        request_id=ordinal,
         input="hi",
     )
     return run_id, cid
@@ -136,10 +137,11 @@ async def test_create_child_session_idempotent(
         environment_id="env_wf",
         agent_version=1,
         parent_run_id=run_id,
+        request_id="sha:x#0",
         input={"q": "hi"},
     )
     assert created is True
-    # A replay (same id) is a rowcount-0 no-op — no double row, no double input.
+    # A replay (same id) is a rowcount-0 no-op — no double row, no double request.
     again = await sessions_service.create_child_session(
         pool,
         session_id=cid,
@@ -148,6 +150,7 @@ async def test_create_child_session_idempotent(
         environment_id="env_wf",
         agent_version=1,
         parent_run_id=run_id,
+        request_id="sha:x#0",
         input={"q": "hi"},
     )
     assert again is False
@@ -158,7 +161,18 @@ async def test_create_child_session_idempotent(
             cid,
             "acc_wf",
         )
-    assert user_msgs == 1  # input delivered exactly once
+        # The request is delivered exactly once, carrying its correlation metadata.
+        req = await conn.fetchrow(
+            "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'message' AND role = 'user' ORDER BY seq ASC LIMIT 1",
+            cid,
+            "acc_wf",
+        )
+    assert user_msgs == 1
+    from aios.db.queries import parse_jsonb
+
+    request = parse_jsonb(req["data"])["metadata"]["request"]
+    assert request["request_id"] == "sha:x#0" and request["caller"] == {"kind": "run", "id": run_id}
 
 
 async def test_child_session_origin_and_parent_round_trip(
@@ -439,6 +453,34 @@ async def test_return_from_non_child_fails_closed(
     async with pool.acquire() as conn:
         marker = await db_queries.read_workflow_child_done(conn, fg.id, account_id="acc_wf")
     assert marker is None
+
+
+async def test_request_is_answered_exactly_once(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A child that responds twice (return then return, or return racing error)
+    yields exactly ONE response — first-writer-wins — and wakes the caller once."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:once#0")
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
+        r1 = await workflow_completion.return_handler(cid, {"value": "first"})
+        r2 = await workflow_completion.error_handler(cid, {"message": "too late"})
+    assert r1 == {"status": "returned"} and r2 == {"status": "errored"}
+    wake.assert_awaited_once_with(run_id)  # only the first response woke the caller
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done'",
+            cid,
+            "acc_wf",
+        )
+    assert len(rows) == 1  # exactly one response
+    response = db_queries.parse_jsonb(rows[0]["data"])
+    assert response["is_error"] is False and response["result"] == "first"  # the first one won
+    assert response["request_id"] == "sha:once#0"  # correlated to the request
 
 
 async def test_return_real_dispatch_appends_result_and_does_not_archive(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -614,9 +614,13 @@ async def test_agent_round_trip_harvest_completes_run(
     assert cr.payload["is_error"] is False and cr.payload["result"] == "child-result"
 
 
-async def test_agent_error_surfaces_in_call_result(
+async def test_uncaught_agent_error_bubbles_and_errors_the_run(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
+    """R3 — an agent error the script does NOT catch is thrown at the ``await`` as
+    an ``AgentError``, propagates out of ``main``, and errors the run (the bubble).
+    The harvest still journals the child's error in the ``call_result``; the run's
+    terminal output is the raised ``AgentError`` repr."""
     from aios.tools import workflow_completion
 
     pool = wf_runtime
@@ -627,14 +631,67 @@ async def test_agent_error_surfaces_in_call_result(
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
         await workflow_completion.error_handler(child_id, {"message": "boom"})
 
-    await run_workflow_step(run_id)
+    await run_workflow_step(run_id)  # harvest -> throw AgentError -> uncaught -> RAISED
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
     cr = next(e for e in events if e.type == "call_result")
     assert cr.payload["is_error"] is True and cr.payload["error"] == {"message": "boom"}
-    # an errored child does NOT auto-raise — the run continues (§3.7).
-    assert run is not None and run.status == "completed" and run.output == "done"
+    rc = next(e for e in events if e.type == "run_completed")
+    assert rc.payload["is_error"] is True
+    assert "AgentError: boom" in rc.payload["output"]  # the raised AgentError bubbled out
+    assert run is not None and run.status == "errored"
+
+
+async def test_workflow_try_except_agent_error_continues(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """R3 headline — a workflow can ``try/except AgentError`` a failing agent and
+    carry on to a clean completion (Tom's "try/except a failing agent")."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentError as e:\n"
+        "        return {'caught': True, 'kind': e.kind}\n"
+        "    return {'caught': False}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    child_id = await _child_id_of(pool, run_id)
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.error_handler(child_id, {"message": "nope"})
+
+    await run_workflow_step(run_id)  # harvest -> throw AgentError -> caught -> return
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    # An explicit error() carries no kind; the script caught it and completed.
+    assert run is not None and run.status == "completed"
+    assert run.output == {"caught": True, "kind": None}
+
+
+async def test_workflow_uses_agent_return_value(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """R3 ``{ok}`` unwrap through the full step: the value the child ``return``s is
+    fast-forwarded into the ``await`` for the script to use."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = f"async def main(input):\n    r = await agent({wf_agent_id!r}, 'go')\n    return {{'got': r}}\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    child_id = await _child_id_of(pool, run_id)
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(child_id, {"value": "the-answer"})
+
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed" and run.output == {"got": "the-answer"}
 
 
 async def test_model_failure_writes_error_response_and_run_resolves(
@@ -668,13 +725,18 @@ async def test_model_failure_writes_error_response_and_run_resolves(
     assert response is not None
     assert response["is_error"] is True and response["error"] == {"kind": "child_errored"}
 
-    await run_workflow_step(run_id)  # harvest the error response -> resolve -> complete
+    await run_workflow_step(run_id)  # harvest the error response -> resolve (no hang)
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
     cr = next(e for e in events if e.type == "call_result")
     assert cr.payload["is_error"] is True and cr.payload["error"] == {"kind": "child_errored"}
-    assert run is not None and run.status == "completed" and run.output == "done"
+    # The run RESOLVES instead of hanging — the harvested child_errored becomes an
+    # AgentError at the await; uncaught here, it bubbles and terminally errors the
+    # run (R3). The totality hole is closed: a dead child no longer hangs the run.
+    rc = next(e for e in events if e.type == "run_completed")
+    assert rc.payload["is_error"] is True and "AgentError" in rc.payload["output"]
+    assert run is not None and run.status == "errored"
 
 
 async def test_model_failure_does_not_clobber_a_prior_response(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -488,30 +488,6 @@ async def test_return_real_dispatch_appends_result_and_does_not_archive(
     assert child.archived_at is None  # un-archived → a sibling tool's appends won't crash
 
 
-async def test_completed_child_is_soft_terminal(
-    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
-) -> None:
-    """A child with a ``workflow_child_done`` marker is excluded from
-    ``find_sessions_needing_inference``, so its unreacted ``return`` tool_result
-    never triggers another model step (no wasted inference, no double-return)."""
-    from aios.harness.sweep import find_sessions_needing_inference
-    from aios.harness.task_registry import TaskRegistry
-    from aios.tools import workflow_completion
-
-    pool = wf_runtime
-    _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:st#0")
-    reg = TaskRegistry()
-
-    # Before completion: the child's first user message is unreacted → needs inference.
-    assert cid in await find_sessions_needing_inference(pool, reg, session_id=cid)
-
-    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        await workflow_completion.return_handler(cid, {"value": "done"})
-
-    # After the marker: soft-terminal, excluded from the wake set.
-    assert cid not in await find_sessions_needing_inference(pool, reg, session_id=cid)
-
-
 async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -22,7 +22,10 @@ import pytest
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.harness import runtime
+from aios.services import agents as agents_service
+from aios.services import sessions as sessions_service
 from aios.workflows import service
+from aios.workflows.child_id import child_session_id
 from aios.workflows.determinism import CallKeyer
 from aios.workflows.host_launcher import HostOutcome
 from aios.workflows.step import run_workflow_step
@@ -49,6 +52,10 @@ async def wf_runtime(
                 "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
                 "VALUES ('acc_wf', NULL, TRUE, 'wf-root')"
             )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ('env_wf', 'wf-env', '{}'::jsonb, 'acc_wf')"
+            )
         with (
             mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.workflows.step.defer_run_wake", new=AsyncMock()),
@@ -68,8 +75,93 @@ async def _events(pool: asyncpg.Pool[Any], run_id: str) -> list[tuple[int, str, 
 async def _make_run(pool: asyncpg.Pool[Any], script: str, *, input: Any = None) -> str:
     async with pool.acquire() as conn:
         wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w", script=script)
-    run = await service.create_run(pool, account_id="acc_wf", workflow_id=wf.id, input=input)
+    run = await service.create_run(
+        pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf", input=input
+    )
     return run.id
+
+
+@pytest.fixture
+async def wf_agent_id(wf_runtime: asyncpg.Pool[Any]) -> str:
+    """A minimal agent for spawning children (model is never called in these tests)."""
+    agent = await agents_service.create_agent(
+        wf_runtime,
+        account_id="acc_wf",
+        name="child-agent",
+        model="test/dummy",
+        system="test child agent",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=1000,
+        window_max=100000,
+    )
+    return agent.id
+
+
+# ─── B2.B — child create (idempotent) + session read-model ───────────────────
+
+
+async def test_create_child_session_idempotent(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    cid = child_session_id(run_id, "sha:x#0")
+
+    created = await sessions_service.create_child_session(
+        pool,
+        session_id=cid,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        agent_version=1,
+        parent_run_id=run_id,
+        input={"q": "hi"},
+    )
+    assert created is True
+    # A replay (same id) is a rowcount-0 no-op — no double row, no double input.
+    again = await sessions_service.create_child_session(
+        pool,
+        session_id=cid,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        agent_version=1,
+        parent_run_id=run_id,
+        input={"q": "hi"},
+    )
+    assert again is False
+    async with pool.acquire() as conn:
+        user_msgs = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'message' AND data->>'role' = 'user'",
+            cid,
+            "acc_wf",
+        )
+    assert user_msgs == 1  # input delivered exactly once
+
+
+async def test_child_session_origin_and_parent_round_trip(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    cid = child_session_id(run_id, "sha:y#0")
+    await sessions_service.create_child_session(
+        pool,
+        session_id=cid,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        agent_version=1,
+        parent_run_id=run_id,
+        input="hi",
+    )
+    child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
+    assert child.origin == "background"
+    assert child.parent_run_id == run_id
+    assert child.agent_version == 1  # pinned, not None
 
 
 async def test_pure_script_completes_in_one_wake(wf_runtime: asyncpg.Pool[Any]) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -402,12 +402,16 @@ async def test_return_writes_response_and_wakes_caller_without_archiving(
     pool = wf_runtime
     run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:d2#0")
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
-        res = await workflow_completion.return_handler(cid, {"value": {"answer": 42}})
+        res = await workflow_completion.return_handler(
+            cid, {"request_id": "sha:d2#0", "value": {"answer": 42}}
+        )
     assert res == {"status": "returned"}
     wake.assert_awaited_once_with(run_id)
 
     async with pool.acquire() as conn:
-        response = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
+        response = await db_queries.read_request_response(
+            conn, cid, account_id="acc_wf", request_id="sha:d2#0"
+        )
     assert response is not None
     assert response["is_error"] is False and response["result"] == {"answer": 42}
     child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
@@ -422,10 +426,14 @@ async def test_error_marker_carries_message(
     pool = wf_runtime
     _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:d2e#0")
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        res = await workflow_completion.error_handler(cid, {"message": "nope"})
+        res = await workflow_completion.error_handler(
+            cid, {"request_id": "sha:d2e#0", "message": "nope"}
+        )
     assert res == {"status": "errored"}
     async with pool.acquire() as conn:
-        marker = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
+        marker = await db_queries.read_request_response(
+            conn, cid, account_id="acc_wf", request_id="sha:d2e#0"
+        )
     assert marker is not None and marker["is_error"] is True
     assert marker["error"] == {"message": "nope"}
 
@@ -446,33 +454,43 @@ async def test_return_from_non_child_fails_closed(
         metadata={},
     )
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
-        res = await workflow_completion.return_handler(fg.id, {"value": 1})
+        res = await workflow_completion.return_handler(fg.id, {"request_id": "x", "value": 1})
     assert isinstance(res, ToolResult) and res.is_error
     wake.assert_not_awaited()  # never signal a NULL parent run
     async with pool.acquire() as conn:
-        marker = await db_queries.read_workflow_child_done(conn, fg.id, account_id="acc_wf")
+        marker = await db_queries.read_request_response(
+            conn, fg.id, account_id="acc_wf", request_id="x"
+        )
     assert marker is None
 
 
 async def test_request_is_answered_exactly_once(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
-    """A child that responds twice (return then return, or return racing error)
-    yields exactly ONE response — first-writer-wins — and wakes the caller once."""
+    """A request is answered exactly once. The first response wins and wakes the
+    caller; a second answer to the now-closed request is rejected as
+    ``unknown_request`` (it's no longer open). The genuinely-concurrent race is
+    still caught one layer down by ``write_response_if_absent``."""
     from aios.tools import workflow_completion
+    from aios.tools.registry import ToolResult
 
     pool = wf_runtime
     run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:once#0")
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
-        r1 = await workflow_completion.return_handler(cid, {"value": "first"})
-        r2 = await workflow_completion.error_handler(cid, {"message": "too late"})
-    assert r1 == {"status": "returned"} and r2 == {"status": "errored"}
+        r1 = await workflow_completion.return_handler(
+            cid, {"request_id": "sha:once#0", "value": "first"}
+        )
+        r2 = await workflow_completion.error_handler(
+            cid, {"request_id": "sha:once#0", "message": "too late"}
+        )
+    assert r1 == {"status": "returned"}
+    assert isinstance(r2, ToolResult) and r2.is_error  # request already answered → not open
     wake.assert_awaited_once_with(run_id)  # only the first response woke the caller
 
     async with pool.acquire() as conn:
         rows = await conn.fetch(
             "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
-            "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done'",
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_response'",
             cid,
             "acc_wf",
         )
@@ -501,7 +519,10 @@ async def test_return_real_dispatch_appends_result_and_does_not_archive(
     run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:rd#0")
     call = {
         "id": "call_ret",
-        "function": {"name": "return", "arguments": _json.dumps({"value": "ok"})},
+        "function": {
+            "name": "return",
+            "arguments": _json.dumps({"request_id": "sha:rd#0", "value": "ok"}),
+        },
     }
 
     prev_reg = runtime.task_registry
@@ -518,7 +539,9 @@ async def test_return_real_dispatch_appends_result_and_does_not_archive(
     wake.assert_awaited_once_with(run_id)
     async with pool.acquire() as conn:
         result = await db_queries.find_tool_result_event(conn, cid, "call_ret", account_id="acc_wf")
-        marker = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
+        marker = await db_queries.read_request_response(
+            conn, cid, account_id="acc_wf", request_id="sha:rd#0"
+        )
         events = await db_queries.read_events(conn, cid, account_id="acc_wf", limit=1000)
     # invariant #4: exactly one tool_result for the call; both spans balanced.
     assert result is not None and not bool(result.data.get("is_error"))
@@ -565,7 +588,7 @@ async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
     from aios.tools import workflow_completion
 
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        await workflow_completion.return_handler(cid, {"value": "r"})
+        await workflow_completion.return_handler(cid, {"request_id": call_key, "value": "r"})
 
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
@@ -585,6 +608,13 @@ async def _child_id_of(pool: asyncpg.Pool[Any], run_id: str) -> str:
     return next(e.payload["child_session_id"] for e in events if e.type == "call_started")
 
 
+async def _open_request_id(pool: asyncpg.Pool[Any], session_id: str) -> str:
+    """The child's single open request id (= the agent() call_key it answers)."""
+    async with pool.acquire() as conn:
+        ids = await db_queries.get_open_request_ids(conn, session_id, account_id="acc_wf")
+    return ids[0]
+
+
 async def test_agent_round_trip_harvest_completes_run(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
@@ -595,9 +625,12 @@ async def test_agent_round_trip_harvest_completes_run(
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     child_id = await _child_id_of(pool, run_id)
+    rid = await _open_request_id(pool, child_id)
 
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        await workflow_completion.return_handler(child_id, {"value": "child-result"})
+        await workflow_completion.return_handler(
+            child_id, {"request_id": rid, "value": "child-result"}
+        )
 
     await run_workflow_step(run_id)  # harvest marker -> call_result -> replay -> complete
     async with pool.acquire() as conn:
@@ -628,8 +661,9 @@ async def test_uncaught_agent_error_bubbles_and_errors_the_run(
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     child_id = await _child_id_of(pool, run_id)
+    rid = await _open_request_id(pool, child_id)
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        await workflow_completion.error_handler(child_id, {"message": "boom"})
+        await workflow_completion.error_handler(child_id, {"request_id": rid, "message": "boom"})
 
     await run_workflow_step(run_id)  # harvest -> throw AgentError -> uncaught -> RAISED
     async with pool.acquire() as conn:
@@ -662,8 +696,9 @@ async def test_workflow_try_except_agent_error_continues(
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     child_id = await _child_id_of(pool, run_id)
+    rid = await _open_request_id(pool, child_id)
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        await workflow_completion.error_handler(child_id, {"message": "nope"})
+        await workflow_completion.error_handler(child_id, {"request_id": rid, "message": "nope"})
 
     await run_workflow_step(run_id)  # harvest -> throw AgentError -> caught -> return
     async with pool.acquire() as conn:
@@ -685,8 +720,11 @@ async def test_workflow_uses_agent_return_value(
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     child_id = await _child_id_of(pool, run_id)
+    rid = await _open_request_id(pool, child_id)
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        await workflow_completion.return_handler(child_id, {"value": "the-answer"})
+        await workflow_completion.return_handler(
+            child_id, {"request_id": rid, "value": "the-answer"}
+        )
 
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
@@ -708,6 +746,7 @@ async def test_model_failure_writes_error_response_and_run_resolves(
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     child_id = await _child_id_of(pool, run_id)
+    rid = await _open_request_id(pool, child_id)  # capture before the erroring path answers it
 
     # Drive the child to its terminal-error landing pad: seed a full rescheduling
     # streak so the next failure spends the retry budget, then run the erroring path.
@@ -721,7 +760,9 @@ async def test_model_failure_writes_error_response_and_run_resolves(
     wake.assert_awaited_once_with(run_id)  # the caller was woken to harvest
 
     async with pool.acquire() as conn:
-        response = await db_queries.read_workflow_child_done(conn, child_id, account_id="acc_wf")
+        response = await db_queries.read_request_response(
+            conn, child_id, account_id="acc_wf", request_id=rid
+        )
     assert response is not None
     assert response["is_error"] is True and response["error"] == {"kind": "child_errored"}
 
@@ -751,7 +792,7 @@ async def test_model_failure_does_not_clobber_a_prior_response(
     pool = wf_runtime
     _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:prec#0")
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
-        await workflow_completion.return_handler(cid, {"value": "real"})
+        await workflow_completion.return_handler(cid, {"request_id": "sha:prec#0", "value": "real"})
 
     for _ in range(len(loop._RETRY_BACKOFF_SECONDS)):
         await loop._append_lifecycle(
@@ -764,13 +805,147 @@ async def test_model_failure_does_not_clobber_a_prior_response(
     async with pool.acquire() as conn:
         rows = await conn.fetch(
             "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
-            "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done'",
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_response'",
             cid,
             "acc_wf",
         )
     assert len(rows) == 1  # still exactly one response
     response = db_queries.parse_jsonb(rows[0]["data"])
     assert response["is_error"] is False and response["result"] == "real"  # the return() won
+
+
+# ─── R4 — the session-quiescence totality guard (nudge → no_return) ───────────
+
+
+async def _idle_assistant_turn(pool: asyncpg.Pool[Any], session_id: str) -> dict[str, Any]:
+    """An assistant message that reacts to everything so far and calls no tools —
+    i.e. a pure-text turn that would leave the session idle (the guard's trigger)."""
+    child = await sessions_service.get_session_basic(pool, session_id, account_id="acc_wf")
+    return {"role": "assistant", "content": "thinking…", "reacting_to": child.last_event_seq}
+
+
+async def test_idle_with_open_request_is_nudged(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A child that ends a tool-call-free turn while still owing a request is nudged
+    in the same transaction as the idling assistant event — so it never goes idle
+    with a debt — and the nudge (a user message) keeps it active for another turn."""
+    pool = wf_runtime
+    _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:n#0")
+
+    assistant = await _idle_assistant_turn(pool, cid)
+    nudged, autoerrored, caller = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, cid, assistant, account_id="acc_wf"
+    )
+    assert nudged and not autoerrored and caller is None
+
+    async with pool.acquire() as conn:
+        open_ids = await db_queries.get_open_request_ids(conn, cid, account_id="acc_wf")
+        nudges = await db_queries.count_request_nudges(
+            conn, cid, account_id="acc_wf", request_id="sha:n#0"
+        )
+        status = await db_queries.derive_session_status(conn, cid, account_id="acc_wf")
+    assert open_ids == ["sha:n#0"]  # still open — nudging is not answering
+    assert nudges == 1
+    assert status == "active"  # the nudge user message keeps it alive, no idle window
+
+
+async def test_quiescence_guard_is_noop_without_open_requests(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The guard is a strict no-op for an ordinary session (no requests owed): the
+    assistant message is appended and the session goes idle, with no nudge."""
+    pool = wf_runtime
+    fg = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )
+    assistant = await _idle_assistant_turn(pool, fg.id)
+    nudged, autoerrored, caller = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, fg.id, assistant, account_id="acc_wf"
+    )
+    assert not nudged and not autoerrored and caller is None
+    async with pool.acquire() as conn:
+        status = await db_queries.derive_session_status(conn, fg.id, account_id="acc_wf")
+        nudge_msgs = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'message' AND role = 'user'",
+            fg.id,
+            "acc_wf",
+        )
+    assert status == "idle"  # an ordinary session is free to rest
+    assert nudge_msgs == 0  # no nudge injected
+
+
+async def test_open_request_is_auto_errored_after_nudge_budget(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """After REQUEST_NUDGE_BUDGET nudges, a still-unanswered request is auto-errored
+    with a monotonic no_return response — so totality holds even for a model that
+    ignores every nudge — and the session is then free to go idle."""
+    pool = wf_runtime
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:nr#0")
+
+    for _ in range(sessions_service.REQUEST_NUDGE_BUDGET):
+        nudged, autoerrored, _caller = await sessions_service.append_assistant_and_guard_quiescence(
+            pool, cid, await _idle_assistant_turn(pool, cid), account_id="acc_wf"
+        )
+        assert nudged and not autoerrored  # still under budget — keep nudging
+
+    # Budget spent: the next pure-text turn auto-errors the request instead.
+    nudged, autoerrored, caller = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, cid, await _idle_assistant_turn(pool, cid), account_id="acc_wf"
+    )
+    assert autoerrored and not nudged
+    assert caller == run_id  # the caller run is woken to harvest the no_return
+
+    async with pool.acquire() as conn:
+        resp = await db_queries.read_request_response(
+            conn, cid, account_id="acc_wf", request_id="sha:nr#0"
+        )
+        open_ids = await db_queries.get_open_request_ids(conn, cid, account_id="acc_wf")
+        status = await db_queries.derive_session_status(conn, cid, account_id="acc_wf")
+    assert resp is not None and resp["is_error"] is True and resp["error"] == {"kind": "no_return"}
+    assert open_ids == []  # answered (by the backstop) → no longer open
+    assert status == "idle"  # nothing owed → free to rest
+
+
+async def test_non_answering_child_resolves_run_via_agent_no_return_error(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """R4 headline — a child that never answers does not hang the run. After the
+    nudge budget the request is auto-errored (no_return); the run harvests it and
+    the script's ``agent()`` raises ``AgentNoReturnError``, which the workflow can
+    catch and continue past."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentNoReturnError:\n"
+        "        return 'gave-up'\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    child_id = await _child_id_of(pool, run_id)
+
+    # The child ignores every nudge: BUDGET nudges, then the auto-error turn.
+    for _ in range(sessions_service.REQUEST_NUDGE_BUDGET + 1):
+        await sessions_service.append_assistant_and_guard_quiescence(
+            pool, child_id, await _idle_assistant_turn(pool, child_id), account_id="acc_wf"
+        )
+
+    await run_workflow_step(run_id)  # harvest no_return -> AgentNoReturnError -> caught -> return
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["is_error"] is True and cr.payload["error"] == {"kind": "no_return"}
+    assert run is not None and run.status == "completed" and run.output == "gave-up"
 
 
 async def test_agent_stays_suspended_until_marker(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -59,6 +59,7 @@ async def wf_runtime(
         with (
             mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.workflows.step.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()),
         ):
             yield pool
     finally:
@@ -231,15 +232,81 @@ async def test_terminal_run_and_double_resume_are_noops(wf_runtime: asyncpg.Pool
     assert await _events(pool, run_id) == before  # journal unchanged
 
 
-async def test_agent_capability_errors_in_block1(wf_runtime: asyncpg.Pool[Any]) -> None:
+# ─── B2.C — the agent spawn arm + crash matrix ───────────────────────────────
+
+
+async def test_agent_spawn_creates_child_and_suspends(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
     pool = wf_runtime
-    run_id = await _make_run(pool, "async def main(input):\n    return await agent('a1')")
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, {{'task': 'go'}})\n"
+    run_id = await _make_run(pool, script)
+    with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as child_wake:
+        await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "suspended"
+    started = [e for e in events if e.type == "call_started"]
+    assert len(started) == 1
+    assert started[0].payload["capability"] == "agent"
+    assert started[0].payload["child_agent_version"] == 1  # pinned
+    child_id = started[0].payload["child_session_id"]
+
+    # The child row exists (background, linked to the run) with the input delivered.
+    child = await sessions_service.get_session_basic(pool, child_id, account_id="acc_wf")
+    assert child.origin == "background" and child.parent_run_id == run_id
+    async with pool.acquire() as conn:
+        user_msgs = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND kind = 'message' "
+            "AND data->>'role' = 'user'",
+            child_id,
+        )
+    assert user_msgs == 1
+    child_wake.assert_awaited_once()  # prompt wake of the child
+
+
+async def test_agent_spawn_idempotent_on_replay(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """C1/C2/C6: a re-step (crash replay) must NOT double-spawn or re-deliver input."""
+    pool = wf_runtime
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi')\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # wake 1: spawn
+    await run_workflow_step(run_id)  # wake 2: replay — re-emits the same frontier
+
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    started = [e for e in events if e.type == "call_started"]
+    assert len(started) == 1  # exactly one call_started — no double-spawn
+    assert children == 1  # exactly one child row
+    child_id = started[0].payload["child_session_id"]
+    async with pool.acquire() as conn:
+        user_msgs = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND kind = 'message' "
+            "AND data->>'role' = 'user'",
+            child_id,
+        )
+    assert user_msgs == 1  # input delivered exactly once across replays
+
+
+async def test_agent_not_found_errors_the_run(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    run_id = await _make_run(
+        pool, "async def main(input):\n    return await agent('agent_nope', 'x')\n"
+    )
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
     assert run is not None and run.status == "errored"
-    completed = (await _events(pool, run_id))[-1]
-    assert completed[1] == "run_completed"
+    assert events[-1].type == "run_completed"
+    assert events[-1].payload["error"]["kind"] == "agent_not_found"
 
 
 # ─── crash-safety + divergence (B1.6 + B1.7) ─────────────────────────────────

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -637,6 +637,80 @@ async def test_agent_error_surfaces_in_call_result(
     assert run is not None and run.status == "completed" and run.output == "done"
 
 
+async def test_model_failure_writes_error_response_and_run_resolves(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """R2 — the totality hole: a child whose model errors past its retry budget can
+    no longer answer its request. The harness erroring path responds on its behalf
+    with a monotonic ``child_errored`` response, so the invoking run harvests it and
+    resolves — instead of hanging forever on a dead child."""
+    from aios.harness import loop
+
+    pool = wf_runtime
+    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    child_id = await _child_id_of(pool, run_id)
+
+    # Drive the child to its terminal-error landing pad: seed a full rescheduling
+    # streak so the next failure spends the retry budget, then run the erroring path.
+    for _ in range(len(loop._RETRY_BACKOFF_SECONDS)):
+        await loop._append_lifecycle(
+            pool, child_id, "turn_ended", "rescheduling", "rescheduling", account_id="acc_wf"
+        )
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
+        delay = await loop._apply_retry_or_failure(pool, child_id, account_id="acc_wf")
+    assert delay is None  # terminal — retry budget spent
+    wake.assert_awaited_once_with(run_id)  # the caller was woken to harvest
+
+    async with pool.acquire() as conn:
+        response = await db_queries.read_workflow_child_done(conn, child_id, account_id="acc_wf")
+    assert response is not None
+    assert response["is_error"] is True and response["error"] == {"kind": "child_errored"}
+
+    await run_workflow_step(run_id)  # harvest the error response -> resolve -> complete
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["is_error"] is True and cr.payload["error"] == {"kind": "child_errored"}
+    assert run is not None and run.status == "completed" and run.output == "done"
+
+
+async def test_model_failure_does_not_clobber_a_prior_response(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """R2 first-writer-wins: a child that already ``return``ed keeps that response
+    even if its model later errors out. The erroring path's ``child_errored``
+    response no-ops and does NOT re-wake the caller (it was woken by the return)."""
+    from aios.harness import loop
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:prec#0")
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(cid, {"value": "real"})
+
+    for _ in range(len(loop._RETRY_BACKOFF_SECONDS)):
+        await loop._append_lifecycle(
+            pool, cid, "turn_ended", "rescheduling", "rescheduling", account_id="acc_wf"
+        )
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
+        await loop._apply_retry_or_failure(pool, cid, account_id="acc_wf")
+    wake.assert_not_awaited()  # duplicate response is a no-op — caller already woken
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'workflow_child_done'",
+            cid,
+            "acc_wf",
+        )
+    assert len(rows) == 1  # still exactly one response
+    response = db_queries.parse_jsonb(rows[0]["data"])
+    assert response["is_error"] is False and response["result"] == "real"  # the return() won
+
+
 async def test_agent_stays_suspended_until_marker(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -834,10 +834,10 @@ async def test_idle_with_open_request_is_nudged(
     _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:n#0")
 
     assistant = await _idle_assistant_turn(pool, cid)
-    nudged, autoerrored, caller = await sessions_service.append_assistant_and_guard_quiescence(
-        pool, cid, assistant, account_id="acc_wf"
+    nudged, caller = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, cid, assistant, account_id="acc_wf", parent_run_id=_run_id
     )
-    assert nudged and not autoerrored and caller is None
+    assert nudged and caller is None
 
     async with pool.acquire() as conn:
         open_ids = await db_queries.get_open_request_ids(conn, cid, account_id="acc_wf")
@@ -850,11 +850,12 @@ async def test_idle_with_open_request_is_nudged(
     assert status == "active"  # the nudge user message keeps it alive, no idle window
 
 
-async def test_quiescence_guard_is_noop_without_open_requests(
+async def test_quiescence_guard_is_noop_for_non_child(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
-    """The guard is a strict no-op for an ordinary session (no requests owed): the
-    assistant message is appended and the session goes idle, with no nudge."""
+    """The guard is a strict no-op for an ordinary (non-child) session: it cannot
+    owe a request, so the assistant is appended, the session goes idle, no nudge —
+    and the parent_run_id gate skips the open-request scan entirely."""
     pool = wf_runtime
     fg = await sessions_service.create_session(
         pool,
@@ -865,10 +866,10 @@ async def test_quiescence_guard_is_noop_without_open_requests(
         metadata={},
     )
     assistant = await _idle_assistant_turn(pool, fg.id)
-    nudged, autoerrored, caller = await sessions_service.append_assistant_and_guard_quiescence(
-        pool, fg.id, assistant, account_id="acc_wf"
+    nudged, caller = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, fg.id, assistant, account_id="acc_wf", parent_run_id=None
     )
-    assert not nudged and not autoerrored and caller is None
+    assert not nudged and caller is None
     async with pool.acquire() as conn:
         status = await db_queries.derive_session_status(conn, fg.id, account_id="acc_wf")
         nudge_msgs = await conn.fetchval(
@@ -891,17 +892,21 @@ async def test_open_request_is_auto_errored_after_nudge_budget(
     run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:nr#0")
 
     for _ in range(sessions_service.REQUEST_NUDGE_BUDGET):
-        nudged, autoerrored, _caller = await sessions_service.append_assistant_and_guard_quiescence(
-            pool, cid, await _idle_assistant_turn(pool, cid), account_id="acc_wf"
+        nudged, _caller = await sessions_service.append_assistant_and_guard_quiescence(
+            pool,
+            cid,
+            await _idle_assistant_turn(pool, cid),
+            account_id="acc_wf",
+            parent_run_id=run_id,
         )
-        assert nudged and not autoerrored  # still under budget — keep nudging
+        assert nudged  # still under budget — keep nudging
 
     # Budget spent: the next pure-text turn auto-errors the request instead.
-    nudged, autoerrored, caller = await sessions_service.append_assistant_and_guard_quiescence(
-        pool, cid, await _idle_assistant_turn(pool, cid), account_id="acc_wf"
+    nudged, caller = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, cid, await _idle_assistant_turn(pool, cid), account_id="acc_wf", parent_run_id=run_id
     )
-    assert autoerrored and not nudged
-    assert caller == run_id  # the caller run is woken to harvest the no_return
+    assert not nudged
+    assert caller == run_id  # auto-errored → the caller run is woken to harvest the no_return
 
     async with pool.acquire() as conn:
         resp = await db_queries.read_request_response(
@@ -936,7 +941,11 @@ async def test_non_answering_child_resolves_run_via_agent_no_return_error(
     # The child ignores every nudge: BUDGET nudges, then the auto-error turn.
     for _ in range(sessions_service.REQUEST_NUDGE_BUDGET + 1):
         await sessions_service.append_assistant_and_guard_quiescence(
-            pool, child_id, await _idle_assistant_turn(pool, child_id), account_id="acc_wf"
+            pool,
+            child_id,
+            await _idle_assistant_turn(pool, child_id),
+            account_id="acc_wf",
+            parent_run_id=run_id,
         )
 
     await run_workflow_step(run_id)  # harvest no_return -> AgentNoReturnError -> caught -> return

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -948,6 +948,96 @@ async def test_non_answering_child_resolves_run_via_agent_no_return_error(
     assert run is not None and run.status == "completed" and run.output == "gave-up"
 
 
+# ─── R5 — archived/deleted-child totality gap + the archived-session guard ────
+
+
+async def test_archived_session_wake_is_a_noop(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A wake for an archived (or deleted) session is an idempotent no-op — the
+    run_session_step entry guard returns before any append, so a stray wake (a
+    sweep racing an archive, a future reclaim) never crashes on append_event's
+    archived guard. Mirrors run_workflow_step's terminal early-return."""
+    from aios.harness import runtime
+    from aios.harness.loop import run_session_step
+
+    pool = wf_runtime
+    sess = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )
+    async with pool.acquire() as conn:
+        await db_queries.archive_session(conn, sess.id, account_id="acc_wf")
+        before = await conn.fetchval("SELECT last_event_seq FROM sessions WHERE id = $1", sess.id)
+
+    prev_reg = runtime.task_registry
+    runtime.task_registry = None  # the guard must return before require_task_registry
+    try:
+        await run_session_step(sess.id)  # must NOT raise
+    finally:
+        runtime.task_registry = prev_reg
+
+    async with pool.acquire() as conn:
+        after = await conn.fetchval("SELECT last_event_seq FROM sessions WHERE id = $1", sess.id)
+    assert after == before  # nothing appended — a clean no-op
+
+
+async def test_operator_archived_child_resolves_run_as_child_gone(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """An operator archiving a *running* child before it answers must not hang the
+    run: derive_response sees the child is no longer live and resolves the call as a
+    catchable AgentError(child_gone)."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentError as e:\n"
+        "        return {'caught': True, 'kind': e.kind}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    child_id = await _child_id_of(pool, run_id)
+    async with pool.acquire() as conn:  # operator archives the child mid-flight
+        await db_queries.archive_session(conn, child_id, account_id="acc_wf")
+
+    await run_workflow_step(run_id)  # harvest -> child_gone -> AgentError -> caught
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == {"caught": True, "kind": "child_gone"}
+
+
+async def test_operator_deleted_child_resolves_run_as_child_gone(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """Same totality guarantee when the child is hard-deleted (its events are gone):
+    the run resolves from the child's absence, not a written response."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'go')\n"
+        "    except AgentError as e:\n"
+        "        return e.kind\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    child_id = await _child_id_of(pool, run_id)
+    async with pool.acquire() as conn:
+        await db_queries.delete_session(conn, child_id, account_id="acc_wf")
+
+    await run_workflow_step(run_id)  # harvest -> child_gone -> AgentError -> caught
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed" and run.output == "child_gone"
+
+
 async def test_agent_stays_suspended_until_marker(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -377,9 +377,13 @@ async def _check_completion_injection(
     assert "return" not in fg_tools and "error" not in fg_tools
 
 
-async def test_return_writes_marker_archives_and_wakes_parent(
+async def test_return_writes_marker_and_wakes_parent_without_archiving(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
+    """Two-phase termination: the handler writes the marker + wakes the parent but
+    does NOT archive. Archive must be a session's last write, yet this handler runs
+    mid tool-lifecycle (the tool_result append follows); physical reap is the
+    in-worker reaper's job once the child is quiescent."""
     from aios.tools import workflow_completion
 
     pool = wf_runtime
@@ -394,7 +398,7 @@ async def test_return_writes_marker_archives_and_wakes_parent(
     assert marker is not None
     assert marker["is_error"] is False and marker["result"] == {"answer": 42}
     child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
-    assert child.archived_at is not None  # self-archived — genuinely terminal
+    assert child.archived_at is None  # NOT archived by the handler — the reaper does that
 
 
 async def test_error_marker_carries_message(
@@ -435,6 +439,124 @@ async def test_return_from_non_child_fails_closed(
     async with pool.acquire() as conn:
         marker = await db_queries.read_workflow_child_done(conn, fg.id, account_id="acc_wf")
     assert marker is None
+
+
+async def test_return_real_dispatch_appends_result_and_does_not_archive(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The blind spot the bug survived in: drive ``return`` through the REAL tool
+    path (``_execute_tool_async``/``_tool_lifecycle``), not the handler directly.
+    Marker-only completion must append exactly one ``tool_result`` + both spans +
+    the marker, wake the parent, and leave the child UN-archived — so a concurrent
+    sibling tool in the same batch could still append (the multi-tool race that
+    sank the terminal-tool design). No exception is the headline: the original bug
+    crashed here on every completion."""
+    import json as _json
+
+    from aios.harness import tool_dispatch
+    from aios.harness.task_registry import TaskRegistry
+
+    pool = wf_runtime
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:rd#0")
+    call = {
+        "id": "call_ret",
+        "function": {"name": "return", "arguments": _json.dumps({"value": "ok"})},
+    }
+
+    prev_reg = runtime.task_registry
+    runtime.task_registry = TaskRegistry()
+    try:
+        with (
+            mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake,
+            mock.patch("aios.harness.sweep.defer_wake", new=AsyncMock()),
+        ):
+            await tool_dispatch._execute_tool_async(pool, cid, call, account_id="acc_wf")
+    finally:
+        runtime.task_registry = prev_reg
+
+    wake.assert_awaited_once_with(run_id)
+    async with pool.acquire() as conn:
+        result = await db_queries.find_tool_result_event(conn, cid, "call_ret", account_id="acc_wf")
+        marker = await db_queries.read_workflow_child_done(conn, cid, account_id="acc_wf")
+        events = await db_queries.read_events(conn, cid, account_id="acc_wf", limit=1000)
+    # invariant #4: exactly one tool_result for the call; both spans balanced.
+    assert result is not None and not bool(result.data.get("is_error"))
+    spans = [e.data.get("event") for e in events if e.kind == "span"]
+    assert spans.count("tool_execute_start") == 1 and spans.count("tool_execute_end") == 1
+    assert marker is not None and marker["result"] == "ok"
+    child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
+    assert child.archived_at is None  # un-archived → a sibling tool's appends won't crash
+
+
+async def test_completed_child_is_soft_terminal(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A child with a ``workflow_child_done`` marker is excluded from
+    ``find_sessions_needing_inference``, so its unreacted ``return`` tool_result
+    never triggers another model step (no wasted inference, no double-return)."""
+    from aios.harness.sweep import find_sessions_needing_inference
+    from aios.harness.task_registry import TaskRegistry
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    _run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:st#0")
+    reg = TaskRegistry()
+
+    # Before completion: the child's first user message is unreacted → needs inference.
+    assert cid in await find_sessions_needing_inference(pool, reg, session_id=cid)
+
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(cid, {"value": "done"})
+
+    # After the marker: soft-terminal, excluded from the wake set.
+    assert cid not in await find_sessions_needing_inference(pool, reg, session_id=cid)
+
+
+async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """``defer_wake(child)`` fires only on first spawn; a re-attach skips it (the
+    child is already sweep-wakeable, and may even be terminal — a wake span would
+    crash). If a re-attached child already has its marker (C1'/C4), the spawn arm
+    requests a self-wake so the parent harvests it now."""
+    from aios.workflows.host_launcher import EmittedCapability
+    from aios.workflows.step import _open_agent_capability
+
+    pool = wf_runtime
+    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    run_id = await _make_run(pool, script)
+    spec = {"agent_id": wf_agent_id, "input": "go", "output_schema": None}
+    call_key = CallKeyer().next("agent", spec)
+    cap = EmittedCapability(capability_id="agent", call_key=call_key, spec=spec)
+    cid = child_session_id(run_id, call_key)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        assert run is not None
+        # First spawn: created → defer_wake fires once.
+        with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as w1:
+            r1 = await _open_agent_capability(conn, pool, run, cap)
+        assert not r1.rejected and not r1.needs_rewake
+        w1.assert_awaited_once()
+        # Re-attach, no marker yet → no defer_wake, no self-wake.
+        with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as w2:
+            r2 = await _open_agent_capability(conn, pool, run, cap)
+        assert not r2.rejected and not r2.needs_rewake
+        w2.assert_not_awaited()
+
+    # Child completes before the parent journals call_started (C1'/C4).
+    from aios.tools import workflow_completion
+
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(cid, {"value": "r"})
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        assert run is not None
+        with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as w3:
+            r3 = await _open_agent_capability(conn, pool, run, cap)
+        assert not r3.rejected and r3.needs_rewake  # marker present → self-wake to harvest
+        w3.assert_not_awaited()
 
 
 # ─── B2.E — harvest the child marker (spawn -> return -> complete) ────────────

--- a/tests/integration/test_wf_sweep.py
+++ b/tests/integration/test_wf_sweep.py
@@ -28,6 +28,10 @@ async def sweep_pool(
                 "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
                 "VALUES ('acc_sw', NULL, TRUE, 'sweep-root')"
             )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ('env_sw', 'sweep-env', '{}'::jsonb, 'acc_sw')"
+            )
         yield pool
     finally:
         await pool.close()
@@ -49,7 +53,12 @@ async def test_sweep_wakes_only_nonterminal_runs(sweep_pool: asyncpg.Pool[Any]) 
         )
         for status in ("pending", "suspended", "completed", "errored"):
             run = await wf_queries.insert_wf_run(
-                conn, account_id="acc_sw", workflow_id=wf.id, script="x", script_sha="x"
+                conn,
+                account_id="acc_sw",
+                workflow_id=wf.id,
+                environment_id="env_sw",
+                script="x",
+                script_sha="x",
             )
             if status != "pending":
                 await wf_queries.set_run_status(conn, run.id, status, account_id="acc_sw")

--- a/tests/unit/test_ids.py
+++ b/tests/unit/test_ids.py
@@ -35,6 +35,26 @@ class TestMakeId:
             make_id("agnet")
 
 
+class TestMakeIdDeterministic:
+    """The additive ``body=`` path for content-addressed (e.g. workflow child) ids."""
+
+    def test_same_body_yields_same_id(self) -> None:
+        body = bytes(range(16))
+        assert make_id(SESSION, body=body) == make_id(SESSION, body=body)
+
+    def test_deterministic_id_is_split_id_parseable(self) -> None:
+        prefix, ulid_part = split_id(make_id(SESSION, body=bytes(range(16))))
+        assert prefix == "sess"
+        assert len(ulid_part) == 26
+
+    def test_different_bodies_yield_different_ids(self) -> None:
+        assert make_id(SESSION, body=bytes(range(16))) != make_id(SESSION, body=bytes(range(1, 17)))
+
+    def test_body_must_be_16_bytes(self) -> None:
+        with pytest.raises(ValueError, match="must be exactly 16 bytes"):
+            make_id(SESSION, body=b"too short")
+
+
 class TestSplitId:
     def test_splits_well_formed_id(self) -> None:
         new_id = make_id(EVENT)

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -119,6 +119,8 @@ def mock_step_dependencies() -> Any:
         agent_id="agt_x",
         agent_version=None,
         focal_channel=None,
+        origin="foreground",
+        parent_run_id=None,
     )
     agent = SimpleNamespace(
         model="openrouter/x",

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -214,20 +214,20 @@ def mock_step_dependencies() -> Any:
             "aios.harness.loop.defer_wake",
             AsyncMock(),
         ) as defer_wake_mock,
-        # The terminal-error branch responds to an open request on the errored
-        # child's behalf. The session here is a non-child, so the real call would
-        # no-op; mock it to keep this unit focused on the retry state machine and
-        # assert whether the hook fired.
+        # The terminal-error branch errors the errored child's open requests on its
+        # behalf. The session here is a non-child, so the real call would no-op;
+        # mock it to keep this unit focused on the retry state machine and assert
+        # whether the hook fired.
         patch(
-            "aios.harness.loop.respond_to_request",
-            AsyncMock(return_value="not_a_child"),
-        ) as respond_to_request_mock,
+            "aios.harness.loop.fail_all_open_requests",
+            AsyncMock(return_value=0),
+        ) as fail_all_open_requests_mock,
     ):
         yield SimpleNamespace(
             set_stop_reason=set_stop_reason,
             append_event=append_event,
             defer_wake=defer_wake_mock,
-            respond_to_request=respond_to_request_mock,
+            fail_all_open_requests=fail_all_open_requests_mock,
         )
 
 
@@ -253,8 +253,8 @@ class TestRunSessionStepOnModelError:
         assert {"type": "rescheduling"} in stop_reasons
         assert {"type": "end_turn"} not in stop_reasons
         # The retry branch never reaches the terminal landing pad, so it must not
-        # respond on the session's behalf — a reschedulable error is not terminal.
-        mock_step_dependencies.respond_to_request.assert_not_awaited()
+        # fail the session's requests — a reschedulable error is not terminal.
+        mock_step_dependencies.fail_all_open_requests.assert_not_awaited()
 
     async def test_exhausted_budget_records_error_stop_reason_without_raising(
         self, mock_step_dependencies: Any
@@ -280,9 +280,9 @@ class TestRunSessionStepOnModelError:
         ]
         assert {"type": "error"} in stop_reasons
         assert {"type": "end_turn"} not in stop_reasons
-        # The terminal landing pad responds on the session's behalf: a workflow
-        # child owing an open request gets a monotonic child_errored response so
-        # its invoking run resolves instead of hanging (a no-op for non-children).
-        mock_step_dependencies.respond_to_request.assert_awaited_once_with(
-            ANY, "sess_x", is_error=True, result=None, error={"kind": "child_errored"}
+        # The terminal landing pad fails the session's open requests on its behalf:
+        # a workflow child's owed requests get a monotonic child_errored response so
+        # the invoking runs resolve instead of hanging (a no-op for non-children).
+        mock_step_dependencies.fail_all_open_requests.assert_awaited_once_with(
+            ANY, "sess_x", account_id=ANY, error={"kind": "child_errored"}
         )

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -214,11 +214,20 @@ def mock_step_dependencies() -> Any:
             "aios.harness.loop.defer_wake",
             AsyncMock(),
         ) as defer_wake_mock,
+        # The terminal-error branch responds to an open request on the errored
+        # child's behalf. The session here is a non-child, so the real call would
+        # no-op; mock it to keep this unit focused on the retry state machine and
+        # assert whether the hook fired.
+        patch(
+            "aios.harness.loop.respond_to_request",
+            AsyncMock(return_value="not_a_child"),
+        ) as respond_to_request_mock,
     ):
         yield SimpleNamespace(
             set_stop_reason=set_stop_reason,
             append_event=append_event,
             defer_wake=defer_wake_mock,
+            respond_to_request=respond_to_request_mock,
         )
 
 
@@ -243,6 +252,9 @@ class TestRunSessionStepOnModelError:
         ]
         assert {"type": "rescheduling"} in stop_reasons
         assert {"type": "end_turn"} not in stop_reasons
+        # The retry branch never reaches the terminal landing pad, so it must not
+        # respond on the session's behalf — a reschedulable error is not terminal.
+        mock_step_dependencies.respond_to_request.assert_not_awaited()
 
     async def test_exhausted_budget_records_error_stop_reason_without_raising(
         self, mock_step_dependencies: Any
@@ -268,3 +280,9 @@ class TestRunSessionStepOnModelError:
         ]
         assert {"type": "error"} in stop_reasons
         assert {"type": "end_turn"} not in stop_reasons
+        # The terminal landing pad responds on the session's behalf: a workflow
+        # child owing an open request gets a monotonic child_errored response so
+        # its invoking run resolves instead of hanging (a no-op for non-children).
+        mock_step_dependencies.respond_to_request.assert_awaited_once_with(
+            ANY, "sess_x", is_error=True, result=None, error={"kind": "child_errored"}
+        )

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,15 +26,16 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0065``."""
+    """The migration ladder has exactly one head: ``0066``."""
     script = _script_directory()
-    assert script.get_heads() == ["0065"]
+    assert script.get_heads() == ["0066"]
 
 
 def test_chain_is_linear_0054_to_0060() -> None:
     """``0054 -> … -> 0060 -> 0061`` is a plain linear chain."""
     script = _script_directory()
 
+    rev_0066 = script.get_revision("0066")
     rev_0065 = script.get_revision("0065")
     rev_0064 = script.get_revision("0064")
     rev_0063 = script.get_revision("0063")
@@ -47,6 +48,7 @@ def test_chain_is_linear_0054_to_0060() -> None:
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0066.down_revision == "0065"
     assert rev_0065.down_revision == "0064"
     assert rev_0064.down_revision == "0063"
     assert rev_0063.down_revision == "0062"

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,15 +26,16 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0066``."""
+    """The migration ladder has exactly one head: ``0067``."""
     script = _script_directory()
-    assert script.get_heads() == ["0066"]
+    assert script.get_heads() == ["0067"]
 
 
 def test_chain_is_linear_0054_to_0060() -> None:
     """``0054 -> … -> 0060 -> 0061`` is a plain linear chain."""
     script = _script_directory()
 
+    rev_0067 = script.get_revision("0067")
     rev_0066 = script.get_revision("0066")
     rev_0065 = script.get_revision("0065")
     rev_0064 = script.get_revision("0064")
@@ -48,6 +49,7 @@ def test_chain_is_linear_0054_to_0060() -> None:
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0067.down_revision == "0066"
     assert rev_0066.down_revision == "0065"
     assert rev_0065.down_revision == "0064"
     assert rev_0064.down_revision == "0063"

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,15 +26,16 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0067``."""
+    """The migration ladder has exactly one head: ``0068``."""
     script = _script_directory()
-    assert script.get_heads() == ["0067"]
+    assert script.get_heads() == ["0068"]
 
 
 def test_chain_is_linear_0054_to_head() -> None:
-    """``0054 -> … -> 0067`` (the current head) is a plain linear chain."""
+    """``0054 -> … -> 0068`` (the current head) is a plain linear chain."""
     script = _script_directory()
 
+    rev_0068 = script.get_revision("0068")
     rev_0067 = script.get_revision("0067")
     rev_0066 = script.get_revision("0066")
     rev_0065 = script.get_revision("0065")
@@ -49,6 +50,7 @@ def test_chain_is_linear_0054_to_head() -> None:
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0068.down_revision == "0067"
     assert rev_0067.down_revision == "0066"
     assert rev_0066.down_revision == "0065"
     assert rev_0065.down_revision == "0064"

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -31,8 +31,8 @@ def test_single_head() -> None:
     assert script.get_heads() == ["0067"]
 
 
-def test_chain_is_linear_0054_to_0060() -> None:
-    """``0054 -> … -> 0060 -> 0061`` is a plain linear chain."""
+def test_chain_is_linear_0054_to_head() -> None:
+    """``0054 -> … -> 0067`` (the current head) is a plain linear chain."""
     script = _script_directory()
 
     rev_0067 = script.get_revision("0067")

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -209,6 +209,10 @@ class TestEntrySweepSpan:
                 AsyncMock(return_value=start_event),
             ) as append_event,
             patch(
+                "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
+                AsyncMock(return_value=(False, False, None)),
+            ),
+            patch(
                 "aios.harness.loop.call_litellm",
                 AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
             ),

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -141,7 +141,12 @@ class TestEntrySweepSpan:
         from aios.harness.loop import run_session_step
 
         session = SimpleNamespace(
-            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+            id="sess_x",
+            agent_id="agt_x",
+            agent_version=None,
+            focal_channel=None,
+            origin="foreground",
+            parent_run_id=None,
         )
         agent = SimpleNamespace(
             model="openrouter/x",

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -210,7 +210,7 @@ class TestEntrySweepSpan:
             ) as append_event,
             patch(
                 "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
-                AsyncMock(return_value=(False, False, None)),
+                AsyncMock(return_value=(False, None)),
             ),
             patch(
                 "aios.harness.loop.call_litellm",

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -488,11 +488,13 @@ class TestStepStartEndSpans:
 @contextlib.asynccontextmanager
 async def _harness_with_guard(
     guard_result: tuple[bool, bool, str | None],
-) -> AsyncIterator[tuple[AsyncMock, AsyncMock]]:
+) -> AsyncIterator[tuple[AsyncMock, AsyncMock, MagicMock]]:
     """Drive ``run_session_step`` past a clean (tool-call-free) model turn with the
-    quiescence guard mocked to ``guard_result``. Yields the captured
-    ``(defer_wake, defer_run_wake)`` so a test can assert the post-guard wiring
-    (loop.py: nudge -> defer_wake(request_nudge); autoerror -> defer_run_wake)."""
+    quiescence guard mocked to ``guard_result``. Yields ``(defer_wake,
+    defer_run_wake, manager)`` — the manager records ``append_event`` and
+    ``defer_wake`` calls in order so a test can assert the post-guard wiring AND
+    that the wakes fire after ``step_end`` (loop.py: nudge -> defer_wake(
+    request_nudge); autoerror -> defer_run_wake)."""
     session = SimpleNamespace(
         id="sess_x",
         agent_id="agt_x",
@@ -512,8 +514,12 @@ async def _harness_with_guard(
         window_min=1000,
         window_max=10000,
     )
+    manager = MagicMock()
+    append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
     defer_wake = AsyncMock()
     defer_run_wake = AsyncMock()
+    manager.attach_mock(append_event, "append_event")
+    manager.attach_mock(defer_wake, "defer_wake")
     with (
         patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
         patch("aios.harness.loop.runtime.require_task_registry", return_value=MagicMock()),
@@ -538,10 +544,7 @@ async def _harness_with_guard(
             ),
         ),
         patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
-        patch(
-            "aios.harness.loop.sessions_service.append_event",
-            AsyncMock(return_value=SimpleNamespace(id="ev")),
-        ),
+        patch("aios.harness.loop.sessions_service.append_event", append_event),
         patch(
             "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
             AsyncMock(return_value=guard_result),
@@ -555,7 +558,7 @@ async def _harness_with_guard(
         patch("aios.harness.loop.defer_wake", defer_wake),
         patch("aios.harness.loop.defer_run_wake", defer_run_wake),
     ):
-        yield defer_wake, defer_run_wake
+        yield defer_wake, defer_run_wake, manager
 
 
 class TestRequestTotalityWiring:
@@ -563,22 +566,40 @@ class TestRequestTotalityWiring:
     the suite leaves untested (every other loop-driving test mocks the guard to the
     all-False no-op)."""
 
-    async def test_nudge_defers_a_session_wake(self) -> None:
+    async def test_nudge_defers_a_session_wake_after_step_end(self) -> None:
         """guard says nudged -> the harness wakes the session (so the model gets
-        another turn to answer), and does NOT wake a caller run."""
+        another turn to answer), AFTER step_end so its wake_deferred lands in the
+        next step's window (#132), and does NOT wake a caller run."""
         from aios.harness.loop import run_session_step
 
-        async with _harness_with_guard((True, False, None)) as (defer_wake, defer_run_wake):
+        async with _harness_with_guard((True, False, None)) as (
+            defer_wake,
+            defer_run_wake,
+            manager,
+        ):
             await run_session_step("sess_x")
         defer_wake.assert_awaited_once_with(ANY, "sess_x", account_id=ANY, cause="request_nudge")
         defer_run_wake.assert_not_awaited()
+        # Ordering fence (mirrors the reschedule path): the nudge wake fires after
+        # the step_end span append, never inside the body.
+        last_step_end = max(
+            i
+            for i, (name, args, _kw) in enumerate(manager.mock_calls)
+            if name == "append_event" and args[2] == "span" and args[3].get("event") == "step_end"
+        )
+        first_defer = [name for name, _a, _kw in manager.mock_calls].index("defer_wake")
+        assert first_defer > last_step_end
 
     async def test_autoerror_defers_the_caller_run_wake(self) -> None:
         """guard says autoerrored -> the harness wakes the caller run to harvest the
         no_return response, and does NOT inject a session (nudge) wake."""
         from aios.harness.loop import run_session_step
 
-        async with _harness_with_guard((False, True, "run_x")) as (defer_wake, defer_run_wake):
+        async with _harness_with_guard((False, True, "run_x")) as (
+            defer_wake,
+            defer_run_wake,
+            _mgr,
+        ):
             await run_session_step("sess_x")
         defer_run_wake.assert_awaited_once_with("run_x")
         defer_wake.assert_not_awaited()

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -363,7 +363,7 @@ class TestStepStartEndSpans:
             ) as append_event,
             patch(
                 "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
-                AsyncMock(return_value=(False, False, None)),
+                AsyncMock(return_value=(False, None)),
             ),
             patch(
                 "aios.harness.loop.call_litellm",
@@ -487,7 +487,7 @@ class TestStepStartEndSpans:
 
 @contextlib.asynccontextmanager
 async def _harness_with_guard(
-    guard_result: tuple[bool, bool, str | None],
+    guard_result: tuple[bool, str | None],
 ) -> AsyncIterator[tuple[AsyncMock, AsyncMock, MagicMock]]:
     """Drive ``run_session_step`` past a clean (tool-call-free) model turn with the
     quiescence guard mocked to ``guard_result``. Yields ``(defer_wake,
@@ -572,7 +572,7 @@ class TestRequestTotalityWiring:
         next step's window (#132), and does NOT wake a caller run."""
         from aios.harness.loop import run_session_step
 
-        async with _harness_with_guard((True, False, None)) as (
+        async with _harness_with_guard((True, None)) as (
             defer_wake,
             defer_run_wake,
             manager,
@@ -595,7 +595,7 @@ class TestRequestTotalityWiring:
         no_return response, and does NOT inject a session (nudge) wake."""
         from aios.harness.loop import run_session_step
 
-        async with _harness_with_guard((False, True, "run_x")) as (
+        async with _harness_with_guard((False, "run_x")) as (
             defer_wake,
             defer_run_wake,
             _mgr,

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -464,6 +464,10 @@ class TestStepStartEndSpans:
                 AsyncMock(side_effect=RuntimeError("provider boom")),
             ),
             patch("aios.harness.loop.defer_wake", AsyncMock()),
+            # The terminal-error branch responds on the errored child's behalf;
+            # this non-child session would no-op in production, so mock the DB-backed
+            # collaborator out to keep the span-ordering assertion pool-free.
+            patch("aios.harness.loop.respond_to_request", AsyncMock(return_value="not_a_child")),
             patch(
                 "aios.harness.loop._count_consecutive_rescheduling",
                 AsyncMock(return_value=4),  # budget exhausted — no re-raise, returns None

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -185,7 +185,12 @@ class TestStepStartEndSpans:
         from aios.harness.loop import run_session_step
 
         session = SimpleNamespace(
-            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+            id="sess_x",
+            agent_id="agt_x",
+            agent_version=None,
+            focal_channel=None,
+            origin="foreground",
+            parent_run_id=None,
         )
         agent = SimpleNamespace(
             model="openrouter/x",
@@ -288,7 +293,12 @@ class TestStepStartEndSpans:
         from aios.harness.loop import run_session_step
 
         session = SimpleNamespace(
-            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+            id="sess_x",
+            agent_id="agt_x",
+            agent_version=None,
+            focal_channel=None,
+            origin="foreground",
+            parent_run_id=None,
         )
         agent = SimpleNamespace(
             model="openrouter/x",
@@ -385,7 +395,12 @@ class TestStepStartEndSpans:
         from aios.harness.loop import run_session_step
 
         session = SimpleNamespace(
-            id="sess_x", agent_id="agt_x", agent_version=None, focal_channel=None
+            id="sess_x",
+            agent_id="agt_x",
+            agent_version=None,
+            focal_channel=None,
+            origin="foreground",
+            parent_run_id=None,
         )
         agent = SimpleNamespace(
             model="openrouter/x",

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -10,7 +10,8 @@ Covers:
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+import contextlib
+from collections.abc import AsyncIterator, Iterator
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -361,6 +362,10 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=start_event),
             ) as append_event,
             patch(
+                "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
+                AsyncMock(return_value=(False, False, None)),
+            ),
+            patch(
                 "aios.harness.loop.call_litellm",
                 AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
             ),
@@ -464,10 +469,10 @@ class TestStepStartEndSpans:
                 AsyncMock(side_effect=RuntimeError("provider boom")),
             ),
             patch("aios.harness.loop.defer_wake", AsyncMock()),
-            # The terminal-error branch responds on the errored child's behalf;
+            # The terminal-error branch fails the errored child's open requests;
             # this non-child session would no-op in production, so mock the DB-backed
             # collaborator out to keep the span-ordering assertion pool-free.
-            patch("aios.harness.loop.respond_to_request", AsyncMock(return_value="not_a_child")),
+            patch("aios.harness.loop.fail_all_open_requests", AsyncMock(return_value=0)),
             patch(
                 "aios.harness.loop._count_consecutive_rescheduling",
                 AsyncMock(return_value=4),  # budget exhausted — no re-raise, returns None
@@ -478,3 +483,102 @@ class TestStepStartEndSpans:
         span_names = _span_event_names(append_event)
         assert span_names[0] == "step_start"
         assert span_names[-1] == "step_end"
+
+
+@contextlib.asynccontextmanager
+async def _harness_with_guard(
+    guard_result: tuple[bool, bool, str | None],
+) -> AsyncIterator[tuple[AsyncMock, AsyncMock]]:
+    """Drive ``run_session_step`` past a clean (tool-call-free) model turn with the
+    quiescence guard mocked to ``guard_result``. Yields the captured
+    ``(defer_wake, defer_run_wake)`` so a test can assert the post-guard wiring
+    (loop.py: nudge -> defer_wake(request_nudge); autoerror -> defer_run_wake)."""
+    session = SimpleNamespace(
+        id="sess_x",
+        agent_id="agt_x",
+        agent_version=None,
+        focal_channel=None,
+        origin="background",
+        parent_run_id="run_x",
+    )
+    agent = SimpleNamespace(
+        model="openrouter/x",
+        tools=[],
+        mcp_servers=[],
+        http_servers=[],
+        skills=[],
+        system="sys",
+        litellm_extra={},
+        window_min=1000,
+        window_max=10000,
+    )
+    defer_wake = AsyncMock()
+    defer_run_wake = AsyncMock()
+    with (
+        patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+        patch("aios.harness.loop.runtime.require_task_registry", return_value=MagicMock()),
+        patch(
+            "aios.harness.loop.find_sessions_needing_inference", AsyncMock(return_value={"sess_x"})
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.get_session_basic", AsyncMock(return_value=session)
+        ),
+        patch("aios.harness.loop.agents_service.get_agent", AsyncMock(return_value=agent)),
+        patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
+        patch(
+            "aios.harness.loop.sessions_service.read_windowed_events", AsyncMock(return_value=[])
+        ),
+        patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
+        patch(
+            "aios.harness.loop.compose_step_context",
+            AsyncMock(
+                return_value=SimpleNamespace(
+                    model="openrouter/x", messages=[], tools=[], reacting_to=0, skill_versions=[]
+                )
+            ),
+        ),
+        patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
+        patch(
+            "aios.harness.loop.sessions_service.append_event",
+            AsyncMock(return_value=SimpleNamespace(id="ev")),
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
+            AsyncMock(return_value=guard_result),
+        ),
+        patch(
+            "aios.harness.loop.stream_litellm",
+            AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+        ),
+        patch("aios.harness.loop.sessions_service.increment_usage", AsyncMock()),
+        patch("aios.db.sse_lock.has_subscriber", AsyncMock(return_value=False)),
+        patch("aios.harness.loop.defer_wake", defer_wake),
+        patch("aios.harness.loop.defer_run_wake", defer_run_wake),
+    ):
+        yield defer_wake, defer_run_wake
+
+
+class TestRequestTotalityWiring:
+    """The loop's post-guard wiring (loop.py) — covers the True branches the rest of
+    the suite leaves untested (every other loop-driving test mocks the guard to the
+    all-False no-op)."""
+
+    async def test_nudge_defers_a_session_wake(self) -> None:
+        """guard says nudged -> the harness wakes the session (so the model gets
+        another turn to answer), and does NOT wake a caller run."""
+        from aios.harness.loop import run_session_step
+
+        async with _harness_with_guard((True, False, None)) as (defer_wake, defer_run_wake):
+            await run_session_step("sess_x")
+        defer_wake.assert_awaited_once_with(ANY, "sess_x", account_id=ANY, cause="request_nudge")
+        defer_run_wake.assert_not_awaited()
+
+    async def test_autoerror_defers_the_caller_run_wake(self) -> None:
+        """guard says autoerrored -> the harness wakes the caller run to harvest the
+        no_return response, and does NOT inject a session (nudge) wake."""
+        from aios.harness.loop import run_session_step
+
+        async with _harness_with_guard((False, True, "run_x")) as (defer_wake, defer_run_wake):
+            await run_session_step("sess_x")
+        defer_run_wake.assert_awaited_once_with("run_x")
+        defer_wake.assert_not_awaited()

--- a/tests/unit/test_wf_child_id.py
+++ b/tests/unit/test_wf_child_id.py
@@ -1,0 +1,25 @@
+"""B2.A — deterministic child-session id (folds the full call_key)."""
+
+from __future__ import annotations
+
+from aios.ids import split_id
+from aios.workflows.child_id import child_session_id
+
+
+def test_deterministic_and_parseable() -> None:
+    a = child_session_id("wfr_run", "sha:abc#0")
+    b = child_session_id("wfr_run", "sha:abc#0")
+    assert a == b  # same (run_id, call_key) -> same id (replay reproduces it)
+    prefix, ulid_part = split_id(a)
+    assert prefix == "sess" and len(ulid_part) == 26
+
+
+def test_identical_siblings_get_distinct_ids() -> None:
+    # The §3.1 pinned invariant: parallel([agent('ping')]*3) -> keys #0/#1/#2 ->
+    # THREE distinct children. Folding the content hash alone would collapse them.
+    ids = {child_session_id("wfr_run", f"sha:abc#{n}") for n in range(3)}
+    assert len(ids) == 3
+
+
+def test_distinct_runs_get_distinct_ids() -> None:
+    assert child_session_id("wfr_a", "sha:abc#0") != child_session_id("wfr_b", "sha:abc#0")


### PR DESCRIPTION
## Block 2 — agent invocation via `invoke_session` (request/response, parallel/pipeline, totality caps)

Makes a workflow run spawn **real agent child-sessions**, resolving every `agent()` call to a value or a raised `AgentError` in **bounded time** (totality).

### The primitive

The committed completion design accreted archival races because it conflated *"the child answered the call"* with *"the child is finished."* Those are two events. The re-architecture adopts the right primitive — **`invoke_session` = capture exactly one response + resume the caller, regardless of the target's subsequent fate.** The target is never terminated on the hot path ("responding ≠ terminating"), so there is nothing to archive to complete a call, and the races dissolve.

### What's here

- **R1 — request/response core.** A child is spawned carrying a request (`request_id == call_key`). `return`/`error` write an exactly-once `request_response` (`write_response_if_absent`, first-writer-wins via `FOR UPDATE` + absent-recheck). `derive_response` is the single monotonic resolver: responded | child_gone | pending, in one snapshot.
- **R2 — model-failure → written error response** (closes the errored-child hole monotonically, not via the recoverable latch).
- **R3 — host outcome channel.** Memo entry is `{ok}` | `{error}`; the driver throws a catchable `AgentError`/`AgentNoReturnError` at the await.
- **R4 — totality as an atomic session-quiescence guard.** A session may not go idle owing an open request — the nudge is appended *atomically* with the would-be-idle assistant turn (same idleness check every external reader uses), then a per-request budget → `no_return` auto-error.
- **R5 — run-end reclaim deferred** (dissolves the eager-reclaim race) + a `run_session_step` archived guard.
- **G — `parallel()` / `pipeline()`** over a deterministic cooperative branch scheduler (`pipeline` composes over `parallel`). call_keys are **branch-local** (`branch.path + per-branch CallKeyer`) so they're replay-stable across partial-memo drives; the barrier absorbs a failed agent (`AgentError` → `None`) and **only** that — any other branch exception fails the run.
- **H — runaway caps.** Lifetime agent-call cap (parent-side, atomic, gates new spawns only), per-`parallel` fan-out cap (host constant, replay-stable, distinct `too_wide_fanout` kind), and a per-call wall-clock deadline → `timeout` response (closes the loops-forever-child hole; fired by the periodic sweep, race-safe via exactly-once write + re-derive).

### Verification

`mypy` ✓ · `ruff` ✓ · **1757 unit** ✓ · **242 integration** ✓ (real-Postgres spawn → suspend → harvest → resume, totality, exactly-once, parallel determinism + order-preservation, all three caps at/over boundary, the derive→write TOCTOU race, mid-flight cap reduction). No openapi/SDK drift.

**Live smoke-tested** on an isolated runtime (worker + Postgres + real Sonnet): pure-Python `parallel` → `[21,42]`; agent round-trip → `"pong"` (model genuinely calls the `return` tool); multi-agent fan-out → `["ALPHA","BETA"]` (branch order preserved despite out-of-order completion); 1001-wide fan-out → `too_wide_fanout`, 0 children spawned.

Each stage ran `/simplify` + `/code-review max --fix` (adversarial multi-agent review, ~50 agents/stage); the determinism, H3-TOCTOU, and H1-retroactive-kill findings were fixed and regression-tested.

### Merged with master

Integrates eumemic/aios#743/#744/#746/#750/#751/#752. Two substantive points: the migration `0066` collision with master's `session_status_scalars` is resolved by renumbering this branch's migrations to `0067–0069` (linear, single head); and eumemic/aios#750's O(1) scalar-column session-status rearchitecture is taken wholesale — the R4 guard stays correct by construction (it appends via `append_event`, which now maintains the scalars, then derives status in the same transaction) and is re-validated by the integration suite **and** a live re-smoke on the merged code.

### Deferred (shaped-for, not built)

`invoke_session` as a session-callable tool · `invoke_workflow` · `output_schema` validation · `schedule-archival-on-quiescence` (so a timed-out looping child is eventually reclaimed — H3 resolves the caller, not the child) · recursive errored-run bubbling to a grandparent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)