### PR TITLE
feat(workflows): Block 3 (slice 1) — the surface (API + CLI + live SSE + gate-resume)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8649,7 +8649,7 @@
           "runs"
         ],
         "summary": "Resume Gate",
-        "description": "Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns\nthe updated run (its status flips back toward ``running``). A bad nonce or a\ncross-tenant run 404s.",
+        "description": "Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns\nthe run (still ``suspended`` here \u2014 the recorded resume signal is harvested on the\nnext wake, which replays past the gate). A nonce that matches no OPEN gate, or a\ncross-tenant run, 404s.",
         "operationId": "resume_gate",
         "parameters": [
           {

--- a/openapi.json
+++ b/openapi.json
@@ -8099,6 +8099,618 @@
           }
         }
       }
+    },
+    "/v1/workflows": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "Create Workflow",
+        "description": "Create a workflow definition (version 1). Versioning/update is deferred.",
+        "operationId": "create_workflow",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workflow"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "List Workflows",
+        "description": "List the account's workflows, newest first. First page: optional ``name`` +\n``limit``; subsequent pages: ``?cursor=<next_cursor>``.",
+        "operationId": "list_workflows",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 200,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_Workflow_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workflows/{workflow_id}": {
+      "get": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "Get Workflow",
+        "description": "Fetch one workflow definition by id.",
+        "operationId": "get_workflow",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workflow"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/runs": {
+      "post": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Create Run",
+        "description": "Launch a run of a workflow. Snapshots the workflow's current script, binds\nthe run to ``environment_id`` (its ``agent()`` children spawn there), and wakes\nit. A missing workflow or environment 404s.",
+        "operationId": "create_run",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WfRunCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WfRun"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "List Runs",
+        "description": "List the account's runs, newest first. First page: optional ``workflow_id`` /\n``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.",
+        "operationId": "list_runs",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "workflow_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 200,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_WfRun_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/runs/{run_id}": {
+      "get": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Get Run",
+        "description": "Fetch one run by id (status, output, last_event_seq, \u2026).",
+        "operationId": "get_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WfRun"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/runs/{run_id}/events": {
+      "get": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "List Run Events",
+        "description": "A run's journal by sequence (oldest first). First page: optional ``limit``;\nsubsequent pages: ``?cursor=<next_cursor>``.",
+        "operationId": "list_run_events",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "maximum": 500,
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResponse_WfRunEvent_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/runs/{run_id}/resume": {
+      "post": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Resume Gate",
+        "description": "Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns\nthe updated run (its status flips back toward ``running``). A bad nonce or a\ncross-tenant run 404s.",
+        "operationId": "resume_gate",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GateResume"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WfRun"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -9597,6 +10209,23 @@
         "title": "FileUploadResponse",
         "description": "Wire shape returned from ``POST /v1/sessions/<id>/files``.\n\n``file_id`` rather than ``id`` matches the #324 contract so callers can\nreference the file in future inbound attachment payloads without rebinding."
       },
+      "GateResume": {
+        "properties": {
+          "gate_nonce": {
+            "type": "string",
+            "title": "Gate Nonce"
+          },
+          "result": {
+            "title": "Result"
+          }
+        },
+        "type": "object",
+        "required": [
+          "gate_nonce"
+        ],
+        "title": "GateResume",
+        "description": "Request body for ``POST /v1/runs/{run_id}/resume`` \u2014 deliver a gate's value.\n\nKeyed by ``gate_nonce`` (the unguessable capability token minted into the gate's\n``call_started`` event), not the internal ``call_key``. ``result`` is the\nexternally-delivered resume value (arbitrary JSON)."
+      },
       "GithubRepositoryResource": {
         "properties": {
           "type": {
@@ -10541,6 +11170,102 @@
           "data"
         ],
         "title": "ListResponse[Vault]"
+      },
+      "ListResponse_WfRunEvent_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WfRunEvent"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListResponse[WfRunEvent]"
+      },
+      "ListResponse_WfRun_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WfRun"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListResponse[WfRun]"
+      },
+      "ListResponse_Workflow_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Workflow"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "ListResponse[Workflow]"
       },
       "McpPermissionPolicy": {
         "properties": {
@@ -14121,6 +14846,183 @@
         "title": "WaitResponse",
         "description": "Response for ``GET /v1/sessions/{id}/wait``."
       },
+      "WfRun": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "workflow_id": {
+            "type": "string",
+            "title": "Workflow Id"
+          },
+          "account_id": {
+            "type": "string",
+            "title": "Account Id"
+          },
+          "environment_id": {
+            "type": "string",
+            "title": "Environment Id"
+          },
+          "parent_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Run Id"
+          },
+          "script": {
+            "type": "string",
+            "title": "Script"
+          },
+          "script_sha": {
+            "type": "string",
+            "title": "Script Sha"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "running",
+              "suspended",
+              "completed",
+              "errored"
+            ],
+            "title": "Status"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "output": {
+            "title": "Output"
+          },
+          "last_event_seq": {
+            "type": "integer",
+            "title": "Last Event Seq"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "workflow_id",
+          "account_id",
+          "environment_id",
+          "script",
+          "script_sha",
+          "status",
+          "last_event_seq",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "WfRun",
+        "description": "A durable workflow execution instance.\n\n``script`` is the run's own immutable snapshot of the workflow source at\ncreation time (``script_sha`` is its hash); every wake execs exactly this.\n``status`` is persisted (unlike sessions): the run loop writes\n``suspended``/``completed``/``errored``."
+      },
+      "WfRunCreate": {
+        "properties": {
+          "workflow_id": {
+            "type": "string",
+            "title": "Workflow Id"
+          },
+          "environment_id": {
+            "type": "string",
+            "title": "Environment Id"
+          },
+          "input": {
+            "title": "Input"
+          }
+        },
+        "type": "object",
+        "required": [
+          "workflow_id",
+          "environment_id"
+        ],
+        "title": "WfRunCreate",
+        "description": "Request body for ``POST /v1/runs`` \u2014 launch a run of a workflow.\n\n``input`` is arbitrary JSON (a workflow's input need not be an object). The run\nbinds to ``environment_id`` (like a session), into which its ``agent()`` children\nspawn."
+      },
+      "WfRunEvent": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "run_id": {
+            "type": "string",
+            "title": "Run Id"
+          },
+          "seq": {
+            "type": "integer",
+            "title": "Seq"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "run_started",
+              "call_started",
+              "call_result",
+              "run_completed"
+            ],
+            "title": "Type"
+          },
+          "call_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Key"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "run_id",
+          "seq",
+          "type",
+          "payload",
+          "created_at"
+        ],
+        "title": "WfRunEvent",
+        "description": "One row of a run's append-only journal (the replay-with-memo source).\n\n``call_key`` is set for ``call_started``/``call_result`` (the memo key) and\n``None`` for the ``run_started``/``run_completed`` bookends."
+      },
       "WhatsappConfirmPairingRequest": {
         "properties": {
           "external_account_id": {
@@ -14237,6 +15139,119 @@
           "external_account_id"
         ],
         "title": "WhatsappUnpairRequest"
+      },
+      "Workflow": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "account_id": {
+            "type": "string",
+            "title": "Account Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
+          "script": {
+            "type": "string",
+            "title": "Script"
+          },
+          "input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Schema"
+          },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Schema"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "account_id",
+          "name",
+          "version",
+          "script",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "Workflow",
+        "description": "An immutable, versioned workflow definition."
+      },
+      "WorkflowCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "script": {
+            "type": "string",
+            "title": "Script"
+          },
+          "input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Schema"
+          },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Schema"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "script"
+        ],
+        "title": "WorkflowCreate",
+        "description": "Request body for ``POST /v1/workflows`` \u2014 a new workflow definition at v1."
       }
     }
   }

--- a/openapi.json
+++ b/openapi.json
@@ -8711,6 +8711,76 @@
           }
         }
       }
