### PR TITLE
feat(runs): await — block-until-complete as a reusable primitive, runs backing

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -8582,6 +8582,77 @@
         }
       }
     },
+    "/v1/runs/{run_id}/wait": {
+      "get": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Await Run",
+        "description": "Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.\n\nThe ``await``-a-completion primitive (runs backing): one JSON round-trip returning the\ncompletion record \u2014 ``done`` + ``output``, or ``is_error`` + ``error``. A run still running\nafter ``timeout`` seconds returns ``done=false`` with its current status; call again to keep\nblocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP\ntool \u2014 an agent can await a sub-run and join. A cross-tenant run 404s.",
+        "operationId": "await_run",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 60,
+              "minimum": 0,
+              "default": 30,
+              "title": "Timeout"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WfRunWaitResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/runs/{run_id}/events": {
       "get": {
         "tags": [
@@ -15217,6 +15288,53 @@
         ],
         "title": "WfRunEvent",
         "description": "One row of a run's append-only journal (the replay-with-memo source).\n\n``call_key`` is set for ``call_started``/``call_result`` (the memo key) and\n``None`` for the ``run_started``/``run_completed`` bookends."
+      },
+      "WfRunWaitResponse": {
+        "properties": {
+          "run_status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "running",
+              "suspended",
+              "completed",
+              "errored",
+              "cancelled"
+            ],
+            "title": "Run Status"
+          },
+          "done": {
+            "type": "boolean",
+            "title": "Done"
+          },
+          "output": {
+            "title": "Output"
+          },
+          "is_error": {
+            "type": "boolean",
+            "title": "Is Error",
+            "default": false
+          },
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "run_status",
+          "done"
+        ],
+        "title": "WfRunWaitResponse",
+        "description": "Response for ``GET /v1/runs/{run_id}/wait`` \u2014 the run's completion record, or its\ncurrent (non-terminal) state if the wait timed out.\n\nDeliberately mirrors the ``{result, is_error, error}`` shape of a request response\n(``derive_response``) so the ``await`` primitive's two backings (run-terminal and, later,\nsession-request) share one envelope. Poll until ``done``: a still-running run returns\n``done=False`` with its live ``run_status`` (``running``/``suspended``/\u2026); call again to\nkeep blocking."
       },
       "WhatsappConfirmPairingRequest": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/await_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/await_run.py
