### PR TITLE
fix(db): O(1) session-status via maintained scalar columns

### DIFF
--- a/migrations/versions/0066_session_status_scalars.py
+++ b/migrations/versions/0066_session_status_scalars.py
@@ -1,14 +1,27 @@
-"""Add four monotonic scalar columns to ``sessions`` for O(1) status derivation.
+"""Add five monotonic scalar columns to ``sessions`` for O(1) status derivation.
 
 Replaces the O(n) correlated-subquery status derivation (``_SESSION_STATUS_EXPR``,
 ``_SESSION_ERRORED_EXPR``, ``_SESSION_ACTIVE_EXPR``) with pure column arithmetic.
-The four columns — ``last_reacted_seq``, ``open_tool_call_count``,
-``last_error_seq``, ``last_user_seq`` — are maintained transactionally inside
-``append_event`` and backfilled from the event log for existing sessions.
+The five columns — ``last_reacted_seq``, ``open_tool_call_count``,
+``last_error_seq``, ``last_user_seq``, ``last_stimulus_seq`` — are maintained
+transactionally inside ``append_event`` and backfilled from the event log for
+existing sessions.
+
+``last_stimulus_seq`` is the max ``seq`` of *stimulus* events the assistant
+must react to: ``kind = 'message' AND role <> 'assistant'`` (user + tool
+messages). It is NOT the same as ``last_user_seq`` (user-only, the error
+latch): the active predicate must include unreacted tool results, the error
+latch must not. Critically, the active predicate compares against
+``last_stimulus_seq``, NOT ``last_event_seq`` — the latter includes the
+session's own assistant replies, so a normal idle session (user → assistant
+reply, no tool calls) would have ``last_event_seq > last_reacted_seq`` and read
+wrongly as ``active``, driving one extra model step (#749 regression). This is
+exactly the pre-#732 ``EXISTS(non-assistant message with seq >
+last_reacted_seq)`` derivation, expressed as a scalar.
 
 Status predicate (pure column arithmetic):
   errored = last_error_seq > 0 AND last_error_seq > last_user_seq
-  active  = (last_event_seq > last_reacted_seq OR open_tool_call_count > 0)
+  active  = (last_stimulus_seq > last_reacted_seq OR open_tool_call_count > 0)
             AND NOT errored
   idle    = otherwise
 
@@ -46,6 +59,10 @@ def upgrade() -> None:
         "ALTER TABLE sessions "
         "ADD COLUMN IF NOT EXISTS last_user_seq BIGINT NOT NULL DEFAULT 0"
     )
+    op.execute(
+        "ALTER TABLE sessions "
+        "ADD COLUMN IF NOT EXISTS last_stimulus_seq BIGINT NOT NULL DEFAULT 0"
+    )
 
     # ── backfill last_user_seq ───────────────────────────────────────────
     op.execute(
@@ -55,6 +72,22 @@ def upgrade() -> None:
                SELECT MAX(e.seq) FROM events e
                 WHERE e.session_id = s.id
                   AND e.kind = 'message' AND e.role = 'user'
+           ), 0)
+        """
+    )
+
+    # ── backfill last_stimulus_seq ───────────────────────────────────────
+    # Max seq of the stimuli the assistant must react to: message events
+    # whose role is NOT 'assistant' (user + tool). Excludes the session's
+    # own assistant replies — that exclusion is the whole point of the
+    # column (see module docstring).
+    op.execute(
+        """
+        UPDATE sessions s
+           SET last_stimulus_seq = COALESCE((
+               SELECT MAX(e.seq) FROM events e
+                WHERE e.session_id = s.id
+                  AND e.kind = 'message' AND e.role <> 'assistant'
            ), 0)
         """
     )
@@ -72,23 +105,20 @@ def upgrade() -> None:
     )
 
     # ── backfill last_reacted_seq ────────────────────────────────────────
-    # GREATEST of: max assistant reacting_to, and max turn_ended seq.
+    # The reaction watermark: MAX(COALESCE(reacting_to, seq)) over assistant
+    # messages — exactly the pre-#732 ``session_max_reacting`` CTE. NOT bumped
+    # by ``turn_ended`` lifecycle events: a rescheduling ``turn_ended`` has no
+    # assistant reaction, and folding it in would falsely mark an unreacted
+    # user message as reacted-to (flipping a retry-pending session to idle).
     op.execute(
         """
         UPDATE sessions s
