### PR TITLE
fix(dispatch): a client-class tool error is a model-visible refusal, not a sandbox eviction

### DIFF
--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -33,6 +33,7 @@ from typing import Any
 
 import asyncpg
 
+from aios.errors import AiosError
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.models.agents import McpServerSpec
@@ -75,6 +76,29 @@ class _ToolCall:
     raw_args: Any
     bound_log: Any
     is_error: bool = False
+
+
+def _classify_tool_error(err: BaseException) -> tuple[bool, str]:
+    """Decide how a tool handler exception is reported: ``(should_evict, message)``.
+
+    Expected, model-visible refusals do NOT evict the sandbox — the model reads the
+    error and self-corrects:
+      * a :class:`ToolBail` (bad args, unknown tool, schema mismatch), and
+      * a client-class (``status_code < 500``) :class:`AiosError` — a permission denial,
+        not-found, conflict, rate-limit, or any tool ``*ArgumentError``.
+    A server-class (``>= 500``) ``AiosError`` or any other exception is a genuine failure
+    that also evicts the sandbox, which may have been left in a bad state. (The eviction
+    itself is still gated on the caller's ``on_exception`` — the MCP path passes none.)
+    """
+    if isinstance(err, ToolBail):
+        return False, str(err)
+    if isinstance(err, AiosError):
+        # ``default=str`` keeps the serialization total: this runs in an except clause,
+        # so a raise here would skip the tool-result append and ghost the call (invariant
+        # #4). A non-JSON-serializable ``detail`` value renders as its ``str()`` instead.
+        detail = f" ({json.dumps(err.detail, default=str)})" if err.detail else ""
+        return err.status_code >= 500, f"{err.message}{detail}"
+    return True, f"{type(err).__name__}: {err}"
 
 
 @asynccontextmanager