@@ -1,0 +1,231 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.wf_run_wait_response import WfRunWaitResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["timeout"] = timeout
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/runs/{run_id}/wait".format(
+            run_id=quote(str(run_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | WfRunWaitResponse | None:
+    if response.status_code == 200:
+        response_200 = WfRunWaitResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | WfRunWaitResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRunWaitResponse]:
+    """Await Run
+
+     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+
+    The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
+    completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
+    after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
+    blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
+    tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRunWaitResponse]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        timeout=timeout,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRunWaitResponse | None:
+    """Await Run
+
+     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+
+    The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
+    completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
+    after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
+    blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
+    tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRunWaitResponse
+    """
+
+    return sync_detailed(
+        run_id=run_id,
+        client=client,
+        timeout=timeout,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WfRunWaitResponse]:
+    """Await Run
+
+     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+
+    The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
+    completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
+    after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
+    blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
+    tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WfRunWaitResponse]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        timeout=timeout,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WfRunWaitResponse | None:
+    """Await Run
+
+     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+
+    The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
+    completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
+    after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
+    blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
+    tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+
+    Args:
+        run_id (str):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WfRunWaitResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            run_id=run_id,
+            client=client,
+            timeout=timeout,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -227,6 +227,9 @@ from .wf_run_event import WfRunEvent
 from .wf_run_event_payload import WfRunEventPayload
 from .wf_run_event_type import WfRunEventType
 from .wf_run_status import WfRunStatus
+from .wf_run_wait_response import WfRunWaitResponse
+from .wf_run_wait_response_error_type_0 import WfRunWaitResponseErrorType0
+from .wf_run_wait_response_run_status import WfRunWaitResponseRunStatus
 from .whatsapp_confirm_pairing_request import WhatsappConfirmPairingRequest
 from .whatsapp_confirm_pairing_response import WhatsappConfirmPairingResponse
 from .whatsapp_confirm_pairing_response_status import (
@@ -458,6 +461,9 @@ __all__ = (
     "WfRunEventPayload",
     "WfRunEventType",
     "WfRunStatus",
+    "WfRunWaitResponse",
+    "WfRunWaitResponseErrorType0",
+    "WfRunWaitResponseRunStatus",
     "WhatsappConfirmPairingRequest",
     "WhatsappConfirmPairingResponse",
     "WhatsappConfirmPairingResponseStatus",

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.wf_run_wait_response_run_status import WfRunWaitResponseRunStatus
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.wf_run_wait_response_error_type_0 import WfRunWaitResponseErrorType0
+
+
+T = TypeVar("T", bound="WfRunWaitResponse")
+
+
+@_attrs_define
+class WfRunWaitResponse:
+    """Response for ``GET /v1/runs/{run_id}/wait`` — the run's completion record, or its
+    current (non-terminal) state if the wait timed out.
+
+    Deliberately mirrors the ``{result, is_error, error}`` shape of a request response
+    (``derive_response``) so the ``await`` primitive's two backings (run-terminal and, later,
+    session-request) share one envelope. Poll until ``done``: a still-running run returns
+    ``done=False`` with its live ``run_status`` (``running``/``suspended``/…); call again to
+    keep blocking.
+
+        Attributes:
+            run_status (WfRunWaitResponseRunStatus):
+            done (bool):
+            output (Any | Unset):
+            is_error (bool | Unset):  Default: False.
+            error (None | Unset | WfRunWaitResponseErrorType0):
+    """
+
+    run_status: WfRunWaitResponseRunStatus
+    done: bool
+    output: Any | Unset = UNSET
+    is_error: bool | Unset = False
+    error: None | Unset | WfRunWaitResponseErrorType0 = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.wf_run_wait_response_error_type_0 import (
+            WfRunWaitResponseErrorType0,
+        )
+
+        run_status = self.run_status.value
+
+        done = self.done
+
+        output = self.output
+
+        is_error = self.is_error
+
+        error: dict[str, Any] | None | Unset
+        if isinstance(self.error, Unset):
+            error = UNSET
+        elif isinstance(self.error, WfRunWaitResponseErrorType0):
+            error = self.error.to_dict()
+        else:
+            error = self.error
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "run_status": run_status,
+                "done": done,
+            }
+        )
+        if output is not UNSET:
+            field_dict["output"] = output
+        if is_error is not UNSET:
+            field_dict["is_error"] = is_error
+        if error is not UNSET:
+            field_dict["error"] = error
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.wf_run_wait_response_error_type_0 import (
+            WfRunWaitResponseErrorType0,
+        )
+
+        d = dict(src_dict)
+        run_status = WfRunWaitResponseRunStatus(d.pop("run_status"))
+
+        done = d.pop("done")
+
+        output = d.pop("output", UNSET)
+
+        is_error = d.pop("is_error", UNSET)
+
+        def _parse_error(data: object) -> None | Unset | WfRunWaitResponseErrorType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                error_type_0 = WfRunWaitResponseErrorType0.from_dict(data)
+
+                return error_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WfRunWaitResponseErrorType0, data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
+        wf_run_wait_response = cls(
+            run_status=run_status,
+            done=done,
+            output=output,
+            is_error=is_error,
+            error=error,
+        )
+
+        wf_run_wait_response.additional_properties = d
+        return wf_run_wait_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response_error_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response_error_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WfRunWaitResponseErrorType0")
+
+
+@_attrs_define
+class WfRunWaitResponseErrorType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        wf_run_wait_response_error_type_0 = cls()
+
+        wf_run_wait_response_error_type_0.additional_properties = d
+        return wf_run_wait_response_error_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response_run_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response_run_status.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class WfRunWaitResponseRunStatus(str, Enum):
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+    ERRORED = "errored"
+    PENDING = "pending"
+    RUNNING = "running"
+    SUSPENDED = "suspended"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -26,6 +26,7 @@ from aios.models.workflows import (
     WfRun,
     WfRunCreate,
     WfRunEvent,
+    WfRunWaitResponse,
     Workflow,
     WorkflowCreate,
 )
@@ -151,6 +152,27 @@ async def list_runs(
 async def get_run(run_id: str, pool: PoolDep, account_id: AccountIdDep) -> WfRun:
     """Fetch one run by id (status, output, last_event_seq, …)."""
     return await service.get_run(pool, run_id, account_id=account_id)
+
+
+@runs_router.get("/{run_id}/wait", operation_id="await_run")
+async def await_run(
+    run_id: str,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    timeout_seconds: Annotated[int, Query(alias="timeout", ge=0, le=60)] = 30,
+) -> WfRunWaitResponse:
+    """Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+
+    The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
+    completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
+    after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
+    blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
+    tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+    """
+    return await service.await_run(
+        pool, db_url, run_id, account_id=account_id, timeout_seconds=timeout_seconds
+    )
 
 
 @runs_router.get("/{run_id}/events", operation_id="list_run_events")

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -36,6 +36,7 @@ from sse_starlette import EventSourceResponse, ServerSentEvent
 
 from aios.db import queries
 from aios.logging import get_logger
+from aios.models.workflows import TERMINAL_RUN_STATUSES
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -248,10 +249,10 @@ async def wf_run_event_stream(
                     run_id,
                     cursor,
                 )
-                if status in ("completed", "errored", "cancelled")
+                if status in TERMINAL_RUN_STATUSES
                 else []
             )
-        if status in ("completed", "errored", "cancelled"):
+        if status in TERMINAL_RUN_STATUSES:
             for row in terminal_tail:
                 payload = _serialize_wf_event(row)
                 cursor = max(cursor, payload["seq"])

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -15,12 +15,13 @@ from typing import Annotated, Any
 
 import typer
 
-from aios.cli.commands._shared import call_single, render_paginated
+from aios.cli.commands._shared import call_single, render_paginated, render_single, unwrap
 from aios.cli.coverage import covers
 from aios.cli.files import PayloadError, load_payload
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk import stream_run
 from aios_sdk._generated.api.runs import (
+    await_run,
     cancel_run,
     create_run,
     get_run,
@@ -136,6 +137,36 @@ def list_runs_(
 def get_run_(ctx: typer.Context, run_id: str) -> None:
     def _run() -> None:
         call_single(ctx, get_run.sync_detailed, run_id=run_id)
+
+    run_or_die(_run)
+
+
+@runs_app.command("wait", help="Block until a run completes, then print its result.")
+@covers("await_run")
+def wait_run_(
+    ctx: typer.Context,
+    run_id: str,
+    timeout: Annotated[
+        int,
+        typer.Option(
+            "--timeout",
+            min=1,
+            max=60,
+            help="Per-request long-poll budget (seconds); the command re-polls until terminal.",
+        ),
+    ] = 30,
+) -> None:
+    def _run() -> None:
+        # The endpoint blocks up to --timeout then returns done|current; re-poll the
+        # bounded call until the run is terminal so the command blocks end-to-end.
+        with get_state(ctx).sdk_client() as client:
+            while True:
+                resp = unwrap(
+                    await_run.sync_detailed(run_id=run_id, client=client, timeout=timeout)
+                )
+                if resp.done:
+                    break
+        render_single(resp.to_dict())
 
     run_or_die(_run)
 

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -420,6 +420,20 @@ async def list_run_events_scoped(
     return [_row_to_wf_run_event(r) for r in rows]
 
 
+async def get_run_completed_event(conn: asyncpg.Connection[Any], run_id: str) -> WfRunEvent | None:
+    """The run's terminal ``run_completed`` event, or ``None`` if it hasn't completed.
+
+    Its payload carries the authoritative ``{output, is_error, error}`` completion detail —
+    in particular ``error.kind``, which ``wf_runs`` does not store (the row keeps only
+    ``status`` + ``output``). Unscoped by account: every caller (``await_run``) pre-checks the
+    run with :func:`get_wf_run`. Exactly one ``run_completed`` bookend exists per run (the
+    ``UNIQUE NULLS NOT DISTINCT (run_id, call_key, type)`` memo), so a bare fetch is exact."""
+    row = await conn.fetchrow(
+        "SELECT * FROM wf_run_events WHERE run_id = $1 AND type = 'run_completed'", run_id
+    )
+    return _row_to_wf_run_event(row) if row is not None else None
+
+
 async def find_open_gate_call_key(
     conn: asyncpg.Connection[Any], run_id: str, *, gate_nonce: str
 ) -> str | None:

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -22,6 +22,11 @@ WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored",
 WfRunEventType = Literal["run_started", "call_started", "call_result", "run_completed"]
 WfRunSignalKind = Literal["gate_resume", "child_done", "cancel"]
 
+# The terminal run statuses — monotonic: once here, a run never leaves. The one source for
+# every "is this run done?" check (the step loop's early-out, the SSE stream's close, the await
+# predicate). ``cancelled`` is terminal too (a user cancel finalizes the run).
+TERMINAL_RUN_STATUSES: frozenset[str] = frozenset({"completed", "errored", "cancelled"})
+
 
 class Workflow(BaseModel):
     """An immutable, versioned workflow definition."""
@@ -91,6 +96,24 @@ class WfRunSignal(BaseModel):
     kind: WfRunSignalKind
     result: Any = None  # arbitrary JSON: the externally-delivered resume value
     delivered_at: datetime
+
+
+class WfRunWaitResponse(BaseModel):
+    """Response for ``GET /v1/runs/{run_id}/wait`` — the run's completion record, or its
+    current (non-terminal) state if the wait timed out.
+
+    Deliberately mirrors the ``{result, is_error, error}`` shape of a request response
+    (``derive_response``) so the ``await`` primitive's two backings (run-terminal and, later,
+    session-request) share one envelope. Poll until ``done``: a still-running run returns
+    ``done=False`` with its live ``run_status`` (``running``/``suspended``/…); call again to
+    keep blocking.
+    """
+
+    run_status: WfRunStatus
+    done: bool  # run_status in {completed, errored} — terminal, never reverts
+    output: Any = None  # the run's return value (on completed; None on error)
+    is_error: bool = False  # run_status == errored
+    error: dict[str, Any] | None = None  # the run_completed event's {kind} (on errored)
 
 
 # ─── request models (the public HTTP surface) ────────────────────────────────

--- a/src/aios/services/await_completion.py
+++ b/src/aios/services/await_completion.py
@@ -1,0 +1,50 @@
+"""``await_completion`` — block until a monotonic done-predicate holds, or a timeout.
+
+The one mechanism behind "await-a-completion": block on a target's notify queue, re-reading
+state on each notify until ``is_done`` holds (or the deadline passes). The predicate must be
+*monotonic* — a terminal record never un-completes — so the loop safely stops the first time it
+holds. Runs are backing #1 (``status in {completed, errored}``, see
+:func:`aios.services.workflows.await_run`); a session backing (watermarked quiescence /
+``request_response`` correlation) is the intended second caller and needs no change here — but it
+is NOT the non-monotonic "wait for idle", which would be the reverted Stop hook.
+
+The caller owns the subscription lifecycle; this helper only consumes the ``queue``, staying a
+pure function of ``(queue, read_state, is_done)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+async def await_completion[S](
+    queue: asyncio.Queue[Any],
+    *,
+    read_state: Callable[[], Awaitable[S]],
+    is_done: Callable[[S], bool],
+    timeout_seconds: float,
+) -> S:
+    """Block until ``is_done(state)`` or ``timeout_seconds`` elapse; return the last state read.
+
+    ``read_state`` is called **after** the caller has subscribed (the LISTEN-before-read
+    invariant: a state change between subscribe and the first read is already queued, so it
+    can't be missed), then again on every notify. Any queue item triggers a re-read — for runs
+    each notify is a committed event; a backing whose channel also carries non-advancing pokes
+    just re-reads harmlessly. Returns the terminal state when done, or the current (non-terminal)
+    state on timeout — the caller's signal to re-poll.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    state = await read_state()
+    while not is_done(state):
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        try:
+            await asyncio.wait_for(queue.get(), timeout=remaining)
+        except TimeoutError:
+            break
+        state = await read_state()
+    return state

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -17,13 +17,22 @@ from typing import Any
 
 import asyncpg
 
+from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
 from aios.errors import NotFoundError
-from aios.models.workflows import WfRun, WfRunEvent, Workflow
+from aios.models.workflows import (
+    TERMINAL_RUN_STATUSES,
+    WfRun,
+    WfRunEvent,
+    WfRunWaitResponse,
+    Workflow,
+)
+from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
+    "await_run",
     "cancel_run",
     "create_run",
     "create_workflow",
@@ -123,6 +132,55 @@ async def list_run_events(
         return await wf_queries.list_run_events_scoped(
             conn, run_id, account_id=account_id, after_seq=after_seq, limit=limit
         )
+
+
+async def await_run(
+    pool: asyncpg.Pool[Any],
+    db_url: str,
+    run_id: str,
+    *,
+    account_id: str,
+    timeout_seconds: float,
+) -> WfRunWaitResponse:
+    """Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+
+    The run backing of the ``await``-a-completion primitive. Account-scopes the run FIRST (so a
+    cross-tenant/missing ``run_id`` 404s before we open any connection — mirroring ``/stream``,
+    and so an unauthorized caller can neither open a LISTEN on a foreign run's channel nor churn
+    connections), then subscribes to the run's ``wf_run_events`` channel BEFORE the predicate's
+    first status read (LISTEN-before-read: a completion landing between subscribe and read has
+    already queued its notify, so it can't be missed), drives :func:`await_completion` with the
+    terminal predicate, and returns the completion record — or, on timeout, the run's current
+    (non-terminal) status so the caller re-polls.
+    """
+    await get_run(pool, run_id, account_id=account_id)  # 404s cross-tenant before we subscribe
+
+    async def _read_run() -> WfRun:
+        async with pool.acquire() as conn:
+            return await wf_queries.get_wf_run(conn, run_id, account_id=account_id)
+
+    subscription = await open_listen_for_run_events(db_url, run_id)
+    try:
+        run = await await_completion(
+            subscription.queue,
+            read_state=_read_run,
+            is_done=lambda r: r.status in TERMINAL_RUN_STATUSES,
+            timeout_seconds=timeout_seconds,
+        )
+    finally:
+        subscription.terminate()
+
+    done = run.status in TERMINAL_RUN_STATUSES
+    is_error = run.status == "errored"
+    error: dict[str, Any] | None = None
+    if is_error:
+        # ``error.kind`` lives only in the run_completed payload, not on the run row.
+        async with pool.acquire() as conn:
+            completed = await wf_queries.get_run_completed_event(conn, run_id)
+        error = completed.payload.get("error") if completed is not None else None
+    return WfRunWaitResponse(
+        run_status=run.status, done=done, output=run.output, is_error=is_error, error=error
+    )
 
 
 async def resume_gate_by_nonce(

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -44,15 +44,13 @@ from aios.db.queries import workflows as wf_queries
 from aios.errors import NotFoundError
 from aios.harness import runtime
 from aios.logging import get_logger
-from aios.models.workflows import WfRun, WfRunEvent
+from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent
 from aios.services.sessions import create_child_session
 from aios.services.wake import defer_run_wake, defer_wake
 from aios.workflows.child_id import child_session_id
 from aios.workflows.host_launcher import EmittedCapability, run_script_host
 
 log = get_logger("aios.workflows.step")
-
-_TERMINAL = ("completed", "errored", "cancelled")
 
 
 def _collect_refs(node: Any) -> list[str]:
@@ -156,7 +154,7 @@ async def run_workflow_step(run_id: str) -> None:
 
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
-        if run is None or run.status in _TERMINAL:
+        if run is None or run.status in TERMINAL_RUN_STATUSES:
             return  # vanished or already terminal — a stray/duplicate wake is a no-op
         account_id = run.account_id
 
@@ -169,7 +167,7 @@ async def run_workflow_step(run_id: str) -> None:
         # terminal event from the request handler would race the gapless-seq
         # allocation). Checked before replay so a pending/suspended/running run is
         # stopped without driving the script. A cancel that lost the race to a
-        # natural terminal already returned at the ``_TERMINAL`` guard above.
+        # natural terminal already returned at the ``TERMINAL_RUN_STATUSES`` guard above.
         if (cancel_sig := signals.get(wf_queries.CANCEL_SIGNAL_CALL_KEY)) is not None:
             await _cancel_run(conn, run, reason=cancel_sig.result)
             return

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -206,3 +206,67 @@ class TestWaitEndpoint:
         assert any(
             e["kind"] == "message" and e["data"].get("content") == "real" for e in body["events"]
         ), body
+
+
+@pytest.fixture
+async def run_id(pool: Any) -> str:
+    """A freshly created (``pending``, never-stepped) run for the run-wait endpoint.
+
+    ``defer_run_wake`` is patched out so creation doesn't need a procrastinate worker;
+    the run stays ``pending`` (nothing steps it), which is exactly the non-terminal state
+    the timeout test exercises."""
+    account_id = "acc_test_stub"  # PR 3 scaffolding
+    from aios.db import queries
+    from aios.services import workflows as wf_svc
+
+    async with pool.acquire() as conn:
+        env = await queries.insert_environment(
+            conn, name=f"runwait-env-{_uniq()}", account_id=account_id
+        )
+    wf = await wf_svc.create_workflow(
+        pool,
+        account_id=account_id,
+        name=f"runwait-wf-{_uniq()}",
+        script="async def main(input):\n    return 1",
+    )
+    with mock.patch("aios.workflows.service.defer_run_wake", new=mock.AsyncMock()):
+        run = await wf_svc.create_run(
+            pool, account_id=account_id, workflow_id=wf.id, environment_id=env.id, input=None
+        )
+    return run.id
+
+
+class TestRunWaitEndpoint:
+    """``GET /v1/runs/{id}/wait`` — the await-a-completion endpoint (runs backing).
+
+    Exercises the HTTP wiring (route registration, the ``timeout`` query alias, the
+    ``WfRunWaitResponse`` serialization, account scoping) over a real ASGI client. The
+    blocking/completion behavior of the service itself is covered in
+    ``tests/integration/test_wf_step.py``; here ``timeout=0`` keeps every case non-blocking."""
+
+    async def test_timeout_returns_done_false_for_pending_run(
+        self, http_client: httpx.AsyncClient, run_id: str
+    ) -> None:
+        """A never-stepped run is non-terminal; ``timeout=0`` returns at once with the live
+        status and ``done=false`` (the re-poll contract) — proving the alias + model wiring."""
+        r = await http_client.get(f"/v1/runs/{run_id}/wait", params={"timeout": 0})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["done"] is False
+        assert body["run_status"] == "pending"
+        assert body["is_error"] is False and body["error"] is None
+
+    async def test_rejects_timeout_above_cap(
+        self, http_client: httpx.AsyncClient, run_id: str
+    ) -> None:
+        """The ``le=60`` bound on the ``timeout`` query param is enforced (422)."""
+        r = await http_client.get(f"/v1/runs/{run_id}/wait", params={"timeout": 3600})
+        assert r.status_code == 422, r.text
+
+    async def test_unknown_run_404s_before_subscribing(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """A run id the caller can't see 404s — and (post-review) the scope check runs BEFORE
+        any LISTEN is opened, so an unauthorized caller never opens a connection on the channel."""
+        r = await http_client.get("/v1/runs/wf_run_nope/wait", params={"timeout": 0})
+        assert r.status_code == 404, r.text

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -11,6 +11,7 @@ directly, which is exactly the surface under test.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest import mock
@@ -2178,3 +2179,84 @@ async def test_defer_wake_priority_reflects_real_origin(
         }
     assert priorities[fg.id] == _FOREGROUND_PRIORITY  # real foreground → default
     assert priorities[cid] == _BACKGROUND_PRIORITY  # real background child → demoted
+
+
+# ─── await_run — the await-a-completion primitive, runs backing ──────────────
+
+
+async def test_await_run_returns_when_already_completed(
+    wf_runtime: asyncpg.Pool[Any], migrated_db_url: str
+) -> None:
+    """A terminal run is returned immediately (the first post-subscribe read sees it):
+    ``done`` + the script's ``output``, no error."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    await run_workflow_step(run_id)  # pure script → completed in one wake
+    resp = await wf_service.await_run(
+        pool, migrated_db_url, run_id, account_id="acc_wf", timeout_seconds=5
+    )
+    assert resp.done is True and resp.run_status == "completed"
+    assert resp.output == 1 and resp.is_error is False and resp.error is None
+
+
+async def test_await_run_surfaces_error_kind(
+    wf_runtime: asyncpg.Pool[Any], migrated_db_url: str
+) -> None:
+    """An errored run returns ``is_error`` + the ``error.kind`` lifted from the
+    ``run_completed`` payload (``author_exception`` for an uncaught script raise)."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    raise ValueError('boom')")
+    await run_workflow_step(run_id)  # raise → errored
+    resp = await wf_service.await_run(
+        pool, migrated_db_url, run_id, account_id="acc_wf", timeout_seconds=5
+    )
+    assert resp.done is True and resp.run_status == "errored" and resp.is_error is True
+    assert resp.error == {"kind": "author_exception"}
+
+
+async def test_await_run_times_out_on_non_terminal_run(
+    wf_runtime: asyncpg.Pool[Any], migrated_db_url: str
+) -> None:
+    """A never-stepped (``pending``) run that doesn't finish within the budget returns
+    ``done=False`` with its live status — the re-poll contract, no archive/mutation."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")  # created, not stepped
+    resp = await wf_service.await_run(
+        pool, migrated_db_url, run_id, account_id="acc_wf", timeout_seconds=0.1
+    )
+    assert resp.done is False and resp.run_status == "pending"
+    assert resp.output is None and resp.is_error is False and resp.error is None
+
+
+async def test_await_run_wakes_on_completion_during_wait(
+    wf_runtime: asyncpg.Pool[Any], migrated_db_url: str
+) -> None:
+    """Completion-during-subscribe: the await blocks on a pending run; a concurrent step
+    drives it terminal; the run_completed notify wakes the await → it returns the record
+    (not a timeout). The LISTEN-before-read ordering is what closes the race."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 7")
+
+    async def _complete_soon() -> None:
+        await asyncio.sleep(0.1)  # let await_run subscribe + first-read (pending) first
+        await run_workflow_step(run_id)
+
+    resp, _ = await asyncio.gather(
+        wf_service.await_run(
+            pool, migrated_db_url, run_id, account_id="acc_wf", timeout_seconds=10
+        ),
+        _complete_soon(),
+    )
+    assert resp.done is True and resp.run_status == "completed" and resp.output == 7
+
+
+async def test_await_run_cross_tenant_404(
+    wf_runtime: asyncpg.Pool[Any], migrated_db_url: str
+) -> None:
+    """The account scope is checked up front (before subscribing): a foreign account 404s."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    with pytest.raises(NotFoundError):
+        await wf_service.await_run(
+            pool, migrated_db_url, run_id, account_id="acc_other", timeout_seconds=1
+        )

