### PR TITLE
fix(harness): claude-fable-5 support — un-mute trailing-tail-block turns + register litellm cost

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -29,6 +29,26 @@ from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT
 # tool-call-only turns; modify_params tells LiteLLM to sanitize them.
 litellm.modify_params = True
 
+# litellm 1.83.4 predates claude-fable-5, so its model_cost map has no entry for
+# it — ``response_cost`` comes back None and every fable-5 turn records
+# ``cost_usd=null``. Register pricing + capabilities explicitly so ``_extract_cost``
+# works and so per-agent thinking params are accepted for the model. Both the bare
+# id and the ``anthropic/``-prefixed routing id are registered; litellm may look up
+# by either. ``setdefault`` so a future litellm that ships its own entry wins.
+_FABLE5_MODEL_COST = {
+    "input_cost_per_token": 10e-6,
+    "output_cost_per_token": 50e-6,
+    "litellm_provider": "anthropic",
+    "mode": "chat",
+    "supports_reasoning": True,
+    "supports_function_calling": True,
+    "supports_prompt_caching": True,
+    "max_input_tokens": 1_000_000,
+    "max_output_tokens": 128_000,
+}
+for _fable5_key in ("claude-fable-5", "anthropic/claude-fable-5"):
+    litellm.model_cost.setdefault(_fable5_key, _FABLE5_MODEL_COST)
+
 # Default per-call bounds. Kept here so they're visible at the wrapper boundary
 # rather than buried in defaults that drift between LiteLLM versions. Agents
 # can override either via ``litellm_extra``; the spread happens after these

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -276,6 +276,9 @@ def _notification_preview(content: str, metadata: dict[str, Any] | None) -> str:
     return ""
 
 
