### PR TITLE
fix(harness): surface model content_filter refusals as errored turns (no dispatch, no poison)

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -535,9 +535,11 @@ async def stream_litellm(
     event channel. SSE clients receive these as ``event: delta`` — no DB
     row is created. After the stream exhausts, the complete message is
     assembled via ``litellm.stream_chunk_builder`` and returned for
-    storage as a normal event. ``litellm.stream_chunk_builder`` carries the
-    final chunk's ``finish_reason`` onto the assembled object's
-    ``choices[0]``, so the refusal signal survives the streaming path too.
+    storage as a normal event. ``stream_chunk_builder`` reassembles the
+    ``finish_reason`` with an unconditional last-wins loop, so a trailing
+    chunk can clobber a ``content_filter`` refusal; the loop below captures
+    the refusal off the wire and re-asserts it so the signal survives the
+    streaming path too.
     """
     inject_cache_breakpoints(messages, tools, model)
     kwargs = _build_litellm_kwargs(
@@ -564,6 +566,17 @@ async def stream_litellm(
     chunks: list[Any] = []
     aiter = response.__aiter__()
     first = True
+    # Capture a ``content_filter`` refusal directly off the wire. litellm
+    # 1.83.4's ``stream_chunk_builder`` derives the assembled ``finish_reason``
+    # via an UNCONDITIONAL last-wins loop over chunks, and its Anthropic
+    # streaming adapter defaults ``finish_reason=""`` on every chunk (setting
+    # the mapped value only on the ``message_delta`` event). So any
+    # choice-bearing chunk arriving AFTER the refusal (e.g. an auto
+    # ``include_usage`` trailer carrying ``finish_reason`` in {"", None,
+    # "stop"}) silently clobbers ``content_filter`` back to ``"stop"`` —
+    # defeating ``loop.REFUSAL_FINISH_REASON`` gating on the streaming path.
+    # Make it sticky: once seen on the wire, override the assembled value.
+    saw_content_filter = False
     while True:
         timeout = _STREAM_TTFT_TIMEOUT_S if first else _STREAM_INTER_CHUNK_TIMEOUT_S
         try:
@@ -576,6 +589,12 @@ async def stream_litellm(
         # include_usage) emit a terminal usage-summary chunk with empty choices.
         if not chunk.choices:
             continue
+        # ``"content_filter"`` == ``loop.REFUSAL_FINISH_REASON`` (literal here
+        # to avoid a loop<->completion import cycle). ``getattr`` guard: real
+        # litellm chunks always carry ``finish_reason`` (defaults None/""), but
+        # a partial/edge chunk that omits it must not crash the stream loop.
+        if getattr(chunk.choices[0], "finish_reason", None) == "content_filter":
+            saw_content_filter = True
         content = chunk.choices[0].delta.content
         if content:
             await _notify_delta(pool, session_id, content)
@@ -596,7 +615,15 @@ async def stream_litellm(
             f"{model!r}; the provider closed the connection without emitting "
             f"any data"
         )
-    return _unpack_litellm_response(assembled, source="stream_chunk_builder")
+    message, usage, cost, finish_reason = _unpack_litellm_response(
+        assembled, source="stream_chunk_builder"
+    )
+    # Restore a refusal that stream_chunk_builder's last-wins loop clobbered
+    # (see ``saw_content_filter`` above). Zero behavior change on the happy
+    # path: only fires when the wire actually carried a ``content_filter``.
+    if saw_content_filter and finish_reason != "content_filter":
+        finish_reason = "content_filter"
+    return message, usage, cost, finish_reason
 
 
 async def _notify_delta(

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -454,20 +454,30 @@ def _build_litellm_kwargs(
 
 def _unpack_litellm_response(
     obj: Any, *, source: str
-) -> tuple[dict[str, Any], dict[str, int], float | None]:
-    """Extract ``(message, usage, cost)``; ``source`` labels the TypeError on bad message shape."""
+) -> tuple[dict[str, Any], dict[str, int], float | None, str | None]:
+    """Extract ``(message, usage, cost, finish_reason)``.
+
+    ``finish_reason`` is litellm's standardized stop reason for the choice
+    (``"stop"``, ``"tool_calls"``, ``"length"``, ``"content_filter"`` for a
+    safety refusal, …). The harness branches on ``"content_filter"`` to treat
+    a refusal as a bricked turn rather than a normal completion (see
+    ``loop.REFUSAL_FINISH_REASON``). ``source`` labels the TypeError on bad
+    message shape.
+    """
     usage_obj = obj.get("usage")
     usage = _normalize_usage(
         usage_obj.model_dump() if hasattr(usage_obj, "model_dump") else usage_obj or {}
     )
     cost = _extract_cost(obj)
-    message = obj["choices"][0]["message"]
+    choice = obj["choices"][0]
+    finish_reason: str | None = choice.get("finish_reason")
+    message = choice["message"]
     # litellm returns a Message object that supports model_dump()
     if hasattr(message, "model_dump"):
         result: dict[str, Any] = message.model_dump()
-        return _normalize_message(result), usage, cost
+        return _normalize_message(result), usage, cost, finish_reason
     if isinstance(message, dict):
-        return _normalize_message(message), usage, cost
+        return _normalize_message(message), usage, cost, finish_reason
     raise TypeError(f"unexpected message type from {source}: {type(message).__name__}")
 
 
@@ -479,14 +489,17 @@ async def call_litellm(
     api_base: str | None = None,
     extra: dict[str, Any] | None = None,
     session_id: str | None = None,
-) -> tuple[dict[str, Any], dict[str, int], float | None]:
-    """Call ``litellm.acompletion`` and return ``(message, usage, cost)``.
+) -> tuple[dict[str, Any], dict[str, int], float | None, str | None]:
+    """Call ``litellm.acompletion`` and return ``(message, usage, cost, finish_reason)``.
 
     Returns the message exactly as litellm produced it, including any
     provider-specific extensions like ``reasoning_content`` or
     ``thinking_blocks``. The harness stores the message dict opaquely.
     Usage is normalized to our canonical field names. Cost is LiteLLM's
     per-request USD figure, or ``None`` when the provider doesn't report it.
+    ``finish_reason`` is litellm's standardized stop reason for the choice
+    (notably ``"content_filter"`` for a safety refusal — see
+    ``_unpack_litellm_response``).
 
     ``session_id`` (when provided on the openai provider path) is forwarded
     as OpenAI's ``prompt_cache_key`` so successive turns of the same
@@ -515,14 +528,16 @@ async def stream_litellm(
     extra: dict[str, Any] | None = None,
     pool: asyncpg.Pool[Any],
     session_id: str,
-) -> tuple[dict[str, Any], dict[str, int], float | None]:
-    """Call ``litellm.acompletion`` with streaming, returning ``(message, usage, cost)``.
+) -> tuple[dict[str, Any], dict[str, int], float | None, str | None]:
+    """Call ``litellm.acompletion`` with streaming, returning ``(message, usage, cost, finish_reason)``.
 
     Each content delta fires a transient ``pg_notify`` on the session's
     event channel. SSE clients receive these as ``event: delta`` — no DB
     row is created. After the stream exhausts, the complete message is
     assembled via ``litellm.stream_chunk_builder`` and returned for
-    storage as a normal event.
+    storage as a normal event. ``litellm.stream_chunk_builder`` carries the
+    final chunk's ``finish_reason`` onto the assembled object's
+    ``choices[0]``, so the refusal signal survives the streaming path too.
     """
     inject_cache_breakpoints(messages, tools, model)
     kwargs = _build_litellm_kwargs(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -79,8 +79,9 @@ REFUSAL_FINISH_REASON = "content_filter"
 # console's "Errored" pill (status idle + stop_reason.type == "error").
 _REFUSAL_STOP_REASON_MESSAGE = (
     "Model returned a content_filter refusal; the turn was not dispatched. "
-    "The model likely refused due to conversation content. Switch the session's "
-    "model or edit context to recover."
+    "The model likely refused due to conversation content. To recover, post a "
+    "message to the session (optionally after switching the agent's model or "
+    "trimming the conversation that triggered the refusal)."
 )
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -64,6 +64,25 @@ _RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
 # budget).
 _JOB_TIMEOUT_S = 300.0
 
+# litellm's standardized ``finish_reason`` for a safety refusal. Anthropic's
+# ``stop_reason: "refusal"`` maps here; OpenAI/Azure ``content_filter`` lands
+# here too. A refusal is a *bricked* turn: the response is often truncated
+# mid-generation (a tool call with a half-written argument the API closes into
+# valid-but-wrong JSON) or empty (refused at token 1). Persisting it poisons
+# subsequent turns and dispatching its tool calls is dangerous, so the step
+# surfaces it as an errored turn instead of treating it as a normal completion.
+# Keyed on the standardized value — NOT on any provider/model name — so it
+# stays provider-agnostic.
+REFUSAL_FINISH_REASON = "content_filter"
+
+# Operator-facing message on the errored stop_reason. Renders behind the
+# console's "Errored" pill (status idle + stop_reason.type == "error").
+_REFUSAL_STOP_REASON_MESSAGE = (
+    "Model returned a content_filter refusal; the turn was not dispatched. "
+    "The model likely refused due to conversation content. Switch the session's "
+    "model or edit context to recover."
+)
+
 
 def _retry_delay_for_attempt(attempt: int) -> float | None:
     """Return the backoff delay for ``attempt``, or ``None`` if the budget is spent."""
@@ -443,7 +462,7 @@ async def _run_session_step_body(
     subscribed = await has_subscriber(pool, session_id)
     try:
         if subscribed:
-            assistant_msg, usage, cost_usd = await stream_litellm(
+            assistant_msg, usage, cost_usd, finish_reason = await stream_litellm(
                 model=agent.model,
                 messages=messages,
                 tools=tools if tools else None,
@@ -452,7 +471,7 @@ async def _run_session_step_body(
                 session_id=session_id,
             )
         else:
-            assistant_msg, usage, cost_usd = await call_litellm(
+            assistant_msg, usage, cost_usd, finish_reason = await call_litellm(
                 model=agent.model,
                 messages=messages,
                 tools=tools if tools else None,
@@ -500,7 +519,9 @@ async def _run_session_step_body(
         account_id=account_id,
     )
 
-    # Increment cumulative session-level token counters.
+    # Increment cumulative session-level token counters. A refusal still
+    # consumed tokens upstream, so this (and the model_request_end span above)
+    # runs unconditionally — only the *persist + dispatch* below is suppressed.
     await sessions_service.increment_usage(
         pool,
         session_id,
@@ -510,6 +531,32 @@ async def _run_session_step_body(
         cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
         account_id=account_id,
     )
+
+    # A refusal bricks the turn: the assistant message is partial/empty and its
+    # tool calls may be truncated. Do NOT persist it as a normal assistant turn
+    # (it would poison subsequent context) and do NOT dispatch its tool calls
+    # (a cut argument can hit a wrong-but-valid target). Record the refusal as a
+    # span (excluded from build_messages replay) and latch the session into the
+    # errored state, where it parks until a user message recovers it. End the
+    # step cleanly — no tool dispatch, normal step_end/turn_ended bracketing.
+    if finish_reason == REFUSAL_FINISH_REASON:
+        await _handle_refusal(
+            pool,
+            session_id,
+            assistant_msg,
+            finish_reason=finish_reason,
+            account_id=account_id,
+        )
+        log.warning(
+            "step.model_refusal",
+            session_id=session_id,
+            finish_reason=finish_reason,
+            had_tool_calls=bool(assistant_msg.get("tool_calls")),
+        )
+        # No ``archive_when_idle``: an errored session parks for recovery, exactly
+        # like the litellm-error / retry-budget-exhausted paths, which never
+        # self-archive. A user message lifts it back to pending.
+        return _StepResult()
 
     if channels:
         from aios.harness.channels import apply_monologue_prefix
@@ -930,6 +977,63 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
         pool, session_id, "turn_ended", "errored", "error", account_id=account_id
     )
     return None
+
+
+async def _handle_refusal(
+    pool: Any,
+    session_id: str,
+    assistant_msg: dict[str, Any],
+    *,
+    finish_reason: str,
+    account_id: str,
+) -> None:
+    """Latch a model refusal (``finish_reason == content_filter``) as an errored turn.
+
+    The refused assistant message is NOT persisted as a normal turn (it would
+    replay as poison) and its tool calls are NOT dispatched (they may be
+    truncated). The partial content/tool_calls are stashed on a ``span`` event
+    for debugging — ``build_messages`` only replays ``kind == "message"`` events,
+    so the span never re-enters context. The session then lands in the terminal
+    ``errored`` state via the same surface as the retry-budget-exhausted path
+    (see ``_apply_retry_or_failure``): a workflow child's open requests are
+    failed so its callers resolve, the stop_reason latches to ``error`` (drives
+    the console "Errored" pill), and the error lifecycle event bumps
+    ``last_error_seq`` so the sweep parks the session until a user message
+    recovers it.
+    """
+    await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {
+            "event": "model_refusal",
+            "is_error": True,
+            "finish_reason": finish_reason,
+            # Kept for debugging only — a span is never replayed by build_messages.
+            "partial_content": assistant_msg.get("content") or "",
+            "partial_tool_calls": assistant_msg.get("tool_calls") or [],
+        },
+        account_id=account_id,
+    )
+    # Mirror the terminal branch of ``_apply_retry_or_failure``: resolve a
+    # workflow child's open requests BEFORE latching the error (the latch makes
+    # the sweep skip the session — see the ordering note there).
+    await fail_all_open_requests(
+        pool, session_id, account_id=account_id, error={"kind": "model_refusal"}
+    )
+    await sessions_service.set_session_stop_reason(
+        pool,
+        session_id,
+        {
+            "type": "error",
+            "message": _REFUSAL_STOP_REASON_MESSAGE,
+            "finish_reason": finish_reason,
+        },
+        account_id=account_id,
+    )
+    await _append_lifecycle(
+        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
+    )
 
 
 async def _handle_step_timeout(pool: Any, session_id: str, *, account_id: str) -> float | None:

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -40,12 +40,23 @@ from aios.tools.registry import ToolHandler, registry
 
 
 def assistant(
-    content: str = "", *, tool_calls: list[dict[str, Any]] | None = None
+    content: str = "",
+    *,
+    tool_calls: list[dict[str, Any]] | None = None,
+    finish_reason: str | None = None,
 ) -> dict[str, Any]:
-    """Build a scripted assistant response dict."""
+    """Build a scripted assistant response dict.
+
+    ``finish_reason`` (when set) is threaded onto the fake litellm envelope's
+    ``choices[0]`` so tests can exercise refusal handling
+    (``finish_reason="content_filter"``). It is stored under a reserved key and
+    stripped before the dict becomes the assistant message.
+    """
     d: dict[str, Any] = {"role": "assistant", "content": content}
     if tool_calls is not None:
         d["tool_calls"] = tool_calls
+    if finish_reason is not None:
+        d["_finish_reason"] = finish_reason
     return d
 
 
@@ -85,6 +96,17 @@ def cancel(tool_call_id: str | None = None, *, call_id: str | None = None) -> di
 
 
 # ─── fake litellm response ──────────────────────────────────────────────────
+
+
+def _split_finish_reason(resp: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Split a scripted response into ``(message, finish_reason)``.
+
+    The ``_finish_reason`` key (set by :func:`assistant`) is a test-only
+    envelope field, not part of the assistant message litellm returns — strip
+    it so it doesn't leak into the persisted message dict.
+    """
+    msg = {k: v for k, v in resp.items() if k != "_finish_reason"}
+    return msg, resp.get("_finish_reason")
 
 
 class _FakeMessage:
@@ -436,8 +458,9 @@ class Harness:
             )
         resp = self._responses[self._response_idx]
         self._response_idx += 1
+        msg, finish_reason = _split_finish_reason(resp)
         return {
-            "choices": [{"message": _FakeMessage(resp)}],
+            "choices": [{"message": _FakeMessage(msg), "finish_reason": finish_reason}],
             "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
         }
 
@@ -482,7 +505,8 @@ class Harness:
         recent ``_pop_streaming_response`` call.
         """
         assert self._last_streaming_response is not None
+        msg, finish_reason = _split_finish_reason(self._last_streaming_response)
         return {
-            "choices": [{"message": _FakeMessage(self._last_streaming_response)}],
+            "choices": [{"message": _FakeMessage(msg), "finish_reason": finish_reason}],
             "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
         }

--- a/tests/e2e/test_refusal.py
+++ b/tests/e2e/test_refusal.py
@@ -1,0 +1,158 @@
+"""E2E tests for model refusal handling (``finish_reason == content_filter``).
+
+A refusal is a bricked turn: litellm maps Anthropic's ``stop_reason: "refusal"``
+(and OpenAI/Azure ``content_filter``) to ``finish_reason: "content_filter"``. The
+response is often truncated mid-generation (a tool call whose argument was cut and
+closed into valid-but-wrong JSON) or empty (refused at token 1). The harness must
+NOT dispatch its tool calls and must NOT persist it as a normal assistant turn —
+instead it surfaces the refusal as an errored turn (console "Errored" pill) and
+parks the session until a user message recovers it.
+
+These tests are model-agnostic: they key on the standardized ``finish_reason``,
+never on a provider/model name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.harness.loop import REFUSAL_FINISH_REASON
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant, tool_call
+
+
+@needs_docker
+class TestRefusalHandling:
+    async def test_refusal_with_truncated_tool_call_does_not_dispatch(
+        self, harness: Harness
+    ) -> None:
+        """A content_filter refusal carrying a (truncated) tool call latches the
+        session into errored without dispatching the tool."""
+        dispatched: list[str] = []
+
+        async def echo_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            dispatched.append(arguments.get("text", ""))  # pragma: no cover
+            return {"output": arguments.get("text", "")}  # pragma: no cover
+
+        harness.register_tool("echo", echo_handler)
+        harness.script_model(
+            [
+                # Refusal truncated mid-tool-call: a half-written argument the API
+                # closed into valid-but-wrong JSON. Must NOT be dispatched.
+                assistant(
+                    tool_calls=[tool_call("echo", {"text": "do something dang"})],
+                    finish_reason=REFUSAL_FINISH_REASON,
+                ),
+            ]
+        )
+        session = await harness.start("please do the thing", tools=[])
+        await harness.run_step(session.id)
+
+        # The tool was never dispatched.
+        await harness.wait_for_tools(session.id)
+        assert dispatched == []
+
+        # Session is errored: idle + stop_reason.type == "error" (the console pill).
+        s = await harness.session(session.id)
+        assert s.status == "idle"
+        assert s.stop_reason is not None
+        assert s.stop_reason["type"] == "error"
+        assert s.stop_reason["finish_reason"] == REFUSAL_FINISH_REASON
+
+        # The refused turn is NOT persisted as an assistant message.
+        events = await harness.events(session.id)
+        assistants = [e for e in events if e.data.get("role") == "assistant"]
+        assert assistants == []
+
+        # It IS recorded as a (non-replayed) span for debugging.
+        all_evts = await harness.all_events(session.id)
+        refusal_spans = [
+            e for e in all_evts if e.kind == "span" and e.data.get("event") == "model_refusal"
+        ]
+        assert len(refusal_spans) == 1
+        assert refusal_spans[0].data["finish_reason"] == REFUSAL_FINISH_REASON
+        assert refusal_spans[0].data["is_error"] is True
+
+    async def test_refusal_with_empty_content_latches_error(self, harness: Harness) -> None:
+        """A refusal at token 1 (empty content, no tool calls) still latches error."""
+        harness.script_model(
+            [assistant("", finish_reason=REFUSAL_FINISH_REASON)],
+        )
+        session = await harness.start("something objectionable")
+        await harness.run_step(session.id)
+
+        s = await harness.session(session.id)
+        assert s.status == "idle"
+        assert s.stop_reason is not None
+        assert s.stop_reason["type"] == "error"
+
+        events = await harness.events(session.id)
+        assert [e for e in events if e.data.get("role") == "assistant"] == []
+
+    async def test_errored_session_not_swept(self, harness: Harness) -> None:
+        """After a refusal the sweep parks the session — no re-wake into a cascade."""
+        harness.script_model(
+            [assistant("", finish_reason=REFUSAL_FINISH_REASON)],
+        )
+        session = await harness.start("trigger refusal")
+        await harness.run_step(session.id)
+
+        needs = await harness.sessions_needing_inference(session.id)
+        assert session.id not in needs
+
+    async def test_refused_turn_absent_from_next_context(self, harness: Harness) -> None:
+        """A user message recovers the session; the refused (poison) content must
+        NOT appear in the recovery turn's context."""
+        poison = "this half-written poison must never replay"
+        harness.script_model(
+            [
+                # Step 1: refusal with poisonous partial content + truncated tool call.
+                assistant(
+                    poison,
+                    tool_calls=[tool_call("noop", {"arg": "truncated"}, call_id="call_bad")],
+                    finish_reason=REFUSAL_FINISH_REASON,
+                ),
+                # Step 2: after recovery user message, model responds normally.
+                assistant("Recovered, here is a fresh answer."),
+            ]
+        )
+
+        async def noop_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            return {"ok": True}  # pragma: no cover
+
+        harness.register_tool("noop", noop_handler)
+
+        session = await harness.start("do the thing", tools=[])
+        await harness.run_step(session.id)
+
+        # A user message lifts errored → pending (existing recovery path).
+        await harness.inject_message(session.id, "let's try a different approach")
+        await harness.run_until_idle(session.id)
+
+        # The recovery step's context must not contain the refused content or its
+        # truncated tool call — build_messages skips the refusal span.
+        assert len(harness.model_calls) == 2
+        recovery_messages = harness.model_calls[1]["messages"]
+        flattened = str(recovery_messages)
+        assert poison not in flattened
+        assert "call_bad" not in flattened
+
+        # And the session recovered normally.
+        events = await harness.events(session.id)
+        last_asst = next(e for e in reversed(events) if e.data.get("role") == "assistant")
+        assert last_asst.data["content"] == "Recovered, here is a fresh answer."
+
+    async def test_normal_finish_reason_is_not_treated_as_refusal(self, harness: Harness) -> None:
+        """A normal turn (finish_reason unset / "stop") is unaffected — guards
+        against an over-broad refusal predicate."""
+        harness.script_model([assistant("Hello, world!", finish_reason="stop")])
+        session = await harness.start("hi")
+        await harness.run_until_idle(session.id)
+
+        s = await harness.session(session.id)
+        assert s.stop_reason == {"type": "end_turn"}
+
+        events = await harness.events(session.id)
+        assistants = [e for e in events if e.data.get("role") == "assistant"]
+        assert len(assistants) == 1
+        assert assistants[0].data["content"] == "Hello, world!"

--- a/tests/unit/test_completion_finish_reason.py
+++ b/tests/unit/test_completion_finish_reason.py
@@ -16,6 +16,7 @@ import pytest
 
 from aios.harness import completion
 from aios.harness.completion import _unpack_litellm_response
+from tests.unit.test_completion_timeouts import _StubPool
 
 
 def _envelope(message: dict[str, Any], finish_reason: str | None) -> dict[str, Any]:
@@ -119,8 +120,6 @@ class TestStreamStickyContentFilter:
 
     @pytest.mark.asyncio
     async def test_refusal_survives_trailing_clobber(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from tests.unit.test_completion_timeouts import _StubPool
-
         # content_filter rides a non-final chunk; a trailing "stop" chunk is
         # what litellm's assembler would last-wins onto the result.
         chunks = [
@@ -149,8 +148,6 @@ class TestStreamStickyContentFilter:
     ) -> None:
         """The capture must not fabricate a refusal: a stream whose wire never
         carried ``content_filter`` returns the assembled value unchanged."""
-        from tests.unit.test_completion_timeouts import _StubPool
-
         chunks = [
             _FakeChunk(finish_reason=None, content="hi"),
             _FakeChunk(finish_reason="stop"),

--- a/tests/unit/test_completion_finish_reason.py
+++ b/tests/unit/test_completion_finish_reason.py
@@ -1,0 +1,56 @@
+"""Unit tests for ``finish_reason`` threading in ``_unpack_litellm_response``.
+
+The refusal-surfacing logic in ``loop.py`` keys on the standardized
+``finish_reason`` litellm puts on each choice. These tests pin that the unpack
+helper extracts it for a normal completion, a tool-call completion, and a
+``content_filter`` refusal, and that absence degrades to ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.harness.completion import _unpack_litellm_response
+
+
+def _envelope(message: dict[str, Any], finish_reason: str | None) -> dict[str, Any]:
+    """Minimal dict-shaped litellm envelope (matches the e2e harness mock)."""
+    choice: dict[str, Any] = {"message": message}
+    if finish_reason is not None:
+        choice["finish_reason"] = finish_reason
+    return {
+        "choices": [choice],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+class TestUnpackFinishReason:
+    def test_threads_stop_for_normal_completion(self) -> None:
+        msg, _usage, _cost, finish_reason = _unpack_litellm_response(
+            _envelope({"role": "assistant", "content": "hello"}, "stop"),
+            source="test",
+        )
+        assert finish_reason == "stop"
+        assert msg["content"] == "hello"
+
+    def test_threads_tool_calls_finish_reason(self) -> None:
+        tc = {"id": "c1", "type": "function", "function": {"name": "bash", "arguments": "{}"}}
+        _msg, _usage, _cost, finish_reason = _unpack_litellm_response(
+            _envelope({"role": "assistant", "content": None, "tool_calls": [tc]}, "tool_calls"),
+            source="test",
+        )
+        assert finish_reason == "tool_calls"
+
+    def test_threads_content_filter_refusal(self) -> None:
+        _msg, _usage, _cost, finish_reason = _unpack_litellm_response(
+            _envelope({"role": "assistant", "content": ""}, "content_filter"),
+            source="test",
+        )
+        assert finish_reason == "content_filter"
+
+    def test_absent_finish_reason_is_none(self) -> None:
+        _msg, _usage, _cost, finish_reason = _unpack_litellm_response(
+            _envelope({"role": "assistant", "content": "hi"}, None),
+            source="test",
+        )
+        assert finish_reason is None

--- a/tests/unit/test_completion_finish_reason.py
+++ b/tests/unit/test_completion_finish_reason.py
@@ -3,13 +3,18 @@
 The refusal-surfacing logic in ``loop.py`` keys on the standardized
 ``finish_reason`` litellm puts on each choice. These tests pin that the unpack
 helper extracts it for a normal completion, a tool-call completion, and a
-``content_filter`` refusal, and that absence degrades to ``None``.
+``content_filter`` refusal, and that absence degrades to ``None`` — and that the
+streaming path's sticky-capture restores a refusal that
+``stream_chunk_builder``'s last-wins assembly clobbers.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
+from aios.harness import completion
 from aios.harness.completion import _unpack_litellm_response
 
 
@@ -54,3 +59,113 @@ class TestUnpackFinishReason:
             source="test",
         )
         assert finish_reason is None
+
+
+class _FakeDelta:
+    def __init__(self, content: str | None) -> None:
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, finish_reason: str | None, content: str | None) -> None:
+        self.finish_reason = finish_reason
+        self.delta = _FakeDelta(content)
+
+
+class _FakeChunk:
+    def __init__(self, finish_reason: str | None, content: str | None = None) -> None:
+        self.choices = [_FakeChoice(finish_reason, content)]
+
+
+class _FakeStream:
+    """Async-iterable of streaming chunks, mirroring litellm's ``acompletion``."""
+
+    def __init__(self, chunks: list[_FakeChunk]) -> None:
+        self._it = iter(chunks)
+
+    def __aiter__(self) -> _FakeStream:
+        return self
+
+    async def __anext__(self) -> _FakeChunk:
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _clobbered_builder(finish_reason: str) -> Any:
+    """A ``stream_chunk_builder`` stand-in returning a given assembled
+    ``finish_reason`` — used to simulate litellm 1.83.4's last-wins clobber."""
+    return lambda chunks: {
+        "usage": {},
+        "choices": [
+            {"message": {"role": "assistant", "content": ""}, "finish_reason": finish_reason}
+        ],
+    }
+
+
+class TestStreamStickyContentFilter:
+    """``stream_litellm`` must preserve a ``content_filter`` refusal across
+    ``stream_chunk_builder``'s last-wins assembly.
+
+    Reproduced against the pinned litellm 1.83.4 during PR review: its
+    ``stream_chunk_builder`` overwrites ``finish_reason`` from every
+    choice-bearing chunk, and the Anthropic streaming adapter defaults
+    ``finish_reason=""`` on all but the ``message_delta`` chunk — so a trailing
+    usage/stop chunk silently clobbers ``content_filter`` back to ``"stop"``,
+    defeating ``loop.REFUSAL_FINISH_REASON`` gating on the SSE/streaming path.
+    ``stream_litellm`` captures the refusal off the wire and re-asserts it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_refusal_survives_trailing_clobber(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tests.unit.test_completion_timeouts import _StubPool
+
+        # content_filter rides a non-final chunk; a trailing "stop" chunk is
+        # what litellm's assembler would last-wins onto the result.
+        chunks = [
+            _FakeChunk(finish_reason="content_filter"),
+            _FakeChunk(finish_reason="stop"),
+        ]
+
+        async def fake_acompletion(**_kwargs: object) -> _FakeStream:
+            return _FakeStream(chunks)
+
+        monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+        monkeypatch.setattr(completion.litellm, "stream_chunk_builder", _clobbered_builder("stop"))
+
+        _msg, _usage, _cost, finish_reason = await completion.stream_litellm(
+            model="anthropic/claude-fable-5",
+            messages=[{"role": "user", "content": "hi"}],
+            pool=_StubPool(),  # type: ignore[arg-type]
+            session_id="sess_refusal",
+        )
+        # Without the sticky-capture this would be "stop" (the clobbered value).
+        assert finish_reason == "content_filter"
+
+    @pytest.mark.asyncio
+    async def test_no_spurious_override_on_normal_stream(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The capture must not fabricate a refusal: a stream whose wire never
+        carried ``content_filter`` returns the assembled value unchanged."""
+        from tests.unit.test_completion_timeouts import _StubPool
+
+        chunks = [
+            _FakeChunk(finish_reason=None, content="hi"),
+            _FakeChunk(finish_reason="stop"),
+        ]
+
+        async def fake_acompletion(**_kwargs: object) -> _FakeStream:
+            return _FakeStream(chunks)
+
+        monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+        monkeypatch.setattr(completion.litellm, "stream_chunk_builder", _clobbered_builder("stop"))
+
+        _msg, _usage, _cost, finish_reason = await completion.stream_litellm(
+            model="anthropic/claude-fable-5",
+            messages=[{"role": "user", "content": "hi"}],
+            pool=_StubPool(),  # type: ignore[arg-type]
+            session_id="sess_ok",
+        )
+        assert finish_reason == "stop"

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -128,7 +128,7 @@ async def test_stream_litellm_long_ttft_succeeds_when_inter_chunk_is_fast(
         },
     )
 
-    message, _, _ = await completion.stream_litellm(
+    message, _, _, _ = await completion.stream_litellm(
         model="anthropic/claude-sonnet-4-6",
         messages=[{"role": "user", "content": "ping"}],
         pool=_StubPool(),  # type: ignore[arg-type]
@@ -259,7 +259,7 @@ async def test_stream_litellm_tolerates_empty_choices_chunk(
     monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
     monkeypatch.setattr(completion.litellm, "stream_chunk_builder", fake_builder)
 
-    message, _, _ = await completion.stream_litellm(
+    message, _, _, _ = await completion.stream_litellm(
         model="openrouter/anthropic/claude-sonnet-4-6",
         messages=[{"role": "user", "content": "ping"}],
         pool=_StubPool(),  # type: ignore[arg-type]

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -215,11 +215,11 @@ class TestEntrySweepSpan:
             ),
             patch(
                 "aios.harness.loop.call_litellm",
-                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0, None)),
             ),
             patch(
                 "aios.harness.loop.stream_litellm",
-                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0, None)),
             ),
             patch(
                 "aios.harness.loop.sessions_service.increment_usage",

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -369,11 +369,11 @@ class TestStepStartEndSpans:
             ),
             patch(
                 "aios.harness.loop.call_litellm",
-                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0, None)),
             ),
             patch(
                 "aios.harness.loop.stream_litellm",
-                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0, None)),
             ),
             patch(
                 "aios.harness.loop.sessions_service.increment_usage",
@@ -471,7 +471,7 @@ class TestStepStartEndSpans:
             patch("aios.harness.loop.sessions_service.reclaim_session_if_idle", reclaim),
             patch(
                 "aios.harness.loop.stream_litellm",
-                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0, None)),
             ),
             patch("aios.harness.loop.sessions_service.increment_usage", AsyncMock()),
             patch("aios.db.sse_lock.has_subscriber", AsyncMock(return_value=False)),
@@ -571,7 +571,7 @@ class TestStepStartEndSpans:
             patch("aios.harness.loop.defer_wake", defer_wake_mock),
             patch(
                 "aios.harness.loop.stream_litellm",
-                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+                AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0, None)),
             ),
             patch("aios.harness.loop.sessions_service.increment_usage", AsyncMock()),
             patch("aios.db.sse_lock.has_subscriber", AsyncMock(return_value=False)),
