### PR TITLE
fix(harness): age-bound ghost-repair for abandoned client-side tool calls (wake-no-progress loop, regression from #750)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -344,6 +344,33 @@ class Settings(BaseSettings):
         "the #155 symptom).",
     )
 
+    client_tool_call_max_age_seconds: int = Field(
+        default=24 * 60 * 60,  # 24 hours
+        ge=60,
+        description="Age ceiling, in seconds, after which an unresolved "
+        "CLIENT-result-pending tool call (a tool the harness never dispatches "
+        "because the CLIENT executes it and returns the result — the non-MCP, "
+        "not-in-registry branch of ``sweep._was_dispatched``) is treated as "
+        "ABANDONED by ghost repair: a synthetic timeout/abandoned error result is "
+        "appended, resolving the call. Unlike "
+        "``connector_backfill_max_age_seconds`` / "
+        "``confirmed_dispatch_max_age_seconds`` (which only SKIP, leaving the log "
+        "untouched), this bound EXPIRES the call — without it the call's "
+        "``open_tool_call_count`` contribution keeps the session a permanent wake "
+        "candidate (``CANDIDATE_ROWS_SQL`` / ``_SESSION_ACTIVE_EXPR``) with no "
+        "progress to make (the #155 wake-no-progress loop; regression from the "
+        "open-tool-call-count predicate added in #750). The bound is on the "
+        "ASSISTANT turn's ``created_at`` (when the call was emitted), consistent "
+        "with the dispatched-ghost age semantics. The default 24h is deliberately "
+        "generous — a legitimate slow client (a human-driven connector, a "
+        "long-running custom tool) returns its result well within a day, so the "
+        "bound only fires for a client that disconnected and will never return. "
+        "Confirmation-pending calls (``always_ask`` tools awaiting a "
+        "``tool_confirmed`` event) are EXCLUDED: those wait on the USER, not a "
+        "client, and erroring them would kill a slow human-in-the-loop "
+        "confirmation.",
+    )
+
     # ── observability ──────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
 

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -18,6 +18,7 @@ Called from three sites:
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -52,6 +53,21 @@ class SweepResult:
     woken_sessions: int
 
 
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    """A tool_call with no result and no in-flight task — a ghost-repair
+    candidate before its dispatch status is known.
+
+    ``created_at`` is the assistant turn's emit time; the abandoned-client-call
+    branch (#752) age-bounds off it.
+    """
+
+    session_id: str
+    tool_call_id: str
+    tool_name: str
+    created_at: dt.datetime
+
+
 # ─── query constants ─────────────────────────────────────────────────────────
 #
 # Sweep SQL lives here as module constants so tests/e2e/test_sweep_perf.py
@@ -63,7 +79,7 @@ class SweepResult:
 
 
 GHOST_ASST_SQL = """
-    SELECT e.session_id, e.data
+    SELECT e.session_id, e.data, e.created_at
       FROM events e
       JOIN sessions s ON s.id = e.session_id
      WHERE s.archived_at IS NULL
@@ -220,8 +236,25 @@ async def find_and_repair_ghosts(
       custom tool or an unconfirmed ``always_ask`` tool still waiting
       for client action).
 
+    Plus a second, age-bounded category — **abandoned client-side tool
+    calls** (#752). A *client-result-pending* call (the non-MCP,
+    not-in-registry branch of :func:`_was_dispatched` — a tool the
+    *client* runs and returns a result for) is normally left alone: it's
+    legitimately waiting for the client. But if its assistant turn is
+    older than ``client_tool_call_max_age_seconds`` (default 24h) with
+    still no result and no in-flight task, the client has disconnected and
+    will never return — so we synthesise an abandoned/timeout error
+    result. Without this the call's ``open_tool_call_count`` contribution
+    keeps the session a permanent wake candidate
+    (``CANDIDATE_ROWS_SQL``) with no progress to make — the #155
+    wake-no-progress loop, a regression from the open-tool-call-count
+    predicate added in #750. *Confirmation-pending* ``always_ask`` calls
+    (awaiting a ``tool_confirmed`` event) are EXCLUDED: those wait on the
+    USER, not a client, and erroring them would kill a slow
+    human-in-the-loop confirmation.
+
     Returns a list of ``(session_id, tool_call_id)`` pairs that were
-    repaired.
+    repaired (both categories count as repairs).
     """
     in_flight = task_registry.all_in_flight_tool_call_ids()
 
