### PR TITLE
fix(harness): stop claude-fable-5 empty-turn cascade — replay hygiene, output-every-step, thinking preservation

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -2590,17 +2590,13 @@ async def append_event(
                 # impossible anyway, since a later tz config change re-renders
                 # history regardless of what was counted here.
                 #
-                # The count also pre-pays the separator assistant message that
-                # ``separate_adjacent_user_messages`` inserts when this user
-                # message follows another user message at compose time.
-                # Separators exist only because of user messages, so charging
-                # each user event its potential separator keeps the windowing
-                # budget an upper bound — without it, the post-window payload
-                # can exceed ``window_max`` by ~5 local tokens per kept
-                # adjacent-user pair (unbudgeted, since separators are not
-                # events). Non-adjacent user messages overcount by the same
-                # ~5 — the same keep-fewer-never-overshoot asymmetry as the
-                # ceil in ``read_windowed_events``.
+                # The count also pre-pays for adjacent-user handling: at
+                # compose time ``merge_adjacent_user_messages`` concatenates
+                # consecutive user inbounds (the old code inserted a ``.``
+                # separator instead). Reserving an assistant-separator's worth
+                # of tokens per user event keeps the windowing budget a
+                # conservative upper bound — the merge delimiter is smaller, so
+                # the post-window payload never exceeds ``window_max``.
                 rendered = render_user_event(
                     data, orig_channel, focal_at_arrival, datetime.now(UTC)
                 )

--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -130,8 +130,13 @@ def build_focal_paradigm_block(channels: list[str]) -> str:
         "\n"
         "Tools run asynchronously — new user messages can arrive while "
         "a tool is in flight, and you will see them on your next step. "
-        "There is no obligation to respond on every step; silence is "
-        "the right choice when there is nothing new requiring a reply."
+        "Not every step needs a channel post — when nothing new requires "
+        "a reply, the right move is to NOT post. But every step must still "
+        "produce output: say so in one line prefixed "
+        f"{MONOLOGUE_PREFIX.strip()!r} (it stays private — no human sees "
+        "it). Never end a step with empty output: an empty step is "
+        "indistinguishable from a malfunction, and a run of them derails "
+        "the conversation."
     )
 
 
@@ -163,9 +168,10 @@ def max_tail_block_local(channels: list[str]) -> int:
         # Preview length matches the 60-char truncation + ellipsis in
         # build_channels_tail_block above.
         lines.append(f'○ channel_id={addr} — 9999 unread: "{"x" * 61}"')
