### PR TITLE
perf(tests): share one FastAPI app per test process; skip the pre-MCP OpenAPI build

### DIFF
--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -13,6 +13,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import Depends, FastAPI
+from fastapi.routing import APIRoute
 
 from aios.api.deps import require_bearer_auth
 from aios.api.routers import (
@@ -155,19 +156,27 @@ def _mount_mcp(app: FastAPI) -> None:
 def _iter_operations(app: FastAPI) -> Iterator[tuple[str, str, dict[str, Any]]]:
     """Yield ``(operation_id, http_verb, x_codegen_dict)`` for every operation.
 
-    Skips path-level keys that aren't HTTP methods (parameters, summary,
-    description, ...) and operations without an ``operationId``. The
-    ``x_codegen_dict`` is the raw ``x-codegen`` extension content (or
-    ``{}`` if absent); each caller projects out the sub-key it needs.
+    Walks ``app.routes`` directly instead of the OpenAPI document: building
+    the document costs a full Pydantic schema generation pass (~200 ms),
+    and fastapi-mcp builds its own copy anyway, so going through
+    ``app.openapi()`` here made every ``create_app()`` pay for the schema
+    twice.  The operationId is derived exactly as FastAPI's
+    ``get_openapi_operation_metadata`` does — ``route.operation_id or
+    route.unique_id`` — so the ids match the document (and fastapi-mcp's
+    tool names) verbatim.  The ``x_codegen_dict`` is the raw ``x-codegen``
+    extension content (or ``{}`` if absent); each caller projects out the
+    sub-key it needs.
     """
-    for path_obj in app.openapi()["paths"].values():
-        for verb, method_obj in path_obj.items():
-            if not isinstance(method_obj, dict):
-                continue
-            op_id = method_obj.get("operationId")
-            if not isinstance(op_id, str):
-                continue
-            yield op_id, verb.lower(), method_obj.get("x-codegen", {})
+    for route in app.routes:
+        if not isinstance(route, APIRoute) or not route.include_in_schema:
+            continue
+        op_id = route.operation_id or route.unique_id
+        x_codegen = (route.openapi_extra or {}).get("x-codegen", {})
+        # sorted() so multi-method routes yield in a deterministic order
+        # (route.methods is a set; every aios route is single-method, but
+        # fastapi-mcp's own /mcp transport route is GET+POST+DELETE).
+        for method in sorted(route.methods):
+            yield op_id, method.lower(), x_codegen
 
 
 def _verb_default_annotations(verb: str) -> dict[str, bool]:
@@ -294,10 +303,12 @@ def _apply_mcp_polish(app: FastAPI, mcp: Any, *, instructions: str) -> None:
     }
 
     for tool in mcp.tools:
-        # Direct lookup, not .get + None-skip: mcp.tools is built from the
-        # same app.openapi() that op_meta walks, so every tool.name must be
-        # an operationId we've seen. A KeyError here is a real invariant
-        # break worth surfacing, not a silent annotation dropout.
+        # Direct lookup, not .get + None-skip: fastapi-mcp names tools by
+        # the operationId of the same routes op_meta walks (both derive it
+        # via ``route.operation_id or route.unique_id``), so every
+        # tool.name must be an operationId we've seen. A KeyError here is
+        # a real invariant break worth surfacing, not a silent annotation
+        # dropout.
         verb, overrides = op_meta[tool.name]
         annotations = _verb_default_annotations(verb) | overrides
         if annotations:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -26,7 +26,7 @@ import pytest
 import uvicorn
 
 from tests.e2e.harness import Harness
