### PR TITLE
feat(workflows): foreground protection — demote background work via job priority

### DIFF
--- a/src/aios/services/wake.py
+++ b/src/aios/services/wake.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from procrastinate import exceptions as procrastinate_exceptions
 from procrastinate.types import JSONValue
 
+from aios.db import queries
 from aios.logging import get_logger
 from aios.services import sessions as sessions_service
 
@@ -19,6 +20,14 @@ if TYPE_CHECKING:
     import asyncpg
 
 log = get_logger("aios.services.wake")
+
+# Foreground protection: procrastinate fetches todo jobs in (priority DESC, id ASC)
+# order, so a negative priority makes a job yield to higher-priority ones. Background
+# workflow work — agent() children + run steps — is demoted below user-facing
+# (foreground) sessions so a workflow's fan-out can't starve a user's message.
+# Foreground stays at the procrastinate default; only background is demoted.
+_FOREGROUND_PRIORITY = 0
+_BACKGROUND_PRIORITY = -10
 
 
 async def defer_wake(
@@ -48,6 +57,18 @@ async def defer_wake(
     """
     from aios.harness.procrastinate_app import app
 
+    # Foreground protection: a workflow agent() child yields to user-facing sessions so a
+    # fan-out can't starve a user's message. The signal is a non-null parent_run_id — set
+    # (together with origin='background') only by create_child_session — read here from the
+    # session's immutable row, so every wake of the child (first spawn, each tool-completion,
+    # the sweep) is demoted uniformly at this single chokepoint, with no caller plumbing. A
+    # missing row (deleted-session race) → foreground default; the wake then no-ops harmlessly.
+    # Resolved before the span/enqueue so it isn't a new failure point between them.
+    async with pool.acquire() as conn:
+        ctx = await queries.get_session_workflow_context(conn, session_id)
+    parent_run_id = ctx[1] if ctx is not None else None  # (account_id, parent_run_id) | None
+    priority = _BACKGROUND_PRIORITY if parent_run_id is not None else _FOREGROUND_PRIORITY
+
     span_data: dict[str, Any] = {"event": "wake_deferred", "cause": cause}
     if delay_seconds is not None:
         span_data["delay_seconds"] = delay_seconds
@@ -60,6 +81,7 @@ async def defer_wake(
             "harness.wake_session",
             lock=session_id,
             queueing_lock=session_id,
+            priority=priority,
             schedule_in={"seconds": delay_seconds},
         )
     else:
@@ -67,6 +89,7 @@ async def defer_wake(
             "harness.wake_session",
             lock=session_id,
             queueing_lock=session_id,
+            priority=priority,
         )
 
     try:
@@ -93,6 +116,7 @@ async def defer_run_wake(run_id: str) -> None:
         "harness.wake_workflow",
         lock=run_id,
         queueing_lock=run_id,
+        priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
     )
     try:
         await deferrer.defer_async(run_id=run_id)

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1877,3 +1877,36 @@ async def test_dangling_ref_output_schema_errors_the_run(
     assert completed and completed[0].payload["error"]["kind"] == "bad_agent_call"
     assert "reference" in completed[0].payload["output"].lower()
     assert children == 0  # rejected before any spawn
+
+
+async def test_defer_wake_priority_reflects_real_origin(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """Foreground protection end-to-end: against real sessions, defer_wake demotes a
+    workflow background child's wake below a user-facing foreground session's, so a
+    fan-out can't starve a user's message. Validates the real origin lookup → priority
+    (the unit tests mock the lookup); the in-memory connector captures the priority."""
+    from procrastinate.testing import InMemoryConnector
+
+    from aios.harness.procrastinate_app import app
+    from aios.services.wake import _BACKGROUND_PRIORITY, _FOREGROUND_PRIORITY, defer_wake
+
+    pool = wf_runtime
+    fg = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )  # origin='foreground', no parent run
+    _run_id, cid = await _spawn_child(pool, wf_agent_id, "prio:1")  # origin='background'
+
+    with app.replace_connector(InMemoryConnector()) as patched:
+        await defer_wake(pool, fg.id, account_id="acc_wf", cause="message")
+        await defer_wake(pool, cid, account_id="acc_wf", cause="message")
+        priorities = {
+            j["args"]["session_id"]: j["priority"] for j in patched.connector.jobs.values()
+        }
+    assert priorities[fg.id] == _FOREGROUND_PRIORITY  # real foreground → default
+    assert priorities[cid] == _BACKGROUND_PRIORITY  # real background child → demoted

--- a/tests/unit/test_wake_priority.py
+++ b/tests/unit/test_wake_priority.py
@@ -1,0 +1,100 @@
+"""Foreground protection: background workflow work is demoted below foreground.
+
+``defer_wake`` derives a procrastinate job ``priority`` from the woken session's
+origin (a workflow ``agent()`` child carries a ``parent_run_id``), so a fan-out of
+background children can't starve a user's message. ``defer_run_wake`` is always
+background. Procrastinate (and the in-memory connector) fetch todo jobs in
+``(priority DESC, id ASC)`` order, so a higher priority is served first.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from procrastinate import App
+from procrastinate.testing import InMemoryConnector
+
+from aios.services.wake import (
+    _BACKGROUND_PRIORITY,
+    _FOREGROUND_PRIORITY,
+    defer_run_wake,
+    defer_wake,
+)
+
+
+def _jobs_by_session(app: App) -> dict[str, int]:
+    connector = app.connector
+    assert isinstance(connector, InMemoryConnector)
+    return {j["args"]["session_id"]: j["priority"] for j in connector.jobs.values()}
+
+
+def _ctx(parent_run_id: str | None) -> tuple[str, str | None]:
+    """A ``get_session_workflow_context`` result: ``(account_id, parent_run_id)``."""
+    return ("acc", parent_run_id)
+
+
+@pytest.mark.parametrize(
+    "ctx_return, expected",
+    [
+        pytest.param(_ctx("wfr_1"), _BACKGROUND_PRIORITY, id="background_child"),
+        pytest.param(_ctx(None), _FOREGROUND_PRIORITY, id="foreground"),
+        pytest.param(None, _FOREGROUND_PRIORITY, id="missing_session_race"),
+    ],
+)
+async def test_defer_wake_priority_by_origin(
+    in_memory_app: App, ctx_return: tuple[str, str | None] | None, expected: int
+) -> None:
+    """The woken session's origin sets the priority: a workflow child (non-null
+    parent_run_id) is demoted; a foreground session — or a vanished one — stays default."""
+    pool = MagicMock()
+    with (
+        patch("aios.services.wake.sessions_service.append_event", AsyncMock()),
+        patch(
+            "aios.services.wake.queries.get_session_workflow_context",
+            AsyncMock(return_value=ctx_return),
+        ),
+    ):
+        await defer_wake(pool, "sess_x", cause="message", account_id="acc")
+    assert _jobs_by_session(in_memory_app)["sess_x"] == expected
+
+
+async def test_delayed_background_wake_is_also_demoted(in_memory_app: App) -> None:
+    """The reschedule-backoff path (``delay_seconds``) carries the priority too."""
+    pool = MagicMock()
+    with (
+        patch("aios.services.wake.sessions_service.append_event", AsyncMock()),
+        patch(
+            "aios.services.wake.queries.get_session_workflow_context",
+            AsyncMock(return_value=_ctx("wfr_2")),
+        ),
+    ):
+        await defer_wake(pool, "sess_bg2", cause="reschedule", delay_seconds=2, account_id="acc")
+    assert _jobs_by_session(in_memory_app)["sess_bg2"] == _BACKGROUND_PRIORITY
+
+
+async def test_run_wake_is_background(in_memory_app: App) -> None:
+    await defer_run_wake("wfr_x")
+    connector = in_memory_app.connector
+    assert isinstance(connector, InMemoryConnector)
+    rows = list(connector.jobs.values())
+    assert len(rows) == 1 and rows[0]["priority"] == _BACKGROUND_PRIORITY
+
+
+async def test_foreground_outranks_background(in_memory_app: App) -> None:
+    """The end goal: a foreground wake is fetched before a queued background wake."""
+    pool = MagicMock()
+    with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
+        with patch(
+            "aios.services.wake.queries.get_session_workflow_context",
+            AsyncMock(return_value=_ctx("wfr_3")),
+        ):
+            await defer_wake(pool, "sess_bg", cause="message", account_id="acc")  # enqueued first
+        with patch(
+            "aios.services.wake.queries.get_session_workflow_context",
+            AsyncMock(return_value=_ctx(None)),
+        ):
+            await defer_wake(pool, "sess_fg", cause="message", account_id="acc")  # enqueued later
+    priorities = _jobs_by_session(in_memory_app)
+    # Foreground enqueued *after* background but outranks it on (priority DESC, id ASC).
+    assert priorities["sess_fg"] > priorities["sess_bg"]


### PR DESCRIPTION
Block 3 (slice 3). A workflow's `agent()` children are spawned as `origin='background'` sessions whose steps are woken through the **same** `defer_wake` → `wake_session` task in the **same `"sessions"` procrastinate queue** as user-facing foreground sessions, sharing one `worker_concurrency` pool (procrastinate 3.8.1 has no per-queue concurrency). So a fan-out of N children floods the queue with N background wake jobs and a user's message waits behind them. `origin` existed but had zero scheduling awareness.

## The change

`defer_wake` derives a procrastinate job `priority` from the woken session's **immutable origin** at the single chokepoint all session wakes funnel through:
- a workflow `agent()` child (non-null `parent_run_id`, reusing the existing `get_session_workflow_context`) → demoted to `-10`;
- a foreground session → the procrastinate default `0` (unchanged).
- `defer_run_wake` (workflow run steps) → always `-10`.

Procrastinate fetches todo jobs `(priority DESC, id ASC)`, so a user's message always outranks a queued fan-out — **no new queue, no second worker loop, no caller plumbing**. Deriving it from the immutable origin means a child's first wake, its tool-completion wakes, and its sweep wakes are all demoted uniformly. The priority is resolved *before* the span/enqueue so it isn't a new failure point between them; a deleted-session race defaults to foreground.

## Scope

**Soft priority only** (chosen with the team over hard reserved lanes / admission budgets). Background runs on spare capacity and stays durable (the 30s sweep re-wakes it). Accepted, documented gaps inherent to soft priority: no slot reservation (an in-flight background step holds its slot until it finishes), and under *sustained* foreground saturation background is best-effort-delayed — never dropped. The agent wall-clock deadline + sweep backstop keep workflow correctness regardless.

## Validation

- mypy · ruff · 1781 unit · 15 wake integration — all green. No API surface touched (no codegen).
- 6 unit tests (`test_wake_priority.py`, in-memory connector + mocked lookup: background demoted, foreground default, missing-session→foreground, delayed path, run-wake, and `fg > bg` ordering) + 1 integration (`test_wf_step.py`: real foreground session vs real background child → correct real-origin→priority).
- Went through `/simplify` (named `parent_run_id`, parametrized tests) and `/code-review --fix` (xhigh: no correctness bug; one reorder so the priority read isn't a failure point between the span and the enqueue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)