### PR TITLE
feat(workflows): symmetry pass — parent_run_id filters, Workflow.description, run cancel

### DIFF
--- a/migrations/versions/0071_workflow_description.py
+++ b/migrations/versions/0071_workflow_description.py
@@ -1,0 +1,30 @@
+"""Workflows: add an optional ``description`` to the definition.
+
+The agent-parity blurb. ``agents`` already carry a ``description`` (surfaced in
+the console list/search/detail); workflows did not. Additive + nullable, so it is
+backward-compatible with every existing row and needs no backfill. The
+``workflows`` table is small and rarely written, so a plain ``ADD COLUMN`` (a
+metadata-only change in PG11+, no table rewrite) is fine — no ``CONCURRENTLY``.
+
+Revision ID: 0071
+Revises: 0070
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0071"
+down_revision: str = "0070"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE workflows ADD COLUMN description text")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE workflows DROP COLUMN IF EXISTS description")

--- a/migrations/versions/0072_workflow_run_cancel.py
+++ b/migrations/versions/0072_workflow_run_cancel.py
@@ -1,0 +1,62 @@
+"""Workflows: a ``cancelled`` terminal status + a ``cancel`` resume-signal kind.
+
+User-initiated cancellation (``POST /v1/runs/{id}/cancel``). The request handler
+must not write the journal directly (it is single-writer, gapless-seq, under the
+run's procrastinate lock), so cancel rides the existing side-marker path: it records
+a ``cancel`` ``wf_run_signals`` row and wakes the run; the next ``run_workflow_step``
+harvests it and finalizes the run as ``cancelled`` — a distinct terminal status so
+the UI can tell a user-cancel from an error.
+
+Two CHECK constraints widen:
+- ``wf_runs.status``        gains ``'cancelled'`` (a new terminal value). The
+  active-sweep partial index lists only the non-terminal statuses, so ``cancelled``
+  is naturally excluded — no index change.
+- ``wf_run_signals.kind``   gains ``'cancel'`` (the side-marker kind).
+
+Both tables are small workflow-runtime tables (not the hot ``events`` table), so a
+plain drop+re-add of the anonymous inline CHECK constraints (PG-default names
+``wf_runs_status_check`` / ``wf_run_signals_kind_check`` from migration 0064) is
+fine — brief ACCESS EXCLUSIVE + a validation scan, no ``CONCURRENTLY`` needed.
+
+Revision ID: 0072
+Revises: 0071
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0072"
+down_revision: str = "0071"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE wf_runs DROP CONSTRAINT wf_runs_status_check")
+    op.execute(
+        "ALTER TABLE wf_runs ADD CONSTRAINT wf_runs_status_check "
+        "CHECK (status IN ('pending','running','suspended','completed','errored','cancelled'))"
+    )
+    op.execute("ALTER TABLE wf_run_signals DROP CONSTRAINT wf_run_signals_kind_check")
+    op.execute(
+        "ALTER TABLE wf_run_signals ADD CONSTRAINT wf_run_signals_kind_check "
+        "CHECK (kind IN ('gate_resume','child_done','cancel'))"
+    )
+
+
+def downgrade() -> None:
+    # Reverting assumes no rows use the widened values (a cancelled run / cancel
+    # signal would fail the narrower CHECK) — acceptable for a down-migration.
+    op.execute("ALTER TABLE wf_run_signals DROP CONSTRAINT wf_run_signals_kind_check")
+    op.execute(
+        "ALTER TABLE wf_run_signals ADD CONSTRAINT wf_run_signals_kind_check "
+        "CHECK (kind IN ('gate_resume','child_done'))"
+    )
+    op.execute("ALTER TABLE wf_runs DROP CONSTRAINT wf_runs_status_check")
+    op.execute(
+        "ALTER TABLE wf_runs ADD CONSTRAINT wf_runs_status_check "
+        "CHECK (status IN ('pending','running','suspended','completed','errored'))"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -1731,6 +1731,22 @@
             }
           },
           {
+            "name": "parent_run_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Parent Run Id"
+            }
+          },
+          {
             "name": "limit",
             "in": "query",
             "required": false,
@@ -8381,7 +8397,7 @@
           "runs"
         ],
         "summary": "List Runs",
-        "description": "List the account's runs, newest first. First page: optional ``workflow_id`` /\n``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.",
+        "description": "List the account's runs, newest first. First page: optional ``workflow_id`` /\n``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:\n``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.",
         "operationId": "list_runs",
         "parameters": [
           {
@@ -8430,6 +8446,22 @@
                 }
               ],
               "title": "Status"
+            }
+          },
+          {
+            "name": "parent_run_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Parent Run Id"
             }
           },
           {
@@ -8688,6 +8720,65 @@
             }
           }
         },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WfRun"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/runs/{run_id}/cancel": {
+      "post": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Cancel Run",
+        "description": "Cancel a run (pending/running/suspended). Records a cancel marker + wakes the\nrun; it finalizes ``cancelled`` on its next wake (so the returned run may still\nshow its pre-cancel status \u2014 like ``resume``). Idempotent on an already-terminal\nrun; a cross-tenant run 404s.",
+        "operationId": "cancel_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -14993,7 +15084,8 @@
               "running",
               "suspended",
               "completed",
-              "errored"
+              "errored",
+              "cancelled"
             ],
             "title": "Status"
           },