@@ -133,24 +157,17 @@ async def _tool_lifecycle(
         await _append_tool_result(
             pool, session_id, call_id, name, account_id=account_id, error="cancelled"
         )
-    except ToolBail as err:
-        bound_log.info(f"{log_prefix}.bail", error=str(err))
-        tc.is_error = True
-        await _append_tool_result(
-            pool, session_id, call_id, name, account_id=account_id, error=str(err)
-        )
     except Exception as err:
-        bound_log.exception(f"{log_prefix}.handler_failed")
         tc.is_error = True
-        if on_exception is not None:
-            on_exception(session_id)
+        evict, message = _classify_tool_error(err)
+        if evict:
+            bound_log.exception(f"{log_prefix}.handler_failed")
+            if on_exception is not None:
+                on_exception(session_id)
+        else:
+            bound_log.info(f"{log_prefix}.refused", error=message)
         await _append_tool_result(
-            pool,
-            session_id,
-            call_id,
-            name,
-            account_id=account_id,
-            error=f"{type(err).__name__}: {err}",
+            pool, session_id, call_id, name, account_id=account_id, error=message
         )
     finally:
         await sessions_service.append_event(

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -32,16 +32,12 @@ builtins attenuate, therefore agent X is contained" if X also holds it.
 
 from __future__ import annotations
 
-import json
-from collections.abc import Iterator
-from contextlib import contextmanager
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic import ValidationError as PydanticValidationError
 
 from aios.config import get_settings
-from aios.errors import AiosError
 from aios.harness import runtime
 from aios.models.workflows import WorkflowCreate, WorkflowUpdate
 from aios.services import sessions as sessions_service
@@ -90,25 +86,12 @@ class _AwaitRunArgs(BaseModel):
 
 
 # ─── handler plumbing ────────────────────────────────────────────────────────
-
-
-@contextmanager
-def _service_errors() -> Iterator[None]:
-    """Map a client-class (4xx) service refusal to a clean, model-visible ``ToolBail``.
-
-    A raised ``Exception`` from a handler triggers sandbox eviction on the model path
-    (``tool_dispatch._tool_lifecycle``); ``ToolBail`` instead lands as a normal
-    ``is_error`` tool result the model can read and self-correct from. A genuine 5xx is
-    an internal failure and propagates unchanged. Wrap only the service call — the
-    explicit kwarg mapping (the F1 invariant) stays inline inside the ``with`` body.
-    """
-    try:
-        yield
-    except AiosError as exc:
-        if exc.status_code >= 500:
-            raise
-        msg = exc.message if not exc.detail else f"{exc.message} ({json.dumps(exc.detail)})"
-        raise ToolBail(msg) from exc
+#
+# Handlers map service kwargs explicitly (F1) and otherwise just let service errors
+# propagate: the dispatch layer (``tool_dispatch._classify_tool_error``) turns a
+# client-class (4xx) ``AiosError`` — a denied attenuation, a stale-version conflict, a
+# depth-cap hit — into a clean, model-visible result without evicting the sandbox, and
+# a 5xx into a genuine failure. Only argument parsing bails locally (``_parse``).
 
 
 def _parse[M: BaseModel](model: type[M], arguments: dict[str, Any]) -> M:
@@ -124,20 +107,19 @@ async def create_workflow_handler(session_id: str, arguments: dict[str, Any]) ->
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     body = _parse(WorkflowCreate, arguments)
-    with _service_errors():
-        wf = await wf_service.create_workflow(
-            pool,
-            account_id=account_id,
-            name=body.name,
-            script=body.script,
-            input_schema=body.input_schema,
-            output_schema=body.output_schema,
-            description=body.description,
-            tools=body.tools,
-            mcp_servers=body.mcp_servers,
-            http_servers=body.http_servers,
-            creator_session_id=session_id,
-        )
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=account_id,
+        name=body.name,
+        script=body.script,
+        input_schema=body.input_schema,
+        output_schema=body.output_schema,
+        description=body.description,
+        tools=body.tools,
+        mcp_servers=body.mcp_servers,
+        http_servers=body.http_servers,
+        creator_session_id=session_id,
+    )
     return wf.model_dump(mode="json", exclude=_WORKFLOW_ECHO_EXCLUDE)
 
 
@@ -145,22 +127,21 @@ async def update_workflow_handler(session_id: str, arguments: dict[str, Any]) ->
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     args = _parse(_UpdateWorkflowArgs, arguments)
-    with _service_errors():
-        wf = await wf_service.update_workflow(
-            pool,
-            args.workflow_id,
-            account_id=account_id,
-            expected_version=args.version,
-            name=args.name,
-            script=args.script,
-            input_schema=args.input_schema,
-            output_schema=args.output_schema,
-            description=args.description,
-            tools=args.tools,
-            mcp_servers=args.mcp_servers,
-            http_servers=args.http_servers,
-            actor_session_id=session_id,
-        )
+    wf = await wf_service.update_workflow(
+        pool,
+        args.workflow_id,
+        account_id=account_id,
+        expected_version=args.version,
+        name=args.name,
+        script=args.script,
+        input_schema=args.input_schema,
+        output_schema=args.output_schema,
+        description=args.description,
+        tools=args.tools,
+        mcp_servers=args.mcp_servers,
+        http_servers=args.http_servers,
+        actor_session_id=session_id,
+    )
     return wf.model_dump(mode="json", exclude=_WORKFLOW_ECHO_EXCLUDE)
 
 
@@ -169,17 +150,16 @@ async def create_run_handler(session_id: str, arguments: dict[str, Any]) -> dict
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     args = _parse(_CreateRunArgs, arguments)
     session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
-    with _service_errors():
-        run = await wf_service.create_run(
-            pool,
-            account_id=account_id,
-            workflow_id=args.workflow_id,
-            environment_id=session.environment_id,  # inherit caller's env (F2)
-            input=args.input,
-            vault_ids=args.vault_ids,
-            launcher_session_id=session_id,
-            parent_run_id=session.parent_run_id,  # lineage + depth cap
-        )
+    run = await wf_service.create_run(
+        pool,
+        account_id=account_id,
+        workflow_id=args.workflow_id,
+        environment_id=session.environment_id,  # inherit caller's env (F2)
+        input=args.input,
+        vault_ids=args.vault_ids,
+        launcher_session_id=session_id,
+        parent_run_id=session.parent_run_id,  # lineage + depth cap
+    )
     return run.model_dump(mode="json", exclude=_RUN_ECHO_EXCLUDE)
 
 
@@ -187,14 +167,13 @@ async def await_run_handler(session_id: str, arguments: dict[str, Any]) -> dict[
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     args = _parse(_AwaitRunArgs, arguments)
-    with _service_errors():
-        resp = await wf_service.await_run(
-            pool,
-            get_settings().db_url,
-            args.run_id,
-            account_id=account_id,
-            timeout_seconds=args.timeout_seconds,
-        )
+    resp = await wf_service.await_run(
+        pool,
+        get_settings().db_url,
+        args.run_id,
+        account_id=account_id,
+        timeout_seconds=args.timeout_seconds,
+    )
     return resp.model_dump(mode="json")
 
 

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -38,7 +38,6 @@ from aios.services import agents as agents_service
 from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
 from aios.tools import workflow_management as wm
-from aios.tools.invoke import ToolBail
 from aios.workflows.service import WORKFLOW_RUN_MAX_DEPTH, WorkflowRunDepthExceededError
 
 pytestmark = pytest.mark.integration
@@ -430,8 +429,9 @@ async def test_create_workflow_builtin_attenuates(vault_pool: asyncpg.Pool[Any])
     )
     assert out["name"] == "wf-bi-ok" and "script" not in out  # heavy field trimmed
 
-    # A server the agent lacks → model-visible ToolBail (the ForbiddenError, converted).
-    with pytest.raises(ToolBail):
+    # A server the agent lacks → ForbiddenError, which the dispatch layer renders as a
+    # clean model-visible refusal (the handler propagates it; see test_tool_dispatch).
+    with pytest.raises(ForbiddenError):
         await wm.create_workflow_handler(
             sess,
             {"name": "wf-bi-bad", "script": _SCRIPT, "mcp_servers": [s2.model_dump(mode="json")]},
@@ -456,9 +456,10 @@ async def test_create_run_builtin_vault_attenuation_and_env(
     async with pool.acquire() as conn:
         assert await wf_queries.get_run_vault_ids(conn, out["id"], account_id=ACC) == [vx]
 
-    # A vault the session doesn't hold → ToolBail, no run row leaks.
+    # A vault the session doesn't hold → ForbiddenError (dispatch renders it model-visible),
+    # no run row leaks.
     before = await _run_count(pool)
-    with pytest.raises(ToolBail):
+    with pytest.raises(ForbiddenError):
         await wm.create_run_handler(sess, {"workflow_id": wf.id, "vault_ids": [vy]})
     assert await _run_count(pool) == before
 

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -1,14 +1,32 @@
-"""Unit tests for the shared invoke core's ``validate_arguments`` helper.
+"""Unit tests for the model-path tool dispatch: the ``validate_arguments`` helper and
+the ``_classify_tool_error`` eviction policy.
 
-It converts JSON Schema failures into a model-readable error string that
-lists every problem at once so a single retry can fix them all.
+``validate_arguments`` converts JSON Schema failures into a model-readable error string
+that lists every problem at once. ``_classify_tool_error`` decides whether a handler
+exception is an expected model-visible refusal (clean ``is_error`` result, no eviction)
+or a genuine failure (also evicts the sandbox).
 """
 
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
-from aios.tools.invoke import validate_arguments
+import pytest
+
+from aios.errors import (
+    AiosError,
+    ConflictError,
+    CryptoDecryptError,
+    ForbiddenError,
+    NotFoundError,
+    RateLimitedError,
+    ValidationError,
+)
+from aios.harness import tool_dispatch
+from aios.harness.tool_dispatch import _classify_tool_error, _tool_lifecycle
+from aios.tools.bash import BashArgumentError
+from aios.tools.invoke import ToolBail, validate_arguments
 
 _SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -76,3 +94,90 @@ class TestValidateArguments:
         loose: dict[str, Any] = {"type": "object"}
         assert validate_arguments({"anything": "goes"}, loose) is None
         assert validate_arguments({}, loose) is None
+
+
+class _InternalAiosError(AiosError):
+    error_type = "internal_thing"
+    status_code = 500
+
+
+class TestClassifyToolError:
+    @pytest.mark.parametrize(
+        ("err", "evict", "message"),
+        [
+            # Expected, model-visible refusals — never evict the sandbox. The headline
+            # fix: a 400 *ArgumentError (BashArgumentError) is a clean refusal now,
+            # where it used to evict the container along with every other AiosError.
+            (ToolBail("bad args"), False, "bad args"),
+            (BashArgumentError("command must be non-empty"), False, "command must be non-empty"),
+            (ForbiddenError("denied", detail={"x": 1}), False, 'denied ({"x": 1})'),
+            (NotFoundError("no such workflow"), False, "no such workflow"),
+            (ConflictError("stale version"), False, "stale version"),
+            (RateLimitedError("slow down"), False, "slow down"),
+            (ValidationError("bad field"), False, "bad field"),
+            # Genuine failures — also evict the sandbox.
+            (_InternalAiosError("internal boom"), True, "internal boom"),
+            # A 5xx WITH detail still gets the json-suffixed message (the detail-format
+            # branch is independent of the evict decision).
+            (_InternalAiosError("boom", detail={"k": 2}), True, 'boom ({"k": 2})'),
+            (CryptoDecryptError("decrypt failed"), True, "decrypt failed"),
+            (ValueError("oops"), True, "ValueError: oops"),
+            (RuntimeError("kaboom"), True, "RuntimeError: kaboom"),
+        ],
+    )
+    def test_classification(self, err: BaseException, evict: bool, message: str) -> None:
+        assert _classify_tool_error(err) == (evict, message)
+
+
+class TestToolLifecycleEviction:
+    """End-to-end: the classifier wired into ``_tool_lifecycle`` — a refusal appends a
+    clean is_error result without evicting; a genuine failure also evicts."""
+
+    @staticmethod
+    async def _drive(monkeypatch: Any, err: BaseException) -> tuple[list[str], Any]:
+        """Run a handler that raises ``err`` through the lifecycle; the DB writes are
+        stubbed. Returns ``(evict_calls, append_result_mock)``."""
+        monkeypatch.setattr(
+            tool_dispatch.sessions_service,
+            "append_event",
+            AsyncMock(return_value=MagicMock(id="span_1")),
+        )
+        append_result = AsyncMock()
+        monkeypatch.setattr(tool_dispatch, "_append_tool_result", append_result)
+        monkeypatch.setattr(tool_dispatch, "_trigger_sweep", AsyncMock())
+
+        evicted: list[str] = []
+        call = {"id": "tc_1", "function": {"name": "demo", "arguments": "{}"}}
+        async with _tool_lifecycle(
+            MagicMock(),
+            "ses_1",
+            call,
+            account_id="acc_1",
+            log_prefix="tool",
+            on_exception=evicted.append,
+        ):
+            raise err
+        return evicted, append_result
+
+    async def test_client_error_refusal_does_not_evict(self, monkeypatch: Any) -> None:
+        evicted, append_result = await self._drive(
+            monkeypatch, ForbiddenError("denied", detail={"x": 1})
+        )
+        assert evicted == []  # a 4xx refusal must NOT evict the sandbox
+        assert append_result.await_count == 1  # but still appends a model-visible result
+        assert append_result.await_args.kwargs["error"] == 'denied ({"x": 1})'
+
+    async def test_toolbail_does_not_evict(self, monkeypatch: Any) -> None:
+        evicted, append_result = await self._drive(monkeypatch, ToolBail("bad json"))
+        assert evicted == []
+        assert append_result.await_args.kwargs["error"] == "bad json"
+
+    async def test_server_error_evicts(self, monkeypatch: Any) -> None:
+        evicted, append_result = await self._drive(monkeypatch, CryptoDecryptError("boom"))
+        assert evicted == ["ses_1"]  # a 5xx is a genuine failure → evict
+        assert append_result.await_count == 1
+
+    async def test_unexpected_exception_evicts(self, monkeypatch: Any) -> None:
+        evicted, append_result = await self._drive(monkeypatch, ValueError("oops"))
+        assert evicted == ["ses_1"]
+        assert append_result.await_args.kwargs["error"] == "ValueError: oops"

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -5,9 +5,10 @@ two identity-load-bearing invariants that don't depend on the DB:
 
 * **F1** — a trusted id smuggled into the arguments is rejected by the tool schema
   (``additionalProperties: false``) before the handler ever runs.
-* **S2** — a 4xx service refusal (or a pydantic semantic error the JSON schema can't
-  encode) becomes a model-visible ``ToolBail``, never a raised exception (which would
-  evict the sandbox); a genuine 5xx still propagates.
+* **Error handling** — a bad-argument pydantic error the JSON schema can't encode (e.g.
+  an ``McpServerSpec`` name rule) bails locally as a ``ToolBail``; a service ``AiosError``
+  propagates unconverted, leaving the dispatch layer (``_classify_tool_error``) to decide
+  eviction vs. a clean model-visible result (see ``test_tool_dispatch``).
 
 Plus the ``await_run`` wiring (it sources ``db_url`` from settings) and the
 script-trimming of returned dicts. Full attenuation/depth behavior is covered by the
@@ -88,24 +89,29 @@ class TestSchemaRejectsInjectedTrustedIds:
             )
 
 
-class TestErrorConversion:
+class TestErrorPropagation:
     async def test_pydantic_semantic_error_becomes_toolbail(self) -> None:
         # An mcp server named after a builtin passes the JSON schema but fails the
-        # McpServerSpec custom validator — must surface as ToolBail, not a raw exception.
+        # McpServerSpec custom validator — _parse surfaces it as ToolBail (the only
+        # error the handler converts locally; service errors propagate to the dispatch
+        # layer — see test_tool_dispatch).
         with pytest.raises(ToolBail, match="invalid arguments"):
             await wm.create_workflow_handler(
                 "ses_1",
                 {"name": "w", "script": "s", "mcp_servers": [{"name": "bash", "url": "https://x"}]},
             )
 
-    async def test_forbidden_becomes_toolbail(self, monkeypatch: Any) -> None:
+    async def test_service_aios_error_propagates_unconverted(self, monkeypatch: Any) -> None:
+        # The handler no longer converts service errors itself — it lets the AiosError
+        # propagate so the dispatch layer (_classify_tool_error) decides eviction vs a
+        # clean model-visible result. A 4xx ForbiddenError reaches the caller as-is here.
         monkeypatch.setattr(
             "aios.services.workflows.create_workflow",
             AsyncMock(
                 side_effect=ForbiddenError("nope", detail={"ungranted": {"tools": ["bash"]}})
             ),
         )
-        with pytest.raises(ToolBail, match="nope"):
+        with pytest.raises(ForbiddenError, match="nope"):
             await wm.create_workflow_handler("ses_1", {"name": "w", "script": "s"})
 
     async def test_internal_5xx_propagates(self, monkeypatch: Any) -> None:


### PR DESCRIPTION
## What

`_tool_lifecycle` — the model-path tool dispatcher — evicted the sandbox container on **any** non-`ToolBail` handler exception. But every tool error subclasses `AiosError`, and the entire `*ArgumentError` family is status **400** — so a bad argument to *any* builtin (empty `bash` command, malformed `glob` pattern, invalid `schedule_wake` spec), or a `wake_session` permission/rate-limit denial, **tore down the sandbox along with the refusal**. Expected, model-correctable refusals should never evict.

This is the dispatch-layer generalization I flagged as a follow-up in #772.

## The fix

Add `_classify_tool_error(err) -> (should_evict, message)` and collapse the separate `except ToolBail` / `except Exception` clauses into one classified clause:

- a `ToolBail` **or** a client-class (`status_code < 500`) `AiosError` → an expected, model-visible refusal: a clean `is_error` result the model self-corrects from, **no eviction**;
- a server-class (`>= 500`) `AiosError` or any other exception → a genuine failure that **also evicts** (the sandbox may be in a bad state).

Eviction stays gated on the caller's `on_exception`, so the MCP path (which passes none) is unchanged. The `except asyncio.CancelledError` clause is untouched.

```
ToolBail("bad args")              -> (evict=False, "bad args")
BashArgumentError(400)            -> (evict=False, ...)        # was: EVICT
ForbiddenError(403, detail=…)     -> (evict=False, 'denied ({"x": 1})')
RateLimitedError(429)             -> (evict=False, ...)        # was: EVICT
CryptoDecryptError(500)           -> (evict=True,  ...)
ValueError("oops")                -> (evict=True,  "ValueError: oops")
```

## Knock-on cleanup (the #772 follow-up realized)

The slice-3 builtins had a local `_service_errors` context manager doing this 4xx→clean-result conversion **per-handler** — the only place in the codebase that did it. That workaround is **removed**: `workflow_management` handlers now just let `AiosError` propagate, and the policy lives in exactly one place for *all* tools. As a bonus this closes the slice-3 reviewers' note that the builtins' own session lookups (`load_session_account_id` / `get_session_basic`) could `404 → evict`.

## Robustness

`json.dumps(err.detail, default=str)` keeps message rendering **total**: it runs inside an except clause, so a raise there would skip the result append and **ghost the call** (invariant #4, tool-always-appends-result). `errors.py` already defends its FastAPI sibling against the same hazard. Not currently triggerable (no `detail` in the tree carries a non-serializable value) — closed correct-by-construction.

## Follow-up (not in this PR)

The CLI broker (`sandbox/tool_broker.py`) is a **separate** `invoke_builtin` path that does not use `_tool_lifecycle`; it still maps every non-`ToolBail` exception to a 500 envelope. So a 4xx from a *CLI-reachable* builtin (`web_search` / `web_fetch` / `wake_self` / `schedule_task_remove`) now diverges from the model path. It's **cosmetic** (a different status envelope, not a wrong result) and **pre-existing** — the workflow + bash/fs tools are `transport="agent_tool"` and never reach the broker. The clean fix is a shared `AiosError.is_client_error` predicate both paths consume; deferred to its own slice.

## Tests

- **`_classify_tool_error`** — parametrized over refusals vs failures, including a **5xx-with-detail** case (the detail-format branch is independent of the evict decision).
- **`_tool_lifecycle` wiring (end-to-end)** — a handler raising a 4xx refusal appends a clean `is_error` result and does **not** call `on_exception`; a 5xx / unexpected exception does. This covers the actual behavior change (the `if evict: on_exception` branch), which the pure classifier test alone didn't.
- Slice-3 handler tests updated to assert `AiosError` now **propagates** (the dispatch layer converts); the `ToolBail` assertions in the integration tests became `ForbiddenError`.

mypy + ruff clean; **1831 unit** green; integration regression (wf_run_vaults + dispatch paths + wake_session) green. Went through `/simplify` (deleted a redundant test) and `/code-review --fix` at xhigh — **zero correctness bugs**; the `default=str` ghost-prevention and the wiring/coverage tests came directly out of the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
