### PR TITLE
test: type-check the test suite under mypy strict + wire it into checks

### DIFF
--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -35,8 +35,8 @@ if ! uv run ruff check "$FILE_PATH" --output-format concise > "$RUFF_OUTPUT" 2>&
     RUFF_FAILED=1
 fi
 
-# Mypy: check src/ for full type context
-if ! uv run mypy src --no-error-summary > "$MYPY_OUTPUT" 2>&1; then
+# Mypy: check src + tests for full type context (tests are strict-checked too)
+if ! uv run mypy src tests --no-error-summary > "$MYPY_OUTPUT" 2>&1; then
     MYPY_FAILED=1
 fi
 

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -133,7 +133,7 @@ jobs:
           uv run ruff format --check src tests packages/aios-sdk/aios_sdk
 
       - name: Type check (mypy)
-        run: uv run mypy src packages/aios-sdk/aios_sdk
+        run: uv run mypy src tests packages/aios-sdk/aios_sdk
 
   unit:
     needs: detect

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 uv sync --dev
 
 # Run checks (do all three before every commit)
-uv run mypy src
+uv run mypy src tests
 uv run ruff check src tests && uv run ruff format --check src tests
 uv run pytest tests/unit -q                    # ~170 tests, <1s, no Docker needed
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ The API process talks to connector subprocesses (which live on the worker) via p
 
 ```bash
 uv sync --dev
-uv run mypy src
+uv run mypy src tests
 uv run ruff check src tests && uv run ruff format --check src tests
 uv run pytest tests/unit -q                   # ~1s, no Docker needed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ plugins = ["pydantic.mypy"]
 module = [
     "litellm.*",
     "mcp.*",
+    "fastapi_mcp.*",
     "aiodocker.*",
     "procrastinate.*",
     "testcontainers.*",
@@ -173,6 +174,7 @@ module = [
     "croniter.*",
     "dateparser",
     "dateparser.*",
+    "jsonschema",
 ]
 ignore_missing_imports = true
 

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -59,7 +59,7 @@ fi
 
 if ! should_skip mypy; then
     echo "── mypy ──"
-    uv run mypy src || fail
+    uv run mypy src tests || fail
 fi
 
 # ── Tests ──────────────────────────────────────────────────────────────────────

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -136,7 +136,7 @@ def _mount_mcp(app: FastAPI) -> None:
     """
     # fastapi-mcp doesn't ship a py.typed marker yet, so mypy can't see
     # the package's actual signatures.
-    from fastapi_mcp import AuthConfig, FastApiMCP  # type: ignore[import-untyped]
+    from fastapi_mcp import AuthConfig, FastApiMCP
 
     mcp = FastApiMCP(
         app,

--- a/src/aios/tools/invoke.py
+++ b/src/aios/tools/invoke.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import jsonschema  # type: ignore[import-untyped]
+import jsonschema
 
 from aios.tools.registry import ToolNotFoundError, ToolResult, registry
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import jsonschema  # type: ignore[import-untyped]
+import jsonschema
 
 from aios.db import queries
 from aios.harness import runtime

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -33,7 +33,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, NamedTuple
 
 import asyncpg
-import jsonschema  # type: ignore[import-untyped]
+import jsonschema
 from referencing import Registry, Resource
 from referencing.exceptions import Unresolvable
 from referencing.jsonschema import DRAFT202012

--- a/tests/e2e/test_agent_litellm_extra.py
+++ b/tests/e2e/test_agent_litellm_extra.py
@@ -64,7 +64,8 @@ async def _create(
         body["litellm_extra"] = litellm_extra
     r = await client.post("/v1/agents", json=body)
     assert r.status_code == 201, r.text
-    return r.json()
+    result: dict[str, Any] = r.json()
+    return result
 
 
 class TestLitellmExtraRoundTrip:

--- a/tests/e2e/test_agents_api.py
+++ b/tests/e2e/test_agents_api.py
@@ -66,7 +66,8 @@ async def _create_agent(http_client: httpx.AsyncClient, name: str) -> str:
         },
     )
     assert r.status_code == 201, r.text
-    return r.json()["id"]
+    agent_id: str = r.json()["id"]
+    return agent_id
 
 
 class TestListAgentsNameFilter:

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -31,7 +31,7 @@ import httpx
 import pytest
 
 from aios.models.agents import ToolSpec
-from aios.models.github_repositories import GithubRepositoryResource
+from aios.models.github_repositories import GithubRepositoryResource, GithubRepositoryResourceEcho
 from aios.services import agents as agents_service
 from aios.services import environments as environments_service
 from aios.services import github_repositories as github_service
@@ -189,6 +189,7 @@ class TestServiceLayer:
             account_id=account_id,
         )
         echo = session.resources[0]
+        assert isinstance(echo, GithubRepositoryResourceEcho)
         async with pool.acquire() as conn:
             recovered = await github_service.get_session_token(
                 conn, crypto_box, session.id, echo.id, account_id=account_id
@@ -221,6 +222,7 @@ class TestServiceLayer:
             account_id=account_id,
         )
         original_echo = session.resources[0]
+        assert isinstance(original_echo, GithubRepositoryResourceEcho)
         new_token = _pat()
         rotated = await github_service.rotate_token(
             pool,
@@ -271,6 +273,7 @@ class TestServiceLayer:
             account_id=account_id,
         )
         echo = session.resources[0]
+        assert isinstance(echo, GithubRepositoryResourceEcho)
         assert echo.git_user_name == "Agent JN"
         assert echo.git_user_email == "agent+jn@example.com"
 
@@ -318,6 +321,7 @@ class TestServiceLayer:
             account_id=account_id,
         )
         echo = session.resources[0]
+        assert isinstance(echo, GithubRepositoryResourceEcho)
 
         rotated = await github_service.rotate_token(
             pool,
@@ -357,6 +361,7 @@ class TestServiceLayer:
             account_id=account_id,
         )
         echo = session.resources[0]
+        assert isinstance(echo, GithubRepositoryResourceEcho)
         assert echo.git_user_name is None
         assert echo.git_user_email is None
 

--- a/tests/e2e/test_memory_cross_session_sync.py
+++ b/tests/e2e/test_memory_cross_session_sync.py
@@ -20,6 +20,7 @@ import pytest
 import pytest_asyncio
 
 from aios.harness import runtime
+from aios.models.github_repositories import GithubRepositoryResource
 from aios.models.memory_stores import MemoryStoreResource
 from aios.services import memory_stores as memory_service
 from aios.services import sessions as sessions_service
@@ -221,7 +222,7 @@ async def _attach_store(harness: Harness, store_name: str) -> str:
 async def _start_session(
     harness: Harness,
     *,
-    resources: list[MemoryStoreResource] | None = None,
+    resources: list[MemoryStoreResource | GithubRepositoryResource] | None = None,
     tools: tuple[str, ...] = ("read", "write", "bash"),
 ) -> Any:
     """Create env+agent+session; prime the runtime mount cache via the
@@ -246,7 +247,7 @@ async def _start_session(
         name=f"test-agent-{make_id('agent')[-8:]}",
         model="fake/test",
         system="memory test",
-        tools=[ToolSpec(type=t) for t in tools],  # type: ignore[arg-type]
+        tools=[ToolSpec(type=t) for t in tools],
         description=None,
         metadata={},
         window_min=50_000,
@@ -297,6 +298,7 @@ class TestCrossSessionSync:
 
         # B's read tool sees A's content.
         b_result = await read_handler(b.id, {"path": "/mnt/memory/xsync-read/shared.md"})
+        assert isinstance(b_result, dict)
         assert "error" not in b_result, b_result
         # cat -n format: "     1\tfrom-A"
         assert "from-A" in b_result["content"]
@@ -316,6 +318,8 @@ class TestCrossSessionSync:
         # Both sessions read /seed.md — both cache the seed sha.
         a_read = await read_handler(a.id, {"path": "/mnt/memory/xsync-race/seed.md"})
         b_read = await read_handler(b.id, {"path": "/mnt/memory/xsync-race/seed.md"})
+        assert isinstance(a_read, dict)
+        assert isinstance(b_read, dict)
         assert "error" not in a_read
         assert "error" not in b_read
 
@@ -356,6 +360,7 @@ class TestCrossSessionSync:
 
         # Read primes the cache with the seed sha.
         r = await read_handler(a.id, {"path": "/mnt/memory/xsync-edit-refresh/seed.md"})
+        assert isinstance(r, dict)
         assert "error" not in r, r
 
         # Edit changes the DB content; without the cache refresh fix the next
@@ -417,6 +422,7 @@ class TestCrossSessionSync:
 
         # Session's read tool sees it via the shared FS.
         result = await read_handler(a.id, {"path": "/mnt/memory/xsync-api/api_made.md"})
+        assert isinstance(result, dict)
         assert "error" not in result, result
         assert "from-api" in result["content"]
 

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -70,7 +70,8 @@ async def _create_store(http_client: httpx.AsyncClient, **kwargs: Any) -> dict[s
         json={"name": kwargs.get("name", f"store-{_uniq()}"), **kwargs},
     )
     assert r.status_code == 201, r.text
-    return r.json()
+    result: dict[str, Any] = r.json()
+    return result
 
 
 async def _create_memory(
@@ -81,7 +82,8 @@ async def _create_memory(
         json={"path": path, "content": content},
     )
     assert r.status_code == 201, r.text
-    return r.json()
+    result: dict[str, Any] = r.json()
+    return result
 
 
 class TestStoreCrud:
@@ -368,6 +370,7 @@ async def _create_session_for_resources_test(
     without importing the model.
     """
     account_id = "acc_test_stub"  # PR 3 scaffolding
+    from aios.models.github_repositories import GithubRepositoryResource
     from aios.models.memory_stores import MemoryStoreResource
     from aios.services import agents as agents_svc
     from aios.services import environments as env_svc
@@ -388,7 +391,7 @@ async def _create_session_for_resources_test(
         window_max=150_000,
         account_id=account_id,
     )
-    resources = (
+    resources: list[MemoryStoreResource | GithubRepositoryResource] | None = (
         None
         if initial_resources is None
         else [MemoryStoreResource.model_validate(r) for r in initial_resources]

--- a/tests/e2e/test_scheduled_tasks.py
+++ b/tests/e2e/test_scheduled_tasks.py
@@ -574,7 +574,7 @@ class TestRecordFire:
         prev_pool = runtime.pool
         prev_registry = runtime.sandbox_registry
         runtime.pool = pool
-        runtime.sandbox_registry = registry  # type: ignore[assignment]
+        runtime.sandbox_registry = registry
         with mock.patch(
             "aios.harness.scheduled_task_runner.defer_wake",
             new_callable=mock.AsyncMock,
@@ -593,7 +593,10 @@ class TestRecordFire:
             )
 
         def _data(row: Any) -> dict[str, Any]:
-            return json.loads(row["data"]) if isinstance(row["data"], str) else row["data"]
+            result: dict[str, Any] = (
+                json.loads(row["data"]) if isinstance(row["data"], str) else row["data"]
+            )
+            return result
 
         disable_messages = [
             r
@@ -633,7 +636,8 @@ class TestHttp:
             json={"agent_id": agent_id, "environment_id": env_id},
         )
         assert r.status_code == 201, r.text
-        return r.json()["id"]
+        session_id: str = r.json()["id"]
+        return session_id
 
     async def test_round_trip(
         self,
@@ -1056,7 +1060,7 @@ class TestOneShotLifecycle:
         prev_pool = runtime.pool
         prev_registry = runtime.sandbox_registry
         runtime.pool = pool
-        runtime.sandbox_registry = registry  # type: ignore[assignment]
+        runtime.sandbox_registry = registry
         try:
             # Wrap delete_scheduled_task_by_id to confirm order.
             orig_delete = queries.delete_scheduled_task_by_id
@@ -1120,7 +1124,7 @@ class TestOneShotLifecycle:
         prev_pool = runtime.pool
         prev_registry = runtime.sandbox_registry
         runtime.pool = pool
-        runtime.sandbox_registry = registry  # type: ignore[assignment]
+        runtime.sandbox_registry = registry
         # defer_wake reaches into procrastinate which isn't wired here;
         # patch to a no-op so the failure-surface path completes.
         with mock.patch(

--- a/tests/e2e/test_signal_registration.py
+++ b/tests/e2e/test_signal_registration.py
@@ -38,7 +38,7 @@ class _FakeSignalConnector(HttpConnector):
     @management_handler()
     async def register(
         self, *, external_account_id: str, captcha: str | None = None, voice: bool = False
-    ) -> dict:
+    ) -> dict[str, object]:
         self.calls.append(
             (
                 "register",
@@ -63,7 +63,9 @@ class _FakeSignalConnector(HttpConnector):
         }
 
     @management_handler()
-    async def verify(self, *, external_account_id: str, code: str, pin: str | None = None) -> dict:
+    async def verify(
+        self, *, external_account_id: str, code: str, pin: str | None = None
+    ) -> dict[str, object]:
         self.calls.append(
             (
                 "verify",
@@ -80,7 +82,7 @@ class _FakeSignalConnector(HttpConnector):
         given_name: str | None = None,
         family_name: str | None = None,
         about: str | None = None,
-    ) -> dict:
+    ) -> dict[str, object]:
         self.calls.append(
             (
                 "updateProfile",

--- a/tests/e2e/test_step_separator.py
+++ b/tests/e2e/test_step_separator.py
@@ -11,6 +11,8 @@ adjacency arrives merged.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from tests.conftest import needs_docker
@@ -21,7 +23,7 @@ pytestmark = pytest.mark.docker
 _TAIL_HEADER = "━━━ Channels ━━━"
 
 
-def _is_dot_placeholder(m: dict) -> bool:
+def _is_dot_placeholder(m: dict[str, Any]) -> bool:
     return m.get("role") == "assistant" and m.get("content") == "."
 
 

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, cast
 
 import asyncpg
 import pytest
@@ -300,7 +300,7 @@ async def _explain(pool: asyncpg.Pool[Any], sql: str, *args: Any) -> dict[str, A
     # asyncpg decodes JSON columns to Python lists/dicts already.
     if isinstance(result, str):
         result = json.loads(result)
-    return result[0]["Plan"]
+    return cast(dict[str, Any], result[0]["Plan"])
 
 
 # ─── structural tests (primary, always-on) ───────────────────────────────────

--- a/tests/e2e/test_vault_oauth.py
+++ b/tests/e2e/test_vault_oauth.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import json as _json
 import os
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
@@ -61,7 +62,7 @@ def _make_handler(
     token_calls: list[dict[str, Any]] | None = None,
     token_expires_in: int | None = 3600,
     token_status: int = 200,
-):
+) -> Callable[[httpx.Request], httpx.Response]:
     """A MockTransport handler emulating a spec-compliant MCP OAuth provider."""
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -125,7 +126,7 @@ _REAL_ASYNC_CLIENT = httpx.AsyncClient
 
 
 @contextmanager
-def _patched_provider(**kwargs: Any):
+def _patched_provider(**kwargs: Any) -> Generator[None]:
     handler = _make_handler(**kwargs)
 
     def factory(*_a: Any, **_k: Any) -> httpx.AsyncClient:
@@ -155,7 +156,7 @@ async def _vault(pool: Any, name: str) -> str:
 
 
 def _decrypt_flow(crypto_box: Any, blob: EncryptedBlob) -> dict[str, Any]:
-    return crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt_dict(blob)
+    return cast(dict[str, Any], crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt_dict(blob))
 
 
 async def _cred_payload(pool: Any, crypto_box: Any, cred_id: str) -> dict[str, Any]:
@@ -164,10 +165,13 @@ async def _cred_payload(pool: Any, crypto_box: Any, cred_id: str) -> dict[str, A
         row = await conn.fetchrow(
             "SELECT ciphertext, nonce FROM vault_credentials WHERE id = $1", cred_id
         )
-    return _json.loads(
-        crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt(
-            EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"]))
-        )
+    return cast(
+        dict[str, Any],
+        _json.loads(
+            crypto_box.derive_account_subkey(ACCOUNT_ID).decrypt(
+                EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"]))
+            )
+        ),
     )
 
 

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -723,7 +723,7 @@ class TestOAuthRefreshE2E:
         )
 
     @staticmethod
-    def _patched_async_client(post_calls: list[Any], body: dict[str, Any]):
+    def _patched_async_client(post_calls: list[Any], body: dict[str, Any]) -> Any:
         """Build a ``patch`` context for ``services.vaults.httpx.AsyncClient``.
 
         Each ``client.post`` invocation is recorded into ``post_calls`` and

--- a/tests/e2e/test_wake_lock_release_latency.py
+++ b/tests/e2e/test_wake_lock_release_latency.py
@@ -90,7 +90,7 @@ class TestWakeLockReleaseLatencyE2E:
                 )
 
                 await defer_wake(pool, session_id, cause="message", account_id=account_id)
-                worker_task = asyncio.create_task(worker.run())
+                worker_task = asyncio.create_task(worker.run())  # type: ignore[no-untyped-call]
 
                 async def _count_wakes(statuses: tuple[str, ...]) -> int:
                     async with pool.acquire() as conn:
@@ -114,7 +114,7 @@ class TestWakeLockReleaseLatencyE2E:
                 await wait_for_predicate(_has_doing, max_wait_s=5.0, interval_s=0.02)
                 await defer_wake(pool, session_id, cause="message", account_id=account_id)
                 await wait_for_predicate(_both_terminal, max_wait_s=15.0, interval_s=0.02)
-                worker.stop()
+                worker.stop()  # type: ignore[no-untyped-call]
                 await asyncio.wait_for(worker_task, timeout=5.0)
         finally:
             await new_connector.close_async()

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -81,7 +81,7 @@ async def _mint_tenant(http_client: httpx.AsyncClient, name: str) -> str:
 async def _create_env(http_client: httpx.AsyncClient) -> str:
     r = await http_client.post("/v1/environments", json={"name": f"wf-env-{_uniq()}"})
     assert r.status_code in (200, 201), r.text
-    return r.json()["id"]
+    return str(r.json()["id"])
 
 
 async def test_create_workflow_run_and_observe(http_client: httpx.AsyncClient) -> None:

--- a/tests/integration/test_abandoned_client_tool_ghost_repair.py
+++ b/tests/integration/test_abandoned_client_tool_ghost_repair.py
@@ -267,9 +267,10 @@ async def session_with_old_unconfirmed_always_ask(
 
 async def _open_tool_call_count(pool: asyncpg.Pool[Any], session_id: str) -> int:
     async with pool.acquire() as conn:
-        return await conn.fetchval(
+        count: int = await conn.fetchval(
             "SELECT open_tool_call_count FROM sessions WHERE id = $1", session_id
         )
+        return count
 
 
 async def _tool_results(

--- a/tests/integration/test_bind_chat_archive_race.py
+++ b/tests/integration/test_bind_chat_archive_race.py
@@ -107,9 +107,11 @@ async def pool_with_connection_and_session(
 
 async def _count_active_chat_sessions(pool: asyncpg.Pool[Any], connection_id: str) -> int:
     async with pool.acquire() as conn:
-        return await conn.fetchval(
-            "SELECT COUNT(*) FROM chat_sessions WHERE connection_id = $1",
-            connection_id,
+        return int(
+            await conn.fetchval(
+                "SELECT COUNT(*) FROM chat_sessions WHERE connection_id = $1",
+                connection_id,
+            )
         )
 
 

--- a/tests/integration/test_confirmed_unresolved_dispatch.py
+++ b/tests/integration/test_confirmed_unresolved_dispatch.py
@@ -24,6 +24,7 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.models.agents import ToolSpec
+from aios.models.events import EventKind
 from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
@@ -75,7 +76,7 @@ async def session_with_mixed_confirmations(
         )
         sid = session.id
 
-        async def append(kind: str, data: dict[str, Any]) -> None:
+        async def append(kind: EventKind, data: dict[str, Any]) -> None:
             async with pool.acquire() as conn:
                 await queries.append_event(
                     conn, account_id=account_id, session_id=sid, kind=kind, data=data

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -28,6 +28,9 @@ def postgres() -> Iterator[object]:
 
 def _alembic_url(pg: object) -> str:
     """Return the connection URL alembic env.py expects."""
+    from testcontainers.postgres import PostgresContainer
+
+    assert isinstance(pg, PostgresContainer)
     host = pg.get_container_host_ip()
     port = pg.get_exposed_port(5432)
     user = pg.username

--- a/tests/integration/test_migrations_reparent.py
+++ b/tests/integration/test_migrations_reparent.py
@@ -51,7 +51,8 @@ async def _connections_indexes(db_url: str) -> set[str]:
 async def _version_num(db_url: str) -> str:
     conn = await asyncpg.connect(db_url)
     try:
-        return await conn.fetchval("SELECT version_num FROM alembic_version")
+        result: str = await conn.fetchval("SELECT version_num FROM alembic_version")
+        return result
     finally:
         await conn.close()
 

--- a/tests/integration/test_migrations_stop_hook.py
+++ b/tests/integration/test_migrations_stop_hook.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
+from typing import cast
 
 import asyncpg
 import pytest
@@ -47,7 +48,7 @@ async def _sessions_columns(db_url: str) -> set[str]:
 async def _version_num(db_url: str) -> str:
     conn = await asyncpg.connect(db_url)
     try:
-        return await conn.fetchval("SELECT version_num FROM alembic_version")
+        return cast(str, await conn.fetchval("SELECT version_num FROM alembic_version"))
     finally:
         await conn.close()
 

--- a/tests/integration/test_resolver_archive_race.py
+++ b/tests/integration/test_resolver_archive_race.py
@@ -112,10 +112,11 @@ async def pool_with_per_chat_connection(
 
 async def _count_chat_sessions(pool: asyncpg.Pool[Any], connection_id: str) -> int:
     async with pool.acquire() as conn:
-        return await conn.fetchval(
+        count: int = await conn.fetchval(
             "SELECT COUNT(*) FROM chat_sessions WHERE connection_id = $1",
             connection_id,
         )
+        return count
 
 
 class TestResolverArchiveRace:

--- a/tests/integration/test_session_resource_eviction.py
+++ b/tests/integration/test_session_resource_eviction.py
@@ -232,7 +232,7 @@ async def test_update_session_idempotent_memory_resources_does_not_evict(
     store = await memory_stores_service.create_store(
         pool, account_id=_ACCOUNT_ID, name="idem-notes", description="d", metadata={}
     )
-    resources = [
+    resources: list[MemoryStoreResource | GithubRepositoryResource] = [
         MemoryStoreResource(
             type="memory_store",
             memory_store_id=store.id,

--- a/tests/integration/test_stale_confirmed_dispatch_recovery.py
+++ b/tests/integration/test_stale_confirmed_dispatch_recovery.py
@@ -60,6 +60,7 @@ from aios.harness import sweep
 from aios.harness.loop import _dispatch_confirmed_tools
 from aios.harness.task_registry import TaskRegistry
 from aios.models.agents import ToolSpec
+from aios.models.events import EventKind
 from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
@@ -131,7 +132,7 @@ async def session_with_stale_connector_send(
         )
         sid = session.id
 
-        async def append(kind: str, data: dict[str, Any]) -> None:
+        async def append(kind: EventKind, data: dict[str, Any]) -> None:
             async with pool.acquire() as conn:
                 await queries.append_event(
                     conn, account_id=account_id, session_id=sid, kind=kind, data=data
@@ -218,7 +219,7 @@ async def session_with_fresh_confirm_on_old_proposal(
         )
         sid = session.id
 
-        async def append(kind: str, data: dict[str, Any]) -> None:
+        async def append(kind: EventKind, data: dict[str, Any]) -> None:
             async with pool.acquire() as conn:
                 await queries.append_event(
                     conn, account_id=account_id, session_id=sid, kind=kind, data=data

--- a/tests/integration/test_stale_connector_backfill.py
+++ b/tests/integration/test_stale_connector_backfill.py
@@ -63,7 +63,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, Literal
 
 import asyncpg
 import pytest
@@ -180,7 +180,9 @@ async def bound_signal_session_with_stale_send(
                 ],
             )
 
-        async def append(kind: str, data: dict[str, Any]) -> None:
+        async def append(
+            kind: Literal["message", "lifecycle", "span", "interrupt"], data: dict[str, Any]
+        ) -> None:
             async with pool.acquire() as conn:
                 await queries.append_event(
                     conn, account_id=account_id, session_id=sid, kind=kind, data=data

--- a/tests/integration/test_wake_session.py
+++ b/tests/integration/test_wake_session.py
@@ -153,6 +153,7 @@ class TestWakeSessionIntegration:
 
         # defer_wake was called against the TARGET with the target's account.
         patched_defer_wake.assert_awaited_once()
+        assert patched_defer_wake.await_args is not None
         assert patched_defer_wake.await_args.args[1] == target.id
         assert patched_defer_wake.await_args.kwargs["account_id"] == "acc_wake_a"
         assert patched_defer_wake.await_args.kwargs["cause"] == "agent_wake"

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -325,6 +325,8 @@ async def test_wf_run_event_stream_backfills_tails_and_terminates(
 
         async def _consume() -> None:
             async for msg in wf_run_event_stream(subscription, pool, run_id):
+                assert msg.event is not None
+                assert isinstance(msg.data, str)
                 kind = json.loads(msg.data).get("type") if msg.event == "event" else None
                 collected.append((msg.event, kind))
                 if msg.event == "done":

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -307,9 +307,11 @@ async def test_cancel_suspended_run_finalizes_cancelled(wf_runtime: asyncpg.Pool
     # Wake: harvest the cancel → cancelled.
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
-        run = await wf_queries.get_run_for_step(conn, run_id)
+        run_or_none = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
-    assert run is not None and run.status == "cancelled" and run.output is None
+    assert run_or_none is not None
+    run = run_or_none
+    assert run.status == "cancelled" and run.output is None
     rc = events[-1]
     assert rc.type == "run_completed"
     assert rc.payload["cancelled"] is True and rc.payload["is_error"] is False
@@ -332,8 +334,9 @@ async def test_cancel_pending_run_finalizes_before_it_starts(wf_runtime: asyncpg
 
     await run_workflow_step(run_id)  # harvest cancel before run_started
     async with pool.acquire() as conn:
-        run = await wf_queries.get_run_for_step(conn, run_id)
-    assert run is not None and run.status == "cancelled"
+        run_or_none = await wf_queries.get_run_for_step(conn, run_id)
+    assert run_or_none is not None
+    assert run_or_none.status == "cancelled"
     assert [t for _s, t, _k in await _events(pool, run_id)] == ["run_completed"]
 
 
@@ -755,7 +758,7 @@ async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
 async def _child_id_of(pool: asyncpg.Pool[Any], run_id: str) -> str:
     async with pool.acquire() as conn:
         events = await wf_queries.list_run_events(conn, run_id)
-    return next(e.payload["child_session_id"] for e in events if e.type == "call_started")
+    return str(next(e.payload["child_session_id"] for e in events if e.type == "call_started"))
 
 
 async def _open_request_id(pool: asyncpg.Pool[Any], session_id: str) -> str:
@@ -1954,7 +1957,8 @@ async def test_return_enforces_output_schema(
             cid,
             {"request_id": "se:1", "value": {"answer": 42}},  # answer must be a string
         )
-    assert isinstance(bad, ToolResult) and bad.is_error and "schema" in bad.content.lower()
+    assert isinstance(bad, ToolResult) and bad.is_error
+    assert isinstance(bad.content, str) and "schema" in bad.content.lower()
     wake.assert_not_awaited()  # nothing answered → caller not woken
     async with pool.acquire() as conn:
         assert (
@@ -2190,12 +2194,11 @@ async def test_defer_wake_priority_reflects_real_origin(
     )  # origin='foreground', no parent run
     _run_id, cid = await _spawn_child(pool, wf_agent_id, "prio:1")  # origin='background'
 
-    with app.replace_connector(InMemoryConnector()) as patched:
+    in_mem = InMemoryConnector()
+    with app.replace_connector(in_mem) as _patched:
         await defer_wake(pool, fg.id, account_id="acc_wf", cause="message")
         await defer_wake(pool, cid, account_id="acc_wf", cause="message")
-        priorities = {
-            j["args"]["session_id"]: j["priority"] for j in patched.connector.jobs.values()
-        }
+        priorities = {j["args"]["session_id"]: j["priority"] for j in in_mem.jobs.values()}
     assert priorities[fg.id] == _FOREGROUND_PRIORITY  # real foreground → default
     assert priorities[cid] == _BACKGROUND_PRIORITY  # real background child → demoted
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -78,7 +78,7 @@ def mocked_cli(monkeypatch: pytest.MonkeyPatch) -> MockedCli:
             return httpx.Response(500, json={"error": "no response queued"})
         return responses.pop(0)
 
-    def _client(self: CliState) -> AiosClient:  # type: ignore[override]
+    def _client(self: CliState) -> AiosClient:
         return AiosClient(
             base_url=self.base_url,
             api_key=self.api_key,

--- a/tests/unit/cli/test_cli_broken_pipe.py
+++ b/tests/unit/cli/test_cli_broken_pipe.py
@@ -48,7 +48,7 @@ def test_run_or_die_swallows_brokenpipe_raised_from_stdout_write(
     ``json`` rendering fails mid-flush after the HTTP call succeeded."""
 
     class BrokenStream(io.StringIO):
-        def write(self, _s: str) -> int:  # type: ignore[override]
+        def write(self, _s: str) -> int:
             raise BrokenPipeError(32, "Broken pipe")
 
     monkeypatch.setattr(sys, "stdout", BrokenStream())

--- a/tests/unit/cli/test_cli_dev.py
+++ b/tests/unit/cli/test_cli_dev.py
@@ -229,14 +229,14 @@ def test_settings_env_file_tuple_layers_and_later_wins(
     ):
         monkeypatch.delenv(k, raising=False)
 
-    s = Settings(_env_file=(str(secrets), str(dotenv)))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets), str(dotenv)))
     assert s.vault_key.get_secret_value() == "vk_secrets"
     # Later file overrides earlier.
     assert s.db_url == "postgresql://dotenv/db"
 
     # Process env beats both files.
     monkeypatch.setenv("AIOS_DB_URL", "postgresql://env/db")
-    s2 = Settings(_env_file=(str(secrets), str(dotenv)))  # type: ignore[call-arg]
+    s2 = Settings(_env_file=(str(secrets), str(dotenv)))
     assert s2.db_url == "postgresql://env/db"
 
 
@@ -250,7 +250,7 @@ def test_settings_instance_id_defaults_to_default(
     secrets.write_text("AIOS_API_KEY=k\nAIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_INSTANCE_ID", raising=False)
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.instance_id == "default"
 
 
@@ -267,4 +267,4 @@ def test_settings_instance_id_rejects_unsafe_value(
     monkeypatch.setenv("AIOS_INSTANCE_ID", "bad-dash")
 
     with pytest.raises(ValidationError):
-        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+        Settings(_env_file=(str(secrets),))

--- a/tests/unit/cli/test_cli_sessions.py
+++ b/tests/unit/cli/test_cli_sessions.py
@@ -7,6 +7,8 @@ path CRUD is exercised elsewhere.
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 from typer.testing import CliRunner
 
@@ -42,7 +44,7 @@ class TestTriggerSummary:
     def test_cron_row(self) -> None:
         from aios.cli.commands.sessions import _trigger_summary
 
-        row = {
+        row: dict[str, Any] = {
             "schedule": "*/5 * * * *",
             "fire_at": None,
             "metadata": {},
@@ -52,7 +54,7 @@ class TestTriggerSummary:
     def test_raw_one_shot(self) -> None:
         from aios.cli.commands.sessions import _trigger_summary
 
-        row = {
+        row: dict[str, Any] = {
             "schedule": None,
             "fire_at": "2026-05-23T15:00:00Z",
             "metadata": {},
@@ -88,7 +90,7 @@ def test_delete_is_hard_delete_with_yes(mocked_cli):
     assert "sess_1" in result.output
 
 
-def _profile_events_page() -> dict:
+def _profile_events_page() -> dict[str, Any]:
     """Minimal events envelope with a single complete step, enough for the
     profiler to emit every section."""
     return {

--- a/tests/unit/cli/test_client.py
+++ b/tests/unit/cli/test_client.py
@@ -7,6 +7,7 @@ auth header injection, error envelope decoding, and SSE streaming.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 
 import httpx
@@ -15,7 +16,9 @@ import pytest
 from aios.cli.client import AiosApiError, AiosClient, NonJSONResponseError
 
 
-def _mock_client(handler, *, api_key: str | None = "key-123") -> AiosClient:
+def _mock_client(
+    handler: Callable[[httpx.Request], httpx.Response], *, api_key: str | None = "key-123"
+) -> AiosClient:
     """Build an AiosClient whose underlying httpx.Client uses ``handler``."""
     return AiosClient(
         base_url="http://test.invalid",

--- a/tests/unit/cli/test_files.py
+++ b/tests/unit/cli/test_files.py
@@ -11,49 +11,49 @@ import pytest
 from aios.cli.files import PayloadError, load_payload, walk_skill_dir
 
 
-def test_load_from_file(tmp_path: Path):
+def test_load_from_file(tmp_path: Path) -> None:
     p = tmp_path / "body.json"
     p.write_text('{"name": "X", "n": 1}')
     out = load_payload(p, False, None)
     assert out == {"name": "X", "n": 1}
 
 
-def test_load_from_data_string():
+def test_load_from_data_string() -> None:
     out = load_payload(None, False, '{"k": true}')
     assert out == {"k": True}
 
 
-def test_load_from_stdin(monkeypatch):
+def test_load_from_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "stdin", io.StringIO('{"via": "stdin"}'))
     out = load_payload(None, True, None)
     assert out == {"via": "stdin"}
 
 
-def test_load_no_source_raises():
+def test_load_no_source_raises() -> None:
     with pytest.raises(PayloadError, match="no payload"):
         load_payload(None, False, None)
 
 
-def test_load_multiple_sources_raises(tmp_path: Path):
+def test_load_multiple_sources_raises(tmp_path: Path) -> None:
     p = tmp_path / "x.json"
     p.write_text("{}")
     with pytest.raises(PayloadError, match="only one of"):
         load_payload(p, False, "{}")
 
 
-def test_load_non_object_raises():
+def test_load_non_object_raises() -> None:
     with pytest.raises(PayloadError, match="must be a JSON object"):
         load_payload(None, False, "[1,2,3]")
 
 
-def test_load_invalid_json_raises(tmp_path: Path):
+def test_load_invalid_json_raises(tmp_path: Path) -> None:
     p = tmp_path / "bad.json"
     p.write_text("not json")
     with pytest.raises(PayloadError, match="invalid JSON"):
         load_payload(p, False, None)
 
 
-def test_walk_skill_dir(tmp_path: Path):
+def test_walk_skill_dir(tmp_path: Path) -> None:
     """Keys are prefixed with the root directory's basename.
 
     The server's ``_extract_skill_metadata`` parses the directory name
@@ -75,7 +75,7 @@ def test_walk_skill_dir(tmp_path: Path):
     assert "SKILL.md" not in files
 
 
-def test_walk_skill_dir_matches_server_contract(tmp_path: Path):
+def test_walk_skill_dir_matches_server_contract(tmp_path: Path) -> None:
     """End-to-end shape check: the dict returned by ``walk_skill_dir``
     round-trips through the server's ``_extract_skill_metadata`` without
     the *"SKILL.md must be inside a directory"* failure that motivated
@@ -97,7 +97,7 @@ def test_walk_skill_dir_matches_server_contract(tmp_path: Path):
     assert "helper.py" in normalized
 
 
-def test_walk_skill_dir_missing_skill_md(tmp_path: Path):
+def test_walk_skill_dir_missing_skill_md(tmp_path: Path) -> None:
     d = tmp_path / "empty"
     d.mkdir()
     (d / "other.md").write_text("x")
@@ -105,14 +105,14 @@ def test_walk_skill_dir_missing_skill_md(tmp_path: Path):
         walk_skill_dir(d)
 
 
-def test_walk_skill_dir_not_a_directory(tmp_path: Path):
+def test_walk_skill_dir_not_a_directory(tmp_path: Path) -> None:
     f = tmp_path / "file.txt"
     f.write_text("x")
     with pytest.raises(PayloadError, match="not a directory"):
         walk_skill_dir(f)
 
 
-def test_walk_skill_dir_rejects_symlinked_file(tmp_path: Path):
+def test_walk_skill_dir_rejects_symlinked_file(tmp_path: Path) -> None:
     """A symlink in a skill dir pointing OUTSIDE the dir must be
     rejected. ``Path.is_file()`` and ``Path.read_text()`` both follow
     symlinks by default; without an explicit guard a planted symlink

--- a/tests/unit/sandbox/test_sandbox_network.py
+++ b/tests/unit/sandbox/test_sandbox_network.py
@@ -3,6 +3,7 @@ runner is patched so no real daemon is required."""
 
 from __future__ import annotations
 
+import socket
 from collections.abc import Callable
 
 import pytest
@@ -83,7 +84,7 @@ class TestEnsureNetworkInContainer:
     @pytest.fixture(autouse=True)
     def _in_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sandbox_network, "is_running_in_container", lambda: True)
-        monkeypatch.setattr(sandbox_network.socket, "gethostname", lambda: "worker-abc")
+        monkeypatch.setattr(socket, "gethostname", lambda: "worker-abc")
 
     async def test_connects_self_with_alias_when_not_joined(
         self, monkeypatch: pytest.MonkeyPatch
@@ -171,7 +172,7 @@ class TestEnsureConnectFailureInContainer:
     @pytest.fixture(autouse=True)
     def _in_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sandbox_network, "is_running_in_container", lambda: True)
-        monkeypatch.setattr(sandbox_network.socket, "gethostname", lambda: "worker-abc")
+        monkeypatch.setattr(socket, "gethostname", lambda: "worker-abc")
 
     async def test_connect_hard_failure_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         def responder(argv: list[str]) -> tuple[int, bytes, bytes]:

--- a/tests/unit/sandbox/test_seccomp_profile.py
+++ b/tests/unit/sandbox/test_seccomp_profile.py
@@ -53,7 +53,8 @@ DENY_NAMES = {
 
 @pytest.fixture(scope="module")
 def profile() -> dict[str, object]:
-    return json.loads(PROFILE_PATH.read_text())
+    data: dict[str, object] = json.loads(PROFILE_PATH.read_text())
+    return data
 
 
 def test_profile_parses(profile: dict[str, object]) -> None:
@@ -175,6 +176,6 @@ def test_settings_default_path_points_at_repo_profile(
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_SANDBOX_SECCOMP_PROFILE", raising=False)
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.sandbox_seccomp_profile.endswith("docker/seccomp-sandbox.json")
     assert Path(s.sandbox_seccomp_profile).exists()

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -19,12 +19,14 @@ lives in ``resolve_bash_timeout_ceiling``. These tests pin each.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from aios.models.environments import EnvironmentConfig
 from aios.sandbox.spec import (
+    ProvisioningPlan,
     _assemble_plan,
     resolve_bash_timeout_ceiling,
 )
@@ -35,7 +37,7 @@ def _call_assemble(
     image: str = "aios-sandbox:test",
     disk_bytes: int | None = None,
     env_config: EnvironmentConfig | None = None,
-) -> object:
+) -> ProvisioningPlan:
     # ``_assemble_plan`` imports its volume helpers function-locally, so
     # patch them at the ``aios.sandbox.volumes`` source module (same shape
     # as ``test_spec_uds_url.py``).
@@ -105,7 +107,7 @@ def _patch_build_spec_deps(
     env_config: EnvironmentConfig | None,
     docker_image: str,
     sandbox_disk_bytes: int | None,
-):
+) -> tuple[Any, ...]:
     """Context manager bundle that stubs every external dependency of
     ``build_spec_from_session`` so it runs to the ``_assemble_plan`` call
     with a synthetic environment config and synthetic settings."""
@@ -176,7 +178,7 @@ async def _build_with(
     env_config: EnvironmentConfig | None,
     docker_image: str = "ghcr.io/eumemic/aios-sandbox:latest",
     sandbox_disk_bytes: int | None = None,
-):
+) -> ProvisioningPlan:
     from contextlib import ExitStack
 
     from aios.sandbox.spec import build_spec_from_session
@@ -257,7 +259,7 @@ def _patch_ceiling_deps(
     env_config: EnvironmentConfig | None,
     default: int,
     load_raises: bool = False,
-):
+) -> tuple[Any, ...]:
     settings = MagicMock()
     settings.bash_default_timeout_seconds = default
     load_env = AsyncMock(return_value=env_config)

--- a/tests/unit/sandbox/test_spec_uds_url.py
+++ b/tests/unit/sandbox/test_spec_uds_url.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 from aios.sandbox.spec import (
     TOOL_BROKER_SECRET_SANDBOX_PATH,
     TOOL_BROKER_SOCKET_SANDBOX_PATH,
+    ProvisioningPlan,
     _assemble_plan,
 )
 
@@ -28,7 +29,7 @@ def _call_assemble(
     tool_socket_host_path: Path | None,
     tool_broker_secret: str = "secret123",
     session_id: str = "sess_01TEST",
-) -> object:
+) -> ProvisioningPlan:
     # ``_assemble_plan`` imports its volume helpers function-locally, so
     # we patch them at the ``aios.sandbox.volumes`` source module.
     with (

--- a/tests/unit/sandbox/test_tool_broker.py
+++ b/tests/unit/sandbox/test_tool_broker.py
@@ -12,7 +12,7 @@ built-in invoke, MCP invoke, and the v1 gate (transport ∈ {cli, both}
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -54,14 +54,14 @@ def _toolset(
     default_transport: str | None = None,
     configs: list[McpToolConfig] | None = None,
 ) -> ToolSpec:
-    pol = McpPermissionPolicy(type=default_policy) if default_policy else None  # type: ignore[arg-type]
+    pol = McpPermissionPolicy(type=default_policy) if default_policy else None
     return ToolSpec(
         type="mcp_toolset",
         enabled=enabled,
         mcp_server_name=server_name,
         default_config=McpToolsetConfig(
             permission_policy=pol,
-            transport=default_transport,  # type: ignore[arg-type]
+            transport=default_transport,
         ),
         configs=configs,
     )
@@ -78,7 +78,7 @@ async def broker() -> AsyncIterator[ToolBroker]:
 
 
 @pytest.fixture
-def hijack_tool() -> AsyncIterator[
+def hijack_tool() -> Iterator[
     Callable[[str, Callable[[str, dict[str, Any]], Awaitable[Any]]], None]
 ]:
     """Yield a function that overrides a real built-in's handler.

--- a/tests/unit/test_append_user_message_size.py
+++ b/tests/unit/test_append_user_message_size.py
@@ -10,8 +10,8 @@ import pytest
 from pydantic import ValidationError
 
 from aios.errors import PayloadTooLargeError
-from aios.models.sessions import SessionCreate
-from aios.services.sessions import MAX_USER_MESSAGE_CHARS, append_user_message
+from aios.models.sessions import MAX_USER_MESSAGE_CHARS, SessionCreate
+from aios.services.sessions import append_user_message
 
 
 class TestAppendUserMessageSizeCap:

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -59,8 +59,8 @@ class _FakeUploadStream:
     def __init__(self, payload: bytes, filename: str, content_type: str) -> None:
         self._payload = payload
         self._pos = 0
-        self.filename = filename
-        self.content_type = content_type
+        self.filename: str | None = filename
+        self.content_type: str | None = content_type
 
     async def read(self, size: int = -1) -> bytes:
         if self._pos >= len(self._payload):
@@ -272,6 +272,9 @@ class TestStaging:
             concurrent ``stage_inbound_attachments`` calls actually
             interleave between ``target.exists()`` and ``os.rename``."""
 
+            filename: str | None = None
+            content_type: str | None = None
+
             def __init__(self, payload: bytes) -> None:
                 self._payload = payload
                 self._pos = 0
@@ -290,10 +293,10 @@ class TestStaging:
 
         a = InboundAttachment(
             stream=_SlowStream(b"A" * 100), filename="img.jpg", content_type="image/jpeg"
-        )  # type: ignore[arg-type]
+        )
         b = InboundAttachment(
             stream=_SlowStream(b"B" * 100), filename="img.jpg", content_type="image/jpeg"
-        )  # type: ignore[arg-type]
+        )
 
         results = await asyncio.gather(
             stage_inbound_attachments(

--- a/tests/unit/test_attenuation.py
+++ b/tests/unit/test_attenuation.py
@@ -49,12 +49,12 @@ def canon(s: Surface, *, dmp: PermissionPolicy = DMP) -> Surface:
 
 
 def _toolset(server: str, **kw: object) -> ToolSpec:
-    return ToolSpec(type="mcp_toolset", mcp_server_name=server, **kw)  # type: ignore[arg-type]
+    return ToolSpec(type="mcp_toolset", mcp_server_name=server, **kw)
 
 
 def _mcp_cfg(name: str, *, perm: PermissionPolicy | None = None, **kw: object) -> McpToolConfig:
     pp = McpPermissionPolicy(type=perm) if perm is not None else None
-    return McpToolConfig(name=name, permission_policy=pp, **kw)  # type: ignore[arg-type]
+    return McpToolConfig(name=name, permission_policy=pp, **kw)
 
 
 # ── builtin / custom tools ────────────────────────────────────────────────────
@@ -108,8 +108,8 @@ class TestBuiltinMeet:
 
     def test_custom_tool_keyed_by_name(self) -> None:
         spec = dict(name="foo", description="d", input_schema={"type": "object"})
-        declared = Surface([ToolSpec(type="custom", **spec)], [], [])  # type: ignore[arg-type]
-        launcher = Surface([ToolSpec(type="custom", **spec)], [], [])  # type: ignore[arg-type]
+        declared = Surface([ToolSpec(type="custom", **spec)], [], [])
+        launcher = Surface([ToolSpec(type="custom", **spec)], [], [])
         out = att(declared, launcher)
         assert [t.name for t in out.tools] == ["foo"]
         assert out == canon(declared)

--- a/tests/unit/test_bash_handler.py
+++ b/tests/unit/test_bash_handler.py
@@ -6,6 +6,7 @@ is stubbed so tests don't touch Docker.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -55,7 +56,7 @@ def canned_result() -> CommandResult:
 @pytest.fixture
 def stub_registry(
     stub_handle: SandboxHandle, canned_result: CommandResult, **kwargs: Any
-) -> _StubRegistry:
+) -> Generator[_StubRegistry]:
     """Install a stub sandbox registry on the runtime module, restore after.
 
     Also pins ``resolve_bash_timeout_ceiling`` to the global default so the
@@ -134,9 +135,10 @@ class TestResultShape:
         self, stub_registry: _StubRegistry, stub_handle: SandboxHandle
     ) -> None:
         await bash_handler("sess_01TEST", {"command": "echo hi"})
-        stub_registry.exec.assert_awaited_once()  # type: ignore[attr-defined]
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
-        args: tuple[Any, ...] = stub_registry.exec.await_args.args  # type: ignore[attr-defined]
+        stub_registry.exec.assert_awaited_once()
+        assert stub_registry.exec.await_args is not None
+        kwargs: dict[str, Any] = dict(stub_registry.exec.await_args.kwargs)
+        args: tuple[Any, ...] = stub_registry.exec.await_args.args
         # call signature is (handle, command, kwargs)
         assert args[1] == "echo hi"
         assert kwargs["timeout_seconds"] > 0
@@ -156,7 +158,8 @@ class TestTimeoutCapping:
             "sess_01TEST",
             {"command": "true", "timeout_seconds": max_allowed * 10},
         )
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_args is not None
+        kwargs: dict[str, Any] = dict(stub_registry.exec.await_args.kwargs)
         assert kwargs["timeout_seconds"] == max_allowed
 
     async def test_respects_smaller_timeout(
@@ -168,7 +171,8 @@ class TestTimeoutCapping:
             "sess_01TEST",
             {"command": "true", "timeout_seconds": 5},
         )
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_args is not None
+        kwargs: dict[str, Any] = dict(stub_registry.exec.await_args.kwargs)
         assert kwargs["timeout_seconds"] == 5
 
 
@@ -193,7 +197,8 @@ class TestPerEnvTimeoutCeiling:
                 "sess_01TEST",
                 {"command": "true", "timeout_seconds": 300},
             )
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_args is not None
+        kwargs: dict[str, Any] = dict(stub_registry.exec.await_args.kwargs)
         # 300 < 600 ceiling → request honored verbatim.
         assert kwargs["timeout_seconds"] == 300
 
@@ -208,7 +213,8 @@ class TestPerEnvTimeoutCeiling:
                 "sess_01TEST",
                 {"command": "true", "timeout_seconds": 5000},
             )
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_args is not None
+        kwargs: dict[str, Any] = dict(stub_registry.exec.await_args.kwargs)
         assert kwargs["timeout_seconds"] == 600
 
     async def test_default_to_per_env_ceiling_when_unspecified(
@@ -222,7 +228,8 @@ class TestPerEnvTimeoutCeiling:
             return_value=600,
         ):
             await bash_handler("sess_01TEST", {"command": "true"})
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_args is not None
+        kwargs: dict[str, Any] = dict(stub_registry.exec.await_args.kwargs)
         assert kwargs["timeout_seconds"] == 600
 
 
@@ -236,7 +243,7 @@ class TestExecRaisedReconcileSuppression:
         exec_error = RuntimeError("container died")
         reconcile_error = RuntimeError("reconcile failed too")
 
-        stub_registry.exec.side_effect = exec_error  # type: ignore[attr-defined]
+        stub_registry.exec.side_effect = exec_error
 
         with (
             patch(

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -28,7 +28,7 @@ def _echo(
 ) -> MemoryStoreResourceEcho:
     return MemoryStoreResourceEcho(
         memory_store_id=store_id,
-        access=access,  # type: ignore[arg-type]
+        access=access,
         instructions="",
         name=name,
         description="",
@@ -268,6 +268,7 @@ class TestReconcile:
 
         assert warnings == []
         mock_create.assert_awaited_once()
+        assert mock_create.await_args is not None
         call_kwargs = mock_create.await_args.kwargs
         assert call_kwargs["store_id"] == STORE_A
         assert call_kwargs["path"] == "/new.md"
@@ -316,6 +317,7 @@ class TestReconcile:
 
         assert warnings == []
         mock_update.assert_awaited_once()
+        assert mock_update.await_args is not None
         call_kwargs = mock_update.await_args.kwargs
         assert call_kwargs["precondition_sha256"] == db_sha
         assert call_kwargs["new_content"] == new_content
@@ -356,6 +358,7 @@ class TestReconcile:
 
         assert warnings == []
         mock_delete.assert_awaited_once()
+        assert mock_delete.await_args is not None
         call_kwargs = mock_delete.await_args.kwargs
         assert call_kwargs["store_id"] == STORE_A
         assert call_kwargs["memory_id"] == fake_memory.id

--- a/tests/unit/test_channels_focal.py
+++ b/tests/unit/test_channels_focal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 from aios.harness.channels import (
     FOCAL_CHANNEL_META_KEY,
@@ -22,7 +23,7 @@ def _evt(
     orig: str | None = None,
     focal_at: str | None = None,
     content: str = "hi",
-    data: dict | None = None,
+    data: dict[str, Any] | None = None,
 ) -> Event:
     if data is None:
         data = {}

--- a/tests/unit/test_completion_finish_reason.py
+++ b/tests/unit/test_completion_finish_reason.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import litellm
 import pytest
 
 from aios.harness import completion
@@ -130,13 +131,13 @@ class TestStreamStickyContentFilter:
         async def fake_acompletion(**_kwargs: object) -> _FakeStream:
             return _FakeStream(chunks)
 
-        monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
-        monkeypatch.setattr(completion.litellm, "stream_chunk_builder", _clobbered_builder("stop"))
+        monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+        monkeypatch.setattr(litellm, "stream_chunk_builder", _clobbered_builder("stop"))
 
         _msg, _usage, _cost, finish_reason = await completion.stream_litellm(
             model="anthropic/claude-fable-5",
             messages=[{"role": "user", "content": "hi"}],
-            pool=_StubPool(),  # type: ignore[arg-type]
+            pool=_StubPool(),
             session_id="sess_refusal",
         )
         # Without the sticky-capture this would be "stop" (the clobbered value).
@@ -156,13 +157,13 @@ class TestStreamStickyContentFilter:
         async def fake_acompletion(**_kwargs: object) -> _FakeStream:
             return _FakeStream(chunks)
 
-        monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
-        monkeypatch.setattr(completion.litellm, "stream_chunk_builder", _clobbered_builder("stop"))
+        monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+        monkeypatch.setattr(litellm, "stream_chunk_builder", _clobbered_builder("stop"))
 
         _msg, _usage, _cost, finish_reason = await completion.stream_litellm(
             model="anthropic/claude-fable-5",
             messages=[{"role": "user", "content": "hi"}],
-            pool=_StubPool(),  # type: ignore[arg-type]
+            pool=_StubPool(),
             session_id="sess_ok",
         )
         assert finish_reason == "stop"

--- a/tests/unit/test_completion_prompt_cache_key.py
+++ b/tests/unit/test_completion_prompt_cache_key.py
@@ -21,6 +21,7 @@ adapter).
 
 from __future__ import annotations
 
+import litellm
 import pytest
 
 from aios.harness import completion
@@ -62,7 +63,7 @@ async def test_call_litellm_openai_path_sends_prompt_cache_key(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="openai/gpt-5.5",
@@ -97,9 +98,9 @@ async def test_stream_litellm_openai_path_sends_prompt_cache_key(
         captured.update(kwargs)
         return _EmptyResponse()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
     monkeypatch.setattr(
-        completion.litellm,
+        litellm,
         "stream_chunk_builder",
         lambda chunks: {
             "usage": {},
@@ -112,7 +113,7 @@ async def test_stream_litellm_openai_path_sends_prompt_cache_key(
     await completion.stream_litellm(
         model="openai/gpt-5.5",
         messages=[{"role": "user", "content": "hi"}],
-        pool=_StubPool(),  # type: ignore[arg-type]
+        pool=_StubPool(),
         session_id="sess_xyz789",
     )
 
@@ -143,7 +144,7 @@ async def test_call_litellm_openrouter_openai_route_sends_prompt_cache_key(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="openrouter/openai/gpt-4o",
@@ -173,7 +174,7 @@ async def test_call_litellm_azure_path_sends_prompt_cache_key(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="azure/gpt-4o",
@@ -204,7 +205,7 @@ async def test_call_litellm_openrouter_non_openai_route_omits_prompt_cache_key(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="openrouter/anthropic/claude-3-5-sonnet",
@@ -236,7 +237,7 @@ async def test_call_litellm_anthropic_path_omits_prompt_cache_key(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="anthropic/claude-opus-4-6",
@@ -264,7 +265,7 @@ async def test_call_litellm_openai_path_session_id_optional(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="openai/gpt-5.5",
@@ -294,7 +295,7 @@ async def test_call_litellm_extra_overrides_prompt_cache_key(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="openai/gpt-5.5",
@@ -327,7 +328,7 @@ async def test_call_litellm_openai_preserves_agent_extra_body_siblings(
         captured.update(kwargs)
         return _ok_response()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="openai/gpt-5.5",

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -14,6 +14,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
 
+import litellm
 import pytest
 
 from aios.harness import completion
@@ -95,13 +96,13 @@ async def test_stream_litellm_raises_timeout_on_stalled_stream(
     async def fake_acompletion(**kwargs: object) -> _StallingResponse:
         return _StallingResponse()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     with pytest.raises(TimeoutError):
         await completion.stream_litellm(
             model="anthropic/claude-sonnet-4-6",
             messages=[{"role": "user", "content": "ping"}],
-            pool=_StubPool(),  # type: ignore[arg-type]
+            pool=_StubPool(),
             session_id="sess_test",
         )
 
@@ -118,9 +119,9 @@ async def test_stream_litellm_long_ttft_succeeds_when_inter_chunk_is_fast(
     async def fake_acompletion(**kwargs: object) -> AsyncIterator[object]:
         return _slow_first_chunk_response(ttft_delay_s=0.1)
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
     monkeypatch.setattr(
-        completion.litellm,
+        litellm,
         "stream_chunk_builder",
         lambda chunks: {
             "usage": {},
@@ -131,7 +132,7 @@ async def test_stream_litellm_long_ttft_succeeds_when_inter_chunk_is_fast(
     message, _, _, _ = await completion.stream_litellm(
         model="anthropic/claude-sonnet-4-6",
         messages=[{"role": "user", "content": "ping"}],
-        pool=_StubPool(),  # type: ignore[arg-type]
+        pool=_StubPool(),
         session_id="sess_test",
     )
 
@@ -157,9 +158,9 @@ async def test_stream_litellm_passes_timeout_kwargs(
         captured.update(kwargs)
         return _EmptyResponse()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
     monkeypatch.setattr(
-        completion.litellm,
+        litellm,
         "stream_chunk_builder",
         lambda chunks: {
             "usage": {},
@@ -170,7 +171,7 @@ async def test_stream_litellm_passes_timeout_kwargs(
     await completion.stream_litellm(
         model="anthropic/claude-sonnet-4-6",
         messages=[{"role": "user", "content": "ping"}],
-        pool=_StubPool(),  # type: ignore[arg-type]
+        pool=_StubPool(),
         session_id="sess_test",
     )
 
@@ -209,7 +210,7 @@ async def test_extra_overrides_default_timeout(
             usage={},
         )
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
 
     await completion.call_litellm(
         model="anthropic/claude-sonnet-4-6",
@@ -256,13 +257,13 @@ async def test_stream_litellm_tolerates_empty_choices_chunk(
             "choices": [{"message": {"role": "assistant", "content": "hello"}}],
         }
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
-    monkeypatch.setattr(completion.litellm, "stream_chunk_builder", fake_builder)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "stream_chunk_builder", fake_builder)
 
     message, _, _, _ = await completion.stream_litellm(
         model="openrouter/anthropic/claude-sonnet-4-6",
         messages=[{"role": "user", "content": "ping"}],
-        pool=_StubPool(),  # type: ignore[arg-type]
+        pool=_StubPool(),
         session_id="sess_test",
     )
 
@@ -303,7 +304,7 @@ async def test_stream_litellm_raises_typed_error_on_zero_chunks(
     async def fake_acompletion(**_kwargs: object) -> _EmptyResponse:
         return _EmptyResponse()
 
-    monkeypatch.setattr(completion.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
     # Intentionally do NOT patch ``stream_chunk_builder`` — we want the
     # real-world behavior where it returns ``None`` for an empty chunk list.
     # (Verified: ``litellm.stream_chunk_builder(chunks=[])`` returns None.)
@@ -312,7 +313,7 @@ async def test_stream_litellm_raises_typed_error_on_zero_chunks(
         await completion.stream_litellm(
             model="anthropic/claude-sonnet-4-6",
             messages=[{"role": "user", "content": "ping"}],
-            pool=_StubPool(),  # type: ignore[arg-type]
+            pool=_StubPool(),
             session_id="sess_test",
         )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,7 +29,7 @@ def test_workspace_root_must_be_absolute(tmp_path: Path, monkeypatch: pytest.Mon
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "./workspaces")
 
     with pytest.raises(ValidationError, match="must be an absolute path"):
-        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+        Settings(_env_file=(str(secrets),))
 
 
 def test_workspace_root_error_mentions_tilde(
@@ -51,7 +51,7 @@ def test_workspace_root_error_mentions_tilde(
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "~/aios/workspaces")
 
     with pytest.raises(ValidationError, match=r"does not expand '~'"):
-        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+        Settings(_env_file=(str(secrets),))
 
 
 def test_workspace_root_accepts_absolute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -62,7 +62,7 @@ def test_workspace_root_accepts_absolute(tmp_path: Path, monkeypatch: pytest.Mon
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.setenv("AIOS_WORKSPACE_ROOT", "/var/lib/test")
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.workspace_root == Path("/var/lib/test")
 
 
@@ -76,7 +76,7 @@ def test_workspace_root_default_is_absolute(
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_WORKSPACE_ROOT", raising=False)
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.workspace_root.is_absolute()
 
 
@@ -94,7 +94,7 @@ def test_github_clone_session_timeout_default(
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", raising=False)
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.github_clone_session_timeout_seconds == 30.0
 
 
@@ -110,7 +110,7 @@ def test_github_clone_cache_timeout_default(
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_GITHUB_CLONE_CACHE_TIMEOUT_SECONDS", raising=False)
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.github_clone_cache_timeout_seconds == 300.0
 
 
@@ -128,7 +128,7 @@ def test_github_clone_session_timeout_below_step_budget(
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", raising=False)
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.github_clone_session_timeout_seconds < _JOB_TIMEOUT_S
 
 
@@ -142,7 +142,7 @@ def test_github_clone_session_timeout_env_override(
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.setenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", "7")
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.github_clone_session_timeout_seconds == 7.0
 
 
@@ -163,7 +163,7 @@ def test_github_clone_session_timeout_rejects_above_step_budget(
     monkeypatch.setenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", "400")
 
     with pytest.raises(ValidationError, match="must be strictly less than"):
-        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+        Settings(_env_file=(str(secrets),))
 
 
 def test_github_clone_session_timeout_mirror_matches_harness_constant(
@@ -190,7 +190,7 @@ def test_sandbox_disk_bytes_default_is_none(
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_SANDBOX_DISK_BYTES", raising=False)
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.sandbox_disk_bytes is None
 
 
@@ -202,7 +202,7 @@ def test_sandbox_disk_bytes_env_override(tmp_path: Path, monkeypatch: pytest.Mon
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.setenv("AIOS_SANDBOX_DISK_BYTES", str(4 * 1024 * 1024 * 1024))
 
-    s = Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+    s = Settings(_env_file=(str(secrets),))
     assert s.sandbox_disk_bytes == 4 * 1024 * 1024 * 1024
 
 
@@ -221,4 +221,4 @@ def test_sandbox_disk_bytes_rejects_below_floor(
     monkeypatch.setenv("AIOS_SANDBOX_DISK_BYTES", "1024")
 
     with pytest.raises(ValidationError):
-        Settings(_env_file=(str(secrets),))  # type: ignore[call-arg]
+        Settings(_env_file=(str(secrets),))

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -428,7 +428,7 @@ class TestTimezoneRendering:
 # ─── monotonicity ──────────────────────────────────────────────────────────
 
 
-def _assert_prefix(short: list[dict], long: list[dict]) -> None:
+def _assert_prefix(short: list[dict[str, Any]], long: list[dict[str, Any]]) -> None:
     """Assert that *short* is a message-for-message prefix of *long*."""
     assert len(short) <= len(long), (
         f"short ({len(short)} msgs) is longer than long ({len(long)} msgs)"
@@ -445,7 +445,7 @@ class TestMonotonicity:
     cache stable between successive inference calls."""
 
     @staticmethod
-    def _build(events: list[Event]) -> list[dict]:
+    def _build(events: list[Event]) -> list[dict[str, Any]]:
         return build_messages(
             events,
             system_prompt=None,
@@ -635,7 +635,7 @@ class TestMonotonicity:
         # The tail block mutates per step, so compare prefixes only up to
         # (but not including) the trailing user turn that carries it —
         # whether standalone or merged into the preceding inbound.
-        def _strip_tail(msgs: list[dict]) -> list[dict]:
+        def _strip_tail(msgs: list[dict[str, Any]]) -> list[dict[str, Any]]:
             for i in range(len(msgs) - 1, -1, -1):
                 m = msgs[i]
                 if m.get("role") == "user" and "━━━ Channels ━━━" in str(m.get("content", "")):
@@ -1616,7 +1616,7 @@ class TestMergeAdjacentUserMessages:
 
     def test_tool_result_between_users_is_not_merged(self) -> None:
         """Adjacent means *consecutive same-role*. Tool results break the run."""
-        msgs = [
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": "one"},
             {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
             {"role": "tool", "tool_call_id": "a", "content": "r"},
@@ -1625,7 +1625,7 @@ class TestMergeAdjacentUserMessages:
         assert merge_adjacent_user_messages(msgs) == msgs
 
     def test_three_consecutive_users_merge_to_one(self) -> None:
-        msgs = [
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": "a"},
             {"role": "user", "content": "b"},
             {"role": "user", "content": "c"},
@@ -1641,7 +1641,7 @@ class TestMergeAdjacentUserMessages:
             {"type": "text", "text": "second"},
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
         ]
-        msgs = [
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": a_blocks},
             {"role": "user", "content": b_blocks},
         ]
@@ -1656,7 +1656,7 @@ class TestMergeAdjacentUserMessages:
             {"type": "text", "text": "see this"},
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
         ]
-        msgs = [
+        msgs: list[dict[str, Any]] = [
             {"role": "user", "content": "look:"},
             {"role": "user", "content": list_blocks},
         ]

--- a/tests/unit/test_edit_handler.py
+++ b/tests/unit/test_edit_handler.py
@@ -93,7 +93,7 @@ class TestIdenticalStrings:
     async def test_identical_old_and_new_returns_error(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses()  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses()
         result = await edit_handler(
             "sess_01TEST",
             {"path": "/workspace/a.txt", "old_string": "a", "new_string": "a"},
@@ -101,14 +101,14 @@ class TestIdenticalStrings:
         assert "error" in result
         assert "identical" in result["error"]
         # Container was never touched — guard short-circuits before cat.
-        stub_registry.exec.assert_not_awaited()  # type: ignore[attr-defined]
+        stub_registry.exec.assert_not_awaited()
 
 
 class TestStrictMatching:
     async def test_not_found_returns_error_with_retry_hint(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(_ok("actual file content\n"))  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(_ok("actual file content\n"))
         result = await edit_handler(
             "sess_01TEST",
             {
@@ -121,12 +121,12 @@ class TestStrictMatching:
         assert "not found" in result["error"]
         assert "read tool" in result["error"]
         # Only the read happened; no write-back because we errored out.
-        assert stub_registry.exec.await_count == 1  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_count == 1
 
     async def test_multiple_matches_requires_replace_all(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(_ok("foo\nbar\nfoo\nfoo\n"))  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(_ok("foo\nbar\nfoo\nfoo\n"))
         result = await edit_handler(
             "sess_01TEST",
             {
@@ -137,12 +137,12 @@ class TestStrictMatching:
         )
         assert "error" in result
         assert result["matches"] == 3
-        assert stub_registry.exec.await_count == 1  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_count == 1
 
     async def test_unique_match_replaces_and_writes_back(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(
             _ok("hello world\n"),  # cat response
             _ok(""),  # write-back response
         )
@@ -161,12 +161,12 @@ class TestStrictMatching:
         assert "-hello world" in result["diff"]
         assert "+goodbye world" in result["diff"]
         # Two run_command calls: cat and base64 write-back
-        assert stub_registry.exec.await_count == 2  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_count == 2
 
     async def test_write_back_uses_modified_content(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(
             _ok("alpha beta gamma\n"),
             _ok(""),
         )
@@ -178,7 +178,7 @@ class TestStrictMatching:
                 "new_string": "BETA",
             },
         )
-        write_cmd: str = stub_registry.exec.await_args_list[1].args[1]  # type: ignore[attr-defined]
+        write_cmd: str = stub_registry.exec.await_args_list[1].args[1]
         expected_b64 = base64.b64encode(b"alpha BETA gamma\n").decode("ascii")
         assert expected_b64 in write_cmd
         # shlex.quote leaves simple paths unquoted.
@@ -187,7 +187,7 @@ class TestStrictMatching:
     async def test_replace_all_replaces_every_occurrence(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(
             _ok("foo\nbar\nfoo\nfoo\n"),
             _ok(""),
         )
@@ -202,7 +202,7 @@ class TestStrictMatching:
         )
         assert "error" not in result
         assert result["replaced"] == 3
-        write_cmd: str = stub_registry.exec.await_args_list[1].args[1]  # type: ignore[attr-defined]
+        write_cmd: str = stub_registry.exec.await_args_list[1].args[1]
         expected_b64 = base64.b64encode(b"FOO\nbar\nFOO\nFOO\n").decode("ascii")
         assert expected_b64 in write_cmd
 
@@ -215,7 +215,7 @@ class TestPerEnvTimeoutCeiling:
     async def test_both_execs_use_resolved_ceiling(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(
             _ok("alpha beta gamma\n"),
             _ok(""),
         )
@@ -228,7 +228,7 @@ class TestPerEnvTimeoutCeiling:
                 "sess_01TEST",
                 {"path": "/workspace/a.txt", "old_string": "beta", "new_string": "BETA"},
             )
-        for call in stub_registry.exec.await_args_list:  # type: ignore[attr-defined]
+        for call in stub_registry.exec.await_args_list:
             assert call.kwargs["timeout_seconds"] == 600
 
 
@@ -236,9 +236,7 @@ class TestErrorPaths:
     async def test_cat_failure_returns_error_dict(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(  # type: ignore[method-assign]
-            _err(1, "cat: /nope: No such file or directory\n")
-        )
+        stub_registry.exec = _script_responses(_err(1, "cat: /nope: No such file or directory\n"))
         result = await edit_handler(
             "sess_01TEST",
             {
@@ -253,7 +251,7 @@ class TestErrorPaths:
     async def test_write_back_failure_returns_error_dict(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = _script_responses(  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(
             _ok("hello\n"),
             _err(1, "bash: /ro/a.txt: Permission denied\n"),
         )
@@ -292,7 +290,7 @@ class TestErrorPaths:
             timed_out=False,
             truncated=True,
         )
-        stub_registry.exec = _script_responses(truncated_result, _ok(""))  # type: ignore[method-assign]
+        stub_registry.exec = _script_responses(truncated_result, _ok(""))
         result = await edit_handler(
             "sess_01TEST",
             {
@@ -312,4 +310,4 @@ class TestErrorPaths:
             f"{result['error']!r}."
         )
         # Critically, no write-back was attempted.
-        assert stub_registry.exec.await_count == 1  # type: ignore[attr-defined]
+        assert stub_registry.exec.await_count == 1

--- a/tests/unit/test_git_proxy.py
+++ b/tests/unit/test_git_proxy.py
@@ -72,8 +72,8 @@ async def proxy_with_mock_upstream() -> AsyncIterator[tuple[GitProxy, list[httpx
     # transport. This is private-attr surgery, but we deliberately want
     # to test that the proxy uses its client correctly without requiring
     # network egress.
-    await p._client.aclose()  # type: ignore[has-type]
-    p._client = httpx.AsyncClient(transport=_make_mock_transport(captured))  # type: ignore[has-type]
+    await p._client.aclose()
+    p._client = httpx.AsyncClient(transport=_make_mock_transport(captured))
     await p.start()
     try:
         yield p, captured
@@ -195,8 +195,8 @@ class TestUpstreamFailure:
             raise httpx.ConnectError("simulated network error")
 
         p = GitProxy({"acme/foo": "ghp_TEST"})
-        await p._client.aclose()  # type: ignore[has-type]
-        p._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))  # type: ignore[has-type]
+        await p._client.aclose()
+        p._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         await p.start()
         try:
             async with httpx.AsyncClient() as client:

--- a/tests/unit/test_glob_handler.py
+++ b/tests/unit/test_glob_handler.py
@@ -90,18 +90,18 @@ class TestHappyPath:
 
     async def test_default_path(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await glob_handler("sess_01TEST", {"pattern": "*.py"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "/workspace" in cmd
         assert "rg --files" in cmd
         assert "*.py" in cmd
 
     async def test_custom_path(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await glob_handler("sess_01TEST", {"pattern": "*.txt", "path": "/workspace/docs"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "/workspace/docs" in cmd
 
     async def test_empty_results(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
-        stub_registry.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_registry.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=0,
                 stdout="",
@@ -118,7 +118,7 @@ class TestErrorPath:
     async def test_find_failure_returns_error_dict(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_registry.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=2,
                 stdout="",
@@ -149,7 +149,7 @@ class TestErrorPath:
         ("Sibling bug exists in tools/glob.py").
         """
         await glob_handler("sess_01TEST", {"pattern": "*.py"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "pipefail" in cmd, (
             f"cmd must enable ``pipefail`` so a failing ``rg`` (e.g., "
             f"invalid glob pattern, missing path) propagates through the "
@@ -171,5 +171,5 @@ class TestPerEnvTimeoutCeiling:
             return_value=600,
         ):
             await glob_handler("sess_01TEST", {"pattern": "*.py"})
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs
         assert kwargs["timeout_seconds"] == 600

--- a/tests/unit/test_grep_handler.py
+++ b/tests/unit/test_grep_handler.py
@@ -96,20 +96,20 @@ class TestHappyPath:
 
     async def test_default_path(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "rg " in cmd
         assert "/workspace" in cmd
 
     async def test_include_flag(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "include": "*.py"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "--glob" in cmd
         assert "*.py" in cmd
 
     async def test_no_matches_returns_empty_string(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_registry.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=1,
                 stdout="",
@@ -127,58 +127,58 @@ class TestOutputModes:
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "output_mode": "files_with_matches"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert " -l " in cmd
 
     async def test_count_mode(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "output_mode": "count"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert " -c " in cmd
 
     async def test_content_mode_has_line_numbers(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "output_mode": "content"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert " -n " in cmd
 
 
 class TestAdvancedFlags:
     async def test_context_lines(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "context": 3})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "-C 3" in cmd
 
     async def test_case_insensitive(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "case_insensitive": True})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert " -i " in cmd
 
     async def test_multiline(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "multiline": True})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "-U" in cmd
         assert "--multiline-dotall" in cmd
 
     async def test_file_type_filter(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "file_type": "py"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "--type" in cmd
         assert "py" in cmd
 
     async def test_custom_limit(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello", "limit": 100})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "head -100" in cmd
 
     async def test_default_limit_250(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "head -250" in cmd
 
     async def test_max_columns_flag(self, stub_registry: Any, stub_handle: SandboxHandle) -> None:
         await grep_handler("sess_01TEST", {"pattern": "hello"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "--max-columns=500" in cmd
 
 
@@ -186,7 +186,7 @@ class TestErrorPath:
     async def test_grep_failure_returns_error_dict(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_registry.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=2,
                 stdout="",
@@ -222,7 +222,7 @@ class TestErrorPath:
         error dict the model can act on.
         """
         await grep_handler("sess_01TEST", {"pattern": "hello"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "pipefail" in cmd, (
             f"cmd must enable ``pipefail`` so a failing ``rg`` (e.g., invalid "
             f"regex, missing path) propagates through the ``| head -N`` to "
@@ -245,5 +245,5 @@ class TestPerEnvTimeoutCeiling:
             return_value=600,
         ):
             await grep_handler("sess_01TEST", {"pattern": "hello"})
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs
         assert kwargs["timeout_seconds"] == 600

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -4,13 +4,20 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from aios.models.agents import HttpPermissionPolicy, HttpRouteSpec, HttpServerSpec, ToolSpec
+from aios.models.agents import (
+    Agent,
+    AgentVersion,
+    HttpPermissionPolicy,
+    HttpRouteSpec,
+    HttpServerSpec,
+    ToolSpec,
+)
 from aios.tools.http_request import (
     _classify_permission,
     _decode_body,
@@ -26,8 +33,8 @@ _REAL_ASYNC_CLIENT = httpx.AsyncClient
 
 def _agent(
     *, http_servers: list[HttpServerSpec], tools: list[ToolSpec] | None = None
-) -> SimpleNamespace:
-    return SimpleNamespace(http_servers=http_servers, tools=tools or [])
+) -> Agent | AgentVersion:
+    return cast(Agent | AgentVersion, SimpleNamespace(http_servers=http_servers, tools=tools or []))
 
 
 def _server(
@@ -49,7 +56,7 @@ def _route(
     policy: str | None = None,
     description: str | None = None,
 ) -> HttpRouteSpec:
-    permission = HttpPermissionPolicy(type=policy) if policy else None  # type: ignore[arg-type]
+    permission = HttpPermissionPolicy(type=policy) if policy else None
     return HttpRouteSpec(
         path_pattern=pattern,
         enabled=enabled,
@@ -119,7 +126,7 @@ class TestClassifyToolCallArguments:
     ``function.arguments`` (providers differ on which shape they emit)."""
 
     @staticmethod
-    def _make_agent() -> SimpleNamespace:
+    def _make_agent() -> Agent | AgentVersion:
         return _agent(
             http_servers=[_server(routes=[_route("/lights/*", policy="always_allow")])],
             tools=[ToolSpec(type="http_request")],
@@ -198,7 +205,7 @@ def _stub_runtime() -> Iterator[SimpleNamespace]:
         yield SimpleNamespace(pool=pool, crypto_box=crypto_box)
 
 
-def _patch_load_agent(agent: SimpleNamespace) -> Any:
+def _patch_load_agent(agent: Agent | AgentVersion) -> Any:
     return patch(
         "aios.tools.http_request._load_session_agent",
         AsyncMock(return_value=(agent, "acc_test_stub")),

--- a/tests/unit/test_management_calls_service.py
+++ b/tests/unit/test_management_calls_service.py
@@ -78,9 +78,11 @@ class TestSubmitCall:
         assert (result, is_error) == (expected, False)
         insert.assert_awaited_once()
         notify.assert_awaited_once()
+        assert notify.await_args is not None
         notified_call_id = notify.await_args.kwargs["call_id"]
         assert notified_call_id.startswith("mgmt_")
         assert notify.await_args.kwargs["connector"] == "signal"
+        assert insert.await_args is not None
         assert insert.await_args.kwargs["call_id"] == notified_call_id
 
     @pytest.mark.asyncio

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -175,6 +175,7 @@ class TestResolveAuthForTargetUrl:
             )
 
         refresh_mock.assert_awaited_once()
+        assert refresh_mock.await_args is not None
         kwargs = refresh_mock.await_args.kwargs
         assert kwargs["vault_id"] == "vlt_s1"
         assert kwargs["target_url"] == "https://mcp.example.com"

--- a/tests/unit/test_mcp_dispatch_spec_headers.py
+++ b/tests/unit/test_mcp_dispatch_spec_headers.py
@@ -59,6 +59,7 @@ class TestMcpDispatchSpecHeaders:
             )
 
         call_mock.assert_awaited_once()
+        assert call_mock.await_args is not None
         assert call_mock.await_args.kwargs.get("spec_headers") == {"X-MCP-Toolsets": "issues"}
         # The resolved URL comes from the spec, not a bare string map value.
         assert call_mock.await_args.args[0] == "https://mcp.github/"

--- a/tests/unit/test_memory_intercept.py
+++ b/tests/unit/test_memory_intercept.py
@@ -6,6 +6,8 @@ Pure in-memory: we install a synthetic mount cache via
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import pytest
 
 from aios.harness import runtime
@@ -18,7 +20,7 @@ SESSION_ID = "sesn_01ABCDEFGHJKMNPQRSTVWXYZ12"
 def _echo(name: str, access: str = "read_write") -> MemoryStoreResourceEcho:
     return MemoryStoreResourceEcho(
         memory_store_id=f"memstore_{name}",
-        access=access,  # type: ignore[arg-type]
+        access=access,
         instructions="",
         name=name,
         description="",
@@ -27,7 +29,7 @@ def _echo(name: str, access: str = "read_write") -> MemoryStoreResourceEcho:
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache() -> None:
+def _clear_cache() -> Generator[None]:
     runtime.clear_session_memory_mounts(SESSION_ID)
     yield
     runtime.clear_session_memory_mounts(SESSION_ID)

--- a/tests/unit/test_memory_stores_block.py
+++ b/tests/unit/test_memory_stores_block.py
@@ -18,7 +18,7 @@ def _echo(
 ) -> MemoryStoreResourceEcho:
     return MemoryStoreResourceEcho(
         memory_store_id=f"memstore_{name}",
-        access=access,  # type: ignore[arg-type]
+        access=access,
         instructions=instructions,
         name=name,
         description=description,

--- a/tests/unit/test_read_handler.py
+++ b/tests/unit/test_read_handler.py
@@ -102,8 +102,8 @@ class TestHappyPath:
             "sess_01TEST",
             {"path": "/workspace/a.txt", "offset": 5, "limit": 10},
         )
-        stub_registry.exec.assert_awaited_once()  # type: ignore[attr-defined]
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        stub_registry.exec.assert_awaited_once()
+        cmd: str = stub_registry.exec.await_args.args[1]
         # shlex.quote leaves simple paths unquoted; just assert substring presence.
         assert "cat -n --" in cmd
         assert "/workspace/a.txt" in cmd
@@ -115,14 +115,14 @@ class TestHappyPath:
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
         await read_handler("sess_01TEST", {"path": "/workspace/a.txt"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "1,2000p" in cmd
 
     async def test_quotes_paths_with_spaces(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
         await read_handler("sess_01TEST", {"path": "/workspace/a file.txt"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "'/workspace/a file.txt'" in cmd
 
 
@@ -141,7 +141,7 @@ class TestPerEnvTimeoutCeiling:
             await read_handler("sess_01TEST", {"path": "/workspace/a.txt"})
         # Only the text-read exec fires for a missing local path (the image
         # probe reads the bind-mount host path directly, no exec).
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs
         assert kwargs["timeout_seconds"] == 600
 
 
@@ -149,7 +149,7 @@ class TestErrorPath:
     async def test_cat_failure_returns_error_dict(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_registry.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=1,
                 stdout="",
@@ -159,6 +159,7 @@ class TestErrorPath:
             )
         )
         result = await read_handler("sess_01TEST", {"path": "/nope"})
+        assert isinstance(result, dict)
         assert "error" in result
         assert "No such file" in result["error"]
         assert result["path"] == "/nope"
@@ -182,7 +183,7 @@ class TestErrorPath:
         previous test expects.
         """
         await read_handler("sess_01TEST", {"path": "/workspace/a.txt"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "pipefail" in cmd, (
             f"cmd must enable ``pipefail`` so a failing ``cat`` (e.g., missing "
             f"file) propagates through the ``| sed -n ...`` to the overall "

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -272,7 +272,7 @@ class TestImageBranch:
         with one combined stat+base64 invocation."""
         stub_get_session_model.value = "model/vision"
         b64_payload = base64.b64encode(b"otherbytes").decode()
-        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_runtime.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=0,
                 stdout=f"10\n{b64_payload}",
@@ -318,7 +318,7 @@ class TestImagePathTraversalAttack:
 
         sandbox_payload = b"sandbox-side-content"
         b64 = base64.b64encode(sandbox_payload).decode()
-        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_runtime.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=0,
                 stdout=f"{len(sandbox_payload)}\n{b64}",
@@ -336,7 +336,7 @@ class TestImagePathTraversalAttack:
             assert b64_secret not in url
         elif isinstance(result, dict):
             assert b64_secret not in str(result)
-        assert stub_runtime.exec.call_count == 1  # type: ignore[attr-defined]
+        assert stub_runtime.exec.call_count == 1
 
     async def test_attachments_traversal_does_not_return_host_bytes(
         self,
@@ -350,7 +350,7 @@ class TestImagePathTraversalAttack:
         (temp_workspace_root / "leak.png").write_bytes(host_secret)
         session_attachments_dir("sess_01TEST").mkdir(parents=True, exist_ok=True)
 
-        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_runtime.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=0,
                 stdout=f"{4}\n{base64.b64encode(b'safe').decode()}",
@@ -388,7 +388,7 @@ class TestImagePathTraversalAttack:
         ws.mkdir(parents=True, exist_ok=True)
         (ws / "sneaky.jpg").symlink_to(outside)
 
-        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_runtime.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=0,
                 stdout=f"{3}\n{base64.b64encode(b'sbx').decode()}",
@@ -406,7 +406,7 @@ class TestImagePathTraversalAttack:
             assert b64_secret not in url
         elif isinstance(result, dict):
             assert b64_secret not in str(result)
-        assert stub_runtime.exec.call_count == 1  # type: ignore[attr-defined]
+        assert stub_runtime.exec.call_count == 1
 
 
 class TestExtensionlessImageDetection:
@@ -489,7 +489,7 @@ class TestExtensionlessImageDetection:
         """A non-image-extension TEXT file reads as text: the local probe sniffs to None and the read falls through to the one-exec text path."""
         stub_get_session_model.value = "model/vision"
         _stage_workspace_image("sess_01TEST", "notes.dat", b"plain text, no magic header")
-        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_runtime.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=0, stdout="     1\thello\n", stderr="", timed_out=False, truncated=False
             )
@@ -509,7 +509,7 @@ class TestExtensionlessImageDetection:
         _stage_workspace_image(
             "sess_01TEST", "random_name", b"just some text, definitely not an image"
         )
-        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_runtime.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=0, stdout="     1\thello\n", stderr="", timed_out=False, truncated=False
             )
@@ -543,7 +543,7 @@ class TestExtensionlessImageDetection:
         stub_get_session_model.value = "model/vision"
         png_head = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
         full = png_head + b"-more-png-bytes"
-        stub_runtime.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_runtime.exec = AsyncMock(
             side_effect=[
                 CommandResult(
                     exit_code=0,

--- a/tests/unit/test_reparent_connection.py
+++ b/tests/unit/test_reparent_connection.py
@@ -286,6 +286,7 @@ class TestReparentConnection:
 
         assert result is updated
         reparent_query.assert_awaited_once()
+        assert reparent_query.await_args is not None
         kwargs = reparent_query.await_args.kwargs
         assert kwargs["destination_account_id"] == "acc_dest"
         assert kwargs["connection_id"] == "conn_x"
@@ -400,6 +401,7 @@ class TestReparentConnection:
             )
 
         reparent_query.assert_awaited_once()
+        assert reparent_query.await_args is not None
         kwargs = reparent_query.await_args.kwargs
         rekeyed = kwargs["secrets_blob"]
         assert rekeyed is not None

--- a/tests/unit/test_run_tools.py
+++ b/tests/unit/test_run_tools.py
@@ -76,8 +76,8 @@ async def test_http_request_routed_to_the_run_resolver() -> None:
 
     with (
         patch.object(run_tools, "_do_http_request", new=_fake_do),
-        patch.object(run_tools.runtime, "require_pool", return_value=object()),
-        patch.object(run_tools.runtime, "require_crypto_box", return_value=object()),
+        patch("aios.harness.runtime.require_pool", return_value=object()),
+        patch("aios.harness.runtime.require_crypto_box", return_value=object()),
         patch.object(
             run_tools,
             "resolve_auth_for_target_url_run",

--- a/tests/unit/test_sandbox_spec.py
+++ b/tests/unit/test_sandbox_spec.py
@@ -114,6 +114,7 @@ async def test_session_clone_timeout_does_not_abort_sibling_clones() -> None:
     assert returned_proxy is mock_proxy
     append_event_mock.assert_awaited_once()
     call_args = append_event_mock.await_args
+    assert call_args is not None
     payload = call_args.args[3] if len(call_args.args) >= 4 else call_args.kwargs["payload"]
     assert payload["event"] == "github_clone_failed"
     assert payload["resource_id"] == failed_echo.id

--- a/tests/unit/test_schedule_wake_handler.py
+++ b/tests/unit/test_schedule_wake_handler.py
@@ -182,6 +182,7 @@ class TestScheduleWakeHandler:
 
         mock_add_task.assert_awaited_once()
         # Inspect the spec passed to add_task.
+        assert mock_add_task.await_args is not None
         spec = mock_add_task.await_args.args[2]
         assert spec.fire_at is not None
         assert spec.schedule is None

--- a/tests/unit/test_search_events_handler.py
+++ b/tests/unit/test_search_events_handler.py
@@ -195,7 +195,7 @@ class TestFormatResults:
 
     def test_single_row(self) -> None:
         rows = [_FakeRecord({"id": "evt_01", "role": "assistant", "content_text": "Hello"})]
-        result = _format_results(rows, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)
         assert "id" in result
         assert "role" in result
         assert "assistant" in result
@@ -206,29 +206,29 @@ class TestFormatResults:
             _FakeRecord({"seq": 1, "role": "user"}),
             _FakeRecord({"seq": 2, "role": "assistant"}),
         ]
-        result = _format_results(rows, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)
         lines = result.strip().split("\n")
         assert len(lines) == 4  # header + divider + 2 data rows
 
     def test_truncated_notice(self) -> None:
         rows = [_FakeRecord({"id": "evt_01"})]
-        result = _format_results(rows, truncated=True)  # type: ignore[arg-type]
+        result = _format_results(rows, truncated=True)
         assert "truncat" in result.lower()
         assert str(MAX_ROWS) in result
 
     def test_not_truncated_no_notice(self) -> None:
         rows = [_FakeRecord({"id": "evt_01"})]
-        result = _format_results(rows, truncated=False)  # type: ignore[arg-type]
+        result = _format_results(rows, truncated=False)
         assert "truncat" not in result.lower()
 
     def test_null_values(self) -> None:
         rows = [_FakeRecord({"id": "evt_01", "role": None, "content_text": "text"})]
-        result = _format_results(rows, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)
         assert "NULL" in result
 
     def test_header_divider_format(self) -> None:
         rows = [_FakeRecord({"a": 1, "b": 2})]
-        result = _format_results(rows, False)  # type: ignore[arg-type]
+        result = _format_results(rows, False)
         lines = result.split("\n")
         assert lines[0] == "a | b"
         assert lines[1] == "-" * len("a | b")

--- a/tests/unit/test_session_read_shas.py
+++ b/tests/unit/test_session_read_shas.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+
 import pytest
 
 from aios.harness import runtime
@@ -12,7 +14,7 @@ STORE = "memstore_X"
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches() -> None:
+def _clear_caches() -> Generator[None]:
     runtime.clear_session_read_shas(SESSION_A)
     runtime.clear_session_read_shas(SESSION_B)
     yield

--- a/tests/unit/test_step_context_tail_gate.py
+++ b/tests/unit/test_step_context_tail_gate.py
@@ -14,6 +14,8 @@ companion *is* the channels tail listing.
 
 from __future__ import annotations
 
+from typing import Any
+
 from aios.harness.step_context import _agent_owes_response
 
 # Mirrors the shape of context._format_notification_marker output.
@@ -25,7 +27,7 @@ _NOTIFICATION = (
 
 class TestAgentOwesResponse:
     def test_last_message_focal_user_owes_response(self) -> None:
-        messages = [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "[received=...]\nplease respond"},
         ]
@@ -34,7 +36,7 @@ class TestAgentOwesResponse:
     def test_last_message_notification_marker_does_not_owe_response(self) -> None:
         # A non-focal 🔔 marker is a navigation prompt, not a direct stimulus —
         # keep the tail so the agent can see channel state and switch_channel.
-        messages = [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "[received=...]\nhi"},
             {"role": "assistant", "content": "."},
@@ -43,14 +45,14 @@ class TestAgentOwesResponse:
         assert _agent_owes_response(messages) is False
 
     def test_notification_marker_in_list_content_does_not_owe(self) -> None:
-        messages = [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": [{"type": "text", "text": _NOTIFICATION}]},
         ]
         assert _agent_owes_response(messages) is False
 
     def test_last_message_tool_owes_response(self) -> None:
-        messages = [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": "sys"},
             {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
             {"role": "tool", "tool_call_id": "t1", "content": "result"},
@@ -58,7 +60,7 @@ class TestAgentOwesResponse:
         assert _agent_owes_response(messages) is True
 
     def test_last_message_assistant_does_not_owe_response(self) -> None:
-        messages = [
+        messages: list[dict[str, Any]] = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "hello"},

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -29,11 +29,12 @@ def _span_events(append_event: AsyncMock) -> list[dict[str, object]]:
 
 
 def _sweep_events(append_event: AsyncMock) -> list[dict[str, object]]:
-    return [
-        payload
-        for payload in _span_events(append_event)
-        if payload.get("event", "").startswith("sweep_")
-    ]
+    result = []
+    for payload in _span_events(append_event):
+        event = payload.get("event")
+        if isinstance(event, str) and event.startswith("sweep_"):
+            result.append(payload)
+    return result
 
 
 # ─── tail site (tool_dispatch._trigger_sweep) ────────────────────────────────

--- a/tests/unit/test_switch_channel.py
+++ b/tests/unit/test_switch_channel.py
@@ -365,6 +365,7 @@ class TestRecapRendering:
             ],
         )
         out = render_reorient_block([asst], CHAN_A)
+        assert isinstance(out, str)
         # All three calls appear in the recap.
         assert '"text": "first"' in out
         assert '"text": "second"' in out
@@ -377,12 +378,14 @@ class TestRecapRendering:
     def test_fences_top_and_bottom(self) -> None:
         events = [_user(1, channel=CHAN_A, content="msg")]
         out = render_reorient_block(events, CHAN_A)
+        assert isinstance(out, str)
         assert out.startswith(f"━━━ Recap: recent messages on {CHAN_A} ━━━")
         assert out.rstrip().endswith("━━━ End recap ━━━")
 
     def test_body_lines_are_blockquoted(self) -> None:
         events = [_user(1, channel=CHAN_A, content="msg")]
         out = render_reorient_block(events, CHAN_A)
+        assert isinstance(out, str)
         # Body lines within the fences all start with "> " (or are a
         # bare ">" for blank spacing lines between blocks).
         for line in out.split("\n"):

--- a/tests/unit/test_switch_channel_handler.py
+++ b/tests/unit/test_switch_channel_handler.py
@@ -68,6 +68,7 @@ class TestPerChatLock:
         assert isinstance(result, ToolResult)
         assert result.is_error is True
         assert "focal channel is locked" in result.content
+        assert result.metadata is not None
         marker = result.metadata[SWITCH_CHANNEL_METADATA_KEY]
         assert marker == {"target": "signal/+1/chat-2", "success": False}
         # Focal-lock short-circuits before any other DB read or write.
@@ -96,6 +97,7 @@ class TestPerChatLock:
             result = await switch_channel_handler("sess_per_chat", {"channel_id": None})
 
         assert result.is_error is True
+        assert result.metadata is not None
         assert result.metadata[SWITCH_CHANNEL_METADATA_KEY] == {
             "target": None,
             "success": False,
@@ -159,6 +161,7 @@ class TestNonPerChatPathStillWorks:
             result = await switch_channel_handler("sess_normal", {"channel_id": None})
 
         assert result.is_error is False
+        assert result.metadata is not None
         assert result.metadata[SWITCH_CHANNEL_METADATA_KEY] == {
             "target": None,
             "success": True,

--- a/tests/unit/test_tool_confirmation.py
+++ b/tests/unit/test_tool_confirmation.py
@@ -15,7 +15,7 @@ def _event(seq: int, data: dict[str, Any], kind: str = "message") -> Event:
         id=f"evt_{seq}",
         session_id="sess_test",
         seq=seq,
-        kind=kind,  # type: ignore[arg-type]
+        kind=kind,
         data=data,
         created_at=datetime.now(UTC),
     )

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -25,6 +25,7 @@ from aios.errors import (
 )
 from aios.harness import tool_dispatch
 from aios.harness.tool_dispatch import _classify_tool_error, _tool_lifecycle
+from aios.services import sessions as sessions_service
 from aios.tools.bash import BashArgumentError
 from aios.tools.invoke import ToolBail, validate_arguments
 
@@ -138,7 +139,7 @@ class TestToolLifecycleEviction:
         """Run a handler that raises ``err`` through the lifecycle; the DB writes are
         stubbed. Returns ``(evict_calls, append_result_mock)``."""
         monkeypatch.setattr(
-            tool_dispatch.sessions_service,
+            sessions_service,
             "append_event",
             AsyncMock(return_value=MagicMock(id="span_1")),
         )
@@ -157,7 +158,7 @@ class TestToolLifecycleEviction:
             on_exception=evicted.append,
         ):
             raise err
-        return evicted, append_result
+        return evicted, append_result  # type: ignore[unreachable]
 
     async def test_client_error_refusal_does_not_evict(self, monkeypatch: Any) -> None:
         evicted, append_result = await self._drive(

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -6,6 +6,7 @@ via ``registry.clear()`` so tests don't poison each other.
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -24,7 +25,7 @@ async def _noop_handler(session_id: str, arguments: dict[str, Any]) -> dict[str,
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry() -> None:
+def _reset_registry() -> Generator[None]:
     """Snapshot the registry before each test and restore after.
 
     The real aios package imports ``aios.tools`` at worker startup

--- a/tests/unit/test_toolspec.py
+++ b/tests/unit/test_toolspec.py
@@ -37,7 +37,7 @@ class TestPermissionField:
 
     def test_invalid_policy_rejected(self) -> None:
         with pytest.raises(ValueError):
-            ToolSpec(type="bash", permission="always_deny")  # type: ignore[arg-type]
+            ToolSpec(type="bash", permission="always_deny")
 
 
 class TestEnabledField:

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -9,10 +9,12 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from pydantic import SecretStr
 
 from aios.crypto.vault import KEY_BYTES, NONCE_BYTES, CryptoBox, EncryptedBlob
+from aios.db import queries
 from aios.errors import CryptoDecryptError, OAuthRefreshError, ValidationError
 from aios.models.vaults import (
     TokenEndpointAuthBasic,
@@ -362,12 +364,12 @@ class TestUpdateVaultCredentialCallSite:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "get_vault_credential_with_blob",
                 AsyncMock(return_value=(existing, existing_blob)),
             ),
             patch.object(
-                vaults_service.queries,
+                queries,
                 "update_vault_credential",
                 AsyncMock(return_value=existing),
             ) as upd,
@@ -383,6 +385,7 @@ class TestUpdateVaultCredentialCallSite:
             )
 
         upd.assert_awaited_once()
+        assert upd.await_args is not None
         kwargs = upd.await_args.kwargs
         assert kwargs["display_name"] is ...
         assert kwargs["metadata"] is ...
@@ -400,12 +403,12 @@ class TestUpdateVaultCredentialCallSite:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "get_vault_credential_with_blob",
                 AsyncMock(return_value=(existing, existing_blob)),
             ),
             patch.object(
-                vaults_service.queries,
+                queries,
                 "update_vault_credential",
                 AsyncMock(return_value=existing),
             ) as upd,
@@ -420,6 +423,7 @@ class TestUpdateVaultCredentialCallSite:
                 account_id=account_id,
             )
 
+        assert upd.await_args is not None
         kwargs = upd.await_args.kwargs
         assert kwargs["display_name"] is None  # not Ellipsis — explicitly passed
 
@@ -530,11 +534,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -561,11 +565,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -594,11 +598,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -625,11 +629,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -662,11 +666,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -695,11 +699,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -731,11 +735,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -765,11 +769,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
         ):
             await refresh_credential(
                 crypto_box,
@@ -798,11 +802,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
             pytest.raises(OAuthRefreshError),
         ):
             await refresh_credential(
@@ -827,11 +831,11 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
-            patch.object(vaults_service.httpx, "AsyncClient", MagicMock(return_value=client)),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
             pytest.raises(OAuthRefreshError, match="access_token"),
         ):
             await refresh_credential(
@@ -848,7 +852,7 @@ class TestRefreshCredential:
         conn = _conn_with_transaction()
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=None),
             ),
@@ -876,7 +880,7 @@ class TestRefreshCredential:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "lock_oauth_credential_for_refresh",
                 AsyncMock(return_value=("vc_1", blob)),
             ),
@@ -972,12 +976,12 @@ class TestServiceWiringIsAccountScoped:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "get_vault_credential_with_blob",
                 AsyncMock(return_value=(_existing_credential(), blob_for_a)),
             ),
             patch.object(
-                vaults_service.queries,
+                queries,
                 "update_vault_credential",
                 AsyncMock(return_value=_existing_credential()),
             ),
@@ -1016,12 +1020,12 @@ class TestServiceWiringIsAccountScoped:
 
         with (
             patch.object(
-                vaults_service.queries,
+                queries,
                 "get_vault_credential_with_blob",
                 AsyncMock(return_value=(_existing_credential(), blob_for_a)),
             ),
             patch.object(
-                vaults_service.queries,
+                queries,
                 "update_vault_credential",
                 AsyncMock(return_value=_existing_credential()),
             ),

--- a/tests/unit/test_vault_models.py
+++ b/tests/unit/test_vault_models.py
@@ -77,23 +77,23 @@ class TestTokenEndpointAuth:
             TokenEndpointAuthPost(method="client_secret_post")  # type: ignore[call-arg]
 
     def test_discriminator_dispatches_none(self) -> None:
-        adapter = TypeAdapter(TokenEndpointAuth)
+        adapter: TypeAdapter[TokenEndpointAuth] = TypeAdapter(TokenEndpointAuth)
         v = adapter.validate_python({"method": "none"})
         assert isinstance(v, TokenEndpointAuthNone)
 
     def test_discriminator_dispatches_basic(self) -> None:
-        adapter = TypeAdapter(TokenEndpointAuth)
+        adapter: TypeAdapter[TokenEndpointAuth] = TypeAdapter(TokenEndpointAuth)
         v = adapter.validate_python({"method": "client_secret_basic", "client_secret": "shh"})
         assert isinstance(v, TokenEndpointAuthBasic)
         assert v.client_secret.get_secret_value() == "shh"
 
     def test_discriminator_dispatches_post(self) -> None:
-        adapter = TypeAdapter(TokenEndpointAuth)
+        adapter: TypeAdapter[TokenEndpointAuth] = TypeAdapter(TokenEndpointAuth)
         v = adapter.validate_python({"method": "client_secret_post", "client_secret": "shh"})
         assert isinstance(v, TokenEndpointAuthPost)
 
     def test_discriminator_rejects_unknown_method(self) -> None:
-        adapter = TypeAdapter(TokenEndpointAuth)
+        adapter: TypeAdapter[TokenEndpointAuth] = TypeAdapter(TokenEndpointAuth)
         with pytest.raises(ValidationError):
             adapter.validate_python({"method": "bogus"})
 
@@ -196,7 +196,7 @@ class TestVaultCredentialCreate:
         with pytest.raises(ValidationError):
             VaultCredentialCreate(
                 target_url="https://x.com",
-                auth_type="unknown",  # type: ignore[arg-type]
+                auth_type="unknown",
                 token=SecretStr("t"),
             )
 

--- a/tests/unit/test_wake.py
+++ b/tests/unit/test_wake.py
@@ -2,18 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from procrastinate import App
+from procrastinate.testing import InMemoryConnector
 
 from aios.services.wake import defer_wake
 
 
 @pytest.fixture(autouse=True)
-def mock_append_event() -> AsyncIterator[AsyncMock]:
+def mock_append_event() -> Generator[AsyncMock]:
     """Patch ``sessions_service.append_event`` so ``wake_deferred`` span
     emission doesn't require a real DB connection (issue #131)."""
     mock = AsyncMock()
@@ -30,7 +31,9 @@ class TestDeferRescheduleWake:
         )
         after = datetime.now(UTC)
 
-        (job,) = in_memory_app.connector.jobs.values()
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        (job,) = connector.jobs.values()
         assert job["scheduled_at"] is not None
         assert before + timedelta(seconds=5) <= job["scheduled_at"] <= after + timedelta(seconds=5)
 
@@ -40,7 +43,9 @@ class TestDeferRescheduleWake:
             MagicMock(), "sess_x", cause="reschedule", delay_seconds=5, account_id=account_id
         )
 
-        (job,) = in_memory_app.connector.jobs.values()
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        (job,) = connector.jobs.values()
         assert job["args"] == {"session_id": "sess_x", "cause": "reschedule"}
 
     async def test_targets_wake_session_task(self, in_memory_app: App) -> None:
@@ -49,7 +54,9 @@ class TestDeferRescheduleWake:
             MagicMock(), "sess_x", cause="reschedule", delay_seconds=5, account_id=account_id
         )
 
-        (job,) = in_memory_app.connector.jobs.values()
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        (job,) = connector.jobs.values()
         assert job["task_name"] == "harness.wake_session"
 
     async def test_swallows_already_enqueued(self, in_memory_app: App) -> None:
@@ -60,7 +67,9 @@ class TestDeferRescheduleWake:
         await defer_wake(
             MagicMock(), "sess_x", cause="reschedule", delay_seconds=5, account_id=account_id
         )
-        assert len(in_memory_app.connector.jobs) == 1
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        assert len(connector.jobs) == 1
 
     async def test_emits_wake_deferred_span_event(
         self, in_memory_app: App, mock_append_event: AsyncMock

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -17,6 +17,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from procrastinate import App
+from procrastinate.testing import InMemoryConnector
 
 
 class TestE2EConftestMockSignatures:
@@ -95,6 +96,7 @@ class TestWakeDeferredEvent:
         causes = [call.args[3]["cause"] for call in mock_append.await_args_list]
         assert causes == ["message", "sweep", "tool_confirmation"]
         # Procrastinate coalesced 2/3 but the third cause still wrote its span.
+        assert isinstance(in_memory_app.connector, InMemoryConnector)
         assert len(in_memory_app.connector.jobs) == 1
 
     async def test_defer_wake_with_reschedule_cause_emits_reschedule_span(

--- a/tests/unit/test_wake_locks.py
+++ b/tests/unit/test_wake_locks.py
@@ -11,13 +11,14 @@ real ``session_id`` per call to ``configure_task``.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from procrastinate import App
 from procrastinate.testing import InMemoryConnector
 
 
-def _job_rows(app: App) -> list[dict]:
+def _job_rows(app: App) -> list[dict[str, Any]]:
     connector = app.connector
     assert isinstance(connector, InMemoryConnector)
     return list(connector.jobs.values())

--- a/tests/unit/test_wake_session_handler.py
+++ b/tests/unit/test_wake_session_handler.py
@@ -9,7 +9,7 @@ integration tests.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
@@ -63,7 +63,7 @@ def _mock_runtime_pool(monkeypatch: Any) -> None:
     """Most tests construct their own pool — patch the runtime to use it."""
 
     def _fake_require_pool() -> MagicMock:
-        return _DEFAULT_POOL_HOLDER["pool"]
+        return cast(MagicMock, _DEFAULT_POOL_HOLDER["pool"])
 
     monkeypatch.setattr("aios.tools.wake_session.runtime.require_pool", _fake_require_pool)
 

--- a/tests/unit/test_web_fetch_handler.py
+++ b/tests/unit/test_web_fetch_handler.py
@@ -27,7 +27,9 @@ def mock_safe_url() -> Any:
 
 
 class TestWebFetchHandler:
-    async def test_valid_url_returns_content(self, mock_tavily: AsyncMock, mock_safe_url: Any):
+    async def test_valid_url_returns_content(
+        self, mock_tavily: AsyncMock, mock_safe_url: Any
+    ) -> None:
         mock_tavily.return_value = {
             "results": [
                 {
@@ -44,7 +46,9 @@ class TestWebFetchHandler:
         assert result["content"] == "# Hello World\n\nSome content."
         mock_tavily.assert_awaited_once()
 
-    async def test_ssrf_blocked_url_returns_error(self, mock_tavily: AsyncMock, mock_safe_url: Any):
+    async def test_ssrf_blocked_url_returns_error(
+        self, mock_tavily: AsyncMock, mock_safe_url: Any
+    ) -> None:
         mock_safe_url.return_value = False
         result = await web_fetch_handler("sess_01TEST", {"url": "http://169.254.169.254/metadata"})
         assert "error" in result
@@ -61,12 +65,12 @@ class TestWebFetchHandler:
 
     async def test_tavily_error_returns_error_dict(
         self, mock_tavily: AsyncMock, mock_safe_url: Any
-    ):
+    ) -> None:
         mock_tavily.side_effect = WebToolError("TAVILY_API_KEY not set")
         with pytest.raises(WebToolError):
             await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
 
-    async def test_content_truncation(self, mock_tavily: AsyncMock, mock_safe_url: Any):
+    async def test_content_truncation(self, mock_tavily: AsyncMock, mock_safe_url: Any) -> None:
         long_content = "x" * 200_000
         mock_tavily.return_value = {
             "results": [
@@ -80,7 +84,9 @@ class TestWebFetchHandler:
         result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
         assert len(result["content"]) == 100_000
 
-    async def test_falls_back_to_content_field(self, mock_tavily: AsyncMock, mock_safe_url: Any):
+    async def test_falls_back_to_content_field(
+        self, mock_tavily: AsyncMock, mock_safe_url: Any
+    ) -> None:
         mock_tavily.return_value = {
             "results": [
                 {

--- a/tests/unit/test_web_search_handler.py
+++ b/tests/unit/test_web_search_handler.py
@@ -27,7 +27,7 @@ _CANNED_RESPONSE: dict[str, Any] = {
 
 
 class TestWebSearchHandler:
-    async def test_valid_query_returns_results(self, mock_tavily: AsyncMock):
+    async def test_valid_query_returns_results(self, mock_tavily: AsyncMock) -> None:
         mock_tavily.return_value = _CANNED_RESPONSE
         result = await web_search_handler("sess_01TEST", {"query": "python testing"})
         assert len(result["results"]) == 2
@@ -35,33 +35,33 @@ class TestWebSearchHandler:
         assert result["results"][0]["url"] == "https://example.com/1"
         assert result["results"][0]["description"] == "Description 1"
 
-    async def test_missing_query_raises(self):
+    async def test_missing_query_raises(self) -> None:
         with pytest.raises(WebSearchArgumentError):
             await web_search_handler("sess_01TEST", {})
 
-    async def test_empty_query_raises(self):
+    async def test_empty_query_raises(self) -> None:
         with pytest.raises(WebSearchArgumentError):
             await web_search_handler("sess_01TEST", {"query": ""})
 
-    async def test_default_limit_is_5(self, mock_tavily: AsyncMock):
+    async def test_default_limit_is_5(self, mock_tavily: AsyncMock) -> None:
         mock_tavily.return_value = _CANNED_RESPONSE
         await web_search_handler("sess_01TEST", {"query": "test"})
         call_payload = mock_tavily.call_args[0][1]
         assert call_payload["max_results"] == 5
 
-    async def test_custom_limit(self, mock_tavily: AsyncMock):
+    async def test_custom_limit(self, mock_tavily: AsyncMock) -> None:
         mock_tavily.return_value = _CANNED_RESPONSE
         await web_search_handler("sess_01TEST", {"query": "test", "limit": 10})
         call_payload = mock_tavily.call_args[0][1]
         assert call_payload["max_results"] == 10
 
-    async def test_limit_capped_at_20(self, mock_tavily: AsyncMock):
+    async def test_limit_capped_at_20(self, mock_tavily: AsyncMock) -> None:
         mock_tavily.return_value = _CANNED_RESPONSE
         await web_search_handler("sess_01TEST", {"query": "test", "limit": 50})
         call_payload = mock_tavily.call_args[0][1]
         assert call_payload["max_results"] == 20
 
-    async def test_tavily_error_raises(self, mock_tavily: AsyncMock):
+    async def test_tavily_error_raises(self, mock_tavily: AsyncMock) -> None:
         mock_tavily.side_effect = WebToolError("TAVILY_API_KEY not set")
         with pytest.raises(WebToolError):
             await web_search_handler("sess_01TEST", {"query": "test"})

--- a/tests/unit/test_wf_run_event_stream_terminal.py
+++ b/tests/unit/test_wf_run_event_stream_terminal.py
@@ -61,7 +61,7 @@ async def test_terminal_status_drains_catch_up_tail_then_done() -> None:
     subscription = _mk_subscription()
 
     collected = [
-        (msg.event, json.loads(msg.data).get("type") if msg.event == "event" else None)
+        (msg.event, json.loads(str(msg.data)).get("type") if msg.event == "event" else None)
         async for msg in wf_run_event_stream(subscription, pool, "wfr_X", after_seq=0)
     ]
 

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -65,7 +65,7 @@ def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) ->
 async def test_no_cumulative_falls_back_to_full_read() -> None:
     account_id = "acc_test_stub"  # PR 3 scaffolding
     conn = _FakeConn(total_local=None, ratio_n=0, ratio_mean=0.0)
-    result = await queries.read_windowed_events(
+    result: list[Any] = await queries.read_windowed_events(
         conn,
         "sess_x",
         window_min=1_000,
@@ -139,7 +139,7 @@ async def test_ratio_below_1_drops_fewer() -> None:
     """ratio=0.5 deflates total_effective below window_max → no drop."""
     account_id = "acc_test_stub"  # PR 3 scaffolding
     conn = _FakeConn(total_local=3_000, ratio_n=5, ratio_mean=0.5)
-    result = await queries.read_windowed_events(
+    result: list[Any] = await queries.read_windowed_events(
         conn,
         "sess_x",
         window_min=1_000,

--- a/tests/unit/test_worker_exit_diagnostics.py
+++ b/tests/unit/test_worker_exit_diagnostics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import faulthandler
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, MutableMapping
 from typing import Any
 
 import pytest
@@ -21,7 +21,12 @@ def captured_atexit(monkeypatch: pytest.MonkeyPatch) -> list[Callable[[], None]]
     ``worker.exit`` line into whatever logger config is live then.
     """
     captured: list[Callable[[], None]] = []
-    monkeypatch.setattr(atexit, "register", lambda fn: captured.append(fn) or fn)
+
+    def _fake_register(fn: Callable[[], None]) -> Callable[[], None]:
+        captured.append(fn)
+        return fn
+
+    monkeypatch.setattr(atexit, "register", _fake_register)
     return captured
 
 
@@ -84,7 +89,7 @@ def test_atexit_hook_emits_worker_exit(
     capture_logs.entries.clear()
     captured_atexit[0]()
 
-    matches: list[dict[str, Any]] = [
+    matches: list[MutableMapping[str, Any]] = [
         e for e in capture_logs.entries if e.get("event") == "worker.exit"
     ]
     assert len(matches) == 1

--- a/tests/unit/test_write_handler.py
+++ b/tests/unit/test_write_handler.py
@@ -104,7 +104,7 @@ class TestHappyPath:
     ) -> None:
         content = "hello world\n"
         await write_handler("sess_01TEST", {"path": "/workspace/a.txt", "content": content})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         expected_b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
         assert f"base64 -d <<< '{expected_b64}'" in cmd
 
@@ -112,7 +112,7 @@ class TestHappyPath:
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
         await write_handler("sess_01TEST", {"path": "/workspace/a/b/c.txt", "content": "hi"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         # shlex.quote leaves simple paths unquoted; assert mkdir + dirname + path.
         assert "mkdir -p --" in cmd
         assert "dirname --" in cmd
@@ -122,7 +122,7 @@ class TestHappyPath:
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
         await write_handler("sess_01TEST", {"path": "/workspace/a file.txt", "content": "hi"})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         assert "> '/workspace/a file.txt'" in cmd
 
     async def test_handles_special_characters_in_content(
@@ -131,7 +131,7 @@ class TestHappyPath:
         # Content containing quotes, newlines, shell metacharacters.
         tricky = "line with 'quotes' and \"doubles\" and $vars\nand newlines"
         await write_handler("sess_01TEST", {"path": "/workspace/a.txt", "content": tricky})
-        cmd: str = stub_registry.exec.await_args.args[1]  # type: ignore[attr-defined]
+        cmd: str = stub_registry.exec.await_args.args[1]
         # Base64 is quote-safe so no escaping gymnastics.
         expected_b64 = base64.b64encode(tricky.encode("utf-8")).decode("ascii")
         assert expected_b64 in cmd
@@ -153,7 +153,7 @@ class TestPerEnvTimeoutCeiling:
             return_value=600,
         ):
             await write_handler("sess_01TEST", {"path": "/workspace/a.txt", "content": "hello"})
-        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs  # type: ignore[attr-defined]
+        kwargs: dict[str, Any] = stub_registry.exec.await_args.kwargs
         assert kwargs["timeout_seconds"] == 600
 
 
@@ -161,7 +161,7 @@ class TestErrorPath:
     async def test_nonzero_exit_returns_error_dict(
         self, stub_registry: Any, stub_handle: SandboxHandle
     ) -> None:
-        stub_registry.exec = AsyncMock(  # type: ignore[method-assign]
+        stub_registry.exec = AsyncMock(
             return_value=CommandResult(
                 exit_code=1,
                 stdout="",


### PR DESCRIPTION
## What & why

The test tree was never part of the mypy gate — every documented/CI invocation ran `mypy src` only. As a result strict-mode type errors had quietly accumulated: **391 across 91 files** once dead `# type: ignore` directives were stripped. This brings the suite to **zero** and adds `tests` to **every** place the project runs mypy, so it can't drift again.

