### PR TITLE
feat(harness): shed oversized tool results at the dispatch boundary (#735)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -179,6 +179,14 @@ class Settings(BaseSettings):
         description="Maximum bytes of stdout+stderr returned from a bash tool call. "
         "Output beyond this is truncated with a [truncated] marker.",
     )
+    tool_result_max_chars: int = Field(
+        default=200_000,
+        ge=1_000,
+        description="Maximum characters of a tool result stored inline in the "
+        "event log. A larger result is spilled to a file under the session's "
+        "attachments mount and replaced inline with a stub pointing the model "
+        "to read it, so a single oversized result can't exceed the context window.",
+    )
     upload_max_size_bytes: int = Field(
         default=50 * 1024 * 1024,
         ge=1,

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -269,6 +269,15 @@ async def _append_tool_result_event(
     """
     from aios.db import queries
 
+    content = event_data.get("content")
+    if isinstance(content, str):
+        from aios.config import get_settings
+        from aios.sandbox.tool_result_spill import cap_tool_result_content
+
+        event_data["content"] = await cap_tool_result_content(
+            session_id, tool_call_id, content, max_chars=get_settings().tool_result_max_chars
+        )
+
     async with pool.acquire() as conn, conn.transaction():
         await conn.execute(
             "SELECT 1 FROM sessions WHERE id = $1 AND account_id = $2 FOR UPDATE",

--- a/src/aios/sandbox/tool_result_spill.py
+++ b/src/aios/sandbox/tool_result_spill.py
@@ -1,0 +1,50 @@
+"""Spill oversized tool-result content to the session attachments mount.
+
+A tool result larger than ``tool_result_max_chars`` would, stored inline,
+exceed the model context window on its own (windowing can only drop whole
+events, never shrink one). Capping it here at the append boundary keeps
+``cumulative_tokens`` honest. The full body is written to the session's
+attachments dir (bind-mounted read-only at ``/mnt/attachments`` every
+provision), recoverable by the model with the ``read`` tool (#735).
+
+Only ``str`` content is capped (the two append sinks guard on
+``isinstance(content, str)``); structured/list tool-result content — rare and
+typically bounded — passes through uncapped, as do oversized non-tool events
+(e.g. an unbounded ``switch_channel`` recap).  Tool results are the dominant
+overflow source; the residual shapes are left for a follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aios.sandbox.volumes import ensure_session_attachments_dir, safe_filename
+
+_SPILL_SUBDIR = "tool_results"
+
+
+async def cap_tool_result_content(
+    session_id: str, tool_call_id: str, content: str, *, max_chars: int
+) -> str:
+    """Return ``content`` unchanged if within ``max_chars``; otherwise spill the
+    full body to ``<attachments>/tool_results/<tool_call_id>.txt`` and return a
+    stub string referencing the in-sandbox path + the ``read`` tool."""
+    if len(content) <= max_chars:
+        return content
+    fname = safe_filename(f"{tool_call_id}.txt")
+    sandbox_path = f"/mnt/attachments/{_SPILL_SUBDIR}/{fname}"
+    await asyncio.to_thread(_write_spill, session_id, fname, content)
+    return (
+        f"[Tool result truncated: the full output ({len(content):,} characters) "
+        f"exceeded the inline result limit and was saved to {sandbox_path}. "
+        f"Use the read tool to view it.]"
+    )
+
+
+def _write_spill(session_id: str, fname: str, content: str) -> None:
+    spill_dir = ensure_session_attachments_dir(session_id) / _SPILL_SUBDIR
+    spill_dir.mkdir(parents=True, exist_ok=True)
+    target = spill_dir / fname
+    tmp = target.with_name(target.name + ".part")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(target)  # atomic rename

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -481,6 +481,12 @@ async def append_tool_result(
     in the connector-facing endpoint).  The caller is responsible for
     deferring the wake afterwards.
     """
+    from aios.sandbox.tool_result_spill import cap_tool_result_content
+
+    if isinstance(content, str):
+        content = await cap_tool_result_content(
+            session_id, tool_call_id, content, max_chars=get_settings().tool_result_max_chars
+        )
     async with conn.transaction():
         await queries.lock_active_session_for_update(conn, session_id, account_id=account_id)
         existing = await queries.find_tool_result_event(

--- a/tests/integration/test_tool_result_spill.py
+++ b/tests/integration/test_tool_result_spill.py
@@ -1,0 +1,164 @@
+"""Integration repro for #735: an oversized tool result must be capped at
+the append (dispatch) boundary so ``cumulative_tokens`` reflects the capped
+size and windowing stays correct by construction.
+
+A single tool result larger than the model context budget wedges the
+session — windowing can only drop whole events, never shrink one, so a
+lone oversized result can't be shed.  The fix caps the result content at
+the SERVICE append sink (``sessions_service.append_tool_result``): the
+inline body is replaced with a stub pointing the model at the full output
+spilled under the session's attachments mount, recoverable via ``read``.
+
+This test drives the real service sink against a testcontainer Postgres,
+then asserts:
+
+* oversized → the stored tool event content is a ``[Tool result
+  truncated:`` stub naming ``/mnt/attachments/tool_results/`` AND the full
+  body is on the host spill file, byte-for-byte.
+* within-cap → the content is stored verbatim, no spill file written.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import asyncpg
+import pytest
+
+from aios.config import get_settings
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.agents import ToolSpec
+from aios.sandbox.volumes import ensure_session_attachments_dir
+from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+_DEFAULT_MAX_CHARS = 200_000
+
+
+@pytest.fixture
+async def spill_session(
+    migrated_db_url: str, _reset_db_state: None, tmp_path: Path
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, session_id, tool_call_id)`` for a session whose event
+    log contains an assistant message carrying a single ``tool_calls`` entry
+    (so ``append_tool_result`` finds a parent), with ``workspace_root``
+    pointed at an isolated ``tmp_path`` so the spill file lands somewhere we
+    can read on the host.
+    """
+    with mock.patch.dict(os.environ, {"AIOS_WORKSPACE_ROOT": str(tmp_path / "workspaces")}):
+        get_settings.cache_clear()
+        pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            account_id = "acc_spill"
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO accounts
+                        (id, parent_account_id, can_mint_children, display_name)
+                    VALUES ($1, NULL, TRUE, 'spill-test-root')
+                    """,
+                    account_id,
+                )
+            _agent, _env, session = await seed_agent_env_session(
+                pool,
+                account_id=account_id,
+                prefix="spill",
+                tools=[ToolSpec(type="bash")],
+            )
+            tool_call_id = "tc_spill_1"
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn,
+                    account_id=account_id,
+                    session_id=session.id,
+                    kind="message",
+                    data={
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": tool_call_id,
+                                "type": "function",
+                                "function": {"name": "bash", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                )
+            yield pool, session.id, tool_call_id
+        finally:
+            await pool.close()
+            get_settings.cache_clear()
+
+
+async def _stored_tool_content(pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str) -> str:
+    async with pool.acquire() as conn:
+        event = await queries.find_tool_result_event(
+            conn, session_id, tool_call_id, account_id="acc_spill"
+        )
+    assert event is not None
+    content = event.data["content"]
+    assert isinstance(content, str)
+    return content
+
+
+class TestToolResultSpill:
+    async def test_oversized_result_spilled_and_stubbed(
+        self,
+        spill_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, session_id, tool_call_id = spill_session
+        original = "X" * 300_000  # > the 200_000 default cap
+        assert len(original) > _DEFAULT_MAX_CHARS
+
+        async with pool.acquire() as conn:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id="acc_spill",
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content=original,
+            )
+
+        stored = await _stored_tool_content(pool, session_id, tool_call_id)
+        assert stored.startswith("[Tool result truncated:")
+        assert "/mnt/attachments/tool_results/" in stored
+        assert len(stored) < len(original)
+
+        spill_file = (
+            ensure_session_attachments_dir(session_id) / "tool_results" / f"{tool_call_id}.txt"
+        )
+        assert spill_file.exists()
+        assert spill_file.read_text(encoding="utf-8") == original
+
+    async def test_within_cap_result_stored_verbatim(
+        self,
+        spill_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, session_id, tool_call_id = spill_session
+        original = "Y" * 100  # well under the cap
+
+        async with pool.acquire() as conn:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id="acc_spill",
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content=original,
+            )
+
+        stored = await _stored_tool_content(pool, session_id, tool_call_id)
+        assert stored == original
+
+        spill_file = (
+            ensure_session_attachments_dir(session_id) / "tool_results" / f"{tool_call_id}.txt"
+        )
+        # ``ensure_session_attachments_dir`` creates the session dir, but the
+        # tool_results spill subdir + file must NOT exist for a within-cap result.
+        assert not spill_file.exists()

--- a/tests/unit/test_tool_result_spill.py
+++ b/tests/unit/test_tool_result_spill.py
@@ -1,0 +1,80 @@
+"""Unit coverage for :func:`aios.sandbox.tool_result_spill.cap_tool_result_content`.
+
+Deterministic, no Docker: a ``tmp_path`` workspace root is monkeypatched onto
+the cached settings so the spill file lands somewhere inspectable (mirrors the
+``monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)`` pattern in
+``test_volumes_attachments.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aios.config import get_settings
+from aios.sandbox.tool_result_spill import cap_tool_result_content
+from aios.sandbox.volumes import ensure_session_attachments_dir
+
+_SESSION_ID = "sess_spill_unit"
+_TOOL_CALL_ID = "tc_unit_1"
+
+
+def _spill_path(session_id: str, tool_call_id: str) -> Path:
+    return ensure_session_attachments_dir(session_id) / "tool_results" / f"{tool_call_id}.txt"
+
+
+async def test_within_cap_returns_unchanged_and_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)
+    content = "z" * 500
+
+    result = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
+
+    assert result == content
+    assert not _spill_path(_SESSION_ID, _TOOL_CALL_ID).exists()
+
+
+async def test_exactly_at_cap_returns_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Boundary: ``len(content) == max_chars`` is within the cap (``<=``)."""
+    monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)
+    content = "a" * 1_000
+
+    result = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
+
+    assert result == content
+    assert not _spill_path(_SESSION_ID, _TOOL_CALL_ID).exists()
+
+
+async def test_over_cap_returns_stub_and_writes_full_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)
+    content = "b" * 1_500
+
+    result = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
+
+    assert result.startswith("[Tool result truncated:")
+    assert "/mnt/attachments/tool_results/tc_unit_1.txt" in result
+    assert "1,500 characters" in result
+    assert "read tool" in result
+
+    spill = _spill_path(_SESSION_ID, _TOOL_CALL_ID)
+    assert spill.exists()
+    assert spill.read_text(encoding="utf-8") == content
+
+
+async def test_no_part_temp_left_behind(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The atomic-rename write must leave only the final file, not its
+    ``.part`` staging sibling."""
+    monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)
+    content = "c" * 2_000
+
+    await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
+
+    spill_dir = _spill_path(_SESSION_ID, _TOOL_CALL_ID).parent
+    names = sorted(p.name for p in spill_dir.iterdir())
+    assert names == [f"{_TOOL_CALL_ID}.txt"]


### PR DESCRIPTION
## Summary

Fixes **#735**. A single tool result so large it alone exceeds the model context window **wedges the session**: windowing can only drop whole events from the front, never *shrink* one, so the over-budget event survives every wake and the session can't make progress.

**Fix — shed the oversized result at the append (dispatch) boundary.** A tool result over `tool_result_max_chars` (`AIOS_`-prefixed, default 200k) is replaced inline with a stub and its full body spilled to the session's attachments dir — bind-mounted read-only at `/mnt/attachments` every provision — recoverable by the model with the `read` tool.

Capping at append, **before** `append_event` computes `cumulative_tokens`, keeps the windowing math correct **by construction**: the oversized body never enters the windowed/rendered path, so a single event can no longer exceed the budget.

- Wired into the **two** `role=tool` append sinks (the complete set): `_append_tool_result_event` (harness built-in/MCP/error) and `append_tool_result` (custom/connector/operator).
- Mirrors the existing `bash_max_output_bytes` truncate-with-marker cap; reuses the attachments mount → **no `/workspace` repo pollution**, existing cleanup lifecycle.
- Per the chosen direction this ships the **shed** (the issue's options 2/3), not the option-1 park/idle floor.

## Residuals (candidate follow-ups, intentionally out of scope)

- Only `str` content is capped — structured/`list` tool results pass through (rare; tool results are overwhelmingly str/JSON-string).
- Oversized **non-tool** events (e.g. an unbounded `switch_channel` recap, eumemic/eumemic-ops#287's harder sibling) aren't shed here.
- An agent with a very small window and a result *between* the char cap and its token budget isn't covered — the option-1 `context_overflow` floor guard (`window.py:26-27,99`, documented-but-unimplemented) would backstop these. Happy to follow up with the floor if you want the belt-and-suspenders.

## Test plan

- [x] `mypy src` — clean
- [x] `ruff check` + format — clean
- [x] Unit — **1748 passed**, incl. 4 new helper tests (within-cap, boundary, over-cap stub+spill, no `.part` left)
- [x] Integration (real Postgres) — repro `test_tool_result_spill.py` fails pre-fix (300k-char result stored verbatim) and passes after (stub + spilled file, full body byte-for-byte)
- [x] No openapi/SDK drift (config field isn't FastAPI-introspected)
- [ ] CI runs the full e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes eumemic/aios#735