-from tests.helpers.connections import authed_client, wait_for_health
+from tests.helpers.connections import authed_client, wait_for_health, wired_app
 
 _DEFAULT_DEFER_WAKE_PATCHES: tuple[str, ...] = (
     "aios.api.routers.sessions.defer_wake",
@@ -50,18 +50,12 @@ async def _live_aios_server_impl(
     graceful shutdown) is identical, so factoring it out keeps the two
     public entry points to a thin wrapper each.
     """
-    from aios.api.app import create_app
     from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
     from aios.db.pool import create_pool
 
     settings = get_settings()
     pool = await create_pool(settings.db_url, min_size=1, max_size=pool_max_size)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
+    app = wired_app(pool)
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(("127.0.0.1", 0))
@@ -414,20 +408,14 @@ async def http_client(aios_env: dict[str, str]) -> AsyncIterator[Any]:
     """
     import httpx
 
-    from aios.api.app import create_app
     from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
     from aios.db.pool import create_pool
     from aios.harness import runtime
     from aios_connectors.providers import SubsystemToolProvider
 
     settings = get_settings()
     pool = await create_pool(settings.db_url, min_size=1, max_size=4)
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
+    app = wired_app(pool)
     # The fixture skips the API lifespan (httpx ASGITransport doesn't
     # fire startup/shutdown), so mirror the lifespan's runtime
     # registrations explicitly — the ``/context`` endpoint reaches

--- a/tests/e2e/test_agent_litellm_extra.py
+++ b/tests/e2e/test_agent_litellm_extra.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import secrets
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest import mock
 
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -30,18 +29,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_agents_api.py
+++ b/tests/e2e/test_agents_api.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 import secrets
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest import mock
 
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -34,18 +33,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_context_endpoint.py
+++ b/tests/e2e/test_context_endpoint.py
@@ -10,7 +10,7 @@ from unittest import mock
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -30,19 +30,13 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox
     from aios.harness import runtime
     from aios_connectors.providers import SubsystemToolProvider
 
-    settings = get_settings()
-    crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = crypto_box
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
+    crypto_box = CryptoBox.from_base64(get_settings().vault_key.get_secret_value())
+    app = wired_app(pool)
 
     # The fixture skips the API lifespan (httpx ASGITransport doesn't
     # fire startup/shutdown), so mirror the lifespan's runtime

--- a/tests/e2e/test_events_pagination.py
+++ b/tests/e2e/test_events_pagination.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 import secrets
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest import mock
 
 import httpx
 import pytest
 
 from aios.models.events import EventKind
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -38,18 +37,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -25,7 +25,6 @@ import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
-from unittest import mock
 
 import httpx
 import pytest
@@ -36,7 +35,7 @@ from aios.services import agents as agents_service
 from aios.services import environments as environments_service
 from aios.services import github_repositories as github_service
 from aios.services import sessions as sessions_service
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 pytestmark = pytest.mark.docker
 
@@ -76,18 +75,7 @@ def crypto_box(aios_env: dict[str, str]) -> Any:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -15,12 +15,11 @@ import hashlib
 import secrets
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest import mock
 
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -44,18 +43,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_pagination_limit_validation.py
+++ b/tests/e2e/test_pagination_limit_validation.py
@@ -22,12 +22,11 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest import mock
 
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 @pytest.fixture
@@ -43,18 +42,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_scheduled_tasks.py
+++ b/tests/e2e/test_scheduled_tasks.py
@@ -37,7 +37,7 @@ from aios.services import agents as agents_service
 from aios.services import environments as environments_service
 from aios.services import scheduled_tasks as st_service
 from aios.services import sessions as sessions_service
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -57,18 +57,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_session_clone.py
+++ b/tests/e2e/test_session_clone.py
@@ -15,7 +15,7 @@ from unittest import mock
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -35,18 +35,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     with mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock):
         async with authed_client(
             "http://testserver",

--- a/tests/e2e/test_session_status_pending.py
+++ b/tests/e2e/test_session_status_pending.py
@@ -11,7 +11,7 @@ from unittest import mock
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -31,18 +31,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     with mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock):
         async with authed_client(
             "http://testserver",

--- a/tests/e2e/test_submit_tool_result_name.py
+++ b/tests/e2e/test_submit_tool_result_name.py
@@ -22,6 +22,8 @@ from unittest import mock
 import httpx
 import pytest
 
+from tests.helpers.connections import wired_app
+
 
 def _uniq() -> str:
     return secrets.token_hex(4)
@@ -40,18 +42,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     # No real worker in these tests; avoid enqueueing a wake for the
     # procrastinate MagicMock.
     with mock.patch(

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -11,7 +11,7 @@ from unittest import mock
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 
 def _uniq() -> str:
@@ -31,18 +31,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(
         "http://testserver",
         aios_env["AIOS_API_KEY"],

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -16,7 +16,7 @@ from unittest import mock
 import httpx
 import pytest
 
-from tests.helpers.connections import authed_client
+from tests.helpers.connections import authed_client, wired_app
 
 _SCRIPT = "async def main(input):\n    return input\n"
 
@@ -38,18 +38,7 @@ async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 @pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     # create_run + resume defer a wake; the procrastinate app isn't open in this ASGI
     # test (the worker drives steps separately), so mock BOTH bindings out — the
     # convention the e2e conftest uses for session defer_wake. (create_run uses the

--- a/tests/helpers/connections.py
+++ b/tests/helpers/connections.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 from unittest import mock
@@ -27,6 +28,51 @@ import httpx
 
 if TYPE_CHECKING:
     import asyncpg
+    from fastapi import FastAPI
+
+
+@functools.cache
+def _shared_app() -> FastAPI:
+    """The one FastAPI app this test process serves — built on first use.
+
+    ``create_app()`` costs ~0.3 s (router registration plus fastapi-mcp's
+    OpenAPI build for the ``/mcp`` mount).  Paying that per test made app
+    construction the dominant cost of the e2e suite, so every app-wiring
+    fixture shares this instance via :func:`wired_app`.  Sharing is sound
+    because tests touch nothing on the app beyond ``app.state``, and
+    request handlers read settings per request (``get_settings`` is
+    cache-cleared per test by ``aios_env_minimal``).  Under pytest-xdist
+    each worker process gets its own instance.
+
+    The load-bearing invariant: tests must NEVER mutate this app beyond
+    ``app.state`` — no ``dependency_overrides``, no route/middleware
+    registration.  Any of those would leak into every later test in the
+    process.  A test that genuinely needs them should build its own
+    ``FastAPI()`` (see ``tests/unit/test_sse_preflight.py``).
+    """
+    from aios.api.app import create_app
+
+    return create_app()
+
+
+def wired_app(pool: Any) -> FastAPI:
+    """The shared app with this test's state bound.
+
+    ``crypto_box`` / ``db_url`` come from settings (already mocked by the
+    caller's ``aios_env*`` fixture); ``procrastinate`` is a fresh
+    ``MagicMock`` per call so mock assertions never see another test's
+    wake deferrals.
+    """
+    from aios.config import get_settings
+    from aios.crypto.vault import CryptoBox
+
+    settings = get_settings()
+    app = _shared_app()
+    app.state.pool = pool
+    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+    app.state.db_url = settings.db_url
+    app.state.procrastinate = mock.MagicMock()
+    return app
 
 
 def authed_client(base_url: str, token: str, **kwargs: Any) -> httpx.AsyncClient:
@@ -102,27 +148,15 @@ async def create_connection(api_key: str, base_url: str, account: str) -> str:
 
 @contextlib.asynccontextmanager
 async def asgi_client(pool: Any) -> AsyncIterator[httpx.AsyncClient]:
-    """In-process ``httpx.AsyncClient`` wired to a fresh FastAPI app.
+    """In-process ``httpx.AsyncClient`` wired to the shared FastAPI app.
 
-    The app's pool / crypto_box / db_url are populated from settings
-    (which the caller's ``aios_env*`` fixture has already mocked); the
-    procrastinate handle is a mock since e2e auth tests don't run jobs.
-    Shared by tests that build the app themselves rather than going
-    through a running uvicorn — see ``tests/e2e/test_account_auth.py``
-    and ``tests/e2e/test_accounts_bootstrap.py``.
+    State binding is :func:`wired_app`'s; the procrastinate handle is a
+    mock since e2e auth tests don't run jobs.  Shared by tests that build
+    the app themselves rather than going through a running uvicorn — see
+    ``tests/e2e/test_account_auth.py`` and
+    ``tests/e2e/test_accounts_bootstrap.py``.
     """
-    from aios.api.app import create_app
-    from aios.config import get_settings
-    from aios.crypto.vault import CryptoBox
-
-    settings = get_settings()
-    app = create_app()
-    app.state.pool = pool
-    app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-    app.state.db_url = settings.db_url
-    app.state.procrastinate = mock.MagicMock()
-
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=wired_app(pool))
     async with httpx.AsyncClient(base_url="http://testserver", transport=transport) as client:
         yield client
 


### PR DESCRIPTION
## What

PR 2 from the CI profiling pass. `create_app()` cost ~0.45 s and the e2e suite paid it **per test** — ~200 of the 312 non-docker tests build the app through `http_client`/`asgi_client`-style fixtures, making app construction (not test logic) the dominant cost of the CI-critical e2e job. Two changes, one cause:

**1. `_iter_operations` walks `app.routes` instead of `app.openapi()["paths"]`** (`src/aios/api/app.py`). Building the OpenAPI document costs a full Pydantic schema-generation pass, and `fastapi_mcp.setup_server` builds its own copy anyway — so the MCP mount made every `create_app()` generate the schema **twice**. The operationId is derived exactly as FastAPI's `get_openapi_operation_metadata` does (`route.operation_id or route.unique_id`), so ids match the document — and fastapi-mcp's tool names — verbatim:
- Equivalence verified empirically: 134 identical `(op_id, verb, x-codegen)` triples between the routes-walk and the document-walk.
- Pinned by the existing `test_excluded_operations_match_x_codegen_annotations`, which cross-checks computed exclusions against the real spec.
- Regenerated `openapi.json` is byte-identical (no codegen-invariant impact).
- `create_app()`: **0.45 s → 0.27 s**, production API boot included.

**2. One shared app per test process** (`tests/helpers/connections.py`): `_shared_app()` (`functools.cache` over `create_app`) + `wired_app(pool)` which rebinds `app.state.{pool, crypto_box, db_url, procrastinate-mock}` per test. All e2e app-wiring fixtures (conftest `http_client`, `_live_aios_server_impl`, `asgi_client`, and the 13 per-file `http_client` clones) collapse their copy-pasted ten-line blocks into one `wired_app(pool)` call. Net **−109 lines**. Sharing is sound because tests touch nothing on the app beyond `app.state` (verified: zero `dependency_overrides` / route / middleware mutation in `tests/e2e`), handlers read settings per request, and xdist workers are separate processes.

## Measured (local, all green)

| Suite | Before | After |
|---|---|---|
| e2e non-docker, serial | 141 s | **50 s** |
| e2e non-docker, `-n 4` (CI shape) | 44 s | **23 s** |
| e2e docker, `-n 4` | ~70 s | ~70 s (sandbox-bound) |
| unit (1990) / integration (326) | pass | pass |

Combined with #837, the local serial e2e run is down **141 s → 50 s** and the CI non-docker shard should drop from ~2 min 20 s to well under a minute, leaving the run bounded by the docker shard.

## Review notes

- Adversarially reviewed pre-push. The reviewer's one high-severity claim (starlette auto-adds HEAD to GET routes → hash-order-dependent verb in `op_meta`) **does not apply**: FastAPI's `APIRoute.__init__` sets `methods` verbatim (no HEAD auto-add; verified 0/56 GET routes carry HEAD). The only multi-method route is fastapi-mcp's own `/mcp` transport route, registered *after* both `_iter_operations` consumers run. `sorted(route.methods)` makes iteration order well-defined regardless.
- The #377 SSE-first-open regression repro keeps its force: the masking factor documented in the fixture is pool/connector warm-up, both still per-test (fresh `create_pool` per fixture call); uvicorn still boots cold per test.
- Follow-up (not this PR): the ~20 identical per-file `pool`/`http_client` fixtures could be promoted to `tests/e2e/conftest.py` — runtime-neutral dedup, left for a kaizen pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)