+_NOTIFICATION_MARKER_PREFIX = "🔔"
+
+
 def _format_notification_marker(
     orig_channel: str,
     metadata: dict[str, Any] | None,
@@ -294,7 +297,7 @@ def _format_notification_marker(
     emitted — it tells the reader how to turn this notification into
     full-content context.
     """
-    parts = [f"🔔 channel_id={orig_channel}"]
+    parts = [f"{_NOTIFICATION_MARKER_PREFIX} channel_id={orig_channel}"]
     if isinstance(metadata, dict):
         sender_name = metadata.get("sender_name")
         if isinstance(sender_name, str) and sender_name:
@@ -305,6 +308,30 @@ def _format_notification_marker(
     header = " · ".join(parts)
     hint = f"(to respond, call switch_channel(channel_id={orig_channel!r}) first)"
     return f"{header}\n{hint}"
+
+
+def message_is_notification_marker(msg: dict[str, Any]) -> bool:
+    """True if *msg* is a non-focal-channel notification marker (``🔔 …``).
+
+    Mirrors the shape produced by :func:`_format_notification_marker`: a
+    user-role message whose (text) content begins with the bell prefix. The
+    composer uses this to tell a *direct* trailing stimulus the agent must
+    answer (a focal inbound or tool result — keep it last, suppress the
+    channels tail block so a literal model doesn't anchor on the tail) apart
+    from a *navigation* prompt (a non-focal notification, whose companion is
+    the tail listing — keep the tail).
+    """
+    if msg.get("role") != "user":
+        return False
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content.startswith(_NOTIFICATION_MARKER_PREFIX)
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                return isinstance(text, str) and text.startswith(_NOTIFICATION_MARKER_PREFIX)
+    return False
 
 
 def render_user_event(

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 from aios.harness._text import join_blocks
 from aios.harness.context import (
     build_messages,
+    message_is_notification_marker,
     separate_adjacent_user_messages,
     stub_missing_reasoning_content,
 )
@@ -271,17 +272,29 @@ def _build_http_servers_block(http_servers: list[HttpServerSpec]) -> str:
 
 
 def _agent_owes_response(messages: list[dict[str, Any]]) -> bool:
-    """True when the conversation ends with a user or tool turn.
+    """True when the conversation ends with a *direct* stimulus to answer.
 
-    Used to gate the ephemeral channels tail block: if the last event-sourced
-    message is a user inbound or a tool result, the agent owes a response and the
-    tail must not be appended (it would become the literal final message and mute
-    literal-minded models). If the last message is an assistant turn, this is an
-    idle/sweep re-check where the channel-status listing is the useful signal.
+    Gates the ephemeral channels tail block. Two trailing cases are a direct
+    stimulus the agent must engage with in focal context, where appending the
+    tail would make a status listing the literal final message and mute
+    literal-minded models (claude-fable-5): a **focal user inbound** (full
+    content) and a **tool result**. Keep the real stimulus last for those.
+
+    Two trailing cases are NOT a direct stimulus, so keep the tail:
+    * a non-focal **notification marker** (``🔔 …``) — the tail's channel
+      listing is its navigation companion (how to ``switch_channel`` to it);
+    * an **assistant** turn — an idle/sweep re-check where the channel-status
+      listing is the useful signal.
     """
     if not messages:
         return False
-    return messages[-1].get("role") in ("user", "tool")
+    last = messages[-1]
+    role = last.get("role")
+    if role == "tool":
+        return True
+    if role == "user":
+        return not message_is_notification_marker(last)
+    return False
 
 
 async def compose_step_context(

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -270,6 +270,20 @@ def _build_http_servers_block(http_servers: list[HttpServerSpec]) -> str:
     return "\n\n".join(sections)
 
 
+def _agent_owes_response(messages: list[dict[str, Any]]) -> bool:
+    """True when the conversation ends with a user or tool turn.
+
+    Used to gate the ephemeral channels tail block: if the last event-sourced
+    message is a user inbound or a tool result, the agent owes a response and the
+    tail must not be appended (it would become the literal final message and mute
+    literal-minded models). If the last message is an assistant turn, this is an
+    idle/sweep re-check where the channel-status listing is the useful signal.
+    """
+    if not messages:
+        return False
+    return messages[-1].get("role") in ("user", "tool")
+
+
 async def compose_step_context(
     *,
     pool: asyncpg.Pool[Any],
@@ -331,8 +345,16 @@ async def compose_step_context(
     # Tail block lives *after* build_messages so its per-step mutations
     # (unread counts, previews) don't bust the prefix cache.  Paradigm
     # prose stays in the cache-stable system prompt above.
+    #
+    # Only append it when the conversation already ends with an assistant turn
+    # (an idle/sweep re-check, where the channel-status listing is the useful
+    # signal). When the last message is a user or tool turn, the agent owes a
+    # response: appending the tail makes a "0 unread" status block the literal
+    # final message, and literal-minded models (claude-fable-5) anchor on it and
+    # emit an empty turn instead of answering (opus looks back past it; fable does
+    # not). Keep the real stimulus last in that case.
     tail = build_channels_tail_block(channels, events, session.focal_channel)
-    if tail is not None:
+    if tail is not None and not _agent_owes_response(ctx.messages):
         ctx.messages.append(tail)
 
     # Block LiteLLM's adjacent-same-role merge on Anthropic so the tail

--- a/tests/unit/test_completion_model_cost.py
+++ b/tests/unit/test_completion_model_cost.py
@@ -1,0 +1,35 @@
+"""Tests for the claude-fable-5 ``litellm.model_cost`` registration.
+
+litellm 1.83.4 predates claude-fable-5, so its model_cost map ships no entry
+and ``response_cost`` comes back None — every fable-5 turn would record
+``cost_usd=null``. Importing ``aios.harness.completion`` registers pricing +
+capabilities explicitly (both the bare id and the ``anthropic/``-prefixed
+routing id), so cost extraction works.
+"""
+
+from __future__ import annotations
+
+import litellm
+
+# Import for the registration side-effect at module import time.
+import aios.harness.completion  # noqa: F401
+
+
+class TestFable5ModelCostRegistration:
+    def test_bare_id_registered_with_pricing(self) -> None:
+        entry = litellm.model_cost["claude-fable-5"]
+        assert entry["input_cost_per_token"] == 10e-6
+        assert entry["output_cost_per_token"] == 50e-6
+
+    def test_prefixed_id_registered_with_pricing(self) -> None:
+        entry = litellm.model_cost["anthropic/claude-fable-5"]
+        assert entry["input_cost_per_token"] == 10e-6
+        assert entry["output_cost_per_token"] == 50e-6
+
+    def test_capabilities_registered(self) -> None:
+        entry = litellm.model_cost["claude-fable-5"]
+        assert entry["litellm_provider"] == "anthropic"
+        assert entry["mode"] == "chat"
+        assert entry["supports_reasoning"] is True
+        assert entry["supports_function_calling"] is True
+        assert entry["supports_prompt_caching"] is True

--- a/tests/unit/test_step_context_tail_gate.py
+++ b/tests/unit/test_step_context_tail_gate.py
@@ -3,25 +3,51 @@
 The ephemeral channels tail block (unread counts / previews) is appended
 *after* ``build_messages`` so its per-step churn doesn't bust the prefix
 cache. But when the agent owes a response — the last event-sourced message
-is a user inbound or a tool result — appending the tail makes a "0 unread"
+is a focal user inbound or a tool result — appending the tail makes a "0 unread"
 status block the literal final message. Literal-minded models (claude-fable-5)
 anchor on it and emit an empty turn instead of answering. The gate suppresses
-the tail in that case; it's only appended on idle/sweep re-checks where the
-conversation already ends with an assistant turn.
+the tail in that case. It is kept (1) on idle/sweep re-checks where the
+conversation already ends with an assistant turn, and (2) when the trailing
+message is a non-focal notification marker (``🔔 …``), whose navigation
+companion *is* the channels tail listing.
 """
 
 from __future__ import annotations
 
 from aios.harness.step_context import _agent_owes_response
 
+# Mirrors the shape of context._format_notification_marker output.
+_NOTIFICATION = (
+    "🔔 channel_id=signal/+1/chat-a · channel inbound\n"
+    "(to respond, call switch_channel(channel_id='signal/+1/chat-a') first)"
+)
+
 
 class TestAgentOwesResponse:
-    def test_last_message_user_owes_response(self) -> None:
+    def test_last_message_focal_user_owes_response(self) -> None:
         messages = [
             {"role": "system", "content": "sys"},
-            {"role": "user", "content": "hi"},
+            {"role": "user", "content": "[received=...]\nplease respond"},
         ]
         assert _agent_owes_response(messages) is True
+
+    def test_last_message_notification_marker_does_not_owe_response(self) -> None:
+        # A non-focal 🔔 marker is a navigation prompt, not a direct stimulus —
+        # keep the tail so the agent can see channel state and switch_channel.
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "[received=...]\nhi"},
+            {"role": "assistant", "content": "."},
+            {"role": "user", "content": _NOTIFICATION},
+        ]
+        assert _agent_owes_response(messages) is False
+
+    def test_notification_marker_in_list_content_does_not_owe(self) -> None:
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": [{"type": "text", "text": _NOTIFICATION}]},
+        ]
+        assert _agent_owes_response(messages) is False
 
     def test_last_message_tool_owes_response(self) -> None:
         messages = [

--- a/tests/unit/test_step_context_tail_gate.py
+++ b/tests/unit/test_step_context_tail_gate.py
@@ -1,0 +1,43 @@
+"""Tests for the channels tail-block gate (``_agent_owes_response``).
+
+The ephemeral channels tail block (unread counts / previews) is appended
+*after* ``build_messages`` so its per-step churn doesn't bust the prefix
+cache. But when the agent owes a response — the last event-sourced message
+is a user inbound or a tool result — appending the tail makes a "0 unread"
+status block the literal final message. Literal-minded models (claude-fable-5)
+anchor on it and emit an empty turn instead of answering. The gate suppresses
+the tail in that case; it's only appended on idle/sweep re-checks where the
+conversation already ends with an assistant turn.
+"""
+
+from __future__ import annotations
+
+from aios.harness.step_context import _agent_owes_response
+
+
+class TestAgentOwesResponse:
+    def test_last_message_user_owes_response(self) -> None:
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ]
+        assert _agent_owes_response(messages) is True
+
+    def test_last_message_tool_owes_response(self) -> None:
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "result"},
+        ]
+        assert _agent_owes_response(messages) is True
+
+    def test_last_message_assistant_does_not_owe_response(self) -> None:
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert _agent_owes_response(messages) is False
+
+    def test_empty_list_does_not_owe_response(self) -> None:
+        assert _agent_owes_response([]) is False


### PR DESCRIPTION
## Why

Putting an agent on `claude-fable-5` surfaced two harness issues. Empirically root-caused and A/B-proven against the live `metals-factchecker`/Ultron session.

## Fix 1 — channels tail block no longer mutes literal-minded models

The per-step `━━━ Channels ━━━ … N unread` status block is appended as the **final** message every turn, after the real user/tool stimulus, with a `.` separator. `claude-fable-5` follows message order literally, anchors on that trailing "0 unread" status block, and emits an **empty turn** (1–9 output tokens, no `signal_send`) instead of answering. `opus-4.x` looks back past it; fable does not.

A/B proof on the real failing turn (`sess_01KQ8N…YWF`, the actual "Ultron… please respond"):

| Last message in context | fable-5 result |
|---|---|
| channels tail block | `out_tok=3, content=""` → **silent** |
| the real user message | `out_tok=465` → "Yes — I'm receiving messages…" |

The fix gates the tail append on `_agent_owes_response(ctx.messages)`: suppress the tail when the conversation ends with a **user/tool** turn (agent owes a reply — keep the real stimulus last); keep it when it ends with an **assistant** turn (idle/sweep re-check, where the channel-status listing is the useful signal). Verified end-to-end on prod data: failing turn now replies (465 tokens), idle turns still get the tail (no regression). Benefits every model — fable just made the latent issue visible.

## Fix 2 — register `claude-fable-5` in `litellm.model_cost`

litellm 1.83.4 predates the model, so `response_cost` came back `None` and **every fable-5 turn recorded `cost_usd=null`**. Register pricing ($10/$50 per MTok) + capabilities for both the bare and `anthropic/`-prefixed ids via `setdefault` (a future litellm that ships its own entry wins). Proven: cost goes from `null` → `0.013` on a fable-5 call.

## Tests

- `test_step_context_tail_gate.py` — `_agent_owes_response` for user/tool/assistant/empty endings.
- `test_completion_model_cost.py` — fable-5 pricing + capabilities registered for both ids.
- 255 existing unit tests in the touched areas still pass.

## Not in scope / follow-up

- `max_tail_block_local` still reserves tail-block tokens in the window budget on turns where the tail is now suppressed — a pre-existing upper-bound reservation, now slightly wasteful but never incorrect.
- The cache `cache_read=0`-on-slow-sessions observation was investigated and intentionally **not** changed: it's the default 5-min ephemeral TTL expiring between slow operator wakes (not a fable bug — caching works), and the operator chose to keep the 5-min TTL rather than pay the 2× write premium of a 1h TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