@@ -750,7 +750,7 @@ async def _harness_with_guard(
         ),
         patch(
             "aios.harness.loop.stream_litellm",
-            AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0)),
+            AsyncMock(return_value=({"role": "assistant", "content": "ok"}, {}, 0.0, None)),
         ),
         patch("aios.harness.loop.sessions_service.increment_usage", AsyncMock()),
         patch("aios.db.sse_lock.has_subscriber", AsyncMock(return_value=False)),


### PR DESCRIPTION
## Problem

litellm maps Anthropic's `stop_reason: "refusal"` (and OpenAI/Azure `content_filter`) to `finish_reason: "content_filter"`. When a model refuses (a safety stop), the response is often **truncated mid-generation** — a tool call with a half-written argument that the API closes into valid-but-wrong JSON — or **empty** (refused at token 1).

Today the harness **drops `finish_reason` entirely** and treats a refusal exactly like a normal turn:

- it **persists the partial/empty assistant message**, which poisons every subsequent turn (the truncated content/tool-call replays into context); and
- it **dispatches the truncated tool calls** — dangerous, because a cut argument can hit a wrong-but-valid target (e.g. a truncated channel UUID that resolves to a different channel).

## Fix (model-agnostic)

Key on litellm's standardized `finish_reason == "content_filter"` — never on a provider/model name.

