### PR TITLE
feat(sessions): archive-on-quiescence — a self-reclaiming session launch flag

### DIFF
--- a/migrations/versions/0070_archive_when_idle.py
+++ b/migrations/versions/0070_archive_when_idle.py
@@ -1,0 +1,39 @@
+"""Archive-on-quiescence: a launch-time flag to reclaim a session when it idles.
+
+``archive_when_idle`` is an immutable launch-time property of a session: when set,
+the harness soft-archives the session the first time it goes idle owing nothing
+(see ``reclaim_session_if_idle`` + ``loop._run_step``). Workflow ``agent()``
+children launch with it ``TRUE`` (they answer one request, then they're done);
+foreground/API and per-chat launches default to ``FALSE``. The same flag rides
+``session_templates`` so the per-chat resolver can copy it down to spawns.
+
+Both columns are ``NOT NULL DEFAULT false`` — existing rows keep today's
+"persist forever" behavior.
+
+Revision ID: 0070
+Revises: 0069
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0070"
+down_revision: str = "0069"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN archive_when_idle boolean NOT NULL DEFAULT false")
+    op.execute(
+        "ALTER TABLE session_templates "
+        "ADD COLUMN archive_when_idle boolean NOT NULL DEFAULT false"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS archive_when_idle")
+    op.execute("ALTER TABLE session_templates DROP COLUMN IF EXISTS archive_when_idle")

--- a/openapi.json
+++ b/openapi.json
@@ -12990,6 +12990,11 @@
             ],
             "title": "Parent Run Id"
           },
+          "archive_when_idle": {
+            "type": "boolean",
+            "title": "Archive When Idle",
+            "default": false
+          },
           "last_event_at": {
             "anyOf": [
               {
@@ -13090,6 +13095,12 @@
             "type": "array",
             "title": "Vault Ids",
             "description": "Vault ids to bind to this session for MCP credential resolution."
+          },
+          "archive_when_idle": {
+            "type": "boolean",
+            "title": "Archive When Idle",
+            "description": "When true, the session is soft-archived the first time it goes idle owing nothing \u2014 a self-reclaiming, one-shot session. Immutable after launch. Workflow agent() children launch with this set.",
+            "default": false
           },
           "workspace_path": {
             "anyOf": [
@@ -13233,6 +13244,11 @@
             "type": "object",
             "title": "Metadata"
           },
+          "archive_when_idle": {
+            "type": "boolean",
+            "title": "Archive When Idle",
+            "default": false
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -13318,6 +13334,12 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
+          },
+          "archive_when_idle": {
+            "type": "boolean",
+            "title": "Archive When Idle",
+            "description": "Copied down to every session this template spawns: when true, each spawned session self-archives the first time it goes idle.",
+            "default": false
           }
         },
         "additionalProperties": false,
@@ -13417,6 +13439,17 @@
               }
             ],
             "title": "Metadata"
+          },
+          "archive_when_idle": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archive When Idle"
           }
         },
         "additionalProperties": false,

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -58,6 +58,7 @@ class Session:
             focal_locked (bool | Unset):  Default: False.
             origin (SessionOrigin | Unset):  Default: SessionOrigin.FOREGROUND.
             parent_run_id (None | str | Unset):
+            archive_when_idle (bool | Unset):  Default: False.
             last_event_at (datetime.datetime | None | Unset):
             total_events (int | Unset):  Default: 0.
     """
@@ -85,6 +86,7 @@ class Session:
     focal_locked: bool | Unset = False
     origin: SessionOrigin | Unset = SessionOrigin.FOREGROUND
     parent_run_id: None | str | Unset = UNSET
+    archive_when_idle: bool | Unset = False
     last_event_at: datetime.datetime | None | Unset = UNSET
     total_events: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -181,6 +183,8 @@ class Session:
         else:
             parent_run_id = self.parent_run_id
 
+        archive_when_idle = self.archive_when_idle
+
         last_event_at: None | str | Unset
         if isinstance(self.last_event_at, Unset):
             last_event_at = UNSET
@@ -228,6 +232,8 @@ class Session:
             field_dict["origin"] = origin
         if parent_run_id is not UNSET:
             field_dict["parent_run_id"] = parent_run_id
+        if archive_when_idle is not UNSET:
+            field_dict["archive_when_idle"] = archive_when_idle
         if last_event_at is not UNSET:
             field_dict["last_event_at"] = last_event_at
         if total_events is not UNSET:
@@ -395,6 +401,8 @@ class Session:
 
         parent_run_id = _parse_parent_run_id(d.pop("parent_run_id", UNSET))
 
+        archive_when_idle = d.pop("archive_when_idle", UNSET)
+
         def _parse_last_event_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -436,6 +444,7 @@ class Session:
             focal_locked=focal_locked,
             origin=origin,
             parent_run_id=parent_run_id,
+            archive_when_idle=archive_when_idle,
             last_event_at=last_event_at,
             total_events=total_events,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
@@ -30,6 +30,9 @@ class SessionCreate:
         title (None | str | Unset):
         metadata (SessionCreateMetadata | Unset):
         vault_ids (list[str] | Unset): Vault ids to bind to this session for MCP credential resolution.
