### PR TITLE
feat(workflows): capability-attenuation operator + author-edge fixpoint predicate (#794 PR1)

### DIFF
--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -1,0 +1,422 @@
+"""The capability-attenuation operator — one lattice meet over a principal's surface.
+
+A *surface* is the triple ``(tools, mcp_servers, http_servers)``. Every principal
+in the system (agent, workflow, run, child session) carries one. The single law of
+the authority story is **materialize ⇒ clamp, frozen-once**: whenever a principal
+materializes its surface it is set to ``attenuate(its declared, its launcher's
+already-frozen effective)`` and never recomputed. Composition is free by
+associativity — each launcher was itself born clamped, so a single-step meet against
+the launcher's frozen effective equals the whole-chain fold; no ancestor walk.
+
+This module is the pure operator behind that law: spec-in, spec-out, principal-
+agnostic, no I/O. It lives at the bottom of the import graph (it imports only
+``models.agents``) so the query layer, the services, and the workflow runtime can all
+reach it without a cycle.
+
+The operator has two uses:
+
+* a **clamp** (run / child birth — store ``attenuate(declared, launcher)``), and
+* a **predicate** (workflow author / edit — admit ``declared`` iff
+  ``attenuate(declared, actor) == canonicalize(declared)``, i.e. ``declared`` is a
+  fixpoint of the meet against the actor: it grants nothing the actor lacks).
+
+**The normal-form contract.** ``canonicalize`` and ``attenuate`` must emit
+*byte-identical* normal forms for the predicate's equality to be exact:
+``attenuate(x, x) == canonicalize(x)`` and ``attenuate(attenuate(d, l), l) ==
+attenuate(d, l)``. Every ``None``-inherit sentinel is resolved to its concrete
+default *before* meeting (resolve-then-meet); ``configs[]`` are sorted by name and
+default-equal entries dropped; empty collections use a single representation. The
+meet only ever narrows, so the predicate's equality fails exactly when ``declared``
+tried to widen.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from aios.models.agents import (
+    HttpServerSpec,
+    McpPermissionPolicy,
+    McpServerSpec,
+    McpToolConfig,
+    McpToolsetConfig,
+    PermissionPolicy,
+    ToolSpec,
+    ToolTransport,
+)
+
+
+class Surface(NamedTuple):
+    """A principal's capability surface — the meet operates on this triple.
+
+    Constructed inline at the four call sites (the author edge, ``create_run``,
+    ``create_child_session``, the frozen-overlay read) from whatever carries the
+    three lists; not a persisted type. The lists are treated as immutable by the
+    operator — it never mutates an input, always builds fresh output.
+    """
+
+    tools: list[ToolSpec]
+    mcp_servers: list[McpServerSpec]
+    http_servers: list[HttpServerSpec]
+
+
+def _tool_key(t: ToolSpec) -> tuple[str, str | None]:
+    """A tool's attenuation identity: builtins by type, custom by name, toolsets by server.
+
+    The join carrier for the tools dimension — two entries are comparable iff their
+    keys are equal. (Module-private; the old ``services.workflows`` copy is gone.)
+    """
+    if t.type == "mcp_toolset":
+        return ("mcp_toolset", t.mcp_server_name)
+    if t.type == "custom":
+        return ("custom", t.name)
+    return ("builtin", t.type)
+
+
+# ── per-discovered-tool authority triple (the meet's atom for MCP) ────────────
+
+
+class _Triple(NamedTuple):
+    """The resolved authority of one (discovered) MCP tool name: the meet's atom."""
+
+    enabled: bool
+    permission: PermissionPolicy
+    transport: ToolTransport
+
+
+# The single canonical representation of an authority-bottom (disabled) tool name.
+# A disabled tool grants nothing, so its permission/transport are dead fields — but the
+# normal-form contract requires two disabled entries to compare *equal*, so they are
+# pinned to fixed values via ``_norm_triple`` wherever a triple is produced (both in
+# ``canonicalize`` and in the meet). Without this, ``canonicalize`` would keep a disabled
+# entry's authored transport while the meet narrowed it, falsely failing the author-edge
+# predicate for a declaration that merely disables a tool. ``transport="cli"`` also hides
+# the tool from the model-discovery path (``loop.discover_session_mcp_tools`` filters on
+# transport only), complementing ``enabled=False`` (honoured by the CLI broker's
+# ``resolve_mcp_enabled``) so a disabled tool is invisible to *both* readers.
+_DISABLED = _Triple(enabled=False, permission="always_ask", transport="cli")
+
+
+def _norm_triple(t: _Triple) -> _Triple:
+    """Collapse any disabled triple to the single canonical bottom (dead fields fixed)."""
+    return _DISABLED if not t.enabled else t
+
+
+def _transport_glb(a: ToolTransport, b: ToolTransport) -> ToolTransport | None:
+    """Greatest lower bound over ``{cli, agent_tool}`` with ``both`` as the top element.
+
+    Returns ``None`` when the meet is empty (``cli`` ⊓ ``agent_tool``) — the tool is
+    reachable from neither side and must drop.
+    """
+    if a == "both":
+        return b
+    if b == "both":
+        return a
+    if a == b:
+        return a
+    return None  # {cli} ⊓ {agent_tool} = ∅
+
+
+def _permission_meet(a: PermissionPolicy, b: PermissionPolicy) -> PermissionPolicy:
+    """``always_ask`` ⊏ ``always_allow``: the meet is the stricter (ask wins)."""
+    return "always_ask" if "always_ask" in (a, b) else "always_allow"
+
+
+def _triple_meet(a: _Triple, b: _Triple) -> _Triple:
+    """Dimension-wise meet, normalized so any disabled result is the single bottom.
+
+    An empty transport GLB (``cli`` ⊓ ``agent_tool``) means the tool is reachable from
+    neither side — also a disabled bottom.
+    """
+    transport = _transport_glb(a.transport, b.transport)
+    if transport is None:
+        return _DISABLED
+    permission = _permission_meet(a.permission, b.permission)
+    return _norm_triple(
+        _Triple(enabled=a.enabled and b.enabled, permission=permission, transport=transport)
+    )
+
+
+# ── MCP toolset normal form ───────────────────────────────────────────────────
+
+
+def _toolset_default_triple(t: ToolSpec, default_mcp_permission: PermissionPolicy) -> _Triple:
+    """Resolve a toolset's default (no-config) authority, reproducing the resolvers.
+
+    Mirrors ``resolve_mcp_permission``/``resolve_mcp_transport``/``resolve_mcp_enabled``
+    for the *fall-through* case (no matching ``configs[]`` entry): ``default_config``
+    fields → ``spec.permission`` → the operator default; transport → ``"both"``.
+    """
+    dc = t.default_config
+    if dc is not None and dc.permission_policy is not None:
+        permission = dc.permission_policy.type
+    elif t.permission is not None:
+        permission = t.permission
+    else:
+        permission = default_mcp_permission
+    enabled = dc.enabled if dc is not None else True
+    transport = (dc.transport if dc is not None else None) or "both"
+    return _norm_triple(_Triple(enabled=enabled, permission=permission, transport=transport))
+
+
+def _config_triple(cfg: McpToolConfig, default_mcp_permission: PermissionPolicy) -> _Triple:
+    """Resolve one ``configs[]`` entry, reproducing the resolver short-circuits exactly.
+
+    A ``configs[]`` entry with ``permission_policy=None`` resolves to the *operator
+    default*, NOT ``default_config`` (``resolve_mcp_permission`` returns ``None`` from
+    the matched entry, blocking fall-through, then the caller substitutes the default);
+    ``transport=None`` resolves to ``"both"``, NOT ``default_config.transport``.
+    """
+    permission = cfg.permission_policy.type if cfg.permission_policy else default_mcp_permission
+    return _norm_triple(
+        _Triple(enabled=cfg.enabled, permission=permission, transport=cfg.transport or "both")
+    )
+
+
+def _build_toolset(
+    server_name: str, default: _Triple, configs: list[tuple[str, _Triple]]
+) -> ToolSpec:
+    """The single constructor of a normal-form ``mcp_toolset`` spec.
+
+    Used by both ``canonicalize`` and the meet so their outputs are byte-identical.
+    ``permission``/``transport`` on the ``ToolSpec`` itself are ``None`` — all
+    authority lives in the concrete ``default_config`` + sorted ``configs``. An empty
+    ``configs`` is represented as ``None`` (the field default), never ``[]``.
+    """
+    return ToolSpec(
+        type="mcp_toolset",
+        mcp_server_name=server_name,
+        enabled=True,
+        permission=None,
+        transport=None,
+        default_config=McpToolsetConfig(
+            enabled=default.enabled,
+            permission_policy=McpPermissionPolicy(type=default.permission),
+            transport=default.transport,
+        ),
+        configs=[
+            McpToolConfig(
+                name=name,
+                enabled=tr.enabled,
+                permission_policy=McpPermissionPolicy(type=tr.permission),
+                transport=tr.transport,
+            )
+            for name, tr in configs
+        ]
+        or None,
+    )
+
+
+def _canon_toolset(t: ToolSpec, default_mcp_permission: PermissionPolicy) -> ToolSpec:
+    """Normalize a toolset to its normal form: concrete default + minimal sorted configs."""
+    default = _toolset_default_triple(t, default_mcp_permission)
+    configs: list[tuple[str, _Triple]] = []
+    for cfg in sorted(t.configs or [], key=lambda c: c.name):
+        triple = _config_triple(cfg, default_mcp_permission)
+        if triple != default:  # drop entries equal to the default — they carry no info
+            configs.append((cfg.name, triple))
+    return _build_toolset(t.mcp_server_name or "", default, configs)
+
+
+def _canon_default_triple(canon: ToolSpec) -> _Triple:
+    """The default triple of a canonical toolset — a plain read of its concrete fields."""
+    dc = canon.default_config
+    assert dc is not None and dc.permission_policy is not None and dc.transport is not None
+    return _Triple(dc.enabled, dc.permission_policy.type, dc.transport)
+
+
+def _canon_toolset_name_triple(canon: ToolSpec, name: str) -> _Triple:
+    """Read a canonical toolset's resolved triple for ``name`` (config override or default).
+
+    ``canon`` is a normal-form toolset (every field concrete), so this is a plain read,
+    not a re-resolution.
+    """
+    for cfg in canon.configs or []:
+        if cfg.name == name:
+            assert cfg.permission_policy is not None and cfg.transport is not None
+            return _Triple(cfg.enabled, cfg.permission_policy.type, cfg.transport)
+    return _canon_default_triple(canon)
+
+
+def _meet_toolset(declared: ToolSpec, launcher: ToolSpec) -> ToolSpec:
+    """Meet two *canonical* toolsets for the same server, on the resolved-per-name policy.
+
+    ``out_default`` is the meet of the two defaults; each name in the union of both
+    config sets gets the meet of its resolved triples, emitted explicitly iff it
+    differs from ``out_default``. This proves the fall-through case: a child omitting a
+    launcher-pinned name still gets an explicit pinned entry whenever the meet is
+    stricter than the child's default.
+    """
+    out_default = _triple_meet(_canon_default_triple(declared), _canon_default_triple(launcher))
+    names = sorted(
+        {c.name for c in (declared.configs or [])} | {c.name for c in (launcher.configs or [])}
+    )
+    configs: list[tuple[str, _Triple]] = []
+    for name in names:
+        meet = _triple_meet(
+            _canon_toolset_name_triple(declared, name),
+            _canon_toolset_name_triple(launcher, name),
+        )
+        if meet != out_default:
+            configs.append((name, meet))
+    return _build_toolset(declared.mcp_server_name or "", out_default, configs)
+
+
+# ── builtin / custom tool normal form ─────────────────────────────────────────
+
+
+def _canon_builtin(t: ToolSpec, *, transport_default: ToolTransport) -> ToolSpec:
+    """Resolve a builtin/custom tool's ``None`` sentinels to concrete defaults.
+
+    ``permission=None`` → ``always_allow`` (the dispatch gate treats ``None`` as
+    immediate); ``transport=None`` → the registry default (builtins) / ``"both"``
+    (custom). Other fields (name/description/input_schema) ride along unchanged.
+    """
+    return t.model_copy(
+        update={
+            "permission": t.permission or "always_allow",
+            "transport": t.transport or transport_default,
+        }
+    )
+
+
+def _meet_builtin(declared: ToolSpec, launcher: ToolSpec) -> ToolSpec | None:
+    """Meet two *canonical* builtin/custom tools (same key). ``None`` if transport ⊓ is empty.
+
+    Emits the declared entry's definition (name/description/input_schema) with the
+    meet of permission and transport.
+    """
+    assert declared.transport is not None and launcher.transport is not None
+    assert declared.permission is not None and launcher.permission is not None
+    transport = _transport_glb(declared.transport, launcher.transport)
+    if transport is None:
+        return None
+    return declared.model_copy(
+        update={
+            "permission": _permission_meet(declared.permission, launcher.permission),
+            "transport": transport,
+        }
+    )
+
+
+# ── the operator ──────────────────────────────────────────────────────────────
+
+
+def canonicalize(
+    s: Surface,
+    *,
+    default_mcp_permission: PermissionPolicy,
+    builtin_transports: dict[str, ToolTransport],
+) -> Surface:
+    """Resolve a surface to its normal form (the identity element of the meet).
+
+    Prunes disabled tools and dangling toolsets, resolves every ``None`` sentinel to
+    its concrete default, and emits toolsets in minimal-config normal form. Servers
+    are kept verbatim (they are compared and copied wholesale; normalizing e.g.
+    ``headers None→{}`` would create needless drift). ``canonicalize(x) ==
+    attenuate(x, x)``.
+
+    ``default_mcp_permission`` and ``builtin_transports`` are passed in (read from
+    settings / the tool registry by the caller) to keep the operator pure.
+    """
+    server_names = {srv.name for srv in s.mcp_servers}
+    tools: list[ToolSpec] = []
+    for t in s.tools:
+        if not t.enabled:
+            continue  # disabled tools are invisible to every reader → drop
+        if t.type == "mcp_toolset":
+            if t.mcp_server_name not in server_names:
+                continue  # dangling toolset — no server → no discovery → drop
+            tools.append(_canon_toolset(t, default_mcp_permission))
+        elif t.type == "custom":
+            tools.append(_canon_builtin(t, transport_default="both"))
+        else:
+            tools.append(
+                _canon_builtin(t, transport_default=builtin_transports.get(t.type, "both"))
+            )
+    return Surface(tools, list(s.mcp_servers), list(s.http_servers))
+
+
+def attenuate(
+    declared: Surface,
+    launcher: Surface,
+    *,
+    default_mcp_permission: PermissionPolicy,
+    builtin_transports: dict[str, ToolTransport],
+) -> Surface:
+    """The lattice meet: ``declared`` clamped to never exceed ``launcher``.
+
+    Per identity key in ``declared``: absent from ``launcher`` → drop; present → the
+    per-dimension meet, dropping if it bottoms out. Servers survive only on an exact
+    key match and are emitted **launcher-verbatim** (parent-wins-frozen: routes and
+    headers come from the launcher; the child narrows only by dropping whole servers).
+    MCP servers key on the joint ``(name, url)`` — a re-pointed name is a different key
+    and drops. Output is canonical (``attenuate(d, l)`` is a fixpoint of ``canonicalize``).
+    """
+    d = canonicalize(
+        declared,
+        default_mcp_permission=default_mcp_permission,
+        builtin_transports=builtin_transports,
+    )
+    lau = canonicalize(
+        launcher,
+        default_mcp_permission=default_mcp_permission,
+        builtin_transports=builtin_transports,
+    )
+
+    # http_servers — key base_url, launcher-verbatim survival.
+    l_http = {srv.base_url: srv for srv in lau.http_servers}
+    out_http = [l_http[srv.base_url] for srv in d.http_servers if srv.base_url in l_http]
+
+    # mcp_servers — joint (name, url) key, launcher-verbatim survival.
+    l_mcp = {(srv.name, srv.url): srv for srv in lau.mcp_servers}
+    out_mcp = [l_mcp[(srv.name, srv.url)] for srv in d.mcp_servers if (srv.name, srv.url) in l_mcp]
+    surviving_servers = {srv.name for srv in out_mcp}
+
+    # tools — _tool_key, per-dimension meet (toolsets gated on surviving server).
+    l_tools = {_tool_key(t): t for t in lau.tools}
+    out_tools: list[ToolSpec] = []
+    for t in d.tools:
+        match = l_tools.get(_tool_key(t))
+        if match is None:
+            continue
+        if t.type == "mcp_toolset":
+            if t.mcp_server_name not in surviving_servers:
+                continue  # the toolset's server was re-pointed or dropped
+            out_tools.append(_meet_toolset(t, match))
+        else:
+            met = _meet_builtin(t, match)
+            if met is not None:
+                out_tools.append(met)
+    return Surface(out_tools, out_mcp, out_http)
+
+
+def surface_diff(expected: Surface, actual: Surface) -> dict[str, list[str]]:
+    """Per-section identity-keys present in ``expected`` but dropped/narrowed in ``actual``.
+
+    ``expected`` is ``canonicalize(declared)``; ``actual`` is ``attenuate(declared,
+    launcher)``. Used to build the author-edge ``ForbiddenError`` detail — names the
+    exact tools/servers the declared surface exceeded the actor on.
+    """
+    out: dict[str, list[str]] = {}
+
+    actual_tools = {_tool_key(t): t for t in actual.tools}
+    bad_tools = [
+        t.name or t.mcp_server_name or t.type
+        for t in expected.tools
+        if actual_tools.get(_tool_key(t)) != t
+    ]
+    if bad_tools:
+        out["tools"] = bad_tools
+
+    actual_mcp = {(s.name, s.url): s for s in actual.mcp_servers}
+    bad_mcp = [s.name for s in expected.mcp_servers if actual_mcp.get((s.name, s.url)) != s]
+    if bad_mcp:
+        out["mcp_servers"] = bad_mcp
+
+    actual_http = {s.base_url: s for s in actual.http_servers}
+    bad_http = [s.name for s in expected.http_servers if actual_http.get(s.base_url) != s]
+    if bad_http:
+        out["http_servers"] = bad_http
+
+    return out

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -17,10 +17,12 @@ from typing import Any
 
 import asyncpg
 
+from aios.config import get_settings
 from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, ForbiddenError, NotFoundError
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.attenuation import Surface, attenuate, canonicalize, surface_diff
 from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
     WfRun,
@@ -32,6 +34,7 @@ from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
+from aios.tools.registry import transport_defaults
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
@@ -53,15 +56,6 @@ __all__ = [
 # ─── workflow definitions ────────────────────────────────────────────────────
 
 
-def _tool_key(t: ToolSpec) -> tuple[str, str | None]:
-    """A tool's attenuation identity: builtins by type, custom by name, toolsets by server."""
-    if t.type == "mcp_toolset":
-        return ("mcp_toolset", t.mcp_server_name)
-    if t.type == "custom":
-        return ("custom", t.name)
-    return ("builtin", t.type)
-
-
 async def _enforce_surface_attenuation(
     pool: asyncpg.Pool[Any],
     *,
@@ -71,35 +65,35 @@ async def _enforce_surface_attenuation(
     mcp_servers: list[McpServerSpec],
     http_servers: list[HttpServerSpec],
 ) -> None:
-    """Raise ``ForbiddenError`` if the declared surface exceeds the acting agent's.
+    """Raise ``ForbiddenError`` unless the declared surface is a fixpoint of the meet
+    against the acting agent's surface — i.e. it grants nothing the agent lacks.
 
-    Serves both create (the creator declaring a surface) and update (the editor's merged
-    final surface). Subset by identity key: ``mcp_servers`` by url, ``http_servers`` by
-    base_url, ``tools`` by (builtin type / custom name / toolset server). The HTTP path
-    passes no actor and skips this — operator authority. (No-widen on
-    permission/transport/routes is a deliberate follow-up; this slice gates membership.)
+    Serves both create (the creator's declared surface) and update (the editor's merged
+    final surface). The predicate is ``attenuate(declared, actor) ==
+    canonicalize(declared)``: equal iff the meet did not have to narrow anything, which
+    is exactly "``declared`` ≤ ``actor``" on every axis — membership *and* per-tool
+    permission/transport, MCP server identity (joint name+url), and http routes (which
+    are parent-wins-frozen, so the agent's must be declared verbatim; R1). The HTTP path
+    passes no actor and skips this — operator authority.
     """
     session = await sessions_service.get_session_basic(
         pool, actor_session_id, account_id=account_id
     )
     agent = await agents_service.load_for_session(pool, session, account_id=account_id)
-    allowed_mcp = {s.url for s in agent.mcp_servers}
-    allowed_http = {s.base_url for s in agent.http_servers}
-    allowed_tools = {_tool_key(t) for t in agent.tools if t.enabled}
-
-    offending: dict[str, list[str]] = {}
-    if bad := [s.name for s in mcp_servers if s.url not in allowed_mcp]:
-        offending["mcp_servers"] = bad
-    if bad := [s.name for s in http_servers if s.base_url not in allowed_http]:
-        offending["http_servers"] = bad
-    if bad := [
-        t.name or t.mcp_server_name or t.type for t in tools if _tool_key(t) not in allowed_tools
-    ]:
-        offending["tools"] = bad
-    if offending:
+    default_mcp = get_settings().default_mcp_permission_policy or "always_ask"
+    builtin_transports = transport_defaults()
+    declared = Surface(tools, mcp_servers, http_servers)
+    actor = Surface(agent.tools, agent.mcp_servers, agent.http_servers)
+    expected = canonicalize(
+        declared, default_mcp_permission=default_mcp, builtin_transports=builtin_transports
+    )
+    effective = attenuate(
+        declared, actor, default_mcp_permission=default_mcp, builtin_transports=builtin_transports
+    )
+    if effective != expected:
         raise ForbiddenError(
-            "workflow declares servers or tools the creating agent does not have",
-            detail={"ungranted": offending},
+            "workflow surface exceeds the acting agent's",
+            detail={"exceeds": surface_diff(expected, effective)},
         )
 
 

--- a/src/aios/tools/registry.py
+++ b/src/aios/tools/registry.py
@@ -242,6 +242,17 @@ def to_openai_tools(agent_tools: list[AgentToolSpec]) -> list[dict[str, Any]]:
     return result
 
 
+def transport_defaults() -> dict[str, ToolTransport]:
+    """Each registered built-in's default transport, for the attenuation operator.
+
+    The pure ``attenuate`` operator resolves a builtin ``ToolSpec.transport=None`` to
+    its registry default; it takes this mapping as an argument rather than importing
+    the runtime registry singleton (which would couple the bottom-of-graph operator to
+    worker startup). Read once by the caller and passed in.
+    """
+    return {name: registry.get(name).transport for name in registry.names()}
+
+
 def effective_transport(name: str, agent_tools: list[AgentToolSpec]) -> ToolTransport:
     """Resolve a tool's effective transport given an agent's tool list.
 

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -32,7 +32,7 @@ from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, ForbiddenError, NotFoundError, RateLimitedError
 from aios.harness import runtime
 from aios.mcp.client import resolve_auth_for_target_url_run
-from aios.models.agents import Agent, HttpServerSpec, McpServerSpec
+from aios.models.agents import Agent, HttpServerSpec, McpServerSpec, ToolSpec
 from aios.models.vaults import VaultCredentialCreate
 from aios.services import agents as agents_service
 from aios.services import vaults as vaults_service
@@ -87,7 +87,12 @@ async def vault_pool(
 
 
 async def _make_agent(
-    pool: asyncpg.Pool[Any], name: str, *, mcp_servers: list[McpServerSpec] | None = None
+    pool: asyncpg.Pool[Any],
+    name: str,
+    *,
+    tools: list[ToolSpec] | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
 ) -> Agent:
     return await agents_service.create_agent(
         pool,
@@ -95,8 +100,9 @@ async def _make_agent(
         name=name,
         model="test/dummy",
         system="x",
-        tools=[],
+        tools=tools or [],
         mcp_servers=mcp_servers,
+        http_servers=http_servers,
         description=None,
         metadata={},
         window_min=1000,
@@ -277,6 +283,47 @@ async def test_create_time_attenuation(vault_pool: asyncpg.Pool[Any]) -> None:
         creator_session_id=None,
     )
     assert [m.url for m in op.mcp_servers] == ["https://s2.example"]
+
+
+async def test_create_time_attenuation_rejects_per_tool_widening(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """The fixpoint predicate rejects *widening* a tool's policy, not just adding tools.
+
+    The agent holds ``bash`` at ``always_ask``. A workflow declaring the same ``bash``
+    at ``always_allow`` is a looser policy on an identically-named tool — membership
+    alone would admit it, but it widens the agent's surface, so the fixpoint predicate
+    rejects it. Re-declaring ``always_ask`` is a fixpoint and passes. This is the half
+    the old membership check missed.
+    """
+    pool = vault_pool
+    agent = await _make_agent(
+        pool, "pin-agent", tools=[ToolSpec(type="bash", permission="always_ask")]
+    )
+    creator = await _make_session(pool, agent)
+
+    before = await _workflow_count(pool)
+    with pytest.raises(ForbiddenError):
+        await wf_service.create_workflow(
+            pool,
+            account_id=ACC,
+            name="w-widen",
+            script=_SCRIPT,
+            tools=[ToolSpec(type="bash", permission="always_allow")],
+            creator_session_id=creator,
+        )
+    assert await _workflow_count(pool) == before
+
+    # Re-declaring the identical policy is a fixpoint → admitted.
+    ok = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-pin",
+        script=_SCRIPT,
+        tools=[ToolSpec(type="bash", permission="always_ask")],
+        creator_session_id=creator,
+    )
+    assert ok.name == "w-pin"
 
 
 async def test_declared_surface_round_trips(vault_pool: asyncpg.Pool[Any]) -> None:

--- a/tests/unit/sandbox/test_docker_seccomp_argv.py
+++ b/tests/unit/sandbox/test_docker_seccomp_argv.py
@@ -73,9 +73,10 @@ async def test_security_opt_always_emitted(monkeypatch: pytest.MonkeyPatch) -> N
     spec = _make_spec(seccomp_profile="/app/docker/seccomp-sandbox.json")
     await DockerBackend().create(spec)
 
-    argv = calls[0]
-    idx = argv.index("--security-opt")
-    assert argv[idx + 1] == "seccomp=/app/docker/seccomp-sandbox.json"
+    # Order-independent: the backend emits multiple --security-opt flags
+    # (no-new-privileges from #812 precedes seccomp), so scan all of them
+    # rather than assuming seccomp is first — matching the sibling tests below.
+    assert "seccomp=/app/docker/seccomp-sandbox.json" in _security_opt_values(calls[0])
 
 
 async def test_unconfined_override_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_attenuation.py
+++ b/tests/unit/test_attenuation.py
@@ -1,0 +1,390 @@
+"""The capability-attenuation operator — pure, table-driven unit tests.
+
+Pure in-memory: no Postgres, no Docker. Covers the meet per dimension, the MCP
+toolset normal form (incl. the resolver short-circuits and the fall-through pin),
+the joint ``(name, url)`` MCP key, the algebraic contract that makes the author-edge
+predicate exact (``attenuate(x, x) == canonicalize(x)`` + idempotence), and the
+``litellm_extra`` tripwire guarding the model-identity axis (#823).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aios.models.agents import (
+    HttpPermissionPolicy,
+    HttpRouteSpec,
+    HttpServerSpec,
+    McpPermissionPolicy,
+    McpServerSpec,
+    McpToolConfig,
+    McpToolsetConfig,
+    PermissionPolicy,
+    ToolSpec,
+    ToolTransport,
+    resolve_mcp_enabled,
+    resolve_mcp_permission,
+)
+from aios.models.attenuation import Surface, attenuate, canonicalize, surface_diff
+
+# Controlled defaults so the meet-logic tests are independent of the live registry.
+DMP: PermissionPolicy = "always_ask"
+BT: dict[str, ToolTransport] = {
+    "bash": "both",
+    "read": "both",
+    "write": "agent_tool",
+    "edit": "cli",
+    "web_fetch": "both",
+}
+
+
+def att(declared: Surface, launcher: Surface, *, dmp: PermissionPolicy = DMP) -> Surface:
+    return attenuate(declared, launcher, default_mcp_permission=dmp, builtin_transports=BT)
+
+
+def canon(s: Surface, *, dmp: PermissionPolicy = DMP) -> Surface:
+    return canonicalize(s, default_mcp_permission=dmp, builtin_transports=BT)
+
+
+def _toolset(server: str, **kw: object) -> ToolSpec:
+    return ToolSpec(type="mcp_toolset", mcp_server_name=server, **kw)  # type: ignore[arg-type]
+
+
+def _mcp_cfg(name: str, *, perm: PermissionPolicy | None = None, **kw: object) -> McpToolConfig:
+    pp = McpPermissionPolicy(type=perm) if perm is not None else None
+    return McpToolConfig(name=name, permission_policy=pp, **kw)  # type: ignore[arg-type]
+
+
+# ── builtin / custom tools ────────────────────────────────────────────────────
+
+
+class TestBuiltinMeet:
+    def test_permission_meet_takes_stricter(self) -> None:
+        declared = Surface([ToolSpec(type="bash", permission="always_ask")], [], [])
+        launcher = Surface([ToolSpec(type="bash", permission="always_allow")], [], [])
+        out = att(declared, launcher)
+        assert [t.permission for t in out.tools] == ["always_ask"]
+        # declared narrows → it is a fixpoint → predicate admits it.
+        assert out == canon(declared)
+
+    def test_widening_permission_is_rejected_by_predicate(self) -> None:
+        declared = Surface([ToolSpec(type="bash", permission="always_allow")], [], [])
+        launcher = Surface([ToolSpec(type="bash", permission="always_ask")], [], [])
+        out = att(declared, launcher)
+        assert [t.permission for t in out.tools] == ["always_ask"]  # clamped down
+        assert out != canon(declared)  # not a fixpoint → ForbiddenError at the author edge
+        assert surface_diff(canon(declared), out) == {"tools": ["bash"]}
+
+    def test_none_permission_resolves_to_always_allow(self) -> None:
+        declared = Surface([ToolSpec(type="bash")], [], [])
+        launcher = Surface([ToolSpec(type="bash")], [], [])
+        assert canon(declared).tools[0].permission == "always_allow"
+        assert att(declared, launcher) == canon(declared)
+
+    def test_tool_absent_from_launcher_is_dropped(self) -> None:
+        declared = Surface([ToolSpec(type="bash"), ToolSpec(type="read")], [], [])
+        launcher = Surface([ToolSpec(type="bash")], [], [])
+        out = att(declared, launcher)
+        assert [t.type for t in out.tools] == ["bash"]
+
+    def test_transport_glb_both_narrows_to_launcher(self) -> None:
+        declared = Surface([ToolSpec(type="bash", transport="both")], [], [])
+        launcher = Surface([ToolSpec(type="bash", transport="agent_tool")], [], [])
+        assert att(declared, launcher).tools[0].transport == "agent_tool"
+
+    def test_disjoint_transport_drops_the_tool(self) -> None:
+        declared = Surface([ToolSpec(type="bash", transport="cli")], [], [])
+        launcher = Surface([ToolSpec(type="bash", transport="agent_tool")], [], [])
+        assert att(declared, launcher).tools == []
+
+    def test_disabled_tool_is_pruned_both_sides(self) -> None:
+        declared = Surface([ToolSpec(type="bash", enabled=False)], [], [])
+        assert canon(declared).tools == []
+        # A launcher-disabled tool grants nothing — declared can't enable it.
+        out = att(Surface([ToolSpec(type="bash")], [], []), declared)
+        assert out.tools == []
+
+    def test_custom_tool_keyed_by_name(self) -> None:
+        spec = dict(name="foo", description="d", input_schema={"type": "object"})
+        declared = Surface([ToolSpec(type="custom", **spec)], [], [])  # type: ignore[arg-type]
+        launcher = Surface([ToolSpec(type="custom", **spec)], [], [])  # type: ignore[arg-type]
+        out = att(declared, launcher)
+        assert [t.name for t in out.tools] == ["foo"]
+        assert out == canon(declared)
+
+
+# ── MCP + HTTP servers ────────────────────────────────────────────────────────
+
+
+class TestServerSurvival:
+    def test_mcp_server_survives_on_joint_name_url(self) -> None:
+        srv = McpServerSpec(name="gh", url="https://gh/mcp")
+        declared = Surface([_toolset("gh")], [srv], [])
+        launcher = Surface([_toolset("gh")], [srv], [])
+        out = att(declared, launcher)
+        assert [(s.name, s.url) for s in out.mcp_servers] == [("gh", "https://gh/mcp")]
+        assert any(t.type == "mcp_toolset" for t in out.tools)
+
+    def test_mcp_server_repointed_url_is_dropped(self) -> None:
+        # Launcher holds (gh, U1) and (other, U2); child re-points gh → U2.
+        u1, u2 = "https://gh/mcp", "https://other/mcp"
+        launcher = Surface(
+            [_toolset("gh"), _toolset("other")],
+            [McpServerSpec(name="gh", url=u1), McpServerSpec(name="other", url=u2)],
+            [],
+        )
+        declared = Surface([_toolset("gh")], [McpServerSpec(name="gh", url=u2)], [])
+        out = att(declared, launcher)
+        assert out.mcp_servers == []  # (gh, U2) is not a launcher key
+        assert out.tools == []  # the toolset's server didn't survive
+        assert out != canon(declared)  # author edge rejects
+
+    def test_mcp_server_emitted_launcher_verbatim(self) -> None:
+        # Launcher carries headers; child declares the same (name, url) without them.
+        l_srv = McpServerSpec(name="gh", url="https://gh/mcp", headers={"X-Toolsets": "issues"})
+        d_srv = McpServerSpec(name="gh", url="https://gh/mcp")
+        out = att(Surface([], [d_srv], []), Surface([], [l_srv], []))
+        assert out.mcp_servers[0].headers == {"X-Toolsets": "issues"}  # launcher wins
+        assert out != canon(Surface([], [d_srv], []))  # child must declare it identically
+
+    def test_http_routes_parent_wins_frozen(self) -> None:
+        # First-match-wins ordering: a child re-declaring the broad route must NOT be
+        # able to escape the launcher's earlier always_ask gate on /reports/admin.
+        l_routes = [
+            HttpRouteSpec(
+                path_pattern="/reports/admin",
+                permission_policy=HttpPermissionPolicy(type="always_ask"),
+            ),
+            HttpRouteSpec(
+                path_pattern="/reports/**",
+                permission_policy=HttpPermissionPolicy(type="always_allow"),
+            ),
+        ]
+        l_srv = HttpServerSpec(name="api", base_url="https://api", routes=l_routes)
+        d_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[
+                HttpRouteSpec(
+                    path_pattern="/reports/**",
+                    permission_policy=HttpPermissionPolicy(type="always_allow"),
+                )
+            ],
+        )
+        out = att(Surface([], [], [d_srv]), Surface([], [], [l_srv]))
+        assert out.http_servers[0].routes == l_routes  # launcher-verbatim, both routes
+        assert out != canon(Surface([], [], [d_srv]))  # narrowing is rejected (R1: verbatim only)
+
+    def test_http_server_absent_is_dropped(self) -> None:
+        d_srv = HttpServerSpec(name="api", base_url="https://api")
+        out = att(Surface([], [], [d_srv]), Surface([], [], []))
+        assert out.http_servers == []
+
+
+# ── MCP toolset normal form ───────────────────────────────────────────────────
+
+
+class TestToolsetNormalForm:
+    def test_dangling_toolset_is_pruned(self) -> None:
+        # No matching McpServerSpec → no discovery → drop.
+        declared = Surface([_toolset("ghost")], [], [])
+        assert canon(declared).tools == []
+
+    def test_default_config_frozen_concrete(self) -> None:
+        srv = McpServerSpec(name="s", url="https://s")
+        out = canon(Surface([_toolset("s")], [srv], []), dmp="always_allow")
+        ts = out.tools[0]
+        assert ts.default_config is not None
+        assert ts.default_config.permission_policy == McpPermissionPolicy(type="always_allow")
+        assert ts.default_config.transport == "both"
+        assert ts.configs is None  # no per-tool overrides → minimal form
+
+    def test_config_none_policy_short_circuits_to_operator_default(self) -> None:
+        # A configs[] entry with permission_policy=None resolves to the OPERATOR default,
+        # NOT default_config — even when default_config says always_allow.
+        srv = McpServerSpec(name="s", url="https://s")
+        ts = _toolset(
+            "s",
+            default_config=McpToolsetConfig(
+                permission_policy=McpPermissionPolicy(type="always_allow")
+            ),
+            configs=[_mcp_cfg("danger")],  # permission_policy=None
+        )
+        out = canon(Surface([ts], [srv], []), dmp="always_ask")
+        assert (
+            resolve_mcp_permission("mcp__s__danger", out.tools) == "always_ask"
+        )  # operator default
+        assert (
+            resolve_mcp_permission("mcp__s__other", out.tools) == "always_allow"
+        )  # default_config
+
+    def test_fall_through_pins_launcher_only_name(self) -> None:
+        # Regression (b): launcher pins delete_repo=always_ask; operator default
+        # always_allow; child declares the toolset bare → the meet must PIN delete_repo.
+        srv = McpServerSpec(name="s", url="https://s")
+        launcher = Surface(
+            [_toolset("s", configs=[_mcp_cfg("delete_repo", perm="always_ask")])], [srv], []
+        )
+        declared = Surface([_toolset("s")], [srv], [])
+        out = att(declared, launcher, dmp="always_allow")
+        assert resolve_mcp_permission("mcp__s__delete_repo", out.tools) == "always_ask"
+        assert resolve_mcp_permission("mcp__s__read_repo", out.tools) == "always_allow"
+
+    def test_per_name_transport_conflict_disables(self) -> None:
+        srv = McpServerSpec(name="s", url="https://s")
+        launcher = Surface([_toolset("s", configs=[_mcp_cfg("x", transport="cli")])], [srv], [])
+        declared = Surface(
+            [_toolset("s", configs=[_mcp_cfg("x", transport="agent_tool")])], [srv], []
+        )
+        out = att(declared, launcher)
+        assert resolve_mcp_enabled("mcp__s__x", out.tools) is False  # disjoint transport → disabled
+
+    def test_disabling_a_tool_is_not_a_widening(self) -> None:
+        # A declaration that merely *disables* a tool can never exceed the launcher,
+        # even when the launcher holds it at a narrower transport. Disabled entries
+        # collapse to one bottom, so their dead fields don't fail the predicate.
+        srv = McpServerSpec(name="s", url="https://s")
+        launcher = Surface(
+            [_toolset("s", default_config=McpToolsetConfig(transport="cli"))], [srv], []
+        )
+        declared = Surface(
+            [
+                _toolset(
+                    "s",
+                    default_config=McpToolsetConfig(transport="cli"),
+                    configs=[_mcp_cfg("t2", enabled=False, perm="always_allow", transport="both")],
+                )
+            ],
+            [srv],
+            [],
+        )
+        assert att(declared, launcher) == canon(declared)  # fixpoint → author edge admits
+
+    def test_toolset_permission_default_widening_rejected(self) -> None:
+        # Child default always_allow vs launcher default always_ask → child widens → reject.
+        srv = McpServerSpec(name="s", url="https://s")
+        launcher = Surface(
+            [
+                _toolset(
+                    "s",
+                    default_config=McpToolsetConfig(
+                        permission_policy=McpPermissionPolicy(type="always_ask")
+                    ),
+                )
+            ],
+            [srv],
+            [],
+        )
+        declared = Surface(
+            [
+                _toolset(
+                    "s",
+                    default_config=McpToolsetConfig(
+                        permission_policy=McpPermissionPolicy(type="always_allow")
+                    ),
+                )
+            ],
+            [srv],
+            [],
+        )
+        out = att(declared, launcher)
+        assert out != canon(declared)
+
+
+# ── the algebraic contract (the predicate's exactness) ────────────────────────
+
+
+def _gnarly_surfaces() -> list[Surface]:
+    s1 = McpServerSpec(name="s1", url="https://s1", headers={"H": "1"})
+    s2 = McpServerSpec(name="s2", url="https://s2")
+    http = HttpServerSpec(
+        name="api",
+        base_url="https://api",
+        routes=[
+            HttpRouteSpec(
+                path_pattern="/a/**", permission_policy=HttpPermissionPolicy(type="always_ask")
+            )
+        ],
+    )
+    return [
+        Surface([], [], []),
+        Surface([ToolSpec(type="bash"), ToolSpec(type="read", permission="always_ask")], [], []),
+        Surface(
+            [
+                _toolset(
+                    "s1",
+                    default_config=McpToolsetConfig(transport="both"),
+                    configs=[_mcp_cfg("write", perm="always_ask")],
+                ),
+                _toolset("s2"),
+                ToolSpec(type="custom", name="c", description="d", input_schema={}),
+            ],
+            [s1, s2],
+            [http],
+        ),
+        # Disabled entries with *divergent* dead fields — the case that broke the
+        # normal-form contract before disabled triples were collapsed to one bottom.
+        Surface(
+            [
+                _toolset(
+                    "s1",
+                    default_config=McpToolsetConfig(enabled=False, transport="both"),
+                    configs=[
+                        _mcp_cfg("a", enabled=False, perm="always_allow", transport="both"),
+                        _mcp_cfg("b", perm="always_ask", transport="cli"),
+                    ],
+                ),
+                _toolset("s2", configs=[_mcp_cfg("x", enabled=False, transport="agent_tool")]),
+            ],
+            [s1, s2],
+            [],
+        ),
+    ]
+
+
+@pytest.mark.parametrize("s", _gnarly_surfaces())
+def test_self_meet_equals_canonicalize(s: Surface) -> None:
+    # The contract that makes the author-edge predicate exact.
+    assert att(s, s) == canon(s)
+
+
+@pytest.mark.parametrize("s", _gnarly_surfaces())
+def test_canonicalize_is_idempotent(s: Surface) -> None:
+    assert canon(canon(s)) == canon(s)
+
+
+@pytest.mark.parametrize("d", _gnarly_surfaces())
+@pytest.mark.parametrize("ln", _gnarly_surfaces())
+def test_attenuate_is_idempotent_against_launcher(d: Surface, ln: Surface) -> None:
+    once = att(d, ln)
+    assert att(once, ln) == once  # already clamped → no further narrowing
+
+
+@pytest.mark.parametrize("d", _gnarly_surfaces())
+@pytest.mark.parametrize("ln", _gnarly_surfaces())
+def test_meet_never_exceeds_either_operand(d: Surface, ln: Surface) -> None:
+    # Absorption: the meet is a fixpoint against each operand (≤ both).
+    out = att(d, ln)
+    assert att(out, ln) == out
+    assert att(out, d) == out
+
+
+# ── the model-identity tripwire (g) ───────────────────────────────────────────
+
+
+def test_no_registered_tool_exposes_litellm_extra() -> None:
+    """No agent_tool may set ``litellm_extra`` (hence ``api_base``) — #823's precondition.
+
+    The surface+credential meet does NOT clamp model routing; it is sound only while no
+    runtime principal can mint/edit an agent's ``litellm_extra``. The day a
+    create_agent-style builtin is added, its schema exposes the agent field and this
+    test fails — forcing the model-identity clamp (#823) to land with it.
+    """
+    import aios.tools  # noqa: F401  — populate the registry
+    from aios.tools.registry import registry
+
+    for name in registry.names():
+        schema = json.dumps(registry.get(name).parameters_schema)
+        assert "litellm_extra" not in schema, f"tool {name!r} exposes litellm_extra (see #823)"


### PR DESCRIPTION
**Stacked PR 1 of 2 for #794** (the symmetric capability-attenuation keystone). This PR ships the pure operator and the author/edit edge; the stacked **PR2** adds the materialize edges (`create_run` / `create_child_session` clamp + frozen child surface + the `load_for_session` overlay + migration).

## What this is

The v2 design pass found the keystone gap: a workflow **run is not a real authority boundary** — a `web_fetch`-only run can `agent("db-admin")` and the child wields db-admin's full surface. #794 resolves this into **one operator + one law**. This PR lands the operator and the first of its two uses (the predicate).

### `models/attenuation.py` (new — bottom of the import graph, spec-in / spec-out, no I/O)

`attenuate(declared, launcher) -> Surface` is a **per-identity-key lattice meet**:
- **tools** key on the existing `_tool_key` (moved here); **http servers** on `base_url`; **MCP servers** on the joint **`(name, url)`** — a re-pointed server name is a different key and drops.
- Surviving servers are emitted **launcher-verbatim** (routes + headers are parent-wins-frozen; the child narrows only by dropping whole servers — so there is **no net-new route-containment code**).
- Per-dimension meets: permission `always_ask` ⊏ `always_allow`; transport GLB over `{cli, agent_tool}` with `both` as top (empty meet → drop); enabled = AND. MCP permission/enabled meet on the **resolved-per-name** policy, emitting a canonical normal form that reproduces the resolver short-circuits exactly (a `configs[]` entry with `permission_policy=None` resolves to the *operator default*, not `default_config`).
- Disabled tool names collapse to a single authority-bottom (`_DISABLED`) so a declaration that merely *disables* a tool can't falsely fail the predicate; its `transport=cli` also hides it from the model-discovery path, complementing `enabled=False` (the CLI broker).
- `canonicalize` resolves every None-inherit sentinel and is the meet's identity element. **`attenuate(x, x) == canonicalize(x)`** is the contract that makes the predicate an exact equality.

### Author edge — `services/workflows.py` `_enforce_surface_attenuation`

Upgraded from membership-only to the **fixpoint predicate**: admit iff `attenuate(declared, actor) == canonicalize(declared)` — equal iff the meet never had to narrow, i.e. `declared ≤ actor` on every axis. Closes the per-tool half the old check missed (looser permission/transport, MCP re-point, broadened routes). Serves create + update unchanged; the operator/HTTP path (no actor) stays unclamped.

## Review notes

- Ran `/simplify` (4 angles) and `/code-review --fix` (xhigh). The review caught a **real normal-form bug** (disabled entries carried live dead fields → the meet narrowed them while `canonicalize` kept them, falsely rejecting ~1/3 of legitimate narrowing declarations); fixed by the `_DISABLED` collapse with property-test coverage that now exercises divergent disabled entries.
- Includes one **unrelated pre-existing fix** (`fix(sandbox): order-independent seccomp argv assertion`): #815's seccomp test asserted argv ordering that #812's `no-new-privileges` had already shifted, leaving the unit suite **red on master HEAD** and blocking the pre-commit gate repo-wide. Separated into its own commit.
- `litellm_extra` tripwire test guards #823's precondition (no `agent_tool` may set model-routing).

## Verification

`uv run mypy src` · `ruff check/format` · `uv run pytest tests/unit -q` (1990 passed) · `pytest tests/integration/test_wf_run_vaults.py` (15 passed, Docker).

Part of #794. Sibling axis: #823 (model identity). Umbrella: #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)