### PR TITLE
fix(workflows): Block-3 surface review follow-ups (SSE terminal-frame drop, gate resolver, pagination)

### DIFF
--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -231,14 +231,31 @@ async def wf_run_event_stream(
             if payload["type"] == "run_completed":
                 yield ServerSentEvent(data="{}", event="done")
                 return
-        # A terminal run never NOTIFYs again. If its run_completed was already past
-        # ``after_seq`` (a reconnect that consumed the terminal frame, or a high
-        # after_seq), the backfill is empty and tailing would block forever — so end
-        # the stream now rather than hang. (run_completed is written for BOTH
-        # completed and errored, so a terminal status implies it exists.)
+        # A terminal run never NOTIFYs again, so we must not block the live tail on an
+        # event that will never come. But the run may have gone terminal in the window
+        # between the backfill SELECT's snapshot and this status read — committing
+        # run_completed (and queueing its NOTIFY) that the backfill could not see. A
+        # terminal run's journal is frozen (append_run_event no-ops once status is
+        # terminal), so a final catch-up read past the cursor delivers any such tail —
+        # notably the run_completed frame carrying output/error — which we'd otherwise
+        # drop by emitting `done` before draining the queue. An empty catch-up (the
+        # genuine reconnect-past-terminal case) just falls through to `done`.
         async with pool.acquire() as conn:
             status = await conn.fetchval("SELECT status FROM wf_runs WHERE id = $1", run_id)
+            terminal_tail = (
+                await conn.fetch(
+                    "SELECT * FROM wf_run_events WHERE run_id = $1 AND seq > $2 ORDER BY seq ASC",
+                    run_id,
+                    cursor,
+                )
+                if status in ("completed", "errored")
+                else []
+            )
         if status in ("completed", "errored"):
+            for row in terminal_tail:
+                payload = _serialize_wf_event(row)
+                cursor = max(cursor, payload["seq"])
+                yield _event_to_sse(payload)
             yield ServerSentEvent(data="{}", event="done")
             return
         # Tail live notifications; dedup against the backfill cursor (an event can

--- a/src/aios/cli/commands/skills.py
+++ b/src/aios/cli/commands/skills.py
@@ -113,7 +113,7 @@ def versions(
             max_widths={"description": 60, "name": 32},
             all_=all_,
             limit=limit,
-            skill_id=skill_id,
+            path_params={"skill_id": skill_id},
         )
 
     run_or_die(_run)

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -180,7 +180,7 @@ def cred_list(
             columns=_CRED_COLS,
             all_=all_,
             limit=limit,
-            vault_id=vault_id,
+            path_params={"vault_id": vault_id},
         )
 
     run_or_die(_run)

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -401,6 +401,46 @@ async def list_run_events_scoped(
     return [_row_to_wf_run_event(r) for r in rows]
 
 
+async def find_open_gate_call_key(
+    conn: asyncpg.Connection[Any], run_id: str, *, gate_nonce: str
+) -> str | None:
+    """Resolve a gate's capability ``nonce`` to the ``call_key`` of its OPEN gate.
+
+    A gate is open when its ``call_started`` has no matching ``call_result`` yet; an
+    already-resolved nonce (or one that never existed) returns ``None``. The earliest
+    such gate wins (``ORDER BY seq``), though a nonce is unique per run in practice.
+
+    Unscoped — the caller (:func:`aios.services.workflows.resume_gate_by_nonce`)
+    account-checks the run via :func:`get_wf_run` first. Pushing the predicate into
+    SQL (vs. materializing the whole journal and scanning in Python) keeps the cost a
+    single indexed row instead of growing with journal length — the gate resolver,
+    like the session ``lookup_tool_name_by_call_id`` it mirrors, lives in the query
+    layer.
+    """
+    call_key: str | None = await conn.fetchval(
+        """
+        SELECT e.call_key
+        FROM wf_run_events e
+        WHERE e.run_id = $1
+          AND e.type = 'call_started'
+          AND e.payload->>'capability' = 'gate'
+          AND e.payload->>'gate_nonce' = $2
+          AND e.call_key IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1 FROM wf_run_events r
+              WHERE r.run_id = e.run_id
+                AND r.type = 'call_result'
+                AND r.call_key = e.call_key
+          )
+        ORDER BY e.seq ASC
+        LIMIT 1
+        """,
+        run_id,
+        gate_nonce,
+    )
+    return call_key
+
+
 # ─── wf_run_signals (external-resume side markers — idempotent) ───────────────
 
 

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -142,19 +142,7 @@ async def resume_gate_by_nonce(
     """
     async with pool.acquire() as conn:
         await wf_queries.get_wf_run(conn, run_id, account_id=account_id)  # 404s cross-tenant
-        events = await wf_queries.list_run_events(conn, run_id)
-        resolved = {e.call_key for e in events if e.type == "call_result"}
-        call_key = None
-        for event in events:
-            if (
-                event.type == "call_started"
-                and event.payload.get("capability") == "gate"
-                and event.payload.get("gate_nonce") == gate_nonce
-                and event.call_key is not None
-                and event.call_key not in resolved
-            ):
-                call_key = event.call_key
-                break
+        call_key = await wf_queries.find_open_gate_call_key(conn, run_id, gate_nonce=gate_nonce)
         if call_key is None:
             raise NotFoundError(
                 "no open gate matches that nonce on this run", detail={"run_id": run_id}

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -55,11 +55,14 @@ async def resume_gate(
     call_key: str,
     result: Any,
 ) -> None:
-    """Deliver an external resume for a suspended gate.
+    """Deliver an external resume for a suspended gate, keyed by ``call_key``.
 
-    The Block-1 internal stand-in for the (deferred) HTTP resume endpoint: record
-    a durable ``wf_run_signals`` row and defer a wake. The run's next step harvests
-    the signal into the journal — keeping ``wf_run_events`` single-writer.
+    The internal/trusted variant: it keys off ``call_key`` directly and does NOT
+    account-scope, so it must never be the HTTP path. The HTTP face is
+    :func:`aios.services.workflows.resume_gate_by_nonce`, which scopes the run and
+    resolves the public ``gate_nonce`` to a ``call_key`` before calling through here.
+    Both record a durable ``wf_run_signals`` row and defer a wake; the run's next
+    step harvests the signal into the journal — keeping ``wf_run_events`` single-writer.
     """
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)

--- a/tests/unit/cli/test_cli_pagination_path_params.py
+++ b/tests/unit/cli/test_cli_pagination_path_params.py
@@ -1,0 +1,61 @@
+"""Regression test for ``--all`` walks of path-param'd list endpoints.
+
+The opaque ``next_cursor`` re-encodes the query filters (so the client needn't
+resend them, and the server 422s if it does), but a URL **path** segment like
+``/v1/vaults/{vault_id}/credentials`` is structural — never in the cursor — so it
+must be resent on every page. ``render_paginated`` carries those via ``path_params``
+(not ``**filters``). A command that mis-wired its id as a filter would drop it on
+page 2, where the SDK call is ``fn(client=..., cursor=...)`` with no id, raising
+``TypeError`` on the missing required argument.
+
+This drives every path-param'd list command across a real two-page boundary and
+asserts the id survives onto page 2 — the contract for all of them at once.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from aios.cli.app import app
+
+runner = CliRunner()
+
+# (argv, page-2 URL path that must still carry the id). The id lives in the path,
+# so the page-2 request — made with only ``?cursor=`` — must still hit this URL.
+_PATH_PARAM_LIST_COMMANDS = [
+    pytest.param(
+        ["agents", "versions", "agt_1", "--all"], "/v1/agents/agt_1/versions", id="agents"
+    ),
+    pytest.param(
+        ["skills", "versions", "skl_1", "--all"], "/v1/skills/skl_1/versions", id="skills"
+    ),
+    pytest.param(
+        ["vaults", "credentials", "list", "vlt_1", "--all"],
+        "/v1/vaults/vlt_1/credentials",
+        id="vaults",
+    ),
+    pytest.param(["runs", "events", "wfr_1", "--all"], "/v1/runs/wfr_1/events", id="runs"),
+]
+
+
+@pytest.mark.parametrize("argv, page2_path", _PATH_PARAM_LIST_COMMANDS)
+def test_all_walk_preserves_url_path_param(mocked_cli, argv, page2_path):
+    # Page 1 advertises a next page; page 2 ends the walk. Empty ``data`` keeps the
+    # SDK parser from needing item fixtures — we only care about request shape.
+    mocked_cli.queue_response(
+        httpx.Response(200, json={"data": [], "has_more": True, "next_cursor": "CUR1"})
+    )
+    mocked_cli.queue_response(
+        httpx.Response(200, json={"data": [], "has_more": False, "next_cursor": None})
+    )
+
+    result = runner.invoke(app, argv)
+
+    # Buggy call sites (id passed as a query filter) raise TypeError on page 2.
+    assert result.exit_code == 0, result.output
+    # ``captured`` holds the last request — page 2 — which carried only the cursor,
+    # so the id can only have survived via the URL path.
+    assert mocked_cli.captured.path == page2_path
+    assert mocked_cli.captured.query.get("cursor") == ["CUR1"]

--- a/tests/unit/test_wf_run_event_stream_terminal.py
+++ b/tests/unit/test_wf_run_event_stream_terminal.py
@@ -1,0 +1,89 @@
+"""Unit test for ``wf_run_event_stream``'s terminal-status catch-up.
+
+The hazard: a run can go terminal in the window between the stream's backfill
+SELECT (whose MVCC snapshot predates the completion) and the subsequent status
+read. The ``run_completed`` event then committed AND queued its NOTIFY, but the
+backfill never saw it. The generator must NOT emit a bare ``done`` and return —
+it would drop the terminal frame (carrying ``output``/``error``) that is sitting
+unread in the queue. Because a terminal run's journal is frozen, a final
+catch-up read past the cursor recovers it deterministically.
+
+This forces that exact interleaving with a mock connection (an integration test
+can't, without injecting a delay between the two real snapshots — which is why
+the live-DB stream test exercises only the live-tail terminal path).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from aios.api.sse import wf_run_event_stream
+from aios.db.listen import ListenSubscription
+
+
+def _mk_subscription() -> ListenSubscription:
+    conn = MagicMock()
+    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=8)
+    return ListenSubscription(queue=queue, _conn=conn)
+
+
+def _mk_pool(conn: MagicMock) -> MagicMock:
+    """Pool whose ``async with pool.acquire()`` always yields ``conn``."""
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool
+
+
+async def test_terminal_status_drains_catch_up_tail_then_done() -> None:
+    """Empty backfill + status='completed' + a run_completed in the catch-up read
+    ⇒ the stream emits the run_completed event frame, THEN done (not bare done)."""
+    run_completed_row = {
+        "id": "wfe_1",
+        "run_id": "wfr_X",
+        "seq": 5,
+        "type": "run_completed",
+        "call_key": None,
+        "payload": json.dumps({"output": 2, "is_error": False}),
+        "created_at": datetime(2024, 1, 1, tzinfo=UTC),
+    }
+    conn = MagicMock()
+    # 1st fetch = backfill (race: snapshot predates completion → empty);
+    # 2nd fetch = catch-up after the terminal status read → the run_completed.
+    conn.fetch = AsyncMock(side_effect=[[], [run_completed_row]])
+    conn.fetchval = AsyncMock(return_value="completed")
+    pool = _mk_pool(conn)
+    subscription = _mk_subscription()
+
+    collected = [
+        (msg.event, json.loads(msg.data).get("type") if msg.event == "event" else None)
+        async for msg in wf_run_event_stream(subscription, pool, "wfr_X", after_seq=0)
+    ]
+
+    assert collected == [("event", "run_completed"), ("done", None)]
+    # The catch-up read was issued (not skipped) and the subscription cleaned up.
+    assert conn.fetch.await_count == 2
+    subscription._conn.terminate.assert_called_once()
+
+
+async def test_terminal_status_empty_catch_up_falls_through_to_done() -> None:
+    """The genuine reconnect-past-terminal case: empty backfill + status terminal +
+    nothing past the cursor ⇒ a single done frame (no hang, no spurious event)."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[[], []])  # backfill empty, catch-up empty
+    conn.fetchval = AsyncMock(return_value="errored")
+    pool = _mk_pool(conn)
+    subscription = _mk_subscription()
+
+    collected = [
+        (msg.event, msg.data)
+        async for msg in wf_run_event_stream(subscription, pool, "wfr_X", after_seq=99)
+    ]
+
+    assert collected == [("done", "{}")]
+    subscription._conn.terminate.assert_called_once()


### PR DESCRIPTION
Addendum to #754, from the `/simplify` + `/code-review max` passes over the Block-3 workflows surface. Three changes, ranked by severity.

## 1. fix(sse) — `wf_run_event_stream` dropped the terminal frame *(correctness, high)*

The terminal-run guard added in #754 ("terminal status ⇒ stop, don't hang") read `status` on a **different MVCC snapshot** than the backfill. If a run went terminal in the window between the backfill `SELECT` and the status read, the `run_completed` event had committed and queued its NOTIFY, but the backfill never saw it — so the generator emitted a bare `done` and **dropped the terminal `output`/`error` frame**.

Fix generalizes the guard from *"stop"* to *"drain the now-frozen journal, then stop"*: a terminal run's journal is immutable (`append_run_event` no-ops once status is terminal), so a single catch-up read past the cursor is provably complete — no locking, no snapshot pinning. New mock-conn unit test forces the exact interleaving (the live-DB stream test can only reach the live-tail terminal path, which is why this slipped through).

## 2. refactor(workflows) — gate resolver moved to the query layer *(altitude/efficiency)*

`resume_gate_by_nonce` materialized the **entire run journal** and scanned it twice in Python to resolve `gate_nonce → call_key` — unbounded on a durable-by-design entity, and query logic living in the service layer. Replaced with a targeted SQL anti-join (`find_open_gate_call_key`), mirroring the session `lookup_tool_name_by_call_id` precedent: one indexed row instead of `O(journal)`, query logic back in `db/queries`. Behavior-preserving (existing resume / bad-nonce / cross-tenant / already-resolved-gate tests cover it).

## 3. fix(cli) — complete the `path_params` pagination fix *(broken windows)*

#754 introduced `render_paginated(path_params=...)` to keep a URL path id on page 2 of an `--all` walk, and wired it into `agents versions` + `runs events` — but two **pre-existing** sibling commands carry the identical latent bug: `aios skills versions --all` and `aios vaults credentials list --all` pass their id as a query filter, so page 2 calls the SDK fn with no `skill_id`/`vault_id` → `TypeError`. Fixed both; added a parametrized regression test over all four path-param'd list commands (proven to fail on the unfixed call sites).

## Out of scope — filed separately

The review also surfaced a **cross-tenant `environment_id` binding gap** (`create_run`/`create_session` validate the environment by FK existence, not ownership). It's pre-existing and system-wide (mirrors `create_session` exactly), so it's filed as #755 rather than fixed here.

## Checks
mypy · ruff · 1781 unit · 94 workflow integration + e2e · codegen snapshots unchanged (no API surface touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)