-    # The tail is user-role and lands after the log's final message; when
-    # that message is also user-role, ``separate_adjacent_user_messages``
-    # inserts a separator the reservation must cover too.
+    # The tail is user-role and lands after the log's final message. When
+    # that message is also user-role, ``merge_adjacent_user_messages``
+    # concatenates them; reserving an assistant-separator's worth of tokens
+    # here keeps the budget a conservative upper bound either way.
     return approx_tokens(
         [
             {"role": "assistant", "content": _USER_MESSAGE_SEPARATOR_CONTENT},

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -49,6 +49,27 @@ _FABLE5_MODEL_COST = {
 for _fable5_key in ("claude-fable-5", "anthropic/claude-fable-5"):
     litellm.model_cost.setdefault(_fable5_key, _FABLE5_MODEL_COST)
 
+# LiteLLM 1.83.4's Anthropic adapter silently DROPS a requested ``thinking``
+# param whenever the last tool-calling assistant message in the replayed
+# history lacks ``thinking_blocks`` (guard for upstream issue #18926). The
+# guard is over-broad: Anthropic accepts a thinking-enabled request against a
+# thinking-less history (verified live against claude-fable-5 and
+# claude-opus-4-8, 2026-06-10) — the real contract only requires that
+# *previously emitted* thinking blocks be preserved, which ``_normalize_message``'s
+# lift + ``_strip_to_spec``'s whitelist now do. Left in place, the guard also
+# creates a bootstrap deadlock: thinking can never turn on for an existing
+# session because no prior turn has thinking blocks, and no turn can produce
+# them while the param keeps being dropped. Neutralize it. Remove when a
+# litellm upgrade narrows the guard upstream.
+try:  # defensive: private module path, may move across litellm versions
+    from litellm.llms.anthropic.chat import transformation as _anthropic_transformation
+
+    _anthropic_transformation.last_assistant_with_tool_calls_has_no_thinking_blocks = (  # type: ignore[attr-defined]
+        lambda *args, **kwargs: False
+    )
+except (ImportError, AttributeError):  # pragma: no cover - litellm layout drift
+    pass
+
 # Default per-call bounds. Kept here so they're visible at the wrapper boundary
 # rather than buried in defaults that drift between LiteLLM versions. Agents
 # can override either via ``litellm_extra``; the spread happens after these
@@ -69,11 +90,38 @@ def _normalize_message(msg: dict[str, Any]) -> dict[str, Any]:
     the key (breaks ``jsonb_array_length``), and ``content: null`` instead
     of ``content: ""`` (breaks providers like MiniMax and Gemma when the
     message is replayed in a cross-model session).
+
+    Anthropic thinking blocks are lifted from
+    ``provider_specific_fields.thinking_blocks`` to the top-level
+    ``thinking_blocks`` key. LiteLLM parks them in the former, but only the
+    latter survives replay (``_strip_to_spec`` whitelists top-level
+    ``thinking_blocks`` for thinking-capable targets). Without the lift,
+    replayed assistant turns carry no thinking blocks, which (a) violates
+    Anthropic's thinking-preservation contract across tool-use turns and
+    (b) trips LiteLLM's guard that silently drops the requested
+    ``thinking`` param — leaving models like claude-fable-5 running
+    thinking-less, where they stochastically emit literal-empty turns that
+    then poison the transcript (fable imitates degenerate turns in its own
+    history; see the empty-turn cascade incident, 2026-06-09). Blocks with
+    empty thinking text (the ``display: "omitted"`` default) are NOT
+    lifted: a signature without its content fails Anthropic-side
+    validation on replay ("Invalid `signature` in `thinking` block").
     """
     if "tool_calls" in msg and msg["tool_calls"] is None:
         del msg["tool_calls"]
     if msg.get("content") is None:
         msg["content"] = ""
+    if not msg.get("thinking_blocks"):
+        psf = msg.get("provider_specific_fields")
+        blocks = psf.get("thinking_blocks") if isinstance(psf, dict) else None
+        if isinstance(blocks, list):
+            kept = [b for b in blocks if isinstance(b, dict) and (b.get("thinking") or "").strip()]
+            if kept:
+                msg["thinking_blocks"] = kept
+            else:
+                msg.pop("thinking_blocks", None)
+        else:
+            msg.pop("thinking_blocks", None)
     return msg
 
 
@@ -249,7 +297,7 @@ def inject_cache_breakpoints(
        message, skipping the trailing channels tail block (which
        mutates every step: unread counts, previews) and any
        empty-assistant separator inserted before it by
-       :func:`separate_adjacent_user_messages`.
+       :func:`~aios.harness.context.merge_adjacent_user_messages`.
 
     Skipping the tail is load-bearing: with the breakpoint on the tail
     itself, the conversation prefix never gets its own cache entry and
@@ -282,7 +330,8 @@ def _last_stable_message_index(messages: list[dict[str, Any]]) -> int | None:
       ``━━━ Channels ━━━`` (always the last user-role message when
       present).
     * Any role-transition separator — inserted by
-      :func:`~aios.harness.context.separate_adjacent_user_messages` to
+      the former separator mechanism (now
+      :func:`~aios.harness.context.merge_adjacent_user_messages`) to
       defeat Anthropic's adjacent-user-merge; carries only a
       single-byte placeholder and would be a wasted breakpoint.
 
@@ -323,7 +372,7 @@ def _is_separator_placeholder(msg: dict[str, Any]) -> bool:
     """Detect the role-transition separator placeholder.
 
     Matches the exact shape produced by
-    :func:`~aios.harness.context.separate_adjacent_user_messages`:
+    the former separator mechanism:
     ``assistant`` role, no tool calls, content equal to
     :data:`~aios.harness.context._USER_MESSAGE_SEPARATOR_CONTENT`.
 

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -881,12 +881,40 @@ def build_messages(
     target_supports_thinking = bool(
         model and ("claude" in model.lower() or litellm.supports_reasoning(model))
     )
-    return ContextResult(
-        messages=[
-            _strip_to_spec(m, target_supports_thinking=target_supports_thinking) for m in messages
-        ],
-        reacting_to=max_stimulus_seq,
-    )
+    stripped = [
+        _strip_to_spec(m, target_supports_thinking=target_supports_thinking) for m in messages
+    ]
+    # Drop degenerate empty assistant turns (no content, no tool_calls, no
+    # thinking) before replay. They carry zero information, and replaying them
+    # teaches literal-minded models — claude-fable-5 in particular — to imitate
+    # silence: a run of empty assistant turns in the window makes fable
+    # deterministically emit another empty turn (proven: 0% empty on a clean
+    # window, 100% empty when the window holds such a run; opus-4.x is immune).
+    # LiteLLM also rewrites their empty content to a "[System: Empty message
+    # content sanitised…]" marker on the wire, so the model literally sees a wall
+    # of its own malfunction markers. Excluding them is safe for every model
+    # (nothing is lost) and breaks the imitation loop at the source.
+    stripped = [m for m in stripped if not _is_degenerate_empty_assistant(m)]
+    return ContextResult(messages=stripped, reacting_to=max_stimulus_seq)
+
+
+def _is_degenerate_empty_assistant(msg: dict[str, Any]) -> bool:
+    """True for an assistant turn carrying no content, no tool_calls, no thinking.
+
+    Such a turn is a non-event — the model produced nothing actionable. It is
+    distinct from a tool-call turn (``tool_calls`` present) or a thinking turn
+    (``thinking_blocks`` present), both of which are load-bearing and kept.
+    """
+    if msg.get("role") != "assistant":
+        return False
+    if msg.get("tool_calls") or msg.get("thinking_blocks"):
+        return False
+    content = msg.get("content")
+    if isinstance(content, str):
+        return not content.strip()
+    if isinstance(content, list):
+        return not any(isinstance(b, dict) and (b.get("text") or "").strip() for b in content)
+    return content is None
 
 
 # ─── helpers ─────────────────────────────────────────────────────────────────
@@ -979,27 +1007,56 @@ imports this constant to stay in lock-step.
 """
 
 
-def separate_adjacent_user_messages(
+def merge_adjacent_user_messages(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Insert a placeholder assistant message between any two adjacent user messages.
+    """Merge consecutive user-role messages into a single user turn.
 
-    LiteLLM's Anthropic translator enforces strict role alternation by
-    merging adjacent same-role messages into a single multi-content-block
-    payload.  When a user inbound is immediately followed by the
-    per-step channels tail block (also user-role), Anthropic sees them
-    as one message with two text blocks — and models narrate "your
-    message included the channel state" about their own scaffolding.
+    Anthropic requires alternating roles, so two adjacent user messages
+    must become one. The earlier approach inserted a placeholder
+    assistant turn (a ``"."``) between them to *force* them apart and
+    stop LiteLLM concatenating a user inbound with the channels tail
+    block (which made models narrate "your message included the channel
+    state"). That placeholder is now both unnecessary and harmful:
 
-    Inserting an assistant turn between two consecutive user messages
-    blocks the merge.  The placeholder uses
-    :data:`_USER_MESSAGE_SEPARATOR_CONTENT` (a single printable byte) so
-    it survives validators on relay routes (OpenRouter → Bedrock, etc.)
-    that reject empty non-final assistant content.
+    * Unnecessary — the channels tail block is no longer appended after
+      an unanswered user inbound (see ``compose_step_context`` /
+      ``_agent_owes_response``), so the tail-merge case it guarded
+      against no longer arises; the only remaining adjacent-user case is
+      genuine successive inbounds (feeder pings + user text that landed
+      before the agent acted), which *should* read as one block.
+    * Harmful — a ``"."`` is a degenerate assistant turn. Literal-minded
+      models imitate it: ``claude-fable-5`` pattern-completes a run of
+      ``"."`` placeholders into silence and emits empty turns
+      deterministically (a single ``"."`` before the prompt flips fable
+      from 0% to 100% empty turns in repro; opus-4.x is immune). The
+      placeholders also accreted with every feeder ping, poisoning
+      long-lived agent sessions.
+
+    Merging here (rather than letting LiteLLM do it implicitly) keeps the
+    behaviour deterministic and route-independent: no degenerate
+    placeholder ever reaches the provider, and each merged inbound keeps
+    its own channel header so the sequence stays legible.
     """
     result: list[dict[str, Any]] = []
     for msg in messages:
         if result and result[-1].get("role") == "user" and msg.get("role") == "user":
-            result.append({"role": "assistant", "content": _USER_MESSAGE_SEPARATOR_CONTENT})
-        result.append(msg)
+            result[-1] = _concat_user_messages(result[-1], msg)
+        else:
+            result.append(dict(msg))
     return result
+
+
+def _concat_user_messages(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    """Concatenate two user messages, preserving content-block structure.
+
+    String contents join with a blank line (each rendered inbound already
+    carries its ``[channel=… received=…]`` header). List contents (vision
+    parts) concatenate block-wise; mixed shapes normalise to a block list.
+    """
+    ca, cb = a.get("content"), b.get("content")
+    if isinstance(ca, str) and isinstance(cb, str):
+        return {"role": "user", "content": f"{ca}\n\n{cb}"}
+    la = ca if isinstance(ca, list) else [{"type": "text", "text": ca or ""}]
+    lb = cb if isinstance(cb, list) else [{"type": "text", "text": cb or ""}]
+    return {"role": "user", "content": [*la, *lb]}

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -31,8 +31,8 @@ from typing import TYPE_CHECKING, Any
 from aios.harness._text import join_blocks
 from aios.harness.context import (
     build_messages,
+    merge_adjacent_user_messages,
     message_is_notification_marker,
-    separate_adjacent_user_messages,
     stub_missing_reasoning_content,
 )
 from aios.tools.registry import to_openai_tools
@@ -370,9 +370,10 @@ async def compose_step_context(
     if tail is not None and not _agent_owes_response(ctx.messages):
         ctx.messages.append(tail)
 
-    # Block LiteLLM's adjacent-same-role merge on Anthropic so the tail
-    # isn't concatenated into the preceding user inbound.
-    messages = separate_adjacent_user_messages(ctx.messages)
+    # Merge consecutive user inbounds into one turn (Anthropic requires
+    # alternating roles). This replaces the old "." placeholder separator,
+    # which degenerate-poisoned literal models like claude-fable-5.
+    messages = merge_adjacent_user_messages(ctx.messages)
 
     # Unblock thinking-mode models: DeepSeek V4 Flash rejects assistant
     # turns without reasoning_content.  Empty stub is ignored by all

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -1,4 +1,13 @@
-"""E2E coverage for the adjacent-user-message separator at the LiteLLM boundary."""
+"""E2E coverage for the adjacent-user-message merge at the LiteLLM boundary.
+
+Two consecutive user-role messages must reach ``litellm.acompletion`` as a
+single merged user turn (Anthropic requires alternating roles). The earlier
+design inserted a placeholder ``{"role": "assistant", "content": "."}``
+separator between them; that degenerate turn taught literal-minded models
+(claude-fable-5) to imitate silence, so it was replaced by an in-place merge.
+These tests pin that no ``"."`` placeholder ever reaches the wire and that the
+adjacency arrives merged.
+"""
 
 from __future__ import annotations
 
@@ -12,27 +21,66 @@ pytestmark = pytest.mark.docker
 _TAIL_HEADER = "━━━ Channels ━━━"
 
 
-@needs_docker
-class TestSeparatorAtLiteLLMBoundary:
-    async def test_adjacent_user_messages_reach_litellm_separated(self, harness: Harness) -> None:
-        """When a session has interacted with a channel, ``build_channels_tail_block``
-        appends a user-role message.  Paired with the user's inbound, this
-        is the exact adjacency PR #69 targets.  Assert that by the time
-        the message list reaches ``litellm.acompletion``, the separator is
-        in place immediately before the tail block.
+def _is_dot_placeholder(m: dict) -> bool:
+    return m.get("role") == "assistant" and m.get("content") == "."
 
-        Channels are now derived from event-log ``channel`` stamps (the
-        connector redesign #200 replaced the explicit ``channel_bindings``
-        table with this view).  An inbound with ``metadata.channel`` set
-        gives the session its single bound channel.
+
+@needs_docker
+class TestAdjacentUserMergeAtLiteLLMBoundary:
+    async def test_adjacent_user_inbounds_reach_litellm_merged(self, harness: Harness) -> None:
+        """Two user inbounds that land before the agent acts are adjacent
+        user-role messages. By the time the message list reaches
+        ``litellm.acompletion`` they must be a single merged user turn —
+        not separated by a ``"."`` placeholder assistant.
+
+        The merge folds string contents with a blank-line join, so both
+        inbounds' text is present in one user message.
+        """
+        harness.script_model([assistant("ok")])
+        session = await harness.start("first inbound")
+        # A second inbound arrives before any inference step runs — the two
+        # user messages are now back-to-back in the event log.
+        await harness.inject_message(session.id, "second inbound")
+        await harness.run_until_idle(session.id)
+
+        assert len(harness.model_calls) == 1, (
+            "expected exactly one model call — no tool round-trip in this flow"
+        )
+        msgs = harness.model_calls[0]["messages"]
+
+        # No degenerate "." placeholder anywhere on the wire.
+        assert not any(_is_dot_placeholder(m) for m in msgs), (
+            f"degenerate '.' placeholder reached litellm: {msgs!r}"
+        )
+
+        # Exactly one user-role message, carrying BOTH inbounds (merged).
+        user_msgs = [m for m in msgs if m.get("role") == "user"]
+        assert len(user_msgs) == 1, f"expected one merged user turn, got {user_msgs!r}"
+        merged = msg_text(user_msgs[0])
+        assert "first inbound" in merged
+        assert "second inbound" in merged
+
+    async def test_inbound_then_tail_block_merge_no_placeholder(self, harness: Harness) -> None:
+        """When a session has interacted with a channel,
+        ``build_channels_tail_block`` appends a user-role tail. If the
+        conversation already ends with an assistant turn (idle re-check),
+        the tail lands adjacent to nothing problematic; but when an
+        inbound precedes it the two user turns merge. Either way, assert
+        no ``"."`` placeholder reaches litellm and the tail content is
+        carried by a user-role message.
+
+        Channels are derived from event-log ``channel`` stamps (connector
+        redesign #200). An inbound with ``metadata.channel`` set gives the
+        session its single bound channel; a following assistant turn means
+        the conversation ends assistant-side, so the tail is appended.
         """
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.services import sessions as sess_svc
 
-        harness.script_model([assistant("ok")])
+        # Two scripted replies: one for the channel inbound, one for the
+        # idle re-check step where the tail block is appended.
+        harness.script_model([assistant("ack"), assistant("idle")])
         session = await harness.start("hello")
-        # Append an inbound stamped with channel metadata — this populates
-        # ``events.channel`` and feeds the new derived bound-channels path.
         await sess_svc.append_user_message(
             harness._pool,
             session.id,
@@ -42,44 +90,29 @@ class TestSeparatorAtLiteLLMBoundary:
         )
         await harness.run_until_idle(session.id)
 
-        assert len(harness.model_calls) == 1, (
-            "expected exactly one model call — no tool round-trip in this flow"
-        )
-        msgs = harness.model_calls[0]["messages"]
+        # No "." placeholder on any model call.
+        for call in harness.model_calls:
+            assert not any(_is_dot_placeholder(m) for m in call["messages"]), (
+                f"degenerate '.' placeholder reached litellm: {call['messages']!r}"
+            )
 
-        # Locate the channels tail block by its content header.  Content
-        # may be a plain string or a cache-wrapped block list — flatten
-        # before matching.
-        tail_idx = next(
-            (
-                i
-                for i, m in enumerate(msgs)
-                if m.get("role") == "user" and _TAIL_HEADER in msg_text(m)
-            ),
-            None,
-        )
-        assert tail_idx is not None, f"tail block not found in messages: {msgs!r}"
-        assert tail_idx > 0, "tail block should not be first — there's an inbound before it"
-
-        prev = msgs[tail_idx - 1]
-        # The separator is an assistant message carrying a single-byte
-        # placeholder ("."); an empty content block leaks through relay
-        # routes (OpenRouter → Bedrock) that don't sanitize it.
-        # ``reasoning_content`` is stubbed empty too so thinking-mode
-        # providers don't reject the transcript (see
-        # ``stub_missing_reasoning_content``).
-        assert prev.get("role") == "assistant" and prev.get("content") == ".", (
-            f"expected placeholder-assistant separator before tail, got prev={prev!r}, tail={msgs[tail_idx]!r}"
-        )
-        assert prev.get("reasoning_content") == "", (
-            f"expected reasoning_content stub on separator, got prev={prev!r}"
+        # Across all calls, when the channels tail block appears it is on a
+        # user-role message (merged into the trailing inbound or standalone).
+        saw_tail = False
+        for call in harness.model_calls:
+            for m in call["messages"]:
+                if m.get("role") == "user" and _TAIL_HEADER in msg_text(m):
+                    saw_tail = True
+        assert saw_tail, (
+            "channels tail block never appeared on a user-role message across "
+            f"model calls: {[c['messages'] for c in harness.model_calls]!r}"
         )
 
-    async def test_no_separator_when_tail_block_absent(self, harness: Harness) -> None:
+    async def test_no_placeholder_when_tail_block_absent(self, harness: Harness) -> None:
         """Without channel bindings, ``build_channels_tail_block`` returns
-        ``None`` and no adjacency arises.  Assert the separator is NOT
-        inserted — guards against a future change that always inserts an
-        empty assistant turn."""
+        ``None`` and no adjacency arises from the tail. Assert no
+        placeholder assistant turn is inserted — guards against a future
+        change that always inserts a degenerate empty assistant turn."""
         harness.script_model([assistant("ok")])
         session = await harness.start("hello")
         # No binding created → tail block is None → no user/user adjacency.
@@ -87,6 +120,6 @@ class TestSeparatorAtLiteLLMBoundary:
 
         assert len(harness.model_calls) == 1
         msgs = harness.model_calls[0]["messages"]
-        assert not any(m.get("role") == "assistant" and m.get("content") == "." for m in msgs), (
+        assert not any(_is_dot_placeholder(m) for m in msgs), (
             f"gratuitous placeholder-assistant separator in messages: {msgs!r}"
         )

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -66,6 +66,20 @@ class TestBuildFocalParadigmBlock:
         block = build_focal_paradigm_block(["signal/alice/chat-1"])
         assert "INTERNAL_MONOLOGUE" in block
 
+    def test_timing_prose_requires_output_every_step(self) -> None:
+        """The ``### Timing`` prose was inverted as part of the empty-turn
+        cascade fix: it no longer tells the model that silence/no-response
+        is acceptable (literal-minded models took that as license to emit
+        empty turns). It now requires output on every step, even when
+        nothing is posted to a channel."""
+        block = build_focal_paradigm_block(["signal/alice/chat-1"])
+        # New wording present.
+        assert "Never end a step with empty output" in block
+        assert "every step must still" in block
+        # Old wording gone — its presence would re-license the empty turn.
+        assert "silence is the right choice" not in block
+        assert "no obligation to respond" not in block
+
     def test_no_per_channel_data_leakage(self) -> None:
         """The block must not name any specific bound channel — that's
         the tail block's job.  Paradigm prose stays cache-stable.

--- a/tests/unit/test_completion_sanitize.py
+++ b/tests/unit/test_completion_sanitize.py
@@ -79,6 +79,105 @@ class TestNormalizeMessage:
         assert "tool_calls" not in result
 
 
+class TestNormalizeMessageThinkingLift:
+    """``_normalize_message`` lifts Anthropic thinking blocks from
+    ``provider_specific_fields.thinking_blocks`` to the top-level
+    ``thinking_blocks`` key (only ``_strip_to_spec``'s whitelisted
+    top-level key survives replay). Blocks with empty ``thinking`` text are
+    NOT lifted: a signature without its content fails Anthropic-side
+    validation on replay."""
+
+    def test_lifts_nonempty_thinking_block_to_top_level(self) -> None:
+        block = {"type": "thinking", "thinking": "real reasoning", "signature": "sig"}
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "answer",
+            "provider_specific_fields": {"thinking_blocks": [block]},
+        }
+        result = _normalize_message(msg)
+        assert result["thinking_blocks"] == [block]
+
+    def test_empty_thinking_block_lifted_then_dropped(self) -> None:
+        """A block whose only payload is a signature (empty ``thinking``
+        text, the ``display: "omitted"`` default) is dropped, not lifted —
+        no top-level ``thinking_blocks`` results."""
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "answer",
+            "provider_specific_fields": {
+                "thinking_blocks": [{"type": "thinking", "thinking": "", "signature": "sig"}]
+            },
+        }
+        result = _normalize_message(msg)
+        assert "thinking_blocks" not in result
+
+    def test_whitespace_only_thinking_block_dropped(self) -> None:
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "answer",
+            "provider_specific_fields": {
+                "thinking_blocks": [{"type": "thinking", "thinking": "   ", "signature": "sig"}]
+            },
+        }
+        result = _normalize_message(msg)
+        assert "thinking_blocks" not in result
+
+    def test_mixed_blocks_keeps_only_nonempty(self) -> None:
+        good = {"type": "thinking", "thinking": "kept", "signature": "s1"}
+        empty = {"type": "thinking", "thinking": "", "signature": "s2"}
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "answer",
+            "provider_specific_fields": {"thinking_blocks": [good, empty]},
+        }
+        result = _normalize_message(msg)
+        assert result["thinking_blocks"] == [good]
+
+    def test_non_dict_provider_specific_fields_unchanged(self) -> None:
+        """A non-dict ``provider_specific_fields`` must not crash, and no
+        top-level ``thinking_blocks`` is synthesised."""
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "answer",
+            "provider_specific_fields": "not-a-dict",
+        }
+        result = _normalize_message(msg)
+        assert "thinking_blocks" not in result
+        assert result["content"] == "answer"
+
+    def test_absent_provider_specific_fields_unchanged(self) -> None:
+        msg: dict[str, object] = {"role": "assistant", "content": "answer"}
+        result = _normalize_message(msg)
+        assert "thinking_blocks" not in result
+
+    def test_existing_top_level_thinking_blocks_preserved(self) -> None:
+        """A truthy top-level ``thinking_blocks`` is left untouched — the
+        lift only fills it when absent/empty, and does not clobber a value
+        already present (e.g. blocks already lifted on a prior pass)."""
+        existing = [{"type": "thinking", "thinking": "already here", "signature": "sig"}]
+        psf_block = {"type": "thinking", "thinking": "should be ignored", "signature": "other"}
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "answer",
+            "thinking_blocks": existing,
+            "provider_specific_fields": {"thinking_blocks": [psf_block]},
+        }
+        result = _normalize_message(msg)
+        assert result["thinking_blocks"] == existing
+
+    def test_falsy_top_level_thinking_blocks_removed_when_no_psf(self) -> None:
+        """An empty/falsy top-level ``thinking_blocks`` with no liftable
+        provider blocks is removed (a falsy value would otherwise confuse
+        downstream replay)."""
+        msg: dict[str, object] = {
+            "role": "assistant",
+            "content": "answer",
+            "thinking_blocks": [],
+        }
+        result = _normalize_message(msg)
+        assert "thinking_blocks" not in result
+
+
 def test_modify_params_enabled_on_import() -> None:
     """Importing aios.harness.completion sets litellm.modify_params = True.
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -13,8 +13,10 @@ import pytest
 
 from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
+    _concat_user_messages,
+    _is_degenerate_empty_assistant,
     build_messages,
-    separate_adjacent_user_messages,
+    merge_adjacent_user_messages,
     stub_missing_reasoning_content,
 )
 from aios.models.events import Event
@@ -25,14 +27,14 @@ def _full_pipeline(
     channels: list[str],
     focal_channel: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Compose ``build_messages`` → tail-block append → separator — the
-    same sequence ``loop.py:run_session_step`` runs before handing the
-    message list to LiteLLM."""
+    """Compose ``build_messages`` → tail-block append → adjacent-user
+    merge — the same sequence ``compose_step_context`` runs before
+    handing the message list to LiteLLM."""
     ctx = build_messages(events, system_prompt=None)
     tail = build_channels_tail_block(channels, events, focal_channel)
     if tail is not None:
         ctx.messages.append(tail)
