### PR TITLE
feat(workflows): tool() — a run calls its declared network/credential tools (slice 2)

### DIFF
--- a/migrations/versions/0074_tool_result_signal_and_run_surface.py
+++ b/migrations/versions/0074_tool_result_signal_and_run_surface.py
@@ -1,0 +1,55 @@
+"""Workflow `tool()` capability: a `tool_result` signal kind + a run's snapshotted surface.
+
+Two additions for slice 2 (runs calling their declared network/credential tools):
+
+1. ``wf_run_signals.kind`` gains ``'tool_result'`` — the side-marker a fire-and-forget
+   worker tool-task writes on completion (harvested into a ``call_result`` by the next
+   step, keeping ``wf_run_events`` single-writer; mirrors the ``gate_resume`` path). Plain
+   drop+re-add of the inline CHECK (PG-default name ``wf_run_signals_kind_check`` from
+   0064), as 0072 did for ``cancel``.
+
+2. ``wf_runs`` gains ``tools``/``mcp_servers``/``http_servers`` jsonb columns — the run's
+   **snapshot** of its workflow's declared surface, copied at ``create_run`` alongside
+   ``script``/``script_sha``. Pinning the surface at launch (rather than reading a live
+   ``get_workflow``) keeps the run deterministic and its tool-authority fixed even when the
+   workflow is later updated. Mirrors the ``workflows`` columns from 0073.
+
+Both are small workflow-runtime tables (not the hot ``events`` table), so plain
+in-transaction DDL is fine.
+
+Revision ID: 0074
+Revises: 0073
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0074"
+down_revision: str = "0073"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE wf_run_signals DROP CONSTRAINT wf_run_signals_kind_check")
+    op.execute(
+        "ALTER TABLE wf_run_signals ADD CONSTRAINT wf_run_signals_kind_check "
+        "CHECK (kind IN ('gate_resume','child_done','cancel','tool_result'))"
+    )
+    op.execute("ALTER TABLE wf_runs ADD COLUMN tools jsonb NOT NULL DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE wf_runs ADD COLUMN mcp_servers jsonb NOT NULL DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE wf_runs ADD COLUMN http_servers jsonb NOT NULL DEFAULT '[]'::jsonb")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE wf_runs DROP COLUMN IF EXISTS http_servers")
+    op.execute("ALTER TABLE wf_runs DROP COLUMN IF EXISTS mcp_servers")
+    op.execute("ALTER TABLE wf_runs DROP COLUMN IF EXISTS tools")
+    op.execute("ALTER TABLE wf_run_signals DROP CONSTRAINT wf_run_signals_kind_check")
+    op.execute(
+        "ALTER TABLE wf_run_signals ADD CONSTRAINT wf_run_signals_kind_check "
+        "CHECK (kind IN ('gate_resume','child_done','cancel'))"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -15148,6 +15148,27 @@
             "type": "string",
             "title": "Script Sha"
           },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/ToolSpec"
+            },
+            "type": "array",
+            "title": "Tools"
+          },
+          "mcp_servers": {
+            "items": {
+              "$ref": "#/components/schemas/McpServerSpec"
+            },
+            "type": "array",
+            "title": "Mcp Servers"
+          },
+          "http_servers": {
+            "items": {
+              "$ref": "#/components/schemas/HttpServerSpec"
+            },
+            "type": "array",
+            "title": "Http Servers"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -15207,7 +15228,7 @@
           "updated_at"
         ],
         "title": "WfRun",
-        "description": "A durable workflow execution instance.\n\n``script`` is the run's own immutable snapshot of the workflow source at\ncreation time (``script_sha`` is its hash); every wake execs exactly this.\n``status`` is persisted (unlike sessions): the run loop writes\n``suspended``/``completed``/``errored``."
+        "description": "A durable workflow execution instance.\n\n``script`` is the run's own immutable snapshot of the workflow source at\ncreation time (``script_sha`` is its hash); every wake execs exactly this.\n``tools``/``mcp_servers``/``http_servers`` are the matching snapshot of the\ndeclared tool surface \u2014 pinned at launch like ``script``, so a later\n``update_workflow`` never shifts an in-flight run's authority.\n``status`` is persisted (unlike sessions): the run loop writes\n``suspended``/``completed``/``errored``."
       },
       "WfRunCreate": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,6 +10,12 @@ from dateutil.parser import isoparse
 
 from ..models.wf_run_status import WfRunStatus
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.http_server_spec import HttpServerSpec
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
+
 
 T = TypeVar("T", bound="WfRun")
 
@@ -20,6 +26,9 @@ class WfRun:
 
     ``script`` is the run's own immutable snapshot of the workflow source at
     creation time (``script_sha`` is its hash); every wake execs exactly this.
+    ``tools``/``mcp_servers``/``http_servers`` are the matching snapshot of the
+    declared tool surface — pinned at launch like ``script``, so a later
+    ``update_workflow`` never shifts an in-flight run's authority.
     ``status`` is persisted (unlike sessions): the run loop writes
     ``suspended``/``completed``/``errored``.
 
@@ -35,6 +44,9 @@ class WfRun:
             created_at (datetime.datetime):
             updated_at (datetime.datetime):
             parent_run_id (None | str | Unset):
+            tools (list[ToolSpec] | Unset):
+            mcp_servers (list[McpServerSpec] | Unset):
+            http_servers (list[HttpServerSpec] | Unset):
             input_ (Any | Unset):
             output (Any | Unset):
             archived_at (datetime.datetime | None | Unset):
@@ -51,6 +63,9 @@ class WfRun:
     created_at: datetime.datetime
     updated_at: datetime.datetime
     parent_run_id: None | str | Unset = UNSET
+    tools: list[ToolSpec] | Unset = UNSET
+    mcp_servers: list[McpServerSpec] | Unset = UNSET
+    http_servers: list[HttpServerSpec] | Unset = UNSET
     input_: Any | Unset = UNSET
     output: Any | Unset = UNSET
     archived_at: datetime.datetime | None | Unset = UNSET
@@ -83,6 +98,27 @@ class WfRun:
         else:
             parent_run_id = self.parent_run_id
 
+        tools: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.tools, Unset):
+            tools = []
+            for tools_item_data in self.tools:
+                tools_item = tools_item_data.to_dict()
+                tools.append(tools_item)
+
+        mcp_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.mcp_servers, Unset):
+            mcp_servers = []
+            for mcp_servers_item_data in self.mcp_servers:
+                mcp_servers_item = mcp_servers_item_data.to_dict()
+                mcp_servers.append(mcp_servers_item)
+
+        http_servers: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.http_servers, Unset):
+            http_servers = []
+            for http_servers_item_data in self.http_servers:
+                http_servers_item = http_servers_item_data.to_dict()
+                http_servers.append(http_servers_item)
+
         input_ = self.input_
 
         output = self.output
@@ -113,6 +149,12 @@ class WfRun:
         )
         if parent_run_id is not UNSET:
             field_dict["parent_run_id"] = parent_run_id
+        if tools is not UNSET:
+            field_dict["tools"] = tools
+        if mcp_servers is not UNSET:
+            field_dict["mcp_servers"] = mcp_servers
+        if http_servers is not UNSET:
+            field_dict["http_servers"] = http_servers
         if input_ is not UNSET:
             field_dict["input"] = input_
         if output is not UNSET:
@@ -124,6 +166,10 @@ class WfRun:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.http_server_spec import HttpServerSpec
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
+
         d = dict(src_dict)
         id = d.pop("id")
 
@@ -153,6 +199,33 @@ class WfRun:
             return cast(None | str | Unset, data)
 
         parent_run_id = _parse_parent_run_id(d.pop("parent_run_id", UNSET))
+
+        _tools = d.pop("tools", UNSET)
+        tools: list[ToolSpec] | Unset = UNSET
+        if _tools is not UNSET:
+            tools = []
+            for tools_item_data in _tools:
+                tools_item = ToolSpec.from_dict(tools_item_data)
+
+                tools.append(tools_item)
+
+        _mcp_servers = d.pop("mcp_servers", UNSET)
+        mcp_servers: list[McpServerSpec] | Unset = UNSET
+        if _mcp_servers is not UNSET:
+            mcp_servers = []
+            for mcp_servers_item_data in _mcp_servers:
+                mcp_servers_item = McpServerSpec.from_dict(mcp_servers_item_data)
+
+                mcp_servers.append(mcp_servers_item)
+
+        _http_servers = d.pop("http_servers", UNSET)
+        http_servers: list[HttpServerSpec] | Unset = UNSET
+        if _http_servers is not UNSET:
+            http_servers = []
+            for http_servers_item_data in _http_servers:
+                http_servers_item = HttpServerSpec.from_dict(http_servers_item_data)
+
+                http_servers.append(http_servers_item)
 
         input_ = d.pop("input", UNSET)
 
@@ -187,6 +260,9 @@ class WfRun:
             created_at=created_at,
             updated_at=updated_at,
             parent_run_id=parent_run_id,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            http_servers=http_servers,
             input_=input_,
             output=output,
             archived_at=archived_at,

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -68,6 +68,9 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         parent_run_id=row["parent_run_id"],
         script=row["script"],
         script_sha=row["script_sha"],
+        tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
+        mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
+        http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
         status=row["status"],
         input=parse_jsonb(row["input"]),
         output=parse_jsonb(row["output"]),
@@ -249,16 +252,21 @@ async def insert_wf_run(
     script_sha: str,
     input: Any = None,
     parent_run_id: str | None = None,
+    tools: list[ToolSpec] | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
 ) -> WfRun:
-    """Insert a fresh ``pending`` run that snapshots ``script`` (+ ``script_sha``)."""
+    """Insert a fresh ``pending`` run that snapshots ``script`` (+ ``script_sha``) and the
+    declared tool surface (``tools``/``mcp_servers``/``http_servers``) — pinned at launch."""
     new_id = make_id(WORKFLOW_RUN)
     try:
         row = await conn.fetchrow(
             """
             INSERT INTO wf_runs
                 (id, workflow_id, account_id, environment_id, parent_run_id,
-                 script, script_sha, status, input)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8::jsonb)
+                 script, script_sha, status, input, tools, mcp_servers, http_servers)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8::jsonb,
+                    $9::jsonb, $10::jsonb, $11::jsonb)
             RETURNING *
             """,
             new_id,
@@ -269,6 +277,9 @@ async def insert_wf_run(
             script,
             script_sha,
             json.dumps(input) if input is not None else None,
+            json.dumps([t.model_dump() for t in (tools or [])]),
+            json.dumps([s.model_dump() for s in (mcp_servers or [])]),
+            json.dumps([s.model_dump() for s in (http_servers or [])]),
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -586,3 +597,20 @@ async def insert_run_signal(
 async def list_run_signals(conn: asyncpg.Connection[Any], run_id: str) -> list[WfRunSignal]:
     rows = await conn.fetch("SELECT * FROM wf_run_signals WHERE run_id = $1", run_id)
     return [_row_to_wf_run_signal(r) for r in rows]
+
+
+async def read_run_signal(
+    conn: asyncpg.Connection[Any], run_id: str, call_key: str
+) -> WfRunSignal | None:
+    """A fresh point-read of one signal — used to disambiguate the harvest's stale snapshot.
+
+    A fire-and-forget tool task commits its ``tool_result`` signal **before** it pops the
+    in-flight registry, and it runs outside the run lock; so when a step's signal *snapshot*
+    shows nothing yet the task is no longer in-flight, the signal may have just landed. This
+    point-read tells "crashed" (None → re-dispatch) from "just finished" (resolve) without
+    re-dispatching a tool that already ran.
+    """
+    row = await conn.fetchrow(
+        "SELECT * FROM wf_run_signals WHERE run_id = $1 AND call_key = $2", run_id, call_key
+    )
+    return _row_to_wf_run_signal(row) if row is not None else None

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -22,7 +22,7 @@ from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
 
 WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored", "cancelled"]
 WfRunEventType = Literal["run_started", "call_started", "call_result", "run_completed"]
-WfRunSignalKind = Literal["gate_resume", "child_done", "cancel"]
+WfRunSignalKind = Literal["gate_resume", "child_done", "cancel", "tool_result"]
 
 # The terminal run statuses — monotonic: once here, a run never leaves. The one source for
 # every "is this run done?" check (the step loop's early-out, the SSE stream's close, the await
@@ -56,6 +56,9 @@ class WfRun(BaseModel):
 
     ``script`` is the run's own immutable snapshot of the workflow source at
     creation time (``script_sha`` is its hash); every wake execs exactly this.
+    ``tools``/``mcp_servers``/``http_servers`` are the matching snapshot of the
+    declared tool surface — pinned at launch like ``script``, so a later
+    ``update_workflow`` never shifts an in-flight run's authority.
     ``status`` is persisted (unlike sessions): the run loop writes
     ``suspended``/``completed``/``errored``.
     """
