### PR TITLE
feat: session await endpoint — invoke-and-await + watermarked quiescence

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3363,6 +3363,109 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/await": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Await Session",
+        "description": "Block until a correlated response lands (``request_id``) or the session has fully\nreacted to a stimulus (``watermark``; defaults to the session's ``last_stimulus_seq`` at\ncall time), or ``timeout`` seconds elapse \u2014 then ``done=false`` so the caller re-polls.\n\nThe ``await`` primitive's session backing: one JSON round-trip, MCP-usable so an agent can\nawait a session it drove and join. Provide ``request_id`` XOR ``watermark`` (both \u2192 422).\nA cross-tenant session 404s before any subscription opens.",
+        "operationId": "await_session",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Request Id"
+            }
+          },
+          {
+            "name": "watermark",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Watermark"
+            }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 60,
+              "minimum": 0,
+              "default": 30,
+              "title": "Timeout"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionAwaitResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/skills": {
       "post": {
         "tags": [
@@ -13299,6 +13402,45 @@
         ],
         "title": "Session",
         "description": "Read view of a session. Internal-only columns are not exposed.\n\n``status`` ({active, idle}) is derived per read from the event log; see\n:data:`SessionStatus`. ``stop_reason`` records why the most recent step\nended. Possible ``type`` values: ``\"end_turn\"``, ``\"interrupt\"``,\n``\"rescheduling\"``, ``\"error\"`` (``idle`` + ``error`` = the errored\nlanding pad). ``awaiting`` lists tool calls the session is blocked on\n(derived per read from the event log + agent tool specs)."
+      },
+      "SessionAwaitResponse": {
+        "properties": {
+          "done": {
+            "type": "boolean",
+            "title": "Done"
+          },
+          "last_reacted_seq": {
+            "type": "integer",
+            "title": "Last Reacted Seq"
+          },
+          "result": {
+            "title": "Result"
+          },
+          "is_error": {
+            "type": "boolean",
+            "title": "Is Error",
+            "default": false
+          },
+          "error": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "done",
+          "last_reacted_seq"
+        ],
+        "title": "SessionAwaitResponse",
+        "description": "Response for GET /v1/sessions/{id}/await \u2014 the await-a-completion primitive,\nsession backing. One envelope over two monotonic predicates (request_id\ncorrelation, or reacted>=watermark). Poll until `done`."
       },
       "SessionCloneRequest": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/await_session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/await_session.py
@@ -1,0 +1,271 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.session_await_response import SessionAwaitResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    request_id: None | str | Unset = UNSET,
+    watermark: int | None | Unset = UNSET,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    json_request_id: None | str | Unset
+    if isinstance(request_id, Unset):
+        json_request_id = UNSET
+    else:
+        json_request_id = request_id
+    params["request_id"] = json_request_id
+
+    json_watermark: int | None | Unset
+    if isinstance(watermark, Unset):
+        json_watermark = UNSET
+    else:
+        json_watermark = watermark
+    params["watermark"] = json_watermark
+
+    params["timeout"] = timeout
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/await".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | SessionAwaitResponse | None:
+    if response.status_code == 200:
+        response_200 = SessionAwaitResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | SessionAwaitResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    request_id: None | str | Unset = UNSET,
+    watermark: int | None | Unset = UNSET,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionAwaitResponse]:
+    """Await Session
+
+     Block until a correlated response lands (``request_id``) or the session has fully
+    reacted to a stimulus (``watermark``; defaults to the session's ``last_stimulus_seq`` at
+    call time), or ``timeout`` seconds elapse — then ``done=false`` so the caller re-polls.
+
+    The ``await`` primitive's session backing: one JSON round-trip, MCP-usable so an agent can
+    await a session it drove and join. Provide ``request_id`` XOR ``watermark`` (both → 422).
+    A cross-tenant session 404s before any subscription opens.
+
+    Args:
+        session_id (str):
+        request_id (None | str | Unset):
+        watermark (int | None | Unset):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionAwaitResponse]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        request_id=request_id,
+        watermark=watermark,
+        timeout=timeout,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    request_id: None | str | Unset = UNSET,
+    watermark: int | None | Unset = UNSET,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionAwaitResponse | None:
+    """Await Session
+
+     Block until a correlated response lands (``request_id``) or the session has fully
+    reacted to a stimulus (``watermark``; defaults to the session's ``last_stimulus_seq`` at
+    call time), or ``timeout`` seconds elapse — then ``done=false`` so the caller re-polls.
+
+    The ``await`` primitive's session backing: one JSON round-trip, MCP-usable so an agent can
+    await a session it drove and join. Provide ``request_id`` XOR ``watermark`` (both → 422).
+    A cross-tenant session 404s before any subscription opens.
+
+    Args:
+        session_id (str):
+        request_id (None | str | Unset):
+        watermark (int | None | Unset):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionAwaitResponse
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        request_id=request_id,
+        watermark=watermark,
+        timeout=timeout,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    request_id: None | str | Unset = UNSET,
+    watermark: int | None | Unset = UNSET,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | SessionAwaitResponse]:
+    """Await Session
+
+     Block until a correlated response lands (``request_id``) or the session has fully
+    reacted to a stimulus (``watermark``; defaults to the session's ``last_stimulus_seq`` at
+    call time), or ``timeout`` seconds elapse — then ``done=false`` so the caller re-polls.
+
+    The ``await`` primitive's session backing: one JSON round-trip, MCP-usable so an agent can
+    await a session it drove and join. Provide ``request_id`` XOR ``watermark`` (both → 422).
+    A cross-tenant session 404s before any subscription opens.
+
+    Args:
+        session_id (str):
+        request_id (None | str | Unset):
+        watermark (int | None | Unset):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | SessionAwaitResponse]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        request_id=request_id,
+        watermark=watermark,
+        timeout=timeout,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    request_id: None | str | Unset = UNSET,
+    watermark: int | None | Unset = UNSET,
+    timeout: int | Unset = 30,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | SessionAwaitResponse | None:
+    """Await Session
+
+     Block until a correlated response lands (``request_id``) or the session has fully
+    reacted to a stimulus (``watermark``; defaults to the session's ``last_stimulus_seq`` at
+    call time), or ``timeout`` seconds elapse — then ``done=false`` so the caller re-polls.
+
+    The ``await`` primitive's session backing: one JSON round-trip, MCP-usable so an agent can
+    await a session it drove and join. Provide ``request_id`` XOR ``watermark`` (both → 422).
+    A cross-tenant session 404s before any subscription opens.
+
+    Args:
+        session_id (str):
+        request_id (None | str | Unset):
+        watermark (int | None | Unset):
+        timeout (int | Unset):  Default: 30.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | SessionAwaitResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            request_id=request_id,
+            watermark=watermark,
+            timeout=timeout,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -153,6 +153,8 @@ from .scheduled_task_echo_metadata import ScheduledTaskEchoMetadata
 from .scheduled_task_update import ScheduledTaskUpdate
 from .scheduled_task_update_metadata_type_0 import ScheduledTaskUpdateMetadataType0
 from .session import Session