+        archive_when_idle (bool | Unset): When true, the session is soft-archived the first time it goes idle owing
+            nothing — a self-reclaiming, one-shot session. Immutable after launch. Workflow agent() children launch with
+            this set. Default: False.
         workspace_path (None | str | Unset): Absolute host path to use as the session workspace. If omitted, defaults to
             workspace_root/<account_id>/<session_id>. Must resolve within the account's workspace subdirectory. The
             directory must exist; aios will not create it.
@@ -54,6 +57,7 @@ class SessionCreate:
     title: None | str | Unset = UNSET
     metadata: SessionCreateMetadata | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
+    archive_when_idle: bool | Unset = False
     workspace_path: None | str | Unset = UNSET
     env: SessionCreateEnv | Unset = UNSET
     initial_message: None | str | Unset = UNSET
@@ -86,6 +90,8 @@ class SessionCreate:
         vault_ids: list[str] | Unset = UNSET
         if not isinstance(self.vault_ids, Unset):
             vault_ids = self.vault_ids
+
+        archive_when_idle = self.archive_when_idle
 
         workspace_path: None | str | Unset
         if isinstance(self.workspace_path, Unset):
@@ -138,6 +144,8 @@ class SessionCreate:
             field_dict["metadata"] = metadata
         if vault_ids is not UNSET:
             field_dict["vault_ids"] = vault_ids
+        if archive_when_idle is not UNSET:
+            field_dict["archive_when_idle"] = archive_when_idle
         if workspace_path is not UNSET:
             field_dict["workspace_path"] = workspace_path
         if env is not UNSET:
@@ -190,6 +198,8 @@ class SessionCreate:
             metadata = SessionCreateMetadata.from_dict(_metadata)
 
         vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
+
+        archive_when_idle = d.pop("archive_when_idle", UNSET)
 
         def _parse_workspace_path(data: object) -> None | str | Unset:
             if data is None:
@@ -261,6 +271,7 @@ class SessionCreate:
             title=title,
             metadata=metadata,
             vault_ids=vault_ids,
+            archive_when_idle=archive_when_idle,
             workspace_path=workspace_path,
             env=env,
             initial_message=initial_message,

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_template.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_template.py
@@ -32,6 +32,7 @@ class SessionTemplate:
         metadata (SessionTemplateMetadata):
         created_at (datetime.datetime):
         updated_at (datetime.datetime):
+        archive_when_idle (bool | Unset):  Default: False.
         archived_at (datetime.datetime | None | Unset):
     """
 
@@ -45,6 +46,7 @@ class SessionTemplate:
     metadata: SessionTemplateMetadata
     created_at: datetime.datetime
     updated_at: datetime.datetime
+    archive_when_idle: bool | Unset = False
     archived_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -70,6 +72,8 @@ class SessionTemplate:
 
         updated_at = self.updated_at.isoformat()
 
+        archive_when_idle = self.archive_when_idle
+
         archived_at: None | str | Unset
         if isinstance(self.archived_at, Unset):
             archived_at = UNSET
@@ -94,6 +98,8 @@ class SessionTemplate:
                 "updated_at": updated_at,
             }
         )
+        if archive_when_idle is not UNSET:
+            field_dict["archive_when_idle"] = archive_when_idle
         if archived_at is not UNSET:
             field_dict["archived_at"] = archived_at
 
@@ -129,6 +135,8 @@ class SessionTemplate:
 
         updated_at = isoparse(d.pop("updated_at"))
 
+        archive_when_idle = d.pop("archive_when_idle", UNSET)
+
         def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -157,6 +165,7 @@ class SessionTemplate:
             metadata=metadata,
             created_at=created_at,
             updated_at=updated_at,
+            archive_when_idle=archive_when_idle,
             archived_at=archived_at,
         )
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_template_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_template_create.py
@@ -27,6 +27,8 @@ class SessionTemplateCreate:
         vault_ids (list[str] | Unset):
         memory_store_ids (list[str] | Unset):
         metadata (SessionTemplateCreateMetadata | Unset):
+        archive_when_idle (bool | Unset): Copied down to every session this template spawns: when true, each spawned
+            session self-archives the first time it goes idle. Default: False.
     """
 
     name: str
@@ -36,6 +38,7 @@ class SessionTemplateCreate:
     vault_ids: list[str] | Unset = UNSET
     memory_store_ids: list[str] | Unset = UNSET
     metadata: SessionTemplateCreateMetadata | Unset = UNSET
+    archive_when_idle: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
@@ -62,6 +65,8 @@ class SessionTemplateCreate:
         if not isinstance(self.metadata, Unset):
             metadata = self.metadata.to_dict()
 
+        archive_when_idle = self.archive_when_idle
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -79,6 +84,8 @@ class SessionTemplateCreate:
             field_dict["memory_store_ids"] = memory_store_ids
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if archive_when_idle is not UNSET:
+            field_dict["archive_when_idle"] = archive_when_idle
 
         return field_dict
 
@@ -115,6 +122,8 @@ class SessionTemplateCreate:
         else:
             metadata = SessionTemplateCreateMetadata.from_dict(_metadata)
 
+        archive_when_idle = d.pop("archive_when_idle", UNSET)
+
         session_template_create = cls(
             name=name,
             agent_id=agent_id,
@@ -123,6 +132,7 @@ class SessionTemplateCreate:
             vault_ids=vault_ids,
             memory_store_ids=memory_store_ids,
             metadata=metadata,
+            archive_when_idle=archive_when_idle,
         )
 
         return session_template_create

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_template_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_template_update.py
@@ -31,6 +31,7 @@ class SessionTemplateUpdate:
             vault_ids (list[str] | None | Unset):
             memory_store_ids (list[str] | None | Unset):
             metadata (None | SessionTemplateUpdateMetadataType0 | Unset):
