### PR TITLE
feat(workflows): agent-acting builtins — create/update/run/await as model tools (the strange loop)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -14290,7 +14290,11 @@
                   "http_request",
                   "schedule_task_add",
                   "schedule_task_remove",
-                  "schedule_task_update"
+                  "schedule_task_update",
+                  "create_workflow",
+                  "update_workflow",
+                  "create_run",
+                  "await_run"
                 ]
               },
               {

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
@@ -2,8 +2,11 @@ from enum import Enum
 
 
 class ToolSpecTypeType0(str, Enum):
+    AWAIT_RUN = "await_run"
     BASH = "bash"
     CANCEL = "cancel"
+    CREATE_RUN = "create_run"
+    CREATE_WORKFLOW = "create_workflow"
     EDIT = "edit"
     GLOB = "glob"
     GREP = "grep"
@@ -14,6 +17,7 @@ class ToolSpecTypeType0(str, Enum):
     SCHEDULE_TASK_UPDATE = "schedule_task_update"
     SCHEDULE_WAKE = "schedule_wake"
     SEARCH_EVENTS = "search_events"
+    UPDATE_WORKFLOW = "update_workflow"
     WAKE_SELF = "wake_self"
     WAKE_SESSION = "wake_session"
     WEB_FETCH = "web_fetch"

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -394,6 +394,33 @@ async def insert_wf_run(
     return _row_to_wf_run(row)
 
 
+async def run_ancestor_depth(conn: asyncpg.Connection[Any], run_id: str, *, account_id: str) -> int:
+    """Depth of ``run_id`` in the ``parent_run_id`` chain (a root run = 1).
+
+    Walks ``wf_runs.parent_run_id`` upward via a recursive CTE, account-scoped on
+    every hop. Returns 0 if ``run_id`` doesn't exist for the account (defensive; the
+    depth cap passes a live ancestor). The chain is immutable once written, so the
+    count is race-free without locking — concurrent sibling inserts can't change an
+    ancestor's depth.
+    """
+    depth: int | None = await conn.fetchval(
+        """
+        WITH RECURSIVE chain AS (
+            SELECT id, parent_run_id, 1 AS depth
+              FROM wf_runs WHERE id = $1 AND account_id = $2
+            UNION ALL
+            SELECT r.id, r.parent_run_id, c.depth + 1
+              FROM wf_runs r JOIN chain c ON r.id = c.parent_run_id
+             WHERE r.account_id = $2
+        )
+        SELECT max(depth) FROM chain
+        """,
+        run_id,
+        account_id,
+    )
+    return depth or 0
+
+
 async def set_run_vaults(
     conn: asyncpg.Connection[Any],
     run_id: str,

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -35,6 +35,10 @@ BuiltinToolType = Literal[
     "schedule_task_add",
     "schedule_task_remove",
     "schedule_task_update",
+    "create_workflow",
+    "update_workflow",
+    "create_run",
+    "await_run",
 ]
 
 # Permission policy for built-in tools. Custom tools are always client-controlled

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -37,4 +37,5 @@ from aios.tools import wake_session as _wake_session  # noqa: F401
 from aios.tools import web_fetch as _web_fetch  # noqa: F401
 from aios.tools import web_search as _web_search  # noqa: F401
 from aios.tools import workflow_completion as _workflow_completion  # noqa: F401
+from aios.tools import workflow_management as _workflow_management  # noqa: F401
 from aios.tools import write as _write  # noqa: F401

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -1,0 +1,260 @@
+"""Agent-acting workflow builtins — the strange loop.
+
+Four model-callable tools that let an agent author, edit, launch, and await
+workflows the way a human operator (or the ``aios`` CLI) does. Each is a thin
+wrapper over the existing workflow services; the agent's authority is bounded by
+the same three attenuations those services already enforce, keyed on the
+**executing session id** the harness supplies (``invoke_builtin(session_id, …)``,
+``tools/invoke.py``) — never model input:
+
+* ``create_workflow`` — surface attenuation: the declared tool/server surface must
+  be a subset of the *creating agent's* own.
+* ``update_workflow`` — merged-surface attenuation + an optimistic ``version`` pin.
+* ``create_run`` — vault attenuation (bound vaults ⊆ the *launching session's*) plus
+  the vertical run-depth cap; the run inherits the caller's environment.
+* ``await_run`` — a bounded long-poll that blocks (as a fire-and-forget tool task,
+  so the session stays responsive) until the run is terminal or the timeout lapses.
+
+**Identity is load-bearing, so two invariants hold (see F1 in the review):**
+1. The trusted ids (``creator_session_id``/``actor_session_id``/``launcher_session_id``,
+   ``account_id``, ``parent_run_id``, ``environment_id``) are NEVER tool-schema fields —
+   every schema is ``additionalProperties: false`` (derived from a pydantic arg model
+   with ``extra="forbid"``), so an injected key is rejected before the handler runs.
+2. Handlers map service kwargs explicitly from the validated model — never ``**arguments``.
+
+All four register ``transport="agent_tool"`` (model-only; the CLI broker refuses them).
+
+**Security boundary (A2):** these builtins attenuate, but a grant of the operator-level
+management API (HTTP / a future management MCP) does not — that path is unattenuated by
+design. Grant the management surface only to operator-trust agents; don't reason "the
+builtins attenuate, therefore agent X is contained" if X also holds it.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ValidationError as PydanticValidationError
+
+from aios.config import get_settings
+from aios.errors import AiosError
+from aios.harness import runtime
+from aios.models.workflows import WorkflowCreate, WorkflowUpdate
+from aios.services import sessions as sessions_service
+from aios.services import workflows as wf_service
+from aios.tools.invoke import ToolBail
+from aios.tools.registry import registry
+
+# Heavy snapshot fields the model already sent (or doesn't need echoed back); trimmed
+# from the returned dicts to keep tool results lean.
+_WORKFLOW_ECHO_EXCLUDE = {"script"}
+_RUN_ECHO_EXCLUDE = {"script", "script_sha", "tools", "mcp_servers", "http_servers"}
+
+
+# ─── argument models (parameters_schema + parse, in one place) ───────────────
+
+
+class _UpdateWorkflowArgs(WorkflowUpdate):
+    """``update_workflow`` arguments — the ``WorkflowUpdate`` body plus the path-style id.
+
+    Subclassing inherits every field (and its constraints) and ``extra="forbid"`` —
+    the trusted ``actor_session_id`` is never a field, so an injected key is rejected.
+    """
+
+    workflow_id: str
+
+
+class _CreateRunArgs(BaseModel):
+    """``create_run`` arguments. No ``environment_id`` — the run always inherits the
+    caller session's env (a caller-chosen env id would be a cross-tenant attack surface)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: str
+    input: Any = None
+    vault_ids: list[str] = Field(default_factory=list)
+
+
+class _AwaitRunArgs(BaseModel):
+    """``await_run`` arguments. ``timeout_seconds`` is a bounded per-call long-poll
+    budget; re-call to keep waiting (each call holds one LISTEN connection)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    timeout_seconds: int = Field(default=300, ge=1, le=1800)
+
+
+# ─── handler plumbing ────────────────────────────────────────────────────────
+
+
+@contextmanager
+def _service_errors() -> Iterator[None]:
+    """Map a client-class (4xx) service refusal to a clean, model-visible ``ToolBail``.
+
+    A raised ``Exception`` from a handler triggers sandbox eviction on the model path
+    (``tool_dispatch._tool_lifecycle``); ``ToolBail`` instead lands as a normal
+    ``is_error`` tool result the model can read and self-correct from. A genuine 5xx is
+    an internal failure and propagates unchanged. Wrap only the service call — the
+    explicit kwarg mapping (the F1 invariant) stays inline inside the ``with`` body.
+    """
+    try:
+        yield
+    except AiosError as exc:
+        if exc.status_code >= 500:
+            raise
+        msg = exc.message if not exc.detail else f"{exc.message} ({json.dumps(exc.detail)})"
+        raise ToolBail(msg) from exc
+
+
+def _parse[M: BaseModel](model: type[M], arguments: dict[str, Any]) -> M:
+    """Parse + validate via the pydantic arg model (semantic checks the JSON schema
+    can't encode, e.g. ``McpServerSpec`` name rules) → ``ToolBail`` on failure."""
+    try:
+        return model.model_validate(arguments)
+    except PydanticValidationError as exc:
+        raise ToolBail(f"invalid arguments: {exc}") from exc
+
+
+async def create_workflow_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    body = _parse(WorkflowCreate, arguments)
+    with _service_errors():
+        wf = await wf_service.create_workflow(
+            pool,
+            account_id=account_id,
+            name=body.name,
+            script=body.script,
+            input_schema=body.input_schema,
+            output_schema=body.output_schema,
+            description=body.description,
+            tools=body.tools,
+            mcp_servers=body.mcp_servers,
+            http_servers=body.http_servers,
+            creator_session_id=session_id,
+        )
+    return wf.model_dump(mode="json", exclude=_WORKFLOW_ECHO_EXCLUDE)
+
+
+async def update_workflow_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    args = _parse(_UpdateWorkflowArgs, arguments)
+    with _service_errors():
+        wf = await wf_service.update_workflow(
+            pool,
+            args.workflow_id,
+            account_id=account_id,
+            expected_version=args.version,
+            name=args.name,
+            script=args.script,
+            input_schema=args.input_schema,
+            output_schema=args.output_schema,
+            description=args.description,
+            tools=args.tools,
+            mcp_servers=args.mcp_servers,
+            http_servers=args.http_servers,
+            actor_session_id=session_id,
+        )
+    return wf.model_dump(mode="json", exclude=_WORKFLOW_ECHO_EXCLUDE)
+
+
+async def create_run_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    args = _parse(_CreateRunArgs, arguments)
+    session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
+    with _service_errors():
+        run = await wf_service.create_run(
+            pool,
+            account_id=account_id,
+            workflow_id=args.workflow_id,
+            environment_id=session.environment_id,  # inherit caller's env (F2)
+            input=args.input,
+            vault_ids=args.vault_ids,
+            launcher_session_id=session_id,
+            parent_run_id=session.parent_run_id,  # lineage + depth cap
+        )
+    return run.model_dump(mode="json", exclude=_RUN_ECHO_EXCLUDE)
+
+
+async def await_run_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    args = _parse(_AwaitRunArgs, arguments)
+    with _service_errors():
+        resp = await wf_service.await_run(
+            pool,
+            get_settings().db_url,
+            args.run_id,
+            account_id=account_id,
+            timeout_seconds=args.timeout_seconds,
+        )
+    return resp.model_dump(mode="json")
+
+
+# ─── descriptions + registration ─────────────────────────────────────────────
+
+CREATE_WORKFLOW_DESCRIPTION = (
+    "Author a new workflow (a deterministic Python orchestrator) under your account. "
+    "Its declared tool/server surface must be a subset of your own — you cannot grant a "
+    "workflow a tool, MCP server, or HTTP server you don't yourself have. Returns the "
+    "created workflow (id, name, version)."
+)
+UPDATE_WORKFLOW_DESCRIPTION = (
+    "Update one of your workflows in place, bumping its version. Pass the current "
+    "'version' as an optimistic-concurrency token (a stale token is rejected — re-read "
+    "and retry). Omitted fields are preserved. The resulting tool/server surface must "
+    "still be a subset of your own. In-flight runs are unaffected (a run pins its "
+    "workflow's script + surface at launch)."
+)
+CREATE_RUN_DESCRIPTION = (
+    "Launch a run of a workflow you can access. The run executes with the workflow's "
+    "declared surface but only the vaults you attach via 'vault_ids' — which must be a "
+    "subset of the vaults bound to you. It runs in your own environment. Returns the run "
+    "id and status; use await_run to block for its result."
+)
+AWAIT_RUN_DESCRIPTION = (
+    "Block until a run reaches a terminal state (completed/errored/cancelled), or until "
+    "'timeout_seconds' elapses. Returns {done, run_status, output, is_error, error}; if "
+    "not yet done, call again to keep waiting. The session stays responsive while you wait."
+)
+
+
+def _register() -> None:
+    registry.register(
+        name="create_workflow",
+        description=CREATE_WORKFLOW_DESCRIPTION,
+        parameters_schema=WorkflowCreate.model_json_schema(),
+        handler=create_workflow_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name="update_workflow",
+        description=UPDATE_WORKFLOW_DESCRIPTION,
+        parameters_schema=_UpdateWorkflowArgs.model_json_schema(),
+        handler=update_workflow_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name="create_run",
+        description=CREATE_RUN_DESCRIPTION,
+        parameters_schema=_CreateRunArgs.model_json_schema(),
+        handler=create_run_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name="await_run",
+        description=AWAIT_RUN_DESCRIPTION,
+        parameters_schema=_AwaitRunArgs.model_json_schema(),
+        handler=await_run_handler,
+        transport="agent_tool",
+    )
+
+
+_register()

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -11,11 +11,24 @@ from typing import Any
 
 import asyncpg
 
-from aios.db.queries import get_session_vault_ids
+from aios.db.queries import get_environment, get_session_vault_ids
 from aios.db.queries import workflows as wf_queries
-from aios.errors import ForbiddenError, NotFoundError
+from aios.errors import AiosError, ForbiddenError, NotFoundError
 from aios.models.workflows import WfRun
 from aios.services.wake import defer_run_wake
+
+# Vertical recursion bound: how deep a chain of runs (a run whose agent() child
+# launches a sub-run, and so on) may nest. Mirrors WAKE_SESSION_MAX_DEPTH — bounds
+# the strange loop the agent-acting builtins enable. Only the agent path threads a
+# parent_run_id, so the operator/HTTP path (parent_run_id=None) is never capped.
+WORKFLOW_RUN_MAX_DEPTH = 10
+
+
+class WorkflowRunDepthExceededError(AiosError):
+    """A ``create_run`` would nest deeper than ``WORKFLOW_RUN_MAX_DEPTH``."""
+
+    error_type = "workflow_run_depth_exceeded"
+    status_code = 409
 
 
 async def create_run(
@@ -27,6 +40,7 @@ async def create_run(
     input: Any = None,
     vault_ids: list[str] | None = None,
     launcher_session_id: str | None = None,
+    parent_run_id: str | None = None,
 ) -> WfRun:
     """Create a run that snapshots the workflow's current script, then wake it.
 
@@ -34,6 +48,8 @@ async def create_run(
     wake execs exactly that source regardless of later edits to the workflow.
     ``environment_id`` binds the run (and the sessions its ``agent()`` children
     spawn into) to an environment — chosen at run-creation time, like a session's.
+    It is validated as account-owned (``[security]``: a bare FK would accept another
+    tenant's env id and leak its image/env-vars/networking into this run).
 
     ``vault_ids`` binds credentials to the run (resolved at tool-call time, like a
     session's). **Launch-time attenuation:** when ``launcher_session_id`` is set (an
@@ -42,11 +58,32 @@ async def create_run(
     :class:`ForbiddenError`. With no launcher (the HTTP/operator path) the requested
     vaults bind as-is, account-scoped. Insert + bind are one transaction, so a breach
     or a bad vault leaves no run row; the wake fires only after commit.
+
+    ``parent_run_id`` records run lineage (an agent inside a run launching a sub-run)
+    and feeds the **vertical depth cap**: nesting past ``WORKFLOW_RUN_MAX_DEPTH`` raises
+    :class:`WorkflowRunDepthExceededError`. The operator/HTTP path passes none, so it is
+    a root run (never capped).
     """
     requested = list(vault_ids or [])
     async with pool.acquire() as conn, conn.transaction():
+        await get_environment(conn, environment_id, account_id=account_id)  # 404s foreign/absent
         workflow = await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
         script_sha = hashlib.sha256(workflow.script.encode("utf-8")).hexdigest()
+        if parent_run_id is not None:
+            # ``parent_run_id`` is trusted same-account: the only caller that sets it is
+            # the builtin, threading the launcher session's own ``parent_run_id`` (set by
+            # the run-spawn machinery to a same-account run). The account-scoped ancestor
+            # walk relies on that — a foreign parent would resolve to depth 0 and read as
+            # a root. If a future path ever lets ``parent_run_id`` be caller-supplied, it
+            # must be account-validated here (like ``environment_id`` above).
+            parent_depth = await wf_queries.run_ancestor_depth(
+                conn, parent_run_id, account_id=account_id
+            )
+            if parent_depth + 1 > WORKFLOW_RUN_MAX_DEPTH:
+                raise WorkflowRunDepthExceededError(
+                    f"run nesting would exceed depth {WORKFLOW_RUN_MAX_DEPTH}",
+                    detail={"max_depth": WORKFLOW_RUN_MAX_DEPTH, "parent_run_id": parent_run_id},
+                )
         if launcher_session_id is not None:
             held = set(
                 await get_session_vault_ids(conn, launcher_session_id, account_id=account_id)
@@ -62,6 +99,7 @@ async def create_run(
             account_id=account_id,
             workflow_id=workflow_id,
             environment_id=environment_id,
+            parent_run_id=parent_run_id,
             script=workflow.script,
             script_sha=script_sha,
             input=input,

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -37,6 +37,9 @@ from aios.models.vaults import VaultCredentialCreate
 from aios.services import agents as agents_service
 from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
+from aios.tools import workflow_management as wm
+from aios.tools.invoke import ToolBail
+from aios.workflows.service import WORKFLOW_RUN_MAX_DEPTH, WorkflowRunDepthExceededError
 
 pytestmark = pytest.mark.integration
 
@@ -405,3 +408,120 @@ async def test_update_time_attenuation(vault_pool: asyncpg.Pool[Any]) -> None:
         pool, broad.id, account_id=ACC, expected_version=1, description="op-edit"
     )
     assert op.version == 2
+
+
+# ─── agent-acting workflow builtins (slice 3) ────────────────────────────────
+#
+# The handlers call the same attenuated services, supplying the executing session as
+# the trusted actor. These drive the handlers directly (the model dispatch path is
+# what passes session_id; here the test plays that role).
+
+
+async def test_create_workflow_builtin_attenuates(vault_pool: asyncpg.Pool[Any]) -> None:
+    """create_workflow via the builtin: the declared surface ⊆ the executing agent's."""
+    pool = vault_pool
+    s1 = McpServerSpec(name="s1", url="https://s1.example")
+    s2 = McpServerSpec(name="s2", url="https://s2.example")
+    agent = await _make_agent(pool, "builtin-author", mcp_servers=[s1])
+    sess = await _make_session(pool, agent)
+
+    out = await wm.create_workflow_handler(
+        sess, {"name": "wf-bi-ok", "script": _SCRIPT, "mcp_servers": [s1.model_dump(mode="json")]}
+    )
+    assert out["name"] == "wf-bi-ok" and "script" not in out  # heavy field trimmed
+
+    # A server the agent lacks → model-visible ToolBail (the ForbiddenError, converted).
+    with pytest.raises(ToolBail):
+        await wm.create_workflow_handler(
+            sess,
+            {"name": "wf-bi-bad", "script": _SCRIPT, "mcp_servers": [s2.model_dump(mode="json")]},
+        )
+
+
+async def test_create_run_builtin_vault_attenuation_and_env(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """create_run via the builtin: vaults ⊆ the session's; the run inherits the caller's env."""
+    pool = vault_pool
+    vx = await _make_vault(pool, "vx")
+    vy = await _make_vault(pool, "vy")
+    agent = await _make_agent(pool, "builtin-launcher")
+    sess = await _make_session(pool, agent, vault_ids=[vx])
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-bi-run", script=_SCRIPT)
+
+    out = await wm.create_run_handler(sess, {"workflow_id": wf.id, "vault_ids": [vx]})
+    assert out["status"] == "pending"
+    assert out["environment_id"] == ENV  # inherited from the caller session (not model input)
+    assert out["parent_run_id"] is None  # a foreground session launches a root run
+    async with pool.acquire() as conn:
+        assert await wf_queries.get_run_vault_ids(conn, out["id"], account_id=ACC) == [vx]
+
+    # A vault the session doesn't hold → ToolBail, no run row leaks.
+    before = await _run_count(pool)
+    with pytest.raises(ToolBail):
+        await wm.create_run_handler(sess, {"workflow_id": wf.id, "vault_ids": [vy]})
+    assert await _run_count(pool) == before
+
+
+async def test_create_run_builtin_threads_parent_run_id(vault_pool: asyncpg.Pool[Any]) -> None:
+    """The handler threads the caller session's parent_run_id, recording run lineage."""
+    pool = vault_pool
+    agent = await _make_agent(pool, "builtin-nested")
+    sess = await _make_session(pool, agent)
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-bi-nest", script=_SCRIPT)
+    root = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+
+    # Set the parent_run_id column directly (the run-spawn machinery is what populates
+    # it on a real child session); this asserts the handler READS it and threads it.
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE sessions SET parent_run_id = $1 WHERE id = $2", root.id, sess)
+
+    out = await wm.create_run_handler(sess, {"workflow_id": wf.id})
+    assert out["parent_run_id"] == root.id
+
+
+async def test_create_run_depth_cap(vault_pool: asyncpg.Pool[Any]) -> None:
+    """The vertical depth cap: a parent_run_id chain may nest WORKFLOW_RUN_MAX_DEPTH deep, no more."""
+    pool = vault_pool
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-depth", script=_SCRIPT)
+
+    # Build a chain of runs at depths 1..MAX (the root has parent_run_id=None, uncapped).
+    parent: str | None = None
+    for _ in range(WORKFLOW_RUN_MAX_DEPTH):
+        run = await wf_service.create_run(
+            pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, parent_run_id=parent
+        )
+        parent = run.id
+
+    # One more would be depth MAX+1 → refused, and no run row leaks.
+    before = await _run_count(pool)
+    with pytest.raises(WorkflowRunDepthExceededError):
+        await wf_service.create_run(
+            pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, parent_run_id=parent
+        )
+    assert await _run_count(pool) == before
+
+
+async def test_create_run_rejects_foreign_environment(vault_pool: asyncpg.Pool[Any]) -> None:
+    """F2: a run's environment_id must be account-owned — a bare FK would accept a
+    foreign tenant's env and leak its image/env-vars. Bounds the HTTP path too."""
+    pool = vault_pool
+    async with pool.acquire() as conn:
+        # A second tenant (a child account — ACC is already the one active root).
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            "VALUES ('acc_foreign', $1, FALSE, 'foreign')",
+            ACC,
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, name, config, account_id) "
+            "VALUES ('env_foreign', 'fe', '{}'::jsonb, 'acc_foreign')"
+        )
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-env", script=_SCRIPT)
+
+    before = await _run_count(pool)
+    with pytest.raises(NotFoundError):
+        await wf_service.create_run(
+            pool, account_id=ACC, workflow_id=wf.id, environment_id="env_foreign"
+        )
+    assert await _run_count(pool) == before

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -1,0 +1,144 @@
+"""Unit tests for the agent-acting workflow builtins (slice 3).
+
+These stub the worker pool + services so they need no live Postgres. They cover the
+two identity-load-bearing invariants that don't depend on the DB:
+
+* **F1** — a trusted id smuggled into the arguments is rejected by the tool schema
+  (``additionalProperties: false``) before the handler ever runs.
+* **S2** — a 4xx service refusal (or a pydantic semantic error the JSON schema can't
+  encode) becomes a model-visible ``ToolBail``, never a raised exception (which would
+  evict the sandbox); a genuine 5xx still propagates.
+
+Plus the ``await_run`` wiring (it sources ``db_url`` from settings) and the
+script-trimming of returned dicts. Full attenuation/depth behavior is covered by the
+integration tests.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+import aios.tools  # noqa: F401 — registers the builtins
+from aios.errors import CryptoDecryptError, ForbiddenError
+from aios.models.workflows import WfRunWaitResponse, Workflow
+from aios.tools import workflow_management as wm
+from aios.tools.invoke import ToolBail, invoke_builtin
+
+_DT = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime(monkeypatch: Any) -> None:
+    """Make ``require_pool`` + ``load_session_account_id`` cheap (no DB)."""
+    monkeypatch.setattr("aios.harness.runtime.require_pool", lambda: object())
+    monkeypatch.setattr(
+        "aios.services.sessions.load_session_account_id", AsyncMock(return_value="acc_x")
+    )
+
+
+def _workflow(**over: Any) -> Workflow:
+    base: dict[str, Any] = dict(
+        id="wf_1",
+        account_id="acc_x",
+        name="w",
+        version=1,
+        script="SECRET",
+        created_at=_DT,
+        updated_at=_DT,
+    )
+    base.update(over)
+    return Workflow(**base)
+
+
+class TestSchemaRejectsInjectedTrustedIds:
+    """F1: the trusted ids are never schema fields, so injection is rejected up front."""
+
+    async def test_create_workflow_creator_session_id_rejected(self) -> None:
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1",
+                "create_workflow",
+                {"name": "w", "script": "s", "creator_session_id": "ses_victim"},
+            )
+
+    async def test_update_workflow_actor_session_id_rejected(self) -> None:
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1",
+                "update_workflow",
+                {"workflow_id": "wf_1", "version": 1, "actor_session_id": "ses_victim"},
+            )
+
+    async def test_create_run_environment_id_rejected(self) -> None:
+        # F2: environment_id is deliberately NOT a field — the run inherits the caller's.
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1", "create_run", {"workflow_id": "wf_1", "environment_id": "env_other"}
+            )
+
+    async def test_create_run_parent_run_id_rejected(self) -> None:
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1", "create_run", {"workflow_id": "wf_1", "parent_run_id": "wfr_x"}
+            )
+
+
+class TestErrorConversion:
+    async def test_pydantic_semantic_error_becomes_toolbail(self) -> None:
+        # An mcp server named after a builtin passes the JSON schema but fails the
+        # McpServerSpec custom validator — must surface as ToolBail, not a raw exception.
+        with pytest.raises(ToolBail, match="invalid arguments"):
+            await wm.create_workflow_handler(
+                "ses_1",
+                {"name": "w", "script": "s", "mcp_servers": [{"name": "bash", "url": "https://x"}]},
+            )
+
+    async def test_forbidden_becomes_toolbail(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "aios.services.workflows.create_workflow",
+            AsyncMock(
+                side_effect=ForbiddenError("nope", detail={"ungranted": {"tools": ["bash"]}})
+            ),
+        )
+        with pytest.raises(ToolBail, match="nope"):
+            await wm.create_workflow_handler("ses_1", {"name": "w", "script": "s"})
+
+    async def test_internal_5xx_propagates(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "aios.services.workflows.create_workflow",
+            AsyncMock(side_effect=CryptoDecryptError("boom")),
+        )
+        with pytest.raises(CryptoDecryptError):
+            await wm.create_workflow_handler("ses_1", {"name": "w", "script": "s"})
+
+
+class TestReturnShape:
+    async def test_create_workflow_excludes_script(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(
+            "aios.services.workflows.create_workflow",
+            AsyncMock(return_value=_workflow(version=1)),
+        )
+        out = await wm.create_workflow_handler("ses_1", {"name": "w", "script": "SECRET"})
+        assert out["name"] == "w" and out["version"] == 1
+        assert "script" not in out  # heavy snapshot field trimmed
+
+    async def test_await_run_passes_settings_db_url(self, monkeypatch: Any) -> None:
+        mock_await = AsyncMock(
+            return_value=WfRunWaitResponse(run_status="completed", done=True, output=5)
+        )
+        monkeypatch.setattr("aios.services.workflows.await_run", mock_await)
+        monkeypatch.setattr(
+            "aios.tools.workflow_management.get_settings",
+            lambda: SimpleNamespace(db_url="postgres://test-db"),
+        )
+        out = await wm.await_run_handler("ses_1", {"run_id": "wfr_1", "timeout_seconds": 7})
+        assert out["done"] is True and out["output"] == 5
+        # db_url is sourced from settings (positional arg 2), not model input.
+        pos = mock_await.call_args.args
+        assert pos[1] == "postgres://test-db"
+        assert mock_await.call_args.kwargs["timeout_seconds"] == 7


### PR DESCRIPTION
## What

Four model-callable **builtin tools** that let an agent author, edit, launch, and await workflows the way a human operator (or the `aios` CLI) does — the first concrete turn of the **strange loop** (an agent authoring and launching workflows just like you do). Each is a thin wrapper over the existing workflow services, supplying the executing session's id as the trusted actor, so authority is bounded by the same three attenuations slices 1–2 built — now consumed from *inside* a session rather than only over HTTP.

| builtin | wraps | trusted id | attenuation |
|---|---|---|---|
| `create_workflow` | `services.workflows.create_workflow` | `creator_session_id` | surface ⊆ agent's |
| `update_workflow` | `services.workflows.update_workflow` | `actor_session_id` | merged surface ⊆ agent's + version pin |
| `create_run` | `workflows.service.create_run` | `launcher_session_id` | vaults ⊆ session's; depth cap |
| `await_run` | `services.workflows.await_run` | (account from session) | account-scoped; bounded long-poll |

The keystone was already in place: the harness passes the executing `session_id` to every builtin handler (`invoke_builtin`), and the model cannot inject or override it. So all four identity params resolve to one trusted value — this slice *consumes* the identity contract slices 1–2 built. All four register `transport="agent_tool"` (the CLI broker refuses them).

## Adversarial-reviewed before implementation

The plan was red-teamed before a line was written ([review artifact in the plan dir]). Three must-fix gaps are folded in:

- **F1 — confused-deputy:** the trusted ids (`creator/actor/launcher_session_id`, `account_id`, `parent_run_id`, `environment_id`) are **never schema fields**. Every tool schema is `additionalProperties:false` (derived from a pydantic arg model with `extra="forbid"`), so an injected key is rejected by `validate_arguments` *before* the handler runs; handlers map service kwargs explicitly (never `**arguments`). Unit-tested with live injection of each id.
- **F2 — cross-tenant env FK:** `create_run` guarded `environment_id` with a bare `REFERENCES environments(id)` FK (existence, not ownership) — a foreign-tenant env id would bind the run and leak its image/env-vars/networking into `agent()` children. Fixed in the **service** (so the existing **HTTP** path is bounded too): `get_environment` account-scopes it. The builtin doesn't expose `environment_id` at all — it inherits the caller session's env.
- **F3 — recursion:** a vertical run-depth cap (`WORKFLOW_RUN_MAX_DEPTH=10`) via a recursive `parent_run_id` CTE — race-free because the ancestor chain is **immutable** once written (no `UPDATE` ever touches `parent_run_id`), so no lock is needed. Per the **depth-cap-only** governance decision, horizontal fan-out governance is deferred (see residual below).

Plus the call-outs: **A2** (the management API/MCP bypasses builtin attenuation by design — operator-level grant; documented in the module), **B2** (surface×vault split is sound but credential-free endpoints are reachable with zero vaults — same as a session), **S3** (`transport="agent_tool"`; not hard-pinned, since the broker binds `session_id` from the per-session secret so CLI exposure can't forge identity — a special-case resolver carve-out would be the wrong altitude).

## Error contract (S2)

A 4xx service refusal becomes a **model-visible `ToolBail`** via a `_service_errors()` context manager; a 5xx propagates (a raised non-`ToolBail` exception evicts the sandbox via `_tool_lifecycle`). So an attenuation denial reads as a clean `is_error` result the model self-corrects from, not an internal failure.

## Flagged residuals (your call)

1. **F3 horizontal fan-out (depth-cap-only, as you chose):** the depth cap is a no-op for *foreground* launchers (`parent_run_id=None`), so a foreground authoring agent's only bound is the per-run 1000-`agent()`-call ceiling. The red-team rates this ~75; the follow-on (a per-launcher/per-account non-terminal-run cap, advisory-lock idiom) is a clean separate slice. Shipping per your decision; flagging so you can fold the horizontal cap in if you'd rather.
2. **Latent global eviction gap (out of scope here):** the per-handler 4xx→`ToolBail` conversion is locally correct but `_tool_lifecycle`'s `except Exception` evicts the sandbox on *any* non-`ToolBail` raise — so `wake_session`/`schedule_task_*` still evict on their expected 4xx refusals today. The real fix is one rule in `_tool_lifecycle` (`AiosError` with `status_code < 500` → clean `is_error`, no eviction), which would also let these handlers drop `_service_errors`. Deliberately not bundled — it's a cross-cutting behavior change to shared infra deserving its own slice + tests.
3. **`parent_run_id` trust assumption:** the account-scoped depth walk relies on `parent_run_id` being trusted same-account (it comes from the session row, never caller input). Documented inline; if a future path exposes it externally it must be account-validated like `environment_id`.

## Tests

- **unit** (`test_workflow_management.py`) — F1 schema rejection of each injected trusted id; pydantic-semantic error (`mcp name = "bash"`) → `ToolBail`; 4xx → `ToolBail` vs 5xx propagates; returns trim the heavy `script` snapshot; `await_run` sources `db_url` from settings (not model input).
- **integration** (`test_wf_run_vaults.py`) — `create_workflow`/`create_run` attenuation through the handlers; run inherits the caller's env; `parent_run_id` threading; depth cap reaching `MAX` then refusing the next; foreign-env F2 rejection.

mypy + ruff clean; 1810 unit green; openapi + SDK regenerated (the `BuiltinToolType` enum). Went through `/simplify` (subclass `_UpdateWorkflowArgs` over `WorkflowUpdate`; extract the 4× error-conversion into the context manager) and `/code-review --fix` at xhigh — **zero correctness bugs**; the two latent-assumption notes were folded in as documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