@@ -67,6 +70,9 @@ class WfRun(BaseModel):
     parent_run_id: str | None = None
     script: str
     script_sha: str
+    tools: list[ToolSpec] = Field(default_factory=list)
+    mcp_servers: list[McpServerSpec] = Field(default_factory=list)
+    http_servers: list[HttpServerSpec] = Field(default_factory=list)
     status: WfRunStatus
     input: Any = None  # arbitrary JSON: a workflow's input need not be an object
     output: Any = None  # arbitrary JSON: the script's return value

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -12,6 +12,7 @@ On error: ``{"error": "..."}``.
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
@@ -93,8 +94,8 @@ HTTP_REQUEST_PARAMETERS_SCHEMA: dict[str, Any] = {
 }
 
 
-def _find_server(agent: Agent | AgentVersion, server_ref: str) -> HttpServerSpec | None:
-    for s in agent.http_servers:
+def _find_server(servers: list[HttpServerSpec], server_ref: str) -> HttpServerSpec | None:
+    for s in servers:
         if s.name == server_ref:
             return s
     return None
@@ -164,7 +165,7 @@ def _classify_permission(
         return None
     if _path_rejected_reason(path) is not None:
         return None
-    server = _find_server(agent, server_ref)
+    server = _find_server(agent.http_servers, server_ref)
     if server is None:
         return None
     route = _match_route(server, path)
@@ -198,7 +199,17 @@ def _decode_body(response: httpx.Response) -> str:
     )
 
 
