### PR TITLE
feat(workflows): horizontal fan-out caps + launcher-attenuated cancel_run builtin

### DIFF
--- a/migrations/versions/0078_run_launcher_and_fanout_cap.py
+++ b/migrations/versions/0078_run_launcher_and_fanout_cap.py
@@ -1,0 +1,48 @@
+"""wf_runs.launcher_session_id + the fan-out cap's count index.
+
+Persists WHO launched a run (the agent session that called the ``create_run``
+builtin; NULL = the operator/HTTP path), enabling the horizontal fan-out cap:
+a per-launcher-session and per-account ceiling on OUTSTANDING (non-terminal)
+runs, counted under a per-account advisory lock at launch time. The vertical
+depth cap (parent_run_id chain) bounds nesting; this bounds sibling fan-out —
+without it a model in a loop could launch unbounded root runs.
+
+``ON DELETE SET NULL``: session rows are hard-deleted via the operator API, so
+a bare FK would break session deletion; a deleted launcher reclassifies its
+live runs as operator-launched (account cap only) — an operator-only surface.
+
+Backfill is NULL for ALL existing rows, including past agent-launched runs
+(the launcher was never persisted before this migration). Those rows escape
+the per-launcher count until they reach a terminal status — a one-time grace
+window, bounded by the account cap like any operator launch.
+
+The partial index serves both cap counts (account via prefix); its status
+list must stay verbatim-identical to ``count_active_runs`` and the
+``wf_runs_active_idx`` predicate (0064) so the planner can use it.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0078"
+down_revision: str = "0077"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE wf_runs ADD COLUMN launcher_session_id text "
+        "REFERENCES sessions(id) ON DELETE SET NULL"
+    )
+    op.execute(r"""
+        CREATE INDEX wf_runs_launcher_active_idx
+            ON wf_runs (account_id, launcher_session_id)
+            WHERE archived_at IS NULL AND status IN ('pending','running','suspended')
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX wf_runs_launcher_active_idx")
+    op.execute("ALTER TABLE wf_runs DROP COLUMN launcher_session_id")

--- a/openapi.json
+++ b/openapi.json
@@ -8655,7 +8655,7 @@
           "runs"
         ],
         "summary": "Await Run",
-        "description": "Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.\n\nThe ``await``-a-completion primitive (runs backing): one JSON round-trip returning the\ncompletion record \u2014 ``done`` + ``output``, or ``is_error`` + ``error``. A run still running\nafter ``timeout`` seconds returns ``done=false`` with its current status; call again to keep\nblocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP\ntool \u2014 an agent can await a sub-run and join. A cross-tenant run 404s.",
+        "description": "Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.\n\nThe ``await``-a-completion primitive (runs backing): one JSON round-trip returning the\ncompletion record \u2014 ``done`` + ``output``, or ``is_error`` + ``error``. A run still running\nafter ``timeout`` seconds returns ``done=false`` with its current status; call again to keep\nblocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP\ntool \u2014 an agent can await a sub-run and join. A cross-tenant run 404s.",
         "operationId": "await_run",
         "parameters": [
           {
@@ -10541,6 +10541,7 @@
             "title": "Result"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "gate_nonce"
@@ -14317,7 +14318,8 @@
                   "create_workflow",
                   "update_workflow",
                   "create_run",
-                  "await_run"
+                  "await_run",
+                  "cancel_run"
                 ]
               },
               {
@@ -15244,6 +15246,17 @@
             ],
             "title": "Parent Run Id"
           },
+          "launcher_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Launcher Session Id"
+          },
           "script": {
             "type": "string",
             "title": "Script"
@@ -15356,13 +15369,14 @@
             "description": "Vault ids to bind to the run for credential resolution. When an agent launches the run, these must be a subset of the launcher's own vaults; the HTTP path is unattenuated operator authority."
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "workflow_id",
           "environment_id"
         ],
         "title": "WfRunCreate",
-        "description": "Request body for ``POST /v1/runs`` \u2014 launch a run of a workflow.\n\n``input`` is arbitrary JSON (a workflow's input need not be an object). The run\nbinds to ``environment_id`` (like a session), into which its ``agent()`` children\nspawn."
+        "description": "Request body for ``POST /v1/runs`` \u2014 launch a run of a workflow.\n\n``input`` is arbitrary JSON (a workflow's input need not be an object). The run\nbinds to ``environment_id`` (like a session), into which its ``agent()`` children\nspawn. (``launcher_session_id`` is deliberately NOT a field \u2014 trusted ids never\nride in request bodies; the HTTP path is always an operator launch.)"
       },
       "WfRunEvent": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/await_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/await_run.py
@@ -78,7 +78,7 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | WfRunWaitResponse]:
     """Await Run
 
-     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+     Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.
 
     The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
     completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
@@ -121,7 +121,7 @@ def sync(
 ) -> HTTPValidationError | WfRunWaitResponse | None:
     """Await Run
 
-     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+     Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.
 
     The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
     completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
@@ -159,7 +159,7 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | WfRunWaitResponse]:
     """Await Run
 
-     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+     Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.
 
     The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
     completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running
@@ -200,7 +200,7 @@ async def asyncio(
 ) -> HTTPValidationError | WfRunWaitResponse | None:
     """Await Run
 