**1. Thread `finish_reason` out of `completion.py`** (`src/aios/harness/completion.py`)
`_unpack_litellm_response`, `call_litellm`, and `stream_litellm` now return a 4-tuple `(message, usage, cost, finish_reason)`. For the streaming path, `litellm.stream_chunk_builder` already carries the final chunk's `finish_reason` onto the assembled object's `choices[0]` (verified against the installed litellm), so the refusal signal survives streaming too.

**2. Branch on refusal in the step** (`src/aios/harness/loop.py`)
Right after the completion call returns — **after** the `model_request_end` span + usage increment (the refusal genuinely consumed tokens, so those stay unconditional and the calibration read remains accurate), but **before** the assistant message is persisted and before tool partition/dispatch — if `finish_reason == REFUSAL_FINISH_REASON` ("content_filter"):

- **No tool dispatch** (truncated calls may be invalid/dangerous).
- **No normal persist.** The partial content/tool_calls are stashed on a `model_refusal` **span** (`is_error: True`) for debugging. `build_messages` only replays `kind == "message"` events, so the span never re-enters context.
- **Latch the session to errored** via the existing surface: `set_session_stop_reason({"type": "error", "message": ..., "finish_reason": "content_filter"})` + the `turn_ended`/`error` lifecycle event (which bumps `last_error_seq`). This is the same mechanism that renders the console "Errored" pill (`status == 'idle' AND stop_reason.type == 'error'`) and that the sweep excludes from candidacy (`_SESSION_ERRORED_EXPR` / `ERRORED_SESSIONS_SQL`) — so the session **parks**, no re-wake into a refusal cascade.
- A workflow child's open requests are failed first (so its callers resolve), mirroring the terminal branch of `_apply_retry_or_failure`.

