### PR TITLE
feat(vaults): environment_variable credential kind — secret_name + host scope (#872)

### DIFF
--- a/migrations/versions/0081_vault_credentials_environment_variable.py
+++ b/migrations/versions/0081_vault_credentials_environment_variable.py
@@ -1,0 +1,94 @@
+"""Add the ``environment_variable`` vault credential kind.
+
+The existing credential kinds (``bearer_header`` / ``oauth2_refresh`` /
+``basic`` / ``custom_header``) are keyed by an immutable ``target_url`` and
+consumed worker-side as outbound auth headers. The new
+``environment_variable`` kind has no ``target_url``: it is materialized into
+the sandbox as an env var named ``secret_name`` and carries an
+``allowed_hosts`` egress scope (bare hostnames, optionally with a
+path-prefix) instead. The secret value still lives in the encrypted blob.
+
+Schema changes:
+  - ``target_url`` becomes nullable (NULL for ``environment_variable`` rows).
+  - new ``secret_name text`` and ``allowed_hosts text[]`` columns.
+  - the ``auth_type`` CHECK is widened to include ``environment_variable``.
+  - a new ``vault_credentials_shape_check`` makes the two kinds disjoint and
+    self-consistent: ``environment_variable`` rows carry
+    ``secret_name``/``allowed_hosts`` (non-empty) and no ``target_url``;
+    every other kind carries ``target_url`` and neither new column. The DB
+    owns this invariant because later epic stages (#874 materialization,
+    #876 swap proxy) read the row directly, bypassing the pydantic layer.
+    Element-level validity of ``allowed_hosts`` (hostname grammar, path
+    charset) is model-layer only, matching the split in
+    ``models/environments.py``.
+  - a partial unique index on ``(vault_id, secret_name)`` among active rows,
+    the ``environment_variable`` analog of ``vault_credentials_url_uniq``.
+
+Part of #871. Concretizes #171.
+
+Downgrade narrows everything back and is fail-loud (see ``downgrade``).
+
+Revision ID: 0081
+Revises: 0080
+Create Date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0081"
+down_revision: str = "0080"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE vault_credentials ALTER COLUMN target_url DROP NOT NULL")
+    op.execute("ALTER TABLE vault_credentials ADD COLUMN secret_name text")
+    op.execute("ALTER TABLE vault_credentials ADD COLUMN allowed_hosts text[]")
+
+    op.execute("ALTER TABLE vault_credentials DROP CONSTRAINT vault_credentials_auth_type_check")
+    op.execute(
+        "ALTER TABLE vault_credentials "
+        "ADD CONSTRAINT vault_credentials_auth_type_check "
+        "CHECK (auth_type IN "
+        "('bearer_header', 'oauth2_refresh', 'basic', 'custom_header', 'environment_variable'))"
+    )
+
+    op.execute(
+        "ALTER TABLE vault_credentials ADD CONSTRAINT vault_credentials_shape_check CHECK ("
+        "(auth_type = 'environment_variable' "
+        "AND target_url IS NULL AND secret_name IS NOT NULL "
+        "AND allowed_hosts IS NOT NULL AND cardinality(allowed_hosts) > 0) "
+        "OR (auth_type <> 'environment_variable' "
+        "AND target_url IS NOT NULL AND secret_name IS NULL AND allowed_hosts IS NULL))"
+    )
+
+    op.execute(
+        "CREATE UNIQUE INDEX vault_credentials_secret_name_uniq "
+        "ON vault_credentials (vault_id, secret_name) WHERE archived_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX vault_credentials_secret_name_uniq")
+    op.execute("ALTER TABLE vault_credentials DROP CONSTRAINT vault_credentials_shape_check")
+    op.execute("ALTER TABLE vault_credentials DROP CONSTRAINT vault_credentials_auth_type_check")
+    # Re-add the narrowed CHECK BEFORE dropping the columns, so it fails loud
+    # (aborting the whole migration) if any ``environment_variable`` row
+    # exists — INCLUDING archived husks (archive zeroes the secret blob but
+    # keeps ``auth_type``, and archived rows are filtered out of API list
+    # output, so they are invisible). The ``target_url SET NOT NULL`` restore
+    # below is a second fail-loud gate on the same rows. Remedy:
+    #   DELETE FROM vault_credentials WHERE auth_type = 'environment_variable';
+    op.execute(
+        "ALTER TABLE vault_credentials "
+        "ADD CONSTRAINT vault_credentials_auth_type_check "
+        "CHECK (auth_type IN ('bearer_header', 'oauth2_refresh', 'basic', 'custom_header'))"
+    )
+    op.execute("ALTER TABLE vault_credentials DROP COLUMN allowed_hosts")
+    op.execute("ALTER TABLE vault_credentials DROP COLUMN secret_name")
+    op.execute("ALTER TABLE vault_credentials ALTER COLUMN target_url SET NOT NULL")

--- a/openapi.json
+++ b/openapi.json
@@ -15004,7 +15004,7 @@
           "auth_type"
         ],
         "title": "VaultCredentialCreate",
-        "description": "Request body for ``POST /v1/vaults/{vault_id}/credentials``.\n\nAll secret fields are write-only. ``target_url``, ``secret_name``, and\n``auth_type`` are immutable after creation. The service layer validates\nrequired secret fields per ``auth_type``; this model validates the\nstructural shape (which kind carries ``target_url`` vs\n``secret_name``/``allowed_hosts``)."
+        "description": "Request body for ``POST /v1/vaults/{vault_id}/credentials``.\n\nAll secret fields are write-only. The structural fields \u2014 ``target_url``,\n``secret_name``, ``allowed_hosts``, and ``auth_type`` \u2014 are immutable after\ncreation; only the secret (and ``display_name``/``metadata``) can be\nrotated via PUT, so changing a credential's egress scope means archiving\nand recreating it. The service layer validates required secret fields per\n``auth_type``; this model validates the structural shape (which kind\ncarries ``target_url`` vs ``secret_name``/``allowed_hosts``)."
       },
       "VaultCredentialUpdate": {
         "properties": {
@@ -15223,7 +15223,7 @@
         "additionalProperties": false,
         "type": "object",
         "title": "VaultCredentialUpdate",
-        "description": "Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.\n\n``target_url`` and ``auth_type`` are immutable \u2014 not accepted here.\nOmitted secret fields are preserved (decrypt-merge-encrypt)."
+        "description": "Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.\n\n``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are\nimmutable \u2014 not accepted here. Omitted secret fields are preserved\n(decrypt-merge-encrypt)."
       },
       "VaultUpdate": {
         "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -4213,7 +4213,7 @@
           "vaults"
         ],
         "summary": "Create Credential",
-        "description": "Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.\n\nValidates required fields per ``auth_type``: ``oauth2_refresh`` requires\n``access_token`` (plus the refresh fields needed for rotation);\n``bearer_header`` requires ``token``; ``basic`` requires ``username``\nand ``password``. Caps at 20 active credentials per vault. The\n``target_url`` is immutable after creation \u2014 to retarget a credential,\narchive the existing one and create a new credential at the new URL.",
+        "description": "Add a credential to a vault. Secrets are encrypted at rest via the CryptoBox.\n\nValidates required fields per ``auth_type``: ``oauth2_refresh`` requires\n``access_token`` (plus the refresh fields needed for rotation);\n``bearer_header`` requires ``token``; ``basic`` requires ``username``\nand ``password``; ``custom_header`` requires ``header_name`` and\n``header_value``. ``environment_variable`` is the sandbox-materialized\nkind: it requires ``secret_name`` (a POSIX env var name) + a non-empty\n``allowed_hosts`` egress scope and ``secret_value``, and carries no\n``target_url``. Caps at 20 active credentials per vault. ``target_url``,\n``secret_name``, and ``auth_type`` are immutable after creation \u2014 archive\nand recreate to change them.",
         "operationId": "create_vault_credential",
         "parameters": [
           {
@@ -14654,7 +14654,14 @@
             "title": "Display Name"
           },
           "target_url": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Target Url"
           },
           "auth_type": {
@@ -14663,9 +14670,35 @@
               "bearer_header",
               "oauth2_refresh",
               "basic",
-              "custom_header"
+              "custom_header",
+              "environment_variable"
             ],
             "title": "Auth Type"
+          },
+          "secret_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secret Name"
+          },
+          "allowed_hosts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Hosts"
           },
           "metadata": {
             "additionalProperties": true,
@@ -14707,7 +14740,7 @@
           "updated_at"
         ],
         "title": "VaultCredential",
-        "description": "Read view of a vault credential. Secrets are never returned."
+        "description": "Read view of a vault credential. Secrets are never returned.\n\n``target_url`` is null for ``environment_variable`` credentials;\n``secret_name``/``allowed_hosts`` are null for every other kind."
       },
       "VaultCredentialCreate": {
         "properties": {
@@ -14885,6 +14918,19 @@
             ],
             "title": "Header Value"
           },
+          "secret_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secret Value"
+          },
           "display_name": {
             "anyOf": [
               {
@@ -14897,18 +14943,14 @@
             ],
             "title": "Display Name"
           },
-          "target_url": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Target Url"
-          },
           "auth_type": {
             "type": "string",
             "enum": [
               "bearer_header",
               "oauth2_refresh",
               "basic",
-              "custom_header"
+              "custom_header",
+              "environment_variable"
             ],
             "title": "Auth Type"
           },
@@ -14916,16 +14958,53 @@
             "additionalProperties": true,
             "type": "object",
             "title": "Metadata"
+          },
+          "target_url": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Url"
+          },
+          "secret_name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secret Name"
+          },
+          "allowed_hosts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Hosts"
           }
         },
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "target_url",
           "auth_type"
         ],
         "title": "VaultCredentialCreate",
-        "description": "Request body for ``POST /v1/vaults/{vault_id}/credentials``.\n\nAll secret fields are write-only. The ``target_url`` is immutable\nafter creation. The service layer validates required fields per\n``auth_type``."
+        "description": "Request body for ``POST /v1/vaults/{vault_id}/credentials``.\n\nAll secret fields are write-only. ``target_url``, ``secret_name``, and\n``auth_type`` are immutable after creation. The service layer validates\nrequired secret fields per ``auth_type``; this model validates the\nstructural shape (which kind carries ``target_url`` vs\n``secret_name``/``allowed_hosts``)."
       },
       "VaultCredentialUpdate": {
         "properties": {
@@ -15102,6 +15181,19 @@
               }
             ],
             "title": "Header Value"
+          },
+          "secret_value": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "password",
+                "writeOnly": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secret Value"
           },
           "display_name": {
             "anyOf": [

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/create_vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/create_vault_credential.py
@@ -81,18 +81,24 @@ def sync_detailed(
     Validates required fields per ``auth_type``: ``oauth2_refresh`` requires
     ``access_token`` (plus the refresh fields needed for rotation);
     ``bearer_header`` requires ``token``; ``basic`` requires ``username``
-    and ``password``. Caps at 20 active credentials per vault. The
-    ``target_url`` is immutable after creation — to retarget a credential,
-    archive the existing one and create a new credential at the new URL.
+    and ``password``; ``custom_header`` requires ``header_name`` and
+    ``header_value``. ``environment_variable`` is the sandbox-materialized
+    kind: it requires ``secret_name`` (a POSIX env var name) + a non-empty
+    ``allowed_hosts`` egress scope and ``secret_value``, and carries no
+    ``target_url``. Caps at 20 active credentials per vault. ``target_url``,
+    ``secret_name``, and ``auth_type`` are immutable after creation — archive
+    and recreate to change them.
 
     Args:
         vault_id (str):
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. The ``target_url`` is immutable
-            after creation. The service layer validates required fields per
-            ``auth_type``.
+            All secret fields are write-only. ``target_url``, ``secret_name``, and
+            ``auth_type`` are immutable after creation. The service layer validates
+            required secret fields per ``auth_type``; this model validates the
+            structural shape (which kind carries ``target_url`` vs
+            ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -129,18 +135,24 @@ def sync(
     Validates required fields per ``auth_type``: ``oauth2_refresh`` requires
     ``access_token`` (plus the refresh fields needed for rotation);
     ``bearer_header`` requires ``token``; ``basic`` requires ``username``
-    and ``password``. Caps at 20 active credentials per vault. The
-    ``target_url`` is immutable after creation — to retarget a credential,
-    archive the existing one and create a new credential at the new URL.
+    and ``password``; ``custom_header`` requires ``header_name`` and
+    ``header_value``. ``environment_variable`` is the sandbox-materialized
+    kind: it requires ``secret_name`` (a POSIX env var name) + a non-empty
+    ``allowed_hosts`` egress scope and ``secret_value``, and carries no
+    ``target_url``. Caps at 20 active credentials per vault. ``target_url``,
+    ``secret_name``, and ``auth_type`` are immutable after creation — archive
+    and recreate to change them.
 
     Args:
         vault_id (str):
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. The ``target_url`` is immutable
-            after creation. The service layer validates required fields per
-            ``auth_type``.
+            All secret fields are write-only. ``target_url``, ``secret_name``, and
+            ``auth_type`` are immutable after creation. The service layer validates
+            required secret fields per ``auth_type``; this model validates the
+            structural shape (which kind carries ``target_url`` vs
+            ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,18 +184,24 @@ async def asyncio_detailed(
     Validates required fields per ``auth_type``: ``oauth2_refresh`` requires
     ``access_token`` (plus the refresh fields needed for rotation);
     ``bearer_header`` requires ``token``; ``basic`` requires ``username``
-    and ``password``. Caps at 20 active credentials per vault. The
-    ``target_url`` is immutable after creation — to retarget a credential,
-    archive the existing one and create a new credential at the new URL.
+    and ``password``; ``custom_header`` requires ``header_name`` and
+    ``header_value``. ``environment_variable`` is the sandbox-materialized
+    kind: it requires ``secret_name`` (a POSIX env var name) + a non-empty
+    ``allowed_hosts`` egress scope and ``secret_value``, and carries no
+    ``target_url``. Caps at 20 active credentials per vault. ``target_url``,
+    ``secret_name``, and ``auth_type`` are immutable after creation — archive
+    and recreate to change them.
 
     Args:
         vault_id (str):
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. The ``target_url`` is immutable
-            after creation. The service layer validates required fields per
-            ``auth_type``.
+            All secret fields are write-only. ``target_url``, ``secret_name``, and
+            ``auth_type`` are immutable after creation. The service layer validates
+            required secret fields per ``auth_type``; this model validates the
+            structural shape (which kind carries ``target_url`` vs
+            ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -218,18 +236,24 @@ async def asyncio(
     Validates required fields per ``auth_type``: ``oauth2_refresh`` requires
     ``access_token`` (plus the refresh fields needed for rotation);
     ``bearer_header`` requires ``token``; ``basic`` requires ``username``
-    and ``password``. Caps at 20 active credentials per vault. The
-    ``target_url`` is immutable after creation — to retarget a credential,
-    archive the existing one and create a new credential at the new URL.
+    and ``password``; ``custom_header`` requires ``header_name`` and
+    ``header_value``. ``environment_variable`` is the sandbox-materialized
+    kind: it requires ``secret_name`` (a POSIX env var name) + a non-empty
+    ``allowed_hosts`` egress scope and ``secret_value``, and carries no
+    ``target_url``. Caps at 20 active credentials per vault. ``target_url``,
+    ``secret_name``, and ``auth_type`` are immutable after creation — archive
+    and recreate to change them.
 
     Args:
         vault_id (str):
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. The ``target_url`` is immutable
-            after creation. The service layer validates required fields per
-            ``auth_type``.
+            All secret fields are write-only. ``target_url``, ``secret_name``, and
+            ``auth_type`` are immutable after creation. The service layer validates
+            required secret fields per ``auth_type``; this model validates the
+            structural shape (which kind carries ``target_url`` vs
+            ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/create_vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/create_vault_credential.py
@@ -94,11 +94,13 @@ def sync_detailed(
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. ``target_url``, ``secret_name``, and
-            ``auth_type`` are immutable after creation. The service layer validates
-            required secret fields per ``auth_type``; this model validates the
-            structural shape (which kind carries ``target_url`` vs
-            ``secret_name``/``allowed_hosts``).
+            All secret fields are write-only. The structural fields — ``target_url``,
+            ``secret_name``, ``allowed_hosts``, and ``auth_type`` — are immutable after
+            creation; only the secret (and ``display_name``/``metadata``) can be
+            rotated via PUT, so changing a credential's egress scope means archiving
+            and recreating it. The service layer validates required secret fields per
+            ``auth_type``; this model validates the structural shape (which kind
+            carries ``target_url`` vs ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -148,11 +150,13 @@ def sync(
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. ``target_url``, ``secret_name``, and
-            ``auth_type`` are immutable after creation. The service layer validates
-            required secret fields per ``auth_type``; this model validates the
-            structural shape (which kind carries ``target_url`` vs
-            ``secret_name``/``allowed_hosts``).
+            All secret fields are write-only. The structural fields — ``target_url``,
+            ``secret_name``, ``allowed_hosts``, and ``auth_type`` — are immutable after
+            creation; only the secret (and ``display_name``/``metadata``) can be
+            rotated via PUT, so changing a credential's egress scope means archiving
+            and recreating it. The service layer validates required secret fields per
+            ``auth_type``; this model validates the structural shape (which kind
+            carries ``target_url`` vs ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -197,11 +201,13 @@ async def asyncio_detailed(
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. ``target_url``, ``secret_name``, and
-            ``auth_type`` are immutable after creation. The service layer validates
-            required secret fields per ``auth_type``; this model validates the
-            structural shape (which kind carries ``target_url`` vs
-            ``secret_name``/``allowed_hosts``).
+            All secret fields are write-only. The structural fields — ``target_url``,
+            ``secret_name``, ``allowed_hosts``, and ``auth_type`` — are immutable after
+            creation; only the secret (and ``display_name``/``metadata``) can be
+            rotated via PUT, so changing a credential's egress scope means archiving
+            and recreating it. The service layer validates required secret fields per
+            ``auth_type``; this model validates the structural shape (which kind
+            carries ``target_url`` vs ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -249,11 +255,13 @@ async def asyncio(
         authorization (None | str | Unset):
         body (VaultCredentialCreate): Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-            All secret fields are write-only. ``target_url``, ``secret_name``, and
-            ``auth_type`` are immutable after creation. The service layer validates
-            required secret fields per ``auth_type``; this model validates the
-            structural shape (which kind carries ``target_url`` vs
-            ``secret_name``/``allowed_hosts``).
+            All secret fields are write-only. The structural fields — ``target_url``,
+            ``secret_name``, ``allowed_hosts``, and ``auth_type`` — are immutable after
+            creation; only the secret (and ``display_name``/``metadata``) can be
+            rotated via PUT, so changing a credential's egress scope means archiving
+            and recreating it. The service layer validates required secret fields per
+            ``auth_type``; this model validates the structural shape (which kind
+            carries ``target_url`` vs ``secret_name``/``allowed_hosts``).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/update_vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/update_vault_credential.py
@@ -94,8 +94,9 @@ def sync_detailed(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url`` and ``auth_type`` are immutable — not accepted here.
-            Omitted secret fields are preserved (decrypt-merge-encrypt).
+            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
+            immutable — not accepted here. Omitted secret fields are preserved
+            (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -144,8 +145,9 @@ def sync(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url`` and ``auth_type`` are immutable — not accepted here.
-            Omitted secret fields are preserved (decrypt-merge-encrypt).
+            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
+            immutable — not accepted here. Omitted secret fields are preserved
+            (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -189,8 +191,9 @@ async def asyncio_detailed(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url`` and ``auth_type`` are immutable — not accepted here.
-            Omitted secret fields are preserved (decrypt-merge-encrypt).
+            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
+            immutable — not accepted here. Omitted secret fields are preserved
+            (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -237,8 +240,9 @@ async def asyncio(
         body (VaultCredentialUpdate): Request body for ``PUT
             /v1/vaults/{vault_id}/credentials/{id}``.
 
-            ``target_url`` and ``auth_type`` are immutable — not accepted here.
-            Omitted secret fields are preserved (decrypt-merge-encrypt).
+            ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
+            immutable — not accepted here. Omitted secret fields are preserved
+            (decrypt-merge-encrypt).
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential.py
@@ -22,26 +22,33 @@ T = TypeVar("T", bound="VaultCredential")
 class VaultCredential:
     """Read view of a vault credential. Secrets are never returned.
 
-    Attributes:
-        id (str):
-        vault_id (str):
-        display_name (None | str):
-        target_url (str):
-        auth_type (VaultCredentialAuthType):
-        metadata (VaultCredentialMetadata):
-        created_at (datetime.datetime):
-        updated_at (datetime.datetime):
-        archived_at (datetime.datetime | None | Unset):
+    ``target_url`` is null for ``environment_variable`` credentials;
+    ``secret_name``/``allowed_hosts`` are null for every other kind.
+
+        Attributes:
+            id (str):
+            vault_id (str):
+            display_name (None | str):
+            target_url (None | str):
+            auth_type (VaultCredentialAuthType):
+            metadata (VaultCredentialMetadata):
+            created_at (datetime.datetime):
+            updated_at (datetime.datetime):
+            secret_name (None | str | Unset):
+            allowed_hosts (list[str] | None | Unset):
+            archived_at (datetime.datetime | None | Unset):
     """
 
     id: str
     vault_id: str
     display_name: None | str
-    target_url: str
+    target_url: None | str
     auth_type: VaultCredentialAuthType
     metadata: VaultCredentialMetadata
     created_at: datetime.datetime
     updated_at: datetime.datetime
+    secret_name: None | str | Unset = UNSET
+    allowed_hosts: list[str] | None | Unset = UNSET
     archived_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -53,6 +60,7 @@ class VaultCredential:
         display_name: None | str
         display_name = self.display_name
 
+        target_url: None | str
         target_url = self.target_url
 
         auth_type = self.auth_type.value
@@ -62,6 +70,21 @@ class VaultCredential:
         created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
+
+        secret_name: None | str | Unset
+        if isinstance(self.secret_name, Unset):
+            secret_name = UNSET
+        else:
+            secret_name = self.secret_name
+
+        allowed_hosts: list[str] | None | Unset
+        if isinstance(self.allowed_hosts, Unset):
+            allowed_hosts = UNSET
+        elif isinstance(self.allowed_hosts, list):
+            allowed_hosts = self.allowed_hosts
+
+        else:
+            allowed_hosts = self.allowed_hosts
 
         archived_at: None | str | Unset
         if isinstance(self.archived_at, Unset):
@@ -85,6 +108,10 @@ class VaultCredential:
                 "updated_at": updated_at,
             }
         )
+        if secret_name is not UNSET:
+            field_dict["secret_name"] = secret_name
+        if allowed_hosts is not UNSET:
+            field_dict["allowed_hosts"] = allowed_hosts
         if archived_at is not UNSET:
             field_dict["archived_at"] = archived_at
 
@@ -106,7 +133,12 @@ class VaultCredential:
 
         display_name = _parse_display_name(d.pop("display_name"))
 
-        target_url = d.pop("target_url")
+        def _parse_target_url(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        target_url = _parse_target_url(d.pop("target_url"))
 
         auth_type = VaultCredentialAuthType(d.pop("auth_type"))
 
@@ -115,6 +147,32 @@ class VaultCredential:
         created_at = isoparse(d.pop("created_at"))
 
         updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_secret_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        secret_name = _parse_secret_name(d.pop("secret_name", UNSET))
+
+        def _parse_allowed_hosts(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                allowed_hosts_type_0 = cast(list[str], data)
+
+                return allowed_hosts_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        allowed_hosts = _parse_allowed_hosts(d.pop("allowed_hosts", UNSET))
 
         def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
@@ -142,6 +200,8 @@ class VaultCredential:
             metadata=metadata,
             created_at=created_at,
             updated_at=updated_at,
+            secret_name=secret_name,
+            allowed_hosts=allowed_hosts,
             archived_at=archived_at,
         )
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_auth_type.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_auth_type.py
@@ -5,6 +5,7 @@ class VaultCredentialAuthType(str, Enum):
     BASIC = "basic"
     BEARER_HEADER = "bearer_header"
     CUSTOM_HEADER = "custom_header"
+    ENVIRONMENT_VARIABLE = "environment_variable"
     OAUTH2_REFRESH = "oauth2_refresh"
 
     def __str__(self) -> str:

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create.py
@@ -24,11 +24,13 @@ T = TypeVar("T", bound="VaultCredentialCreate")
 class VaultCredentialCreate:
     """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-    All secret fields are write-only. ``target_url``, ``secret_name``, and
-    ``auth_type`` are immutable after creation. The service layer validates
-    required secret fields per ``auth_type``; this model validates the
-    structural shape (which kind carries ``target_url`` vs
-    ``secret_name``/``allowed_hosts``).
+    All secret fields are write-only. The structural fields — ``target_url``,
+    ``secret_name``, ``allowed_hosts``, and ``auth_type`` — are immutable after
+    creation; only the secret (and ``display_name``/``metadata``) can be
+    rotated via PUT, so changing a credential's egress scope means archiving
+    and recreating it. The service layer validates required secret fields per
+    ``auth_type``; this model validates the structural shape (which kind
+    carries ``target_url`` vs ``secret_name``/``allowed_hosts``).
 
         Attributes:
             auth_type (VaultCredentialCreateAuthType):

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create.py
@@ -24,12 +24,13 @@ T = TypeVar("T", bound="VaultCredentialCreate")
 class VaultCredentialCreate:
     """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-    All secret fields are write-only. The ``target_url`` is immutable
-    after creation. The service layer validates required fields per
-    ``auth_type``.
+    All secret fields are write-only. ``target_url``, ``secret_name``, and
+    ``auth_type`` are immutable after creation. The service layer validates
+    required secret fields per ``auth_type``; this model validates the
+    structural shape (which kind carries ``target_url`` vs
+    ``secret_name``/``allowed_hosts``).
 
         Attributes:
-            target_url (str):
             auth_type (VaultCredentialCreateAuthType):
             access_token (None | str | Unset):
             expires_at (datetime.datetime | None | Unset):
@@ -44,11 +45,14 @@ class VaultCredentialCreate:
             password (None | str | Unset):
             header_name (None | str | Unset):
             header_value (None | str | Unset):
+            secret_value (None | str | Unset):
             display_name (None | str | Unset):
             metadata (VaultCredentialCreateMetadata | Unset):
+            target_url (None | str | Unset):
+            secret_name (None | str | Unset):
+            allowed_hosts (list[str] | None | Unset):
     """
 
-    target_url: str
     auth_type: VaultCredentialCreateAuthType
     access_token: None | str | Unset = UNSET
     expires_at: datetime.datetime | None | Unset = UNSET
@@ -69,15 +73,17 @@ class VaultCredentialCreate:
     password: None | str | Unset = UNSET
     header_name: None | str | Unset = UNSET
     header_value: None | str | Unset = UNSET
+    secret_value: None | str | Unset = UNSET
     display_name: None | str | Unset = UNSET
     metadata: VaultCredentialCreateMetadata | Unset = UNSET
+    target_url: None | str | Unset = UNSET
+    secret_name: None | str | Unset = UNSET
+    allowed_hosts: list[str] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.token_endpoint_auth_basic import TokenEndpointAuthBasic
         from ..models.token_endpoint_auth_none import TokenEndpointAuthNone
         from ..models.token_endpoint_auth_post import TokenEndpointAuthPost
-
-        target_url = self.target_url
 
         auth_type = self.auth_type.value
 
@@ -167,6 +173,12 @@ class VaultCredentialCreate:
         else:
             header_value = self.header_value
 
+        secret_value: None | str | Unset
+        if isinstance(self.secret_value, Unset):
+            secret_value = UNSET
+        else:
+            secret_value = self.secret_value
+
         display_name: None | str | Unset
         if isinstance(self.display_name, Unset):
             display_name = UNSET
@@ -177,11 +189,31 @@ class VaultCredentialCreate:
         if not isinstance(self.metadata, Unset):
             metadata = self.metadata.to_dict()
 
+        target_url: None | str | Unset
+        if isinstance(self.target_url, Unset):
+            target_url = UNSET
+        else:
+            target_url = self.target_url
+
+        secret_name: None | str | Unset
+        if isinstance(self.secret_name, Unset):
+            secret_name = UNSET
+        else:
+            secret_name = self.secret_name
+
+        allowed_hosts: list[str] | None | Unset
+        if isinstance(self.allowed_hosts, Unset):
+            allowed_hosts = UNSET
+        elif isinstance(self.allowed_hosts, list):
+            allowed_hosts = self.allowed_hosts
+
+        else:
+            allowed_hosts = self.allowed_hosts
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
             {
-                "target_url": target_url,
                 "auth_type": auth_type,
             }
         )
