### PR TITLE
feat: surface cron auto-disable + add schedule_task_list tool

### DIFF
--- a/src/aios/harness/scheduled_task_runner.py
+++ b/src/aios/harness/scheduled_task_runner.py
@@ -237,6 +237,7 @@ async def _surface_failure(session_id: str, account_id: str, content: str) -> No
         log.exception(
             "scheduled_task.surface_failure_failed",
             session_id=session_id,
+            content=content,
         )
 
 

--- a/src/aios/harness/scheduled_task_runner.py
+++ b/src/aios/harness/scheduled_task_runner.py
@@ -210,6 +210,34 @@ async def run_scheduled_task_step(task_id: str) -> None:
                     name=task.name,
                     consecutive_failures=new_failures,
                 )
+        # Surface the auto-disable AFTER the transaction commits — _surface_failure
+        # re-acquires the pool, so nesting it inside the open transaction connection
+        # risks deadlock on the small pool. Mirrors the one-shot path, which also
+        # holds no transaction while surfacing.
+        if new_failures >= MAX_CONSECUTIVE_FAILURES:
+            content = (
+                f"[Scheduled task '{task.name}' auto-disabled after "
+                f"{MAX_CONSECUTIVE_FAILURES} consecutive failures: "
+                f"{error_summary or status}]"
+            )
+            await _surface_failure(task.session_id, task.account_id, content)
+
+
+async def _surface_failure(session_id: str, account_id: str, content: str) -> None:
+    """Append a synthetic user message + defer a wake (best-effort).
+
+    Shared by the one-shot failure path and the cron auto-disable path so
+    both surface a user-visible event instead of failing silently.
+    """
+    pool = runtime.require_pool()
+    try:
+        await sessions_service.append_user_message(pool, session_id, content, account_id=account_id)
+        await defer_wake(pool, session_id, cause="message", account_id=account_id)
+    except Exception:
+        log.exception(
+            "scheduled_task.surface_failure_failed",
+            session_id=session_id,
+        )
 
 
 async def _surface_one_shot_failure(
@@ -230,19 +258,6 @@ async def _surface_one_shot_failure(
     the model sees a deterministic failure event and can decide what to
     do next.
     """
-    pool = runtime.require_pool()
     detail = error_summary or status
     content = f"[Scheduled wake '{name}' failed to deliver: {detail}]"
-    try:
-        await sessions_service.append_user_message(pool, session_id, content, account_id=account_id)
-        await defer_wake(pool, session_id, cause="message", account_id=account_id)
-    except Exception:
-        # Best-effort: if we can't even append the failure event, log
-        # loudly so the operator notices. The agent will not see this
-        # particular wake's outcome.
-        log.exception(
-            "scheduled_task.surface_failure_failed",
-            session_id=session_id,
-            name=name,
-            status=status,
-        )
+    await _surface_failure(session_id, account_id, content)

--- a/src/aios/tools/__init__.py
+++ b/src/aios/tools/__init__.py
@@ -27,6 +27,7 @@ from aios.tools import grep as _grep  # noqa: F401
 from aios.tools import http_request as _http_request  # noqa: F401
 from aios.tools import read as _read  # noqa: F401
 from aios.tools import schedule_task_add as _schedule_task_add  # noqa: F401
+from aios.tools import schedule_task_list as _schedule_task_list  # noqa: F401
 from aios.tools import schedule_task_remove as _schedule_task_remove  # noqa: F401
 from aios.tools import schedule_task_update as _schedule_task_update  # noqa: F401
 from aios.tools import schedule_wake as _schedule_wake  # noqa: F401

--- a/src/aios/tools/schedule_task_list.py
+++ b/src/aios/tools/schedule_task_list.py
@@ -1,0 +1,47 @@
+"""The ``schedule_task_list`` tool — list this session's scheduled tasks.
+
+Complements ``schedule_task_add`` / ``schedule_task_remove`` (#798) by giving
+the model a direct read of each task's health: name, enabled state, last fire
+status, and consecutive-failure count. This is the signal it needs to notice a
+task that auto-disabled after repeated failures and decide what to do next.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.harness import runtime
+from aios.services import scheduled_tasks as scheduled_tasks_service
+from aios.services import sessions as sessions_service
+from aios.tools.registry import registry
+
+SCHEDULE_TASK_LIST_DESCRIPTION = (
+    "List all scheduled tasks for this session, with each task's name, "
+    "enabled state, last fire status, and consecutive failure count."
+)
+
+SCHEDULE_TASK_LIST_PARAMETERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+    "required": [],
+}
+
+
+async def schedule_task_list_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    echoes = await scheduled_tasks_service.list_tasks(pool, session_id, account_id=account_id)
+    return {"tasks": [e.model_dump(mode="json") for e in echoes]}
+
+
+def _register() -> None:
+    registry.register(
+        name="schedule_task_list",
+        description=SCHEDULE_TASK_LIST_DESCRIPTION,
+        parameters_schema=SCHEDULE_TASK_LIST_PARAMETERS_SCHEMA,
+        handler=schedule_task_list_handler,
+    )
+
+
+_register()

--- a/src/aios/tools/schedule_task_remove.py
+++ b/src/aios/tools/schedule_task_remove.py
@@ -2,8 +2,8 @@
 
 Idempotency note: removing a non-existent name raises ``NotFoundError``
 (surfaced as a tool error). The model can list and confirm before remove
-if uncertain — there is no ``list`` tool yet, but ``Session.scheduled_tasks``
-in the system context lists current entries.
+if uncertain — the ``schedule_task_list`` tool enumerates current entries,
+and ``Session.scheduled_tasks`` in the system context also lists them.
 """
 
 from __future__ import annotations

--- a/tests/e2e/test_scheduled_tasks.py
+++ b/tests/e2e/test_scheduled_tasks.py
@@ -118,6 +118,37 @@ def _spec(
     )
 
 
+# ─── schedule_task_list tool ──────────────────────────────────────────────
+
+
+class TestScheduleTaskListTool:
+    async def test_schedule_task_list_handler_returns_tasks(
+        self, pool: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        from aios.harness import runtime
+        from aios.tools.schedule_task_list import schedule_task_list_handler
+
+        env_id, agent_id = env_and_agent
+        sid = await _create_session(pool, env_id, agent_id)
+        account_id = "acc_test_stub"
+
+        await st_service.add_task(pool, sid, _spec("alpha"), account_id=account_id)
+        await st_service.add_task(pool, sid, _spec("beta"), account_id=account_id)
+
+        prev_pool = runtime.pool
+        runtime.pool = pool
+        try:
+            result = await schedule_task_list_handler(sid, {})
+        finally:
+            runtime.pool = prev_pool
+
+        assert len(result["tasks"]) == 2
+        assert {t["name"] for t in result["tasks"]} == {"alpha", "beta"}
+        for t in result["tasks"]:
+            assert t["enabled"] is True
+            assert t["consecutive_failures"] == 0
+
+
 # ─── service-layer round-trip ─────────────────────────────────────────────
 
 
@@ -511,6 +542,83 @@ class TestRecordFire:
         assert row is not None
         assert row["enabled"] is False
         assert row["next_fire"] is None
+
+    async def test_cron_auto_disable_surfaces_user_event(
+        self, pool: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """When a cron task crosses MAX_CONSECUTIVE_FAILURES and auto-disables,
+        the runner surfaces a synthetic user-role message so the agent learns
+        the task is dead instead of just going silent."""
+        from aios.harness import runtime, scheduled_task_runner
+
+        env_id, agent_id = env_and_agent
+        sid = await _create_session(pool, env_id, agent_id)
+        account_id = "acc_test_stub"
+
+        echo = await st_service.add_task(pool, sid, _spec("doomed"), account_id=account_id)
+
+        # Pre-seed so this fire is the threshold-crosser (4 + 1 = 5 = MAX) and
+        # the row is claimed (running_since set) so the runner doesn't early-out.
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE session_scheduled_tasks "
+                "SET consecutive_failures = 4, running_since = $1 WHERE id = $2",
+                datetime.now(UTC),
+                echo.id,
+            )
+
+        async def _fail_run(_self: object, _handle: object, _cmd: str, **_kw: Any) -> Any:
+            return mock.MagicMock(exit_code=2, timed_out=False, stderr="boom: cron failed")
+
+        registry = _make_fake_sandbox_registry(_fail_run)
+        prev_pool = runtime.pool
+        prev_registry = runtime.sandbox_registry
+        runtime.pool = pool
+        runtime.sandbox_registry = registry  # type: ignore[assignment]
+        with mock.patch(
+            "aios.harness.scheduled_task_runner.defer_wake",
+            new_callable=mock.AsyncMock,
+        ) as mock_defer:
+            try:
+                await scheduled_task_runner.run_scheduled_task_step(echo.id)
+            finally:
+                runtime.pool = prev_pool
+                runtime.sandbox_registry = prev_registry
+
+        # (a) A user-role message announcing the auto-disable is in the log.
+        async with pool.acquire() as conn:
+            event_rows = await conn.fetch(
+                "SELECT kind, data FROM events WHERE session_id = $1 ORDER BY seq ASC",
+                sid,
+            )
+
+        def _data(row: Any) -> dict[str, Any]:
+            return json.loads(row["data"]) if isinstance(row["data"], str) else row["data"]
+
+        disable_messages = [
+            r
+            for r in event_rows
+            if r["kind"] == "message"
+            and _data(r).get("role") == "user"
+            and "auto-disabled" in _data(r).get("content", "")
+        ]
+        assert disable_messages, "expected an auto-disable user message in the session log"
+        latest_content = _data(disable_messages[-1])["content"]
+        assert "doomed" in latest_content
+        assert "5" in latest_content
+
+        # (b) A wake was deferred so the agent reacts to the message.
+        mock_defer.assert_called()
+
+        # (c) The row is disabled and the failure count landed at MAX.
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT enabled, consecutive_failures FROM session_scheduled_tasks WHERE id = $1",
+                echo.id,
+            )
+        assert row is not None
+        assert row["enabled"] is False
+        assert row["consecutive_failures"] == 5
 
 
 # ─── HTTP surface ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes the WS0 "cron task health" roadmap bullet. Agents could previously neither notice a silently auto-disabled cron task nor list their own scheduled tasks — both gaps are fixed here.

**What changed**

*Part A — surface cron auto-disable:* When a cron task crosses the MAX_CONSECUTIVE_FAILURES (5) threshold, a synthetic user-role event `[Scheduled task '<name>' auto-disabled after 5 consecutive failures: <error_summary>]` is now appended and a wake is deferred, mirroring the existing one-shot failure path. The shared append+wake logic was extracted into a `_surface_failure` helper used by both code paths. The surface call happens after the disable transaction commits to avoid a nested pool-acquire deadlock.

*Part B — `schedule_task_list` tool:* New no-args registry tool (`src/aios/tools/schedule_task_list.py`) that wraps the existing `scheduled_tasks_service.list_tasks` and returns all tasks for the session. Registered in `src/aios/tools/__init__.py` alongside the other schedule tools. No new service, query, or model needed.

**Testing**

Two new e2e tests in `tests/e2e/test_scheduled_tasks.py`: one forces a 5th consecutive cron failure and asserts the user event + wake + disabled task row; the other adds two tasks and asserts the handler returns both with correct fields. Full file: 46 passed. `mypy`, `ruff check`, and `ruff format --check` all clean. A mutation check confirmed the cron test is non-vacuous.

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)
