### PR TITLE
feat(workflows): accept finite floats in canonical_json call keys

### DIFF
--- a/src/aios/workflows/determinism.py
+++ b/src/aios/workflows/determinism.py
@@ -5,13 +5,15 @@ Replay-with-memo only works if re-running a deterministic script produces the
 that:
 
 - :func:`canonical_json` — a total, order-independent serialization over a
-  **restricted** input domain. Floats, sets, tuples, bytes, datetimes, and
-  arbitrary objects are **rejected** at the call site (raising
-  :class:`WorkflowInputTypeError`) rather than silently coerced — these are
-  exactly the types whose serialization is ambiguous (``1.0`` vs ``1``) or whose
-  iteration order is ``PYTHONHASHSEED``-sensitive (``set``), which would desync
-  the key across a worker restart. ``sort_keys`` makes dict key order
-  irrelevant.
+  **restricted** input domain. Non-finite floats (NaN/Inf), sets, tuples, bytes,
+  datetimes, and arbitrary objects are **rejected** at the call site (raising
+  :class:`WorkflowInputTypeError`). Finite floats are accepted; integer-valued
+  floats (``1.0``, ``2.0``) are normalized to their ``int`` form so ``1`` and
+  ``1.0`` produce the same JSON token — the call key is stable even when an
+  upstream agent returns ``{"count": 1.0}`` and the script author wrote
+  ``{"count": 1}``. Sets and dicts with non-str keys are rejected because their
+  iteration order is ``PYTHONHASHSEED``-sensitive, which would desync the key
+  across a worker restart. ``sort_keys`` makes dict key order irrelevant.
 
 - :class:`CallKeyer` — turns ``(capability_id, input)`` into
   ``"sha:<hex>#<n>"`` where ``n`` is the count of *prior* emissions in this run
@@ -28,6 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from typing import Any
 
 
@@ -36,14 +39,20 @@ class WorkflowInputTypeError(TypeError):
 
     Raised deterministically at the call site (same input → same rejection on
     every replay), so a bad input is a loud author error, never a silent hash
-    desync. Allowed: ``None``, ``bool``, ``int``, ``str``, and ``list``/``dict``
-    of those. Authors needing a float pass a string or scaled int; a set, a
-    sorted list.
+    desync. Allowed: ``None``, ``bool``, ``int``, ``float`` (finite only),
+    ``str``, and ``list``/``dict`` of those. NaN/Inf floats, sets, tuples,
+    bytes, datetimes, and arbitrary objects are rejected.
     """
 
 
 def _validate(x: Any, *, path: str = "input") -> None:
     if x is None or isinstance(x, (bool, int, str)):
+        return
+    if isinstance(x, float):
+        if not math.isfinite(x):
+            raise WorkflowInputTypeError(
+                f"{path}: non-finite float {x!r} (NaN/Inf have no canonical form)"
+            )
         return
     if isinstance(x, list):
         for i, item in enumerate(x):
@@ -59,36 +68,53 @@ def _validate(x: Any, *, path: str = "input") -> None:
         return
     raise WorkflowInputTypeError(
         f"{path}: unsupported workflow input type {type(x).__name__} "
-        f"(allowed: None, bool, int, str, list, dict)"
+        f"(allowed: None, bool, int, float, str, list, dict)"
     )
+
+
+def _canon_numbers(x: Any) -> Any:
+    """Collapse integer-valued floats so ``1.0`` and ``1`` produce the same JSON token."""
+    if isinstance(x, float):
+        return int(x) if x.is_integer() else x
+    if isinstance(x, list):
+        return [_canon_numbers(i) for i in x]
+    if isinstance(x, dict):
+        return {k: _canon_numbers(v) for k, v in x.items()}
+    return x
 
 
 def canonical_json(x: Any) -> str:
     """Deterministic, order-independent JSON over the allowed input domain.
 
     Raises :class:`WorkflowInputTypeError` for any disallowed type *before*