--- a/tests/unit/test_await_completion.py
+++ b/tests/unit/test_await_completion.py
@@ -1,0 +1,61 @@
+"""Unit tests for ``await_completion`` — the await-a-completion loop.
+
+Pure: a real ``asyncio.Queue`` + scripted ``read_state``/``is_done``, no DB. Covers the
+three exit shapes (already-done, done-after-notify, timeout) and the LISTEN-before-read
+ordering the run/session backings rely on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aios.services.await_completion import await_completion
+
+
+async def test_returns_immediately_when_already_done() -> None:
+    """A first read that already satisfies the predicate returns without ever consuming the
+    queue — which also proves the read happens BEFORE any ``queue.get`` (LISTEN-before-read):
+    an empty queue + a 5s budget could not return this fast had it waited on the queue first."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    reads = 0
+
+    async def read_state() -> str:
+        nonlocal reads
+        reads += 1
+        return "completed"
+
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda s: s == "completed", timeout_seconds=5
+    )
+    assert state == "completed"
+    assert reads == 1
+    assert queue.empty()
+
+
+async def test_returns_terminal_state_after_a_notify() -> None:
+    """A notify drives a re-read; the loop stops the first time the predicate holds."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    states = iter(["running", "completed"])
+
+    async def read_state() -> str:
+        return next(states)
+
+    queue.put_nowait("evt_1")  # one notify so the loop advances to the second read
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda s: s == "completed", timeout_seconds=5
+    )
+    assert state == "completed"
+
+
+async def test_returns_current_state_on_timeout() -> None:
+    """Never-done + empty queue → return the last (non-terminal) state once the deadline
+    passes — the caller's signal to re-poll."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_state() -> str:
+        return "running"
+
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda s: s == "completed", timeout_seconds=0.05
+    )
+    assert state == "running"

