### PR TITLE
fix(harness): age-guard the confirmed-tool dispatch path (#746)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -323,6 +323,26 @@ class Settings(BaseSettings):
         "unresolved-tool-call read-model, which surfaces all unresolved calls "
         "regardless of age (#741).",
     )
+    confirmed_dispatch_max_age_seconds: int = Field(
+        default=60 * 60,  # 1 hour
+        ge=60,
+        description="Age ceiling, in seconds, on the confirmation of an "
+        "operator-confirmed-but-unresolved tool call surfaced for auto-dispatch "
+        "on resume (``list_confirmed_unresolved_tool_calls`` / sweep "
+        "``CONFIRMED_ROWS_SQL``). A confirmed call whose ``tool_confirmed`` event "
+        "is older than this is SKIPPED — excluded from re-dispatch, not expired "
+        "(the event log is left untouched, no synthetic result). The bound is on "
+        "the CONFIRM event's ``created_at``, NOT the assistant turn: an operator "
+        "can confirm an OLD proposal, which is a FRESH intent to dispatch, so the "
+        "dispatchable-since timestamp is when confirmation was granted. A "
+        "legitimately confirmed call dispatches within seconds, so the default 1h "
+        "never touches a real one; the bound only suppresses weeks-stale "
+        "confirmations from re-running a side-effecting tool on a worker restart "
+        "(#746). Parallel to ``connector_backfill_max_age_seconds`` (#744); both "
+        "detection (sweep) and dispatch (resolver) apply this same bound in sync "
+        "so they resolve the identical condition (no wake-with-no-progress loop, "
+        "the #155 symptom).",
+    )
 
     # ── observability ──────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -2013,6 +2013,7 @@ async def list_confirmed_unresolved_tool_calls(
     session_id: str,
     *,
     account_id: str,
+    max_age_seconds: int | None = None,
 ) -> list[dict[str, Any]]:
     """Return the dispatchable ``tool_call`` dicts for a session: those
     operator-confirmed (``tool_confirmed``/``allow``) whose ``tool_call_id``
@@ -2022,12 +2023,28 @@ async def list_confirmed_unresolved_tool_calls(
     This is the dispatch-side resolver of the SAME predicate the sweep uses to
     wake the session for case (c) — ``sweep.CONFIRMED_ROWS_SQL``: a
     ``tool_confirmed``/``allow`` lifecycle event whose ``tool_call_id`` has no
-    ``role='tool'`` result.  Detection (the sweep, cross-session, projecting
+    ``role='tool'`` result, AND (when bounded) whose confirmation is within
+    ``max_age_seconds``.  Detection (the sweep, cross-session, projecting
     only ``session_id``) and dispatch (here, per-session, projecting the
     ``tool_call`` dicts) therefore agree by construction; re-resolving per step
-    is load-bearing against the wake→step TOCTOU window.
+    is load-bearing against the wake→step TOCTOU window.  CRITICAL: the age
+    clause here MUST stay byte-for-byte identical to ``CONFIRMED_ROWS_SQL`` —
+    a mismatch surfaces a session for wake that then yields no dispatchable
+    call, the wake-with-no-progress loop (#155 symptom).
 
-    Unwindowed and unbounded — keyed on ``tool_call_id`` via the
+    ``max_age_seconds`` is an OPTIONAL age bound on the ``tool_confirmed``
+    lifecycle event's (``lc``) ``created_at`` — when set, calls whose
+    CONFIRMATION is older than that many seconds are SKIPPED (excluded from
+    dispatch, not expired; no synthetic result).  It is keyed on the CONFIRM
+    event, NOT the assistant turn: an operator can confirm an OLD proposal,
+    which is a FRESH intent to dispatch (#746).  It defaults to ``None`` (no
+    bound) for safety/testability; this path is dispatch-only (the sole caller
+    is ``_dispatch_confirmed_tools`` via ``sessions.py``, no read-model
+    caller), so the dispatch caller always passes
+    ``settings.confirmed_dispatch_max_age_seconds``.  Parallel to the connector
+    backfill bound in :func:`_unresolved_tool_calls` (#744).
+
+    Unwindowed otherwise — keyed on ``tool_call_id`` via the
     ``events_tool_confirmed_allow_idx`` partial index (migration 0065), so a
     confirmed tool whose parent assistant has scrolled out of the token window,
     or simply isn't the latest assistant, is still recovered (#737).  The
@@ -2055,6 +2072,10 @@ async def list_confirmed_unresolved_tool_calls(
            AND lc.kind = 'lifecycle'
            AND lc.data->>'event' = 'tool_confirmed'
            AND lc.data->>'result' = 'allow'
+           AND (
+                 $3::bigint IS NULL
+                 OR lc.created_at >= now() - make_interval(secs => $3::bigint)
+               )
            AND NOT EXISTS (
                SELECT 1 FROM events tr
                 WHERE tr.session_id = lc.session_id
@@ -2067,6 +2088,7 @@ async def list_confirmed_unresolved_tool_calls(
         """,
         session_id,
         account_id,