@@ -211,10 +243,18 @@ class VaultCredentialCreate:
             field_dict["header_name"] = header_name
         if header_value is not UNSET:
             field_dict["header_value"] = header_value
+        if secret_value is not UNSET:
+            field_dict["secret_value"] = secret_value
         if display_name is not UNSET:
             field_dict["display_name"] = display_name
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if target_url is not UNSET:
+            field_dict["target_url"] = target_url
+        if secret_name is not UNSET:
+            field_dict["secret_name"] = secret_name
+        if allowed_hosts is not UNSET:
+            field_dict["allowed_hosts"] = allowed_hosts
 
         return field_dict
 
@@ -228,8 +268,6 @@ class VaultCredentialCreate:
         )
 
         d = dict(src_dict)
-        target_url = d.pop("target_url")
-
         auth_type = VaultCredentialCreateAuthType(d.pop("auth_type"))
 
         def _parse_access_token(data: object) -> None | str | Unset:
@@ -404,6 +442,15 @@ class VaultCredentialCreate:
 
         header_value = _parse_header_value(d.pop("header_value", UNSET))
 
+        def _parse_secret_value(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        secret_value = _parse_secret_value(d.pop("secret_value", UNSET))
+
         def _parse_display_name(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -420,8 +467,42 @@ class VaultCredentialCreate:
         else:
             metadata = VaultCredentialCreateMetadata.from_dict(_metadata)
 
+        def _parse_target_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        target_url = _parse_target_url(d.pop("target_url", UNSET))
+
+        def _parse_secret_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        secret_name = _parse_secret_name(d.pop("secret_name", UNSET))
+
+        def _parse_allowed_hosts(data: object) -> list[str] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                allowed_hosts_type_0 = cast(list[str], data)
+
+                return allowed_hosts_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[str] | None | Unset, data)
+
+        allowed_hosts = _parse_allowed_hosts(d.pop("allowed_hosts", UNSET))
+
         vault_credential_create = cls(
-            target_url=target_url,
             auth_type=auth_type,
             access_token=access_token,
             expires_at=expires_at,
@@ -436,8 +517,12 @@ class VaultCredentialCreate:
             password=password,
             header_name=header_name,
             header_value=header_value,
+            secret_value=secret_value,
             display_name=display_name,
             metadata=metadata,
+            target_url=target_url,
+            secret_name=secret_name,
+            allowed_hosts=allowed_hosts,
         )
 
         return vault_credential_create

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create_auth_type.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_create_auth_type.py
@@ -5,6 +5,7 @@ class VaultCredentialCreateAuthType(str, Enum):
     BASIC = "basic"
     BEARER_HEADER = "bearer_header"
     CUSTOM_HEADER = "custom_header"
+    ENVIRONMENT_VARIABLE = "environment_variable"
     OAUTH2_REFRESH = "oauth2_refresh"
 
     def __str__(self) -> str:

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
@@ -42,6 +42,7 @@ class VaultCredentialUpdate:
             password (None | str | Unset):
             header_name (None | str | Unset):
             header_value (None | str | Unset):
+            secret_value (None | str | Unset):
             display_name (None | str | Unset):
             metadata (None | Unset | VaultCredentialUpdateMetadataType0):
     """
@@ -65,6 +66,7 @@ class VaultCredentialUpdate:
     password: None | str | Unset = UNSET
     header_name: None | str | Unset = UNSET
     header_value: None | str | Unset = UNSET
+    secret_value: None | str | Unset = UNSET
     display_name: None | str | Unset = UNSET
     metadata: None | Unset | VaultCredentialUpdateMetadataType0 = UNSET
 
@@ -162,6 +164,12 @@ class VaultCredentialUpdate:
         else:
             header_value = self.header_value
 
+        secret_value: None | str | Unset
+        if isinstance(self.secret_value, Unset):
+            secret_value = UNSET
+        else:
+            secret_value = self.secret_value
+
         display_name: None | str | Unset
         if isinstance(self.display_name, Unset):
             display_name = UNSET
@@ -205,6 +213,8 @@ class VaultCredentialUpdate:
             field_dict["header_name"] = header_name
         if header_value is not UNSET:
             field_dict["header_value"] = header_value
+        if secret_value is not UNSET:
+            field_dict["secret_value"] = secret_value
         if display_name is not UNSET:
             field_dict["display_name"] = display_name
         if metadata is not UNSET:
@@ -395,6 +405,15 @@ class VaultCredentialUpdate:
 
         header_value = _parse_header_value(d.pop("header_value", UNSET))
 
+        def _parse_secret_value(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        secret_value = _parse_secret_value(d.pop("secret_value", UNSET))
+
         def _parse_display_name(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -437,6 +456,7 @@ class VaultCredentialUpdate:
             password=password,
             header_name=header_name,
             header_value=header_value,
+            secret_value=secret_value,
             display_name=display_name,
             metadata=metadata,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/vault_credential_update.py
@@ -25,8 +25,9 @@ T = TypeVar("T", bound="VaultCredentialUpdate")
 class VaultCredentialUpdate:
     """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
 
-    ``target_url`` and ``auth_type`` are immutable — not accepted here.
-    Omitted secret fields are preserved (decrypt-merge-encrypt).
+    ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
+    immutable — not accepted here. Omitted secret fields are preserved
+    (decrypt-merge-encrypt).
 
         Attributes:
             access_token (None | str | Unset):

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -133,9 +133,13 @@ async def create_credential(
     Validates required fields per ``auth_type``: ``oauth2_refresh`` requires
     ``access_token`` (plus the refresh fields needed for rotation);
     ``bearer_header`` requires ``token``; ``basic`` requires ``username``
-    and ``password``. Caps at 20 active credentials per vault. The
-    ``target_url`` is immutable after creation — to retarget a credential,
-    archive the existing one and create a new credential at the new URL.
+    and ``password``; ``custom_header`` requires ``header_name`` and
+    ``header_value``. ``environment_variable`` is the sandbox-materialized
+    kind: it requires ``secret_name`` (a POSIX env var name) + a non-empty
+    ``allowed_hosts`` egress scope and ``secret_value``, and carries no
+    ``target_url``. Caps at 20 active credentials per vault. ``target_url``,
+    ``secret_name``, and ``auth_type`` are immutable after creation — archive
+    and recreate to change them.
     """
     return await service.create_vault_credential(
         pool, crypto_box, vault_id=vault_id, body=body, account_id=account_id

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -43,7 +43,7 @@ app.add_typer(credentials, name="credentials")
 # ── vaults CRUD ─────────────────────────────────────────────────────────────
 
 _VAULT_COLS = ("id", "display_name", "archived_at", "updated_at")
-_CRED_COLS = ("id", "display_name", "auth_type", "target_url", "updated_at")
+_CRED_COLS = ("id", "display_name", "auth_type", "target_url", "secret_name", "updated_at")
 
 
 @app.command("list", help="List vaults.")

--- a/src/aios/cli/commands/vaults.py
+++ b/src/aios/cli/commands/vaults.py
@@ -43,7 +43,15 @@ app.add_typer(credentials, name="credentials")
 # ── vaults CRUD ─────────────────────────────────────────────────────────────
 
 _VAULT_COLS = ("id", "display_name", "archived_at", "updated_at")
-_CRED_COLS = ("id", "display_name", "auth_type", "target_url", "secret_name", "updated_at")
+_CRED_COLS = (
+    "id",
+    "display_name",
+    "auth_type",
+    "target_url",
+    "secret_name",
+    "allowed_hosts",
+    "updated_at",
+)
 
 
 @app.command("list", help="List vaults.")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -3541,6 +3541,8 @@ def _row_to_vault_credential(row: asyncpg.Record) -> VaultCredential:
         display_name=row["display_name"],
         target_url=row["target_url"],
         auth_type=row["auth_type"],
+        secret_name=row["secret_name"],
+        allowed_hosts=row["allowed_hosts"],
         metadata=metadata,
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -3554,7 +3556,9 @@ async def insert_vault_credential(
     account_id: str,
     vault_id: str,
     display_name: str | None,
-    target_url: str,
+    target_url: str | None,
+    secret_name: str | None,
+    allowed_hosts: list[str] | None,
     auth_type: AuthType,
     blob: EncryptedBlob,
     metadata: dict[str, Any],
@@ -3565,16 +3569,18 @@ async def insert_vault_credential(
         row = await conn.fetchrow(
             """
             INSERT INTO vault_credentials (
-                id, vault_id, display_name, target_url,
-                auth_type, ciphertext, nonce, metadata, account_id
+                id, vault_id, display_name, target_url, secret_name,
+                allowed_hosts, auth_type, ciphertext, nonce, metadata, account_id
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11)
             RETURNING *
             """,
             new_id,
             vault_id,
             display_name,
             target_url,
+            secret_name,
+            allowed_hosts,
             auth_type,
             blob.ciphertext,
             blob.nonce,
@@ -3582,6 +3588,16 @@ async def insert_vault_credential(
             account_id,
         )
     except asyncpg.UniqueViolationError as exc:
+        # By construction each insert shape can violate exactly one partial
+        # unique index: env-var rows have target_url NULL (NULLS DISTINCT, can
+        # never trip the url index) and every other kind has secret_name NULL
+        # (can never trip the secret_name index). Branch on the kind rather
+        # than introspecting the constraint name.
+        if auth_type == "environment_variable":
+            raise ConflictError(
+                f"an active credential named {secret_name!r} already exists in this vault",
+                detail={"secret_name": secret_name, "vault_id": vault_id},
+            ) from exc
         raise ConflictError(
             f"an active credential for {target_url!r} already exists in this vault",
             detail={"target_url": target_url, "vault_id": vault_id},

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -162,6 +162,13 @@ def _auth_headers_from_payload(payload: dict[str, Any], auth_type: AuthType) -> 
         if not header_name or not header_value:
             return {}
         return {header_name: header_value}
+    if auth_type == "environment_variable":
+        # environment_variable credentials are materialized into the sandbox
+        # env, never rendered as outbound auth headers. They carry no
+        # target_url, so the target_url-keyed resolvers cannot select them —
+        # reaching here means a resolver returned a NULL-target_url row, an
+        # invariant violation rather than a model-recoverable error.
+        raise ValueError("environment_variable credentials are not rendered as auth headers")
     assert_never(auth_type)
 
 

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -25,7 +25,9 @@ from pydantic import (
 
 # Hostname: RFC 952 / RFC 1123 labels joined by dots.  Only characters that
 # are safe to embed in a shell script (no metacharacters, no slashes).
-_HOSTNAME_RE = re.compile(
+# Public so vault env-var credentials (``models/vaults.py``) validate their
+# host allowlists against the same grammar the sandbox networking layer uses.
+HOSTNAME_RE = re.compile(
     r"^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)*$"
 )
 
@@ -62,7 +64,7 @@ class LimitedNetworking(BaseModel):
                 raise ValueError("allowed_hosts entries must not be empty")
             if len(host) > 253:
                 raise ValueError(f"hostname too long ({len(host)} > 253): {host!r}")
-            if not _HOSTNAME_RE.match(host):
+            if not HOSTNAME_RE.match(host):
                 raise ValueError(
                     f"invalid hostname {host!r}: only alphanumerics, hyphens, and dots allowed"
                 )

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -64,7 +64,10 @@ class LimitedNetworking(BaseModel):
                 raise ValueError("allowed_hosts entries must not be empty")
             if len(host) > 253:
                 raise ValueError(f"hostname too long ({len(host)} > 253): {host!r}")
-            if not HOSTNAME_RE.match(host):
+            # fullmatch, not match: a trailing ``$`` lets ``re.match`` accept a
+            # single trailing newline ("host\n"), which would then be embedded
+            # verbatim into the iptables lockdown script (sandbox/setup.py).
+            if not HOSTNAME_RE.fullmatch(host):
                 raise ValueError(
                     f"invalid hostname {host!r}: only alphanumerics, hyphens, and dots allowed"
                 )

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -85,7 +85,9 @@ def _validate_credential_host(host: str) -> str:
     """
     # HOSTNAME_RE rejects the empty string and anything with a port/slash/
     # wildcard; the explicit length bound is the only thing the regex lacks.
-    if len(host) > 253 or not HOSTNAME_RE.match(host):
+    # fullmatch, not match: the trailing ``$`` would otherwise admit a single
+    # trailing newline ("host\n") and store an unmatchable control char.
+    if len(host) > 253 or not HOSTNAME_RE.fullmatch(host):
         raise ValueError(
             f"invalid host {host!r}: a bare hostname is required "
             "(no scheme, port, path, wildcard, or IPv6)"
@@ -129,7 +131,8 @@ def parse_allowed_host_entry(entry: str) -> tuple[str, str | None]:
             raise ValueError(f"invalid allowed_hosts entry {entry!r}: '.'/'..' path segment")
         # The pchar charset excludes ``%`` (and every shell/URL metachar), so
         # percent-encoding and illegal characters are both rejected here.
-        if not _PATH_SEGMENT_RE.match(seg):
+        # fullmatch, not match: ``$`` would otherwise admit a trailing newline.
+        if not _PATH_SEGMENT_RE.fullmatch(seg):
             raise ValueError(f"invalid allowed_hosts entry {entry!r}: illegal path character")
     return host, "/" + "/".join(segments)
 
@@ -244,11 +247,13 @@ class _VaultCredentialSecrets(BaseModel):
 class VaultCredentialCreate(_VaultCredentialSecrets):
     """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-    All secret fields are write-only. ``target_url``, ``secret_name``, and
-    ``auth_type`` are immutable after creation. The service layer validates
-    required secret fields per ``auth_type``; this model validates the
-    structural shape (which kind carries ``target_url`` vs
-    ``secret_name``/``allowed_hosts``).
+    All secret fields are write-only. The structural fields — ``target_url``,
+    ``secret_name``, ``allowed_hosts``, and ``auth_type`` — are immutable after
+    creation; only the secret (and ``display_name``/``metadata``) can be
+    rotated via PUT, so changing a credential's egress scope means archiving
+    and recreating it. The service layer validates required secret fields per
+    ``auth_type``; this model validates the structural shape (which kind
+    carries ``target_url`` vs ``secret_name``/``allowed_hosts``).
     """
 
     display_name: str | None = Field(default=None, max_length=128)
@@ -284,12 +289,14 @@ class VaultCredentialCreate(_VaultCredentialSecrets):
                     "environment_variable credentials require a non-empty allowed_hosts"
                 )
             # Canonicalize every entry so there is one stored spelling per
-            # semantics (``host/`` → ``host``, ``host/foo/`` → ``host/foo``).
+            # semantics (``host/`` → ``host``, ``host/foo/`` → ``host/foo``),
+            # then drop cross-entry duplicates (the list is a set of egress
+            # scopes; ``dict.fromkeys`` preserves first-seen order).
             canonical: list[str] = []
             for entry in self.allowed_hosts:
                 host, prefix = parse_allowed_host_entry(entry)
                 canonical.append(host if prefix is None else host + prefix)
-            self.allowed_hosts = canonical
+            self.allowed_hosts = list(dict.fromkeys(canonical))
         else:
             if not self.target_url:
                 raise ValueError(f"{self.auth_type} credentials require target_url")
@@ -303,8 +310,9 @@ class VaultCredentialCreate(_VaultCredentialSecrets):
 class VaultCredentialUpdate(_VaultCredentialSecrets):
     """Request body for ``PUT /v1/vaults/{vault_id}/credentials/{id}``.
 
-    ``target_url`` and ``auth_type`` are immutable — not accepted here.
-    Omitted secret fields are preserved (decrypt-merge-encrypt).
+    ``target_url``, ``secret_name``, ``allowed_hosts``, and ``auth_type`` are
+    immutable — not accepted here. Omitted secret fields are preserved
+    (decrypt-merge-encrypt).
     """
 
     display_name: str | None = Field(default=None, max_length=128)

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -1,20 +1,137 @@
 """Vault and vault credential resources.
 
 Vaults are named collections of credentials for authenticated outbound
-services (MCP servers, HTTP APIs). Each credential is keyed by
-``target_url`` and encrypted at rest via the CryptoBox. Secrets
-(tokens, client secrets, passwords) are write-only — never returned in
-API responses.
+services (MCP servers, HTTP APIs). Most credentials are keyed by an
+immutable ``target_url`` and consumed worker-side as outbound auth headers.
+The ``environment_variable`` kind is different: it has no ``target_url`` and
+is keyed by ``secret_name`` (the env var materialized into the sandbox),
+carrying an ``allowed_hosts`` egress scope instead. Secrets are encrypted at
+rest via the CryptoBox and are write-only — never returned in API responses.
 """
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
-AuthType = Literal["bearer_header", "oauth2_refresh", "basic", "custom_header"]
+from aios.models.environments import HOSTNAME_RE
+
+AuthType = Literal[
+    "bearer_header",
+    "oauth2_refresh",
+    "basic",
+    "custom_header",
+    "environment_variable",
+]
+
+# Env var names the harness injects into every sandbox (see
+# ``sandbox/spec.py`` ``merged_env`` and ``sandbox/setup.py``
+# ``WORKSPACE_RUNTIME_ENV``). An ``environment_variable`` credential may not
+# claim one as its ``secret_name``: a collision either hijacks a load-bearing
+# sandbox variable (e.g. ``PATH`` repointed → unqualified-binary takeover) or
+# is silently shadowed by the harness's own merge order — both defects, and
+# ``secret_name`` is immutable post-create. Hardcoded here rather than
+# imported from ``sandbox.setup`` (that would cycle via ``aios.config``); a
+# unit test pins this set against the live merge order so it can't drift.
+RESERVED_SANDBOX_ENV_KEYS: frozenset[str] = frozenset(
+    {
+        "VIRTUAL_ENV",
+        "NPM_CONFIG_PREFIX",
+        "NODE_PATH",
+        "PATH",
+        "TOOL_BROKER_URL",
+        "TOOL_BROKER_SECRET",
+        "AIOS_SESSION_ID",
+    }
+)
+
+# A path-prefix segment: RFC 3986 ``pchar`` minus percent-encoding. ``%`` is
+# excluded so stored entries stay canonical (the swap proxy owns request-side
+# percent-decoding); ``/`` is the segment separator, handled by the split.
+_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._~!$&'()*+,;=:@-]+$")
+
+# POSIX portable env var name: a leading letter/underscore, then word chars.
+_SECRET_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# A final hostname label that is a pure numeric token in any base — decimal
+# ("10", "2130706433"), hex ("0x7f000001", "0xA"), or octal ("0177"). The
+# last octet of every IPv4-literal spelling is such a token, and no real DNS
+# top label is, so rejecting these labels rejects IP literals without a libc
+# parse. (The bare alpha check alone misses hex, whose letters look "alpha".)
+_NUMERIC_LABEL_RE = re.compile(r"0[xX][0-9A-Fa-f]+|[0-9]+", re.ASCII)
+
+# Upper bound on one ``allowed_hosts`` entry (host[/path]). The host part is
+# already capped at 253; this bounds the optional path prefix.
+_MAX_ALLOWED_HOST_ENTRY_LEN = 512
+
+
+def _validate_credential_host(host: str) -> str:
+    """Validate the host part of one ``allowed_hosts`` entry.
+
+    Bare hostname only (same grammar as environment ``allowed_hosts``), and
+    DNS-names-only: the swap proxy (#876) matches on the request ``Host``/SNI
+    name, so an IP-literal entry could never match as intended. Rejecting a
+    final label that is a pure numeric token (decimal, hex, or octal) rejects
+    every IP-literal spelling — dotted-quad, integer, and hex/octal — without
+    a libc parse. Resolve-time SSRF — a NAME that *resolves* to an internal
+    address, incl. DNS rebinding — is the egress boundary's job (#876), not
+    create-time's. Returns the host unchanged (stored as-given, like
+    environment ``allowed_hosts``; downstream comparisons case-fold both
+    sides).
+    """
+    # HOSTNAME_RE rejects the empty string and anything with a port/slash/
+    # wildcard; the explicit length bound is the only thing the regex lacks.
+    if len(host) > 253 or not HOSTNAME_RE.match(host):
+        raise ValueError(
+            f"invalid host {host!r}: a bare hostname is required "
+            "(no scheme, port, path, wildcard, or IPv6)"
+        )
+    final_label = host.rsplit(".", 1)[-1]
+    if _NUMERIC_LABEL_RE.fullmatch(final_label) or not any(c.isalpha() for c in final_label):
+        raise ValueError(f"invalid host {host!r}: a DNS hostname is required, not an IP literal")
+    return host
+
+
+def parse_allowed_host_entry(entry: str) -> tuple[str, str | None]:
+    """Split one ``allowed_hosts`` entry into ``(host, path_prefix)``.
+
+    Grammar: ``host`` or ``host/<path-prefix>``. A bare host (and the
+    explicit-whole-host spelling ``host/``) returns ``(host, None)``;
+    otherwise the prefix is returned in canonical leading-slash form
+    (``/repos/eumemic``). One trailing slash is dropped, so ``host/`` ≡
+    ``host`` and ``host/foo/`` ≡ ``host/foo`` — exactly one parse per
+    semantics.
+
+    This is the single grammar authority: the egress swap proxy (#876) and
+    the cred-⊆-env check (#879) import it rather than re-deriving the split,
+    so the stored entry and the runtime matcher can never disagree.
+
+    Raises ``ValueError`` on a malformed entry.
+    """
+    if not entry or len(entry) > _MAX_ALLOWED_HOST_ENTRY_LEN:
+        raise ValueError(f"invalid allowed_hosts entry {entry!r}: empty or too long")
+    host_part, sep, rest = entry.partition("/")
+    host = _validate_credential_host(host_part)
+    if not sep:
+        return host, None
+    if rest.endswith("/"):
+        rest = rest[:-1]
+    if not rest:
+        return host, None
+    segments = rest.split("/")
+    for seg in segments:
+        if not seg:
+            raise ValueError(f"invalid allowed_hosts entry {entry!r}: empty path segment")
+        if seg in (".", ".."):
+            raise ValueError(f"invalid allowed_hosts entry {entry!r}: '.'/'..' path segment")
+        # The pchar charset excludes ``%`` (and every shell/URL metachar), so
+        # percent-encoding and illegal characters are both rejected here.
+        if not _PATH_SEGMENT_RE.match(seg):
+            raise ValueError(f"invalid allowed_hosts entry {entry!r}: illegal path character")
+    return host, "/" + "/".join(segments)
 
 
 # ── Token endpoint auth (for OAuth refresh) ─────────────────────────────────
@@ -120,19 +237,67 @@ class _VaultCredentialSecrets(BaseModel):
     header_name: str | None = None
     header_value: SecretStr | None = None
 
+    # environment_variable
+    secret_value: SecretStr | None = None
+
 
 class VaultCredentialCreate(_VaultCredentialSecrets):
     """Request body for ``POST /v1/vaults/{vault_id}/credentials``.
 
-    All secret fields are write-only. The ``target_url`` is immutable
-    after creation. The service layer validates required fields per
-    ``auth_type``.
+    All secret fields are write-only. ``target_url``, ``secret_name``, and
+    ``auth_type`` are immutable after creation. The service layer validates
+    required secret fields per ``auth_type``; this model validates the
+    structural shape (which kind carries ``target_url`` vs
+    ``secret_name``/``allowed_hosts``).
     """
 
     display_name: str | None = Field(default=None, max_length=128)
-    target_url: str = Field(min_length=1)
     auth_type: AuthType
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    # Header credentials (everything except ``environment_variable``) carry a
+    # ``target_url``; ``environment_variable`` carries ``secret_name`` +
+    # ``allowed_hosts`` instead. The ``_validate_shape`` validator enforces
+    # the xor.
+    target_url: str | None = Field(default=None, min_length=1)
+    secret_name: str | None = Field(default=None, max_length=128)
+    allowed_hosts: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> VaultCredentialCreate:
+        if self.auth_type == "environment_variable":
+            if self.target_url is not None:
+                raise ValueError("environment_variable credentials must not set target_url")
+            if not self.secret_name:
+                raise ValueError("environment_variable credentials require secret_name")
+            if not _SECRET_NAME_RE.fullmatch(self.secret_name):
+                raise ValueError(
+                    f"invalid secret_name {self.secret_name!r}: must be a POSIX env var name "
+                    "([A-Za-z_][A-Za-z0-9_]*)"
+                )
+            if self.secret_name in RESERVED_SANDBOX_ENV_KEYS:
+                raise ValueError(
+                    f"secret_name {self.secret_name!r} is reserved by the sandbox runtime"
+                )
+            if not self.allowed_hosts:
+                raise ValueError(
+                    "environment_variable credentials require a non-empty allowed_hosts"
+                )
+            # Canonicalize every entry so there is one stored spelling per
+            # semantics (``host/`` → ``host``, ``host/foo/`` → ``host/foo``).
+            canonical: list[str] = []
+            for entry in self.allowed_hosts:
+                host, prefix = parse_allowed_host_entry(entry)
+                canonical.append(host if prefix is None else host + prefix)
+            self.allowed_hosts = canonical
+        else:
+            if not self.target_url:
+                raise ValueError(f"{self.auth_type} credentials require target_url")
+            if self.secret_name is not None or self.allowed_hosts is not None:
+                raise ValueError(
+                    f"{self.auth_type} credentials must not set secret_name/allowed_hosts"
+                )
+        return self
 
 
 class VaultCredentialUpdate(_VaultCredentialSecrets):
@@ -147,13 +312,19 @@ class VaultCredentialUpdate(_VaultCredentialSecrets):
 
 
 class VaultCredential(BaseModel):
-    """Read view of a vault credential. Secrets are never returned."""
+    """Read view of a vault credential. Secrets are never returned.
+
+    ``target_url`` is null for ``environment_variable`` credentials;
+    ``secret_name``/``allowed_hosts`` are null for every other kind.
+    """
 
     id: str
     vault_id: str
     display_name: str | None
-    target_url: str
+    target_url: str | None
     auth_type: AuthType
+    secret_name: str | None = None
+    allowed_hosts: list[str] | None = None
     metadata: dict[str, Any]
     created_at: datetime
     updated_at: datetime

--- a/src/aios/models/vaults.py
+++ b/src/aios/models/vaults.py
@@ -57,11 +57,12 @@ _PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._~!$&'()*+,;=:@-]+$")
 _SECRET_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 # A final hostname label that is a pure numeric token in any base — decimal
-# ("10", "2130706433"), hex ("0x7f000001", "0xA"), or octal ("0177"). The
-# last octet of every IPv4-literal spelling is such a token, and no real DNS
-# top label is, so rejecting these labels rejects IP literals without a libc
-# parse. (The bare alpha check alone misses hex, whose letters look "alpha".)
-_NUMERIC_LABEL_RE = re.compile(r"0[xX][0-9A-Fa-f]+|[0-9]+", re.ASCII)
+# ("10", "2130706433"), hex ("0x7f000001", "0xA"), or octal ("0177"). The last
+# octet of every IPv4-literal spelling is such a token, so rejecting these
+# labels rejects IP literals without a libc parse. A must-contain-a-letter
+# test would be both too weak (hex octets contain letters) and too strict
+# (rejects legitimate digit-hyphen labels), which is why this is a token match.
+_NUMERIC_LABEL_RE = re.compile(r"0[xX][0-9A-Fa-f]+|[0-9]+")
 
 # Upper bound on one ``allowed_hosts`` entry (host[/path]). The host part is
 # already capped at 253; this bounds the optional path prefix.
@@ -89,8 +90,7 @@ def _validate_credential_host(host: str) -> str:
             f"invalid host {host!r}: a bare hostname is required "
             "(no scheme, port, path, wildcard, or IPv6)"
         )
-    final_label = host.rsplit(".", 1)[-1]
-    if _NUMERIC_LABEL_RE.fullmatch(final_label) or not any(c.isalpha() for c in final_label):
+    if _NUMERIC_LABEL_RE.fullmatch(host.rsplit(".", 1)[-1]):
         raise ValueError(f"invalid host {host!r}: a DNS hostname is required, not an IP literal")
     return host
 

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -69,6 +69,7 @@ _OAUTH_FIELDS = (
 _BEARER_FIELDS = ("token",)
 _BASIC_FIELDS = ("username", "password")
 _CUSTOM_HEADER_FIELDS = ("header_name", "header_value")
+_ENV_VAR_FIELDS = ("secret_value",)
 
 # Fields required by each auth_type. Used by both create-time validation
 # (against the request body) and post-merge validation (against the merged
@@ -78,6 +79,7 @@ _AUTH_REQUIRED: dict[AuthType, tuple[str, ...]] = {
     "basic": _BASIC_FIELDS,
     "custom_header": _CUSTOM_HEADER_FIELDS,
     "oauth2_refresh": ("access_token",),
+    "environment_variable": _ENV_VAR_FIELDS,
 }
 
 
@@ -90,6 +92,8 @@ def _fields_for(auth_type: AuthType) -> tuple[str, ...]:
         return _BASIC_FIELDS
     if auth_type == "custom_header":
         return _CUSTOM_HEADER_FIELDS
+    if auth_type == "environment_variable":
+        return _ENV_VAR_FIELDS
     assert_never(auth_type)
 
 
@@ -465,6 +469,8 @@ async def create_vault_credential(
             vault_id=vault_id,
             display_name=body.display_name,
             target_url=body.target_url,
+            secret_name=body.secret_name,
+            allowed_hosts=body.allowed_hosts,
             auth_type=body.auth_type,
             blob=blob,
             metadata=body.metadata,

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -245,6 +245,141 @@ class TestVaultCredentialCRUD:
         )
         assert cred2.id != cred1.id
 
+    async def test_create_environment_variable(self, pool: Any, crypto_box: Any) -> None:
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        from aios.db import queries
+        from aios.services import vaults as svc
+
+        vault = await svc.create_vault(
+            pool, display_name="env-var-test", metadata={}, account_id=account_id
+        )
+        body = VaultCredentialCreate(
+            auth_type="environment_variable",
+            secret_name="GITHUB_TOKEN",
+            allowed_hosts=["api.github.com/repos/eumemic", "api.tavily.com"],
+            secret_value=SecretStr("ghp_supersecret"),
+            display_name="gh",
+        )
+        cred = await svc.create_vault_credential(
+            pool, crypto_box, vault_id=vault.id, body=body, account_id=account_id
+        )
+        assert cred.id.startswith("vcr_")
+        assert cred.auth_type == "environment_variable"
+        assert cred.target_url is None
+        assert cred.secret_name == "GITHUB_TOKEN"
+        assert cred.allowed_hosts == ["api.github.com/repos/eumemic", "api.tavily.com"]
+
+        # Secrets are write-only; the secret value only survives in the
+        # encrypted blob, recoverable solely with the account subkey.
+        fetched = await svc.get_vault_credential(pool, vault.id, cred.id, account_id=account_id)
+        dumped = fetched.model_dump()
+        assert "secret_value" not in dumped
+        assert "ciphertext" not in dumped
+        async with pool.acquire() as conn:
+            _, blob = await queries.get_vault_credential_with_blob(
+                conn, vault.id, cred.id, account_id=account_id
+            )
+        payload = crypto_box.derive_account_subkey(account_id).decrypt_dict(blob)
+        assert payload == {"secret_value": "ghp_supersecret"}
+
+    async def test_environment_variable_requires_secret_value(
+        self, pool: Any, crypto_box: Any
+    ) -> None:
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        from aios.errors import ValidationError
+        from aios.services import vaults as svc
+
+        # secret_value is required at the service layer (like bearer's token),
+        # not at model construction — the structural shape validator only
+        # governs secret_name / allowed_hosts / target_url.
+        vault = await svc.create_vault(
+            pool, display_name="env-req", metadata={}, account_id=account_id
+        )
+        body = VaultCredentialCreate(
+            auth_type="environment_variable",
+            secret_name="GITHUB_TOKEN",
+            allowed_hosts=["api.github.com"],
+        )
+        with pytest.raises(ValidationError):
+            await svc.create_vault_credential(
+                pool, crypto_box, vault_id=vault.id, body=body, account_id=account_id
+            )
+
+    async def test_secret_name_unique_per_vault(self, pool: Any, crypto_box: Any) -> None:
+        """Two active env-var creds with the same secret_name in one vault conflict;
+        archiving the first frees the name; the same name in another vault is fine."""
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        from aios.errors import ConflictError
+        from aios.services import vaults as svc
+
+        vault = await svc.create_vault(
+            pool, display_name="env-uniq", metadata={}, account_id=account_id
+        )
+        other = await svc.create_vault(
+            pool, display_name="env-uniq-other", metadata={}, account_id=account_id
+        )
+
+        def _body() -> VaultCredentialCreate:
+            return VaultCredentialCreate(
+                auth_type="environment_variable",
+                secret_name="API_KEY",
+                allowed_hosts=["api.example.com"],
+                secret_value=SecretStr("k1"),
+            )
+
+        cred1 = await svc.create_vault_credential(
+            pool, crypto_box, vault_id=vault.id, body=_body(), account_id=account_id
+        )
+        with pytest.raises(ConflictError):
+            await svc.create_vault_credential(
+                pool, crypto_box, vault_id=vault.id, body=_body(), account_id=account_id
+            )
+        # Same secret_name in a different vault is allowed.
+        await svc.create_vault_credential(
+            pool, crypto_box, vault_id=other.id, body=_body(), account_id=account_id
+        )
+        # Archiving frees the name for reuse in the original vault.
+        await svc.archive_vault_credential(pool, vault.id, cred1.id, account_id=account_id)
+        cred2 = await svc.create_vault_credential(
+            pool, crypto_box, vault_id=vault.id, body=_body(), account_id=account_id
+        )
+        assert cred2.id != cred1.id
+
+    async def test_environment_variable_rotates_secret(self, pool: Any, crypto_box: Any) -> None:
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        from aios.db import queries
+        from aios.services import vaults as svc
+
+        vault = await svc.create_vault(
+            pool, display_name="env-rotate", metadata={}, account_id=account_id
+        )
+        cred = await svc.create_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault.id,
+            body=VaultCredentialCreate(
+                auth_type="environment_variable",
+                secret_name="ROTATING",
+                allowed_hosts=["api.example.com"],
+                secret_value=SecretStr("old"),
+            ),
+            account_id=account_id,
+        )
+        await svc.update_vault_credential(
+            pool,
+            crypto_box,
+            vault_id=vault.id,
+            credential_id=cred.id,
+            body=VaultCredentialUpdate(secret_value=SecretStr("new")),
+            account_id=account_id,
+        )
+        async with pool.acquire() as conn:
+            _, blob = await queries.get_vault_credential_with_blob(
+                conn, vault.id, cred.id, account_id=account_id
+            )
+        payload = crypto_box.derive_account_subkey(account_id).decrypt_dict(blob)
+        assert payload == {"secret_value": "new"}
+
     async def test_update_credential(self, pool: Any, crypto_box: Any) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         from aios.services import vaults as svc

--- a/tests/integration/test_migrations_environment_variable.py
+++ b/tests/integration/test_migrations_environment_variable.py
@@ -1,0 +1,132 @@
+"""Integration tests for migration 0081 (environment_variable credentials).
+
+Pins two behaviors of the round-trip against a real Postgres:
+  - a clean upgrade→downgrade→upgrade cycle (no env-var rows) is reversible;
+  - the downgrade is fail-loud when an ``environment_variable`` row exists —
+    the narrowed ``auth_type`` CHECK is re-added BEFORE the new columns are
+    dropped, so the migration aborts (preserving ``secret_name``/
+    ``allowed_hosts``) rather than silently destroying the data.
+
+Each test mutates ``alembic_version``, so the container is function-scoped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+_ACCOUNT_SQL = """
+INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+VALUES ('acc_root', NULL, TRUE, 'root')
+ON CONFLICT DO NOTHING
+"""
+
+_VAULT_SQL = """
+INSERT INTO vaults (id, account_id, display_name, metadata)
+VALUES ('vlt_test', 'acc_root', 'test', '{}'::jsonb)
+"""
+
+_ENV_VAR_CRED_SQL = r"""
+INSERT INTO vault_credentials (
+    id, vault_id, account_id, display_name, target_url, secret_name,
+    allowed_hosts, auth_type, ciphertext, nonce, metadata
+)
+VALUES (
+    'vcr_test', 'vlt_test', 'acc_root', NULL, NULL, 'GITHUB_TOKEN',
+    ARRAY['api.github.com/repos/eumemic'], 'environment_variable',
+    '\x00'::bytea, '\x00'::bytea, '{}'::jsonb
+)
+"""
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _vault_credentials_columns(db_url: str) -> set[str]:
+    conn = await asyncpg.connect(db_url)
+    try:
+        rows = await conn.fetch(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema='public' AND table_name='vault_credentials'"
+        )
+        return {row["column_name"] for row in rows}
+    finally:
+        await conn.close()
+
+
+async def _execute(db_url: str, sql: str) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+async def _row_exists(db_url: str, cred_id: str) -> bool:
+    conn = await asyncpg.connect(db_url)
+    try:
+        return bool(await conn.fetchval("SELECT 1 FROM vault_credentials WHERE id = $1", cred_id))
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+def test_clean_round_trip(postgres: object) -> None:
+    """Upgrade adds the columns; downgrade (no env-var rows) removes them; re-upgrade restores."""
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "head"], db_url)
+    assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
+    cols = asyncio.run(_vault_credentials_columns(db_url))
+    assert {"secret_name", "allowed_hosts"} <= cols
+
+    down = _run_alembic(["downgrade", "0080"], db_url)
+    assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
+    cols = asyncio.run(_vault_credentials_columns(db_url))
+    assert "secret_name" not in cols
+    assert "allowed_hosts" not in cols
+
+    reup = _run_alembic(["upgrade", "head"], db_url)
+    assert reup.returncode == 0, f"re-upgrade failed:\n{reup.stderr}\n{reup.stdout}"
+
+
+@needs_docker
+@pytest.mark.integration
+def test_env_var_row_accepted_and_blocks_downgrade(postgres: object) -> None:
+    """An env-var row passes the widened CHECKs; the downgrade then fails loud,
+    preserving the row rather than dropping its columns."""
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "head"], db_url)
+    assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
+
+    # The widened auth_type CHECK + shape CHECK + secret_name uniq index all
+    # accept a well-formed environment_variable row.
+    asyncio.run(_execute(db_url, _ACCOUNT_SQL))
+    asyncio.run(_execute(db_url, _VAULT_SQL))
+    asyncio.run(_execute(db_url, _ENV_VAR_CRED_SQL))
+
+    # Downgrade must abort: the narrowed auth_type CHECK is re-added before the
+    # columns are dropped, so the env-var row blocks it fail-loud.
+    down = _run_alembic(["downgrade", "0080"], db_url)
+    assert down.returncode != 0, f"downgrade should have failed loud:\n{down.stdout}"
+
+    # The row (and its secret_name/allowed_hosts columns) survived intact.
+    assert asyncio.run(_row_exists(db_url, "vcr_test"))
+    cols = asyncio.run(_vault_credentials_columns(db_url))
+    assert {"secret_name", "allowed_hosts"} <= cols

--- a/tests/unit/sandbox/test_reserved_env_keys.py
+++ b/tests/unit/sandbox/test_reserved_env_keys.py
@@ -1,0 +1,44 @@
+"""Drift pin: ``RESERVED_SANDBOX_ENV_KEYS`` must equal the set of env keys the
+harness injects into every sandbox.
+
+``models/vaults.py`` rejects an ``environment_variable`` credential whose
+``secret_name`` collides with a harness-injected key (a collision would either
+hijack a load-bearing variable like ``PATH`` or be silently shadowed by the
+merge order). That blocklist is hardcoded in the model layer because importing
+``sandbox.setup`` there would cycle via ``aios.config``. This test builds a
+real provisioning plan with no user-supplied env and asserts the blocklist is
+exactly the harness-injected key set — so adding a key to ``merged_env`` (or to
+``WORKSPACE_RUNTIME_ENV``) fails here until the blocklist follows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from aios.models.vaults import RESERVED_SANDBOX_ENV_KEYS
+from aios.sandbox.spec import _assemble_plan
+
+
+def test_reserved_keys_match_injected_sandbox_env() -> None:
+    with (
+        patch("aios.sandbox.volumes.ensure_session_attachments_dir", return_value=Path("/tmp/a")),
+        patch("aios.sandbox.volumes.ensure_session_uploads_dir", return_value=Path("/tmp/u")),
+    ):
+        plan = _assemble_plan(
+            session_id="sess_01TEST",
+            instance_id="inst_TEST",
+            image="aios-sandbox:test",
+            workspace_path=Path("/tmp/w"),
+            env_config=None,
+            session_env={},
+            memory_echoes=[],
+            github_echoes=[],
+            git_proxy=None,
+            tool_broker_url="http://aios-worker:54321",
+            tool_broker_secret="secret123",
+            tool_socket_host_path=None,
+        )
+    # With no env_config / session_env, every key in the merged env is
+    # harness-injected; the reserved blocklist must cover exactly that set.
+    assert set(plan.spec.environment) == RESERVED_SANDBOX_ENV_KEYS

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -14,12 +14,23 @@ import pytest
 
 from aios.crypto.vault import CryptoBox
 from aios.mcp.client import (
+    _auth_headers_from_payload,
     call_mcp_tool,
     discover_mcp_tools,
     resolve_auth_for_target_url,
     resolve_auth_for_target_url_run,
 )
 from tests.unit.conftest import fake_pool_yielding_conn
+
+
+class TestAuthHeadersFromPayload:
+    def test_environment_variable_is_not_header_rendered(self) -> None:
+        # env-var creds carry a NULL target_url, so the target_url-keyed
+        # resolvers never select them; reaching header rendering is an
+        # invariant violation that must fail hard, not return empty headers.
+        with pytest.raises(ValueError, match="not rendered as auth headers"):
+            _auth_headers_from_payload({"secret_value": "x"}, "environment_variable")
+
 
 # ── resolve_auth_for_target_url ──────────────────────────────────────────────────────
 

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0080``."""
+    """The migration ladder has exactly one head: ``0081``."""
     script = _script_directory()
-    assert script.get_heads() == ["0080"]
+    assert script.get_heads() == ["0081"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -74,6 +74,12 @@ class TestLimitedNetworking:
         with pytest.raises(ValueError, match="invalid hostname"):
             LimitedNetworking(type="limited", allowed_hosts=["example.com; rm -rf /"])
 
+    def test_rejects_hostname_with_trailing_newline(self) -> None:
+        # The hostname regex is anchored ^...$; `re.match` would forgive a
+        # single trailing newline and let it through into the iptables script.
+        with pytest.raises(ValueError, match="invalid hostname"):
+            LimitedNetworking(type="limited", allowed_hosts=["example.com\n"])
+
     def test_rejects_hostname_with_path(self) -> None:
         with pytest.raises(ValueError, match="invalid hostname"):
             LimitedNetworking(type="limited", allowed_hosts=["example.com/path"])

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -181,6 +181,27 @@ class TestExtractAuthPayload:
         payload = _extract_auth_payload(body)
         assert payload == {"header_name": "X-Api-Key", "header_value": "bu_secret"}
 
+    def test_environment_variable_only_secret_value(self) -> None:
+        body = VaultCredentialCreate(
+            auth_type="environment_variable",
+            secret_name="GITHUB_TOKEN",
+            allowed_hosts=["api.github.com"],
+            secret_value=SecretStr("ghp_xxx"),
+        )
+        payload = _extract_auth_payload(body)
+        # Only the secret value lands in the encrypted blob; secret_name /
+        # allowed_hosts are plaintext columns, not part of the payload.
+        assert payload == {"secret_value": "ghp_xxx"}
+
+    def test_environment_variable_requires_secret_value(self) -> None:
+        body = VaultCredentialCreate(
+            auth_type="environment_variable",
+            secret_name="GITHUB_TOKEN",
+            allowed_hosts=["api.github.com"],
+        )
+        with pytest.raises(ValidationError):
+            _extract_auth_payload(body)
+
     def test_custom_header_requires_header_name(self) -> None:
         body = VaultCredentialCreate(
             target_url="https://api.example.com",
@@ -328,6 +349,23 @@ class TestMergeAuthPayload:
         update = VaultCredentialUpdate(access_token=None)
         with pytest.raises(ValidationError, match="oauth2_refresh"):
             _merge_auth_payload(existing, update, "oauth2_refresh")
+
+    def test_environment_variable_rotates_secret_value(self) -> None:
+        existing = {"secret_value": "old"}
+        update = VaultCredentialUpdate(secret_value=SecretStr("new"))
+        merged = _merge_auth_payload(existing, update, "environment_variable")
+        assert merged == {"secret_value": "new"}
+
+    def test_environment_variable_preserves_secret_on_omit(self) -> None:
+        existing = {"secret_value": "keep"}
+        merged = _merge_auth_payload(existing, VaultCredentialUpdate(), "environment_variable")
+        assert merged == {"secret_value": "keep"}
+
+    def test_unsetting_required_secret_value_is_rejected(self) -> None:
+        existing = {"secret_value": "secret"}
+        update = VaultCredentialUpdate(secret_value=None)
+        with pytest.raises(ValidationError, match="environment_variable"):
+            _merge_auth_payload(existing, update, "environment_variable")
 
 
 # ── update_vault_credential: no private sentinel leaks into queries ──────────

--- a/tests/unit/test_vault_models.py
+++ b/tests/unit/test_vault_models.py
@@ -297,11 +297,20 @@ class TestEnvironmentVariableCredential:
             "0xA.0xB.0xC.0xD",  # dotted hex IPv4 literal
             "0Xa",  # short hex IPv4 literal, uppercase prefix
             "0177.0.0.1",  # octal-leading IPv4 literal
+            "api.github.com\n",  # trailing newline — the regex `$` anchor must not admit it
+            "api.github.com\nevil.com",  # embedded newline
         ],
     )
     def test_rejects_bad_host(self, host: str) -> None:
         with pytest.raises(ValidationError):
             self._create(allowed_hosts=[host])
+
+    def test_dedups_canonical_allowed_hosts(self) -> None:
+        c = self._create(
+            allowed_hosts=["api.github.com", "api.github.com/", "api.github.com", "api.tavily.com"]
+        )
+        # All three github spellings canonicalize to one entry; order preserved.
+        assert c.allowed_hosts == ["api.github.com", "api.tavily.com"]
 
     @pytest.mark.parametrize(
         "host",
@@ -367,7 +376,17 @@ class TestParseAllowedHostEntry:
         assert parse_allowed_host_entry(entry) == expected
 
     @pytest.mark.parametrize(
-        "entry", ["", "127.0.0.1", "0x7f000001", "host//x", "host/../x", "host/%2e"]
+        "entry",
+        [
+            "",
+            "127.0.0.1",
+            "0x7f000001",
+            "host//x",
+            "host/../x",
+            "host/%2e",
+            "host\n",  # trailing newline in the host part
+            "host/repos\n",  # trailing newline in a path segment
+        ],
     )
     def test_rejects(self, entry: str) -> None:
         with pytest.raises(ValueError):

--- a/tests/unit/test_vault_models.py
+++ b/tests/unit/test_vault_models.py
@@ -310,9 +310,11 @@ class TestEnvironmentVariableCredential:
             "c0ffee.io",  # alphanumeric label with digits
             "3m.com",  # leading-digit label
             "xn--p1ai",  # punycode
+            "example.9-9",  # letterless final label that is NOT an IP literal — only IP
+            "foo.1-2",  # literals are rejected, not every digits-only-looking label
         ],
     )
-    def test_accepts_hostname_with_hexish_labels(self, host: str) -> None:
+    def test_accepts_non_ip_numeric_looking_labels(self, host: str) -> None:
         c = self._create(allowed_hosts=[host])
         assert c.allowed_hosts == [host]
 

--- a/tests/unit/test_vault_models.py
+++ b/tests/unit/test_vault_models.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import SecretStr, TypeAdapter, ValidationError
 
 from aios.models.vaults import (
+    RESERVED_SANDBOX_ENV_KEYS,
     TokenEndpointAuth,
     TokenEndpointAuthBasic,
     TokenEndpointAuthNone,
@@ -14,6 +15,7 @@ from aios.models.vaults import (
     VaultCredentialCreate,
     VaultCredentialUpdate,
     VaultUpdate,
+    parse_allowed_host_entry,
 )
 
 
@@ -216,6 +218,158 @@ class TestVaultCredentialCreate:
                 token=SecretStr("t"),
                 bogus="x",  # type: ignore[call-arg]
             )
+
+
+class TestEnvironmentVariableCredential:
+    def _create(self, **overrides: object) -> VaultCredentialCreate:
+        kwargs: dict[str, object] = {
+            "auth_type": "environment_variable",
+            "secret_name": "GITHUB_TOKEN",
+            "allowed_hosts": ["api.github.com"],
+            "secret_value": SecretStr("ghp_xxx"),
+        }
+        kwargs.update(overrides)
+        return VaultCredentialCreate(**kwargs)
+
+    def test_valid_bare_host(self) -> None:
+        c = self._create()
+        assert c.auth_type == "environment_variable"
+        assert c.secret_name == "GITHUB_TOKEN"
+        assert c.allowed_hosts == ["api.github.com"]
+        assert c.target_url is None
+        assert c.secret_value is not None
+        assert c.secret_value.get_secret_value() == "ghp_xxx"
+
+    def test_valid_host_with_path_prefix(self) -> None:
+        c = self._create(allowed_hosts=["api.github.com/repos/eumemic"])
+        assert c.allowed_hosts == ["api.github.com/repos/eumemic"]
+
+    def test_explicit_whole_host_canonicalizes_to_bare(self) -> None:
+        c = self._create(allowed_hosts=["api.github.com/"])
+        assert c.allowed_hosts == ["api.github.com"]
+
+    def test_trailing_slash_prefix_canonicalizes(self) -> None:
+        c = self._create(allowed_hosts=["api.github.com/repos/eumemic/"])
+        assert c.allowed_hosts == ["api.github.com/repos/eumemic"]
+
+    def test_multiple_hosts(self) -> None:
+        c = self._create(allowed_hosts=["api.github.com", "api.tavily.com"])
+        assert c.allowed_hosts == ["api.github.com", "api.tavily.com"]
+
+    def test_rejects_missing_secret_name(self) -> None:
+        with pytest.raises(ValidationError):
+            self._create(secret_name=None)
+
+    def test_rejects_target_url_on_env_var(self) -> None:
+        with pytest.raises(ValidationError):
+            self._create(target_url="https://x.com")
+
+    def test_rejects_empty_allowed_hosts(self) -> None:
+        with pytest.raises(ValidationError):
+            self._create(allowed_hosts=[])
+
+    @pytest.mark.parametrize("name", ["1FOO", "FOO-BAR", "FOO BAR", "FOO.BAR", "", "FOO$"])
+    def test_rejects_bad_secret_name(self, name: str) -> None:
+        with pytest.raises(ValidationError):
+            self._create(secret_name=name)
+
+    @pytest.mark.parametrize("name", sorted(RESERVED_SANDBOX_ENV_KEYS))
+    def test_rejects_reserved_secret_name(self, name: str) -> None:
+        with pytest.raises(ValidationError):
+            self._create(secret_name=name)
+
+    def test_rejects_secret_name_too_long(self) -> None:
+        with pytest.raises(ValidationError):
+            self._create(secret_name="A" * 129)
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "api.example.com:443",  # port
+            "*.example.com",  # wildcard
+            "exa_mple.com",  # underscore
+            "127.0.0.1",  # IPv4 literal
+            "169.254.169.254",  # metadata IPv4
+            "2130706433",  # integer IP form / all-numeric label
+            "10",  # bare numeric label
+            "::1",  # IPv6
+            "0x7f000001",  # hex IPv4 literal (alpha letters, still an IP)
+            "0xA.0xB.0xC.0xD",  # dotted hex IPv4 literal
+            "0Xa",  # short hex IPv4 literal, uppercase prefix
+            "0177.0.0.1",  # octal-leading IPv4 literal
+        ],
+    )
+    def test_rejects_bad_host(self, host: str) -> None:
+        with pytest.raises(ValidationError):
+            self._create(allowed_hosts=[host])
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "0xdeadbeef.example.com",  # hex-looking label is fine when it isn't the final label
+            "c0ffee.io",  # alphanumeric label with digits
+            "3m.com",  # leading-digit label
+            "xn--p1ai",  # punycode
+        ],
+    )
+    def test_accepts_hostname_with_hexish_labels(self, host: str) -> None:
+        c = self._create(allowed_hosts=[host])
+        assert c.allowed_hosts == [host]
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "api.github.com/repos/../gists",  # dot-segment
+            "api.github.com/repos/./x",  # single-dot segment
+            "api.github.com//repos",  # empty segment
+            "api.github.com/repos/%2e%2e",  # percent-encoding
+        ],
+    )
+    def test_rejects_bad_path_prefix(self, entry: str) -> None:
+        with pytest.raises(ValidationError):
+            self._create(allowed_hosts=[entry])
+
+    def test_other_secret_fields_ignored_not_rejected(self) -> None:
+        # Cross-kind secret fields follow the shared-base accept-and-ignore
+        # convention (a bearer create silently ignores username, etc.); only
+        # the structural fields are governed by the shape validator.
+        c = self._create(token=SecretStr("ignored"))
+        assert c.auth_type == "environment_variable"
+
+
+class TestHeaderCredentialShape:
+    @pytest.mark.parametrize("extra", [{"secret_name": "FOO"}, {"allowed_hosts": ["x.com"]}])
+    def test_rejects_env_var_fields_on_bearer(self, extra: dict[str, object]) -> None:
+        with pytest.raises(ValidationError):
+            VaultCredentialCreate(
+                target_url="https://x.com",
+                auth_type="bearer_header",
+                token=SecretStr("t"),
+                **extra,
+            )
+
+
+class TestParseAllowedHostEntry:
+    @pytest.mark.parametrize(
+        "entry,expected",
+        [
+            ("api.github.com", ("api.github.com", None)),
+            ("api.github.com/", ("api.github.com", None)),
+            ("api.github.com/repos/eumemic", ("api.github.com", "/repos/eumemic")),
+            ("api.github.com/repos/eumemic/", ("api.github.com", "/repos/eumemic")),
+            ("registry.npmjs.org/@myorg", ("registry.npmjs.org", "/@myorg")),
+            ("host.example/v1/r:action", ("host.example", "/v1/r:action")),
+        ],
+    )
+    def test_parses(self, entry: str, expected: tuple[str, str | None]) -> None:
+        assert parse_allowed_host_entry(entry) == expected
+
+    @pytest.mark.parametrize(
+        "entry", ["", "127.0.0.1", "0x7f000001", "host//x", "host/../x", "host/%2e"]
+    )
+    def test_rejects(self, entry: str) -> None:
+        with pytest.raises(ValueError):
+            parse_allowed_host_entry(entry)
 
 
 class TestVaultCredentialUpdate:


### PR DESCRIPTION
Foundation of epic **#871** (sandbox-resident secrets via placeholder + egress exchange). Adds a vault credential kind that is **materialized into the sandbox as an env var** rather than consumed worker-side as an outbound auth header — carrying `secret_name` (the env var name) and `allowed_hosts` (the egress scope) in place of `target_url`.

**Scope:** the credential model + storage only. Per-session placeholder minting (#873), sandbox materialization (#874), and the TLS-terminating swap proxy (#876) follow. Closes #872.

## Design decisions (folded from a 5-lens adversarial pre-review + a verified post-implementation correctness review)

**Single table, not a sibling table.** Env-var creds reuse the whole credential spine — per-account-subkey encryption, decrypt-merge-encrypt rotation, archive-zeroes-blob, the 20-per-vault cap under the vault-row lock, the write-only read view, CRUD. A sibling table would duplicate all of it to drop one nullable column. The cost is a nullable `target_url` + a row-shape `CHECK` that keeps the two kinds disjoint and self-consistent. The **DB owns** that invariant because #874/#876 read the row directly, bypassing pydantic. The `target_url`-keyed resolvers (`resolve_session_credential` / `_run_credential` / `_vault_credential`) filter `vc.target_url = $2`, so NULL-`target_url` env-var rows are excluded from header rendering by construction — confirmed unreachable, and `_auth_headers_from_payload` fails hard if it ever isn't.

**`secret_name` collision safety (the blocker the pre-review caught).** A `secret_name` may not collide with any key the harness injects into the sandbox env (`PATH`, `VIRTUAL_ENV`, `NODE_PATH`, `NPM_CONFIG_PREFIX`, `TOOL_BROKER_URL`, `TOOL_BROKER_SECRET`, `AIOS_SESSION_ID`) — a collision would either hijack a load-bearing variable (PATH-repoint → unqualified-binary takeover) or be silently shadowed by the merge order. `RESERVED_SANDBOX_ENV_KEYS` lives in the model (importing `sandbox.setup` would cycle via `aios.config`) and is **drift-pinned** by a unit test that builds a real provisioning plan and asserts the blocklist equals the actual injected env, so adding a sandbox env key fails CI until the blocklist follows.

**`allowed_hosts` grammar (#880 resolution).** Entries are `host` or `host/<path-prefix>` (bare host = whole-host, CMA parity). `parse_allowed_host_entry` is the **single grammar authority** #876's matcher and #879's host-extraction import rather than re-deriving the split; entries canonicalize on store (`host/` ≡ `host`, `host/foo/` ≡ `host/foo`). The host part is **DNS-names-only** — IP literals in every spelling (dotted-quad, integer, **hex**, octal) are rejected via a numeric-final-label test, so the column can't carry an entry the #876 matcher can't enforce. The hex case (`0x7f000001` → `127.0.0.1` on glibc) was a real hole the post-implementation review caught and is now pinned in tests.

**Migration 0081** widens the `auth_type` CHECK, adds `vault_credentials_shape_check` and a `(vault_id, secret_name)` partial unique index. The downgrade is **fail-loud** on any `environment_variable` row — including archived husks (archive keeps `auth_type`) — with the `DELETE` remedy inline; the narrowed CHECK is re-added before the columns drop, so data is preserved on abort.

## Decision gates resolved / deferred (posted on the issues)
- **#880** scope granularity → host + optional path-prefix grammar (this PR ships the schema/validation half).
- **#876** gets a hard acceptance criterion: resolve-time block of swaps toward internal-resolving hosts (covers DNS rebinding + any name→internal-IP; the layer create-time validation structurally can't reach). Plus a dot-segment path-evasion note for the matcher.
- **#879** owns cred-⊆-env validation + the content-host denylist (relational, needs session context).

## Tests
- `test_vault_models.py` — the full env-var shape matrix: valid bare/prefix/trailing-slash hosts, reserved-name + bad-POSIX-name rejection, IP-literal rejection (incl. hex/octal) with hexish-hostname acceptance, path-segment grammar; `parse_allowed_host_entry` round-trip.
- `test_vault.py` / `test_mcp_client.py` — service-layer extract/merge/rotation; the header-render invariant raise.
- `test_reserved_env_keys.py` — the drift pin against the real injected sandbox env.
- `test_vaults.py` (e2e) — create, write-only blob round-trip, `(vault_id, secret_name)` uniqueness + archive-frees-name + cross-vault duplicate, rotation.
- `test_migrations_environment_variable.py` — clean upgrade→downgrade→upgrade and fail-loud downgrade with an env-var row present.

`mypy src tests`, `ruff`, the 2076-test unit suite, the e2e vault suite, and the migration round-trip all pass. `openapi.json` + the generated SDK are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)