-    return separate_adjacent_user_messages(ctx.messages)
+    return merge_adjacent_user_messages(ctx.messages)
 
 
 # Fixed receipt time so the per-message ``received=`` envelope field
@@ -372,6 +374,38 @@ class TestBuildMessages:
         assert [m["role"] for m in msgs] == ["user"]
         assert msgs[0]["content"] == f"[received={RECEIVED}]\nnext"
 
+    def test_degenerate_empty_assistant_dropped_load_bearing_turns_kept(self) -> None:
+        """A degenerate empty assistant turn (no content, no tool_calls, no
+        thinking) is excluded from the composed messages — replaying it
+        teaches literal-minded models to imitate silence. A tool-call turn
+        and a real text turn are load-bearing and survive."""
+        events = [
+            _evt(1, "user", content="do it"),
+            # A genuine empty turn the model emitted at some prior step.
+            _evt(2, "assistant", content=""),
+            _evt(3, "user", content="still there?"),
+            _evt(4, "assistant", tool_calls=[_tc("a")]),
+            _evt(5, "tool", tool_call_id="a", content="result a"),
+            _evt(6, "assistant", content="here is the answer"),
+        ]
+        events[1].data["reacting_to"] = 1
+        events[3].data["reacting_to"] = 3
+        events[5].data["reacting_to"] = 5
+
+        msgs = build_messages(events, system_prompt=None).messages
+
+        # The degenerate empty assistant at seq=2 is gone.
+        assert not any(
+            m["role"] == "assistant" and m.get("content") == "" and "tool_calls" not in m
+            for m in msgs
+        )
+        # The tool-call turn + its result and the text turn are kept.
+        assert any(m["role"] == "assistant" and m.get("tool_calls") for m in msgs)
+        assert any(m["role"] == "tool" and "result a" in m.get("content", "") for m in msgs)
+        assert any(
+            m["role"] == "assistant" and m.get("content") == "here is the answer" for m in msgs
+        )
+
 
 class TestTimezoneRendering:
     """The ``received=`` envelope renders in the account's effective timezone
@@ -565,12 +599,19 @@ class TestMonotonicity:
         _assert_prefix(ctx1, ctx2)
         _assert_prefix(ctx2, ctx3)
 
-    def test_separator_insertion_preserves_monotonicity(self) -> None:
-        """Full pipeline (build_messages → tail-block → separator) must
-        keep the prefix-stability invariant: output(L1) is a prefix of
-        output(L2) when L1 ⊂ L2.  Pins the "insertions only at the
-        volatile suffix" claim — a refactor that inserted separators
-        into the cache-stable prefix would fail this."""
+    def test_merge_insertion_preserves_monotonicity(self) -> None:
+        """Full pipeline (build_messages → tail-block → adjacent-user
+        merge) must keep the prefix-stability invariant: output(L1) is a
+        prefix of output(L2) when L1 ⊂ L2.  Pins the "mutations only at
+        the volatile suffix" claim — a refactor that merged messages into
+        the cache-stable prefix would fail this.
+
+        The tail block lands as the trailing user-role message. When the
+        preceding message is also user-role (L2: ``…, user "do B"``), the
+        merge folds the tail *into* that user turn, so the tail header is
+        no longer a standalone message — it's a substring of the final
+        user content. ``_strip_tail`` drops any trailing user message
+        carrying the header either way."""
         bindings = ["signal/test/1"]
 
         l1 = [
@@ -584,18 +625,18 @@ class TestMonotonicity:
         out2 = _full_pipeline(l2, bindings)
         out3 = _full_pipeline(l3, bindings)
 
-        # The tail block mutates per step, so compare prefixes only up
-        # to (but not including) the tail and any separator before it.
+        # No degenerate "." separator is ever produced now.
+        for out in (out1, out2, out3):
+            assert not any(m == {"role": "assistant", "content": "."} for m in out)
+
+        # The tail block mutates per step, so compare prefixes only up to
+        # (but not including) the trailing user turn that carries it —
+        # whether standalone or merged into the preceding inbound.
         def _strip_tail(msgs: list[dict]) -> list[dict]:
             for i in range(len(msgs) - 1, -1, -1):
                 m = msgs[i]
-                if m.get("role") == "user" and str(m.get("content", "")).startswith(
-                    "━━━ Channels ━━━"
-                ):
-                    stop = i
-                    if i > 0 and msgs[i - 1] == {"role": "assistant", "content": "."}:
-                        stop = i - 1
-                    return msgs[:stop]
+                if m.get("role") == "user" and "━━━ Channels ━━━" in str(m.get("content", "")):
+                    return msgs[:i]
             return msgs
 
         _assert_prefix(_strip_tail(out1), _strip_tail(out2))
@@ -948,24 +989,31 @@ class TestToolCallSanitization:
         assert msgs[1]["tool_calls"][0]["function"]["name"] == ""
 
     def test_missing_id_filtered_out(self) -> None:
-        """A tool_call entry without an ``id`` is unjoinable — dropped, not preserved with id=''."""
+        """A tool_call entry without an ``id`` is unjoinable — dropped, not
+        preserved with id=''. Once its sole tool_call is stripped the
+        assistant turn has no content and no tool_calls, so the
+        degenerate-empty-assistant drop removes the turn entirely; only
+        the user message survives."""
         bad_tc = {"type": "function", "function": {"name": "bash", "arguments": "{}"}}
         events = [
             _evt(1, "user", content="go"),
             _evt(2, "assistant", tool_calls=[bad_tc]),
         ]
         msgs = build_messages(events, system_prompt=None).messages
-        assert "tool_calls" not in msgs[1]
+        assert [m["role"] for m in msgs] == ["user"]
+        assert not any(m.get("tool_calls") for m in msgs)
 
     def test_empty_id_string_filtered(self) -> None:
-        """An explicit empty-string id is also unjoinable and filtered."""
+        """An explicit empty-string id is also unjoinable and filtered;
+        the resulting degenerate empty assistant turn is then dropped."""
         bad_tc = {"id": "", "type": "function", "function": {"name": "bash", "arguments": "{}"}}
         events = [
             _evt(1, "user", content="go"),
             _evt(2, "assistant", tool_calls=[bad_tc]),
         ]
         msgs = build_messages(events, system_prompt=None).messages
-        assert "tool_calls" not in msgs[1]
+        assert [m["role"] for m in msgs] == ["user"]
+        assert not any(m.get("tool_calls") for m in msgs)
 
     def test_mid_window_malformed_filtered_among_valid(self) -> None:
         """Mid-window assistant with mixed valid + malformed tool_calls keeps only the valid entry."""
@@ -1533,65 +1581,189 @@ class TestFocalRendering:
         assert msgs[1]["content"].startswith(f"[channel={self._CHAN_A}")
 
 
-class TestSeparateAdjacentUserMessages:
-    def test_inserts_empty_assistant_between_two_users(self) -> None:
+def _has_dot_placeholder(msgs: list[dict[str, Any]]) -> bool:
+    """True if any message is the old degenerate ``"."`` assistant separator."""
+    return any(m == {"role": "assistant", "content": "."} for m in msgs)
+
+
+class TestMergeAdjacentUserMessages:
+    """``merge_adjacent_user_messages`` folds consecutive user-role turns
+    into one, replacing the old ``"."`` placeholder-assistant separator
+    (which literal-minded models imitated into silence)."""
+
+    def test_merges_two_users_into_one(self) -> None:
         msgs = [
             {"role": "user", "content": "one"},
             {"role": "user", "content": "two"},
         ]
-        assert separate_adjacent_user_messages(msgs) == [
-            {"role": "user", "content": "one"},
-            {"role": "assistant", "content": "."},
-            {"role": "user", "content": "two"},
-        ]
+        result = merge_adjacent_user_messages(msgs)
+        assert result == [{"role": "user", "content": "one\n\ntwo"}]
+        assert not _has_dot_placeholder(result)
 
     def test_preserves_existing_alternation(self) -> None:
+        """A user/assistant/user sequence has no adjacency — no merge
+        across the assistant turn."""
         msgs = [
             {"role": "user", "content": "one"},
             {"role": "assistant", "content": "hi"},
             {"role": "user", "content": "two"},
         ]
-        assert separate_adjacent_user_messages(msgs) == msgs
+        assert merge_adjacent_user_messages(msgs) == msgs
+        assert not _has_dot_placeholder(merge_adjacent_user_messages(msgs))
 
-    def test_tool_result_between_users_is_not_separated(self) -> None:
-        """Adjacent means *consecutive same-role*. Tool results don't trigger."""
+    def test_tool_result_between_users_is_not_merged(self) -> None:
+        """Adjacent means *consecutive same-role*. Tool results break the run."""
         msgs = [
             {"role": "user", "content": "one"},
             {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
             {"role": "tool", "tool_call_id": "a", "content": "r"},
             {"role": "user", "content": "two"},
         ]
-        assert separate_adjacent_user_messages(msgs) == msgs
+        assert merge_adjacent_user_messages(msgs) == msgs
 
-    def test_three_consecutive_users_get_two_separators(self) -> None:
+    def test_three_consecutive_users_merge_to_one(self) -> None:
         msgs = [
             {"role": "user", "content": "a"},
             {"role": "user", "content": "b"},
             {"role": "user", "content": "c"},
         ]
-        assert separate_adjacent_user_messages(msgs) == [
-            {"role": "user", "content": "a"},
-            {"role": "assistant", "content": "."},
-            {"role": "user", "content": "b"},
-            {"role": "assistant", "content": "."},
-            {"role": "user", "content": "c"},
+        result = merge_adjacent_user_messages(msgs)
+        assert result == [{"role": "user", "content": "a\n\nb\n\nc"}]
+        assert not _has_dot_placeholder(result)
+
+    def test_list_content_users_concatenate_blocks(self) -> None:
+        """Vision/multi-part list contents concatenate block-wise."""
+        a_blocks = [{"type": "text", "text": "first"}]
+        b_blocks = [
+            {"type": "text", "text": "second"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
         ]
+        msgs = [
+            {"role": "user", "content": a_blocks},
+            {"role": "user", "content": b_blocks},
+        ]
+        result = merge_adjacent_user_messages(msgs)
+        assert result == [{"role": "user", "content": [*a_blocks, *b_blocks]}]
+        assert not _has_dot_placeholder(result)
+
+    def test_string_plus_list_normalizes_to_block_list(self) -> None:
+        """A string user followed by a list user normalises the string to
+        a text block and concatenates."""
+        list_blocks = [
+            {"type": "text", "text": "see this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        msgs = [
+            {"role": "user", "content": "look:"},
+            {"role": "user", "content": list_blocks},
+        ]
+        result = merge_adjacent_user_messages(msgs)
+        assert result == [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "look:"}, *list_blocks],
+            }
+        ]
+        assert not _has_dot_placeholder(result)
 
     def test_empty_input_returns_empty(self) -> None:
-        assert separate_adjacent_user_messages([]) == []
+        assert merge_adjacent_user_messages([]) == []
 
-    def test_system_then_user_then_user_separates_only_users(self) -> None:
+    def test_system_then_user_then_user_merges_only_users(self) -> None:
         msgs = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "one"},
             {"role": "user", "content": "two"},
         ]