+        max_age_seconds,
     )
     out: list[dict[str, Any]] = []
     seen: set[str] = set()

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -27,6 +27,7 @@ import asyncpg
 if TYPE_CHECKING:
     from aios.models.agents import ToolSpec
 
+from aios.config import get_settings
 from aios.db.queries import parse_jsonb
 from aios.harness.task_registry import TaskRegistry
 from aios.logging import get_logger
@@ -125,8 +126,14 @@ CANDIDATE_ROWS_SQL = """
 # decision (case (c)).  The dispatch-side counterpart that resolves these same
 # confirmed-allow, result-less tool_calls into the actual tool_call dicts to
 # launch is ``queries.list_confirmed_unresolved_tool_calls`` (per-session) —
-# keep the predicate (``tool_confirmed``/``allow`` ∧ no ``role='tool'`` result)
-# in sync.  Both are served by ``events_tool_confirmed_allow_idx`` (0065).
+# keep the predicate (``tool_confirmed``/``allow`` ∧ no ``role='tool'`` result
+# ∧ confirm event within ``confirmed_dispatch_max_age_seconds``) in sync.  The
+# age bound is on ``lc.created_at`` (the CONFIRM event), NOT the assistant
+# turn: a fresh confirm of an old proposal is a fresh intent to dispatch
+# (#746).  CRITICAL: this age clause MUST stay byte-for-byte identical to the
+# dispatch resolver's — if detection surfaces a session for wake that dispatch
+# then can't resolve (or vice-versa), the worker wakes with no progress, the
+# #155 symptom.  Both are served by ``events_tool_confirmed_allow_idx`` (0065).
 CONFIRMED_ROWS_SQL = """
     SELECT DISTINCT lc.session_id
       FROM events lc
@@ -135,6 +142,10 @@ CONFIRMED_ROWS_SQL = """
        AND lc.kind = 'lifecycle'
        AND lc.data->>'event' = 'tool_confirmed'
        AND lc.data->>'result' = 'allow'
+       AND (
+             {age_param}::bigint IS NULL
+             OR lc.created_at >= now() - make_interval(secs => {age_param}::bigint)
+           )
        AND NOT EXISTS (
            SELECT 1 FROM events tr
             WHERE tr.session_id = lc.session_id
@@ -510,9 +521,17 @@ async def find_sessions_needing_inference(
         candidates = {r["session_id"] for r in candidate_rows}
 
         # Case (c) bypasses the batch filter — confirmed tools need dispatch.
+        # The confirm-event age bound (#746) MUST match the dispatch resolver's
+        # (``queries.list_confirmed_unresolved_tool_calls``) so detection and
+        # dispatch resolve the identical condition (no wake-with-no-progress,
+        # the #155 symptom).  ``$N`` is positional after ``scope_params``; bind
+        # the setting so a weeks-stale confirmation is not surfaced for wake.
+        confirmed_max_age_seconds = get_settings().confirmed_dispatch_max_age_seconds
+        age_param = f"${len(scope_params) + 1}"
         confirmed_rows = await conn.fetch(
-            CONFIRMED_ROWS_SQL.format(scope_clause=scope_clause),
+            CONFIRMED_ROWS_SQL.format(scope_clause=scope_clause, age_param=age_param),
             *scope_params,
+            confirmed_max_age_seconds,
         )
         confirmed_sessions = {r["session_id"] for r in confirmed_rows}
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -584,10 +584,18 @@ async def list_confirmed_unresolved_tool_calls(
     ``always_ask`` tool whose parent assistant has scrolled out of the token
     window (#737) — or simply isn't the latest assistant — is still recovered,
     and one that already has a result is not re-dispatched (invariant #4).
+
+    Passes ``settings.confirmed_dispatch_max_age_seconds`` as the age bound on
+    the CONFIRM event: a confirmation older than that is skipped, so a
+    weeks-stale confirmed side-effecting call is not re-dispatched on a worker
+    restart (#746). This path is dispatch-only (no read-model caller), so the
+    bound is always applied here; it stays in sync with the sweep's detection
+    predicate (``sweep.CONFIRMED_ROWS_SQL``), which reads the same setting.
     """
