### PR TITLE
feat(workflows): materialize the attenuation clamp — frozen child surface, run vaults, top edge (#794 PR2)

### DIFF
--- a/migrations/versions/0079_session_frozen_surface.py
+++ b/migrations/versions/0079_session_frozen_surface.py
@@ -1,0 +1,71 @@
+"""A workflow child session's frozen, run-attenuated capability surface (#794).
+
+A run's ``agent()`` child must wield ``agent ∩ run`` authority, not the agent's full
+surface — and that clamped surface must be **frozen at spawn** so replay reads the same
+value every wake (never re-running the meet against a since-changed agent or operator
+default). The child's surface lives on the ``sessions`` row:
+
+* ``tools`` / ``mcp_servers`` / ``http_servers`` (jsonb, nullable) — the frozen meet result.
+* ``surface_frozen`` (boolean) — the discriminator. A foreground/operator session leaves
+  it ``false`` and its surface columns ``NULL`` (``load_for_session`` reads the live agent).
+  A workflow child sets it ``true`` (even when the frozen surface is empty ``[]`` — an
+  empty clamp ≠ an absent one), and ``load_for_session`` reads the frozen columns,
+  **failing closed** if a ``parent_run_id`` child is somehow not frozen.
+
+Columns are nullable rather than ``NOT NULL DEFAULT '[]'`` precisely so ``surface_frozen``
+is the single source of truth for "is this a frozen child" — a defaulted ``'[]'`` would be
+ambiguous against a legitimately-empty clamp.
+
+**Grandfather backfill:** in-flight ``parent_run_id`` children that predate this column
+read the pinned ``AgentVersion``'s surface verbatim today. Freeze exactly that — the meet
+result for them is unknowable retroactively, but their *observed* surface is the pinned
+version's, so copying it preserves behavior with zero bricked runs (the fail-closed branch
+would otherwise error every in-flight child's next step). A child whose ``agent_versions``
+row is missing stays unfrozen → fails closed, which is correct for that corrupt state.
+
+``sessions`` is not the hot ``events`` table, so plain in-transaction DDL is fine.
+
+Revision ID: 0079
+Revises: 0078
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0079"
+down_revision: str = "0078"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ADD COLUMN tools jsonb")
+    op.execute("ALTER TABLE sessions ADD COLUMN mcp_servers jsonb")
+    op.execute("ALTER TABLE sessions ADD COLUMN http_servers jsonb")
+    op.execute("ALTER TABLE sessions ADD COLUMN surface_frozen boolean NOT NULL DEFAULT false")
+    # Grandfather in-flight children: freeze the pinned AgentVersion's surface verbatim —
+    # exactly what load_for_session returns for them today, so behavior is unchanged.
+    op.execute(
+        """
+        UPDATE sessions s
+           SET tools = av.tools,
+               mcp_servers = av.mcp_servers,
+               http_servers = av.http_servers,
+               surface_frozen = TRUE
+          FROM agent_versions av
+         WHERE s.parent_run_id IS NOT NULL
+           AND av.agent_id = s.agent_id
+           AND av.version = s.agent_version
+           AND av.account_id = s.account_id
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS surface_frozen")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS http_servers")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS mcp_servers")
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS tools")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -56,6 +56,7 @@ from aios.ids import (
 )
 from aios.models.accounts import Account, AccountConfig
 from aios.models.agents import Agent, AgentVersion, HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.attenuation import Surface
 from aios.models.connections import BindingMode, Connection, ConnectionMode
 from aios.models.environments import Environment, EnvironmentConfig
 from aios.models.events import Event, EventKind
@@ -527,24 +528,6 @@ async def get_agent(conn: asyncpg.Connection[Any], agent_id: str, *, account_id:
     )
 
 
