### PR TITLE
feat(workflows): update_workflow — in-place versioned updates, agent-style

### DIFF
--- a/migrations/versions/0075_workflow_update_constraint.py
+++ b/migrations/versions/0075_workflow_update_constraint.py
@@ -1,0 +1,41 @@
+"""Workflows become updatable in place: name-unique, not (name, version)-unique.
+
+``update_workflow`` bumps ``workflows.version`` in place (agent-style optimistic
+concurrency; no snapshot table — runs already snapshot script + surface at launch).
+Under in-place bumps the version-qualified unique is wrong: renaming workflow A (at v3)
+to workflow B's name (at v1) would NOT collide on ``(account_id, name, version)``,
+leaving two live workflows with one name. Swap to the agent-style name constraint.
+
+The ``workflows`` table is small (definitions, not events); a brief ACCESS EXCLUSIVE
+for the constraint swap is fine.
+
+Revision ID: 0075
+Revises: 0074
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0075"
+down_revision: str = "0074"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE workflows DROP CONSTRAINT workflows_account_id_name_version_key")
+    op.execute(
+        "ALTER TABLE workflows ADD CONSTRAINT workflows_account_id_name_key "
+        "UNIQUE (account_id, name)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE workflows DROP CONSTRAINT workflows_account_id_name_key")
+    op.execute(
+        "ALTER TABLE workflows ADD CONSTRAINT workflows_account_id_name_version_key "
+        "UNIQUE (account_id, name, version)"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -8122,7 +8122,7 @@
           "workflows"
         ],
         "summary": "Create Workflow",
-        "description": "Create a workflow definition (version 1). Versioning/update is deferred.\n\nThe HTTP path is unattenuated operator authority \u2014 no ``creator_session_id``, so the\ndeclared tool surface is not subset-checked against any agent (an agent authoring a\nworkflow goes through the create-time-attenuated builtin, a later slice).",
+        "description": "Create a workflow definition (version 1).\n\nThe HTTP path is unattenuated operator authority \u2014 no ``creator_session_id``, so the\ndeclared tool surface is not subset-checked against any agent (an agent authoring a\nworkflow goes through the create-time-attenuated builtin, a later slice).",
         "operationId": "create_workflow",
         "parameters": [
           {
@@ -8275,6 +8275,73 @@
       }
     },
     "/v1/workflows/{workflow_id}": {
+      "put": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "Update Workflow",
+        "description": "Update a workflow in place, bumping ``version``.\n\n``body.version`` must match the current version (optimistic concurrency \u2014 409 on a\nstale token; re-fetch and retry). Omitted fields are preserved; an identical update\nis a no-op. In-flight runs are unaffected (a run snapshots script + surface at\nlaunch). The HTTP path is unattenuated operator authority \u2014 no ``actor_session_id``.",
+        "operationId": "update_workflow",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workflow"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "tags": [
           "workflows"
@@ -15582,12 +15649,14 @@
           "updated_at"
         ],
         "title": "Workflow",
-        "description": "An immutable, versioned workflow definition."
+        "description": "A versioned workflow definition (updated in place; ``version`` bumps per change)."
       },
       "WorkflowCreate": {
         "properties": {
           "name": {
             "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
             "title": "Name"
           },
           "script": {
@@ -15651,6 +15720,7 @@
             "title": "Http Servers"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "name",
@@ -15658,6 +15728,122 @@
         ],
         "title": "WorkflowCreate",
         "description": "Request body for ``POST /v1/workflows`` \u2014 a new workflow definition at v1."
+      },
+      "WorkflowUpdate": {
+        "properties": {
+          "version": {
+            "type": "integer",
+            "title": "Version"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Script"
+          },
+          "input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Schema"
+          },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Schema"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ToolSpec"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools"
+          },
+          "mcp_servers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/McpServerSpec"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Servers"
+          },
+          "http_servers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/HttpServerSpec"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Http Servers"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "title": "WorkflowUpdate",
+        "description": "Request body for ``PUT /v1/workflows/{id}`` \u2014 update in place, bumping ``version``.\n\n``version`` is the optimistic-concurrency token: it must match the workflow's\ncurrent version or the update 409s (re-fetch and retry). Omitted fields are\npreserved \u2014 nullable fields (``input_schema``/``output_schema``/``description``)\ncan therefore be replaced but never cleared back to null, as on ``AgentUpdate``.\nAn identical update is a no-op (no bump). There is no version-snapshot table \u2014\na run pins ``script`` + the declared surface onto itself at launch, so in-flight\nruns never observe an update. (The ``AgentUpdate`` shape, minus history.)"
       }
     }
   }

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/create_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/create_workflow.py
@@ -71,7 +71,7 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | Workflow]:
     """Create Workflow
 