-async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+async def _do_http_request(
+    *,
+    servers: list[HttpServerSpec],
+    arguments: dict[str, Any],
+    resolve_auth: Callable[[str], Awaitable[tuple[str | None, dict[str, str]]]],
+) -> dict[str, Any]:
+    """The owner-agnostic core: match a path against ``servers``' route allowlist,
+    author the ``Authorization`` header via the injected ``resolve_auth``, and make the
+    request. Shared by the session handler (servers = agent's) and the workflow-run
+    dispatcher (servers = run's snapshot); the core never learns which principal it serves.
+    """
     server_ref = arguments["server_ref"]
     path = arguments["path"]
     method = arguments["method"]
@@ -213,10 +224,9 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
     if reason is not None:
         return {"error": reason}
 
-    agent, account_id = await _load_session_agent(session_id)
-    server = _find_server(agent, server_ref)
+    server = _find_server(servers, server_ref)
     if server is None:
-        return {"error": (f"unknown server_ref {server_ref!r}; not declared on agent.http_servers")}
+        return {"error": (f"unknown server_ref {server_ref!r}; not declared on http_servers")}
     if _match_route(server, path) is None:
         return {
             "error": (
@@ -228,15 +238,11 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
     if not is_safe_url(full_url):
         return {"error": f"Blocked: URL targets a private/internal address: {full_url}"}
 
-    pool = runtime.require_pool()
-    crypto_box = runtime.require_crypto_box()
-    _vault_id, auth_headers = await resolve_auth_for_target_url(
-        pool, crypto_box, session_id, server.base_url, account_id=account_id
-    )
+    _vault_id, auth_headers = await resolve_auth(server.base_url)
 
-    # Strip headers the worker manages on the agent's behalf. ``Authorization``
-    # is rendered from the session vault below. ``Host`` is derived from the
-    # request URL by httpx; an agent override would land the request on a
+    # Strip headers the worker manages on the caller's behalf. ``Authorization``
+    # is rendered from the bound vault by ``resolve_auth``. ``Host`` is derived
+    # from the request URL by httpx; a caller override would land the request on a
     # different name-based virtual host than the operator's base_url scopes
     # to (NGINX, Cloudflare, ALB, Ingress — all route by Host header), so
     # leaving it caller-controlled effectively defeats the route allowlist.
@@ -261,6 +267,22 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
         "headers": dict(response.headers),
         "body": _decode_body(response),
     }
+
+
+async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Session entry: resolve the agent's ``http_servers`` + a session-scoped vault resolver."""
+    agent, account_id = await _load_session_agent(session_id)
+    pool = runtime.require_pool()
+    crypto_box = runtime.require_crypto_box()
+
+    async def resolve_auth(base_url: str) -> tuple[str | None, dict[str, str]]:
+        return await resolve_auth_for_target_url(
+            pool, crypto_box, session_id, base_url, account_id=account_id
+        )
+
+    return await _do_http_request(
+        servers=agent.http_servers, arguments=arguments, resolve_auth=resolve_auth
+    )
 
 
 def _register() -> None:

--- a/src/aios/workflows/run_tools.py
+++ b/src/aios/workflows/run_tools.py
@@ -1,0 +1,162 @@
+"""Run-side tool execution — a workflow run calls its declared network/credential tools.
+
+**Park-and-harvest.** The step opens a ``tool`` frontier (journals ``call_started``),
+launches a fire-and-forget **worker** task here, and parks the run. The task runs the tool
+and, on completion, writes a ``tool_result`` ``wf_run_signals`` row + wakes the run; the next
+step's pre-replay harvest folds the signal into a ``call_result``. This is the ``agent()`` /
+``gate()`` shape — the run never holds its lock/slot while a tool runs.
+
+**Owner-minimal.** ``web_search`` / ``web_fetch`` handlers are owner-agnostic (called with an
+empty owner id). ``http_request`` reuses the shared :func:`aios.tools.http_request._do_http_request`
+core, fed the run's *snapshotted* ``http_servers`` and a run-scoped credential resolver
+(:func:`resolve_auth_for_target_url_run`). ``invoke_builtin`` is untouched.
+
+**Surface gating.** A tool is callable only if it is in the slice-2 builtin set AND declared in
+the run's snapshotted ``tools``. An undeclared/unknown tool is a *recoverable* ``{"error": …}``
+value the script branches on — not a run-terminal error (matching ``agent()``'s "errors resolve"
+and ``http_request``'s own error contract).
+
+**At-least-once.** A hard worker crash mid-task leaves no signal; the periodic sweep re-wakes the
+run and the step re-dispatches. Safe for idempotent tools (``web_*`` / GET); a non-idempotent
+``http_request`` (POST/DELETE) may double-execute — the same exposure the session tool path has.
+The ``idempotent`` flag that would surface ``may_have_completed`` instead of re-dispatching is a
+deferred follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import asyncpg
+
+from aios.db.queries import workflows as wf_queries
+from aios.harness import runtime
+from aios.logging import get_logger
+from aios.mcp.client import resolve_auth_for_target_url_run
+from aios.models.workflows import WfRun
+from aios.services.wake import defer_run_wake
+from aios.tools.http_request import _do_http_request, _find_server, _match_route
+from aios.tools.invoke import validate_arguments
+from aios.tools.registry import registry
+from aios.tools.web_fetch import web_fetch_handler
+from aios.tools.web_search import web_search_handler
+
+log = get_logger("aios.workflows.run_tools")
+
+# The network/credential builtins a run may call directly (slice 2). Sandbox tools
+# (bash/read/…) and authed-MCP / search_events are out of scope (filesystem horizon /
+# later slices).
+RUN_TOOLS: frozenset[str] = frozenset({"web_search", "web_fetch", "http_request"})
+
+# Per-worker in-flight tool tasks, keyed (run_id, call_key). Gates *launching* (so a
+# sibling-triggered re-wake — e.g. parallel([tool(), agent()]) — doesn't double-dispatch a
+# still-running tool); never gates *harvesting* (the signal in the DB is the truth).
+_INFLIGHT: dict[tuple[str, str], asyncio.Task[None]] = {}
+
+
+def has_inflight(run_id: str, call_key: str) -> bool:
+    """True iff a live tool task for ``(run_id, call_key)`` is running on this worker."""
+    task = _INFLIGHT.get((run_id, call_key))
+    return task is not None and not task.done()
+
+
+def launch_tool_task(
+    pool: asyncpg.Pool[Any],
+    run: WfRun,
+    *,
+    call_key: str,
+    tool_name: str,
+    tool_input: Any,
+) -> None:
+    """Launch the worker task for a freshly-opened tool frontier (no-op if already live)."""
+    key = (run.id, call_key)
+    if has_inflight(*key):
+        return
+    _INFLIGHT[key] = asyncio.create_task(
+        _run_tool_task(pool, run, call_key=call_key, tool_name=tool_name, tool_input=tool_input)
+    )
+
+
+async def _run_tool_task(
+    pool: asyncpg.Pool[Any],
+    run: WfRun,
+    *,
+    call_key: str,
+    tool_name: str,
+    tool_input: Any,
+) -> None:
+    """Run one tool, write its ``tool_result`` signal, and wake the run (always-signals)."""
+    try:
+        try:
+            result = await invoke_run_tool(
+                run=run, account_id=run.account_id, tool_name=tool_name, tool_input=tool_input
+            )
+        except Exception as exc:  # backstop — invoke_run_tool returns dicts, never raises
+            log.exception("run_tool.unexpected", run_id=run.id, tool=tool_name)
+            result = {"error": f"tool {tool_name!r} failed: {type(exc).__name__}: {exc}"}
+        try:
+            async with pool.acquire() as conn:
+                await wf_queries.insert_run_signal(
+                    conn, run_id=run.id, call_key=call_key, kind="tool_result", result=result
+                )
+            await defer_run_wake(run.id)
+        except Exception:
+            # The tool ran but persisting/waking failed (DB blip, pool exhaustion). No signal
+            # → the run stalls 'suspended' until the periodic sweep re-wakes it and the harvest
+            # re-dispatches. Log so the stall is diagnosable, not a silent unretrieved-task warning.
+            log.exception(
+                "run_tool.signal_failed", run_id=run.id, call_key=call_key, tool=tool_name
+            )
+    finally:
+        # CancelledError (worker shutdown) propagates here with no signal written — the
+        # periodic sweep re-wakes the run and the step re-dispatches.
+        _INFLIGHT.pop((run.id, call_key), None)
+
+
+async def invoke_run_tool(
+    *, run: WfRun, account_id: str, tool_name: str, tool_input: Any
+) -> dict[str, Any]:
+    """Dispatch one declared tool for a run. Always returns a dict (success or ``{"error": …}``);
+    never raises — gating, validation, and handler errors all surface as recoverable values."""
+    if tool_name not in RUN_TOOLS:
+        return {"error": f"tool {tool_name!r} is not callable from a workflow run"}
+    if tool_name not in {t.type for t in run.tools if t.enabled}:
+        return {"error": f"tool {tool_name!r} is not in the workflow's declared tools"}
+
+    args = tool_input if isinstance(tool_input, dict) else {}
+    schema_error = validate_arguments(args, registry.get(tool_name).parameters_schema)
+    if schema_error is not None:
+        return {"error": schema_error}
+
+    if tool_name == "http_request":
+        # A route an operator marked ``always_ask`` requires per-call human confirmation —
+        # which a run has no channel for. Deny rather than execute unconfirmed, so a run is
+        # never *more* privileged than a session on the identical declared surface.
+        server = _find_server(run.http_servers, str(args.get("server_ref", "")))
+        route = _match_route(server, str(args.get("path", ""))) if server is not None else None
+        if (
+            route is not None
+            and route.permission_policy is not None
+            and (route.permission_policy.type == "always_ask")
+        ):
+            return {
+                "error": (
+                    "this route is marked always_ask (per-call confirmation), which a "
+                    "workflow run cannot satisfy"
+                )
+            }
+        pool = runtime.require_pool()
+        crypto_box = runtime.require_crypto_box()
+
+        async def resolve_auth(base_url: str) -> tuple[str | None, dict[str, str]]:
+            return await resolve_auth_for_target_url_run(
+                pool, crypto_box, run.id, base_url, account_id=account_id
+            )
+
+        return await _do_http_request(
+            servers=run.http_servers, arguments=args, resolve_auth=resolve_auth
+        )
+    if tool_name == "web_search":
+        return await web_search_handler("", args)
+    return await web_fetch_handler("", args)

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -65,6 +65,11 @@ async def create_run(
             script=workflow.script,
             script_sha=script_sha,
             input=input,
+            # Snapshot the declared surface at launch (like script), so a later
+            # update_workflow never shifts this run's tool-authority.
+            tools=workflow.tools,
+            mcp_servers=workflow.mcp_servers,
+            http_servers=workflow.http_servers,
         )
         if requested:
             await wf_queries.set_run_vaults(conn, run.id, requested, account_id=account_id)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -47,6 +47,7 @@ from aios.logging import get_logger
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent
 from aios.services.sessions import create_child_session
 from aios.services.wake import defer_run_wake, defer_wake
+from aios.workflows import run_tools
 from aios.workflows.child_id import child_session_id
 from aios.workflows.host_launcher import EmittedCapability, run_script_host
 
@@ -218,6 +219,28 @@ async def run_workflow_step(run_id: str) -> None:
                 )
                 if result_payload is None:
                     continue  # still pending, within deadline — stay suspended
+            elif cap_payload.get("capability") == "tool":
+                sig = signals.get(call_key)
+                if sig is None and not run_tools.has_inflight(run_id, call_key):
+                    # No signal in the snapshot AND no live task — but the snapshot can be
+                    # stale: a task running outside the run lock commits its signal *before*
+                    # it leaves the registry, so "not in-flight" may mean "just finished" as
+                    # easily as "crashed". A fresh point-read disambiguates — so a tool that
+                    # already ran is never re-dispatched (which would double-execute a
+                    # non-idempotent http_request).
+                    sig = await wf_queries.read_run_signal(conn, run_id, call_key)
+                    if sig is None:
+                        run_tools.launch_tool_task(
+                            pool,
+                            run,
+                            call_key=call_key,
+                            tool_name=cap_payload["tool_name"],
+                            tool_input=cap_payload.get("input"),
+                        )
+                        continue
+                if sig is None:
+                    continue  # a live task is still running — stay suspended, it will signal
+                result_payload = {"result": sig.result, "is_error": False}
             else:  # gate: the resume value lives in the signal
                 sig = signals.get(call_key)
                 if sig is None:
@@ -240,6 +263,9 @@ async def run_workflow_step(run_id: str) -> None:
     outcome = await run_script_host(source=run.script, input=run.input, memo=memo)
 
     needs_rewake = False
+    # (call_key, tool_name, input) for tool frontiers opened this wake — launched AFTER
+    # the txn commits (below), so call_started is visible before a task can signal+wake.
+    tools_to_launch: list[tuple[str, str, Any]] = []
     async with pool.acquire() as conn:
         if outcome.kind == "raised":
             if outcome.error_kind == "script_host_spawn_failed":
@@ -333,6 +359,34 @@ async def run_workflow_step(run_id: str) -> None:
                     return  # the frontier was terminally rejected (bad call) — run errored
                 if spawn.needs_rewake:
                     needs_rewake = True  # C1'/C4: harvest the already-present marker next step
+            elif cap.capability_id == "tool":
+                spec = cap.spec if isinstance(cap.spec, dict) else {}
+                tool_name = spec.get("tool_name")
+                if not isinstance(tool_name, str):
+                    # A malformed spec is a deterministic author bug (replay-identical),
+                    # so it terminally errors the run — unlike an undeclared/unknown tool
+                    # name, which the dispatcher returns as a recoverable error value.
+                    await _complete_run(
+                        conn,
+                        run,
+                        output=f"tool() requires a string tool name, got {tool_name!r}",
+                        is_error=True,
+                        error_kind="bad_tool_call",
+                    )
+                    return
+                await wf_queries.append_run_event(
+                    conn,
+                    account_id=account_id,
+                    run_id=run_id,
+                    type="call_started",
+                    call_key=cap.call_key,
+                    payload={
+                        "capability": "tool",
+                        "tool_name": tool_name,
+                        "input": spec.get("input"),
+                    },
+                )
+                tools_to_launch.append((cap.call_key, tool_name, spec.get("input")))
             else:
                 # parallel/pipeline reach the step as their `agent` leaves (B2.G);
                 # any other capability id is unknown.
@@ -346,8 +400,14 @@ async def run_workflow_step(run_id: str) -> None:
                 return
         await wf_queries.set_run_status(conn, run_id, "suspended", account_id=account_id)
 
-    # Outside the txn (after the suspend commits): a self-wake so the next step
-    # harvests an already-delivered resume for a gate opened this wake.
+    # Outside the txn (after the suspend commits): launch this wake's tool tasks — now
+    # that their call_started rows are committed, a task that signals+wakes lands a step
+    # that sees them (no double-dispatch) — then self-wake so the next step harvests an
+    # already-delivered gate resume opened this wake.
+    for launch_key, launch_name, launch_input in tools_to_launch:
+        run_tools.launch_tool_task(
+            pool, run, call_key=launch_key, tool_name=launch_name, tool_input=launch_input
+        )
     if needs_rewake:
         await defer_run_wake(run_id)
 

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -155,6 +155,19 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
     )
 
 
+def tool(name: str, input: Any) -> _Capability:
+    """Invoke one of the workflow's declared network/credential tools (``http_request``,
+    ``web_search``, ``web_fetch``) and await its result.
+
+    ``input`` is the tool's arguments (a JSON-serialisable dict). The result is the tool's
+    own return value — a plain dict the script branches on (e.g. ``{"status": 200, …}`` or
+    ``{"error": "…"}``); a tool error resolves as a value, it does **not** raise. The tool runs
+    in the worker against the run's bound vaults and declared surface; the script subprocess
+    only emits the request.
+    """
+    return _Capability("tool", {"tool_name": name, "input": input})
+
+
 async def _branch(thunk: Any) -> Any:
     """Run one parallel branch: call the thunk, await whatever it returns. Wrapping
     it in a coroutine lets the driver schedule a uniform set of branches and lets a