## How

**Root-cause config fixes** (cleared ~135 before any per-file work):
- Add `src/aios_connectors/py.typed` — our own first-party package was missing its PEP 561 marker, so test imports of it resolved as untyped.
- Centralize `fastapi_mcp` / `jsonschema` into the mypy `ignore_missing_imports` list (both verified load-bearing) and drop the 4 now-redundant inline ignores in `src`.
- Strip 123 dead `# type: ignore` directives.

**Per-file fixes** (260 errors / 71 files), done via a fan-out of agents against a strict playbook — *prefer real fixes over silencing*:
- Narrowing (`isinstance` / `is not None` asserts) for unions and `Optional`.
- Conform test doubles to their protocols (e.g. the attachment `UploadStream` fake) instead of casting.
- Import modules directly rather than reaching through a service module (defeats `no_implicit_reexport`) — e.g. `from aios.db import queries` in the vault tests.
- Only **3** precise-coded ignores remain across the whole suite, each justified: an exception-suppressing async context manager mypy mis-flags as `unreachable`, and two calls into untyped `procrastinate` internals. **Zero bare ignores.**

**Wire-in** — these now run `mypy src tests`: `scripts/run-checks.sh`, CI `code-validation.yml`, the pre-commit + post-tool-use hooks, `CLAUDE.md`, `README.md`.

## Notes for review

- **Seccomp test:** `test_security_opt_always_emitted` was failing on master — a semantic merge conflict where `#812` (no-new-privileges) and `#815` (seccomp) each added a `--security-opt` flag, so `argv.index(...)` matched the wrong one. Master (`#834`) fixed it independently while this branch was in flight; the rebase took master's version.
- **Newly-gated parallel work:** adding `mypy tests` means this PR now owns type-cleanliness of tests merged in parallel. The new gate immediately caught 4 dead ignores in master's `test_attenuation.py` (added in `#834`, never type-checked) — stripped here.

## Verification

| Gate | Result |
|---|---|
| `mypy src tests` (the new gate) | ✅ Success, 500 files |
| `mypy src` | ✅ Success |
| `ruff check` + `ruff format --check` | ✅ clean |
| `pytest tests/unit` | ✅ 1990 passed |
| `pytest tests/integration` | ✅ 318 passed |
| `pytest tests/e2e` (highest-risk files — all `isinstance` narrowings) | ✅ 30 passed |
| `scripts/run-checks.sh` end-to-end | ✅ All checks passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
