### PR TITLE
fix(sandbox): enforce bash timeout inside the container

### DIFF
--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -38,6 +38,20 @@ from aios.sandbox.network import SANDBOX_NETWORK_NAME
 
 log = get_logger("aios.sandbox.backends.docker")
 
+# In-container timeout (#844). The agent command is wrapped in GNU
+# coreutils ``timeout -k <kill-after> -s KILL <deadline>`` INSIDE the
+# container so the SIGKILL actually reaches the daemon-spawned workload —
+# host-side ``proc.kill()`` only ever hit the ``docker`` CLI, leaving the
+# in-container process running (moby#9098).
+_CONTAINER_TIMEOUT_KILL_AFTER_S = 5
+_HOST_BACKSTOP_MARGIN_S = 5
+# GNU ``timeout`` exits 124 (TERM path) or 137 (128+9, SIGKILL path) when it
+# force-kills on timeout. Empirically, ``timeout -s KILL`` in the sandbox
+# image (python:3.13-slim-bookworm, GNU coreutils) exits 137 — but map both
+# so a real in-container timeout is reported honestly instead of looking like
+# a normal exit regardless of coreutils internals. See ``timeout --help``.
+_CONTAINER_TIMEOUT_EXIT_CODES = (124, 137)
+
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
     """Decode ``raw`` as UTF-8 (with replacement) and truncate to ``max_bytes``.
@@ -192,19 +206,41 @@ class DockerBackend:
         cwd: str = "/workspace",
     ) -> CommandResult:
         """Run ``bash -c <command>`` inside the container via ``docker exec``."""
+        # Wrap the agent command in an in-container ``timeout`` so the SIGKILL
+        # on deadline lands on the workload itself, not just the host
+        # ``docker exec`` client (#844 / moby#9098). ``-k 5`` is a kill-after
+        # backstop in case the workload survives the first signal.
         argv = [
             "docker",
             "exec",
             "--workdir",
             cwd,
             handle.sandbox_id,
+            "timeout",
+            "-k",
+            str(_CONTAINER_TIMEOUT_KILL_AFTER_S),
+            "-s",
+            "KILL",
+            str(timeout_seconds),
             "bash",
             "-c",
             command,
         ]
-        rc, stdout_bytes, stderr_bytes, timed_out = await run_subprocess_with_timeout(
-            argv, timeout_s=float(timeout_seconds)
+        # Host-side ``wait_for`` is now only a backstop for the rare case the
+        # in-container ``timeout`` never returns (binary missing, docker exec
+        # wedged). It MUST exceed the container deadline + its kill-after so it
+        # never pre-empts the honest in-container path.
+        host_timeout_s = float(
+            timeout_seconds + _CONTAINER_TIMEOUT_KILL_AFTER_S + _HOST_BACKSTOP_MARGIN_S
         )
+        rc, stdout_bytes, stderr_bytes, timed_out = await run_subprocess_with_timeout(
+            argv, timeout_s=host_timeout_s
+        )
+        # When the in-container ``timeout`` fires it returns 124/137 well before
+        # the host backstop, so the host-derived ``timed_out`` is False on a real
+        # timeout. Map the timeout exit code so we stop telling the model the
+        # command finished when it was actually killed (#844).
+        timed_out = timed_out or rc in _CONTAINER_TIMEOUT_EXIT_CODES
         stdout_str, out_truncated = _decode_and_truncate(stdout_bytes, max_output_bytes)
         stderr_str, err_truncated = _decode_and_truncate(stderr_bytes, max_output_bytes)
         return CommandResult(

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -45,12 +45,11 @@ log = get_logger("aios.sandbox.backends.docker")
 # in-container process running (moby#9098).
 _CONTAINER_TIMEOUT_KILL_AFTER_S = 5
 _HOST_BACKSTOP_MARGIN_S = 5
-# GNU ``timeout`` exits 124 (TERM path) or 137 (128+9, SIGKILL path) when it
-# force-kills on timeout. Empirically, ``timeout -s KILL`` in the sandbox
-# image (python:3.13-slim-bookworm, GNU coreutils) exits 137 — but map both
-# so a real in-container timeout is reported honestly instead of looking like
-# a normal exit regardless of coreutils internals. See ``timeout --help``.
-_CONTAINER_TIMEOUT_EXIT_CODES = (124, 137)
+# GNU ``timeout -s KILL`` exits 137 (128+9) when it force-kills the workload
+# on timeout — verified in the sandbox image and locally. We map exactly this
+# code to ``timed_out``: our invocation never yields the 124 (TERM-path) code
+# from a timeout, and a command that exits 124 on its own is not a timeout.
+_CONTAINER_TIMEOUT_EXIT_CODE = 137
 
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
@@ -206,10 +205,12 @@ class DockerBackend:
         cwd: str = "/workspace",
     ) -> CommandResult:
         """Run ``bash -c <command>`` inside the container via ``docker exec``."""
-        # Wrap the agent command in an in-container ``timeout`` so the SIGKILL
-        # on deadline lands on the workload itself, not just the host
-        # ``docker exec`` client (#844 / moby#9098). ``-k 5`` is a kill-after
-        # backstop in case the workload survives the first signal.
+        # Wrap the agent command in an in-container ``timeout`` so the SIGKILL on
+        # deadline lands on the workload itself, not just the host ``docker exec``
+        # client (#844 / moby#9098). The primary signal is already SIGKILL (-s KILL),
+        # which is unblockable; ``-k 5`` is a redundant kill-after backstop kept to
+        # match the agreed invocation and only matters if the primary signal is ever
+        # softened.
         argv = [
             "docker",
             "exec",
@@ -236,11 +237,11 @@ class DockerBackend:
         rc, stdout_bytes, stderr_bytes, timed_out = await run_subprocess_with_timeout(
             argv, timeout_s=host_timeout_s
         )
-        # When the in-container ``timeout`` fires it returns 124/137 well before
-        # the host backstop, so the host-derived ``timed_out`` is False on a real
+        # When the in-container ``timeout`` fires it returns 137 well before the
+        # host backstop, so the host-derived ``timed_out`` is False on a real
         # timeout. Map the timeout exit code so we stop telling the model the
         # command finished when it was actually killed (#844).
-        timed_out = timed_out or rc in _CONTAINER_TIMEOUT_EXIT_CODES
+        timed_out = timed_out or rc == _CONTAINER_TIMEOUT_EXIT_CODE
         stdout_str, out_truncated = _decode_and_truncate(stdout_bytes, max_output_bytes)
         stderr_str, err_truncated = _decode_and_truncate(stderr_bytes, max_output_bytes)
         return CommandResult(

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -91,8 +91,10 @@ BASH_PARAMETERS_SCHEMA: dict[str, Any] = {
             "description": (
                 "Optional maximum runtime in seconds. Defaults to the "
                 "server's configured default. Capped at the server's "
-                "maximum. The command is killed (SIGKILL) if it exceeds "
-                "this duration."
+                "maximum. If the command exceeds this duration it is "
+                "terminated (SIGKILL) inside the sandbox; any output "
+                "produced up to that point is returned and `timed_out` "
+                "is set true in the result."
             ),
             "minimum": 1,
         },

--- a/src/aios/tools/cancel.py
+++ b/src/aios/tools/cancel.py
@@ -28,12 +28,15 @@ class CancelArgumentError(AiosError):
 
 
 CANCEL_DESCRIPTION = (
-    "Cancel in-flight tool executions for this session. If "
-    "`tool_call_id` is provided, cancels that specific tool call. "
-    "If omitted, cancels all currently running tool calls. "
-    "Cancelled tools will report an error result. Use this when "
-    "you want to stop a long-running operation (e.g. a slow bash "
-    "command) and try a different approach."
+    "Stop waiting on in-flight tool executions for this session. If "
+    "`tool_call_id` is provided, detaches from that specific tool call; "
+    "if omitted, detaches from all currently running tool calls. The "
+    "tool call reports a cancelled error result so you can move on. "
+    "Note: this stops you waiting on the call, but an already-running "
+    "bash command keeps executing inside the sandbox until it finishes "
+    "or hits its own timeout — it is not killed. Avoid re-running a "
+    "non-idempotent command (build, migration, network write) on the "
+    "assumption that cancel stopped it."
 )
 
 CANCEL_PARAMETERS_SCHEMA: dict[str, Any] = {

--- a/tests/unit/sandbox/test_docker_exec_timeout_argv.py
+++ b/tests/unit/sandbox/test_docker_exec_timeout_argv.py
@@ -1,0 +1,146 @@
+"""``DockerBackend.exec`` wraps the agent command in an in-container GNU
+``timeout`` so the SIGKILL on deadline reaches the daemon-spawned workload
+itself, not just the host ``docker exec`` client (issue #844 / moby#9098).
+
+These tests pin the exact argv the backend builds and the ``timed_out``
+mapping, by monkeypatching ``run_subprocess_with_timeout`` (imported into
+the docker backend module at import time) to capture the call and return a
+synthetic ``(rc, stdout, stderr, timed_out)`` tuple. The real docker daemon
+is never touched. ``asyncio_mode = "auto"`` means ``async def test_...``
+needs no decorator.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aios.sandbox.backends import docker as docker_backend
+from aios.sandbox.backends.base import SandboxHandle
+from aios.sandbox.backends.docker import DockerBackend
+
+
+def _install_exec_capture(
+    monkeypatch: pytest.MonkeyPatch, *, rc: int = 0, timed_out: bool = False
+) -> dict[str, object]:
+    """Patch ``run_subprocess_with_timeout`` to record argv + timeout_s and
+    return a synthetic result tuple."""
+    calls: dict[str, object] = {}
+
+    async def fake_run(argv: list[str], *, timeout_s: float) -> tuple[int, bytes, bytes, bool]:
+        calls["argv"] = list(argv)
+        calls["timeout_s"] = timeout_s
+        return rc, b"out", b"err", timed_out
+
+    monkeypatch.setattr(docker_backend, "run_subprocess_with_timeout", fake_run)
+    return calls
+
+
+def _handle() -> SandboxHandle:
+    return SandboxHandle(
+        session_id="sess_exec",
+        sandbox_id="container_abc123",
+        workspace_path=Path("/tmp/ws"),
+    )
+
+
+async def test_argv_wraps_command_in_container_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC1 (AC#1, #3): the in-container command is wrapped in GNU
+    ``timeout -k 5 -s KILL <deadline>`` before ``bash -c``."""
+    calls = _install_exec_capture(monkeypatch)
+    await DockerBackend().exec(_handle(), "echo hi", timeout_seconds=30, max_output_bytes=1000)
+    assert calls["argv"] == [
+        "docker",
+        "exec",
+        "--workdir",
+        "/workspace",
+        "container_abc123",
+        "timeout",
+        "-k",
+        "5",
+        "-s",
+        "KILL",
+        "30",
+        "bash",
+        "-c",
+        "echo hi",
+    ]
+
+
+async def test_argv_deadline_tracks_timeout_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC1 cont.: the deadline element (immediately before ``bash``) is the
+    requested ``timeout_seconds``."""
+    calls = _install_exec_capture(monkeypatch)
+    await DockerBackend().exec(_handle(), "echo hi", timeout_seconds=42, max_output_bytes=1000)
+    argv = calls["argv"]
+    assert isinstance(argv, list)
+    bash_idx = argv.index("bash")
+    assert argv[bash_idx - 1] == "42"
+
+
+async def test_host_backstop_exceeds_container_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC2 (AC#1): the host-side ``wait_for`` backstop is larger than the
+    in-container deadline so it never pre-empts the honest in-container path."""
+    calls = _install_exec_capture(monkeypatch)
+    await DockerBackend().exec(_handle(), "echo hi", timeout_seconds=30, max_output_bytes=1000)
+    assert calls["timeout_s"] == 40.0
+    assert isinstance(calls["timeout_s"], float)
+    assert calls["timeout_s"] > 30
+
+
+async def test_rc_137_maps_to_timed_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC3: a SIGKILL-path timeout exit (137) is reported as ``timed_out`` even
+    though the host backstop did not fire."""
+    _install_exec_capture(monkeypatch, rc=137, timed_out=False)
+    result = await DockerBackend().exec(
+        _handle(), "sleep 999", timeout_seconds=30, max_output_bytes=1000
+    )
+    assert result.timed_out is True
+    assert result.exit_code == 137
+
+
+async def test_rc_124_maps_to_timed_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC4: the canonical ``timeout`` exit (124, TERM path) is also reported as
+    ``timed_out``."""
+    _install_exec_capture(monkeypatch, rc=124, timed_out=False)
+    result = await DockerBackend().exec(
+        _handle(), "sleep 999", timeout_seconds=30, max_output_bytes=1000
+    )
+    assert result.timed_out is True
+
+
+async def test_ordinary_exit_codes_not_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC5: a clean exit (0) and an ordinary failure (1) are NOT flagged as
+    timed out."""
+    _install_exec_capture(monkeypatch, rc=0, timed_out=False)
+    result = await DockerBackend().exec(
+        _handle(), "true", timeout_seconds=30, max_output_bytes=1000
+    )
+    assert result.timed_out is False
+
+    _install_exec_capture(monkeypatch, rc=1, timed_out=False)
+    result = await DockerBackend().exec(
+        _handle(), "false", timeout_seconds=30, max_output_bytes=1000
+    )
+    assert result.timed_out is False
+
+
+async def test_host_backstop_path_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC6: when the host backstop fires (rc=-1, timed_out=True) the result
+    still reports ``timed_out`` — the host path is preserved."""
+    _install_exec_capture(monkeypatch, rc=-1, timed_out=True)
+    result = await DockerBackend().exec(
+        _handle(), "sleep 999", timeout_seconds=30, max_output_bytes=1000
+    )
+    assert result.timed_out is True
+
+
+def test_cancel_description_corrected() -> None:
+    """TC7 (AC#2): the cancel description no longer promises stopping a
+    long-running operation, and tells the model the bash command keeps
+    executing inside the sandbox."""
+    from aios.tools.cancel import CANCEL_DESCRIPTION
+
+    assert "stop a long-running operation" not in CANCEL_DESCRIPTION
+    assert "keeps executing inside the sandbox" in CANCEL_DESCRIPTION

--- a/tests/unit/sandbox/test_docker_exec_timeout_argv.py
+++ b/tests/unit/sandbox/test_docker_exec_timeout_argv.py
@@ -90,8 +90,10 @@ async def test_host_backstop_exceeds_container_deadline(monkeypatch: pytest.Monk
 
 
 async def test_rc_137_maps_to_timed_out(monkeypatch: pytest.MonkeyPatch) -> None:
-    """TC3: a SIGKILL-path timeout exit (137) is reported as ``timed_out`` even
-    though the host backstop did not fire."""
+    """TC3: the SIGKILL-path timeout exit (137) — the ONLY code our
+    ``timeout -s KILL`` invocation produces on a timeout — is reported as
+    ``timed_out`` even though the host backstop did not fire, and the exit code
+    passes through unchanged."""
     _install_exec_capture(monkeypatch, rc=137, timed_out=False)
     result = await DockerBackend().exec(
         _handle(), "sleep 999", timeout_seconds=30, max_output_bytes=1000
@@ -100,14 +102,17 @@ async def test_rc_137_maps_to_timed_out(monkeypatch: pytest.MonkeyPatch) -> None
     assert result.exit_code == 137
 
 
-async def test_rc_124_maps_to_timed_out(monkeypatch: pytest.MonkeyPatch) -> None:
-    """TC4: the canonical ``timeout`` exit (124, TERM path) is also reported as
-    ``timed_out``."""
+async def test_rc_124_not_flagged_as_timed_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """TC4: 124 is the GNU ``timeout`` TERM-path code, which our ``-s KILL``
+    invocation never yields on a timeout. A command that exits 124 on its own is
+    therefore NOT a timeout — it is not flagged, and the exit code passes
+    through unchanged."""
     _install_exec_capture(monkeypatch, rc=124, timed_out=False)
     result = await DockerBackend().exec(
         _handle(), "sleep 999", timeout_seconds=30, max_output_bytes=1000
     )
-    assert result.timed_out is True
+    assert result.timed_out is False
+    assert result.exit_code == 124
 
 
 async def test_ordinary_exit_codes_not_flagged(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #844

## Summary

- `DockerBackend.exec` now wraps the agent command with GNU coreutils `timeout -k 5 -s KILL <timeout_seconds>` inside the container, so SIGKILL actually reaches the workload instead of only killing the host-side `docker` CLI process (moby#9098).
- The host-side `wait_for` backstop is retained at `timeout_seconds + 10s` to cover the rare case where the in-container `timeout` binary is missing or `docker exec` wedges.
- Exit code **137** (the SIGKILL path — the empirically confirmed code for `timeout -s KILL` on timeout, verified both in the sandbox image and locally) is mapped to `timed_out=True`. Exit 124 (the TERM-path code, which this invocation never produces from a timeout) and ordinary non-zero exits (e.g. 1) are deliberately **not** mapped, to avoid false positives.
- The bash `timeout_seconds` schema description and the `cancel` tool description are corrected: they no longer promise a kill the client cannot deliver. The cancel description now explicitly warns that an already-running bash command continues executing inside the sandbox until it finishes or hits its own timeout, and that the model must not re-run non-idempotent commands assuming cancel stopped them.

## Root cause

`docker exec` spawns the command via the containerd shim inside the container. Killing the host `docker` CLI process (what the old `wait_for` SIGKILL did) has no effect on that in-container process. Commands kept running in `/workspace` after the harness reported `timed_out=true`, causing the model to retry non-idempotent operations (builds, migrations, HTTP POSTs) that then raced the still-running survivor.

## Test plan

- New unit tests in `tests/unit/sandbox/test_docker_exec_timeout_argv.py` (8 tests, no real Docker needed):
  - `timeout -k 5 -s KILL <deadline>` wrapper is present at the correct argv position
  - Host backstop is enlarged to `deadline + 10s`
  - Exit 137 maps to `timed_out=True` (with `exit_code` preserved)
  - Exit 124, 0, and 1 are **not** flagged as `timed_out` (124's `exit_code` still passes through)
  - Host-backstop `timed_out=True` path is preserved
  - Cancel tool description no longer contains the incorrect kill promise
- Full unit suite (`tests/unit/test_bash_handler.py`, `tests/unit/sandbox/`, 105 tests), mypy strict, and ruff all green
- No OpenAPI/SDK codegen impact: the changed strings feed only `to_openai_tools()`, not any FastAPI response model

🤖 Generated with [Claude Code](https://claude.com/claude-code)
