### PR TITLE
feat(workflows): curated script stdlib — imports, classes, tuple coercion, PYTHONHASHSEED pin (#778)

### DIFF
--- a/src/aios/workflows/determinism.py
+++ b/src/aios/workflows/determinism.py
@@ -5,15 +5,18 @@ Replay-with-memo only works if re-running a deterministic script produces the
 that:
 
 - :func:`canonical_json` — a total, order-independent serialization over a
-  **restricted** input domain. Non-finite floats (NaN/Inf), sets, tuples, bytes,
+  **restricted** input domain. Non-finite floats (NaN/Inf), sets, bytes,
   datetimes, and arbitrary objects are **rejected** at the call site (raising
   :class:`WorkflowInputTypeError`). Finite floats are accepted; integer-valued
   floats (``1.0``, ``2.0``) are normalized to their ``int`` form so ``1`` and
   ``1.0`` produce the same JSON token — the call key is stable even when an
   upstream agent returns ``{"count": 1.0}`` and the script author wrote
-  ``{"count": 1}``. Sets and dicts with non-str keys are rejected because their
-  iteration order is ``PYTHONHASHSEED``-sensitive, which would desync the key
-  across a worker restart. ``sort_keys`` makes dict key order irrelevant.
+  ``{"count": 1}``. Tuples are coerced to lists the same way (JSON has no
+  tuple; list is the canonical form). Sets and dicts with non-str keys are
+  rejected because an unordered collection has no canonical JSON form (the
+  script host pins ``PYTHONHASHSEED=0``, so iteration order is at least stable —
+  but stable-arbitrary is not canonical, and the order would still shift across
+  interpreter versions). ``sort_keys`` makes dict key order irrelevant.
 
 - :class:`CallKeyer` — turns ``(capability_id, input)`` into
   ``"sha:<hex>#<n>"`` where ``n`` is the count of *prior* emissions in this run
@@ -40,13 +43,34 @@ class WorkflowInputTypeError(TypeError):
     Raised deterministically at the call site (same input → same rejection on
     every replay), so a bad input is a loud author error, never a silent hash
     desync. Allowed: ``None``, ``bool``, ``int``, ``float`` (finite only),
-    ``str``, and ``list``/``dict`` of those. NaN/Inf floats, sets, tuples,
-    bytes, datetimes, and arbitrary objects are rejected.
+    ``str``, and ``list``/``tuple``/``dict`` of those (tuples canonicalize as
+    lists). NaN/Inf floats, sets, bytes, datetimes, and arbitrary objects are
+    rejected, as are strings Postgres jsonb cannot store (NUL, unpaired
+    surrogates).
     """
 
 
-def _validate(x: Any, *, path: str = "input") -> None:
-    if x is None or isinstance(x, (bool, int, str)):
+def validate_value(x: Any, *, path: str = "input") -> None:
+    """Check ``x`` against the workflow value domain (see
+    :class:`WorkflowInputTypeError`), raising with a path-precise message on the
+    first violation. Capability inputs are validated via :func:`canonical_json`;
+    the script host also validates return values directly (same domain, same
+    error vocabulary, no canonicalization needed)."""
+    if isinstance(x, str):
+        # The domain must be storable: Postgres jsonb rejects NUL and lone
+        # surrogates, so accepting one here would let the value sail through the
+        # host only to detonate at the parent's ::jsonb cast — wedging the run in
+        # a deterministic re-wake crashloop instead of a loud author error.
+        if "\x00" in x:
+            raise WorkflowInputTypeError(f"{path}: NUL (U+0000) is not storable in a workflow")
+        try:
+            x.encode("utf-8")
+        except UnicodeEncodeError as exc:
+            raise WorkflowInputTypeError(
+                f"{path}: unpaired surrogate is not storable in a workflow"
+            ) from exc
+        return
+    if x is None or isinstance(x, (bool, int)):
         return
     if isinstance(x, float):
         if not math.isfinite(x):
@@ -54,9 +78,9 @@ def _validate(x: Any, *, path: str = "input") -> None:
                 f"{path}: non-finite float {x!r} (NaN/Inf have no canonical form)"
             )
         return
-    if isinstance(x, list):
+    if isinstance(x, (list, tuple)):
         for i, item in enumerate(x):
-            _validate(item, path=f"{path}[{i}]")
+            validate_value(item, path=f"{path}[{i}]")
         return
     if isinstance(x, dict):
         for key, value in x.items():
@@ -64,22 +88,23 @@ def _validate(x: Any, *, path: str = "input") -> None:
                 raise WorkflowInputTypeError(
                     f"{path}: dict keys must be str, got {type(key).__name__}"
                 )
-            _validate(value, path=f"{path}.{key}")
+            validate_value(value, path=f"{path}.{key}")
         return
     raise WorkflowInputTypeError(
         f"{path}: unsupported workflow input type {type(x).__name__} "
-        f"(allowed: None, bool, int, float, str, list, dict)"
+        f"(allowed: None, bool, int, float, str, list, tuple, dict)"
     )
 
 
-def _canon_numbers(x: Any) -> Any:
-    """Collapse integer-valued floats so ``1.0`` and ``1`` produce the same JSON token."""
+def _canon(x: Any) -> Any:
+    """Collapse integer-valued floats (``1.0`` → ``1``) and tuples (→ lists) so
+    equal content produces the same JSON token whichever form the author built."""
     if isinstance(x, float):
         return int(x) if x.is_integer() else x
-    if isinstance(x, list):
-        return [_canon_numbers(i) for i in x]
+    if isinstance(x, (list, tuple)):
+        return [_canon(i) for i in x]
     if isinstance(x, dict):
-        return {k: _canon_numbers(v) for k, v in x.items()}
+        return {k: _canon(v) for k, v in x.items()}
     return x
 
 
@@ -90,11 +115,12 @@ def canonical_json(x: Any) -> str:
     serializing. Integer-valued floats (``1.0``, ``2.0``) are collapsed to their
     ``int`` form so ``1`` and ``1.0`` produce the same JSON token — the call key is
     content-hash-stable even when an upstream agent returns ``{"count": 1.0}`` and
-    the script author wrote ``{"count": 1}``.
+    the script author wrote ``{"count": 1}``. Tuples are coerced to lists for the
+    same reason: ``(1, 2)`` and ``[1, 2]`` key identically.
     """
-    _validate(x)
+    validate_value(x)
     return json.dumps(
-        _canon_numbers(x), separators=(",", ":"), sort_keys=True, ensure_ascii=True, allow_nan=False
+        _canon(x), separators=(",", ":"), sort_keys=True, ensure_ascii=True, allow_nan=False
     )
 
 

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -73,7 +73,6 @@ _CHILD_ENV_ALLOWLIST: frozenset[str] = frozenset(
         "TZ",
         "PYTHONPATH",
         "PYTHONHOME",
-        "PYTHONHASHSEED",
         "VIRTUAL_ENV",
         "__PYVENV_LAUNCHER__",  # macOS venv re-exec
         "SYSTEMROOT",  # Windows interpreter launch
@@ -171,6 +170,13 @@ async def run_script_host(
     # spawn (see ``_CHILD_ENV_ALLOWLIST``), plus the two rlimit knobs the child
     # self-applies. The child must stay credential-free.
     env = {k: os.environ[k] for k in _CHILD_ENV_ALLOWLIST if k in os.environ}
+    # DETERMINISM (load-bearing): pin the hash seed so str-hash-dependent orderings
+    # are identical across wakes. Every wake is a fresh interpreter; under an
+    # inherited/random seed, ``list({"a", "b"})`` reorders per wake, and if such an
+    # ordering feeds a capability spec the call_key desyncs and replay-with-memo
+    # breaks. (``canonical_json`` rejects sets directly, but a list *built from* a
+    # set is indistinguishable from any other list.)
+    env["PYTHONHASHSEED"] = "0"
     env["AIOS_WF_RLIMIT_CPU_S"] = str(cpu_seconds)
     env["AIOS_WF_RLIMIT_AS_BYTES"] = str(address_space_bytes or 0)
     try:

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -14,8 +14,8 @@ never import ``aios.harness.*`` / ``aios.crypto*`` / ``aios.db*`` / ``aios.servi
 / ``aios.tools.*`` / ``aios.sandbox.spec`` — those hold the worker's master
 ``CryptoBox`` and all-accounts pool. Because the child is a fresh ``spawn``ed
 interpreter that never imports them, even a full sandbox escape in author code
-reaches only this credential-free process. ``SAFE_BUILTINS`` and the absence of
-``__import__`` are determinism/footgun aids, **not** the security boundary.
+reaches only this credential-free process. ``SAFE_BUILTINS`` and the curated
+``__import__`` allowlist are determinism/footgun aids, **not** the security boundary.
 
 ``gate()`` and ``agent()`` are real capabilities (for ``agent()`` the parent spawns
 a child session and harvests its completion marker). ``parallel()``/``pipeline()``
@@ -31,6 +31,7 @@ import contextlib
 import os
 import sys
 import traceback
+import types
 from typing import Any
 
 from aios.workflows._protocol import (
@@ -42,7 +43,7 @@ from aios.workflows._protocol import (
     read_frame_sync,
     write_frame_sync,
 )
-from aios.workflows.determinism import CallKeyer, canonical_schema_json
+from aios.workflows.determinism import CallKeyer, canonical_schema_json, validate_value
 
 
 class WorkflowScriptError(Exception):
@@ -218,7 +219,7 @@ def log(*args: Any) -> None:
     sys.stderr.write(" ".join(str(a) for a in args) + "\n")
 
 
-# ─── restricted builtins (a footgun aid, NOT the security boundary) ──────────
+# ─── restricted builtins + curated imports (footgun aids, NOT the boundary) ──
 
 _SAFE_BUILTIN_NAMES = frozenset(
     {
@@ -231,6 +232,7 @@ _SAFE_BUILTIN_NAMES = frozenset(
         "bytes",
         "callable",
         "chr",
+        "classmethod",
         "dict",
         "divmod",
         "enumerate",
@@ -238,6 +240,8 @@ _SAFE_BUILTIN_NAMES = frozenset(
         "float",
         "format",
         "frozenset",
+        "getattr",
+        "hasattr",
         "hash",
         "hex",
         "int",
@@ -250,19 +254,25 @@ _SAFE_BUILTIN_NAMES = frozenset(
         "max",
         "min",
         "next",
+        "object",
         "oct",
         "ord",
         "pow",
+        "property",
         "range",
         "repr",
         "reversed",
         "round",
         "set",
+        "setattr",
         "slice",
         "sorted",
+        "staticmethod",
         "str",
         "sum",
+        "super",
         "tuple",
+        "type",
         "zip",
         # constants + exceptions (so authors can raise / except)
         "NotImplemented",
@@ -272,6 +282,7 @@ _SAFE_BUILTIN_NAMES = frozenset(
         "AttributeError",
         "BaseException",
         "Exception",
+        "ImportError",
         "IndexError",
         "KeyError",
         "LookupError",
@@ -287,22 +298,93 @@ SAFE_BUILTINS: dict[str, Any] = {
     name: getattr(builtins, name) for name in _SAFE_BUILTIN_NAMES if hasattr(builtins, name)
 }
 
+# The curated import surface: modules whose direct API is deterministic, I/O-free
+# parse/transform glue. An entry admits itself and its submodules
+# (``collections.abc``). First-order claim only — module *attributes* stay
+# reachable regardless (``statistics.random`` is one hop away), and the
+# fail-closed replay check, not this list, is the determinism enforcement layer.
+# Like SAFE_BUILTINS, a footgun aid, NOT the security boundary. ``__future__`` is
+# deliberately rejected: under PEP 563 every annotation becomes a string and
+# dataclasses' ClassVar/InitVar detection silently misclassifies fields (see
+# ``dont_inherit`` in ``_build_coroutine``).
+_IMPORTABLE_MODULES = frozenset(
+    {
+        "base64",
+        "collections",
+        "dataclasses",
+        "functools",
+        "hashlib",
+        "itertools",
+        "json",
+        "math",
+        "re",
+        "statistics",
+        "string",
+        "textwrap",
+        "urllib.parse",
+    }
+)
+
+
+def _safe_import(
+    name: str,
+    globals: Any = None,
+    locals: Any = None,
+    fromlist: Any = (),
+    level: int = 0,
+) -> Any:
+    """The ``__import__`` behind a script's ``import`` statements: allowlist the
+    dotted name (an entry or a submodule of one), then the real import machinery.
+    The error message carries the full allowlist — it IS the author-facing
+    documentation. ``from urllib import parse`` is rejected (the name ``__import__``
+    receives is ``urllib``, which is not listed); the author retries as
+    ``import urllib.parse`` / ``from urllib.parse import …``."""
+    allowed = level == 0 and any(name == m or name.startswith(m + ".") for m in _IMPORTABLE_MODULES)
+    if not allowed:
+        raise ImportError(
+            f"cannot import {name!r}: workflow scripts may only import "
+            f"{', '.join(sorted(_IMPORTABLE_MODULES))}"
+        )
+    return builtins.__import__(name, globals, locals, fromlist, level)
+
+
+# The two dunders an author never calls by name: ``import x`` desugars to
+# ``__import__`` (the curated shim) and ``class X:`` to ``__build_class__`` (the
+# real one — classes are fully enabled; the allowlist includes ``dataclasses``).
+SAFE_BUILTINS["__import__"] = _safe_import
+SAFE_BUILTINS["__build_class__"] = builtins.__build_class__
+
 
 def _build_coroutine(source: str, input_value: Any) -> Any:
-    namespace: dict[str, Any] = {
-        "__builtins__": SAFE_BUILTINS,
-        "gate": gate,
-        "agent": agent,
-        "tool": tool,
-        "parallel": parallel,
-        "pipeline": pipeline,
-        "log": log,
-        # The agent() failure type lives with its capability in the author API
-        # (not SAFE_BUILTINS), so `try/except AgentError` resolves it as a global.
-        "AgentError": AgentError,
-        "AgentNoReturnError": AgentNoReturnError,
-    }
-    code = compile(source, "<workflow>", "exec")
+    # The script runs as a REAL module registered in sys.modules: a class body's
+    # first op is ``__module__ = __name__`` (so the name must resolve), and
+    # consumers like dataclasses resolve string annotations against
+    # ``sys.modules[cls.__module__].__dict__`` — pointing that at the script's own
+    # namespace keeps such lookups truthful (an explicit ``"InitVar[int]"``
+    # annotation finds the *script's* import, not a bystander module's globals).
+    module = types.ModuleType("<workflow>")
+    sys.modules[module.__name__] = module
+    namespace: dict[str, Any] = module.__dict__
+    namespace.update(
+        {
+            "__builtins__": SAFE_BUILTINS,
+            "gate": gate,
+            "agent": agent,
+            "tool": tool,
+            "parallel": parallel,
+            "pipeline": pipeline,
+            "log": log,
+            # The agent() failure type lives with its capability in the author API
+            # (not SAFE_BUILTINS), so `try/except AgentError` resolves it as a global.
+            "AgentError": AgentError,
+            "AgentNoReturnError": AgentNoReturnError,
+        }
+    )
+    # dont_inherit: without it the script inherits THIS module's ``from __future__
+    # import annotations`` (PEP 563), stringifying every annotation — which silently
+    # breaks dataclasses' ClassVar/InitVar detection. Compiled clean, annotations
+    # are live objects, evaluated eagerly against the script's own namespace.
+    code = compile(source, "<workflow>", "exec", dont_inherit=True)
     exec(code, namespace)
     entry = namespace.get("main")
     if entry is None or not callable(entry):
@@ -461,6 +543,19 @@ def _drive(root_coro: Any, memo: dict[str, Any], emit: Any) -> None:
             except StopIteration as stop:
                 progressed = True
                 if branch is root:
+                    # The return value must live in the same JSON value domain as
+                    # capability inputs — validate it at the source (path-precise
+                    # author error) rather than letting ``json.dumps`` decide: a
+                    # dataclass instance would die as an opaque host crash, and a
+                    # NaN would sail through ``allow_nan`` only to detonate at the
+                    # parent's jsonb cast. ANY exception out of the walk is
+                    # author-caused (RecursionError on a cyclic value, a raising
+                    # ``.items()`` on a dict subclass), so all are author errors.
+                    try:
+                        validate_value(stop.value, path="return")
+                    except Exception as exc:
+                        _emit_raised(emit, exc)
+                        return
                     emit({"type": RETURNED, "value": stop.value})
                     return
                 _finish(branch, stop.value)

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -8,6 +8,9 @@ deadline and the parent stays healthy).
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
 import subprocess
 import sys
 import textwrap
@@ -408,6 +411,29 @@ async def test_child_env_is_scrubbed_of_secrets(monkeypatch: pytest.MonkeyPatch)
     assert out.kind == "returned"
     assert out.value["leaked"] == []  # no secret crossed the spawn
     assert out.value["has_path"] is True  # but non-secret launch essentials still do
+
+
+async def test_hash_ordering_is_pinned_across_wakes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The launcher pins PYTHONHASHSEED=0 in the child: str-hash-dependent orderings
+    (``list({...})``) must be identical on every wake, whatever seed the worker
+    itself runs under — an inherited/random seed would desync any call_key built
+    from such an ordering."""
+    strings = '{"alpha", "bravo", "charlie", "delta", "echo"}'  # 0/1/2 orderings all differ
+    outs = []
+    for worker_seed in ("1", "2"):
+        monkeypatch.setenv("PYTHONHASHSEED", worker_seed)
+        outs.append(await _run(f"async def main(input):\n    return list({strings})"))
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        f"import json; print(json.dumps(list({strings})))",
+        stdout=asyncio.subprocess.PIPE,
+        env={**os.environ, "PYTHONHASHSEED": "0"},  # inherit env, pin only the seed
+    )
+    stdout, _ = await proc.communicate()
+    assert proc.returncode == 0
+    assert [o.kind for o in outs] == ["returned", "returned"]
+    assert outs[0].value == outs[1].value == json.loads(stdout)
 
 
 # ─── runaway containment (B1.1) ──────────────────────────────────────────────

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import pytest
 
+from aios.workflows.determinism import content_hash
 from aios.workflows.host_launcher import HostOutcome, run_script_host
 from aios.workflows.wf_script_host import MAX_PARALLEL_FANOUT
 
@@ -152,16 +153,192 @@ async def test_agent_requires_non_none_input() -> None:
 
 async def test_bad_capability_input_is_raised() -> None:
     out = await _run(
-        "async def main(input):\n    return await gate({'t': (1, 2)})"
-    )  # tuple spec rejected
+        "async def main(input):\n    return await gate({'t': {1, 2}})"
+    )  # set spec rejected (hash-ordering hazard)
     assert out.kind == "raised"
     assert "WorkflowInputTypeError" in (out.error_repr or "")
+
+
+async def test_tuple_spec_is_coerced_not_rejected() -> None:
+    # Tuples canonicalize as lists: a tuple-spec gate suspends, keyed exactly as
+    # its list twin (the author and an upstream JSON round-trip agree).
+    out = await _run("async def main(input):\n    return await gate({'t': (1, 2)})")
+    assert out.kind == "suspended"
+    assert out.emitted[0].call_key == f"sha:{content_hash('gate', {'t': [1, 2]})}#0"
 
 
 async def test_missing_main_is_raised() -> None:
     out = await _run("x = 1")
     assert out.kind == "raised"
     assert "main(input)" in (out.error_repr or "")
+
+
+# ─── curated stdlib + classes (T5) ───────────────────────────────────────────
+
+
+async def test_script_can_import_curated_stdlib() -> None:
+    out = await _run(
+        r"""
+        import collections.abc  # an entry admits its submodules
+        import json
+        import math
+        import re
+        from urllib.parse import quote
+
+        async def main(input):
+            data = json.loads('{"items": ["a 12", "b 7"]}')
+            nums = [int(re.search(r"\d+", s).group()) for s in data["items"]]
+            return {
+                "total": sum(nums),
+                "hypot": math.hypot(3, 4),
+                "quoted": quote("a b"),
+                "encoded": json.dumps(sorted(nums)),
+                "is_seq": isinstance(nums, collections.abc.Sequence),
+            }
+        """
+    )
+    assert out.kind == "returned"
+    assert out.value == {
+        "total": 19,
+        "hypot": 5.0,
+        "quoted": "a%20b",
+        "encoded": "[7, 12]",
+        "is_seq": True,
+    }
+
+
+async def test_script_parses_json_tool_body_with_regex() -> None:
+    """The acceptance workload: parse a JSON HTTP body and regex it — the glue
+    every non-trivial coordination script needs (previously unwritable: scripts
+    hand-rolled JSON escaping and delegated parsing to agent() children)."""
+    source = r"""
+    import json
+    import re
+
+    async def main(input):
+        resp = await tool("http_request", {"method": "GET", "url": "https://api.test/x"})
+        body = json.loads(resp["body"])
+        return re.findall(r"#(\d+)", body["title"])
+    """
+    first = await _run(source)
+    assert first.kind == "suspended"  # the tool call is the frontier
+    (cap,) = first.emitted
+    memo = {cap.call_key: {"ok": {"status": 200, "body": '{"title": "fixes #12 and #7"}'}}}
+    out = await _run(source, memo=memo)
+    assert out.kind == "returned"
+    assert out.value == ["12", "7"]
+
+
+async def test_script_can_define_classes() -> None:
+    out = await _run(
+        """
+        class Node:
+            def __init__(self, name):
+                self.name = name
+
+            @property
+            def label(self):
+                return self.name.upper()
+
+        class Leaf(Node):
+            def __init__(self, name):
+                super().__init__(name)
+
+        async def main(input):
+            return Leaf("tip").label
+        """
+    )
+    assert out.kind == "returned"
+    assert out.value == "TIP"
+
+
+async def test_script_dataclasses_have_live_annotations() -> None:
+    """Annotations are LIVE objects (``dont_inherit`` pins this: without it the
+    script inherits the host's PEP 563 future and every annotation stringifies).
+    The ``live`` probe is the actual pin — InitVar correctness alone would pass
+    either way, because the registered script module lets dataclasses resolve
+    even *string* annotations correctly."""
+    out = await _run(
+        """
+        from dataclasses import InitVar, asdict, dataclass, field
+
+        @dataclass
+        class Row:
+            x: int
+            tags: list = field(default_factory=list)
+            scale: InitVar[int] = 1
+
+            def __post_init__(self, scale):
+                self.x *= scale
+
+        async def main(input):
+            return {"row": asdict(Row(5, scale=3)), "live": Row.__annotations__["x"] is int}
+        """
+    )
+    assert out.kind == "returned"
+    assert out.value == {"row": {"x": 15, "tags": []}, "live": True}
+
+
+async def test_annotations_evaluate_eagerly_against_script_namespace() -> None:
+    # The flip side of live annotations: an out-of-scope name is a loud NameError
+    # at def time, not a silently-stored string. (CPython 3.13 semantics — under
+    # PEP 649 (3.14+) annotations evaluate lazily and this assertion will need
+    # revisiting at the version bump; the `live` probe above is the durable pin.)
+    out = await _run("async def main(input: Any):\n    return 1")
+    assert out.kind == "raised"
+    assert "NameError" in (out.error_repr or "")
+
+
+async def test_disallowed_import_is_a_loud_import_error() -> None:
+    stmts = (
+        "import os",
+        "import importlib",
+        "import urllib.request",  # allowlisting urllib.parse does not open the package
+        "from urllib import parse",  # the name imported is `urllib`: rejected; use `import urllib.parse`
+        "from __future__ import annotations",  # would stringify annotations (PEP 563)
+    )
+    outs = await asyncio.gather(
+        *(_run(f"{stmt}\n\nasync def main(input):\n    return 1") for stmt in stmts)
+    )
+    for stmt, out in zip(stmts, outs, strict=True):
+        assert out.kind == "raised", stmt
+        assert "ImportError" in (out.error_repr or ""), stmt
+        assert "may only import" in (out.error_repr or ""), stmt  # the error IS the docs
+
+
+async def test_non_json_return_is_an_author_error_not_a_host_crash() -> None:
+    out = await _run(
+        """
+        from dataclasses import dataclass
+
+        @dataclass
+        class Point:
+            x: int
+
+        async def main(input):
+            return Point(1)  # forgot asdict()
+        """
+    )
+    assert out.kind == "raised"
+    assert out.error_kind == "author_exception"
+    assert "WorkflowInputTypeError" in (out.error_repr or "")
+    assert "return: unsupported workflow input type Point" in (out.error_repr or "")
+    # NaN would survive json.dumps (allow_nan) only to detonate at the parent's
+    # jsonb cast — the domain validator rejects it at the source instead.
+    nan = await _run("async def main(input):\n    return float('nan')")
+    assert nan.kind == "raised"
+    assert "return: non-finite float" in (nan.error_repr or "")
+    # Same class: Postgres jsonb cannot store NUL — caught here, not as a parent
+    # crashloop after a "successful" host run.
+    nul = await _run("async def main(input):\n    return chr(0)")
+    assert nul.kind == "raised"
+    assert "return: NUL" in (nul.error_repr or "")
+    # A cyclic return RecursionErrors inside the validator — still an author
+    # error, never an rc=1 host crash with the cause lost to stderr.
+    cyc = await _run("async def main(input):\n    x = []\n    x.append(x)\n    return x")
+    assert cyc.kind == "raised"
+    assert cyc.error_kind == "author_exception"
+    assert "RecursionError" in (cyc.error_repr or "")
 
 
 # ─── parallel / pipeline (B2.G — the concurrent scheduler) ───────────────────
@@ -380,7 +557,8 @@ def test_host_transitive_imports_are_credential_free() -> None:
 
 async def test_script_cannot_import_aios() -> None:
     out = await _run("async def main(input):\n    import aios.harness.runtime\n    return 1")
-    assert out.kind == "raised"  # __import__ is not in SAFE_BUILTINS
+    assert out.kind == "raised"  # rejected by the curated-import shim (still ImportError)
+    assert "ImportError" in (out.error_repr or "")
 
 
 async def test_injected_globals_cannot_reach_runtime() -> None:

--- a/tests/unit/test_wf_determinism.py
+++ b/tests/unit/test_wf_determinism.py
@@ -36,7 +36,6 @@ def test_canonical_json_accepts_allowed_types() -> None:
     "bad",
     [
         {1, 2},
-        (1, 2),
         b"bytes",
         datetime(2026, 1, 1),
         {"when": datetime(2026, 1, 1)},
@@ -46,6 +45,21 @@ def test_canonical_json_accepts_allowed_types() -> None:
 def test_canonical_json_rejects_disallowed_types(bad: object) -> None:
     with pytest.raises(WorkflowInputTypeError):
         canonical_json(bad)
+
+
+def test_canonical_json_coerces_tuples_to_lists() -> None:
+    # JSON has no tuple; list is the canonical form (mirrors the 1.0/1 collapse).
+    assert canonical_json((1, 2)) == canonical_json([1, 2]) == "[1,2]"
+    assert canonical_json({"pairs": [(1, "a"), (2, "b")]}) == canonical_json(
+        {"pairs": [[1, "a"], [2, "b"]]}
+    )
+    assert content_hash("agent", {"x": (1, 2)}) == content_hash("agent", {"x": [1, 2]})
+    # Tuple *elements* are still validated...
+    with pytest.raises(WorkflowInputTypeError):
+        canonical_json(({1, 2},))
+    # ...and dict KEYS stay str-only — a tuple key is still rejected.
+    with pytest.raises(WorkflowInputTypeError):
+        canonical_json({(1, 2): "x"})
 
 
 def test_canonical_json_accepts_finite_floats() -> None:
@@ -82,6 +96,17 @@ def test_canonical_json_float_repr_stability() -> None:
 def test_canonical_json_rejects_non_str_dict_keys() -> None:
     with pytest.raises(WorkflowInputTypeError):
         canonical_json({1: "x"})
+
+
+def test_canonical_json_rejects_unstorable_strings() -> None:
+    # Postgres jsonb rejects NUL and lone surrogates; accepting either here would
+    # defer the failure to the parent's ::jsonb cast (a re-wake crashloop).
+    with pytest.raises(WorkflowInputTypeError, match="NUL"):
+        canonical_json("a\x00b")
+    with pytest.raises(WorkflowInputTypeError, match="surrogate"):
+        canonical_json({"s": "\ud800"})
+    # Paired-surrogate-free astral text is fine.
+    assert canonical_json("éπ💡") == '"\\u00e9\\u03c0\\ud83d\\udca1"'
 
 
 def test_content_hash_is_sensitive_to_capability_and_spec() -> None:


### PR DESCRIPTION
Closes #778 (T5-B, Stage-1 substrate). Two commits: the live nondeterminism fix, then the authoring surface.

## Commit 1 — `fix`: pin `PYTHONHASHSEED=0` in the script-host child

Each wake spawns a fresh interpreter; the env allowlist passed the worker's (usually unset → random) seed through, so any str-hash-dependent ordering (`list({...})`) could differ across wakes and desync call keys. Pinned unconditionally; the allowlist pass-through is removed. The regression test drives the same set-ordering script under two different worker seeds and asserts the seed-0 ordering both times (string set verified to order-differently under seeds 0/1/2 — the assertion can't be vacuously green).

## Commit 2 — `feat`: curated stdlib + classes + tuple coercion + storable value domain

- **`__import__` shim** over the locked 13-module allowlist; an entry admits its submodules (`collections.abc`). The ImportError names the rejected module and carries the full allowlist — the error is the author documentation. Footgun aid, **not** the security boundary (process isolation, unchanged — the module docstring's framing is updated, not weakened).
- **Classes**: `__build_class__` + class pack (`object`/`type`/`super`/`property`/`staticmethod`/`classmethod`/`getattr`/`setattr`/`hasattr`/`ImportError`). The script execs as a **real module registered in `sys.modules`** so `__module__` resolution (class bodies, dataclasses' string-annotation detection) is truthful.
- **`compile(..., dont_inherit=True)`** — the subtle one: without it every script inherited the *host module's* `from __future__ import annotations`, stringifying all annotations and silently misclassifying `InitVar`/`ClassVar` dataclass fields. Behavior change: annotations now evaluate eagerly (`input: Any` → loud NameError; quoted annotations still fine). Deploy note: any pre-existing stored script with typing-style annotations would now fail at def time — none are known pre-GA.
- **Tuple→list coercion** in `canonical_json` (mirrors the `1.0`/`1` collapse): `(1,2)` and `[1,2]` key identically. namedtuples serialize positionally, exactly as stdlib `json.dumps` does — deliberate.
- **Storability-honest value domain**: `validate_value` (public; was `_validate`) now rejects NUL and unpaired surrogates. Previously `return chr(0)` survived the host and detonated at the parent's `::jsonb` cast → non-terminal run + deterministic re-wake **crashloop**. Now a loud author error, on the input path and the return path alike.
- **Return values validated before the RETURNED emit**: a dataclass instance / NaN / cyclic value is a path-precise `author_exception` (`return: ...`), never an opaque rc=1 `script_host_crash` with the cause lost to discarded stderr.

## Process

Plan red-teamed before coding (4-lens adversarial workflow): caught the `dont_inherit` inheritance bug, an existing tuple-rejection test that would have shipped red, and the opaque-crash return path. `/simplify` (4 angles) + `/code-review --fix` (5 correctness angles + verify + sweep) after implementation: caught the NUL/surrogate crashloop, the missing module name in the ImportError, the dataclass test not actually pinning `dont_inherit` (the `live` probe now does — mutation-verified), and stale rationale comments.

Ops note (PLAUSIBLE, accepted): pinned-seed orderings are stable per CPython version but a worker interpreter major upgrade can re-arm hash-ordering divergence for in-flight suspended runs — fail-closed as `nondeterministic_replay`; drain suspended runs across Python upgrades.

Next in the umbrella (#777): #780 (per-run compute ceiling — 30s wake deadline + full-memo reship) is the non-negotiable follow-on; with #778 alone a deep-research script is authorable but bricks mid-fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
