### PR TITLE
feat(workflows): runs as credentialed principals — declared surface, vault binding, attenuation (slice 1)

### DIFF
--- a/migrations/versions/0073_wf_run_vaults_and_declared_surface.py
+++ b/migrations/versions/0073_wf_run_vaults_and_declared_surface.py
@@ -1,0 +1,53 @@
+"""Workflow runs as credentialed principals: ``wf_run_vaults`` + a declared surface.
+
+Two additive changes that let a workflow declare a tool surface like an agent and a
+run bind vaults like a session — the substrate for credentialed tool calls from a run:
+
+1. ``wf_run_vaults`` — the run↔vault junction, mirroring ``session_vaults`` (migration
+   0005) with rank-based first-match resolution, but with ``account_id`` baked in from
+   the start (``session_vaults`` only gained it retroactively in 0043/0044) and
+   ``run_id`` cascading from ``wf_runs``.
+2. ``workflows.{tools, mcp_servers, http_servers}`` — three ``jsonb`` columns mirroring
+   the agent envelope (agents migration 0052), each defaulting ``'[]'::jsonb`` so
+   existing rows Just Work. They declare the run's reachable tool surface; enforcement
+   lands with the ``tool()`` dispatch in a later slice.
+
+Both tables are small workflow-runtime tables (not the hot ``events`` table), so plain
+in-transaction DDL is fine — no ``CONCURRENTLY`` needed.
+
+Revision ID: 0073
+Revises: 0072
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0073"
+down_revision: str = "0072"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE wf_run_vaults (
+            run_id     text NOT NULL REFERENCES wf_runs(id) ON DELETE CASCADE,
+            vault_id   text NOT NULL REFERENCES vaults(id),
+            rank       integer NOT NULL,
+            account_id text NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+            PRIMARY KEY (run_id, vault_id)
+        )
+    """)
+    op.execute("ALTER TABLE workflows ADD COLUMN tools jsonb NOT NULL DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE workflows ADD COLUMN mcp_servers jsonb NOT NULL DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE workflows ADD COLUMN http_servers jsonb NOT NULL DEFAULT '[]'::jsonb")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE workflows DROP COLUMN IF EXISTS http_servers")
+    op.execute("ALTER TABLE workflows DROP COLUMN IF EXISTS mcp_servers")
+    op.execute("ALTER TABLE workflows DROP COLUMN IF EXISTS tools")
+    op.execute("DROP TABLE IF EXISTS wf_run_vaults")

--- a/openapi.json
+++ b/openapi.json
@@ -8122,7 +8122,7 @@
           "workflows"
         ],
         "summary": "Create Workflow",
-        "description": "Create a workflow definition (version 1). Versioning/update is deferred.",
+        "description": "Create a workflow definition (version 1). Versioning/update is deferred.\n\nThe HTTP path is unattenuated operator authority \u2014 no ``creator_session_id``, so the\ndeclared tool surface is not subset-checked against any agent (an agent authoring a\nworkflow goes through the create-time-attenuated builtin, a later slice).",
         "operationId": "create_workflow",
         "parameters": [
           {
@@ -8339,7 +8339,7 @@
           "runs"
         ],
         "summary": "Create Run",
-        "description": "Launch a run of a workflow. Snapshots the workflow's current script, binds\nthe run to ``environment_id`` (its ``agent()`` children spawn there), and wakes\nit. A missing workflow or environment 404s.",
+        "description": "Launch a run of a workflow. Snapshots the workflow's current script, binds\nthe run to ``environment_id`` (its ``agent()`` children spawn there) and to\n``vault_ids`` (credentials it resolves at tool-call time), and wakes it. A missing\nworkflow or environment 404s. The HTTP path is unattenuated operator authority \u2014 no\n``launcher_session_id``, so the requested vaults are bound as-is (account-scoped).",
         "operationId": "create_run",
         "parameters": [
           {
@@ -15221,6 +15221,14 @@
           },
           "input": {
             "title": "Input"
+          },
+          "vault_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Vault Ids",
+            "description": "Vault ids to bind to the run for credential resolution. When an agent launches the run, these must be a subset of the launcher's own vaults; the HTTP path is unattenuated operator authority."
           }
         },
         "type": "object",
@@ -15510,6 +15518,27 @@
             ],
             "title": "Description"
           },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/ToolSpec"