-    serializing.
+    serializing. Integer-valued floats (``1.0``, ``2.0``) are collapsed to their
+    ``int`` form so ``1`` and ``1.0`` produce the same JSON token — the call key is
+    content-hash-stable even when an upstream agent returns ``{"count": 1.0}`` and
+    the script author wrote ``{"count": 1}``.
     """
     _validate(x)
-    return json.dumps(x, separators=(",", ":"), sort_keys=True, ensure_ascii=True, allow_nan=False)
+    return json.dumps(
+        _canon_numbers(x), separators=(",", ":"), sort_keys=True, ensure_ascii=True, allow_nan=False
+    )
 
 
 def canonical_schema_json(schema: Any) -> str:
     """Deterministic JSON for a JSON Schema carried in a capability spec.
 
-    Unlike :func:`canonical_json` (which serves the **data** domain and rejects floats
-    — a workflow input's ``1.0`` vs ``1`` must never desync the call key), a JSON
-    *Schema* legitimately carries decimal numeric constraints (``minimum`` /
-    ``multipleOf`` / …). Those are author-written literals that serialize
+    Unlike :func:`canonical_json` (which serves the **data** domain and normalises
+    integer-valued floats to their ``int`` form), a JSON *Schema* legitimately carries
+    decimal numeric constraints (``minimum`` / ``multipleOf`` / …) that must be
+    preserved verbatim — normalising ``"minimum": 1.0`` to ``1`` would silently alter
+    the schema's meaning. Those are author-written literals that serialize
     deterministically (the ``json.dumps`` float repr is stable for a given value), so
     they are admitted here; ``allow_nan=False`` still rejects the genuinely
     non-deterministic NaN/Inf. ``sort_keys`` keeps the string — and thus the call key —
     independent of the schema's key order.
 
-    ``agent()`` stores this string in the spec so a float-bearing schema never reaches
-    the float-banning :func:`canonical_json`; the worker reconstructs the schema with
-    ``json.loads``. Raises ``TypeError`` for a non-JSON-serialisable schema (e.g. a set
-    value) — a loud author error, surfaced like any other bad ``agent()`` argument.
+    ``agent()`` stores this string in the spec so schema floats are preserved verbatim;
+    the worker reconstructs the schema with ``json.loads``. Raises ``TypeError`` for a
+    non-JSON-serialisable schema (e.g. a set value) — a loud author error, surfaced
+    like any other bad ``agent()`` argument.
     """
     return json.dumps(
         schema, separators=(",", ":"), sort_keys=True, ensure_ascii=True, allow_nan=False

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -138,9 +138,10 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
     """
     if input is None:
         raise ValueError("agent() requires a non-None input (the child's first message)")
-    # Carry output_schema as a canonical JSON *string* so a schema's decimal numeric
-    # constraints (minimum/multipleOf/…) survive the call_key hash — canonical_json (the
-    # spec serializer) bans floats in the data domain; a schema is metadata. The worker
+    # Carry output_schema as a canonical JSON *string* so a schema's numeric literals
+    # (minimum/multipleOf/…) are preserved verbatim — canonical_json normalises
+    # integer-valued floats (1.0 → 1), which would alter schema constraints like
+    # "minimum": 1.0. A schema is metadata, not workflow data. The worker
     # reconstructs the dict with json.loads. None stays None (no schema demanded).
     return _Capability(
         "agent",

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -149,8 +149,8 @@ async def test_agent_requires_non_none_input() -> None:
 
 async def test_bad_capability_input_is_raised() -> None:
     out = await _run(
-        "async def main(input):\n    return await gate({'t': 1.5})"
-    )  # float spec rejected
+        "async def main(input):\n    return await gate({'t': (1, 2)})"
+    )  # tuple spec rejected
     assert out.kind == "raised"
     assert "WorkflowInputTypeError" in (out.error_repr or "")
 

--- a/tests/unit/test_wf_determinism.py
+++ b/tests/unit/test_wf_determinism.py
@@ -35,9 +35,6 @@ def test_canonical_json_accepts_allowed_types() -> None:
 @pytest.mark.parametrize(
     "bad",
     [
-        1.0,
-        {"n": 1.5},
-        [1, 2.0],
         {1, 2},
         (1, 2),
         b"bytes",
@@ -49,6 +46,37 @@ def test_canonical_json_accepts_allowed_types() -> None:
 def test_canonical_json_rejects_disallowed_types(bad: object) -> None:
     with pytest.raises(WorkflowInputTypeError):
         canonical_json(bad)
+
+
+def test_canonical_json_accepts_finite_floats() -> None:
+    assert canonical_json(1.5) == "1.5"
+    assert canonical_json({"x": 3.14}) == '{"x":3.14}'
+    assert canonical_json([0.5, 2.5]) == "[0.5,2.5]"
+
+
+def test_canonical_json_normalises_integer_floats() -> None:
+    # 1.0 and 1 must hash identically — the stated invariant.
+    assert canonical_json(1.0) == canonical_json(1) == "1"
+    assert canonical_json({"n": 2.0}) == canonical_json({"n": 2}) == '{"n":2}'
+    assert canonical_json([1.0, 2.0]) == canonical_json([1, 2]) == "[1,2]"
+    # content_hash must reflect this too.
+    assert content_hash("agent", {"x": 1}) == content_hash("agent", {"x": 1.0})
+
+
+def test_canonical_json_rejects_nan_inf() -> None:
+    for bad in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(WorkflowInputTypeError, match="non-finite"):
+            canonical_json(bad)
+    # Nested too.
+    with pytest.raises(WorkflowInputTypeError, match="input\\.x"):
+        canonical_json({"x": float("nan")})
+
+
+def test_canonical_json_float_repr_stability() -> None:
+    # json.dumps float repr is stable for a given value (documented guarantee).
+    val = 0.1 + 0.2  # classic float imprecision — still stable across calls
+    assert canonical_json(val) == canonical_json(val)
+    assert canonical_json(0.95) == "0.95"
 
 
 def test_canonical_json_rejects_non_str_dict_keys() -> None:


### PR DESCRIPTION
Closes #762

## Summary

- `canonical_json` previously rejected all floats, causing `WorkflowInputTypeError` when typed agent results (e.g. confidence scores) were passed as inputs to downstream `agent()` calls
- Finite floats are now accepted; NaN and Inf still raise loudly with a "non-finite float" message
- Integer-valued floats (`1.0 → 1`) are collapsed before `json.dumps` to preserve hash-stability between integer and float representations of the same value
- Updated stale docstrings in `determinism.py` (module docstring, `WorkflowInputTypeError`, `canonical_json`, `canonical_schema_json`) and a comment in `wf_script_host.py`

## Changes

- `src/aios/workflows/determinism.py` — added `import math`, float branch in `_validate()`, new `_canon_numbers()` helper, `canonical_json()` now calls `_canon_numbers()`, docstring updates throughout
- `src/aios/workflows/wf_script_host.py` — updated comment that cited the old float ban as motivation for carrying `output_schema` as a string
- `tests/unit/test_wf_determinism.py` — removed `1.0`, `{"n": 1.5}`, `[1, 2.0]` from rejection parametrize list; added 4 new tests: `test_canonical_json_accepts_finite_floats`, `test_canonical_json_normalises_integer_floats`, `test_canonical_json_rejects_nan_inf`, `test_canonical_json_float_repr_stability`
- `tests/integration/test_wf_host.py` — replaced `gate({'t': 1.5})` with `gate({'t': (1, 2)})` (tuples remain disallowed)

## Test plan

- [ ] `uv run pytest tests/unit -q` — all unit tests pass (including 4 new determinism tests)
- [ ] `1.0`/`1` normalization: `content_hash("agent", {"x": 1}) == content_hash("agent", {"x": 1.0})`
- [ ] NaN/Inf → `WorkflowInputTypeError` with "non-finite" in message
- [ ] Integration test still catches actually-disallowed types (tuples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)