+from .session_await_response import SessionAwaitResponse
+from .session_await_response_error_type_0 import SessionAwaitResponseErrorType0
 from .session_clone_request import SessionCloneRequest
 from .session_create import SessionCreate
 from .session_create_env import SessionCreateEnv
@@ -391,6 +393,8 @@ __all__ = (
     "ScheduledTaskUpdate",
     "ScheduledTaskUpdateMetadataType0",
     "Session",
+    "SessionAwaitResponse",
+    "SessionAwaitResponseErrorType0",
     "SessionCloneRequest",
     "SessionCreate",
     "SessionCreateEnv",

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_await_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_await_response.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.session_await_response_error_type_0 import (
+        SessionAwaitResponseErrorType0,
+    )
+
+
+T = TypeVar("T", bound="SessionAwaitResponse")
+
+
+@_attrs_define
+class SessionAwaitResponse:
+    """Response for GET /v1/sessions/{id}/await — the await-a-completion primitive,
+    session backing. One envelope over two monotonic predicates (request_id
+    correlation, or reacted>=watermark). Poll until `done`.
+
+        Attributes:
+            done (bool):
+            last_reacted_seq (int):
+            result (Any | Unset):
+            is_error (bool | Unset):  Default: False.
+            error (None | SessionAwaitResponseErrorType0 | Unset):
+    """
+
+    done: bool
+    last_reacted_seq: int
+    result: Any | Unset = UNSET
+    is_error: bool | Unset = False
+    error: None | SessionAwaitResponseErrorType0 | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.session_await_response_error_type_0 import (
+            SessionAwaitResponseErrorType0,
+        )
+
+        done = self.done
+
+        last_reacted_seq = self.last_reacted_seq
+
+        result = self.result
+
+        is_error = self.is_error
+
+        error: dict[str, Any] | None | Unset
+        if isinstance(self.error, Unset):
+            error = UNSET
+        elif isinstance(self.error, SessionAwaitResponseErrorType0):
+            error = self.error.to_dict()
+        else:
+            error = self.error
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "done": done,
+                "last_reacted_seq": last_reacted_seq,
+            }
+        )
+        if result is not UNSET:
+            field_dict["result"] = result
+        if is_error is not UNSET:
+            field_dict["is_error"] = is_error
+        if error is not UNSET:
+            field_dict["error"] = error
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.session_await_response_error_type_0 import (
+            SessionAwaitResponseErrorType0,
+        )
+
+        d = dict(src_dict)
+        done = d.pop("done")
+
+        last_reacted_seq = d.pop("last_reacted_seq")
+
+        result = d.pop("result", UNSET)
+
+        is_error = d.pop("is_error", UNSET)
+
+        def _parse_error(data: object) -> None | SessionAwaitResponseErrorType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                error_type_0 = SessionAwaitResponseErrorType0.from_dict(data)
+
+                return error_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SessionAwaitResponseErrorType0 | Unset, data)
+
+        error = _parse_error(d.pop("error", UNSET))
+
+        session_await_response = cls(
+            done=done,
+            last_reacted_seq=last_reacted_seq,
+            result=result,
+            is_error=is_error,
+            error=error,
+        )
+
+        session_await_response.additional_properties = d
+        return session_await_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_await_response_error_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_await_response_error_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SessionAwaitResponseErrorType0")
+
+
+@_attrs_define
+class SessionAwaitResponseErrorType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        session_await_response_error_type_0 = cls()
+
+        session_await_response_error_type_0.additional_properties = d
+        return session_await_response_error_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -50,6 +50,7 @@ from aios.models.scheduled_tasks import (
 from aios.models.sessions import (
     ContextResponse,
     Session,
+    SessionAwaitResponse,
     SessionCloneRequest,
     SessionCreate,
     SessionInterruptRequest,
@@ -796,4 +797,33 @@ async def wait_for_events(
         session_stop_reason=session.stop_reason,
         session_awaiting=session.awaiting,
         next_after=events[-1].seq if events else after,
+    )
+
+
+@router.get("/{session_id}/await", operation_id="await_session")
+async def await_session(
+    session_id: str,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    request_id: str | None = None,
+    watermark: int | None = None,
+    timeout_seconds: Annotated[int, Query(alias="timeout", ge=0, le=60)] = 30,
+) -> SessionAwaitResponse:
+    """Block until a correlated response lands (``request_id``) or the session has fully
+    reacted to a stimulus (``watermark``; defaults to the session's ``last_stimulus_seq`` at
+    call time), or ``timeout`` seconds elapse — then ``done=false`` so the caller re-polls.
+
+    The ``await`` primitive's session backing: one JSON round-trip, MCP-usable so an agent can
+    await a session it drove and join. Provide ``request_id`` XOR ``watermark`` (both → 422).
+    A cross-tenant session 404s before any subscription opens.
+    """
+    return await service.await_session(
+        pool,
+        db_url,
+        session_id,
+        account_id=account_id,
+        request_id=request_id,
+        watermark=watermark,
+        timeout_seconds=timeout_seconds,
     )

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -68,6 +68,11 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
     "wait_for_events_v1_sessions__session_id__wait_get": (
         "Long-poll endpoint; use `aios sessions stream` / `aios tail` instead."
     ),
+    "await_session": (
+        "Await-a-completion long-poll (the await primitive's session backing); "
+        "MCP-surfaced for agents, but operators watch a session via "
+        "`aios sessions stream` / `aios tail` rather than a blocking poll."
+    ),
     # ── Interactive (browser-redirect) OAuth ─────────────────────────
     # The vault-credential "Connect" flow returns an authorization URL for the
     # user to sign in at the provider, then exchanges the returned code. It is

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -144,6 +144,7 @@ async def open_listen_for_events(
     session_id: str,
     *,
     queue_max: int = 1000,
+    acquire_lock: bool = True,
 ) -> ListenSubscription:
     """Open a dedicated asyncpg connection, LISTEN events_<session_id>,
     acquire the SSE subscriber lock, and return a :class:`ListenSubscription`.
@@ -151,6 +152,16 @@ async def open_listen_for_events(
     Two-phase counterpart to :func:`listen_for_events` for callers (SSE
     route handlers) that need to preflight setup BEFORE constructing the
     streaming response.
+
+    ``acquire_lock`` (default ``True``) controls whether the subscriber
+    advisory lock is taken (issue #81): with it held, the worker's
+    :func:`aios.db.sse_lock.has_subscriber` check returns True and the model
+    call takes the streaming path (deltas → ``pg_notify`` → SSE clients).
+    A caller that consumes ONLY the terminal completion state — never the
+    deltas — should pass ``acquire_lock=False`` so it doesn't force the
+    awaited session's worker into the slower streaming path for a consumer
+    that ignores deltas. The ``await``-primitive poller does exactly this,
+    mirroring how :func:`open_listen_for_run_events` omits the lock entirely.
 
     Any failure after the initial ``asyncpg.connect`` succeeds will
     ``conn.terminate()`` and re-raise.
@@ -185,10 +196,11 @@ async def open_listen_for_events(
                     pass
 
         await conn.add_listener(channel, _callback)
-        # Hold a shared advisory lock on this dedicated connection so the
-        # worker can detect that an SSE subscriber exists (issue #81).
-        # pg_locks releases automatically on connection close — no cleanup.
-        await acquire_subscriber_lock(conn, session_id)
+        if acquire_lock:
+            # Hold a shared advisory lock on this dedicated connection so the
+            # worker can detect that an SSE subscriber exists (issue #81).
+            # pg_locks releases automatically on connection close — no cleanup.
+            await acquire_subscriber_lock(conn, session_id)
     except BaseException:
         conn.terminate()
         raise

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -1199,6 +1199,24 @@ async def derive_response(
     return None
 
 
+async def read_session_watermarks(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> tuple[int, int] | None:
+    """(last_reacted_seq, last_stimulus_seq) for a scoped session, or None if absent.
+
+    The Mode-2 scalar read for await_session: the monotonic quiescence columns, read
+    directly with no event-log status derivation."""
+    row = await conn.fetchrow(
+        "SELECT last_reacted_seq, last_stimulus_seq FROM sessions "
+        "WHERE id = $1 AND account_id = $2",
+        session_id,
+        account_id,
+    )
+    if row is None:
+        return None
+    return (row["last_reacted_seq"], row["last_stimulus_seq"])
+
+
 async def derive_session_status(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> str:

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -362,6 +362,18 @@ class WaitResponse(BaseModel):
     next_after: int
 
 
+class SessionAwaitResponse(BaseModel):
+    """Response for GET /v1/sessions/{id}/await — the await-a-completion primitive,
+    session backing. One envelope over two monotonic predicates (request_id
+    correlation, or reacted>=watermark). Poll until `done`."""
+
+    done: bool
+    last_reacted_seq: int
+    result: Any = None
+    is_error: bool = False
+    error: dict[str, Any] | None = None
+
+
 class ContextResponse(BaseModel):
     """Response for ``GET /v1/sessions/{id}/context``.
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -19,7 +19,14 @@ import asyncpg
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
-from aios.errors import ConflictError, NotFoundError, PayloadTooLargeError, RateLimitedError
+from aios.db.listen import open_listen_for_events
+from aios.errors import (
+    ConflictError,
+    NotFoundError,
+    PayloadTooLargeError,
+    RateLimitedError,
+    ValidationError,
+)
 from aios.models.agents import (
     Agent,
     AgentVersion,
@@ -36,6 +43,7 @@ from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
     AwaitingToolCall,
     Session,
+    SessionAwaitResponse,
     SessionResource,
     SessionResourceEcho,
     SessionStatus,
@@ -45,6 +53,7 @@ from aios.sandbox.volumes import validate_workspace_path
 from aios.services import agents as agents_service
 from aios.services import github_repositories as github_repo_service
 from aios.services import memory_stores as memory_service
+from aios.services.await_completion import await_completion
 
 
 async def load_session_account_id(pool: asyncpg.Pool[Any], session_id: str) -> str:
@@ -467,6 +476,88 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: s
             "scheduled_tasks": task_echoes,
             "awaiting": awaiting_by_sid.get(session_id, []),
         }
+    )
+
+
+async def await_session(
+    pool: asyncpg.Pool[Any],
+    db_url: str,
+    session_id: str,
+    *,
+    account_id: str,
+    request_id: str | None,
+    watermark: int | None,
+    timeout_seconds: float,
+) -> SessionAwaitResponse:
+    """Block until a correlated response lands (request_id mode) or the session has fully
+    reacted to a fixed stimulus (watermark mode; watermark defaults to last_stimulus_seq
+    captured at call time), or timeout. The session backing of the await primitive.
+
+    Account-scopes the session FIRST (cross-tenant/missing 404s before any LISTEN opens),
+    then subscribes to events_<session_id> BEFORE the first predicate read (LISTEN-before-read),
+    drives await_completion with the monotonic done-predicate, and returns the completion
+    envelope — or, on timeout, done=False so the caller re-polls. Never waits on bare idle:
+    both modes are monotonic w.r.t. a fixed stimulus (request_id, or reacted>=watermark).
+    """
+    if request_id is not None and watermark is not None:
+        raise ValidationError("provide request_id or watermark, not both")
+
+    # Scope-check FIRST (404s cross-tenant before any LISTEN opens) and capture the
+    # default watermark's ``last_stimulus_seq`` in the same acquire.
+    async with pool.acquire() as conn:
+        await queries.get_session(conn, session_id, account_id=account_id)  # 404s cross-tenant
+        captured = await queries.read_session_watermarks(conn, session_id, account_id=account_id)
+    captured_last_stimulus_seq = captured[1] if captured is not None else 0
+    effective_watermark = watermark if watermark is not None else captured_last_stimulus_seq
+
+    if request_id is not None:
+
+        async def _read() -> Any:
+            async with pool.acquire() as conn:
+                return await queries.derive_response(
+                    conn, session_id, account_id=account_id, request_id=request_id
+                )
+
+        def _is_done(state: Any) -> bool:
+            return state is not None  # a response (or child_gone) has landed
+    else:
+
+        async def _read() -> Any:
+            async with pool.acquire() as conn:
+                wm = await queries.read_session_watermarks(conn, session_id, account_id=account_id)
+                return wm[0] if wm is not None else 0  # last_reacted_seq
+
+        def _is_done(state: Any) -> bool:
+            return bool(state >= effective_watermark)
+
+    subscription = await open_listen_for_events(db_url, session_id)
+    try:
+        state = await await_completion(
+            subscription.queue,
+            read_state=_read,
+            is_done=_is_done,
+            timeout_seconds=timeout_seconds,
+        )
+    finally:
+        subscription.terminate()
+
+    async with pool.acquire() as conn:
+        wm = await queries.read_session_watermarks(conn, session_id, account_id=account_id)
+    last_reacted_seq = wm[0] if wm is not None else 0
+
+    if request_id is not None:
+        if state is not None:
+            return SessionAwaitResponse(
+                done=True,
+                last_reacted_seq=last_reacted_seq,
+                result=state["result"],
+                is_error=state["is_error"],
+                error=state["error"],
+            )
+        return SessionAwaitResponse(done=False, last_reacted_seq=last_reacted_seq)
+
+    return SessionAwaitResponse(
+        done=last_reacted_seq >= effective_watermark, last_reacted_seq=last_reacted_seq
     )
 
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -530,7 +530,13 @@ async def await_session(
         def _is_done(state: Any) -> bool:
             return bool(state >= effective_watermark)
 
-    subscription = await open_listen_for_events(db_url, session_id)
+    # An await poller consumes only the terminal completion state, never the
+    # token-by-token deltas, so it must NOT acquire the subscriber lock: doing
+    # so would make has_subscriber() return True and force the awaited
+    # session's worker into the streaming model path for the entire await
+    # window — wasted work for a consumer that ignores deltas. Mirrors how
+    # open_listen_for_run_events omits the lock (issue #81).
+    subscription = await open_listen_for_events(db_url, session_id, acquire_lock=False)
     try:
         state = await await_completion(
             subscription.queue,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -503,12 +503,15 @@ async def await_session(
         raise ValidationError("provide request_id or watermark, not both")
 
     # Scope-check FIRST (404s cross-tenant before any LISTEN opens) and capture the
-    # default watermark's ``last_stimulus_seq`` in the same acquire.
+    # default watermark's ``last_stimulus_seq`` in the same read. ``read_session_watermarks``
+    # already enforces ``WHERE id = $1 AND account_id = $2`` and returns None when the row is
+    # missing OR cross-tenant — the same scope guarantee as ``get_session`` — so one call both
+    # 404s and yields the watermark scalars.
     async with pool.acquire() as conn:
-        await queries.get_session(conn, session_id, account_id=account_id)  # 404s cross-tenant
         captured = await queries.read_session_watermarks(conn, session_id, account_id=account_id)
-    captured_last_stimulus_seq = captured[1] if captured is not None else 0
-    effective_watermark = watermark if watermark is not None else captured_last_stimulus_seq
+    if captured is None:
+        raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
+    effective_watermark = watermark if watermark is not None else captured[1]  # last_stimulus_seq
 
     if request_id is not None:
 

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -259,3 +259,73 @@ class TestRunWaitEndpoint:
         any LISTEN is opened, so an unauthorized caller never opens a connection on the channel."""
         r = await http_client.get("/v1/runs/wf_run_nope/wait", params={"timeout": 0})
         assert r.status_code == 404, r.text
+
+
+class TestSessionAwaitEndpoint:
+    """``GET /v1/sessions/{id}/await`` — the await-a-completion endpoint (session backing).
+
+    Exercises the HTTP wiring (route registration, the ``timeout`` query alias, the either/or
+    ``request_id``/``watermark`` params, the ``SessionAwaitResponse`` serialization, account
+    scoping) over a real ASGI client. The blocking/completion behavior of the service is covered
+    in ``tests/integration/test_await_session.py``; here ``timeout=0`` keeps each case
+    non-blocking."""
+
+    async def test_mode1_timeout_zero_pending_done_false(
+        self, http_client: httpx.AsyncClient, session_id: str
+    ) -> None:
+        """An unanswered request_id is non-terminal; ``timeout=0`` returns at once with
+        ``done=false`` — the re-poll contract."""
+        r = await http_client.get(
+            f"/v1/sessions/{session_id}/await", params={"request_id": "nope", "timeout": 0}
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["done"] is False
+        assert body["is_error"] is False
+        assert body["result"] is None
+
+    async def test_mode2_default_watermark_unmet_done_false(
+        self, http_client: httpx.AsyncClient, pool: Any, session_id: str
+    ) -> None:
+        """A pending user stimulus (last_stimulus_seq > last_reacted_seq) with the default
+        watermark is unmet at ``timeout=0`` → ``done=false`` with ``last_reacted_seq == 0``."""
+        from aios.services import sessions as sessions_svc
+
+        await sessions_svc.append_user_message(pool, session_id, "hi", account_id="acc_test_stub")
+
+        r = await http_client.get(f"/v1/sessions/{session_id}/await", params={"timeout": 0})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["done"] is False
+        assert body["last_reacted_seq"] == 0
+
+    async def test_mode2_met_watermark_done_true(
+        self, http_client: httpx.AsyncClient, session_id: str
+    ) -> None:
+        """A fresh session has ``last_reacted_seq == 0``; ``watermark=0`` is met → ``done``."""
+        r = await http_client.get(
+            f"/v1/sessions/{session_id}/await", params={"watermark": 0, "timeout": 0}
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["done"] is True
+
+    async def test_both_params_422(self, http_client: httpx.AsyncClient, session_id: str) -> None:
+        """``request_id`` and ``watermark`` are mutually exclusive (422)."""
+        r = await http_client.get(
+            f"/v1/sessions/{session_id}/await",
+            params={"request_id": "r", "watermark": 1, "timeout": 0},
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_rejects_timeout_above_cap(
+        self, http_client: httpx.AsyncClient, session_id: str
+    ) -> None:
+        """The ``le=60`` bound on the ``timeout`` query param is enforced (422)."""
+        r = await http_client.get(f"/v1/sessions/{session_id}/await", params={"timeout": 3600})
+        assert r.status_code == 422, r.text
+
+    async def test_unknown_session_404(self, http_client: httpx.AsyncClient) -> None:
+        """A session id the caller can't see 404s before any LISTEN opens."""
+        r = await http_client.get("/v1/sessions/sess_nope/await", params={"timeout": 0})
+        assert r.status_code == 404, r.text

--- a/tests/integration/test_await_session.py
+++ b/tests/integration/test_await_session.py
@@ -22,7 +22,9 @@ import asyncpg
 import pytest
 
 from aios.db import queries
+from aios.db.listen import open_listen_for_events
 from aios.db.pool import create_pool
+from aios.db.sse_lock import has_subscriber
 from aios.errors import NotFoundError, ValidationError
 from aios.services import sessions as service
 from tests.integration.conftest import seed_agent_env_session
@@ -279,6 +281,37 @@ async def test_mode2_explicit_watermark_below_reacted_immediate(
     )
     assert resp.done is True
     assert resp.last_reacted_seq >= 2
+
+
+# ─── subscriber lock: await poller must not toggle the streaming path ─────────
+
+
+async def test_await_listen_does_not_acquire_subscriber_lock(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    """An await poller consumes terminal state only, so its LISTEN must NOT
+    acquire the subscriber lock — otherwise has_subscriber() would force the
+    awaited session's worker onto the streaming model path (issue #81).
+
+    The lock lives on the listener's own dedicated connection; check
+    has_subscriber via the pool (a separate connection).
+    """
+    pool, _account_id, session_id = pool_and_session
+
+    # await-poller open: lock skipped → no subscriber observed.
+    sub = await open_listen_for_events(migrated_db_url, session_id, acquire_lock=False)
+    try:
+        assert await has_subscriber(pool, session_id) is False
+    finally:
+        sub.terminate()
+
+    # default open (SSE /stream, wait_for_events): lock held → subscriber observed.
+    sub = await open_listen_for_events(migrated_db_url, session_id)
+    try:
+        assert await has_subscriber(pool, session_id) is True
+    finally:
+        sub.terminate()
 
 
 # ─── validation + scoping ────────────────────────────────────────────────────

--- a/tests/integration/test_await_session.py
+++ b/tests/integration/test_await_session.py
@@ -1,0 +1,318 @@
+"""Integration tests for ``await_session`` — the session backing of the await primitive.
+
+Two monotonic modes over one endpoint:
+
+* **Mode 1 (request_id)**: correlate a posted request to its response via
+  ``derive_response`` — ``done`` once a response (or a ``child_gone`` outcome) lands.
+* **Mode 2 (watermark)**: block until ``last_reacted_seq >= watermark`` (watermark
+  defaults to ``last_stimulus_seq`` captured at call time).
+
+DB-backed (testcontainer Postgres). Exercises the service (scope-check, LISTEN
+subscribe, predicate, response build) end to end against real session rows; the pure
+loop behavior is covered in ``tests/unit/test_await_session_predicates.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError, ValidationError
+from aios.services import sessions as service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_and_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a fresh session."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_await_session', NULL, TRUE, 'await-session-test')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_await_session", prefix="await-session-test"
+        )
+        yield pool, "acc_await_session", session.id
+    finally:
+        await pool.close()
+
+
+# ─── Mode 1: request_id correlation ──────────────────────────────────────────
+
+
+async def test_mode1_already_responded_done_with_result(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+    async with pool.acquire() as conn:
+        await queries.write_response_if_absent(
+            conn,
+            session_id,
+            account_id=account_id,
+            request_id="req1",
+            is_error=False,
+            result={"answer": 7},
+            error=None,
+        )
+
+    resp = await service.await_session(
+        pool,
+        migrated_db_url,
+        session_id,
+        account_id=account_id,
+        request_id="req1",
+        watermark=None,
+        timeout_seconds=5,
+    )
+    assert resp.done is True
+    assert resp.result == {"answer": 7}
+    assert resp.is_error is False
+    assert resp.error is None
+
+
+async def test_mode1_pending_times_out_done_false(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+    resp = await service.await_session(
+        pool,
+        migrated_db_url,
+        session_id,
+        account_id=account_id,
+        request_id="reqX",
+        watermark=None,
+        timeout_seconds=0.1,
+    )
+    assert resp.done is False
+    assert resp.result is None
+    assert resp.is_error is False
+
+
+async def test_mode1_child_gone_is_error(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+    async with pool.acquire() as conn:
+        await queries.archive_session(conn, session_id, account_id=account_id)
+
+    resp = await service.await_session(
+        pool,
+        migrated_db_url,
+        session_id,
+        account_id=account_id,
+        request_id="req_gone",
+        watermark=None,
+        timeout_seconds=5,
+    )
+    assert resp.done is True
+    assert resp.is_error is True
+    assert resp.error == {"kind": "child_gone"}
+
+
+async def test_mode1_wakes_on_response_during_wait(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+
+    async def write_late() -> None:
+        await asyncio.sleep(0.1)
+        async with pool.acquire() as conn:
+            await queries.write_response_if_absent(
+                conn,
+                session_id,
+                account_id=account_id,
+                request_id="req_race",
+                is_error=False,
+                result="hi",
+                error=None,
+            )
+
+    resp, _ = await asyncio.gather(
+        service.await_session(
+            pool,
+            migrated_db_url,
+            session_id,
+            account_id=account_id,
+            request_id="req_race",
+            watermark=None,
+            timeout_seconds=10,
+        ),
+        write_late(),
+    )
+    assert resp.done is True
+    assert resp.result == "hi"
+
+
+# ─── Mode 2: watermark ───────────────────────────────────────────────────────
+
+
+async def test_mode2_reacted_at_or_above_watermark_done(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+    async with pool.acquire() as conn:
+        # user (seq 1) → last_stimulus_seq = 1
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "user", "content": "hi"},
+        )
+        # assistant reacting_to=1 (seq 2) → last_reacted_seq = 1
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "assistant", "content": "ok", "reacting_to": 1},
+        )
+
+    resp = await service.await_session(
+        pool,
+        migrated_db_url,
+        session_id,
+        account_id=account_id,
+        request_id=None,
+        watermark=1,
+        timeout_seconds=5,
+    )
+    assert resp.done is True
+    assert resp.last_reacted_seq >= 1
+
+
+async def test_mode2_default_watermark_blocks(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+    async with pool.acquire() as conn:
+        # only a user message: last_stimulus_seq=1 > last_reacted_seq=0
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "user", "content": "hi"},
+        )
+
+    resp = await service.await_session(
+        pool,
+        migrated_db_url,
+        session_id,
+        account_id=account_id,
+        request_id=None,
+        watermark=None,
+        timeout_seconds=0.1,
+    )
+    assert resp.done is False
+    assert resp.last_reacted_seq == 0
+
+
+async def test_mode2_explicit_watermark_below_reacted_immediate(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+    async with pool.acquire() as conn:
+        # user (seq 1)
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "user", "content": "one"},
+        )
+        # assistant reacting_to=1 (seq 2) → last_reacted_seq = 1
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "assistant", "content": "ack", "reacting_to": 1},
+        )
+        # user (seq 3)
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "user", "content": "two"},
+        )
+        # assistant reacting_to=3 (seq 4) → last_reacted_seq = 3 (>= 2)
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "assistant", "content": "ack2", "reacting_to": 3},
+        )
+
+    resp = await service.await_session(
+        pool,
+        migrated_db_url,
+        session_id,
+        account_id=account_id,
+        request_id=None,
+        watermark=1,
+        timeout_seconds=5,
+    )
+    assert resp.done is True
+    assert resp.last_reacted_seq >= 2
+
+
+# ─── validation + scoping ────────────────────────────────────────────────────
+
+
+async def test_both_params_rejected(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, session_id = pool_and_session
+    with pytest.raises(ValidationError):
+        await service.await_session(
+            pool,
+            migrated_db_url,
+            session_id,
+            account_id=account_id,
+            request_id="r",
+            watermark=1,
+            timeout_seconds=1,
+        )
+
+
+async def test_cross_tenant_404_before_subscribe(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, _account_id, session_id = pool_and_session
+    with pytest.raises(NotFoundError):
+        await service.await_session(
+            pool,
+            migrated_db_url,
+            session_id,
+            account_id="acc_other",
+            request_id="x",
+            watermark=None,
+            timeout_seconds=1,
+        )

--- a/tests/unit/test_await_session_predicates.py
+++ b/tests/unit/test_await_session_predicates.py
@@ -1,0 +1,109 @@
+"""Unit tests for the await_session done-predicates over ``await_completion``.
+
+Pure: a real ``asyncio.Queue`` + scripted ``read_state``/``is_done``, no DB — the
+session backing's two monotonic modes (request_id correlation, reacted>=watermark)
+exercised against the shared :func:`aios.services.await_completion.await_completion`
+loop without standing up a session row.
+
+Mirrors ``tests/unit/test_await_completion.py``: covers the three exit shapes
+(already-done, done-after-notify, timeout) for each mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+
+from aios.services.await_completion import await_completion
+
+# ─── Mode 1: request_id correlation (is_done = state is not None) ─────────────
+
+
+async def test_mode1_pending_then_response_done() -> None:
+    """A notify drives a re-read; the loop stops once a response (non-None) lands."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    it: Iterator[dict[str, Any] | None] = iter(
+        [None, {"result": 42, "is_error": False, "error": None}]
+    )
+
+    async def read_state() -> dict[str, Any] | None:
+        return next(it)
+
+    queue.put_nowait("evt")  # one notify so the loop advances to the second read
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda s: s is not None, timeout_seconds=5
+    )
+    assert state == {"result": 42, "is_error": False, "error": None}
+
+
+async def test_mode1_already_responded_returns_immediately() -> None:
+    """A first read that already has the response returns without touching the queue."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_state() -> dict[str, Any] | None:
+        return {"result": 7, "is_error": False, "error": None}
+
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda s: s is not None, timeout_seconds=5
+    )
+    assert state == {"result": 7, "is_error": False, "error": None}
+    assert queue.empty()
+
+
+async def test_mode1_pending_times_out() -> None:
+    """Never-responded + empty queue → return the last (None) state on timeout."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_state() -> dict[str, Any] | None:
+        return None
+
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda s: s is not None, timeout_seconds=0.05
+    )
+    assert state is None
+
+
+# ─── Mode 2: watermark (is_done = reacted >= watermark) ──────────────────────
+
+
+async def test_mode2_reacted_reaches_watermark() -> None:
+    """A notify drives a re-read; the loop stops once reacted reaches the watermark."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    it: Iterator[int] = iter([3, 5])
+
+    async def read_state() -> int:
+        return next(it)
+
+    queue.put_nowait("evt")
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda r: r >= 5, timeout_seconds=5
+    )
+    assert state == 5
+
+
+async def test_mode2_already_at_watermark() -> None:
+    """A first read already at/above the watermark returns without touching the queue."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_state() -> int:
+        return 5
+
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda r: r >= 5, timeout_seconds=5
+    )
+    assert state == 5
+    assert queue.empty()
+
+
+async def test_mode2_blocks_below_watermark_times_out() -> None:
+    """reacted stuck below the watermark + empty queue → return the last value on timeout."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def read_state() -> int:
+        return 3
+
+    state = await await_completion(
+        queue, read_state=read_state, is_done=lambda r: r >= 5, timeout_seconds=0.05
+    )
+    assert state == 3

--- a/tests/unit/test_mcp_mount.py
+++ b/tests/unit/test_mcp_mount.py
@@ -149,6 +149,7 @@ def test_apply_mcp_polish_populates_annotations_and_instructions(polished_mcp: A
     # await_run is MCP-included (no x-codegen opt-out) — an agent awaits a sub-run as a
     # read-only tool. Its whole reason to exist is reachability over MCP.
     assert by_name["await_run"].annotations.readOnlyHint is True
+    assert by_name["await_session"].annotations.readOnlyHint is True
 
     # DELETE → destructiveHint
     assert by_name["delete_vault"].annotations.destructiveHint is True


### PR DESCRIPTION
Add `GET /v1/sessions/{session_id}/await` as the second caller of the `await_completion` bounded-LISTEN primitive introduced in #764. The mechanism is reused byte-for-byte unchanged; this PR contributes two monotonic predicates over it.

## What and why

The runs backing (`GET /v1/runs/{id}/wait`) established the generic pattern. Sessions need the same capability for two distinct use cases:

1. **Invoke-and-await (request/response correlation)** — a client or parent agent holds a `request_id` it posted and wants the correlated response. Resolves via `derive_response` into `{result, is_error, error}`.
2. **Watermarked quiescence** — wait until `last_reacted_seq >= N`, where the watermark defaults to the session's `last_stimulus_seq` captured at await-start. This is the safe expression of "wait for my turn to finish."

The hard constraint both modes satisfy: the predicate is always monotonic. No path waits on bare `idle` — that is the #603/#615 stop-hook trap (`idle` is derived, recurring, and reversible).

## Design decisions

- **One endpoint, one either/or param**: `request_id` XOR `watermark` (both → 422). `request_id` present → mode 1; absent → mode 2 (watermark optional, defaults to captured `last_stimulus_seq`).
- **`SessionAwaitResponse` deliberately omits `session_status`**: exposing the derived idle/active label would re-introduce the idle trap on this very endpoint. `last_reacted_seq` is the monotonic observability scalar instead.
- **Account-scope check before LISTEN opens**: cross-tenant or missing session → 404, never a timing-dependent leak.
- **LISTEN-before-read ordering**: subscribes to `events_{session_id}` before the first predicate read, closing the completion-during-subscribe race (same discipline as the runs backing).
- **MCP-included with `readOnlyHint=True`**: an agent can await a session it drove and join. Allowlisted in `NOT_CLI_OPERATIONS` alongside the existing `wait_for_events` long-poll (same class — blocking poll; operators reach it via `aios sessions stream`). This was an unplanned but required broken-windows fix for the CI CLI-coverage invariant.
- **Nested `def`s instead of lambdas**: Ruff E731 forbids assigned lambdas; both `is_done` predicates are nested defs with a shared signature.

## Test coverage

| Tier | File | Cases |
|------|------|-------|
| Unit predicates | `tests/unit/test_await_session_predicates.py` | 6 — exit shapes for both modes (pending→done-after-notify, already-done, timeout) via pure asyncio.Queue |
| Integration | `tests/integration/test_await_session.py` | 9 — mode-1 already-responded/pending/timeout/child_gone/completion-during-subscribe race; mode-2 watermark met/default-blocks/explicit; mutual-exclusivity 422; cross-tenant 404 |
| E2E | `tests/e2e/test_wait_endpoint.py` | +6 — timeout wiring, `le=60` → 422, mutual-exclusivity 422, unknown session 404 |
| MCP mount | `tests/unit/test_mcp_mount.py` | asserts `await_session` is MCP-included with `readOnlyHint=True` |

Full unit suite: 2039 passed. Codegen (`openapi.json` + SDK) regenerated and committed in sync. Non-vacuity verified: flipping `done=True` → `False` in the mode-1 build path failed the corresponding integration test.

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
