### PR TITLE
feat(workflows): per-run compute ceiling — scaled budgets, needs-step sweep, wake coalescing (#780)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -363,6 +363,19 @@ class Settings(BaseSettings):
         "semantics; worst-case standing exposure is this many runs each "
         "entitled to ``workflow_max_agent_calls`` children.",
     )
+    workflow_wake_batch_seconds: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Coalescing window for run wakes from child completions and "
+        "tool results: completions landing within the window collapse into one "
+        "re-drive (the scheduled wake occupies the dedup lock, so further defers "
+        "are absorbed — including, for the window's duration, otherwise-immediate "
+        "wakes like a gate resume; their signals are still harvested by the "
+        "delayed step). 0 disables (every completion wakes immediately — today's "
+        "behavior). Note the effective floor: a not-yet-due scheduled job is "
+        "picked up by worker polling (~5s on an otherwise-idle worker), so "
+        "sub-second windows buy nothing.",
+    )
 
     # ── connectors ─────────────────────────────────────────────────────────
     inbound_debounce_seconds: float = Field(

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -218,7 +218,8 @@ async def open_listen_for_run_events(
     The workflow-run analog of :func:`open_listen_for_events` — same dedicated
     connection + bounded-queue-with-drop shape, feeding the ``/v1/runs/{id}/stream``
     generator. No subscriber advisory lock: that is a session-worker coordination
-    signal (issue #81) with no workflow equivalent (the run sweep is unconditional).
+    signal (issue #81) with no workflow equivalent (a lost run wake self-heals via
+    the needs-step sweep clauses, not via subscriber gating).
     """
     conn = await _connect_listener(db_url)
     try:

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -590,12 +590,63 @@ async def set_run_terminal(
     )
 
 
-async def list_active_run_ids(conn: asyncpg.Connection[Any]) -> list[str]:
-    """``id`` for every non-terminal, live run — the sweep predicate. (No
-    ``account_id``: ``defer_run_wake`` needs none and appends no journal span.)"""
+async def list_run_ids_needing_step(
+    conn: asyncpg.Connection[Any],
+    *,
+    agent_deadline_seconds: float,
+    tool_stale_seconds: float,
+) -> list[str]:
+    """``id`` for every live run with something for a step to DO — the sweep
+    predicate (#780). A parked run with nothing new is deliberately NOT matched
+    (waking it costs a full memo reship + script replay), so each clause carries a
+    recall obligation; the fail direction must always be "wake too much":
+
+    - ``pending``/``running`` — seeded-but-never-stepped, and the step lease
+      (every step flips ``running`` before its first journal write, so ANY
+      mid-step crash — including the deliberate spawn-failed re-raise — lands
+      here until the step's closing park/terminal write).
+    - an unharvested signal (``gate_resume``/``tool_result``/``child_done``/
+      ``cancel`` row with no matching ``call_result``) — every external resume
+      and child completion commits one atomically with its payload, so a lost
+      ``defer_run_wake`` is always visible here.
+    - a stale inflight call: an ``agent`` past the wall-clock deadline (the step
+      must force-resolve its timeout — this clause DRIVES that backstop) or a
+      ``tool`` past the re-dispatch horizon (its task crashed without a signal;
+      re-dispatch is idempotent). A ``gate`` maps to NULL — resume-driven only,
+      never stale.
+
+    (No ``account_id``: ``defer_run_wake`` needs none and appends no journal span.)
+    """
     rows = await conn.fetch(
-        "SELECT id FROM wf_runs "
-        "WHERE archived_at IS NULL AND status IN ('pending','running','suspended')"
+        """
+        SELECT r.id FROM wf_runs r
+        WHERE r.archived_at IS NULL
+          AND r.status IN ('pending','running','suspended')
+          AND (
+            r.status IN ('pending','running')
+            OR EXISTS (
+              SELECT 1 FROM wf_run_signals s
+              WHERE s.run_id = r.id
+                AND NOT EXISTS (
+                  SELECT 1 FROM wf_run_events e
+                  WHERE e.run_id = r.id AND e.call_key = s.call_key
+                    AND e.type = 'call_result'))
+            OR EXISTS (
+              SELECT 1 FROM wf_run_events cs
+              WHERE cs.run_id = r.id AND cs.type = 'call_started'
+                AND cs.created_at < now() - make_interval(secs =>
+                      CASE cs.payload->>'capability'
+                        WHEN 'agent' THEN $1::float8
+                        WHEN 'tool' THEN $2::float8
+                      END)
+                AND NOT EXISTS (
+                  SELECT 1 FROM wf_run_events e
+                  WHERE e.run_id = r.id AND e.call_key = cs.call_key
+                    AND e.type = 'call_result'))
+          )
+        """,
+        agent_deadline_seconds,
+        tool_stale_seconds,
     )
     return [r["id"] for r in rows]
 

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -558,8 +558,15 @@ async def get_run_for_step(conn: asyncpg.Connection[Any], run_id: str) -> WfRun 
 async def set_run_status(
     conn: asyncpg.Connection[Any], run_id: str, status: str, *, account_id: str
 ) -> None:
+    """Set a NON-terminal status transition. Never overwrites a terminal status:
+    under procrastinate dual execution (a reaped stale worker resuming next to its
+    replacement), a stale step's lease flip or park must not resurrect a run the
+    replacement already completed. Terminal writes go through
+    :func:`set_run_terminal`."""
     await conn.execute(
-        "UPDATE wf_runs SET status = $3, updated_at = now() WHERE id = $1 AND account_id = $2",
+        "UPDATE wf_runs SET status = $3, updated_at = now() "
+        "WHERE id = $1 AND account_id = $2 "
+        "AND status NOT IN ('completed','errored','cancelled')",
         run_id,
         account_id,
         status,
@@ -611,9 +618,13 @@ async def list_run_ids_needing_step(
       ``defer_run_wake`` is always visible here.
     - a stale inflight call: an ``agent`` past the wall-clock deadline (the step
       must force-resolve its timeout — this clause DRIVES that backstop) or a
-      ``tool`` past the re-dispatch horizon (its task crashed without a signal;
-      re-dispatch is idempotent). A ``gate`` maps to NULL — resume-driven only,
-      never stale.
+      ``tool`` past the re-dispatch horizon (its task crashed without a signal).
+      A ``gate`` maps to NULL — resume-driven only, never stale. The agent
+      deadline is also the (deliberately slow) backstop for a child archived or
+      deleted BEFORE answering: that path writes no signal, so the run waits out
+      the deadline before the harvest resolves ``child_gone`` — acceptable for a
+      rare operator action, but a recall mode this filter covers only at the
+      horizon, not within a tick.
 
     (No ``account_id``: ``defer_run_wake`` needs none and appends no journal span.)
     """

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -261,7 +261,8 @@ async def run_session_step(
         if result.nudge_session:
             await defer_wake(pool, session_id, cause="request_nudge", account_id=account_id)
         if result.autoerror_caller_run_id is not None:
-            await defer_run_wake(result.autoerror_caller_run_id)
+            # batch: a no_return auto-error is a child completion like any other.
+            await defer_run_wake(result.autoerror_caller_run_id, batch=True)
 
         # Archive-on-quiescence, performed LAST: a session launched ``archive_when_idle``
         # self-archives the first time it goes idle. It runs after ``step_end`` and every

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -712,6 +712,43 @@ def _nudge_content(request_ids: list[str]) -> str:
     )
 
 
+async def write_child_response(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    parent_run_id: str,
+    request_id: str,
+    is_error: bool,
+    result: Any,
+    error: dict[str, Any] | None,
+) -> bool:
+    """Write a workflow child's response AND its ``child_done`` side-marker, on the
+    caller's open connection/transaction — THE seam for every external response
+    writer (``respond_to_request`` and the quiescence guard's ``no_return``
+    backstop). The marker is what keeps a lost post-commit caller wake visible to
+    the needs-step sweep (#780, ``list_run_ids_needing_step``), so the two writes
+    must be atomic: a writer that bypassed this and forgot the marker would
+    silently re-open the permanently-stalled-run hole. The one deliberate bypass
+    is the step's own timeout force-resolve, which journals the ``call_result``
+    in the same step — there is no wake to lose, and a marker would only queue a
+    spurious wake. ``request_id`` IS the agent call's ``call_key``."""
+    wrote = await queries.write_response_if_absent(
+        conn,
+        session_id,
+        account_id=account_id,
+        request_id=request_id,
+        is_error=is_error,
+        result=result,
+        error=error,
+    )
+    if wrote:
+        await wf_queries.insert_run_signal(
+            conn, run_id=parent_run_id, call_key=request_id, kind="child_done"
+        )
+    return wrote
+
+
 async def append_assistant_and_guard_quiescence(
     pool: asyncpg.Pool[Any],
     session_id: str,
@@ -770,22 +807,16 @@ async def append_assistant_and_guard_quiescence(
                 conn, session_id, account_id=account_id, request_id=request_id
             )
             if nudges >= REQUEST_NUDGE_BUDGET:
-                if await queries.write_response_if_absent(
+                if await write_child_response(
                     conn,
                     session_id,
                     account_id=account_id,
+                    parent_run_id=parent_run_id,
                     request_id=request_id,
                     is_error=True,
                     result=None,
                     error={"kind": "no_return"},
                 ):
-                    # The second of the two response-write sites (the first is
-                    # respond_to_request): the ``child_done`` side-marker commits
-                    # in the guard's own transaction, so a lost post-commit caller
-                    # wake is SQL-visible to the needs-step sweep (#780).
-                    await wf_queries.insert_run_signal(
-                        conn, run_id=parent_run_id, call_key=request_id, kind="child_done"
-                    )
                     autoerror_caller_run_id = parent_run_id
             else:
                 to_nudge.append(request_id)

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -20,6 +20,7 @@ from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.db.listen import open_listen_for_events
+from aios.db.queries import workflows as wf_queries
 from aios.errors import (
     ConflictError,
     NotFoundError,
@@ -778,6 +779,13 @@ async def append_assistant_and_guard_quiescence(
                     result=None,
                     error={"kind": "no_return"},
                 ):
+                    # The second of the two response-write sites (the first is
+                    # respond_to_request): the ``child_done`` side-marker commits
+                    # in the guard's own transaction, so a lost post-commit caller
+                    # wake is SQL-visible to the needs-step sweep (#780).
+                    await wf_queries.insert_run_signal(
+                        conn, run_id=parent_run_id, call_key=request_id, kind="child_done"
+                    )
                     autoerror_caller_run_id = parent_run_id
             else:
                 to_nudge.append(request_id)

--- a/src/aios/services/wake.py
+++ b/src/aios/services/wake.py
@@ -105,21 +105,43 @@ async def defer_wake(
         )
 
 
-async def defer_run_wake(run_id: str) -> None:
+async def defer_run_wake(run_id: str, *, batch: bool = False) -> None:
     """Enqueue a ``wake_workflow`` job for a run, swallowing ``AlreadyEnqueued``.
 
     Unlike :func:`defer_wake`, this appends **no** journal span: ``wf_run_events``
     is single-writer — only ``run_workflow_step`` (under ``lock=run_id``) writes
     it. ``queueing_lock`` dedups concurrent wakes for the same run.
+
+    ``batch`` (#780) schedules the wake ``workflow_wake_batch_seconds`` out
+    instead of immediately, so a burst of completions collapses into one
+    re-drive: the scheduled job sits in ``todo`` holding the ``queueing_lock``,
+    absorbing every further defer until it runs — including otherwise-immediate
+    wakes (a gate resume, the step's self-wake) arriving inside the window.
+    That absorption is sound because every wake source commits its signal/
+    response BEFORE deferring, so the delayed step harvests it; the cost is
+    latency bounded by the window. The high-frequency sources (child
+    completions, tool results) pass ``batch=True``; with the setting at 0
+    (the default) batching is off and every wake is immediate.
     """
+    from aios.config import get_settings
     from aios.harness.procrastinate_app import app
 
-    deferrer = app.configure_task(
-        "harness.wake_workflow",
-        lock=run_id,
-        queueing_lock=run_id,
-        priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
-    )
+    window = get_settings().workflow_wake_batch_seconds if batch else 0.0
+    if window > 0:
+        deferrer = app.configure_task(
+            "harness.wake_workflow",
+            lock=run_id,
+            queueing_lock=run_id,
+            priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
+            schedule_in={"seconds": window},
+        )
+    else:
+        deferrer = app.configure_task(
+            "harness.wake_workflow",
+            lock=run_id,
+            queueing_lock=run_id,
+            priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
+        )
     try:
         await deferrer.defer_async(run_id=run_id)
     except procrastinate_exceptions.AlreadyEnqueued:

--- a/src/aios/services/wake.py
+++ b/src/aios/services/wake.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from procrastinate import exceptions as procrastinate_exceptions
 from procrastinate.types import JSONValue
 
+from aios.config import get_settings
 from aios.db import queries
 from aios.logging import get_logger
 from aios.services import sessions as sessions_service
@@ -78,21 +79,14 @@ async def defer_wake(
 
     task_kwargs: dict[str, JSONValue] = {"session_id": session_id, "cause": cause}
 
-    if delay_seconds is not None:
-        deferrer = app.configure_task(
-            "harness.wake_session",
-            lock=session_id,
-            queueing_lock=session_id,
-            priority=priority,
-            schedule_in={"seconds": delay_seconds},
-        )
-    else:
-        deferrer = app.configure_task(
-            "harness.wake_session",
-            lock=session_id,
-            queueing_lock=session_id,
-            priority=priority,
-        )
+    # configure_task accepts schedule_in=None (treated as "no schedule").
+    deferrer = app.configure_task(
+        "harness.wake_session",
+        lock=session_id,
+        queueing_lock=session_id,
+        priority=priority,
+        schedule_in={"seconds": delay_seconds} if delay_seconds is not None else None,
+    )
 
     try:
         await deferrer.defer_async(**task_kwargs)
@@ -123,25 +117,16 @@ async def defer_run_wake(run_id: str, *, batch: bool = False) -> None:
     completions, tool results) pass ``batch=True``; with the setting at 0
     (the default) batching is off and every wake is immediate.
     """
-    from aios.config import get_settings
     from aios.harness.procrastinate_app import app
 
     window = get_settings().workflow_wake_batch_seconds if batch else 0.0
-    if window > 0:
-        deferrer = app.configure_task(
-            "harness.wake_workflow",
-            lock=run_id,
-            queueing_lock=run_id,
-            priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
-            schedule_in={"seconds": window},
-        )
-    else:
-        deferrer = app.configure_task(
-            "harness.wake_workflow",
-            lock=run_id,
-            queueing_lock=run_id,
-            priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
-        )
+    deferrer = app.configure_task(
+        "harness.wake_workflow",
+        lock=run_id,
+        queueing_lock=run_id,
+        priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
+        schedule_in={"seconds": window} if window > 0 else None,
+    )
     try:
         await deferrer.defer_async(run_id=run_id)
     except procrastinate_exceptions.AlreadyEnqueued:

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -35,8 +35,8 @@ from typing import Any
 import jsonschema
 
 from aios.db import queries
-from aios.db.queries import workflows as wf_queries
 from aios.harness import runtime
+from aios.services import sessions as sessions_service
 from aios.services.wake import defer_run_wake
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
 
@@ -118,24 +118,17 @@ async def respond_to_request(
             conn, session_id, account_id=account_id
         ):
             return "unknown_request"  # already answered, never asked, or a typo from the model
-        # The response and its ``child_done`` side-marker commit ATOMICALLY: the
-        # marker is what makes a lost caller wake SQL-visible to the needs-step
-        # sweep (#780), so a crash between the two writes must not be possible.
-        # ``request_id`` IS the agent call's ``call_key`` (the call is the request).
         async with conn.transaction():
-            wrote = await queries.write_response_if_absent(
+            wrote = await sessions_service.write_child_response(
                 conn,
                 session_id,
                 account_id=account_id,
+                parent_run_id=parent_run_id,
                 request_id=request_id,
                 is_error=is_error,
                 result=result,
                 error=error,
             )
-            if wrote:
-                await wf_queries.insert_run_signal(
-                    conn, run_id=parent_run_id, call_key=request_id, kind="child_done"
-                )
     if wrote:
         # batch: child completions are the high-frequency wake source — a fan-out's
         # burst coalesces into one re-drive when the window setting is on.

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -137,7 +137,9 @@ async def respond_to_request(
                     conn, run_id=parent_run_id, call_key=request_id, kind="child_done"
                 )
     if wrote:
-        await defer_run_wake(parent_run_id)
+        # batch: child completions are the high-frequency wake source — a fan-out's
+        # burst coalesces into one re-drive when the window setting is on.
+        await defer_run_wake(parent_run_id, batch=True)
     return "responded" if wrote else "duplicate"
 
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -35,6 +35,7 @@ from typing import Any
 import jsonschema
 
 from aios.db import queries
+from aios.db.queries import workflows as wf_queries
 from aios.harness import runtime
 from aios.services.wake import defer_run_wake
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
@@ -117,15 +118,24 @@ async def respond_to_request(
             conn, session_id, account_id=account_id
         ):
             return "unknown_request"  # already answered, never asked, or a typo from the model
-        wrote = await queries.write_response_if_absent(
-            conn,
-            session_id,
-            account_id=account_id,
-            request_id=request_id,
-            is_error=is_error,
-            result=result,
-            error=error,
-        )
+        # The response and its ``child_done`` side-marker commit ATOMICALLY: the
+        # marker is what makes a lost caller wake SQL-visible to the needs-step
+        # sweep (#780), so a crash between the two writes must not be possible.
+        # ``request_id`` IS the agent call's ``call_key`` (the call is the request).
+        async with conn.transaction():
+            wrote = await queries.write_response_if_absent(
+                conn,
+                session_id,
+                account_id=account_id,
+                request_id=request_id,
+                is_error=is_error,
+                result=result,
+                error=error,
+            )
+            if wrote:
+                await wf_queries.insert_run_signal(
+                    conn, run_id=parent_run_id, call_key=request_id, kind="child_done"
+                )
     if wrote:
         await defer_run_wake(parent_run_id)
     return "responded" if wrote else "duplicate"

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -11,13 +11,15 @@ captured for it, by whichever of these writes first:
   (``fail_all_open_requests``, when the model fails past its retry budget) both go
   through :func:`respond_to_request`,
 * the run's totality backstop (``services.sessions`` quiescence guard) writes
-  ``write_response_if_absent`` directly — it runs inside the guard's open
-  transaction, so it can't acquire its own connection.
+  inside its own open transaction — it can't acquire its own connection.
 
-The common, load-bearing seam is therefore ``write_response_if_absent`` (the
-exactly-once, first-writer-wins guard), not :func:`respond_to_request`: a
-``return``+``error`` batch, a model double-call, a model-failure racing a late
-``return``, or the backstop racing any of them all collapse to one response there.
+The common, load-bearing seam for an external writer is
+``sessions_service.write_child_response`` — exactly-once first-writer-wins (via
+``write_response_if_absent``) PLUS the atomic ``child_done`` marker the
+needs-step sweep's recall depends on (a writer that bypassed it would silently
+re-open the lost-wake stall the marker closes). A ``return``+``error`` batch, a
+model double-call, a model-failure racing a late ``return``, or the backstop
+racing any of them all collapse to one response there.
 :func:`respond_to_request` adds the caller-wake on top for the pool-level callers.
 
 It does **not** archive or terminate the child. Responding resumes the caller

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -185,9 +185,12 @@ async def run_script_host(
 
     ``deadline_seconds`` is the BASE budget; the effective budget scales with the
     INIT frame size (see :func:`_scaled_seconds`). The CPU rlimit is DERIVED —
-    one second above the wall deadline — so a CPU-bound child is killed by the
-    parent's deadline (a clean ``script_host_timeout``), never by the rlimit
-    SIGKILL (an opaque host crash): true by construction, not by matching bases.
+    one second above the wall deadline — so a single-threaded CPU-bound child is
+    killed by the parent's deadline (a clean ``script_host_timeout``), never by
+    the rlimit SIGKILL (an opaque host crash). RLIMIT_CPU sums across threads, so
+    a child that escapes the restricted builtins into GIL-releasing threads can
+    still hit the rlimit first — containment holds either way (both outcomes are
+    terminal raised); only the error kind differs.
     """
     init_bytes = encode_frame({"type": INIT, "source": source, "input": input, "memo": memo})
     deadline = _scaled_seconds(deadline_seconds, len(init_bytes))

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -35,6 +35,25 @@ from aios.workflows._protocol import (
 
 DEFAULT_CPU_SECONDS = 30
 DEFAULT_DEADLINE_SECONDS = 30.0
+# Per-wake budgets SCALE with the INIT frame (#780): a wake that replays a bigger
+# memo is entitled to proportionally more wall/CPU time, so a run can never time
+# out merely because it has accumulated results. 30s/MiB is ~3 orders of magnitude
+# above measured parse+replay cost — the headroom is for the author's own glue
+# (sorting/joining N results), which is what actually grows with the memo. The cap
+# bounds how long one wake can hold a worker (a run cancel is only consumed at the
+# next step, and a deploy drains in-flight steps): a capped budget is still
+# ~15,000x the measured replay cost of a frame-cap-sized INIT.
+DEADLINE_SECONDS_PER_INIT_MIB = 30.0
+MAX_SCALED_SECONDS = 600.0
+
+
+def _scaled_seconds(base: float, init_len: int) -> float:
+    """The effective per-wake budget: ``base`` plus the INIT-size allowance, capped."""
+    return min(
+        base + (init_len / (1024 * 1024)) * DEADLINE_SECONDS_PER_INIT_MIB, MAX_SCALED_SECONDS
+    )
+
+
 # 4 GiB virtual-address ceiling: bounds a runaway allocation (e.g. ``[0]*10**10``
 # ≈ 80 GB) that the wall-clock deadline does NOT bound — the deadline caps
 # duration, not peak memory — while leaving ample headroom for a coordination
@@ -164,8 +183,17 @@ async def run_script_host(
     address_space_bytes: int | None = DEFAULT_ADDRESS_SPACE_BYTES,
     deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
 ) -> HostOutcome:
-    """Drive one wake of ``source`` in a fresh, credential-free subprocess."""
+    """Drive one wake of ``source`` in a fresh, credential-free subprocess.
+
+    ``deadline_seconds``/``cpu_seconds`` are the BASE budgets; the effective
+    budgets scale with the INIT frame size (see :func:`_scaled_seconds`). CPU is
+    pinned one second above the wall deadline so a CPU-bound child is killed by
+    the parent's deadline (a clean ``script_host_timeout``), never by the rlimit
+    SIGKILL (an opaque host crash).
+    """
     init_bytes = encode_frame({"type": INIT, "source": source, "input": input, "memo": memo})
+    deadline = _scaled_seconds(deadline_seconds, len(init_bytes))
+    cpu = int(_scaled_seconds(cpu_seconds, len(init_bytes))) + 1
     # Deny-by-default env: only non-secret launch/locale essentials cross the
     # spawn (see ``_CHILD_ENV_ALLOWLIST``), plus the two rlimit knobs the child
     # self-applies. The child must stay credential-free.
@@ -177,7 +205,7 @@ async def run_script_host(
     # breaks. (``canonical_json`` rejects sets directly, but a list *built from* a
     # set is indistinguishable from any other list.)
     env["PYTHONHASHSEED"] = "0"
-    env["AIOS_WF_RLIMIT_CPU_S"] = str(cpu_seconds)
+    env["AIOS_WF_RLIMIT_CPU_S"] = str(cpu)
     env["AIOS_WF_RLIMIT_AS_BYTES"] = str(address_space_bytes or 0)
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -196,7 +224,7 @@ async def run_script_host(
 
     try:
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(input=init_bytes), timeout=deadline_seconds
+            proc.communicate(input=init_bytes), timeout=deadline
         )
     except TimeoutError:
         with contextlib.suppress(ProcessLookupError):
@@ -208,7 +236,9 @@ async def run_script_host(
         return HostOutcome(
             kind="raised",
             error_kind="script_host_timeout",
-            error_repr=f"script host exceeded the {deadline_seconds}s wall-clock deadline",
+            # The EFFECTIVE (scaled) deadline — this string becomes the run's
+            # terminal output, so it must state the number actually enforced.
+            error_repr=f"script host exceeded the {deadline:.1f}s wall-clock deadline",
         )
     except BaseException:
         with contextlib.suppress(ProcessLookupError):

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -33,7 +33,6 @@ from aios.workflows._protocol import (
     encode_frame,
 )
 
-DEFAULT_CPU_SECONDS = 30
 DEFAULT_DEADLINE_SECONDS = 30.0
 # Per-wake budgets SCALE with the INIT frame (#780): a wake that replays a bigger
 # memo is entitled to proportionally more wall/CPU time, so a run can never time
@@ -179,21 +178,20 @@ async def run_script_host(
     source: str,
     input: Any,
     memo: dict[str, Any],
-    cpu_seconds: int = DEFAULT_CPU_SECONDS,
     address_space_bytes: int | None = DEFAULT_ADDRESS_SPACE_BYTES,
     deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
 ) -> HostOutcome:
     """Drive one wake of ``source`` in a fresh, credential-free subprocess.
 
-    ``deadline_seconds``/``cpu_seconds`` are the BASE budgets; the effective
-    budgets scale with the INIT frame size (see :func:`_scaled_seconds`). CPU is
-    pinned one second above the wall deadline so a CPU-bound child is killed by
-    the parent's deadline (a clean ``script_host_timeout``), never by the rlimit
-    SIGKILL (an opaque host crash).
+    ``deadline_seconds`` is the BASE budget; the effective budget scales with the
+    INIT frame size (see :func:`_scaled_seconds`). The CPU rlimit is DERIVED —
+    one second above the wall deadline — so a CPU-bound child is killed by the
+    parent's deadline (a clean ``script_host_timeout``), never by the rlimit
+    SIGKILL (an opaque host crash): true by construction, not by matching bases.
     """
     init_bytes = encode_frame({"type": INIT, "source": source, "input": input, "memo": memo})
     deadline = _scaled_seconds(deadline_seconds, len(init_bytes))
-    cpu = int(_scaled_seconds(cpu_seconds, len(init_bytes))) + 1
+    cpu = int(deadline) + 1
     # Deny-by-default env: only non-secret launch/locale essentials cross the
     # spawn (see ``_CHILD_ENV_ALLOWLIST``), plus the two rlimit knobs the child
     # self-applies. The child must stay credential-free.

--- a/src/aios/workflows/run_tools.py
+++ b/src/aios/workflows/run_tools.py
@@ -104,9 +104,11 @@ async def _run_tool_task(
             # completions — a burst coalesces into one re-drive when the window is on.
             await defer_run_wake(run.id, batch=True)
         except Exception:
-            # The tool ran but persisting/waking failed (DB blip, pool exhaustion). No signal
-            # → the run stalls 'suspended' until the periodic sweep re-wakes it and the harvest
-            # re-dispatches. Log so the stall is diagnosable, not a silent unretrieved-task warning.
+            # The tool ran but persisting/waking failed (DB blip, pool exhaustion). If the
+            # signal committed and only the wake failed, the sweep's unharvested-signal clause
+            # re-wakes within a tick; with no signal at all, the stale-tool clause re-wakes at
+            # the staleness horizon and the harvest re-dispatches. Log so the stall is
+            # diagnosable, not a silent unretrieved-task warning.
             log.exception(
                 "run_tool.signal_failed", run_id=run.id, call_key=call_key, tool=tool_name
             )

--- a/src/aios/workflows/run_tools.py
+++ b/src/aios/workflows/run_tools.py
@@ -100,7 +100,9 @@ async def _run_tool_task(
                 await wf_queries.insert_run_signal(
                     conn, run_id=run.id, call_key=call_key, kind="tool_result", result=result
                 )
-            await defer_run_wake(run.id)
+            # batch: tool results are a high-frequency wake source, like child
+            # completions — a burst coalesces into one re-drive when the window is on.
+            await defer_run_wake(run.id, batch=True)
         except Exception:
             # The tool ran but persisting/waking failed (DB blip, pool exhaustion). No signal
             # → the run stalls 'suspended' until the periodic sweep re-wakes it and the harvest

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -231,6 +231,7 @@ async def _run_workflow_step_body(
         # gate with a delivered resume signal, or an agent child with a response (or a
         # past-deadline timeout) — and fold its result into memo so replay
         # fast-forwards past it.
+        harvested = False  # any call_result journaled this step
         now = datetime.now(UTC)
         agent_deadline = timedelta(seconds=get_settings().workflow_agent_deadline_seconds)
         for call_key, cap_event in list(inflight.items()):
@@ -288,6 +289,21 @@ async def _run_workflow_step_body(
             # fast-forward into the await, or an `{error}` to throw as AgentError.
             memo[call_key] = _memo_outcome(result_payload)
             del inflight[call_key]
+            harvested = True
+
+        # QUIET WAKE early-exit (#780): the run entered parked ('suspended' means
+        # the previous step's closing park committed, so the journal is a complete
+        # suspension) and the harvest resolved nothing — by determinism the replay
+        # would re-emit the same frontier and re-park, so the O(memo) reship +
+        # replay is a provable no-op. Park back and return. This is what keeps a
+        # sweep wake of a heavy parked run O(1): without it, a replay that outlives
+        # the sweep interval re-arms the next tick's wake forever (lease/sweep
+        # resonance), and a slow tool's run pays a full replay per tick. A
+        # 'pending' or 'running' entry MUST drive: first wake, or a crashed step
+        # whose frontier may be only part-journaled.
+        if run.status == "suspended" and not harvested:
+            await wf_queries.set_run_status(conn, run_id, "suspended", account_id=account_id)
+            return
 
     # Drive one wake in the credential-free subprocess (no DB conn held).
     outcome = await run_script_host(source=run.script, input=run.input, memo=memo)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -179,6 +179,17 @@ async def _run_workflow_step_body(
     pool: asyncpg.Pool[Any], run_id: str, run: WfRun, account_id: str
 ) -> None:
     async with pool.acquire() as conn:
+        # ``running`` is the step's LEASE (#780): flipped on EVERY wake before any
+        # journal write — not just the first — so a crash anywhere mid-step
+        # (including the deliberate spawn-failed re-raise below) leaves a state the
+        # needs-step sweep matches unconditionally. Without this, a crash after the
+        # harvest journals its last call_result but before the re-drive parks/ends
+        # the run would leave a 'suspended' row no filter clause ever wakes again.
+        # The step's closing write — park to 'suspended' or a terminal — hands the
+        # lease back. (``run.status`` is the entry snapshot, read just above.)
+        if run.status != "running":
+            await wf_queries.set_run_status(conn, run_id, "running", account_id=account_id)
+
         events = await wf_queries.list_run_events(conn, run_id)
         signals = {s.call_key: s for s in await wf_queries.list_run_signals(conn, run_id)}
 
@@ -215,7 +226,6 @@ async def _run_workflow_step_body(
                 type="run_started",
                 payload={"input": run.input},
             )
-            await wf_queries.set_run_status(conn, run_id, "running", account_id=account_id)
 
         # Pre-replay harvest: resolve any inflight capability that is now done — a
         # gate with a delivered resume signal, or an agent child with a response (or a

--- a/src/aios/workflows/sweep.py
+++ b/src/aios/workflows/sweep.py
@@ -28,13 +28,17 @@ log = get_logger("aios.workflows.sweep")
 
 # How long an inflight ``tool`` call may sit without a result signal before the
 # sweep re-wakes its run for re-dispatch (the task crashed / its signal write
-# failed). MUST dominate the slowest legitimate tool: tavily's 60s client
-# timeout and http_request's 60s PER-READ timeout (a trickling chunked response
-# can legitimately exceed 60s wall-clock). A tool still running when its run is
-# re-woken is absorbed same-worker by the in-process task registry (one wasted
-# wake) — but CROSS-worker the registry doesn't apply, and a premature horizon
-# would double-dispatch a non-idempotent http_request. 180s clears the 60s
-# bounds with margin while keeping crashed-task recovery within a few ticks.
+# failed). Sized against the slowest BOUNDED legitimate tool: tavily's 60s client
+# timeout; 180s clears it with margin while keeping crashed-task recovery within
+# a few ticks. A still-running tool past the horizon costs a cheap quiet wake per
+# tick same-worker (the in-process registry suppresses re-dispatch and the step's
+# quiet-wake early-exit skips the replay). Named residual: http_request's 60s
+# read timeout is PER-READ, so a trickling chunked response is wall-clock
+# UNBOUNDED — no finite horizon dominates it, and a cross-worker wake (where the
+# registry can't be consulted) would re-dispatch the still-running call,
+# double-executing a non-idempotent request. Closing that needs a total-time
+# bound on run tools or idempotency keys (the at-least-once caveat run_tools.py
+# already documents).
 TOOL_REDISPATCH_STALE_SECONDS = 180.0
 
 

--- a/src/aios/workflows/sweep.py
+++ b/src/aios/workflows/sweep.py
@@ -1,10 +1,14 @@
 """Periodic re-enqueue sweep for workflow runs — the durable backstop for a lost
 run wake.
 
-Mirrors the session sweep: every non-terminal run gets a deferred wake (deduped
-by ``queueing_lock``, so an already-queued/running step is a no-op). A wake lost
-to a crash therefore self-heals within one sweep interval, and a run suspended on
-a gate whose resume signal landed while the wake was dropped still gets stepped.
+Mirrors the session sweep, but with a **needs-step filter** (#780): only a run
+with something for a step to do is woken — an unharvested signal, a stale
+inflight call, or a non-parked status (the per-step ``running`` lease). A parked
+run with nothing new is skipped, because every wake costs a full memo reship +
+script replay; the old blanket every-non-terminal-run sweep made each tick O(memo)
+per parked run. A wake lost to a crash still self-heals within one sweep interval:
+every loss mode leaves SQL-visible state one of the filter clauses matches (see
+``list_run_ids_needing_step``).
 """
 
 from __future__ import annotations
@@ -13,17 +17,30 @@ from typing import Any
 
 import asyncpg
 
+from aios.config import get_settings
 from aios.db.queries import workflows as wf_queries
 from aios.logging import get_logger
 from aios.services.wake import defer_run_wake
 
 log = get_logger("aios.workflows.sweep")
 
+# How long an inflight ``tool`` call may sit without a result signal before the
+# sweep re-wakes its run for re-dispatch (the task crashed / its signal write
+# failed). Re-dispatch is idempotent — the harvest point-reads the signal and
+# checks the in-process task registry before launching — so the only cost of a
+# false positive is one wasted wake. Run tools are network calls (seconds), so a
+# minute of grace is generous.
+TOOL_REDISPATCH_STALE_SECONDS = 60.0
+
 
 async def wake_runs_needing_step(pool: asyncpg.Pool[Any]) -> int:
-    """Defer a wake for every non-terminal run. Returns the number swept."""
+    """Defer a wake for every run needing a step. Returns the number swept."""
     async with pool.acquire() as conn:
-        run_ids = await wf_queries.list_active_run_ids(conn)
+        run_ids = await wf_queries.list_run_ids_needing_step(
+            conn,
+            agent_deadline_seconds=get_settings().workflow_agent_deadline_seconds,
+            tool_stale_seconds=TOOL_REDISPATCH_STALE_SECONDS,
+        )
     for run_id in run_ids:
         try:
             await defer_run_wake(run_id)

--- a/src/aios/workflows/sweep.py
+++ b/src/aios/workflows/sweep.py
@@ -6,9 +6,11 @@ with something for a step to do is woken — an unharvested signal, a stale
 inflight call, or a non-parked status (the per-step ``running`` lease). A parked
 run with nothing new is skipped, because every wake costs a full memo reship +
 script replay; the old blanket every-non-terminal-run sweep made each tick O(memo)
-per parked run. A wake lost to a crash still self-heals within one sweep interval:
-every loss mode leaves SQL-visible state one of the filter clauses matches (see
-``list_run_ids_needing_step``).
+per parked run. A wake lost to a crash still self-heals: every loss mode leaves
+SQL-visible state one of the filter clauses matches (see
+``list_run_ids_needing_step``) — within one sweep interval for signal-backed and
+lease-backed modes, within the staleness horizon for a tool task that crashed
+before writing its signal.
 """
 
 from __future__ import annotations
@@ -26,11 +28,14 @@ log = get_logger("aios.workflows.sweep")
 
 # How long an inflight ``tool`` call may sit without a result signal before the
 # sweep re-wakes its run for re-dispatch (the task crashed / its signal write
-# failed). Re-dispatch is idempotent — the harvest point-reads the signal and
-# checks the in-process task registry before launching — so the only cost of a
-# false positive is one wasted wake. Run tools are network calls (seconds), so a
-# minute of grace is generous.
-TOOL_REDISPATCH_STALE_SECONDS = 60.0
+# failed). MUST dominate the slowest legitimate tool: tavily's 60s client
+# timeout and http_request's 60s PER-READ timeout (a trickling chunked response
+# can legitimately exceed 60s wall-clock). A tool still running when its run is
+# re-woken is absorbed same-worker by the in-process task registry (one wasted
+# wake) — but CROSS-worker the registry doesn't apply, and a premature horizon
+# would double-dispatch a non-idempotent http_request. 180s clears the 60s
+# bounds with margin while keeping crashed-task recovery within a few ticks.
+TOOL_REDISPATCH_STALE_SECONDS = 180.0
 
 
 async def wake_runs_needing_step(pool: asyncpg.Pool[Any]) -> int:

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -646,6 +646,26 @@ async def test_address_space_bomb_is_contained_and_parent_survives() -> None:
     assert ok.kind == "returned" and ok.value == "alive"
 
 
+async def test_big_memo_replay_outlives_a_tiny_base_deadline() -> None:
+    """The wall budget scales with INIT bytes (#780). The base here (0.01s) is
+    deliberately below interpreter spawn time (~20-50ms), so an UNSCALED host
+    deterministically times out — what passes is the multi-MiB memo's scale
+    allowance. This pins that ``_scaled_seconds`` is actually wired into
+    ``run_script_host``, not merely unit-green."""
+    source = "async def main(input):\n    g = await gate('x')\n    return len(g)"
+    first = await _run(source)
+    (cap,) = first.emitted  # learn the gate's call_key
+    memo = {
+        cap.call_key: {"ok": "v"},
+        # An unmatched memo key is never consulted by the driver — it exists only
+        # to inflate the INIT frame past 2MiB.
+        "pad": {"ok": "x" * (2 * 1024 * 1024)},
+    }
+    out = await _run(source, memo=memo, deadline_seconds=0.01)
+    assert out.kind == "returned"
+    assert out.value == 1
+
+
 async def test_log_goes_to_stderr_not_the_frame_stream() -> None:
     out = await _run("async def main(input):\n    log('diagnostic')\n    return 7")
     assert out.kind == "returned"

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -665,6 +665,27 @@ async def test_big_memo_replay_outlives_a_tiny_base_deadline() -> None:
     assert out.value == 1
 
 
+async def test_cpu_rlimit_derives_from_the_scaled_deadline() -> None:
+    """The child's CPU budget must track the SCALED wall deadline (int(deadline)+1),
+    not the base — pinned end-to-end by reading the env the child was handed (via
+    the documented builtins-escape, like the env-scrub test). A base-derived
+    mutation would hand a multi-MiB replay a 1s CPU budget."""
+    source = (
+        "async def main(input):\n"
+        "    return gate.__globals__['os'].environ['AIOS_WF_RLIMIT_CPU_S']\n"
+    )
+    tiny = await _run(source, deadline_seconds=2.0)
+    assert tiny.kind == "returned"
+    assert tiny.value == "3"  # tiny INIT: int(~2.0) + 1
+    big = await _run(
+        source,
+        memo={"pad": {"ok": "x" * (2 * 1024 * 1024)}},  # ~2MiB INIT → ~60s wall
+        deadline_seconds=0.01,
+    )
+    assert big.kind == "returned"
+    assert 61 <= int(big.value) <= 62  # int(0.01 + ~2*30) + 1
+
+
 async def test_log_goes_to_stderr_not_the_frame_stream() -> None:
     out = await _run("async def main(input):\n    log('diagnostic')\n    return 7")
     assert out.kind == "returned"

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -620,8 +620,7 @@ async def test_hash_ordering_is_pinned_across_wakes(monkeypatch: pytest.MonkeyPa
 async def test_cpu_bomb_is_killed_and_parent_survives() -> None:
     out = await _run(
         "async def main(input):\n    while True:\n        pass",
-        cpu_seconds=2,
-        deadline_seconds=2.0,
+        deadline_seconds=2.0,  # the CPU rlimit derives from this (deadline + 1s)
     )
     assert out.kind == "raised"
     assert out.error_kind in ("script_host_timeout", "script_host_crash")

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1726,8 +1726,9 @@ async def test_resumes_from_journaled_call_result_after_crash(
     gate_key = (await _events(pool, run_id))[1][2]
     assert gate_key is not None
 
-    # Simulate the harvest that committed just before the crash (status stays
-    # 'suspended' — the run_completed + status flip never happened).
+    # Simulate the harvest that committed just before the crash. The step's
+    # lease means a mid-step crash leaves 'running' (the park/terminal write
+    # never happened) — suspended + fully-harvested is unreachable by design.
     async with pool.acquire() as conn:
         await wf_queries.append_run_event(
             conn,
@@ -1737,6 +1738,7 @@ async def test_resumes_from_journaled_call_result_after_crash(
             call_key=gate_key,
             payload={"result": "yes", "is_error": False},
         )
+        await wf_queries.set_run_status(conn, run_id, "running", account_id="acc_wf")
 
     await run_workflow_step(run_id)  # fast-forward past the gate → complete
     async with pool.acquire() as conn:
@@ -1786,17 +1788,26 @@ async def test_host_crash_on_suspended_gate_is_not_divergence(
     the REAL infra cause, not a fabricated ``nondeterministic_replay`` — the
     divergence check runs only on a real replay, after the raised branch."""
     pool = wf_runtime
-    run_id = await _make_run(pool, _GATE_SCRIPT)
-    await run_workflow_step(run_id)  # wake 1: opens the gate, suspends
+    two_gates = (
+        "async def main(input):\n"
+        "    return await parallel([lambda: gate({'g': 1}), lambda: gate({'g': 2})])\n"
+    )
+    run_id = await _make_run(pool, two_gates)
+    await run_workflow_step(run_id)  # wake 1: opens both gates, suspends
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "suspended"
+    # Resume ONE gate so wake 2 harvests (and therefore drives — a quiet wake
+    # would skip the host); the other gate stays inflight across the crash.
+    first_key = (await _events(pool, run_id))[1][2]
+    assert first_key is not None
+    await service.resume_gate(pool, run_id=run_id, call_key=first_key, result="yes")
 
     timeout = HostOutcome(
         kind="raised", error_kind="script_host_timeout", error_repr="deadline", emitted=[]
     )
     with mock.patch("aios.workflows.step.run_script_host", new=AsyncMock(return_value=timeout)):
-        await run_workflow_step(run_id)  # wake 2: host killed before re-emitting the gate
+        await run_workflow_step(run_id)  # wake 2: host killed before re-emitting the open gate
 
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
@@ -1905,6 +1916,58 @@ async def test_child_done_signal_is_atomic_with_the_response(
     assert [(s.call_key, s.kind) for s in signals] == [("sha:at#0", "child_done")]
 
 
+async def test_lease_flips_before_the_harvest(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """Ordering pin: the 'running' lease must commit BEFORE any harvest write. If
+    the flip itself dies, nothing may have been harvested yet — the resume signal
+    is still unharvested and the sweep still sees the run. (A flip moved after
+    the harvest would leave suspended + fully-harvested on this crash: the
+    exact zombie the lease exists to prevent.)"""
+    pool = wf_runtime
+    run_id = await _make_run(pool, _GATE_SCRIPT)
+    await run_workflow_step(run_id)
+    gate_key = (await _events(pool, run_id))[1][2]
+    assert gate_key is not None
+    await service.resume_gate(pool, run_id=run_id, call_key=gate_key, result="yes")
+
+    real_set_run_status = wf_queries.set_run_status
+
+    async def exploding_flip(conn: Any, rid: str, status: str, *, account_id: str) -> None:
+        if status == "running":
+            raise RuntimeError("died at the lease flip")
+        await real_set_run_status(conn, rid, status, account_id=account_id)
+
+    with (
+        mock.patch("aios.workflows.step.wf_queries.set_run_status", new=exploding_flip),
+        pytest.raises(RuntimeError),
+    ):
+        await run_workflow_step(run_id)
+
+    events = await _events(pool, run_id)
+    assert not any(t == "call_result" for _s, t, _k in events)  # nothing harvested yet
+    assert run_id in await _needing(pool)  # the resume signal is still sweep-visible
+
+
+async def test_quiet_wake_of_a_parked_run_skips_the_replay(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A wake of a parked run with nothing new must NOT reship + replay (the
+    lease/sweep resonance guard): the host is never spawned, and the run parks
+    straight back. Without this, a replay outliving the 30s sweep interval
+    re-arms the next tick's wake forever."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, _GATE_SCRIPT)
+    await run_workflow_step(run_id)  # parks on the gate
+    with mock.patch(
+        "aios.workflows.step.run_script_host",
+        new=AsyncMock(side_effect=AssertionError("quiet wake must not drive the host")),
+    ) as host:
+        await run_workflow_step(run_id)  # a sweep-style wake with nothing to do
+    host.assert_not_awaited()
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "suspended"  # parked straight back
+
+
 async def test_large_fanout_completes_and_parks_quiet(wf_runtime: asyncpg.Pool[Any]) -> None:
     """#780 acceptance proxy: 200 resolved calls through the REAL step path. The
     discriminating assertions are the needs-step ones — a parked 200-wide fan-out
@@ -1914,7 +1977,7 @@ async def test_large_fanout_completes_and_parks_quiet(wf_runtime: asyncpg.Pool[A
     script = (
         "async def main(input):\n"
         "    results = await parallel([(lambda i=i: gate({'i': i})) for i in range(200)])\n"
-        "    return sum(r['v'] for r in results)\n"
+        "    return [r['v'] for r in results]\n"  # ordered: pins resume->branch routing
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # parks on a 200-wide frontier
@@ -1937,7 +2000,7 @@ async def test_large_fanout_completes_and_parks_quiet(wf_runtime: asyncpg.Pool[A
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "completed"
-    assert run.output == sum(range(200))
+    assert run.output == list(range(200))  # each resume reached ITS branch, in order
     assert run_id not in await _needing(pool)  # terminal: out of the sweep for good
 
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -91,6 +91,16 @@ async def _events(pool: asyncpg.Pool[Any], run_id: str) -> list[tuple[int, str, 
     return [(e.seq, e.type, e.call_key) for e in rows]
 
 
+async def _needing(pool: asyncpg.Pool[Any]) -> set[str]:
+    """Run ids the needs-step sweep filter currently matches (fixed horizons)."""
+    async with pool.acquire() as conn:
+        return set(
+            await wf_queries.list_run_ids_needing_step(
+                conn, agent_deadline_seconds=3600, tool_stale_seconds=60
+            )
+        )
+
+
 async def _make_run(pool: asyncpg.Pool[Any], script: str, *, input: Any = None) -> str:
     async with pool.acquire() as conn:
         wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w", script=script)
@@ -1814,15 +1824,12 @@ async def test_spawn_failure_is_transient_not_terminal(wf_runtime: asyncpg.Pool[
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
-        needing = await wf_queries.list_run_ids_needing_step(
-            conn, agent_deadline_seconds=3600, tool_stale_seconds=60
-        )
     assert run is not None and run.status != "errored"  # retriable, not terminal
     assert not any(e.type == "run_completed" for e in events)
     # The step LEASE (#780): the crashed step left 'running', which the needs-step
     # sweep matches unconditionally — what makes the re-raise actually retriable.
     assert run.status == "running"
-    assert run_id in needing
+    assert run_id in await _needing(pool)
 
 
 async def test_post_harvest_crash_leaves_lease_for_the_sweep(
@@ -1852,12 +1859,9 @@ async def test_post_harvest_crash_leaves_lease_for_the_sweep(
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
-        needing = await wf_queries.list_run_ids_needing_step(
-            conn, agent_deadline_seconds=3600, tool_stale_seconds=60
-        )
     assert run is not None and run.status == "running"  # the lease, not 'suspended'
     assert any(e.type == "call_result" for e in events)  # the harvest DID commit
-    assert run_id in needing  # ...and the sweep still sees the run
+    assert run_id in await _needing(pool)  # ...and the sweep still sees the run
 
     # The next (healthy) step replays with the journaled memo and completes.
     await run_workflow_step(run_id)
@@ -1915,29 +1919,26 @@ async def test_large_fanout_completes_and_parks_quiet(wf_runtime: asyncpg.Pool[A
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # parks on a 200-wide frontier
 
-    async def needing() -> set[str]:
-        async with pool.acquire() as conn:
-            return set(
-                await wf_queries.list_run_ids_needing_step(
-                    conn, agent_deadline_seconds=3600, tool_stale_seconds=60
-                )
-            )
-
     gate_keys = [k for _s, t, k in await _events(pool, run_id) if t == "call_started"]
-    assert len(gate_keys) == 200
-    assert run_id not in await needing()  # parked on gates: quiet
+    assert len(gate_keys) == 200 and all(k is not None for k in gate_keys)
+    assert run_id not in await _needing(pool)  # parked on gates: quiet
 
-    for i, key in enumerate(gate_keys):
-        assert key is not None
-        await service.resume_gate(pool, run_id=run_id, call_key=key, result={"v": i})
-    assert run_id in await needing()  # unharvested resumes: hot
+    # A real fan-in IS concurrent — resume all 200 gates at once.
+    await asyncio.gather(
+        *(
+            service.resume_gate(pool, run_id=run_id, call_key=key, result={"v": i})
+            for i, key in enumerate(gate_keys)
+            if key is not None
+        )
+    )
+    assert run_id in await _needing(pool)  # unharvested resumes: hot
 
     await run_workflow_step(run_id)  # harvests all 200, replays past them, completes
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "completed"
     assert run.output == sum(range(200))
-    assert run_id not in await needing()  # terminal: out of the sweep for good
+    assert run_id not in await _needing(pool)  # terminal: out of the sweep for good
 
 
 async def test_early_gate_signal_triggers_self_rewake(wf_runtime: asyncpg.Pool[Any]) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -558,7 +558,7 @@ async def test_return_writes_response_and_wakes_caller_without_archiving(
             cid, {"request_id": "sha:d2#0", "value": {"answer": 42}}
         )
     assert res == {"status": "returned"}
-    wake.assert_awaited_once_with(run_id)
+    wake.assert_awaited_once_with(run_id, batch=True)
 
     async with pool.acquire() as conn:
         response = await db_queries.read_request_response(
@@ -642,7 +642,7 @@ async def test_request_is_answered_exactly_once(
         )
     assert r1 == {"status": "returned"}
     assert isinstance(r2, ToolResult) and r2.is_error  # request already answered → not open
-    wake.assert_awaited_once_with(run_id)  # only the first response woke the caller
+    wake.assert_awaited_once_with(run_id, batch=True)  # only the first response woke the caller
 
     async with pool.acquire() as conn:
         rows = await conn.fetch(
@@ -693,7 +693,7 @@ async def test_return_real_dispatch_appends_result_and_does_not_archive(
     finally:
         runtime.task_registry = prev_reg
 
-    wake.assert_awaited_once_with(run_id)
+    wake.assert_awaited_once_with(run_id, batch=True)
     async with pool.acquire() as conn:
         result = await db_queries.find_tool_result_event(conn, cid, "call_ret", account_id="acc_wf")
         marker = await db_queries.read_request_response(
@@ -914,7 +914,7 @@ async def test_model_failure_writes_error_response_and_run_resolves(
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()) as wake:
         delay = await loop._apply_retry_or_failure(pool, child_id, account_id="acc_wf")
     assert delay is None  # terminal — retry budget spent
-    wake.assert_awaited_once_with(run_id)  # the caller was woken to harvest
+    wake.assert_awaited_once_with(run_id, batch=True)  # the caller was woken to harvest
 
     async with pool.acquire() as conn:
         response = await db_queries.read_request_response(
@@ -2103,7 +2103,7 @@ async def test_return_enforces_output_schema(
             cid, {"request_id": "se:1", "value": {"answer": "yes"}}
         )
     assert good == {"status": "returned"}
-    wake.assert_awaited_once_with(run_id)
+    wake.assert_awaited_once_with(run_id, batch=True)
     async with pool.acquire() as conn:
         resp = await db_queries.read_request_response(
             conn, cid, account_id="acc_wf", request_id="se:1"

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -564,8 +564,12 @@ async def test_return_writes_response_and_wakes_caller_without_archiving(
         response = await db_queries.read_request_response(
             conn, cid, account_id="acc_wf", request_id="sha:d2#0"
         )
+        signals = await wf_queries.list_run_signals(conn, run_id)
     assert response is not None
     assert response["is_error"] is False and response["result"] == {"answer": 42}
+    # The child_done side-marker committed with the response (#780): a lost caller
+    # wake stays SQL-visible to the needs-step sweep.
+    assert [(s.call_key, s.kind) for s in signals] == [("sha:d2#0", "child_done")]
     child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
     # NOT archived by the handler — archive-on-quiescence reclaims at the next idle step.
     assert child.archived_at is None
@@ -1067,9 +1071,13 @@ async def test_open_request_is_auto_errored_after_nudge_budget(
         )
         open_ids = await db_queries.get_open_request_ids(conn, cid, account_id="acc_wf")
         status = await db_queries.derive_session_status(conn, cid, account_id="acc_wf")
+        signals = await wf_queries.list_run_signals(conn, run_id)
     assert resp is not None and resp["is_error"] is True and resp["error"] == {"kind": "no_return"}
     assert open_ids == []  # answered (by the backstop) → no longer open
     assert status == "idle"  # nothing owed → free to rest
+    # The backstop is the SECOND response writer — it too leaves the child_done
+    # marker, so a lost post-commit caller wake stays sweep-visible (#780).
+    assert [(s.call_key, s.kind) for s in signals] == [("sha:nr#0", "child_done")]
 
 
 async def test_non_answering_child_resolves_run_via_agent_no_return_error(
@@ -1806,8 +1814,130 @@ async def test_spawn_failure_is_transient_not_terminal(wf_runtime: asyncpg.Pool[
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
+        needing = await wf_queries.list_run_ids_needing_step(
+            conn, agent_deadline_seconds=3600, tool_stale_seconds=60
+        )
     assert run is not None and run.status != "errored"  # retriable, not terminal
     assert not any(e.type == "run_completed" for e in events)
+    # The step LEASE (#780): the crashed step left 'running', which the needs-step
+    # sweep matches unconditionally — what makes the re-raise actually retriable.
+    assert run.status == "running"
+    assert run_id in needing
+
+
+async def test_post_harvest_crash_leaves_lease_for_the_sweep(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """The filter's hardest loss mode (#780 red-team, critical): a step harvests
+    its last pending signal into a call_result, then dies before the re-drive
+    parks the run. With the harvest committed, no signal is unharvested and no
+    call is inflight — only the per-step 'running' lease keeps the run
+    sweep-visible. Without the lease this state was a permanent zombie."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, _GATE_SCRIPT)
+    await run_workflow_step(run_id)  # suspends on the gate
+    gate_key = (await _events(pool, run_id))[1][2]
+    assert gate_key is not None
+    await service.resume_gate(pool, run_id=run_id, call_key=gate_key, result="yes")
+
+    with (
+        mock.patch(
+            "aios.workflows.step.run_script_host",
+            new=AsyncMock(side_effect=RuntimeError("worker died mid-step")),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+        needing = await wf_queries.list_run_ids_needing_step(
+            conn, agent_deadline_seconds=3600, tool_stale_seconds=60
+        )
+    assert run is not None and run.status == "running"  # the lease, not 'suspended'
+    assert any(e.type == "call_result" for e in events)  # the harvest DID commit
+    assert run_id in needing  # ...and the sweep still sees the run
+
+    # The next (healthy) step replays with the journaled memo and completes.
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+
+
+async def test_child_done_signal_is_atomic_with_the_response(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """Fault injection: if the child_done insert fails, the response write must
+    roll back with it — two separate autocommits would re-open the exact lost-wake
+    hole the marker exists to close (a committed response with no marker)."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    run_id, cid = await _spawn_child(pool, wf_agent_id, "sha:at#0")
+    with (
+        mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()),
+        mock.patch(
+            "aios.db.queries.workflows.insert_run_signal",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await workflow_completion.return_handler(cid, {"request_id": "sha:at#0", "value": 1})
+
+    async with pool.acquire() as conn:
+        response = await db_queries.read_request_response(
+            conn, cid, account_id="acc_wf", request_id="sha:at#0"
+        )
+    assert response is None  # rolled back WITH the failed signal — still unanswered
+
+    # A retry (signal write healthy again) responds normally, not 'duplicate'.
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        res = await workflow_completion.return_handler(cid, {"request_id": "sha:at#0", "value": 1})
+    assert res == {"status": "returned"}
+    async with pool.acquire() as conn:
+        signals = await wf_queries.list_run_signals(conn, run_id)
+    assert [(s.call_key, s.kind) for s in signals] == [("sha:at#0", "child_done")]
+
+
+async def test_large_fanout_completes_and_parks_quiet(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """#780 acceptance proxy: 200 resolved calls through the REAL step path. The
+    discriminating assertions are the needs-step ones — a parked 200-wide fan-out
+    is QUIET (the old blanket sweep re-drove it, full memo reship, every tick) and
+    flips hot exactly while resumes sit unharvested."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    results = await parallel([(lambda i=i: gate({'i': i})) for i in range(200)])\n"
+        "    return sum(r['v'] for r in results)\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # parks on a 200-wide frontier
+
+    async def needing() -> set[str]:
+        async with pool.acquire() as conn:
+            return set(
+                await wf_queries.list_run_ids_needing_step(
+                    conn, agent_deadline_seconds=3600, tool_stale_seconds=60
+                )
+            )
+
+    gate_keys = [k for _s, t, k in await _events(pool, run_id) if t == "call_started"]
+    assert len(gate_keys) == 200
+    assert run_id not in await needing()  # parked on gates: quiet
+
+    for i, key in enumerate(gate_keys):
+        assert key is not None
+        await service.resume_gate(pool, run_id=run_id, call_key=key, result={"v": i})
+    assert run_id in await needing()  # unharvested resumes: hot
+
+    await run_workflow_step(run_id)  # harvests all 200, replays past them, completes
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == sum(range(200))
+    assert run_id not in await needing()  # terminal: out of the sweep for good
 
 
 async def test_early_gate_signal_triggers_self_rewake(wf_runtime: asyncpg.Pool[Any]) -> None:

--- a/tests/integration/test_wf_sweep.py
+++ b/tests/integration/test_wf_sweep.py
@@ -177,6 +177,32 @@ async def test_inflight_tool_wakes_past_redispatch_horizon(
     assert run_id not in await _needing(pool)
 
 
+async def test_signal_clause_correlates_by_call_key(sweep_pool: asyncpg.Pool[Any]) -> None:
+    """A harvested call must not quiet an UNRELATED unharvested signal — the
+    anti-join correlates on call_key, and dropping that correlation would zombie
+    any partially-harvested run (a recall loss, the forbidden fail direction)."""
+    pool = sweep_pool
+    run_id = await _make_run(pool)
+    await _call_started(pool, run_id, "sha:a#0", "gate")
+    await _call_result(pool, run_id, "sha:a#0")  # call A harvested...
+    await _signal(pool, run_id, "sha:b#0", "gate_resume")  # ...signal B is not
+    assert run_id in await _needing(pool)
+
+
+async def test_signal_clause_correlates_by_run(sweep_pool: asyncpg.Pool[Any]) -> None:
+    """call_keys are pure content hashes — IDENTICAL across two runs of the same
+    workflow+input — so one run's harvested call must never quiet another run's
+    unharvested signal under the same key."""
+    pool = sweep_pool
+    run1 = await _make_run(pool)
+    run2 = await _make_run(pool)
+    await _call_result(pool, run1, "sha:k#0")
+    await _signal(pool, run2, "sha:k#0", "gate_resume")
+    needing = await _needing(pool)
+    assert run2 in needing
+    assert run1 not in needing
+
+
 async def test_inflight_gate_is_never_stale(sweep_pool: asyncpg.Pool[Any]) -> None:
     """A gate is resume-driven only: a run parked on one for a day is exactly the
     run the filter exists to leave alone."""

--- a/tests/integration/test_wf_sweep.py
+++ b/tests/integration/test_wf_sweep.py
@@ -1,7 +1,14 @@
-"""B1.9 — worker wiring: the wake_workflow task + the run re-enqueue sweep."""
+"""B1.9 — worker wiring: the wake_workflow task + the needs-step run sweep (#780).
+
+The filter's contract is recall: every lost-wake mode must leave SQL-visible state
+one clause matches, while a parked run with nothing new is NOT woken (each blanket
+wake costs a full memo reship + script replay). Each test pins one clause from
+``list_run_ids_needing_step``'s docstring.
+"""
 
 from __future__ import annotations
 
+import secrets
 from collections.abc import AsyncIterator
 from typing import Any
 from unittest import mock
@@ -12,9 +19,13 @@ import pytest
 
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
+from aios.models.workflows import WfRunSignalKind
 from aios.workflows.sweep import wake_runs_needing_step
 
 pytestmark = pytest.mark.integration
+
+AGENT_DEADLINE = 3600.0
+TOOL_STALE = 60.0
 
 
 @pytest.fixture
@@ -44,29 +55,152 @@ def test_wake_workflow_task_registered_on_workflows_queue() -> None:
     assert app.tasks["harness.wake_workflow"].queue == "workflows"
 
 
-async def test_sweep_wakes_only_nonterminal_runs(sweep_pool: asyncpg.Pool[Any]) -> None:
-    pool = sweep_pool
-    runs: dict[str, str] = {}
+async def _make_run(pool: asyncpg.Pool[Any], *, status: str = "suspended") -> str:
     async with pool.acquire() as conn:
         wf = await wf_queries.insert_workflow(
-            conn, account_id="acc_sw", name="w", script="async def main(input):\n    return 1"
+            conn,
+            account_id="acc_sw",
+            name=f"w-{secrets.token_hex(4)}",  # (account_id, name) is unique
+            script="async def main(input):\n    return 1",
         )
-        for status in ("pending", "suspended", "completed", "errored"):
-            run = await wf_queries.insert_wf_run(
-                conn,
-                account_id="acc_sw",
-                workflow_id=wf.id,
-                environment_id="env_sw",
-                script="x",
-                script_sha="x",
-            )
-            if status != "pending":
-                await wf_queries.set_run_status(conn, run.id, status, account_id="acc_sw")
-            runs[status] = run.id
+        run = await wf_queries.insert_wf_run(
+            conn,
+            account_id="acc_sw",
+            workflow_id=wf.id,
+            environment_id="env_sw",
+            script="x",
+            script_sha="x",
+        )
+        if status != "pending":
+            await wf_queries.set_run_status(conn, run.id, status, account_id="acc_sw")
+    return run.id
 
+
+async def _call_started(
+    pool: asyncpg.Pool[Any], run_id: str, call_key: str, capability: str, *, age_seconds: float = 0
+) -> None:
+    async with pool.acquire() as conn:
+        await wf_queries.append_run_event(
+            conn,
+            account_id="acc_sw",
+            run_id=run_id,
+            type="call_started",
+            call_key=call_key,
+            payload={"capability": capability},
+        )
+        if age_seconds:
+            await conn.execute(
+                "UPDATE wf_run_events SET created_at = now() - make_interval(secs => $1) "
+                "WHERE run_id = $2 AND call_key = $3 AND type = 'call_started'",
+                age_seconds,
+                run_id,
+                call_key,
+            )
+
+
+async def _call_result(pool: asyncpg.Pool[Any], run_id: str, call_key: str) -> None:
+    async with pool.acquire() as conn:
+        await wf_queries.append_run_event(
+            conn,
+            account_id="acc_sw",
+            run_id=run_id,
+            type="call_result",
+            call_key=call_key,
+            payload={"result": "v", "is_error": False},
+        )
+
+
+async def _signal(
+    pool: asyncpg.Pool[Any], run_id: str, call_key: str, kind: WfRunSignalKind
+) -> None:
+    async with pool.acquire() as conn:
+        await wf_queries.insert_run_signal(conn, run_id=run_id, call_key=call_key, kind=kind)
+
+
+async def _needing(pool: asyncpg.Pool[Any]) -> set[str]:
+    async with pool.acquire() as conn:
+        ids = await wf_queries.list_run_ids_needing_step(
+            conn, agent_deadline_seconds=AGENT_DEADLINE, tool_stale_seconds=TOOL_STALE
+        )
+    return set(ids)
+
+
+async def test_status_clauses(sweep_pool: asyncpg.Pool[Any]) -> None:
+    """pending (seeded, never stepped — the locked MUST) and running (the per-step
+    lease: any mid-step crash) are ALWAYS swept; a bare parked run and terminals
+    never are."""
+    pool = sweep_pool
+    runs = {s: await _make_run(pool, status=s) for s in ("pending", "running", "suspended")}
+    for s in ("completed", "errored", "cancelled"):
+        runs[s] = await _make_run(pool, status=s)
+    assert await _needing(pool) == {runs["pending"], runs["running"]}
+
+
+@pytest.mark.parametrize("kind", ["gate_resume", "child_done", "tool_result", "cancel"])
+async def test_unharvested_signal_wakes(sweep_pool: asyncpg.Pool[Any], kind: str) -> None:
+    """Every signal kind is a wake source until a matching call_result exists —
+    a lost defer_run_wake from any resume/completion path self-heals in one tick."""
+    pool = sweep_pool
+    run_id = await _make_run(pool)
+    await _signal(pool, run_id, f"sha:{kind}#0", kind)  # type: ignore[arg-type]
+    assert run_id in await _needing(pool)
+    # Harvested (call_result journaled) → the signal row is inert; back to quiet.
+    await _call_result(pool, run_id, f"sha:{kind}#0")
+    assert run_id not in await _needing(pool)
+
+
+async def test_inflight_agent_wakes_only_past_deadline(sweep_pool: asyncpg.Pool[Any]) -> None:
+    """A run waiting on a live agent child is QUIET (the child's completion wakes
+    it); past the wall-clock deadline the sweep must wake it so the step's harvest
+    force-resolves the timeout — this clause DRIVES the H3 backstop."""
+    pool = sweep_pool
+    run_id = await _make_run(pool)
+    await _call_started(pool, run_id, "sha:a#0", "agent")
+    assert run_id not in await _needing(pool)
+    await _call_started(pool, run_id, "sha:a#1", "agent", age_seconds=AGENT_DEADLINE + 60)
+    assert run_id in await _needing(pool)
+
+
+async def test_inflight_tool_wakes_past_redispatch_horizon(
+    sweep_pool: asyncpg.Pool[Any],
+) -> None:
+    """A tool task that crashed without a signal leaves only its call_started; the
+    stale-tool clause re-wakes the run so the harvest re-dispatches (idempotent)."""
+    pool = sweep_pool
+    run_id = await _make_run(pool)
+    await _call_started(pool, run_id, "sha:t#0", "tool")
+    assert run_id not in await _needing(pool)
+    await _call_started(pool, run_id, "sha:t#1", "tool", age_seconds=TOOL_STALE * 2)
+    assert run_id in await _needing(pool)
+    # Resolved → quiet again.
+    await _call_result(pool, run_id, "sha:t#1")
+    assert run_id not in await _needing(pool)
+
+
+async def test_inflight_gate_is_never_stale(sweep_pool: asyncpg.Pool[Any]) -> None:
+    """A gate is resume-driven only: a run parked on one for a day is exactly the
+    run the filter exists to leave alone."""
+    pool = sweep_pool
+    run_id = await _make_run(pool)
+    await _call_started(pool, run_id, "sha:g#0", "gate", age_seconds=86_400)
+    assert run_id not in await _needing(pool)
+
+
+async def test_archived_run_is_never_swept(sweep_pool: asyncpg.Pool[Any]) -> None:
+    pool = sweep_pool
+    run_id = await _make_run(pool, status="pending")
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE wf_runs SET archived_at = now() WHERE id = $1", run_id)
+    assert run_id not in await _needing(pool)
+
+
+async def test_wake_runs_needing_step_defers_for_matches(sweep_pool: asyncpg.Pool[Any]) -> None:
+    """The sweep entrypoint (settings-bound) defers exactly the filter's matches."""
+    pool = sweep_pool
+    pending = await _make_run(pool, status="pending")
+    parked = await _make_run(pool)  # suspended, nothing new — must stay quiet
     with mock.patch("aios.workflows.sweep.defer_run_wake", new=AsyncMock()) as deferred:
         swept = await wake_runs_needing_step(pool)
-
-    assert swept == 2  # only pending + suspended
     woken = {call.args[0] for call in deferred.call_args_list}
-    assert woken == {runs["pending"], runs["suspended"]}
+    assert swept == 1 and woken == {pending}
+    assert parked not in woken

--- a/tests/unit/test_wake.py
+++ b/tests/unit/test_wake.py
@@ -10,7 +10,7 @@ import pytest
 from procrastinate import App
 from procrastinate.testing import InMemoryConnector
 
-from aios.services.wake import defer_wake
+from aios.services.wake import defer_run_wake, defer_wake
 
 
 @pytest.fixture(autouse=True)
@@ -86,3 +86,66 @@ class TestDeferRescheduleWake:
             {"event": "wake_deferred", "cause": "reschedule", "delay_seconds": 5},
             account_id=ANY,
         )
+
+
+@pytest.fixture
+def batch_window(monkeypatch: pytest.MonkeyPatch) -> Generator[float]:
+    """Set ``workflow_wake_batch_seconds`` to 2.0 for the test, clearing the
+    settings cache both ways (it is lru-cached; without the clears the override
+    silently tests the default — and would leak into later tests)."""
+    from aios.config import get_settings
+
+    monkeypatch.setenv("AIOS_WORKFLOW_WAKE_BATCH_SECONDS", "2.0")
+    get_settings.cache_clear()
+    yield 2.0
+    get_settings.cache_clear()
+
+
+class TestDeferRunWakeBatching:
+    """#780 — the coalescing window, dark by default (setting 0.0)."""
+
+    async def test_batch_schedules_inside_the_window(
+        self, in_memory_app: App, batch_window: float
+    ) -> None:
+        before = datetime.now(UTC)
+        await defer_run_wake("run_b", batch=True)
+        after = datetime.now(UTC)
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        (job,) = connector.jobs.values()
+        assert job["task_name"] == "harness.wake_workflow"
+        assert job["scheduled_at"] is not None
+        window = timedelta(seconds=batch_window)
+        assert before + window <= job["scheduled_at"] <= after + window
+
+    async def test_batch_with_setting_zero_is_immediate(self, in_memory_app: App) -> None:
+        # Dark by default: batch=True with the setting at 0 behaves exactly like today.
+        await defer_run_wake("run_b", batch=True)
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        (job,) = connector.jobs.values()
+        assert job["scheduled_at"] is None
+
+    async def test_unbatched_is_immediate_even_with_window_set(
+        self, in_memory_app: App, batch_window: float
+    ) -> None:
+        await defer_run_wake("run_b")
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        (job,) = connector.jobs.values()
+        assert job["scheduled_at"] is None
+
+    async def test_pending_batched_wake_absorbs_further_defers(
+        self, in_memory_app: App, batch_window: float
+    ) -> None:
+        """The scheduled job holds the queueing_lock for the whole window: a burst
+        of batched completions AND an otherwise-immediate defer (a gate resume)
+        all collapse into the one pending wake. Sound because every wake source
+        commits its signal/response BEFORE deferring — the delayed step harvests
+        them; the cost is latency bounded by the window."""
+        await defer_run_wake("run_b", batch=True)
+        await defer_run_wake("run_b", batch=True)  # burst: coalesced
+        await defer_run_wake("run_b")  # "immediate" defer: absorbed by the pending wake
+        connector = in_memory_app.connector
+        assert isinstance(connector, InMemoryConnector)
+        assert len(connector.jobs) == 1

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -806,5 +806,5 @@ class TestRequestTotalityWiring:
             _mgr,
         ):
             await run_session_step("sess_x")
-        defer_run_wake.assert_awaited_once_with("run_x")
+        defer_run_wake.assert_awaited_once_with("run_x", batch=True)
         defer_wake.assert_not_awaited()

--- a/tests/unit/test_wf_host_scaling.py
+++ b/tests/unit/test_wf_host_scaling.py
@@ -1,0 +1,37 @@
+"""#780 — per-wake budget scaling: the pure ``_scaled_seconds`` contract.
+
+Exact values (not just monotonicity): the constant itself is load-bearing — the
+integration rescue test only proves the scale exceeds interpreter spawn cost, so
+this table is what pins 30s/MiB and the 600s cap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.workflows.host_launcher import (
+    DEADLINE_SECONDS_PER_INIT_MIB,
+    MAX_SCALED_SECONDS,
+    _scaled_seconds,
+)
+
+_MIB = 1024 * 1024
+
+
+def test_scaled_seconds_exact_values() -> None:
+    assert _scaled_seconds(30.0, 0) == 30.0  # empty INIT → base
+    assert _scaled_seconds(30.0, _MIB) == 60.0  # +30s per MiB
+    assert _scaled_seconds(0.01, 2 * _MIB) == pytest.approx(60.01)
+    assert _scaled_seconds(2.0, 100) == pytest.approx(2.0, abs=0.01)  # tiny INIT ≈ base
+
+
+def test_scaled_seconds_is_capped() -> None:
+    # The 64MiB frame cap would otherwise imply a ~32min budget — the cap bounds
+    # cancel latency and deploy drain instead.
+    assert _scaled_seconds(30.0, 64 * _MIB) == MAX_SCALED_SECONDS
+    assert _scaled_seconds(30.0, 1024 * _MIB) == MAX_SCALED_SECONDS
+
+
+def test_constants_sane() -> None:
+    # The cap must dominate the base + a generous real-world INIT, or scaling is dead.
+    assert MAX_SCALED_SECONDS > 30.0 + 5 * DEADLINE_SECONDS_PER_INIT_MIB


### PR DESCRIPTION
Closes #780 (Stage-1 substrate; the second half of the #778→#780 two-step). Five commits, three mechanisms — locked direction: needs-step sweep filter (incl. `status='pending'`), batch-window wake coalescing, deadline/rlimit scaling on INIT bytes. The deferred-frontier-marker red-team note is **#784's contract** (recorded there — this PR defers no admission); the true O(memo) fix (long-lived suspended host) stays deferred by design.

## 1. Per-wake budgets scale with INIT size (commit 1)

`base + 30s/MiB, capped at 600s` — a run can never `script_host_timeout` merely because it accumulated results. The constant is ~3 orders of magnitude above measured parse+replay cost (headroom is for author glue, which is what grows with the memo); the **cap** exists because the 64MiB frame limit would otherwise imply a ~32min budget, and one wake holds the worker that long (run cancel is consumed only at the next step; deploys drain in-flight steps). CPU rlimit is **derived** (`int(deadline)+1`) so the wall deadline always wins for single-threaded children — a clean timeout, never an opaque rlimit SIGKILL. The rescue test's base (0.01s) is below interpreter spawn time, so an unscaled host deterministically fails it (mutation-verified); the CPU derivation is pinned end-to-end by reading the child's env.

## 2. Needs-step sweep filter + `child_done` marker + step lease (commit 2)

The sweep no longer blanket-re-drives every active run each 30s tick (each such wake = full memo reship + replay). Three clauses with an explicit recall contract (fail direction: wake too much):

- **`pending`/`running`** — `running` becomes the step's **lease**, flipped on EVERY wake before the first journal write. The plan red-team found (critical) that without this, a crash after the harvest commits its last `call_result` but before the park leaves a `suspended` row no clause ever wakes: a permanent zombie. The lease covers every mid-step crash — including the deliberate `script_host_spawn_failed` re-raise — by construction.
- **Unharvested signal** — child completions previously left no SQL-visible trace. Both response writers (`respond_to_request` AND the quiescence guard's `no_return` backstop — the second writer the "single chokepoint" assumption missed) now go through one fused conn-level seam, `write_child_response`, which commits the response + a `child_done` `wf_run_signals` row **atomically** (the kind has sat unused in the schema CHECK since 0064 — no migration). Fault-injection test pins the atomicity.
- **Stale inflight call** — agents past `workflow_agent_deadline_seconds` (this clause now DRIVES the H3 force-timeout backstop) and tools past a 180s re-dispatch horizon. Gates map to NULL: never stale.

## 3. Quiet-wake early-exit + terminal guard (commit 5, from /code-review)

The review's strongest find: **lease/sweep resonance** — a replay outliving the 30s tick queues the next tick's wake against the `doing` job, which replays into the next tick, indefinitely, for exactly the heavy runs #780 targets. Fix at the root: a run that entered `suspended` whose harvest resolved nothing **skips the replay entirely** (sound by determinism — same memo ⇒ same suspension ⇒ same park). This also makes slow-tool sweep wakes O(1). And `set_run_status` now refuses to overwrite a terminal status, so a reaped-then-resumed stale worker's lease flip/park can't resurrect a completed run.

## 4. Batch-window coalescing, shipped DARK (commit 3)

`defer_run_wake(batch=True)` at the three child-completion/tool-result sources schedules the wake `workflow_wake_batch_seconds` out; the scheduled job holds the queueing_lock so a burst collapses into one re-drive. **Default 0.0 = off** (today's behavior exactly, test-pinned). Known semantics when lit (documented): a pending batched wake absorbs otherwise-immediate defers for the window's remainder; effective pickup floor is the worker poll interval (~5s idle).

## Accepted residuals (sign-off requested)

- **#904 (filed)**: archiving/deleting an *unanswered* child writes no signal → its caller recalls only at the agent deadline (≤1h default) vs ≤30s pre-filter. Fix direction: archive/delete fail open requests through the fused seam — own PR (several tests pin today's lazy `child_gone`).
- **Trickling http_request is wall-clock unbounded** (per-read timeout): no finite staleness horizon dominates it; a cross-worker wake can re-dispatch a still-running non-idempotent call. Pre-existing at-least-once caveat, now honestly documented; closing needs a total-time bound or idempotency keys.
- **Filter cost grows with journal size** (measured: ~0.4–1.9s/tick at 50 parked runs × 500–2000 resolved calls; sub-ms at today's sizes): fixable via a denormalized `stale_check_at` on `wf_runs` and harvest-time signal deletion — both the denormalization pattern this codebase resists, both subsumed by the long-lived-host rework. Not built without sign-off.
- Status now flaps `suspended→running→suspended` per step (honest: `running` = a step is executing).

## Acceptance

The 200-call proxy drives `parallel` over 200 gates through the real step path: parked 200-wide fan-out is **quiet** under the filter, flips **hot** exactly while resumes sit unharvested, completes with the ordered result list (routing-discriminating), and leaves the sweep for good at terminal. Process: plan red-teamed pre-code (4 lenses; caught the zombie + the vacuous tests), `/simplify` (4 angles; fused seam, CPU derivation, horizon sizing), `/code-review` (5 angles + verify + sweep; resonance, resurrect, 4 mutation-coverage gaps — all folded). Full unit (2019) + integration (358) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