@@ -15289,6 +15381,17 @@
             ],
             "title": "Output Schema"
           },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15346,6 +15449,17 @@
               }
             ],
             "title": "Output Schema"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
           }
         },
         "type": "object",

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/cancel_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/cancel_run.py
@@ -1,0 +1,199 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.wf_run import WfRun
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/runs/{run_id}/cancel".format(
+            run_id=quote(str(run_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | WfRun | None:
+    if response.status_code == 200:
+        response_200 = WfRun.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | WfRun]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Cancel Run
+
+     Cancel a run (pending/running/suspended). Records a cancel marker + wakes the
+    run; it finalizes ``cancelled`` on its next wake (so the returned run may still
+    show its pre-cancel status — like ``resume``). Idempotent on an already-terminal
+    run; a cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Cancel Run
+
+     Cancel a run (pending/running/suspended). Records a cancel marker + wakes the
+    run; it finalizes ``cancelled`` on its next wake (so the returned run may still
+    show its pre-cancel status — like ``resume``). Idempotent on an already-terminal
+    run; a cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return sync_detailed(
+        run_id=run_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRun]:
+    """Cancel Run
+
+     Cancel a run (pending/running/suspended). Records a cancel marker + wakes the
+    run; it finalizes ``cancelled`` on its next wake (so the returned run may still
+    show its pre-cancel status — like ``resume``). Idempotent on an already-terminal
+    run; a cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRun]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRun | None:
+    """Cancel Run
+
+     Cancel a run (pending/running/suspended). Records a cancel marker + wakes the
+    run; it finalizes ``cancelled`` on its next wake (so the returned run may still
+    show its pre-cancel status — like ``resume``). Idempotent on an already-terminal
+    run; a cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRun
+    """
+
+    return (
+        await asyncio_detailed(
+            run_id=run_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/list_runs.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/list_runs.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     cursor: None | str | Unset = UNSET,
     workflow_id: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
@@ -44,6 +45,13 @@ def _get_kwargs(
     else:
         json_status = status
     params["status"] = json_status
+
+    json_parent_run_id: None | str | Unset
+    if isinstance(parent_run_id, Unset):
+        json_parent_run_id = UNSET
+    else:
+        json_parent_run_id = parent_run_id
+    params["parent_run_id"] = json_parent_run_id
 
     json_limit: int | None | Unset
     if isinstance(limit, Unset):
@@ -100,18 +108,21 @@ def sync_detailed(
     cursor: None | str | Unset = UNSET,
     workflow_id: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseWfRun]:
     """List Runs
 
      List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+    ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:
         cursor (None | str | Unset):
         workflow_id (None | str | Unset):
         status (None | str | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -127,6 +138,7 @@ def sync_detailed(
         cursor=cursor,
         workflow_id=workflow_id,
         status=status,
+        parent_run_id=parent_run_id,
         limit=limit,
         authorization=authorization,
     )
@@ -144,18 +156,21 @@ def sync(
     cursor: None | str | Unset = UNSET,
     workflow_id: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseWfRun | None:
     """List Runs
 
      List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+    ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:
         cursor (None | str | Unset):
         workflow_id (None | str | Unset):
         status (None | str | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -172,6 +187,7 @@ def sync(
         cursor=cursor,
         workflow_id=workflow_id,
         status=status,
+        parent_run_id=parent_run_id,
         limit=limit,
         authorization=authorization,
     ).parsed
@@ -183,18 +199,21 @@ async def asyncio_detailed(
     cursor: None | str | Unset = UNSET,
     workflow_id: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseWfRun]:
     """List Runs
 
      List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+    ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:
         cursor (None | str | Unset):
         workflow_id (None | str | Unset):
         status (None | str | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -210,6 +229,7 @@ async def asyncio_detailed(
         cursor=cursor,
         workflow_id=workflow_id,
         status=status,
+        parent_run_id=parent_run_id,
         limit=limit,
         authorization=authorization,
     )
@@ -225,18 +245,21 @@ async def asyncio(
     cursor: None | str | Unset = UNSET,
     workflow_id: None | str | Unset = UNSET,
     status: None | str | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseWfRun | None:
     """List Runs
 
      List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``.
+    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+    ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs.
 
     Args:
         cursor (None | str | Unset):
         workflow_id (None | str | Unset):
         status (None | str | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -254,6 +277,7 @@ async def asyncio(
             cursor=cursor,
             workflow_id=workflow_id,
             status=status,
+            parent_run_id=parent_run_id,
             limit=limit,
             authorization=authorization,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_sessions.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_sessions.py
@@ -16,6 +16,7 @@ def _get_kwargs(
     cursor: None | str | Unset = UNSET,
     agent_id: None | str | Unset = UNSET,
     status: ListSessionsStatusType0 | None | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
@@ -47,6 +48,13 @@ def _get_kwargs(
     else:
         json_status = status
     params["status"] = json_status
+
+    json_parent_run_id: None | str | Unset
+    if isinstance(parent_run_id, Unset):
+        json_parent_run_id = UNSET
+    else:
+        json_parent_run_id = parent_run_id
+    params["parent_run_id"] = json_parent_run_id
 
     json_limit: int | None | Unset
     if isinstance(limit, Unset):
@@ -103,6 +111,7 @@ def sync_detailed(
     cursor: None | str | Unset = UNSET,
     agent_id: None | str | Unset = UNSET,
     status: ListSessionsStatusType0 | None | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseSession]:
@@ -112,6 +121,7 @@ def sync_detailed(
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -127,6 +137,7 @@ def sync_detailed(
         cursor=cursor,
         agent_id=agent_id,
         status=status,
+        parent_run_id=parent_run_id,
         limit=limit,
         authorization=authorization,
     )
@@ -144,6 +155,7 @@ def sync(
     cursor: None | str | Unset = UNSET,
     agent_id: None | str | Unset = UNSET,
     status: ListSessionsStatusType0 | None | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseSession | None:
@@ -153,6 +165,7 @@ def sync(
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -169,6 +182,7 @@ def sync(
         cursor=cursor,
         agent_id=agent_id,
         status=status,
+        parent_run_id=parent_run_id,
         limit=limit,
         authorization=authorization,
     ).parsed
@@ -180,6 +194,7 @@ async def asyncio_detailed(
     cursor: None | str | Unset = UNSET,
     agent_id: None | str | Unset = UNSET,
     status: ListSessionsStatusType0 | None | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseSession]:
@@ -189,6 +204,7 @@ async def asyncio_detailed(
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -204,6 +220,7 @@ async def asyncio_detailed(
         cursor=cursor,
         agent_id=agent_id,
         status=status,
+        parent_run_id=parent_run_id,
         limit=limit,
         authorization=authorization,
     )
@@ -219,6 +236,7 @@ async def asyncio(
     cursor: None | str | Unset = UNSET,
     agent_id: None | str | Unset = UNSET,
     status: ListSessionsStatusType0 | None | Unset = UNSET,
+    parent_run_id: None | str | Unset = UNSET,
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseSession | None:
@@ -228,6 +246,7 @@ async def asyncio(
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
         status (ListSessionsStatusType0 | None | Unset):
+        parent_run_id (None | str | Unset):
         limit (int | None | Unset):
         authorization (None | str | Unset):
 
@@ -245,6 +264,7 @@ async def asyncio(
             cursor=cursor,
             agent_id=agent_id,
             status=status,
+            parent_run_id=parent_run_id,
             limit=limit,
             authorization=authorization,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_status.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class WfRunStatus(str, Enum):
+    CANCELLED = "cancelled"
     COMPLETED = "completed"
     ERRORED = "errored"
     PENDING = "pending"

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
@@ -32,6 +32,7 @@ class Workflow:
         updated_at (datetime.datetime):
         input_schema (None | Unset | WorkflowInputSchemaType0):
         output_schema (None | Unset | WorkflowOutputSchemaType0):
+        description (None | str | Unset):
     """
 
     id: str
@@ -43,6 +44,7 @@ class Workflow:
     updated_at: datetime.datetime
     input_schema: None | Unset | WorkflowInputSchemaType0 = UNSET
     output_schema: None | Unset | WorkflowOutputSchemaType0 = UNSET
+    description: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -79,6 +81,12 @@ class Workflow:
         else:
             output_schema = self.output_schema
 
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -96,6 +104,8 @@ class Workflow:
             field_dict["input_schema"] = input_schema
         if output_schema is not UNSET:
             field_dict["output_schema"] = output_schema
+        if description is not UNSET:
+            field_dict["description"] = description
 
         return field_dict
 
@@ -157,6 +167,15 @@ class Workflow:
 
         output_schema = _parse_output_schema(d.pop("output_schema", UNSET))
 
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
         workflow = cls(
             id=id,
             account_id=account_id,
@@ -167,6 +186,7 @@ class Workflow:
             updated_at=updated_at,
             input_schema=input_schema,
             output_schema=output_schema,
+            description=description,
         )
 
         workflow.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
@@ -29,12 +29,14 @@ class WorkflowCreate:
         script (str):
         input_schema (None | Unset | WorkflowCreateInputSchemaType0):
         output_schema (None | Unset | WorkflowCreateOutputSchemaType0):
+        description (None | str | Unset):
     """
 
     name: str
     script: str
     input_schema: None | Unset | WorkflowCreateInputSchemaType0 = UNSET
     output_schema: None | Unset | WorkflowCreateOutputSchemaType0 = UNSET
+    description: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -65,6 +67,12 @@ class WorkflowCreate:
         else:
             output_schema = self.output_schema
 
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -77,6 +85,8 @@ class WorkflowCreate:
             field_dict["input_schema"] = input_schema
         if output_schema is not UNSET:
             field_dict["output_schema"] = output_schema
+        if description is not UNSET:
+            field_dict["description"] = description
 
         return field_dict
 
@@ -132,11 +142,21 @@ class WorkflowCreate:
 
         output_schema = _parse_output_schema(d.pop("output_schema", UNSET))
 
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
         workflow_create = cls(
             name=name,
             script=script,
             input_schema=input_schema,
             output_schema=output_schema,
+            description=description,
         )
 
         workflow_create.additional_properties = d

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -115,18 +115,29 @@ async def list_(
         SessionStatus | None,
         Query(alias="status"),
     ] = None,
+    parent_run_id: str | None = None,
     limit: Annotated[int | None, Query(ge=1, le=200)] = None,
 ) -> ListResponse[Session]:
-    st = page_cursor(cursor, {"agent_id": agent_id, "status": status_filter, "limit": limit})
+    st = page_cursor(
+        cursor,
+        {
+            "agent_id": agent_id,
+            "status": status_filter,
+            "parent_run_id": parent_run_id,
+            "limit": limit,
+        },
+    )
     after = str(st.cursor) if st is not None else None
     page_limit = st.limit if st is not None else (limit if limit is not None else 50)
     if st is not None:
         agent_id = st.filters.get("agent_id")
         status_filter = st.filters.get("status")
+        parent_run_id = st.filters.get("parent_run_id")
     items = await service.list_sessions(
         pool,
         agent_id=agent_id,
         status=status_filter,
+        parent_run_id=parent_run_id,
         limit=page_limit + 1,
         after=after,
         account_id=account_id,
@@ -135,7 +146,7 @@ async def list_(
         items,
         page_limit,
         cursor=lambda x: x.id,
-        filters={"agent_id": agent_id, "status": status_filter},
+        filters={"agent_id": agent_id, "status": status_filter, "parent_run_id": parent_run_id},
     )
 
 

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -52,6 +52,7 @@ async def create_workflow(
         script=body.script,
         input_schema=body.input_schema,
         output_schema=body.output_schema,
+        description=body.description,
     )
 
 
@@ -108,16 +109,27 @@ async def list_runs(
     cursor: str | None = None,
     workflow_id: str | None = None,
     status: str | None = None,
+    parent_run_id: str | None = None,
     limit: Annotated[int | None, Query(ge=1, le=200)] = None,
 ) -> ListResponse[WfRun]:
     """List the account's runs, newest first. First page: optional ``workflow_id`` /
-    ``status`` filters + ``limit``; subsequent pages: ``?cursor=<next_cursor>``."""
-    st = page_cursor(cursor, {"workflow_id": workflow_id, "status": status, "limit": limit})
+    ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
+    ``?cursor=<next_cursor>``. ``parent_run_id`` scopes to a run's child runs."""
+    st = page_cursor(
+        cursor,
+        {
+            "workflow_id": workflow_id,
+            "status": status,
+            "parent_run_id": parent_run_id,
+            "limit": limit,
+        },
+    )
     after = str(st.cursor) if st is not None else None
     page_limit = st.limit if st is not None else (limit if limit is not None else 50)
     if st is not None:
         workflow_id = st.filters.get("workflow_id")
         status = st.filters.get("status")
+        parent_run_id = st.filters.get("parent_run_id")
     items = await service.list_runs(
         pool,
         account_id=account_id,
@@ -125,12 +137,13 @@ async def list_runs(
         after=after,
         workflow_id=workflow_id,
         status=status,
+        parent_run_id=parent_run_id,
     )
     return ListResponse[WfRun].paginate(
         items,
         page_limit,
         cursor=lambda x: x.id,
-        filters={"workflow_id": workflow_id, "status": status},
+        filters={"workflow_id": workflow_id, "status": status, "parent_run_id": parent_run_id},
     )
 
 
@@ -181,6 +194,15 @@ async def resume_gate(
         pool, run_id=run_id, account_id=account_id, gate_nonce=body.gate_nonce, result=body.result
     )
     return await service.get_run(pool, run_id, account_id=account_id)
+
+
+@runs_router.post("/{run_id}/cancel", operation_id="cancel_run")
+async def cancel_run(run_id: str, pool: PoolDep, account_id: AccountIdDep) -> WfRun:
+    """Cancel a run (pending/running/suspended). Records a cancel marker + wakes the
+    run; it finalizes ``cancelled`` on its next wake (so the returned run may still
+    show its pre-cancel status — like ``resume``). Idempotent on an already-terminal
+    run; a cross-tenant run 404s."""
+    return await service.cancel_run(pool, run_id=run_id, account_id=account_id)
 
 
 @runs_router.get("/{run_id}/stream", openapi_extra={"x-codegen": {"targets": []}})

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -248,10 +248,10 @@ async def wf_run_event_stream(
                     run_id,
                     cursor,
                 )
-                if status in ("completed", "errored")
+                if status in ("completed", "errored", "cancelled")
                 else []
             )
-        if status in ("completed", "errored"):
+        if status in ("completed", "errored", "cancelled"):
             for row in terminal_tail:
                 payload = _serialize_wf_event(row)
                 cursor = max(cursor, payload["seq"])

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -21,6 +21,7 @@ from aios.cli.files import PayloadError, load_payload
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk import stream_run
 from aios_sdk._generated.api.runs import (
+    cancel_run,
     create_run,
     get_run,
     list_run_events,
@@ -178,6 +179,15 @@ def run_events_(
             limit=limit,
             path_params={"run_id": run_id},
         )
+
+    run_or_die(_run)
+
+
+@runs_app.command("cancel", help="Cancel a run (it finalizes 'cancelled' on its next wake).")
+@covers("cancel_run")
+def cancel_run_(ctx: typer.Context, run_id: str) -> None:
+    def _run() -> None:
+        call_single(ctx, cancel_run.sync_detailed, run_id=run_id)
 
     run_or_die(_run)
 

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1392,6 +1392,7 @@ async def list_sessions(
     account_id: str,
     agent_id: str | None = None,
     status: SessionStatus | None = None,
+    parent_run_id: str | None = None,
     limit: int = 50,
     after: str | None = None,
 ) -> list[Session]:
@@ -1404,6 +1405,10 @@ async def list_sessions(
     pagination stays correct (post-filtering the page would conflate "few
     matches in this window" with "no more results"). ``status`` and
     ``last_event_at`` are derived in ``extra_select``.
+
+    ``parent_run_id`` is a plain column filter (the session is a workflow run's
+    ``agent()`` child) — the session-side analog of filtering runs by their
+    parent, so a run can list the agent sessions it spawned.
     """
     return await _list_scoped(
         conn,
@@ -1412,7 +1417,11 @@ async def list_sessions(
         row=_row_to_session,
         limit=limit,
         after=after,
-        filters=[("agent_id", agent_id), (f"({_SESSION_STATUS_EXPR})", status)],
+        filters=[
+            ("agent_id", agent_id),
+            (f"({_SESSION_STATUS_EXPR})", status),
+            ("parent_run_id", parent_run_id),
+        ],
         # last_event_at: timestamp of the session's newest event. ``ORDER BY
         # seq DESC LIMIT 1`` rides the (session_id, seq) index — O(log n) even
         # for huge sessions (unlike MAX(created_at), which has no index).

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -33,6 +33,12 @@ from aios.models.workflows import (
     Workflow,
 )
 
+# A reserved ``call_key`` for the run-cancel side-marker. Real call_keys are
+# call-site hashes, so this sentinel never collides; the ``(run_id, call_key)`` PK
+# makes it one cancel signal per run — i.e. cancellation is idempotent. The next
+# ``run_workflow_step`` harvests it (under the lock) and finalizes ``cancelled``.
+CANCEL_SIGNAL_CALL_KEY = "__cancel__"
+
 
 def _row_to_workflow(row: asyncpg.Record) -> Workflow:
     return Workflow(
@@ -43,6 +49,7 @@ def _row_to_workflow(row: asyncpg.Record) -> Workflow:
         script=row["script"],
         input_schema=parse_jsonb(row["input_schema"]),
         output_schema=parse_jsonb(row["output_schema"]),
+        description=row["description"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
@@ -101,6 +108,7 @@ async def insert_workflow(
     version: int = 1,
     input_schema: dict[str, Any] | None = None,
     output_schema: dict[str, Any] | None = None,
+    description: str | None = None,
 ) -> Workflow:
     """Insert an immutable workflow definition. Raises ``ConflictError`` on a
     duplicate ``(account_id, name, version)``."""
@@ -109,8 +117,8 @@ async def insert_workflow(
         row = await conn.fetchrow(
             """
             INSERT INTO workflows
-                (id, account_id, name, version, script, input_schema, output_schema)
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb)
+                (id, account_id, name, version, script, input_schema, output_schema, description)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8)
             RETURNING *
             """,
             new_id,
@@ -120,6 +128,7 @@ async def insert_workflow(
             script,
             json.dumps(input_schema) if input_schema is not None else None,
             json.dumps(output_schema) if output_schema is not None else None,
+            description,
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -196,8 +205,14 @@ async def list_wf_runs(
     after: str | None = None,
     workflow_id: str | None = None,
     status: str | None = None,
+    parent_run_id: str | None = None,
 ) -> list[WfRun]:
-    """Keyset-paginated list of an account's runs (non-archived), newest first."""
+    """Keyset-paginated list of an account's runs (non-archived), newest first.
+
+    ``parent_run_id`` scopes to a run's children (the runs a workflow's nested
+    ``workflow()`` calls spawned) — the run-side analog of filtering sessions by
+    ``parent_run_id`` for a run's ``agent()`` children.
+    """
     return await _list_scoped(
         conn,
         table="wf_runs",
@@ -205,7 +220,11 @@ async def list_wf_runs(
         row=_row_to_wf_run,
         limit=limit,
         after=after,
-        filters=[("workflow_id", workflow_id), ("status", status)],
+        filters=[
+            ("workflow_id", workflow_id),
+            ("status", status),
+            ("parent_run_id", parent_run_id),
+        ],
     )
 
 
@@ -339,7 +358,7 @@ async def append_run_event(
             SELECT $1, r.id, r.last_event_seq + 1, $4, $5, $6::jsonb
             FROM wf_runs r
             WHERE r.id = $2 AND r.account_id = $3 AND r.archived_at IS NULL
-              AND r.status NOT IN ('completed', 'errored')
+              AND r.status NOT IN ('completed', 'errored', 'cancelled')
             ON CONFLICT (run_id, call_key, type) DO NOTHING
             RETURNING *
             """,

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -18,9 +18,9 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
-WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored"]
+WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored", "cancelled"]
 WfRunEventType = Literal["run_started", "call_started", "call_result", "run_completed"]
-WfRunSignalKind = Literal["gate_resume", "child_done"]
+WfRunSignalKind = Literal["gate_resume", "child_done", "cancel"]
 
 
 class Workflow(BaseModel):
@@ -33,6 +33,7 @@ class Workflow(BaseModel):
     script: str
     input_schema: dict[str, Any] | None = None
     output_schema: dict[str, Any] | None = None
+    description: str | None = None  # optional human blurb (the agent ``description`` analog)
     created_at: datetime
     updated_at: datetime
 
@@ -102,6 +103,7 @@ class WorkflowCreate(BaseModel):
     script: str
     input_schema: dict[str, Any] | None = None
     output_schema: dict[str, Any] | None = None
+    description: str | None = None
 
 
 class WfRunCreate(BaseModel):

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -444,13 +444,20 @@ async def list_sessions(
     account_id: str,
     agent_id: str | None = None,
     status: SessionStatus | None = None,
+    parent_run_id: str | None = None,
     limit: int = 50,
     after: str | None = None,
 ) -> list[Session]:
     # See ``get_session`` for the rationale on the snapshot wrap.
     async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
         sessions = await queries.list_sessions(
-            conn, agent_id=agent_id, status=status, limit=limit, after=after, account_id=account_id
+            conn,
+            agent_id=agent_id,
+            status=status,
+            parent_run_id=parent_run_id,
+            limit=limit,
+            after=after,
+            account_id=account_id,
         )
         if not sessions:
             return sessions

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -24,6 +24,7 @@ from aios.services.wake import defer_run_wake
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
+    "cancel_run",
     "create_run",
     "create_workflow",
     "get_run",
@@ -47,6 +48,7 @@ async def create_workflow(
     script: str,
     input_schema: dict[str, Any] | None = None,
     output_schema: dict[str, Any] | None = None,
+    description: str | None = None,
 ) -> Workflow:
     async with pool.acquire() as conn:
         return await wf_queries.insert_workflow(
@@ -56,6 +58,7 @@ async def create_workflow(
             script=script,
             input_schema=input_schema,
             output_schema=output_schema,
+            description=description,
         )
 
 
@@ -94,6 +97,7 @@ async def list_runs(
     after: str | None = None,
     workflow_id: str | None = None,
     status: str | None = None,
+    parent_run_id: str | None = None,
 ) -> list[WfRun]:
     async with pool.acquire() as conn:
         return await wf_queries.list_wf_runs(
@@ -103,6 +107,7 @@ async def list_runs(
             after=after,
             workflow_id=workflow_id,
             status=status,
+            parent_run_id=parent_run_id,
         )
 
 
@@ -151,3 +156,33 @@ async def resume_gate_by_nonce(
             conn, run_id=run_id, call_key=call_key, kind="gate_resume", result=result
         )
     await defer_run_wake(run_id)
+
+
+async def cancel_run(
+    pool: asyncpg.Pool[Any], *, run_id: str, account_id: str, reason: Any = None
+) -> WfRun:
+    """Request cancellation of a run, returning it (still in its pre-cancel status).
+
+    Signal-driven, mirroring :func:`resume_gate_by_nonce`: record a ``cancel``
+    side-marker and wake the run; the next ``run_workflow_step`` harvests it under
+    the lock and finalizes ``cancelled`` (so the journal keeps a single writer and
+    any live ``/stream`` closes on the terminal ``run_completed``). The flip lands
+    on the wake, so the returned run still shows its current status — as gate-resume
+    returns a still-``suspended`` run.
+
+    Idempotent: an already-terminal run is returned unchanged, with no signal or
+    wake. A cross-tenant / missing run 404s (via :func:`get_wf_run`).
+    """
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_wf_run(conn, run_id, account_id=account_id)  # 404s cross-tenant
+        if run.status in ("completed", "errored", "cancelled"):
+            return run  # already terminal — nothing to cancel
+        await wf_queries.insert_run_signal(
+            conn,
+            run_id=run_id,
+            call_key=wf_queries.CANCEL_SIGNAL_CALL_KEY,
+            kind="cancel",
+            result=reason,
+        )
+    await defer_run_wake(run_id)
+    return run

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -52,7 +52,7 @@ from aios.workflows.host_launcher import EmittedCapability, run_script_host
 
 log = get_logger("aios.workflows.step")
 
-_TERMINAL = ("completed", "errored")
+_TERMINAL = ("completed", "errored", "cancelled")
 
 
 def _collect_refs(node: Any) -> list[str]:
@@ -162,6 +162,18 @@ async def run_workflow_step(run_id: str) -> None:
 
         events = await wf_queries.list_run_events(conn, run_id)
         signals = {s.call_key: s for s in await wf_queries.list_run_signals(conn, run_id)}
+
+        # User-requested cancel (signal-driven): the cancel API records a ``cancel``
+        # side-marker + wakes the run, and we finalize it here — under the
+        # procrastinate lock, so the journal keeps its single writer (appending a
+        # terminal event from the request handler would race the gapless-seq
+        # allocation). Checked before replay so a pending/suspended/running run is
+        # stopped without driving the script. A cancel that lost the race to a
+        # natural terminal already returned at the ``_TERMINAL`` guard above.
+        if (cancel_sig := signals.get(wf_queries.CANCEL_SIGNAL_CALL_KEY)) is not None:
+            await _cancel_run(conn, run, reason=cancel_sig.result)
+            return
+
         memo: dict[str, Any] = {
             e.call_key: _memo_outcome(e.payload)
             for e in events
@@ -527,4 +539,26 @@ async def _complete_run(
             status="errored" if is_error else "completed",
             output=None if is_error else output,
             account_id=run.account_id,
+        )
+
+
+async def _cancel_run(conn: asyncpg.Connection[Any], run: WfRun, *, reason: Any = None) -> None:
+    """Finalize a run as ``cancelled`` — the terminal path for a user cancel.
+
+    Structurally :func:`_complete_run` for cancellation: a non-error
+    ``run_completed`` bookend (``cancelled: True``, so a live ``/stream`` closes on
+    the event) + a ``cancelled`` terminal status, atomically. Reached only from the
+    pre-replay cancel harvest, so it runs under the lock as the journal's single
+    writer. Like a natural completion, child reclaim is left to the deferred
+    quiescence sweep (see :func:`_complete_run`).
+    """
+    payload: dict[str, Any] = {"output": None, "is_error": False, "cancelled": True}
+    if reason is not None:
+        payload["reason"] = reason
+    async with conn.transaction():
+        await wf_queries.append_run_event(
+            conn, account_id=run.account_id, run_id=run.id, type="run_completed", payload=payload
+        )
+        await wf_queries.set_run_terminal(
+            conn, run.id, status="cancelled", output=None, account_id=run.account_id
         )

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -170,6 +170,79 @@ async def test_run_reads_and_resume_404_on_unknown(http_client: httpx.AsyncClien
     assert r.status_code == 404, r.text
 
 
+async def test_workflow_description_round_trips(http_client: httpx.AsyncClient) -> None:
+    """The optional ``description`` (agent-parity blurb) survives create → get → list,
+    and stays ``None`` when omitted."""
+    name = f"wf-{_uniq()}"
+    r = await http_client.post(
+        "/v1/workflows", json={"name": name, "script": _SCRIPT, "description": "does a thing"}
+    )
+    assert r.status_code == 201, r.text
+    wf_id = r.json()["id"]
+    assert r.json()["description"] == "does a thing"
+    assert (await http_client.get(f"/v1/workflows/{wf_id}")).json()["description"] == "does a thing"
+    listed = (await http_client.get("/v1/workflows", params={"name": name})).json()["data"]
+    assert listed[0]["description"] == "does a thing"
+    # Omitting it is allowed (nullable).
+    r2 = await http_client.post("/v1/workflows", json={"name": f"wf-{_uniq()}", "script": _SCRIPT})
+    assert r2.status_code == 201 and r2.json()["description"] is None
+
+
+async def test_cancel_run_endpoint(http_client: httpx.AsyncClient) -> None:
+    """The cancel endpoint is wired + account-scoped + idempotent. (The terminal flip
+    lands on a worker wake — mocked out here, as for create/resume — so the returned
+    run still shows its pre-cancel status; the finalize-to-``cancelled`` path is the
+    step integration test's job.)"""
+    env_id = await _create_env(http_client)
+    wf = (
+        await http_client.post("/v1/workflows", json={"name": f"c-{_uniq()}", "script": _SCRIPT})
+    ).json()
+    run = (
+        await http_client.post("/v1/runs", json={"workflow_id": wf["id"], "environment_id": env_id})
+    ).json()
+
+    r = await http_client.post(f"/v1/runs/{run['id']}/cancel")
+    assert r.status_code == 200 and r.json()["id"] == run["id"], r.text
+    # Idempotent: a second cancel is still 200.
+    assert (await http_client.post(f"/v1/runs/{run['id']}/cancel")).status_code == 200
+    # Unknown + cross-tenant both 404.
+    assert (await http_client.post("/v1/runs/wfr_nope/cancel")).status_code == 404
+    key_b = await _mint_tenant(http_client, f"tenant-b-{_uniq()}")
+    cross = await http_client.post(f"/v1/runs/{run['id']}/cancel", headers=_bearer(key_b))
+    assert cross.status_code == 404, cross.text
+
+
+async def test_runs_parent_run_id_filter(http_client: httpx.AsyncClient, pool: Any) -> None:
+    """``GET /v1/runs?parent_run_id=`` scopes to a run's children. Child runs are
+    spawned internally (a nested ``workflow()``), so seed one via the query layer and
+    assert only it comes back for the parent."""
+    from aios.db.queries import workflows as wf_queries
+
+    env_id = await _create_env(http_client)
+    wf = (
+        await http_client.post("/v1/workflows", json={"name": f"p-{_uniq()}", "script": _SCRIPT})
+    ).json()
+    parent = (
+        await http_client.post("/v1/runs", json={"workflow_id": wf["id"], "environment_id": env_id})
+    ).json()
+    async with pool.acquire() as conn:
+        child = await wf_queries.insert_wf_run(
+            conn,
+            account_id=parent["account_id"],
+            workflow_id=wf["id"],
+            environment_id=env_id,
+            script=_SCRIPT,
+            script_sha="sha",
+            parent_run_id=parent["id"],
+        )
+    # An unrelated (parentless) run that must be excluded.
+    await http_client.post("/v1/runs", json={"workflow_id": wf["id"], "environment_id": env_id})
+
+    r = await http_client.get("/v1/runs", params={"parent_run_id": parent["id"]})
+    assert r.status_code == 200, r.text
+    assert [x["id"] for x in r.json()["data"]] == [child.id]  # only the child
+
+
 async def test_requires_auth(http_client: httpx.AsyncClient) -> None:
     r = await http_client.get("/v1/workflows", headers={"Authorization": ""})
     assert r.status_code == 401, r.text

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -263,6 +263,124 @@ async def test_terminal_run_and_double_resume_are_noops(wf_runtime: asyncpg.Pool
     assert await _events(pool, run_id) == before  # journal unchanged
 
 
+# ─── cancel — user-requested termination via the cancel signal ───────────────
+
+
+async def test_cancel_suspended_run_finalizes_cancelled(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """A suspended run is cancelled on its next wake: the cancel API records a signal
+    (journal untouched, run still suspended), then the wake harvests it under the lock
+    and finalizes ``cancelled`` with a non-error ``run_completed`` bookend (so a live
+    ``/stream`` closes on the event). A further wake / re-cancel is an idempotent
+    no-op."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, _GATE_SCRIPT)
+    await run_workflow_step(run_id)  # → suspended at the gate
+    async with pool.acquire() as conn:
+        suspended = await wf_queries.get_run_for_step(conn, run_id)
+    assert suspended is not None and suspended.status == "suspended"
+
+    # Request cancel: signal recorded, run still suspended (the flip lands on the wake).
+    run = await wf_service.cancel_run(pool, run_id=run_id, account_id="acc_wf")
+    assert run.status == "suspended"
+    assert [t for _s, t, _k in await _events(pool, run_id)] == ["run_started", "call_started"]
+
+    # Wake: harvest the cancel → cancelled.
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "cancelled" and run.output is None
+    rc = events[-1]
+    assert rc.type == "run_completed"
+    assert rc.payload["cancelled"] is True and rc.payload["is_error"] is False
+
+    # Idempotent: a wake on a cancelled run is a no-op; a re-cancel returns it unchanged.
+    before = await _events(pool, run_id)
+    await run_workflow_step(run_id)
+    again = await wf_service.cancel_run(pool, run_id=run_id, account_id="acc_wf")
+    assert again.status == "cancelled"
+    assert await _events(pool, run_id) == before  # journal frozen
+
+
+async def test_cancel_pending_run_finalizes_before_it_starts(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """A run cancelled before its first wake never runs the script: its journal is a
+    lone terminal ``run_completed`` and the status is ``cancelled``."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, _GATE_SCRIPT)  # pending — no events yet
+    run = await wf_service.cancel_run(pool, run_id=run_id, account_id="acc_wf")
+    assert run.status == "pending"
+
+    await run_workflow_step(run_id)  # harvest cancel before run_started
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "cancelled"
+    assert [t for _s, t, _k in await _events(pool, run_id)] == ["run_completed"]
+
+
+async def test_cancel_is_noop_on_an_already_terminal_run(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """Cancelling a run that already completed is a pure no-op: it returns the run
+    unchanged, records no ``cancel`` signal, and a subsequent wake stays a no-op."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    await run_workflow_step(run_id)  # → completed
+    before = await _events(pool, run_id)
+
+    run = await wf_service.cancel_run(pool, run_id=run_id, account_id="acc_wf")
+    assert run.status == "completed"  # returned unchanged
+    async with pool.acquire() as conn:
+        signals = await wf_queries.list_run_signals(conn, run_id)
+    assert all(s.kind != "cancel" for s in signals)  # no cancel marker written
+    await run_workflow_step(run_id)
+    assert await _events(pool, run_id) == before  # journal unchanged
+
+
+# ─── parent_run_id filters — a run's child runs + child agent-sessions ────────
+
+
+async def test_children_listable_by_parent_run_id(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A run's children are listable by ``parent_run_id`` on both surfaces: child
+    agent-sessions via ``list_sessions`` and nested child runs via ``list_wf_runs``,
+    each scoped to the parent and excluding an unrelated run's children."""
+    pool = wf_runtime
+    parent_id, child_sid = await _spawn_child(pool, wf_agent_id, "sha:pf#0")
+    # An unrelated foreground session (parent_run_id is None) that must be excluded.
+    other = await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )
+
+    async with pool.acquire() as conn:
+        scoped = await db_queries.list_sessions(
+            conn, account_id="acc_wf", parent_run_id=parent_id, limit=50
+        )
+        parent_run = await wf_queries.get_run_for_step(conn, parent_id)
+        assert parent_run is not None
+        # A nested child run under the parent (the parent run itself is parentless).
+        child_run = await wf_queries.insert_wf_run(
+            conn,
+            account_id="acc_wf",
+            workflow_id=parent_run.workflow_id,
+            environment_id="env_wf",
+            script="async def main(i):\n    return 1",
+            script_sha="sha",
+            parent_run_id=parent_id,
+        )
+        child_runs = await wf_queries.list_wf_runs(
+            conn, account_id="acc_wf", parent_run_id=parent_id, limit=50
+        )
+
+    scoped_ids = [s.id for s in scoped]
+    assert scoped_ids == [child_sid]  # only the parent's child session
+    assert other.id not in scoped_ids  # the foreground session is excluded
+    assert [r.id for r in child_runs] == [child_run.id]  # only the nested child run
+
+
 # ─── B2.C — the agent spawn arm + crash matrix ───────────────────────────────
 
 

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0070``."""
+    """The migration ladder has exactly one head: ``0072``."""
     script = _script_directory()
-    assert script.get_heads() == ["0070"]
+    assert script.get_heads() == ["0072"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -30,6 +30,7 @@ class TestWorkflowCreate:
             **payload,
             "input_schema": {"type": "object"},
             "output_schema": {"type": "integer"},
+            "description": None,
         }
 
     def test_requires_name_and_script(self) -> None:


### PR DESCRIPTION
Brings the workflow/run surface closer to the agent/session surface it mirrors, so a console UI can offer the same visibility + control without dead-ends. Small, surgical changes — mostly read-path, with one new terminal status.

## What's in here

**A1/A2 — `parent_run_id` filter on `GET /v1/runs` and `GET /v1/sessions`** (no migration)
Exposes a run's execution tree: its child **runs** (nested `workflow()` calls) and its child **agent-sessions** (`agent()` calls). The keyset helper already took an arbitrary filter list — this just threads the param through query → service → router on both endpoints.

**A3 — `Workflow.description`** (migration `0070`)
The agent-parity blurb (agents already carry one). Nullable + additive; `list`/`get` already `SELECT *`, so it surfaces automatically.

**A4 — `POST /v1/runs/{id}/cancel` + a new `cancelled` terminal status** (migration `0071`)
The genuine "stop" verb, parallel to session interrupt. **Signal-driven** (mirrors gate-resume) so the journal keeps its single writer: cancel records a `cancel` `wf_run_signals` row + wakes the run, and the next `run_workflow_step` harvests it **under the lock** and finalizes `cancelled` with a `run_completed` bookend (so any live `/stream` closes cleanly). Appending a terminal event from the request handler would have raced the gapless-seq allocation — this avoids that entirely.

Touch points for the new terminal status: the `WfRunStatus` Literal, the `wf_runs.status` + `wf_run_signals.kind` CHECK constraints (migration `0071`), `step.py`'s `_TERMINAL`, `append_run_event`'s status guard, and the SSE terminal-tail catch-up guard. Idempotent on an already-terminal run; cross-tenant 404s. `aios runs cancel` CLI command added.

Regenerated `openapi.json` + the typed SDK.

## Tests
- **Integration** (`test_wf_step.py`): cancel finalization (suspended/pending/already-terminal) + `parent_run_id` filters on both runs and sessions, driving the real step loop against Postgres.
- **E2E** (`test_workflows_api.py`): `description` round-trip, cancel endpoint wiring + idempotency + cross-tenant 404, runs `parent_run_id` filter.
- Updated the migration-head + model-dump snapshot tests.
- `mypy` · `ruff` · 1775 unit tests · the workflow integration/e2e suites all green; OpenAPI + SDK snapshots regenerated.

## Why
This unblocks the **aios-console** Workflows/Runs UI (separate PR on `aios-console`), which needs the parent/child drill-down, the `description` field, and a working cancel to mirror the Agents/Sessions experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)