The session ends the step cleanly (normal `step_end`/`turn_ended` bracketing).

## Recovery

No new logic — the **existing** errored→pending path: a user message lifts the session out of errored (its seq overtakes `last_error_seq`, the seq-bump in queries) and the sweep re-picks it. The operator-facing stop_reason message tells them to switch the model or edit context.

## Tests (harness layer — the lowest layer the logic lives)

- `tests/e2e/test_refusal.py` (5 cases): truncated-tool-call refusal does **not** dispatch + latches errored with `stop_reason.finish_reason`; empty-content refusal latches error; errored session excluded from sweep; **the refused turn is absent from the next (recovery) context** (poison content + truncated `call_id` both verified gone via `build_messages`); and a normal `finish_reason="stop"` turn is unaffected (guards against an over-broad predicate).
- `tests/unit/test_completion_finish_reason.py`: `_unpack_litellm_response` threads `finish_reason` for normal/`tool_calls`/`content_filter`/absent cases.
- The e2e harness (`assistant(..., finish_reason=...)`) now threads `finish_reason` onto the fake litellm envelope; existing 3-tuple call sites/mocks updated to the 4-tuple shape.

`pytest tests/ -k "completion or loop or refusal or context"` → **241 passed**. `ruff check`/`ruff format`/`mypy` clean on all touched files (the repo's pre-existing test-suite mypy debt is untouched).

## Notes for review

⚠️ **High blast radius** — this touches the worker step every agent turn flows through (`_run_session_step_body`) and the return shape of the completion functions. Wants careful review before merge.

Pairs with the already-merged #793 (which removes the degenerate-history seed material that triggers many of these refusals): #793 cuts the inflow, this PR makes the residual refusals fail safe instead of poisoning the session.

## Update — hardening from adversarial review (commit `cf279be`)

A multi-perspective review surfaced one **runtime** gap (reproduced against the pinned litellm 1.83.4) plus an operator-guidance bug; both are now fixed:

1. **Streaming-path `content_filter` clobber.** `litellm.stream_chunk_builder` reassembles `finish_reason` with an unconditional last-wins loop, and litellm's Anthropic streaming adapter defaults `finish_reason=""` on every chunk except `message_delta`. So a trailing choice-bearing chunk (auto-`include_usage` / stop) silently overwrites `content_filter` back to `"stop"`, bypassing the `REFUSAL_FINISH_REASON` gate on the **SSE/streaming path** for the fleet's primary provider — exactly where refusals are most visible. `stream_litellm` now captures `content_filter` directly off the wire (getattr-guarded) and re-asserts it after assembly. New unit tests (`tests/unit/test_completion_finish_reason.py::TestStreamStickyContentFilter`) simulate the clobber and pin recovery; a `getattr` guard also fixes 3 pre-existing streaming-timeout tests whose minimal chunk stubs lack `finish_reason`.
2. **Operator recovery message** said "switch the session's model or edit context to recover" — but neither lifts the errored latch (`last_error_seq > last_user_seq`), which **only a user message** clears. Reworded to name posting a message as the recovery trigger.

**Validation after hardening:** `1884` unit tests pass (incl. the 2 new + 3 fixed) and all `5` e2e refusal tests pass; `ruff check`/`ruff format` clean; `mypy src` clean.

## Known follow-ups (from adversarial review — not blocking, deliberately deferred)

- **(low) Refusal tokens skew the calibration read.** The refusal's `model_request_end` span is written `is_error: False` (it runs before the refusal branch), so refused/truncated turns enter the token-ratio calibration read. Consider stamping that span `is_error: True` for refusals, or moving the refusal check ahead of span emission — deferred because `is_error` span semantics have other consumers and want a careful separate change.
- **(low) Truncation-by-length is not covered.** litellm maps Anthropic `max_tokens`/`compaction` to `finish_reason="length"`, not `content_filter`, so a tool call truncated by hitting the token cap is still persisted + dispatched. Pre-existing; this PR correctly narrows to safety refusals — noted so readers don't assume general truncated-dispatch prevention.
- **(low) Streaming-path e2e coverage.** All e2e refusal tests route through the non-streaming `call_litellm` path (no SSE subscriber held). FIX 1's unit test now covers the assembly seam directly; a streaming-path e2e test (holding a real subscriber lock so `has_subscriber()` → True) would additionally guard the gate from ever becoming path-conditional.

**Verified during review (no action needed):** litellm 1.83.4 maps Anthropic `refusal → content_filter`; ant-proxy forwards the response body byte-for-byte (so the signal survives to litellm); `build_messages` excludes the `model_refusal` span (no replay poison); no migration (safe lockstep promote). And confirmed empirically against captured ant-proxy dumps: real Claude **does** emit `stop_reason: refusal` (136 instances in one production day), so the handler targets a real, frequent signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

