### PR TITLE
feat(context): uniform `received` envelope on every user message

### DIFF
--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -472,7 +472,7 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         The target message is identified by ``(target_author_uuid,
         target_timestamp_ms)``.  Every inbound Signal message in your
         conversation starts with a header line like ``[channel=... ·
-        from=... · sender_uuid=<uuid> · timestamp_ms=<ms> (<iso>)]``;
+        from=... · sender_uuid=<uuid> · timestamp_ms=<ms> · received=<iso>]``;
         copy ``sender_uuid`` and the raw ``timestamp_ms`` integer from
         that header.
 

--- a/connectors/signal/src/aios_signal/prompts.py
+++ b/connectors/signal/src/aios_signal/prompts.py
@@ -103,7 +103,11 @@ Header shape (newlines added for clarity):
 
     [channel=signal/<account>/<chat_id> · chat_type=<dm|group> ·
      chat_name='Group Name' · from=Alice · sender_uuid=<uuid> ·
-     timestamp_ms=<ms> (<iso>)]
+     timestamp_ms=<ms> · received=<iso>]
+
+``timestamp_ms`` is the raw value the tools consume (copy it verbatim).
+``received`` is the message's receipt time (UTC ISO-8601) for your temporal
+awareness only — it is never a tool argument.
 
 When the inbound is a reply, a second line follows:
 
@@ -116,7 +120,7 @@ When it's a reaction:
 So a reply to message 1700000000000 from Alice would look like:
 
     [channel=signal/.../grp_id · chat_type=group · from=Alice ·
-     sender_uuid=fb2c91e2-... · timestamp_ms=1700000000999 (...)]
+     sender_uuid=fb2c91e2-... · timestamp_ms=1700000000999 · received=<iso>]
     [reply_to: author_uuid=22334455-... · timestamp_ms=1700000000000]
      > earlier message text...
 
@@ -213,7 +217,7 @@ of the message you're reacting to:
 For example, if you see:
 
     [channel=... · from=Alice · sender_uuid=fb2c91e2-aaaa-... ·
-     timestamp_ms=1700000000000 (...)]
+     timestamp_ms=1700000000000 · received=<iso>]
     Done with the deploy!
 
 react with:

--- a/connectors/whatsapp/src/aios_whatsapp/prompts.py
+++ b/connectors/whatsapp/src/aios_whatsapp/prompts.py
@@ -129,10 +129,11 @@ Header shape (newlines added for clarity):
 
     [channel=whatsapp/<account>/<chat_id> · chat_type=<dm|group> ·
      chat_name='Group Name' · from=Alice · sender_jid=<jid> ·
-     timestamp_ms=<ms> (<iso>) · message_id='<id>']
+     timestamp_ms=<ms> · message_id='<id>' · received=<iso>]
 
 WhatsApp message ids are hex strings like ``3EB0E03B46303C22D750E2``
-— pass them verbatim.
+— pass them verbatim.  ``received`` is the message's receipt time
+(UTC ISO-8601) for your temporal awareness only — never a tool argument.
 
 ## Sending messages — `whatsapp_send`
 

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -17,7 +17,7 @@ import json
 import math
 import time
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from types import EllipsisType
 from typing import Any, NamedTuple, NoReturn, cast
 
