### PR TITLE
fix: cap procrastinate job growth, add DB timeouts, drop dup index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Built-in and externally-executed tools can be called in the same response. The i
 ### Two pools in one process
 
 The worker runs **two** Postgres connection pools:
-- **asyncpg** (ours): event log, session state, all application queries
+- **asyncpg** (ours): event log, session state, all application queries. The pool sets `statement_timeout`/`idle_in_transaction_session_timeout` and TCP keepalive GUCs via `server_settings` (see `db/pool.py`); the psycopg3/migrate path deliberately does not.
 - **psycopg3** (procrastinate's): job queue. Separate connector, separate connections.
 
 They don't share connections; they share Postgres state.

--- a/migrations/versions/0065_tool_confirmed_allow_index.py
+++ b/migrations/versions/0065_tool_confirmed_allow_index.py
@@ -7,7 +7,8 @@ Two readers resolve the same "confirmed ``allow`` whose ``tool_call`` has no
 * ``sweep.CONFIRMED_ROWS_SQL`` (``find_sessions_needing_inference`` case (c))
   scans confirmed-allow lifecycle rows **cross-session** every sweep pass to
   decide which sessions need a dispatch step — previously unindexed for this
-  predicate (only the wide ``events_session_seq_idx`` applied).
+  predicate (only the wide btree backing the ``events``
+  ``UNIQUE (session_id, seq)`` constraint applied).
 * ``queries.list_confirmed_unresolved_tool_calls`` resolves the dispatchable
   ``tool_call`` dicts for one session on **every** inference step; without this
   index it would scan all of a long session's lifecycle rows per step.

--- a/migrations/versions/0080_drop_events_session_seq_idx.py
+++ b/migrations/versions/0080_drop_events_session_seq_idx.py
@@ -1,0 +1,42 @@
+"""Drop the redundant ``events_session_seq_idx`` on ``events``.
+
+``events_session_seq_idx`` (created in migration 0001) duplicates the implicit
+btree Postgres builds to back the ``UNIQUE (session_id, seq)`` constraint on
+``events``. Two identical ``(session_id, seq)`` btrees write-amplify every
+insert on the hottest table in the system; dropping the redundant one removes
+that overhead with no read-path regression (the unique-constraint btree serves
+the same lookups). Migration 0064 already declined the same redundancy on
+``wf_run_events`` — the rule was learned there but the original ``events`` copy
+was never repaired.
+
+Built with ``DROP INDEX CONCURRENTLY`` (outside a transaction via
+``autocommit_block``) so it never takes an ACCESS EXCLUSIVE lock on the
+live-written ``events`` table — same pattern as migrations 0023 / 0062.
+
+Revision ID: 0080
+Revises: 0079
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0080"
+down_revision: str = "0079"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_session_seq_idx")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_session_seq_idx "
+            "ON events (session_id, seq)"
+        )

--- a/src/aios/db/pool.py
+++ b/src/aios/db/pool.py
@@ -27,8 +27,21 @@ def normalize_dsn(db_url: str) -> str:
 
 async def create_pool(db_url: str, *, min_size: int = 1, max_size: int = 8) -> asyncpg.Pool[Any]:
     """Create a new asyncpg pool against ``db_url``."""
+    # asyncpg exposes no client-side keepalive kwarg, so the statement/idle
+    # timeouts and TCP keepalive are applied as Postgres USERSET GUCs on every
+    # pooled connection — bounding runaway scans, idle-in-txn leaks, and dead
+    # connections behind a silently-dropped TCP link.
     pool = await asyncpg.create_pool(
-        dsn=normalize_dsn(db_url), min_size=min_size, max_size=max_size
+        dsn=normalize_dsn(db_url),
+        min_size=min_size,
+        max_size=max_size,
+        server_settings={
+            "statement_timeout": "30000",
+            "idle_in_transaction_session_timeout": "60000",
+            "tcp_keepalives_idle": "60",
+            "tcp_keepalives_interval": "10",
+            "tcp_keepalives_count": "5",
+        },
     )
     if pool is None:
         raise RuntimeError(f"asyncpg.create_pool returned None for {db_url}")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -2934,7 +2934,8 @@ async def _unresolved_tool_calls(
     # ``events_assistant_tool_calls_idx``; the ``jsonb_array_length > 0``
     # post-filter narrows to non-empty arrays (the index admits
     # ``null`` / ``[]`` too).  Without the ``?`` conjunct the planner
-    # falls back to the wider ``events_session_seq_idx``.
+    # falls back to the wider btree backing the ``events``
+    # ``UNIQUE (session_id, seq)`` constraint.
     #
     # ``$3`` carries the optional age bound (seconds); NULL disables it so
     # the awaiting read-model path is byte-for-byte unchanged (#741), while

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -218,6 +218,10 @@ async def worker_main() -> None:
             concurrency=settings.worker_concurrency,
             wait=True,
             install_signal_handlers=True,
+            # procrastinate defaults to NEVER deleting finished jobs, so
+            # ``procrastinate_jobs`` would grow one row per wake forever.
+            # Reap successful jobs; keep failures around for triage.
+            delete_jobs="successful",
         )
     finally:
         log.info("worker.shutdown")

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -100,13 +100,15 @@ def test_migration_creates_all_tables(postgres: object) -> None:
             for required in (
                 "credentials_name_uniq",
                 "agents_name_uniq",
-                "events_session_seq_idx",
                 "events_session_message_seq_idx",
                 "events_model_request_end_calibration_idx",
                 "bindings_connection_active_uniq",
                 "runtime_tokens_connector_idx",
             ):
                 assert required in index_names, f"missing index {required}"
+            assert "events_session_seq_idx" not in index_names, (
+                "events_session_seq_idx should be dropped by migration 0080"
+            )
         finally:
             await conn.close()
 

--- a/tests/unit/test_db_pool.py
+++ b/tests/unit/test_db_pool.py
@@ -51,6 +51,22 @@ async def test_default_max_size_is_8() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pool_sets_timeouts_and_keepalive() -> None:
+    fake_pool = _make_fake_pool("200")
+    with patch(
+        "aios.db.pool.asyncpg.create_pool", new=AsyncMock(return_value=fake_pool)
+    ) as mock_create:
+        await create_pool("postgresql://stub/db")
+        _, kwargs = mock_create.call_args
+        ss = kwargs["server_settings"]
+        assert ss["statement_timeout"] == "30000"
+        assert ss["idle_in_transaction_session_timeout"] == "60000"
+        assert ss["tcp_keepalives_idle"] == "60"
+        assert ss["tcp_keepalives_interval"] == "10"
+        assert ss["tcp_keepalives_count"] == "5"
+
+
+@pytest.mark.asyncio
 async def test_warning_emitted_when_capacity_reaches_pg_max(
     capture_logs: structlog.testing.LogCapture,
 ) -> None:

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0079``."""
+    """The migration ladder has exactly one head: ``0080``."""
     script = _script_directory()
-    assert script.get_heads() == ["0079"]
+    assert script.get_heads() == ["0080"]
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
Closes #846

## What

Three production-readiness fixes targeting row/connection growth and missing DB-side backstops:

**1. Procrastinate job retention** (`harness/worker.py`)

`run_worker_async` was passing no `delete_jobs` argument. Procrastinate 3.8.1 defaults to `NEVER`, so `procrastinate_jobs` accumulated one row per wake indefinitely — the second-hottest write path, amplified by the 30s workflow sweep. Now passes `delete_jobs="successful"` to reap completed jobs while keeping failures for triage.

**2. DB-side timeouts + TCP keepalive** (`db/pool.py`)

`create_pool` set no `server_settings`. Now configures:
- `statement_timeout=30000` (30s) — bounds O(history) scans
- `idle_in_transaction_session_timeout=60000` (60s) — bounds lock-held stalls
- `tcp_keepalives_idle=60`, `tcp_keepalives_interval=10`, `tcp_keepalives_count=5` — closes the ~2h connection-leak window (dead-connection detection ≈110s)

TCP keepalive is set via Postgres USERSET GUCs in `server_settings` because asyncpg 0.31 exposes no client-side keepalive kwarg. The migration path (`migrations/env.py`, SQLAlchemy NullPool + psycopg3) is deliberately left without `statement_timeout` so long-running migrations are never killed mid-run.

**3. Drop redundant `events_session_seq_idx`** (migration `0080`)

This index has duplicated the implicit btree backing `UNIQUE (session_id, seq)` on `events` since migration 0001. Migration 0064 already declined the same redundancy on `wf_run_events`. The new migration drops it with `DROP INDEX CONCURRENTLY` inside an `autocommit_block` (no `ACCESS EXCLUSIVE` lock on the hot events table); downgrade recreates it `CONCURRENTLY`. Stale planner-fallback comments in `db/queries/__init__.py` and migration 0065 are updated to point at the UNIQUE constraint's btree.

## Blast-radius note

`statement_timeout=30000` now applies to every asyncpg query in the API and worker processes. Any application query that legitimately needs more than 30s will be cancelled. 30s is the value specified by the issue; flag here if any known query approaches that bound.

## Testing

- New unit test `tests/unit/test_db_pool.py::test_pool_sets_timeouts_and_keepalive` — asserts all five `server_settings` keys are passed; includes a non-vacuous mutation check.
- `tests/integration/test_migrations.py` — removed `events_session_seq_idx` from the required-index tuple; added a positive assertion that it is absent after the full migration ladder. Verified against testcontainer Postgres (1 passed, index gone after 0080).
- `tests/unit/test_migration_chain.py::test_single_head` — head pin advanced 0079 → 0080.
- mypy strict, ruff check, ruff format, full unit suite: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