@@ -280,6 +293,7 @@ def _build_coroutine(source: str, input_value: Any) -> Any:
         "__builtins__": SAFE_BUILTINS,
         "gate": gate,
         "agent": agent,
+        "tool": tool,
         "parallel": parallel,
         "pipeline": pipeline,
         "log": log,

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -12,23 +12,30 @@ directly, which is exactly the surface under test.
 from __future__ import annotations
 
 import asyncio
+import os
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import asyncpg
+import httpx
 import pytest
+from pydantic import SecretStr
 
+from aios.crypto.vault import CryptoBox
 from aios.db import queries as db_queries
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.errors import NotFoundError
 from aios.harness import runtime
+from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
+from aios.models.vaults import VaultCredentialCreate
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
+from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
-from aios.workflows import service
+from aios.workflows import run_tools, service
 from aios.workflows.child_id import child_session_id
 from aios.workflows.determinism import CallKeyer
 from aios.workflows.host_launcher import HostOutcome
@@ -60,14 +67,19 @@ async def wf_runtime(
                 "INSERT INTO environments (id, name, config, account_id) "
                 "VALUES ('env_wf', 'wf-env', '{}'::jsonb, 'acc_wf')"
             )
+        run_tools._INFLIGHT.clear()  # no leaked tasks from a prior (possibly failed) test
         with (
             mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.workflows.step.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()),