+            },
+            "type": "array",
+            "title": "Tools"
+          },
+          "mcp_servers": {
+            "items": {
+              "$ref": "#/components/schemas/McpServerSpec"
+            },
+            "type": "array",
+            "title": "Mcp Servers"
+          },
+          "http_servers": {
+            "items": {
+              "$ref": "#/components/schemas/HttpServerSpec"
+            },
+            "type": "array",
+            "title": "Http Servers"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -15578,6 +15607,27 @@
               }
             ],
             "title": "Description"
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/ToolSpec"
+            },
+            "type": "array",
+            "title": "Tools"
+          },
+          "mcp_servers": {
+            "items": {
+              "$ref": "#/components/schemas/McpServerSpec"
+            },
+            "type": "array",
+            "title": "Mcp Servers"
+          },
+          "http_servers": {
+            "items": {
+              "$ref": "#/components/schemas/HttpServerSpec"
+            },
+            "type": "array",
+            "title": "Http Servers"
           }
         },
         "type": "object",

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/create_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/create_run.py
@@ -72,8 +72,10 @@ def sync_detailed(
     """Create Run
 
      Launch a run of a workflow. Snapshots the workflow's current script, binds
-    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
-    it. A missing workflow or environment 404s.
+    the run to ``environment_id`` (its ``agent()`` children spawn there) and to
+    ``vault_ids`` (credentials it resolves at tool-call time), and wakes it. A missing
+    workflow or environment 404s. The HTTP path is unattenuated operator authority — no
+    ``launcher_session_id``, so the requested vaults are bound as-is (account-scoped).
 
     Args:
         authorization (None | str | Unset):
@@ -112,8 +114,10 @@ def sync(
     """Create Run
 
      Launch a run of a workflow. Snapshots the workflow's current script, binds
-    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
-    it. A missing workflow or environment 404s.
+    the run to ``environment_id`` (its ``agent()`` children spawn there) and to
+    ``vault_ids`` (credentials it resolves at tool-call time), and wakes it. A missing
+    workflow or environment 404s. The HTTP path is unattenuated operator authority — no
+    ``launcher_session_id``, so the requested vaults are bound as-is (account-scoped).
 
     Args:
         authorization (None | str | Unset):
@@ -147,8 +151,10 @@ async def asyncio_detailed(
     """Create Run
 
      Launch a run of a workflow. Snapshots the workflow's current script, binds
-    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
-    it. A missing workflow or environment 404s.
+    the run to ``environment_id`` (its ``agent()`` children spawn there) and to
+    ``vault_ids`` (credentials it resolves at tool-call time), and wakes it. A missing
+    workflow or environment 404s. The HTTP path is unattenuated operator authority — no
+    ``launcher_session_id``, so the requested vaults are bound as-is (account-scoped).
 
     Args:
         authorization (None | str | Unset):
@@ -185,8 +191,10 @@ async def asyncio(
     """Create Run
 
      Launch a run of a workflow. Snapshots the workflow's current script, binds
-    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
-    it. A missing workflow or environment 404s.
+    the run to ``environment_id`` (its ``agent()`` children spawn there) and to
+    ``vault_ids`` (credentials it resolves at tool-call time), and wakes it. A missing
+    workflow or environment 404s. The HTTP path is unattenuated operator authority — no
+    ``launcher_session_id``, so the requested vaults are bound as-is (account-scoped).
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/create_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/create_workflow.py
@@ -73,6 +73,10 @@ def sync_detailed(
 
      Create a workflow definition (version 1). Versioning/update is deferred.
 
+    The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
+    declared tool surface is not subset-checked against any agent (an agent authoring a
+    workflow goes through the create-time-attenuated builtin, a later slice).
+
     Args:
         authorization (None | str | Unset):
         body (WorkflowCreate): Request body for ``POST /v1/workflows`` — a new workflow definition
@@ -108,6 +112,10 @@ def sync(
 
      Create a workflow definition (version 1). Versioning/update is deferred.
 
+    The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
+    declared tool surface is not subset-checked against any agent (an agent authoring a
+    workflow goes through the create-time-attenuated builtin, a later slice).
+
     Args:
         authorization (None | str | Unset):
         body (WorkflowCreate): Request body for ``POST /v1/workflows`` — a new workflow definition
@@ -137,6 +145,10 @@ async def asyncio_detailed(
     """Create Workflow
 
      Create a workflow definition (version 1). Versioning/update is deferred.
+
+    The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
+    declared tool surface is not subset-checked against any agent (an agent authoring a
+    workflow goes through the create-time-attenuated builtin, a later slice).
 
     Args:
         authorization (None | str | Unset):
@@ -170,6 +182,10 @@ async def asyncio(
     """Create Workflow
 
      Create a workflow definition (version 1). Versioning/update is deferred.
+
+    The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
+    declared tool surface is not subset-checked against any agent (an agent authoring a
+    workflow goes through the create-time-attenuated builtin, a later slice).
 
     Args:
         authorization (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,11 +23,14 @@ class WfRunCreate:
             workflow_id (str):
             environment_id (str):
             input_ (Any | Unset):
+            vault_ids (list[str] | Unset): Vault ids to bind to the run for credential resolution. When an agent launches
+                the run, these must be a subset of the launcher's own vaults; the HTTP path is unattenuated operator authority.
     """
 
     workflow_id: str
     environment_id: str
     input_: Any | Unset = UNSET
+    vault_ids: list[str] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -36,6 +39,10 @@ class WfRunCreate:
         environment_id = self.environment_id
 
         input_ = self.input_
+
+        vault_ids: list[str] | Unset = UNSET
+        if not isinstance(self.vault_ids, Unset):
+            vault_ids = self.vault_ids
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -47,6 +54,8 @@ class WfRunCreate:
         )
         if input_ is not UNSET:
             field_dict["input"] = input_
+        if vault_ids is not UNSET:
+            field_dict["vault_ids"] = vault_ids
 
         return field_dict
 
@@ -59,10 +68,13 @@ class WfRunCreate:
 
         input_ = d.pop("input", UNSET)
 
+        vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
+
         wf_run_create = cls(
             workflow_id=workflow_id,
             environment_id=environment_id,
             input_=input_,
+            vault_ids=vault_ids,
         )
 
         wf_run_create.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
@@ -11,6 +11,9 @@ from dateutil.parser import isoparse
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.http_server_spec import HttpServerSpec
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
     from ..models.workflow_input_schema_type_0 import WorkflowInputSchemaType0
     from ..models.workflow_output_schema_type_0 import WorkflowOutputSchemaType0
 
@@ -33,6 +36,9 @@ class Workflow:
         input_schema (None | Unset | WorkflowInputSchemaType0):
         output_schema (None | Unset | WorkflowOutputSchemaType0):
         description (None | str | Unset):
+        tools (list[ToolSpec] | Unset):
+        mcp_servers (list[McpServerSpec] | Unset):
+        http_servers (list[HttpServerSpec] | Unset):
     """
 
     id: str
@@ -45,6 +51,9 @@ class Workflow:
     input_schema: None | Unset | WorkflowInputSchemaType0 = UNSET
     output_schema: None | Unset | WorkflowOutputSchemaType0 = UNSET
     description: None | str | Unset = UNSET
+    tools: list[ToolSpec] | Unset = UNSET
+    mcp_servers: list[McpServerSpec] | Unset = UNSET
+    http_servers: list[HttpServerSpec] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -87,6 +96,27 @@ class Workflow:
         else:
             description = self.description
 
+        tools: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.tools, Unset):
+            tools = []
+            for tools_item_data in self.tools:
+                tools_item = tools_item_data.to_dict()
+                tools.append(tools_item)
+
+        mcp_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.mcp_servers, Unset):
+            mcp_servers = []
+            for mcp_servers_item_data in self.mcp_servers:
+                mcp_servers_item = mcp_servers_item_data.to_dict()
+                mcp_servers.append(mcp_servers_item)
+
+        http_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.http_servers, Unset):
+            http_servers = []
+            for http_servers_item_data in self.http_servers:
+                http_servers_item = http_servers_item_data.to_dict()
+                http_servers.append(http_servers_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -106,11 +136,20 @@ class Workflow:
             field_dict["output_schema"] = output_schema
         if description is not UNSET:
             field_dict["description"] = description
+        if tools is not UNSET:
+            field_dict["tools"] = tools
+        if mcp_servers is not UNSET:
+            field_dict["mcp_servers"] = mcp_servers
+        if http_servers is not UNSET:
+            field_dict["http_servers"] = http_servers
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.http_server_spec import HttpServerSpec
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
         from ..models.workflow_input_schema_type_0 import WorkflowInputSchemaType0
         from ..models.workflow_output_schema_type_0 import WorkflowOutputSchemaType0
 
@@ -176,6 +215,33 @@ class Workflow:
 
         description = _parse_description(d.pop("description", UNSET))
 
+        _tools = d.pop("tools", UNSET)
+        tools: list[ToolSpec] | Unset = UNSET
+        if _tools is not UNSET:
+            tools = []
+            for tools_item_data in _tools:
+                tools_item = ToolSpec.from_dict(tools_item_data)
+
+                tools.append(tools_item)
+
+        _mcp_servers = d.pop("mcp_servers", UNSET)
+        mcp_servers: list[McpServerSpec] | Unset = UNSET
+        if _mcp_servers is not UNSET:
+            mcp_servers = []
+            for mcp_servers_item_data in _mcp_servers:
+                mcp_servers_item = McpServerSpec.from_dict(mcp_servers_item_data)
+
+                mcp_servers.append(mcp_servers_item)
+
+        _http_servers = d.pop("http_servers", UNSET)
+        http_servers: list[HttpServerSpec] | Unset = UNSET
+        if _http_servers is not UNSET:
+            http_servers = []
+            for http_servers_item_data in _http_servers:
+                http_servers_item = HttpServerSpec.from_dict(http_servers_item_data)
+
+                http_servers.append(http_servers_item)
+
         workflow = cls(
             id=id,
             account_id=account_id,
@@ -187,6 +253,9 @@ class Workflow:
             input_schema=input_schema,
             output_schema=output_schema,
             description=description,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            http_servers=http_servers,
         )
 
         workflow.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
@@ -9,6 +9,9 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
+    from ..models.http_server_spec import HttpServerSpec
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
     from ..models.workflow_create_input_schema_type_0 import (
         WorkflowCreateInputSchemaType0,
     )
@@ -30,6 +33,9 @@ class WorkflowCreate:
         input_schema (None | Unset | WorkflowCreateInputSchemaType0):
         output_schema (None | Unset | WorkflowCreateOutputSchemaType0):
         description (None | str | Unset):
+        tools (list[ToolSpec] | Unset):
+        mcp_servers (list[McpServerSpec] | Unset):
+        http_servers (list[HttpServerSpec] | Unset):
     """
 
     name: str
@@ -37,6 +43,9 @@ class WorkflowCreate:
     input_schema: None | Unset | WorkflowCreateInputSchemaType0 = UNSET
     output_schema: None | Unset | WorkflowCreateOutputSchemaType0 = UNSET
     description: None | str | Unset = UNSET
+    tools: list[ToolSpec] | Unset = UNSET
+    mcp_servers: list[McpServerSpec] | Unset = UNSET
+    http_servers: list[HttpServerSpec] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -73,6 +82,27 @@ class WorkflowCreate:
         else:
             description = self.description
 
+        tools: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.tools, Unset):
+            tools = []
+            for tools_item_data in self.tools:
+                tools_item = tools_item_data.to_dict()
+                tools.append(tools_item)
+
+        mcp_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.mcp_servers, Unset):
+            mcp_servers = []
+            for mcp_servers_item_data in self.mcp_servers:
+                mcp_servers_item = mcp_servers_item_data.to_dict()
+                mcp_servers.append(mcp_servers_item)
+
+        http_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.http_servers, Unset):
+            http_servers = []
+            for http_servers_item_data in self.http_servers:
+                http_servers_item = http_servers_item_data.to_dict()
+                http_servers.append(http_servers_item)
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -87,11 +117,20 @@ class WorkflowCreate:
             field_dict["output_schema"] = output_schema
         if description is not UNSET:
             field_dict["description"] = description
+        if tools is not UNSET:
+            field_dict["tools"] = tools
+        if mcp_servers is not UNSET:
+            field_dict["mcp_servers"] = mcp_servers
+        if http_servers is not UNSET:
+            field_dict["http_servers"] = http_servers
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.http_server_spec import HttpServerSpec
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
         from ..models.workflow_create_input_schema_type_0 import (
             WorkflowCreateInputSchemaType0,
         )
@@ -151,12 +190,42 @@ class WorkflowCreate:
 
         description = _parse_description(d.pop("description", UNSET))
 
+        _tools = d.pop("tools", UNSET)
+        tools: list[ToolSpec] | Unset = UNSET
+        if _tools is not UNSET:
+            tools = []
+            for tools_item_data in _tools:
+                tools_item = ToolSpec.from_dict(tools_item_data)
+
+                tools.append(tools_item)
+
+        _mcp_servers = d.pop("mcp_servers", UNSET)
+        mcp_servers: list[McpServerSpec] | Unset = UNSET
+        if _mcp_servers is not UNSET:
+            mcp_servers = []
+            for mcp_servers_item_data in _mcp_servers:
+                mcp_servers_item = McpServerSpec.from_dict(mcp_servers_item_data)
+
+                mcp_servers.append(mcp_servers_item)
+
+        _http_servers = d.pop("http_servers", UNSET)
+        http_servers: list[HttpServerSpec] | Unset = UNSET
+        if _http_servers is not UNSET:
+            http_servers = []
+            for http_servers_item_data in _http_servers:
+                http_servers_item = HttpServerSpec.from_dict(http_servers_item_data)
+
+                http_servers.append(http_servers_item)
+
         workflow_create = cls(
             name=name,
             script=script,
             input_schema=input_schema,
             output_schema=output_schema,
             description=description,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            http_servers=http_servers,
         )
 
         workflow_create.additional_properties = d

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -45,7 +45,11 @@ runs_router = APIRouter(prefix="/v1/runs", tags=["runs"])
 async def create_workflow(
     body: WorkflowCreate, pool: PoolDep, account_id: AccountIdDep
 ) -> Workflow:
-    """Create a workflow definition (version 1). Versioning/update is deferred."""
+    """Create a workflow definition (version 1). Versioning/update is deferred.
+
+    The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
+    declared tool surface is not subset-checked against any agent (an agent authoring a
+    workflow goes through the create-time-attenuated builtin, a later slice)."""
     return await service.create_workflow(
         pool,
         account_id=account_id,
@@ -54,6 +58,9 @@ async def create_workflow(
         input_schema=body.input_schema,
         output_schema=body.output_schema,
         description=body.description,
+        tools=body.tools,
+        mcp_servers=body.mcp_servers,
+        http_servers=body.http_servers,
     )
 
 
@@ -92,14 +99,17 @@ async def get_workflow(workflow_id: str, pool: PoolDep, account_id: AccountIdDep
 @runs_router.post("", operation_id="create_run", status_code=status.HTTP_201_CREATED)
 async def create_run(body: WfRunCreate, pool: PoolDep, account_id: AccountIdDep) -> WfRun:
     """Launch a run of a workflow. Snapshots the workflow's current script, binds
-    the run to ``environment_id`` (its ``agent()`` children spawn there), and wakes
-    it. A missing workflow or environment 404s."""
+    the run to ``environment_id`` (its ``agent()`` children spawn there) and to
+    ``vault_ids`` (credentials it resolves at tool-call time), and wakes it. A missing
+    workflow or environment 404s. The HTTP path is unattenuated operator authority — no
+    ``launcher_session_id``, so the requested vaults are bound as-is (account-scoped)."""
     return await service.create_run(
         pool,
         account_id=account_id,
         workflow_id=body.workflow_id,
         environment_id=body.environment_id,
         input=body.input,
+        vault_ids=body.vault_ids,
     )
 
 

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -178,6 +178,9 @@ def create_run_(
     workflow_id: Annotated[str, typer.Option("--workflow-id")],
     environment_id: Annotated[str, typer.Option("--environment-id")],
     input_: Annotated[str | None, typer.Option("--input", help="The run's input as JSON.")] = None,
+    vault_id: Annotated[
+        list[str] | None, typer.Option("--vault-id", help="Vault id to bind (repeatable).")
+    ] = None,
 ) -> None:
     def _run() -> int | None:
         body = WfRunCreate.from_dict(
@@ -185,6 +188,7 @@ def create_run_(
                 "workflow_id": workflow_id,
                 "environment_id": environment_id,
                 "input": _json_arg(input_),
+                "vault_ids": vault_id or [],
             }
         )
         call_single(ctx, create_run.sync_detailed, body=body)

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -3980,6 +3980,46 @@ async def resolve_session_credential(
     )
 
 
+async def resolve_run_credential(
+    conn: asyncpg.Connection[Any],
+    run_id: str,
+    target_url: str,
+    *,
+    account_id: str,
+) -> tuple[EncryptedBlob, AuthType, str] | None:
+    """Find the first matching credential across a *run*'s bound vaults.
+
+    The run analog of :func:`resolve_session_credential` — identical query with
+    ``wf_run_vaults``/``run_id`` swapped for ``session_vaults``/``session_id``. The
+    decrypt + OAuth-refresh + header-render tail downstream is owner-agnostic (it
+    keys off ``account_id`` + ``vault_id``), so only this lookup differs by owner.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT vc.ciphertext, vc.nonce, vc.auth_type, vc.vault_id
+          FROM wf_run_vaults rv
+          JOIN vault_credentials vc ON vc.vault_id = rv.vault_id
+         WHERE rv.run_id = $1
+           AND vc.target_url = $2
+           AND vc.archived_at IS NULL
+           AND rv.account_id = $3
+           AND vc.account_id = $3
+         ORDER BY rv.rank
+         LIMIT 1
+        """,
+        run_id,
+        target_url,
+        account_id,
+    )
+    if row is None:
+        return None
+    return (
+        EncryptedBlob(ciphertext=row["ciphertext"], nonce=row["nonce"]),
+        cast(AuthType, str(row["auth_type"])),
+        str(row["vault_id"]),
+    )
+
+
 # ─── skills ──────────────────────────────────────────────────────────────────
 
 

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -24,6 +24,7 @@ import asyncpg
 from aios.db.queries import _get_scoped, _list_scoped, parse_jsonb
 from aios.errors import ConflictError, NotFoundError
 from aios.ids import WORKFLOW, WORKFLOW_EVENT, WORKFLOW_RUN, make_id
+from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
 from aios.models.workflows import (
     WfRun,
     WfRunEvent,
@@ -50,6 +51,9 @@ def _row_to_workflow(row: asyncpg.Record) -> Workflow:
         input_schema=parse_jsonb(row["input_schema"]),
         output_schema=parse_jsonb(row["output_schema"]),
         description=row["description"],
+        tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
+        mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
+        http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )
@@ -109,6 +113,9 @@ async def insert_workflow(
     input_schema: dict[str, Any] | None = None,
     output_schema: dict[str, Any] | None = None,
     description: str | None = None,
+    tools: list[ToolSpec] | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
 ) -> Workflow:
     """Insert an immutable workflow definition. Raises ``ConflictError`` on a
     duplicate ``(account_id, name, version)``."""
@@ -117,8 +124,9 @@ async def insert_workflow(
         row = await conn.fetchrow(
             """
             INSERT INTO workflows
-                (id, account_id, name, version, script, input_schema, output_schema, description)
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8)
+                (id, account_id, name, version, script, input_schema, output_schema,
+                 description, tools, mcp_servers, http_servers)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9::jsonb, $10::jsonb, $11::jsonb)
             RETURNING *
             """,
             new_id,
@@ -129,6 +137,9 @@ async def insert_workflow(
             json.dumps(input_schema) if input_schema is not None else None,
             json.dumps(output_schema) if output_schema is not None else None,
             description,
+            json.dumps([t.model_dump() for t in (tools or [])]),
+            json.dumps([s.model_dump() for s in (mcp_servers or [])]),
+            json.dumps([s.model_dump() for s in (http_servers or [])]),
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
@@ -266,6 +277,68 @@ async def insert_wf_run(
         ) from exc
     assert row is not None
     return _row_to_wf_run(row)
+
+
+async def set_run_vaults(
+    conn: asyncpg.Connection[Any],
+    run_id: str,
+    vault_ids: list[str],
+    *,
+    account_id: str,
+) -> None:
+    """Bind vaults to a run, rank-ordered (first-match credential resolution).
+
+    The run analog of :func:`set_session_vaults`, with a tighter ownership guard: each
+    vault must exist **and belong to ``account_id``** — a foreign or unknown vault id
+    raises ``NotFoundError``, so a run can never bind another account's vault. (The
+    ``vault_id`` FK alone checks existence, not ownership — the same tenant-confusion the
+    ``create_vault_credential`` lock guards against; we mirror that here rather than
+    inherit the gap.) Duplicate ids are de-duplicated (a binding is a set). Called inside
+    ``create_run``'s transaction, so its inner ``conn.transaction()`` is a savepoint.
+    """
+    deduped = list(dict.fromkeys(vault_ids))
+    async with conn.transaction():
+        await conn.execute(
+            "DELETE FROM wf_run_vaults WHERE run_id = $1 AND account_id = $2",
+            run_id,
+            account_id,
+        )
+        if not deduped:
+            return
+        owned = {
+            str(r["id"])
+            for r in await conn.fetch(
+                "SELECT id FROM vaults WHERE id = ANY($1) AND account_id = $2",
+                deduped,
+                account_id,
+            )
+        }
+        missing = [v for v in deduped if v not in owned]
+        if missing:
+            raise NotFoundError(
+                f"vault(s) not found in this account: {missing}",
+                detail={"vault_ids": missing},
+            )
+        for rank, vault_id in enumerate(deduped):
+            await conn.execute(
+                "INSERT INTO wf_run_vaults (run_id, vault_id, rank, account_id) "
+                "VALUES ($1, $2, $3, $4)",
+                run_id,
+                vault_id,
+                rank,
+                account_id,
+            )
+
+
+async def get_run_vault_ids(
+    conn: asyncpg.Connection[Any], run_id: str, *, account_id: str
+) -> list[str]:
+    rows = await conn.fetch(
+        "SELECT vault_id FROM wf_run_vaults WHERE run_id = $1 AND account_id = $2 ORDER BY rank",
+        run_id,
+        account_id,
+    )
+    return [str(r["vault_id"]) for r in rows]
 
 
 async def get_run_for_step(conn: asyncpg.Connection[Any], run_id: str) -> WfRun | None:

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -28,7 +28,7 @@ from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import InitializeResult
 
-from aios.crypto.vault import CryptoBox
+from aios.crypto.vault import CryptoBox, EncryptedBlob
 from aios.db import queries
 from aios.logging import get_logger
 from aios.mcp.pool import HttpErrorSink
@@ -229,33 +229,76 @@ async def resolve_auth_for_target_url(
     to the stale token.
     """
     async with pool.acquire() as conn:
-        session_result = await queries.resolve_session_credential(
+        cred = await queries.resolve_session_credential(
             conn, session_id, target_url, account_id=account_id
         )
-        if session_result is None:
+        if cred is None:
             return None, {}
-        blob, auth_type, vault_id = session_result
-        subkey = crypto_box.derive_account_subkey(account_id)
+        return await _auth_from_credential(
+            conn, crypto_box, cred, target_url, account_id=account_id
+        )
 
-        if auth_type == "oauth2_refresh":
+
+async def resolve_auth_for_target_url_run(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    run_id: str,
+    target_url: str,
+    *,
+    account_id: str,
+) -> tuple[str | None, dict[str, str]]:
+    """Resolve auth identity + headers for ``target_url`` via a *run*'s bound vaults.
+
+    The run analog of :func:`resolve_auth_for_target_url`: it differs only in the
+    credential lookup (``wf_run_vaults`` instead of ``session_vaults``), reusing the
+    same decrypt + OAuth-refresh + header-render engine — so a run resolves
+    credentials exactly as a session does, scoped to the vaults bound at launch.
+    """
+    async with pool.acquire() as conn:
+        cred = await queries.resolve_run_credential(conn, run_id, target_url, account_id=account_id)
+        if cred is None:
+            return None, {}
+        return await _auth_from_credential(
+            conn, crypto_box, cred, target_url, account_id=account_id
+        )
+
+
+async def _auth_from_credential(
+    conn: asyncpg.Connection[Any],
+    crypto_box: CryptoBox,
+    cred: tuple[EncryptedBlob, AuthType, str],
+    target_url: str,
+    *,
+    account_id: str,
+) -> tuple[str | None, dict[str, str]]:
+    """Decrypt → (OAuth-refresh) → render headers for an already-resolved credential.
+
+    The owner-agnostic engine shared by the session and run resolvers: it keys off
+    ``account_id`` + ``vault_id`` only, never the owner. Returns ``(vault_id, headers)``
+    or ``(None, {})`` when there is no header to send (empty secret / missed refresh).
+    """
+    blob, auth_type, vault_id = cred
+    subkey = crypto_box.derive_account_subkey(account_id)
+
+    if auth_type == "oauth2_refresh":
+        payload = json.loads(subkey.decrypt(blob))
+        if is_expiring(payload):
+            await refresh_credential(
+                crypto_box,
+                conn,
+                vault_id=vault_id,
+                target_url=target_url,
+                account_id=account_id,
+            )
+            refreshed = await queries.resolve_vault_credential(
+                conn, vault_id=vault_id, target_url=target_url, account_id=account_id
+            )
+            if refreshed is None:
+                return None, {}
+            blob = refreshed[0]
             payload = json.loads(subkey.decrypt(blob))
-            if is_expiring(payload):
-                await refresh_credential(
-                    crypto_box,
-                    conn,
-                    vault_id=vault_id,
-                    target_url=target_url,
-                    account_id=account_id,
-                )
-                refreshed = await queries.resolve_vault_credential(
-                    conn, vault_id=vault_id, target_url=target_url, account_id=account_id
-                )
-                if refreshed is None:
-                    return None, {}
-                blob = refreshed[0]
-                payload = json.loads(subkey.decrypt(blob))
-        else:
-            payload = json.loads(subkey.decrypt(blob))
+    else:
+        payload = json.loads(subkey.decrypt(blob))
 
     headers = _auth_headers_from_payload(payload, auth_type)
     if not headers:

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
 
 WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored", "cancelled"]
 WfRunEventType = Literal["run_started", "call_started", "call_result", "run_completed"]
@@ -39,6 +41,12 @@ class Workflow(BaseModel):
     input_schema: dict[str, Any] | None = None
     output_schema: dict[str, Any] | None = None
     description: str | None = None  # optional human blurb (the agent ``description`` analog)
+    # The declared tool surface — the verbatim agent envelope. A run reaches these
+    # (authed MCP / http_request / builtins) directly via ``tool()`` (a later slice);
+    # an agent authoring a workflow may only declare a subset of its own surface.
+    tools: list[ToolSpec] = Field(default_factory=list)
+    mcp_servers: list[McpServerSpec] = Field(default_factory=list)
+    http_servers: list[HttpServerSpec] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
@@ -127,6 +135,12 @@ class WorkflowCreate(BaseModel):
     input_schema: dict[str, Any] | None = None
     output_schema: dict[str, Any] | None = None
     description: str | None = None
+    # The declared tool surface (verbatim agent envelope). When an agent authors a
+    # workflow, these must be a subset of the creating agent's own surface; the HTTP
+    # path is unattenuated operator authority.
+    tools: list[ToolSpec] = Field(default_factory=list)
+    mcp_servers: list[McpServerSpec] = Field(default_factory=list)
+    http_servers: list[HttpServerSpec] = Field(default_factory=list)
 
 
 class WfRunCreate(BaseModel):
@@ -140,6 +154,14 @@ class WfRunCreate(BaseModel):
     workflow_id: str
     environment_id: str
     input: Any = None
+    vault_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Vault ids to bind to the run for credential resolution. When an agent "
+            "launches the run, these must be a subset of the launcher's own vaults; "
+            "the HTTP path is unattenuated operator authority."
+        ),
+    )
 
 
 class GateResume(BaseModel):

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -19,7 +19,8 @@ import asyncpg
 
 from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
-from aios.errors import NotFoundError
+from aios.errors import ForbiddenError, NotFoundError
+from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
 from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
     WfRun,
@@ -27,6 +28,8 @@ from aios.models.workflows import (
     WfRunWaitResponse,
     Workflow,
 )
+from aios.services import agents as agents_service
+from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
 from aios.workflows.service import create_run, resume_gate
@@ -49,6 +52,55 @@ __all__ = [
 # ─── workflow definitions ────────────────────────────────────────────────────
 
 
+def _tool_key(t: ToolSpec) -> tuple[str, str | None]:
+    """A tool's attenuation identity: builtins by type, custom by name, toolsets by server."""
+    if t.type == "mcp_toolset":
+        return ("mcp_toolset", t.mcp_server_name)
+    if t.type == "custom":
+        return ("custom", t.name)
+    return ("builtin", t.type)
+
+
+async def _enforce_surface_attenuation(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    creator_session_id: str,
+    tools: list[ToolSpec],
+    mcp_servers: list[McpServerSpec],
+    http_servers: list[HttpServerSpec],
+) -> None:
+    """Raise ``ForbiddenError`` if the declared surface exceeds the creator agent's.
+
+    Subset by identity key: ``mcp_servers`` by url, ``http_servers`` by base_url,
+    ``tools`` by (builtin type / custom name / toolset server). The HTTP path passes no
+    creator and skips this — operator authority. (No-widen on permission/transport/routes
+    is a deliberate follow-up; this slice gates membership.)
+    """
+    session = await sessions_service.get_session_basic(
+        pool, creator_session_id, account_id=account_id
+    )
+    agent = await agents_service.load_for_session(pool, session, account_id=account_id)
+    allowed_mcp = {s.url for s in agent.mcp_servers}
+    allowed_http = {s.base_url for s in agent.http_servers}
+    allowed_tools = {_tool_key(t) for t in agent.tools if t.enabled}
+
+    offending: dict[str, list[str]] = {}
+    if bad := [s.name for s in mcp_servers if s.url not in allowed_mcp]:
+        offending["mcp_servers"] = bad
+    if bad := [s.name for s in http_servers if s.base_url not in allowed_http]:
+        offending["http_servers"] = bad
+    if bad := [
+        t.name or t.mcp_server_name or t.type for t in tools if _tool_key(t) not in allowed_tools
+    ]:
+        offending["tools"] = bad
+    if offending:
+        raise ForbiddenError(
+            "workflow declares servers or tools the creating agent does not have",
+            detail={"ungranted": offending},
+        )
+
+
 async def create_workflow(
     pool: asyncpg.Pool[Any],
     *,
@@ -58,7 +110,28 @@ async def create_workflow(
     input_schema: dict[str, Any] | None = None,
     output_schema: dict[str, Any] | None = None,
     description: str | None = None,
+    tools: list[ToolSpec] | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
+    creator_session_id: str | None = None,
 ) -> Workflow:
+    """Create a workflow definition.
+
+    **Create-time attenuation:** when ``creator_session_id`` is set (an agent authoring
+    the workflow), the declared surface (``tools``/``mcp_servers``/``http_servers``) must
+    be a subset of the creating agent's own — an agent cannot grant a workflow a tool or
+    server it does not itself have; a breach raises :class:`ForbiddenError`. With no
+    creator (the HTTP/operator path) any surface may be declared, account-scoped.
+    """
+    if creator_session_id is not None:
+        await _enforce_surface_attenuation(
+            pool,
+            account_id=account_id,
+            creator_session_id=creator_session_id,
+            tools=tools or [],
+            mcp_servers=mcp_servers or [],
+            http_servers=http_servers or [],
+        )
     async with pool.acquire() as conn:
         return await wf_queries.insert_workflow(
             conn,
@@ -68,6 +141,9 @@ async def create_workflow(
             input_schema=input_schema,
             output_schema=output_schema,
             description=description,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            http_servers=http_servers,
         )
 
 

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -11,8 +11,9 @@ from typing import Any
 
 import asyncpg
 
+from aios.db.queries import get_session_vault_ids
 from aios.db.queries import workflows as wf_queries
-from aios.errors import NotFoundError
+from aios.errors import ForbiddenError, NotFoundError
 from aios.models.workflows import WfRun
 from aios.services.wake import defer_run_wake
 
@@ -24,6 +25,8 @@ async def create_run(
     workflow_id: str,
     environment_id: str,
     input: Any = None,
+    vault_ids: list[str] | None = None,
+    launcher_session_id: str | None = None,
 ) -> WfRun:
     """Create a run that snapshots the workflow's current script, then wake it.
 
@@ -31,10 +34,29 @@ async def create_run(
     wake execs exactly that source regardless of later edits to the workflow.
     ``environment_id`` binds the run (and the sessions its ``agent()`` children
     spawn into) to an environment — chosen at run-creation time, like a session's.
+
+    ``vault_ids`` binds credentials to the run (resolved at tool-call time, like a
+    session's). **Launch-time attenuation:** when ``launcher_session_id`` is set (an
+    agent launching the run), the requested vaults must be a subset of the launcher's
+    own — authority never exceeds the invoker, so a breach raises
+    :class:`ForbiddenError`. With no launcher (the HTTP/operator path) the requested
+    vaults bind as-is, account-scoped. Insert + bind are one transaction, so a breach
+    or a bad vault leaves no run row; the wake fires only after commit.
     """
-    async with pool.acquire() as conn:
+    requested = list(vault_ids or [])
+    async with pool.acquire() as conn, conn.transaction():
         workflow = await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
         script_sha = hashlib.sha256(workflow.script.encode("utf-8")).hexdigest()
+        if launcher_session_id is not None:
+            held = set(
+                await get_session_vault_ids(conn, launcher_session_id, account_id=account_id)
+            )
+            ungranted = [v for v in requested if v not in held]
+            if ungranted:
+                raise ForbiddenError(
+                    "run requested vaults the launching agent does not hold",
+                    detail={"ungranted_vault_ids": ungranted},
+                )
         run = await wf_queries.insert_wf_run(
             conn,
             account_id=account_id,
@@ -44,6 +66,8 @@ async def create_run(
             script_sha=script_sha,
             input=input,
         )
+        if requested:
+            await wf_queries.set_run_vaults(conn, run.id, requested, account_id=account_id)
     await defer_run_wake(run.id)
     return run
 

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -1,0 +1,333 @@
+"""Workflow runs as credentialed principals — the credential substrate + attenuation.
+
+Slice 1 of the credentialed-runs lane, against a real Postgres. No tool() call site
+yet: the proof is in the asymmetries —
+  * a run resolves a credential through its OWN bound vaults (``resolve_run_credential``),
+    and a run with no binding resolves nothing;
+  * **launch-time attenuation** — an agent launching a run can only bind vaults it holds;
+  * **create-time attenuation** — an agent authoring a workflow can only declare a tool
+    surface it holds;
+  * the declared surface round-trips through the ``workflows`` columns.
+
+``defer_run_wake`` is patched out — these tests exercise creation + resolution, not the
+run loop.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+from pydantic import SecretStr
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries as db_queries
+from aios.db.pool import create_pool
+from aios.db.queries import workflows as wf_queries
+from aios.errors import ForbiddenError, NotFoundError
+from aios.harness import runtime
+from aios.mcp.client import resolve_auth_for_target_url_run
+from aios.models.agents import Agent, HttpServerSpec, McpServerSpec
+from aios.models.vaults import VaultCredentialCreate
+from aios.services import agents as agents_service
+from aios.services import vaults as vaults_service
+from aios.services import workflows as wf_service
+
+pytestmark = pytest.mark.integration
+
+ACC = "acc_v"
+ENV = "env_v"
+_SCRIPT = "async def main(i):\n    return i\n"
+
+
+@pytest.fixture
+def crypto_box() -> CryptoBox:
+    return CryptoBox(os.urandom(32))
+
+
+@pytest.fixture
+async def vault_pool(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    """A pool on ``runtime.pool`` + a seeded ``(account, environment)``; wakes patched out."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = pool
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'vault-root')",
+                ACC,
+            )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ($1, 'vault-env', '{}'::jsonb, $2)",
+                ENV,
+                ACC,
+            )
+        with mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()):
+            yield pool
+    finally:
+        runtime.pool = prev
+        await pool.close()
+
+
+async def _make_agent(
+    pool: asyncpg.Pool[Any], name: str, *, mcp_servers: list[McpServerSpec] | None = None
+) -> Agent:
+    return await agents_service.create_agent(
+        pool,
+        account_id=ACC,
+        name=name,
+        model="test/dummy",
+        system="x",
+        tools=[],
+        mcp_servers=mcp_servers,
+        description=None,
+        metadata={},
+        window_min=1000,
+        window_max=100000,
+    )
+
+
+async def _make_session(
+    pool: asyncpg.Pool[Any], agent: Agent, *, vault_ids: list[str] | None = None
+) -> str:
+    """Insert a bare session row (no sandbox/crypto) bound to ``agent``, optionally to vaults."""
+    async with pool.acquire() as conn:
+        session = await db_queries.insert_session(
+            conn,
+            account_id=ACC,
+            agent_id=agent.id,
+            environment_id=ENV,
+            agent_version=agent.version,
+            title=None,
+            metadata={},
+        )
+        if vault_ids:
+            await db_queries.set_session_vaults(conn, session.id, vault_ids, account_id=ACC)
+    return session.id
+
+
+async def _make_vault(pool: asyncpg.Pool[Any], name: str) -> str:
+    vault = await vaults_service.create_vault(pool, account_id=ACC, display_name=name, metadata={})
+    return vault.id
+
+
+async def _run_count(pool: asyncpg.Pool[Any]) -> int:
+    async with pool.acquire() as conn:
+        return int(await conn.fetchval("SELECT count(*) FROM wf_runs WHERE account_id = $1", ACC))
+
+
+async def _workflow_count(pool: asyncpg.Pool[Any]) -> int:
+    async with pool.acquire() as conn:
+        return int(await conn.fetchval("SELECT count(*) FROM workflows WHERE account_id = $1", ACC))
+
+
+async def test_resolver_asymmetry(vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox) -> None:
+    """A run resolves the credential in its OWN bound vaults; an unbound run resolves nothing."""
+    pool = vault_pool
+    vault_id = await _make_vault(pool, "v-x")
+    url = "https://api.example/mcp"
+    await vaults_service.create_vault_credential(
+        pool,
+        crypto_box,
+        account_id=ACC,
+        vault_id=vault_id,
+        body=VaultCredentialCreate(
+            target_url=url, auth_type="bearer_header", token=SecretStr("tok-123")
+        ),
+    )
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="w-res", script=_SCRIPT)
+    bound = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, vault_ids=[vault_id]
+    )
+    unbound = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV
+    )
+
+    resolved_vault_id, headers = await resolve_auth_for_target_url_run(
+        pool, crypto_box, bound.id, url, account_id=ACC
+    )
+    assert resolved_vault_id == vault_id
+    assert headers == {"Authorization": "Bearer tok-123"}
+
+    none_id, none_headers = await resolve_auth_for_target_url_run(
+        pool, crypto_box, unbound.id, url, account_id=ACC
+    )
+    assert none_id is None
+    assert none_headers == {}
+
+    # The resolve path is account-scoped: the same bound run resolved under a different
+    # account sees nothing (a dropped account filter on the join would leak here).
+    foreign = await resolve_auth_for_target_url_run(
+        pool, crypto_box, bound.id, url, account_id="acc_intruder"
+    )
+    assert foreign == (None, {})
+
+
+async def test_launch_time_attenuation(vault_pool: asyncpg.Pool[Any]) -> None:
+    """A run can only bind vaults the launching agent holds; a breach rolls back."""
+    pool = vault_pool
+    vx = await _make_vault(pool, "v-x")
+    vy = await _make_vault(pool, "v-y")
+    agent = await _make_agent(pool, "launcher-agent")
+    launcher = await _make_session(pool, agent, vault_ids=[vx])
+    both = await _make_session(pool, agent, vault_ids=[vx, vy])
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="w-launch", script=_SCRIPT)
+
+    # Held vault → succeeds and binds.
+    ok = await wf_service.create_run(
+        pool,
+        account_id=ACC,
+        workflow_id=wf.id,
+        environment_id=ENV,
+        vault_ids=[vx],
+        launcher_session_id=launcher,
+    )
+    async with pool.acquire() as conn:
+        assert await wf_queries.get_run_vault_ids(conn, ok.id, account_id=ACC) == [vx]
+
+    # Strict subset of a richer launcher → succeeds.
+    sub = await wf_service.create_run(
+        pool,
+        account_id=ACC,
+        workflow_id=wf.id,
+        environment_id=ENV,
+        vault_ids=[vx],
+        launcher_session_id=both,
+    )
+    async with pool.acquire() as conn:
+        assert await wf_queries.get_run_vault_ids(conn, sub.id, account_id=ACC) == [vx]
+
+    # Ungranted vault → ForbiddenError, and no run row leaks (txn rolled back).
+    before = await _run_count(pool)
+    with pytest.raises(ForbiddenError):
+        await wf_service.create_run(
+            pool,
+            account_id=ACC,
+            workflow_id=wf.id,
+            environment_id=ENV,
+            vault_ids=[vy],
+            launcher_session_id=launcher,
+        )
+    assert await _run_count(pool) == before
+
+    # Operator path (no launcher) binds anything, account-scoped.
+    op = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, vault_ids=[vy]
+    )
+    async with pool.acquire() as conn:
+        assert await wf_queries.get_run_vault_ids(conn, op.id, account_id=ACC) == [vy]
+
+
+async def test_create_time_attenuation(vault_pool: asyncpg.Pool[Any]) -> None:
+    """A workflow may declare only servers/tools the creating agent itself has."""
+    pool = vault_pool
+    s1 = McpServerSpec(name="s1", url="https://s1.example")
+    s2 = McpServerSpec(name="s2", url="https://s2.example")
+    creator_agent = await _make_agent(pool, "creator-agent", mcp_servers=[s1])
+    creator = await _make_session(pool, creator_agent)
+
+    # Declares a subset of the creator's surface → ok.
+    ok = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-ct-ok",
+        script=_SCRIPT,
+        mcp_servers=[s1],
+        creator_session_id=creator,
+    )
+    assert [m.url for m in ok.mcp_servers] == ["https://s1.example"]
+
+    # Declares a server the creator lacks → ForbiddenError, no workflow row leaks.
+    before = await _workflow_count(pool)
+    with pytest.raises(ForbiddenError):
+        await wf_service.create_workflow(
+            pool,
+            account_id=ACC,
+            name="w-ct-bad",
+            script=_SCRIPT,
+            mcp_servers=[s2],
+            creator_session_id=creator,
+        )
+    assert await _workflow_count(pool) == before
+
+    # Operator path (no creator) declares anything.
+    op = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-ct-op",
+        script=_SCRIPT,
+        mcp_servers=[s2],
+        creator_session_id=None,
+    )
+    assert [m.url for m in op.mcp_servers] == ["https://s2.example"]
+
+
+async def test_declared_surface_round_trips(vault_pool: asyncpg.Pool[Any]) -> None:
+    """mcp_servers / http_servers persist on the workflow and read back equal."""
+    pool = vault_pool
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-surface",
+        script=_SCRIPT,
+        mcp_servers=[McpServerSpec(name="s", url="https://s.example")],
+        http_servers=[HttpServerSpec(name="h", base_url="https://h.example")],
+    )
+    fetched = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    assert [m.url for m in fetched.mcp_servers] == ["https://s.example"]
+    assert [h.base_url for h in fetched.http_servers] == ["https://h.example"]
+
+
+async def test_run_cannot_bind_foreign_or_missing_vault(vault_pool: asyncpg.Pool[Any]) -> None:
+    """A run binds only its own account's vaults; a foreign/unknown id rolls the insert back.
+
+    This is the operator path (no launcher) — the only path where an over-broad vault set
+    isn't already bounded by a launcher's holdings — so the account-scoped binding guard is
+    the load-bearing check. It also exercises the genuine rollback: ``insert_wf_run`` lands,
+    then ``set_run_vaults`` raises, and the outer transaction must leave no run row.
+    """
+    pool = vault_pool
+    async with pool.acquire() as conn:
+        # A child account (only one active root is allowed — accounts_one_active_root).
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            "VALUES ('acc_other', $1, FALSE, 'other-tenant')",
+            ACC,
+        )
+    foreign_vault = await vaults_service.create_vault(
+        pool, account_id="acc_other", display_name="other-v", metadata={}
+    )
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="w-foreign", script=_SCRIPT)
+
+    before = await _run_count(pool)
+    # Another account's (existing) vault — the FK alone would accept it; the ownership
+    # guard rejects it, and the insert that already ran rolls back.
+    with pytest.raises(NotFoundError):
+        await wf_service.create_run(
+            pool,
+            account_id=ACC,
+            workflow_id=wf.id,
+            environment_id=ENV,
+            vault_ids=[foreign_vault.id],
+        )
+    assert await _run_count(pool) == before
+
+    # A plainly nonexistent vault id is likewise NotFound, no run row.
+    with pytest.raises(NotFoundError):
+        await wf_service.create_run(
+            pool,
+            account_id=ACC,
+            workflow_id=wf.id,
+            environment_id=ENV,
+            vault_ids=["vlt_does_not_exist"],
+        )
+    assert await _run_count(pool) == before

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -13,7 +13,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aios.crypto.vault import CryptoBox
-from aios.mcp.client import call_mcp_tool, discover_mcp_tools, resolve_auth_for_target_url
+from aios.mcp.client import (
+    call_mcp_tool,
+    discover_mcp_tools,
+    resolve_auth_for_target_url,
+    resolve_auth_for_target_url_run,
+)
 from tests.unit.conftest import fake_pool_yielding_conn
 
 # ── resolve_auth_for_target_url ──────────────────────────────────────────────────────
