### PR TITLE
feat(sandbox): add named user aios (1000:1000) + writable home

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -63,6 +63,24 @@ RUN apt-get update \
 COPY bin/tool /usr/local/bin/tool
 RUN chmod 0755 /usr/local/bin/tool
 
+# Named non-root user `aios` (uid:gid 1000:1000) with a writable home.
+#
+# DELIBERATELY no top-level `USER aios` directive. The image runs on a
+# one-shot-exec model: `CMD ["tail","-f","/dev/null"]` keeps the
+# container alive as **root**, and every tool call is a separate
+# `docker exec`. The agent uid is supplied per-exec via
+# `docker exec --user 1000:1000 ...` (follow-up seam issue), never as the
+# image default. Root must remain the default exec uid because setup
+# execs run apt and the iptables networking lockdown, which require uid 0
+# (the contract test `test_runs_as_root` asserts this).
+#
+# `--create-home` makes /home/aios owned by uid 1000 so the agent exec can
+# write there; `ENV HOME=/home/aios` applies to every exec (docker
+# `--user` does not reset HOME), so both root and uid-1000 execs see it.
+# This is inert until the follow-up flips agent execs to `--user 1000:1000`.
+RUN groupadd --gid 1000 aios && useradd --uid 1000 --gid 1000 --create-home --home-dir /home/aios aios
+ENV HOME=/home/aios
+
 # Default broker URL for bash scripts inside the sandbox that read
 # $TOOL_BROKER_URL directly (the python ``tool`` CLI has its own
 # default). Always overridden by ``docker run --env TOOL_BROKER_URL=...``

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -64,15 +64,22 @@ def pulled_image() -> str:
 
 
 def _docker_run(
-    image: str, *args: str, volume: str | None = None, timeout: int = 30
+    image: str,
+    *args: str,
+    volume: str | None = None,
+    user: str | None = None,
+    timeout: int = 30,
 ) -> subprocess.CompletedProcess[str]:
     """Run ``docker run --rm IMAGE *args`` and return the completed process.
 
     If *volume* is given it is passed as ``--volume <volume>`` before the image name.
+    If *user* is given it is passed as ``--user <user>`` before the image name.
     """
     cmd = ["docker", "run", "--rm"]
     if volume is not None:
         cmd += ["--volume", volume]
+    if user is not None:
+        cmd += ["--user", user]
     cmd.append(image)
     cmd.extend(args)
     return subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=timeout)
@@ -169,6 +176,41 @@ class TestRuntimeBehaviour:
         r = _docker_run(pulled_image, "bash", "-c", "id -u")
         assert r.returncode == 0, r.stderr
         assert r.stdout.strip() == "0", f"expected uid 0, got {r.stdout.strip()!r}"
+
+    def test_named_user_1000_is_aios(self, pulled_image: str) -> None:
+        """`docker exec --user 1000:1000` (the follow-up agent-exec uid) must
+        resolve to the named `aios` user, not a bare anonymous uid. The image
+        keeps no top-level USER directive (see test_runs_as_root); the uid is
+        supplied per-exec."""
+        r = _docker_run(pulled_image, "id", "-u", user="1000:1000")
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "1000", f"expected uid 1000, got {r.stdout.strip()!r}"
+        r = _docker_run(pulled_image, "id", "-un", user="1000:1000")
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "aios", f"expected user aios, got {r.stdout.strip()!r}"
+
+    def test_user_1000_has_writable_home(self, pulled_image: str) -> None:
+        """uid 1000 owns /home/aios (created via --create-home) and ENV
+        HOME=/home/aios applies under `--user` (docker --user does not reset
+        HOME), so the agent can write to $HOME."""
+        r = _docker_run(
+            pulled_image,
+            "bash",
+            "-c",
+            "touch $HOME/.probe && echo ok",
+            user="1000:1000",
+        )
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "ok", (
+            f"expected writable $HOME, got {r.stdout.strip()!r}: {r.stderr}"
+        )
+
+    def test_home_env_is_aios_home_for_root(self, pulled_image: str) -> None:
+        """Root (default) execs inherit ENV HOME=/home/aios too — the ENV is
+        unconditional, not gated on uid."""
+        r = _docker_run(pulled_image, "bash", "-c", "echo $HOME")
+        assert r.returncode == 0, r.stderr
+        assert r.stdout.strip() == "/home/aios", f"expected /home/aios, got {r.stdout.strip()!r}"
 
     def test_tool_broker_url_default_in_image_env(self, pulled_image: str) -> None:
         """Dockerfile sets a UDS default so bash scripts reading


### PR DESCRIPTION
Closes #805

## What changed

`docker/Dockerfile.sandbox` now creates a `aios` user and group at uid/gid 1000 with a home directory at `/home/aios`, and sets `ENV HOME=/home/aios`. This is inserted after the `COPY bin/tool` block, before `WORKDIR /workspace`.

Deliberately, there is **no top-level `USER` directive**. The container's default exec stays root — setup execs (apt, iptables lockdown) require it, and the existing `test_runs_as_root` contract continues to assert uid 0. The aios identity will be applied at the `docker exec --user 1000:1000` callsite in the follow-up exec-user seam, not in the image default.

`tests/e2e/test_sandbox_image_contract.py` gains a `--user` passthrough on the `_docker_run` helper and three new contract tests:

- uid 1000 resolves to the named user `aios` (passwd entry present)
- `--user 1000:1000` can write to `$HOME`
- root execs inherit `ENV HOME=/home/aios`

`test_runs_as_root` is untouched and stays green.

## Why it's safe now

No code passes `--user` to `docker exec` yet, so nothing changes for running sessions until the follow-up lands. `WORKSPACE_RUNTIME_ENV["PATH"]` is absolute, so the `HOME` env change doesn't affect tool resolution.

## Things to watch

- `/home/aios` lives on the container writable layer — ephemeral per container. Will want a tmpfs once read-only rootfs lands.
- `ENV HOME` shifts root's `$HOME` from `/root` to `/home/aios`. No known consumer caches under `/root`, but worth watching the first canary session after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