+    max_age_seconds = get_settings().confirmed_dispatch_max_age_seconds
     async with pool.acquire() as conn:
         return await queries.list_confirmed_unresolved_tool_calls(
-            conn, session_id, account_id=account_id
+            conn, session_id, account_id=account_id, max_age_seconds=max_age_seconds
         )
 
 

--- a/tests/integration/test_stale_confirmed_dispatch_recovery.py
+++ b/tests/integration/test_stale_confirmed_dispatch_recovery.py
@@ -1,0 +1,415 @@
+"""Regression suite for aios #746 — age-guard the confirmed-tool dispatch path.
+
+Background
+----------
+Commit 775554e ("fix(harness): confirmed-tool dispatch hardening — window-edge
+#737 / awaiting #741 / sweep-predicate unification #740") replaced the OLD
+*windowed* confirmed-tool dispatch with a NEW *unwindowed* recovery query
+``queries.list_confirmed_unresolved_tool_calls`` (``src/aios/db/queries/__init__.py``),
+called by ``_dispatch_confirmed_tools`` (``src/aios/harness/loop.py``).  Its
+detection twin is ``sweep.CONFIRMED_ROWS_SQL`` (the case-(c) wake predicate).
+
+Both predicates matched a ``tool_confirmed``/``allow`` lifecycle event whose
+``tool_call_id`` has no paired ``role='tool'`` result — *unwindowed, with no age
+bound* (``created_at`` was never consulted).  So an operator-confirmed
+``always_ask`` tool call that never dispatched was re-dispatched on the next
+worker-restart / resume regardless of age (re-running a weeks-stale,
+side-effecting tool).
+
+Incident (#744, the connector sibling): on a worker restart, this recovered 17
+``signal_send`` calls confirmed-but-undispatched since ~2.5 weeks earlier and
+dispatched them with stale content (synchronous connector RPC at dispatch time),
+so the messages went out fresh-stamped but stale-content.
+
+The fix (#746)
+--------------
+A new setting ``confirmed_dispatch_max_age_seconds`` (default 1h, parallel to
+``connector_backfill_max_age_seconds`` from #744) bounds BOTH predicates on the
+CONFIRM event's ``created_at`` — the ``tool_confirmed`` lifecycle row, NOT the
+assistant turn.  An operator can confirm an OLD proposal, which is a FRESH
+intent to dispatch, so the dispatchable-since timestamp is when confirmation was
+granted.  Skip-not-expire: stale calls are simply excluded; no synthetic
+results, no log mutation.
+
+CRITICAL: detection (sweep) and dispatch (resolver) apply the IDENTICAL age
+clause, so they resolve the same condition — a mismatch surfaces a session for
+wake that dispatch can't resolve (or vice-versa), the wake-with-no-progress loop
+(#155 symptom).  ``TestConfirmDispatchSweepSync`` pins that invariant directly.
+
+The invariant this suite pins
+-----------------------------
+A confirmed-unresolved tool call whose CONFIRMATION is far older than any sane
+staleness window MUST NOT be auto-dispatched (or surfaced for wake) on recovery
+— but a FRESH confirmation MUST be, even when the underlying assistant proposal
+is old (the bound is on confirm-time, not assistant-time).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.config import get_settings
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.harness import sweep
+from aios.harness.loop import _dispatch_confirmed_tools
+from aios.harness.task_registry import TaskRegistry
+from aios.models.agents import ToolSpec
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+# A confirmation that has sat unresolved for ~3 weeks. The incident's stale
+# ``signal_send`` calls were ~2.5 weeks old; 21 days is comfortably past the
+# default ``confirmed_dispatch_max_age_seconds`` (1h) staleness window.
+STALE_AGE = dt.timedelta(days=21)
+
+
+def _assistant(tool_call_ids: list[str], name: str = "bash") -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": tcid,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+            for tcid in tool_call_ids
+        ],
+    }
+
+
+def _allow(tool_call_id: str) -> dict[str, Any]:
+    return {"event": "tool_confirmed", "result": "allow", "tool_call_id": tool_call_id}
+
+
+@pytest.fixture
+async def session_with_stale_connector_send(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a session whose log is:
+
+        A1[tc_stale (signal_send)]  ← confirmed (allow) ~3 weeks ago, NO result
+        user("are you still there?")
+        A2[tc_fresh (signal_send)]  ← confirmed (allow), result present
+        allow(tc_stale)             ← backdated ~3 weeks
+        allow(tc_fresh)
+        tool_result(tc_fresh)
+
+    A1 is deliberately NOT the latest assistant (A2 is), so ``tc_stale`` is the
+    #737 window-edge / non-latest-assistant case the unwindowed resolver was
+    built to recover.  ``tc_stale`` is a CONNECTOR send (``signal_send``) and is
+    aged so its confirmation predates the staleness window.  ``tc_fresh`` is the
+    control: confirmed AND resolved, so it must never re-dispatch (invariant #4)
+    — it is here to prove the fixture's recovery surface is real.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_stale_confirmed_dispatch"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, $2)",
+                account_id,
+                "stale-confirmed-dispatch-test",
+            )
+        # ``signal_send`` is a connector tool; the resolver matches whatever
+        # tool_call dict sits on the assistant (it does not filter by tool
+        # name), so a real ToolSpec is unnecessary — mirror the existing test
+        # and seed a plain bash ToolSpec for the agent scaffold.
+        _agent, _env, session = await seed_agent_env_session(
+            pool,
+            account_id=account_id,
+            prefix="stale-confirmed-dispatch",
+            tools=[ToolSpec(type="bash")],
+        )
+        sid = session.id
+
+        async def append(kind: str, data: dict[str, Any]) -> None:
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn, account_id=account_id, session_id=sid, kind=kind, data=data
+                )
+
+        # A1 carries the stale connector send (confirmed, never resolved); A2 is
+        # the LATEST assistant and carries a resolved connector send — so the
+        # stale tool's parent is deliberately not the latest assistant.
+        await append("message", _assistant(["tc_stale"], name="signal_send"))
+        await append("message", {"role": "user", "content": "are you still there?"})
+        await append("message", _assistant(["tc_fresh"], name="signal_send"))
+        await append("lifecycle", _allow("tc_stale"))
+        await append("lifecycle", _allow("tc_fresh"))
+        await append(
+            "message",
+            {
+                "role": "tool",
+                "tool_call_id": "tc_fresh",
+                "content": "sent",
+                "name": "signal_send",
+            },
+        )
+
+        # Backdate the stale call's age. ``append_event`` stamps
+        # ``created_at = now()`` (the table default); rewrite it on the rows
+        # that carry the call's age — the A1 assistant that issued the
+        # ``signal_send`` AND its ``tool_confirmed``/``allow`` lifecycle event —
+        # so the confirmation is ~3 weeks old, well past the window.  The fix
+        # (#746) keys on the CONFIRM event's ``created_at``, so backdating the
+        # lifecycle row is load-bearing here; the assistant backdate is kept too
+        # so the fixture also reflects a genuinely old proposal.
+        old = dt.datetime.now(dt.UTC) - STALE_AGE
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE events SET created_at = $1 "
+                "WHERE session_id = $2 AND account_id = $3 "
+                "AND ("
+                "  (kind = 'message' AND role = 'assistant' "
+                "   AND data->'tool_calls' @> jsonb_build_array("
+                "       jsonb_build_object('id', 'tc_stale'::text)))"
+                "  OR (kind = 'lifecycle' AND data->>'event' = 'tool_confirmed' "
+                "      AND data->>'tool_call_id' = 'tc_stale')"
+                ")",
+                old,
+                sid,
+                account_id,
+            )
+
+        yield pool, account_id, sid
+    finally:
+        await pool.close()
+
+
+@pytest.fixture
+async def session_with_fresh_confirm_on_old_proposal(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for the over-reach guard:
+
+        A1[tc_revived (signal_send)]  ← assistant turn backdated ~3 weeks
+        allow(tc_revived)             ← confirmation created NOW, NO result
+
+    An operator left an ``always_ask`` proposal sitting for ~3 weeks, then
+    confirmed it NOW.  The bound is on the CONFIRM event's ``created_at``, not
+    the assistant turn, so this MUST still dispatch — the confirmation is a
+    fresh intent.  Backdating ONLY the assistant turn (not the lifecycle row)
+    is the whole point of the fixture.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_fresh_confirm_old_proposal"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, $2)",
+                account_id,
+                "fresh-confirm-old-proposal-test",
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool,
+            account_id=account_id,
+            prefix="fresh-confirm-old-proposal",
+            tools=[ToolSpec(type="bash")],
+        )
+        sid = session.id
+
+        async def append(kind: str, data: dict[str, Any]) -> None:
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn, account_id=account_id, session_id=sid, kind=kind, data=data
+                )
+
+        await append("message", _assistant(["tc_revived"], name="signal_send"))
+        await append("lifecycle", _allow("tc_revived"))
+
+        # Backdate ONLY the assistant turn — NOT the ``tool_confirmed`` event.
+        # The confirmation stays stamped at ``now()`` (fresh), so the bound (on
+        # the confirm event) must NOT exclude it even though the proposal is old.
+        old = dt.datetime.now(dt.UTC) - STALE_AGE
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE events SET created_at = $1 "
+                "WHERE session_id = $2 AND account_id = $3 "
+                "AND kind = 'message' AND role = 'assistant' "
+                "AND data->'tool_calls' @> jsonb_build_array("
+                "    jsonb_build_object('id', 'tc_revived'::text))",
+                old,
+                sid,
+                account_id,
+            )
+
+        yield pool, account_id, sid
+    finally:
+        await pool.close()
+
+
+class TestStaleConfirmedDispatchExcluded:
+    async def test_stale_confirm_excluded_by_resolver(
+        self,
+        session_with_stale_connector_send: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """The raw resolver, when passed the age bound, drops the ~3-week-old
+        confirmed ``signal_send`` (regression for #746 at the query layer).
+
+        Passing ``max_age_seconds`` explicitly here exercises the new clause;
+        the production dispatch path (the test below) reads the setting itself.
+        """
+        pool, account_id, session_id = session_with_stale_connector_send
+        async with pool.acquire() as conn:
+            dispatchable = await queries.list_confirmed_unresolved_tool_calls(
+                conn,
+                session_id,
+                account_id=account_id,
+                max_age_seconds=get_settings().confirmed_dispatch_max_age_seconds,
+            )
+        ids = [tc["id"] for tc in dispatchable]
+        assert ids == [], (
+            "stale confirmed signal_send (confirmed ~3 weeks ago) must be "
+            f"excluded once the age bound is applied; got {ids}"
+        )
+
+        # Unbounded (the default), the resolver still recovers it — the bound is
+        # opt-in and the only difference, so the old recovery surface is intact.
+        async with pool.acquire() as conn:
+            unbounded = await queries.list_confirmed_unresolved_tool_calls(
+                conn, session_id, account_id=account_id
+            )
+        assert [tc["id"] for tc in unbounded] == ["tc_stale"], (
+            "without the age bound the resolver must still recover the stale "
+            "call (the bound is the only behavioral change)"
+        )
+
+    async def test_stale_connector_send_excluded(
+        self,
+        session_with_stale_connector_send: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """INVARIANT (#746 / #744): a confirmed-unresolved CONNECTOR send whose
+        confirmation is far older than the staleness window MUST NOT be
+        auto-dispatched on recovery.  This is the brought-in repro's contract —
+        it was RED on master and is GREEN with the fix.
+        """
+        pool, account_id, session_id = session_with_stale_connector_send
+
+        pending = await _dispatch_confirmed_tools(
+            pool,
+            session_id,
+            account_id=account_id,
+            task_registry=TaskRegistry(),
+        )
+        pending_ids = [tc["id"] for tc in pending]
+
+        assert "tc_stale" not in pending_ids, (
+            "STALE CONNECTOR SEND RECOVERED (bug #744/#746): a signal_send "
+            f"confirmed ~{STALE_AGE.days} days ago was returned for auto-dispatch "
+            "and would be transmitted with stale content on this worker restart. "
+            "The age guard on the confirm event must exclude it. "
+            f"dispatchable={pending_ids}"
+        )
+
+
+class TestFreshConfirmOnOldProposalStillDispatches:
+    """Over-reach guard: the bound is on confirm-time, NOT assistant-time."""
+
+    async def test_fresh_confirm_old_proposal_is_dispatched(
+        self,
+        session_with_fresh_confirm_on_old_proposal: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A FRESH confirmation of an OLD (~3-week) assistant proposal MUST
+        still dispatch — confirming an old proposal is a fresh intent to act,
+        and the age bound keys on the ``tool_confirmed`` event, not the
+        assistant turn.  Guards against the bound over-reaching onto the
+        assistant timestamp (which would silently drop legitimately-revived
+        proposals).
+        """
+        pool, account_id, session_id = session_with_fresh_confirm_on_old_proposal
+
+        pending = await _dispatch_confirmed_tools(
+            pool,
+            session_id,
+            account_id=account_id,
+            task_registry=TaskRegistry(),
+        )
+        pending_ids = [tc["id"] for tc in pending]
+
+        assert pending_ids == ["tc_revived"], (
+            "a fresh confirmation of a ~3-week-old proposal must dispatch (the "
+            "bound is on the confirm event, not the assistant turn); got "
+            f"{pending_ids} — if empty, the bound wrongly keys on assistant-time"
+        )
+        assert pending[0]["function"]["name"] == "signal_send"
+
+
+class TestConfirmDispatchSweepSync:
+    """Detection (sweep ``CONFIRMED_ROWS_SQL``) and dispatch
+    (``list_confirmed_unresolved_tool_calls``) MUST agree on the same age
+    bound, or the worker wakes a session it then can't make progress on (the
+    #155 wake-with-no-progress symptom)."""
+
+    async def test_stale_confirm_surfaced_by_neither(
+        self,
+        session_with_stale_connector_send: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A session whose only confirmed-unresolved call is stale (confirm >
+        threshold) is surfaced for wake by NEITHER detection nor dispatch."""
+        pool, account_id, session_id = session_with_stale_connector_send
+        max_age = get_settings().confirmed_dispatch_max_age_seconds
+
+        # Detection: the sweep's CONFIRMED_ROWS_SQL, scoped to this session,
+        # must NOT return it (its only confirmed-unresolved call is stale).
+        async with pool.acquire() as conn:
+            detected = await conn.fetch(
+                sweep.CONFIRMED_ROWS_SQL.format(scope_clause="AND s.id = $1", age_param="$2"),
+                session_id,
+                max_age,
+            )
+        assert [r["session_id"] for r in detected] == [], (
+            "detection (CONFIRMED_ROWS_SQL) surfaced a session whose only "
+            "confirmed-unresolved call is weeks-stale — it would wake the "
+            "worker with no dispatchable call (wake-no-progress, #155)"
+        )
+
+        # Dispatch: the resolver, with the same bound, must agree (no call).
+        async with pool.acquire() as conn:
+            dispatchable = await queries.list_confirmed_unresolved_tool_calls(
+                conn, session_id, account_id=account_id, max_age_seconds=max_age
+            )
+        assert dispatchable == [], (
+            "dispatch resolver disagreed with detection on the stale call — "
+            "the two predicates must stay in sync"
+        )
+
+    async def test_fresh_confirm_surfaced_by_both(
+        self,
+        session_with_fresh_confirm_on_old_proposal: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """The inverse: a FRESH confirmation (on an old proposal) IS surfaced by
+        BOTH detection and dispatch — they stay in sync on the positive case
+        too, so a legitimately-dispatchable call still triggers a wake AND
+        resolves to a tool_call."""
+        pool, account_id, session_id = session_with_fresh_confirm_on_old_proposal
+        max_age = get_settings().confirmed_dispatch_max_age_seconds
+
+        async with pool.acquire() as conn:
+            detected = await conn.fetch(
+                sweep.CONFIRMED_ROWS_SQL.format(scope_clause="AND s.id = $1", age_param="$2"),
+                session_id,
+                max_age,
+            )
+        assert [r["session_id"] for r in detected] == [session_id], (
+            "detection must surface the session with a fresh confirmation "
+            "(even on an old proposal) so the worker wakes to dispatch it"
+        )
+
+        async with pool.acquire() as conn:
+            dispatchable = await queries.list_confirmed_unresolved_tool_calls(
+                conn, session_id, account_id=account_id, max_age_seconds=max_age
+            )
+        assert [tc["id"] for tc in dispatchable] == ["tc_revived"], (
+            "dispatch must resolve the same fresh-confirmed call detection "
+            "surfaced — the two predicates stay in sync on the positive case"
+        )


### PR DESCRIPTION
## Summary

Age-guards the confirmed-tool dispatch path so an operator-confirmed-but-unresolved tool call is no longer re-dispatched weeks later on a worker restart/resume. This is the dispatch-path sibling of [#744](https://github.com/eumemic/eumemic-ops/issues/298) (the connector-SSE backfill guard, just merged).

## Root cause

The confirmed-tool dispatch resolver `queries.list_confirmed_unresolved_tool_calls` (used by `_dispatch_confirmed_tools`, `loop.py`) and its **detection** twin `sweep.CONFIRMED_ROWS_SQL` (the case-(c) wake predicate) both matched a `tool_confirmed`/`allow` lifecycle event whose `tool_call_id` has no paired `role='tool'` result — **unwindowed, with no age bound** (`created_at` was never consulted).

So an `always_ask` tool call an operator confirmed but that never dispatched (worker died between confirm and launch, etc.) is recovered and re-dispatched on the next resume **regardless of age** — re-running a weeks-stale, side-effecting tool. [#744](https://github.com/eumemic/eumemic-ops/issues/298) was the connector instance: a restart re-sent 17 `signal_send`s confirmed ~2.5 weeks earlier, fresh-stamped but stale-content.

## Fix — two predicates in sync, bound on confirm-time

1. **New setting** `confirmed_dispatch_max_age_seconds` (`config.py`, default 1h, `ge=60`), mirroring `connector_backfill_max_age_seconds` from [#744](https://github.com/eumemic/eumemic-ops/issues/298).

2. **Both predicates bounded on the CONFIRM event's `created_at`** (the `tool_confirmed` lifecycle row `lc`), NOT the assistant turn. The design point: an operator can confirm an **OLD** proposal, which is a **FRESH** intent to dispatch — so the dispatchable-since timestamp is when confirmation was granted, not when the model proposed the call.
   - `list_confirmed_unresolved_tool_calls` gains an optional `max_age_seconds` param (default `None` = no bound, for safety/testability). It is **dispatch-only** (sole caller is `_dispatch_confirmed_tools` via `sessions.py` — no read-model caller, unlike [#744](https://github.com/eumemic/eumemic-ops/issues/298)'s `_unresolved_tool_calls`), so the dispatch caller always passes the setting.
   - `sweep.CONFIRMED_ROWS_SQL` gains the same clause, parameterized; the setting is bound at the `find_sessions_needing_inference` call site.

3. **The two age clauses are byte-for-byte identical** — `lc.created_at >= now() - make_interval(secs => $N::bigint)`, gated by `$N::bigint IS NULL OR ...`, placed immediately before the `NOT EXISTS` result guard in both. The in-code comments at both sites flag this. A mismatch would surface a session for wake that dispatch then can't resolve — the [#155](https://github.com/eumemic/aios/issues/155) wake-with-no-progress loop.

4. **Skip-not-expire**: stale calls are simply excluded. No synthetic results, no log mutation.

## Test evidence (Postgres testcontainer)

The brought-in repro was **RED on master**:
```
FAILED test_stale_connector_send_excluded — assert 'tc_stale' not in ['tc_stale']
```
**GREEN with the fix**, alongside the new tests:
```
tests/integration/test_stale_confirmed_dispatch_recovery.py .....  5 passed
```

- **repro / invariant** — a 21-day-old confirmed `signal_send` is excluded from `_dispatch_confirmed_tools` (and from the raw resolver when the bound is passed; still recovered unbounded, so the bound is the only behavioral change).
- **over-reach guard** — a **FRESH** confirm of a **~3-week-old** assistant proposal STILL dispatches (the bound is on confirm-time, not assistant-time). Guards against the bound wrongly keying on the assistant timestamp.
- **sweep-sync** — `CONFIRMED_ROWS_SQL` (detection) and `list_confirmed_unresolved_tool_calls` (dispatch) BOTH exclude the stale call, and BOTH surface the fresh one — proving detection and dispatch stay in lockstep (no wake-no-progress).
- **regression** — `test_confirmed_unresolved_dispatch.py` (fresh confirmed calls dispatch normally, default `None` bound) + the full confirm/dispatch/sweep/errored slice (36 tests) + the sweep perf guard (EXPLAIN — no SubPlan / N+1 regression) all still pass.

`ruff check` / `ruff format` / `mypy src` clean.

Closes eumemic/aios#746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
