### PR TITLE
ci: add connector suites to CI lint, type-check, and test

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -143,12 +143,18 @@ jobs:
         # ``extend-exclude`` and ``mypy.overrides``; including the package
         # here lets ruff and mypy cover the hand-written surface so the
         # release workflow's ``no re-gate'' assumption is honored.
+        #
+        # The three ``connectors/*/src`` trees (signal/telegram/whatsapp)
+        # and ``packages/aios-connector-http/aios_connector_http`` (whose
+        # package lives at the package root, not under ``src/``) are
+        # workspace members whose source had never been linted/typed.  The
+        # echo-http connector has no ``src/`` and is omitted.
         run: |
-          uv run ruff check src tests packages/aios-sdk/aios_sdk
-          uv run ruff format --check src tests packages/aios-sdk/aios_sdk
+          uv run ruff check src tests packages/aios-sdk/aios_sdk connectors/signal/src connectors/telegram/src connectors/whatsapp/src packages/aios-connector-http/aios_connector_http
+          uv run ruff format --check src tests packages/aios-sdk/aios_sdk connectors/signal/src connectors/telegram/src connectors/whatsapp/src packages/aios-connector-http/aios_connector_http
 
       - name: Type check (mypy)
-        run: uv run mypy src tests packages/aios-sdk/aios_sdk
+        run: uv run mypy src tests packages/aios-sdk/aios_sdk connectors/signal/src connectors/telegram/src connectors/whatsapp/src packages/aios-connector-http/aios_connector_http
 
   unit:
     needs: detect
@@ -180,6 +186,45 @@ jobs:
         # per-worker ``AIOS_INSTANCE_ID`` via tests/conftest.py.
         # Measured locally: 45 s serial → 17 s at ``-n 4``.
         run: uv run pytest tests/unit -q -n 4
+
+  connectors:
+    needs: detect
+    if: needs.detect.outputs.run_checks == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
+      AIOS_API_KEY: test-key-for-ci
+      AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Connector tests
+        # Each connector ``tests/`` dir has its own ``__init__.py`` and no
+        # parent package, so pytest resolves every connector conftest to the
+        # module name ``tests.conftest`` — collecting two in one process is an
+        # ``ImportPathMismatchError``.  The connectors are independent uv
+        # workspace members (own ``pyproject.toml``, own pytest rootdir/
+        # config), so each runs as its own invocation, using its own config.
+        # These are pure unit tests (mocked daemons; no Postgres/Docker/
+        # network), so no ``services:`` block is needed.  Run under ``bash
+        # -e`` (the Actions default), a failing suite aborts the job.
+        run: |
+          uv run pytest connectors/signal/tests -q
+          uv run pytest connectors/telegram/tests -q
+          uv run pytest connectors/whatsapp/tests -q
+          uv run pytest packages/aios-connector-http/tests -q
 
   integration:
     needs: detect
@@ -343,14 +388,6 @@ jobs:
           }
 
       - name: E2E tests (non-docker shard)
-        # signal_connector / signal_registration / telegram_connector need
-        # external daemon RPC infrastructure (signal-cli, a live telegram
-        # bot) that GitHub Actions does not supply.  Those files carry
-        # the ``docker`` marker, so ``-m "not docker"`` excludes them
-        # here naturally — the explicit ``--ignore`` list on the docker
-        # shard below remains the source of truth for "needs daemon
-        # infrastructure, skip in CI."
-        #
         # ``-n 4`` matches the 4 vCPUs on public-repo ubuntu-latest
         # runners.  Default ``load`` dist (not ``loadfile``): the
         # non-docker set has no module-scoped fixtures — the only one in
@@ -376,7 +413,4 @@ jobs:
         env:
           AIOS_DOCKER_IMAGE: aios-sandbox:ci
         run: |
-          uv run pytest tests/e2e -q -m docker -n 4 --dist=loadfile \
-            --ignore=tests/e2e/test_signal_connector.py \
-            --ignore=tests/e2e/test_signal_registration.py \
-            --ignore=tests/e2e/test_telegram_connector.py
+          uv run pytest tests/e2e -q -m docker -n 4 --dist=loadfile

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -192,11 +192,6 @@ jobs:
     if: needs.detect.outputs.run_checks == 'true'
     runs-on: ubuntu-latest
 