-async def get_agent_head_version(
-    conn: asyncpg.Connection[Any], agent_id: str, *, account_id: str
-) -> int:
-    """The agent's current head ``version`` as a scalar — no full-row hydration.
-
-    Used to pin a workflow child's ``agent_version`` at spawn (the spawn path
-    needs only the int, not the parsed Agent). Raises ``NotFoundError`` if the
-    agent is absent, mirroring :func:`get_agent`. (Distinct from
-    :func:`get_agent_version`, which fetches one historical ``AgentVersion`` row.)
-    """
-    version = await conn.fetchval(
-        "SELECT version FROM agents WHERE id = $1 AND account_id = $2", agent_id, account_id
-    )
-    if version is None:
-        raise NotFoundError(f"agent {agent_id} not found", detail={"id": agent_id})
-    return int(version)
-
-
 async def list_agents(
     conn: asyncpg.Connection[Any],
     *,
@@ -968,6 +951,9 @@ async def insert_child_session(
     environment_id: str,
     agent_version: int,
     parent_run_id: str,
+    tools: list[ToolSpec],
+    mcp_servers: list[McpServerSpec],
+    http_servers: list[HttpServerSpec],
 ) -> Session | None:
     """Insert a workflow ``agent()`` child under a deterministic ``session_id``.
 
@@ -975,9 +961,14 @@ async def insert_child_session(
     :class:`Session` on first spawn, or ``None`` on conflict (a replay found the
     existing row, so the caller harvests instead of re-spawning). ``origin`` is
     ``'background'`` and ``agent_version`` is the **pinned** int resolved at
-    spawn (never ``None`` — a child must not track "latest"). v1 children carry
-    no vaults/resources/scheduled-tasks; the caller delivers the agent input in
-    the same transaction.
+    spawn (never ``None`` — a child must not track "latest").
+
+    ``tools``/``mcp_servers``/``http_servers`` are the child's **frozen, run-attenuated
+    surface** (the ``attenuate(agent, run)`` meet result) and ``surface_frozen`` is set
+    ``TRUE`` — read back by ``load_for_session`` instead of the live agent, and pinned
+    under ``ON CONFLICT DO NOTHING`` so a replay can never re-freeze a shifted surface.
+    The caller delivers the agent input and copies the run's vaults in the same
+    transaction.
     """
     workspace_path = _default_workspace_path(account_id, session_id)
     try:
@@ -986,10 +977,12 @@ async def insert_child_session(
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 workspace_volume_path, env, focal_channel, focal_locked,
-                account_id, parent_run_id, origin, archive_when_idle
+                account_id, parent_run_id, origin, archive_when_idle,
+                tools, mcp_servers, http_servers, surface_frozen
             )
             VALUES ($1, $2, $3, $4, NULL, '{}'::jsonb, $5, '{}'::jsonb,
-                    NULL, FALSE, $6, $7, 'background', TRUE)
+                    NULL, FALSE, $6, $7, 'background', TRUE,
+                    $8::jsonb, $9::jsonb, $10::jsonb, TRUE)
             ON CONFLICT (id) DO NOTHING
             RETURNING *
             """,
@@ -1000,6 +993,9 @@ async def insert_child_session(
             workspace_path,
             account_id,
             parent_run_id,
+            json.dumps([t.model_dump() for t in tools]),
+            json.dumps([s.model_dump() for s in mcp_servers]),
+            json.dumps([s.model_dump() for s in http_servers]),
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -1007,6 +1003,32 @@ async def insert_child_session(
             detail={"agent_id": agent_id, "environment_id": environment_id},
         ) from exc
     return _row_to_session(row) if row is not None else None
+
+
+async def get_session_frozen_surface(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> Surface | None:
+    """A workflow child's frozen surface, or ``None`` if the row is not ``surface_frozen``.
+
+    ``None`` is the load-bearing signal that this is *not* a frozen child (a foreground
+    session, or — for a ``parent_run_id`` child — a corrupt/unmigrated row the caller
+    must fail closed on). Raises ``NotFoundError`` if the session is absent.
+    """
+    row = await conn.fetchrow(
+        "SELECT tools, mcp_servers, http_servers, surface_frozen "
+        "FROM sessions WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
+    )
+    if row is None:
+        raise NotFoundError("session not found", detail={"session_id": session_id})
+    if not row["surface_frozen"]:
+        return None
+    return Surface(
+        tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
+        mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
+        http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
+    )
 
 
 async def get_session_workflow_context(

--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -32,7 +32,7 @@ tried to widen.
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import NamedTuple, Protocol
 
 from aios.models.agents import (
     HttpServerSpec,
@@ -49,15 +49,28 @@ from aios.models.agents import (
 class Surface(NamedTuple):
     """A principal's capability surface — the meet operates on this triple.
 
-    Constructed inline at the four call sites (the author edge, ``create_run``,
-    ``create_child_session``, the frozen-overlay read) from whatever carries the
-    three lists; not a persisted type. The lists are treated as immutable by the
-    operator — it never mutates an input, always builds fresh output.
+    Constructed via :func:`surface_of` at the materialize edges (the author edge,
+    ``create_run``, ``create_child_session``, the frozen-overlay read) from whatever
+    carries the three lists; not a persisted type. The lists are treated as immutable
+    by the operator — it never mutates an input, always builds fresh output.
     """
 
     tools: list[ToolSpec]
     mcp_servers: list[McpServerSpec]
     http_servers: list[HttpServerSpec]
+
+
+class HasSurface(Protocol):
+    """Anything carrying the surface triple — ``Agent``/``AgentVersion``/``Workflow``/``WfRun``."""
+
+    tools: list[ToolSpec]
+    mcp_servers: list[McpServerSpec]
+    http_servers: list[HttpServerSpec]
+
+
+def surface_of(principal: HasSurface) -> Surface:
+    """Project a principal's ``(tools, mcp_servers, http_servers)`` into a ``Surface``."""
+    return Surface(principal.tools, principal.mcp_servers, principal.http_servers)
 
 
 def _tool_key(t: ToolSpec) -> tuple[str, str | None]:

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -144,9 +144,41 @@ async def load_for_session(
 ) -> Agent | AgentVersion:
     """Load the Agent / AgentVersion the harness sees for ``session`` at step time.
 
-    ``session.agent_version is None`` means "latest" — fetches the
-    current ``Agent``; an integer pins to a specific ``AgentVersion``.
+    A **workflow child** (``parent_run_id`` set) reads the surface **frozen at spawn**
+    (#794: the ``attenuate(agent, run)`` clamp) over its pinned ``AgentVersion`` —
+    model/system/skills/litellm_extra preserved, only tools/mcp/http overridden. This is
+    the single chokepoint every reader (loop, broker, http_request, prelude,
+    compute_awaiting, the context preview) inherits the clamp through, with no per-site
+    edit. The meet is **never recomputed** here — the frozen result is read verbatim, so
+    replay is stable against later agent-version or operator-default changes. A
+    ``parent_run_id`` child whose row is somehow not ``surface_frozen`` **fails closed**
+    (never silently falls back to the full agent surface).
+
+    Otherwise: ``session.agent_version is None`` means "latest" — fetches the current
+    ``Agent``; an integer pins to a specific ``AgentVersion``.
     """