@@ -261,11 +294,14 @@ async def find_and_repair_ghosts(
 
     # First pass: find candidate ghosts (no result, no in-flight task).
     # We don't yet know their dispatch status — that requires agent config.
-    candidates: list[tuple[str, str, str]] = []  # (session_id, tool_call_id, tool_name)
+    # ``created_at`` is the assistant turn's emit time, carried so the
+    # abandoned-client-call branch can age-bound off it (#752).
+    candidates: list[_Candidate] = []
 
     for row in asst_rows:
         sid = row["session_id"]
         data = parse_jsonb(row["data"])
+        created_at = row["created_at"]
         existing_results = results_by_session.get(sid, set())
         session_in_flight = in_flight.get(sid, set())
 
@@ -274,14 +310,16 @@ async def find_and_repair_ghosts(
             if not tcid or tcid in existing_results or tcid in session_in_flight:
                 continue
             name = (tc.get("function") or {}).get("name", "")
-            candidates.append((sid, tcid, name))
+            candidates.append(_Candidate(sid, tcid, name, created_at))
 
     if not candidates:
         return []
 
     # Second pass: load agent config only for sessions with candidates,
-    # then filter to actually-dispatched tools.
-    candidate_sids = list({sid for sid, _, _ in candidates})
+    # then classify each candidate into one of two repairable buckets
+    # (dispatched ghost, or abandoned client-result-pending call past the age
+    # bound). All other candidates are left alone (legitimately waiting).
+    candidate_sids = list({c.session_id for c in candidates})
     async with pool.acquire() as conn:
         # LEFT JOIN agent_versions to respect version pinning.
         agent_rows = await conn.fetch(
@@ -306,12 +344,31 @@ async def find_and_repair_ghosts(
             ToolSpec.model_validate(t) for t in (tools_list or [])
         ]
 
-    ghosts: list[tuple[str, str, str]] = []
-    for sid, tcid, name in candidates:
-        confirmed = confirmed_by_session.get(sid, set())
-        agent_tools = agent_tools_by_session.get(sid, [])
-        if _was_dispatched(name, tcid, confirmed, agent_tools):
-            ghosts.append((sid, tcid, name))
+    # Abandoned-client-call bound (#752): a client-result-pending call whose
+    # assistant turn is older than this is treated as abandoned. The cutoff is
+    # computed once per sweep against ``created_at`` (the assistant turn's emit
+    # time), consistent with the dispatched-ghost age semantics.
+    client_max_age = get_settings().client_tool_call_max_age_seconds
+    abandoned_cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=client_max_age)
+
+    ghosts: list[_Candidate] = []
+    abandoned: list[_Candidate] = []
+    for c in candidates:
+        confirmed = confirmed_by_session.get(c.session_id, set())
+        agent_tools = agent_tools_by_session.get(c.session_id, [])
+        if _was_dispatched(c.tool_name, c.tool_call_id, confirmed, agent_tools):
+            ghosts.append(c)
+        elif (
+            _is_client_result_pending(c.tool_name, agent_tools) and c.created_at < abandoned_cutoff
+        ):
+            # Not dispatched AND client-result-pending AND older than the bound:
+            # the client disconnected and will never return a result. Without
+            # resolving it, the call's open_tool_call_count contribution keeps
+            # the session a permanent wake candidate with no progress (#155 loop,
+            # regression from #750). Confirmation-pending always_ask calls are
+            # NOT client-result-pending, so they fall through here and are left
+            # to wait on the user.
+            abandoned.append(c)
 
     # ``tool_execute_start`` span presence per (session, tcid) — drives the
     # two-branch recovery message below (#685).  Tcids missing from this set
@@ -319,19 +376,20 @@ async def find_and_repair_ghosts(
     # tcids present may have executed and committed side effects.  Scope to
     # the post-``_was_dispatched`` ghost set (not the wider candidate set) so
     # the seq-scan touches only the tcids the per-ghost loop will actually
-    # consult.
+    # consult.  Abandoned client calls are never dispatched by the harness, so
+    # they have no ``tool_execute_start`` span and don't need this lookup.
     started: set[tuple[str, str]] = set()
     if ghosts:
-        ghost_sids = list({sid for sid, _, _ in ghosts})
-        ghost_tcids = list({tcid for _, tcid, _ in ghosts})
+        ghost_sids = list({c.session_id for c in ghosts})
+        ghost_tcids = list({c.tool_call_id for c in ghosts})
         async with pool.acquire() as conn:
             span_rows = await conn.fetch(GHOST_SPAN_START_SQL, ghost_sids, ghost_tcids)
         started = {(r["session_id"], r["tool_call_id"]) for r in span_rows}
 
-    # Per-ghost isolation; see ``wake_sessions_needing_inference`` below
-    # for the rationale.
-    repaired: list[tuple[str, str]] = []
-    for sid, tcid, name in ghosts:
+    # Build the unified repair worklist: each item carries its candidate, an
+    # operational ``branch`` tag (for the log), and the synthetic error text.
+    repair_items: list[tuple[_Candidate, str, str]] = []
+    for c in ghosts:
         # Don't lie: distinguish "never dispatched" (safe to retry) from
         # "may have executed" (verify before retrying).  The previous
         # single fabricated "No result was received" message double-fired
@@ -347,19 +405,45 @@ async def find_and_repair_ghosts(
         # design eliminates.  Tighter classification would require a second
         # marker written immediately before each tool's side-effectful call
         # — deferred until the over-pessimism is shown to matter.
-        if (sid, tcid) in started:
-            branch = "may_have_completed"
-            error_text = (
-                "Tool dispatch was interrupted after execution began. "
-                "The tool may have completed and side effects may have "
-                "committed. Verify the outcome before retrying."
+        if (c.session_id, c.tool_call_id) in started:
+            repair_items.append(
+                (
+                    c,
+                    "may_have_completed",
+                    "Tool dispatch was interrupted after execution began. "
+                    "The tool may have completed and side effects may have "
+                    "committed. Verify the outcome before retrying.",
+                )
             )
         else:
-            branch = "did_not_run"
-            error_text = (
-                "Tool dispatch was lost before execution began; "
-                "the tool did not run. You may retry."
+            repair_items.append(
+                (
+                    c,
+                    "did_not_run",
+                    "Tool dispatch was lost before execution began; "
+                    "the tool did not run. You may retry.",
+                )
             )
+    for c in abandoned:
+        # Distinct wording from the dispatched-ghost branches: this tool is run
+        # by the CLIENT, which never returned a result within the bound.
+        repair_items.append(
+            (
+                c,
+                "client_abandoned",
+                f"Tool call abandoned: the client returned no result within "
+                f"{client_max_age}s. The client is no longer connected; do not "
+                f"wait for this result.",
+            )
+        )
+
+    # Per-ghost isolation; see ``wake_sessions_needing_inference`` below
+    # for the rationale.
+    repaired: list[tuple[str, str]] = []
+    for c, branch, error_text in repair_items:
+        sid = c.session_id
+        tcid = c.tool_call_id
+        name = c.tool_name
         content = json.dumps({"error": error_text}, ensure_ascii=False)
         # Load each ghost's session account_id individually so the
         # cross-session sweeper (session_id=None) doesn't stamp empty
@@ -436,6 +520,31 @@ def _was_dispatched(
     if perm == "always_ask":
         return tool_call_id in confirmed_ids
     return True
+
+
+def _is_client_result_pending(name: str, agent_tools: list[ToolSpec]) -> bool:
+    """True if ``name`` is a CLIENT-result-pending tool.
+
+    A client-result-pending tool is one the harness never dispatches because
+    the *client* executes it and returns the result — the non-MCP,
+    not-in-registry branch of :func:`_was_dispatched` (a custom tool, or a tool
+    the model emitted under a bare name the harness can't resolve to a registry
+    entry or an MCP toolset). When the client disconnects, such a call sits
+    unresolved forever; the abandoned-client-call repair (#752) errors it past
+    an age bound.
+
+    Deliberately NARROW — it must EXCLUDE confirmation-pending calls
+    (``always_ask`` registered tools, or non-``always_allow`` MCP tools, awaiting
+    a ``tool_confirmed`` event). Those wait on the USER, not a client, and
+    erroring them would kill a slow human-in-the-loop confirmation. Both
+    excluded classes are reached only when ``is_mcp_tool_name`` is true or
+    ``registry.has`` is true, so testing the negation of both is exactly the
+    client-result-pending set.
+    """
+    from aios.models.agents import is_mcp_tool_name
+    from aios.tools.registry import registry
+
+    return not is_mcp_tool_name(name) and not registry.has(name)
 
 
 # ─── sessions needing inference ──────────────────────────────────────────────

--- a/tests/integration/test_abandoned_client_tool_ghost_repair.py
+++ b/tests/integration/test_abandoned_client_tool_ghost_repair.py
@@ -1,0 +1,432 @@
+"""Regression suite for aios #752 — age-bound ghost-repair for abandoned
+client-side tool calls (the wake-no-progress loop, a regression from #750).
+
+Background
+----------
+Migration 0066 / #750 added the maintained scalar ``open_tool_call_count`` to
+``sessions`` and wired it into the wake predicate
+(``sweep.CANDIDATE_ROWS_SQL`` ∧ its read-path twin
+``queries._SESSION_ACTIVE_EXPR``): a session with ``open_tool_call_count > 0``
+is a permanent wake candidate.
+
+The incident
+------------
+A session (``metals-factchecker``) accumulated two unresolved ``search_issues``
+tool calls (no ``role='tool'`` result, no in-flight task) ~10 days earlier.
+``search_issues`` was emitted as a BARE name (no ``mcp__`` prefix) and is not in
+the tool registry, so it is a CLIENT-result-pending tool — one the harness never
+dispatches because the CLIENT runs it and returns the result.
+``sweep._was_dispatched`` returns ``False`` for it (the non-MCP, not-in-registry
+branch), so ``find_and_repair_ghosts`` would NEVER resolve it. Those two calls
+held ``open_tool_call_count = 2`` forever, so the sweep woke the session every
+~32s, the agent emitted a no-op monologue (no tool_calls), and re-woke —
+~111 Opus calls/hour for hours (``woken_sessions: 1, repaired_ghosts: 0``).
+
+The fix (#752)
+--------------
+A new setting ``client_tool_call_max_age_seconds`` (default 24h) extends
+ghost-repair: an unresolved, not-in-flight, client-result-pending tool call
+whose ASSISTANT turn is older than the bound is treated as ABANDONED — a
+synthetic timeout/abandoned error result is appended (the SAME append path the
+dispatched-ghost repair uses, so ``open_tool_call_count`` decrements). The call
+resolves → the wake predicate goes false → the session quiesces, and the agent
+gets an explicit "tool call abandoned" signal instead of silent looping.
+
+CRITICAL discriminator: only CLIENT-result-pending calls (non-MCP,
+not-in-registry) are age-errored. CONFIRMATION-pending calls (``always_ask``
+tools awaiting a ``tool_confirmed`` event) are EXCLUDED — those wait on the
+USER, not a client, and erroring them would kill a slow human-in-the-loop
+confirmation.
+
+The invariant this suite pins
+-----------------------------
+- An ABANDONED client-result-pending call (older than the bound) IS repaired,
+  resolving ``open_tool_call_count`` and quiescing the session.
+- A RECENT client-result-pending call (within the bound) is NOT repaired.
+- A confirmation-pending ``always_ask`` call (any age) is NOT repaired.
+- ``CANDIDATE_ROWS_SQL`` / ``_SESSION_ACTIVE_EXPR`` are UNCHANGED — the fix is
+  purely on the resolution side; the existing predicate naturally stops waking
+  once the call resolves.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.harness import sweep
+from aios.harness.sweep import find_and_repair_ghosts, find_sessions_needing_inference
+from aios.harness.task_registry import TaskRegistry
+from aios.models.agents import ToolSpec
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+# A client tool call left unresolved for ~10 days — the incident's age. Well
+# past the default ``client_tool_call_max_age_seconds`` (24h).
+ABANDONED_AGE = dt.timedelta(days=10)
+# A client tool call dispatched a few minutes ago — comfortably inside the 24h
+# bound, a legitimately in-flight client call.
+RECENT_AGE = dt.timedelta(minutes=5)
+
+
+def _assistant(tool_call_ids: list[str], name: str) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": tcid,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+            for tcid in tool_call_ids
+        ],
+    }
+
+
+async def _backdate_assistant_turn(
+    pool: asyncpg.Pool[Any],
+    *,
+    session_id: str,
+    account_id: str,
+    tool_call_id: str,
+    age: dt.timedelta,
+) -> None:
+    """Rewrite the ``created_at`` of the assistant turn that issued
+    ``tool_call_id`` so the call's age is ``age``. ``append_event`` stamps
+    ``created_at = now()`` (the table default); the fix keys on the assistant
+    turn's ``created_at`` (when the call was emitted), so this is load-bearing.
+    """
+    old = dt.datetime.now(dt.UTC) - age
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE events SET created_at = $1 "
+            "WHERE session_id = $2 AND account_id = $3 "
+            "AND kind = 'message' AND role = 'assistant' "
+            "AND data->'tool_calls' @> jsonb_build_array("
+            "    jsonb_build_object('id', $4::text))",
+            old,
+            session_id,
+            account_id,
+            tool_call_id,
+        )
+
+
+async def _seed(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    prefix: str,
+    tools: list[ToolSpec],
+) -> str:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            "VALUES ($1, NULL, TRUE, $2)",
+            account_id,
+            prefix,
+        )
+    _agent, _env, session = await seed_agent_env_session(
+        pool,
+        account_id=account_id,
+        prefix=prefix,
+        tools=tools,
+    )
+    return session.id
+
+
+@pytest.fixture
+async def session_with_abandoned_client_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for the incident shape:
+
+        A1[tc_abandoned (search_issues)]  ← assistant turn backdated ~10 days,
+                                            NO result, NO confirmation
+
+    ``search_issues`` is a BARE-name tool the agent does NOT declare as a
+    registered/MCP tool (the agent has only ``bash``), so it resolves to the
+    CLIENT-result-pending branch of ``_was_dispatched`` — exactly the metals
+    incident. ``open_tool_call_count`` is maintained at 1 by ``append_event``,
+    so the session is a permanent wake candidate until the call resolves.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_abandoned_client_call"
+        sid = await _seed(
+            pool,
+            account_id=account_id,
+            prefix="abandoned-client-call",
+            tools=[ToolSpec(type="bash")],
+        )
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=sid,
+                kind="message",
+                data=_assistant(["tc_abandoned"], name="search_issues"),
+            )
+        await _backdate_assistant_turn(
+            pool,
+            session_id=sid,
+            account_id=account_id,
+            tool_call_id="tc_abandoned",
+            age=ABANDONED_AGE,
+        )
+        yield pool, account_id, sid
+    finally:
+        await pool.close()
+
+
+@pytest.fixture
+async def session_with_recent_client_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a client call still INSIDE
+    the bound — a legitimately in-flight client call that must NOT be errored.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_recent_client_call"
+        sid = await _seed(
+            pool,
+            account_id=account_id,
+            prefix="recent-client-call",
+            tools=[ToolSpec(type="bash")],
+        )
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=sid,
+                kind="message",
+                data=_assistant(["tc_recent"], name="search_issues"),
+            )
+        await _backdate_assistant_turn(
+            pool,
+            session_id=sid,
+            account_id=account_id,
+            tool_call_id="tc_recent",
+            age=RECENT_AGE,
+        )
+        yield pool, account_id, sid
+    finally:
+        await pool.close()
+
+
+@pytest.fixture
+async def session_with_old_unconfirmed_always_ask(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for the discriminator guard:
+
+        A1[tc_pending (bash, always_ask)]  ← assistant turn backdated ~10 days,
+                                             NO ``tool_confirmed``, NO result
+
+    ``bash`` is a REGISTERED ``always_ask`` tool with no confirmation yet, so it
+    is CONFIRMATION-pending (waiting on the USER), NOT client-result-pending.
+    Even though it is old, it MUST NOT be errored — erroring it would kill a
+    slow human-in-the-loop confirmation.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_old_unconfirmed_always_ask"
+        sid = await _seed(
+            pool,
+            account_id=account_id,
+            prefix="old-unconfirmed-always-ask",
+            tools=[ToolSpec(type="bash", permission="always_ask")],
+        )
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=sid,
+                kind="message",
+                data=_assistant(["tc_pending"], name="bash"),
+            )
+        await _backdate_assistant_turn(
+            pool,
+            session_id=sid,
+            account_id=account_id,
+            tool_call_id="tc_pending",
+            age=ABANDONED_AGE,
+        )
+        yield pool, account_id, sid
+    finally:
+        await pool.close()
+
+
+async def _open_tool_call_count(pool: asyncpg.Pool[Any], session_id: str) -> int:
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT open_tool_call_count FROM sessions WHERE id = $1", session_id
+        )
+
+
+async def _tool_results(
+    pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str
+) -> list[dict[str, Any]]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events "
+            "WHERE session_id = $1 AND kind = 'message' AND role = 'tool' "
+            "AND data->>'tool_call_id' = $2",
+            session_id,
+            tool_call_id,
+        )
+    return [queries.parse_jsonb(r["data"]) for r in rows]
+
+
+class TestAbandonedClientCallRepaired:
+    """The keystone: an abandoned client-result-pending call older than the
+    bound IS repaired, resolving the wake predicate.
+
+    Pre-fix (master) this test is RED — ``find_and_repair_ghosts`` returns ``[]``
+    (``_was_dispatched`` is False, so the call is never repaired) and
+    ``find_sessions_needing_inference`` keeps returning the session forever
+    (``open_tool_call_count > 0`` with nothing to dispatch = wake-no-progress).
+    """
+
+    async def test_abandoned_call_is_repaired_and_session_quiesces(
+        self,
+        session_with_abandoned_client_call: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = session_with_abandoned_client_call
+        registry = TaskRegistry()
+
+        # Precondition: the call holds open_tool_call_count > 0, so the session
+        # is a wake candidate. Pre-fix it has NO unreacted stimulus and nothing
+        # in-flight — the wake produces a no-op monologue and re-arms (the loop).
+        assert await _open_tool_call_count(pool, session_id) == 1
+        before = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id in before, (
+            "precondition: an unresolved client call must make the session a "
+            "wake candidate (open_tool_call_count > 0) — this is the loop"
+        )
+
+        # Ghost repair MUST now resolve the abandoned call (RED on master).
+        repaired = await find_and_repair_ghosts(pool, registry, session_id=session_id)
+        assert (session_id, "tc_abandoned") in repaired, (
+            "abandoned client-result-pending call (~10 days old) must be repaired "
+            f"by ghost-repair once the age bound applies; got {repaired}. On "
+            "master this is empty — _was_dispatched is False so the call is never "
+            "resolved, and the session loops forever (#155 / regression from #750)"
+        )
+
+        # A synthetic, clearly-worded error result resolves the call.
+        results = await _tool_results(pool, session_id, "tc_abandoned")
+        assert len(results) == 1, f"exactly one synthetic result expected; got {results}"
+        assert results[0].get("is_error") is True
+        assert "abandoned" in (results[0].get("content") or "").lower()
+
+        # open_tool_call_count decremented to 0. The synthetic tool result is now
+        # a genuine unreacted stimulus, so the session DOES need inference once —
+        # this is real progress (the agent reacts to the abandoned-tool error),
+        # NOT the no-op loop. The fix turns "permanent candidate, nothing to do"
+        # into "react once, then quiesce".
+        assert await _open_tool_call_count(pool, session_id) == 0
+        after_repair = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id in after_repair, (
+            "after repair the session reacts ONCE to the synthetic error — the "
+            "unreacted tool result is real progress, unlike the pre-fix no-op loop"
+        )
+
+        # Simulate the agent reacting to the error (an assistant turn with no new
+        # tool_calls, ``reacting_to`` the latest stimulus). With open_tool_call_count
+        # at 0 and the stimulus reacted-to, the wake predicate is now false: the
+        # session quiesces. No infinite loop.
+        async with pool.acquire() as conn:
+            last_seq = await conn.fetchval(
+                "SELECT last_event_seq FROM sessions WHERE id = $1", session_id
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": "The search_issues call was abandoned; moving on.",
+                    "reacting_to": last_seq,
+                },
+            )
+        quiesced = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id not in quiesced, (
+            "after the agent reacts the session must quiesce — open_tool_call_count "
+            "is 0 and the stimulus is reacted-to, so the wake predicate is false. "
+            "The wake-no-progress loop is broken."
+        )
+
+
+class TestRecentClientCallNotRepaired:
+    """A client call still INSIDE the bound is a legitimately in-flight client
+    call — it must keep waiting, not be errored."""
+
+    async def test_recent_call_not_errored(
+        self,
+        session_with_recent_client_call: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, _account_id, session_id = session_with_recent_client_call
+        registry = TaskRegistry()
+
+        repaired = await find_and_repair_ghosts(pool, registry, session_id=session_id)
+        assert repaired == [], (
+            "a client-result-pending call only ~5 minutes old is well inside the "
+            f"24h bound and must NOT be errored; got {repaired}"
+        )
+        assert await _tool_results(pool, session_id, "tc_recent") == []
+        assert await _open_tool_call_count(pool, session_id) == 1
+
+
+class TestConfirmationPendingExcluded:
+    """The discriminator guard: ``always_ask`` confirmation-pending calls wait
+    on the USER, not a client, and are EXCLUDED from age-error at ANY age."""
+
+    async def test_old_unconfirmed_always_ask_not_errored(
+        self,
+        session_with_old_unconfirmed_always_ask: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, _account_id, session_id = session_with_old_unconfirmed_always_ask
+        registry = TaskRegistry()
+
+        repaired = await find_and_repair_ghosts(pool, registry, session_id=session_id)
+        assert repaired == [], (
+            "an unconfirmed always_ask call is confirmation-pending (waiting on "
+            "the USER), NOT client-result-pending — it must NOT be age-errored "
+            f"even at ~10 days old; got {repaired}. Erroring it would kill a slow "
+            "human-in-the-loop confirmation."
+        )
+        assert await _tool_results(pool, session_id, "tc_pending") == []
+        assert await _open_tool_call_count(pool, session_id) == 1
+
+
+class TestCandidatePredicateUnchanged:
+    """The fix must NOT touch ``CANDIDATE_ROWS_SQL`` — it stays byte-identical to
+    its read-path twin ``queries._SESSION_ACTIVE_EXPR`` (modulo table alias).
+    The resolution side changes; the predicate does not."""
+
+    def test_candidate_sql_mirrors_session_active_expr(self) -> None:
+        import re
+
+        def norm(s: str) -> str:
+            return re.sub(r"\s+", " ", s).strip()
+
+        candidate = norm(sweep.CANDIDATE_ROWS_SQL)
+        active = norm(queries._SESSION_ACTIVE_EXPR)
+
+        # Both must key on the same two disjuncts; the fix adds NO new clause.
+        # (modulo table alias: the candidate uses ``s.``, the active expr uses
+        # ``sessions.``)
+        assert "s.last_stimulus_seq > s.last_reacted_seq" in candidate
+        assert "s.open_tool_call_count > 0" in candidate
+        assert "sessions.last_stimulus_seq > sessions.last_reacted_seq" in active
+        assert "sessions.open_tool_call_count > 0" in active

--- a/tests/unit/test_sweep_isolation.py
+++ b/tests/unit/test_sweep_isolation.py
@@ -6,12 +6,19 @@ their wake deferred or their ghost repaired."""
 
 from __future__ import annotations
 
+import datetime as dt
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aios.harness.sweep import find_and_repair_ghosts, wake_sessions_needing_inference
 from aios.harness.task_registry import TaskRegistry
 from tests.unit.conftest import fake_pool_yielding_conn
+
+# Assistant-turn emit time carried on each GHOST_ASST_SQL row (the column added
+# for the abandoned-client-call age bound, #752). These tests exercise the
+# DISPATCHED-ghost branches, so the value only needs to be present; "now" keeps
+# every candidate well inside any age bound.
+_NOW = dt.datetime.now(dt.UTC)
 
 
 async def test_defer_wake_failure_does_not_abort_sweep_batch() -> None:
@@ -42,6 +49,7 @@ async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> No
     ghost_rows = [
         {
             "session_id": "sess_a",
+            "created_at": _NOW,
             "data": {
                 "role": "assistant",
                 "tool_calls": [{"id": "tc_a", "type": "function", "function": {"name": "bash"}}],
@@ -49,6 +57,7 @@ async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> No
         },
         {
             "session_id": "sess_b",
+            "created_at": _NOW,
             "data": {
                 "role": "assistant",
                 "tool_calls": [{"id": "tc_b", "type": "function", "function": {"name": "bash"}}],
@@ -113,6 +122,7 @@ async def test_ghost_repair_branch_may_have_completed(monkeypatch: Any) -> None:
     ghost_rows = [
         {
             "session_id": "sess_a",
+            "created_at": _NOW,
             "data": {
                 "role": "assistant",
                 "tool_calls": [{"id": "tc_a", "type": "function", "function": {"name": "bash"}}],
@@ -165,6 +175,7 @@ async def test_ghost_repair_branch_did_not_run(monkeypatch: Any) -> None:
     ghost_rows = [
         {
             "session_id": "sess_a",
+            "created_at": _NOW,
             "data": {
                 "role": "assistant",
                 "tool_calls": [{"id": "tc_a", "type": "function", "function": {"name": "bash"}}],


### PR DESCRIPTION
## The bug

A session (`metals-factchecker`) entered an infinite **wake-no-progress loop** ([#155](https://github.com/eumemic/aios/issues/155) family): the harness sweep woke it every ~32s, it emitted a no-op internal monologue (no `tool_calls`), and re-woke — ~111 Opus calls/hour, for hours (`woken_sessions: 1, repaired_ghosts: 0`).

**Root cause:**

1. The wake predicate (`sweep.CANDIDATE_ROWS_SQL`, mirrored by `queries._SESSION_ACTIVE_EXPR`) keys on `open_tool_call_count > 0` — the maintained scalar added by [#750](https://github.com/eumemic/aios/pull/750) / migration 0066. A session with an open tool call is a permanent wake candidate.
2. The session had **2 unresolved `search_issues` tool calls from ~10 days ago** — no `role='tool'` result, no in-flight task. They held `open_tool_call_count = 2` permanently.
3. **Ghost-repair could not resolve them.** Those calls were emitted under the **bare name `search_issues`** (no `mcp__` prefix) and are not in the tool registry, so they are **client-result-pending** — a tool the *client* runs and returns the result for. `_was_dispatched()` returns `False` for the non-MCP, not-in-registry branch, so `find_and_repair_ghosts` never appended a result for them.
4. Result: wake forever (`open_tool_call_count > 0`), repair never. In `_filter_incomplete_batches`, the `if not unreacted: if not in_flight: result.add(sid)` branch re-adds the session each sweep with nothing to react to → the no-op monologue.

## The fix — age-bound ghost-repair (resolution side only)

`CANDIDATE_ROWS_SQL` / `_SESSION_ACTIVE_EXPR` are left **byte-identical**. The fix is purely on the **resolution** side: extend `find_and_repair_ghosts` with a second, age-bounded category.

A call where `_was_dispatched()` is `False` AND it is **client-result-pending** (the discriminator below) AND its **assistant turn's `created_at`** is older than the new bound AND it has no result and no in-flight task → gets a synthetic, clearly-worded error result (`"Tool call abandoned: the client returned no result within {N}s..."`, distinct from the dispatched-ghost messages). This routes through the **same `append_tool_result` path** the existing ghost-repair uses, so the `open_tool_call_count = GREATEST(open_tool_call_count + $5, 0)` maintenance decrements the scalar correctly. The wake predicate then goes false and the session quiesces — and the agent gets an explicit "abandoned" signal instead of silent looping. These count in `repaired_ghosts`.

### Discriminator — what to age-error vs. leave alone

- **DO age-error: client-result-pending** = `not is_mcp_tool_name(name) and not registry.has(name)` (the non-MCP, not-in-registry branch of `_was_dispatched`). The client runs these; when it disconnects they sit forever. New helper `_is_client_result_pending`.
- **DO NOT age-error: confirmation-pending** = `always_ask` registered tools / non-`always_allow` MCP tools awaiting a `tool_confirmed` event. Those wait on the **user**, not a client — erroring them would kill a slow human-in-the-loop confirmation. They are reached only when `is_mcp_tool_name` or `registry.has` is true, so they fall outside the discriminator by construction.

This mirrors the age-bound design of [#745](https://github.com/eumemic/aios/pull/745)/[#747](https://github.com/eumemic/aios/pull/747)' `confirmed_dispatch_max_age_seconds` and `connector_backfill_max_age_seconds`, with one deliberate difference: those **skip** (leave the log untouched); this one **expires** the call (appends a result), because an unresolved client call is what holds `open_tool_call_count > 0` and drives the loop.

### Chosen bound: `client_tool_call_max_age_seconds`, default `86400` (24h)

Same config file / `Field` style / `ge=60` as the sibling settings. The bound is on the **assistant turn's `created_at`** (when the call was emitted), consistent with the dispatched-ghost age semantics. **24h is deliberately more generous than the siblings' 1h**: a client tool is run by a real client (a human-driven connector, a long-running custom tool) and can legitimately take far longer to return than an in-process dispatch or a connector reconnect — a day is ample headroom for any real client, while a call unresolved past 24h is unambiguously abandoned.

## Tests

New `tests/integration/test_abandoned_client_tool_ghost_repair.py`:

- **Keystone (repro):** an abandoned client-result-pending `search_issues` call (~10 days old) — RED on master (`find_and_repair_ghosts` returns `[]`, `find_sessions_needing_inference` keeps returning the session = wake-no-progress); GREEN with the fix (call errored, `open_tool_call_count` → 0, session reacts once to the error then quiesces — no loop).
- A **recent** client call (~5 min, inside the bound) is NOT errored.
- A confirmation-pending **`always_ask`** call (~10 days old) is NOT errored (discriminator guard).
- `CANDIDATE_ROWS_SQL` / `_SESSION_ACTIVE_EXPR` byte-equivalence guard.

Existing ghost-repair coverage (`tests/e2e/test_sweep.py` — 13 tests, incl. dispatched-ghost repair, `test_custom_tool_not_ghost`, `test_unconfirmed_always_ask_not_ghost`) still passes, plus the sibling age-bound suites and sweep perf/isolation/instrumentation tests.

## Prod note

Prod was already stabilized by zeroing `open_tool_call_count` on the one affected session (loop verified stopped). This fix **prevents recurrence** for any session with an abandoned client-side tool call, and will let ghost-repair clean that session's 2 still-dangling calls on the next sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