-           SET last_reacted_seq = GREATEST(
-               COALESCE((
-                   SELECT MAX(COALESCE((e.data->>'reacting_to')::bigint, e.seq))
-                     FROM events e
-                    WHERE e.session_id = s.id
-                      AND e.kind = 'message' AND e.role = 'assistant'
-               ), 0),
-               COALESCE((
-                   SELECT MAX(e.seq) FROM events e
-                    WHERE e.session_id = s.id
-                      AND e.kind = 'lifecycle' AND e.data->>'event' = 'turn_ended'
-               ), 0)
-           )
+           SET last_reacted_seq = COALESCE((
+               SELECT MAX(COALESCE((e.data->>'reacting_to')::bigint, e.seq))
+                 FROM events e
+                WHERE e.session_id = s.id
+                  AND e.kind = 'message' AND e.role = 'assistant'
+           ), 0)
         """
     )
 
@@ -121,3 +151,4 @@ def downgrade() -> None:
     op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS open_tool_call_count")
     op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS last_error_seq")
     op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS last_user_seq")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS last_stimulus_seq")

--- a/migrations/versions/0066_session_status_scalars.py
+++ b/migrations/versions/0066_session_status_scalars.py
@@ -1,0 +1,123 @@
+"""Add four monotonic scalar columns to ``sessions`` for O(1) status derivation.
+
+Replaces the O(n) correlated-subquery status derivation (``_SESSION_STATUS_EXPR``,
+``_SESSION_ERRORED_EXPR``, ``_SESSION_ACTIVE_EXPR``) with pure column arithmetic.
+The four columns — ``last_reacted_seq``, ``open_tool_call_count``,
+``last_error_seq``, ``last_user_seq`` — are maintained transactionally inside
+``append_event`` and backfilled from the event log for existing sessions.
+
+Status predicate (pure column arithmetic):
+  errored = last_error_seq > 0 AND last_error_seq > last_user_seq
+  active  = (last_event_seq > last_reacted_seq OR open_tool_call_count > 0)
+            AND NOT errored
+  idle    = otherwise
+
+Revision ID: 0066
+Revises: 0065
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0066"
+down_revision: str = "0065"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ── add columns ──────────────────────────────────────────────────────
+    op.execute(
+        "ALTER TABLE sessions "
+        "ADD COLUMN IF NOT EXISTS last_reacted_seq BIGINT NOT NULL DEFAULT 0"
+    )
+    op.execute(
+        "ALTER TABLE sessions "
+        "ADD COLUMN IF NOT EXISTS open_tool_call_count INT NOT NULL DEFAULT 0"
+    )
+    op.execute(
+        "ALTER TABLE sessions "
+        "ADD COLUMN IF NOT EXISTS last_error_seq BIGINT NOT NULL DEFAULT 0"
+    )
+    op.execute(
+        "ALTER TABLE sessions "
+        "ADD COLUMN IF NOT EXISTS last_user_seq BIGINT NOT NULL DEFAULT 0"
+    )
+
+    # ── backfill last_user_seq ───────────────────────────────────────────
+    op.execute(
+        """
+        UPDATE sessions s
+           SET last_user_seq = COALESCE((
+               SELECT MAX(e.seq) FROM events e
+                WHERE e.session_id = s.id
+                  AND e.kind = 'message' AND e.role = 'user'
+           ), 0)
+        """
+    )
+
+    # ── backfill last_error_seq ──────────────────────────────────────────
+    op.execute(
+        """
+        UPDATE sessions s
+           SET last_error_seq = COALESCE((
+               SELECT MAX(e.seq) FROM events e
+                WHERE e.session_id = s.id
+                  AND e.kind = 'lifecycle' AND e.data->>'stop_reason' = 'error'
+           ), 0)
+        """
+    )
+
+    # ── backfill last_reacted_seq ────────────────────────────────────────
+    # GREATEST of: max assistant reacting_to, and max turn_ended seq.
+    op.execute(
+        """
+        UPDATE sessions s
+           SET last_reacted_seq = GREATEST(
+               COALESCE((
+                   SELECT MAX(COALESCE((e.data->>'reacting_to')::bigint, e.seq))
+                     FROM events e
+                    WHERE e.session_id = s.id
+                      AND e.kind = 'message' AND e.role = 'assistant'
+               ), 0),
+               COALESCE((
+                   SELECT MAX(e.seq) FROM events e
+                    WHERE e.session_id = s.id
+                      AND e.kind = 'lifecycle' AND e.data->>'event' = 'turn_ended'
+               ), 0)
+           )
+        """
+    )
+
+    # ── backfill open_tool_call_count ────────────────────────────────────
+    # Count tool_call_ids from assistant messages that have no paired
+    # tool-role result event, using per-tool_call_id anti-join.
+    op.execute(
+        """
+        UPDATE sessions s
+           SET open_tool_call_count = COALESCE((
+               SELECT COUNT(*)
+                 FROM events ate
+                CROSS JOIN LATERAL jsonb_array_elements(ate.data->'tool_calls') tc
+                WHERE ate.session_id = s.id
+                  AND ate.kind = 'message' AND ate.role = 'assistant'
+                  AND ate.data ? 'tool_calls'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM events tr
+                       WHERE tr.session_id = s.id
+                         AND tr.kind = 'message' AND tr.role = 'tool'
+                         AND tr.data->>'tool_call_id' = tc->>'id'
+                  )
+           ), 0)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS last_reacted_seq")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS open_tool_call_count")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS last_error_seq")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS last_user_seq")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -780,64 +780,30 @@ async def list_agent_versions(
 
 # ─── sessions ─────────────────────────────────────────────────────────────────
 
-# Read-time derivation of the session ``status`` ({active, idle}) from the event
-# log — there is no persisted status column (#728-era status collapse). A
-# session is ``active`` when it has owed/in-flight work that will advance
-# WITHOUT a new unprompted user message:
-#   * an unreacted stimulus  — a non-assistant message event past the assistant
-#     ``reacting_to`` watermark (queued/generating/tool-completed-awaiting-step), OR
-#   * an unresolved tool_call — an assistant tool_call with no tool-role result
-#     (harness tool in-flight, or blocked on an approval/custom-tool result).
-# ...EXCEPT when ``errored`` (retry budget exhausted, not yet recovered): the
-# latest ``turn_ended``/``error`` lifecycle event is more recent than the latest
-# user message. Errored forces ``idle`` (a special case of idle) and the sweep
-# skips it — see ``sweep.ERRORED_SESSIONS_SQL`` (the same predicate, used to
-# exclude errored sessions from inference; keep the two in sync).
+# O(1) session status derivation from four maintained scalar columns
+# (``last_reacted_seq``, ``open_tool_call_count``, ``last_error_seq``,
+# ``last_user_seq``). These scalars are updated transactionally inside
+# ``append_event`` and backfilled by migration 0066. The status predicate
+# is pure column arithmetic — no correlated subqueries over ``events``.
 #
-# Correlated on ``sessions.id``/``sessions.account_id`` so it drops into any
-# query with ``sessions`` in scope. Each EXISTS rides a partial index
-# (events_session_message_seq_idx, events_assistant_tool_calls_idx,
-# events_tool_result_idx, events_turn_error_idx). For single reads and
-# keyset-limited list pages it evaluates on O(page) rows.
+# ``errored`` = last_error_seq > 0 AND last_error_seq > last_user_seq
+# ``active``  = (last_event_seq > last_reacted_seq OR open_tool_call_count > 0)
+#               AND NOT errored
+# ``idle``    = otherwise
 #
-# ``_SESSION_ACTIVE_EXPR`` — has owed/in-flight work (unreacted stimulus OR
-# unresolved tool_call). ``_SESSION_ERRORED_EXPR`` — parked-errored latch
-# (also reused by ``lock_active_session_for_update`` and the clone gate).
-_SESSION_ACTIVE_EXPR = """(
-        EXISTS (
-            SELECT 1 FROM events ev
-             WHERE ev.session_id = sessions.id AND ev.account_id = sessions.account_id
-               AND ev.kind = 'message' AND ev.role <> 'assistant'
-               AND ev.seq > COALESCE((
-                   SELECT MAX(COALESCE((ae.data->>'reacting_to')::bigint, ae.seq))
-                     FROM events ae
-                    WHERE ae.session_id = sessions.id AND ae.account_id = sessions.account_id
-                      AND ae.kind = 'message' AND ae.role = 'assistant'), 0))
-        OR EXISTS (
-            SELECT 1 FROM events ate
-             CROSS JOIN LATERAL jsonb_array_elements(ate.data->'tool_calls') tc
-             WHERE ate.session_id = sessions.id AND ate.account_id = sessions.account_id
-               AND ate.kind = 'message' AND ate.role = 'assistant' AND ate.data ? 'tool_calls'
-               AND NOT EXISTS (
-                   SELECT 1 FROM events tr
-                    WHERE tr.session_id = sessions.id AND tr.account_id = sessions.account_id
-                      AND tr.kind = 'message' AND tr.role = 'tool'
-                      AND tr.data->>'tool_call_id' = tc->>'id'))
-    )"""
-
-_SESSION_ERRORED_EXPR = """EXISTS (
-        SELECT 1 FROM events le
-         WHERE le.session_id = sessions.id AND le.account_id = sessions.account_id
-           AND le.kind = 'lifecycle' AND le.data->>'stop_reason' = 'error'
-           AND le.seq > COALESCE((
-               SELECT MAX(ue.seq) FROM events ue
-                WHERE ue.session_id = sessions.id AND ue.account_id = sessions.account_id
-                  AND ue.kind = 'message' AND ue.role = 'user'), 0))"""
-
-_SESSION_STATUS_EXPR = (
-    f"CASE WHEN {_SESSION_ACTIVE_EXPR} AND NOT {_SESSION_ERRORED_EXPR} "
-    "THEN 'active' ELSE 'idle' END"
+# ``_SESSION_ERRORED_EXPR`` is also reused by ``lock_active_session_for_update``
+# and the clone gate.
+_SESSION_ERRORED_EXPR = (
+    "(sessions.last_error_seq > 0 AND sessions.last_error_seq > sessions.last_user_seq)"
 )
+
+_SESSION_ACTIVE_EXPR = (
+    "((sessions.last_event_seq > sessions.last_reacted_seq"
+    " OR sessions.open_tool_call_count > 0)"
+    f" AND NOT {_SESSION_ERRORED_EXPR})"
+)
+
+_SESSION_STATUS_EXPR = f"CASE WHEN {_SESSION_ACTIVE_EXPR} THEN 'active' ELSE 'idle' END"
 
 
 def _row_to_session(row: asyncpg.Record) -> Session:
@@ -1478,11 +1444,17 @@ async def clone_session(
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 stop_reason, workspace_volume_path, env, last_event_seq,
-                focal_channel, focal_locked, account_id
+                focal_channel, focal_locked,
+                last_reacted_seq, open_tool_call_count,
+                last_error_seq, last_user_seq,
+                account_id
             )
             SELECT $1, agent_id, environment_id, agent_version, title, metadata,
                    stop_reason, $2, env, last_event_seq, focal_channel,
-                   focal_locked, account_id
+                   focal_locked,
+                   last_reacted_seq, open_tool_call_count,
+                   last_error_seq, last_user_seq,
+                   account_id
               FROM sessions WHERE id = $3
             RETURNING *
             """,
@@ -2164,17 +2136,40 @@ async def append_event(
     # (its seq exceeds the latest error lifecycle event — see
     # ``_SESSION_ERRORED_EXPR``), and the sweep stops skipping it (#39, #353).
     is_user_message = kind == "message" and role == "user"
+    is_error_lifecycle = kind == "lifecycle" and (data or {}).get("stop_reason") == "error"
+    is_turn_ended = kind == "lifecycle" and (data or {}).get("event") == "turn_ended"
+    tool_call_count_delta = (
+        len((data or {}).get("tool_calls") or [])
+        if kind == "message" and role == "assistant"
+        else (-1 if kind == "message" and role == "tool" else 0)
+    )
+    reacting_to_seq = (
+        int((data or {}).get("reacting_to") or 0)
+        if kind == "message" and role == "assistant"
+        else 0
+    )
 
     async with conn.transaction():
         seq_row = await conn.fetchrow(
             "UPDATE sessions "
             "SET last_event_seq = last_event_seq + 1, "
-            "    updated_at = CASE WHEN $3 THEN now() ELSE updated_at END "
+            "    updated_at = CASE WHEN $3 THEN now() ELSE updated_at END, "
+            "    last_user_seq = CASE WHEN $3 THEN last_event_seq + 1 ELSE last_user_seq END, "
+            "    last_error_seq = CASE WHEN $4 THEN last_event_seq + 1 ELSE last_error_seq END, "
+            "    open_tool_call_count = GREATEST(open_tool_call_count + $5, 0), "
+            "    last_reacted_seq = CASE "
+            "        WHEN $7 THEN last_event_seq + 1 "
+            "        WHEN $6 > 0 THEN GREATEST(last_reacted_seq, $6) "
+            "        ELSE last_reacted_seq END "
             "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL "
             "RETURNING last_event_seq, focal_channel",
             session_id,
             account_id,
             is_user_message,
+            is_error_lifecycle,
+            tool_call_count_delta,
+            reacting_to_seq,
+            is_turn_ended,
         )
         if seq_row is None:
             # Treat archived as "session no longer exists for write purposes."

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -780,16 +780,28 @@ async def list_agent_versions(
 
 # ─── sessions ─────────────────────────────────────────────────────────────────
 
-# O(1) session status derivation from four maintained scalar columns
+# O(1) session status derivation from five maintained scalar columns
 # (``last_reacted_seq``, ``open_tool_call_count``, ``last_error_seq``,
-# ``last_user_seq``). These scalars are updated transactionally inside
-# ``append_event`` and backfilled by migration 0066. The status predicate
-# is pure column arithmetic — no correlated subqueries over ``events``.
+# ``last_user_seq``, ``last_stimulus_seq``). These scalars are updated
+# transactionally inside ``append_event`` and backfilled by migration 0066.
+# The status predicate is pure column arithmetic — no correlated subqueries
+# over ``events``.
 #
 # ``errored`` = last_error_seq > 0 AND last_error_seq > last_user_seq
-# ``active``  = (last_event_seq > last_reacted_seq OR open_tool_call_count > 0)
+# ``active``  = (last_stimulus_seq > last_reacted_seq OR open_tool_call_count > 0)
 #               AND NOT errored
 # ``idle``    = otherwise
+#
+# ``last_stimulus_seq`` — NOT ``last_event_seq`` — is the unreacted-stimulus
+# watermark: it is the max seq of non-assistant messages (role <> 'assistant';
+# user + tool). ``last_event_seq`` includes the session's OWN assistant replies,
+# so after a normal idle turn (user → assistant reply) ``last_event_seq >
+# last_reacted_seq`` and the session would read wrongly as ``active`` — driving
+# one extra model step (#749). This expr is exactly the pre-#732 derivation
+# ``EXISTS(non-assistant message with seq > last_reacted_seq)``, as a scalar.
+# Must stay byte-for-byte in sync with ``CANDIDATE_ROWS_SQL`` in
+# ``harness/sweep.py`` — the sweep candidate filter and the read-path status
+# predicate MUST agree, or the worker wakes with no progress / vice-versa.
 #
 # ``_SESSION_ERRORED_EXPR`` is also reused by ``lock_active_session_for_update``
 # and the clone gate.
@@ -798,7 +810,7 @@ _SESSION_ERRORED_EXPR = (
 )
 
 _SESSION_ACTIVE_EXPR = (
-    "((sessions.last_event_seq > sessions.last_reacted_seq"
+    "((sessions.last_stimulus_seq > sessions.last_reacted_seq"
     " OR sessions.open_tool_call_count > 0)"
     f" AND NOT {_SESSION_ERRORED_EXPR})"
 )
@@ -1446,14 +1458,14 @@ async def clone_session(
                 stop_reason, workspace_volume_path, env, last_event_seq,
                 focal_channel, focal_locked,
                 last_reacted_seq, open_tool_call_count,
-                last_error_seq, last_user_seq,
+                last_error_seq, last_user_seq, last_stimulus_seq,
                 account_id
             )
             SELECT $1, agent_id, environment_id, agent_version, title, metadata,
                    stop_reason, $2, env, last_event_seq, focal_channel,
                    focal_locked,
                    last_reacted_seq, open_tool_call_count,
-                   last_error_seq, last_user_seq,
+                   last_error_seq, last_user_seq, last_stimulus_seq,
                    account_id
               FROM sessions WHERE id = $3
             RETURNING *
@@ -2136,16 +2148,31 @@ async def append_event(
     # (its seq exceeds the latest error lifecycle event — see
     # ``_SESSION_ERRORED_EXPR``), and the sweep stops skipping it (#39, #353).
     is_user_message = kind == "message" and role == "user"
+    # A *stimulus* is any message the assistant must react to: user OR tool
+    # (role <> 'assistant'). ``last_stimulus_seq`` tracks its max seq and drives
+    # the active predicate. This is deliberately broader than ``is_user_message``
+    # (the error latch) — an unreacted tool result keeps the session active, but
+    # must NOT clear an error. See ``_SESSION_ACTIVE_EXPR``.
+    is_stimulus = kind == "message" and role != "assistant"
     is_error_lifecycle = kind == "lifecycle" and data.get("stop_reason") == "error"
-    is_turn_ended = kind == "lifecycle" and data.get("event") == "turn_ended"
+    is_assistant_message = kind == "message" and role == "assistant"
     tool_call_count_delta = (
         len(data.get("tool_calls") or [])
-        if kind == "message" and role == "assistant"
+        if is_assistant_message
         else (-1 if kind == "message" and role == "tool" else 0)
     )
-    reacting_to_seq = (
-        int(data.get("reacting_to") or 0) if kind == "message" and role == "assistant" else 0
-    )
+    # The reaction watermark advances to MAX(COALESCE(reacting_to, seq)) over
+    # assistant messages — exactly the pre-#732 ``session_max_reacting`` CTE. An
+    # assistant message with an explicit ``reacting_to`` uses it; one without
+    # (seeded data, or an unprompted assistant turn) falls back to the
+    # assistant's OWN new seq (``last_event_seq + 1``). ``turn_ended`` lifecycle
+    # events do NOT bump it: a rescheduling ``turn_ended`` appends with no
+    # assistant reaction, and bumping the watermark there would falsely mark the
+    # still-unreacted user message as reacted-to, flipping a retry-pending
+    # session to idle (breaks the litellm/harness-error retry loop — the
+    # session must stay active so the sweep re-picks it). Reaction is tracked by
+    # assistant ``reacting_to``, never by turn boundaries.
+    reacting_to_seq = int(data.get("reacting_to") or 0) if is_assistant_message else 0
 
     async with conn.transaction():
         seq_row = await conn.fetchrow(
@@ -2153,11 +2180,13 @@ async def append_event(
             "SET last_event_seq = last_event_seq + 1, "
             "    updated_at = CASE WHEN $3 THEN now() ELSE updated_at END, "
             "    last_user_seq = CASE WHEN $3 THEN last_event_seq + 1 ELSE last_user_seq END, "
+            "    last_stimulus_seq = CASE WHEN $8 THEN last_event_seq + 1 "
+            "        ELSE last_stimulus_seq END, "
             "    last_error_seq = CASE WHEN $4 THEN last_event_seq + 1 ELSE last_error_seq END, "
             "    open_tool_call_count = GREATEST(open_tool_call_count + $5, 0), "
             "    last_reacted_seq = CASE "
-            "        WHEN $7 THEN last_event_seq + 1 "
-            "        WHEN $6 > 0 THEN GREATEST(last_reacted_seq, $6) "
+            "        WHEN $7 THEN GREATEST(last_reacted_seq, "
+            "            CASE WHEN $6 > 0 THEN $6 ELSE last_event_seq + 1 END) "
             "        ELSE last_reacted_seq END "
             "WHERE id = $1 AND account_id = $2 AND archived_at IS NULL "
             "RETURNING last_event_seq, focal_channel",
@@ -2167,7 +2196,8 @@ async def append_event(
             is_error_lifecycle,
             tool_call_count_delta,
             reacting_to_seq,
-            is_turn_ended,
+            is_assistant_message,
+            is_stimulus,
         )
         if seq_row is None:
             # Treat archived as "session no longer exists for write purposes."

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -2136,17 +2136,15 @@ async def append_event(
     # (its seq exceeds the latest error lifecycle event — see
     # ``_SESSION_ERRORED_EXPR``), and the sweep stops skipping it (#39, #353).
     is_user_message = kind == "message" and role == "user"
-    is_error_lifecycle = kind == "lifecycle" and (data or {}).get("stop_reason") == "error"
-    is_turn_ended = kind == "lifecycle" and (data or {}).get("event") == "turn_ended"
+    is_error_lifecycle = kind == "lifecycle" and data.get("stop_reason") == "error"
+    is_turn_ended = kind == "lifecycle" and data.get("event") == "turn_ended"
     tool_call_count_delta = (
-        len((data or {}).get("tool_calls") or [])
+        len(data.get("tool_calls") or [])
         if kind == "message" and role == "assistant"
         else (-1 if kind == "message" and role == "tool" else 0)
     )
     reacting_to_seq = (
-        int((data or {}).get("reacting_to") or 0)
-        if kind == "message" and role == "assistant"
-        else 0
+        int(data.get("reacting_to") or 0) if kind == "message" and role == "assistant" else 0
     )
 
     async with conn.transaction():

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -187,7 +187,8 @@ ALL_ASST_ROWS_SQL = """
 ERRORED_SESSIONS_SQL = """
     SELECT s.id AS session_id
       FROM sessions s
-     WHERE s.last_error_seq > 0
+     WHERE s.archived_at IS NULL
+       AND s.last_error_seq > 0
        AND s.last_error_seq > s.last_user_seq
        {scope_clause}
 """

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -100,11 +100,18 @@ GHOST_SPAN_START_SQL = """
        AND e.data->>'tool_call_id' = ANY($2::text[])
 """
 
+# Candidate filter — MUST stay byte-for-byte in sync (modulo table alias) with
+# ``queries._SESSION_ACTIVE_EXPR``: the read-path status predicate and this wake
+# predicate have to agree, or the worker either wakes a session with no progress
+# to make (#155 symptom) or skips one that needs inference. ``last_stimulus_seq``
+# (non-assistant messages — user + tool), NOT ``last_event_seq`` (which includes
+# the session's own assistant replies): the latter classifies an idle turn
+# (user → assistant reply) as a candidate and drives one extra model step (#749).
 CANDIDATE_ROWS_SQL = """
     SELECT s.id AS session_id
       FROM sessions s
      WHERE s.archived_at IS NULL
-       AND (s.last_event_seq > s.last_reacted_seq
+       AND (s.last_stimulus_seq > s.last_reacted_seq
             OR s.open_tool_call_count > 0)
        AND NOT (s.last_error_seq > 0 AND s.last_error_seq > s.last_user_seq)
        {scope_clause}

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -55,13 +55,11 @@ class SweepResult:
 # ─── query constants ─────────────────────────────────────────────────────────
 #
 # Sweep SQL lives here as module constants so tests/e2e/test_sweep_perf.py
-# can EXPLAIN the exact production query text — a structural assertion
-# guards against accidental reintroduction of the correlated-subquery
-# N+1 pattern that #140 fixed. Column predicates use ``role`` (from
-# migration 0022) instead of ``data->>'role'``; partial indexes were
-# re-predicated to match in migration 0023. The two MAX(reacting_to)
-# queries use a CTE to hoist the aggregation out of the outer scan —
-# see PR #145 for the ~800-900x speedup that revealed.
+# can EXPLAIN the exact production query text. ``CANDIDATE_ROWS_SQL``
+# and ``ERRORED_SESSIONS_SQL`` now use the four maintained scalar columns
+# on ``sessions`` (migration 0066) — pure column arithmetic, no event-log
+# scans. Ghost-repair queries still scan ``events`` because they need
+# per-tool_call_id resolution the scalars don't carry.
 
 
 GHOST_ASST_SQL = """
@@ -103,22 +101,12 @@ GHOST_SPAN_START_SQL = """
 """
 
 CANDIDATE_ROWS_SQL = """
-    WITH session_max_reacting AS (
-        SELECT session_id,
-               MAX(COALESCE((data->>'reacting_to')::bigint, seq)) AS max_reacting
-          FROM events
-         WHERE kind = 'message' AND role = 'assistant'
-         {cte_scope_clause}
-         GROUP BY session_id
-    )
-    SELECT DISTINCT e.session_id
-      FROM events e
-      JOIN sessions s ON s.id = e.session_id
-      LEFT JOIN session_max_reacting smr ON smr.session_id = e.session_id
+    SELECT s.id AS session_id
+      FROM sessions s
      WHERE s.archived_at IS NULL
-       AND e.kind = 'message'
-       AND e.role <> 'assistant'
-       AND (smr.max_reacting IS NULL OR e.seq > smr.max_reacting)
+       AND (s.last_event_seq > s.last_reacted_seq
+            OR s.open_tool_call_count > 0)
+       AND NOT (s.last_error_seq > 0 AND s.last_error_seq > s.last_user_seq)
        {scope_clause}
 """
 
@@ -191,39 +179,17 @@ ALL_ASST_ROWS_SQL = """
        AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
 """
 
-# Sessions currently in the terminal "errored" state, derived from the event
-# log (there is no denormalized ``status`` column). A session is errored when
-# its most recent ``turn_ended``/``error`` lifecycle event is more recent than
-# its most recent user message — i.e. a model-call failure exhausted the retry
-# budget and no user message has since arrived to recover it. A later user
-# message flips the inequality (``user_seq > err_seq``), which is exactly the
-# recovery semantics the pre-derivation ``append_event`` ``idle/errored →
-# pending`` flip provided.
-#
-# Shape: two ``MAX(seq)``-per-session CTEs joined — the same hoisted-aggregation
-# pattern as ``session_max_reacting`` above, so no correlated SubPlan re-scans
-# ``events`` (the #140 pathology). The error CTE is backed by the partial index
-# ``events_turn_error_idx`` (migration 0062); the user CTE reuses
-# ``events_session_message_seq_idx`` (migration 0001).
+# Sessions currently in the terminal "errored" state, derived from the
+# maintained scalar columns on ``sessions`` (migration 0066). A session is
+# errored when ``last_error_seq > 0 AND last_error_seq > last_user_seq``.
+# A later user message bumps ``last_user_seq``, flipping the inequality —
+# exactly the recovery semantics the pre-derivation status flip provided.
 ERRORED_SESSIONS_SQL = """
-    WITH err_max AS (
-        SELECT session_id, MAX(seq) AS err_seq
-          FROM events
-         WHERE kind = 'lifecycle' AND data->>'stop_reason' = 'error'
-         {scope_clause}
-         GROUP BY session_id
-    ),
-    user_max AS (
-        SELECT session_id, MAX(seq) AS user_seq
-          FROM events
-         WHERE kind = 'message' AND role = 'user'
-         {scope_clause}
-         GROUP BY session_id
-    )
-    SELECT em.session_id
-      FROM err_max em
-      LEFT JOIN user_max um ON um.session_id = em.session_id
-     WHERE um.user_seq IS NULL OR em.err_seq > um.user_seq
+    SELECT s.id AS session_id
+      FROM sessions s
+     WHERE s.last_error_seq > 0
+       AND s.last_error_seq > s.last_user_seq
+       {scope_clause}
 """
 
 
@@ -477,7 +443,7 @@ async def _errored_session_ids(
     message recovers it (mirrors the pre-derivation ``status = 'errored'``
     skip + the ``append_event`` recovery flip).
     """
-    scope_clause = "AND session_id = $1" if session_id else ""
+    scope_clause = "AND s.id = $1" if session_id else ""
     params: list[Any] = [session_id] if session_id else []
     rows = await conn.fetch(ERRORED_SESSIONS_SQL.format(scope_clause=scope_clause), *params)
     return {r["session_id"] for r in rows}
@@ -506,15 +472,11 @@ async def find_sessions_needing_inference(
     yet ready. Case (c) sessions bypass this filter.
     """
     scope_clause = "AND s.id = $1" if session_id else ""
-    # CANDIDATE_ROWS_SQL's CTE aggregates per-session; when scoped, prune it
-    # to the target session too so the planner isn't leaning on predicate-
-    # pushdown-through-GROUP-BY to rescue an unscoped scan at scale.
-    cte_scope_clause = "AND session_id = $1" if session_id else ""
     scope_params: list[Any] = [session_id] if session_id else []
 
     async with pool.acquire() as conn:
         candidate_rows = await conn.fetch(
-            CANDIDATE_ROWS_SQL.format(scope_clause=scope_clause, cte_scope_clause=cte_scope_clause),
+            CANDIDATE_ROWS_SQL.format(scope_clause=scope_clause),
             *scope_params,
         )
 

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -240,24 +240,21 @@ async def _seed_pathological(pool: asyncpg.Pool[Any]) -> list[str]:
                        SELECT MAX(e.seq) FROM events e
                         WHERE e.session_id = s.id AND e.kind = 'message' AND e.role = 'user'
                    ), 0),
+                   last_stimulus_seq = COALESCE((
+                       SELECT MAX(e.seq) FROM events e
+                        WHERE e.session_id = s.id AND e.kind = 'message' AND e.role <> 'assistant'
+                   ), 0),
                    last_error_seq = COALESCE((
                        SELECT MAX(e.seq) FROM events e
                         WHERE e.session_id = s.id
                           AND e.kind = 'lifecycle' AND e.data->>'stop_reason' = 'error'
                    ), 0),
-                   last_reacted_seq = GREATEST(
-                       COALESCE((
-                           SELECT MAX(COALESCE((e.data->>'reacting_to')::bigint, e.seq))
-                             FROM events e
-                            WHERE e.session_id = s.id
-                              AND e.kind = 'message' AND e.role = 'assistant'
-                       ), 0),
-                       COALESCE((
-                           SELECT MAX(e.seq) FROM events e
-                            WHERE e.session_id = s.id
-                              AND e.kind = 'lifecycle' AND e.data->>'event' = 'turn_ended'
-                       ), 0)
-                   ),
+                   last_reacted_seq = COALESCE((
+                       SELECT MAX(COALESCE((e.data->>'reacting_to')::bigint, e.seq))
+                         FROM events e
+                        WHERE e.session_id = s.id
+                          AND e.kind = 'message' AND e.role = 'assistant'
+                   ), 0),
                    open_tool_call_count = COALESCE((
                        SELECT COUNT(*)
                          FROM events ate

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -225,6 +225,54 @@ async def _seed_pathological(pool: asyncpg.Pool[Any]) -> list[str]:
                 rows,
             )
 
+        # Backfill the scalar columns on sessions to match the seeded events.
+        # The production path maintains these in append_event; this test inserts
+        # events directly, so it must reconcile the sessions rows manually.
+        await conn.execute(
+            """
+            UPDATE sessions s
+               SET last_event_seq = COALESCE((
+                       SELECT MAX(e.seq) FROM events e WHERE e.session_id = s.id
+                   ), 0),
+                   last_user_seq = COALESCE((
+                       SELECT MAX(e.seq) FROM events e
+                        WHERE e.session_id = s.id AND e.kind = 'message' AND e.role = 'user'
+                   ), 0),
+                   last_error_seq = COALESCE((
+                       SELECT MAX(e.seq) FROM events e
+                        WHERE e.session_id = s.id
+                          AND e.kind = 'lifecycle' AND e.data->>'stop_reason' = 'error'
+                   ), 0),
+                   last_reacted_seq = GREATEST(
+                       COALESCE((
+                           SELECT MAX(COALESCE((e.data->>'reacting_to')::bigint, e.seq))
+                             FROM events e
+                            WHERE e.session_id = s.id
+                              AND e.kind = 'message' AND e.role = 'assistant'
+                       ), 0),
+                       COALESCE((
+                           SELECT MAX(e.seq) FROM events e
+                            WHERE e.session_id = s.id
+                              AND e.kind = 'lifecycle' AND e.data->>'event' = 'turn_ended'
+                       ), 0)
+                   ),
+                   open_tool_call_count = COALESCE((
+                       SELECT COUNT(*)
+                         FROM events ate
+                        CROSS JOIN LATERAL jsonb_array_elements(ate.data->'tool_calls') tc
+                        WHERE ate.session_id = s.id
+                          AND ate.kind = 'message' AND ate.role = 'assistant'
+                          AND ate.data ? 'tool_calls'
+                          AND NOT EXISTS (
+                              SELECT 1 FROM events tr
+                               WHERE tr.session_id = s.id
+                                 AND tr.kind = 'message' AND tr.role = 'tool'
+                                 AND tr.data->>'tool_call_id' = tc->>'id'
+                          )
+                   ), 0)
+            """
+        )
+
         # ANALYZE so the planner has fresh stats matching the fixture.
         await conn.execute("ANALYZE events")
         await conn.execute("ANALYZE sessions")
@@ -265,14 +313,12 @@ class TestNoCorrelatedSubplanOverEvents:
     a correlated SubPlan. That shape was the N+1 pathology behind #140."""
 
     async def test_candidate_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
-        plan = await _explain(
-            seeded_pool, CANDIDATE_ROWS_SQL.format(scope_clause="", cte_scope_clause="")
-        )
+        plan = await _explain(seeded_pool, CANDIDATE_ROWS_SQL.format(scope_clause=""))
         found = find_subplans_over_events(plan)
         assert not found, (
             f"N+1 regression in find_sessions_needing_inference candidate query: "
             f"{len(found)} correlated subplan(s) over events. "
-            f"See PR #145 — this query must hoist MAX(reacting_to) via a CTE."
+            f"CANDIDATE_ROWS_SQL should use session scalar columns, not event-log scans."
         )
 
     async def test_unreacted_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:
@@ -328,7 +374,7 @@ class TestSweepQueryBudget:
     async def test_candidate_rows_buffer_budget(self, seeded_pool: asyncpg.Pool[Any]) -> None:
         async with seeded_pool.acquire() as conn:
             result = await conn.fetchval(
-                f"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {CANDIDATE_ROWS_SQL.format(scope_clause='', cte_scope_clause='')}"
+                f"EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {CANDIDATE_ROWS_SQL.format(scope_clause='')}"
             )
         if isinstance(result, str):
             result = json.loads(result)

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -1,16 +1,16 @@
 """Perf regression tests for sweep queries (issue #140).
 
-The sweep path ran correlated subqueries against ``events`` that computed
-``MAX(reacting_to)`` per session inside a per-row SubPlan — an N+1 pattern
-that on JN's live data made one sweep pass cost ~7.5s on a 10k-event
-table. The fix in this PR hoists the aggregation to a CTE and swaps
-``data->>'role'`` for the normalized ``role`` column (from migration 0022).
+The sweep path originally ran correlated subqueries against ``events`` that
+computed ``MAX(reacting_to)`` per session inside a per-row SubPlan — an N+1
+pattern that on JN's live data made one sweep pass cost ~7.5s on a 10k-event
+table. ``CANDIDATE_ROWS_SQL`` and ``ERRORED_SESSIONS_SQL`` now use scalar
+columns maintained on the ``sessions`` row (migration 0066) — simple column
+arithmetic with no event-log scan at all.
 
 These tests encode the fix as a **structural** invariant: after
 ``EXPLAIN (FORMAT JSON)``, no node in the plan tree is a SubPlan scanning
 ``events``. Deterministic, no wall-clock assertion, no flake on slow CI.
-A regression from a well-meaning refactor ("why is this a CTE?") fails
-this test immediately.
+A regression from a well-meaning refactor fails this test immediately.
 
 The budget smoke test (``@pytest.mark.slow``) is a secondary fence: on
 the same seeded fixture, assert the rewritten queries actually complete
@@ -228,6 +228,8 @@ async def _seed_pathological(pool: asyncpg.Pool[Any]) -> list[str]:
         # Backfill the scalar columns on sessions to match the seeded events.
         # The production path maintains these in append_event; this test inserts
         # events directly, so it must reconcile the sessions rows manually.
+        # The backfill SQL below intentionally mirrors migration 0066's
+        # backfill logic — keep them in sync if either changes.
         await conn.execute(
             """
             UPDATE sessions s
@@ -340,7 +342,7 @@ class TestNoCorrelatedSubplanOverEvents:
         assert not found, (
             f"N+1 regression in errored-session derivation: "
             f"{len(found)} correlated subplan(s) over events. This query must "
-            f"hoist MAX(seq) per session via CTEs (see session_max_reacting)."
+            f"use maintained scalar columns on sessions (migration 0066), not event-log scans."
         )
 
     async def test_span_start_rows_is_not_n_plus_1(self, seeded_pool: asyncpg.Pool[Any]) -> None:

--- a/tests/integration/test_session_status_scalars.py
+++ b/tests/integration/test_session_status_scalars.py
@@ -1,0 +1,585 @@
+"""Integration tests for the four monotonic session-status scalar columns.
+
+The columns — ``last_reacted_seq``, ``open_tool_call_count``,
+``last_error_seq``, ``last_user_seq`` — are maintained transactionally
+inside ``append_event`` and replace the O(n) correlated-subquery status
+derivation with pure column arithmetic.
+
+Tests exercise both the scalar maintenance (column values after specific
+event sequences) and the derived ``status`` predicate (active/idle from
+column arithmetic). Written TDD-first: they must fail before the
+migration and ``append_event`` changes land.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+# ─── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def pool_and_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a fresh session."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_scalars', NULL, TRUE, 'scalars-test')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_scalars", prefix="scalars-test"
+        )
+        yield pool, "acc_scalars", session.id
+    finally:
+        await pool.close()
+
+
+async def _scalars(conn: asyncpg.Connection[Any], session_id: str) -> dict[str, int]:
+    """Read the four scalar columns directly from the sessions row."""
+    row = await conn.fetchrow(
+        "SELECT last_reacted_seq, open_tool_call_count, "
+        "last_error_seq, last_user_seq "
+        "FROM sessions WHERE id = $1",
+        session_id,
+    )
+    assert row is not None
+    return dict(row)
+
+
+# ─── scalar maintenance tests ────────────────────────────────────────────────
+
+
+class TestScalarMaintenance:
+    async def test_fresh_session_scalars_zero(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, _account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            s = await _scalars(conn, session_id)
+        assert s["last_reacted_seq"] == 0
+        assert s["open_tool_call_count"] == 0
+        assert s["last_error_seq"] == 0
+        assert s["last_user_seq"] == 0
+
+    async def test_user_message_bumps_last_user_seq(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            s = await _scalars(conn, session_id)
+        assert s["last_user_seq"] == 1
+
+    async def test_assistant_with_reacting_to(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi", "reacting_to": 1},
+            )
+            s = await _scalars(conn, session_id)
+        assert s["last_reacted_seq"] == 1
+
+    async def test_turn_ended_bumps_last_reacted_seq(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi", "reacting_to": 1},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"event": "turn_ended"},
+            )
+            s = await _scalars(conn, session_id)
+        # turn_ended is seq 3; last_reacted_seq should be 3
+        assert s["last_reacted_seq"] == 3
+
+    async def test_assistant_with_tool_calls_increments_open_count(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                        {
+                            "id": "tc_2",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                    ],
+                },
+            )
+            s = await _scalars(conn, session_id)
+        assert s["open_tool_call_count"] == 2
+
+    async def test_tool_result_decrements_open_count(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                        {
+                            "id": "tc_2",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                    ],
+                },
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_1", "content": "ok"},
+            )
+            s = await _scalars(conn, session_id)
+            assert s["open_tool_call_count"] == 1
+
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_2", "content": "ok"},
+            )
+            s = await _scalars(conn, session_id)
+            assert s["open_tool_call_count"] == 0
+
+    async def test_error_lifecycle_sets_last_error_seq(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"stop_reason": "error"},
+            )
+            s = await _scalars(conn, session_id)
+        assert s["last_error_seq"] == 1
+
+    async def test_user_message_clears_error(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"stop_reason": "error"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "retry"},
+            )
+            s = await _scalars(conn, session_id)
+        assert s["last_user_seq"] > s["last_error_seq"]
+
+
+# ─── derived status tests ────────────────────────────────────────────────────
+
+
+class TestDerivedStatus:
+    async def test_status_idle_fresh(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        assert session.status == "idle"
+
+    async def test_status_active_after_user(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        assert session.status == "active"
+
+    async def test_status_idle_after_full_turn(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi", "reacting_to": 1},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"event": "turn_ended"},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        assert session.status == "idle"
+
+    async def test_status_active_with_open_tools(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                    ],
+                },
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"event": "turn_ended"},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        assert session.status == "active"
+
+    async def test_status_idle_after_tools_resolved_and_reacted(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            # assistant with tool call
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                    ],
+                },
+            )
+            # tool result
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_1", "content": "ok"},
+            )
+            # assistant reacts
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "done", "reacting_to": 2},
+            )
+            # turn ended
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"event": "turn_ended"},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        assert session.status == "idle"
+
+    async def test_status_active_tools_resolved_before_reaction(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """Tool results land after turn_ended but before the model reacts
+        — last_event_seq > last_reacted_seq so the session is active."""
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            # assistant with tool call
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                    ],
+                },
+            )
+            # turn ended
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"event": "turn_ended"},
+            )
+            # tool result arrives after turn_ended
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_1", "content": "ok"},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        # last_event_seq=3 (tool result) > last_reacted_seq=2 (turn_ended)
+        # AND open_tool_call_count went 1 -> 0 (but last_event_seq > last_reacted_seq)
+        assert session.status == "active"
+
+    async def test_errored_hides_active(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """An errored session reads as idle, not active."""
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            # Error lifecycle — normally this would mean active (unreacted user),
+            # but errored overrides.
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"stop_reason": "error"},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        assert session.status == "idle"
+
+
+# ─── clone + list filter tests ───────────────────────────────────────────────
+
+
+class TestCloneAndListFilter:
+    async def test_clone_copies_scalars(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            # Create a complete turn so the session is idle and cloneable,
+            # with non-zero scalars.
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi", "reacting_to": 1},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={"event": "turn_ended"},
+            )
+
+            parent_scalars = await _scalars(conn, session_id)
+
+            clone = await queries.clone_session(conn, session_id, account_id=account_id)
+            clone_scalars = await _scalars(conn, clone.id)
+
+        assert clone_scalars["last_reacted_seq"] == parent_scalars["last_reacted_seq"]
+        assert clone_scalars["open_tool_call_count"] == parent_scalars["open_tool_call_count"]
+        assert clone_scalars["last_error_seq"] == parent_scalars["last_error_seq"]
+        assert clone_scalars["last_user_seq"] == parent_scalars["last_user_seq"]
+
+    async def test_list_sessions_status_filter(
+        self,
+        migrated_db_url: str,
+        _reset_db_state: None,
+    ) -> None:
+        pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    """
+                    INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                    VALUES ('acc_filter', NULL, TRUE, 'filter-test')
+                    """
+                )
+            _agent, _env, sess_idle = await seed_agent_env_session(
+                pool, account_id="acc_filter", prefix="filter-idle"
+            )
+            _agent2, _env2, sess_active = await seed_agent_env_session(
+                pool, account_id="acc_filter", prefix="filter-active"
+            )
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn,
+                    account_id="acc_filter",
+                    session_id=sess_active.id,
+                    kind="message",
+                    data={"role": "user", "content": "hello"},
+                )
+
+                active_list = await queries.list_sessions(
+                    conn, account_id="acc_filter", status="active"
+                )
+                idle_list = await queries.list_sessions(
+                    conn, account_id="acc_filter", status="idle"
+                )
+            assert {s.id for s in active_list} == {sess_active.id}
+            assert sess_idle.id in {s.id for s in idle_list}
+            assert sess_active.id not in {s.id for s in idle_list}
+        finally:
+            await pool.close()
+
+
+# ─── structural assertion ────────────────────────────────────────────────────
+
+
+class TestNoEventsSubquery:
+    def test_no_events_subquery_in_status(self) -> None:
+        """The status expression must use column arithmetic, not event-log
+        correlated subqueries."""
+        from aios.db.queries import _SESSION_STATUS_EXPR
+
+        assert "FROM events" not in _SESSION_STATUS_EXPR, (
+            "_SESSION_STATUS_EXPR still contains a correlated subquery over events"
+        )

--- a/tests/integration/test_session_status_scalars.py
+++ b/tests/integration/test_session_status_scalars.py
@@ -55,7 +55,7 @@ async def _scalars(conn: asyncpg.Connection[Any], session_id: str) -> dict[str, 
     """Read the four scalar columns directly from the sessions row."""
     row = await conn.fetchrow(
         "SELECT last_reacted_seq, open_tool_call_count, "
-        "last_error_seq, last_user_seq "
+        "last_error_seq, last_user_seq, last_stimulus_seq "
         "FROM sessions WHERE id = $1",
         session_id,
     )
@@ -118,10 +118,18 @@ class TestScalarMaintenance:
             s = await _scalars(conn, session_id)
         assert s["last_reacted_seq"] == 1
 
-    async def test_turn_ended_bumps_last_reacted_seq(
+    async def test_turn_ended_does_not_bump_last_reacted_seq(
         self,
         pool_and_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
+        """``last_reacted_seq`` tracks the assistant's ``reacting_to`` watermark
+        ONLY — ``turn_ended`` lifecycle events must NOT advance it.
+
+        Bumping it on turn_ended (as #749's first cut did) breaks the retry
+        loop: a rescheduling ``turn_ended`` appends with no assistant reaction,
+        so bumping the watermark falsely marks the unreacted user message as
+        reacted-to, flipping a retry-pending session to idle (see
+        ``test_litellm_502_recovery``)."""
         pool, account_id, session_id = pool_and_session
         async with pool.acquire() as conn:
             await queries.append_event(
@@ -146,8 +154,35 @@ class TestScalarMaintenance:
                 data={"event": "turn_ended"},
             )
             s = await _scalars(conn, session_id)
-        # turn_ended is seq 3; last_reacted_seq should be 3
-        assert s["last_reacted_seq"] == 3
+        # The assistant reacted to seq 1; turn_ended (seq 3) does NOT bump it.
+        assert s["last_reacted_seq"] == 1
+
+    async def test_assistant_without_reacting_to_uses_own_seq(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """An assistant message with no explicit ``reacting_to`` advances the
+        watermark to its OWN seq (mirrors the pre-#732
+        ``MAX(COALESCE(reacting_to, seq))`` fallback)."""
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            # assistant reply, no reacting_to → watermark = its own seq (2)
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi"},
+            )
+            s = await _scalars(conn, session_id)
+        assert s["last_reacted_seq"] == 2
 
     async def test_assistant_with_tool_calls_increments_open_count(
         self,
@@ -327,6 +362,171 @@ class TestDerivedStatus:
             session = await queries.get_session(conn, session_id, account_id=account_id)
         assert session.status == "idle"
 
+    async def test_status_idle_after_assistant_reply(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """The canonical idle state (#749 regression): a user message followed
+        by a plain assistant reply (no tool calls), with NO ``turn_ended``
+        lifecycle event yet.
+
+        ``last_event_seq`` (=2, the assistant reply) exceeds
+        ``last_reacted_seq`` (=1, what the assistant reacted to), so the OLD
+        predicate ``last_event_seq > last_reacted_seq`` reads this as ACTIVE
+        and the harness does one extra model step — the bug that fails the
+        whole e2e suite. The fix keys the active predicate on
+        ``last_stimulus_seq`` (non-assistant messages only): the assistant's
+        own reply is not a stimulus, so ``last_stimulus_seq`` (=1) ==
+        ``last_reacted_seq`` (=1) → idle.
+        """
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi", "reacting_to": 1},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        assert session.status == "idle"
+
+    async def test_status_active_tool_result_after_assistant_reply(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """Over-correction guard for #749: a tool result that lands AFTER a
+        plain assistant reply is an unreacted stimulus — the assistant must
+        react to it, so the session is ACTIVE.
+
+        This proves ``last_stimulus_seq`` tracks tool messages (role <>
+        'assistant'), not just user messages: keying the predicate on
+        ``last_user_seq`` instead would wrongly read this idle.
+        """
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            # user message (seq 1)
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "run a tool"},
+            )
+            # assistant reply that reacted to the user (seq 2)
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi", "reacting_to": 1},
+            )
+            # a tool result lands after the reply (seq 3) — an unreacted
+            # stimulus the assistant must now react to.
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_late", "content": "ok"},
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        # last_stimulus_seq=3 (tool) > last_reacted_seq=1 → active.
+        assert session.status == "active"
+
+    async def test_last_stimulus_seq_tracks_user_and_tool_not_assistant(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """``last_stimulus_seq`` advances on user + tool messages but never on
+        the assistant's own reply."""
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            # user (seq 1) → last_stimulus_seq = 1
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            row = await conn.fetchrow(
+                "SELECT last_stimulus_seq FROM sessions WHERE id = $1", session_id
+            )
+            assert row is not None and row["last_stimulus_seq"] == 1
+
+            # assistant reply (seq 2) → last_stimulus_seq stays 1
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "hi", "reacting_to": 1},
+            )
+            row = await conn.fetchrow(
+                "SELECT last_stimulus_seq FROM sessions WHERE id = $1", session_id
+            )
+            assert row is not None and row["last_stimulus_seq"] == 1
+
+            # tool result (seq 3) → last_stimulus_seq advances to 3
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "tool", "tool_call_id": "tc_1", "content": "ok"},
+            )
+            row = await conn.fetchrow(
+                "SELECT last_stimulus_seq FROM sessions WHERE id = $1", session_id
+            )
+            assert row is not None and row["last_stimulus_seq"] == 3
+
+    async def test_status_active_rescheduling_after_failed_step(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A retry-pending session (user message, NO assistant reaction, then a
+        rescheduling ``turn_ended``) stays ACTIVE so the sweep re-picks it.
+
+        This is the harness/litellm error-retry path: the step fails before any
+        assistant message is appended, ``_apply_retry_or_failure`` writes a
+        rescheduling ``turn_ended``, and the unreacted user message must keep
+        the session active. If ``turn_ended`` bumped ``last_reacted_seq``, this
+        would flip idle and the retry would never fire (#749 over-correction).
+        """
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            # user message (seq 1) — never reacted to (the step failed)
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "hello"},
+            )
+            # rescheduling turn_ended (seq 2), no assistant reaction
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="lifecycle",
+                data={
+                    "event": "turn_ended",
+                    "status": "rescheduling",
+                    "stop_reason": "rescheduling",
+                },
+            )
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        # last_stimulus_seq=1 (user) > last_reacted_seq=0 → active.
+        assert session.status == "active"
+
     async def test_status_active_with_open_tools(
         self,
         pool_and_session: tuple[asyncpg.Pool[Any], str, str],
@@ -416,7 +616,7 @@ class TestDerivedStatus:
         pool_and_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
         """Tool results land after turn_ended but before the model reacts
-        — last_event_seq > last_reacted_seq so the session is active."""
+        — last_stimulus_seq > last_reacted_seq so the session is active."""
         pool, account_id, session_id = pool_and_session
         async with pool.acquire() as conn:
             # assistant with tool call
@@ -454,8 +654,8 @@ class TestDerivedStatus:
                 data={"role": "tool", "tool_call_id": "tc_1", "content": "ok"},
             )
             session = await queries.get_session(conn, session_id, account_id=account_id)
-        # last_event_seq=3 (tool result) > last_reacted_seq=2 (turn_ended)
-        # AND open_tool_call_count went 1 -> 0 (but last_event_seq > last_reacted_seq)
+        # last_stimulus_seq=3 (tool result) > last_reacted_seq=2 (turn_ended)
+        # AND open_tool_call_count went 1 -> 0 (but last_stimulus_seq > last_reacted_seq)
         assert session.status == "active"
 
     async def test_errored_hides_active(
@@ -528,6 +728,7 @@ class TestCloneAndListFilter:
         assert clone_scalars["open_tool_call_count"] == parent_scalars["open_tool_call_count"]
         assert clone_scalars["last_error_seq"] == parent_scalars["last_error_seq"]
         assert clone_scalars["last_user_seq"] == parent_scalars["last_user_seq"]
+        assert clone_scalars["last_stimulus_seq"] == parent_scalars["last_stimulus_seq"]
 
     async def test_list_sessions_status_filter(
         self,

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,15 +26,16 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0065``."""
+    """The migration ladder has exactly one head: ``0066``."""
     script = _script_directory()
-    assert script.get_heads() == ["0065"]
+    assert script.get_heads() == ["0066"]
 
 
 def test_chain_is_linear_0054_to_0060() -> None:
     """``0054 -> … -> 0060 -> 0061`` is a plain linear chain."""
     script = _script_directory()
 
+    rev_0066 = script.get_revision("0066")
     rev_0065 = script.get_revision("0065")
     rev_0064 = script.get_revision("0064")
     rev_0063 = script.get_revision("0063")
@@ -47,6 +48,7 @@ def test_chain_is_linear_0054_to_0060() -> None:
     rev_0056 = script.get_revision("0056")
     rev_0055 = script.get_revision("0055")
 
+    assert rev_0066.down_revision == "0065"
     assert rev_0065.down_revision == "0064"
     assert rev_0064.down_revision == "0063"
     assert rev_0063.down_revision == "0062"


### PR DESCRIPTION
Replaces the O(session-event-count) correlated-subquery status derivation with four monotonic scalar columns maintained transactionally inside `append_event`'s existing UPDATE statement.

## What changed

**Four new columns** (all `NOT NULL DEFAULT 0`) on the sessions table:
- `last_reacted_seq` — MAX(reacting_to) over assistant events; bumped on `turn_ended` lifecycle
- `open_tool_call_count` — net count of unresolved tool calls (+N on assistant, -1 on tool result)
- `last_error_seq` — seq of most recent error lifecycle
- `last_user_seq` — seq of most recent user message

**Status predicate** is now pure column arithmetic, zero subqueries:
- errored = `last_error_seq > 0 AND last_error_seq > last_user_seq`
- active = `(last_event_seq > last_reacted_seq OR open_tool_call_count > 0) AND NOT errored`
- idle = otherwise

## Changes by area

- **Migration 0066**: adds columns + backfills (`open_tool_call_count` uses per-`tool_call_id` anti-join)
- **`append_event`**: maintains all four scalars atomically in the existing session UPDATE
- **`clone_session`**: copies all four scalars
- **Status expressions**: `_SESSION_STATUS_EXPR`, `_SESSION_ERRORED_EXPR`, `_SESSION_ACTIVE_EXPR` rewritten as pure column arithmetic
- **Sweep**: `CANDIDATE_ROWS_SQL` and `ERRORED_SESSIONS_SQL` rewritten as sessions-only queries (no join to events table); errored exclusion is now inline
- 18 integration tests covering the new scalars and status transitions

Closes #749