+    if session.parent_run_id is not None:
+        async with pool.acquire() as conn:
+            frozen = await queries.get_session_frozen_surface(
+                conn, session.id, account_id=account_id
+            )
+            if frozen is None:
+                raise RuntimeError(
+                    f"workflow child {session.id} has no frozen surface snapshot "
+                    "(parent_run_id set but surface_frozen is false)"
+                )
+            # A workflow child always pins a concrete agent_version at spawn
+            # (insert_child_session requires the int), so this is never a "latest" read.
+            version = await queries.get_agent_version(
+                conn, session.agent_id, session.agent_version, account_id=account_id
+            )
+        return version.model_copy(
+            update={
+                "tools": frozen.tools,
+                "mcp_servers": frozen.mcp_servers,
+                "http_servers": frozen.http_servers,
+            }
+        )
     if session.agent_version is not None:
         return await get_agent_version(
             pool, session.agent_id, session.agent_version, account_id=account_id

--- a/src/aios/services/attenuation.py
+++ b/src/aios/services/attenuation.py
@@ -1,0 +1,40 @@
+"""Runtime-bound capability attenuation — the pure operator + this process's defaults.
+
+:mod:`aios.models.attenuation` is pure: it takes the operator-default MCP permission and
+the builtin transport map as arguments. Every materialize edge (the workflow author edge,
+``create_run``, ``create_child_session``) reads the *same* two runtime values — the
+``AIOS_DEFAULT_MCP_PERMISSION_POLICY`` setting and the tool registry's transport defaults —
+so this module binds them once and exposes ``clamp`` / ``normalize`` over ``Surface``,
+keeping the ``or "always_ask"`` / ``transport_defaults()`` plumbing in one place.
+"""
+
+from __future__ import annotations
+
+from aios.config import get_settings
+from aios.models.agents import PermissionPolicy, ToolTransport
+from aios.models.attenuation import Surface, attenuate, canonicalize
+from aios.tools.registry import transport_defaults
+
+
+def _defaults() -> tuple[PermissionPolicy, dict[str, ToolTransport]]:
+    """The two operator defaults bound to this process: settings policy + registry transports."""
+    return get_settings().default_mcp_permission_policy or "always_ask", transport_defaults()
+
+
+def clamp(declared: Surface, launcher: Surface) -> Surface:
+    """``attenuate(declared, launcher)`` bound to this process's operator defaults."""
+    default_mcp, builtin_transports = _defaults()
+    return attenuate(
+        declared,
+        launcher,
+        default_mcp_permission=default_mcp,
+        builtin_transports=builtin_transports,
+    )
+
+
+def normalize(declared: Surface) -> Surface:
+    """``canonicalize(declared)`` bound to this process's defaults (the meet's identity element)."""
+    default_mcp, builtin_transports = _defaults()
+    return canonicalize(
+        declared, default_mcp_permission=default_mcp, builtin_transports=builtin_transports
+    )

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -26,6 +26,7 @@ from aios.models.agents import (
     is_mcp_tool_name,
     resolve_permission,
 )
+from aios.models.attenuation import Surface
 from aios.models.events import Event, EventKind
 from aios.models.scheduled_tasks import (
     ScheduledTaskCreate,
@@ -278,6 +279,8 @@ async def create_child_session(
     environment_id: str,
     agent_version: int,
     parent_run_id: str,
+    surface: Surface,
+    vault_ids: list[str],
     request_id: str,
     input: Any,
     output_schema: dict[str, Any] | None = None,
@@ -297,11 +300,18 @@ async def create_child_session(
     a child owing several requests can carry a distinct schema for each — surfaced to
     the model alongside the request and enforced when it calls ``return``.
 
+    ``surface`` is the child's **frozen, run-attenuated** capability surface
+    (``attenuate(agent, run)`` — #794); ``vault_ids`` is the run's vault bindings,
+    copied into the child's ``session_vaults`` so it resolves credentials off its own
+    (subset) table. Both are written **only on a real insert**, inside the one
+    transaction, so a replay never re-freezes a shifted surface or re-binds vaults.
+
     One transaction: insert the child row (``ON CONFLICT (id) DO NOTHING``) and,
-    **only on a real insert**, deliver the request — without a stimulus the child
-    would be born-idle. Atomic, so a crash can never leave a child row without its
-    request. Returns ``True`` on first spawn, ``False`` on conflict (replay → the
-    caller harvests the response instead of re-spawning).
+    **only on a real insert**, freeze the surface, bind the vaults, and deliver the
+    request — without a stimulus the child would be born-idle. Atomic, so a crash can
+    never leave a child row without its request. Returns ``True`` on first spawn,
+    ``False`` on conflict (replay → the caller harvests the response instead of
+    re-spawning).
     """
     content = input if isinstance(input, str) else json.dumps(input)
     async with pool.acquire() as conn, conn.transaction():
@@ -313,9 +323,14 @@ async def create_child_session(
             environment_id=environment_id,
             agent_version=agent_version,
             parent_run_id=parent_run_id,
+            tools=surface.tools,
+            mcp_servers=surface.mcp_servers,
+            http_servers=surface.http_servers,
         )
         if child is None:
             return False  # replay: row exists — do NOT re-deliver the request
+        if vault_ids:
+            await queries.set_session_vaults(conn, session_id, vault_ids, account_id=account_id)
         request_meta: dict[str, Any] = {
             "request_id": request_id,
             "caller": {"kind": "run", "id": parent_run_id},
@@ -397,13 +412,22 @@ async def compute_awaiting(
         )
     if not unresolved_by_sid:
         return {}
-    agent_cache: dict[tuple[str, int | None], Agent | AgentVersion] = {}
+    # Foreground sessions sharing an (agent_id, agent_version) share a surface, so they
+    # dedupe the agent load. Workflow children do NOT: each carries its own frozen,
+    # run-attenuated surface (#794), so two children of the same agent/version under
+    # different runs would collide on the old key and misclassify authority — they key
+    # per-session instead.
+    agent_cache: dict[str | tuple[str, int | None], Agent | AgentVersion] = {}
     out: dict[str, list[AwaitingToolCall]] = {}
     for session in sessions:
         unresolved = unresolved_by_sid.get(session.id)
         if not unresolved:
             continue
-        key = (session.agent_id, session.agent_version)
+        key: str | tuple[str, int | None] = (
+            session.id
+            if session.parent_run_id is not None
+            else (session.agent_id, session.agent_version)
+        )
         if key not in agent_cache:
             agent_cache[key] = await agents_service.load_for_session(
                 pool, session, account_id=account_id

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -17,12 +17,11 @@ from typing import Any
 
 import asyncpg
 
-from aios.config import get_settings
 from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, ForbiddenError, NotFoundError
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
-from aios.models.attenuation import Surface, attenuate, canonicalize, surface_diff
+from aios.models.attenuation import Surface, surface_diff, surface_of
 from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
     WfRun,
@@ -31,10 +30,10 @@ from aios.models.workflows import (
     Workflow,
 )
 from aios.services import agents as agents_service
+from aios.services import attenuation as attenuation_service
 from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
-from aios.tools.registry import transport_defaults
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
@@ -80,16 +79,9 @@ async def _enforce_surface_attenuation(
         pool, actor_session_id, account_id=account_id
     )
     agent = await agents_service.load_for_session(pool, session, account_id=account_id)
-    default_mcp = get_settings().default_mcp_permission_policy or "always_ask"
-    builtin_transports = transport_defaults()
     declared = Surface(tools, mcp_servers, http_servers)
-    actor = Surface(agent.tools, agent.mcp_servers, agent.http_servers)
-    expected = canonicalize(
-        declared, default_mcp_permission=default_mcp, builtin_transports=builtin_transports
-    )
-    effective = attenuate(
-        declared, actor, default_mcp_permission=default_mcp, builtin_transports=builtin_transports
-    )
+    expected = attenuation_service.normalize(declared)
+    effective = attenuation_service.clamp(declared, surface_of(agent))
     if effective != expected:
         raise ForbiddenError(
             "workflow surface exceeds the acting agent's",

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -15,7 +15,11 @@ from aios.config import get_settings
 from aios.db.queries import get_environment, get_session_vault_ids
 from aios.db.queries import workflows as wf_queries
 from aios.errors import AiosError, ForbiddenError, NotFoundError, RateLimitedError
+from aios.models.attenuation import Surface, surface_of
 from aios.models.workflows import WfRun
+from aios.services import agents as agents_service
+from aios.services import attenuation as attenuation_service
+from aios.services import sessions as sessions_service
 from aios.services.wake import defer_run_wake
 
 # Vertical recursion bound: how deep a chain of runs (a run whose agent() child
@@ -74,10 +78,35 @@ async def create_run(
     stale-high — a conservative early refusal, never a cap breach.)
     """
     requested = list(vault_ids or [])
+    # #794 top edge: an agent-launched run cannot exceed the launcher's own surface.
+    # Load the launcher's effective surface BEFORE acquiring the run's connection (a
+    # second pool.acquire() while holding `conn` would deadlock a small pool); the meet
+    # itself runs inside the transaction once the workflow is fetched. The operator/HTTP
+    # path (no launcher) is the lattice top — the run snapshots the workflow verbatim.
+    # (Consistency note: this read is outside the run txn, so a concurrent agent edit
+    # between it and the snapshot clamps against a slightly-stale launcher surface — a
+    # same-account, bounded-to-recent-state lag, the same read-then-act window as the
+    # author edge, never a cross-tenant breach. A conn-threaded load would close it.)
+    launcher_surface: Surface | None = None
+    if launcher_session_id is not None:
+        launcher_session = await sessions_service.get_session_basic(
+            pool, launcher_session_id, account_id=account_id
+        )
+        launcher_agent = await agents_service.load_for_session(
+            pool, launcher_session, account_id=account_id
+        )
+        launcher_surface = surface_of(launcher_agent)
     async with pool.acquire() as conn, conn.transaction():
         await get_environment(conn, environment_id, account_id=account_id)  # 404s foreign/absent
         workflow = await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
         script_sha = hashlib.sha256(workflow.script.encode("utf-8")).hexdigest()
+        # Clamp the snapshot to the launcher's surface (sub-runs compose for free: a
+        # child launcher's load_for_session already returns its frozen clamp).
+        effective = (
+            attenuation_service.clamp(surface_of(workflow), launcher_surface)
+            if launcher_surface is not None
+            else surface_of(workflow)
+        )
         if parent_run_id is not None:
             # ``parent_run_id`` is trusted same-account: the only caller that sets it is
             # the builtin, threading the launcher session's own ``parent_run_id`` (set by
@@ -138,11 +167,11 @@ async def create_run(
             script=workflow.script,
             script_sha=script_sha,
             input=input,
-            # Snapshot the declared surface at launch (like script), so a later
+            # Snapshot the launch-clamped surface (like script), so a later
             # update_workflow never shifts this run's tool-authority.
-            tools=workflow.tools,
-            mcp_servers=workflow.mcp_servers,
-            http_servers=workflow.http_servers,
+            tools=effective.tools,
+            mcp_servers=effective.mcp_servers,
+            http_servers=effective.http_servers,
         )
         if requested:
             await wf_queries.set_run_vaults(conn, run.id, requested, account_id=account_id)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -44,7 +44,9 @@ from aios.db.queries import workflows as wf_queries
 from aios.errors import NotFoundError
 from aios.harness import runtime
 from aios.logging import get_logger
+from aios.models.attenuation import surface_of
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent
+from aios.services import attenuation as attenuation_service
 from aios.services.sessions import create_child_session
 from aios.services.wake import defer_run_wake, defer_wake
 from aios.workflows import run_tools
@@ -496,7 +498,9 @@ async def _open_agent_capability(
 
     child_id = child_session_id(run.id, cap.call_key)
     try:
-        pinned = await db_queries.get_agent_head_version(conn, agent_id, account_id=account_id)
+        # The full agent (head row) — both the pinned version AND its declared surface,
+        # which the run clamps. One query, same NotFoundError contract as before.
+        agent = await db_queries.get_agent(conn, agent_id, account_id=account_id)
     except NotFoundError:
         await _complete_run(
             conn,
@@ -506,6 +510,10 @@ async def _open_agent_capability(
             error_kind="agent_not_found",
         )
         return _SpawnResult(rejected=True, needs_rewake=False)
+    pinned = agent.version
+    # #794: the child wields agent ∩ run, frozen at spawn; its vaults are the run's.
+    child_surface = attenuation_service.clamp(surface_of(agent), surface_of(run))
+    run_vaults = await wf_queries.get_run_vault_ids(conn, run.id, account_id=account_id)
 
     created = await create_child_session(
         pool,
@@ -515,6 +523,8 @@ async def _open_agent_capability(
         environment_id=run.environment_id,
         agent_version=pinned,
         parent_run_id=run.id,
+        surface=child_surface,
+        vault_ids=run_vaults,
         request_id=cap.call_key,  # the agent() call IS the request the child must answer
         input=spec.get("input"),
         output_schema=output_schema,

--- a/tests/integration/test_migrations_session_frozen_surface.py
+++ b/tests/integration/test_migrations_session_frozen_surface.py
@@ -1,0 +1,144 @@
+"""Integration test for migration 0079's grandfather backfill (#794).
+
+0079 adds the frozen-surface columns to ``sessions`` (``tools``/``mcp_servers``/
+``http_servers``/``surface_frozen``) and backfills in-flight workflow children — rows
+with ``parent_run_id`` set that predate the columns — by freezing the pinned
+``AgentVersion``'s surface verbatim. That is exactly what ``load_for_session`` returns
+for them today, so behavior is unchanged and no in-flight run bricks on the new
+fail-closed read path. Non-child sessions stay ``surface_frozen=false`` with NULL surface.
+
+Seed at 0078 (pre-columns), ``upgrade head``, assert the backfill. Mirrors
+``test_migrations_session_status_backfill.py`` (seed-at-N then upgrade against a fresh
+per-test Postgres).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _seed_at_0078(db_url: str) -> None:
+    """Seed an in-flight child + a foreground session at revision 0078 (raw SQL)."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            "VALUES ('acc_root', NULL, TRUE, 'root')"
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, account_id, name, config, created_at) "
+            "VALUES ('env_test', 'acc_root', 'test', '{}'::jsonb, now())"
+        )
+        await conn.execute(
+            """
+            INSERT INTO agents (
+                id, account_id, name, model, system, tools, description, metadata,
+                window_min, window_max, version, created_at, updated_at
+            )
+            VALUES ('agent_test', 'acc_root', 'test', 'openrouter/test', '',
+                    '[]'::jsonb, NULL, '{}'::jsonb, 50000, 150000, 1, now(), now())
+            """
+        )
+        # The pinned version carries a non-empty surface the backfill must copy verbatim.
+        await conn.execute(
+            """
+            INSERT INTO agent_versions (agent_id, version, model, account_id, tools, mcp_servers)
+            VALUES ('agent_test', 1, 'openrouter/test', 'acc_root',
+                    '[{"type": "bash"}]'::jsonb,
+                    '[{"type": "url", "name": "s", "url": "https://s"}]'::jsonb)
+            """
+        )
+        await conn.execute(
+            "INSERT INTO workflows (id, account_id, name, script) "
+            "VALUES ('wf_1', 'acc_root', 'w', 'async def main(i): return i')"
+        )
+        await conn.execute(
+            """
+            INSERT INTO wf_runs (id, workflow_id, account_id, environment_id, script, script_sha)
+            VALUES ('run_1', 'wf_1', 'acc_root', 'env_test', 'async def main(i): return i', 'sha')
+            """
+        )
+        # An in-flight child (parent_run_id set, agent_version pinned).
+        await conn.execute(
+            """
+            INSERT INTO sessions (
+                id, account_id, agent_id, environment_id, agent_version,
+                parent_run_id, workspace_volume_path
+            )
+            VALUES ('sess_child', 'acc_root', 'agent_test', 'env_test', 1,
+                    'run_1', '/ws/child')
+            """
+        )
+        # A foreground session (no parent_run_id) — must stay unfrozen.
+        await conn.execute(
+            """
+            INSERT INTO sessions (
+                id, account_id, agent_id, environment_id, workspace_volume_path
+            )
+            VALUES ('sess_fg', 'acc_root', 'agent_test', 'env_test', '/ws/fg')
+            """
+        )
+    finally:
+        await conn.close()
+
+
+@needs_docker
+def test_backfill_freezes_in_flight_children(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+
+    result = _run_alembic(["upgrade", "0078"], db_url)
+    assert result.returncode == 0, f"upgrade 0078 failed:\n{result.stderr}\n{result.stdout}"
+
+    asyncio.run(_seed_at_0078(db_url))
+
+    result = _run_alembic(["upgrade", "head"], db_url)
+    assert result.returncode == 0, (
+        f"upgrade head (0079 backfill) failed:\n{result.stderr}\n{result.stdout}"
+    )
+
+    async def check() -> None:
+        conn = await asyncpg.connect(db_url)
+        try:
+            child = await conn.fetchrow(
+                "SELECT surface_frozen, tools, mcp_servers FROM sessions WHERE id = 'sess_child'"
+            )
+            assert child is not None
+            assert child["surface_frozen"] is True  # grandfathered → frozen
+            # Verbatim copy of the pinned AgentVersion's surface (what it read pre-0079).
+            # Compare parsed JSON — Postgres stores jsonb with canonical key order.
+            assert json.loads(child["tools"]) == [{"type": "bash"}]
+            assert json.loads(child["mcp_servers"]) == [
+                {"type": "url", "name": "s", "url": "https://s"}
+            ]
+
+            fg = await conn.fetchrow(
+                "SELECT surface_frozen, tools FROM sessions WHERE id = 'sess_fg'"
+            )
+            assert fg is not None
+            assert fg["surface_frozen"] is False  # foreground → untouched
+            assert fg["tools"] is None
+        finally:
+            await conn.close()
+
+    asyncio.run(check())

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -33,11 +33,16 @@ from aios.errors import ConflictError, ForbiddenError, NotFoundError, RateLimite
 from aios.harness import runtime
 from aios.mcp.client import resolve_auth_for_target_url_run
 from aios.models.agents import Agent, HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.attenuation import surface_of
 from aios.models.vaults import VaultCredentialCreate
 from aios.services import agents as agents_service
+from aios.services import attenuation as attenuation_service
+from aios.services import sessions as sessions_service
 from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
+from aios.services.sessions import create_child_session
 from aios.tools import workflow_management as wm
+from aios.workflows.child_id import child_session_id
 from aios.workflows.service import WORKFLOW_RUN_MAX_DEPTH, WorkflowRunDepthExceededError
 
 pytestmark = pytest.mark.integration
@@ -525,10 +530,17 @@ async def test_create_run_builtin_threads_parent_run_id(vault_pool: asyncpg.Pool
     wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-bi-nest", script=_SCRIPT)
     root = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
 
-    # Set the parent_run_id column directly (the run-spawn machinery is what populates
-    # it on a real child session); this asserts the handler READS it and threads it.
+    # Make the session a real child: parent_run_id + a frozen surface (the run-spawn
+    # machinery populates both; load_for_session fails closed on a parent_run_id session
+    # that is not surface_frozen). This asserts the handler READS the lineage and threads it.
     async with pool.acquire() as conn:
-        await conn.execute("UPDATE sessions SET parent_run_id = $1 WHERE id = $2", root.id, sess)
+        await conn.execute(
+            "UPDATE sessions SET parent_run_id = $1, surface_frozen = TRUE, "
+            "tools = '[]'::jsonb, mcp_servers = '[]'::jsonb, http_servers = '[]'::jsonb "
+            "WHERE id = $2",
+            root.id,
+            sess,
+        )
 
     out = await wm.create_run_handler(sess, {"workflow_id": wf.id})
     assert out["parent_run_id"] == root.id
@@ -670,3 +682,185 @@ async def test_cancel_run_builtin_only_own_runs(vault_pool: asyncpg.Pool[Any]) -
         await wm.cancel_run_handler(other, {"run_id": own["id"]})
     with pytest.raises(ForbiddenError):
         await wm.cancel_run_handler(sess, {"run_id": op.id})
+
+
+# ─── #794: the run→child materialize edge (frozen, run-attenuated surface) ────
+#
+# A run's agent() child must wield agent ∩ run, frozen at spawn, with the run's vaults —
+# closing the "agent-shaped side door". These spawn children the way step.py does
+# (clamp(agent, run) then create_child_session) and read the frozen surface back through
+# load_for_session, the one chokepoint every reader inherits.
+
+
+async def _spawn_child(
+    pool: asyncpg.Pool[Any],
+    run_id: str,
+    agent: Agent,
+    *,
+    surface: Any,
+    vault_ids: list[str] | None = None,
+) -> Any:
+    """Spawn one child for ``run_id`` (as step.py does) and return its Session."""
+    cid = child_session_id(run_id, "0")
+    await create_child_session(
+        pool,
+        session_id=cid,
+        account_id=ACC,
+        agent_id=agent.id,
+        environment_id=ENV,
+        agent_version=agent.version,
+        parent_run_id=run_id,
+        surface=surface,
+        vault_ids=vault_ids or [],
+        request_id="0",
+        input="hi",
+    )
+    return await sessions_service.get_session_basic(pool, cid, account_id=ACC)
+
+
+async def test_child_surface_is_the_frozen_clamp_not_the_live_agent(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """The setuid regression: a child wields agent ∩ run, NOT the agent's full surface.
+
+    The agent has bash + read; the run only bash. The child — read back through
+    load_for_session, the chokepoint every reader uses — has bash but NOT read, even
+    though its agent does. Anything the run can't do, its child can't do either.
+    """
+    pool = vault_pool
+    agent = await _make_agent(
+        pool, "db-admin", tools=[ToolSpec(type="bash"), ToolSpec(type="read")]
+    )
+    # Operator-authored workflow with the run's (narrower) surface; launched operator-side.
+    wf = await wf_service.create_workflow(
+        pool, account_id=ACC, name="wf-run-bash", script=_SCRIPT, tools=[ToolSpec(type="bash")]
+    )
+    run = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    child_surface = attenuation_service.clamp(surface_of(agent), surface_of(run))
+
+    child = await _spawn_child(pool, run.id, agent, surface=child_surface)
+    loaded = await agents_service.load_for_session(pool, child, account_id=ACC)
+    assert {t.type for t in loaded.tools} == {"bash"}  # read dropped — the side door closed
+
+
+async def test_child_vaults_copied_from_run(vault_pool: asyncpg.Pool[Any]) -> None:
+    """The credential half (#794 P1=A): a child's session_vaults are the run's, frozen."""
+    pool = vault_pool
+    vx = await _make_vault(pool, "v-x")
+    agent = await _make_agent(pool, "vault-child-agent")
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-vc", script=_SCRIPT)
+    run = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, vault_ids=[vx]
+    )
+    async with pool.acquire() as conn:
+        run_vaults = await wf_queries.get_run_vault_ids(conn, run.id, account_id=ACC)
+
+    child = await _spawn_child(pool, run.id, agent, surface=surface_of(agent), vault_ids=run_vaults)
+    async with pool.acquire() as conn:
+        child_vaults = await db_queries.get_session_vault_ids(conn, child.id, account_id=ACC)
+    assert child_vaults == [vx]
+
+
+async def test_frozen_surface_wins_over_a_later_agent_edit(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Replay-soundness: the child reads its spawn-time frozen surface, not the live
+    agent, even after the agent's surface is rewritten (a new version)."""
+    pool = vault_pool
+    agent = await _make_agent(pool, "evolving-agent", tools=[ToolSpec(type="bash")])
+    wf = await wf_service.create_workflow(
+        pool, account_id=ACC, name="wf-frozen", script=_SCRIPT, tools=[ToolSpec(type="bash")]
+    )
+    run = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    child = await _spawn_child(
+        pool, run.id, agent, surface=attenuation_service.clamp(surface_of(agent), surface_of(run))
+    )
+
+    # Rewrite the agent's surface (a new version) AFTER the child froze.
+    await agents_service.update_agent(
+        pool,
+        agent.id,
+        account_id=ACC,
+        expected_version=agent.version,
+        tools=[ToolSpec(type="read")],
+    )
+
+    loaded = await agents_service.load_for_session(pool, child, account_id=ACC)
+    assert {t.type for t in loaded.tools} == {"bash"}  # the frozen surface, not the new [read]
+
+
+async def test_load_for_session_fails_closed_on_unfrozen_child(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """A parent_run_id session with no frozen snapshot fails closed — never the full agent."""
+    pool = vault_pool
+    agent = await _make_agent(pool, "ghost-child-agent", tools=[ToolSpec(type="bash")])
+    sess_id = await _make_session(pool, agent)
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-ghost", script=_SCRIPT)
+    run = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    # Make it look like a child (parent_run_id) WITHOUT a frozen surface — the corrupt state.
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE sessions SET parent_run_id = $1 WHERE id = $2", run.id, sess_id)
+    sess = await sessions_service.get_session_basic(pool, sess_id, account_id=ACC)
+    with pytest.raises(RuntimeError, match="no frozen surface"):
+        await agents_service.load_for_session(pool, sess, account_id=ACC)
+
+
+async def test_create_run_clamps_top_edge_to_launcher(vault_pool: asyncpg.Pool[Any]) -> None:
+    """The top edge: an agent-launched run is clamped to the launcher's surface; the
+    operator path snapshots the workflow verbatim."""
+    pool = vault_pool
+    agent = await _make_agent(pool, "narrow-launcher", tools=[ToolSpec(type="bash")])
+    launcher = await _make_session(pool, agent)
+    # Operator authors a BROADER workflow (the agent couldn't, but the operator can).
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="wf-broad-run",
+        script=_SCRIPT,
+        tools=[ToolSpec(type="bash"), ToolSpec(type="read")],
+    )
+    launched = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, launcher_session_id=launcher
+    )
+    assert {t.type for t in launched.tools} == {"bash"}  # read clamped away
+
+    operator = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV
+    )
+    assert {t.type for t in operator.tools} == {"bash", "read"}  # operator = top — verbatim
+
+
+async def test_subrun_composes_against_child_frozen_clamp(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """A sub-run launched by a child cannot exceed the child's frozen surface —
+    composition with no ancestor walk: the child's load_for_session returns its clamp,
+    and create_run meets the sub-workflow against it."""
+    pool = vault_pool
+    agent = await _make_agent(pool, "nesting-agent", tools=[ToolSpec(type="bash")])
+    wf = await wf_service.create_workflow(
+        pool, account_id=ACC, name="wf-parent", script=_SCRIPT, tools=[ToolSpec(type="bash")]
+    )
+    run = await wf_service.create_run(pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV)
+    child = await _spawn_child(
+        pool, run.id, agent, surface=attenuation_service.clamp(surface_of(agent), surface_of(run))
+    )
+
+    # The child launches a sub-run of a broader operator workflow; it clamps to [bash].
+    sub_wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="wf-sub-broad",
+        script=_SCRIPT,
+        tools=[ToolSpec(type="bash"), ToolSpec(type="read")],
+    )
+    subrun = await wf_service.create_run(
+        pool,
+        account_id=ACC,
+        workflow_id=sub_wf.id,
+        environment_id=ENV,
+        launcher_session_id=child.id,
+        parent_run_id=run.id,
+    )
+    assert {t.type for t in subrun.tools} == {"bash"}  # composed clamp: read dropped

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -30,6 +30,7 @@ from aios.db.queries import workflows as wf_queries
 from aios.errors import NotFoundError
 from aios.harness import runtime
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
+from aios.models.attenuation import Surface
 from aios.models.vaults import VaultCredentialCreate
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
@@ -135,6 +136,8 @@ async def _spawn_child(
         environment_id="env_wf",
         agent_version=1,
         parent_run_id=run_id,
+        surface=Surface([], [], []),
+        vault_ids=[],
         request_id=ordinal,
         input="hi",
         output_schema=output_schema,
@@ -160,6 +163,8 @@ async def test_create_child_session_idempotent(
         environment_id="env_wf",
         agent_version=1,
         parent_run_id=run_id,
+        surface=Surface([], [], []),
+        vault_ids=[],
         request_id="sha:x#0",
         input={"q": "hi"},
     )
@@ -173,6 +178,8 @@ async def test_create_child_session_idempotent(
         environment_id="env_wf",
         agent_version=1,
         parent_run_id=run_id,
+        surface=Surface([], [], []),
+        vault_ids=[],
         request_id="sha:x#0",
         input={"q": "hi"},
     )

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0078``."""
+    """The migration ladder has exactly one head: ``0079``."""
     script = _script_directory()
-    assert script.get_heads() == ["0078"]
+    assert script.get_heads() == ["0079"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -228,7 +228,7 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=session),
             ),
             patch(
-                "aios.harness.loop.agents_service.get_agent",
+                "aios.harness.loop.agents_service.load_for_session",
                 AsyncMock(return_value=agent),
             ),
             patch(
@@ -331,7 +331,7 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=session),
             ),
             patch(
-                "aios.harness.loop.agents_service.get_agent",
+                "aios.harness.loop.agents_service.load_for_session",
                 AsyncMock(return_value=agent),
             ),
             patch(
@@ -443,7 +443,9 @@ class TestStepStartEndSpans:
                 "aios.harness.loop.sessions_service.get_session_basic",
                 AsyncMock(return_value=session),
             ),
-            patch("aios.harness.loop.agents_service.get_agent", AsyncMock(return_value=agent)),
+            patch(
+                "aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)
+            ),
             patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
@@ -539,7 +541,9 @@ class TestStepStartEndSpans:
                 "aios.harness.loop.sessions_service.get_session_basic",
                 AsyncMock(return_value=session),
             ),
-            patch("aios.harness.loop.agents_service.get_agent", AsyncMock(return_value=agent)),
+            patch(
+                "aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)
+            ),
             patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
@@ -633,7 +637,7 @@ class TestStepStartEndSpans:
                 AsyncMock(return_value=session),
             ),
             patch(
-                "aios.harness.loop.agents_service.get_agent",
+                "aios.harness.loop.agents_service.load_for_session",
                 AsyncMock(return_value=agent),
             ),
             patch(
@@ -728,7 +732,7 @@ async def _harness_with_guard(
         patch(
             "aios.harness.loop.sessions_service.get_session_basic", AsyncMock(return_value=session)
         ),
-        patch("aios.harness.loop.agents_service.get_agent", AsyncMock(return_value=agent)),
+        patch("aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)),
         patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
         patch(
             "aios.harness.loop.sessions_service.read_windowed_events", AsyncMock(return_value=[])


### PR DESCRIPTION
**Stacked PR 2 of 2 for #794** — base is **PR1** (`feat/794-attenuate-operator`, #833), not master. Review/merge PR1 first. This PR makes a workflow **run** a real authority boundary: the operator's *clamp* use at every materialize edge, frozen at spawn.

## The law — materialize ⇒ clamp, frozen-once

| edge | change |
|---|---|
| **top** (`create_run`) | an agent-launched run snapshots `attenuate(workflow, launcher-effective)` instead of the workflow verbatim — killing the setuid-ish "run gets the authored surface regardless of launcher". Operator/HTTP (no launcher) stays verbatim. |
| **spawn** (`_open_agent_capability`) | the run's `agent()` child is born clamped to `attenuate(child-agent, run)`, **frozen** into the child session, and bound to the run's vaults. `get_agent` replaces `get_agent_head_version` (now removed) — the head row carries both the pinned version and the surface to clamp. |
| **read chokepoint** (`load_for_session`) | a `parent_run_id` child reads its frozen surface overlaid on the pinned `AgentVersion` (model/system/skills/litellm_extra preserved), **never recomputing** the meet — replay-stable. Every reader (loop, broker, http_request, prelude, compute_awaiting, context preview) inherits the clamp here with **zero per-site edits**. A `parent_run_id` child that is not `surface_frozen` **fails closed**. |
| **credentials** (P1=A) | `create_child_session` copies the run's vault-ids into the child's `session_vaults` in the spawn transaction. |

**Composition is free** by associativity: a sub-run's launcher is a child whose `load_for_session` already returns its frozen clamp, so `create_run` meets against it — no ancestor walk (proved by `test_subrun_composes_against_child_frozen_clamp`).

## Plumbing
- **Migration 0079** adds `sessions.{tools,mcp_servers,http_servers,surface_frozen}` (nullable; `surface_frozen` is the discriminator) and **grandfathers** in-flight children by freezing their pinned `AgentVersion` surface verbatim — exactly what they read today, so zero runs brick on the new fail-closed path. `Session` model untouched (columns invisible to `_row_to_session`) → **no openapi/SDK regen**.
- `insert_child_session` writes the columns under the existing `ON CONFLICT (id) DO NOTHING` (a replay can never re-freeze a shifted surface); new `get_session_frozen_surface` reads them back as a `Surface`.
- `compute_awaiting` re-keys its agent cache per-session for children (their frozen surfaces differ across runs of the same agent/version) — also fixes a **latent collision** where two sibling children would misclassify against each other's surface.
- New `services/attenuation.py` (`clamp`/`normalize`) binds the pure operator to this process's settings + registry defaults; `surface_of` projects a principal to a `Surface`. Both collapse the defaults/projection fan-out across the edges, and the PR1 author edge is refactored onto them.

## Review notes (`/simplify` + `/code-review --fix`, xhigh)
Two independent correctness passes verified the core sound: **every** surface reader goes through `load_for_session` (the broker included — the bash-shell-out side door is closed); the migration backfill is behavior-preserving; all changed-signature callers updated; replay-safe (`ON CONFLICT` never re-freezes); fail-closed correct. Applied: deduped the runtime-defaults binding in `services/attenuation.py`; documented the child-is-pinned invariant.

**Known residual (flagged for your call, not fixed here):** the launcher surface in `create_run` is read *before* the run transaction (a `pool.acquire()` under the held connection would deadlock a small pool), while the vault check is in-txn — so a concurrent agent edit between the read and the snapshot clamps against a slightly-stale launcher surface. Same-account, bounded to recent launcher state, never a cross-tenant breach — the same read-then-act window as the PR1 author edge. Closing it cleanly means threading a `conn` through `load_for_session` (a core-function change worth your sign-off rather than an autonomous refactor).

## Verification
`uv run mypy src` · `ruff check/format` · `uv run pytest tests/unit -q` (1990) · `pytest tests/integration -q` (326, Docker). New tests: migration backfill (seed-at-0078 → upgrade → assert grandfather); the setuid regression (child of a bash-only run drops the agent's `read`); vault copy; frozen-wins-over-agent-edit; fail-closed on an unfrozen child; top-edge clamp; sub-run composition. E2e not run locally (sandbox-heavy; the changed paths aren't exercised by e2e — no worker-step child spawning there).

Part of #794. Sibling axis: #823. Umbrella: #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
