### PR TITLE
fix(context): quarantine poison events in build_messages

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -790,6 +790,7 @@ def build_messages(
         # rather than failing the whole build. The inner isinstance/OSError
         # guards still pre-empt this for the shapes they cover; this catches
         # novel raisers they don't.
+        mark = len(messages)
         try:
             role = e.data.get("role")
 
@@ -892,6 +893,19 @@ def build_messages(
                     max_stimulus_seq = max(max_stimulus_seq, e.seq)
 
         except Exception as exc:
+            # Roll back any partial appends from THIS event so the quarantine
+            # is atomic w.r.t. ``messages``: exactly one placeholder per
+            # quarantined position, never a half-rendered assistant turn
+            # (e.g. the assistant message appended before a corrupt
+            # ``tool_calls`` raised, which would leave an orphan tool_calls
+            # turn — an invalid chat-completions sequence that re-bricks).
+            # Residual limitation: a quarantined ASSISTANT event's downstream
+            # tool-result events (later in the window) may still render as
+            # orphan ``tool`` messages — accepted, because assistant events are
+            # harness-produced, not external connector poison (the realistic
+            # source), and the alternative is the permanent brick this guard exists
+            # to prevent.
+            del messages[mark:]
             log.warning(
                 "context.poison_event_quarantined",
                 session_id=session_id,

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -19,6 +19,16 @@ own seq. This correctly handles the race where a tool result arrives
 during inference — the model's response has a ``reacting_to`` that
 predates the tool result, so the result is "new" and triggers a
 follow-up step.
+
+Because this replay runs on EVERY wake over the immutable log, a per-event
+render failure is a structural brick risk: the model is never called, so
+the "model sees the error and retries" recovery cannot engage. A quarantine
+backstop guards against it — any per-event render that raises is caught and
+replaced by a deterministic placeholder that is a function of ``e.seq`` ONLY
+(see :func:`_quarantine_placeholder`), preserving the monotonicity invariant,
+and the failure is signalled via the ``context.poison_event_quarantined``
+structlog event. One poison event degrades exactly one position; every other
+event in the window still renders.
 """
 
 from __future__ import annotations
@@ -695,6 +705,17 @@ class ContextResult:
     reacting_to: int  # max seq of user/tool events included in context
 
 
+def _quarantine_placeholder(seq: int) -> dict[str, Any]:
+    """Deterministic stand-in for an event whose render raised.
+
+    A function of ``seq`` ONLY — no timestamps, no counters — so the
+    context stays a monotonic function of the log (see module docstring):
+    re-rendering the same window always produces byte-identical output at
+    this position, and appending later events never rewrites it.
+    """
+    return {"role": "user", "content": f"[unrenderable event seq={seq} — quarantined]"}
+
+
 def build_messages(
     events: list[Event],
     *,
@@ -760,101 +781,125 @@ def build_messages(
     for e in events:
         if e.kind != "message":
             continue
-        role = e.data.get("role")
+        # Quarantine backstop (#686): build_messages is a pure replay over
+        # the immutable log, run on EVERY wake. A single event that makes the
+        # render dispatch raise would brick the session permanently — the
+        # model is never called, so the "model sees the error and retries"
+        # recovery never engages. Degrade THAT ONE event to a deterministic
+        # placeholder (a function of e.seq only, preserving monotonicity)
+        # rather than failing the whole build. The inner isinstance/OSError
+        # guards still pre-empt this for the shapes they cover; this catches
+        # novel raisers they don't.
+        try:
+            role = e.data.get("role")
 
-        if role == "user":
-            msg = render_user_event(
-                e.data,
-                e.orig_channel,
-                e.focal_channel_at_arrival,
-                e.created_at,
-                tz_name=tz_name,
-                model=model,
-                session_id=session_id,
-                workspace_path=workspace_path,
-            )
-            messages.append(msg)
-            max_stimulus_seq = max(max_stimulus_seq, e.seq)
+            if role == "user":
+                msg = render_user_event(
+                    e.data,
+                    e.orig_channel,
+                    e.focal_channel_at_arrival,
+                    e.created_at,
+                    tz_name=tz_name,
+                    model=model,
+                    session_id=session_id,
+                    workspace_path=workspace_path,
+                )
+                messages.append(msg)
+                max_stimulus_seq = max(max_stimulus_seq, e.seq)
 
-        elif role == "assistant":
-            messages.append(e.data)
-            horizon = horizon_for.get(e.seq, _INF)
-            for tc in e.data.get("tool_calls") or []:
-                tcid = tc.get("id")
-                if not tcid or tcid in emitted_tcids:
-                    continue
-                rseq = real_result_seqs.get(tcid)
-                if rseq is not None and rseq <= horizon:
-                    messages.append(real_results[tcid])
-                    max_stimulus_seq = max(max_stimulus_seq, rseq)
-                else:
-                    placeholder = (
-                        _PENDING_BACKGROUND
-                        if tcid in in_flight_tool_call_ids
-                        else _PENDING_EXTERNAL
-                    )
-                    messages.append({"role": "tool", "tool_call_id": tcid, "content": placeholder})
-                    if tcid in real_results:
-                        # Safe: last assistant has horizon=INF so rseq<=INF
-                        # always takes the REAL branch above; only non-last
-                        # assistants reach here, and they all have entries.
-                        setter_seq = horizon_setter_for[e.seq]
-                        inject_after.setdefault(setter_seq, []).append((tcid, real_results[tcid]))
-                emitted_tcids.add(tcid)
+            elif role == "assistant":
+                messages.append(e.data)
+                horizon = horizon_for.get(e.seq, _INF)
+                for tc in e.data.get("tool_calls") or []:
+                    tcid = tc.get("id")
+                    if not tcid or tcid in emitted_tcids:
+                        continue
+                    rseq = real_result_seqs.get(tcid)
+                    if rseq is not None and rseq <= horizon:
+                        messages.append(real_results[tcid])
+                        max_stimulus_seq = max(max_stimulus_seq, rseq)
+                    else:
+                        placeholder = (
+                            _PENDING_BACKGROUND
+                            if tcid in in_flight_tool_call_ids
+                            else _PENDING_EXTERNAL
+                        )
+                        messages.append(
+                            {"role": "tool", "tool_call_id": tcid, "content": placeholder}
+                        )
+                        if tcid in real_results:
+                            # Safe: last assistant has horizon=INF so rseq<=INF
+                            # always takes the REAL branch above; only non-last
+                            # assistants reach here, and they all have entries.
+                            setter_seq = horizon_setter_for[e.seq]
+                            inject_after.setdefault(setter_seq, []).append(
+                                (tcid, real_results[tcid])
+                            )
+                    emitted_tcids.add(tcid)
 
-            # Inline blind-spot injections anchored to this assistant
-            # (preserves prefix monotonicity — see docstring).
-            for inj_tcid, inj_data in inject_after.pop(e.seq, []):
-                name = inj_data.get("name", "tool")
-                header = f"[Tool result: {name} (call {inj_tcid}) completed]"
-                inj_content = inj_data.get("content", "")
-                if isinstance(inj_content, list):
-                    # Multimodal tool result (e.g. image-aware read returning a
-                    # text + image_url part list).  F-stringing would emit the
-                    # Python repr of the list, losing the pixels — splice the
-                    # parts into the synthetic user message instead so the model
-                    # sees the image in the blind-spot signal too.  Spec'd text
-                    # parts are concatenated under the header; non-text parts
-                    # (image_url, etc.) follow as siblings.
-                    text_chunks: list[str] = [header]
-                    other_parts: list[dict[str, Any]] = []
-                    for part in inj_content:
-                        if not isinstance(part, dict):
-                            continue
-                        if part.get("type") == "text":
-                            txt = part.get("text")
-                            if isinstance(txt, str) and txt:
-                                text_chunks.append(txt)
+                # Inline blind-spot injections anchored to this assistant
+                # (preserves prefix monotonicity — see docstring).
+                for inj_tcid, inj_data in inject_after.pop(e.seq, []):
+                    name = inj_data.get("name", "tool")
+                    header = f"[Tool result: {name} (call {inj_tcid}) completed]"
+                    inj_content = inj_data.get("content", "")
+                    if isinstance(inj_content, list):
+                        # Multimodal tool result (e.g. image-aware read returning a
+                        # text + image_url part list).  F-stringing would emit the
+                        # Python repr of the list, losing the pixels — splice the
+                        # parts into the synthetic user message instead so the model
+                        # sees the image in the blind-spot signal too.  Spec'd text
+                        # parts are concatenated under the header; non-text parts
+                        # (image_url, etc.) follow as siblings.
+                        text_chunks: list[str] = [header]
+                        other_parts: list[dict[str, Any]] = []
+                        for part in inj_content:
+                            if not isinstance(part, dict):
+                                continue
+                            if part.get("type") == "text":
+                                txt = part.get("text")
+                                if isinstance(txt, str) and txt:
+                                    text_chunks.append(txt)
+                            else:
+                                other_parts.append(part)
+                        combined_text = "\n".join(text_chunks)
+                        if other_parts:
+                            messages.append(
+                                {
+                                    "role": "user",
+                                    "content": [
+                                        {"type": "text", "text": combined_text},
+                                        *other_parts,
+                                    ],
+                                }
+                            )
                         else:
-                            other_parts.append(part)
-                    combined_text = "\n".join(text_chunks)
-                    if other_parts:
+                            messages.append({"role": "user", "content": combined_text})
+                    else:
                         messages.append(
                             {
                                 "role": "user",
-                                "content": [
-                                    {"type": "text", "text": combined_text},
-                                    *other_parts,
-                                ],
+                                "content": f"{header}\n{inj_content}",
                             }
                         )
-                    else:
-                        messages.append({"role": "user", "content": combined_text})
-                else:
-                    messages.append(
-                        {
-                            "role": "user",
-                            "content": f"{header}\n{inj_content}",
-                        }
-                    )
-                max_stimulus_seq = max(max_stimulus_seq, real_result_seqs[inj_tcid])
+                    max_stimulus_seq = max(max_stimulus_seq, real_result_seqs[inj_tcid])
 
-        elif role == "tool":
-            tcid = e.data.get("tool_call_id")
-            if tcid and tcid not in emitted_tcids:
-                messages.append(e.data)
-                emitted_tcids.add(tcid)
-                max_stimulus_seq = max(max_stimulus_seq, e.seq)
+            elif role == "tool":
+                tcid = e.data.get("tool_call_id")
+                if tcid and tcid not in emitted_tcids:
+                    messages.append(e.data)
+                    emitted_tcids.add(tcid)
+                    max_stimulus_seq = max(max_stimulus_seq, e.seq)
+
+        except Exception as exc:
+            log.warning(
+                "context.poison_event_quarantined",
+                session_id=session_id,
+                seq=e.seq,
+                error_type=type(exc).__name__,
+            )
+            messages.append(_quarantine_placeholder(e.seq))
+            max_stimulus_seq = max(max_stimulus_seq, e.seq)
 
     # Prune dangling messages at the start of the window.  DB-level
     # windowing can cut in the middle of an assistant+tool_result group,

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -2104,8 +2104,12 @@ class TestPoisonEventQuarantine:
         assert len(ctx.messages) == 1
         msg = ctx.messages[0]
         assert msg["role"] == "user"
-        # Union invariant: normally-rendered text OR the quarantine placeholder.
-        assert msg == _quarantine_placeholder(1) or isinstance(msg["content"], (str, list))
+        content = msg["content"]
+        assert isinstance(content, (str, list))
+        # A normal render must never accidentally produce a quarantine-shaped
+        # message; the marker string appears iff this is the exact placeholder.
+        if isinstance(content, str) and "unrenderable event seq=" in content:
+            assert msg == _quarantine_placeholder(1)
 
     def test_unserializable_output_schema_reaches_outer_quarantine(self) -> None:
         """The one shape that genuinely reaches the OUTER quarantine: a
@@ -2123,3 +2127,25 @@ class TestPoisonEventQuarantine:
         ctx = build_messages([e], system_prompt=None, model="gpt-4o", session_id="s")
         assert ctx.messages == [_quarantine_placeholder(1)]
         assert ctx.reacting_to == 1
+
+    def test_quarantined_assistant_event_is_atomic_single_message(self) -> None:
+        """The assistant branch appends ``e.data`` BEFORE iterating
+        ``tool_calls``; a raise mid-branch (here a truthy non-iterable
+        ``tool_calls`` so ``for tc in 42`` raises ``TypeError`` after the
+        append) must NOT leave both the orphan assistant turn AND the
+        placeholder — that invalid chat-completions sequence (tool_calls not
+        followed by results) re-bricks the session. The rollback makes the
+        quarantine atomic: exactly the placeholder remains."""
+        e = Event(
+            id="evt_5",
+            session_id="sess_01TEST",
+            seq=5,
+            kind="message",
+            data={"role": "assistant", "content": "x", "tool_calls": 42},
+            created_at=_FIXED_CREATED_AT,
+            orig_channel=None,
+            focal_channel_at_arrival=None,
+        )
+        ctx = build_messages([e], system_prompt=None)
+        assert len(ctx.messages) == 1
+        assert ctx.messages[0] == _quarantine_placeholder(5)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -6,7 +6,8 @@ Uses lightweight FakeEvent objects to avoid touching the DB.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+import logging
+from datetime import MINYEAR, UTC, datetime
 from typing import Any
 
 import pytest
@@ -15,8 +16,10 @@ from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
     _concat_user_messages,
     _is_degenerate_empty_assistant,
+    _quarantine_placeholder,
     build_messages,
     merge_adjacent_user_messages,
+    render_user_event,
     stub_missing_reasoning_content,
 )
 from aios.models.events import Event
@@ -1943,3 +1946,180 @@ class TestEventDataImmutability:
         assert out_url.startswith("data:image/jpeg;base64,"), (
             f"renderer should have corrected png → jpeg in the output, got {out_url[:50]}"
         )
+
+
+class TestPoisonEventQuarantine:
+    """``build_messages`` is a pure replay over the immutable event log,
+    run on EVERY wake. A single event that makes the renderer raise would
+    permanently brick the session — the model is never called, so the
+    "model sees the error and retries" recovery never engages (#686).
+
+    The quarantine backstop catches any per-event render failure and
+    degrades THAT ONE event to a deterministic placeholder (a function of
+    ``e.seq`` only, preserving the monotonicity invariant) while every
+    other event in the window still renders. The failure is signalled via
+    the ``context.poison_event_quarantined`` structlog event.
+
+    The pre-existing inner ``isinstance`` / ``OSError`` guards take
+    precedence — those shapes render normally, NOT via quarantine. The
+    outer quarantine is the last-resort backstop for novel raisers the
+    inner guards don't cover.
+    """
+
+    def test_out_of_range_created_at_is_quarantined(self) -> None:
+        """The GENUINE current brick: a ``created_at`` so small that
+        ``_format_received``'s ``astimezone`` raises ``OverflowError``
+        (``date value out of range``). No inner guard covers it, so it
+        must degrade to the deterministic placeholder rather than propagate.
+        """
+        e = _evt(7, "user", content="hi", created_at=datetime(MINYEAR, 1, 1, tzinfo=UTC))
+        ctx = build_messages([e], system_prompt=None, tz_name="America/Los_Angeles")
+        assert ctx.messages == [_quarantine_placeholder(7)]
+        assert ctx.messages[0]["role"] == "user"
+        assert ctx.messages[0]["content"] == "[unrenderable event seq=7 — quarantined]"
+        # The placeholder occupies seq 7's position; reacting_to must move
+        # past it so find_sessions_needing_inference doesn't treat the
+        # poison event as perpetually-new.
+        assert ctx.reacting_to == 7
+
+    def test_non_dict_attachment_renders_normally_not_quarantined(self) -> None:
+        """The inner ``context.attachment_record_not_dict`` guard pre-empts
+        the outer quarantine: non-dict attachment records are skipped
+        in-place, so the event renders as a plain string with no
+        ``[unrenderable`` marker."""
+        md = {"channel": "echo/a/c", "attachments": ["oops", None, 42]}
+        e = _evt(1, "user", content="hi", metadata=md, focal_channel_at_arrival="echo/a/c")
+        ctx = build_messages([e], system_prompt=None, model="gpt-4o", session_id="s")
+        content = ctx.messages[0]["content"]
+        assert isinstance(content, str)
+        assert "[unrenderable" not in content
+        assert "hi" in content
+
+    def test_render_user_event_raise_is_quarantined(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A synthetic novel raiser inside ``render_user_event`` — the kind
+        of new event shape that today would brick the session — degrades to
+        the placeholder."""
+
+        def _boom(*a: Any, **k: Any) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("aios.harness.context.render_user_event", _boom)
+        ctx = build_messages([_evt(3, "user", content="x")], system_prompt=None)
+        assert ctx.messages == [_quarantine_placeholder(3)]
+        assert ctx.reacting_to == 3
+
+    def test_quarantine_emits_structlog_signal(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Quarantines are observable: a ``context.poison_event_quarantined``
+        warning carrying ``session_id``, ``seq``, and ``error_type``.
+
+        The conftest routes structlog through stdlib's ConsoleRenderer, which
+        flattens the event + bound fields into ``record.getMessage()`` rather
+        than preserving them as record attributes — so we substring-match the
+        rendered line (same convention as test_attachment_staging.py)."""
+
+        def _boom(*a: Any, **k: Any) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("aios.harness.context.render_user_event", _boom)
+        with caplog.at_level(logging.WARNING):
+            build_messages(
+                [_evt(3, "user", content="x")], system_prompt=None, session_id="sess_01TEST"
+            )
+        rec = next(
+            r for r in caplog.records if "context.poison_event_quarantined" in r.getMessage()
+        )
+        rendered = rec.getMessage()
+        assert "seq=3" in rendered
+        assert "session_id=sess_01TEST" in rendered
+        assert "error_type=RuntimeError" in rendered
+
+    def test_only_poison_event_quarantined_others_render(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One poison event among good events: exactly its position is
+        quarantined; the others (including assistant turns) render normally."""
+        original = render_user_event
+
+        def _selective(event_data: dict[str, Any], *a: Any, **k: Any) -> dict[str, Any]:
+            if event_data.get("content") == "gamma":
+                raise RuntimeError("gamma is poison")
+            return original(event_data, *a, **k)
+
+        monkeypatch.setattr("aios.harness.context.render_user_event", _selective)
+        events = [
+            _evt(1, "user", content="alpha"),
+            _evt(2, "assistant", content="beta"),
+            _evt(3, "user", content="gamma"),
+            _evt(4, "assistant", content="delta"),
+        ]
+        ctx = build_messages(events, system_prompt=None)
+        assert ctx.messages[0]["content"] == f"[received={RECEIVED}]\nalpha"
+        assert ctx.messages[1]["role"] == "assistant"
+        assert ctx.messages[1]["content"] == "beta"
+        assert ctx.messages[2] == _quarantine_placeholder(3)
+        assert ctx.messages[3]["role"] == "assistant"
+        assert ctx.messages[3]["content"] == "delta"
+        assert ctx.reacting_to == 3
+
+    @pytest.mark.parametrize(
+        "metadata",
+        [
+            {"channel": "c", "timestamp_ms": "not-an-int"},
+            {"channel": "c", "timestamp_ms": 10**30},
+            {"channel": "c", "mentions": "not-a-list"},
+            {"channel": "c", "mentions": [None, 42, {"uuid": 5}, {"name": []}]},
+            {"channel": "c", "reaction": "not-a-dict"},
+            {"channel": "c", "reaction": {"emoji": {"nested": "obj"}}},
+            {"channel": "c", "reaction": {"new_emojis": "not-a-list"}},
+            {"channel": "c", "reply_to": {"text": {"blocks": [1, 2]}}},
+            {"channel": "c", "reply_to": "not-a-dict"},
+            {"channel": "c", "request": {"output_schema": {1: object()}}},
+            {"channel": "c", "attachments": "not-a-list"},
+            {"channel": "c", "attachments": [{"in_sandbox_path": 123}]},
+            {"channel": 12345},
+            {},
+        ],
+    )
+    def test_build_messages_never_raises_on_adversarial_metadata(
+        self, metadata: dict[str, Any]
+    ) -> None:
+        """Hand-rolled fuzz over adversarial metadata shapes. For each,
+        ``build_messages`` must NOT raise, and the single resulting message
+        is EITHER a normally-rendered user message OR the quarantine
+        placeholder (union invariant — passes regardless of which path each
+        shape takes). Most shapes are absorbed by inner ``isinstance``
+        guards and render normally."""
+        focal = metadata.get("channel") if isinstance(metadata, dict) else None
+        focal = focal if isinstance(focal, str) else None
+        e = _evt(
+            1,
+            "user",
+            content="x",
+            metadata=metadata,
+            focal_channel_at_arrival=focal,
+        )
+        ctx = build_messages([e], system_prompt=None, model="gpt-4o", session_id="s")
+        assert len(ctx.messages) == 1
+        msg = ctx.messages[0]
+        assert msg["role"] == "user"
+        # Union invariant: normally-rendered text OR the quarantine placeholder.
+        assert msg == _quarantine_placeholder(1) or isinstance(msg["content"], (str, list))
+
+    def test_unserializable_output_schema_reaches_outer_quarantine(self) -> None:
+        """The one shape that genuinely reaches the OUTER quarantine: a
+        request whose ``output_schema`` is un-JSON-serializable. The
+        ``json.dumps(output_schema)`` line only executes when a string
+        ``request_id`` is also present (the surrounding guard), so the
+        adversarial fuzz shape #10 — which omits ``request_id`` — renders
+        normally; this companion case includes it to exercise the outer
+        backstop."""
+        md = {
+            "channel": "c",
+            "request": {"request_id": "req_1", "output_schema": {1: object()}},
+        }
+        e = _evt(1, "user", content="x", metadata=md, focal_channel_at_arrival="c")
+        ctx = build_messages([e], system_prompt=None, model="gpt-4o", session_id="s")
+        assert ctx.messages == [_quarantine_placeholder(1)]
+        assert ctx.reacting_to == 1

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -19,10 +19,12 @@ from aios.config import get_settings
 from aios.harness import vision
 from aios.harness.context import (
     _apply_attachments,
+    build_messages,
 )
 from aios.harness.context import (
     render_user_event as _render_user_event_impl,
 )
+from aios.models.events import Event
 from aios.sandbox.volumes import session_attachments_dir
 
 # These tests exercise attachment/vision rendering, not the `received=` envelope
@@ -541,6 +543,49 @@ class TestVisionAwareRendering:
         assert "[attachment: b.pdf" in content[0]["text"]
         assert content[1]["type"] == "image_url"
         assert content[1]["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    def test_vanished_staged_file_renders_normally_not_quarantined(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """The inner ``context.attachment_read_failed`` OSError guard
+        pre-empts the outer #686 quarantine: when the staged file has
+        vanished (manual cleanup, FS corruption, GC race), the renderer
+        falls back to the ``[image: …]`` text marker rather than raising —
+        so ``build_messages`` produces a normal user message with NO
+        ``[unrenderable`` quarantine marker."""
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"jpegbytes"
+        )
+        # The host path mirrors how _stage_image laid the file down.
+        host_path = session_attachments_dir("sess-1") / "echo" / "evt-1-photo.jpg"
+        event_data = _user_event(
+            content="hello",
+            attachments=[
+                {
+                    "filename": "photo.jpg",
+                    "content_type": "image/jpeg",
+                    "size": len(b"jpegbytes"),
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        # Delete the staged file so read_bytes raises OSError mid-render.
+        host_path.unlink()
+        event = Event(
+            id="evt_1",
+            session_id="sess-1",
+            seq=1,
+            kind="message",
+            data=event_data,
+            created_at=_CREATED_AT,
+            orig_channel="echo/acct/chat-1",
+            focal_channel_at_arrival="echo/acct/chat-1",
+        )
+        ctx = build_messages([event], system_prompt=None, model="model/vision", session_id="sess-1")
+        content = ctx.messages[0]["content"]
+        assert isinstance(content, str)
+        assert "[unrenderable" not in content
+        assert "[image: photo.jpg" in content
 
 
 class TestNonFocalAttachmentRendering:


### PR DESCRIPTION
Closes eumemic/eumemic-ops#353

## Problem

`build_messages` is a pure replay over the immutable event log, executed on every wake. Because events never change, a single event that makes the renderer raise permanently bricks the session — the model is never called, so the "model sees the error and retries" recovery path cannot engage. The mitigation had been a growing pile of reactive `try/except` guards added one production brick at a time (out-of-range timestamp, non-dict attachment record, vanished staged file) — each closing one event shape, never the class.

## Fix

Wrap the per-event render dispatch in the `build_messages` loop in a single `try/except`. On any exception, emit a deterministic placeholder user message `[unrenderable event seq=N — quarantined]` (a pure function of `e.seq`, preserving the log-monotonicity invariant) and emit a structured `context.poison_event_quarantined` structlog signal (`session_id`, `seq`, `error_type`) so quarantines are observable in production. One poison event quarantines exactly one position; every other event in the window renders normally. The `reacting_to` watermark advances past the quarantined position, so the session keeps making forward progress.

The existing inner guards are preserved and still pre-empt the outer quarantine for their known shapes — the quarantine is a backstop for the *next, unknown* shape, not a replacement.

**Scope:** `src/aios/harness/context.py` + tests only. No API surface changes, no codegen needed.

## Testing

- Regression tests for each of the three historical bricks: out-of-range `created_at` (hits `astimezone` → `OverflowError`), non-dict attachment record, vanished staged file. The latter two assert they still render *normally* via the inner guards — documenting the layering explicitly.
- Synthetic novel raiser (monkeypatched `render_user_event`) → confirms outer quarantine fires.
- One-poison-among-good-events: asserts only the poison position is quarantined; neighbours render intact.
- Observability: asserts the `context.poison_event_quarantined` log signal carries `seq`, `session_id`, and `error_type`.
- Hand-rolled parametrized fuzz over ~14 adversarial metadata shapes asserting `build_messages` never raises.

Full unit suite green (1899 tests), mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)