### PR TITLE
feat(workflows): agent() structured output (output_schema)

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1079,24 +1079,26 @@ async def get_open_request_ids(
 
 
 async def get_request_output_schema(
-    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
+    conn: asyncpg.Connection[Any], session_id: str, *, request_id: str
 ) -> dict[str, Any] | None:
     """The JSON Schema a request demands of its response ``value``, or ``None``.
 
-    Reads ``metadata.request.output_schema`` off the request's user message (mirrors
-    :func:`get_open_request_ids`). Keyed on ``request_id`` — a child can owe several
-    requests, each with its own schema — so the ``return`` enforcement validates a
-    ``value`` against *its* request's schema. ``None`` when the request demands no
-    schema (the common case) or the id matches nothing.
+    Reads ``metadata.request.output_schema`` off the request's user message. Keyed on
+    ``(session_id, request_id)`` — a child can owe several requests, each with its own
+    schema — so the ``return`` enforcement validates a ``value`` against *its* request's
+    schema. Like :func:`get_session_workflow_context` (the other return-path read),
+    ``session_id`` is a unique PK and so is sufficient scope on its own — no
+    ``account_id`` predicate, which lets the tool path resolve the schema without first
+    looking up the session's account. ``None`` when the request demands no schema (the
+    common case) or the id matches nothing.
     """
     schema = await conn.fetchval(
         "SELECT req.data->'metadata'->'request'->'output_schema' FROM events req "
-        "WHERE req.session_id = $1 AND req.account_id = $2 "
+        "WHERE req.session_id = $1 "
         "AND req.kind = 'message' AND req.role = 'user' "
-        "AND req.data->'metadata'->'request'->>'request_id' = $3 "
-        "LIMIT 1",
+        "AND req.data->'metadata'->'request'->>'request_id' = $2 "
+        "ORDER BY req.seq ASC LIMIT 1",  # oldest-first, like get_open_request_ids — deterministic
         session_id,
-        account_id,
         request_id,
     )
     return parse_jsonb(schema) if schema is not None else None

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1078,6 +1078,30 @@ async def get_open_request_ids(
     return [r["rid"] for r in rows]
 
 
+async def get_request_output_schema(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
+) -> dict[str, Any] | None:
+    """The JSON Schema a request demands of its response ``value``, or ``None``.
+
+    Reads ``metadata.request.output_schema`` off the request's user message (mirrors
+    :func:`get_open_request_ids`). Keyed on ``request_id`` — a child can owe several
+    requests, each with its own schema — so the ``return`` enforcement validates a
+    ``value`` against *its* request's schema. ``None`` when the request demands no
+    schema (the common case) or the id matches nothing.
+    """
+    schema = await conn.fetchval(
+        "SELECT req.data->'metadata'->'request'->'output_schema' FROM events req "
+        "WHERE req.session_id = $1 AND req.account_id = $2 "
+        "AND req.kind = 'message' AND req.role = 'user' "
+        "AND req.data->'metadata'->'request'->>'request_id' = $3 "
+        "LIMIT 1",
+        session_id,
+        account_id,
+        request_id,
+    )
+    return parse_jsonb(schema) if schema is not None else None
+
+
 async def count_request_nudges(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
 ) -> int:

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -341,6 +341,15 @@ def render_user_event(
     if isinstance(request, dict) and isinstance(request.get("request_id"), str):
         rid = request["request_id"]
         marker = f"[request_id: {rid} — reply with return/error using this request_id]"
+        output_schema = request.get("output_schema")
+        if output_schema is not None:
+            # The request demands a typed `value`; show the shape so the model
+            # conforms first-try (return enforces it regardless). Per-request — each
+            # request carries its own schema.
+            marker += (
+                "\nYour return `value` must match this JSON Schema:\n"
+                f"```json\n{json.dumps(output_schema, indent=2)}\n```"
+            )
         existing = msg.get("content") or ""
         msg["content"] = f"{marker}\n{existing}" if existing else marker
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -247,6 +247,7 @@ async def create_child_session(
     parent_run_id: str,
     request_id: str,
     input: Any,
+    output_schema: dict[str, Any] | None = None,
 ) -> bool:
     """Idempotently spawn a workflow ``agent()`` child and inject the first request.
 
@@ -257,6 +258,11 @@ async def create_child_session(
     ``return``/``error`` (exactly once); the ``request_id`` is surfaced to the model
     as a render-time marker on the message (see ``render_user_event``) so it knows
     which id to echo back.
+
+    ``output_schema`` (optional) is the JSON Schema the request demands of the
+    response ``value``. It rides ``metadata.request.output_schema`` — per-request, so
+    a child owing several requests can carry a distinct schema for each — surfaced to
+    the model alongside the request and enforced when it calls ``return``.
 
     One transaction: insert the child row (``ON CONFLICT (id) DO NOTHING``) and,
     **only on a real insert**, deliver the request — without a stimulus the child
@@ -277,6 +283,12 @@ async def create_child_session(
         )
         if child is None:
             return False  # replay: row exists — do NOT re-deliver the request
+        request_meta: dict[str, Any] = {
+            "request_id": request_id,
+            "caller": {"kind": "run", "id": parent_run_id},
+        }
+        if output_schema is not None:
+            request_meta["output_schema"] = output_schema
         await queries.append_event(
             conn,
             account_id=account_id,
@@ -285,12 +297,7 @@ async def create_child_session(
             data={
                 "role": "user",
                 "content": content,
-                "metadata": {
-                    "request": {
-                        "request_id": request_id,
-                        "caller": {"kind": "run", "id": parent_run_id},
-                    }
-                },
+                "metadata": {"request": request_meta},
             },
         )
         return True

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -29,7 +29,10 @@ caller's harvest reads; the periodic ``wf_runs`` sweep is the lost-wake backstop
 
 from __future__ import annotations
 
+import json
 from typing import Any
+
+import jsonschema  # type: ignore[import-untyped]
 
 from aios.db import queries
 from aios.harness import runtime
@@ -170,7 +173,62 @@ async def _finish(
     return {"status": "errored" if is_error else "returned"}
 
 
+def _validate_value(value: Any, schema: dict[str, Any]) -> str | None:
+    """Validate a ``return`` ``value`` against the request's ``output_schema``.
+
+    ``None`` on success; otherwise a model-facing error enumerating every failure
+    (mirrors :func:`aios.tools.invoke.validate_arguments`' formatting) so the child
+    self-corrects and calls ``return`` again through the normal tool-error loop.
+    """
+    errors = sorted(
+        jsonschema.Draft202012Validator(schema).iter_errors(value),
+        key=lambda e: list(e.absolute_path),
+    )
+    if not errors:
+        return None
+    lines = [
+        f"`value` does not match the request's required schema. You sent: {json.dumps(value)}",
+        "Errors:",
+    ]
+    for err in errors:
+        path = ".".join(str(p) for p in err.absolute_path)
+        lines.append(f"  - at {'value.' + path if path else 'value'}: {err.message}")
+    lines.append("Fix `value` to match the schema shown with the request and call return again.")
+    return "\n".join(lines)
+
+
+async def _enforce_output_schema(session_id: str, request_id: Any, value: Any) -> str | None:
+    """Validate ``value`` against the schema this request demands, if any.
+
+    Returns a model-facing error string to bounce back (the child retries), or
+    ``None`` to proceed. A non-str/unknown ``request_id`` or non-child session is
+    left for :func:`respond_to_request` to reject (``unknown_request`` /
+    ``not_a_child``); a request with no ``output_schema`` (the common case) passes.
+    """
+    if not isinstance(request_id, str):
+        return None
+    pool = runtime.require_pool()
+    async with pool.acquire() as conn:
+        ctx = await queries.get_session_workflow_context(conn, session_id)
+        if ctx is None:
+            return None
+        account_id, _ = ctx
+        schema = await queries.get_request_output_schema(
+            conn, session_id, account_id=account_id, request_id=request_id
+        )
+    return None if schema is None else _validate_value(value, schema)
+
+
 async def return_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:
+    # Structured output: when the request demanded an output_schema, the value must
+    # match it. A mismatch is a tool error the child retries on (no response written),
+    # exactly like a malformed tool arg — so the workflow only ever harvests a
+    # schema-valid value. error() is unconstrained (a child that can't conform bails).
+    schema_error = await _enforce_output_schema(
+        session_id, arguments.get("request_id"), arguments.get("value")
+    )
+    if schema_error is not None:
+        return ToolResult(content=schema_error, is_error=True)
     return await _finish(
         session_id,
         request_id=arguments.get("request_id"),

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -201,21 +201,15 @@ async def _enforce_output_schema(session_id: str, request_id: Any, value: Any) -
     """Validate ``value`` against the schema this request demands, if any.
 
     Returns a model-facing error string to bounce back (the child retries), or
-    ``None`` to proceed. A non-str/unknown ``request_id`` or non-child session is
-    left for :func:`respond_to_request` to reject (``unknown_request`` /
-    ``not_a_child``); a request with no ``output_schema`` (the common case) passes.
+    ``None`` to proceed. A non-str ``request_id`` (or one matching no request) and a
+    non-child session resolve to no schema, leaving the rejection to
+    :func:`respond_to_request` (``unknown_request`` / ``not_a_child``); a request with
+    no ``output_schema`` (the common case) also passes.
     """
     if not isinstance(request_id, str):
         return None
-    pool = runtime.require_pool()
-    async with pool.acquire() as conn:
-        ctx = await queries.get_session_workflow_context(conn, session_id)
-        if ctx is None:
-            return None
-        account_id, _ = ctx
-        schema = await queries.get_request_output_schema(
-            conn, session_id, account_id=account_id, request_id=request_id
-        )
+    async with runtime.require_pool().acquire() as conn:
+        schema = await queries.get_request_output_schema(conn, session_id, request_id=request_id)
     return None if schema is None else _validate_value(value, schema)
 
 

--- a/src/aios/workflows/determinism.py
+++ b/src/aios/workflows/determinism.py
@@ -73,6 +73,28 @@ def canonical_json(x: Any) -> str:
     return json.dumps(x, separators=(",", ":"), sort_keys=True, ensure_ascii=True, allow_nan=False)
 
 
+def canonical_schema_json(schema: Any) -> str:
+    """Deterministic JSON for a JSON Schema carried in a capability spec.
+
+    Unlike :func:`canonical_json` (which serves the **data** domain and rejects floats
+    — a workflow input's ``1.0`` vs ``1`` must never desync the call key), a JSON
+    *Schema* legitimately carries decimal numeric constraints (``minimum`` /
+    ``multipleOf`` / …). Those are author-written literals that serialize
+    deterministically (the ``json.dumps`` float repr is stable for a given value), so
+    they are admitted here; ``allow_nan=False`` still rejects the genuinely
+    non-deterministic NaN/Inf. ``sort_keys`` keeps the string — and thus the call key —
+    independent of the schema's key order.
+
+    ``agent()`` stores this string in the spec so a float-bearing schema never reaches
+    the float-banning :func:`canonical_json`; the worker reconstructs the schema with
+    ``json.loads``. Raises ``TypeError`` for a non-JSON-serialisable schema (e.g. a set
+    value) — a loud author error, surfaced like any other bad ``agent()`` argument.
+    """
+    return json.dumps(
+        schema, separators=(",", ":"), sort_keys=True, ensure_ascii=True, allow_nan=False
+    )
+
+
 def content_hash(capability_id: str, spec: Any) -> str:
     """``sha256(capability_id ‖ "\\0" ‖ canonical_json(spec))`` as hex."""
     payload = f"{capability_id}\0{canonical_json(spec)}"

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -27,12 +27,16 @@ One wake:
 from __future__ import annotations
 
 import contextlib
+import json
 import secrets
 from datetime import UTC, datetime, timedelta
 from typing import Any, NamedTuple
 
 import asyncpg
 import jsonschema  # type: ignore[import-untyped]
+from referencing import Registry, Resource
+from referencing.exceptions import Unresolvable
+from referencing.jsonschema import DRAFT202012
 
 from aios.config import get_settings
 from aios.db import queries as db_queries
@@ -49,6 +53,44 @@ from aios.workflows.host_launcher import EmittedCapability, run_script_host
 log = get_logger("aios.workflows.step")
 
 _TERMINAL = ("completed", "errored")
+
+
+def _collect_refs(node: Any) -> list[str]:
+    """Every ``$ref`` / ``$dynamicRef`` / ``$recursiveRef`` string anywhere in a schema."""
+    refs: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in ("$ref", "$dynamicRef", "$recursiveRef") and isinstance(value, str):
+                refs.append(value)
+            refs.extend(_collect_refs(value))
+    elif isinstance(node, list):
+        for item in node:
+            refs.extend(_collect_refs(item))
+    return refs
+
+
+def _unresolvable_ref(schema: dict[str, Any]) -> str | None:
+    """The first reference in ``schema`` that does not resolve within the schema itself,
+    or ``None`` if every reference resolves.
+
+    A dangling local ``$ref`` or a remote ``$ref`` passes ``check_schema`` but raises a
+    referencing error when the child *applies* the schema — bricking the child (it can
+    never ``return`` a conforming value) until its wall-clock deadline. Rejecting it at
+    the spawn gate turns that into a clean author-facing error. Remote refs are
+    unresolvable by design: a sandboxed child must not fetch a schema over the network.
+    Valid self-contained refs (``#/$defs/…``) resolve and are left alone.
+    """
+    refs = _collect_refs(schema)
+    if not refs:
+        return None
+    resource = Resource.from_contents(schema, default_specification=DRAFT202012)
+    resolver = Registry().with_resource("", resource).resolver(base_uri="")
+    for ref in refs:
+        try:
+            resolver.lookup(ref)
+        except Unresolvable:
+            return ref
+    return None
 
 
 def _memo_outcome(call_result_payload: dict[str, Any]) -> dict[str, Any]:
@@ -332,14 +374,20 @@ async def _open_agent_capability(
     """
     account_id = run.account_id
     spec = cap.spec if isinstance(cap.spec, dict) else {}
-    output_schema = spec.get("output_schema")
+    # agent() carries output_schema as a canonical JSON *string* (so a schema's floats
+    # survive the call_key hash); reconstruct the dict. None means no schema demanded.
+    output_schema_raw = spec.get("output_schema")
+    output_schema = (
+        json.loads(output_schema_raw) if isinstance(output_schema_raw, str) else output_schema_raw
+    )
     if output_schema is not None:
         # Structured output: the child must return a value matching this schema (the
         # return tool enforces it; see workflow_completion). Reject a bad schema here —
-        # author-facing — rather than letting it explode when the child builds its
-        # validator. Require an *object* schema: a bare boolean (valid JSON Schema, but
-        # `false` rejects every value and `true` disables enforcement) is a degenerate
-        # author input, better surfaced as a bad call than a child that can never return.
+        # author-facing — rather than letting it brick the child when it applies the
+        # schema. Three author-facing failures: a non-object schema (a bare boolean is
+        # valid JSON Schema, but `false` rejects every value and `true` disables
+        # enforcement), a structurally-invalid schema, and one with an unresolvable
+        # reference (passes check_schema but raises at validation time).
         schema_error: str | None = None
         if not isinstance(output_schema, dict):
             schema_error = (
@@ -350,6 +398,12 @@ async def _open_agent_capability(
                 jsonschema.Draft202012Validator.check_schema(output_schema)
             except jsonschema.SchemaError as exc:
                 schema_error = f"output_schema is not a valid JSON Schema: {exc.message}"
+            else:
+                if (bad_ref := _unresolvable_ref(output_schema)) is not None:
+                    schema_error = (
+                        f"output_schema has an unresolvable reference {bad_ref!r} "
+                        "(references must resolve within the schema; remote refs are unsupported)"
+                    )
         if schema_error is not None:
             await _complete_run(
                 conn,

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -335,16 +335,26 @@ async def _open_agent_capability(
     output_schema = spec.get("output_schema")
     if output_schema is not None:
         # Structured output: the child must return a value matching this schema (the
-        # return tool enforces it; see workflow_completion). Reject a malformed schema
-        # here — author-facing — rather than letting it explode when the child builds
-        # its validator.
-        try:
-            jsonschema.Draft202012Validator.check_schema(output_schema)
-        except jsonschema.SchemaError as exc:
+        # return tool enforces it; see workflow_completion). Reject a bad schema here —
+        # author-facing — rather than letting it explode when the child builds its
+        # validator. Require an *object* schema: a bare boolean (valid JSON Schema, but
+        # `false` rejects every value and `true` disables enforcement) is a degenerate
+        # author input, better surfaced as a bad call than a child that can never return.
+        schema_error: str | None = None
+        if not isinstance(output_schema, dict):
+            schema_error = (
+                f"output_schema must be a JSON object schema, got {type(output_schema).__name__}"
+            )
+        else:
+            try:
+                jsonschema.Draft202012Validator.check_schema(output_schema)
+            except jsonschema.SchemaError as exc:
+                schema_error = f"output_schema is not a valid JSON Schema: {exc.message}"
+        if schema_error is not None:
             await _complete_run(
                 conn,
                 run,
-                output=f"agent() output_schema is not a valid JSON Schema: {exc.message}",
+                output=f"agent() {schema_error}",
                 is_error=True,
                 error_kind="bad_agent_call",
             )

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -32,6 +32,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, NamedTuple
 
 import asyncpg
+import jsonschema  # type: ignore[import-untyped]
 
 from aios.config import get_settings
 from aios.db import queries as db_queries
@@ -331,15 +332,23 @@ async def _open_agent_capability(
     """
     account_id = run.account_id
     spec = cap.spec if isinstance(cap.spec, dict) else {}
-    if spec.get("output_schema") is not None:
-        await _complete_run(
-            conn,
-            run,
-            output="agent() output_schema is not supported in v1 (lands in Block 3)",
-            is_error=True,
-            error_kind="not_implemented",
-        )
-        return _SpawnResult(rejected=True, needs_rewake=False)
+    output_schema = spec.get("output_schema")
+    if output_schema is not None:
+        # Structured output: the child must return a value matching this schema (the
+        # return tool enforces it; see workflow_completion). Reject a malformed schema
+        # here — author-facing — rather than letting it explode when the child builds
+        # its validator.
+        try:
+            jsonschema.Draft202012Validator.check_schema(output_schema)
+        except jsonschema.SchemaError as exc:
+            await _complete_run(
+                conn,
+                run,
+                output=f"agent() output_schema is not a valid JSON Schema: {exc.message}",
+                is_error=True,
+                error_kind="bad_agent_call",
+            )
+            return _SpawnResult(rejected=True, needs_rewake=False)
     agent_id = spec.get("agent_id")
     if not isinstance(agent_id, str):
         await _complete_run(
@@ -374,6 +383,7 @@ async def _open_agent_capability(
         parent_run_id=run.id,
         request_id=cap.call_key,  # the agent() call IS the request the child must answer
         input=spec.get("input"),
+        output_schema=output_schema,
     )
     # On replay the row already carries its first-spawn version — journal THAT, so
     # call_started.child_agent_version always matches the version the child runs under.
@@ -396,17 +406,20 @@ async def _open_agent_capability(
             )
             is not None
         )
+    cap_payload: dict[str, Any] = {
+        "capability": "agent",
+        "child_session_id": child_id,
+        "child_agent_version": child_version,
+    }
+    if output_schema is not None:
+        cap_payload["output_schema"] = output_schema  # audit: the shape this call demanded
     await wf_queries.append_run_event(
         conn,
         account_id=account_id,
         run_id=run.id,
         type="call_started",
         call_key=cap.call_key,
-        payload={
-            "capability": "agent",
-            "child_session_id": child_id,
-            "child_agent_version": child_version,
-        },
+        payload=cap_payload,
     )
     # Prompt wake of the child ONLY on first spawn. On a re-attach the child is
     # already sweep-wakeable via its own first user message (delivered with the

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -42,7 +42,7 @@ from aios.workflows._protocol import (
     read_frame_sync,
     write_frame_sync,
 )
-from aios.workflows.determinism import CallKeyer
+from aios.workflows.determinism import CallKeyer, canonical_schema_json
 
 
 class WorkflowScriptError(Exception):
@@ -138,8 +138,19 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
     """
     if input is None:
         raise ValueError("agent() requires a non-None input (the child's first message)")
+    # Carry output_schema as a canonical JSON *string* so a schema's decimal numeric
+    # constraints (minimum/multipleOf/…) survive the call_key hash — canonical_json (the
+    # spec serializer) bans floats in the data domain; a schema is metadata. The worker
+    # reconstructs the dict with json.loads. None stays None (no schema demanded).
     return _Capability(
-        "agent", {"agent_id": agent_id, "input": input, "output_schema": output_schema}
+        "agent",
+        {
+            "agent_id": agent_id,
+            "input": input,
+            "output_schema": None
+            if output_schema is None
+            else canonical_schema_json(output_schema),
+        },
     )
 
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -104,7 +104,13 @@ async def wf_agent_id(wf_runtime: asyncpg.Pool[Any]) -> str:
     return agent.id
 
 
-async def _spawn_child(pool: asyncpg.Pool[Any], agent_id: str, ordinal: str) -> tuple[str, str]:
+async def _spawn_child(
+    pool: asyncpg.Pool[Any],
+    agent_id: str,
+    ordinal: str,
+    *,
+    output_schema: dict[str, Any] | None = None,
+) -> tuple[str, str]:
     """Make a run + idempotently spawn one child for ``ordinal``; return (run_id, cid)."""
     run_id = await _make_run(pool, "async def main(input):\n    return 1")
     cid = child_session_id(run_id, ordinal)
@@ -118,6 +124,7 @@ async def _spawn_child(pool: asyncpg.Pool[Any], agent_id: str, ordinal: str) -> 
         parent_run_id=run_id,
         request_id=ordinal,
         input="hi",
+        output_schema=output_schema,
     )
     return run_id, cid
 
@@ -1604,3 +1611,156 @@ async def test_service_resume_by_nonce_rejects_bad_nonce_and_cross_tenant(
         await wf_service.get_run(pool, run.id, account_id="acc_intruder")
     # The run is untouched — still suspended, resumable by its owner.
     assert (await wf_service.get_run(pool, run.id, account_id="acc_wf")).status == "suspended"
+
+
+# ─── B3 slice 2 — agent() structured output (output_schema) ───────────────────
+
+_OBJ_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+    "additionalProperties": False,
+}
+
+
+async def test_get_request_output_schema_is_per_request(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The schema is keyed by request_id: a child owing several requests with
+    different schemas resolves each independently (unknown id / schema-less → None).
+    The workflow path is 1:1 today, but the query is per-request by design."""
+    pool = wf_runtime
+    schema_b = {"type": "number"}
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "req:a", output_schema=_OBJ_SCHEMA)
+    async with pool.acquire() as conn:
+        for rid, schema in (("req:b", schema_b), ("req:none", None)):
+            request: dict[str, Any] = {"request_id": rid, "caller": {"kind": "run", "id": run_id}}
+            if schema is not None:
+                request["output_schema"] = schema
+            await db_queries.append_event(
+                conn,
+                account_id="acc_wf",
+                session_id=cid,
+                kind="message",
+                data={"role": "user", "content": "x", "metadata": {"request": request}},
+            )
+        get = db_queries.get_request_output_schema
+        assert await get(conn, cid, account_id="acc_wf", request_id="req:a") == _OBJ_SCHEMA
+        assert await get(conn, cid, account_id="acc_wf", request_id="req:b") == schema_b
+        assert await get(conn, cid, account_id="acc_wf", request_id="req:none") is None
+        assert await get(conn, cid, account_id="acc_wf", request_id="req:nope") is None
+
+
+async def test_return_enforces_output_schema(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A non-conforming value bounces back as a tool error with NO response written
+    (the request stays open for the child to retry); a conforming value is answered."""
+    from aios.tools import workflow_completion
+    from aios.tools.registry import ToolResult
+
+    pool = wf_runtime
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "se:1", output_schema=_OBJ_SCHEMA)
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
+        bad = await workflow_completion.return_handler(
+            cid,
+            {"request_id": "se:1", "value": {"answer": 42}},  # answer must be a string
+        )
+    assert isinstance(bad, ToolResult) and bad.is_error and "schema" in bad.content.lower()
+    wake.assert_not_awaited()  # nothing answered → caller not woken
+    async with pool.acquire() as conn:
+        assert (
+            await db_queries.read_request_response(
+                conn, cid, account_id="acc_wf", request_id="se:1"
+            )
+            is None  # request stays open for a retry
+        )
+
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
+        good = await workflow_completion.return_handler(
+            cid, {"request_id": "se:1", "value": {"answer": "yes"}}
+        )
+    assert good == {"status": "returned"}
+    wake.assert_awaited_once_with(run_id)
+    async with pool.acquire() as conn:
+        resp = await db_queries.read_request_response(
+            conn, cid, account_id="acc_wf", request_id="se:1"
+        )
+    assert resp is not None and resp["result"] == {"answer": "yes"}
+
+
+async def test_malformed_output_schema_errors_the_run(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A malformed output_schema fails the run cleanly (author-facing bad_agent_call)
+    and never spawns a child."""
+    pool = wf_runtime
+    bad_schema = {"type": "not-a-real-type"}
+    script = (
+        f"async def main(input):\n"
+        f"    return await agent({wf_agent_id!r}, 'hi', output_schema={bad_schema!r})\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert run is not None and run.status == "errored"
+    completed = [e for e in events if e.type == "run_completed"]
+    assert completed and completed[0].payload["error"]["kind"] == "bad_agent_call"
+    assert children == 0  # rejected before any spawn
+
+
+async def test_agent_output_schema_end_to_end(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """Full slice: the spawn carries the schema (request metadata + call_started
+    audit), the child must return a conforming value (a bad one is rejected with no
+    response), and the run harvests the validated value as the agent() result."""
+    from aios.tools import workflow_completion
+    from aios.tools.registry import ToolResult
+
+    pool = wf_runtime
+    script = (
+        f"async def main(input):\n"
+        f"    return await agent({wf_agent_id!r}, 'task', output_schema={_OBJ_SCHEMA!r})\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "suspended"
+    started = next(e for e in events if e.type == "call_started")
+    request_id = started.call_key
+    child_id = started.payload["child_session_id"]
+    assert started.payload["output_schema"] == _OBJ_SCHEMA  # journaled for audit
+    assert request_id is not None
+
+    # The request message carries the schema (for both the model and the validator).
+    async with pool.acquire() as conn:
+        seen = await db_queries.get_request_output_schema(
+            conn, child_id, account_id="acc_wf", request_id=request_id
+        )
+    assert seen == _OBJ_SCHEMA
+
+    # The child must conform: a bad value is rejected, a good one answers.
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        rejected = await workflow_completion.return_handler(
+            child_id, {"request_id": request_id, "value": {"answer": 7}}
+        )
+        assert isinstance(rejected, ToolResult) and rejected.is_error
+        ok = await workflow_completion.return_handler(
+            child_id, {"request_id": request_id, "value": {"answer": "done"}}
+        )
+    assert ok == {"status": "returned"}
+
+    await run_workflow_step(run_id)  # harvest → complete
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == {"answer": "done"}

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1786,3 +1786,94 @@ async def test_agent_output_schema_end_to_end(
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "completed"
     assert run.output == {"answer": "done"}
+
+
+async def test_float_bearing_output_schema_spawns_and_enforces(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A schema with a decimal numeric constraint (a legitimate, common JSON Schema)
+    must NOT crash the run at call_key time: output_schema is canonicalized as a string
+    so the determinism float-ban (which guards input DATA) doesn't reject it. The floats
+    survive the round-trip and enforcement honors them."""
+    from aios.tools import workflow_completion
+    from aios.tools.registry import ToolResult
+
+    pool = wf_runtime
+    schema = {"type": "number", "minimum": 1.5, "maximum": 9.5}
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'pick', output_schema={schema!r})\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "suspended"  # spawned, not crashed on the float
+    started = next(e for e in events if e.type == "call_started")
+    child_id = started.payload["child_session_id"]
+    assert started.payload["output_schema"] == schema  # floats intact in the audit stamp
+    assert started.call_key is not None
+
+    async with pool.acquire() as conn:
+        seen = await db_queries.get_request_output_schema(
+            conn, child_id, request_id=started.call_key
+        )
+    assert seen == schema  # floats survive the request round-trip
+
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        bad = await workflow_completion.return_handler(
+            child_id,
+            {"request_id": started.call_key, "value": 0.5},  # below minimum
+        )
+        assert isinstance(bad, ToolResult) and bad.is_error
+        ok = await workflow_completion.return_handler(
+            child_id, {"request_id": started.call_key, "value": 5.0}
+        )
+    assert ok == {"status": "returned"}
+
+
+async def test_valid_local_ref_output_schema_spawns(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A self-contained schema using ``$ref`` into ``$defs`` is valid and must spawn —
+    the unresolvable-ref gate rejects only refs that DON'T resolve, not all refs."""
+    pool = wf_runtime
+    schema = {
+        "$defs": {"Name": {"type": "string"}},
+        "type": "object",
+        "properties": {"name": {"$ref": "#/$defs/Name"}},
+        "required": ["name"],
+    }
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'x', output_schema={schema!r})\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert run is not None and run.status == "suspended"  # valid local $ref → spawned
+    assert children == 1
+
+
+async def test_dangling_ref_output_schema_errors_the_run(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A schema whose ``$ref`` doesn't resolve passes check_schema but would raise at
+    the child's validation time (bricking it until the deadline). Reject it
+    author-facing at the spawn gate, before any child spawns."""
+    pool = wf_runtime
+    schema = {"type": "object", "properties": {"a": {"$ref": "#/$defs/missing"}}, "required": ["a"]}
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'x', output_schema={schema!r})\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert run is not None and run.status == "errored"
+    completed = [e for e in events if e.type == "run_completed"]
+    assert completed and completed[0].payload["error"]["kind"] == "bad_agent_call"
+    assert "reference" in completed[0].payload["output"].lower()
+    assert children == 0  # rejected before any spawn

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1645,10 +1645,10 @@ async def test_get_request_output_schema_is_per_request(
                 data={"role": "user", "content": "x", "metadata": {"request": request}},
             )
         get = db_queries.get_request_output_schema
-        assert await get(conn, cid, account_id="acc_wf", request_id="req:a") == _OBJ_SCHEMA
-        assert await get(conn, cid, account_id="acc_wf", request_id="req:b") == schema_b
-        assert await get(conn, cid, account_id="acc_wf", request_id="req:none") is None
-        assert await get(conn, cid, account_id="acc_wf", request_id="req:nope") is None
+        assert await get(conn, cid, request_id="req:a") == _OBJ_SCHEMA
+        assert await get(conn, cid, request_id="req:b") == schema_b
+        assert await get(conn, cid, request_id="req:none") is None
+        assert await get(conn, cid, request_id="req:nope") is None
 
 
 async def test_return_enforces_output_schema(
@@ -1714,6 +1714,30 @@ async def test_malformed_output_schema_errors_the_run(
     assert children == 0  # rejected before any spawn
 
 
+async def test_non_object_output_schema_errors_the_run(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A non-object output_schema (a bare boolean — valid JSON Schema, but ``false``
+    rejects every value and ``true`` disables enforcement) is a degenerate author input:
+    fail the run cleanly as bad_agent_call rather than spawn a child that can never
+    return (or one with no enforcement)."""
+    pool = wf_runtime
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi', output_schema=False)\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert run is not None and run.status == "errored"
+    completed = [e for e in events if e.type == "run_completed"]
+    assert completed and completed[0].payload["error"]["kind"] == "bad_agent_call"
+    assert "object schema" in completed[0].payload["output"]
+    assert children == 0  # rejected before any spawn
+
+
 async def test_agent_output_schema_end_to_end(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
@@ -1743,9 +1767,7 @@ async def test_agent_output_schema_end_to_end(
 
     # The request message carries the schema (for both the model and the validator).
     async with pool.acquire() as conn:
-        seen = await db_queries.get_request_output_schema(
-            conn, child_id, account_id="acc_wf", request_id=request_id
-        )
+        seen = await db_queries.get_request_output_schema(conn, child_id, request_id=request_id)
     assert seen == _OBJ_SCHEMA
 
     # The child must conform: a bad value is rejected, a good one answers.

--- a/tests/unit/test_workflow_output_schema.py
+++ b/tests/unit/test_workflow_output_schema.py
@@ -8,8 +8,14 @@ context builder renders into the child's request message.
 
 from __future__ import annotations
 
+import math
+
+import pytest
+
 from aios.harness.context import render_user_event
 from aios.tools.workflow_completion import _validate_value
+from aios.workflows.determinism import canonical_schema_json
+from aios.workflows.step import _unresolvable_ref
 
 _SCHEMA = {
     "type": "object",
@@ -55,3 +61,35 @@ def test_render_without_schema_is_unchanged() -> None:
     msg = render_user_event(event, None, None)
     assert "request_id: r1" in msg["content"]
     assert "JSON Schema" not in msg["content"]
+
+
+def test_canonical_schema_json_admits_floats_deterministically() -> None:
+    # A schema's decimal numeric constraints (which canonical_json bans for data) are
+    # admitted here and serialized stably + key-order-independent.
+    a = canonical_schema_json({"type": "number", "minimum": 1.5, "maximum": 9.9})
+    b = canonical_schema_json({"maximum": 9.9, "minimum": 1.5, "type": "number"})
+    assert a == b  # sort_keys → key order irrelevant
+    assert "1.5" in a and "9.9" in a
+    # NaN/Inf stay rejected (genuinely non-deterministic).
+    with pytest.raises(ValueError):
+        canonical_schema_json({"const": math.inf})
+
+
+def test_unresolvable_ref_accepts_valid_rejects_broken() -> None:
+    # No refs / valid self-contained local ref → resolves → None.
+    assert _unresolvable_ref({"type": "object", "properties": {"a": {"type": "number"}}}) is None
+    assert (
+        _unresolvable_ref(
+            {
+                "$defs": {"N": {"type": "string"}},
+                "properties": {"a": {"$ref": "#/$defs/N"}},
+            }
+        )
+        is None
+    )
+    # Dangling local ref, remote ref, dangling $dynamicRef → the offending ref.
+    assert (
+        _unresolvable_ref({"properties": {"a": {"$ref": "#/$defs/missing"}}}) == "#/$defs/missing"
+    )
+    assert _unresolvable_ref({"$ref": "https://example.com/s.json"}) == "https://example.com/s.json"
+    assert _unresolvable_ref({"properties": {"a": {"$dynamicRef": "#nope"}}}) == "#nope"

--- a/tests/unit/test_workflow_output_schema.py
+++ b/tests/unit/test_workflow_output_schema.py
@@ -1,0 +1,57 @@
+"""Unit tests for agent() structured output: value validation + prompt guidance.
+
+The runtime pieces (storage, the per-request DB read, the end-to-end spawn→return
+flow) are covered in tests/integration/test_wf_step.py. These cover the two pure
+functions: the ``return`` value validator and the per-request schema guidance the
+context builder renders into the child's request message.
+"""
+
+from __future__ import annotations
+
+from aios.harness.context import render_user_event
+from aios.tools.workflow_completion import _validate_value
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"answer": {"type": "string"}},
+    "required": ["answer"],
+    "additionalProperties": False,
+}
+
+
+def test_validate_value_accepts_conforming() -> None:
+    assert _validate_value({"answer": "hi"}, _SCHEMA) is None
+
+
+def test_validate_value_rejects_with_path_and_retry_hint() -> None:
+    err = _validate_value({"answer": 1}, _SCHEMA)
+    assert err is not None
+    assert "value.answer" in err  # the failing path, scoped under `value`
+    assert "call return again" in err  # the model is told to retry
+    # A bare-scalar schema is honored too (output_schema replaces `value` wholesale).
+    assert _validate_value("hi", {"type": "number"}) is not None
+    assert _validate_value(3, {"type": "number"}) is None
+
+
+def test_render_surfaces_request_schema_per_request() -> None:
+    event = {
+        "role": "user",
+        "content": "do the thing",
+        "metadata": {"request": {"request_id": "r1", "output_schema": _SCHEMA}},
+    }
+    msg = render_user_event(event, None, None)
+    assert "request_id: r1" in msg["content"]
+    assert "must match this JSON Schema" in msg["content"]
+    assert '"answer"' in msg["content"]  # the schema itself is rendered
+    assert "do the thing" in msg["content"]  # original content preserved
+
+
+def test_render_without_schema_is_unchanged() -> None:
+    event = {
+        "role": "user",
+        "content": "hi",
+        "metadata": {"request": {"request_id": "r1"}},
+    }
+    msg = render_user_event(event, None, None)
+    assert "request_id: r1" in msg["content"]
+    assert "JSON Schema" not in msg["content"]


### PR DESCRIPTION
Block 3 (slice 2): unblock `agent(agent_id, input, output_schema=...)`, which the runtime previously rejected with `not_implemented` ("lands in Block 3"). A workflow author can now demand that a child agent return a value matching a JSON Schema, and `agent(...)` returns a guaranteed-conforming value — the dual of input, and what makes structured data flow reliably through a `pipeline()`/`parallel()`.

## The design

The schema is a property of the **request**, not the session or the tool — the `return` tool is `request_id`-keyed because a child can owe multiple open requests, so a single per-step tool can't carry one `value` schema.

- **Storage** — `create_child_session` stamps `metadata.request.output_schema`; `get_request_output_schema` reads it back, keyed by `request_id` (oldest-first, mirroring `get_open_request_ids`).
- **Enforcement** — `return_handler` validates `value` against *the answered request's* schema and bounces a non-conforming one back as a tool error (a `ToolResult` sentinel), so the child retries in its own session loop. The workflow only ever harvests a schema-valid value; **no new retry machinery**, and determinism is intact (the child's retries are tool errors in the *child's* log, never journaled to `wf_run_events`).
- **Guidance** — `render_user_event` surfaces each request's schema in its own prompt so the model conforms first-try. The generic `return` tool is unchanged.
- **Spawn gate** — a malformed / non-object / unresolvable-`$ref` schema fails author-facing (`bad_agent_call`) before any child spawns.

Enforcement lives in `return_handler`, not the injected tool schema, because dispatch validates against the static module-registry schema (`invoke_builtin`), not the per-step spec the model sees — a constrained tool spec would only *guide*, never *enforce*.

## Commits

1. **feat** — the feature (storage + enforcement + guidance + spawn unblock).
2. **refactor** — `/simplify` + `/code-review` pass: drop a redundant `get_session_workflow_context` lookup on the return path; reject a non-object schema (a bare boolean is valid JSON Schema but `false` bricks the child and `true` disables enforcement); deterministic `ORDER BY` on the schema lookup.
3. **fix** — two schema edge cases caught in review and fixed test-first:
   - **Decimal constraints** (`minimum: 1.5`, `multipleOf: 0.1`) crashed the run at call_key time — `output_schema` rode the spec through `canonical_json`, which bans floats in the *data* domain (`1.0` vs `1` would desync the hash). `agent()` now carries the schema as a canonical JSON string (`canonical_schema_json`) so its float literals — which serialize deterministically — never reach `canonical_json`; the worker reconstructs the dict. The input-data float ban is untouched.
   - **Unresolvable `$ref`** (dangling or remote) passed `check_schema` but raised when the child applied the schema, bricking it until the deadline. The spawn gate now rejects it author-facing; valid self-contained local refs (`#/$defs/…`) still resolve and spawn.

## Validation

- mypy · ruff · **1787 unit** · **100 wf integration + e2e** — all green. No API surface touched (no codegen).
- **Live smoke** over the real CLI + a real Sonnet child: a workflow demanding `{name, age}` produced a typed result (`age` an integer) harvested as the `agent()` value; the malformed-schema path errored cleanly with no child spawned. The child conformed first-try even when baited to add a forbidden field (the prompt guidance working).
- The float and `$ref` fixes were verified empirically (red) then driven green via TDD, exercising the **real host subprocess** (call_key/spawn machinery), not mocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)