### PR TITLE
feat(inbound): debounce connector-inbound wake on burst arrival

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -356,6 +356,26 @@ class Settings(BaseSettings):
     )
 
     # ── connectors ─────────────────────────────────────────────────────────
+    inbound_debounce_seconds: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Debounce window (seconds) before the FIRST wake of an "
+        "idle session on a connector inbound. aios already coalesces "
+        "mid-turn arrivals, but the very first wake of an idle session "
+        "fires immediately, so a bursty sender that jitters several "
+        "messages a few seconds apart (e.g. Jarvis, 2-5s between sends) "
+        "spawns one turn per message instead of one turn for the burst. "
+        "When > 0, the inbound path schedules the wake this many seconds "
+        "out via ``defer_wake``'s ``delay_seconds``; the existing "
+        "``queueing_lock=session_id`` dedup then collapses any follow-on "
+        "inbounds that land inside the window into the same single wake. "
+        "0.0 (the default) disables debounce — the wake fires immediately, "
+        "preserving pre-feature behavior. Fixed delay, not random jitter "
+        "(v1). Only the connector-inbound first wake is affected; the "
+        "harness retry-backoff path (cause='reschedule') and the async "
+        "tool-completion path (cause='connector_tool_result') are "
+        "untouched.",
+    )
     connector_backfill_max_age_seconds: int = Field(
         default=60 * 60,  # 1 hour
         ge=60,

--- a/src/aios/services/inbound.py
+++ b/src/aios/services/inbound.py
@@ -19,6 +19,7 @@ from typing import Any, NamedTuple
 
 import asyncpg
 
+from aios.config import get_settings
 from aios.db import queries
 from aios.errors import NotFoundError
 from aios.models.sessions import MAX_USER_MESSAGE_CHARS
@@ -186,7 +187,23 @@ async def handle_inbound(
 
     # Defer wake unconditionally — both first-append and dedup paths
     # heal the case where a prior attempt committed but failed to wake.
-    await defer_wake(pool, target_session_id, cause="inbound", account_id=account_id)
+    #
+    # Inbound debounce (#799): when configured (> 0), schedule the first
+    # wake of an idle session ``inbound_debounce_seconds`` out instead of
+    # immediately. ``defer_wake``'s ``queueing_lock=session_id`` then
+    # collapses any follow-on inbounds that arrive inside the window into
+    # this same single wake — one turn for a bursty sender's whole burst.
+    # Only the inbound path is debounced; the harness retry (cause=
+    # 'reschedule') and tool-completion (cause='connector_tool_result')
+    # paths pass their own delay semantics and are untouched. When the
+    # knob is 0.0 (off), omit ``delay_seconds`` entirely so the call is
+    # byte-identical to pre-feature behavior (and so the test assertion
+    # for the off case can require its absence).
+    debounce_seconds = get_settings().inbound_debounce_seconds
+    wake_kwargs: dict[str, Any] = {"cause": "inbound", "account_id": account_id}
+    if debounce_seconds > 0:
+        wake_kwargs["delay_seconds"] = debounce_seconds
+    await defer_wake(pool, target_session_id, **wake_kwargs)
 
     return InboundResult(
         appended_event_id=event_id,

--- a/src/aios/services/wake.py
+++ b/src/aios/services/wake.py
@@ -45,8 +45,10 @@ async def defer_wake(
     it runs — no need for a second job.
 
     ``delay_seconds`` schedules the job that many seconds in the future
-    (procrastinate's ``schedule_in``). Used for the harness retry-backoff
-    path; the user-visible scheduled-wake feature now goes through
+    (procrastinate's ``schedule_in``). Used by the harness retry-backoff
+    path (``cause="reschedule"``) and the connector-inbound debounce path
+    (``cause="inbound"``, gated by the ``inbound_debounce_seconds`` setting);
+    the user-visible scheduled-wake feature now goes through
     :mod:`aios.tools.schedule_wake` and creates one-shot scheduled_tasks
     rows instead.
 

--- a/tests/unit/test_inbound_metadata.py
+++ b/tests/unit/test_inbound_metadata.py
@@ -327,3 +327,152 @@ async def test_archived_connection_drops_inbound_without_routing(
         f"connection is decommissioned but messages keep flowing."
     )
     assert not resolver_called, "resolver must be skipped entirely for archived connections"
+
+
+# ── inbound debounce (#799) ─────────────────────────────────────────────────
+
+
+async def _drive_inbound_to_wake(
+    pool: MagicMock,
+    *,
+    debounce_seconds: float,
+    defer_wake_mock: AsyncMock,
+    event_id: str = "evt_1",
+) -> Any:
+    """Drive one ``handle_inbound`` through to its ``defer_wake`` call.
+
+    Patches everything between the connection fetch and the wake so the
+    happy path resolves to ``sess_X`` and reaches ``defer_wake`` (the
+    assertion target supplied by the caller). ``get_settings`` is stubbed
+    with the given ``inbound_debounce_seconds`` so the inbound-layer
+    debounce branch is exercised without a real ``Settings`` instance.
+    """
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    from aios.models.connections import Connection
+    from aios.services.inbound import handle_inbound
+    from aios_connectors.resolver import ResolveResult
+
+    live = Connection(
+        id="conn_01LIVE000000000000000000001",
+        connector="telegram",
+        external_account_id="bot1",
+        session_id=None,
+        session_template_id=None,
+        metadata={},
+        secrets_set=False,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        attached_at=None,
+        updated_at=datetime(2026, 1, 2, tzinfo=UTC),
+        archived_at=None,  # ← live
+    )
+
+    async def fake_get_connection(*_args: Any, **_kwargs: Any) -> Connection:
+        return live
+
+    async def fake_resolver(*_args: Any, **_kwargs: Any) -> ResolveResult:
+        return ResolveResult(session_id="sess_X", drop=None)
+
+    async def fake_stage(*_args: Any, **_kwargs: Any) -> tuple[list[Any], list[Any]]:
+        return [], []
+
+    async def fake_append_event(*_args: Any, **_kwargs: Any) -> Any:
+        ev = MagicMock()
+        ev.seq = 7
+        return ev
+
+    with (
+        patch(
+            "aios.services.inbound.queries.get_connection",
+            AsyncMock(side_effect=fake_get_connection),
+        ),
+        patch("aios_connectors.resolver.resolve_target_session", fake_resolver),
+        patch(
+            "aios.services.inbound.stage_inbound_attachments",
+            AsyncMock(side_effect=fake_stage),
+        ),
+        patch(
+            "aios.services.inbound.queries.append_event",
+            AsyncMock(side_effect=fake_append_event),
+        ),
+        patch(
+            "aios.services.inbound.queries.try_record_inbound_ack",
+            AsyncMock(return_value=True),
+        ),
+        patch("aios.services.inbound.defer_wake", defer_wake_mock),
+        patch(
+            "aios.services.inbound.get_settings",
+            lambda: SimpleNamespace(inbound_debounce_seconds=debounce_seconds),
+        ),
+    ):
+        return await handle_inbound(
+            pool,
+            account_id="acc_test_stub",
+            connection_id=live.id,
+            event_id=event_id,
+            chat_id="chat_1",
+            sender={"display_name": "Alice"},
+            content="hello",
+        )
+
+
+async def test_inbound_debounce_applies_delay_when_configured(
+    fake_pool: MagicMock,
+) -> None:
+    """When ``inbound_debounce_seconds`` > 0, the inbound path schedules
+    the first wake that many seconds out via ``defer_wake``'s
+    ``delay_seconds`` so a bursty sender collapses into one turn."""
+    from unittest.mock import ANY
+
+    defer_wake_mock = AsyncMock()
+    result = await _drive_inbound_to_wake(
+        fake_pool, debounce_seconds=2.0, defer_wake_mock=defer_wake_mock
+    )
+
+    assert result.drop_reason is None
+    defer_wake_mock.assert_awaited_once_with(
+        ANY, "sess_X", cause="inbound", account_id=ANY, delay_seconds=2.0
+    )
+
+
+async def test_inbound_no_delay_when_debounce_off(
+    fake_pool: MagicMock,
+) -> None:
+    """When ``inbound_debounce_seconds`` == 0.0 (the default, off), the
+    inbound path omits ``delay_seconds`` entirely so the call is
+    byte-identical to pre-feature behavior — the wake fires immediately."""
+    from unittest.mock import ANY
+
+    defer_wake_mock = AsyncMock()
+    await _drive_inbound_to_wake(fake_pool, debounce_seconds=0.0, defer_wake_mock=defer_wake_mock)
+
+    # No ``delay_seconds`` kwarg: this assertion fails if delay_seconds was passed.
+    defer_wake_mock.assert_awaited_once_with(ANY, "sess_X", cause="inbound", account_id=ANY)
+
+
+async def test_inbound_burst_within_window_shares_session_and_delay(
+    fake_pool: MagicMock,
+) -> None:
+    """Two inbounds on the same chat within the debounce window both carry
+    the same target session id and the same ``delay_seconds``.
+
+    This verifies only the inbound-LAYER precondition: each call hands
+    ``defer_wake`` the same ``(session_id, delay_seconds)`` so the burst
+    is eligible to collapse. The actual single-job collapse is enforced by
+    ``queueing_lock=session_id`` inside ``defer_wake`` (already-tested
+    wake.py behavior), not exercised here.
+    """
+    defer_wake_mock = AsyncMock()
+    await _drive_inbound_to_wake(
+        fake_pool, debounce_seconds=2.0, defer_wake_mock=defer_wake_mock, event_id="evt_1"
+    )
+    await _drive_inbound_to_wake(
+        fake_pool, debounce_seconds=2.0, defer_wake_mock=defer_wake_mock, event_id="evt_2"
+    )
+
+    assert defer_wake_mock.await_count == 2
+    for call in defer_wake_mock.await_args_list:
+        assert call.args[1] == "sess_X"  # positional session_id
+        assert call.kwargs["delay_seconds"] == 2.0
+        assert call.kwargs["cause"] == "inbound"


### PR DESCRIPTION
Closes #799

When a bursty sender (e.g. Jarvis, which jitters 2–5 s between messages) hits an idle session, the current code fires a `defer_wake` immediately on the first message and then relies on `queueing_lock` to deduplicate follow-ons within the same turn. That deduplication only kicks in once a wake is already in flight — it does nothing for the very first message, so a 4-message burst becomes 4 agent turns.

The plumbing to fix this was already there: `defer_wake` accepts a `delay_seconds` arg, and `queueing_lock=session_id` means any follow-on wakes scheduled before the delayed job runs are collapsed into it for free. The fix is small:

- New `inbound_debounce_seconds: float` setting (default `0.0`, i.e. off) in `config.py`, with a comment explaining the Jarvis origin.
- In `inbound.py`'s `handle_inbound`, when the setting is non-zero, the kwarg is forwarded to `defer_wake`. When it's `0.0` the call is byte-identical to the pre-feature path — no behavioral change for deployments that don't opt in.

**Scope boundaries** worth calling out for reviewers: only the `cause="inbound"` call site is touched. The harness retry-backoff path (`cause="reschedule"` in `loop.py`) and the async tool-completion path (`cause="connector_tool_result"` in `connectors.py`) have their own delay semantics and are deliberately left alone.

This is a fixed delay for v1 — no random jitter. The unit tests in `tests/unit/test_inbound_metadata.py` cover: delay applied when config > 0, no delay kwarg emitted when config is 0.0, and two-message burst deferring both wakes with the same delay (the `queueing_lock` collapse itself is exercised in the existing `wake.py` tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
