### PR TITLE
fix: account-scope environment_id on create paths (#755)

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -344,9 +344,13 @@ async def get_environment_config_for_session(
     Filters both ``s.account_id`` AND ``e.account_id`` against the same
     caller account: ``insert_session`` only relies on the
     ``environment_id REFERENCES environments(id)`` FK and does not
-    validate cross-account ownership, so a session row can carry an
-    ``environment_id`` from a different tenant. Without the
-    ``e.account_id`` predicate this read would surface the foreign
+    validate cross-account ownership. As of issue #755 the service-layer
+    create paths (``create_session`` and ``create_run``) verify
+    environment ownership before insert, so the normal path no longer
+    binds a session to a foreign-tenant environment. The ``e.account_id``
+    predicate remains as defense-in-depth for rows created via paths that
+    bypass the service layer (direct ``insert_session`` in tests,
+    pre-existing rows): without it this read would surface the foreign
     tenant's ``EnvironmentConfig`` — env vars, networking, packages —
     inside the worker's step context [security].
     """

--- a/src/aios/services/session_templates.py
+++ b/src/aios/services/session_templates.py
@@ -28,7 +28,12 @@ async def create_session_template(
     metadata: dict[str, Any],
     archive_when_idle: bool = False,
 ) -> SessionTemplate:
-    async with pool.acquire() as conn:
+    async with pool.acquire() as conn, conn.transaction():
+        # Validate the environment is account-owned before binding the template
+        # to it. A bare FK would accept another tenant's env id and leak its
+        # image / env-vars / networking into spawned sessions — mirrors
+        # create_session / create_run (issue #755).
+        await queries.get_environment(conn, environment_id, account_id=account_id)
         return await queries.insert_session_template(
             conn,
             name=name,
@@ -73,7 +78,12 @@ async def update_session_template(
     metadata: dict[str, Any] | None = None,
     archive_when_idle: bool | None = None,
 ) -> SessionTemplate:
-    async with pool.acquire() as conn:
+    async with pool.acquire() as conn, conn.transaction():
+        # Validate ownership only when the caller supplies a new env — omitting
+        # it preserves the current binding, so no check is needed there. A bare
+        # FK would accept another tenant's env id (issue #755).
+        if environment_id is not None:
+            await queries.get_environment(conn, environment_id, account_id=account_id)
         return await queries.update_session_template(
             conn,
             template_id,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -191,6 +191,10 @@ async def create_session(
     # written spec. Eviction is only meaningful for mutations to an
     # already-provisioned session (see update_session / connections).
     async with pool.acquire() as conn, conn.transaction():
+        # Validate the environment is account-owned before binding the session to
+        # it. A bare FK would accept another tenant's env id and leak its image /
+        # env-vars / networking into this session — mirrors create_run (issue #755).
+        await queries.get_environment(conn, environment_id, account_id=account_id)
         session = await queries.insert_session(
             conn,
             agent_id=agent_id,

--- a/tests/e2e/test_tenant_isolation.py
+++ b/tests/e2e/test_tenant_isolation.py
@@ -261,6 +261,59 @@ class TestTwoTenantIsolation:
         assert list_b.status_code == 200
         assert list_b.json()["data"] == []
 
+    async def test_session_create_cross_tenant_env_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """POST /v1/sessions binding tenant B's environment_id as tenant A must 404.
+
+        ``services.sessions.create_session`` opened its insert transaction and
+        called ``insert_session`` directly — the environment was validated only
+        by its FK (existence, not ownership). Tenant A could pass tenant B's
+        ``environment_id`` and the session was created bound to B's environment
+        (its image / env-vars / networking). The sibling ``create_run`` path
+        already validates the env as account-owned; match that posture here
+        (issue #755). NotFound, not silent cross-tenant binding.
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-sess-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-sess-b")
+
+        # Tenant B owns env_b.
+        env_b = await http_client.post(
+            "/v1/environments", headers=_bearer(kb), json={"name": "sess-env-b"}
+        )
+        assert env_b.status_code == 201, env_b.text
+        env_b_id = env_b.json()["id"]
+
+        # Tenant A owns the agent.
+        agent_a = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(ka),
+            json={"name": "sess-agent-a", "model": "openrouter/test"},
+        )
+        assert agent_a.status_code == 201, agent_a.text
+        agent_a_id = agent_a.json()["id"]
+
+        # Tenant A targets tenant B's env_id; expected 404, not a bound session.
+        cross = await http_client.post(
+            "/v1/sessions",
+            headers=_bearer(ka),
+            json={"agent_id": agent_a_id, "environment_id": env_b_id},
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Same-tenant control: tenant A's own env still binds a session (201).
+        env_a = await http_client.post(
+            "/v1/environments", headers=_bearer(ka), json={"name": "sess-env-a"}
+        )
+        assert env_a.status_code == 201, env_a.text
+        env_a_id = env_a.json()["id"]
+        ok = await http_client.post(
+            "/v1/sessions",
+            headers=_bearer(ka),
+            json={"agent_id": agent_a_id, "environment_id": env_a_id},
+        )
+        assert ok.status_code == 201, ok.text
+
     async def test_keys_isolated(
         self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
     ) -> None:

--- a/tests/e2e/test_tenant_isolation.py
+++ b/tests/e2e/test_tenant_isolation.py
@@ -314,6 +314,137 @@ class TestTwoTenantIsolation:
         )
         assert ok.status_code == 201, ok.text
 
+    async def test_session_template_create_cross_tenant_env_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """POST /v1/session-templates binding tenant B's env as tenant A must 404.
+
+        ``services.session_templates.create_session_template`` wrote the
+        caller-supplied ``environment_id`` with no ownership check — only the
+        FK guarded it (existence, not ownership). Tenant A could bind tenant B's
+        environment (its image / env-vars / networking) into a template. Same
+        defect class as the sessions/runs paths; match that posture
+        (issue #755). NotFound, not silent cross-tenant binding.
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmpl-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmpl-b")
+
+        # Tenant B owns env_b.
+        env_b = await http_client.post(
+            "/v1/environments", headers=_bearer(kb), json={"name": "tmpl-create-env-b"}
+        )
+        assert env_b.status_code == 201, env_b.text
+        env_b_id = env_b.json()["id"]
+
+        # Tenant A owns the agent.
+        agent_a = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(ka),
+            json={"name": "tmpl-create-agent-a", "model": "openrouter/test"},
+        )
+        assert agent_a.status_code == 201, agent_a.text
+        agent_a_id = agent_a.json()["id"]
+
+        # Tenant A targets tenant B's env_id; expected 404, not a bound template.
+        cross = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmpl-create-cross",
+                "agent_id": agent_a_id,
+                "environment_id": env_b_id,
+            },
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Same-tenant control: tenant A's own env still binds a template (201).
+        env_a = await http_client.post(
+            "/v1/environments", headers=_bearer(ka), json={"name": "tmpl-create-env-a"}
+        )
+        assert env_a.status_code == 201, env_a.text
+        env_a_id = env_a.json()["id"]
+        ok = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmpl-create-own",
+                "agent_id": agent_a_id,
+                "environment_id": env_a_id,
+            },
+        )
+        assert ok.status_code == 201, ok.text
+
+    async def test_session_template_update_cross_tenant_env_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """PUT /v1/session-templates/{id} rebinding to tenant B's env must 404.
+
+        ``services.session_templates.update_session_template`` wrote the
+        caller-supplied ``environment_id`` with no ownership check. Tenant A
+        could rebind its own template onto tenant B's environment. Validate the
+        new env as account-owned only when the caller actually supplies one —
+        omitting it must still allow partial updates (issue #755).
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplu-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplu-b")
+
+        # Tenant B owns env_b.
+        env_b = await http_client.post(
+            "/v1/environments", headers=_bearer(kb), json={"name": "tmpl-update-env-b"}
+        )
+        assert env_b.status_code == 201, env_b.text
+        env_b_id = env_b.json()["id"]
+
+        # Tenant A owns the agent + its own env, and a template bound to env_a.
+        agent_a = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(ka),
+            json={"name": "tmpl-update-agent-a", "model": "openrouter/test"},
+        )
+        assert agent_a.status_code == 201, agent_a.text
+        agent_a_id = agent_a.json()["id"]
+        env_a = await http_client.post(
+            "/v1/environments", headers=_bearer(ka), json={"name": "tmpl-update-env-a"}
+        )
+        assert env_a.status_code == 201, env_a.text
+        env_a_id = env_a.json()["id"]
+        tmpl = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmpl-update",
+                "agent_id": agent_a_id,
+                "environment_id": env_a_id,
+            },
+        )
+        assert tmpl.status_code == 201, tmpl.text
+        template_id = tmpl.json()["id"]
+
+        # Tenant A rebinds onto tenant B's env_id; expected 404, not a rebind.
+        cross = await http_client.put(
+            f"/v1/session-templates/{template_id}",
+            headers=_bearer(ka),
+            json={"environment_id": env_b_id},
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Same-tenant control: rebinding onto tenant A's own env succeeds (200).
+        ok = await http_client.put(
+            f"/v1/session-templates/{template_id}",
+            headers=_bearer(ka),
+            json={"environment_id": env_a_id},
+        )
+        assert ok.status_code == 200, ok.text
+
+        # Partial update with no env change still succeeds — the conditional
+        # ownership check must not block updates that omit environment_id.
+        name_only = await http_client.put(
+            f"/v1/session-templates/{template_id}",
+            headers=_bearer(ka),
+            json={"name": "tmpl-update-renamed"},
+        )
+        assert name_only.status_code == 200, name_only.text
+
     async def test_keys_isolated(
         self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
     ) -> None:

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -152,6 +152,35 @@ async def test_create_run_with_unknown_workflow_404s(http_client: httpx.AsyncCli
     assert r.status_code == 404, r.text
 
 
+async def test_create_run_cross_tenant_env_404(http_client: httpx.AsyncClient) -> None:
+    """POST /v1/runs binding tenant B's environment_id as tenant A must 404.
+
+    Regression guard for the runs path (already fixed): ``create_run`` validates
+    the env as account-owned at ``services.py`` before inserting the run, so a
+    cross-tenant ``environment_id`` is rejected as NotFound. The sibling sessions
+    path is the subject of issue #755; this locks the already-correct runs side.
+    """
+    key_b = await _mint_tenant(http_client, f"tenant-b-{_uniq()}")
+
+    # Tenant B owns env_b.
+    env_b = await http_client.post(
+        "/v1/environments", json={"name": f"wf-env-{_uniq()}"}, headers=_bearer(key_b)
+    )
+    assert env_b.status_code in (200, 201), env_b.text
+    env_b_id = env_b.json()["id"]
+
+    # Tenant A (default bearer) owns the workflow.
+    wf = (
+        await http_client.post("/v1/workflows", json={"name": f"a-{_uniq()}", "script": _SCRIPT})
+    ).json()
+
+    # Tenant A targets tenant B's env_id; expected 404, not a bound run.
+    cross = await http_client.post(
+        "/v1/runs", json={"workflow_id": wf["id"], "environment_id": env_b_id}
+    )
+    assert cross.status_code == 404, cross.text
+
+
 async def test_run_reads_and_resume_404_on_unknown(http_client: httpx.AsyncClient) -> None:
     assert (await http_client.get("/v1/runs/wfr_nope")).status_code == 404
     assert (await http_client.get("/v1/runs/wfr_nope/events")).status_code == 404

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -170,9 +170,11 @@ async def test_create_run_cross_tenant_env_404(http_client: httpx.AsyncClient) -
     env_b_id = env_b.json()["id"]
 
     # Tenant A (default bearer) owns the workflow.
-    wf = (
-        await http_client.post("/v1/workflows", json={"name": f"a-{_uniq()}", "script": _SCRIPT})
-    ).json()
+    wf_resp = await http_client.post(
+        "/v1/workflows", json={"name": f"a-{_uniq()}", "script": _SCRIPT}
+    )
+    assert wf_resp.status_code == 201, wf_resp.text
+    wf = wf_resp.json()
 
     # Tenant A targets tenant B's env_id; expected 404, not a bound run.
     cross = await http_client.post(


### PR DESCRIPTION
## Security fix: cross-tenant environment binding on create paths

**Impact.** Several create paths validated `environment_id` only via a foreign key, which checks existence but not ownership. Tenant A could pass tenant B's `environment_id` and the row was accepted — binding the resource (and any `agent()` children) to B's environment. Exploitation requires the attacker to already know an opaque prefixed-ULID from another tenant, so this is a bounded but real cross-tenant isolation gap.

## What changed

The fix adds an ownership check — `queries.get_environment(conn, environment_id, account_id=account_id)`, which raises `NotFoundError` → HTTP 404 for a foreign/absent env — before the DB write on every create path that binds a **caller-supplied** `environment_id`:

- **`create_session`** (`src/aios/services/sessions.py`) — the path named in #755. Now guarded.
- **`create_session_template`** (`src/aios/services/session_templates.py`, `POST /v1/session-templates`) — same defect, surfaced during review. Now guarded (env required → always validated).
- **`update_session_template`** (`PUT /v1/session-templates/{id}`) — same defect. Now guarded *conditionally* — validated only when the caller supplies a new `environment_id`, so partial updates that omit it still work.
- **`create_run`** (`src/aios/workflows/service.py`) — was already guarded; a regression test locks it in.

The checks live in the service layer (an authorization concern), sharing the existing transaction/connection with the write so check-and-insert stay atomic. The query-layer FK remains as defense-in-depth.

### Exhaustive enumeration

Every `environment_id` writer in `src/aios` was enumerated to ensure no path was missed:

| Path | Status |
|------|--------|
| `create_session` | guarded (this PR) |
| `create_session_template` / `update_session_template` | guarded (this PR) |
| `create_run` | already guarded (regression test added) |
| `clone_session` | safe — copies `environment_id` from an already-account-scoped parent row |
| `create_child_session` | safe — uses the run's already-validated `environment_id` |

`clone_session` and `create_child_session` need no check because their `environment_id` is not caller-supplied — it comes from a row already filtered by `account_id`.

## Test coverage

New two-tenant e2e tests (tenant A binds tenant B's env → 404; same-tenant control → success):

- `test_session_create_cross_tenant_env_404` (`tests/e2e/test_tenant_isolation.py`)
- `test_session_template_create_cross_tenant_env_404` (`tests/e2e/test_tenant_isolation.py`)
- `test_session_template_update_cross_tenant_env_404` (`tests/e2e/test_tenant_isolation.py`) — includes a name-only partial-update control proving the conditional guard doesn't break omit-env updates
- `test_create_run_cross_tenant_env_404` (`tests/e2e/test_workflows_api.py`) — regression guard for the already-fixed runs path

Each cross-tenant test was confirmed RED before its fix and GREEN after; mutation checks confirm the assertions are not vacuous.

## Out of scope (tracked separately)

- **`agent_id` is not account-scoped in `create_session`** — a real sibling gap on a *different* field, already documented in the codebase and read-side-defended. Filed as **#899** with its own (more nuanced, agent-version-aware) fix and test plan.
- **Archived environments pass `get_environment`** — a soft-delete-state concern, not tenancy; identical shared behavior with `create_run`. Flagged for maintainers.

## Validation

- `mypy`, `ruff check`, and `ruff format` all clean.
- No API shape change; OpenAPI regen produced no drift, no SDK codegen needed.

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)