+            archive_when_idle (bool | None | Unset):
     """
 
     name: None | str | Unset = UNSET
@@ -40,6 +41,7 @@ class SessionTemplateUpdate:
     vault_ids: list[str] | None | Unset = UNSET
     memory_store_ids: list[str] | None | Unset = UNSET
     metadata: None | SessionTemplateUpdateMetadataType0 | Unset = UNSET
+    archive_when_idle: bool | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.session_template_update_metadata_type_0 import (
@@ -96,6 +98,12 @@ class SessionTemplateUpdate:
         else:
             metadata = self.metadata
 
+        archive_when_idle: bool | None | Unset
+        if isinstance(self.archive_when_idle, Unset):
+            archive_when_idle = UNSET
+        else:
+            archive_when_idle = self.archive_when_idle
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
@@ -113,6 +121,8 @@ class SessionTemplateUpdate:
             field_dict["memory_store_ids"] = memory_store_ids
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if archive_when_idle is not UNSET:
+            field_dict["archive_when_idle"] = archive_when_idle
 
         return field_dict
 
@@ -213,6 +223,15 @@ class SessionTemplateUpdate:
 
         metadata = _parse_metadata(d.pop("metadata", UNSET))
 
+        def _parse_archive_when_idle(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        archive_when_idle = _parse_archive_when_idle(d.pop("archive_when_idle", UNSET))
+
         session_template_update = cls(
             name=name,
             agent_id=agent_id,
@@ -221,6 +240,7 @@ class SessionTemplateUpdate:
             vault_ids=vault_ids,
             memory_store_ids=memory_store_ids,
             metadata=metadata,
+            archive_when_idle=archive_when_idle,
         )
 
         return session_template_update

--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -47,6 +47,7 @@ async def create(
         vault_ids=body.vault_ids,
         memory_store_ids=body.memory_store_ids,
         metadata=body.metadata,
+        archive_when_idle=body.archive_when_idle,
         account_id=account_id,
     )
 
@@ -98,6 +99,7 @@ async def update(
         vault_ids=body.vault_ids,
         memory_store_ids=body.memory_store_ids,
         metadata=body.metadata,
+        archive_when_idle=body.archive_when_idle,
         account_id=account_id,
     )
 

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -93,6 +93,7 @@ async def create(
         crypto_box=crypto_box,
         workspace_path=body.workspace_path,
         env=body.env or None,
+        archive_when_idle=body.archive_when_idle,
         account_id=account_id,
     )
     if body.initial_message is not None:

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -872,6 +872,7 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         # explicit-column reads that don't select them.
         origin=row.get("origin") or "foreground",
         parent_run_id=row.get("parent_run_id"),
+        archive_when_idle=bool(row.get("archive_when_idle")),
         # Present only when the query derives it (list_sessions); other callers
         # (single read, INSERT ... RETURNING) leave it None.
         last_event_at=row.get("last_event_at"),
@@ -903,6 +904,7 @@ async def insert_session(
     env: dict[str, str] | None = None,
     focal_channel: str | None = None,
     focal_locked: bool = False,
+    archive_when_idle: bool = False,
 ) -> Session:
     """Insert a fresh session row.
 
@@ -927,9 +929,9 @@ async def insert_session(
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 workspace_volume_path, env,
-                focal_channel, focal_locked, account_id
+                focal_channel, focal_locked, account_id, archive_when_idle
             )
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9, $10, $11)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9, $10, $11, $12)
             RETURNING *
             """,
             new_id,
@@ -943,6 +945,7 @@ async def insert_session(
             focal_channel,
             focal_locked,
             account_id,
+            archive_when_idle,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -983,10 +986,10 @@ async def insert_child_session(
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 workspace_volume_path, env, focal_channel, focal_locked,
-                account_id, parent_run_id, origin
+                account_id, parent_run_id, origin, archive_when_idle
             )
             VALUES ($1, $2, $3, $4, NULL, '{}'::jsonb, $5, '{}'::jsonb,
-                    NULL, FALSE, $6, $7, 'background')
+                    NULL, FALSE, $6, $7, 'background', TRUE)
             ON CONFLICT (id) DO NOTHING
             RETURNING *
             """,
@@ -1186,6 +1189,30 @@ async def derive_session_status(
         account_id,
     )
     return status or "idle"