-     Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+     Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.
 
     The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
     completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/create_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/create_run.py
@@ -83,7 +83,8 @@ def sync_detailed(
 
             ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
             binds to ``environment_id`` (like a session), into which its ``agent()`` children
-            spawn.
+            spawn. (``launcher_session_id`` is deliberately NOT a field — trusted ids never
+            ride in request bodies; the HTTP path is always an operator launch.)
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -125,7 +126,8 @@ def sync(
 
             ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
             binds to ``environment_id`` (like a session), into which its ``agent()`` children
-            spawn.
+            spawn. (``launcher_session_id`` is deliberately NOT a field — trusted ids never
+            ride in request bodies; the HTTP path is always an operator launch.)
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -162,7 +164,8 @@ async def asyncio_detailed(
 
             ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
             binds to ``environment_id`` (like a session), into which its ``agent()`` children
-            spawn.
+            spawn. (``launcher_session_id`` is deliberately NOT a field — trusted ids never
+            ride in request bodies; the HTTP path is always an operator launch.)
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -202,7 +205,8 @@ async def asyncio(
 
             ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
             binds to ``environment_id`` (like a session), into which its ``agent()`` children
-            spawn.
+            spawn. (``launcher_session_id`` is deliberately NOT a field — trusted ids never
+            ride in request bodies; the HTTP path is always an operator launch.)
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/models/gate_resume.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/gate_resume.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
-from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -26,7 +25,6 @@ class GateResume:
 
     gate_nonce: str
     result: Any | Unset = UNSET
-    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         gate_nonce = self.gate_nonce
@@ -34,7 +32,7 @@ class GateResume:
         result = self.result
 
         field_dict: dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
+
         field_dict.update(
             {
                 "gate_nonce": gate_nonce,
@@ -57,21 +55,4 @@ class GateResume:
             result=result,
         )
 
-        gate_resume.additional_properties = d
         return gate_resume
-
-    @property
-    def additional_keys(self) -> list[str]:
-        return list(self.additional_properties.keys())
-
-    def __getitem__(self, key: str) -> Any:
-        return self.additional_properties[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        self.additional_properties[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self.additional_properties[key]
-
-    def __contains__(self, key: str) -> bool:
-        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
@@ -5,6 +5,7 @@ class ToolSpecTypeType0(str, Enum):
     AWAIT_RUN = "await_run"
     BASH = "bash"
     CANCEL = "cancel"
+    CANCEL_RUN = "cancel_run"
     CREATE_RUN = "create_run"
     CREATE_WORKFLOW = "create_workflow"
     EDIT = "edit"

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -44,6 +44,7 @@ class WfRun:
             created_at (datetime.datetime):
             updated_at (datetime.datetime):
             parent_run_id (None | str | Unset):
+            launcher_session_id (None | str | Unset):
             tools (list[ToolSpec] | Unset):
             mcp_servers (list[McpServerSpec] | Unset):
             http_servers (list[HttpServerSpec] | Unset):
@@ -63,6 +64,7 @@ class WfRun:
     created_at: datetime.datetime
     updated_at: datetime.datetime
     parent_run_id: None | str | Unset = UNSET
+    launcher_session_id: None | str | Unset = UNSET
     tools: list[ToolSpec] | Unset = UNSET
     mcp_servers: list[McpServerSpec] | Unset = UNSET
     http_servers: list[HttpServerSpec] | Unset = UNSET
@@ -97,6 +99,12 @@ class WfRun:
             parent_run_id = UNSET
         else:
             parent_run_id = self.parent_run_id
+
+        launcher_session_id: None | str | Unset
+        if isinstance(self.launcher_session_id, Unset):
+            launcher_session_id = UNSET
+        else:
+            launcher_session_id = self.launcher_session_id
 
         tools: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.tools, Unset):
@@ -149,6 +157,8 @@ class WfRun:
         )
         if parent_run_id is not UNSET:
             field_dict["parent_run_id"] = parent_run_id
+        if launcher_session_id is not UNSET:
+            field_dict["launcher_session_id"] = launcher_session_id
         if tools is not UNSET:
             field_dict["tools"] = tools
         if mcp_servers is not UNSET:
@@ -199,6 +209,17 @@ class WfRun:
             return cast(None | str | Unset, data)
 
         parent_run_id = _parse_parent_run_id(d.pop("parent_run_id", UNSET))
+
+        def _parse_launcher_session_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        launcher_session_id = _parse_launcher_session_id(
+            d.pop("launcher_session_id", UNSET)
+        )
 
         _tools = d.pop("tools", UNSET)
         tools: list[ToolSpec] | Unset = UNSET
@@ -260,6 +281,7 @@ class WfRun:
             created_at=created_at,
             updated_at=updated_at,
             parent_run_id=parent_run_id,
+            launcher_session_id=launcher_session_id,
             tools=tools,
             mcp_servers=mcp_servers,
             http_servers=http_servers,

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
@@ -4,7 +4,6 @@ from collections.abc import Mapping
 from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
-from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -17,7 +16,8 @@ class WfRunCreate:
 
     ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
     binds to ``environment_id`` (like a session), into which its ``agent()`` children
-    spawn.
+    spawn. (``launcher_session_id`` is deliberately NOT a field — trusted ids never
+    ride in request bodies; the HTTP path is always an operator launch.)
 
         Attributes:
             workflow_id (str):
@@ -31,7 +31,6 @@ class WfRunCreate:
     environment_id: str
     input_: Any | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
-    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         workflow_id = self.workflow_id
@@ -45,7 +44,7 @@ class WfRunCreate:
             vault_ids = self.vault_ids
 
         field_dict: dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
+
         field_dict.update(
             {
                 "workflow_id": workflow_id,
@@ -77,21 +76,4 @@ class WfRunCreate:
             vault_ids=vault_ids,
         )
 
-        wf_run_create.additional_properties = d
         return wf_run_create
-
-    @property
-    def additional_keys(self) -> list[str]:
-        return list(self.additional_properties.keys())
-
-    def __getitem__(self, key: str) -> Any:
-        return self.additional_properties[key]
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        self.additional_properties[key] = value
-
-    def __delitem__(self, key: str) -> None:
-        del self.additional_properties[key]
-
-    def __contains__(self, key: str) -> bool:
-        return key in self.additional_properties

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -199,7 +199,7 @@ async def await_run(
     account_id: AccountIdDep,
     timeout_seconds: Annotated[int, Query(alias="timeout", ge=0, le=60)] = 30,
 ) -> WfRunWaitResponse:
-    """Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+    """Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.
 
     The ``await``-a-completion primitive (runs backing): one JSON round-trip returning the
     completion record — ``done`` + ``output``, or ``is_error`` + ``error``. A run still running

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -333,6 +333,27 @@ class Settings(BaseSettings):
         "— a child doing real model+tool work can legitimately run for minutes; "
         "this is the never-resolves backstop, not a tight SLA.",
     )
+    workflow_runs_per_launcher_max: int = Field(
+        default=20,
+        ge=1,
+        description="Per-launcher-session ceiling on OUTSTANDING (non-terminal) "
+        "runs — the horizontal fan-out bound on the agent's ``create_run`` "
+        "builtin (the operator/HTTP path has no launcher and is exempt). A "
+        "concurrency cap, not a rate or lifetime budget: slots free as runs "
+        "reach a terminal status, so a sequential launch loop is unbounded by "
+        "design. Enforced with the per-account cap under one advisory lock; "
+        "on exceed, ``create_run`` raises ``RateLimitedError``.",
+    )
+    workflow_runs_per_account_max: int = Field(
+        default=100,
+        ge=1,
+        description="Per-account ceiling on OUTSTANDING (non-terminal) runs "
+        "across all launchers, operator launches included — the backstop the "
+        "per-launcher cap can't provide (many sessions, or a run's agent() "
+        "children, are each fresh launchers). Same concurrency-not-budget "
+        "semantics; worst-case standing exposure is this many runs each "
+        "entitled to ``workflow_max_agent_calls`` children.",
+    )
 
     # ── connectors ─────────────────────────────────────────────────────────
     connector_backfill_max_age_seconds: int = Field(

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -66,6 +66,7 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         account_id=row["account_id"],
         environment_id=row["environment_id"],
         parent_run_id=row["parent_run_id"],
+        launcher_session_id=row["launcher_session_id"],
         script=row["script"],
         script_sha=row["script_sha"],
         tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
@@ -356,21 +357,24 @@ async def insert_wf_run(
     script_sha: str,
     input: Any = None,
     parent_run_id: str | None = None,
+    launcher_session_id: str | None = None,
     tools: list[ToolSpec] | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
     http_servers: list[HttpServerSpec] | None = None,
 ) -> WfRun:
     """Insert a fresh ``pending`` run that snapshots ``script`` (+ ``script_sha``) and the
-    declared tool surface (``tools``/``mcp_servers``/``http_servers``) — pinned at launch."""
+    declared tool surface (``tools``/``mcp_servers``/``http_servers``) — pinned at launch.
+    ``launcher_session_id`` records the agent session that launched it (NULL = operator)."""
     new_id = make_id(WORKFLOW_RUN)
     try:
         row = await conn.fetchrow(
             """
             INSERT INTO wf_runs
                 (id, workflow_id, account_id, environment_id, parent_run_id,
-                 script, script_sha, status, input, tools, mcp_servers, http_servers)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending', $8::jsonb,
-                    $9::jsonb, $10::jsonb, $11::jsonb)
+                 launcher_session_id, script, script_sha, status, input,
+                 tools, mcp_servers, http_servers)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', $9::jsonb,
+                    $10::jsonb, $11::jsonb, $12::jsonb)
             RETURNING *
             """,
             new_id,
@@ -378,6 +382,7 @@ async def insert_wf_run(
             account_id,
             environment_id,
             parent_run_id,
+            launcher_session_id,
             script,
             script_sha,
             json.dumps(input) if input is not None else None,
@@ -387,8 +392,13 @@ async def insert_wf_run(
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
-            f"workflow {workflow_id} or environment {environment_id} not found",
-            detail={"workflow_id": workflow_id, "environment_id": environment_id},
+            "a referenced resource is gone: workflow, environment, parent run, or launcher session",
+            detail={
+                "workflow_id": workflow_id,
+                "environment_id": environment_id,
+                "parent_run_id": parent_run_id,
+                "launcher_session_id": launcher_session_id,
+            },
         ) from exc
     assert row is not None
     return _row_to_wf_run(row)
@@ -419,6 +429,59 @@ async def run_ancestor_depth(conn: asyncpg.Connection[Any], run_id: str, *, acco
         account_id,
     )
     return depth or 0
+
+
+async def count_active_runs(
+    conn: asyncpg.Connection[Any], *, account_id: str, launcher_session_id: str | None = None
+) -> int:
+    """Count the account's OUTSTANDING (non-terminal, non-archived) runs — optionally
+    only those launched by one session. The two fan-out cap reads.
+
+    The status list is verbatim-identical to the ``wf_runs_launcher_active_idx``
+    predicate (migration 0078) — keep them in sync so the planner uses the partial
+    index — and is the exact complement of ``TERMINAL_RUN_STATUSES``.
+
+    Cap invariant: ``archived_at IS NULL`` assumes archival is terminal-only. No run
+    archival exists today; if one lands, it must refuse non-terminal runs (or take
+    ``acquire_account_wf_runs_lock``), else an archived-but-running run would escape
+    the count while still consuming real capacity.
+    """
+    if launcher_session_id is None:
+        count: int = await conn.fetchval(
+            """
+            SELECT count(*) FROM wf_runs
+             WHERE account_id = $1 AND archived_at IS NULL
+               AND status IN ('pending','running','suspended')
+            """,
+            account_id,
+        )
+        return count
+    count = await conn.fetchval(
+        """
+        SELECT count(*) FROM wf_runs
+         WHERE account_id = $1 AND launcher_session_id = $2 AND archived_at IS NULL
+           AND status IN ('pending','running','suspended')
+        """,
+        account_id,
+        launcher_session_id,
+    )
+    return count
+
+
+async def acquire_account_wf_runs_lock(conn: asyncpg.Connection[Any], account_id: str) -> None:
+    """Take the per-account, transaction-scoped advisory lock serializing the fan-out
+    cap's COUNT+INSERT (released automatically at commit/rollback).
+
+    One account-level lock guards BOTH caps (a launcher's runs are a subset of its
+    account's), making them contractual against concurrent launches rather than
+    best-effort. The key is ``hashtextextended('aios_wf_runs_cap:' || account_id, 0)``
+    — a distinct namespace from the scheduled-tasks and worker-singleton locks, and
+    the two cap locks are never co-held in one transaction (no deadlock cycle).
+    """
+    await conn.execute(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        f"aios_wf_runs_cap:{account_id}",
+    )
 
 
 async def set_run_vaults(

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -96,13 +96,13 @@ class ForbiddenError(AiosError):
 
 
 class RateLimitedError(AiosError):
-    """Per-account resource cap exceeded.
+    """A resource-cap ceiling was reached.
 
-    Raised when a tenant has reached a per-account ceiling — currently
-    only the scheduled_tasks-per-account cap (see
-    ``Settings.scheduled_tasks_per_account_max``), but the type is
-    intentionally general so future caps (active sessions, MCP
-    connections, etc.) can reuse it.
+    Raised for the scheduled-tasks caps (``Settings.scheduled_tasks_per_account_max``
+    + the per-session cap) and the workflow-run fan-out caps
+    (``Settings.workflow_runs_per_launcher_max`` / ``workflow_runs_per_account_max``).
+    Intentionally general so future caps (active sessions, MCP connections, etc.)
+    can reuse it.
     """
 
     error_type = "rate_limited"

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -39,6 +39,7 @@ BuiltinToolType = Literal[
     "update_workflow",
     "create_run",
     "await_run",
+    "cancel_run",
 ]
 
 # Permission policy for built-in tools. Custom tools are always client-controlled

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -69,6 +69,9 @@ class WfRun(BaseModel):
     account_id: str
     environment_id: str  # the run binds to an environment; agent() children inherit it
     parent_run_id: str | None = None
+    # The agent session that launched this run (None = operator/HTTP). Lineage, plus
+    # the per-launcher fan-out cap's count key.
+    launcher_session_id: str | None = None
     script: str
     script_sha: str
     tools: list[ToolSpec] = Field(default_factory=list)
@@ -125,8 +128,8 @@ class WfRunWaitResponse(BaseModel):
     """
 
     run_status: WfRunStatus
-    done: bool  # run_status in {completed, errored} — terminal, never reverts
-    output: Any = None  # the run's return value (on completed; None on error)
+    done: bool  # run_status in TERMINAL_RUN_STATUSES (completed/errored/cancelled)
+    output: Any = None  # the run's return value (on completed; None otherwise)
     is_error: bool = False  # run_status == errored
     error: dict[str, Any] | None = None  # the run_completed event's {kind} (on errored)
 
@@ -182,8 +185,11 @@ class WfRunCreate(BaseModel):
 
     ``input`` is arbitrary JSON (a workflow's input need not be an object). The run
     binds to ``environment_id`` (like a session), into which its ``agent()`` children
-    spawn.
+    spawn. (``launcher_session_id`` is deliberately NOT a field — trusted ids never
+    ride in request bodies; the HTTP path is always an operator launch.)
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     workflow_id: str
     environment_id: str
@@ -205,6 +211,8 @@ class GateResume(BaseModel):
     ``call_started`` event), not the internal ``call_key``. ``result`` is the
     externally-delivered resume value (arbitrary JSON).
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     gate_nonce: str
     result: Any = None

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -290,7 +290,7 @@ async def await_run(
     account_id: str,
     timeout_seconds: float,
 ) -> WfRunWaitResponse:
-    """Block until the run reaches a terminal status (``completed``/``errored``), or ``timeout``.
+    """Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.
 
     The run backing of the ``await``-a-completion primitive. Account-scopes the run FIRST (so a
     cross-tenant/missing ``run_id`` 404s before we open any connection — mirroring ``/stream``,
@@ -365,7 +365,12 @@ async def resume_gate_by_nonce(
 
 
 async def cancel_run(
-    pool: asyncpg.Pool[Any], *, run_id: str, account_id: str, reason: Any = None
+    pool: asyncpg.Pool[Any],
+    *,
+    run_id: str,
+    account_id: str,
+    reason: Any = None,
+    canceller_session_id: str | None = None,
 ) -> WfRun:
     """Request cancellation of a run, returning it (still in its pre-cancel status).
 
@@ -376,12 +381,23 @@ async def cancel_run(
     on the wake, so the returned run still shows its current status — as gate-resume
     returns a still-``suspended`` run.
 
+    **Cancel-time attenuation:** when ``canceller_session_id`` is set (an agent
+    cancelling via the builtin), the run must have been launched by that very session
+    — you may cancel what you launched, nothing else; a breach raises
+    :class:`ForbiddenError`. With no canceller (the HTTP/operator path) any
+    account-scoped run may be cancelled.
+
     Idempotent: an already-terminal run is returned unchanged, with no signal or
     wake. A cross-tenant / missing run 404s (via :func:`get_wf_run`).
     """
     async with pool.acquire() as conn:
         run = await wf_queries.get_wf_run(conn, run_id, account_id=account_id)  # 404s cross-tenant
-        if run.status in ("completed", "errored", "cancelled"):
+        if canceller_session_id is not None and run.launcher_session_id != canceller_session_id:
+            raise ForbiddenError(
+                "run was not launched by this session; only the operator can cancel it",
+                detail={"run_id": run_id},
+            )
+        if run.status in TERMINAL_RUN_STATUSES:
             return run  # already terminal — nothing to cancel
         await wf_queries.insert_run_signal(
             conn,

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -1,19 +1,23 @@
 """Agent-acting workflow builtins — the strange loop.
 
-Four model-callable tools that let an agent author, edit, launch, and await
+Model-callable tools that let an agent author, edit, launch, await, and cancel
 workflows the way a human operator (or the ``aios`` CLI) does. Each is a thin
 wrapper over the existing workflow services; the agent's authority is bounded by
-the same three attenuations those services already enforce, keyed on the
-**executing session id** the harness supplies (``invoke_builtin(session_id, …)``,
+the attenuations those services already enforce, keyed on the **executing
+session id** the harness supplies (``invoke_builtin(session_id, …)``,
 ``tools/invoke.py``) — never model input:
 
 * ``create_workflow`` — surface attenuation: the declared tool/server surface must
   be a subset of the *creating agent's* own.
 * ``update_workflow`` — merged-surface attenuation + an optimistic ``version`` pin.
 * ``create_run`` — vault attenuation (bound vaults ⊆ the *launching session's*) plus
-  the vertical run-depth cap; the run inherits the caller's environment.
+  the vertical run-depth cap and the horizontal fan-out caps (outstanding runs per
+  launcher and per account); the run inherits the caller's environment.
 * ``await_run`` — a bounded long-poll that blocks (as a fire-and-forget tool task,
   so the session stays responsive) until the run is terminal or the timeout lapses.
+* ``cancel_run`` — cancel-time attenuation: a session may cancel only runs *it
+  launched* (the self-service escape for the fan-out cap; operator-launched runs
+  need the operator).
 
 **Identity is load-bearing, so two invariants hold (see F1 in the review):**
 1. The trusted ids (``creator_session_id``/``actor_session_id``/``launcher_session_id``,
@@ -22,7 +26,7 @@ the same three attenuations those services already enforce, keyed on the
    with ``extra="forbid"``), so an injected key is rejected before the handler runs.
 2. Handlers map service kwargs explicitly from the validated model — never ``**arguments``.
 
-All four register ``transport="agent_tool"`` (model-only; the CLI broker refuses them).
+All register ``transport="agent_tool"`` (model-only; the CLI broker refuses them).
 
 **Security boundary (A2):** these builtins attenuate, but a grant of the operator-level
 management API (HTTP / a future management MCP) does not — that path is unattenuated by
@@ -83,6 +87,15 @@ class _AwaitRunArgs(BaseModel):
 
     run_id: str
     timeout_seconds: int = Field(default=300, ge=1, le=1800)
+
+
+class _CancelRunArgs(BaseModel):
+    """``cancel_run`` arguments — just the run id; the canceller is the trusted
+    executing session (you may cancel only runs you launched)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
 
 
 # ─── handler plumbing ────────────────────────────────────────────────────────
@@ -177,6 +190,19 @@ async def await_run_handler(session_id: str, arguments: dict[str, Any]) -> dict[
     return resp.model_dump(mode="json")
 
 
+async def cancel_run_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    args = _parse(_CancelRunArgs, arguments)
+    run = await wf_service.cancel_run(
+        pool,
+        run_id=args.run_id,
+        account_id=account_id,
+        canceller_session_id=session_id,  # cancel only what this session launched
+    )
+    return run.model_dump(mode="json", exclude=_RUN_ECHO_EXCLUDE)
+
+
 # ─── descriptions + registration ─────────────────────────────────────────────
 
 CREATE_WORKFLOW_DESCRIPTION = (
@@ -196,12 +222,20 @@ CREATE_RUN_DESCRIPTION = (
     "Launch a run of a workflow you can access. The run executes with the workflow's "
     "declared surface but only the vaults you attach via 'vault_ids' — which must be a "
     "subset of the vaults bound to you. It runs in your own environment. Returns the run "
-    "id and status; use await_run to block for its result."
+    "id and status; use await_run to block for its result. The number of runs you may "
+    "have outstanding at once is capped — finish (await_run) or cancel (cancel_run) "
+    "runs to free slots."
 )
 AWAIT_RUN_DESCRIPTION = (
     "Block until a run reaches a terminal state (completed/errored/cancelled), or until "
     "'timeout_seconds' elapses. Returns {done, run_status, output, is_error, error}; if "
     "not yet done, call again to keep waiting. The session stays responsive while you wait."
+)
+CANCEL_RUN_DESCRIPTION = (
+    "Cancel a run YOU launched (you cannot cancel runs launched by others or by the "
+    "operator). The run finalizes 'cancelled' on its next wake — usually within moments "
+    "— freeing one of your outstanding-run slots once it does. Idempotent: an "
+    "already-finished run is returned unchanged."
 )
 
 
@@ -232,6 +266,13 @@ def _register() -> None:
         description=AWAIT_RUN_DESCRIPTION,
         parameters_schema=_AwaitRunArgs.model_json_schema(),
         handler=await_run_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name="cancel_run",
+        description=CANCEL_RUN_DESCRIPTION,
+        parameters_schema=_CancelRunArgs.model_json_schema(),
+        handler=cancel_run_handler,
         transport="agent_tool",
     )
 

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -11,9 +11,10 @@ from typing import Any
 
 import asyncpg
 
+from aios.config import get_settings
 from aios.db.queries import get_environment, get_session_vault_ids
 from aios.db.queries import workflows as wf_queries
-from aios.errors import AiosError, ForbiddenError, NotFoundError
+from aios.errors import AiosError, ForbiddenError, NotFoundError, RateLimitedError
 from aios.models.workflows import WfRun
 from aios.services.wake import defer_run_wake
 
@@ -63,6 +64,14 @@ async def create_run(
     and feeds the **vertical depth cap**: nesting past ``WORKFLOW_RUN_MAX_DEPTH`` raises
     :class:`WorkflowRunDepthExceededError`. The operator/HTTP path passes none, so it is
     a root run (never capped).
+
+    **Horizontal fan-out caps:** outstanding (non-terminal) runs are bounded per
+    launcher session (``workflow_runs_per_launcher_max``, agent path only) and per
+    account (``workflow_runs_per_account_max``, every launch) — a breach raises
+    :class:`RateLimitedError`. COUNT+INSERT are serialized by a per-account advisory
+    lock, so the caps are contractual against concurrent launches. (A concurrently
+    *completing* run flips terminal without the lock, so a count can only be
+    stale-high — a conservative early refusal, never a cap breach.)
     """
     requested = list(vault_ids or [])
     async with pool.acquire() as conn, conn.transaction():
@@ -94,12 +103,38 @@ async def create_run(
                     "run requested vaults the launching agent does not hold",
                     detail={"ungranted_vault_ids": ungranted},
                 )
+        # Fan-out caps, last (after all other validation, so a doomed launch never
+        # takes the lock). The advisory lock serializes COUNT+INSERT account-wide.
+        settings = get_settings()
+        await wf_queries.acquire_account_wf_runs_lock(conn, account_id)
+        if launcher_session_id is not None:
+            launcher_cap = settings.workflow_runs_per_launcher_max
+            outstanding = await wf_queries.count_active_runs(
+                conn, account_id=account_id, launcher_session_id=launcher_session_id
+            )
+            if outstanding >= launcher_cap:
+                raise RateLimitedError(
+                    f"launcher at outstanding-run cap ({outstanding}/{launcher_cap}); "
+                    "wait for runs you launched to finish (await_run) or cancel one "
+                    "you no longer need (cancel_run) to free a slot",
+                    detail={"outstanding": outstanding, "max": launcher_cap},
+                )
+        account_cap = settings.workflow_runs_per_account_max
+        outstanding = await wf_queries.count_active_runs(conn, account_id=account_id)
+        if outstanding >= account_cap:
+            raise RateLimitedError(
+                f"account at outstanding-run cap ({outstanding}/{account_cap}); "
+                "wait for outstanding runs to complete, or have stuck runs cancelled, "
+                "to free a slot",
+                detail={"outstanding": outstanding, "max": account_cap},
+            )
         run = await wf_queries.insert_wf_run(
             conn,
             account_id=account_id,
             workflow_id=workflow_id,
             environment_id=environment_id,
             parent_run_id=parent_run_id,
+            launcher_session_id=launcher_session_id,
             script=workflow.script,
             script_sha=script_sha,
             input=input,

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -29,7 +29,7 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries as db_queries
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
-from aios.errors import ConflictError, ForbiddenError, NotFoundError
+from aios.errors import ConflictError, ForbiddenError, NotFoundError, RateLimitedError
 from aios.harness import runtime
 from aios.mcp.client import resolve_auth_for_target_url_run
 from aios.models.agents import Agent, HttpServerSpec, McpServerSpec
@@ -73,7 +73,13 @@ async def vault_pool(
                 ENV,
                 ACC,
             )
-        with mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()):
+        # Both defer_run_wake bindings: create_run uses aios.workflows.service's,
+        # cancel_run uses aios.services.workflows' own import (same split the e2e
+        # conftest patches).
+        with (
+            mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
+        ):
             yield pool
     finally:
         runtime.pool = prev
@@ -526,3 +532,94 @@ async def test_create_run_rejects_foreign_environment(vault_pool: asyncpg.Pool[A
             pool, account_id=ACC, workflow_id=wf.id, environment_id="env_foreign"
         )
     assert await _run_count(pool) == before
+
+
+# ─── horizontal fan-out caps + launcher-attenuated cancel ────────────────────
+
+
+def _cap_settings(monkeypatch: pytest.MonkeyPatch, **caps: int) -> None:
+    """Patch ``aios.workflows.service.get_settings`` with lowered fan-out caps."""
+    from aios.config import get_settings
+
+    capped = get_settings().model_copy(update=caps)
+    monkeypatch.setattr("aios.workflows.service.get_settings", lambda: capped)
+
+
+async def _force_terminal(pool: asyncpg.Pool[Any], run_id: str) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE wf_runs SET status = 'completed' WHERE id = $1", run_id)
+
+
+async def test_launcher_fanout_cap(
+    vault_pool: asyncpg.Pool[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A launcher session may hold at most N outstanding runs; slots free as runs
+    reach a terminal status. The operator path is exempt from the launcher cap."""
+    pool = vault_pool
+    _cap_settings(monkeypatch, workflow_runs_per_launcher_max=2)
+    agent = await _make_agent(pool, "fanout-agent")
+    sess = await _make_session(pool, agent)
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-cap", script=_SCRIPT)
+
+    first = await wm.create_run_handler(sess, {"workflow_id": wf.id})
+    assert first["launcher_session_id"] == sess  # persisted lineage (the cap's count key)
+    await wm.create_run_handler(sess, {"workflow_id": wf.id})
+
+    before = await _run_count(pool)
+    with pytest.raises(RateLimitedError, match="outstanding-run cap"):
+        await wm.create_run_handler(sess, {"workflow_id": wf.id})
+    assert await _run_count(pool) == before  # refusal leaves no row
+
+    # Self-healing: a run reaching terminal frees the slot.
+    await _force_terminal(pool, first["id"])
+    await wm.create_run_handler(sess, {"workflow_id": wf.id})
+
+    # Operator launches carry no launcher (and are exempt from the launcher cap).
+    op = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    assert op.launcher_session_id is None
+
+
+async def test_account_fanout_cap_binds_every_launch(
+    vault_pool: asyncpg.Pool[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The account cap is the backstop: it counts agent AND operator launches."""
+    pool = vault_pool
+    _cap_settings(monkeypatch, workflow_runs_per_account_max=2)
+    agent = await _make_agent(pool, "fanout-acct-agent")
+    sess = await _make_session(pool, agent)
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-acap", script=_SCRIPT)
+
+    await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    await wm.create_run_handler(sess, {"workflow_id": wf.id})  # agent launch counts too
+
+    # Third launch refused on BOTH paths.
+    with pytest.raises(RateLimitedError, match="account at outstanding-run cap"):
+        await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    with pytest.raises(RateLimitedError, match="account at outstanding-run cap"):
+        await wm.create_run_handler(sess, {"workflow_id": wf.id})
+
+
+async def test_cancel_run_builtin_only_own_runs(vault_pool: asyncpg.Pool[Any]) -> None:
+    """cancel_run cancels only runs the executing session launched — the self-service
+    escape for the launcher cap; operator-launched runs are out of its reach."""
+    pool = vault_pool
+    agent = await _make_agent(pool, "canceller-agent")
+    sess = await _make_session(pool, agent)
+    other = await _make_session(pool, agent)
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-cxl", script=_SCRIPT)
+
+    own = await wm.create_run_handler(sess, {"workflow_id": wf.id})
+    out = await wm.cancel_run_handler(sess, {"run_id": own["id"]})
+    assert out["id"] == own["id"]  # accepted; the run finalizes on its next wake
+    async with pool.acquire() as conn:
+        signal = await conn.fetchrow(
+            "SELECT 1 FROM wf_run_signals WHERE run_id = $1 AND kind = 'cancel'", own["id"]
+        )
+    assert signal is not None
+
+    # Another session's run and an operator run are both forbidden.
+    op = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    with pytest.raises(ForbiddenError):
+        await wm.cancel_run_handler(other, {"run_id": own["id"]})
+    with pytest.raises(ForbiddenError):
+        await wm.cancel_run_handler(sess, {"run_id": op.id})

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0077``."""
+    """The migration ladder has exactly one head: ``0078``."""
     script = _script_directory()
-    assert script.get_heads() == ["0077"]
+    assert script.get_heads() == ["0078"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -88,6 +88,12 @@ class TestSchemaRejectsInjectedTrustedIds:
                 "ses_1", "create_run", {"workflow_id": "wf_1", "parent_run_id": "wfr_x"}
             )
 
+    async def test_cancel_run_canceller_session_id_rejected(self) -> None:
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1", "cancel_run", {"run_id": "wfr_1", "canceller_session_id": "ses_victim"}
+            )
+
 
 class TestErrorPropagation:
     async def test_pydantic_semantic_error_becomes_toolbail(self) -> None:


### PR DESCRIPTION
## What

Closes the **depth-cap-only residual** from #772 (red-team severity ~75): the vertical depth cap is a no-op for foreground launchers (`parent_run_id=None`), so a model in a loop could launch unbounded sibling root runs — each entitled to up to `workflow_max_agent_calls=1000` model calls. This bounds the horizontal axis.

## The dual cap (your scope call)

Mirrors the scheduled-tasks idiom (dual scope, advisory-lock-serialized COUNT+INSERT, `RateLimitedError` with actionable messages):

- **`workflow_runs_per_launcher_max`** (default 20) — outstanding (non-terminal) runs per **launcher session**: the targeted bound on a looping model. The operator/HTTP path has no launcher and is exempt, consistent with attenuation being agent-path-only.
- **`workflow_runs_per_account_max`** (default 100) — outstanding runs per **account**, every launch counted: the backstop the launcher cap can't provide (many sessions, or a run's `agent()` children, are each fresh launchers).

Both are **concurrency caps, not budgets** — slots free as runs reach a terminal status. COUNT+INSERT serialize under a per-account `pg_advisory_xact_lock` (distinct namespace; never co-held with the scheduled-tasks lock → no deadlock cycle), making the caps **contractual** against concurrent launches. A concurrently *completing* run flips terminal without the lock, so a count can only be stale-**high** — a conservative early refusal, never a breach.

**Migration 0078** persists `wf_runs.launcher_session_id` (the count key + genuine lineage; NULL = operator; `ON DELETE SET NULL` since sessions hard-delete) + one partial index serving both counts. Existing rows backfill NULL — a one-time grace window for pre-migration agent-launched runs, documented in the migration.

## The escape hatch (your call at the design review)

The pre-implementation red-team's sharpest find: an agent whose outstanding runs all suspend on **never-resumed gates** would be *permanently bricked* from launching (gates have no deadline, runs no TTL) with no self-service remedy. So this ships a 5th workflow builtin — **`cancel_run`**, with cancel-time attenuation: a session may cancel **only runs it launched** (`run.launcher_session_id ==` the harness-trusted executing session). Operator-launched runs stay operator-only; the HTTP cancel route is unchanged (unattenuated operator authority). The cancel finalizes on the run's next wake (signal-driven, wake deferred immediately) — the tool description is honest that the slot frees once it does, so a model doesn't loop on cancel→retry→429.

The attenuation verb set is now symmetric: create (surface ⊆ yours) · launch (vaults ⊆ yours, env = yours, depth + fan-out capped) · update (merged surface ⊆ yours, version-pinned) · cancel (launched-by-you).

## Review fixes folded in (xhigh, zero correctness bugs)

- `insert_wf_run`'s FK-violation message named only workflow/environment but the INSERT now carries four FKs — widened.
- The **archival-must-be-terminal-only** cap invariant documented on `count_active_runs` (today `wf_runs.archived_at` has zero writers; a future archive surface must refuse non-terminal runs or take the cap lock, else an archived-but-running run escapes the count).
- `WfRunCreate`/`GateResume` gain `extra="forbid"` (broken windows — request models must not silently drop unknown fields; `launcher_session_id` is deliberately **not** a request field, per the trusted-ids-never-in-bodies invariant).
- `await_run` docs corrected: `cancelled` is terminal too (`done=true`) — routine now that agents can cancel.
- A `cancel_run` F1 injection test completes the trusted-id rejection pattern.

## Tests

- **Launcher cap**: engages at N; refusal leaves no row (txn rollback); slot frees when a run reaches terminal (self-healing); operator launches exempt + persist `launcher_session_id=NULL`; agent launches persist the launcher (the lineage assertion).
- **Account cap**: binds agent AND operator paths (third launch refused on both).
- **cancel_run**: cancels own run (cancel signal written); `ForbiddenError` on another session's run and on an operator-launched run.

1852 unit green; mypy + ruff clean; openapi/SDK regenerated (`WfRun.launcher_session_id`, `cancel_run` enum, `extra="forbid"` schemas). Adversarially reviewed **before** implementation; `/simplify` + `/code-review --fix` (xhigh) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
