### PR TITLE
feat: API logging, /ready probe, bind_contextvars (#847)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ USER aios
 EXPOSE 8080
 
 HEALTHCHECK --interval=15s --timeout=5s --retries=3 \
-    CMD curl -fsS http://127.0.0.1:8080/health || exit 1
+    CMD curl -fsS http://127.0.0.1:8080/ready || exit 1
 
 CMD ["aios", "api"]
 

--- a/compose.yml
+++ b/compose.yml
@@ -87,7 +87,7 @@ services:
       - signal_state:/var/lib/aios/signal-data
     ports:
       - "${AIOS_API_PORT:-8080}:8080"
-    # Healthcheck inherited from Dockerfile (curl http://127.0.0.1:8080/health).
+    # Healthcheck inherited from Dockerfile (curl http://127.0.0.1:8080/ready).
 
   worker:
     build:

--- a/openapi.json
+++ b/openapi.json
@@ -9,7 +9,7 @@
     "/health": {
       "get": {
         "summary": "Health",
-        "description": "Liveness probe. Unauthenticated; returns the running aios version.\n\nSuitable for load balancer health checks and monitoring probes. Always\nreturns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the\nprocess is up.",
+        "description": "Liveness probe. Unauthenticated; returns the running aios version.\n\nSuitable for load balancer health checks and monitoring probes. Always\nreturns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the\nprocess is up. Deliberately does NOT touch the DB pool \u2014 a post-startup\nPostgres outage must not flip liveness (that's ``/ready``'s job), or an\norchestrator would kill an otherwise-healthy process during a DB blip.",
         "operationId": "get_health",
         "responses": {
           "200": {
@@ -23,6 +23,23 @@
                   "type": "object",
                   "title": "Response Get Health"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "summary": "Ready",
+        "description": "Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.\n\nReturns 200 ``{\"status\": \"ready\"}`` when Postgres answers, 503\n``{\"status\": \"unavailable\"}`` when the pool can't be acquired, the query\nraises, or it exceeds the 2 s budget. This is the signal the Docker/compose\nhealthcheck watches, so a silent post-startup DB outage becomes a visibly\nunhealthy container instead of a 200-returning black hole.",
+        "operationId": "get_ready",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
               }
             }
           }

--- a/packages/aios-sdk/aios_sdk/_generated/api/default/get_health.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/default/get_health.py
@@ -54,7 +54,9 @@ def sync_detailed(
 
     Suitable for load balancer health checks and monitoring probes. Always
     returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up.
+    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    Postgres outage must not flip liveness (that's ``/ready``'s job), or an
+    orchestrator would kill an otherwise-healthy process during a DB blip.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -83,7 +85,9 @@ def sync(
 
     Suitable for load balancer health checks and monitoring probes. Always
     returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up.
+    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    Postgres outage must not flip liveness (that's ``/ready``'s job), or an
+    orchestrator would kill an otherwise-healthy process during a DB blip.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -108,7 +112,9 @@ async def asyncio_detailed(
 
     Suitable for load balancer health checks and monitoring probes. Always
     returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up.
+    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    Postgres outage must not flip liveness (that's ``/ready``'s job), or an
+    orchestrator would kill an otherwise-healthy process during a DB blip.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -135,7 +141,9 @@ async def asyncio(
 
     Suitable for load balancer health checks and monitoring probes. Always
     returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up.
+    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    Postgres outage must not flip liveness (that's ``/ready``'s job), or an
+    orchestrator would kill an otherwise-healthy process during a DB blip.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/api/default/get_ready.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/default/get_ready.py
@@ -1,0 +1,101 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/ready",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | None:
+    if response.status_code == 200:
+        return None
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    r"""Ready
+
+     Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.
+
+    Returns 200 ``{\"status\": \"ready\"}`` when Postgres answers, 503
+    ``{\"status\": \"unavailable\"}`` when the pool can't be acquired, the query
+    raises, or it exceeds the 2 s budget. This is the signal the Docker/compose
+    healthcheck watches, so a silent post-startup DB outage becomes a visibly
+    unhealthy container instead of a 200-returning black hole.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[Any]:
+    r"""Ready
+
+     Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.
+
+    Returns 200 ``{\"status\": \"ready\"}`` when Postgres answers, 503
+    ``{\"status\": \"unavailable\"}`` when the pool can't be acquired, the query
+    raises, or it exceeds the 2 s budget. This is the signal the Docker/compose
+    healthcheck watches, so a silent post-startup DB outage becomes a visibly
+    unhealthy container instead of a 200-returning black hole.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -16,6 +16,7 @@ from fastapi import Depends, FastAPI
 from fastapi.routing import APIRoute
 
 from aios.api.deps import require_bearer_auth
+from aios.api.middleware import RequestLoggingMiddleware
 from aios.api.routers import (
     accounts,
     agents,
@@ -90,6 +91,11 @@ def create_app() -> FastAPI:
         separate_input_output_schemas=False,
     )
     install_exception_handlers(app)
+    # Outermost middleware: a pure-ASGI request logger that runs in the same
+    # task context as the route (so an ``account_id`` bound by the auth dep is
+    # visible on its line) and brackets the whole stack, including the exception
+    # handlers, in its duration measurement.
+    app.add_middleware(RequestLoggingMiddleware)
     app.include_router(health.router)
     app.include_router(accounts.router)
     app.include_router(environments.router)

--- a/src/aios/api/deps.py
+++ b/src/aios/api/deps.py
@@ -12,6 +12,7 @@ from typing import Annotated, cast
 import asyncpg
 from fastapi import Depends, Header, Request
 from procrastinate import App as ProcrastinateApp
+from structlog.contextvars import bind_contextvars
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
@@ -74,6 +75,11 @@ async def require_bearer_auth(
     if result is None:
         raise UnauthorizedError("invalid api key")
     account, key_id = result
+    # Bind account_id onto the request's contextvars so every downstream log line
+    # — the request-logging middleware, the exception handlers — can attribute the
+    # request to its tenant. No clear here: Starlette runs each request in its own
+    # task context, so the binding is scoped to this request and doesn't leak.
+    bind_contextvars(account_id=account.id)
     return (account.id, key_id, account.can_mint_children)
 
 

--- a/src/aios/api/middleware.py
+++ b/src/aios/api/middleware.py
@@ -1,0 +1,58 @@
+"""Pure-ASGI request-logging middleware.
+
+Emits exactly one ``api.request`` structlog line per http request with the
+method, path, response status, and wall-clock duration. Implemented as a raw
+ASGI middleware (not ``@app.middleware("http")``) so it runs in the same task
+context as the route handler — an ``account_id`` bound by the auth dependency
+via ``bind_contextvars`` is therefore visible on the request line through
+``merge_contextvars`` (already in the processor chain). It is registered as the
+OUTERMOST middleware so its duration covers the whole stack, including the
+exception handlers.
+"""
+
+from __future__ import annotations
+
+import time
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from aios.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class RequestLoggingMiddleware:
+    """One ``api.request`` line per http request (method, path, status, duration_ms)."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Only http requests are logged; websocket/lifespan pass straight through.
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        path = scope["path"]
+        start = time.perf_counter()
+        status: int | None = None
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status
+            if message["type"] == "http.response.start":
+                status = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            # Always emit the line, even if the downstream raised before any
+            # response-start was sent — fall back to 500 when status is unknown.
+            log.info(
+                "api.request",
+                method=method,
+                path=path,
+                status=status if status is not None else 500,
+                duration_ms=round((time.perf_counter() - start) * 1000, 2),
+            )

--- a/src/aios/api/routers/health.py
+++ b/src/aios/api/routers/health.py
@@ -37,6 +37,11 @@ async def ready(request: Request) -> Response:
     """
     pool = request.app.state.pool
     try:
+        # The timeout intentionally covers both ``pool.acquire()`` and the query: a
+        # pool that can't hand out a connection (exhausted/stuck) is genuinely "not
+        # ready" to serve DB-backed traffic, same as a DB that won't answer — both are
+        # a correct 503. We don't distinguish the two; the probe's job is liveness of
+        # the DB path, not root-cause attribution.
         async with asyncio.timeout(2.0):
             async with pool.acquire() as conn:
                 await conn.fetchval("SELECT 1")

--- a/src/aios/api/routers/health.py
+++ b/src/aios/api/routers/health.py
@@ -1,8 +1,11 @@
-"""Health check endpoint. Unauthenticated."""
+"""Health and readiness endpoints. Unauthenticated."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import asyncio
+
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import JSONResponse
 
 from aios import __version__
 
@@ -15,6 +18,28 @@ async def health() -> dict[str, str]:
 
     Suitable for load balancer health checks and monitoring probes. Always
     returns 200 with ``{"status": "ok", "version": <version>}`` if the
-    process is up.
+    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    Postgres outage must not flip liveness (that's ``/ready``'s job), or an
+    orchestrator would kill an otherwise-healthy process during a DB blip.
     """
     return {"status": "ok", "version": __version__}
+
+
+@router.get("/ready", operation_id="get_ready")
+async def ready(request: Request) -> Response:
+    """Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.
+
+    Returns 200 ``{"status": "ready"}`` when Postgres answers, 503
+    ``{"status": "unavailable"}`` when the pool can't be acquired, the query
+    raises, or it exceeds the 2 s budget. This is the signal the Docker/compose
+    healthcheck watches, so a silent post-startup DB outage becomes a visibly
+    unhealthy container instead of a 200-returning black hole.
+    """
+    pool = request.app.state.pool
+    try:
+        async with asyncio.timeout(2.0):
+            async with pool.acquire() as conn:
+                await conn.fetchval("SELECT 1")
+    except Exception:
+        return JSONResponse(status_code=503, content={"status": "unavailable"})
+    return JSONResponse(status_code=200, content={"status": "ready"})

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -57,6 +57,12 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
     "put_connector_tools_schema": (
         "Called by connector containers via runtime token; not for operators."
     ),
+    # ── Infra/orchestrator probe ─────────────────────────────────────
+    "get_ready": (
+        "Readiness probe (SELECT 1 under a short timeout) consumed by the "
+        "Docker/compose healthcheck and load balancers, not operators. "
+        "Operators check reachability + auth via `aios status` (get_health)."
+    ),
     # ── Multipart / long-poll ────────────────────────────────────────
     "upload_session_file": ("Multipart upload; file as a dedicated CLI issue if/when needed."),
     "wait_for_events_v1_sessions__session_id__wait_get": (

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 from typing import Any
 
-import structlog
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -229,46 +228,31 @@ class SSEPreflightFailedError(AiosError):
 # ─── FastAPI integration ─────────────────────────────────────────────────────
 
 
-async def aios_error_handler(request: Request, exc: Exception) -> JSONResponse:
-    """Render an :class:`AiosError` as a JSON response (and log it).
+def _log_handler_error(event: str, request: Request, status: int, **fields: object) -> None:
+    """Log an exception-handler event at the level the status dictates.
 
-    4xx is operator/client noise (``warning``); 5xx is a real fault
-    (``log.exception`` — valid here because the handler runs inside the live
-    exception context, so it attaches the traceback). ``account_id`` is read
-    from the contextvar the auth dep bound, so a 5xx can be attributed to a
-    tenant even though the handler has no dep-injected account.
+    5xx is a real fault → ``log.exception`` (valid here because the handler runs
+    inside the live exception context, so it attaches the traceback); 4xx is
+    operator/client noise → ``log.warning``. ``account_id`` is NOT passed
+    explicitly: ``merge_contextvars`` (first in the processor chain) already folds
+    the contextvar the auth dep bound into every line, so an authenticated request's
+    line carries it and an unauthenticated one simply omits the key.
     """
+    log_fn = log.exception if status >= 500 else log.warning
+    log_fn(event, path=request.url.path, status=status, **fields)
+
+
+async def aios_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Render an :class:`AiosError` as a JSON response (and log it)."""
     assert isinstance(exc, AiosError)
-    path = request.url.path
-    account_id = structlog.contextvars.get_contextvars().get("account_id")
-    if exc.status_code >= 500:
-        log.exception(
-            "api.error",
-            path=path,
-            status=exc.status_code,
-            error_type=exc.error_type,
-            account_id=account_id,
-        )
-    else:
-        log.warning(
-            "api.error",
-            path=path,
-            status=exc.status_code,
-            error_type=exc.error_type,
-            account_id=account_id,
-        )
+    _log_handler_error("api.error", request, exc.status_code, error_type=exc.error_type)
     return JSONResponse(status_code=exc.status_code, content=exc.to_body())
 
 
 async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Render Starlette/FastAPI HTTPExceptions in our error envelope (and log it)."""
     assert isinstance(exc, StarletteHTTPException)
-    path = request.url.path
-    account_id = structlog.contextvars.get_contextvars().get("account_id")
-    if exc.status_code >= 500:
-        log.exception("api.http_error", path=path, status=exc.status_code, account_id=account_id)
-    else:
-        log.warning("api.http_error", path=path, status=exc.status_code, account_id=account_id)
+    _log_handler_error("api.http_error", request, exc.status_code, error_type="http_error")
     return JSONResponse(
         status_code=exc.status_code,
         content={
@@ -291,12 +275,7 @@ async def validation_error_handler(request: Request, exc: Exception) -> JSONResp
     clients.
     """
     assert isinstance(exc, RequestValidationError)
-    log.warning(
-        "api.validation_error",
-        path=request.url.path,
-        status=422,
-        account_id=structlog.contextvars.get_contextvars().get("account_id"),
-    )
+    _log_handler_error("api.validation_error", request, 422, error_type="validation_error")
     errors = [{k: v for k, v in err.items() if k != "ctx"} for err in exc.errors()]
     return JSONResponse(
         status_code=422,

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -13,10 +13,15 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import structlog
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from aios.logging import get_logger
+
+log = get_logger(__name__)
 
 
 class AiosError(Exception):
@@ -224,15 +229,46 @@ class SSEPreflightFailedError(AiosError):
 # ─── FastAPI integration ─────────────────────────────────────────────────────
 
 
-async def aios_error_handler(_request: Request, exc: Exception) -> JSONResponse:
-    """Render an :class:`AiosError` as a JSON response."""
+async def aios_error_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Render an :class:`AiosError` as a JSON response (and log it).
+
+    4xx is operator/client noise (``warning``); 5xx is a real fault
+    (``log.exception`` — valid here because the handler runs inside the live
+    exception context, so it attaches the traceback). ``account_id`` is read
+    from the contextvar the auth dep bound, so a 5xx can be attributed to a
+    tenant even though the handler has no dep-injected account.
+    """
     assert isinstance(exc, AiosError)
+    path = request.url.path
+    account_id = structlog.contextvars.get_contextvars().get("account_id")
+    if exc.status_code >= 500:
+        log.exception(
+            "api.error",
+            path=path,
+            status=exc.status_code,
+            error_type=exc.error_type,
+            account_id=account_id,
+        )
+    else:
+        log.warning(
+            "api.error",
+            path=path,
+            status=exc.status_code,
+            error_type=exc.error_type,
+            account_id=account_id,
+        )
     return JSONResponse(status_code=exc.status_code, content=exc.to_body())
 
 
-async def http_exception_handler(_request: Request, exc: Exception) -> JSONResponse:
-    """Render Starlette/FastAPI HTTPExceptions in our error envelope."""
+async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Render Starlette/FastAPI HTTPExceptions in our error envelope (and log it)."""
     assert isinstance(exc, StarletteHTTPException)
+    path = request.url.path
+    account_id = structlog.contextvars.get_contextvars().get("account_id")
+    if exc.status_code >= 500:
+        log.exception("api.http_error", path=path, status=exc.status_code, account_id=account_id)
+    else:
+        log.warning("api.http_error", path=path, status=exc.status_code, account_id=account_id)
     return JSONResponse(
         status_code=exc.status_code,
         content={
@@ -244,7 +280,7 @@ async def http_exception_handler(_request: Request, exc: Exception) -> JSONRespo
     )
 
 
-async def validation_error_handler(_request: Request, exc: Exception) -> JSONResponse:
+async def validation_error_handler(request: Request, exc: Exception) -> JSONResponse:
     """Render pydantic/FastAPI request validation errors.
 
     Pydantic's ``value_error`` entries include a ``ctx`` field that
@@ -255,6 +291,12 @@ async def validation_error_handler(_request: Request, exc: Exception) -> JSONRes
     clients.
     """
     assert isinstance(exc, RequestValidationError)
+    log.warning(
+        "api.validation_error",
+        path=request.url.path,
+        status=422,
+        account_id=structlog.contextvars.get_contextvars().get("account_id"),
+    )
     errors = [{k: v for k, v in err.items() if k != "ctx"} for err in exc.errors()]
     return JSONResponse(
         status_code=422,

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -168,32 +168,35 @@ async def run_session_step(
     # see that block). Bound AFTER the gone-session guard — that path is an
     # idempotent no-op with no account to attribute.
     bind_contextvars(session_id=session_id, account_id=account_id, cause=cause)
-    task_registry = runtime.require_task_registry()
-
-    # Outermost span pair: brackets the entire step (issue #131).  Emitted
-    # before the sweep guard so early-outs are also measured — a "wasted
-    # wake" cost shows up as a ``step_start``/``step_end`` pair with no
-    # ``context_build_*`` inside.  ``step_start_id`` backpointer on the
-    # end event matches the ``context_build_start_id`` convention.
-    step_start = await sessions_service.append_event(
-        pool,
-        session_id,
-        "span",
-        {"event": "step_start", "cause": cause},
-        account_id=account_id,
-    )
-    current_task = asyncio.current_task()
-    assert current_task is not None
-    task_registry.register_step(session_id, current_task)
-    result = _StepResult()
     # Outer try/finally guarantees ``clear_contextvars`` is the VERY LAST thing the
     # step does: the post-step wakes and archive-reclaim below (and their nested
     # ``defer_wake`` logging) must still carry account_id/session_id/cause, so the
     # clear can only run once every per-step log line has been emitted. Clearing is
     # defensive hygiene — contextvars are task-scoped and procrastinate runs each job
     # in a fresh asyncio task, but dropping the bindings here keeps them from
-    # outliving the step regardless of how the worker schedules tasks.
+    # outliving the step regardless of how the worker schedules tasks. The try opens
+    # IMMEDIATELY after the bind so the still-fallible setup below (``step_start``
+    # append, ``register_step``) can't escape with the contextvars still bound — e.g.
+    # a DB drop or a session archived in the race window past the account_id guard.
     try:
+        task_registry = runtime.require_task_registry()
+
+        # Outermost span pair: brackets the entire step (issue #131).  Emitted
+        # before the sweep guard so early-outs are also measured — a "wasted
+        # wake" cost shows up as a ``step_start``/``step_end`` pair with no
+        # ``context_build_*`` inside.  ``step_start_id`` backpointer on the
+        # end event matches the ``context_build_start_id`` convention.
+        step_start = await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {"event": "step_start", "cause": cause},
+            account_id=account_id,
+        )
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        task_registry.register_step(session_id, current_task)
+        result = _StepResult()
         try:
             try:
                 result = await asyncio.wait_for(

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
+from structlog.contextvars import bind_contextvars, clear_contextvars
+
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
 from aios.harness.completion import call_litellm, stream_litellm
@@ -161,6 +163,11 @@ async def run_session_step(
     account_id = await sessions_service.load_live_session_account_id(pool, session_id)
     if account_id is None:
         return
+    # Bind tenant/session/cause onto structlog contextvars so every line this step
+    # emits is attributable; cleared in the finally below so it never leaks to the
+    # next job on this worker task. Bound AFTER the gone-session guard — that path
+    # is an idempotent no-op with no account to attribute.
+    bind_contextvars(session_id=session_id, account_id=account_id, cause=cause)
     task_registry = runtime.require_task_registry()
 
     # Outermost span pair: brackets the entire step (issue #131).  Emitted
@@ -225,6 +232,10 @@ async def run_session_step(
             {"event": "step_end", "step_start_id": step_start.id},
             account_id=account_id,
         )
+        # Clear last: the step's logging is done, so drop the bindings before the
+        # worker task picks up the next job (contextvars are task-scoped, and the
+        # worker reuses tasks across jobs).
+        clear_contextvars()
 
     # Every wake fires AFTER ``step_end`` so its ``wake_deferred`` span lands in
     # step N+1's temporal window, not step N's — the "all wake_deferred since the

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -164,9 +164,9 @@ async def run_session_step(
     if account_id is None:
         return
     # Bind tenant/session/cause onto structlog contextvars so every line this step
-    # emits is attributable; cleared in the finally below so it never leaks to the
-    # next job on this worker task. Bound AFTER the gone-session guard — that path
-    # is an idempotent no-op with no account to attribute.
+    # emits is attributable; cleared in the outer finally below (defensive hygiene —
+    # see that block). Bound AFTER the gone-session guard — that path is an
+    # idempotent no-op with no account to attribute.
     bind_contextvars(session_id=session_id, account_id=account_id, cause=cause)
     task_registry = runtime.require_task_registry()
 
@@ -186,88 +186,94 @@ async def run_session_step(
     assert current_task is not None
     task_registry.register_step(session_id, current_task)
     result = _StepResult()
+    # Outer try/finally guarantees ``clear_contextvars`` is the VERY LAST thing the
+    # step does: the post-step wakes and archive-reclaim below (and their nested
+    # ``defer_wake`` logging) must still carry account_id/session_id/cause, so the
+    # clear can only run once every per-step log line has been emitted. Clearing is
+    # defensive hygiene — contextvars are task-scoped and procrastinate runs each job
+    # in a fresh asyncio task, but dropping the bindings here keeps them from
+    # outliving the step regardless of how the worker schedules tasks.
     try:
         try:
-            result = await asyncio.wait_for(
-                _run_session_step_body(
+            try:
+                result = await asyncio.wait_for(
+                    _run_session_step_body(
+                        pool,
+                        task_registry,
+                        session_id,
+                        cause=cause,
+                        account_id=account_id,
+                    ),
+                    timeout=_JOB_TIMEOUT_S,
+                )
+            except TimeoutError:
+                # Job-level safety net: a per-call timeout was missing or didn't
+                # fire. Force a reschedulable error state so the next wake can
+                # proceed (matches what the body's litellm-error handler does).
+                log.exception("step.job_timeout", session_id=session_id, timeout=_JOB_TIMEOUT_S)
+                result = _StepResult(
+                    retry_delay=await _handle_step_timeout(pool, session_id, account_id=account_id)
+                )
+            except Exception:
+                # Unexpected harness error (not a model/tool error — those are caught
+                # inside _run_session_step_body). Emit a span so the event log has a
+                # record, then apply the retry-or-failure state machine identically to
+                # the timeout path. Re-raise when the budget is exhausted.
+                log.exception("step.harness_error", session_id=session_id)
+                await sessions_service.append_event(
                     pool,
-                    task_registry,
                     session_id,
-                    cause=cause,
+                    "span",
+                    {"event": "harness_error", "is_error": True},
                     account_id=account_id,
-                ),
-                timeout=_JOB_TIMEOUT_S,
-            )
-        except TimeoutError:
-            # Job-level safety net: a per-call timeout was missing or didn't
-            # fire. Force a reschedulable error state so the next wake can
-            # proceed (matches what the body's litellm-error handler does).
-            log.exception("step.job_timeout", session_id=session_id, timeout=_JOB_TIMEOUT_S)
-            result = _StepResult(
-                retry_delay=await _handle_step_timeout(pool, session_id, account_id=account_id)
-            )
-        except Exception:
-            # Unexpected harness error (not a model/tool error — those are caught
-            # inside _run_session_step_body). Emit a span so the event log has a
-            # record, then apply the retry-or-failure state machine identically to
-            # the timeout path. Re-raise when the budget is exhausted.
-            log.exception("step.harness_error", session_id=session_id)
+                )
+                delay = await _apply_retry_or_failure(pool, session_id, account_id=account_id)
+                result = _StepResult(retry_delay=delay)
+                if delay is None:
+                    raise
+        finally:
+            task_registry.unregister_step(session_id)
             await sessions_service.append_event(
                 pool,
                 session_id,
                 "span",
-                {"event": "harness_error", "is_error": True},
+                {"event": "step_end", "step_start_id": step_start.id},
                 account_id=account_id,
             )
-            delay = await _apply_retry_or_failure(pool, session_id, account_id=account_id)
-            result = _StepResult(retry_delay=delay)
-            if delay is None:
-                raise
+
+        # Every wake fires AFTER ``step_end`` so its ``wake_deferred`` span lands in
+        # step N+1's temporal window, not step N's — the "all wake_deferred since the
+        # previous step_end" pairing rule the profiler keys off (#132). Emitting inside
+        # the body would mis-attribute the gap. ``reschedule`` carries a known backoff
+        # delay; the ``request_nudge`` re-wakes the session for another answer turn; the
+        # auto-error wakes the caller run to harvest the ``no_return``.
+        if result.retry_delay is not None:
+            await defer_wake(
+                pool,
+                session_id,
+                cause="reschedule",
+                delay_seconds=result.retry_delay,
+                account_id=account_id,
+            )
+        if result.nudge_session:
+            await defer_wake(pool, session_id, cause="request_nudge", account_id=account_id)
+        if result.autoerror_caller_run_id is not None:
+            await defer_run_wake(result.autoerror_caller_run_id)
+
+        # Archive-on-quiescence, performed LAST: a session launched ``archive_when_idle``
+        # self-archives the first time it goes idle. It runs after ``step_end`` and every
+        # wake span so it is the step's final session write — once archived, ``append_event``
+        # rejects writes (``archived_at IS NULL`` fence). ``reclaim_session_if_idle`` is
+        # conditional on still-idle, so a nudge or a user message that re-activated the
+        # session (its ``defer_wake`` span already appended just above) wins and the archive
+        # no-ops. Only the clean end-of-turn return sets the flag (error/reschedule paths
+        # leave it False), so a rescheduling session is never reclaimed out from under a retry.
+        if result.archive_when_idle and await sessions_service.reclaim_session_if_idle(
+            pool, session_id, account_id=account_id
+        ):
+            log.info("step.session_reclaimed", session_id=session_id, cause=cause)
     finally:
-        task_registry.unregister_step(session_id)
-        await sessions_service.append_event(
-            pool,
-            session_id,
-            "span",
-            {"event": "step_end", "step_start_id": step_start.id},
-            account_id=account_id,
-        )
-        # Clear last: the step's logging is done, so drop the bindings before the
-        # worker task picks up the next job (contextvars are task-scoped, and the
-        # worker reuses tasks across jobs).
         clear_contextvars()
-
-    # Every wake fires AFTER ``step_end`` so its ``wake_deferred`` span lands in
-    # step N+1's temporal window, not step N's — the "all wake_deferred since the
-    # previous step_end" pairing rule the profiler keys off (#132). Emitting inside
-    # the body would mis-attribute the gap. ``reschedule`` carries a known backoff
-    # delay; the ``request_nudge`` re-wakes the session for another answer turn; the
-    # auto-error wakes the caller run to harvest the ``no_return``.
-    if result.retry_delay is not None:
-        await defer_wake(
-            pool,
-            session_id,
-            cause="reschedule",
-            delay_seconds=result.retry_delay,
-            account_id=account_id,
-        )
-    if result.nudge_session:
-        await defer_wake(pool, session_id, cause="request_nudge", account_id=account_id)
-    if result.autoerror_caller_run_id is not None:
-        await defer_run_wake(result.autoerror_caller_run_id)
-
-    # Archive-on-quiescence, performed LAST: a session launched ``archive_when_idle``
-    # self-archives the first time it goes idle. It runs after ``step_end`` and every
-    # wake span so it is the step's final session write — once archived, ``append_event``
-    # rejects writes (``archived_at IS NULL`` fence). ``reclaim_session_if_idle`` is
-    # conditional on still-idle, so a nudge or a user message that re-activated the
-    # session (its ``defer_wake`` span already appended just above) wins and the archive
-    # no-ops. Only the clean end-of-turn return sets the flag (error/reschedule paths
-    # leave it False), so a rescheduling session is never reclaimed out from under a retry.
-    if result.archive_when_idle and await sessions_service.reclaim_session_if_idle(
-        pool, session_id, account_id=account_id
-    ):
-        log.info("step.session_reclaimed", session_id=session_id, cause=cause)
 
 
 async def _run_session_step_body(

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -162,10 +162,12 @@ async def run_workflow_step(run_id: str) -> None:
             return  # vanished or already terminal — a stray/duplicate wake is a no-op
         account_id = run.account_id
     # Bind run/tenant onto structlog contextvars so every line this step emits is
-    # attributable; cleared in the finally so it never leaks to the next job on this
-    # worker task. Bound AFTER the gone/terminal guard above — that path is an
-    # idempotent no-op with no account to attribute. ``cause`` is omitted: workflows
-    # have no per-wake cause concept (unlike a session step's message/reschedule/etc).
+    # attributable; cleared in the finally as defensive hygiene (contextvars are
+    # task-scoped and procrastinate runs each job in a fresh asyncio task, but the
+    # clear keeps the bindings from outliving the step regardless). Bound AFTER the
+    # gone/terminal guard above — that path is an idempotent no-op with no account to
+    # attribute. ``cause`` is omitted: workflows have no per-wake cause concept
+    # (unlike a session step's message/reschedule/etc).
     bind_contextvars(run_id=run_id, account_id=account_id)
     try:
         await _run_workflow_step_body(pool, run_id, run, account_id)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -37,6 +37,7 @@ import jsonschema
 from referencing import Registry, Resource
 from referencing.exceptions import Unresolvable
 from referencing.jsonschema import DRAFT202012
+from structlog.contextvars import bind_contextvars, clear_contextvars
 
 from aios.config import get_settings
 from aios.db import queries as db_queries
@@ -160,7 +161,22 @@ async def run_workflow_step(run_id: str) -> None:
         if run is None or run.status in TERMINAL_RUN_STATUSES:
             return  # vanished or already terminal — a stray/duplicate wake is a no-op
         account_id = run.account_id
+    # Bind run/tenant onto structlog contextvars so every line this step emits is
+    # attributable; cleared in the finally so it never leaks to the next job on this
+    # worker task. Bound AFTER the gone/terminal guard above — that path is an
+    # idempotent no-op with no account to attribute. ``cause`` is omitted: workflows
+    # have no per-wake cause concept (unlike a session step's message/reschedule/etc).
+    bind_contextvars(run_id=run_id, account_id=account_id)
+    try:
+        await _run_workflow_step_body(pool, run_id, run, account_id)
+    finally:
+        clear_contextvars()
 
+
+async def _run_workflow_step_body(
+    pool: asyncpg.Pool[Any], run_id: str, run: WfRun, account_id: str
+) -> None:
+    async with pool.acquire() as conn:
         events = await wf_queries.list_run_events(conn, run_id)
         signals = {s.call_key: s for s in await wf_queries.list_run_signals(conn, run_id)}
 

--- a/tests/e2e/test_ready.py
+++ b/tests/e2e/test_ready.py
@@ -1,0 +1,67 @@
+"""E2E tests for the readiness/liveness probes (Docker: testcontainer Postgres).
+
+``/ready`` does a real ``SELECT 1`` against the live pool; ``/health`` stays
+pure liveness. Fixtures mirror ``tests/e2e/test_account_auth.py`` (a real pool
++ an in-process ASGI client wired to the shared app).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.helpers.connections import asgi_client
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
+    async with asgi_client(pool) as client:
+        yield client
+
+
+async def test_ready_200_db_up(http_client: httpx.AsyncClient) -> None:
+    """With Postgres up, ``/ready`` runs ``SELECT 1`` and returns 200."""
+    r = await http_client.get("/ready")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"status": "ready"}
+
+
+async def test_health_still_200(http_client: httpx.AsyncClient) -> None:
+    """``/health`` stays pure liveness — 200 with the running version."""
+    r = await http_client.get("/health")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert "version" in body
+
+
+async def test_401_logged(http_client: httpx.AsyncClient, caplog: pytest.LogCaptureFixture) -> None:
+    """An unauthenticated protected request 401s, and the request-logging
+    middleware still emits an ``api.request`` line carrying status 401 (no
+    account_id, since auth never resolved)."""
+    from aios.logging import configure_logging
+
+    configure_logging("INFO")
+    with caplog.at_level(logging.INFO):
+        r = await http_client.get("/v1/agents")
+    assert r.status_code == 401, r.text
+
+    request_lines = [
+        m for r in caplog.records if (m := r.getMessage()).startswith("{") and '"api.request"' in m
+    ]
+    assert any('"status": 401' in line and '"path": "/v1/agents"' in line for line in request_lines)

--- a/tests/unit/test_error_handler_logging.py
+++ b/tests/unit/test_error_handler_logging.py
@@ -1,0 +1,162 @@
+"""Unit tests that the three exception handlers emit structured log lines.
+
+Before this change the handlers returned JSON and logged nothing, so a 500
+(or a silent 401) left no trace. Now:
+
+* ``AiosError`` < 500 → ``api.error`` at WARNING; >= 500 → at ERROR with
+  ``exc_info`` (``log.exception``).
+* ``StarletteHTTPException`` → ``api.http_error`` (warn < 500 / exception >= 500).
+* request validation error → ``api.validation_error`` WARNING, status 422.
+* ``account_id`` (bound via the auth dep contextvar) appears on the line.
+
+structlog renders the event dict to a single message string via the configured
+chain, so we read the JSON line off ``caplog`` rather than expecting kv
+attributes on the record.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, field_validator
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from structlog.contextvars import bind_contextvars, clear_contextvars
+
+from aios.errors import (
+    CryptoDecryptError,
+    NotFoundError,
+    install_exception_handlers,
+)
+from aios.logging import configure_logging
+
+
+@pytest.fixture(autouse=True)
+def _logging_and_contextvars() -> object:
+    configure_logging("INFO")
+    clear_contextvars()
+    yield
+    clear_contextvars()
+
+
+def _find(
+    caplog: pytest.LogCaptureFixture, event: str
+) -> tuple[dict[str, object], logging.LogRecord]:
+    for r in caplog.records:
+        msg = r.getMessage()
+        if not msg.startswith("{"):
+            continue
+        try:
+            payload = json.loads(msg)
+        except ValueError:
+            continue
+        if payload.get("event") == event:
+            return payload, r
+    raise AssertionError(f"no {event!r} log line captured")
+
+
+def test_aios_error_4xx_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.get("/boom")
+    async def _boom() -> None:
+        raise NotFoundError("nope")
+
+    with caplog.at_level(logging.WARNING):
+        TestClient(app, raise_server_exceptions=False).get("/boom")
+
+    payload, record = _find(caplog, "api.error")
+    assert payload["status"] == 404
+    assert payload["path"] == "/boom"
+    assert record.levelno == logging.WARNING
+
+
+def test_aios_error_5xx_logs_exception(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.get("/boom")
+    async def _boom() -> None:
+        raise CryptoDecryptError("decrypt failed")
+
+    with caplog.at_level(logging.INFO):
+        TestClient(app, raise_server_exceptions=False).get("/boom")
+
+    payload, record = _find(caplog, "api.error")
+    assert payload["status"] == 500
+    assert payload["path"] == "/boom"
+    assert record.levelno == logging.ERROR
+    # log.exception → structlog's format_exc_info renders the traceback into
+    # the line (an ``exception`` key), which is the captured-traceback signal.
+    assert "exception" in payload
+    assert "CryptoDecryptError" in str(payload["exception"])
+
+
+def test_http_exception_logs_http_error(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.get("/forbidden")
+    async def _forbidden() -> None:
+        raise StarletteHTTPException(status_code=403, detail="no")
+
+    with caplog.at_level(logging.WARNING):
+        TestClient(app, raise_server_exceptions=False).get("/forbidden")
+
+    payload, record = _find(caplog, "api.http_error")
+    assert payload["status"] == 403
+    assert payload["path"] == "/forbidden"
+    assert record.levelno == logging.WARNING
+
+
+class _Model(BaseModel):
+    x: str
+
+    @field_validator("x")
+    @classmethod
+    def _v(cls, v: str) -> str:
+        if v == "bad":
+            raise ValueError("x must not be 'bad'")
+        return v
+
+
+def test_validation_error_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.post("/echo")
+    async def _echo(body: _Model) -> dict[str, str]:
+        return {"ok": "true"}
+
+    with caplog.at_level(logging.WARNING):
+        TestClient(app, raise_server_exceptions=False).post("/echo", json={"x": "bad"})
+
+    payload, record = _find(caplog, "api.validation_error")
+    assert payload["status"] == 422
+    assert payload["path"] == "/echo"
+    assert record.levelno == logging.WARNING
+
+
+def test_account_id_present_on_error_line(caplog: pytest.LogCaptureFixture) -> None:
+    """When the auth dep has bound account_id, the error line carries it."""
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    async def _bind() -> None:
+        bind_contextvars(account_id="acc_y")
+
+    from fastapi import Depends
+
+    @app.get("/boom", dependencies=[Depends(_bind)])
+    async def _boom() -> None:
+        raise NotFoundError("nope")
+
+    with caplog.at_level(logging.WARNING):
+        TestClient(app, raise_server_exceptions=False).get("/boom")
+
+    payload, _ = _find(caplog, "api.error")
+    assert payload["account_id"] == "acc_y"

--- a/tests/unit/test_ready_route.py
+++ b/tests/unit/test_ready_route.py
@@ -1,0 +1,126 @@
+"""Unit tests for the ``/ready`` readiness probe and ``/health`` liveness purity.
+
+``/ready`` runs a ``SELECT 1`` against the pool under a short timeout: 200 when
+the DB answers, 503 when ``acquire``/``fetchval`` raises or the query times out.
+``/health`` stays pure liveness — it must NEVER touch the pool — so a Postgres
+outage is loud on ``/ready`` while ``/health`` still reports the process is up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aios.api.routers import health
+
+
+class _FakeConn:
+    def __init__(self, fetchval_impl: Any) -> None:
+        self._fetchval_impl = fetchval_impl
+
+    async def fetchval(self, query: str) -> Any:
+        return await self._fetchval_impl(query)
+
+
+class _FakeAcquireCM:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _FakeConn:
+        return self._conn
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+
+class _FakePool:
+    """Minimal stand-in for ``asyncpg.Pool``.
+
+    ``acquire()`` yields a conn whose ``fetchval`` runs *fetchval_impl*; if
+    *acquire_raises* is set, ``acquire()`` itself raises (models a dead pool).
+    """
+
+    def __init__(
+        self, fetchval_impl: Any = None, *, acquire_raises: BaseException | None = None
+    ) -> None:
+        self._fetchval_impl = fetchval_impl
+        self._acquire_raises = acquire_raises
+
+    def acquire(self) -> _FakeAcquireCM:
+        if self._acquire_raises is not None:
+            raise self._acquire_raises
+        return _FakeAcquireCM(_FakeConn(self._fetchval_impl))
+
+
+def _app_with_pool(pool: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(health.router)
+    app.state.pool = pool
+    return app
+
+
+def test_ready_200_when_select_ok() -> None:
+    async def _ok(_query: str) -> int:
+        return 1
+
+    client = TestClient(_app_with_pool(_FakePool(_ok)))
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ready"}
+
+
+def test_ready_503_when_fetchval_raises() -> None:
+    async def _boom(_query: str) -> int:
+        raise RuntimeError("db gone")
+
+    client = TestClient(_app_with_pool(_FakePool(_boom)))
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    assert resp.json() == {"status": "unavailable"}
+
+
+def test_ready_503_when_acquire_raises() -> None:
+    client = TestClient(_app_with_pool(_FakePool(acquire_raises=RuntimeError("pool closed"))))
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    assert resp.json() == {"status": "unavailable"}
+
+
+def test_ready_503_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A slow ``SELECT 1`` trips the timeout → 503. We shrink the timeout to a
+    tiny value so the test stays fast and deterministic."""
+
+    async def _slow(_query: str) -> int:
+        await asyncio.sleep(1.0)
+        return 1
+
+    real_timeout = asyncio.timeout
+
+    def _tiny_timeout(_delay: float) -> Any:
+        return real_timeout(0.01)
+
+    monkeypatch.setattr("aios.api.routers.health.asyncio.timeout", _tiny_timeout)
+    client = TestClient(_app_with_pool(_FakePool(_slow)))
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    assert resp.json() == {"status": "unavailable"}
+
+
+def test_health_still_200_and_pool_untouched() -> None:
+    """``/health`` must not touch the pool: a pool that raises on ``acquire``
+    still yields a 200 from ``/health``."""
+
+    class _ExplodingPool:
+        def acquire(self) -> Any:
+            raise AssertionError("/health must not touch the pool")
+
+    client = TestClient(_app_with_pool(_ExplodingPool()))
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "version" in body

--- a/tests/unit/test_request_logging_middleware.py
+++ b/tests/unit/test_request_logging_middleware.py
@@ -1,0 +1,153 @@
+"""Unit tests for ``RequestLoggingMiddleware`` (pure-ASGI request logging).
+
+The middleware emits exactly one ``api.request`` structlog line per http
+request with method, path, status and duration_ms. Because it is a pure-ASGI
+middleware (same task context as the route), an ``account_id`` bound by an
+auth dependency via ``bind_contextvars`` is visible on the request line through
+``merge_contextvars`` — the core guarantee these tests pin.
+
+structlog renders the event dict into a single message string before it
+reaches stdlib logging (the configured ``LoggerFactory`` + renderer), so the
+key/value fields are NOT attributes on a ``caplog`` record. We capture the
+structured event dicts directly with ``structlog.testing.capture_logs`` and
+read the fields off those.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from structlog.contextvars import bind_contextvars, clear_contextvars
+from structlog.testing import capture_logs
+
+from aios.api.middleware import RequestLoggingMiddleware
+from aios.logging import configure_logging
+
+
+@pytest.fixture(autouse=True)
+def _clear_contextvars() -> Any:
+    """Keep ``account_id`` (and any other) bindings from leaking across tests."""
+    clear_contextvars()
+    yield
+    clear_contextvars()
+
+
+def _find_request_log(
+    entries: list[MutableMapping[str, Any]],
+) -> MutableMapping[str, Any] | None:
+    """Return the first captured ``api.request`` event dict, or ``None``."""
+    for entry in entries:
+        if entry.get("event") == "api.request":
+            return entry
+    return None
+
+
+def test_request_log_line_emitted() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.get("/ping")
+    async def _ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    client = TestClient(app)
+    with capture_logs() as entries:
+        resp = client.get("/ping")
+    assert resp.status_code == 200
+
+    rec = _find_request_log(entries)
+    assert rec is not None
+    assert rec["method"] == "GET"
+    assert rec["path"] == "/ping"
+    assert rec["status"] == 200
+    assert isinstance(rec["duration_ms"], (int, float))
+    assert rec["duration_ms"] >= 0
+
+
+def test_status_captured_for_404() -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.get("/ping")
+    async def _ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    client = TestClient(app)
+    with capture_logs() as entries:
+        resp = client.get("/nonexistent")
+    assert resp.status_code == 404
+
+    rec = _find_request_log(entries)
+    assert rec is not None
+    assert rec["status"] == 404
+    assert rec["path"] == "/nonexistent"
+
+
+async def test_non_http_scope_passthrough() -> None:
+    """A non-http scope is delegated straight through; no api.request line."""
+    delegated: list[MutableMapping[str, Any]] = []
+
+    async def dummy_app(
+        scope: MutableMapping[str, Any],
+        receive: Callable[[], Awaitable[MutableMapping[str, Any]]],
+        send: Callable[[MutableMapping[str, Any]], Awaitable[None]],
+    ) -> None:
+        delegated.append(scope)
+
+    async def recv() -> MutableMapping[str, Any]:
+        return {"type": "lifespan.startup"}
+
+    async def send(_message: MutableMapping[str, Any]) -> None:
+        return None
+
+    mw = RequestLoggingMiddleware(dummy_app)
+    with capture_logs() as entries:
+        await mw({"type": "lifespan"}, recv, send)
+
+    assert delegated == [{"type": "lifespan"}]
+    assert _find_request_log(entries) is None
+
+
+def test_account_id_present_when_bound(caplog: pytest.LogCaptureFixture) -> None:
+    """An account_id bound in a route dep is visible on the api.request line.
+
+    Proves the same-task contextvar visibility that the pure-ASGI shape buys:
+    ``bind_contextvars`` in the dep and ``merge_contextvars`` in the processor
+    chain put account_id on the middleware's own log line.
+
+    ``capture_logs`` can't see this — it swaps in a minimal processor chain
+    without ``merge_contextvars`` — so we exercise the real chain via
+    ``configure_logging`` and read the rendered JSON line off ``caplog``.
+    """
+
+    async def _bind_account() -> None:
+        bind_contextvars(account_id="acc_x")
+
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.get("/ping", dependencies=[Depends(_bind_account)])
+    async def _ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    configure_logging("INFO")
+    client = TestClient(app)
+    with caplog.at_level(logging.INFO):
+        resp = client.get("/ping")
+    assert resp.status_code == 200
+
+    payloads = [
+        json.loads(r.getMessage())
+        for r in caplog.records
+        if r.getMessage().startswith("{") and '"api.request"' in r.getMessage()
+    ]
+    assert payloads, "no api.request JSON log line captured"
+    rec = payloads[0]
+    assert rec["event"] == "api.request"
+    assert rec["account_id"] == "acc_x"

--- a/tests/unit/test_step_contextvars.py
+++ b/tests/unit/test_step_contextvars.py
@@ -1,0 +1,165 @@
+"""Unit tests for contextvar binding in the harness/workflow step entrypoints.
+
+``run_session_step`` / ``run_workflow_step`` bind ``account_id`` (plus
+``session_id``/``cause`` resp. ``run_id``) onto structlog contextvars so every
+log line a step emits is attributable to its tenant, and clear them in a
+``finally`` so the binding never leaks to the next job on the same worker task.
+
+The early-return guards run BEFORE ``account_id`` is known (a wake for a
+gone/terminal session-or-run is an idempotent no-op), so they must NOT bind —
+and they must leave contextvars untouched. We pin both: the no-bind early path
+and the bind→clear lifecycle on a step that proceeds past the guard.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import structlog
+from structlog.contextvars import clear_contextvars, get_contextvars
+
+from aios.harness import runtime
+from aios.harness.loop import run_session_step
+from aios.workflows.step import run_workflow_step
+from tests.unit.conftest import fake_pool_yielding_conn
+
+
+@pytest.fixture(autouse=True)
+def _clean_contextvars() -> Any:
+    clear_contextvars()
+    yield
+    clear_contextvars()
+
+
+async def test_session_step_missing_session_leaves_contextvars_empty() -> None:
+    """A wake for a gone session early-returns BEFORE any bind, so contextvars
+    stay empty (the guard runs ahead of ``bind_contextvars``)."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)  # no live session → account_id None
+    pool = fake_pool_yielding_conn(conn)
+
+    prev_pool = runtime.pool
+    runtime.pool = pool
+    try:
+        await run_session_step("ses_does_not_exist")
+    finally:
+        runtime.pool = prev_pool
+
+    assert get_contextvars() == {}
+
+
+async def test_session_step_binds_then_clears() -> None:
+    """Once ``account_id`` resolves, the step binds session_id/account_id/cause,
+    and the ``finally`` clears them — so nothing leaks past the step.
+
+    We stub the step body to snapshot the contextvars mid-step (proving the bind
+    happened) and otherwise no-op, avoiding the full DB-backed step.
+    """
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="acc_live")
+    pool = fake_pool_yielding_conn(conn)
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_body(*_args: Any, **_kwargs: Any) -> Any:
+        seen.update(get_contextvars())
+        from aios.harness.loop import _StepResult
+
+        return _StepResult()
+
+    prev_pool = runtime.pool
+    runtime.pool = pool
+    try:
+        with (
+            mock.patch("aios.harness.loop._run_session_step_body", new=_fake_body),
+            mock.patch(
+                "aios.services.sessions.append_event",
+                new=AsyncMock(return_value=MagicMock(id="evt_1")),
+            ),
+            mock.patch.object(runtime, "require_task_registry", return_value=MagicMock()),
+        ):
+            await run_session_step("ses_live", cause="message")
+    finally:
+        runtime.pool = prev_pool
+
+    # Bound mid-step …
+    assert seen.get("account_id") == "acc_live"
+    assert seen.get("session_id") == "ses_live"
+    assert seen.get("cause") == "message"
+    # … and cleared afterward.
+    assert get_contextvars() == {}
+
+
+async def test_workflow_step_missing_run_leaves_contextvars_empty() -> None:
+    """A wake for a vanished run early-returns BEFORE any bind, contextvars empty."""
+    conn = MagicMock()
+    pool = fake_pool_yielding_conn(conn)
+
+    prev_pool = runtime.pool
+    runtime.pool = pool
+    try:
+        with mock.patch(
+            "aios.workflows.step.wf_queries.get_run_for_step",
+            new=AsyncMock(return_value=None),
+        ):
+            await run_workflow_step("wfr_gone")
+    finally:
+        runtime.pool = prev_pool
+
+    assert get_contextvars() == {}
+
+
+async def test_workflow_step_binds_then_clears() -> None:
+    """Once the run loads, the step binds run_id/account_id (no ``cause`` for
+    workflows) and the ``finally`` clears them."""
+    conn = MagicMock()
+    pool = fake_pool_yielding_conn(conn)
+
+    run = MagicMock()
+    run.account_id = "acc_wf"
+    run.status = "running"
+
+    seen: dict[str, Any] = {}
+
+    async def _fake_body(*_args: Any, **_kwargs: Any) -> None:
+        seen.update(get_contextvars())
+
+    prev_pool = runtime.pool
+    runtime.pool = pool
+    try:
+        with (
+            mock.patch(
+                "aios.workflows.step.wf_queries.get_run_for_step",
+                new=AsyncMock(return_value=run),
+            ),
+            mock.patch("aios.workflows.step._run_workflow_step_body", new=_fake_body),
+        ):
+            await run_workflow_step("wfr_live")
+    finally:
+        runtime.pool = prev_pool
+
+    assert seen.get("account_id") == "acc_wf"
+    assert seen.get("run_id") == "wfr_live"
+    assert "cause" not in seen  # workflows omit cause
+    assert get_contextvars() == {}
+
+
+def test_logging_emits_account_id_when_bound() -> None:
+    """Sanity: with account_id on the contextvars, a logged line carries it
+    through ``merge_contextvars`` (the mechanism the step binds for)."""
+    from structlog.contextvars import bind_contextvars
+
+    from aios.logging import configure_logging
+
+    configure_logging("INFO")
+    clear_contextvars()
+    bind_contextvars(account_id="acc_z", session_id="ses_z")
+    try:
+        assert get_contextvars()["account_id"] == "acc_z"
+        log = structlog.get_logger("test")
+        log.info("noop")  # smoke: does not raise with bindings present
+    finally:
+        clear_contextvars()


### PR DESCRIPTION
Closes #847

## Why

Before this change the API was effectively a black box at runtime:

- All three exception handlers returned JSON and logged nothing — a 500 produced zero log output.
- `require_bearer_auth` 401s were silent.
- `/health` returned 200 without touching the pool, so a post-startup Postgres outage was a fully silent outage (the liveness probe stayed green while every request was 500-ing).
- `merge_contextvars` was wired into the structlog processor chain but `bind_contextvars` was never called, so `account_id` appeared on roughly 8 of ~180 log lines — unusable for per-tenant filtering or attribution in a multi-tenant runtime.

This change implements the O1 + O3 + O6 observability floor: every request gets a log line, errors surface at the right level, and tenant context travels with every log event.

## Changes

### Error handlers (`src/aios/errors.py`)
`log.warning` for 4xx responses and `log.exception` for 5xx, both carrying request path, status, error type, and `account_id` from contextvars.

### Request logging middleware (`src/aios/api/middleware.py`, new)
A pure-ASGI `RequestLoggingMiddleware` emits one `api.request` line per request (method, path, status, duration_ms). Implemented as pure ASGI rather than `BaseHTTPMiddleware` because `BaseHTTPMiddleware` runs the downstream app in a separate anyio task, which would sever the `account_id` contextvar bound by the auth dependency. A dedicated unit test (`test_account_id_present_when_bound`) guards this invariant.

### Context binding (`src/aios/api/deps.py`, `harness/loop.py`, `workflows/step.py`)
- `require_bearer_auth` calls `bind_contextvars(account_id=...)` once the token resolves, so every downstream log event in that request carries the tenant identity.
- `run_session_step` and `run_workflow_step` bind `session_id`/`run_id`, `account_id`, and (for sessions) `cause` at step entry; `clear_contextvars()` runs in a `finally` across every exit path.
- `run_workflow_step` was refactored into a thin outer wrapper + `_run_workflow_step_body` specifically to make the `finally`-clear reliable without restructuring the existing return logic.

### Readiness probe (`src/aios/api/routers/health.py`)
New `/ready` route runs `SELECT 1` under a 2-second `asyncio.timeout` and returns a 503 `JSONResponse` directly (no raise) when the DB is unreachable. The direct-return approach is deliberate: raising would route through the new 5xx exception logger and emit a traceback on every infra probe during a DB blip. `/health` is unchanged and remains a pure liveness probe.

### Infrastructure (`Dockerfile`, `compose.yml`)
The API container healthcheck now targets `/ready`, so the container is only reported healthy when it can actually reach Postgres.

### SDK / OpenAPI
`openapi.json` and `packages/aios-sdk/aios_sdk/_generated/` regenerated for the new `get_ready` operation. `/ready` is classified `NOT_CLI` in `src/aios/cli/allowlist.py` (orchestrator probe, not an operator command).

## Testing

- New unit tests (no Docker): `test_request_logging_middleware.py`, `test_ready_route.py`, `test_error_handler_logging.py`, `test_step_contextvars.py`.
- New e2e test (Docker): `tests/e2e/test_ready.py`.
- Full suite green: mypy clean, ruff clean, 2010 unit tests pass; e2e `-k "auth or health or ready"` = 33 passed; workflow/session integration tests pass.
- Mutation check: commenting out the `log.info` call in the middleware turns the request-log test red, confirming it is non-vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