-     Create a workflow definition (version 1). Versioning/update is deferred.
+     Create a workflow definition (version 1).
 
     The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
     declared tool surface is not subset-checked against any agent (an agent authoring a
@@ -110,7 +110,7 @@ def sync(
 ) -> HTTPValidationError | Workflow | None:
     """Create Workflow
 
-     Create a workflow definition (version 1). Versioning/update is deferred.
+     Create a workflow definition (version 1).
 
     The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
     declared tool surface is not subset-checked against any agent (an agent authoring a
@@ -144,7 +144,7 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | Workflow]:
     """Create Workflow
 
-     Create a workflow definition (version 1). Versioning/update is deferred.
+     Create a workflow definition (version 1).
 
     The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
     declared tool surface is not subset-checked against any agent (an agent authoring a
@@ -181,7 +181,7 @@ async def asyncio(
 ) -> HTTPValidationError | Workflow | None:
     """Create Workflow
 
-     Create a workflow definition (version 1). Versioning/update is deferred.
+     Create a workflow definition (version 1).
 
     The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
     declared tool surface is not subset-checked against any agent (an agent authoring a

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/update_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/update_workflow.py
@@ -1,0 +1,261 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.workflow import Workflow
+from ...models.workflow_update import WorkflowUpdate
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    workflow_id: str,
+    *,
+    body: WorkflowUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/workflows/{workflow_id}".format(
+            workflow_id=quote(str(workflow_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Workflow | None:
+    if response.status_code == 200:
+        response_200 = Workflow.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Workflow]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Update Workflow
+
+     Update a workflow in place, bumping ``version``.
+
+    ``body.version`` must match the current version (optimistic concurrency — 409 on a
+    stale token; re-fetch and retry). Omitted fields are preserved; an identical update
+    is a no-op. In-flight runs are unaffected (a run snapshots script + surface at
+    launch). The HTTP path is unattenuated operator authority — no ``actor_session_id``.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+        body (WorkflowUpdate): Request body for ``PUT /v1/workflows/{id}`` — update in place,
+            bumping ``version``.
+
+            ``version`` is the optimistic-concurrency token: it must match the workflow's
+            current version or the update 409s (re-fetch and retry). Omitted fields are
+            preserved — nullable fields (``input_schema``/``output_schema``/``description``)
+            can therefore be replaced but never cleared back to null, as on ``AgentUpdate``.
+            An identical update is a no-op (no bump). There is no version-snapshot table —
+            a run pins ``script`` + the declared surface onto itself at launch, so in-flight
+            runs never observe an update. (The ``AgentUpdate`` shape, minus history.)
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Update Workflow
+
+     Update a workflow in place, bumping ``version``.
+
+    ``body.version`` must match the current version (optimistic concurrency — 409 on a
+    stale token; re-fetch and retry). Omitted fields are preserved; an identical update
+    is a no-op. In-flight runs are unaffected (a run snapshots script + surface at
+    launch). The HTTP path is unattenuated operator authority — no ``actor_session_id``.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+        body (WorkflowUpdate): Request body for ``PUT /v1/workflows/{id}`` — update in place,
+            bumping ``version``.
+
+            ``version`` is the optimistic-concurrency token: it must match the workflow's
+            current version or the update 409s (re-fetch and retry). Omitted fields are
+            preserved — nullable fields (``input_schema``/``output_schema``/``description``)
+            can therefore be replaced but never cleared back to null, as on ``AgentUpdate``.
+            An identical update is a no-op (no bump). There is no version-snapshot table —
+            a run pins ``script`` + the declared surface onto itself at launch, so in-flight
+            runs never observe an update. (The ``AgentUpdate`` shape, minus history.)
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return sync_detailed(
+        workflow_id=workflow_id,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Update Workflow
+
+     Update a workflow in place, bumping ``version``.
+
+    ``body.version`` must match the current version (optimistic concurrency — 409 on a
+    stale token; re-fetch and retry). Omitted fields are preserved; an identical update
+    is a no-op. In-flight runs are unaffected (a run snapshots script + surface at
+    launch). The HTTP path is unattenuated operator authority — no ``actor_session_id``.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+        body (WorkflowUpdate): Request body for ``PUT /v1/workflows/{id}`` — update in place,
+            bumping ``version``.
+
+            ``version`` is the optimistic-concurrency token: it must match the workflow's
+            current version or the update 409s (re-fetch and retry). Omitted fields are
+            preserved — nullable fields (``input_schema``/``output_schema``/``description``)
+            can therefore be replaced but never cleared back to null, as on ``AgentUpdate``.
+            An identical update is a no-op (no bump). There is no version-snapshot table —
+            a run pins ``script`` + the declared surface onto itself at launch, so in-flight
+            runs never observe an update. (The ``AgentUpdate`` shape, minus history.)
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: WorkflowUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Update Workflow
+
+     Update a workflow in place, bumping ``version``.
+
+    ``body.version`` must match the current version (optimistic concurrency — 409 on a
+    stale token; re-fetch and retry). Omitted fields are preserved; an identical update
+    is a no-op. In-flight runs are unaffected (a run snapshots script + surface at
+    launch). The HTTP path is unattenuated operator authority — no ``actor_session_id``.
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+        body (WorkflowUpdate): Request body for ``PUT /v1/workflows/{id}`` — update in place,
+            bumping ``version``.
+
+            ``version`` is the optimistic-concurrency token: it must match the workflow's
+            current version or the update 409s (re-fetch and retry). Omitted fields are
+            preserved — nullable fields (``input_schema``/``output_schema``/``description``)
+            can therefore be replaced but never cleared back to null, as on ``AgentUpdate``.
+            An identical update is a no-op (no bump). There is no version-snapshot table —
+            a run pins ``script`` + the declared surface onto itself at launch, so in-flight
+            runs never observe an update. (The ``AgentUpdate`` shape, minus history.)
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return (
+        await asyncio_detailed(
+            workflow_id=workflow_id,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -244,6 +244,9 @@ from .workflow_create_input_schema_type_0 import WorkflowCreateInputSchemaType0
 from .workflow_create_output_schema_type_0 import WorkflowCreateOutputSchemaType0
 from .workflow_input_schema_type_0 import WorkflowInputSchemaType0
 from .workflow_output_schema_type_0 import WorkflowOutputSchemaType0
+from .workflow_update import WorkflowUpdate
+from .workflow_update_input_schema_type_0 import WorkflowUpdateInputSchemaType0
+from .workflow_update_output_schema_type_0 import WorkflowUpdateOutputSchemaType0
 
 __all__ = (
     "Account",
@@ -476,4 +479,7 @@ __all__ = (
     "WorkflowCreateOutputSchemaType0",
     "WorkflowInputSchemaType0",
     "WorkflowOutputSchemaType0",
+    "WorkflowUpdate",
+    "WorkflowUpdateInputSchemaType0",
+    "WorkflowUpdateOutputSchemaType0",
 )

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
@@ -23,7 +23,7 @@ T = TypeVar("T", bound="Workflow")
 
 @_attrs_define
 class Workflow:
-    """An immutable, versioned workflow definition.
+    """A versioned workflow definition (updated in place; ``version`` bumps per change).
 
     Attributes:
         id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
-from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -46,7 +45,6 @@ class WorkflowCreate:
     tools: list[ToolSpec] | Unset = UNSET
     mcp_servers: list[McpServerSpec] | Unset = UNSET
     http_servers: list[HttpServerSpec] | Unset = UNSET
-    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.workflow_create_input_schema_type_0 import (
@@ -104,7 +102,7 @@ class WorkflowCreate:
                 http_servers.append(http_servers_item)
 
         field_dict: dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
+
         field_dict.update(
             {
                 "name": name,
@@ -228,21 +226,4 @@ class WorkflowCreate:
             http_servers=http_servers,
         )
 
-        workflow_create.additional_properties = d
         return workflow_create
-
-    @property
-    def additional_keys(self) -> list[str]:
-        return list(self.additional_properties.keys())
-
-    def __getitem__(self, key: str) -> Any:
-        return self.additional_properties[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        self.additional_properties[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self.additional_properties[key]
-
-    def __contains__(self, key: str) -> bool:
-        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_update.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.http_server_spec import HttpServerSpec
+    from ..models.mcp_server_spec import McpServerSpec
+    from ..models.tool_spec import ToolSpec
+    from ..models.workflow_update_input_schema_type_0 import (
+        WorkflowUpdateInputSchemaType0,
+    )
+    from ..models.workflow_update_output_schema_type_0 import (
+        WorkflowUpdateOutputSchemaType0,
+    )
+
+
+T = TypeVar("T", bound="WorkflowUpdate")
+
+
+@_attrs_define
+class WorkflowUpdate:
+    """Request body for ``PUT /v1/workflows/{id}`` — update in place, bumping ``version``.
+
+    ``version`` is the optimistic-concurrency token: it must match the workflow's
+    current version or the update 409s (re-fetch and retry). Omitted fields are
+    preserved — nullable fields (``input_schema``/``output_schema``/``description``)
+    can therefore be replaced but never cleared back to null, as on ``AgentUpdate``.
+    An identical update is a no-op (no bump). There is no version-snapshot table —
+    a run pins ``script`` + the declared surface onto itself at launch, so in-flight
+    runs never observe an update. (The ``AgentUpdate`` shape, minus history.)
+
+        Attributes:
+            version (int):
+            name (None | str | Unset):
+            script (None | str | Unset):
+            input_schema (None | Unset | WorkflowUpdateInputSchemaType0):
+            output_schema (None | Unset | WorkflowUpdateOutputSchemaType0):
+            description (None | str | Unset):
+            tools (list[ToolSpec] | None | Unset):
+            mcp_servers (list[McpServerSpec] | None | Unset):
+            http_servers (list[HttpServerSpec] | None | Unset):
+    """
+
+    version: int
+    name: None | str | Unset = UNSET
+    script: None | str | Unset = UNSET
+    input_schema: None | Unset | WorkflowUpdateInputSchemaType0 = UNSET
+    output_schema: None | Unset | WorkflowUpdateOutputSchemaType0 = UNSET
+    description: None | str | Unset = UNSET
+    tools: list[ToolSpec] | None | Unset = UNSET
+    mcp_servers: list[McpServerSpec] | None | Unset = UNSET
+    http_servers: list[HttpServerSpec] | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.workflow_update_input_schema_type_0 import (
+            WorkflowUpdateInputSchemaType0,
+        )
+        from ..models.workflow_update_output_schema_type_0 import (
+            WorkflowUpdateOutputSchemaType0,
+        )
+
+        version = self.version
+
+        name: None | str | Unset
+        if isinstance(self.name, Unset):
+            name = UNSET
+        else:
+            name = self.name
+
+        script: None | str | Unset
+        if isinstance(self.script, Unset):
+            script = UNSET
+        else:
+            script = self.script
+
+        input_schema: dict[str, Any] | None | Unset
+        if isinstance(self.input_schema, Unset):
+            input_schema = UNSET
+        elif isinstance(self.input_schema, WorkflowUpdateInputSchemaType0):
+            input_schema = self.input_schema.to_dict()
+        else:
+            input_schema = self.input_schema
+
+        output_schema: dict[str, Any] | None | Unset
+        if isinstance(self.output_schema, Unset):
+            output_schema = UNSET
+        elif isinstance(self.output_schema, WorkflowUpdateOutputSchemaType0):
+            output_schema = self.output_schema.to_dict()
+        else:
+            output_schema = self.output_schema
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        tools: list[dict[str, Any]] | None | Unset
+        if isinstance(self.tools, Unset):
+            tools = UNSET
+        elif isinstance(self.tools, list):
+            tools = []
+            for tools_type_0_item_data in self.tools:
+                tools_type_0_item = tools_type_0_item_data.to_dict()
+                tools.append(tools_type_0_item)
+
+        else:
+            tools = self.tools
+
+        mcp_servers: list[dict[str, Any]] | None | Unset
+        if isinstance(self.mcp_servers, Unset):
+            mcp_servers = UNSET
+        elif isinstance(self.mcp_servers, list):
+            mcp_servers = []
+            for mcp_servers_type_0_item_data in self.mcp_servers:
+                mcp_servers_type_0_item = mcp_servers_type_0_item_data.to_dict()
+                mcp_servers.append(mcp_servers_type_0_item)
+
+        else:
+            mcp_servers = self.mcp_servers
+
+        http_servers: list[dict[str, Any]] | None | Unset
+        if isinstance(self.http_servers, Unset):
+            http_servers = UNSET
+        elif isinstance(self.http_servers, list):
+            http_servers = []
+            for http_servers_type_0_item_data in self.http_servers:
+                http_servers_type_0_item = http_servers_type_0_item_data.to_dict()
+                http_servers.append(http_servers_type_0_item)
+
+        else:
+            http_servers = self.http_servers
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "version": version,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if script is not UNSET:
+            field_dict["script"] = script
+        if input_schema is not UNSET:
+            field_dict["input_schema"] = input_schema
+        if output_schema is not UNSET:
+            field_dict["output_schema"] = output_schema
+        if description is not UNSET:
+            field_dict["description"] = description
+        if tools is not UNSET:
+            field_dict["tools"] = tools
+        if mcp_servers is not UNSET:
+            field_dict["mcp_servers"] = mcp_servers
+        if http_servers is not UNSET:
+            field_dict["http_servers"] = http_servers
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.http_server_spec import HttpServerSpec
+        from ..models.mcp_server_spec import McpServerSpec
+        from ..models.tool_spec import ToolSpec
+        from ..models.workflow_update_input_schema_type_0 import (
+            WorkflowUpdateInputSchemaType0,
+        )
+        from ..models.workflow_update_output_schema_type_0 import (
+            WorkflowUpdateOutputSchemaType0,
+        )
+
+        d = dict(src_dict)
+        version = d.pop("version")
+
+        def _parse_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        name = _parse_name(d.pop("name", UNSET))
+
+        def _parse_script(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        script = _parse_script(d.pop("script", UNSET))
+
+        def _parse_input_schema(
+            data: object,
+        ) -> None | Unset | WorkflowUpdateInputSchemaType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                input_schema_type_0 = WorkflowUpdateInputSchemaType0.from_dict(data)
+
+                return input_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WorkflowUpdateInputSchemaType0, data)
+
+        input_schema = _parse_input_schema(d.pop("input_schema", UNSET))
+
+        def _parse_output_schema(
+            data: object,
+        ) -> None | Unset | WorkflowUpdateOutputSchemaType0:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                output_schema_type_0 = WorkflowUpdateOutputSchemaType0.from_dict(data)
+
+                return output_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WorkflowUpdateOutputSchemaType0, data)
+
+        output_schema = _parse_output_schema(d.pop("output_schema", UNSET))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_tools(data: object) -> list[ToolSpec] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                tools_type_0 = []
+                _tools_type_0 = data
+                for tools_type_0_item_data in _tools_type_0:
+                    tools_type_0_item = ToolSpec.from_dict(tools_type_0_item_data)
+
+                    tools_type_0.append(tools_type_0_item)
+
+                return tools_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[ToolSpec] | None | Unset, data)
+
+        tools = _parse_tools(d.pop("tools", UNSET))
+
+        def _parse_mcp_servers(data: object) -> list[McpServerSpec] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                mcp_servers_type_0 = []
+                _mcp_servers_type_0 = data
+                for mcp_servers_type_0_item_data in _mcp_servers_type_0:
+                    mcp_servers_type_0_item = McpServerSpec.from_dict(
+                        mcp_servers_type_0_item_data
+                    )
+
+                    mcp_servers_type_0.append(mcp_servers_type_0_item)
+
+                return mcp_servers_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[McpServerSpec] | None | Unset, data)
+
+        mcp_servers = _parse_mcp_servers(d.pop("mcp_servers", UNSET))
+
+        def _parse_http_servers(data: object) -> list[HttpServerSpec] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                http_servers_type_0 = []
+                _http_servers_type_0 = data
+                for http_servers_type_0_item_data in _http_servers_type_0:
+                    http_servers_type_0_item = HttpServerSpec.from_dict(
+                        http_servers_type_0_item_data
+                    )
+
+                    http_servers_type_0.append(http_servers_type_0_item)
+
+                return http_servers_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[HttpServerSpec] | None | Unset, data)
+
+        http_servers = _parse_http_servers(d.pop("http_servers", UNSET))
+
+        workflow_update = cls(
+            version=version,
+            name=name,
+            script=script,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            description=description,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            http_servers=http_servers,
+        )
+
+        return workflow_update

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_update_input_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_update_input_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WorkflowUpdateInputSchemaType0")
+
+
+@_attrs_define
+class WorkflowUpdateInputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        workflow_update_input_schema_type_0 = cls()
+
+        workflow_update_input_schema_type_0.additional_properties = d
+        return workflow_update_input_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_update_output_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_update_output_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WorkflowUpdateOutputSchemaType0")
+
+
+@_attrs_define
+class WorkflowUpdateOutputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        workflow_update_output_schema_type_0 = cls()
+
+        workflow_update_output_schema_type_0.additional_properties = d
+        return workflow_update_output_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -29,6 +29,7 @@ from aios.models.workflows import (
     WfRunWaitResponse,
     Workflow,
     WorkflowCreate,
+    WorkflowUpdate,
 )
 from aios.services import workflows as service
 
@@ -45,7 +46,7 @@ runs_router = APIRouter(prefix="/v1/runs", tags=["runs"])
 async def create_workflow(
     body: WorkflowCreate, pool: PoolDep, account_id: AccountIdDep
 ) -> Workflow:
-    """Create a workflow definition (version 1). Versioning/update is deferred.
+    """Create a workflow definition (version 1).
 
     The HTTP path is unattenuated operator authority — no ``creator_session_id``, so the
     declared tool surface is not subset-checked against any agent (an agent authoring a
@@ -53,6 +54,32 @@ async def create_workflow(
     return await service.create_workflow(
         pool,
         account_id=account_id,
+        name=body.name,
+        script=body.script,
+        input_schema=body.input_schema,
+        output_schema=body.output_schema,
+        description=body.description,
+        tools=body.tools,
+        mcp_servers=body.mcp_servers,
+        http_servers=body.http_servers,
+    )
+
+
+@router.put("/{workflow_id}", operation_id="update_workflow")
+async def update_workflow(
+    workflow_id: str, body: WorkflowUpdate, pool: PoolDep, account_id: AccountIdDep
+) -> Workflow:
+    """Update a workflow in place, bumping ``version``.
+
+    ``body.version`` must match the current version (optimistic concurrency — 409 on a
+    stale token; re-fetch and retry). Omitted fields are preserved; an identical update
+    is a no-op. In-flight runs are unaffected (a run snapshots script + surface at
+    launch). The HTTP path is unattenuated operator authority — no ``actor_session_id``."""
+    return await service.update_workflow(
+        pool,
+        workflow_id,
+        account_id=account_id,
+        expected_version=body.version,
         name=body.name,
         script=body.script,
         input_schema=body.input_schema,

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -33,10 +33,12 @@ from aios_sdk._generated.api.workflows import (
     create_workflow,
     get_workflow,
     list_workflows,
+    update_workflow,
 )
 from aios_sdk._generated.models.gate_resume import GateResume
 from aios_sdk._generated.models.wf_run_create import WfRunCreate
 from aios_sdk._generated.models.workflow_create import WorkflowCreate
+from aios_sdk._generated.models.workflow_update import WorkflowUpdate
 
 app = typer.Typer(name="workflows", help="Manage workflow definitions.", no_args_is_help=True)
 runs_app = typer.Typer(name="runs", help="Launch and observe workflow runs.", no_args_is_help=True)
@@ -101,6 +103,24 @@ def create_workflow_(
     def _run() -> int | None:
         payload = load_payload(file, stdin, data)
         call_single(ctx, create_workflow.sync_detailed, body=WorkflowCreate.from_dict(payload))
+        return None
+
+    run_or_die(_run)
+
+
+@app.command("update", help="Update a workflow (WorkflowUpdate shape; include 'version').")
+@covers("update_workflow")
+def update_workflow_(
+    ctx: typer.Context,
+    workflow_id: str,
+    file: Annotated[Path | None, typer.Option("--file", help="Read JSON body from a file.")] = None,
+    stdin: Annotated[bool, typer.Option("--stdin", help="Read JSON body from stdin.")] = False,
+    data: Annotated[str | None, typer.Option("--data", help="Inline JSON body.")] = None,
+) -> None:
+    def _run() -> int | None:
+        payload = load_payload(file, stdin, data)
+        body = WorkflowUpdate.from_dict(payload)
+        call_single(ctx, update_workflow.sync_detailed, workflow_id=workflow_id, body=body)
         return None
 
     run_or_die(_run)

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -112,7 +112,6 @@ async def insert_workflow(
     account_id: str,
     name: str,
     script: str,
-    version: int = 1,
     input_schema: dict[str, Any] | None = None,
     output_schema: dict[str, Any] | None = None,
     description: str | None = None,
@@ -120,8 +119,8 @@ async def insert_workflow(
     mcp_servers: list[McpServerSpec] | None = None,
     http_servers: list[HttpServerSpec] | None = None,
 ) -> Workflow:
-    """Insert an immutable workflow definition. Raises ``ConflictError`` on a
-    duplicate ``(account_id, name, version)``."""
+    """Insert a workflow definition at version 1. Raises ``ConflictError`` on a
+    duplicate ``(account_id, name)``."""
     new_id = make_id(WORKFLOW)
     try:
         row = await conn.fetchrow(
@@ -129,13 +128,12 @@ async def insert_workflow(
             INSERT INTO workflows
                 (id, account_id, name, version, script, input_schema, output_schema,
                  description, tools, mcp_servers, http_servers)
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9::jsonb, $10::jsonb, $11::jsonb)
+            VALUES ($1, $2, $3, 1, $4, $5::jsonb, $6::jsonb, $7, $8::jsonb, $9::jsonb, $10::jsonb)
             RETURNING *
             """,
             new_id,
             account_id,
             name,
-            version,
             script,
             json.dumps(input_schema) if input_schema is not None else None,
             json.dumps(output_schema) if output_schema is not None else None,
@@ -146,10 +144,117 @@ async def insert_workflow(
         )
     except asyncpg.UniqueViolationError as exc:
         raise ConflictError(
-            f"workflow {name!r} v{version} already exists",
-            detail={"name": name, "version": version},
+            f"workflow {name!r} already exists",
+            detail={"name": name},
         ) from exc
     assert row is not None
+    return _row_to_workflow(row)
+
+
+async def update_workflow(
+    conn: asyncpg.Connection[Any],
+    workflow_id: str,
+    *,
+    account_id: str,
+    expected_version: int,
+    name: str | None = None,
+    script: str | None = None,
+    input_schema: dict[str, Any] | None = None,
+    output_schema: dict[str, Any] | None = None,
+    description: str | None = None,
+    tools: list[ToolSpec] | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
+) -> Workflow:
+    """Update a workflow in place, bumping ``version`` (the ``update_agent`` shape,
+    minus the version-snapshot — runs pin script + surface onto themselves at launch).
+
+    Requires ``expected_version`` to match the current version (optimistic
+    concurrency). Omitted fields are preserved. If nothing changed, the current row
+    is returned without a bump (no-op). The version match is enforced by the
+    UPDATE's ``AND version = $expected`` — the authoritative serialization point;
+    exactly one of two racing writers matches, the other gets a clean 409.
+    """
+    current = await get_workflow(conn, workflow_id, account_id=account_id)
+    if expected_version != current.version:
+        # Validate the token up front so the contract is uniform — without this, the
+        # write-free no-op path below would return 200 for a stale token + identical
+        # values. This is *in addition to* the UPDATE's ``WHERE version`` (which stays
+        # the authoritative write-time serializer), not instead of it — the pre-check
+        # alone would be racy for the write path (the update_agent lesson).
+        raise ConflictError(
+            f"version mismatch: expected {expected_version}, current is {current.version}",
+            detail={
+                "expected": expected_version,
+                "current": current.version,
+                "id": workflow_id,
+            },
+        )
+
+    # Resolve final values (omitted = preserve current).
+    new_name = name if name is not None else current.name
+    new_script = script if script is not None else current.script
+    new_input_schema = input_schema if input_schema is not None else current.input_schema
+    new_output_schema = output_schema if output_schema is not None else current.output_schema
+    new_desc = description if description is not None else current.description
+    new_tools = tools if tools is not None else current.tools
+    new_mcp = mcp_servers if mcp_servers is not None else current.mcp_servers
+    new_http = http_servers if http_servers is not None else current.http_servers
+
+    if (
+        new_name == current.name
+        and new_script == current.script
+        and new_input_schema == current.input_schema
+        and new_output_schema == current.output_schema
+        and new_desc == current.description
+        and new_tools == current.tools
+        and new_mcp == current.mcp_servers
+        and new_http == current.http_servers
+    ):
+        return current
+
+    try:
+        row = await conn.fetchrow(
+            """
+            UPDATE workflows
+               SET version = workflows.version + 1, name = $3, script = $4,
+                   input_schema = $5::jsonb, output_schema = $6::jsonb, description = $7,
+                   tools = $8::jsonb, mcp_servers = $9::jsonb, http_servers = $10::jsonb,
+                   updated_at = now()
+             WHERE id = $1 AND account_id = $2 AND version = $11
+            RETURNING *
+            """,
+            workflow_id,
+            account_id,
+            new_name,
+            new_script,
+            json.dumps(new_input_schema) if new_input_schema is not None else None,
+            json.dumps(new_output_schema) if new_output_schema is not None else None,
+            new_desc,
+            json.dumps([t.model_dump() for t in new_tools]),
+            json.dumps([s.model_dump() for s in new_mcp]),
+            json.dumps([s.model_dump() for s in new_http]),
+            expected_version,
+        )
+    except asyncpg.UniqueViolationError as exc:
+        # A rename onto another live workflow's name (UNIQUE(account_id, name)).
+        raise ConflictError(
+            f"workflow {new_name!r} already exists",
+            detail={"name": new_name},
+        ) from exc
+    if row is None:
+        # No row matched (id, account_id, version): a stale/raced ``expected_version``.
+        # The re-read makes the 409 message accurate (and would 404 a vanished row,
+        # though workflows have no delete path today).
+        fresh = await get_workflow(conn, workflow_id, account_id=account_id)
+        raise ConflictError(
+            f"version mismatch: expected {expected_version}, current is {fresh.version}",
+            detail={
+                "expected": expected_version,
+                "current": fresh.version,
+                "id": workflow_id,
+            },
+        )
     return _row_to_workflow(row)
 
 
@@ -177,9 +282,8 @@ async def list_workflows(
     """Keyset-paginated list of an account's workflows, newest first.
 
     Hand-written (not ``_list_scoped``) because the ``workflows`` table has no
-    ``archived_at`` column — workflow definitions are immutable and never archived.
-    Each returned row is one ``(name, version)``; versioning/update is deferred, so
-    today there is one row per name.
+    ``archived_at`` column — workflows are never archived. One row per name
+    (``UNIQUE(account_id, name)``); ``version`` bumps in place on update.
     """
     args: list[Any] = [account_id]
     where = ["account_id = $1"]

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -52,7 +52,7 @@ SCHEDULED_TASK: Final = "sched"
 # expiry — see ``oauth_flows`` (migration 0061).
 OAUTH_FLOW: Final = "oaf"
 # Workflows: a deterministic-Python orchestrator (the dual of an agent).
-# ``workflows`` are immutable versioned definitions; ``wf_runs`` are durable
+# ``workflows`` are versioned definitions (updated in place); ``wf_runs`` are durable
 # execution instances; ``wf_run_events`` is each run's append-only journal.
 # (``wf_run_signals`` has a composite PK and mints no id.) See migration 0064.
 WORKFLOW: Final = "wf"

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -1,10 +1,11 @@
 """Workflows: read models for the durable runtime core (Block 1).
 
 A *workflow* is a deterministic-Python orchestrator (the dual of an agent):
-``workflows`` are immutable versioned definitions; a ``WfRun`` is a durable
-execution instance whose state lives entirely in its append-only journal
-(``WfRunEvent``); ``WfRunSignal`` is the side-marker an external resume writes
-so the journal keeps a single writer.
+``workflows`` are versioned definitions (updated in place, agent-style); a ``WfRun``
+is a durable execution instance whose state lives entirely in its append-only journal
+(``WfRunEvent``) and which pins its workflow's script + declared surface at launch;
+``WfRunSignal`` is the side-marker an external resume writes so the journal keeps a
+single writer.
 
 The read views below carry ``account_id`` (internal); the ``*Create`` / resume
 request models at the bottom back the public HTTP surface (Block 3). Responses
@@ -16,7 +17,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
 
@@ -31,7 +32,7 @@ TERMINAL_RUN_STATUSES: frozenset[str] = frozenset({"completed", "errored", "canc
 
 
 class Workflow(BaseModel):
-    """An immutable, versioned workflow definition."""
+    """A versioned workflow definition (updated in place; ``version`` bumps per change)."""
 
     id: str
     account_id: str
@@ -136,7 +137,9 @@ class WfRunWaitResponse(BaseModel):
 class WorkflowCreate(BaseModel):
     """Request body for ``POST /v1/workflows`` — a new workflow definition at v1."""
 
-    name: str
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=128)
     script: str
     input_schema: dict[str, Any] | None = None
     output_schema: dict[str, Any] | None = None
@@ -147,6 +150,31 @@ class WorkflowCreate(BaseModel):
     tools: list[ToolSpec] = Field(default_factory=list)
     mcp_servers: list[McpServerSpec] = Field(default_factory=list)
     http_servers: list[HttpServerSpec] = Field(default_factory=list)
+
+
+class WorkflowUpdate(BaseModel):
+    """Request body for ``PUT /v1/workflows/{id}`` — update in place, bumping ``version``.
+
+    ``version`` is the optimistic-concurrency token: it must match the workflow's
+    current version or the update 409s (re-fetch and retry). Omitted fields are
+    preserved — nullable fields (``input_schema``/``output_schema``/``description``)
+    can therefore be replaced but never cleared back to null, as on ``AgentUpdate``.
+    An identical update is a no-op (no bump). There is no version-snapshot table —
+    a run pins ``script`` + the declared surface onto itself at launch, so in-flight
+    runs never observe an update. (The ``AgentUpdate`` shape, minus history.)
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: int
+    name: str | None = Field(default=None, min_length=1, max_length=128)
+    script: str | None = None
+    input_schema: dict[str, Any] | None = None
+    output_schema: dict[str, Any] | None = None
+    description: str | None = None
+    tools: list[ToolSpec] | None = None
+    mcp_servers: list[McpServerSpec] | None = None
+    http_servers: list[HttpServerSpec] | None = None
 
 
 class WfRunCreate(BaseModel):

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -19,7 +19,7 @@ import asyncpg
 
 from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
-from aios.errors import ForbiddenError, NotFoundError
+from aios.errors import ConflictError, ForbiddenError, NotFoundError
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
 from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
@@ -46,6 +46,7 @@ __all__ = [
     "list_workflows",
     "resume_gate",
     "resume_gate_by_nonce",
+    "update_workflow",
 ]
 
 
@@ -65,20 +66,21 @@ async def _enforce_surface_attenuation(
     pool: asyncpg.Pool[Any],
     *,
     account_id: str,
-    creator_session_id: str,
+    actor_session_id: str,
     tools: list[ToolSpec],
     mcp_servers: list[McpServerSpec],
     http_servers: list[HttpServerSpec],
 ) -> None:
-    """Raise ``ForbiddenError`` if the declared surface exceeds the creator agent's.
+    """Raise ``ForbiddenError`` if the declared surface exceeds the acting agent's.
 
-    Subset by identity key: ``mcp_servers`` by url, ``http_servers`` by base_url,
-    ``tools`` by (builtin type / custom name / toolset server). The HTTP path passes no
-    creator and skips this — operator authority. (No-widen on permission/transport/routes
-    is a deliberate follow-up; this slice gates membership.)
+    Serves both create (the creator declaring a surface) and update (the editor's merged
+    final surface). Subset by identity key: ``mcp_servers`` by url, ``http_servers`` by
+    base_url, ``tools`` by (builtin type / custom name / toolset server). The HTTP path
+    passes no actor and skips this — operator authority. (No-widen on
+    permission/transport/routes is a deliberate follow-up; this slice gates membership.)
     """
     session = await sessions_service.get_session_basic(
-        pool, creator_session_id, account_id=account_id
+        pool, actor_session_id, account_id=account_id
     )
     agent = await agents_service.load_for_session(pool, session, account_id=account_id)
     allowed_mcp = {s.url for s in agent.mcp_servers}
@@ -127,7 +129,7 @@ async def create_workflow(
         await _enforce_surface_attenuation(
             pool,
             account_id=account_id,
-            creator_session_id=creator_session_id,
+            actor_session_id=creator_session_id,
             tools=tools or [],
             mcp_servers=mcp_servers or [],
             http_servers=http_servers or [],
@@ -136,6 +138,76 @@ async def create_workflow(
         return await wf_queries.insert_workflow(
             conn,
             account_id=account_id,
+            name=name,
+            script=script,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            description=description,
+            tools=tools,
+            mcp_servers=mcp_servers,
+            http_servers=http_servers,
+        )
+
+
+async def update_workflow(
+    pool: asyncpg.Pool[Any],
+    workflow_id: str,
+    *,
+    account_id: str,
+    expected_version: int,
+    name: str | None = None,
+    script: str | None = None,
+    input_schema: dict[str, Any] | None = None,
+    output_schema: dict[str, Any] | None = None,
+    description: str | None = None,
+    tools: list[ToolSpec] | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
+    actor_session_id: str | None = None,
+) -> Workflow:
+    """Update a workflow in place (optimistic concurrency on ``expected_version``).
+
+    **Update-time attenuation:** when ``actor_session_id`` is set (an agent editing the
+    workflow), the **merged final surface** must be a subset of the acting agent's own —
+    checked even when the update doesn't touch the surface fields, because an agent that
+    rewrites the *script* of a workflow with a broader surface would wield that surface
+    through it. An agent may only update a workflow whose resulting surface it could have
+    declared itself. With no actor (the HTTP/operator path) anything may be updated.
+
+    In-flight runs are unaffected: a run snapshots ``script`` + the declared surface at
+    launch; only runs created after the update see the new definition.
+    """
+    if actor_session_id is not None:
+        current = await get_workflow(pool, workflow_id, account_id=account_id)
+        if current.version != expected_version:
+            # Pin the attenuation read to the caller's token. Without this, an actor
+            # could send a FUTURE token: attenuation passes against today's surface,
+            # a concurrent update broadens it and bumps to exactly that token, and the
+            # optimistic UPDATE then matches — landing the actor's script on a surface
+            # that was never checked. With the pin, the UPDATE's ``WHERE version``
+            # guarantees nothing changed between this read and the write.
+            raise ConflictError(
+                f"version mismatch: expected {expected_version}, current is {current.version}",
+                detail={
+                    "expected": expected_version,
+                    "current": current.version,
+                    "id": workflow_id,
+                },
+            )
+        await _enforce_surface_attenuation(
+            pool,
+            account_id=account_id,
+            actor_session_id=actor_session_id,
+            tools=tools if tools is not None else current.tools,
+            mcp_servers=mcp_servers if mcp_servers is not None else current.mcp_servers,
+            http_servers=http_servers if http_servers is not None else current.http_servers,
+        )
+    async with pool.acquire() as conn:
+        return await wf_queries.update_workflow(
+            conn,
+            workflow_id,
+            account_id=account_id,
+            expected_version=expected_version,
             name=name,
             script=script,
             input_schema=input_schema,

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -246,3 +246,28 @@ async def test_runs_parent_run_id_filter(http_client: httpx.AsyncClient, pool: A
 async def test_requires_auth(http_client: httpx.AsyncClient) -> None:
     r = await http_client.get("/v1/workflows", headers={"Authorization": ""})
     assert r.status_code == 401, r.text
+
+
+async def test_update_workflow_roundtrip_and_stale_409(http_client: httpx.AsyncClient) -> None:
+    name = f"upd-{_uniq()}"
+    r = await http_client.post("/v1/workflows", json={"name": name, "script": _SCRIPT})
+    assert r.status_code == 201
+    wf = r.json()
+    assert wf["version"] == 1
+
+    # PUT with the current version token → 200, version bumps, omitted fields preserved.
+    r = await http_client.put(
+        f"/v1/workflows/{wf['id']}",
+        json={"version": 1, "script": "async def main(input):\n    return 'v2'\n"},
+    )
+    assert r.status_code == 200
+    updated = r.json()
+    assert updated["version"] == 2
+    assert "v2" in updated["script"]
+    assert updated["name"] == name
+
+    # Stale token → 409; unknown id → 404.
+    r = await http_client.put(f"/v1/workflows/{wf['id']}", json={"version": 1, "script": "x"})
+    assert r.status_code == 409
+    r = await http_client.put("/v1/workflows/wf_nope", json={"version": 1, "script": "x"})
+    assert r.status_code == 404

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -19,6 +19,7 @@ from aios.db.listen import open_listen_for_run_events
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, NotFoundError
+from aios.models.agents import ToolSpec
 
 
 @pytest.fixture
@@ -71,7 +72,7 @@ async def test_insert_and_get_workflow(wf_conn: asyncpg.Connection[Any]) -> None
     assert fetched.input_schema == {"type": "object"}
 
 
-async def test_duplicate_workflow_version_conflicts(wf_conn: asyncpg.Connection[Any]) -> None:
+async def test_duplicate_workflow_name_conflicts(wf_conn: asyncpg.Connection[Any]) -> None:
     await wf_queries.insert_workflow(wf_conn, account_id="acc_root", name="dup", script="x")
     with pytest.raises(ConflictError):
         await wf_queries.insert_workflow(wf_conn, account_id="acc_root", name="dup", script="y")
@@ -349,3 +350,68 @@ async def test_wf_run_event_stream_backfills_tails_and_terminates(
         ("event", "run_completed"),  # live tail
         ("done", None),  # terminal
     ]
+
+
+# ─── update_workflow — in-place versioned updates (optimistic concurrency) ────
+
+
+async def test_update_workflow_merges_and_bumps(wf_conn: asyncpg.Connection[Any]) -> None:
+    wf = await wf_queries.insert_workflow(
+        wf_conn, account_id="acc_root", name="up", script="A", description="d1"
+    )
+    updated = await wf_queries.update_workflow(
+        wf_conn,
+        wf.id,
+        account_id="acc_root",
+        expected_version=1,
+        script="B",
+        tools=[ToolSpec(type="web_search")],
+    )
+    assert updated.version == 2
+    assert updated.script == "B"
+    assert [t.type for t in updated.tools] == ["web_search"]
+    # Omitted fields preserved; id stable.
+    assert updated.name == "up" and updated.description == "d1" and updated.id == wf.id
+
+
+async def test_update_workflow_noop_keeps_version(wf_conn: asyncpg.Connection[Any]) -> None:
+    wf = await wf_queries.insert_workflow(wf_conn, account_id="acc_root", name="noop", script="A")
+    same = await wf_queries.update_workflow(
+        wf_conn, wf.id, account_id="acc_root", expected_version=1, script="A"
+    )
+    assert same.version == 1  # identical values → no bump
+    assert (await wf_queries.get_workflow(wf_conn, wf.id, account_id="acc_root")).version == 1
+
+
+async def test_update_workflow_stale_version_conflicts(wf_conn: asyncpg.Connection[Any]) -> None:
+    wf = await wf_queries.insert_workflow(wf_conn, account_id="acc_root", name="stale", script="A")
+    await wf_queries.update_workflow(
+        wf_conn, wf.id, account_id="acc_root", expected_version=1, script="B"
+    )  # → v2
+    with pytest.raises(ConflictError):
+        await wf_queries.update_workflow(
+            wf_conn, wf.id, account_id="acc_root", expected_version=1, script="C"
+        )
+    # The contract is uniform: a stale token 409s even when the values are identical
+    # (the write-free no-op path must not skip token validation).
+    with pytest.raises(ConflictError):
+        await wf_queries.update_workflow(
+            wf_conn, wf.id, account_id="acc_root", expected_version=1, script="B"
+        )
+    with pytest.raises(NotFoundError):
+        await wf_queries.update_workflow(
+            wf_conn, "wf_does_not_exist", account_id="acc_root", expected_version=1, script="C"
+        )
+
+
+async def test_update_workflow_rename_collision_conflicts(
+    wf_conn: asyncpg.Connection[Any],
+) -> None:
+    await wf_queries.insert_workflow(wf_conn, account_id="acc_root", name="taken", script="A")
+    other = await wf_queries.insert_workflow(
+        wf_conn, account_id="acc_root", name="renameme", script="A"
+    )
+    with pytest.raises(ConflictError):
+        await wf_queries.update_workflow(
+            wf_conn, other.id, account_id="acc_root", expected_version=1, name="taken"
+        )

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -29,7 +29,7 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries as db_queries
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
-from aios.errors import ForbiddenError, NotFoundError
+from aios.errors import ConflictError, ForbiddenError, NotFoundError
 from aios.harness import runtime
 from aios.mcp.client import resolve_auth_for_target_url_run
 from aios.models.agents import Agent, HttpServerSpec, McpServerSpec
@@ -331,3 +331,77 @@ async def test_run_cannot_bind_foreign_or_missing_vault(vault_pool: asyncpg.Pool
             vault_ids=["vlt_does_not_exist"],
         )
     assert await _run_count(pool) == before
+
+
+async def test_update_time_attenuation(vault_pool: asyncpg.Pool[Any]) -> None:
+    """An agent-actor may only update a workflow whose merged final surface it could have
+    declared itself — enforced even for a script-only edit (else an agent could rewrite the
+    script of an operator-created workflow with a broader surface and wield it). The
+    operator path (no actor) updates anything."""
+    pool = vault_pool
+    s1 = McpServerSpec(name="s1", url="https://s1.example")
+    s2 = McpServerSpec(name="s2", url="https://s2.example")
+    agent = await _make_agent(pool, "updater-agent", mcp_servers=[s1])
+    actor = await _make_session(pool, agent)
+
+    # Operator creates a workflow whose surface exceeds the agent's (s2 ∉ agent's).
+    broad = await wf_service.create_workflow(
+        pool, account_id=ACC, name="w-broad", script=_SCRIPT, mcp_servers=[s2]
+    )
+    # Script-only edit by the agent → ForbiddenError (merged surface still ⊉ agent's).
+    with pytest.raises(ForbiddenError):
+        await wf_service.update_workflow(
+            pool,
+            broad.id,
+            account_id=ACC,
+            expected_version=1,
+            script="async def main(i):\n    return 2\n",
+            actor_session_id=actor,
+        )
+
+    # On a workflow within the agent's surface, the same edit succeeds.
+    narrow = await wf_service.create_workflow(
+        pool, account_id=ACC, name="w-narrow", script=_SCRIPT, mcp_servers=[s1]
+    )
+    ok = await wf_service.update_workflow(
+        pool,
+        narrow.id,
+        account_id=ACC,
+        expected_version=1,
+        script="async def main(i):\n    return 2\n",
+        actor_session_id=actor,
+    )
+    assert ok.version == 2
+
+    # The agent cannot widen a surface beyond its own.
+    with pytest.raises(ForbiddenError):
+        await wf_service.update_workflow(
+            pool,
+            narrow.id,
+            account_id=ACC,
+            expected_version=2,
+            mcp_servers=[s1, s2],
+            actor_session_id=actor,
+        )
+
+    # An actor's token must match the version the attenuation read observes — a FUTURE
+    # token 409s up front (else: pass attenuation against today's surface, let a
+    # concurrent broadening update bump to exactly that token, and land unchecked).
+    # Probed against the BROAD workflow so the assertion discriminates the service-layer
+    # pin specifically: with the pin, ConflictError fires before attenuation; without
+    # it, attenuation against the broad surface would raise ForbiddenError instead.
+    with pytest.raises(ConflictError):
+        await wf_service.update_workflow(
+            pool,
+            broad.id,
+            account_id=ACC,
+            expected_version=2,
+            script="async def main(i):\n    return 3\n",
+            actor_session_id=actor,
+        )
+
+    # Operator (no actor) updates anything, including the broad workflow.
+    op = await wf_service.update_workflow(
+        pool, broad.id, account_id=ACC, expected_version=1, description="op-edit"
+    )
+    assert op.version == 2

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -2521,3 +2521,56 @@ async def test_tool_http_request_credential_e2e(wf_runtime: asyncpg.Pool[Any]) -
         assert run.output["status"] == 200
     finally:
         runtime.crypto_box = prev_box
+
+
+# ─── update_workflow — in-flight runs are immune (snapshot pinning) ───────────
+
+
+async def test_update_workflow_does_not_disturb_inflight_runs(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """The load-bearing update proof: a run executes the script + surface it snapshotted
+    at launch, even when the workflow is updated mid-flight; a NEW run gets the update."""
+    pool = wf_runtime
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(
+            conn,
+            account_id="acc_wf",
+            name="w-immune",
+            script="async def main(input):\n    return 'OLD'\n",
+            tools=[ToolSpec(type="web_search")],
+        )
+    old_run = await service.create_run(
+        pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf"
+    )
+
+    # Update the workflow mid-flight: new script, surface dropped.
+    updated = await wf_service.update_workflow(
+        pool,
+        wf.id,
+        account_id="acc_wf",
+        expected_version=1,
+        script="async def main(input):\n    return 'NEW'\n",
+        tools=[],
+    )
+    assert updated.version == 2
+
+    # The in-flight run still carries (and executes) its launch snapshot.
+    async with pool.acquire() as conn:
+        old_run_row = await wf_queries.get_wf_run(conn, old_run.id, account_id="acc_wf")
+    assert "OLD" in old_run_row.script
+    assert [t.type for t in old_run_row.tools] == ["web_search"]
+    await run_workflow_step(old_run.id)
+    async with pool.acquire() as conn:
+        finished = await wf_queries.get_wf_run(conn, old_run.id, account_id="acc_wf")
+    assert finished.status == "completed" and finished.output == "OLD"
+
+    # A run launched after the update gets the new definition.
+    new_run = await service.create_run(
+        pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf"
+    )
+    await run_workflow_step(new_run.id)
+    async with pool.acquire() as conn:
+        fresh = await wf_queries.get_wf_run(conn, new_run.id, account_id="acc_wf")
+    assert fresh.status == "completed" and fresh.output == "NEW"
+    assert fresh.tools == []

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0074``."""
+    """The migration ladder has exactly one head: ``0075``."""
     script = _script_directory()
-    assert script.get_heads() == ["0074"]
+    assert script.get_heads() == ["0075"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from aios.models.workflows import GateResume, WfRunCreate, WorkflowCreate
+from aios.models.workflows import GateResume, WfRunCreate, WorkflowCreate, WorkflowUpdate
 
 
 class TestWorkflowCreate:
@@ -54,6 +54,15 @@ class TestWorkflowCreate:
             WorkflowCreate.model_validate({"name": "w"})
         with pytest.raises(ValidationError):
             WorkflowCreate.model_validate({"script": "x"})
+
+
+class TestWorkflowUpdate:
+    def test_version_required_fields_optional(self) -> None:
+        upd = WorkflowUpdate.model_validate({"version": 3, "script": "async def main(i): pass"})
+        assert upd.version == 3 and upd.script is not None
+        assert upd.name is None and upd.tools is None  # omitted = preserved
+        with pytest.raises(ValidationError):
+            WorkflowUpdate.model_validate({"script": "x"})  # version is mandatory
 
 
 class TestWfRunCreate:


### PR DESCRIPTION
## What

Workflows become **updatable like agents** (the agreed next slice after #769): `PUT /v1/workflows/{id}` with a required `version` optimistic-concurrency token, partial update (omitted = preserved), no-op detection, and an atomic **in-place version bump**.

**Deliberately no `workflow_versions` snapshot table** (decided with Tom): agents need one because sessions pin versions and load old snapshots at step time — but a run already pins `script`, `script_sha`, and the whole declared surface onto itself at launch (slices 1–2), so nothing at runtime ever reads an old workflow version. **In-flight runs are immune to edits by construction**, proven by an integration test that updates a workflow mid-flight and drives both the old run (executes the old script + surface) and a new run (gets the new) to completion.

## Mechanics

- **Migration 0075:** `UNIQUE(account_id, name, version)` → `UNIQUE(account_id, name)` — under in-place bumps the version-qualified unique would let a rename collide "successfully" across versions (two live workflows, one name). `insert_workflow` drops its inert `version` param.
- **Query:** mirrors `update_agent`'s battle-tested shape (merge → no-op detect → `UPDATE … SET version = workflows.version + 1 WHERE version = $expected` → 0-rows → re-read → 409; rename collision → 409). The token is **also validated up front** so the write-free no-op path can't return 200 on a stale token — a contract gap the review found in the agent template itself (uniform here; the `WHERE` stays the authoritative write-time serializer).
- **Update-time attenuation (the one rule beyond the agent mirror):** when an agent-actor edits a workflow, the **merged final surface** must be ⊆ the actor's own — enforced **even for a script-only edit**, because an agent that rewrites the script of an operator-created workflow with a broader surface would wield that surface through it. The actor's token is **pinned to the attenuation read**, closing a future-token TOCTOU the review caught: without the pin, an actor could send `version=N+1`, pass attenuation against today's narrow surface, and have a concurrent broadening update bump to exactly that token so the UPDATE lands unchecked. HTTP stays unattenuated operator authority.
- **Model hardening:** `WorkflowUpdate`/`WorkflowCreate` gain `extra="forbid"` + name length bounds (AgentUpdate parity) — a typo'd field (`scirpt`) is a 422, not a silent 200 no-op.
- CLI `aios workflows update <id> --file/--stdin/--data`; stale "immutable workflow" docstrings fixed (they were exported into openapi).

## Slice-3 wiring notes (for the reviewer)

- `actor_session_id` has no production caller yet (HTTP passes none). When the agent-acting builtins land, it must be supplied from **trusted execution context** — never model-controlled input (a model-supplied id would be a same-account confused-deputy vector).
- The pin serializes *workflow* mutations; a concurrent `update_agent` narrowing the actor's surface between the attenuation read and the commit is a residual cross-object window (same shape as create) — bounded, noted, not closed here.

## Tests

- **unit** — `WorkflowUpdate` validation (version required, partial fields).
- **integration** — merge+bump with field preservation; no-op keeps version; stale token 409 **including identical-values** (the uniform-contract proof); rename collision; **run-immunity drive-through**; update-time attenuation (script-only edit on a broader-surface workflow → 403; covering surface → ok; widening → 403; **pin-discriminating future-token probe** on the broad workflow → 409, which would be a 403 if the pin were removed; operator unrestricted).
- **e2e** — PUT round-trip (200 → v2, fields preserved), stale 409, unknown 404.

1801 unit green; mypy + ruff clean; `openapi.json` + SDK regenerated. Went through `/simplify` and `/code-review --fix` (xhigh — which contributed the TOCTOU pin, the uniform token contract, and the model hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