-        assert separate_adjacent_user_messages(msgs) == [
+        result = merge_adjacent_user_messages(msgs)
+        assert result == [
             {"role": "system", "content": "sys"},
+            {"role": "user", "content": "one\n\ntwo"},
+        ]
+        assert not _has_dot_placeholder(result)
+
+    def test_does_not_mutate_input_messages(self) -> None:
+        """Merge produces new dicts; the caller's input list is untouched."""
+        original = [
             {"role": "user", "content": "one"},
-            {"role": "assistant", "content": "."},
             {"role": "user", "content": "two"},
         ]
+        snapshot = [dict(m) for m in original]
+        merge_adjacent_user_messages(original)
+        assert original == snapshot
+
+
+class TestConcatUserMessages:
+    """``_concat_user_messages`` is the block-aware joiner behind the merge."""
+
+    def test_two_strings_join_with_blank_line(self) -> None:
+        a = {"role": "user", "content": "alpha"}
+        b = {"role": "user", "content": "beta"}
+        assert _concat_user_messages(a, b) == {"role": "user", "content": "alpha\n\nbeta"}
+
+    def test_two_lists_concatenate(self) -> None:
+        a = {"role": "user", "content": [{"type": "text", "text": "x"}]}
+        b = {"role": "user", "content": [{"type": "text", "text": "y"}]}
+        assert _concat_user_messages(a, b) == {
+            "role": "user",
+            "content": [{"type": "text", "text": "x"}, {"type": "text", "text": "y"}],
+        }
+
+    def test_string_then_list_normalizes_string(self) -> None:
+        a = {"role": "user", "content": "hi"}
+        b = {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "u"}}]}
+        assert _concat_user_messages(a, b) == {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hi"},
+                {"type": "image_url", "image_url": {"url": "u"}},
+            ],
+        }
+
+
+class TestIsDegenerateEmptyAssistant:
+    """``_is_degenerate_empty_assistant`` flags assistant turns carrying no
+    content, no tool_calls, and no thinking — the non-events that
+    ``build_messages`` drops to break the empty-turn imitation loop."""
+
+    def test_empty_string_no_tools_no_thinking_is_degenerate(self) -> None:
+        assert _is_degenerate_empty_assistant({"role": "assistant", "content": ""}) is True
+
+    def test_whitespace_only_content_is_degenerate(self) -> None:
+        assert _is_degenerate_empty_assistant({"role": "assistant", "content": "  \n\t"}) is True
+
+    def test_content_none_is_degenerate(self) -> None:
+        assert _is_degenerate_empty_assistant({"role": "assistant", "content": None}) is True
+
+    def test_missing_content_is_degenerate(self) -> None:
+        assert _is_degenerate_empty_assistant({"role": "assistant"}) is True
+
+    def test_text_content_is_not_degenerate(self) -> None:
+        assert _is_degenerate_empty_assistant({"role": "assistant", "content": "hi"}) is False
+
+    def test_tool_calls_present_is_not_degenerate(self) -> None:
+        msg = {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]}
+        assert _is_degenerate_empty_assistant(msg) is False
+
+    def test_thinking_blocks_present_is_not_degenerate(self) -> None:
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "thinking_blocks": [{"type": "thinking", "thinking": "hmm"}],
+        }
+        assert _is_degenerate_empty_assistant(msg) is False
+
+    def test_list_content_with_nonempty_text_block_is_not_degenerate(self) -> None:
+        msg = {"role": "assistant", "content": [{"type": "text", "text": "real"}]}
+        assert _is_degenerate_empty_assistant(msg) is False
+
+    def test_list_content_with_only_empty_text_blocks_is_degenerate(self) -> None:
+        msg = {"role": "assistant", "content": [{"type": "text", "text": "  "}]}
+        assert _is_degenerate_empty_assistant(msg) is True
+
+    def test_non_assistant_role_is_never_degenerate(self) -> None:
+        assert _is_degenerate_empty_assistant({"role": "user", "content": ""}) is False
+        assert _is_degenerate_empty_assistant({"role": "tool", "content": ""}) is False
 
 
 class TestStubMissingReasoningContent:
@@ -1620,10 +1792,12 @@ class TestStubMissingReasoningContent:
         stub_missing_reasoning_content(msgs)
         assert msgs[0] == {"role": "tool", "tool_call_id": "x", "content": "result"}
 
-    def test_stubs_separator_placeholder(self) -> None:
-        """The placeholder assistant inserted by
-        :func:`separate_adjacent_user_messages` is still an assistant
-        message and must also carry the stub."""
+    def test_stubs_bare_dot_assistant(self) -> None:
+        """Any assistant turn — including a stray single-byte one — must
+        carry the empty reasoning stub so thinking-mode providers don't
+        reject the transcript. (``merge_adjacent_user_messages`` no longer
+        produces such a turn, but the stub must still cover one if present
+        from any other source.)"""
         msgs = [
             {"role": "user", "content": "a"},
             {"role": "assistant", "content": "."},
@@ -1646,24 +1820,29 @@ class TestStubMissingReasoningContent:
         assert msgs[0]["tool_calls"] == [{"id": "a"}]
 
 
-class TestSeparateAdjacentUserMessagesPipeline:
-    """Exercise the separator against realistic ``build_messages`` output
+class TestMergeAdjacentUserMessagesPipeline:
+    """Exercise the merge against realistic ``build_messages`` output
     (rather than synthetic dicts) so a refactor that changes the output's
     role sequence can't silently break the fix."""
 
-    def test_inbound_then_tail_block_gets_separator(self) -> None:
+    def test_inbound_then_tail_block_merge_into_one_user(self) -> None:
+        """An inbound followed by the user-role channels tail block is the
+        canonical adjacency: the two fold into a single user turn, and no
+        degenerate ``"."`` assistant placeholder is produced."""
         events = [_evt(1, "user", content="hello")]
         msgs = _full_pipeline(events, ["signal/test/1"])
 
-        assert [m["role"] for m in msgs] == ["user", "assistant", "user"]
-        assert msgs[1] == {"role": "assistant", "content": "."}
-        assert msgs[2]["content"].startswith("━━━ Channels ━━━")
+        assert [m["role"] for m in msgs] == ["user"]
+        assert not any(m == {"role": "assistant", "content": "."} for m in msgs)
+        merged = msgs[0]["content"]
+        assert merged.startswith(f"[received={RECEIVED}]\nhello")
+        assert "\n\n━━━ Channels ━━━" in merged
 
-    def test_blind_spot_injection_adjacent_user_gets_separator(self) -> None:
+    def test_blind_spot_injection_adjacent_user_merges(self) -> None:
         """``build_messages`` inlines a blind-spot tool result as a
-        synthetic user message right after the horizon-setter.  When
-        a real user event follows, the two land back-to-back and need
-        separating."""
+        synthetic user message right after the horizon-setter.  When a
+        real user event follows, the two land back-to-back and merge into
+        one user turn (was: separated by a ``"."`` placeholder)."""
         events = [
             _evt(1, "user", content="run it"),
             _evt(2, "assistant", tool_calls=[_tc("t1")]),
@@ -1678,18 +1857,19 @@ class TestSeparateAdjacentUserMessagesPipeline:
 
         msgs = _full_pipeline(events, channels=[])
 
-        injection_idx = next(
-            i
-            for i, m in enumerate(msgs)
-            if m["role"] == "user" and "RESULT" in str(m.get("content", ""))
+        assert not any(m == {"role": "assistant", "content": "."} for m in msgs)
+        merged = next(
+            m for m in msgs if m["role"] == "user" and "RESULT" in str(m.get("content", ""))
         )
-        assert msgs[injection_idx + 1] == {"role": "assistant", "content": "."}
-        assert msgs[injection_idx + 2]["role"] == "user"
-        assert msgs[injection_idx + 2]["content"] == f"[received={RECEIVED}]\nanything else?"
+        # The injected blind-spot result and the following real inbound are
+        # one user turn now.
+        assert "anything else?" in merged["content"]
+        # The original inbound stays its own (earlier) user turn.
+        assert merged["content"].count("RESULT") == 1
 
-    def test_alternating_events_no_tail_block_no_separator(self) -> None:
-        """Guards against a future change that inserts a separator when
-        no adjacency exists (empty bindings → tail block is ``None``)."""
+    def test_alternating_events_no_tail_block_no_merge(self) -> None:
+        """No adjacency (empty bindings → tail block is ``None``) → the
+        role sequence is untouched and no placeholder is produced."""
         events = [
             _evt(1, "user", content="hi"),
             _evt(2, "assistant", content="hello"),

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -236,12 +236,16 @@ class TestInjectCacheBreakpoints:
         assert msgs[3]["content"] == tail["content"]
 
     def test_skips_tail_and_adjacency_separator(self) -> None:
-        """When the last stable event was user-role,
-        ``separate_adjacent_user_messages`` inserts a placeholder
-        assistant before the tail.  The breakpoint must skip *both* —
-        annotating the single-byte placeholder would be a wasted
-        breakpoint that also wouldn't survive content normalization on
-        some routes.
+        """``inject_cache_breakpoints`` must skip *both* the tail block and
+        a single-byte ``"."`` placeholder assistant separator before it —
+        annotating the placeholder would be a wasted breakpoint that also
+        wouldn't survive content normalization on some routes.
+
+        ``merge_adjacent_user_messages`` no longer *produces* this
+        placeholder (adjacent users are merged in place), but
+        ``_is_separator_placeholder`` / the breakpoint-skip logic must
+        still recognise one from any other source — pinned here against a
+        hand-constructed separator.
         """
         tail = _msg("user", "━━━ Channels ━━━\n▸ channel_id=x (focal)")
         stable = _msg("user", "real peer message")


### PR DESCRIPTION
## What & why

`claude-fable-5` agents (Ultron) go **mute** — emitting empty turns until the session is dead — where `opus-4.x` runs fine. Root-caused in a **local repro of the real prod Ultron session** (cloned into a local aios; composes through the real harness + completion path through ant-proxy with the worker's key; deterministic, ~0 variance).

### The mechanism (proven)

| context | fable | opus |
|---|---|---|
| clean history | **0/10 empty** | — |
| history containing a run of degenerate assistant turns | **10/10 EMPTY** | **0/8** |

Fable **amplifies degenerate patterns in its own history into a silence feedback loop**; opus ignores them. It's *accretive*, not a single bug — so this PR removes the aios-side sources that seed and feed the loop, matching the contract Claude Code runs under (CC **never** emits empty turns).

### Why CC never empties, and aios does — three stacked causes, three fixes

1. **CC always thinks; aios-fable structurally couldn't.** aios stored thinking blocks under `provider_specific_fields`, where `_strip_to_spec` drops them on replay → LiteLLM sees a thinking-less history and **silently drops the `thinking` param** (over-broad guard + a bootstrap deadlock). Thinking-less fable stochastically emits empty turns. → **Commit 3**: lift thinking blocks to top-level on store (drop empty-thinking blocks that fail signature validation); neutralize the guard so existing sessions can transition.
2. **CC's contract has no sanctioned silence; aios's did.** The focal paradigm said *"silence is the right choice."* Fable complies literally (empty turn); opus writes a private monologue. → **Commit 2**: every step must produce output (a private `INTERNAL_MONOLOGUE…` line if nothing needs a reply).
3. **The amplifier.** Any degenerate turn that lands gets imitated. Empty turns + the `.` placeholder separator between adjacent user messages (one `.` flips fable 0%→100% in repro) feed it. → **Commit 1**: drop degenerate empty turns from replay; merge adjacent user inbounds instead of inserting `.` placeholders (the placeholder's original purpose — guarding the channels tail block — was already eliminated by #774).

## Scope / honest limits

These remove the aios-side **seed material and amplifier**; they don't make fable's amplification *itself* disappear (that's model behavior — being reported to Anthropic with this repro). With all three, an empty turn becomes **rare, invisible, and sterile** instead of common, visible, and viral. No retries / extra inference. Already-saturated sessions still need a window roll-off; a clean session post-#774 + this PR stays clean.

## Commits (independently reviewable/revertible)

1. `fix(harness): replay hygiene` — drop degenerate empty turns + merge adjacent user messages
2. `fix(harness): focal paradigm mandates output every step`
3. `fix(harness): preserve Anthropic thinking blocks across replay; unblock thinking param`

**Riskiest piece**, isolated in commit 3: a module-level monkeypatch neutralizing a private LiteLLM guard (`last_assistant_with_tool_calls_has_no_thinking_blocks`). Wrapped in try/except, verified live (no 400s on fable or opus), tagged for removal when LiteLLM narrows the guard upstream.

## Tests

- New unit coverage: `_is_degenerate_empty_assistant`, `merge_adjacent_user_messages`/`_concat_user_messages`, `_normalize_message` thinking-lift, the paradigm prose contract.
- Rewrote `tests/e2e/test_step_separator.py` to assert the merge behavior (adjacent inbounds → one user turn, no `.` placeholder).
- `ruff` + `ruff format` + `mypy` clean; **1878 unit + e2e (separator/focal) green** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