@@ -234,6 +239,49 @@ class TestResolveAuthForTargetUrl:
             await resolve_auth_for_target_url(
                 pool, crypto_box, "sess_123", "https://mcp.example.com", account_id="acc_test_stub"
             )
+
+
+class TestResolveAuthForTargetUrlRun:
+    """The run arm resolves through a *run*'s bound vaults via ``resolve_run_credential``,
+    reusing the same decrypt/render engine as the session arm — so a run resolves
+    credentials identically, scoped to ``wf_run_vaults`` instead of ``session_vaults``."""
+
+    @pytest.fixture
+    def crypto_box(self) -> CryptoBox:
+        import os
+
+        return CryptoBox(os.urandom(32))
+
+    async def test_resolves_via_run_vaults(self, crypto_box: CryptoBox) -> None:
+        payload = json.dumps({"token": "run-token"})
+        blob = crypto_box.derive_account_subkey("acc_test_stub").encrypt(payload)
+        pool = fake_pool_yielding_conn(MagicMock())
+        with patch(
+            "aios.mcp.client.queries.resolve_run_credential",
+            new_callable=AsyncMock,
+        ) as r:
+            r.return_value = (blob, "bearer_header", "vlt_r1")
+            vault_id, result = await resolve_auth_for_target_url_run(
+                pool, crypto_box, "wfr_123", "https://mcp.example.com", account_id="acc_test_stub"
+            )
+        # Proves: the run arm calls the run query (not the session one) and the shared
+        # engine renders the header identically to the session path.
+        assert vault_id == "vlt_r1"
+        assert result == {"Authorization": "Bearer run-token"}
+        r.assert_awaited_once()
+
+    async def test_no_credential_returns_empty(self, crypto_box: CryptoBox) -> None:
+        pool = fake_pool_yielding_conn(MagicMock())
+        with patch(
+            "aios.mcp.client.queries.resolve_run_credential",
+            new_callable=AsyncMock,
+        ) as r:
+            r.return_value = None
+            vault_id, result = await resolve_auth_for_target_url_run(
+                pool, crypto_box, "wfr_123", "https://mcp.example.com", account_id="acc_test_stub"
+            )
+        assert vault_id is None
+        assert result == {}
 
 
 # ── discover_mcp_tools ────────────────────────────────────────────────────────

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0072``."""
+    """The migration ladder has exactly one head: ``0073``."""
     script = _script_directory()
-    assert script.get_heads() == ["0072"]
+    assert script.get_heads() == ["0073"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -31,7 +31,23 @@ class TestWorkflowCreate:
             "input_schema": {"type": "object"},
             "output_schema": {"type": "integer"},
             "description": None,
+            "tools": [],
+            "mcp_servers": [],
+            "http_servers": [],
         }
+
+    def test_declared_surface_round_trips(self) -> None:
+        wf = WorkflowCreate.model_validate(
+            {
+                "name": "w",
+                "script": "async def main(i): return 1",
+                "mcp_servers": [{"name": "s", "url": "https://srv.example"}],
+                "http_servers": [{"name": "h", "base_url": "https://api.example"}],
+            }
+        )
+        assert wf.mcp_servers[0].url == "https://srv.example"
+        assert wf.http_servers[0].base_url == "https://api.example"
+        assert wf.tools == []
 
     def test_requires_name_and_script(self) -> None:
         with pytest.raises(ValidationError):
@@ -45,6 +61,13 @@ class TestWfRunCreate:
         run = WfRunCreate.model_validate({"workflow_id": "wf_1", "environment_id": "env_1"})
         assert run.workflow_id == "wf_1" and run.environment_id == "env_1"
         assert run.input is None
+        assert run.vault_ids == []
+
+    def test_vault_ids_round_trip(self) -> None:
+        run = WfRunCreate.model_validate(
+            {"workflow_id": "wf_1", "environment_id": "env_1", "vault_ids": ["v_1", "v_2"]}
+        )
+        assert run.vault_ids == ["v_1", "v_2"]
 
     def test_requires_workflow_and_environment(self) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## What

Slice 1 of the **"workflow runs as first-class credentialed actors"** lane. A workflow declares a tool surface like an agent and a run binds vaults like a session, with authority that **attenuates monotonically down the chain** — an agent can't grant a workflow more than it has, and a run can't bind a credential its launcher lacks.

This slice ships the **credential substrate + both attenuations, proven by asymmetry tests** — no `tool()` call site yet (that's slice 2). It's purely additive: new columns, a junction, a parallel resolver arm, and two subset checks. No hot-path change.

## The shape

A credentialed tool call will need **both** halves, gated at different times — neither alone can widen authority:

| | gated at | check |
|---|---|---|
| **declared server** (mcp/http/tool) | workflow create | `workflow.surface ⊆ creating-agent.surface` |
| **bound credential** (vault) | run launch | `run.vaults ⊆ launcher.vaults` |

The agent-acting callers that supply the creator/launcher identity land in **slice 3**; both checks are built and tested directly but dormant on the operator (HTTP) surface — which is unattenuated account authority — until then.

## Changes

- **Declared surface** — `workflows.{tools, mcp_servers, http_servers}`, the verbatim agent envelope, stored + round-tripping (migration `0073`).
- **Run vault binding** — `wf_run_vaults` junction + `set_run_vaults`/`get_run_vault_ids`, mirroring `session_vaults` but with an **account-scoped ownership guard**: a run can never bind another account's vault (the FK checks existence, not ownership — the same tenant-confusion `create_vault_credential`'s lock guards against). Duplicate ids de-duped.
- **Owner-widened resolver** — `resolve_auth_for_target_url_run` + `resolve_run_credential`: a run resolves credentials through its **own** bound vaults, reusing the shared decrypt / OAuth-refresh / header engine (extracted to `_auth_from_credential`; the 6 existing session callers + their mocks are untouched — the asymmetry is one query call).
- **Two attenuations** (service layer) — `create_workflow` gains `creator_session_id`; `create_run` gains `launcher_session_id` + `vault_ids` (insert + bind atomic, `ForbiddenError` on a breach leaves no row).
- API/CLI threading + regenerated `openapi.json` / SDK.

## Deferred by design

- The `tool()` author capability + `step.py` dispatch + owner-widened `invoke_builtin` (slice 2).
- The `invoke_workflow`/`create_workflow` model-callable builtins that supply the acting session (slice 3).
- **Sandbox/filesystem tools from a run** — a run reaches `bash`/`read`/`write` via `agent()` children for now; the direct path (re-homing `build_spec_from_session` onto an owner handle) is a later, larger piece.

## Tests

- **unit** — run-arm resolver (proves it calls the run query + shares the header engine), model round-trips.
- **integration** (real Postgres) — resolver asymmetry, **account-scoped resolution**, launch-time attenuation, create-time attenuation, declared-surface round-trip, and **foreign/missing-vault binding rollback** (covers the ownership guard + the genuine insert→bind-fail rollback).

1791 unit + 71 wf-integration green; mypy + ruff clean; `openapi.json` / SDK regenerated. Went through `/simplify` and `/code-review --fix` (the review hardened `set_run_vaults` against cross-account binding + duplicate-id 500s, and added the binding-boundary / rollback tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