+            # The fire-and-forget tool task's own wake — patch it too, else it enqueues a
+            # real wake_workflow job against the test DB (the harvest is driven manually).
+            mock.patch("aios.workflows.run_tools.defer_run_wake", new=AsyncMock()),
         ):
             yield pool
     finally:
+        run_tools._INFLIGHT.clear()
         runtime.pool = prev
         await pool.close()
 
@@ -2260,3 +2272,252 @@ async def test_await_run_cross_tenant_404(
         await wf_service.await_run(
             pool, migrated_db_url, run_id, account_id="acc_other", timeout_seconds=1
         )
+
+
+# ─── tool() — a run invokes its declared network/credential tools (slice 2) ───
+
+_WEB_SCRIPT = (
+    "async def main(input):\n    r = await tool('web_search', {'query': 'q'})\n    return r\n"
+)
+
+
+async def _make_tool_run(
+    pool: asyncpg.Pool[Any],
+    script: str,
+    *,
+    tools: list[ToolSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
+    vault_ids: list[str] | None = None,
+    name: str = "wt",
+) -> str:
+    """A run whose workflow declares ``tools``/``http_servers``; the run snapshots them."""
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(
+            conn,
+            account_id="acc_wf",
+            name=name,
+            script=script,
+            tools=tools,
+            http_servers=http_servers,
+        )
+    run = await service.create_run(
+        pool,
+        account_id="acc_wf",
+        workflow_id=wf.id,
+        environment_id="env_wf",
+        vault_ids=vault_ids,
+    )
+    return run.id
+
+
+async def _drain_tool_tasks() -> None:
+    """Await any fire-and-forget tool tasks (``defer_run_wake`` is patched, so they don't
+    self-wake; the test drives the harvest step itself)."""
+    tasks = list(run_tools._INFLIGHT.values())
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _capturing_client(captured: dict[str, Any]) -> type:
+    """A stand-in for ``httpx.AsyncClient`` that records the outbound request + returns 200."""
+
+    class _Client:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _Client:
+            return self
+
+        async def __aexit__(self, *_: Any) -> bool:
+            return False
+
+        async def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            return httpx.Response(200, json={"ok": True})
+
+    return _Client
+
+
+async def _get_run(pool: asyncpg.Pool[Any], run_id: str) -> Any:
+    async with pool.acquire() as conn:
+        return await wf_queries.get_run_for_step(conn, run_id)
+
+
+async def _call_starteds(pool: asyncpg.Pool[Any], run_id: str) -> list[Any]:
+    async with pool.acquire() as conn:
+        return [
+            e for e in await wf_queries.list_run_events(conn, run_id) if e.type == "call_started"
+        ]
+
+
+async def test_tool_web_search_park_harvest_replay(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    run_id = await _make_tool_run(pool, _WEB_SCRIPT, tools=[ToolSpec(type="web_search")])
+    with mock.patch(
+        "aios.workflows.run_tools.web_search_handler",
+        new=AsyncMock(return_value={"results": ["R"]}),
+    ):
+        # Wake 1: drive to the tool and park; the worker task is launched after commit.
+        await run_workflow_step(run_id)
+        run = await _get_run(pool, run_id)
+        assert run is not None and run.status == "suspended"
+        assert [t for _s, t, _k in await _events(pool, run_id)] == ["run_started", "call_started"]
+        cs = (await _call_starteds(pool, run_id))[0]
+        assert cs.payload["capability"] == "tool" and cs.payload["tool_name"] == "web_search"
+
+        await _drain_tool_tasks()  # the task writes its tool_result signal
+
+        # Wake 2: harvest the signal → fast-forward past the tool → complete.
+        await run_workflow_step(run_id)
+    run = await _get_run(pool, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == {"results": ["R"]}
+    assert [t for _s, t, _k in await _events(pool, run_id)] == [
+        "run_started",
+        "call_started",
+        "call_result",
+        "run_completed",
+    ]
+
+
+async def test_tool_undeclared_resolves_as_recoverable_error(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    # web_search is NOT declared on the workflow → a recoverable error value; run COMPLETES.
+    run_id = await _make_tool_run(pool, _WEB_SCRIPT, tools=[], name="wt-undeclared")
+    await run_workflow_step(run_id)  # park at the tool (no handler patch — gating short-circuits)
+    await _drain_tool_tasks()  # task: invoke_run_tool → gating error → signal {"error": …}
+    await run_workflow_step(run_id)  # harvest → complete with the error value
+    run = await _get_run(pool, run_id)
+    assert run is not None and run.status == "completed"  # recoverable, NOT errored
+    assert isinstance(run.output, dict) and "error" in run.output
+
+
+async def test_tool_parallel_fanout(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    rs = await parallel([\n"
+        "        lambda: tool('web_search', {'query': 'a'}),\n"
+        "        lambda: tool('web_search', {'query': 'b'}),\n"
+        "        lambda: tool('web_search', {'query': 'c'}),\n"
+        "    ])\n"
+        "    return rs\n"
+    )
+    run_id = await _make_tool_run(
+        pool, script, tools=[ToolSpec(type="web_search")], name="wt-fanout"
+    )
+
+    def _echo(_sid: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"q": args["query"]}
+
+    with mock.patch(
+        "aios.workflows.run_tools.web_search_handler", new=AsyncMock(side_effect=_echo)
+    ):
+        await run_workflow_step(run_id)  # parks with 3 tool frontiers, 3 tasks launched
+        cs = await _call_starteds(pool, run_id)
+        assert len(cs) == 3 and all(e.payload["capability"] == "tool" for e in cs)
+        await _drain_tool_tasks()  # 3 tasks signal
+        await run_workflow_step(run_id)  # harvest all 3 → complete
+    run = await _get_run(pool, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == [{"q": "a"}, {"q": "b"}, {"q": "c"}]
+
+
+async def test_tool_crash_redispatches(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    run_id = await _make_tool_run(
+        pool, _WEB_SCRIPT, tools=[ToolSpec(type="web_search")], name="wt-crash"
+    )
+
+    block = asyncio.Event()  # never set — the first task blocks until cancelled
+
+    async def _blocked(_sid: str, _args: dict[str, Any]) -> dict[str, Any]:
+        await block.wait()
+        return {"never": True}
+
+    with mock.patch("aios.workflows.run_tools.web_search_handler", new=_blocked):
+        await run_workflow_step(run_id)  # parks; the task blocks before it can signal
+        # Simulate a hard worker crash: cancel the in-flight task + drop the registry.
+        for task in list(run_tools._INFLIGHT.values()):
+            task.cancel()
+        await asyncio.gather(*list(run_tools._INFLIGHT.values()), return_exceptions=True)
+        run_tools._INFLIGHT.clear()
+
+    # No signal exists. Wake 2 (the periodic-sweep re-wake): harvest finds no signal + no
+    # live task → re-dispatch — without journaling a second call_started.
+    with mock.patch(
+        "aios.workflows.run_tools.web_search_handler", new=AsyncMock(return_value={"ok": 1})
+    ):
+        await run_workflow_step(run_id)
+        assert len(await _call_starteds(pool, run_id)) == 1  # exactly one — no double-open
+        await _drain_tool_tasks()  # the re-dispatched task signals
+        await run_workflow_step(run_id)  # harvest → complete
+    run = await _get_run(pool, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == {"ok": 1}
+    assert [t for _s, t, _k in await _events(pool, run_id)] == [
+        "run_started",
+        "call_started",
+        "call_result",
+        "run_completed",
+    ]
+
+
+async def test_tool_http_request_credential_e2e(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """The payoff: a run calls http_request and the Authorization header is authored from the
+    run's OWN bound vault, via resolve_auth_for_target_url_run, with no agent in the loop."""
+    pool = wf_runtime
+    box = CryptoBox(os.urandom(32))
+    prev_box = runtime.crypto_box
+    runtime.crypto_box = box
+    try:
+        base_url = "https://api.example/v1"
+        vault = await vaults_service.create_vault(
+            pool, account_id="acc_wf", display_name="v", metadata={}
+        )
+        await vaults_service.create_vault_credential(
+            pool,
+            box,
+            account_id="acc_wf",
+            vault_id=vault.id,
+            body=VaultCredentialCreate(
+                target_url=base_url, auth_type="bearer_header", token=SecretStr("tok-XYZ")
+            ),
+        )
+        http_servers = [
+            HttpServerSpec(
+                name="api", base_url=base_url, routes=[HttpRouteSpec(path_pattern="/things/*")]
+            )
+        ]
+        script = (
+            "async def main(input):\n"
+            "    r = await tool('http_request',"
+            " {'server_ref': 'api', 'path': '/things/1', 'method': 'GET'})\n"
+            "    return r\n"
+        )
+        run_id = await _make_tool_run(
+            pool,
+            script,
+            tools=[ToolSpec(type="http_request")],
+            http_servers=http_servers,
+            vault_ids=[vault.id],
+            name="wt-http",
+        )
+        captured: dict[str, Any] = {}
+        with (
+            mock.patch("aios.tools.http_request.httpx.AsyncClient", _capturing_client(captured)),
+            mock.patch("aios.tools.http_request.is_safe_url", return_value=True),
+        ):
+            await run_workflow_step(run_id)  # park at the tool
+            await (
+                _drain_tool_tasks()
+            )  # task: _do_http_request → run resolver authors header → httpx
+            await run_workflow_step(run_id)  # harvest → complete
+        assert captured["headers"]["Authorization"] == "Bearer tok-XYZ"
+        run = await _get_run(pool, run_id)
+        assert run is not None and run.status == "completed"
+        assert run.output["status"] == 200
+    finally:
+        runtime.crypto_box = prev_box

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -14,6 +14,7 @@ from aios.models.agents import HttpPermissionPolicy, HttpRouteSpec, HttpServerSp
 from aios.tools.http_request import (
     _classify_permission,
     _decode_body,
+    _do_http_request,
     http_request_handler,
 )
 
@@ -595,3 +596,47 @@ class TestHttpRequestHandler:
             f"upstream request was dispatched despite embedded '..' "
             f"traversal; captured={captured!r}"
         )
+
+
+# ── _do_http_request (owner-agnostic core; the session/run shared entry) ───────
+
+
+class TestDoHttpRequest:
+    """The extracted core takes ``servers`` + an injected ``resolve_auth`` directly, so the
+    session handler and the workflow-run dispatcher exercise one code path."""
+
+    async def test_authors_header_from_injected_resolver(self) -> None:
+        servers = [
+            _server(name="api", base_url="https://api.example.com/v1", routes=[_route("/lights/*")])
+        ]
+        capture: dict[str, Any] = {}
+
+        async def resolve_auth(base_url: str) -> tuple[str | None, dict[str, str]]:
+            assert base_url == "https://api.example.com/v1"
+            return ("vlt", {"Authorization": "Bearer RUNTOKEN"})
+
+        with (
+            _patch_safe_url(True),
+            patch(
+                "aios.tools.http_request.httpx.AsyncClient",
+                _make_stub_client(response=httpx.Response(200, json={"ok": True}), capture=capture),
+            ),
+        ):
+            out = await _do_http_request(
+                servers=servers,
+                arguments={"server_ref": "api", "path": "/lights/1", "method": "GET"},
+                resolve_auth=resolve_auth,
+            )
+        assert out["status"] == 200
+        assert capture["kwargs"]["headers"]["Authorization"] == "Bearer RUNTOKEN"
+
+    async def test_unknown_server_ref_is_an_error_value(self) -> None:
+        async def resolve_auth(base_url: str) -> tuple[str | None, dict[str, str]]:
+            return (None, {})
+
+        out = await _do_http_request(
+            servers=[],
+            arguments={"server_ref": "missing", "path": "/x", "method": "GET"},
+            resolve_auth=resolve_auth,
+        )
+        assert "error" in out and "unknown server_ref" in out["error"]

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0073``."""
+    """The migration ladder has exactly one head: ``0074``."""
     script = _script_directory()
-    assert script.get_heads() == ["0073"]
+    assert script.get_heads() == ["0074"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_run_tools.py
+++ b/tests/unit/test_run_tools.py
@@ -1,0 +1,131 @@
+"""run_tools: surface gating + routing for a workflow run's ``tool()`` calls.
+
+Pure in-memory — the run is a stand-in carrying only the snapshotted surface the
+dispatcher reads (``tools``/``http_servers``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from aios.models.agents import HttpPermissionPolicy, HttpRouteSpec, HttpServerSpec, ToolSpec
+from aios.workflows import run_tools
+from aios.workflows.run_tools import invoke_run_tool
+from aios.workflows.wf_script_host import tool
+
+
+def _run(
+    *, tools: list[ToolSpec] | None = None, http_servers: list[HttpServerSpec] | None = None
+) -> Any:
+    return SimpleNamespace(
+        id="wfr_1", account_id="acc_t", tools=tools or [], http_servers=http_servers or []
+    )
+
+
+async def test_undeclared_tool_is_recoverable_error() -> None:
+    # web_search is a run tool, but the workflow didn't declare it → recoverable value.
+    run = _run(tools=[])
+    out = await invoke_run_tool(
+        run=run, account_id="acc_t", tool_name="web_search", tool_input={"query": "x"}
+    )
+    assert "error" in out and "declared" in out["error"]
+
+
+async def test_non_run_tool_rejected() -> None:
+    # bash is a sandbox tool — not callable from a run, even if (somehow) declared.
+    run = _run(tools=[ToolSpec(type="bash")])
+    out = await invoke_run_tool(run=run, account_id="acc_t", tool_name="bash", tool_input={})
+    assert "error" in out and "workflow run" in out["error"]
+
+
+async def test_web_search_routed_when_declared() -> None:
+    run = _run(tools=[ToolSpec(type="web_search")])
+    with patch.object(
+        run_tools, "web_search_handler", new=AsyncMock(return_value={"results": ["R"]})
+    ) as handler:
+        out = await invoke_run_tool(
+            run=run, account_id="acc_t", tool_name="web_search", tool_input={"query": "x"}
+        )
+    assert out == {"results": ["R"]}
+    handler.assert_awaited_once_with("", {"query": "x"})  # owner-agnostic: empty owner id
+
+
+async def test_invalid_args_surface_a_schema_error() -> None:
+    run = _run(tools=[ToolSpec(type="web_search")])
+    out = await invoke_run_tool(
+        run=run, account_id="acc_t", tool_name="web_search", tool_input={}
+    )  # missing required "query"
+    assert "error" in out
+
+
+async def test_http_request_routed_to_the_run_resolver() -> None:
+    """invoke_run_tool feeds the run's snapshotted http_servers + the RUN credential
+    resolver into the shared http core — never an agent's surface or the session resolver."""
+    run = _run(
+        tools=[ToolSpec(type="http_request")],
+        http_servers=[HttpServerSpec(name="api", base_url="https://x")],
+    )
+    captured: dict[str, Any] = {}
+
+    async def _fake_do(*, servers: Any, arguments: Any, resolve_auth: Any) -> dict[str, Any]:
+        captured["servers"] = servers
+        captured["auth"] = await resolve_auth("https://x")  # exercise the injected resolver
+        return {"status": 200}
+
+    with (
+        patch.object(run_tools, "_do_http_request", new=_fake_do),
+        patch.object(run_tools.runtime, "require_pool", return_value=object()),
+        patch.object(run_tools.runtime, "require_crypto_box", return_value=object()),
+        patch.object(
+            run_tools,
+            "resolve_auth_for_target_url_run",
+            new=AsyncMock(return_value=("vlt", {"Authorization": "Bearer t"})),
+        ) as run_resolver,
+    ):
+        out = await invoke_run_tool(
+            run=run,
+            account_id="acc_t",
+            tool_name="http_request",
+            tool_input={"server_ref": "api", "path": "/p", "method": "GET"},
+        )
+
+    assert out == {"status": 200}
+    assert captured["servers"] == run.http_servers  # the run's snapshot
+    assert captured["auth"] == ("vlt", {"Authorization": "Bearer t"})
+    run_resolver.assert_awaited_once()  # the run-scoped resolver, not the session one
+
+
+async def test_disabled_tool_is_treated_as_undeclared() -> None:
+    # A declared-but-disabled tool is invisible to the run (fail-closed), like a session.
+    run = _run(tools=[ToolSpec(type="web_search", enabled=False)])
+    out = await invoke_run_tool(
+        run=run, account_id="acc_t", tool_name="web_search", tool_input={"query": "x"}
+    )
+    assert "error" in out and "declared" in out["error"]
+
+
+async def test_always_ask_route_is_denied_from_a_run() -> None:
+    # An always_ask route needs human confirmation, which a run has no channel for → denied
+    # (a run must not be more privileged than a session on the same declared surface).
+    route = HttpRouteSpec(
+        path_pattern="/things/*", permission_policy=HttpPermissionPolicy(type="always_ask")
+    )
+    run = _run(
+        tools=[ToolSpec(type="http_request")],
+        http_servers=[HttpServerSpec(name="api", base_url="https://x", routes=[route])],
+    )
+    out = await invoke_run_tool(
+        run=run,
+        account_id="acc_t",
+        tool_name="http_request",
+        tool_input={"server_ref": "api", "path": "/things/1", "method": "GET"},
+    )
+    assert "error" in out and "always_ask" in out["error"]
+
+
+def test_tool_verb_builds_capability() -> None:
+    cap = tool("web_search", {"query": "x"})
+    assert cap._capability_id == "tool"
+    assert cap._spec == {"tool_name": "web_search", "input": {"query": "x"}}


### PR DESCRIPTION
## What

Slice 2 of the **credentialed-runs lane** (slice 1 = #767). The `tool(name, input)` author capability, so a workflow run **directly invokes its declared network/credential tools** (`web_search`, `web_fetch`, `http_request`) — the payoff of the lane: a workflow hits a credentialed HTTP API using the run's *own* bound vault, no `agent()` round-trip.

**Dispatch: park-and-harvest, like `agent()`/`gate()`** (chosen with Tom over inline). The step journals `call_started`, launches a fire-and-forget **worker** task, and **parks** the run (releasing the slot); the task runs the tool and writes a `tool_result` `wf_run_signals` row + wakes the run; the next step harvests it into `call_result`. So a run never holds its lock/slot while a tool runs, and `parallel([tool() …])` fans out N tasks holding zero slots.

## Changes

- **`tool()` verb** (`wf_script_host`) + the **`tool` dispatch arm** in `step.py` (open: journal `call_started` + launch the task *after* the txn commits; harvest: signal-first).
- **`run_tools.py`** — `invoke_run_tool`: surface-gates against the run's declared tools (undeclared → a *recoverable* error value, not a run-error), routes `web_*` (owner-agnostic) and `http_request` (the run's snapshotted `http_servers` + the run-scoped `resolve_auth_for_target_url_run`), and **denies `always_ask` routes** (a run has no per-call confirmation channel → must not exceed a session's privilege). A per-run in-flight task registry gates re-launch.
- **`http_request` refactor** — extracted the owner-agnostic `_do_http_request(servers, resolve_auth)` core; the session handler is now the thin session entry. (Mirrors slice 1's `_auth_from_credential` split.)
- **Run-surface snapshot** — a run pins `tools`/`mcp_servers`/`http_servers` at launch (like `script`/`script_sha`), so the coming `update_workflow` never shifts an in-flight run's tool-authority. The step reads the run's own snapshot — no live `get_workflow`, fully deterministic.
- A `tool_result` signal kind + the snapshot columns (migration `0074`).

## Correctness notes

- **Result is dedup'd by the `(run_id, call_key)` signal PK** → exactly one `call_result` regardless of how many times a tool executes (at-least-once). The harvest point-reads the signal before re-dispatch, so a finished tool is never re-run on a same-worker sibling re-wake.
- **A non-idempotent `http_request` POST/DELETE may double-*execute*** on a hard crash or cross-worker re-wake — the same exposure the session tool path has, documented in the `run_tools` docstring. The `idempotent` flag (surfacing `may_have_completed` instead of re-dispatching) is the deferred follow-up.

## Deferred (later slices)

`update_workflow` (the agreed next slice; runs are already immune via the snapshot); authed-MCP tools (need run-side MCP discovery); `search_events` (run-scoped event view); sandbox/filesystem tools (the filesystem horizon); the `idempotent` flag.

## Tests

- **unit** — `run_tools` gating/routing (undeclared, non-run-tool, web routing, schema error, **disabled-tool**, **`always_ask` denial**, http_request → run resolver), the shared `_do_http_request` core (session/run via injected `resolve_auth`), the `tool()` verb.
- **integration** (real Postgres) — web_search park→harvest→replay, **http_request credential e2e** (the `Authorization` header authored from the run's bound vault), surface-gating rejection (recoverable, run completes), parallel fan-out, **crash/re-dispatch** (exactly one `call_started`, eventual completion).

1801 unit + 76 wf-integration green; mypy + ruff clean; `openapi.json` + SDK regenerated (`WfRun` surface). Went through `/simplify` (clean) and `/code-review --fix` (which closed a same-worker double-execute race, added the `always_ask` denial, and logged the signal-write-failure path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