+
+
+async def reclaim_session_if_idle(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> bool:
+    """Soft-archive the session **iff it is currently idle** — the archive-on-quiescence reclaim.
+
+    One conditional UPDATE reusing ``_SESSION_ACTIVE_EXPR`` (the same predicate every reader and
+    the sweep use): a stimulus arriving as the session idles flips the predicate to active → no
+    row matches → no-op, so a late user/tool message always wins over reclaim. Idempotent via
+    ``archived_at IS NULL``. Returns ``True`` iff this call archived the row.
+
+    The caller gates on the session's immutable ``archive_when_idle`` launch flag; this query
+    enforces the idle condition atomically and must be the **last** session write of the step
+    (no write may follow — ``append_event`` fences on ``archived_at IS NULL``).
+    """
+    row = await conn.fetchrow(
+        "UPDATE sessions SET archived_at = now(), updated_at = now() "
+        f"WHERE id = $1 AND account_id = $2 AND archived_at IS NULL AND NOT {_SESSION_ACTIVE_EXPR} "
+        "RETURNING id",
+        session_id,
+        account_id,
+    )
+    return row is not None
 
 
 async def write_response_if_absent(
@@ -5239,6 +5266,7 @@ def _row_to_session_template(row: asyncpg.Record) -> SessionTemplate:
         vault_ids=list(row["vault_ids"] or []),
         memory_store_ids=list(row["memory_store_ids"] or []),
         metadata=metadata,
+        archive_when_idle=row["archive_when_idle"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
@@ -5256,6 +5284,7 @@ async def insert_session_template(
     vault_ids: list[str],
     memory_store_ids: list[str],
     metadata: dict[str, Any],
+    archive_when_idle: bool = False,
 ) -> SessionTemplate:
     new_id = make_id(SESSION_TEMPLATE)
     try:
@@ -5263,8 +5292,8 @@ async def insert_session_template(
             """
             INSERT INTO session_templates
                 (id, name, agent_id, agent_version, environment_id,
-                 vault_ids, memory_store_ids, metadata, account_id)
-            VALUES ($1, $2, $3, $4, $5, $6::text[], $7::text[], $8::jsonb, $9)
+                 vault_ids, memory_store_ids, metadata, account_id, archive_when_idle)
+            VALUES ($1, $2, $3, $4, $5, $6::text[], $7::text[], $8::jsonb, $9, $10)
             RETURNING *
             """,
             new_id,
@@ -5276,6 +5305,7 @@ async def insert_session_template(
             memory_store_ids,
             json.dumps(metadata),
             account_id,
+            archive_when_idle,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -5329,6 +5359,7 @@ async def update_session_template(
     vault_ids: list[str] | None = None,
     memory_store_ids: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
+    archive_when_idle: bool | None = None,
 ) -> SessionTemplate:
     # Refuse updates to archived templates: the resolver's
     # ``_spawn_per_chat_session`` already drops inbounds that target an
@@ -5361,6 +5392,8 @@ async def update_session_template(
         fields.append(("memory_store_ids", memory_store_ids, "text[]"))
     if metadata is not None:
         fields.append(("metadata", metadata, "jsonb"))
+    if archive_when_idle is not None:
+        fields.append(("archive_when_idle", archive_when_idle, None))
     sets = _build_set_assignments(fields, args)
     if not sets:
         return await get_session_template(conn, template_id, account_id=account_id)

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -84,11 +84,15 @@ class _StepResult(NamedTuple):
       session so the model gets another turn (``defer_wake``).
     * ``autoerror_caller_run_id`` — the guard auto-errored a request past its budget;
       wake that caller run to harvest the ``no_return`` (``defer_run_wake``).
+    * ``archive_when_idle`` — the session was launched self-reclaiming; archive it
+      (iff still idle) as the LAST write of the step, after ``step_end`` and the wakes
+      (once archived, any further ``append_event`` hits the ``archived_at IS NULL`` fence).
     """
 
     retry_delay: float | None = None
     nudge_session: bool = False
     autoerror_caller_run_id: str | None = None
+    archive_when_idle: bool = False
 
 
 async def refresh_session_mount_state(
@@ -220,6 +224,19 @@ async def run_session_step(
         await defer_wake(pool, session_id, cause="request_nudge", account_id=account_id)
     if result.autoerror_caller_run_id is not None:
         await defer_run_wake(result.autoerror_caller_run_id)
+
+    # Archive-on-quiescence, performed LAST: a session launched ``archive_when_idle``
+    # self-archives the first time it goes idle. It runs after ``step_end`` and every
+    # wake span so it is the step's final session write — once archived, ``append_event``
+    # rejects writes (``archived_at IS NULL`` fence). ``reclaim_session_if_idle`` is
+    # conditional on still-idle, so a nudge or a user message that re-activated the
+    # session (its ``defer_wake`` span already appended just above) wins and the archive
+    # no-ops. Only the clean end-of-turn return sets the flag (error/reschedule paths
+    # leave it False), so a rescheduling session is never reclaimed out from under a retry.
+    if result.archive_when_idle and await sessions_service.reclaim_session_if_idle(
+        pool, session_id, account_id=account_id
+    ):
+        log.info("step.session_reclaimed", session_id=session_id, cause=cause)
 
 
 async def _run_session_step_body(
@@ -602,10 +619,14 @@ async def _run_session_step_body(
         pool, session_id, "turn_ended", "idle", "end_turn", account_id=account_id
     )
     log.info("step.turn_ended", session_id=session_id, cause=cause)
-    # Hand the quiescence guard's wakes to run_session_step to defer after step_end.
+    # Hand the quiescence guard's wakes — and the archive-on-quiescence reclaim — to
+    # run_session_step to perform AFTER step_end (the reclaim must be the step's last
+    # session write; see _StepResult.archive_when_idle). The flag is the session's
+    # immutable launch property, read once from the start-of-step ``session``.
     return _StepResult(
         nudge_session=nudged,
         autoerror_caller_run_id=autoerror_caller_run_id,
+        archive_when_idle=session.archive_when_idle,
     )
 
 

--- a/src/aios/models/session_templates.py
+++ b/src/aios/models/session_templates.py
@@ -38,6 +38,13 @@ class SessionTemplateCreate(BaseModel):
     vault_ids: list[str] = Field(default_factory=list)
     memory_store_ids: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    archive_when_idle: bool = Field(
+        default=False,
+        description=(
+            "Copied down to every session this template spawns: when true, each "
+            "spawned session self-archives the first time it goes idle."
+        ),
+    )
 
 
 class SessionTemplateUpdate(BaseModel):
@@ -56,6 +63,7 @@ class SessionTemplateUpdate(BaseModel):
     vault_ids: list[str] | None = None
     memory_store_ids: list[str] | None = None
     metadata: dict[str, Any] | None = None
+    archive_when_idle: bool | None = None
 
 
 class SessionTemplate(BaseModel):
@@ -69,6 +77,7 @@ class SessionTemplate(BaseModel):
     vault_ids: list[str]
     memory_store_ids: list[str]
     metadata: dict[str, Any]
+    archive_when_idle: bool = False
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -148,6 +148,14 @@ class SessionCreate(BaseModel):
         default_factory=list,
         description="Vault ids to bind to this session for MCP credential resolution.",
     )
+    archive_when_idle: bool = Field(
+        default=False,
+        description=(
+            "When true, the session is soft-archived the first time it goes idle "
+            "owing nothing — a self-reclaiming, one-shot session. Immutable after "
+            "launch. Workflow agent() children launch with this set."
+        ),
+    )
 
     workspace_path: str | None = Field(
         default=None,
@@ -274,6 +282,7 @@ class Session(BaseModel):
     focal_locked: bool = False
     origin: SessionOrigin = "foreground"
     parent_run_id: str | None = None  # set for a workflow-spawned (background) child
+    archive_when_idle: bool = False  # self-archive on first idle (immutable launch property)
     last_event_at: datetime | None = None
     total_events: int = 0
 

--- a/src/aios/services/session_templates.py
+++ b/src/aios/services/session_templates.py
@@ -26,6 +26,7 @@ async def create_session_template(
     vault_ids: list[str],
     memory_store_ids: list[str],
     metadata: dict[str, Any],
+    archive_when_idle: bool = False,
 ) -> SessionTemplate:
     async with pool.acquire() as conn:
         return await queries.insert_session_template(
@@ -37,6 +38,7 @@ async def create_session_template(
             vault_ids=vault_ids,
             memory_store_ids=memory_store_ids,
             metadata=metadata,
+            archive_when_idle=archive_when_idle,
             account_id=account_id,
         )
 
@@ -69,6 +71,7 @@ async def update_session_template(
     vault_ids: list[str] | None = None,
     memory_store_ids: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
+    archive_when_idle: bool | None = None,
 ) -> SessionTemplate:
     async with pool.acquire() as conn:
         return await queries.update_session_template(
@@ -81,6 +84,7 @@ async def update_session_template(
             vault_ids=vault_ids,
             memory_store_ids=memory_store_ids,
             metadata=metadata,
+            archive_when_idle=archive_when_idle,
             account_id=account_id,
         )
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -137,6 +137,7 @@ async def create_session(
     env: dict[str, str] | None = None,
     focal_channel: str | None = None,
     focal_locked: bool = False,
+    archive_when_idle: bool = False,
 ) -> Session:
     """Create a session row and return it.
 
@@ -169,6 +170,7 @@ async def create_session(
             env=env,
             focal_channel=focal_channel,
             focal_locked=focal_locked,
+            archive_when_idle=archive_when_idle,
             account_id=account_id,
         )
         if vault_ids:
@@ -823,6 +825,14 @@ async def set_session_stop_reason(
     writes a status column."""
     async with pool.acquire() as conn:
         await queries.set_session_stop_reason(conn, session_id, stop_reason, account_id=account_id)
+
+
+async def reclaim_session_if_idle(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
+) -> bool:
+    """Pool wrapper for :func:`queries.reclaim_session_if_idle` — soft-archive iff idle."""
+    async with pool.acquire() as conn:
+        return await queries.reclaim_session_if_idle(conn, session_id, account_id=account_id)
 
 
 async def increment_usage(

--- a/src/aios_connectors/resolver.py
+++ b/src/aios_connectors/resolver.py
@@ -230,6 +230,7 @@ async def _spawn_per_chat_session(
         vault_ids=template.vault_ids or None,
         focal_channel=focal_channel,
         focal_locked=True,
+        archive_when_idle=template.archive_when_idle,
         account_id=account_id,
     )
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -405,8 +405,9 @@ async def test_return_writes_response_and_wakes_caller_without_archiving(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     """return() writes the request's response + wakes the caller, but does NOT
-    archive the child — responding is not terminating. Reclamation is run-end
-    (off the correctness path), so right after responding the child is unarchived."""
+    archive the child — responding is not terminating. Archive-on-quiescence reclaims
+    the child only at its next idle end-of-step, so right after responding (still mid-turn,
+    a tool_result just landed) the child is unarchived."""
     from aios.tools import workflow_completion
 
     pool = wf_runtime
@@ -425,7 +426,8 @@ async def test_return_writes_response_and_wakes_caller_without_archiving(
     assert response is not None
     assert response["is_error"] is False and response["result"] == {"answer": 42}
     child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
-    assert child.archived_at is None  # NOT archived by the handler — run-end reclaim does that
+    # NOT archived by the handler — archive-on-quiescence reclaims at the next idle step.
+    assert child.archived_at is None
 
 
 async def test_error_marker_carries_message(
@@ -1003,6 +1005,154 @@ async def test_archived_session_wake_is_a_noop(
     async with pool.acquire() as conn:
         after = await conn.fetchval("SELECT last_event_seq FROM sessions WHERE id = $1", sess.id)
     assert after == before  # nothing appended — a clean no-op
+
+
+# ─── archive-on-quiescence: the general reclaim hook + its workflow-child use ──
+
+
+async def test_reclaim_session_if_idle_archives_only_when_idle(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """``reclaim_session_if_idle`` is the atomic conditional behind archive-on-quiescence:
+    it archives an idle session, no-ops on an active one (a stimulus racing the idle
+    transition flips ``_SESSION_ACTIVE_EXPR`` and wins), and no-ops once archived."""
+    pool = wf_runtime
+
+    # Active session (an unreacted user stimulus) → reclaim is a no-op.
+    active = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+        archive_when_idle=True,
+    )
+    await sessions_service.append_user_message(pool, active.id, "hi", account_id="acc_wf")
+    async with pool.acquire() as conn:
+        assert (
+            await db_queries.derive_session_status(conn, active.id, account_id="acc_wf") == "active"
+        )
+        assert (
+            await db_queries.reclaim_session_if_idle(conn, active.id, account_id="acc_wf") is False
+        )
+    assert (
+        await sessions_service.get_session_basic(pool, active.id, account_id="acc_wf")
+    ).archived_at is None
+
+    # Idle session → archived; a second call is an idempotent no-op.
+    idle = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+        archive_when_idle=True,
+    )
+    async with pool.acquire() as conn:
+        assert await db_queries.derive_session_status(conn, idle.id, account_id="acc_wf") == "idle"
+        assert await db_queries.reclaim_session_if_idle(conn, idle.id, account_id="acc_wf") is True
+        assert await db_queries.reclaim_session_if_idle(conn, idle.id, account_id="acc_wf") is False
+    assert (
+        await sessions_service.get_session_basic(pool, idle.id, account_id="acc_wf")
+    ).archived_at is not None
+
+
+async def test_child_reclaimed_on_quiescence_and_parent_still_harvests(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The workflow-child use of the general feature: a child is born ephemeral
+    (``insert_child_session`` sets ``archive_when_idle`` TRUE), answers its request,
+    and on its first genuine idle is reclaimed — yet the parent's harvest still returns
+    the answer, because ``derive_response`` reads the response *event* (which survives
+    archival), not the live row."""
+    pool = wf_runtime
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:reclaim#0")
+
+    # Born ephemeral — the workflow-child wiring, no per-call plumbing.
+    born = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
+    assert born.archive_when_idle is True
+
+    # It answers its request, then ends a tool-free turn → idle owing nothing. The guard
+    # does not nudge an already-answered child, so it is free to rest.
+    async with pool.acquire() as conn:
+        await db_queries.write_response_if_absent(
+            conn,
+            cid,
+            account_id="acc_wf",
+            request_id="sha:reclaim#0",
+            is_error=False,
+            result={"answer": 42},
+            error=None,
+        )
+    nudged, caller = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, cid, await _idle_assistant_turn(pool, cid), account_id="acc_wf", parent_run_id=run_id
+    )
+    assert not nudged and caller is None
+
+    # End-of-step reclaim (what loop._run_step does for an archive_when_idle session).
+    assert await sessions_service.reclaim_session_if_idle(pool, cid, account_id="acc_wf") is True
+    child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
+    assert child.archived_at is not None
+
+    # The parent harvest still resolves to the answer — archival did not lose it.
+    async with pool.acquire() as conn:
+        resp = await db_queries.derive_response(
+            conn, cid, account_id="acc_wf", request_id="sha:reclaim#0"
+        )
+    assert resp is not None and resp["is_error"] is False and resp["result"] == {"answer": 42}
+
+
+async def test_archive_when_idle_persists_across_launch_surfaces(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The launch flag round-trips on every surface: SessionCreate carries it onto the
+    row (default False), and a session_template stores + updates it — the value the
+    per-chat resolver copies into ``create_session``."""
+    from aios.services import session_templates as st_service
+
+    pool = wf_runtime
+    fg = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+        archive_when_idle=True,
+    )
+    assert fg.archive_when_idle is True
+    fg_default = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )
+    assert fg_default.archive_when_idle is False
+
+    tmpl = await st_service.create_session_template(
+        pool,
+        account_id="acc_wf",
+        name="ephemeral-tmpl",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        agent_version=None,
+        vault_ids=[],
+        memory_store_ids=[],
+        metadata={},
+        archive_when_idle=True,
+    )
+    assert tmpl.archive_when_idle is True
+    assert (
+        await st_service.get_session_template(pool, tmpl.id, account_id="acc_wf")
+    ).archive_when_idle is True
+    updated = await st_service.update_session_template(
+        pool, tmpl.id, account_id="acc_wf", archive_when_idle=False
+    )
+    assert updated.archive_when_idle is False
 
 
 async def test_operator_archived_child_resolves_run_as_child_gone(

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0069``."""
+    """The migration ladder has exactly one head: ``0070``."""
     script = _script_directory()
-    assert script.get_heads() == ["0069"]
+    assert script.get_heads() == ["0070"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -147,6 +147,7 @@ class TestEntrySweepSpan:
             focal_channel=None,
             origin="foreground",
             parent_run_id=None,
+            archive_when_idle=False,
         )
         agent = SimpleNamespace(
             model="openrouter/x",

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -192,6 +192,7 @@ class TestStepStartEndSpans:
             focal_channel=None,
             origin="foreground",
             parent_run_id=None,
+            archive_when_idle=False,
         )
         agent = SimpleNamespace(
             model="openrouter/x",
@@ -300,6 +301,7 @@ class TestStepStartEndSpans:
             focal_channel=None,
             origin="foreground",
             parent_run_id=None,
+            archive_when_idle=False,
         )
         agent = SimpleNamespace(
             model="openrouter/x",
@@ -395,6 +397,201 @@ class TestStepStartEndSpans:
             "step_end",
         ]
 
+    async def test_archive_when_idle_reclaims_after_step_end(self) -> None:
+        """Regression fence: an ``archive_when_idle`` session is reclaimed as the LAST
+        session write of the step — strictly AFTER ``step_end``. If the reclaim ran inside
+        the step body (before the ``step_end`` append in run_session_step's finally), the
+        archive would fence that append on ``archived_at IS NULL`` and the step would crash."""
+        from aios.harness.loop import run_session_step
+
+        session = SimpleNamespace(
+            id="sess_x",
+            agent_id="agt_x",
+            agent_version=None,
+            focal_channel=None,
+            origin="background",
+            parent_run_id="run_x",
+            archive_when_idle=True,
+        )
+        agent = SimpleNamespace(
+            model="openrouter/x",
+            tools=[],
+            mcp_servers=[],
+            http_servers=[],
+            skills=[],
+            system="sys",
+            litellm_extra={},
+            window_min=1000,
+            window_max=10000,
+        )
+        start_event = SimpleNamespace(id="ev_step")
+
+        manager = MagicMock()
+        append_event = AsyncMock(return_value=start_event)
+        reclaim = AsyncMock(return_value=True)
+        manager.attach_mock(append_event, "append_event")
+        manager.attach_mock(reclaim, "reclaim")
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch("aios.harness.loop.runtime.require_task_registry", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value={"sess_x"}),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.get_session_basic",
+                AsyncMock(return_value=session),
+            ),
+            patch("aios.harness.loop.agents_service.get_agent", AsyncMock(return_value=agent)),
+            patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
+            patch(
+                "aios.harness.loop.sessions_service.read_windowed_events",
+                AsyncMock(return_value=[]),
+            ),
+            patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
+            patch(
+                "aios.harness.loop.compose_step_context",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        model="openrouter/x",
+                        messages=[],
+                        tools=[],
+                        reacting_to=0,
+                        skill_versions=[],
+                    )
+                ),
+            ),
+            patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+            patch(
+                "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
+                AsyncMock(return_value=(False, None)),
+            ),
+            patch("aios.harness.loop.sessions_service.reclaim_session_if_idle", reclaim),
+            patch(
+                "aios.harness.loop.stream_litellm",
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+            ),
+            patch("aios.harness.loop.sessions_service.increment_usage", AsyncMock()),
+            patch("aios.db.sse_lock.has_subscriber", AsyncMock(return_value=False)),
+        ):
+            await run_session_step("sess_x")
+
+        # Reclaim is awaited exactly once, against the live pool + session.
+        reclaim.assert_awaited_once_with(ANY, "sess_x", account_id=ANY)
+        # …and strictly AFTER the step_end span append (the bug: reclaim-before-step_end).
+        last_step_end = max(
+            i
+            for i, (name, args, _kw) in enumerate(manager.mock_calls)
+            if name == "append_event" and args[2] == "span" and args[3].get("event") == "step_end"
+        )
+        reclaim_idx = next(
+            i for i, (name, *_rest) in enumerate(manager.mock_calls) if name == "reclaim"
+        )
+        assert reclaim_idx > last_step_end, (
+            f"reclaim must run after step_end; step_end at {last_step_end}, reclaim at {reclaim_idx}"
+        )
+
+    async def test_archive_when_idle_reclaim_follows_the_nudge_wake(self) -> None:
+        """When the quiescence guard nudges (re-activating the session), the reclaim still
+        runs AFTER the ``request_nudge`` defer_wake — which appends a ``wake_deferred`` span.
+        If reclaim ran first it would archive the row and that span append would crash; here
+        the reclaim no-ops (the nudged session is active) but the ORDERING is the fence."""
+        from aios.harness.loop import run_session_step
+
+        session = SimpleNamespace(
+            id="sess_x",
+            agent_id="agt_x",
+            agent_version=None,
+            focal_channel=None,
+            origin="background",
+            parent_run_id="run_x",
+            archive_when_idle=True,
+        )
+        agent = SimpleNamespace(
+            model="openrouter/x",
+            tools=[],
+            mcp_servers=[],
+            http_servers=[],
+            skills=[],
+            system="sys",
+            litellm_extra={},
+            window_min=1000,
+            window_max=10000,
+        )
+        start_event = SimpleNamespace(id="ev_step")
+
+        manager = MagicMock()
+        defer_wake_mock = AsyncMock()
+        reclaim = AsyncMock(return_value=False)  # nudged → active → reclaim no-ops
+        manager.attach_mock(defer_wake_mock, "defer_wake")
+        manager.attach_mock(reclaim, "reclaim")
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch("aios.harness.loop.runtime.require_task_registry", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(return_value={"sess_x"}),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.get_session_basic",
+                AsyncMock(return_value=session),
+            ),
+            patch("aios.harness.loop.agents_service.get_agent", AsyncMock(return_value=agent)),
+            patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
+            patch(
+                "aios.harness.loop.sessions_service.read_windowed_events",
+                AsyncMock(return_value=[]),
+            ),
+            patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
+            patch(
+                "aios.harness.loop.compose_step_context",
+                AsyncMock(
+                    return_value=SimpleNamespace(
+                        model="openrouter/x",
+                        messages=[],
+                        tools=[],
+                        reacting_to=0,
+                        skill_versions=[],
+                    )
+                ),
+            ),
+            patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()),
+            patch(
+                "aios.harness.loop.sessions_service.append_event",
+                AsyncMock(return_value=start_event),
+            ),
+            patch(
+                "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
+                AsyncMock(return_value=(True, None)),  # guard nudged
+            ),
+            patch("aios.harness.loop.sessions_service.reclaim_session_if_idle", reclaim),
+            patch("aios.harness.loop.defer_wake", defer_wake_mock),
+            patch(
+                "aios.harness.loop.stream_litellm",
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+            ),
+            patch("aios.harness.loop.sessions_service.increment_usage", AsyncMock()),
+            patch("aios.db.sse_lock.has_subscriber", AsyncMock(return_value=False)),
+        ):
+            await run_session_step("sess_x")
+
+        defer_wake_mock.assert_awaited_once_with(
+            ANY, "sess_x", cause="request_nudge", account_id=ANY
+        )
+        reclaim.assert_awaited_once_with(ANY, "sess_x", account_id=ANY)
+        nudge_idx = next(
+            i for i, (name, *_r) in enumerate(manager.mock_calls) if name == "defer_wake"
+        )
+        reclaim_idx = next(
+            i for i, (name, *_r) in enumerate(manager.mock_calls) if name == "reclaim"
+        )
+        assert reclaim_idx > nudge_idx, (
+            f"reclaim must run after the nudge defer_wake; nudge at {nudge_idx}, reclaim at {reclaim_idx}"
+        )
+
     async def test_step_end_emitted_when_budget_exhausted(self) -> None:
         """If the model-call budget is exhausted, ``step_end`` still fires."""
         from aios.harness.loop import run_session_step
@@ -406,6 +603,7 @@ class TestStepStartEndSpans:
             focal_channel=None,
             origin="foreground",
             parent_run_id=None,
+            archive_when_idle=False,
         )
         agent = SimpleNamespace(
             model="openrouter/x",
@@ -502,6 +700,7 @@ async def _harness_with_guard(
         focal_channel=None,
         origin="background",
         parent_run_id="run_x",
+        archive_when_idle=False,
     )
     agent = SimpleNamespace(
         model="openrouter/x",


### PR DESCRIPTION
## What

Adds `archive_when_idle`, an **immutable launch-time property of a session**: when set, the harness soft-archives the session the first time it goes idle owing nothing. This generalises the long-deferred "reclaim a workflow `agent()` child once it's done" into a property of *launching* a session — workflows are simply the first caller (Block-3 slice 4).

## Mechanism (correct-by-construction)

- **Column** `sessions.archive_when_idle` (+ the same on `session_templates`). Foreground/API and per-chat launches default `false`; **workflow children launch `true`** (`insert_child_session` hardcodes it — ephemerality is what a v1 child *is*); the per-chat resolver copies the template's value down.
- **`reclaim_session_if_idle`**: one conditional `UPDATE … WHERE archived_at IS NULL AND NOT (_SESSION_ACTIVE_EXPR)`. Reusing the *same* active-status predicate the sweep and every reader use makes it atomic against the only race that matters — a stimulus landing as the session idles flips the predicate to active, the UPDATE matches zero rows, and the late message wins. No edge-detection state: an archived session can never run another step (append/wake/sweep all fence on `archived_at IS NULL`), so "if idle → archive" is naturally once-only.
- **Last write of the step.** The reclaim is deferred via `_StepResult.archive_when_idle` and performed by `run_session_step` *after* `step_end` and the wake spans. This ordering is load-bearing — those appends would otherwise hit the archived-row fence.

## Why the workflow child composes for free

The totality guard runs *before* the reclaim and ensures a child never idles owing a request: it nudges (→ active → reclaim no-ops) or auto-errors (→ idle owing nothing → archived). The parent's `derive_response` reads the response **event**, which survives archival, so an answered-then-reclaimed child still harvests correctly.

## Review note

`/code-review` caught a real bug in the first cut: the reclaim was inside the step *body*, but `step_end` + wake spans append in the outer `run_session_step` **after** the body — so the archived-row fence would have crashed every reclaim and dropped the auto-error parent-wake. Fixed by moving the reclaim after `step_end` via `_StepResult`, and added two unit regressions that drive the **real** `run_session_step` and assert the reclaim runs after `step_end` (clean path) and after the nudge `defer_wake` (nudge path) — closing the fidelity gap that let it through.

## Tests

- Unit: 2 new regressions driving `run_session_step` ordering; model-default coverage via openapi/sdk snapshots.
- Integration (Docker PG): `reclaim_session_if_idle` predicate (idle archives / active + already-archived no-op); the workflow-child money test (answer → idle → archived → parent still harvests); launch-surface round-trip on SessionCreate + session_templates.
- Full battery green: 1783 unit, mypy, ruff, 57 wf_step integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)