### PR TITLE
fix(sandbox): no-new-privileges + ipc private on docker run

### DIFF
--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -89,6 +89,29 @@ class DockerBackend:
         if isinstance(spec.network_policy, Limited):
             argv.extend(["--cap-add", "NET_ADMIN"])
 
+        # WS0 phase-1 hardening: two flags safe to land before the exec-user
+        # seam is in place.
+        #
+        # --security-opt no-new-privileges: blocks privilege *gain* across
+        # execve (setuid bits, file capabilities).  Root setup execs don't
+        # escalate — apt's _apt drop uses seteuid downward via CAP_SETUID;
+        # the Limited iptables lockdown already runs as root holding NET_ADMIN.
+        # No setuid binaries ship in the sandbox image today.  Any future
+        # setuid binary added to the image will silently not escalate under
+        # NNP — acceptable and intended.
+        #
+        # --ipc private: drops SysV-shm / POSIX-mq sharing with the host and
+        # sibling containers.  Nothing uses cross-container IPC; this is the
+        # modern Docker default — an explicit assertion rather than a behaviour
+        # change.
+        #
+        # --cap-drop=ALL, --read-only, and a seccomp profile are deferred:
+        # cap-drop interacts with apt/dpkg; --read-only conflicts with
+        # root-agent workspace writes.  Track those in separate follow-up
+        # issues.
+        argv.extend(["--security-opt", "no-new-privileges"])
+        argv.extend(["--ipc", "private"])
+
         if spec.host_gateway_alias is not None:
             argv.extend(["--add-host", f"{spec.host_gateway_alias}:host-gateway"])
 

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -185,6 +185,36 @@ class TestDockerBackendArgs:
         argv = await _capture_docker_argv(_make_spec(Unrestricted()))
         assert "--cap-add" not in argv
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            Limited(allowed_hosts=frozenset({"example.com"})),
+            Unrestricted(),
+        ],
+        ids=["limited", "unrestricted"],
+    )
+    async def test_security_opt_no_new_privileges(self, policy: Limited | Unrestricted) -> None:
+        argv = await _capture_docker_argv(_make_spec(policy))
+        assert "--security-opt" in argv
+        i = argv.index("--security-opt")
+        assert argv[i + 1] == "no-new-privileges"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "policy",
+        [
+            Limited(allowed_hosts=frozenset({"example.com"})),
+            Unrestricted(),
+        ],
+        ids=["limited", "unrestricted"],
+    )
+    async def test_ipc_private(self, policy: Limited | Unrestricted) -> None:
+        argv = await _capture_docker_argv(_make_spec(policy))
+        assert "--ipc" in argv
+        i = argv.index("--ipc")
+        assert argv[i + 1] == "private"
+
 
 class TestDockerBackendIsAlive:
     """DockerBackend.is_alive maps ``docker inspect`` outcomes to a bool (#691).


### PR DESCRIPTION
Unconditionally appends two security flags to every sandbox `docker run` invocation in `DockerBackend.create`:

- `--security-opt no-new-privileges` — blocks privilege escalation via setuid/file-caps across execve
- `--ipc private` — disables cross-container SysV-shm/POSIX-mq sharing

Both flags are placed adjacent to the existing `--cap-add NET_ADMIN` conditional but are not gated on network policy — they apply to every container regardless of spec.

## Why these two are safe now

**`no-new-privileges`** only blocks privilege *gain* across execve. Nothing in the sandbox image escalates:
- apt's `_apt` sandbox drop uses `seteuid()` downward via `CAP_SETUID` — a demotion, not escalation
- The Limited-network iptables lockdown runs as root already holding `NET_ADMIN` from `--cap-add` — no escalation path
- No setuid binaries (sudo, ping, etc.) ship in the sandbox image

Any future setuid binary added to the image will silently not escalate under NNP — that's the intended behavior.

**`--ipc private`** is the modern Docker default on most daemons. Nothing in the sandbox uses cross-container IPC, so this is an explicit assertion rather than a behavior change.

## What's deferred

`--cap-drop=ALL` and `--read-only` are **not** included here — both interact with apt/dpkg and root-agent writes in ways that aren't safe until the exec-user seam is in place. Tracked in separate follow-up issues.

## Tests

Extended `TestDockerBackendArgs` in `tests/unit/test_networking.py` with parametrized async tests asserting both flags are present for both Limited and Unrestricted specs. Includes a mutation check (flipping `--ipc private` to `shareable`) that correctly fails.

The existing Limited-networking e2e suite serves as the regression test for `no-new-privileges` — the fail-closed provisioning path would abort if NNP interfered with iptables setup, so a green Limited e2e confirms it doesn't.

Full unit suite (1882 tests) passes; mypy and ruff clean.

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)