### PR TITLE
fix: read create_run launcher surface inside the run txn (#835)

### DIFF
--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -139,8 +139,48 @@ async def get_agent_version(
         return await queries.get_agent_version(conn, agent_id, version, account_id=account_id)
 
 
+async def _load_for_session_conn(
+    conn: asyncpg.Connection[Any], session: Any, *, account_id: str
+) -> Agent | AgentVersion:
+    """Resolve a session's effective surface on a caller-supplied ``conn``.
+
+    The body of :func:`load_for_session` — see that function's docstring for the
+    branch semantics (frozen-child overlay / pinned version / latest). Kept on a
+    supplied ``conn`` so a caller already inside a transaction (``create_run``'s
+    launcher read) resolves at the same consistency point without a second acquire.
+    """
+    if session.parent_run_id is not None:
+        frozen = await queries.get_session_frozen_surface(conn, session.id, account_id=account_id)
+        if frozen is None:
+            raise RuntimeError(
+                f"workflow child {session.id} has no frozen surface snapshot "
+                "(parent_run_id set but surface_frozen is false)"
+            )
+        # A workflow child always pins a concrete agent_version at spawn
+        # (insert_child_session requires the int), so this is never a "latest" read.
+        version = await queries.get_agent_version(
+            conn, session.agent_id, session.agent_version, account_id=account_id
+        )
+        return version.model_copy(
+            update={
+                "tools": frozen.tools,
+                "mcp_servers": frozen.mcp_servers,
+                "http_servers": frozen.http_servers,
+            }
+        )
+    if session.agent_version is not None:
+        return await queries.get_agent_version(
+            conn, session.agent_id, session.agent_version, account_id=account_id
+        )
+    return await queries.get_agent(conn, session.agent_id, account_id=account_id)
+
+
 async def load_for_session(
-    pool: asyncpg.Pool[Any], session: Any, *, account_id: str
+    pool: asyncpg.Pool[Any],
+    session: Any,
+    *,
+    account_id: str,
+    conn: asyncpg.Connection[Any] | None = None,
 ) -> Agent | AgentVersion:
     """Load the Agent / AgentVersion the harness sees for ``session`` at step time.
 
@@ -156,34 +196,14 @@ async def load_for_session(
 
     Otherwise: ``session.agent_version is None`` means "latest" — fetches the current
     ``Agent``; an integer pins to a specific ``AgentVersion``.
+
+    Pass ``conn`` to resolve on a caller-supplied connection (e.g. inside an open
+    transaction); with no ``conn`` the read self-acquires from ``pool`` as before.
     """
-    if session.parent_run_id is not None:
-        async with pool.acquire() as conn:
-            frozen = await queries.get_session_frozen_surface(
-                conn, session.id, account_id=account_id
-            )
-            if frozen is None:
-                raise RuntimeError(
-                    f"workflow child {session.id} has no frozen surface snapshot "
-                    "(parent_run_id set but surface_frozen is false)"
-                )
-            # A workflow child always pins a concrete agent_version at spawn
-            # (insert_child_session requires the int), so this is never a "latest" read.
-            version = await queries.get_agent_version(
-                conn, session.agent_id, session.agent_version, account_id=account_id
-            )
-        return version.model_copy(
-            update={
-                "tools": frozen.tools,
-                "mcp_servers": frozen.mcp_servers,
-                "http_servers": frozen.http_servers,
-            }
-        )
-    if session.agent_version is not None:
-        return await get_agent_version(
-            pool, session.agent_id, session.agent_version, account_id=account_id
-        )
-    return await get_agent(pool, session.agent_id, account_id=account_id)
+    if conn is not None:
+        return await _load_for_session_conn(conn, session, account_id=account_id)
+    async with pool.acquire() as acquired:
+        return await _load_for_session_conn(acquired, session, account_id=account_id)
 
 
 def effective_mcp_permission(name: str, agent_tools: list[ToolSpec]) -> PermissionPolicy:

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -12,14 +12,13 @@ from typing import Any
 import asyncpg
 
 from aios.config import get_settings
-from aios.db.queries import get_environment, get_session_vault_ids
+from aios.db.queries import get_environment, get_session_bare, get_session_vault_ids
 from aios.db.queries import workflows as wf_queries
 from aios.errors import AiosError, ForbiddenError, NotFoundError, RateLimitedError
 from aios.models.attenuation import Surface, surface_of
 from aios.models.workflows import WfRun
 from aios.services import agents as agents_service
 from aios.services import attenuation as attenuation_service
-from aios.services import sessions as sessions_service
 from aios.services.wake import defer_run_wake
 
 # Vertical recursion bound: how deep a chain of runs (a run whose agent() child
@@ -79,27 +78,25 @@ async def create_run(
     """
     requested = list(vault_ids or [])
     # #794 top edge: an agent-launched run cannot exceed the launcher's own surface.
-    # Load the launcher's effective surface BEFORE acquiring the run's connection (a
-    # second pool.acquire() while holding `conn` would deadlock a small pool); the meet
-    # itself runs inside the transaction once the workflow is fetched. The operator/HTTP
-    # path (no launcher) is the lattice top — the run snapshots the workflow verbatim.
-    # (Consistency note: this read is outside the run txn, so a concurrent agent edit
-    # between it and the snapshot clamps against a slightly-stale launcher surface — a
-    # same-account, bounded-to-recent-state lag, the same read-then-act window as the
-    # author edge, never a cross-tenant breach. A conn-threaded load would close it.)
+    # #835: the launcher's effective surface is read INSIDE the run transaction (below),
+    # threading `conn` into load_for_session — the same consistency point as the vault
+    # check and the snapshot write, so a concurrent agent edit can't land a stale-broad
+    # snapshot. The operator/HTTP path (no launcher) is the lattice top — the run
+    # snapshots the workflow verbatim. Threading `conn` (vs a second pool.acquire())
+    # keeps the whole path single-connection, so it is safe on a size-1 pool.
     launcher_surface: Surface | None = None
-    if launcher_session_id is not None:
-        launcher_session = await sessions_service.get_session_basic(
-            pool, launcher_session_id, account_id=account_id
-        )
-        launcher_agent = await agents_service.load_for_session(
-            pool, launcher_session, account_id=account_id
-        )
-        launcher_surface = surface_of(launcher_agent)
     async with pool.acquire() as conn, conn.transaction():
         await get_environment(conn, environment_id, account_id=account_id)  # 404s foreign/absent
         workflow = await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
         script_sha = hashlib.sha256(workflow.script.encode("utf-8")).hexdigest()
+        if launcher_session_id is not None:
+            launcher_session = await get_session_bare(
+                conn, launcher_session_id, account_id=account_id
+            )
+            launcher_agent = await agents_service.load_for_session(
+                pool, launcher_session, account_id=account_id, conn=conn
+            )
+            launcher_surface = surface_of(launcher_agent)
         # Clamp the snapshot to the launcher's surface (sub-runs compose for free: a
         # child launcher's load_for_session already returns its frozen clamp).
         effective = (

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -42,6 +42,7 @@ from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
 from aios.services.sessions import create_child_session
 from aios.tools import workflow_management as wm
+from aios.workflows import service as wf_service_module
 from aios.workflows.child_id import child_session_id
 from aios.workflows.service import WORKFLOW_RUN_MAX_DEPTH, WorkflowRunDepthExceededError
 
@@ -829,6 +830,75 @@ async def test_create_run_clamps_top_edge_to_launcher(vault_pool: asyncpg.Pool[A
         pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV
     )
     assert {t.type for t in operator.tools} == {"bash", "read"}  # operator = top — verbatim
+
+
+async def test_create_run_clamps_to_launcher_revoked_mid_launch(
+    vault_pool: asyncpg.Pool[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#835: the launcher surface is read INSIDE the run txn, not before it.
+
+    A live-read launcher (``agent_version=None``) holds ``[bash, read]``. The operator
+    authors a broad ``[bash, read]`` workflow. We inject an ``update_agent`` that revokes
+    ``read`` at the txn boundary — patching ``get_environment`` (the first in-txn query)
+    to commit the revoke before calling through. The snapshot must clamp to the
+    post-revoke surface ``{bash}``.
+
+    Discriminates the bug: pre-fix, ``load_for_session`` runs BEFORE the txn and reads the
+    stale-broad ``[bash, read]`` (the revoke commits too late) → snapshot ``{bash, read}``.
+    Post-fix, the in-txn read happens AFTER the revoke barrier → snapshot ``{bash}``.
+    """
+    pool = vault_pool
+    agent = await _make_agent(
+        pool, "revoked-launcher", tools=[ToolSpec(type="bash"), ToolSpec(type="read")]
+    )
+    # Live/latest-read launcher session (agent_version=None) — the only kind with a live
+    # surface read to race; a pinned/frozen session would read an immutable version.
+    async with pool.acquire() as conn:
+        launcher_session = await db_queries.insert_session(
+            conn,
+            account_id=ACC,
+            agent_id=agent.id,
+            environment_id=ENV,
+            agent_version=None,
+            title=None,
+            metadata={},
+        )
+    launcher = launcher_session.id
+    # Operator authors a BROAD workflow (the run will clamp against the launcher).
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="wf-revoke-mid",
+        script=_SCRIPT,
+        tools=[ToolSpec(type="bash"), ToolSpec(type="read")],
+    )
+
+    # The real in-txn env read (imported from aios.db.queries; we patch the name bound
+    # in the service module, so capture the original from its source here).
+    real_get_environment = db_queries.get_environment
+    revoked = False
+
+    async def revoking_get_environment(conn: Any, environment_id: str, *, account_id: str) -> Any:
+        nonlocal revoked
+        if not revoked:
+            revoked = True
+            # Commit the revoke on a fresh pool connection (its own txn), simulating a
+            # concurrent operator edit landing at the txn boundary.
+            await agents_service.update_agent(
+                pool, agent.id, account_id=ACC, expected_version=1, tools=[ToolSpec(type="bash")]
+            )
+        return await real_get_environment(conn, environment_id, account_id=account_id)
+
+    monkeypatch.setattr(wf_service_module, "get_environment", revoking_get_environment)
+
+    run = await wf_service.create_run(
+        pool,
+        account_id=ACC,
+        workflow_id=wf.id,
+        environment_id=ENV,
+        launcher_session_id=launcher,
+    )
+    assert {t.type for t in run.tools} == {"bash"}  # clamped to the post-revoke surface
 
 
 async def test_subrun_composes_against_child_frozen_clamp(

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -153,7 +153,7 @@ def mock_step_dependencies() -> Any:
             AsyncMock(return_value=session),
         ),
         patch(
-            "aios.harness.loop.agents_service.get_agent",
+            "aios.harness.loop.agents_service.load_for_session",
             AsyncMock(return_value=agent),
         ),
         # Channels helpers are imported lazily inside run_session_step —

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -178,7 +178,7 @@ class TestEntrySweepSpan:
                 AsyncMock(return_value=session),
             ),
             patch(
-                "aios.harness.loop.agents_service.get_agent",
+                "aios.harness.loop.agents_service.load_for_session",
                 AsyncMock(return_value=agent),
             ),
             patch(


### PR DESCRIPTION
## Summary

Closes #835

The launcher's tool-surface was read **outside** the run transaction (pre-txn, to avoid deadlocking a size-1 pool) while its vault holdings were checked **inside** it. A concurrent `update_agent` revoking a tool from the launching agent could land between those two points, letting the child run snapshot the pre-revoke (broader) surface. Blast radius was same-account only and bounded to a narrow time window, but the authority axes of a single launch were evaluated at different consistency points.

This was a deliberately-deferred residual from #794 / #834.

## What changed

**`src/aios/services/agents.py`** — `load_for_session` now accepts an optional `conn` parameter. The body was extracted into a private `_load_for_session_conn(conn, session, *, account_id)` helper that resolves the frozen-overlay, pinned-version, and latest branches on the supplied connection without a second `pool.acquire()`. When no `conn` is passed, the public wrapper acquires one as before. All ~7 existing callers are unaffected (backward compatible).

**`src/aios/workflows/service.py`** — `create_run` now reads the launcher session row (`get_session_bare`) and its surface (`load_for_session(..., conn=conn)`) **inside** the run transaction, at the same consistency point as the vault subset-check and the `insert_wf_run` snapshot write. The whole launch holds exactly one connection, eliminating the original size-1 pool deadlock risk that motivated hoisting the read out of the txn. Removed the stale "consistency note" comment documenting the residual.

**`tests/integration/test_wf_run_vaults.py`** — Added a deterministic regression test `test_create_run_clamps_to_launcher_revoked_mid_launch`. A live-read launcher holds `[bash, read]`; a broad `[bash, read]` workflow is authored; `get_environment` (the first in-txn statement) is monkeypatched to commit an `update_agent` revoke of `read` at the transaction boundary before calling through. The test asserts the snapshot clamps to `{bash}`. It fails on the old code and passes on the fix; moving the surface read back outside the txn re-fails it (non-vacuous).

**`tests/unit/test_loop_retry.py`, `tests/unit/test_sweep_instrumentation.py`** — Repointed patches from `aios.harness.loop.agents_service.get_agent` to `load_for_session` (the layer-accurate patch point), since the refactored latest branch now calls `queries.get_agent(conn, ...)` directly and the old patch no longer intercepted.

## Validation

- `mypy src tests` — clean (500 files)
- `ruff check + format` — clean
- `tests/unit` — 1991 passed
- `tests/integration/{test_wf_run_vaults,test_wf_step,test_update_agent_concurrent}` — 96 passed
- No codegen required — purely internal; FastAPI routes and `WfRunCreate`/`WfRun` models are untouched

## Acceptance criteria

- `load_for_session` resolves a session's effective surface on a caller-supplied connection (all three branches, including frozen-overlay) without a second `pool.acquire()`
- `create_run` reads the launcher surface inside its transaction; a concurrent `update_agent` cannot produce a stale-broad run snapshot
- No deadlock on a size-1 pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)