-    env:
-      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
-      AIOS_API_KEY: test-key-for-ci
-      AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
-
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -83,6 +83,9 @@ from aios_sdk._generated.models.runtime_management_call_result_request import (
 from aios_sdk._generated.models.runtime_tool_result_request import (
     RuntimeToolResultRequest,
 )
+from aios_sdk._generated.models.runtime_tool_result_request_content_type_1_item import (
+    RuntimeToolResultRequestContentType1Item,
+)
 from aios_sdk._generated.models.tools_schema_update import ToolsSchemaUpdate
 from aios_sdk._generated.models.tools_schema_update_tools_item import (
     ToolsSchemaUpdateToolsItem,
@@ -1083,11 +1086,21 @@ class HttpConnector:
         is_error: bool = False,
     ) -> None:
         """POST one tool result via the generated runtime op."""
+        # The generated model's list branch is typed as
+        # ``list[RuntimeToolResultRequestContentType1Item]``; that item type is
+        # a thin ``additional_properties`` bag whose ``from_dict``/``to_dict``
+        # round-trips a plain dict unchanged, so adapting our ``list[dict]``
+        # here keeps the wire payload byte-identical while satisfying the type.
+        body_content: list[RuntimeToolResultRequestContentType1Item] | str = (
+            [RuntimeToolResultRequestContentType1Item.from_dict(item) for item in content]
+            if isinstance(content, list)
+            else content
+        )
         body = RuntimeToolResultRequest(
             connection_id=connection_id,
             session_id=session_id,
             tool_call_id=tool_call_id,
-            content=content,
+            content=body_content,
             is_error=is_error,
         )
         response = await _post_runtime_tool_result(client=client, body=body)

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -763,6 +763,68 @@ class TestWaitReady:
                 await task
 
 
+class TestPostToolResultSerialization:
+    """Regression for #843: a tool returning multimodal ``list[dict]``
+    content must serialize byte-identically on the wire.
+
+    The bug lived at ``RuntimeToolResultRequest.to_dict()`` time — a raw
+    ``list[dict]`` item has no ``.to_dict()``, so the generated model's
+    list branch crashed with ``AttributeError`` and the POST never fired.
+    These tests drive the *real* ``_post_tool_result`` (NOT the
+    ``_ProbeConnector`` override) through the generated runtime op, which
+    serializes ``body.to_dict()`` into the POST ``json`` kwarg — so they
+    genuinely exercise the serialization path the override bypasses.
+    """
+
+    @staticmethod
+    def _client_capturing_body() -> tuple[Any, list[Any]]:
+        """A real ``Client`` backed by an ``httpx.MockTransport`` that
+        captures the JSON the runtime op actually puts on the wire.
+
+        Routing the POST through real httpx serialization means the test
+        sees the bytes the server would — the exact path the #843 bug
+        crashed on before reaching the network."""
+        from aios_sdk import Client
+
+        captured: list[Any] = []
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(201, json={})
+
+        client = Client(base_url="http://x", token="aios_runtime_x")
+        client.set_async_httpx_client(
+            httpx.AsyncClient(base_url="http://x", transport=httpx.MockTransport(_handler))
+        )
+        return client, captured
+
+    async def test_list_dict_content_serializes_byte_identical(self) -> None:
+        client, captured = self._client_capturing_body()
+        await HttpConnector._post_tool_result(
+            client,
+            connection_id="conn_1",
+            session_id="sess_1",
+            tool_call_id="call_1",
+            content=[{"type": "text", "text": "hello"}],
+        )
+        assert len(captured) == 1
+        # Byte-identical: the list[dict] round-trips unchanged on the wire.
+        assert captured[0]["content"] == [{"type": "text", "text": "hello"}]
+
+    async def test_str_content_serializes_as_string(self) -> None:
+        """Guards against over-wrapping — plain ``str`` stays a ``str``."""
+        client, captured = self._client_capturing_body()
+        await HttpConnector._post_tool_result(
+            client,
+            connection_id="conn_1",
+            session_id="sess_1",
+            tool_call_id="call_1",
+            content="hello",
+        )
+        assert len(captured) == 1
+        assert captured[0]["content"] == "hello"
+
+
 class TestWaitConnectionServed:
     async def test_times_out_if_connection_never_added(self) -> None:
         """wait_connection_served raises TimeoutError when connection never appears."""

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -52,9 +52,12 @@ if ! should_skip ruff; then
     echo "── ruff ──"
 
     if [[ $FAIL_ON_AUTOFIX -eq 1 ]]; then
-        # Check + format, then detect if anything changed
-        uv run ruff check --fix "${LINT_TARGETS[@]}" 2>&1
-        uv run ruff format "${LINT_TARGETS[@]}" 2>&1
+        # Check + format, then detect if anything changed.  A non-zero ruff
+        # exit means it reported lint errors it could NOT auto-fix; those
+        # leave no diff, so we must surface the exit status explicitly or the
+        # pre-commit gate would pass an unfixable error.
+        uv run ruff check --fix "${LINT_TARGETS[@]}" 2>&1 || fail
+        uv run ruff format "${LINT_TARGETS[@]}" 2>&1 || fail
         if [[ -n "$(git diff --name-only)" ]]; then
             echo "ruff auto-fixed files — please re-stage:" >&2
             git diff --name-only >&2

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -8,7 +8,7 @@
 #   scripts/run-checks.sh --fail-on-autofix # fail if ruff auto-formats (for pre-commit)
 #   scripts/run-checks.sh --fail-fast      # stop at first failure
 #
-# Checks: ruff, mypy, tests (unit only — e2e needs Docker)
+# Checks: ruff, mypy, tests (unit + connector suites — e2e needs Docker)
 
 set -uo pipefail
 
@@ -35,6 +35,17 @@ should_skip() { [[ "$SKIP" == *"$1"* ]]; }
 OVERALL=0
 fail() { OVERALL=1; [[ $FAIL_FAST -eq 1 ]] && exit 1; }
 
+# Lint/type targets, kept in lock-step with code-validation.yml's lint job:
+# the harness (src/tests), the hand-written aios-sdk surface, the three
+# connector source trees (signal/telegram/whatsapp — echo-http has no src/),
+# and the connector-http package (which lives at the package root, not src/).
+LINT_TARGETS=(
+    src tests
+    packages/aios-sdk/aios_sdk
+    connectors/signal/src connectors/telegram/src connectors/whatsapp/src
+    packages/aios-connector-http/aios_connector_http
+)
+
 # ── Ruff ───────────────────────────────────────────────────────────────────────
 
 if ! should_skip ruff; then
@@ -42,16 +53,16 @@ if ! should_skip ruff; then
 
     if [[ $FAIL_ON_AUTOFIX -eq 1 ]]; then
         # Check + format, then detect if anything changed
-        uv run ruff check --fix src tests 2>&1
-        uv run ruff format src tests 2>&1
+        uv run ruff check --fix "${LINT_TARGETS[@]}" 2>&1
+        uv run ruff format "${LINT_TARGETS[@]}" 2>&1
         if [[ -n "$(git diff --name-only)" ]]; then
             echo "ruff auto-fixed files — please re-stage:" >&2
             git diff --name-only >&2
             fail
         fi
     else
-        uv run ruff check src tests || fail
-        uv run ruff format --check src tests || fail
+        uv run ruff check "${LINT_TARGETS[@]}" || fail
+        uv run ruff format --check "${LINT_TARGETS[@]}" || fail
     fi
 fi
 
@@ -59,7 +70,7 @@ fi
 
 if ! should_skip mypy; then
     echo "── mypy ──"
-    uv run mypy src tests || fail
+    uv run mypy "${LINT_TARGETS[@]}" || fail
 fi
 
 # ── Tests ──────────────────────────────────────────────────────────────────────
@@ -67,6 +78,19 @@ fi
 if ! should_skip tests; then
     echo "── pytest (unit) ──"
     uv run pytest tests/unit -q || fail
+
+    # Each connector suite runs as its own invocation: every connector
+    # ``tests/`` dir has an ``__init__.py`` and no parent package, so pytest
+    # resolves each conftest to the module name ``tests.conftest`` —
+    # collecting two in one process is an ``ImportPathMismatchError``.  The
+    # connectors are independent uv workspace members with their own pytest
+    # config, so per-invocation is correct-by-construction.  All mocked; no
+    # Postgres/Docker/network.
+    echo "── pytest (connectors) ──"
+    uv run pytest connectors/signal/tests -q || fail
+    uv run pytest connectors/telegram/tests -q || fail
+    uv run pytest connectors/whatsapp/tests -q || fail
+    uv run pytest packages/aios-connector-http/tests -q || fail
 fi
 
 echo ""


### PR DESCRIPTION
Closes #843

## Problem

494 tests across four connector packages (Signal, Telegram, WhatsApp, `aios-connector-http`) were never executed, linted, or type-checked by CI. The `code-validation.yml` pytest jobs ran only `tests/{unit,integration,e2e}`; ruff and mypy covered only `src tests packages/aios-sdk/aios_sdk`. The connector trees were "dark" — actively maintained, so contributors reasonably believed they were protected. Separately, three fully-mocked connector e2e test files were `--ignore`'d in the docker shard under a stale "needs external daemon" comment.

## Approach

**`.github/workflows/code-validation.yml`**

- New `connectors` job mirroring the `unit` job structure (`needs: detect`, same `if` gate, standard env block, no Postgres service — these are pure unit tests). Runs the four suites as four separate `pytest` invocations (see below).
- Extended the `lint` job's ruff check, ruff format, and mypy targets to include `connectors/signal/src connectors/telegram/src connectors/whatsapp/src packages/aios-connector-http/aios_connector_http`.
- Removed all three `--ignore` flags from the e2e docker shard and deleted the stale daemon comment.

**`packages/aios-connector-http/aios_connector_http/runner.py`**

Fixed the single mypy `[arg-type]` error surfaced when type-checking the source. Details below.

**`scripts/run-checks.sh`**

Extended ruff/mypy to the same target list (also picking up `aios-sdk`, previously omitted locally vs CI) via a `LINT_TARGETS` array, and added the four connector suites after the unit run.

## Reviewers: two things to scrutinize

### 1. Four separate `pytest` invocations, not one

The acceptance criteria specified a single command:

```
uv run pytest connectors/signal/tests connectors/telegram/tests connectors/whatsapp/tests packages/aios-connector-http/tests -q
```

That command **fails at collection today** with `ImportPathMismatchError: ('tests.conftest', ...)` — each connector `tests/` directory has its own `__init__.py` with no parent package, so every conftest resolves to the same module name `tests.conftest`, colliding when more than one is collected in a single process.

The connectors are independent uv workspace members, each with its own `pyproject.toml`, `[tool.pytest.ini_options]`, and pytest rootdir. Running each suite in its own invocation respects that structure (each suite uses its own config) and is correct-by-construction. The alternative — deleting `__init__.py`s, switching to `--import-mode=importlib`, and refactoring ~14 cross-importing test files or shipping shared test constants in production wheels — is far more invasive for no runtime benefit. All 494 tests still execute, lint, and type-check in CI.

### 2. Production type fix in `runner.py`

`_post_tool_result` passed `content: str | list[dict]` into `RuntimeToolResultRequest(content=...)`, whose list branch expects `list[RuntimeToolResultRequestContentType1Item]`. The fix adapts each list item via `RuntimeToolResultRequestContentType1Item.from_dict(...)`. That generated item type round-trips a dict through `additional_properties`, so the wire payload is byte-identical. No `# type: ignore`, no generated-code edits, no schema change.

Mutation check: reverting this fix made mypy report the exact `[arg-type]` error; restoring it returned mypy to success (red→green confirmed).

## Verification

- Four connector suites individually green: Signal 159, Telegram 97, WhatsApp 142, connector-http 96 (494 total).
- Combined mypy across the full extended target list: 0 errors. ruff check + format: clean.
- `scripts/run-checks.sh`: green (unit + 494 connector + lint/types).
- The three re-enabled e2e files collect (5 tests) and ran green under Docker (5 passed in ~8s), confirming they are fully mocked, not daemon-dependent.
- `detect` path filter unchanged: connector `.py` paths already trigger `run_checks=true` via the existing `\.py$` pattern.
- No codegen needed — sdk and openapi snapshot tests stay green.

## Out of scope

Go `go test` for the WhatsApp daemon (`connectors/whatsapp/daemon/`) — the AC is Python-only. The Python `test_daemon.py` spawns a Python fake-daemon subprocess (no Go toolchain) and runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