@@ -2562,7 +2562,7 @@ async def append_event(
         cum_tokens: int | None = None
         if kind == "message":
             prev = await _latest_cumulative_tokens(conn, session_id)
-            if is_user_message and orig_channel is not None:
+            if is_user_message:
                 # TODO(vision): plumb ``agent.model`` through here so
                 # :func:`render_user_event` matches build-time output for
                 # image-bearing events.  Today this call site renders without
@@ -2573,7 +2573,14 @@ async def append_event(
                 # ``model_token_ratio`` calibration in
                 # :func:`read_windowed_events`; see PR #218 for the
                 # follow-up plan to make append-time vision-aware.
-                rendered = render_user_event(data, orig_channel, focal_at_arrival)
+                #
+                # ``created_at`` isn't assigned until the INSERT below (DB
+                # DEFAULT now()), so pass a now() stand-in: the count only needs
+                # the rendered length, and the ``received`` envelope is
+                # fixed-width, so it matches the build-time render's token count.
+                rendered = render_user_event(
+                    data, orig_channel, focal_at_arrival, datetime.now(UTC)
+                )
                 cum_tokens = (prev or 0) + approx_tokens([rendered])
             else:
                 cum_tokens = (prev or 0) + approx_tokens([data])

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -89,7 +89,24 @@ def _extract_reaction_emoji(reaction: dict[str, Any]) -> str | None:
     return None
 
 
-def _format_channel_header(metadata: dict[str, Any]) -> str:
+def _format_received(created_at: datetime) -> str:
+    """Absolute receipt timestamp for the message envelope.
+
+    Sourced from the event's immutable ``created_at`` (DB-commit time, UTC),
+    so it renders byte-identical on every rebuild — deterministic and
+    prompt-cache-stable, unlike a relative or render-time clock.  This is
+    the uniform envelope field every user message carries, connector or not.
+    """
+    return created_at.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _prepend_header(msg: dict[str, Any], header: str) -> None:
+    """Prepend a bracketed header line above the message's existing content."""
+    existing = msg.get("content") or ""
+    msg["content"] = f"{header}\n{existing}" if existing else header
+
+
+def _format_channel_header(metadata: dict[str, Any], received: str) -> str:
     """Render a one-line header describing the origin of an inbound message.
 
     When a user message carries channel metadata, the raw fields are
@@ -97,11 +114,13 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
     ever sees them (see ``_ALLOWED_FIELDS``).  That leaves the model
     with no way to know the sender or timestamp — values the connector
     tools need as arguments.  Inline the salient fields into the
-    visible ``content`` so the model can read them natively.
+    visible ``content`` so the model can read them natively.  The
+    ``received`` envelope field is always appended (see
+    :func:`_format_received`); the connector fields are added when present.
     """
-    if not isinstance(metadata, dict) or "channel" not in metadata:
-        return ""
-    parts: list[str] = [f"channel={metadata['channel']}"]
+    parts: list[str] = []
+    if "channel" in metadata:
+        parts.append(f"channel={metadata['channel']}")
     chat_type = metadata.get("chat_type")
     if isinstance(chat_type, str) and chat_type:
         parts.append(f"chat_type={chat_type}")
@@ -119,18 +138,10 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         parts.append(f"sender_id={sender_id}")
     timestamp_ms = metadata.get("timestamp_ms")
     if isinstance(timestamp_ms, int):
-        try:
-            iso = datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).isoformat(
-                timespec="milliseconds"
-            )
-            parts.append(f"timestamp_ms={timestamp_ms} ({iso})")
-        except (ValueError, OverflowError, OSError):
-            # An int outside the valid Unix-millisecond range (a connector
-            # sending micro/nanoseconds, say) makes datetime.fromtimestamp
-            # raise. The renderer runs on every wake, so an unguarded raise
-            # bricks the session permanently — same failure class as #446.
-            # The raw int still goes to the model; only the ISO is dropped.
-            parts.append(f"timestamp_ms={timestamp_ms}")
+        # Raw origin-time int — the model copies it verbatim into signal_send /
+        # react / edit / delete tool args. The human-readable ISO now lives in
+        # the envelope's `received=` field (receipt time), so no parenthetical.
+        parts.append(f"timestamp_ms={timestamp_ms}")
     message_id = metadata.get("message_id")
     # Telegram surfaces ints; WhatsApp's whatsmeow IDs are hex strings
     # like "3EB0E03B46303C22D750E2".  Both render the same — the model
@@ -183,6 +194,7 @@ def _format_channel_header(metadata: dict[str, Any]) -> str:
         # value still signals "a sticker arrived" without breaking
         # the established field-name pattern.
         parts.append(f"sticker_emoji={sticker_emoji!r}")
+    parts.append(f"received={received}")
     header = "[" + " · ".join(parts) + "]"
     mentions = metadata.get("mentions")
     if isinstance(mentions, list) and mentions:
@@ -295,6 +307,7 @@ def render_user_event(
     event_data: dict[str, Any],
     orig_channel: str | None,
     focal_channel_at_arrival: str | None,
+    created_at: datetime,
     *,
     model: str | None = None,
     session_id: str | None = None,
@@ -303,35 +316,46 @@ def render_user_event(
     """Render a user event into its chat-completions message form.
 
     Rendering is a deterministic function of the event's stamped
-    ``orig_channel``, ``focal_channel_at_arrival``, and the optional
-    vision policy inputs ``model`` / ``session_id``.  ``build_messages``
-    threads vision policy through; the append-time token counter in
-    ``queries.append_event`` does not (and pays a small under-count
-    per inlined image, absorbed by ``model_token_ratio`` calibration).
+    ``orig_channel``, ``focal_channel_at_arrival``, ``created_at``, and
+    the optional vision policy inputs ``model`` / ``session_id``.
+    ``build_messages`` threads vision policy through; the append-time
+    token counter in ``queries.append_event`` does not (and pays a small
+    under-count per inlined image, absorbed by ``model_token_ratio``
+    calibration).
+
+    Every user message carries a ``received`` envelope field (the absolute
+    receipt timestamp, from the immutable ``created_at``; see
+    :func:`_format_received`) — so even the metadata-less ``channel=None``
+    path is structured, not raw.
 
     Branches:
 
-    * ``orig_channel`` is ``None`` → legacy / non-connector event;
-      metadata stripped, no header, no notification.  Covers direct
-      ``POST /sessions/{id}/messages`` traffic and pre-migration rows.
+    * ``orig_channel`` is ``None`` → non-connector event; the only header
+      is the ``received`` envelope.  Covers direct
+      ``POST /sessions/{id}/messages`` traffic, workflow children, and
+      pre-migration rows.
     * ``orig == focal_at_arrival`` (non-NULL) → full content with a
-      metadata header inlined.  When the focal event's metadata
-      carries ``attachments`` and the bound model supports vision,
-      inlinable images are emitted as ``image_url`` content parts;
-      everything else gets a text marker referencing the in-sandbox
-      path.
+      metadata header inlined (connector fields + ``received``).  When the
+      focal event's metadata carries ``attachments`` and the bound model
+      supports vision, inlinable images are emitted as ``image_url``
+      content parts; everything else gets a text marker referencing the
+      in-sandbox path.
     * Otherwise (focal is NULL, or focal differs from orig) →
       notification marker: a short, emoji-prefixed one-liner surfacing
-      the origin channel, sender, and a truncated content preview.
-      Any attachments are appended as ``text_marker`` lines (images →
-      ``[image: … at <path>]``, others → ``[attachment: …]``) — never
-      inlined off-channel — so the model can ``read`` the in-sandbox
-      path now, or ``switch_channel`` to recover pixels via the
-      reorient recap.  Before #718 they were silently dropped here.
+      the origin channel, sender, and a truncated content preview.  Kept
+      deliberately terse — no ``received`` envelope; the per-message
+      timestamp surfaces when the model ``switch_channel``s in and reads
+      the full-content recap.  Any attachments are appended as
+      ``text_marker`` lines (images → ``[image: … at <path>]``, others →
+      ``[attachment: …]``) — never inlined off-channel — so the model can
+      ``read`` the in-sandbox path now, or ``switch_channel`` to recover
+      pixels via the reorient recap.  Before #718 they were silently
+      dropped here.
     """
     msg = {k: v for k, v in event_data.items() if k != "metadata"}
     metadata = event_data.get("metadata")
     metadata = metadata if isinstance(metadata, dict) else None
+    received = _format_received(created_at)
 
     # A request injected via invoke_session (e.g. a workflow agent child's first
     # message) carries metadata.request.request_id. return/error require that id, so
@@ -350,18 +374,18 @@ def render_user_event(
                 "\nYour return `value` must match this JSON Schema:\n"
                 f"```json\n{json.dumps(output_schema, indent=2)}\n```"
             )
-        existing = msg.get("content") or ""
-        msg["content"] = f"{marker}\n{existing}" if existing else marker
+        _prepend_header(msg, marker)
 
     if orig_channel is None:
+        _prepend_header(msg, f"[received={received}]")
         return msg
 
     if orig_channel == focal_channel_at_arrival:
+        header = (
+            _format_channel_header(metadata, received) if metadata else f"[received={received}]"
+        )
+        _prepend_header(msg, header)
         if metadata:
-            header = _format_channel_header(metadata)
-            if header:
-                existing = msg.get("content") or ""
-                msg["content"] = f"{header}\n{existing}" if existing else header
             attachments = metadata.get("attachments")
             if isinstance(attachments, list) and attachments:
                 _apply_attachments(
@@ -710,6 +734,7 @@ def build_messages(
                 e.data,
                 e.orig_channel,
                 e.focal_channel_at_arrival,
+                e.created_at,
                 model=model,
                 session_id=session_id,
                 workspace_path=workspace_path,

--- a/src/aios/tools/switch_channel.py
+++ b/src/aios/tools/switch_channel.py
@@ -348,6 +348,7 @@ def _render_recap_event(
             event.data,
             event.orig_channel,
             event.orig_channel,
+            event.created_at,
             model=model,
             session_id=session_id,
             workspace_path=workspace_path,

--- a/tests/e2e/test_context_endpoint.py
+++ b/tests/e2e/test_context_endpoint.py
@@ -118,12 +118,14 @@ class TestContextEndpoint:
         assert r.status_code == 200
         messages = r.json()["messages"]
 
+        # The content carries a leading ``[received=<iso>]`` envelope line
+        # (uniform on every user message), so match the body as a substring.
         user_msgs = [m for m in messages if m.get("role") == "user"]
         assert any(
-            (isinstance(m.get("content"), str) and m["content"] == "hello")
+            (isinstance(m.get("content"), str) and "hello" in m["content"])
             or (
                 isinstance(m.get("content"), list)
-                and any(isinstance(b, dict) and b.get("text") == "hello" for b in m["content"])
+                and any(isinstance(b, dict) and "hello" in b.get("text", "") for b in m["content"])
             )
             for m in user_msgs
         ), messages

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -35,6 +35,12 @@ def _full_pipeline(
     return separate_adjacent_user_messages(ctx.messages)
 
 
+# Fixed receipt time so the per-message ``received=`` envelope field
+# (see ``_format_received``) renders deterministically across assertions.
+_FIXED_CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+RECEIVED = "2026-01-02T03:04:05Z"  # _format_received(_FIXED_CREATED_AT)
+
+
 def _evt(
     seq: int,
     role: str,
@@ -45,6 +51,7 @@ def _evt(
     metadata: dict[str, Any] | None = None,
     orig_channel: str | None = None,
     focal_channel_at_arrival: str | None = None,
+    created_at: datetime | None = None,
 ) -> Event:
     """Build a minimal message Event for testing.
 
@@ -53,6 +60,9 @@ def _evt(
     way :func:`aios.services.sessions.append_user_message` does at the
     real append site, so focal-aware rendering kicks in for these
     events just as it would in production.
+
+    ``created_at`` defaults to :data:`_FIXED_CREATED_AT` so the
+    ``received=`` envelope field is a stable :data:`RECEIVED` constant.
     """
     data: dict[str, Any] = {"role": role, "content": content}
     if tool_calls is not None:
@@ -71,7 +81,7 @@ def _evt(
         seq=seq,
         kind="message",
         data=data,
-        created_at=datetime.now(tz=UTC),
+        created_at=created_at if created_at is not None else _FIXED_CREATED_AT,
         orig_channel=orig_channel,
         focal_channel_at_arrival=focal_channel_at_arrival,
     )
@@ -151,12 +161,12 @@ class TestBuildMessages:
         ).messages
         # Should be: user, assistant+tool_calls, tool_result_x, user_injection
         assert msgs[0]["role"] == "user"
-        assert msgs[0]["content"] == "do X"
+        assert msgs[0]["content"] == f"[received={RECEIVED}]\ndo X"
         assert msgs[1]["role"] == "assistant"
         assert msgs[2]["role"] == "tool"
         assert msgs[2]["tool_call_id"] == "x"
         assert msgs[3]["role"] == "user"
-        assert msgs[3]["content"] == "how goes?"
+        assert msgs[3]["content"] == f"[received={RECEIVED}]\nhow goes?"
 
     def test_no_system_prompt_when_none(self) -> None:
         events = [_evt(1, "user", content="hi")]
@@ -311,7 +321,7 @@ class TestBuildMessages:
         ]
         msgs = build_messages(events, system_prompt=None).messages
         assert msgs[0]["role"] == "user"
-        assert msgs[0]["content"] == "next question"
+        assert msgs[0]["content"] == f"[received={RECEIVED}]\nnext question"
         assert msgs[1]["role"] == "assistant"
 
     def test_user_metadata_excluded_from_messages(self) -> None:
@@ -320,7 +330,7 @@ class TestBuildMessages:
         e = _evt(1, "user", content="hello")
         e.data["metadata"] = {"run_id": "abc123"}
         msgs = build_messages([e], system_prompt=None).messages
-        assert msgs[0] == {"role": "user", "content": "hello"}
+        assert msgs[0] == {"role": "user", "content": f"[received={RECEIVED}]\nhello"}
 
     def test_prune_partial_assistant_tool_group(self) -> None:
         """If DB windowing keeps an assistant with tool_calls but dropped
@@ -360,7 +370,7 @@ class TestBuildMessages:
         ]
         msgs = build_messages(events, system_prompt=None).messages
         assert [m["role"] for m in msgs] == ["user"]
-        assert msgs[0]["content"] == "next"
+        assert msgs[0]["content"] == f"[received={RECEIVED}]\nnext"
 
 
 # ─── monotonicity ──────────────────────────────────────────────────────────
@@ -1042,10 +1052,11 @@ class TestFocalRendering:
     _CHAN_B = "signal/bot/bob"
 
     def test_legacy_null_event_phase2_rendering(self) -> None:
-        """orig_channel=None: no header, no marker — same as Phase 2."""
+        """orig_channel=None: only the uniform ``received=`` envelope, no
+        connector header, no notification marker."""
         events = [_evt(1, "user", content="hi")]
         msg = build_messages(events, system_prompt=None).messages[0]
-        assert msg["content"] == "hi"
+        assert msg["content"] == f"[received={RECEIVED}]\nhi"
         assert "metadata" not in msg
         assert "🔔" not in msg["content"]
 
@@ -1212,29 +1223,15 @@ class TestFocalRendering:
         assert "revoke_target_message_id='3EB0ORIGINAL'" in content
 
     def test_focal_match_iso_timestamp(self) -> None:
+        """The raw origin ``timestamp_ms`` int is surfaced for connector tool
+        args; its human-readable ISO now lives in the uniform ``received=``
+        envelope field (receipt time), not as a parenthetical."""
         md = {"channel": self._CHAN_A, "timestamp_ms": 1776401210703}
         events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
         content = build_messages(events, system_prompt=None).messages[0]["content"]
         assert "timestamp_ms=1776401210703" in content
-        assert "(2026-04-17T" in content
-
-    def test_focal_match_timestamp_ms_out_of_range_does_not_brick_session(self) -> None:
-        """An int ``timestamp_ms`` outside the valid millisecond-Unix
-        range (a connector sending micro/nanoseconds, say) makes
-        ``datetime.fromtimestamp`` raise. ``_format_channel_header`` runs
-        on every wake, so an unguarded raise bricks the session
-        permanently (same failure class as #446)."""
-        # 1776401210703 ms is a sane 2026 timestamp; 1000x larger
-        # (microseconds mistaken for milliseconds) lands the divided
-        # value past datetime's MAXYEAR.
-        md = {"channel": self._CHAN_A, "timestamp_ms": 1_776_401_210_703_000}
-        events = [_evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival=self._CHAN_A)]
-        content = build_messages(events, system_prompt=None).messages[0]["content"]
-        # The raw int is still surfaced — connector tools need it as an
-        # argument — but the unconvertible value yields no ISO
-        # parenthetical (the success path appends " (<iso>)").
-        assert "timestamp_ms=1776401210703000" in content
-        assert "timestamp_ms=1776401210703000 (" not in content
+        assert "timestamp_ms=1776401210703 (" not in content  # no parenthetical ISO
+        assert f"received={RECEIVED}" in content
 
     def test_focal_match_message_id_inlined(self) -> None:
         """The ``message_id`` lets the model react/edit/delete the user
@@ -1673,7 +1670,7 @@ class TestSeparateAdjacentUserMessagesPipeline:
         )
         assert msgs[injection_idx + 1] == {"role": "assistant", "content": "."}
         assert msgs[injection_idx + 2]["role"] == "user"
-        assert msgs[injection_idx + 2]["content"] == "anything else?"
+        assert msgs[injection_idx + 2]["content"] == f"[received={RECEIVED}]\nanything else?"
 
     def test_alternating_events_no_tail_block_no_separator(self) -> None:
         """Guards against a future change that inserts a separator when

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -9,6 +9,7 @@ non-vision models and oversize images, and the legacy-stub path.
 from __future__ import annotations
 
 import base64
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -16,8 +17,29 @@ import pytest
 
 from aios.config import get_settings
 from aios.harness import vision
-from aios.harness.context import render_user_event
+from aios.harness.context import (
+    _apply_attachments,
+)
+from aios.harness.context import (
+    render_user_event as _render_user_event_impl,
+)
 from aios.sandbox.volumes import session_attachments_dir
+
+# These tests exercise attachment/vision rendering, not the `received=` envelope
+# (their assertions are substring checks). Inject a fixed created_at so callers
+# needn't thread one through; the resulting `received` field is inert here.
+_CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+
+
+def render_user_event(
+    event_data: dict[str, Any],
+    orig_channel: str | None,
+    focal_channel_at_arrival: str | None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    return _render_user_event_impl(
+        event_data, orig_channel, focal_channel_at_arrival, _CREATED_AT, **kwargs
+    )
 
 
 @pytest.fixture
@@ -328,62 +350,45 @@ class TestVisionAwareRendering:
         assert isinstance(msg["content"], str)
         assert "[image: photo.jpg" in msg["content"]
 
-    def test_image_only_no_caption_no_header_omits_empty_text(
-        self, temp_workspace_root: Path
-    ) -> None:
-        """An image-only event with no caption AND no channel header must
-        NOT emit ``{"type":"text","text":""}`` — Anthropic rejects empty
-        text blocks (``text content blocks must be non-empty``).  The
-        common path is fine because the channel header populates the
-        leading text, but legacy events with metadata-stripped headers
-        would 400 against Anthropic-routed models.  Regression test for
+    def test_apply_attachments_omits_empty_text_block(self, temp_workspace_root: Path) -> None:
+        """``_apply_attachments`` must NOT emit ``{"type":"text","text":""}``
+        when the leading text is empty — Anthropic rejects empty text blocks
+        (``text content blocks must be non-empty``), which would 400 and wedge
+        the session on a caption-less image-only inbound.  Regression test for
         PR #218.
+
+        Tested at ``_apply_attachments``'s own boundary with an empty
+        ``leading_text``: the render path always prepends a non-empty
+        ``[received=…]`` envelope now, so the function's self-guard must stay
+        correct independent of what its caller happens to prepend.
         """
         sandbox_path = _stage_image(
             temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"PNG"
         )
-        # Construct an event whose metadata has attachments but lacks
-        # ``channel`` — _format_channel_header returns "" so leading_text
-        # stays empty.  Content is also empty (image-only inbound).
-        event: dict[str, Any] = {
-            "role": "user",
-            "content": "",
-            "metadata": {
-                "channel": "echo/acct/chat-1",
-                "attachments": [
-                    {
-                        "filename": "photo.jpg",
-                        "content_type": "image/jpeg",
-                        "size": 3,
-                        "in_sandbox_path": sandbox_path,
-                    }
-                ],
-            },
-        }
-        # Strip the channel header by zeroing all the fields _format_channel_header
-        # consumes after the bare "channel" key: the header is the channel marker
-        # plus the inbound content, both empty here, so leading_text is just the
-        # bare ``[channel=...]`` line.  To exercise the no-header branch we drop
-        # ``channel`` from metadata entirely below.
-        event["metadata"].pop("channel")
-        # Re-add ``attachments`` only — _format_channel_header returns "" when
-        # channel is absent, leaving leading_text empty for the image-only path.
-        msg = render_user_event(
-            event,
-            "echo/acct/chat-1",
-            "echo/acct/chat-1",
+        msg: dict[str, Any] = {"role": "user", "content": ""}  # empty leading text
+        _apply_attachments(
+            msg,
+            [
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": 3,
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
             model="model/vision",
             session_id="sess-1",
         )
         content = msg["content"]
         assert isinstance(content, list), (
-            "image_only message must still emit content parts when image is inlined"
+            "image-only message must still emit content parts when the image inlines"
         )
-        # No empty text block in the parts.
+        # The guard: an empty leading text must yield NO text part at all, never
+        # an empty one. If the omission broke, content would carry
+        # {"type":"text","text":""} and this assertion would fire.
         for part in content:
             if isinstance(part, dict) and part.get("type") == "text":
                 assert part.get("text"), f"empty text part rejected by Anthropic — got {part!r}"
-        # And the image_url part is preserved.
         assert any(p.get("type") == "image_url" for p in content)
 
     def test_mime_corrected_when_event_declares_wrong_type(self, temp_workspace_root: Path) -> None:

--- a/tests/unit/test_inbound_metadata.py
+++ b/tests/unit/test_inbound_metadata.py
@@ -225,10 +225,13 @@ async def test_inbound_sender_display_name_reaches_renderer(
     channel = metadata["channel"]
 
     # 1. Renderer's full-content header must include the sender clause.
+    from datetime import UTC, datetime
+
     rendered = render_user_event(
         data,
         orig_channel=channel,
         focal_channel_at_arrival=channel,
+        created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC),
     )
     assert "from=Alice" in rendered["content"], (
         f"focal-render must include from=Alice; got content={rendered['content']!r}. "

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any, ClassVar
 
 from aios.harness.context import render_user_event
 from aios.harness.tokens import approx_tokens
+
+_CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
 
 
 class TestApproxTokens:
@@ -75,17 +78,19 @@ class TestApproxTokensUnderFocalRendering:
         }
         data = {"role": "user", "content": long_text, "metadata": metadata}
 
-        focal_render = render_user_event(data, self._CHAN, self._CHAN)
-        notif_render = render_user_event(data, self._CHAN, "signal/bot/other")
+        focal_render = render_user_event(data, self._CHAN, self._CHAN, _CREATED_AT)
+        notif_render = render_user_event(data, self._CHAN, "signal/bot/other", _CREATED_AT)
 
         assert approx_tokens([notif_render]) < approx_tokens([focal_render])
 
-    def test_legacy_null_matches_raw_data(self) -> None:
-        """orig=None → Phase 2 rendering: tokens match the raw data
-        (minus metadata stripping, which is content-preserving)."""
+    def test_legacy_null_render_adds_received_envelope(self) -> None:
+        """orig=None now carries the uniform ``received=`` envelope, so the
+        rendered form costs a few tokens more than the raw data (was: equal
+        — the channel=None path used to pass content through untouched)."""
         data = {"role": "user", "content": "hello"}
-        rendered = render_user_event(data, None, None)
-        assert approx_tokens([rendered]) == approx_tokens([data])
+        rendered = render_user_event(data, None, None, _CREATED_AT)
+        assert rendered["content"].startswith("[received=")
+        assert approx_tokens([rendered]) > approx_tokens([data])
 
 
 class TestApproxTokensWithTools:

--- a/tests/unit/test_workflow_output_schema.py
+++ b/tests/unit/test_workflow_output_schema.py
@@ -9,6 +9,7 @@ context builder renders into the child's request message.
 from __future__ import annotations
 
 import math
+from datetime import UTC, datetime
 
 import pytest
 
@@ -16,6 +17,8 @@ from aios.harness.context import render_user_event
 from aios.tools.workflow_completion import _validate_value
 from aios.workflows.determinism import canonical_schema_json
 from aios.workflows.step import _unresolvable_ref
+
+_CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
 
 _SCHEMA = {
     "type": "object",
@@ -45,7 +48,7 @@ def test_render_surfaces_request_schema_per_request() -> None:
         "content": "do the thing",
         "metadata": {"request": {"request_id": "r1", "output_schema": _SCHEMA}},
     }
-    msg = render_user_event(event, None, None)
+    msg = render_user_event(event, None, None, _CREATED_AT)
     assert "request_id: r1" in msg["content"]
     assert "must match this JSON Schema" in msg["content"]
     assert '"answer"' in msg["content"]  # the schema itself is rendered
@@ -58,7 +61,7 @@ def test_render_without_schema_is_unchanged() -> None:
         "content": "hi",
         "metadata": {"request": {"request_id": "r1"}},
     }
-    msg = render_user_event(event, None, None)
+    msg = render_user_event(event, None, None, _CREATED_AT)
     assert "request_id: r1" in msg["content"]
     assert "JSON Schema" not in msg["content"]
 


### PR DESCRIPTION
## What

Every user message the model sees now carries a uniform `[received=<iso>]` envelope field, sourced from the event's immutable `created_at`:

```
channel=None (was raw):     [received=2026-06-06T16:00:00Z]
                            What's the weather in SF?

connector 1:1:              [channel=signal/… · from=Tom · sender_uuid=abc-123 ·
                             timestamp_ms=1717689600000 · message_id=… · received=2026-06-06T16:00:00Z]
                            What's the weather in SF?
```

## Why

The `channel=None` path (direct API, CLI, workflow children) was previously rendered as **raw content with no structure at all** — and we wanted to give the model a per-message timestamp. Rather than bolt a one-off timestamp onto raw text, this establishes a single uniform metadata envelope across every user message, connector or not.

**Why brackets, not XML.** The connector path was already semi-structured (`[k=v · k=v]`); the real fork was *enclose the content or not*. A content-enclosing `<message>…</message>` envelope would force entity-escaping of the body — the model would see `a[0] &lt; b &amp;&amp; c` for pasted code, a real legibility regression. Keeping the metadata as a header and the content **verbatim below it** sidesteps that entirely; once content stays outside any tag, `<message k="v"/>` and `[k=v]` are isomorphic, so the existing bracket convention (which connector prompts already document) wins.

## What changed

- **`harness/context.py`** — `_format_received()` helper (absolute, UTC, byte-stable across rebuilds → deterministic + prompt-cache-safe); `render_user_event()` takes `created_at` and prepends `received` on the `channel=None` and connector-focal branches via a small `_prepend_header()` helper. `_format_channel_header()` drops the redundant `timestamp_ms (iso)` parenthetical (raw int stays for tool args; the human ISO now lives once in `received`) — which also deletes the `datetime.fromtimestamp` brick-risk it was guarded against.
- **Off-focal `🔔` notifications stay terse** (no `received`); the omitted timestamp resurfaces in the full-content **recap** when the model `switch_channel`s in.
- **Three call sites threaded**: `build_messages` (`e.created_at`), the `switch_channel` recap (`event.created_at`), and the append-time token counter (`datetime.now(UTC)` stand-in — the envelope is fixed-width, so the count matches build time).
- **Connector prompts** (signal, whatsapp) + a signal tool docstring updated so the model's documented header contract matches what it now sees.
- **Tests** updated for the prefix; the PR #218 empty-text-block regression guard was rewritten to exercise `_apply_attachments`'s boundary directly (the render path can no longer produce empty leading text); deleted the now-moot `timestamp_ms` out-of-range brick test.

## Testing

- `mypy src` ✓ · `ruff check` ✓ · `ruff format --check` ✓ · **1786 unit tests** ✓
- Ran `/simplify` (extracted the 3× prepend idiom) and `/code-review max` (33-agent recall pass: **zero CONFIRMED correctness findings**; fixed one regression-test rot it surfaced).
- Integration/e2e require Docker (not run locally); audited — only the `/context` endpoint test was render-coupled (updated to a substring match); the rest assert on stored event data, which is unchanged.

## Notes for reviewers

- This is a one-time prompt-cache invalidation for live sessions on deploy (every user message re-renders once), self-healing after one wake per session — same class as any renderer change.
- `received` is sourced from `created_at` (commit time); connector messages additionally keep `timestamp_ms` (origin time) as the raw value tools consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