+    },
+    "/v1/runs/{run_id}/stream": {
+      "get": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Stream Run Events",
+        "description": "Stream a run's journal as Server-Sent Events: backfill from ``after_seq``,\nthen live, ending on ``run_completed``.\n\nPreflights the LISTEN before constructing the response (issue #376), so a\ntransient connect failure is a clean 503 rather than a half-open stream.",
+        "operationId": "stream_run_events_v1_runs__run_id__stream_get",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "after_seq",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "title": "After Seq"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen": {
+          "targets": []
+        }
+      }
     }
   },
   "components": {

--- a/packages/aios-sdk/aios_sdk/__init__.py
+++ b/packages/aios-sdk/aios_sdk/__init__.py
@@ -19,6 +19,7 @@ from aios_sdk.streaming import (
     stream_connection_discovery,
     stream_connector_calls,
     stream_management_calls,
+    stream_run,
     stream_session,
 )
 
@@ -31,5 +32,6 @@ __all__ = [
     "stream_connection_discovery",
     "stream_connector_calls",
     "stream_management_calls",
+    "stream_run",
     "stream_session",
 ]

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/create_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/create_run.py
@@ -1,0 +1,213 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.wf_run import WfRun
+from ...models.wf_run_create import WfRunCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: WfRunCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/runs",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | WfRun | None:
+    if response.status_code == 201:
+        response_201 = WfRun.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | WfRun]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WfRunCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Create Run
+
+     Launch a run of a workflow. Snapshots the workflow's current script, binds
+    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
+    it. A missing workflow or environment 404s.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WfRunCreate): Request body for ``POST /v1/runs`` — launch a run of a workflow.
+
+            ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
+            binds to ``environment_id`` (like a session), into which its ``agent()`` children
+            spawn.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WfRunCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Create Run
+
+     Launch a run of a workflow. Snapshots the workflow's current script, binds
+    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
+    it. A missing workflow or environment 404s.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WfRunCreate): Request body for ``POST /v1/runs`` — launch a run of a workflow.
+
+            ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
+            binds to ``environment_id`` (like a session), into which its ``agent()`` children
+            spawn.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WfRunCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Create Run
+
+     Launch a run of a workflow. Snapshots the workflow's current script, binds
+    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
+    it. A missing workflow or environment 404s.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WfRunCreate): Request body for ``POST /v1/runs`` — launch a run of a workflow.
+
+            ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
+            binds to ``environment_id`` (like a session), into which its ``agent()`` children
+            spawn.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WfRunCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Create Run
+
+     Launch a run of a workflow. Snapshots the workflow's current script, binds
+    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
+    it. A missing workflow or environment 404s.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WfRunCreate): Request body for ``POST /v1/runs`` — launch a run of a workflow.
+
+            ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
+            binds to ``environment_id`` (like a session), into which its ``agent()`` children
+            spawn.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/get_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/get_run.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.wf_run import WfRun
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/runs/{run_id}".format(
+            run_id=quote(str(run_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | WfRun | None:
+    if response.status_code == 200:
+        response_200 = WfRun.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | WfRun]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Get Run
+
+     Fetch one run by id (status, output, last_event_seq, …).
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Get Run
+
+     Fetch one run by id (status, output, last_event_seq, …).
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return sync_detailed(
+        run_id=run_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Get Run
+
+     Fetch one run by id (status, output, last_event_seq, …).
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Get Run
+
+     Fetch one run by id (status, output, last_event_seq, …).
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return (
+        await asyncio_detailed(
+            run_id=run_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/list_run_events.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/list_run_events.py
@@ -1,0 +1,236 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_wf_run_event import ListResponseWfRunEvent
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    cursor: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_cursor: None | str | Unset
+    if isinstance(cursor, Unset):
+        json_cursor = UNSET
+    else:
+        json_cursor = cursor
+    params["cursor"] = json_cursor
+
+    json_limit: int | None | Unset
+    if isinstance(limit, Unset):
+        json_limit = UNSET
+    else:
+        json_limit = limit
+    params["limit"] = json_limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/runs/{run_id}/events".format(
+            run_id=quote(str(run_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseWfRunEvent | None:
+    if response.status_code == 200:
+        response_200 = ListResponseWfRunEvent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseWfRunEvent]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseWfRunEvent]:
+    """List Run Events
+
+     A run's journal by sequence (oldest first). First page: optional ``limit``;
+    subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        run_id (str):
+        cursor (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseWfRunEvent]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        cursor=cursor,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseWfRunEvent | None:
+    """List Run Events
+
+     A run's journal by sequence (oldest first). First page: optional ``limit``;
+    subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        run_id (str):
+        cursor (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseWfRunEvent
+    """
+
+    return sync_detailed(
+        run_id=run_id,
+        client=client,
+        cursor=cursor,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseWfRunEvent]:
+    """List Run Events
+
+     A run's journal by sequence (oldest first). First page: optional ``limit``;
+    subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        run_id (str):
+        cursor (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseWfRunEvent]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        cursor=cursor,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseWfRunEvent | None:
+    """List Run Events
+
+     A run's journal by sequence (oldest first). First page: optional ``limit``;
+    subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        run_id (str):
+        cursor (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseWfRunEvent
+    """
+
+    return (
+        await asyncio_detailed(
+            run_id=run_id,
+            client=client,
+            cursor=cursor,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/list_runs.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/list_runs.py
@@ -1,0 +1,260 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_wf_run import ListResponseWfRun
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    cursor: None | str | Unset = UNSET,
+    workflow_id: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_cursor: None | str | Unset
+    if isinstance(cursor, Unset):
+        json_cursor = UNSET
+    else:
+        json_cursor = cursor
+    params["cursor"] = json_cursor
+
+    json_workflow_id: None | str | Unset
+    if isinstance(workflow_id, Unset):
+        json_workflow_id = UNSET
+    else:
+        json_workflow_id = workflow_id
+    params["workflow_id"] = json_workflow_id
+
+    json_status: None | str | Unset
+    if isinstance(status, Unset):
+        json_status = UNSET
+    else:
+        json_status = status
+    params["status"] = json_status
+
+    json_limit: int | None | Unset
+    if isinstance(limit, Unset):
+        json_limit = UNSET
+    else:
+        json_limit = limit
+    params["limit"] = json_limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/runs",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseWfRun | None:
+    if response.status_code == 200:
+        response_200 = ListResponseWfRun.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseWfRun]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    workflow_id: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseWfRun]:
+    """List Runs
+
+     List the account's runs, newest first. First page: optional ``workflow_id`` /
+    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        workflow_id (None | str | Unset):
+        status (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseWfRun]
+    """
+
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        workflow_id=workflow_id,
+        status=status,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    workflow_id: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseWfRun | None:
+    """List Runs
+
+     List the account's runs, newest first. First page: optional ``workflow_id`` /
+    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        workflow_id (None | str | Unset):
+        status (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseWfRun
+    """
+
+    return sync_detailed(
+        client=client,
+        cursor=cursor,
+        workflow_id=workflow_id,
+        status=status,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    workflow_id: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseWfRun]:
+    """List Runs
+
+     List the account's runs, newest first. First page: optional ``workflow_id`` /
+    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        workflow_id (None | str | Unset):
+        status (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseWfRun]
+    """
+
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        workflow_id=workflow_id,
+        status=status,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    workflow_id: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseWfRun | None:
+    """List Runs
+
+     List the account's runs, newest first. First page: optional ``workflow_id`` /
+    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        workflow_id (None | str | Unset):
+        status (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseWfRun
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            cursor=cursor,
+            workflow_id=workflow_id,
+            status=status,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/resume_gate.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/resume_gate.py
@@ -77,8 +77,9 @@ def sync_detailed(
     """Resume Gate
 
      Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
-    the updated run (its status flips back toward ``running``). A bad nonce or a
-    cross-tenant run 404s.
+    the run (still ``suspended`` here — the recorded resume signal is harvested on the
+    next wake, which replays past the gate). A nonce that matches no OPEN gate, or a
+    cross-tenant run, 404s.
 
     Args:
         run_id (str):
@@ -121,8 +122,9 @@ def sync(
     """Resume Gate
 
      Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
-    the updated run (its status flips back toward ``running``). A bad nonce or a
-    cross-tenant run 404s.
+    the run (still ``suspended`` here — the recorded resume signal is harvested on the
+    next wake, which replays past the gate). A nonce that matches no OPEN gate, or a
+    cross-tenant run, 404s.
 
     Args:
         run_id (str):
@@ -160,8 +162,9 @@ async def asyncio_detailed(
     """Resume Gate
 
      Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
-    the updated run (its status flips back toward ``running``). A bad nonce or a
-    cross-tenant run 404s.
+    the run (still ``suspended`` here — the recorded resume signal is harvested on the
+    next wake, which replays past the gate). A nonce that matches no OPEN gate, or a
+    cross-tenant run, 404s.
 
     Args:
         run_id (str):
@@ -202,8 +205,9 @@ async def asyncio(
     """Resume Gate
 
      Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
-    the updated run (its status flips back toward ``running``). A bad nonce or a
-    cross-tenant run 404s.
+    the run (still ``suspended`` here — the recorded resume signal is harvested on the
+    next wake, which replays past the gate). A nonce that matches no OPEN gate, or a
+    cross-tenant run, 404s.
 
     Args:
         run_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/resume_gate.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/resume_gate.py
@@ -1,0 +1,233 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.gate_resume import GateResume
+from ...models.http_validation_error import HTTPValidationError
+from ...models.wf_run import WfRun
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    body: GateResume,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/runs/{run_id}/resume".format(
+            run_id=quote(str(run_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | WfRun | None:
+    if response.status_code == 200:
+        response_200 = WfRun.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | WfRun]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GateResume,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Resume Gate
+
+     Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
+    the updated run (its status flips back toward ``running``). A bad nonce or a
+    cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+        body (GateResume): Request body for ``POST /v1/runs/{run_id}/resume`` — deliver a gate's
+            value.
+
+            Keyed by ``gate_nonce`` (the unguessable capability token minted into the gate's
+            ``call_started`` event), not the internal ``call_key``. ``result`` is the
+            externally-delivered resume value (arbitrary JSON).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GateResume,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Resume Gate
+
+     Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
+    the updated run (its status flips back toward ``running``). A bad nonce or a
+    cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+        body (GateResume): Request body for ``POST /v1/runs/{run_id}/resume`` — deliver a gate's
+            value.
+
+            Keyed by ``gate_nonce`` (the unguessable capability token minted into the gate's
+            ``call_started`` event), not the internal ``call_key``. ``result`` is the
+            externally-delivered resume value (arbitrary JSON).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return sync_detailed(
+        run_id=run_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GateResume,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Resume Gate
+
+     Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
+    the updated run (its status flips back toward ``running``). A bad nonce or a
+    cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+        body (GateResume): Request body for ``POST /v1/runs/{run_id}/resume`` — deliver a gate's
+            value.
+
+            Keyed by ``gate_nonce`` (the unguessable capability token minted into the gate's
+            ``call_started`` event), not the internal ``call_key``. ``result`` is the
+            externally-delivered resume value (arbitrary JSON).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: GateResume,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Resume Gate
+
+     Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
+    the updated run (its status flips back toward ``running``). A bad nonce or a
+    cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+        body (GateResume): Request body for ``POST /v1/runs/{run_id}/resume`` — deliver a gate's
+            value.
+
+            Keyed by ``gate_nonce`` (the unguessable capability token minted into the gate's
+            ``call_started`` event), not the internal ``call_key``. ``result`` is the
+            externally-delivered resume value (arbitrary JSON).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return (
+        await asyncio_detailed(
+            run_id=run_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/stream_run_events_v1_runs_run_id_stream_get.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/stream_run_events_v1_runs_run_id_stream_get.py
@@ -1,0 +1,221 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["after_seq"] = after_seq
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/runs/{run_id}/stream".format(
+            run_id=quote(str(run_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Stream Run Events
+
+     Stream a run's journal as Server-Sent Events: backfill from ``after_seq``,
+    then live, ending on ``run_completed``.
+
+    Preflights the LISTEN before constructing the response (issue #376), so a
+    transient connect failure is a clean 503 rather than a half-open stream.
+
+    Args:
+        run_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        after_seq=after_seq,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Stream Run Events
+
+     Stream a run's journal as Server-Sent Events: backfill from ``after_seq``,
+    then live, ending on ``run_completed``.
+
+    Preflights the LISTEN before constructing the response (issue #376), so a
+    transient connect failure is a clean 503 rather than a half-open stream.
+
+    Args:
+        run_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        run_id=run_id,
+        client=client,
+        after_seq=after_seq,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Stream Run Events
+
+     Stream a run's journal as Server-Sent Events: backfill from ``after_seq``,
+    then live, ending on ``run_completed``.
+
+    Preflights the LISTEN before constructing the response (issue #376), so a
+    transient connect failure is a clean 503 rather than a half-open stream.
+
+    Args:
+        run_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        after_seq=after_seq,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    after_seq: int | Unset = 0,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Stream Run Events
+
+     Stream a run's journal as Server-Sent Events: backfill from ``after_seq``,
+    then live, ending on ``run_completed``.
+
+    Preflights the LISTEN before constructing the response (issue #376), so a
+    transient connect failure is a clean 503 rather than a half-open stream.
+
+    Args:
+        run_id (str):
+        after_seq (int | Unset):  Default: 0.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            run_id=run_id,
+            client=client,
+            after_seq=after_seq,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/create_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/create_workflow.py
@@ -1,0 +1,193 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.workflow import Workflow
+from ...models.workflow_create import WorkflowCreate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: WorkflowCreate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/workflows",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Workflow | None:
+    if response.status_code == 201:
+        response_201 = Workflow.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Workflow]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Create Workflow
+
+     Create a workflow definition (version 1). Versioning/update is deferred.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WorkflowCreate): Request body for ``POST /v1/workflows`` — a new workflow definition
+            at v1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Create Workflow
+
+     Create a workflow definition (version 1). Versioning/update is deferred.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WorkflowCreate): Request body for ``POST /v1/workflows`` — a new workflow definition
+            at v1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowCreate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Create Workflow
+
+     Create a workflow definition (version 1). Versioning/update is deferred.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WorkflowCreate): Request body for ``POST /v1/workflows`` — a new workflow definition
+            at v1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowCreate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Create Workflow
+
+     Create a workflow definition (version 1). Versioning/update is deferred.
+
+    Args:
+        authorization (None | str | Unset):
+        body (WorkflowCreate): Request body for ``POST /v1/workflows`` — a new workflow definition
+            at v1.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/get_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/get_workflow.py
@@ -1,0 +1,187 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.workflow import Workflow
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    workflow_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/workflows/{workflow_id}".format(
+            workflow_id=quote(str(workflow_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Workflow | None:
+    if response.status_code == 200:
+        response_200 = Workflow.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Workflow]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Get Workflow
+
+     Fetch one workflow definition by id.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Get Workflow
+
+     Fetch one workflow definition by id.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return sync_detailed(
+        workflow_id=workflow_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Get Workflow
+
+     Fetch one workflow definition by id.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Get Workflow
+
+     Fetch one workflow definition by id.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return (
+        await asyncio_detailed(
+            workflow_id=workflow_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/list_workflows.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/list_workflows.py
@@ -1,0 +1,240 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.list_response_workflow import ListResponseWorkflow
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    cursor: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_cursor: None | str | Unset
+    if isinstance(cursor, Unset):
+        json_cursor = UNSET
+    else:
+        json_cursor = cursor
+    params["cursor"] = json_cursor
+
+    json_name: None | str | Unset
+    if isinstance(name, Unset):
+        json_name = UNSET
+    else:
+        json_name = name
+    params["name"] = json_name
+
+    json_limit: int | None | Unset
+    if isinstance(limit, Unset):
+        json_limit = UNSET
+    else:
+        json_limit = limit
+    params["limit"] = json_limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/workflows",
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | ListResponseWorkflow | None:
+    if response.status_code == 200:
+        response_200 = ListResponseWorkflow.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | ListResponseWorkflow]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseWorkflow]:
+    """List Workflows
+
+     List the account's workflows, newest first. First page: optional ``name`` +
+    ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        name (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseWorkflow]
+    """
+
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        name=name,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseWorkflow | None:
+    """List Workflows
+
+     List the account's workflows, newest first. First page: optional ``name`` +
+    ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        name (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseWorkflow
+    """
+
+    return sync_detailed(
+        client=client,
+        cursor=cursor,
+        name=name,
+        limit=limit,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | ListResponseWorkflow]:
+    """List Workflows
+
+     List the account's workflows, newest first. First page: optional ``name`` +
+    ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        name (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | ListResponseWorkflow]
+    """
+
+    kwargs = _get_kwargs(
+        cursor=cursor,
+        name=name,
+        limit=limit,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    cursor: None | str | Unset = UNSET,
+    name: None | str | Unset = UNSET,
+    limit: int | None | Unset = UNSET,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | ListResponseWorkflow | None:
+    """List Workflows
+
+     List the account's workflows, newest first. First page: optional ``name`` +
+    ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+
+    Args:
+        cursor (None | str | Unset):
+        name (None | str | Unset):
+        limit (int | None | Unset):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | ListResponseWorkflow
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            cursor=cursor,
+            name=name,
+            limit=limit,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -52,6 +52,7 @@ from .event import Event
 from .event_data import EventData
 from .event_kind import EventKind
 from .file_upload_response import FileUploadResponse
+from .gate_resume import GateResume
 from .get_health_response_get_health import GetHealthResponseGetHealth
 from .github_repository_resource import GithubRepositoryResource
 from .github_repository_resource_echo import GithubRepositoryResourceEcho
@@ -86,6 +87,9 @@ from .list_response_union_memory_memory_prefix import (
 )
 from .list_response_vault import ListResponseVault
 from .list_response_vault_credential import ListResponseVaultCredential
+from .list_response_wf_run import ListResponseWfRun
+from .list_response_wf_run_event import ListResponseWfRunEvent
+from .list_response_workflow import ListResponseWorkflow
 from .list_session_events_dir import ListSessionEventsDir
 from .list_session_events_kind_type_0 import ListSessionEventsKindType0
 from .list_sessions_status_type_0 import ListSessionsStatusType0
@@ -217,6 +221,12 @@ from .vault_update_metadata_type_0 import VaultUpdateMetadataType0
 from .wait_response import WaitResponse
 from .wait_response_session_status import WaitResponseSessionStatus
 from .wait_response_session_stop_reason_type_0 import WaitResponseSessionStopReasonType0
+from .wf_run import WfRun
+from .wf_run_create import WfRunCreate
+from .wf_run_event import WfRunEvent
+from .wf_run_event_payload import WfRunEventPayload
+from .wf_run_event_type import WfRunEventType
+from .wf_run_status import WfRunStatus
 from .whatsapp_confirm_pairing_request import WhatsappConfirmPairingRequest
 from .whatsapp_confirm_pairing_response import WhatsappConfirmPairingResponse
 from .whatsapp_confirm_pairing_response_status import (
@@ -225,6 +235,12 @@ from .whatsapp_confirm_pairing_response_status import (
 from .whatsapp_start_pairing_request import WhatsappStartPairingRequest
 from .whatsapp_start_pairing_response import WhatsappStartPairingResponse
 from .whatsapp_unpair_request import WhatsappUnpairRequest
+from .workflow import Workflow
+from .workflow_create import WorkflowCreate
+from .workflow_create_input_schema_type_0 import WorkflowCreateInputSchemaType0
+from .workflow_create_output_schema_type_0 import WorkflowCreateOutputSchemaType0
+from .workflow_input_schema_type_0 import WorkflowInputSchemaType0
+from .workflow_output_schema_type_0 import WorkflowOutputSchemaType0
 
 __all__ = (
     "Account",
@@ -279,6 +295,7 @@ __all__ = (
     "EventData",
     "EventKind",
     "FileUploadResponse",
+    "GateResume",
     "GetHealthResponseGetHealth",
     "GithubRepositoryResource",
     "GithubRepositoryResourceEcho",
@@ -309,6 +326,9 @@ __all__ = (
     "ListResponseUnionMemoryMemoryPrefix",
     "ListResponseVault",
     "ListResponseVaultCredential",
+    "ListResponseWfRun",
+    "ListResponseWfRunEvent",
+    "ListResponseWorkflow",
     "ListSessionEventsDir",
     "ListSessionEventsKindType0",
     "ListSessionsStatusType0",
@@ -432,10 +452,22 @@ __all__ = (
     "WaitResponse",
     "WaitResponseSessionStatus",
     "WaitResponseSessionStopReasonType0",
+    "WfRun",
+    "WfRunCreate",
+    "WfRunEvent",
+    "WfRunEventPayload",
+    "WfRunEventType",
+    "WfRunStatus",
     "WhatsappConfirmPairingRequest",
     "WhatsappConfirmPairingResponse",
     "WhatsappConfirmPairingResponseStatus",
     "WhatsappStartPairingRequest",
     "WhatsappStartPairingResponse",
     "WhatsappUnpairRequest",
+    "Workflow",
+    "WorkflowCreate",
+    "WorkflowCreateInputSchemaType0",
+    "WorkflowCreateOutputSchemaType0",
+    "WorkflowInputSchemaType0",
+    "WorkflowOutputSchemaType0",
 )

--- a/packages/aios-sdk/aios_sdk/_generated/models/gate_resume.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/gate_resume.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GateResume")
+
+
+@_attrs_define
+class GateResume:
+    """Request body for ``POST /v1/runs/{run_id}/resume`` — deliver a gate's value.
+
+    Keyed by ``gate_nonce`` (the unguessable capability token minted into the gate's
+    ``call_started`` event), not the internal ``call_key``. ``result`` is the
+    externally-delivered resume value (arbitrary JSON).
+
+        Attributes:
+            gate_nonce (str):
+            result (Any | Unset):
+    """
+
+    gate_nonce: str
+    result: Any | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        gate_nonce = self.gate_nonce
+
+        result = self.result
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "gate_nonce": gate_nonce,
+            }
+        )
+        if result is not UNSET:
+            field_dict["result"] = result
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        gate_nonce = d.pop("gate_nonce")
+
+        result = d.pop("result", UNSET)
+
+        gate_resume = cls(
+            gate_nonce=gate_nonce,
+            result=result,
+        )
+
+        gate_resume.additional_properties = d
+        return gate_resume
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_response_wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_response_wf_run.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.wf_run import WfRun
+
+
+T = TypeVar("T", bound="ListResponseWfRun")
+
+
+@_attrs_define
+class ListResponseWfRun:
+    """
+    Attributes:
+        data (list[WfRun]):
+        has_more (bool | Unset):  Default: False.
+        next_cursor (None | str | Unset):
+    """
+
+    data: list[WfRun]
+    has_more: bool | Unset = False
+    next_cursor: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_cursor: None | str | Unset
+        if isinstance(self.next_cursor, Unset):
+            next_cursor = UNSET
+        else:
+            next_cursor = self.next_cursor
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.wf_run import WfRun
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = WfRun.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_cursor(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_cursor = _parse_next_cursor(d.pop("next_cursor", UNSET))
+
+        list_response_wf_run = cls(
+            data=data,
+            has_more=has_more,
+            next_cursor=next_cursor,
+        )
+
+        list_response_wf_run.additional_properties = d
+        return list_response_wf_run
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_response_wf_run_event.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_response_wf_run_event.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.wf_run_event import WfRunEvent
+
+
+T = TypeVar("T", bound="ListResponseWfRunEvent")
+
+
+@_attrs_define
+class ListResponseWfRunEvent:
+    """
+    Attributes:
+        data (list[WfRunEvent]):
+        has_more (bool | Unset):  Default: False.
+        next_cursor (None | str | Unset):
+    """
+
+    data: list[WfRunEvent]
+    has_more: bool | Unset = False
+    next_cursor: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_cursor: None | str | Unset
+        if isinstance(self.next_cursor, Unset):
+            next_cursor = UNSET
+        else:
+            next_cursor = self.next_cursor
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.wf_run_event import WfRunEvent
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = WfRunEvent.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_cursor(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_cursor = _parse_next_cursor(d.pop("next_cursor", UNSET))
+
+        list_response_wf_run_event = cls(
+            data=data,
+            has_more=has_more,
+            next_cursor=next_cursor,
+        )
+
+        list_response_wf_run_event.additional_properties = d
+        return list_response_wf_run_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_response_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_response_workflow.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.workflow import Workflow
+
+
+T = TypeVar("T", bound="ListResponseWorkflow")
+
+
+@_attrs_define
+class ListResponseWorkflow:
+    """
+    Attributes:
+        data (list[Workflow]):
+        has_more (bool | Unset):  Default: False.
+        next_cursor (None | str | Unset):
+    """
+
+    data: list[Workflow]
+    has_more: bool | Unset = False
+    next_cursor: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = []
+        for data_item_data in self.data:
+            data_item = data_item_data.to_dict()
+            data.append(data_item)
+
+        has_more = self.has_more
+
+        next_cursor: None | str | Unset
+        if isinstance(self.next_cursor, Unset):
+            next_cursor = UNSET
+        else:
+            next_cursor = self.next_cursor
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "data": data,
+            }
+        )
+        if has_more is not UNSET:
+            field_dict["has_more"] = has_more
+        if next_cursor is not UNSET:
+            field_dict["next_cursor"] = next_cursor
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.workflow import Workflow
+
+        d = dict(src_dict)
+        data = []
+        _data = d.pop("data")
+        for data_item_data in _data:
+            data_item = Workflow.from_dict(data_item_data)
+
+            data.append(data_item)
+
+        has_more = d.pop("has_more", UNSET)
+
+        def _parse_next_cursor(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        next_cursor = _parse_next_cursor(d.pop("next_cursor", UNSET))
+
+        list_response_workflow = cls(
+            data=data,
+            has_more=has_more,
+            next_cursor=next_cursor,
+        )
+
+        list_response_workflow.additional_properties = d
+        return list_response_workflow
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.wf_run_status import WfRunStatus
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="WfRun")
+
+
+@_attrs_define
+class WfRun:
+    """A durable workflow execution instance.
+
+    ``script`` is the run's own immutable snapshot of the workflow source at
+    creation time (``script_sha`` is its hash); every wake execs exactly this.
+    ``status`` is persisted (unlike sessions): the run loop writes
+    ``suspended``/``completed``/``errored``.
+
+        Attributes:
+            id (str):
+            workflow_id (str):
+            account_id (str):
+            environment_id (str):
+            script (str):
+            script_sha (str):
+            status (WfRunStatus):
+            last_event_seq (int):
+            created_at (datetime.datetime):
+            updated_at (datetime.datetime):
+            parent_run_id (None | str | Unset):
+            input_ (Any | Unset):
+            output (Any | Unset):
+            archived_at (datetime.datetime | None | Unset):
+    """
+
+    id: str
+    workflow_id: str
+    account_id: str
+    environment_id: str
+    script: str
+    script_sha: str
+    status: WfRunStatus
+    last_event_seq: int
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    parent_run_id: None | str | Unset = UNSET
+    input_: Any | Unset = UNSET
+    output: Any | Unset = UNSET
+    archived_at: datetime.datetime | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        workflow_id = self.workflow_id
+
+        account_id = self.account_id
+
+        environment_id = self.environment_id
+
+        script = self.script
+
+        script_sha = self.script_sha
+
+        status = self.status.value
+
+        last_event_seq = self.last_event_seq
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        parent_run_id: None | str | Unset
+        if isinstance(self.parent_run_id, Unset):
+            parent_run_id = UNSET
+        else:
+            parent_run_id = self.parent_run_id
+
+        input_ = self.input_
+
+        output = self.output
+
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "workflow_id": workflow_id,
+                "account_id": account_id,
+                "environment_id": environment_id,
+                "script": script,
+                "script_sha": script_sha,
+                "status": status,
+                "last_event_seq": last_event_seq,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if parent_run_id is not UNSET:
+            field_dict["parent_run_id"] = parent_run_id
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+        if output is not UNSET:
+            field_dict["output"] = output
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        workflow_id = d.pop("workflow_id")
+
+        account_id = d.pop("account_id")
+
+        environment_id = d.pop("environment_id")
+
+        script = d.pop("script")
+
+        script_sha = d.pop("script_sha")
+
+        status = WfRunStatus(d.pop("status"))
+
+        last_event_seq = d.pop("last_event_seq")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_parent_run_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        parent_run_id = _parse_parent_run_id(d.pop("parent_run_id", UNSET))
+
+        input_ = d.pop("input", UNSET)
+
+        output = d.pop("output", UNSET)
+
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
+        wf_run = cls(
+            id=id,
+            workflow_id=workflow_id,
+            account_id=account_id,
+            environment_id=environment_id,
+            script=script,
+            script_sha=script_sha,
+            status=status,
+            last_event_seq=last_event_seq,
+            created_at=created_at,
+            updated_at=updated_at,
+            parent_run_id=parent_run_id,
+            input_=input_,
+            output=output,
+            archived_at=archived_at,
+        )
+
+        wf_run.additional_properties = d
+        return wf_run
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="WfRunCreate")
+
+
+@_attrs_define
+class WfRunCreate:
+    """Request body for ``POST /v1/runs`` — launch a run of a workflow.
+
+    ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
+    binds to ``environment_id`` (like a session), into which its ``agent()`` children
+    spawn.
+
+        Attributes:
+            workflow_id (str):
+            environment_id (str):
+            input_ (Any | Unset):
+    """
+
+    workflow_id: str
+    environment_id: str
+    input_: Any | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        workflow_id = self.workflow_id
+
+        environment_id = self.environment_id
+
+        input_ = self.input_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "workflow_id": workflow_id,
+                "environment_id": environment_id,
+            }
+        )
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        workflow_id = d.pop("workflow_id")
+
+        environment_id = d.pop("environment_id")
+
+        input_ = d.pop("input", UNSET)
+
+        wf_run_create = cls(
+            workflow_id=workflow_id,
+            environment_id=environment_id,
+            input_=input_,
+        )
+
+        wf_run_create.additional_properties = d
+        return wf_run_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.wf_run_event_type import WfRunEventType
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.wf_run_event_payload import WfRunEventPayload
+
+
+T = TypeVar("T", bound="WfRunEvent")
+
+
+@_attrs_define
+class WfRunEvent:
+    """One row of a run's append-only journal (the replay-with-memo source).
+
+    ``call_key`` is set for ``call_started``/``call_result`` (the memo key) and
+    ``None`` for the ``run_started``/``run_completed`` bookends.
+
+        Attributes:
+            id (str):
+            run_id (str):
+            seq (int):
+            type_ (WfRunEventType):
+            payload (WfRunEventPayload):
+            created_at (datetime.datetime):
+            call_key (None | str | Unset):
+    """
+
+    id: str
+    run_id: str
+    seq: int
+    type_: WfRunEventType
+    payload: WfRunEventPayload
+    created_at: datetime.datetime
+    call_key: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        run_id = self.run_id
+
+        seq = self.seq
+
+        type_ = self.type_.value
+
+        payload = self.payload.to_dict()
+
+        created_at = self.created_at.isoformat()
+
+        call_key: None | str | Unset
+        if isinstance(self.call_key, Unset):
+            call_key = UNSET
+        else:
+            call_key = self.call_key
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "run_id": run_id,
+                "seq": seq,
+                "type": type_,
+                "payload": payload,
+                "created_at": created_at,
+            }
+        )
+        if call_key is not UNSET:
+            field_dict["call_key"] = call_key
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.wf_run_event_payload import WfRunEventPayload
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        run_id = d.pop("run_id")
+
+        seq = d.pop("seq")
+
+        type_ = WfRunEventType(d.pop("type"))
+
+        payload = WfRunEventPayload.from_dict(d.pop("payload"))
+
+        created_at = isoparse(d.pop("created_at"))
+
+        def _parse_call_key(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        call_key = _parse_call_key(d.pop("call_key", UNSET))
+
+        wf_run_event = cls(
+            id=id,
+            run_id=run_id,
+            seq=seq,
+            type_=type_,
+            payload=payload,
+            created_at=created_at,
+            call_key=call_key,
+        )
+
+        wf_run_event.additional_properties = d
+        return wf_run_event
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event_payload.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event_payload.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WfRunEventPayload")
+
+
+@_attrs_define
+class WfRunEventPayload:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        wf_run_event_payload = cls()
+
+        wf_run_event_payload.additional_properties = d
+        return wf_run_event_payload
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event_type.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event_type.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class WfRunEventType(str, Enum):
+    CALL_RESULT = "call_result"
+    CALL_STARTED = "call_started"
+    RUN_COMPLETED = "run_completed"
+    RUN_STARTED = "run_started"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class WfRunStatus(str, Enum):
+    COMPLETED = "completed"
+    ERRORED = "errored"
+    PENDING = "pending"
+    RUNNING = "running"
+    SUSPENDED = "suspended"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.workflow_input_schema_type_0 import WorkflowInputSchemaType0
+    from ..models.workflow_output_schema_type_0 import WorkflowOutputSchemaType0
+
+
+T = TypeVar("T", bound="Workflow")
+
+
+@_attrs_define
+class Workflow:
+    """An immutable, versioned workflow definition.
+
+    Attributes:
+        id (str):
+        account_id (str):
+        name (str):
+        version (int):
+        script (str):
+        created_at (datetime.datetime):
+        updated_at (datetime.datetime):
+        input_schema (None | Unset | WorkflowInputSchemaType0):
+        output_schema (None | Unset | WorkflowOutputSchemaType0):
+    """
+
+    id: str
+    account_id: str
+    name: str
+    version: int
+    script: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+    input_schema: None | Unset | WorkflowInputSchemaType0 = UNSET
+    output_schema: None | Unset | WorkflowOutputSchemaType0 = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.workflow_input_schema_type_0 import WorkflowInputSchemaType0
+        from ..models.workflow_output_schema_type_0 import WorkflowOutputSchemaType0
+
+        id = self.id
+
+        account_id = self.account_id
+
+        name = self.name
+
+        version = self.version
+
+        script = self.script
+
+        created_at = self.created_at.isoformat()
+
+        updated_at = self.updated_at.isoformat()
+
+        input_schema: dict[str, Any] | None | Unset
+        if isinstance(self.input_schema, Unset):
+            input_schema = UNSET
+        elif isinstance(self.input_schema, WorkflowInputSchemaType0):
+            input_schema = self.input_schema.to_dict()
+        else:
+            input_schema = self.input_schema
+
+        output_schema: dict[str, Any] | None | Unset
+        if isinstance(self.output_schema, Unset):
+            output_schema = UNSET
+        elif isinstance(self.output_schema, WorkflowOutputSchemaType0):
+            output_schema = self.output_schema.to_dict()
+        else:
+            output_schema = self.output_schema
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "account_id": account_id,
+                "name": name,
+                "version": version,
+                "script": script,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
+        if input_schema is not UNSET:
+            field_dict["input_schema"] = input_schema
+        if output_schema is not UNSET:
+            field_dict["output_schema"] = output_schema
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.workflow_input_schema_type_0 import WorkflowInputSchemaType0
+        from ..models.workflow_output_schema_type_0 import WorkflowOutputSchemaType0
+
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        account_id = d.pop("account_id")
+
+        name = d.pop("name")
+
+        version = d.pop("version")
+
+        script = d.pop("script")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_input_schema(
+            data: object,
+        ) -> None | Unset | WorkflowInputSchemaType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                input_schema_type_0 = WorkflowInputSchemaType0.from_dict(data)
+
+                return input_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WorkflowInputSchemaType0, data)
+
+        input_schema = _parse_input_schema(d.pop("input_schema", UNSET))
+
+        def _parse_output_schema(
+            data: object,
+        ) -> None | Unset | WorkflowOutputSchemaType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                output_schema_type_0 = WorkflowOutputSchemaType0.from_dict(data)
+
+                return output_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WorkflowOutputSchemaType0, data)
+
+        output_schema = _parse_output_schema(d.pop("output_schema", UNSET))
+
+        workflow = cls(
+            id=id,
+            account_id=account_id,
+            name=name,
+            version=version,
+            script=script,
+            created_at=created_at,
+            updated_at=updated_at,
+            input_schema=input_schema,
+            output_schema=output_schema,
+        )
+
+        workflow.additional_properties = d
+        return workflow
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.workflow_create_input_schema_type_0 import (
+        WorkflowCreateInputSchemaType0,
+    )
+    from ..models.workflow_create_output_schema_type_0 import (
+        WorkflowCreateOutputSchemaType0,
+    )
+
+
+T = TypeVar("T", bound="WorkflowCreate")
+
+
+@_attrs_define
+class WorkflowCreate:
+    """Request body for ``POST /v1/workflows`` — a new workflow definition at v1.
+
+    Attributes:
+        name (str):
+        script (str):
+        input_schema (None | Unset | WorkflowCreateInputSchemaType0):
+        output_schema (None | Unset | WorkflowCreateOutputSchemaType0):
+    """
+
+    name: str
+    script: str
+    input_schema: None | Unset | WorkflowCreateInputSchemaType0 = UNSET
+    output_schema: None | Unset | WorkflowCreateOutputSchemaType0 = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.workflow_create_input_schema_type_0 import (
+            WorkflowCreateInputSchemaType0,
+        )
+        from ..models.workflow_create_output_schema_type_0 import (
+            WorkflowCreateOutputSchemaType0,
+        )
+
+        name = self.name
+
+        script = self.script
+
+        input_schema: dict[str, Any] | None | Unset
+        if isinstance(self.input_schema, Unset):
+            input_schema = UNSET
+        elif isinstance(self.input_schema, WorkflowCreateInputSchemaType0):
+            input_schema = self.input_schema.to_dict()
+        else:
+            input_schema = self.input_schema
+
+        output_schema: dict[str, Any] | None | Unset
+        if isinstance(self.output_schema, Unset):
+            output_schema = UNSET
+        elif isinstance(self.output_schema, WorkflowCreateOutputSchemaType0):
+            output_schema = self.output_schema.to_dict()
+        else:
+            output_schema = self.output_schema
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "script": script,
+            }
+        )
+        if input_schema is not UNSET:
+            field_dict["input_schema"] = input_schema
+        if output_schema is not UNSET:
+            field_dict["output_schema"] = output_schema
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.workflow_create_input_schema_type_0 import (
+            WorkflowCreateInputSchemaType0,
+        )
+        from ..models.workflow_create_output_schema_type_0 import (
+            WorkflowCreateOutputSchemaType0,
+        )
+
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        script = d.pop("script")
+
+        def _parse_input_schema(
+            data: object,
+        ) -> None | Unset | WorkflowCreateInputSchemaType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                input_schema_type_0 = WorkflowCreateInputSchemaType0.from_dict(data)
+
+                return input_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WorkflowCreateInputSchemaType0, data)
+
+        input_schema = _parse_input_schema(d.pop("input_schema", UNSET))
+
+        def _parse_output_schema(
+            data: object,
+        ) -> None | Unset | WorkflowCreateOutputSchemaType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                output_schema_type_0 = WorkflowCreateOutputSchemaType0.from_dict(data)
+
+                return output_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WorkflowCreateOutputSchemaType0, data)
+
+        output_schema = _parse_output_schema(d.pop("output_schema", UNSET))
+
+        workflow_create = cls(
+            name=name,
+            script=script,
+            input_schema=input_schema,
+            output_schema=output_schema,
+        )
+
+        workflow_create.additional_properties = d
+        return workflow_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create_input_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create_input_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WorkflowCreateInputSchemaType0")
+
+
+@_attrs_define
+class WorkflowCreateInputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        workflow_create_input_schema_type_0 = cls()
+
+        workflow_create_input_schema_type_0.additional_properties = d
+        return workflow_create_input_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create_output_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create_output_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WorkflowCreateOutputSchemaType0")
+
+
+@_attrs_define
+class WorkflowCreateOutputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        workflow_create_output_schema_type_0 = cls()
+
+        workflow_create_output_schema_type_0.additional_properties = d
+        return workflow_create_output_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_input_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_input_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WorkflowInputSchemaType0")
+
+
+@_attrs_define
+class WorkflowInputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        workflow_input_schema_type_0 = cls()
+
+        workflow_input_schema_type_0.additional_properties = d
+        return workflow_input_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_output_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_output_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WorkflowOutputSchemaType0")
+
+
+@_attrs_define
+class WorkflowOutputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        workflow_output_schema_type_0 = cls()
+
+        workflow_output_schema_type_0.additional_properties = d
+        return workflow_output_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/streaming.py
+++ b/packages/aios-sdk/aios_sdk/streaming.py
@@ -68,6 +68,32 @@ def stream_session(
         yield parse_sse_lines(response.iter_lines())
 
 
+@contextmanager
+def stream_run(
+    client: AuthenticatedClient,
+    run_id: str,
+    *,
+    after_seq: int = 0,
+) -> Iterator[Iterator[SseMessage]]:
+    """Stream a workflow run's journal events as :class:`SseMessage` values.
+
+    The workflow-run analog of :func:`stream_session` (``GET /v1/runs/{id}/stream``).
+    Backfills from ``after_seq`` then tails live, ending on the ``done`` event after
+    ``run_completed``. Same lazy context-manager + unbounded-read-timeout contract.
+    """
+    params: dict[str, int] = {"after_seq": after_seq} if after_seq else {}
+    httpx_client = client.get_httpx_client()
+    with httpx_client.stream(
+        "GET",
+        f"/v1/runs/{run_id}/stream",
+        params=params,
+        headers={"Accept": "text/event-stream"},
+        timeout=httpx.Timeout(60.0, read=None),
+    ) as response:
+        response.raise_for_status()
+        yield parse_sse_lines(response.iter_lines())
+
+
 def parse_sse_lines(lines: Iterable[str]) -> Iterator[SseMessage]:
     """Yield :class:`SseMessage` values from an SSE line iterator.
 

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -28,6 +28,7 @@ from aios.api.routers import (
     sessions,
     skills,
     vaults,
+    workflows,
 )
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
@@ -100,6 +101,8 @@ def create_app() -> FastAPI:
     app.include_router(runtime_tokens.router)
     app.include_router(connectors.router)
     app.include_router(session_templates.router)
+    app.include_router(workflows.router)
+    app.include_router(workflows.runs_router)
     _mount_mcp(app)
     return app
 

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -162,7 +162,11 @@ async def list_run_events(
     items = await service.list_run_events(
         pool, run_id, account_id=account_id, after_seq=after_seq, limit=page_limit + 1
     )
-    return ListResponse[WfRunEvent].paginate(items, page_limit, cursor=lambda x: x.seq)
+    # Forward (ascending seq) read — label the cursor accordingly (paginate defaults
+    # to "backward", which is right only for the id-DESC list endpoints).
+    return ListResponse[WfRunEvent].paginate(
+        items, page_limit, cursor=lambda x: x.seq, direction="forward"
+    )
 
 
 @runs_router.post("/{run_id}/resume", operation_id="resume_gate")
@@ -170,8 +174,9 @@ async def resume_gate(
     run_id: str, body: GateResume, pool: PoolDep, account_id: AccountIdDep
 ) -> WfRun:
     """Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
-    the updated run (its status flips back toward ``running``). A bad nonce or a
-    cross-tenant run 404s."""
+    the run (still ``suspended`` here — the recorded resume signal is harvested on the
+    next wake, which replays past the gate). A nonce that matches no OPEN gate, or a
+    cross-tenant run, 404s."""
     await service.resume_gate_by_nonce(
         pool, run_id=run_id, account_id=account_id, gate_nonce=body.gate_nonce, result=body.result
     )

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -1,0 +1,171 @@
+"""Workflow + run HTTP endpoints (Block 3 surface).
+
+Two routers in one module: ``/v1/workflows`` (the definition resource, mirroring
+``/v1/agents``) and the top-level ``/v1/runs`` (the execution instances, mirroring
+``/v1/sessions`` — a run carries ``workflow_id`` the way a session carries
+``agent_id``). Both are account-scoped via ``AccountIdDep``; the SSE
+``/v1/runs/{id}/stream`` endpoint is added in the streaming slice.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Query, status
+
+from aios.api.deps import AccountIdDep, PoolDep
+from aios.models.common import ListResponse
+from aios.models.pagination import page_cursor
+from aios.models.workflows import (
+    GateResume,
+    WfRun,
+    WfRunCreate,
+    WfRunEvent,
+    Workflow,
+    WorkflowCreate,
+)
+from aios.services import workflows as service
+
+router = APIRouter(prefix="/v1/workflows", tags=["workflows"])
+runs_router = APIRouter(prefix="/v1/runs", tags=["runs"])
+
+
+# ─── /v1/workflows (definitions) ─────────────────────────────────────────────
+
+
+@router.post("", operation_id="create_workflow", status_code=status.HTTP_201_CREATED)
+async def create_workflow(
+    body: WorkflowCreate, pool: PoolDep, account_id: AccountIdDep
+) -> Workflow:
+    """Create a workflow definition (version 1). Versioning/update is deferred."""
+    return await service.create_workflow(
+        pool,
+        account_id=account_id,
+        name=body.name,
+        script=body.script,
+        input_schema=body.input_schema,
+        output_schema=body.output_schema,
+    )
+
+
+@router.get("", operation_id="list_workflows")
+async def list_workflows(
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    cursor: str | None = None,
+    name: str | None = None,
+    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+) -> ListResponse[Workflow]:
+    """List the account's workflows, newest first. First page: optional ``name`` +
+    ``limit``; subsequent pages: ``?cursor=<next_cursor>``."""
+    st = page_cursor(cursor, {"name": name, "limit": limit})
+    after = str(st.cursor) if st is not None else None
+    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    if st is not None:
+        name = st.filters.get("name")
+    items = await service.list_workflows(
+        pool, account_id=account_id, limit=page_limit + 1, after=after, name=name
+    )
+    return ListResponse[Workflow].paginate(
+        items, page_limit, cursor=lambda x: x.id, filters={"name": name}
+    )
+
+
+@router.get("/{workflow_id}", operation_id="get_workflow")
+async def get_workflow(workflow_id: str, pool: PoolDep, account_id: AccountIdDep) -> Workflow:
+    """Fetch one workflow definition by id."""
+    return await service.get_workflow(pool, workflow_id, account_id=account_id)
+
+
+# ─── /v1/runs (execution instances) ──────────────────────────────────────────
+
+
+@runs_router.post("", operation_id="create_run", status_code=status.HTTP_201_CREATED)
+async def create_run(body: WfRunCreate, pool: PoolDep, account_id: AccountIdDep) -> WfRun:
+    """Launch a run of a workflow. Snapshots the workflow's current script, binds
+    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
+    it. A missing workflow or environment 404s."""
+    return await service.create_run(
+        pool,
+        account_id=account_id,
+        workflow_id=body.workflow_id,
+        environment_id=body.environment_id,
+        input=body.input,
+    )
+
+
+@runs_router.get("", operation_id="list_runs")
+async def list_runs(
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    cursor: str | None = None,
+    workflow_id: str | None = None,
+    status: str | None = None,
+    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+) -> ListResponse[WfRun]:
+    """List the account's runs, newest first. First page: optional ``workflow_id`` /
+    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``."""
+    st = page_cursor(cursor, {"workflow_id": workflow_id, "status": status, "limit": limit})
+    after = str(st.cursor) if st is not None else None
+    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    if st is not None:
+        workflow_id = st.filters.get("workflow_id")
+        status = st.filters.get("status")
+    items = await service.list_runs(
+        pool,
+        account_id=account_id,
+        limit=page_limit + 1,
+        after=after,
+        workflow_id=workflow_id,
+        status=status,
+    )
+    return ListResponse[WfRun].paginate(
+        items,
+        page_limit,
+        cursor=lambda x: x.id,
+        filters={"workflow_id": workflow_id, "status": status},
+    )
+
+
+@runs_router.get("/{run_id}", operation_id="get_run")
+async def get_run(run_id: str, pool: PoolDep, account_id: AccountIdDep) -> WfRun:
+    """Fetch one run by id (status, output, last_event_seq, …)."""
+    return await service.get_run(pool, run_id, account_id=account_id)
+
+
+@runs_router.get("/{run_id}/events", operation_id="list_run_events")
+async def list_run_events(
+    run_id: str,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    cursor: str | None = None,
+    limit: Annotated[int | None, Query(ge=1, le=500)] = None,
+) -> ListResponse[WfRunEvent]:
+    """A run's journal by sequence (oldest first). First page: optional ``limit``;
+    subsequent pages: ``?cursor=<next_cursor>``."""
+    # Scope check: 404 a cross-tenant run id before reading its journal.
+    await service.get_run(pool, run_id, account_id=account_id)
+    st = page_cursor(cursor, {"limit": limit})
+    if st is not None:
+        page_limit = st.limit
+        after_seq = int(st.cursor)
+    else:
+        page_limit = limit if limit is not None else 200
+        after_seq = 0
+    items = await service.list_run_events(
+        pool, run_id, account_id=account_id, after_seq=after_seq, limit=page_limit + 1
+    )
+    return ListResponse[WfRunEvent].paginate(items, page_limit, cursor=lambda x: x.seq)
+
+
+@runs_router.post("/{run_id}/resume", operation_id="resume_gate")
+async def resume_gate(
+    run_id: str, body: GateResume, pool: PoolDep, account_id: AccountIdDep
+) -> WfRun:
+    """Resume a suspended gate by its ``gate_nonce``, delivering ``result``. Returns
+    the updated run (its status flips back toward ``running``). A bad nonce or a
+    cross-tenant run 404s."""
+    await service.resume_gate_by_nonce(
+        pool, run_id=run_id, account_id=account_id, gate_nonce=body.gate_nonce, result=body.result
+    )
+    return await service.get_run(pool, run_id, account_id=account_id)

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -12,8 +12,13 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Query, status
+from sse_starlette import EventSourceResponse
 
-from aios.api.deps import AccountIdDep, PoolDep
+from aios.api.deps import AccountIdDep, DbUrlDep, PoolDep
+from aios.api.sse import SSE_PREFLIGHT_EXCEPTIONS, make_sse_response, wf_run_event_stream
+from aios.db.listen import open_listen_for_run_events
+from aios.errors import SSEPreflightFailedError
+from aios.logging import get_logger
 from aios.models.common import ListResponse
 from aios.models.pagination import page_cursor
 from aios.models.workflows import (
@@ -25,6 +30,8 @@ from aios.models.workflows import (
     WorkflowCreate,
 )
 from aios.services import workflows as service
+
+log = get_logger("aios.api.routers.workflows")
 
 router = APIRouter(prefix="/v1/workflows", tags=["workflows"])
 runs_router = APIRouter(prefix="/v1/runs", tags=["runs"])
@@ -169,3 +176,36 @@ async def resume_gate(
         pool, run_id=run_id, account_id=account_id, gate_nonce=body.gate_nonce, result=body.result
     )
     return await service.get_run(pool, run_id, account_id=account_id)
+
+
+@runs_router.get("/{run_id}/stream", openapi_extra={"x-codegen": {"targets": []}})
+async def stream_run_events(
+    run_id: str,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    after_seq: int = 0,
+) -> EventSourceResponse:
+    """Stream a run's journal as Server-Sent Events: backfill from ``after_seq``,
+    then live, ending on ``run_completed``.
+
+    Preflights the LISTEN before constructing the response (issue #376), so a
+    transient connect failure is a clean 503 rather than a half-open stream.
+    """
+    await service.get_run(pool, run_id, account_id=account_id)  # 404s cross-tenant
+    try:
+        subscription = await open_listen_for_run_events(db_url, run_id)
+    except SSE_PREFLIGHT_EXCEPTIONS as exc:
+        log.warning(
+            "sse.wf_run_events.preflight_failed",
+            run_id=run_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        raise SSEPreflightFailedError(
+            "could not establish LISTEN connection for run events stream",
+            detail={"stream": "wf_run_events"},
+        ) from exc
+    return make_sse_response(
+        subscription, wf_run_event_stream(subscription, pool, run_id, after_seq=after_seq)
+    )

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -186,6 +186,75 @@ async def sse_event_stream(
         subscription.terminate()
 
 
+def _serialize_wf_event(row: asyncpg.Record) -> dict[str, Any]:
+    """Convert a ``wf_run_events`` row to a JSON-friendly dict (matches WfRunEvent)."""
+    return {
+        "id": row["id"],
+        "run_id": row["run_id"],
+        "seq": row["seq"],
+        "type": row["type"],
+        "call_key": row["call_key"],
+        "payload": queries.parse_jsonb(row["payload"]),
+        "created_at": row["created_at"].isoformat(),
+    }
+
+
+async def wf_run_event_stream(
+    subscription: ListenSubscription,
+    pool: asyncpg.Pool[Any],
+    run_id: str,
+    after_seq: int = 0,
+) -> AsyncIterator[ServerSentEvent]:
+    """Yield ServerSentEvents for a workflow run: backfill from ``after_seq``, then
+    tail live NOTIFY on ``wf_run_events_<run_id>``.
+
+    The workflow analog of :func:`sse_event_stream`. Two differences: the run-event
+    channel carries only event ids (no transient streaming deltas), and the terminal
+    is the ``run_completed`` event (vs the session's ``status: terminated``
+    lifecycle). Owns terminating the subscription in ``finally``; the route handler
+    must have opened it via ``open_listen_for_run_events`` before this runs
+    (LISTEN-before-backfill).
+    """
+    queue = subscription.queue
+    try:
+        cursor = after_seq
+        async with pool.acquire() as conn:
+            backfill_rows = await conn.fetch(
+                "SELECT * FROM wf_run_events WHERE run_id = $1 AND seq > $2 ORDER BY seq ASC",
+                run_id,
+                after_seq,
+            )
+        for row in backfill_rows:
+            payload = _serialize_wf_event(row)
+            cursor = max(cursor, payload["seq"])
+            yield _event_to_sse(payload)
+            if payload["type"] == "run_completed":
+                yield ServerSentEvent(data="{}", event="done")
+                return
+        # Tail live notifications; dedup against the backfill cursor (an event can
+        # appear in BOTH if it committed during the backfill SELECT's snapshot).
+        while True:
+            event_id = await queue.get()
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow("SELECT * FROM wf_run_events WHERE id = $1", event_id)
+            if row is None:
+                log.warning("sse.wf_event_not_found", event_id=event_id)
+                continue
+            event_data = _serialize_wf_event(row)
+            if event_data["seq"] <= cursor:
+                continue
+            cursor = event_data["seq"]
+            yield _event_to_sse(event_data)
+            if event_data["type"] == "run_completed":
+                yield ServerSentEvent(data="{}", event="done")
+                return
+    except Exception:
+        log.exception("sse.wf_run_events.body_raised", run_id=run_id)
+        raise
+    finally:
+        subscription.terminate()
+
+
 async def runtime_connector_calls_stream(
     subscription: ListenSubscription,
     pool: asyncpg.Pool[Any],

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -231,6 +231,16 @@ async def wf_run_event_stream(
             if payload["type"] == "run_completed":
                 yield ServerSentEvent(data="{}", event="done")
                 return
+        # A terminal run never NOTIFYs again. If its run_completed was already past
+        # ``after_seq`` (a reconnect that consumed the terminal frame, or a high
+        # after_seq), the backfill is empty and tailing would block forever — so end
+        # the stream now rather than hang. (run_completed is written for BOTH
+        # completed and errored, so a terminal status implies it exists.)
+        async with pool.acquire() as conn:
+            status = await conn.fetchval("SELECT status FROM wf_runs WHERE id = $1", run_id)
+        if status in ("completed", "errored"):
+            yield ServerSentEvent(data="{}", event="done")
+            return
         # Tail live notifications; dedup against the backfill cursor (an event can
         # appear in BOTH if it committed during the backfill SELECT's snapshot).
         while True:

--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -108,6 +108,7 @@ from aios.cli.commands import status as _status  # noqa: E402
 from aios.cli.commands import tail as _tail  # noqa: E402
 from aios.cli.commands import vaults as _vaults  # noqa: E402
 from aios.cli.commands import whatsapp as _whatsapp  # noqa: E402
+from aios.cli.commands import workflows as _workflows  # noqa: E402
 
 app.add_typer(_accounts.app, name="accounts")
 app.add_typer(_agents.app, name="agents")
@@ -120,6 +121,8 @@ app.add_typer(_envs.app, name="envs")
 app.add_typer(_dev.app, name="dev")
 app.add_typer(_signal.app, name="signal")
 app.add_typer(_whatsapp.app, name="whatsapp")
+app.add_typer(_workflows.app, name="workflows")
+app.add_typer(_workflows.runs_app, name="runs")
 
 _ops.register(app)
 _status.register(app)

--- a/src/aios/cli/commands/_shared.py
+++ b/src/aios/cli/commands/_shared.py
@@ -148,6 +148,7 @@ def render_paginated(
     limit: int = 50,
     max_widths: dict[str, int] | None = None,
     page_size: int = 200,
+    path_params: dict[str, Any] | None = None,
     **filters: Any,
 ) -> None:
     """Render an SDK list endpoint, paginated or fully fetched per ``all_``.
@@ -156,7 +157,14 @@ def render_paginated(
     opens an SDK client, walks pages when ``all_`` is True (or fetches one
     page otherwise), then renders through :func:`render_list`. The first page
     carries the filters + ``limit``; later pages send only the opaque ``cursor``.
+
+    ``path_params`` (e.g. the ``run_id`` of ``aios runs events``) are part of the
+    URL, so they are sent on EVERY page — unlike ``filters`` (query params), which
+    the opaque cursor carries and the server rejects (422) if re-sent alongside
+    ``?cursor=``. Without this, a ``--all`` walk of a path-param'd endpoint dropped
+    the path param on page 2 and the SDK call raised on the missing argument.
     """
+    path = path_params or {}
     state = get_state(ctx)
     with state.sdk_client() as client:
         if all_:
@@ -164,9 +172,9 @@ def render_paginated(
             cursor: str | None = None
             while True:
                 if cursor is not None:
-                    page = unwrap(fn(client=client, cursor=cursor))
+                    page = unwrap(fn(client=client, cursor=cursor, **path))
                 else:
-                    page = unwrap(fn(client=client, limit=page_size, **filters))
+                    page = unwrap(fn(client=client, limit=page_size, **path, **filters))
                 items.extend(page.data)
                 if isinstance(page.has_more, Unset) or not page.has_more:
                     break
@@ -179,7 +187,7 @@ def render_paginated(
                 "next_cursor": None,
             }
         else:
-            page = unwrap(fn(client=client, limit=limit, **filters))
+            page = unwrap(fn(client=client, limit=limit, **path, **filters))
             envelope = page.to_dict()
     render_list(state.output_format, envelope, columns=columns, max_widths=max_widths)
 

--- a/src/aios/cli/commands/agents.py
+++ b/src/aios/cli/commands/agents.py
@@ -123,7 +123,7 @@ def versions(
             max_widths={"model": 40},
             all_=all_,
             limit=limit,
-            agent_id=agent_id,
+            path_params={"agent_id": agent_id},
         )
 
     run_or_die(_run)

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -9,6 +9,7 @@ payload (the script body is long). ``--input`` / ``--result`` are parsed as JSON
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -17,7 +18,8 @@ import typer
 from aios.cli.commands._shared import call_single, render_paginated
 from aios.cli.coverage import covers
 from aios.cli.files import load_payload
-from aios.cli.runtime import run_or_die
+from aios.cli.runtime import get_state, run_or_die
+from aios_sdk import stream_run
 from aios_sdk._generated.api.runs import (
     create_run,
     get_run,
@@ -185,5 +187,33 @@ def resume_run_(
         body = GateResume.from_dict({"gate_nonce": gate_nonce, "result": _json_arg(result)})
         call_single(ctx, resume_gate.sync_detailed, run_id=run_id, body=body)
         return None
+
+    run_or_die(_run)
+
+
+@runs_app.command("stream", help="Tail a run's journal as Server-Sent Events.")
+@covers("stream_run_events_v1_runs__run_id__stream_get")
+def stream_run_(
+    ctx: typer.Context,
+    run_id: str,
+    after_seq: Annotated[int, typer.Option("--after-seq", min=0)] = 0,
+    raw: Annotated[
+        bool, typer.Option("--raw", help="Print each SSE message as JSON (no formatting).")
+    ] = False,
+) -> None:
+    def _run() -> None:
+        client = get_state(ctx).sdk_client()
+        with client, stream_run(client, run_id, after_seq=after_seq) as messages:
+            for msg in messages:
+                if raw:
+                    sys.stdout.write(json.dumps({"event": msg.event, "data": msg.data}) + "\n")
+                elif msg.event == "event":
+                    e = json.loads(msg.data)
+                    sys.stdout.write(
+                        f"{e['seq']:<4} {e['type']:<14} {json.dumps(e['payload'])[:100]}\n"
+                    )
+                sys.stdout.flush()
+                if msg.event == "done":
+                    break
 
     run_or_die(_run)

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -17,7 +17,7 @@ import typer
 
 from aios.cli.commands._shared import call_single, render_paginated
 from aios.cli.coverage import covers
-from aios.cli.files import load_payload
+from aios.cli.files import PayloadError, load_payload
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk import stream_run
 from aios_sdk._generated.api.runs import (
@@ -41,8 +41,17 @@ runs_app = typer.Typer(name="runs", help="Launch and observe workflow runs.", no
 
 
 def _json_arg(value: str | None) -> Any:
-    """Parse a JSON CLI argument (``--input`` / ``--result``); ``None`` stays ``None``."""
-    return json.loads(value) if value is not None else None
+    """Parse a JSON CLI argument (``--input`` / ``--result``); ``None`` stays ``None``.
+
+    A malformed value raises :class:`PayloadError` so ``run_or_die`` prints a clean
+    one-line message + exit 64, rather than letting ``json.loads`` bubble a traceback.
+    """
+    if value is None:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise PayloadError(f"invalid JSON: {exc}") from exc
 
 
 # ─── aios workflows (definitions) ────────────────────────────────────────────
@@ -167,7 +176,7 @@ def run_events_(
             columns=("seq", "type", "call_key"),
             all_=all_,
             limit=limit,
-            run_id=run_id,
+            path_params={"run_id": run_id},
         )
 
     run_or_die(_run)

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -1,0 +1,189 @@
+"""``aios workflows ...`` (definitions) + ``aios runs ...`` (executions).
+
+Two typer sub-apps mirroring the two routers. ``runs`` favours convenience flags
+(launch + resume are usually ad-hoc) while ``workflows create`` takes a JSON
+payload (the script body is long). ``--input`` / ``--result`` are parsed as JSON
+(a workflow's input / a gate's result are arbitrary JSON).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+
+from aios.cli.commands._shared import call_single, render_paginated
+from aios.cli.coverage import covers
+from aios.cli.files import load_payload
+from aios.cli.runtime import run_or_die
+from aios_sdk._generated.api.runs import (
+    create_run,
+    get_run,
+    list_run_events,
+    list_runs,
+    resume_gate,
+)
+from aios_sdk._generated.api.workflows import (
+    create_workflow,
+    get_workflow,
+    list_workflows,
+)
+from aios_sdk._generated.models.gate_resume import GateResume
+from aios_sdk._generated.models.wf_run_create import WfRunCreate
+from aios_sdk._generated.models.workflow_create import WorkflowCreate
+
+app = typer.Typer(name="workflows", help="Manage workflow definitions.", no_args_is_help=True)
+runs_app = typer.Typer(name="runs", help="Launch and observe workflow runs.", no_args_is_help=True)
+
+
+def _json_arg(value: str | None) -> Any:
+    """Parse a JSON CLI argument (``--input`` / ``--result``); ``None`` stays ``None``."""
+    return json.loads(value) if value is not None else None
+
+
+# ─── aios workflows (definitions) ────────────────────────────────────────────
+
+
+@app.command("list", help="List workflow definitions.")
+@covers("list_workflows")
+def list_workflows_(
+    ctx: typer.Context,
+    name: Annotated[str | None, typer.Option("--name", help="Filter by exact name.")] = None,
+    limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
+    all_: Annotated[bool, typer.Option("--all", help="Fetch every page.")] = False,
+) -> None:
+    def _run() -> None:
+        render_paginated(
+            ctx,
+            list_workflows.sync_detailed,
+            columns=("id", "name", "version", "updated_at"),
+            max_widths={"name": 32},
+            all_=all_,
+            limit=limit,
+            name=name,
+        )
+
+    run_or_die(_run)
+
+
+@app.command("get", help="Fetch a workflow definition by id.")
+@covers("get_workflow")
+def get_workflow_(ctx: typer.Context, workflow_id: str) -> None:
+    def _run() -> None:
+        call_single(ctx, get_workflow.sync_detailed, workflow_id=workflow_id)
+
+    run_or_die(_run)
+
+
+@app.command("create", help="Create a workflow from a JSON payload (WorkflowCreate shape).")
+@covers("create_workflow")
+def create_workflow_(
+    ctx: typer.Context,
+    file: Annotated[Path | None, typer.Option("--file", help="Read JSON body from a file.")] = None,
+    stdin: Annotated[bool, typer.Option("--stdin", help="Read JSON body from stdin.")] = False,
+    data: Annotated[str | None, typer.Option("--data", help="Inline JSON body.")] = None,
+) -> None:
+    def _run() -> int | None:
+        payload = load_payload(file, stdin, data)
+        call_single(ctx, create_workflow.sync_detailed, body=WorkflowCreate.from_dict(payload))
+        return None
+
+    run_or_die(_run)
+
+
+# ─── aios runs (executions) ──────────────────────────────────────────────────
+
+
+@runs_app.command("list", help="List workflow runs.")
+@covers("list_runs")
+def list_runs_(
+    ctx: typer.Context,
+    workflow_id: Annotated[str | None, typer.Option("--workflow-id")] = None,
+    status: Annotated[str | None, typer.Option("--status", help="pending|running|…")] = None,
+    limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
+    all_: Annotated[bool, typer.Option("--all", help="Fetch every page.")] = False,
+) -> None:
+    def _run() -> None:
+        render_paginated(
+            ctx,
+            list_runs.sync_detailed,
+            columns=("id", "workflow_id", "status", "updated_at"),
+            all_=all_,
+            limit=limit,
+            workflow_id=workflow_id,
+            status=status,
+        )
+
+    run_or_die(_run)
+
+
+@runs_app.command("get", help="Fetch a run by id.")
+@covers("get_run")
+def get_run_(ctx: typer.Context, run_id: str) -> None:
+    def _run() -> None:
+        call_single(ctx, get_run.sync_detailed, run_id=run_id)
+
+    run_or_die(_run)
+
+
+@runs_app.command("create", help="Launch a run of a workflow.")
+@covers("create_run")
+def create_run_(
+    ctx: typer.Context,
+    workflow_id: Annotated[str, typer.Option("--workflow-id")],
+    environment_id: Annotated[str, typer.Option("--environment-id")],
+    input_: Annotated[str | None, typer.Option("--input", help="The run's input as JSON.")] = None,
+) -> None:
+    def _run() -> int | None:
+        body = WfRunCreate.from_dict(
+            {
+                "workflow_id": workflow_id,
+                "environment_id": environment_id,
+                "input": _json_arg(input_),
+            }
+        )
+        call_single(ctx, create_run.sync_detailed, body=body)
+        return None
+
+    run_or_die(_run)
+
+
+@runs_app.command("events", help="List a run's journal events (oldest first).")
+@covers("list_run_events")
+def run_events_(
+    ctx: typer.Context,
+    run_id: str,
+    limit: Annotated[int, typer.Option("--limit", min=1, max=500)] = 200,
+    all_: Annotated[bool, typer.Option("--all", help="Fetch every page.")] = False,
+) -> None:
+    def _run() -> None:
+        render_paginated(
+            ctx,
+            list_run_events.sync_detailed,
+            columns=("seq", "type", "call_key"),
+            all_=all_,
+            limit=limit,
+            run_id=run_id,
+        )
+
+    run_or_die(_run)
+
+
+@runs_app.command("resume", help="Resume a suspended gate by its nonce.")
+@covers("resume_gate")
+def resume_run_(
+    ctx: typer.Context,
+    run_id: str,
+    gate_nonce: Annotated[str, typer.Option("--gate-nonce", help="The gate's capability nonce.")],
+    result: Annotated[
+        str | None, typer.Option("--result", help="The resume value as JSON.")
+    ] = None,
+) -> None:
+    def _run() -> int | None:
+        body = GateResume.from_dict({"gate_nonce": gate_nonce, "result": _json_arg(result)})
+        call_single(ctx, resume_gate.sync_detailed, run_id=run_id, body=body)
+        return None
+
+    run_or_die(_run)

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -179,6 +179,51 @@ async def open_listen_for_events(
     return ListenSubscription(queue=queue, _conn=conn)
 
 
+async def open_listen_for_run_events(
+    db_url: str,
+    run_id: str,
+    *,
+    queue_max: int = 1000,
+) -> ListenSubscription:
+    """Open a dedicated asyncpg connection LISTENing ``wf_run_events_<run_id>``.
+
+    The workflow-run analog of :func:`open_listen_for_events` — same dedicated
+    connection + bounded-queue-with-drop shape, feeding the ``/v1/runs/{id}/stream``
+    generator. No subscriber advisory lock: that is a session-worker coordination
+    signal (issue #81) with no workflow equivalent (the run sweep is unconditional).
+    """
+    conn = await asyncpg.connect(normalize_dsn(db_url))
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
+        channel = f"wf_run_events_{run_id}"
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            # Sync-only (asyncpg read loop). Same drop-oldest backpressure; the SSE
+            # consumer recovers by reconnecting with `?after_seq=`.
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning(
+                    "listen.wf_run_events_queue_full_drop", run_id=run_id, queue_max=queue_max
+                )
+                try:
+                    queue.get_nowait()
+                    queue.put_nowait(payload)
+                except (asyncio.QueueEmpty, asyncio.QueueFull):
+                    pass
+
+        await conn.add_listener(channel, _callback)
+    except BaseException:
+        conn.terminate()
+        raise
+    return ListenSubscription(queue=queue, _conn=conn)
+
+
 async def open_listen_for_connector_calls_by_type(
     db_url: str,
     connector: str,

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import asyncpg
 
-from aios.db.queries import _get_scoped, parse_jsonb
+from aios.db.queries import _get_scoped, _list_scoped, parse_jsonb
 from aios.errors import ConflictError, NotFoundError
 from aios.ids import WORKFLOW, WORKFLOW_EVENT, WORKFLOW_RUN, make_id
 from aios.models.workflows import (
@@ -143,7 +143,70 @@ async def get_workflow(
     )
 
 
+async def list_workflows(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    limit: int = 50,
+    after: str | None = None,
+    name: str | None = None,
+) -> list[Workflow]:
+    """Keyset-paginated list of an account's workflows, newest first.
+
+    Hand-written (not ``_list_scoped``) because the ``workflows`` table has no
+    ``archived_at`` column — workflow definitions are immutable and never archived.
+    Each returned row is one ``(name, version)``; versioning/update is deferred, so
+    today there is one row per name.
+    """
+    args: list[Any] = [account_id]
+    where = ["account_id = $1"]
+    if name is not None:
+        args.append(name)
+        where.append(f"name = ${len(args)}")
+    if after is not None:
+        args.append(after)
+        where.append(f"id < ${len(args)}")
+    args.append(limit)
+    sql = f"SELECT * FROM workflows WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ${len(args)}"
+    return [_row_to_workflow(r) for r in await conn.fetch(sql, *args)]
+
+
 # ─── wf_runs (execution instances) ───────────────────────────────────────────
+
+
+async def get_wf_run(conn: asyncpg.Connection[Any], run_id: str, *, account_id: str) -> WfRun:
+    """Account-scoped run read (the public surface). Raises ``NotFoundError`` on a
+    miss — including a cross-tenant id, so it never leaks another account's run.
+    (The unscoped :func:`get_run_for_step` is the internal/trusted variant.)"""
+    return await _get_scoped(
+        conn,
+        table="wf_runs",
+        id_=run_id,
+        account_id=account_id,
+        row=_row_to_wf_run,
+        noun="workflow run",
+    )
+
+
+async def list_wf_runs(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    limit: int = 50,
+    after: str | None = None,
+    workflow_id: str | None = None,
+    status: str | None = None,
+) -> list[WfRun]:
+    """Keyset-paginated list of an account's runs (non-archived), newest first."""
+    return await _list_scoped(
+        conn,
+        table="wf_runs",
+        account_id=account_id,
+        row=_row_to_wf_run,
+        limit=limit,
+        after=after,
+        filters=[("workflow_id", workflow_id), ("status", status)],
+    )
 
 
 async def insert_wf_run(
@@ -294,11 +357,47 @@ async def append_run_event(
             run_id,
             row["seq"],
         )
+    # NOTIFY *after* the insert/bump txn (never inside it — a subscriber must not
+    # see a payload for an uncommitted row). pg_notify is transactional, so when an
+    # outer txn wraps this call (``_complete_run``'s run_completed + set_terminal
+    # unit), delivery is deferred to that commit; in the common autocommit path it
+    # fires immediately on the already-committed row. ``pg_notify`` function form,
+    # not literal NOTIFY: run-event ids are mixed-case prefixed-ULIDs (Postgres
+    # case-folds unquoted identifiers). Mirrors session ``append_event``. The
+    # ``/runs/{id}/stream`` backfill + seq-dedup recovers any missed tick.
+    await conn.execute("SELECT pg_notify($1, $2)", f"wf_run_events_{run_id}", row["id"])
     return _row_to_wf_run_event(row)
 
 
 async def list_run_events(conn: asyncpg.Connection[Any], run_id: str) -> list[WfRunEvent]:
+    """Unscoped, unpaginated journal read — the internal harvest path
+    (``run_workflow_step``). For the public surface use :func:`list_run_events_scoped`."""
     rows = await conn.fetch("SELECT * FROM wf_run_events WHERE run_id = $1 ORDER BY seq", run_id)
+    return [_row_to_wf_run_event(r) for r in rows]
+
+
+async def list_run_events_scoped(
+    conn: asyncpg.Connection[Any],
+    run_id: str,
+    *,
+    account_id: str,
+    after_seq: int = 0,
+    limit: int = 200,
+) -> list[WfRunEvent]:
+    """Account-scoped, forward-only (``seq > after_seq``) journal page.
+
+    ``wf_run_events`` has no ``account_id`` column, so scope via a join to
+    ``wf_runs`` — defense in depth even though the router pre-checks the run with
+    :func:`get_wf_run`. Ascending seq, like the session events read path."""
+    rows = await conn.fetch(
+        "SELECT e.* FROM wf_run_events e JOIN wf_runs r ON r.id = e.run_id "
+        "WHERE e.run_id = $1 AND r.account_id = $2 AND e.seq > $3 "
+        "ORDER BY e.seq ASC LIMIT $4",
+        run_id,
+        account_id,
+        after_seq,
+        limit,
+    )
     return [_row_to_wf_run_event(r) for r in rows]
 
 

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -6,9 +6,9 @@ execution instance whose state lives entirely in its append-only journal
 (``WfRunEvent``); ``WfRunSignal`` is the side-marker an external resume writes
 so the journal keeps a single writer.
 
-These are internal read views (they carry ``account_id``); request/echo models
-and the public HTTP surface arrive in a later block. The runtime is driven
-internally via ``services.workflows`` + integration tests for now.
+The read views below carry ``account_id`` (internal); the ``*Create`` / resume
+request models at the bottom back the public HTTP surface (Block 3). Responses
+reuse the read views directly, the way ``Agent``/``Session`` do.
 """
 
 from __future__ import annotations
@@ -90,3 +90,40 @@ class WfRunSignal(BaseModel):
     kind: WfRunSignalKind
     result: Any = None  # arbitrary JSON: the externally-delivered resume value
     delivered_at: datetime
+
+
+# ─── request models (the public HTTP surface) ────────────────────────────────
+
+
+class WorkflowCreate(BaseModel):
+    """Request body for ``POST /v1/workflows`` — a new workflow definition at v1."""
+
+    name: str
+    script: str
+    input_schema: dict[str, Any] | None = None
+    output_schema: dict[str, Any] | None = None
+
+
+class WfRunCreate(BaseModel):
+    """Request body for ``POST /v1/runs`` — launch a run of a workflow.
+
+    ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
+    binds to ``environment_id`` (like a session), into which its ``agent()`` children
+    spawn.
+    """
+
+    workflow_id: str
+    environment_id: str
+    input: Any = None
+
+
+class GateResume(BaseModel):
+    """Request body for ``POST /v1/runs/{run_id}/resume`` — deliver a gate's value.
+
+    Keyed by ``gate_nonce`` (the unguessable capability token minted into the gate's
+    ``call_started`` event), not the internal ``call_key``. ``result`` is the
+    externally-delivered resume value (arbitrary JSON).
+    """
+
+    gate_nonce: str
+    result: Any = None

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -133,24 +133,32 @@ async def resume_gate_by_nonce(
     The HTTP-facing gate resume: account-scope the run first (the internal
     :func:`aios.workflows.service.resume_gate` keys off ``call_key`` and does NOT
     scope, so it must never be the HTTP path), then resolve ``gate_nonce`` →
-    ``call_key`` by scanning the run's ``call_started`` events for the gate whose
-    payload carries that nonce. ``insert_run_signal`` is idempotent, so a repeated
-    resume is a no-op. Raises ``NotFoundError`` if no gate matches the nonce.
+    ``call_key`` by scanning the run's **open** gate ``call_started`` events for the
+    one whose payload carries that nonce. Only an OPEN gate (no ``call_result`` yet)
+    matches — a nonce for an already-resolved gate (or any gate on a terminal run)
+    raises ``NotFoundError`` rather than writing an orphaned signal nothing harvests.
+    ``insert_run_signal`` is idempotent, so a concurrent double-resume of a
+    still-open gate is a no-op.
     """
     async with pool.acquire() as conn:
         await wf_queries.get_wf_run(conn, run_id, account_id=account_id)  # 404s cross-tenant
+        events = await wf_queries.list_run_events(conn, run_id)
+        resolved = {e.call_key for e in events if e.type == "call_result"}
         call_key = None
-        for event in await wf_queries.list_run_events(conn, run_id):
+        for event in events:
             if (
                 event.type == "call_started"
                 and event.payload.get("capability") == "gate"
                 and event.payload.get("gate_nonce") == gate_nonce
                 and event.call_key is not None
+                and event.call_key not in resolved
             ):
                 call_key = event.call_key
                 break
         if call_key is None:
-            raise NotFoundError("no gate matches that nonce on this run", detail={"run_id": run_id})
+            raise NotFoundError(
+                "no open gate matches that nonce on this run", detail={"run_id": run_id}
+            )
         await wf_queries.insert_run_signal(
             conn, run_id=run_id, call_key=call_key, kind="gate_resume", result=result
         )

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -1,0 +1,157 @@
+"""Service layer for the workflows HTTP/CLI surface (Block 3).
+
+The router imports this as ``from aios.services import workflows as service``,
+matching every other resource router. It is the account-scoped, pool-taking face
+over the query layer (``db.queries.workflows``) and the runtime entry points.
+
+``create_run`` / ``resume_gate`` (the runtime entry points) live in
+``aios.workflows.service`` — re-exported here so callers have one import, and kept
+there because the integration tests patch ``aios.workflows.service.defer_run_wake``.
+The HTTP path adds account-scoping (the runtime variants are internal/trusted) and
+the **by-nonce** gate resume.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.db.queries import workflows as wf_queries
+from aios.errors import NotFoundError
+from aios.models.workflows import WfRun, WfRunEvent, Workflow
+from aios.services.wake import defer_run_wake
+from aios.workflows.service import create_run, resume_gate
+
+__all__ = [
+    "create_run",
+    "create_workflow",
+    "get_run",
+    "get_workflow",
+    "list_run_events",
+    "list_runs",
+    "list_workflows",
+    "resume_gate",
+    "resume_gate_by_nonce",
+]
+
+
+# ─── workflow definitions ────────────────────────────────────────────────────
+
+
+async def create_workflow(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    name: str,
+    script: str,
+    input_schema: dict[str, Any] | None = None,
+    output_schema: dict[str, Any] | None = None,
+) -> Workflow:
+    async with pool.acquire() as conn:
+        return await wf_queries.insert_workflow(
+            conn,
+            account_id=account_id,
+            name=name,
+            script=script,
+            input_schema=input_schema,
+            output_schema=output_schema,
+        )
+
+
+async def get_workflow(pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str) -> Workflow:
+    async with pool.acquire() as conn:
+        return await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
+
+
+async def list_workflows(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    limit: int = 50,
+    after: str | None = None,
+    name: str | None = None,
+) -> list[Workflow]:
+    async with pool.acquire() as conn:
+        return await wf_queries.list_workflows(
+            conn, account_id=account_id, limit=limit, after=after, name=name
+        )
+
+
+# ─── runs ────────────────────────────────────────────────────────────────────
+
+
+async def get_run(pool: asyncpg.Pool[Any], run_id: str, *, account_id: str) -> WfRun:
+    async with pool.acquire() as conn:
+        return await wf_queries.get_wf_run(conn, run_id, account_id=account_id)
+
+
+async def list_runs(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    limit: int = 50,
+    after: str | None = None,
+    workflow_id: str | None = None,
+    status: str | None = None,
+) -> list[WfRun]:
+    async with pool.acquire() as conn:
+        return await wf_queries.list_wf_runs(
+            conn,
+            account_id=account_id,
+            limit=limit,
+            after=after,
+            workflow_id=workflow_id,
+            status=status,
+        )
+
+
+async def list_run_events(
+    pool: asyncpg.Pool[Any],
+    run_id: str,
+    *,
+    account_id: str,
+    after_seq: int = 0,
+    limit: int = 200,
+) -> list[WfRunEvent]:
+    async with pool.acquire() as conn:
+        return await wf_queries.list_run_events_scoped(
+            conn, run_id, account_id=account_id, after_seq=after_seq, limit=limit
+        )
+
+
+async def resume_gate_by_nonce(
+    pool: asyncpg.Pool[Any],
+    *,
+    run_id: str,
+    account_id: str,
+    gate_nonce: str,
+    result: Any,
+) -> None:
+    """Deliver an external resume to the gate identified by its capability ``nonce``.
+
+    The HTTP-facing gate resume: account-scope the run first (the internal
+    :func:`aios.workflows.service.resume_gate` keys off ``call_key`` and does NOT
+    scope, so it must never be the HTTP path), then resolve ``gate_nonce`` →
+    ``call_key`` by scanning the run's ``call_started`` events for the gate whose
+    payload carries that nonce. ``insert_run_signal`` is idempotent, so a repeated
+    resume is a no-op. Raises ``NotFoundError`` if no gate matches the nonce.
+    """
+    async with pool.acquire() as conn:
+        await wf_queries.get_wf_run(conn, run_id, account_id=account_id)  # 404s cross-tenant
+        call_key = None
+        for event in await wf_queries.list_run_events(conn, run_id):
+            if (
+                event.type == "call_started"
+                and event.payload.get("capability") == "gate"
+                and event.payload.get("gate_nonce") == gate_nonce
+                and event.call_key is not None
+            ):
+                call_key = event.call_key
+                break
+        if call_key is None:
+            raise NotFoundError("no gate matches that nonce on this run", detail={"run_id": run_id})
+        await wf_queries.insert_run_signal(
+            conn, run_id=run_id, call_key=call_key, kind="gate_resume", result=result
+        )
+    await defer_run_wake(run_id)

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -50,14 +50,32 @@ async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[http
     app.state.procrastinate = mock.MagicMock()
 
     transport = httpx.ASGITransport(app=app)
-    # create_run defers a wake; the procrastinate app isn't open in this ASGI test
-    # (the worker drives steps separately), so mock it out — the convention the e2e
-    # conftest uses for session defer_wake.
-    with mock.patch("aios.workflows.service.defer_run_wake", new=mock.AsyncMock()):
+    # create_run + resume defer a wake; the procrastinate app isn't open in this ASGI
+    # test (the worker drives steps separately), so mock BOTH bindings out — the
+    # convention the e2e conftest uses for session defer_wake. (create_run uses the
+    # binding in aios.workflows.service; resume_gate_by_nonce uses its own copy in
+    # aios.services.workflows.)
+    with (
+        mock.patch("aios.workflows.service.defer_run_wake", new=mock.AsyncMock()),
+        mock.patch("aios.services.workflows.defer_run_wake", new=mock.AsyncMock()),
+    ):
         async with authed_client(
             "http://testserver", aios_env["AIOS_API_KEY"], transport=transport
         ) as client:
             yield client
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _mint_tenant(http_client: httpx.AsyncClient, name: str) -> str:
+    """Mint a child tenant under the root account; return its plaintext API key."""
+    r = await http_client.post(
+        "/v1/accounts/children", json={"display_name": name, "can_mint_children": False}
+    )
+    assert r.status_code in (200, 201), r.text
+    return str(r.json()["plaintext_key"])
 
 
 async def _create_env(http_client: httpx.AsyncClient) -> str:
@@ -101,6 +119,40 @@ async def test_create_workflow_run_and_observe(http_client: httpx.AsyncClient) -
     # isn't running in this ASGI test).
     r = await http_client.get(f"/v1/runs/{run['id']}/events")
     assert r.status_code == 200 and r.json()["data"] == []
+
+
+async def test_runs_cross_tenant_isolated(http_client: httpx.AsyncClient) -> None:
+    """A run owned by tenant A is invisible to tenant B over the HTTP surface — the
+    end-to-end proof that AccountIdDep threads into the scoped reads/ops (a router
+    regression that dropped account_id would leak here, where the query/service tests
+    can't see it)."""
+    key_b = await _mint_tenant(http_client, f"tenant-b-{_uniq()}")
+
+    # Tenant A (the default bearer) creates a workflow + run.
+    env_a = await _create_env(http_client)
+    wf = (
+        await http_client.post("/v1/workflows", json={"name": f"a-{_uniq()}", "script": _SCRIPT})
+    ).json()
+    run = (
+        await http_client.post("/v1/runs", json={"workflow_id": wf["id"], "environment_id": env_a})
+    ).json()
+
+    # Tenant B sees none of it: 404 on the point reads + resume, empty list.
+    assert (
+        await http_client.get(f"/v1/runs/{run['id']}", headers=_bearer(key_b))
+    ).status_code == 404
+    assert (
+        await http_client.get(f"/v1/runs/{run['id']}/events", headers=_bearer(key_b))
+    ).status_code == 404
+    resume_b = await http_client.post(
+        f"/v1/runs/{run['id']}/resume", headers=_bearer(key_b), json={"gate_nonce": "x"}
+    )
+    assert resume_b.status_code == 404, resume_b.text
+    list_b = await http_client.get("/v1/runs", headers=_bearer(key_b))
+    assert list_b.status_code == 200 and run["id"] not in [x["id"] for x in list_b.json()["data"]]
+
+    # Tenant A still owns it.
+    assert (await http_client.get(f"/v1/runs/{run['id']}")).status_code == 200
 
 
 async def test_create_run_with_unknown_workflow_404s(http_client: httpx.AsyncClient) -> None:

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -1,0 +1,123 @@
+"""E2E tests for the ``/v1/workflows`` + ``/v1/runs`` HTTP endpoints (Block 3).
+
+Covers the router contract over real routes: auth, status codes, create→get→list,
+the run journal, and the 404 paths. The full gate-resume round-trip (which needs the
+worker to drive a step) is covered by the service test + the live smoke; here we
+assert the HTTP wiring and the resume endpoint's 404s.
+"""
+
+from __future__ import annotations
+
+import secrets
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+
+import httpx
+import pytest
+
+from tests.helpers.connections import authed_client
+
+_SCRIPT = "async def main(input):\n    return input\n"
+
+
+def _uniq() -> str:
+    return secrets.token_hex(4)
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    from aios.api.app import create_app
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = create_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+
+    transport = httpx.ASGITransport(app=app)
+    # create_run defers a wake; the procrastinate app isn't open in this ASGI test
+    # (the worker drives steps separately), so mock it out — the convention the e2e
+    # conftest uses for session defer_wake.
+    with mock.patch("aios.workflows.service.defer_run_wake", new=mock.AsyncMock()):
+        async with authed_client(
+            "http://testserver", aios_env["AIOS_API_KEY"], transport=transport
+        ) as client:
+            yield client
+
+
+async def _create_env(http_client: httpx.AsyncClient) -> str:
+    r = await http_client.post("/v1/environments", json={"name": f"wf-env-{_uniq()}"})
+    assert r.status_code in (200, 201), r.text
+    return r.json()["id"]
+
+
+async def test_create_workflow_run_and_observe(http_client: httpx.AsyncClient) -> None:
+    env_id = await _create_env(http_client)
+
+    # Create a workflow (201).
+    name = f"wf-{_uniq()}"
+    r = await http_client.post("/v1/workflows", json={"name": name, "script": _SCRIPT})
+    assert r.status_code == 201, r.text
+    workflow = r.json()
+    assert workflow["name"] == name and workflow["version"] == 1
+
+    # It shows up in the list (filtered by name).
+    r = await http_client.get("/v1/workflows", params={"name": name})
+    assert r.status_code == 200, r.text
+    assert [w["id"] for w in r.json()["data"]] == [workflow["id"]]
+
+    # Launch a run (201, pending).
+    r = await http_client.post(
+        "/v1/runs",
+        json={"workflow_id": workflow["id"], "environment_id": env_id, "input": {"x": 1}},
+    )
+    assert r.status_code == 201, r.text
+    run = r.json()
+    assert run["workflow_id"] == workflow["id"] and run["status"] == "pending"
+    assert run["input"] == {"x": 1}
+
+    # Fetch + list it.
+    r = await http_client.get(f"/v1/runs/{run['id']}")
+    assert r.status_code == 200 and r.json()["id"] == run["id"]
+    r = await http_client.get("/v1/runs", params={"workflow_id": workflow["id"]})
+    assert r.status_code == 200 and [x["id"] for x in r.json()["data"]] == [run["id"]]
+
+    # Its journal is readable (a fresh pending run has no events yet — the worker
+    # isn't running in this ASGI test).
+    r = await http_client.get(f"/v1/runs/{run['id']}/events")
+    assert r.status_code == 200 and r.json()["data"] == []
+
+
+async def test_create_run_with_unknown_workflow_404s(http_client: httpx.AsyncClient) -> None:
+    env_id = await _create_env(http_client)
+    r = await http_client.post(
+        "/v1/runs", json={"workflow_id": "wf_does_not_exist", "environment_id": env_id}
+    )
+    assert r.status_code == 404, r.text
+
+
+async def test_run_reads_and_resume_404_on_unknown(http_client: httpx.AsyncClient) -> None:
+    assert (await http_client.get("/v1/runs/wfr_nope")).status_code == 404
+    assert (await http_client.get("/v1/runs/wfr_nope/events")).status_code == 404
+    r = await http_client.post("/v1/runs/wfr_nope/resume", json={"gate_nonce": "x"})
+    assert r.status_code == 404, r.text
+
+
+async def test_requires_auth(http_client: httpx.AsyncClient) -> None:
+    r = await http_client.get("/v1/workflows", headers={"Authorization": ""})
+    assert r.status_code == 401, r.text

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -6,6 +6,7 @@ gapless, idempotent journal writer the runtime depends on.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -13,7 +14,7 @@ import asyncpg
 import pytest
 
 from aios.db.queries import workflows as wf_queries
-from aios.errors import ConflictError
+from aios.errors import ConflictError, NotFoundError
 
 
 @pytest.fixture
@@ -170,3 +171,85 @@ async def test_run_signal_idempotent(wf_conn: asyncpg.Connection[Any]) -> None:
     assert s2.result == {"answer": "yes"}
     signals = await wf_queries.list_run_signals(wf_conn, run_id)
     assert len(signals) == 1
+
+
+# ─── Block 3 surface: account-scoped reads + the stream NOTIFY ────────────────
+
+
+async def test_account_scoped_reads_isolate_tenants(wf_conn: asyncpg.Connection[Any]) -> None:
+    """The public reads (get_wf_run / list_wf_runs / list_workflows /
+    list_run_events_scoped) never surface another account's data."""
+    # A second tenant (a child account — only one active ROOT is allowed).
+    await wf_conn.execute(
+        "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+        "VALUES ('acc_other', 'acc_root', FALSE, 'tenant-other')"
+    )
+    run_id = await _seed_run(wf_conn)  # one workflow 'demo' + one run, under acc_root
+    await wf_queries.append_run_event(
+        wf_conn, account_id="acc_root", run_id=run_id, type="run_started", payload={"input": None}
+    )
+
+    # Owner sees everything.
+    assert (await wf_queries.get_wf_run(wf_conn, run_id, account_id="acc_root")).id == run_id
+    assert [r.id for r in await wf_queries.list_wf_runs(wf_conn, account_id="acc_root")] == [run_id]
+    assert len(await wf_queries.list_workflows(wf_conn, account_id="acc_root")) == 1
+    assert len(await wf_queries.list_run_events_scoped(wf_conn, run_id, account_id="acc_root")) == 1
+
+    # The other tenant sees nothing — a 404 on the point read, empty lists otherwise.
+    with pytest.raises(NotFoundError):
+        await wf_queries.get_wf_run(wf_conn, run_id, account_id="acc_other")
+    assert await wf_queries.list_wf_runs(wf_conn, account_id="acc_other") == []
+    assert await wf_queries.list_workflows(wf_conn, account_id="acc_other") == []
+    assert await wf_queries.list_run_events_scoped(wf_conn, run_id, account_id="acc_other") == []
+
+
+async def test_list_run_events_scoped_paginates_forward(wf_conn: asyncpg.Connection[Any]) -> None:
+    run_id = await _seed_run(wf_conn)
+    for i in range(3):
+        await wf_queries.append_run_event(
+            wf_conn,
+            account_id="acc_root",
+            run_id=run_id,
+            type="call_started",
+            call_key=f"sha:k#{i}",
+            payload={"capability": "gate"},
+        )
+    page1 = await wf_queries.list_run_events_scoped(
+        wf_conn, run_id, account_id="acc_root", after_seq=0, limit=2
+    )
+    assert [e.seq for e in page1] == [1, 2]
+    page2 = await wf_queries.list_run_events_scoped(
+        wf_conn, run_id, account_id="acc_root", after_seq=page1[-1].seq, limit=2
+    )
+    assert [e.seq for e in page2] == [3]
+
+
+async def test_append_run_event_notifies(
+    wf_conn: asyncpg.Connection[Any], migrated_db_url: str
+) -> None:
+    """append_run_event fires a pg_notify on wf_run_events_<run_id> with the event
+    id — the load-bearing signal the /runs/{id}/stream endpoint tails."""
+    run_id = await _seed_run(wf_conn)
+    listener = await asyncpg.connect(migrated_db_url)
+    try:
+        received: asyncio.Queue[str] = asyncio.Queue()
+        await listener.add_listener(
+            f"wf_run_events_{run_id}",
+            lambda _conn, _pid, _channel, payload: received.put_nowait(payload),
+        )
+        event = await wf_queries.append_run_event(
+            wf_conn, account_id="acc_root", run_id=run_id, type="run_started", payload={"input": 1}
+        )
+        assert event is not None
+        payload = await asyncio.wait_for(received.get(), timeout=5)
+        assert payload == event.id
+
+        # An idempotent no-op append (deduped) must NOT notify.
+        dup = await wf_queries.append_run_event(
+            wf_conn, account_id="acc_root", run_id=run_id, type="run_started", payload={"input": 1}
+        )
+        assert dup is None
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(received.get(), timeout=0.5)
+    finally:
+        await listener.close()

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -7,12 +7,16 @@ gapless, idempotent journal writer the runtime depends on.
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator
 from typing import Any
 
 import asyncpg
 import pytest
 
+from aios.api.sse import wf_run_event_stream
+from aios.db.listen import open_listen_for_run_events
+from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, NotFoundError
 
@@ -253,3 +257,49 @@ async def test_append_run_event_notifies(
             await asyncio.wait_for(received.get(), timeout=0.5)
     finally:
         await listener.close()
+
+
+async def test_wf_run_event_stream_backfills_tails_and_terminates(
+    wf_conn: asyncpg.Connection[Any], migrated_db_url: str
+) -> None:
+    """The SSE generator: a pre-subscription event arrives via backfill, a
+    post-subscription event via the live NOTIFY tail, and ``run_completed`` ends the
+    stream with a ``done`` frame."""
+    run_id = await _seed_run(wf_conn)
+    # Appended BEFORE we subscribe → must come through the backfill.
+    await wf_queries.append_run_event(
+        wf_conn, account_id="acc_root", run_id=run_id, type="run_started", payload={"input": 1}
+    )
+
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=2)
+    subscription = await open_listen_for_run_events(migrated_db_url, run_id)
+    collected: list[tuple[str, str | None]] = []
+    try:
+
+        async def _consume() -> None:
+            async for msg in wf_run_event_stream(subscription, pool, run_id):
+                kind = json.loads(msg.data).get("type") if msg.event == "event" else None
+                collected.append((msg.event, kind))
+                if msg.event == "done":
+                    return
+
+        task = asyncio.create_task(_consume())
+        await asyncio.sleep(0.2)  # let the backfill drain, then block on the queue
+        # Appended AFTER we subscribe → must come through the live NOTIFY tail.
+        await wf_queries.append_run_event(
+            wf_conn,
+            account_id="acc_root",
+            run_id=run_id,
+            type="run_completed",
+            payload={"output": 2, "is_error": False},
+        )
+        await asyncio.wait_for(task, timeout=5)
+    finally:
+        subscription.terminate()
+        await pool.close()
+
+    assert collected == [
+        ("event", "run_started"),  # backfill
+        ("event", "run_completed"),  # live tail
+        ("done", None),  # terminal
+    ]

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -259,6 +259,52 @@ async def test_append_run_event_notifies(
         await listener.close()
 
 
+async def test_append_run_event_notify_defers_to_outer_commit(
+    wf_conn: asyncpg.Connection[Any], migrated_db_url: str
+) -> None:
+    """pg_notify is transactional: when an OUTER txn wraps append_run_event (the real
+    _complete_run path), the notify is NOT delivered until that txn commits, and is
+    not delivered at all on rollback. This guards the NOTIFY-after-commit invariant
+    against a refactor moving the notify inside the txn (which the autocommit test
+    can't catch)."""
+    run_id = await _seed_run(wf_conn)
+    listener = await asyncpg.connect(migrated_db_url)
+    try:
+        received: asyncio.Queue[str] = asyncio.Queue()
+        await listener.add_listener(
+            f"wf_run_events_{run_id}",
+            lambda _conn, _pid, _channel, payload: received.put_nowait(payload),
+        )
+
+        async with wf_conn.transaction():
+            event = await wf_queries.append_run_event(
+                wf_conn, account_id="acc_root", run_id=run_id, type="run_started", payload={}
+            )
+            assert event is not None
+            # Inside the open outer txn: the notify is queued, NOT yet delivered.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(received.get(), timeout=0.5)
+        # Outer txn committed → now it arrives.
+        assert await asyncio.wait_for(received.get(), timeout=5) == event.id
+
+        # Rollback path: the insert AND the notify are both undone → nothing delivered.
+        with pytest.raises(RuntimeError):
+            async with wf_conn.transaction():
+                await wf_queries.append_run_event(
+                    wf_conn,
+                    account_id="acc_root",
+                    run_id=run_id,
+                    type="call_started",
+                    call_key="sha:g#0",
+                    payload={"capability": "gate"},
+                )
+                raise RuntimeError("force rollback")
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(received.get(), timeout=0.5)
+    finally:
+        await listener.close()
+
+
 async def test_wf_run_event_stream_backfills_tails_and_terminates(
     wf_conn: asyncpg.Connection[Any], migrated_db_url: str
 ) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1563,6 +1563,13 @@ async def test_service_create_and_resume_by_nonce_roundtrip(wf_runtime: asyncpg.
     done = await wf_service.get_run(pool, run.id, account_id="acc_wf")
     assert done.status == "completed" and done.output == {"answer": "yes"}
 
+    # The gate is now resolved — re-resuming with the same (valid) nonce 404s
+    # ("no OPEN gate matches") rather than writing an orphaned signal nothing harvests.
+    with pytest.raises(NotFoundError):
+        await wf_service.resume_gate_by_nonce(
+            pool, run_id=run.id, account_id="acc_wf", gate_nonce=nonce, result="again"
+        )
+
 
 async def test_service_resume_by_nonce_rejects_bad_nonce_and_cross_tenant(
     wf_runtime: asyncpg.Pool[Any],

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -22,9 +22,11 @@ import pytest
 from aios.db import queries as db_queries
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
+from aios.errors import NotFoundError
 from aios.harness import runtime
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
+from aios.services import workflows as wf_service
 from aios.workflows import service
 from aios.workflows.child_id import child_session_id
 from aios.workflows.determinism import CallKeyer
@@ -59,6 +61,7 @@ async def wf_runtime(
             )
         with (
             mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.workflows.step.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()),
         ):
@@ -1530,3 +1533,67 @@ async def test_early_gate_signal_triggers_self_rewake(wf_runtime: asyncpg.Pool[A
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "completed"
     assert run.output == {"answer": "early"}
+
+
+# ─── Block 3 surface: the services.workflows facade (create + by-nonce resume) ─
+
+
+async def test_service_create_and_resume_by_nonce_roundtrip(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """The public service path: create a workflow + run, drive to a gate, resume by
+    the gate's NONCE (not call_key), and complete."""
+    pool = wf_runtime
+    wf = await wf_service.create_workflow(
+        pool, account_id="acc_wf", name="gate-demo", script=_GATE_SCRIPT
+    )
+    run = await wf_service.create_run(
+        pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf"
+    )
+
+    await run_workflow_step(run.id)  # → suspends at the gate
+    assert (await wf_service.get_run(pool, run.id, account_id="acc_wf")).status == "suspended"
+    events = await wf_service.list_run_events(pool, run.id, account_id="acc_wf")
+    call_started = next(e for e in events if e.type == "call_started")
+    nonce = call_started.payload["gate_nonce"]
+    assert isinstance(nonce, str) and nonce
+
+    await wf_service.resume_gate_by_nonce(
+        pool, run_id=run.id, account_id="acc_wf", gate_nonce=nonce, result="yes"
+    )
+    await run_workflow_step(run.id)  # harvest the signal → replay past the gate → complete
+    done = await wf_service.get_run(pool, run.id, account_id="acc_wf")
+    assert done.status == "completed" and done.output == {"answer": "yes"}
+
+
+async def test_service_resume_by_nonce_rejects_bad_nonce_and_cross_tenant(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    pool = wf_runtime
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            "VALUES ('acc_intruder', 'acc_wf', FALSE, 'intruder')"
+        )
+    wf = await wf_service.create_workflow(
+        pool, account_id="acc_wf", name="gate-demo", script=_GATE_SCRIPT
+    )
+    run = await wf_service.create_run(
+        pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf"
+    )
+    await run_workflow_step(run.id)  # → suspended at the gate
+    events = await wf_service.list_run_events(pool, run.id, account_id="acc_wf")
+    nonce = next(e for e in events if e.type == "call_started").payload["gate_nonce"]
+
+    # Wrong nonce → 404 (no gate matches).
+    with pytest.raises(NotFoundError):
+        await wf_service.resume_gate_by_nonce(
+            pool, run_id=run.id, account_id="acc_wf", gate_nonce="not-a-real-nonce", result="x"
+        )
+    # Cross-tenant resume → 404 on the scope check, BEFORE the (correct) nonce is read.
+    with pytest.raises(NotFoundError):
+        await wf_service.resume_gate_by_nonce(
+            pool, run_id=run.id, account_id="acc_intruder", gate_nonce=nonce, result="x"
+        )
+    with pytest.raises(NotFoundError):
+        await wf_service.get_run(pool, run.id, account_id="acc_intruder")
+    # The run is untouched — still suspended, resumable by its owner.
+    assert (await wf_service.get_run(pool, run.id, account_id="acc_wf")).status == "suspended"

--- a/tests/unit/test_sse_generator_cleanup.py
+++ b/tests/unit/test_sse_generator_cleanup.py
@@ -22,6 +22,7 @@ from aios.api.sse import (
     management_calls_stream,
     runtime_connector_calls_stream,
     sse_event_stream,
+    wf_run_event_stream,
 )
 from aios.db.listen import ListenSubscription
 
@@ -75,6 +76,26 @@ def _install_session_event_backfill(
     pool.acquire = MagicMock(return_value=acquire_cm)
 
 
+def _install_wf_run_backfill(
+    monkeypatch: pytest.MonkeyPatch,
+    pool: MagicMock,
+    exc: Exception | None,
+) -> None:
+    """``wf_run_event_stream`` backfills via ``conn.fetch`` then status-checks via
+    ``conn.fetchval``. With no exc, return an empty backfill + a non-terminal status
+    so it falls through to the live tail; with exc, the backfill ``fetch`` raises."""
+    conn = MagicMock()
+    if exc is None:
+        conn.fetch = AsyncMock(return_value=[])
+        conn.fetchval = AsyncMock(return_value="running")  # non-terminal → live tail
+    else:
+        conn.fetch = AsyncMock(side_effect=exc)
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool.acquire = MagicMock(return_value=acquire_cm)
+
+
 # Each case: (build_generator, install_backfill).
 #  - build_generator(subscription, pool) returns the async generator under test.
 #  - install_backfill(monkeypatch, pool, exc) wires up the backfill path:
@@ -106,6 +127,11 @@ _CASES = [
         lambda sub, pool: connection_discovery_stream(sub, pool, "telegram", account_id="acct_X"),
         lambda mp, pool, exc: _install_query_backfill(mp, "list_connections", pool, exc),
         id="connection_discovery_stream",
+    ),
+    pytest.param(
+        lambda sub, pool: wf_run_event_stream(sub, pool, "wfr_X", after_seq=0),
+        lambda mp, pool, exc: _install_wf_run_backfill(mp, pool, exc),
+        id="wf_run_event_stream",
     ),
 ]
 

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -1,0 +1,73 @@
+"""Pydantic validation for the workflow request models (Block 3 surface).
+
+Pure in-memory: no Postgres, no Docker.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios.models.workflows import GateResume, WfRunCreate, WorkflowCreate
+
+
+class TestWorkflowCreate:
+    def test_minimal(self) -> None:
+        wf = WorkflowCreate.model_validate(
+            {"name": "echo", "script": "async def main(i): return i"}
+        )
+        assert wf.name == "echo"
+        assert wf.input_schema is None and wf.output_schema is None
+
+    def test_with_schemas_round_trips(self) -> None:
+        payload = {
+            "name": "w",
+            "script": "async def main(i): return 1",
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "integer"},
+        }
+        assert WorkflowCreate.model_validate(payload).model_dump() == {
+            **payload,
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "integer"},
+        }
+
+    def test_requires_name_and_script(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowCreate.model_validate({"name": "w"})
+        with pytest.raises(ValidationError):
+            WorkflowCreate.model_validate({"script": "x"})
+
+
+class TestWfRunCreate:
+    def test_minimal(self) -> None:
+        run = WfRunCreate.model_validate({"workflow_id": "wf_1", "environment_id": "env_1"})
+        assert run.workflow_id == "wf_1" and run.environment_id == "env_1"
+        assert run.input is None
+
+    @pytest.mark.parametrize("value", [42, "go", ["a", "b"], {"x": 1}, None])
+    def test_input_accepts_arbitrary_json(self, value: object) -> None:
+        run = WfRunCreate.model_validate(
+            {"workflow_id": "wf_1", "environment_id": "env_1", "input": value}
+        )
+        assert run.input == value
+
+    def test_requires_workflow_and_environment(self) -> None:
+        with pytest.raises(ValidationError):
+            WfRunCreate.model_validate({"workflow_id": "wf_1"})
+        with pytest.raises(ValidationError):
+            WfRunCreate.model_validate({"environment_id": "env_1"})
+
+
+class TestGateResume:
+    def test_minimal(self) -> None:
+        g = GateResume.model_validate({"gate_nonce": "abc"})
+        assert g.gate_nonce == "abc" and g.result is None
+
+    @pytest.mark.parametrize("value", [True, "approved", {"answer": 42}, [1, 2]])
+    def test_result_accepts_arbitrary_json(self, value: object) -> None:
+        assert GateResume.model_validate({"gate_nonce": "n", "result": value}).result == value
+
+    def test_requires_nonce(self) -> None:
+        with pytest.raises(ValidationError):
+            GateResume.model_validate({"result": 1})


### PR DESCRIPTION
## Block 3 — slice 1: the workflows surface

The workflow **runtime** (Blocks 0–2, merged) works — runs spawn real agent children, `parallel()`/`pipeline()`, gates, totality — but there was **no way to use it**: no HTTP API, no CLI, only the internal `workflows.service.create_run`. (During Block-2 smoke-testing I had to hand-write a Python launcher just to start a run.) This adds the outward **surface** so workflows are usable over HTTP and the `aios` CLI, and unblocks the Block-3 "port a real workload" validation.

First slice of Block 3 ("gates + limits + surface"). Foreground-protection (origin priority lanes) and child-reclaim are **not** here (separate slices).

### What's here

- **`/v1/workflows`** (definitions, like `/v1/agents`): `create` / `list` / `get`. Versioning/update deferred (recreate to change).
- **`/v1/runs`** (executions, top-level like `/v1/sessions` — `workflow_id` in the create body): `create` / `list` / `get` / `events` / `resume` / **`stream`**.
- **Live SSE** `GET /v1/runs/{id}/stream` — the workflow analog of the session event stream (`open_listen_for_run_events` + `wf_run_event_stream`): backfill from `after_seq`, tail the live NOTIFY (`append_run_event` now fires `pg_notify` after-commit on `wf_run_events_<run_id>`), end on `run_completed`.
- **Gate resume by nonce** — `POST /v1/runs/{id}/resume` keyed by the unguessable `gate_nonce` (the capability token already minted into the gate's `call_started`, previously unread), not the internal `call_key`. Account-scopes the run first, matches only an **open** gate.
- **CLI**: `aios workflows {create,list,get}` + `aios runs {create,list,get,events,resume,stream}` over the generated SDK + a hand-written `stream_run`.

All public reads/ops are account-scoped (the internal `get_run_for_step`/`list_run_events` are unscoped and never reachable from HTTP); cross-tenant ids 404.

### Verification

`mypy` ✓ · `ruff` ✓ · **1775 unit** ✓ · **249 integration** ✓ · **e2e** ✓ (workflows + agents + tenant-isolation). openapi/SDK in sync (CI guards). Built in 6 commits, each green.

**Live smoke over the real CLI** (isolated runtime, real worker + Postgres + Sonnet): `aios workflows create` → `aios runs create` → `aios runs stream` watched a real **multi-agent fan-out** in real time (`run_started` → 2 `call_started` → 2 `call_result` out-of-order → `run_completed` `["ALPHA","BETA"]`, branch order preserved) → for a gated workflow, `aios runs events` surfaced the nonce and `aios runs resume --gate-nonce` drove it to `{"approved":"approved"}`. This replaces the Block-2 hand-written launcher.

A `/code-review max` pass (52-agent adversarial fan-out) caught a handful of real issues — fixed in the last commit: the SSE stream hanging on a reconnect to a finished run; resuming an already-resolved gate; a `render_paginated` crash on `--all` page 2 for path-param'd endpoints (also fixed the pre-existing `agents versions --all`); bad-JSON CLI tracebacks; and three invariant-protecting test gaps (a real cross-tenant HTTP test, the NOTIFY-after-commit outer-txn deferral, the SSE generator's cancel/exception cleanup).

### Notable design calls

- `list_workflows` is hand-written (not `_list_scoped`) because the `workflows` table has no `archived_at` (definitions are immutable).
- The HTTP facade lives in `services/workflows.py`; the runtime entry points (`create_run`/`resume_gate`) stay in `aios.workflows.service` (re-exported) — tests patch its `defer_run_wake`.

### Deferred (later Block-3 slices)

Foreground protection (origin priority lanes + background step budget), child teardown/reclaim (`schedule-archival-on-quiescence`), `output_schema`/StructuredOutput, workflow update/versioning, `/v1/runs/{id}/wait`, and porting a real workload as the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)