--- a/tests/unit/test_mcp_mount.py
+++ b/tests/unit/test_mcp_mount.py
@@ -146,6 +146,9 @@ def test_apply_mcp_polish_populates_annotations_and_instructions(polished_mcp: A
     assert by_name["list_agents"].annotations is not None
     assert by_name["list_agents"].annotations.readOnlyHint is True
     assert by_name["get_health"].annotations.readOnlyHint is True
+    # await_run is MCP-included (no x-codegen opt-out) — an agent awaits a sub-run as a
+    # read-only tool. Its whole reason to exist is reachability over MCP.
+    assert by_name["await_run"].annotations.readOnlyHint is True
 
     # DELETE → destructiveHint
     assert by_name["delete_vault"].annotations.destructiveHint is True


### PR DESCRIPTION
## What

Adds `await` — a **block-until-this-unit-of-work-is-done** primitive, the synchronous face of an inherently async substrate. For a client (or a parent agent over MCP) that started a workflow run and wants its result (Block-3 slice 5).

Design (agreed with Tom): **one reusable mechanism, two backings, runs first** — runs are *monotonic* (`completed`/`errored` is terminal-forever) — and an explicit **refusal** to build a watermark-less "wait for a session to be idle". That is the reverted #603/#615 Stop hook wearing a pull-shaped mask: idle is a *derived, recurring, reversible* state, so awaiting it conflates quiescence with termination. The session backing (next slice) is only ever the safe shapes: watermarked quiescence (`idle ∧ reacted ≥ N`) and invoke-and-await (the `request_response` correlation), both monotonic w.r.t. their stimulus.

## The primitive

`services/await_completion.py` — a bounded-LISTEN loop parameterised by a **monotonic done-predicate**: read state *after* subscribe (LISTEN-before-read), re-read on each notify until `is_done(state)` or the deadline; return the terminal state, or the current state on timeout (the re-poll signal). A pure function of `(queue, read_state, is_done)`, so the future session backing is a second *caller*, not a rewrite.

## Runs backing

`services/workflows.await_run` + `GET /v1/runs/{id}/wait`: account-scope the run **first** (a cross-tenant/missing id 404s *before any connection opens* — mirroring `/stream`, and so an unauthorized caller can neither open a LISTEN on a foreign run's channel nor churn connections), subscribe to `wf_run_events_{id}`, drive the loop with the terminal predicate, return `WfRunWaitResponse {run_status, done, output, is_error, error}` — a shape that deliberately echoes `derive_response`'s `{result, is_error, error}` so the two backings converge on one envelope. **MCP-included** (an agent awaits a sub-run and joins); bounded (≤60s, re-poll). `aios runs wait` blocks end-to-end by re-polling until `done`.

Also threads the terminal-run-status concept into one shared `TERMINAL_RUN_STATUSES` (models), adopted by the step loop and the SSE stream — replacing three independent `("completed","errored")` definitions.

## Review notes

- `/code-review` caught a **security regression** that `/simplify` had introduced: an efficiency pass dropped the up-front scope check, so a cross-tenant `await` would open a LISTEN connection on a foreign run's channel before 404ing (enumeration + connection-churn). Restored scope-check-before-subscribe (matches `/stream`); the one extra read is negligible.
- Pre-existing stale comment noticed (not in this PR's scope): `step.py:_complete_run` calls archive-on-quiescence a "deferred" mechanism — now shipped (#760). A clean follow-up.

## Tests

- **Unit**: the loop's three exit shapes (already-done, done-after-notify, timeout).
- **Integration** (Docker PG): already-completed, error-kind extraction, timeout/re-poll, completion-during-subscribe race (LISTEN-before-read), cross-tenant 404.
- **e2e** (real ASGI HTTP): the endpoint's `timeout` alias wiring, the `le=60` cap (422), 404-before-subscribe.
- **MCP-inclusion** assertion; full battery green: 1786 unit, mypy, ruff, 64 wf integration, 8 e2e wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)