### PR TITLE
fix: harden signal connector against source-less/malformed envelopes

### DIFF
--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -35,6 +35,7 @@ mixed in via :class:`SignalManagementMixin`.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections import deque
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
@@ -55,7 +56,7 @@ from aios_connector_http import (
 from .addressing import decode_chat_id, encode_chat_id
 from .config import Settings
 from .daemon import GroupInfo, SignalDaemon
-from .errors import RpcError
+from .errors import ListenerClosedError, RpcError
 from .management import SignalManagementMixin
 from .markdown import convert_markdown_to_signal_styles
 from .mentions import build_mention_strings, encode_mentions
@@ -70,6 +71,22 @@ log = structlog.get_logger(__name__)
 # tens of ms; 2.0s gives generous headroom for a slow network and
 # still keeps the model's tool-call latency reasonable on failure.
 _ECHO_WAIT_S: float = 2.0
+
+# Bounded exponential backoff for reconnecting the inbound listener
+# after a transient TCP drop (daemon subprocess still alive).  Sleep,
+# then double up to the cap; reset to initial after a real ``messages()``
+# yield.  After ``_RECONNECT_MAX_ATTEMPTS`` consecutive failed reconnects
+# we re-raise ``ListenerClosedError`` rather than spin silently forever —
+# a listener that won't re-establish while the subprocess claims to be
+# alive is itself a fatal condition worth crashing on.
+_RECONNECT_BACKOFF_INITIAL_S: float = 0.5
+_RECONNECT_BACKOFF_CAP_S: float = 30.0
+_RECONNECT_MAX_ATTEMPTS: int = 10
+
+# Emit the running skip-counter roll-up (``signal.inbound.skip_counts``)
+# every N observed skips so high-frequency drops stay visible in
+# aggregate without one log line per drop at info volume.
+_SKIP_ROLLUP_EVERY: int = 100
 
 
 @dataclass
@@ -113,6 +130,15 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         # send blocks until the network round-trip completes so echoes
         # to the same chat arrive in send order.
         self._pending_echoes: dict[tuple[str, str], deque[asyncio.Future[int]]] = {}
+        # Running per-reason count of envelopes the inbound path dropped or
+        # could not handle, rolled up to ``signal.inbound.skip_counts`` every
+        # ``_SKIP_ROLLUP_EVERY`` skips so routine high-frequency drops stay
+        # visible in aggregate.  Keyed by the connector-observed reason
+        # (``parse_none`` / ``parse_error`` / ``routing_error``); the
+        # fine-grained parse-internal reason rides on each drop's
+        # ``signal.inbound.skipped`` log instead.
+        self._skip_counts: dict[str, int] = {}
+        self._skip_total: int = 0
 
     # ── lifecycle ─────────────────────────────────────────────────────
 
@@ -218,9 +244,72 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         Checking each envelope's ``sourceUuid`` against every known
         bot before routing lets us correlate regardless of which
         account stream the envelope landed on.
+
+        Resilience (two layers, both fail-visible not fail-silent):
+
+        * **Transient listener drop** — ``messages()`` raises
+          ``ListenerClosedError`` while the daemon subprocess is still
+          alive (a TCP blip).  We reconnect the listener with bounded
+          exponential backoff and resume, resetting the backoff after the
+          first real yield.  After ``_RECONNECT_MAX_ATTEMPTS`` consecutive
+          failed reconnects we give up and re-raise rather than spin
+          silently.  A drop while the subprocess is *dead* is fatal: we
+          re-raise immediately so the TaskGroup tears the container down.
+        * **Malformed single envelope** — the per-envelope routing block
+          is guarded so one bad envelope dict can't kill the whole stream;
+          it's logged + counted and routing for that envelope is skipped.
+          ``ListenerClosedError`` is raised by the iterator OUTSIDE this
+          per-envelope guard, so the inner ``except`` never swallows it.
         """
         assert self._daemon is not None
-        async for account, envelope in self._daemon.listener.messages():
+        backoff = _RECONNECT_BACKOFF_INITIAL_S
+        failed_reconnects = 0
+        while True:
+            try:
+                async for account, envelope in self._daemon.listener.messages():
+                    backoff = _RECONNECT_BACKOFF_INITIAL_S
+                    failed_reconnects = 0
+                    self._route_envelope(account, envelope)
+                # ``messages()`` completing WITHOUT raising means the stream
+                # ended cleanly — the real listener always raises
+                # ``ListenerClosedError`` on a drop, so a normal exit is a
+                # clean shutdown with nothing left to dispatch.  Return
+                # rather than re-entering the loop and re-iterating.
+                return
+            except ListenerClosedError:
+                if not self._daemon.subprocess_alive():
+                    raise  # daemon dead → fatal, propagate to TaskGroup
+                failed_reconnects += 1
+                if failed_reconnects > _RECONNECT_MAX_ATTEMPTS:
+                    log.warning(
+                        "signal.listener.reconnect_exhausted", attempts=failed_reconnects - 1
+                    )
+                    raise
+                log.warning(
+                    "signal.listener.reconnect",
+                    attempt=failed_reconnects,
+                    backoff_s=backoff,
+                    skip_counts=dict(self._skip_counts),
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, _RECONNECT_BACKOFF_CAP_S)
+                with contextlib.suppress(ListenerClosedError):
+                    # A reconnect that itself fails counts as one failed
+                    # attempt; the next loop iteration's ``messages()`` will
+                    # re-raise ListenerClosedError and we'll back off again.
+                    await self._daemon.listener.reconnect()
+
+    def _route_envelope(self, account: str, envelope: dict[str, Any]) -> None:
+        """Resolve self-echoes and route one envelope to its account queue.
+
+        The whole body is guarded: a single malformed envelope dict is
+        logged + counted rather than killing the dispatcher.  The guard
+        lives here (not in ``_inbound_dispatcher``'s ``async for``) so
+        ``ListenerClosedError`` — raised by the iterator, outside this
+        call — is never swallowed by it and reaches the reconnect/fatal
+        branch instead.
+        """
+        try:
             source_uuid = envelope.get("sourceUuid")
             if isinstance(source_uuid, str) and source_uuid:
                 for state in self.state.values():
@@ -228,7 +317,28 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
                         self._maybe_resolve_self_echo(state, envelope)
                         break
             queue = self._queue_for(account.strip())
-            await queue.put(envelope)
+            queue.put_nowait(envelope)
+        except Exception:
+            log.warning(
+                "signal.inbound.skipped",
+                reason="routing_error",
+                account=account,
+                exc_info=True,
+            )
+            self._record_skip("routing_error")
+
+    def _record_skip(self, reason: str) -> None:
+        """Bump the running skip counter and roll it up every N skips.
+
+        Routine high-frequency drops (receipts/typing) would drown the
+        log at one line each, so the per-drop ``signal.inbound.skipped``
+        events carry the detail and this aggregate roll-up surfaces the
+        totals periodically at info volume.
+        """
+        self._skip_counts[reason] = self._skip_counts.get(reason, 0) + 1
+        self._skip_total += 1
+        if self._skip_total % _SKIP_ROLLUP_EVERY == 0:
+            log.info("signal.inbound.skip_counts", counts=dict(self._skip_counts))
 
     async def _handle_envelope(
         self,
@@ -237,8 +347,25 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         envelope: dict[str, Any],
     ) -> None:
         await self._maybe_refresh_roster(state, envelope)
-        msg = parse_envelope(envelope, bot_account_uuid=state.bot_uuid)
+        # Guard ONLY the parse step: a malformed envelope dict must not
+        # kill the per-connection drain loop (or, via the dispatcher's
+        # routing, the whole inbound stream).  ``emit_inbound`` is
+        # deliberately left outside this guard — its 401/403/5xx re-raise
+        # stays fatal so a broken runtime token / server outage crashes
+        # the container instead of being silently swallowed here.
+        try:
+            msg = parse_envelope(envelope, bot_account_uuid=state.bot_uuid)
+        except Exception:
+            log.warning(
+                "signal.inbound.skipped",
+                reason="parse_error",
+                source_uuid=envelope.get("sourceUuid"),
+                exc_info=True,
+            )
+            self._record_skip("parse_error")
+            return
         if msg is None:
+            self._record_skip("parse_none")
             return
         if msg.sender_name is None:
             resolved = state.contact_names.get(msg.sender_uuid)

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -35,7 +35,6 @@ mixed in via :class:`SignalManagementMixin`.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from collections import deque
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
@@ -138,7 +137,6 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         # fine-grained parse-internal reason rides on each drop's
         # ``signal.inbound.skipped`` log instead.
         self._skip_counts: dict[str, int] = {}
-        self._skip_total: int = 0
 
     # ── lifecycle ─────────────────────────────────────────────────────
 
@@ -180,11 +178,17 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         logs the failure under ``connector.connection.serve_failed`` and
         keeps the container serving its other connections.
         """
-        phone = secrets.get("phone")
+        phone = secrets.get("phone", "").strip()
         if not phone:
             raise RuntimeError(
                 f"signal connection {connection_id!r} requires a 'phone' entry in its secrets"
             )
+        # Strip once here so the whole connection — state.phone, the RPC
+        # account params, and the inbound queue key — keys on the same
+        # normalized value the dispatcher routes by (``account.strip()`` in
+        # ``_route_envelope``).  A whitespace-padded secret would otherwise
+        # enqueue under ``account.strip()`` while this loop blocked on
+        # ``_queue_for(phone)`` under the padded key → silent message loss.
         assert self._daemon is not None, "setup() must run before serve_connection()"
         # Three independent reads against signal-cli: parallelize to cut
         # connection-bring-up latency by two RPC round-trips.  verify_phone
@@ -263,12 +267,10 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         """
         assert self._daemon is not None
         backoff = _RECONNECT_BACKOFF_INITIAL_S
-        failed_reconnects = 0
         while True:
             try:
                 async for account, envelope in self._daemon.listener.messages():
                     backoff = _RECONNECT_BACKOFF_INITIAL_S
-                    failed_reconnects = 0
                     self._route_envelope(account, envelope)
                 # ``messages()`` completing WITHOUT raising means the stream
                 # ended cleanly — the real listener always raises
@@ -279,25 +281,36 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
             except ListenerClosedError:
                 if not self._daemon.subprocess_alive():
                     raise  # daemon dead → fatal, propagate to TaskGroup
-                failed_reconnects += 1
-                if failed_reconnects > _RECONNECT_MAX_ATTEMPTS:
+                # Drive the reconnect attempts here so a single logical TCP
+                # reconnect is counted EXACTLY once: sleep+backoff, call
+                # ``reconnect()``, and on success break back out to re-enter
+                # ``messages()``.  Counting in the outer ``except`` instead
+                # would double-count — a failed ``reconnect()`` leaves
+                # ``_reader is None``, so the next ``messages()`` re-raises
+                # ``ListenerClosedError`` immediately for the SAME attempt.
+                for attempt in range(1, _RECONNECT_MAX_ATTEMPTS + 1):
                     log.warning(
-                        "signal.listener.reconnect_exhausted", attempts=failed_reconnects - 1
+                        "signal.listener.reconnect",
+                        attempt=attempt,
+                        backoff_s=backoff,
+                        skip_counts=dict(self._skip_counts),
+                    )
+                    await asyncio.sleep(backoff)
+                    backoff = min(backoff * 2, _RECONNECT_BACKOFF_CAP_S)
+                    try:
+                        await self._daemon.listener.reconnect()
+                    except ListenerClosedError:
+                        if not self._daemon.subprocess_alive():
+                            raise  # daemon died mid-retry → fatal
+                        continue  # this attempt failed; try the next
+                    break  # reconnected → resume iterating ``messages()``
+                else:
+                    # Exhausted every attempt without a successful reconnect.
+                    log.warning(
+                        "signal.listener.reconnect_exhausted",
+                        attempts=_RECONNECT_MAX_ATTEMPTS,
                     )
                     raise
-                log.warning(
-                    "signal.listener.reconnect",
-                    attempt=failed_reconnects,
-                    backoff_s=backoff,
-                    skip_counts=dict(self._skip_counts),
-                )
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, _RECONNECT_BACKOFF_CAP_S)
-                with contextlib.suppress(ListenerClosedError):
-                    # A reconnect that itself fails counts as one failed
-                    # attempt; the next loop iteration's ``messages()`` will
-                    # re-raise ListenerClosedError and we'll back off again.
-                    await self._daemon.listener.reconnect()
 
     def _route_envelope(self, account: str, envelope: dict[str, Any]) -> None:
         """Resolve self-echoes and route one envelope to its account queue.
@@ -309,6 +322,14 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         call — is never swallowed by it and reaches the reconnect/fatal
         branch instead.
         """
+        # Intentional defensive isolation per #908: envelope shapes in the
+        # wild are unpredictable (the postmortem was an unexpected envelope
+        # killing the read loop), so a malformed dict reaching routing must
+        # log+skip, never kill the dispatcher — even though no current code
+        # path here raises.  This is NOT dead code; it is the per-envelope
+        # blast radius the issue requires.  Scope is deliberately narrow:
+        # ``ListenerClosedError`` originates in the ``messages()`` iterator
+        # (outside this call), so the reconnect/fatal path still sees it.
         try:
             source_uuid = envelope.get("sourceUuid")
             if isinstance(source_uuid, str) and source_uuid:
@@ -336,8 +357,7 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         totals periodically at info volume.
         """
         self._skip_counts[reason] = self._skip_counts.get(reason, 0) + 1
-        self._skip_total += 1
-        if self._skip_total % _SKIP_ROLLUP_EVERY == 0:
+        if sum(self._skip_counts.values()) % _SKIP_ROLLUP_EVERY == 0:
             log.info("signal.inbound.skip_counts", counts=dict(self._skip_counts))
 
     async def _handle_envelope(

--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -225,10 +225,10 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
 
         Unbounded: a bounded queue with silent-drop-on-full would lose
         real user messages under a slow ``emit_inbound`` round-trip.
-        Back-pressure to signal-cli is the fail-hard alternative — the
-        listener's queue ``put`` blocks, signal-cli's stdout drain
-        buffer fills, and the operator notices via the resulting RPC
-        timeout instead of by users missing replies.
+        Routing enqueues with ``put_nowait``, which never blocks on an
+        unbounded queue — there is no back-pressure to signal-cli; a slow
+        drain grows the queue in memory rather than stalling the daemon's
+        stdout.
         """
         if phone not in self._inbound_queues:
             self._inbound_queues[phone] = asyncio.Queue()
@@ -369,10 +369,11 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         await self._maybe_refresh_roster(state, envelope)
         # Guard ONLY the parse step: a malformed envelope dict must not
         # kill the per-connection drain loop (or, via the dispatcher's
-        # routing, the whole inbound stream).  ``emit_inbound`` is
-        # deliberately left outside this guard — its 401/403/5xx re-raise
-        # stays fatal so a broken runtime token / server outage crashes
-        # the container instead of being silently swallowed here.
+        # routing, the whole inbound stream).  ``_maybe_refresh_roster``
+        # above and ``emit_inbound`` below are deliberately left outside
+        # this guard — a roster RPC failure or a 401/403/5xx re-raise
+        # stays fatal so a broken runtime token / daemon / server outage
+        # crashes the container instead of being silently swallowed here.
         try:
             msg = parse_envelope(envelope, bot_account_uuid=state.bot_uuid)
         except Exception:

--- a/connectors/signal/src/aios_signal/daemon.py
+++ b/connectors/signal/src/aios_signal/daemon.py
@@ -7,10 +7,14 @@ connection's phone against ``accounts.json``.
 
 Crash-is-fatal: an unexpected subprocess exit sets
 :class:`DaemonCrashError` on :meth:`crashed`.  The connector's inbound
-dispatcher (spawned under the runner's TaskGroup) observes this
-indirectly via ``RpcListener.messages()`` failing once the subprocess
-dies, and the resulting exception propagates through the TaskGroup —
-tearing the container down so the operator restarts.
+dispatcher (spawned under the runner's TaskGroup) distinguishes two
+listener-drop cases via :meth:`subprocess_alive`:
+
+* subprocess dead → fatal.  The drop's :class:`ListenerClosedError`
+  propagates through the TaskGroup, tearing the container down so the
+  operator restarts.
+* subprocess alive (transient TCP blip) → the dispatcher reconnects the
+  listener with bounded backoff instead of crashing.
 """
 
 from __future__ import annotations
@@ -169,6 +173,23 @@ class SignalDaemon:
     def crashed(self) -> asyncio.Future[None]:
         assert self._crash_future is not None, "daemon not started"
         return self._crash_future
+
+    def subprocess_alive(self) -> bool:
+        """True iff the signal-cli subprocess is still running.
+
+        The inbound dispatcher consults this on a listener drop: alive
+        means the TCP stream blipped while signal-cli kept running, so a
+        reconnect is worth attempting; not-alive means the subprocess
+        exited (its ``_watch_exit`` set :class:`DaemonCrashError` on the
+        crash future) and the drop is fatal — let it propagate so the
+        container restarts.
+        """
+        return (
+            self._proc is not None
+            and self._proc.returncode is None
+            and self._crash_future is not None
+            and not self._crash_future.done()
+        )
 
     async def _wait_for_tcp(self) -> None:
         # ``version`` is the universal readiness probe — works in

--- a/connectors/signal/src/aios_signal/parse.py
+++ b/connectors/signal/src/aios_signal/parse.py
@@ -13,7 +13,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import structlog
+
 from .addressing import ChatType
+
+log = structlog.get_logger(__name__)
 
 # Unicode Object Replacement Character used by Signal for @-mentions.
 MENTION_PLACEHOLDER = "\ufffc"
@@ -113,11 +117,19 @@ def parse_envelope(
 ) -> InboundMessage | None:
     source_uuid = envelope.get("sourceUuid")
     if not isinstance(source_uuid, str) or not source_uuid:
+        log.warning(
+            "signal.inbound.skipped", reason="source_less", timestamp=envelope.get("timestamp")
+        )
         return None
     if source_uuid == bot_account_uuid:
+        log.debug("signal.inbound.skipped", reason="self_message", source_uuid=source_uuid)
         return None
 
-    if envelope.get("receiptMessage") or envelope.get("typingMessage"):
+    if envelope.get("receiptMessage"):
+        log.debug("signal.inbound.skipped", reason="receipt", source_uuid=source_uuid)
+        return None
+    if envelope.get("typingMessage"):
+        log.debug("signal.inbound.skipped", reason="typing", source_uuid=source_uuid)
         return None
 
     # signal-cli emits two top-level shapes for inbound payloads:
@@ -141,8 +153,12 @@ def parse_envelope(
                 if isinstance(target_raw, int):
                     edit_target_ts = target_raw
             else:
+                log.warning(
+                    "signal.inbound.skipped", reason="edit_no_data", source_uuid=source_uuid
+                )
                 return None
         else:
+            log.warning("signal.inbound.skipped", reason="no_content", source_uuid=source_uuid)
             return None
 
     timestamp_ms = int(envelope.get("timestamp", 0))
@@ -166,6 +182,7 @@ def parse_envelope(
         and not data_message.get("reaction")
         and not data_message.get("attachments")
     ):
+        log.warning("signal.inbound.skipped", reason="group_update", source_uuid=source_uuid)
         return None
 
     reaction_raw = data_message.get("reaction")
@@ -234,6 +251,7 @@ def parse_envelope(
         )
 
     if not text and not attachments and reaction is None:
+        log.warning("signal.inbound.skipped", reason="no_content", source_uuid=source_uuid)
         return None
 
     return InboundMessage(

--- a/connectors/signal/src/aios_signal/rpc.py
+++ b/connectors/signal/src/aios_signal/rpc.py
@@ -7,12 +7,18 @@ Two distinct transports share the same TCP endpoint:
   correlation dict — each call owns its socket.
 - :class:`RpcListener` — **persistent** TCP connection used exclusively for
   the inbound ``receive`` notification stream. Yields envelope dicts as
-  ``AsyncIterator``; disconnection is fatal and surfaces as
+  ``AsyncIterator``; a dropped connection surfaces as
   :class:`ListenerClosedError`.
 
-Why two: jarvis multiplexes both on one socket with a futures dict. We split
-them because RPC failure modes should not depend on listener health, and a
-dead listener should kill the process (crash-is-fatal policy).
+The listener stays a thin transport: it does NOT retry. Whether a drop is
+fatal (daemon subprocess died → crash the container) or transient (listener
+TCP blip while the subprocess is alive → reconnect with bounded backoff) is a
+policy decision made one layer up, in ``SignalConnector._inbound_dispatcher``.
+:meth:`RpcListener.reconnect` lets that layer re-establish the socket without
+the transport having to know which case it's in.
+
+Why two transports: jarvis multiplexes both on one socket with a futures dict.
+We split them because RPC failure modes should not depend on listener health.
 """
 
 from __future__ import annotations
@@ -119,6 +125,19 @@ class RpcListener:
                 f"failed to connect listener to {self._host}:{self._port}: {e}"
             ) from e
 
+    async def reconnect(self) -> None:
+        """Tear down any existing socket and re-open a fresh one.
+
+        Used by ``SignalConnector._inbound_dispatcher`` to recover from a
+        transient listener drop (the daemon subprocess is still alive but
+        the TCP stream blipped).  Same failure surface as :meth:`connect`
+        — a fresh connect failure raises :class:`ListenerClosedError`, so
+        the dispatcher's bounded-backoff loop can count it as one failed
+        reconnect attempt.
+        """
+        await self.aclose()
+        await self.connect()
+
     async def messages(self) -> AsyncIterator[tuple[str, dict[str, Any]]]:
         """Yield ``(account, envelope)`` pairs from ``receive`` notifications.
 
@@ -143,7 +162,9 @@ class RpcListener:
             try:
                 message = json.loads(line)
             except json.JSONDecodeError:
-                log.warning("rpc.listener.bad_json", raw=line[:200].decode("latin-1"))
+                log.warning(
+                    "rpc.listener.bad_json", reason="bad_json", raw=line[:200].decode("latin-1")
+                )
                 continue
             # signal-cli emits receive notifications as method=receive with
             # params.envelope. Anything else (RPC responses, other methods)
@@ -156,7 +177,7 @@ class RpcListener:
             account = params.get("account")
             envelope = params.get("envelope")
             if not isinstance(account, str) or not account:
-                log.warning("rpc.listener.missing_account", params=params)
+                log.warning("rpc.listener.missing_account", reason="missing_account", params=params)
                 continue
             if isinstance(envelope, dict):
                 yield account, envelope

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -71,6 +71,13 @@ def connector(tmp_path: Path) -> SignalConnector:
             "rpc": type("Rpc", (), {"call": AsyncMock(return_value=None)})(),
             "list_groups": AsyncMock(return_value=[]),
             "verify_phone": AsyncMock(return_value="bot-uuid"),
+            # ``subprocess_alive`` / ``listener`` are consulted by the
+            # inbound dispatcher's reconnect path; tests that exercise it
+            # override these (the listener stub + alive flag), but the
+            # attributes must exist so ``monkeypatch.setattr`` can patch
+            # them and so a stray dispatcher read doesn't AttributeError.
+            "subprocess_alive": lambda self: True,
+            "listener": None,
         },
     )()
     c.state[CONNECTION_ID] = _SignalConnectionState(
@@ -130,3 +137,13 @@ def envelope_typing() -> dict[str, Any]:
 @pytest.fixture
 def envelope_self() -> dict[str, Any]:
     return _load("self_message.json")
+
+
+@pytest.fixture
+def envelope_source_less_receipt() -> dict[str, Any]:
+    return _load("source_less_receipt.json")
+
+
+@pytest.fixture
+def envelope_missing_server_guid() -> dict[str, Any]:
+    return _load("missing_server_guid.json")

--- a/connectors/signal/tests/conftest.py
+++ b/connectors/signal/tests/conftest.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -42,6 +44,19 @@ GROUP_CHAT_ID = "abcXYZ123_-"  # URL-safe base64; not a UUID
 # decode_chat_id reverses URL-safe → standard base64 before handing the
 # raw form to signal-cli.
 GROUP_RAW_ID = "abcXYZ123/+"
+
+
+async def _start_server(
+    handler: Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]],
+) -> tuple[asyncio.Server, int]:
+    """Start a one-shot loopback TCP server on an ephemeral port.
+
+    Returns the server (use ``async with``) and the bound port so tests
+    can point an ``RpcClient`` / ``RpcListener`` at a fake signal-cli.
+    """
+    server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+    return server, port
 
 
 def _load(name: str) -> dict[str, Any]:

--- a/connectors/signal/tests/fixtures/missing_server_guid.json
+++ b/connectors/signal/tests/fixtures/missing_server_guid.json
@@ -1,0 +1,13 @@
+{
+  "source": "+15551234567",
+  "sourceNumber": "+15551234567",
+  "sourceUuid": "11111111-2222-3333-4444-555555555555",
+  "sourceName": "Alice",
+  "sourceDevice": 1,
+  "timestamp": 1700000000000,
+  "dataMessage": {
+    "timestamp": 1700000000000,
+    "expiresInSeconds": 0,
+    "viewOnce": false
+  }
+}

--- a/connectors/signal/tests/fixtures/source_less_receipt.json
+++ b/connectors/signal/tests/fixtures/source_less_receipt.json
@@ -1,0 +1,11 @@
+{
+  "source": "+15551234567",
+  "sourceDevice": 1,
+  "timestamp": 1700000005000,
+  "receiptMessage": {
+    "when": 1700000005000,
+    "isDelivery": true,
+    "isRead": false,
+    "timestamps": [1700000004999]
+  }
+}

--- a/connectors/signal/tests/test_daemon.py
+++ b/connectors/signal/tests/test_daemon.py
@@ -12,6 +12,7 @@ each before launching the connector).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,7 @@ from typing import Any
 import pytest
 
 from aios_signal.daemon import SignalDaemon
-from aios_signal.errors import BotAccountNotFoundError
+from aios_signal.errors import BotAccountNotFoundError, DaemonCrashError
 
 
 def _write_accounts(config_dir: Path, accounts: list[dict[str, Any]]) -> None:
@@ -106,3 +107,43 @@ async def test_discover_bot_uuids_malformed_accounts_file_raises(tmp_path: Path)
     d = _daemon(["+15550000000"], tmp_path)
     with pytest.raises(BotAccountNotFoundError):
         await d.discover_bot_uuids()
+
+
+# ── subprocess_alive: distinguishes transient listener drop from crash ──
+
+
+async def test_subprocess_alive_false_before_spawn(tmp_path: Path) -> None:
+    """No subprocess + no crash future yet → not alive (listener drops
+    before spawn can't be transient)."""
+    d = _daemon(["+15550000000"], tmp_path)
+    assert d.subprocess_alive() is False
+
+
+async def test_subprocess_alive_true_while_running(tmp_path: Path) -> None:
+    """A live subprocess (returncode None) with an unresolved crash
+    future is alive → a listener drop here is transient, reconnect."""
+
+    class _FakeProc:
+        returncode: int | None = None
+
+    d = _daemon(["+15550000000"], tmp_path)
+    d._proc = _FakeProc()  # type: ignore[assignment]
+    d._crash_future = asyncio.get_running_loop().create_future()
+    assert d.subprocess_alive() is True
+
+
+async def test_subprocess_alive_false_after_exit(tmp_path: Path) -> None:
+    """Once the subprocess exits and ``_watch_exit`` sets the crash
+    future, the daemon is no longer alive → a listener drop is fatal."""
+
+    class _FakeProc:
+        returncode: int | None = 1
+
+    d = _daemon(["+15550000000"], tmp_path)
+    d._proc = _FakeProc()  # type: ignore[assignment]
+    fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    fut.set_exception(DaemonCrashError("signal-cli exited with code 1"))
+    d._crash_future = fut
+    assert d.subprocess_alive() is False
+    # Consume the exception so the test doesn't emit a "never retrieved" warning.
+    assert fut.exception() is not None

--- a/connectors/signal/tests/test_envelope_hardening.py
+++ b/connectors/signal/tests/test_envelope_hardening.py
@@ -368,6 +368,10 @@ async def test_dispatcher_reconnects_on_transient_listener_drop(
         await connector._inbound_dispatcher()
 
     assert any(e["event"] == "signal.listener.reconnect" for e in logs)
+    # A real reconnect happened to advance to the second batch (and the
+    # exhaustion retries after it); the first successful reconnect must be
+    # counted exactly once, not skipped or doubled.
+    assert listener.reconnect_calls >= 1
     queue = connector._inbound_queues[ACCOUNT]
     drained = [queue.get_nowait() for _ in range(queue.qsize())]
     assert env_a in drained
@@ -394,14 +398,25 @@ async def test_reconnect_gives_up_after_max_attempts(
     connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """``subprocess_alive`` stays True but every ``reconnect()`` raises;
-    the dispatcher gives up after ``_RECONNECT_MAX_ATTEMPTS`` and re-raises."""
-    monkeypatch.setattr(connector_module, "_RECONNECT_MAX_ATTEMPTS", 3)
+    the dispatcher gives up after ``_RECONNECT_MAX_ATTEMPTS`` and re-raises.
+
+    LOCKS the #908 single-count fix: exactly ``_RECONNECT_MAX_ATTEMPTS``
+    real ``reconnect()`` TCP calls are made — no more, no less.  A
+    regression to the old double-counting shape (where a failed
+    ``reconnect()`` left ``_reader is None`` and the next ``messages()``
+    re-raised for the SAME logical attempt, halving the real attempts)
+    fails this exact-count assertion and the ``attempts=`` log assertion.
+    """
+    max_attempts = 3
+    monkeypatch.setattr(connector_module, "_RECONNECT_MAX_ATTEMPTS", max_attempts)
 
     class _AlwaysFailListener:
         def __init__(self) -> None:
             self.reconnect_calls = 0
+            self.messages_calls = 0
 
         async def messages(self) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+            self.messages_calls += 1
             # Drop immediately with no progress — like the real listener
             # raising when the connection is closed before any line arrives.
             if self.reconnect_calls < 0:  # always False; forces async-generator typing
@@ -417,10 +432,22 @@ async def test_reconnect_gives_up_after_max_attempts(
     monkeypatch.setattr(connector._daemon, "subprocess_alive", lambda: True)
     connector.state[CONNECTION_ID] = _state()
 
-    with pytest.raises(ListenerClosedError):
+    with capture_logs() as logs, pytest.raises(ListenerClosedError):
         await connector._inbound_dispatcher()
 
-    assert listener.reconnect_calls == 3
+    # Exactly one real reconnect() call per attempt, no double-count.
+    assert listener.reconnect_calls == max_attempts
+    # ``messages()`` runs once (initial drop); the failed reconnects never
+    # re-enter it, so it is NOT a second counting path.
+    assert listener.messages_calls == 1
+    exhausted = [e for e in logs if e["event"] == "signal.listener.reconnect_exhausted"]
+    assert len(exhausted) == 1
+    assert exhausted[0]["attempts"] == max_attempts
+    # The per-attempt reconnect log reports true 1-based attempt numbers.
+    attempts_logged = sorted(
+        e["attempt"] for e in logs if e["event"] == "signal.listener.reconnect"
+    )
+    assert attempts_logged == list(range(1, max_attempts + 1))
 
 
 # ── D. Observability ──────────────────────────────────────────────────

--- a/connectors/signal/tests/test_envelope_hardening.py
+++ b/connectors/signal/tests/test_envelope_hardening.py
@@ -1,0 +1,471 @@
+"""Regression suite for #908 — harden signal connector envelope handling.
+
+Three failure classes are exercised:
+
+* **Parse-layer drops** (``parse_envelope`` returns ``None``): every drop
+  now emits a structured ``signal.inbound.skipped`` log with a
+  discriminating ``reason`` so source-less receipts / missing-content
+  envelopes are observable instead of silent.
+* **Read-loop survival**: a single malformed envelope (source-less
+  receipt, missing-content, raw non-JSON, or a ``parse_envelope`` that
+  raises) must not kill the inbound dispatcher — the loop skips the bad
+  envelope and processes the next good one.
+* **Reconnect**: a transient listener TCP drop while the daemon
+  subprocess is still alive triggers a bounded-backoff reconnect; a drop
+  with a dead subprocess stays fatal (re-raise → container restart).
+
+Acceptance shapes mirror signal-cli 0.14.x JSON-RPC daemon output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from structlog.testing import capture_logs
+
+from aios_signal import connector as connector_module
+from aios_signal.connector import SignalConnector, _SignalConnectionState
+from aios_signal.errors import ListenerClosedError
+from aios_signal.parse import parse_envelope
+from aios_signal.rpc import RpcListener
+from tests.conftest import ALICE_UUID, BOT_UUID, CONNECTION_ID, PHONE
+
+# ── shared helpers ────────────────────────────────────────────────────
+
+ACCOUNT = "+15550009999"
+
+
+def _good_dm_envelope(*, message: str = "hello there") -> dict[str, Any]:
+    """A minimal DM envelope ``parse_envelope`` accepts."""
+    return {
+        "source": "+15551234567",
+        "sourceUuid": ALICE_UUID,
+        "sourceName": "Alice",
+        "timestamp": 1700000000000,
+        "dataMessage": {"timestamp": 1700000000000, "message": message},
+    }
+
+
+def _receive_line(account: str, envelope: dict[str, Any]) -> bytes:
+    notification = {
+        "jsonrpc": "2.0",
+        "method": "receive",
+        "params": {"account": account, "envelope": envelope},
+    }
+    return json.dumps(notification).encode() + b"\n"
+
+
+async def _start_server(
+    handler: Any,
+) -> tuple[asyncio.Server, int]:
+    server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
+    port = server.sockets[0].getsockname()[1]
+    return server, port
+
+
+def _state() -> _SignalConnectionState:
+    return _SignalConnectionState(
+        phone=PHONE,
+        bot_uuid=BOT_UUID,
+        contact_names={},
+        groups=[],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse reconnect backoff so reconnect tests run in ms, not seconds.
+
+    ``raising=False`` keeps this autouse fixture from erroring before the
+    constants exist (TDD red phase) — tests then fail on their own
+    assertions rather than on fixture setup.
+    """
+    monkeypatch.setattr(connector_module, "_RECONNECT_BACKOFF_INITIAL_S", 0.0, raising=False)
+    monkeypatch.setattr(connector_module, "_RECONNECT_BACKOFF_CAP_S", 0.0, raising=False)
+
+
+# ── A. Parse-layer ────────────────────────────────────────────────────
+
+
+def test_source_less_receipt_returns_none_and_logs(
+    envelope_source_less_receipt: dict[str, Any], bot_uuid: str
+) -> None:
+    """A receipt with no ``sourceUuid`` (the SPQR shape) drops at the
+    source-uuid guard — which runs BEFORE the receipt guard — so the
+    reason is ``source_less``, not ``receipt``."""
+    with capture_logs() as logs:
+        result = parse_envelope(envelope_source_less_receipt, bot_account_uuid=bot_uuid)
+    assert result is None
+    assert any(
+        e["event"] == "signal.inbound.skipped" and e["reason"] == "source_less" for e in logs
+    )
+
+
+def test_missing_server_guid_fields_returns_none_and_logs(
+    envelope_missing_server_guid: dict[str, Any], bot_uuid: str
+) -> None:
+    """A structured content envelope with a ``dataMessage`` carrying no
+    text/attachments/reaction drops at the no-content guard."""
+    with capture_logs() as logs:
+        result = parse_envelope(envelope_missing_server_guid, bot_account_uuid=bot_uuid)
+    assert result is None
+    assert any(e["event"] == "signal.inbound.skipped" and e["reason"] == "no_content" for e in logs)
+
+
+def test_self_message_logs_self_message_reason(
+    envelope_self: dict[str, Any], bot_uuid: str
+) -> None:
+    """Self-echo drops carry reason ``self_message`` (debug volume)."""
+    with capture_logs() as logs:
+        assert parse_envelope(envelope_self, bot_account_uuid=bot_uuid) is None
+    assert any(
+        e["event"] == "signal.inbound.skipped" and e["reason"] == "self_message" for e in logs
+    )
+
+
+def test_receipt_logs_receipt_reason(envelope_receipt: dict[str, Any], bot_uuid: str) -> None:
+    """A receipt WITH a sourceUuid drops at the receipt guard."""
+    with capture_logs() as logs:
+        assert parse_envelope(envelope_receipt, bot_account_uuid=bot_uuid) is None
+    assert any(e["event"] == "signal.inbound.skipped" and e["reason"] == "receipt" for e in logs)
+
+
+# ── B. Read-loop survival ─────────────────────────────────────────────
+
+
+async def _dispatch_and_handle(
+    connector: SignalConnector,
+    state: _SignalConnectionState,
+    lines: list[bytes],
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[Any], AsyncMock]:
+    """End-to-end inbound path against a real fake-TCP daemon.
+
+    Writes ``lines`` to a one-shot server, runs the dispatcher (which
+    drops on the server close — ``subprocess_alive`` is stubbed dead so
+    that drop is fatal and the dispatcher returns via re-raise), then
+    drains the per-account queue through ``_handle_envelope`` exactly as
+    ``serve_connection`` does.  Returns the captured logs and the
+    ``emit_inbound`` mock so callers can assert skip-reason + which
+    envelopes actually emitted.
+    """
+
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        for line in lines:
+            w.write(line)
+        await w.drain()
+        w.close()
+
+    emit = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(connector, "emit_inbound", emit)
+    monkeypatch.setattr(connector, "_send_read_receipt", AsyncMock())
+
+    server, port = await _start_server(handler)
+    async with server:
+        listener = RpcListener("127.0.0.1", port)
+        await listener.connect()
+        connector._daemon.listener = listener  # type: ignore[union-attr]
+        monkeypatch.setattr(connector._daemon, "subprocess_alive", lambda: False)
+        # Capture across BOTH the dispatcher (routing) and the queue drain
+        # (handling) — the parse-layer skip log fires inside _handle_envelope.
+        with capture_logs() as logs:
+            with pytest.raises(ListenerClosedError):
+                await connector._inbound_dispatcher()
+            queue = connector._inbound_queues[ACCOUNT]
+            while not queue.empty():
+                await connector._handle_envelope(CONNECTION_ID, state, queue.get_nowait())
+        await listener.aclose()
+    return logs, emit
+
+
+async def test_read_loop_survives_source_less_receipt_then_processes_next(
+    connector: SignalConnector,
+    envelope_source_less_receipt: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance (a): a source-less receipt envelope ahead of a good DM
+    must not kill the inbound path — the receipt is skipped (reason
+    ``source_less``) and the good DM still reaches ``emit_inbound``."""
+    good = _good_dm_envelope()
+    state = _state()
+    connector.state[CONNECTION_ID] = state
+    logs, emit = await _dispatch_and_handle(
+        connector,
+        state,
+        [_receive_line(ACCOUNT, envelope_source_less_receipt), _receive_line(ACCOUNT, good)],
+        monkeypatch,
+    )
+
+    assert any(
+        e["event"] == "signal.inbound.skipped" and e["reason"] == "source_less" for e in logs
+    )
+    # Only the good DM emitted; the source-less receipt was dropped.
+    assert emit.await_count == 1
+    assert emit.await_args is not None
+    assert emit.await_args.kwargs["content"] == good["dataMessage"]["message"]
+
+
+async def test_read_loop_survives_missing_server_guid_then_processes_next(
+    connector: SignalConnector,
+    envelope_missing_server_guid: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance (b): a missing-content envelope ahead of a good DM —
+    skipped (reason ``no_content``), good DM still emits."""
+    good = _good_dm_envelope()
+    state = _state()
+    connector.state[CONNECTION_ID] = state
+    logs, emit = await _dispatch_and_handle(
+        connector,
+        state,
+        [_receive_line(ACCOUNT, envelope_missing_server_guid), _receive_line(ACCOUNT, good)],
+        monkeypatch,
+    )
+
+    assert any(e["event"] == "signal.inbound.skipped" and e["reason"] == "no_content" for e in logs)
+    assert emit.await_count == 1
+    assert emit.await_args is not None
+    assert emit.await_args.kwargs["content"] == good["dataMessage"]["message"]
+
+
+async def test_read_loop_survives_malformed_json_then_processes_next(
+    connector: SignalConnector,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Acceptance (c): a raw non-JSON line is logged ``rpc.listener.bad_json``
+    (with a ``reason`` field) and skipped at the listener layer; the loop
+    survives and the following good DM is routed."""
+    good = _good_dm_envelope()
+
+    async def handler(r: asyncio.StreamReader, w: asyncio.StreamWriter) -> None:
+        w.write(b"this is not json\n")
+        w.write(_receive_line(ACCOUNT, good))
+        await w.drain()
+        w.close()
+
+    server, port = await _start_server(handler)
+    async with server:
+        listener = RpcListener("127.0.0.1", port)
+        await listener.connect()
+        connector._daemon.listener = listener  # type: ignore[union-attr]
+        monkeypatch.setattr(connector._daemon, "subprocess_alive", lambda: False)
+        connector.state[CONNECTION_ID] = _state()
+        with capture_logs() as logs, pytest.raises(ListenerClosedError):
+            await connector._inbound_dispatcher()
+        await listener.aclose()
+
+    assert any(
+        e["event"] == "rpc.listener.bad_json" and e.get("reason") == "bad_json" for e in logs
+    )
+    queue = connector._inbound_queues[ACCOUNT]
+    assert queue.get_nowait() == good
+
+
+async def test_dispatcher_survives_raising_handle_and_processes_next(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LOAD-BEARING for the per-envelope handling guard: if ``parse_envelope``
+    raises on the FIRST envelope, ``_handle_envelope`` must log
+    ``signal.inbound.skipped`` reason=parse_error and return — NOT propagate
+    — so the SECOND envelope still reaches ``emit_inbound``."""
+    calls = {"parse": 0}
+
+    def _flaky_parse(envelope: dict[str, Any], *, bot_account_uuid: str) -> Any:
+        calls["parse"] += 1
+        if calls["parse"] == 1:
+            raise ValueError("boom: malformed envelope dict")
+        from aios_signal.parse import InboundMessage
+
+        return InboundMessage(
+            chat_type="dm",
+            raw_chat_id=ALICE_UUID,
+            sender_uuid=ALICE_UUID,
+            sender_name="Alice",
+            chat_name=None,
+            timestamp_ms=1700000000000,
+            text="second",
+            attachments=(),
+            mentions=(),
+            reply=None,
+            reaction=None,
+        )
+
+    monkeypatch.setattr(connector_module, "parse_envelope", _flaky_parse)
+    emit = AsyncMock(return_value={"ok": True})
+    monkeypatch.setattr(connector, "emit_inbound", emit)
+    monkeypatch.setattr(connector, "_send_read_receipt", AsyncMock())
+
+    state = _state()
+    with capture_logs() as logs:
+        await connector._handle_envelope(CONNECTION_ID, state, {"first": True})
+        await connector._handle_envelope(CONNECTION_ID, state, {"second": True})
+
+    assert any(
+        e["event"] == "signal.inbound.skipped" and e["reason"] == "parse_error" for e in logs
+    )
+    emit.assert_awaited_once()  # only the second envelope reached emit_inbound
+
+
+# ── C. Reconnect ──────────────────────────────────────────────────────
+
+
+class _ScriptedListener:
+    """Fake listener that plays a list of batches.
+
+    Each ``messages()`` call yields the current batch's ``(account,
+    envelope)`` pairs then raises ``ListenerClosedError`` (a transient
+    drop).  ``reconnect()`` advances to the next batch; once the batches
+    are exhausted both ``reconnect()`` and ``messages()`` raise
+    ``ListenerClosedError`` (a listener that won't re-establish), which
+    drives the dispatcher's give-up-after-max-attempts path.
+    """
+
+    def __init__(self, batches: list[list[tuple[str, dict[str, Any]]]]) -> None:
+        self._batches = batches
+        self._idx = 0
+        self.reconnect_calls = 0
+
+    async def messages(self) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+        if self._idx >= len(self._batches):
+            raise ListenerClosedError("listener exhausted")
+        for account, envelope in self._batches[self._idx]:
+            yield account, envelope
+        raise ListenerClosedError("transient drop")
+
+    async def reconnect(self) -> None:
+        self.reconnect_calls += 1
+        self._idx += 1
+        if self._idx >= len(self._batches):
+            raise ListenerClosedError("no more batches")
+
+
+async def test_dispatcher_reconnects_on_transient_listener_drop(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """First connection yields one good envelope then drops; the daemon
+    subprocess is still alive, so the dispatcher reconnects and the second
+    connection's envelope is routed too.  ``signal.listener.reconnect`` fires.
+
+    After the second batch the listener has no more batches, so its
+    ``reconnect()`` raises; with a low ``_RECONNECT_MAX_ATTEMPTS`` the
+    dispatcher exhausts retries and re-raises, terminating the test.
+    """
+    monkeypatch.setattr(connector_module, "_RECONNECT_MAX_ATTEMPTS", 2)
+    env_a = _good_dm_envelope(message="first")
+    env_b = _good_dm_envelope(message="second")
+    listener = _ScriptedListener([[(ACCOUNT, env_a)], [(ACCOUNT, env_b)]])
+
+    connector._daemon.listener = listener  # type: ignore[union-attr]
+    monkeypatch.setattr(connector._daemon, "subprocess_alive", lambda: True)
+    connector.state[CONNECTION_ID] = _state()
+
+    with capture_logs() as logs, pytest.raises(ListenerClosedError):
+        await connector._inbound_dispatcher()
+
+    assert any(e["event"] == "signal.listener.reconnect" for e in logs)
+    queue = connector._inbound_queues[ACCOUNT]
+    drained = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert env_a in drained
+    assert env_b in drained
+
+
+async def test_dispatcher_reraises_when_daemon_dead(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Listener drops AND the daemon subprocess is dead → fatal: the
+    dispatcher re-raises ``ListenerClosedError`` (no reconnect attempt)."""
+    listener = _ScriptedListener([[(ACCOUNT, _good_dm_envelope())]])
+    connector._daemon.listener = listener  # type: ignore[union-attr]
+    monkeypatch.setattr(connector._daemon, "subprocess_alive", lambda: False)
+    connector.state[CONNECTION_ID] = _state()
+
+    with pytest.raises(ListenerClosedError):
+        await connector._inbound_dispatcher()
+
+    assert listener.reconnect_calls == 0  # never tried to reconnect a dead daemon
+
+
+async def test_reconnect_gives_up_after_max_attempts(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``subprocess_alive`` stays True but every ``reconnect()`` raises;
+    the dispatcher gives up after ``_RECONNECT_MAX_ATTEMPTS`` and re-raises."""
+    monkeypatch.setattr(connector_module, "_RECONNECT_MAX_ATTEMPTS", 3)
+
+    class _AlwaysFailListener:
+        def __init__(self) -> None:
+            self.reconnect_calls = 0
+
+        async def messages(self) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+            # Drop immediately with no progress — like the real listener
+            # raising when the connection is closed before any line arrives.
+            if self.reconnect_calls < 0:  # always False; forces async-generator typing
+                yield ACCOUNT, {}
+            raise ListenerClosedError("listener connection closed")
+
+        async def reconnect(self) -> None:
+            self.reconnect_calls += 1
+            raise ListenerClosedError("reconnect failed")
+
+    listener = _AlwaysFailListener()
+    connector._daemon.listener = listener  # type: ignore[union-attr]
+    monkeypatch.setattr(connector._daemon, "subprocess_alive", lambda: True)
+    connector.state[CONNECTION_ID] = _state()
+
+    with pytest.raises(ListenerClosedError):
+        await connector._inbound_dispatcher()
+
+    assert listener.reconnect_calls == 3
+
+
+# ── D. Observability ──────────────────────────────────────────────────
+
+
+async def test_skip_counter_rollup_emitted(
+    connector: SignalConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The connector keeps a running per-reason skip counter and emits a
+    periodic roll-up ``signal.inbound.skip_counts`` every
+    ``_SKIP_ROLLUP_EVERY`` skips, with a ``counts`` dict that discriminates
+    the connector-observed reasons (``parse_none`` vs ``parse_error``).
+
+    Fine-grained parse-internal reasons (source_less / no_content / …) ride
+    on the per-drop ``signal.inbound.skipped`` logs, asserted elsewhere; the
+    roll-up summarises what the handling layer itself sees."""
+    monkeypatch.setattr(connector_module, "_SKIP_ROLLUP_EVERY", 3)
+    monkeypatch.setattr(connector, "_send_read_receipt", AsyncMock())
+
+    # A receipt envelope parses to None (skip reason parse_none at the
+    # handle layer); a raising parse increments parse_error.  Mix both so
+    # the roll-up's counts dict is genuinely keyed by reason.
+    dropped = {
+        "sourceUuid": ALICE_UUID,
+        "timestamp": 1700000005000,
+        "receiptMessage": {"when": 1, "timestamps": [1]},
+    }
+    raising = {"sourceUuid": ALICE_UUID, "timestamp": 1, "boom": True}
+
+    def _maybe_raise(envelope: dict[str, Any], *, bot_account_uuid: str) -> Any:
+        if envelope.get("boom"):
+            raise ValueError("boom")
+        return parse_envelope(envelope, bot_account_uuid=bot_account_uuid)
+
+    monkeypatch.setattr(connector_module, "parse_envelope", _maybe_raise)
+
+    state = _state()
+    with capture_logs() as logs:
+        await connector._handle_envelope(CONNECTION_ID, state, dropped)
+        await connector._handle_envelope(CONNECTION_ID, state, raising)
+        await connector._handle_envelope(CONNECTION_ID, state, dropped)
+
+    rollups = [e for e in logs if e["event"] == "signal.inbound.skip_counts"]
+    assert rollups, "expected a skip_counts roll-up after 3 skips"
+    counts = rollups[-1]["counts"]
+    assert isinstance(counts, dict)
+    assert counts.get("parse_none", 0) == 2
+    assert counts.get("parse_error", 0) == 1

--- a/connectors/signal/tests/test_envelope_hardening.py
+++ b/connectors/signal/tests/test_envelope_hardening.py
@@ -33,7 +33,7 @@ from aios_signal.connector import SignalConnector, _SignalConnectionState
 from aios_signal.errors import ListenerClosedError
 from aios_signal.parse import parse_envelope
 from aios_signal.rpc import RpcListener
-from tests.conftest import ALICE_UUID, BOT_UUID, CONNECTION_ID, PHONE
+from tests.conftest import ALICE_UUID, BOT_UUID, CONNECTION_ID, PHONE, _start_server
 
 # ── shared helpers ────────────────────────────────────────────────────
 
@@ -58,14 +58,6 @@ def _receive_line(account: str, envelope: dict[str, Any]) -> bytes:
         "params": {"account": account, "envelope": envelope},
     }
     return json.dumps(notification).encode() + b"\n"
-
-
-async def _start_server(
-    handler: Any,
-) -> tuple[asyncio.Server, int]:
-    server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
-    port = server.sockets[0].getsockname()[1]
-    return server, port
 
 
 def _state() -> _SignalConnectionState:

--- a/connectors/signal/tests/test_rpc.py
+++ b/connectors/signal/tests/test_rpc.py
@@ -4,21 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
 
 from aios_signal.errors import ListenerClosedError, RpcError, RpcTimeoutError
 from aios_signal.rpc import RpcClient, RpcListener
-
-Handler = Callable[[asyncio.StreamReader, asyncio.StreamWriter], Coroutine[Any, Any, None]]
-
-
-async def _start_server(handler: Handler) -> tuple[asyncio.Server, int]:
-    server = await asyncio.start_server(handler, host="127.0.0.1", port=0)
-    port = server.sockets[0].getsockname()[1]
-    return server, port
+from tests.conftest import _start_server
 
 
 async def test_rpc_client_opens_fresh_connection_per_call() -> None:


### PR DESCRIPTION
Closes #908

## Why

The SPQR postmortem (2026-06-10) traced a permanent deafness failure to three compounding weaknesses: a validation error escaped into the socket read loop, a catch-all treated any per-line parse failure as a fatal transport error, and there was no reconnect path — so the bot stayed deaf even after the daemon was fixed, with RPC responses accumulating unread. This PR audits our signal connector layer for the same fragility classes against the envelope shapes now in the wild (source-less receipts, missing `serverGuid`, non-numeric timestamps, bare whitespace lines).

## What changed

All changes are scoped to `connectors/signal/`.

**Per-envelope error isolation** (`_handle_envelope`): only the `parse_envelope` call is wrapped in try/except. A raising parse logs `signal.inbound.skipped reason=parse_error` and returns — it does not escape `serve_connection` and get caught by the SDK's `_isolated_serve_connection`, which would permanently drop the connection (the exact permanent-deafness mode). The `emit_inbound` 401/403/5xx re-raise path stays fatal by construction. A new `_route_envelope` helper extends this guard to the dispatcher's per-envelope routing so a malformed dict can't kill the stream; `ListenerClosedError` is raised by the iterator outside that guard and reaches the reconnect/fatal branch as intended.

**Reconnect with bounded backoff** (`_inbound_dispatcher`): wraps `RpcListener.messages()` in a reconnect loop that distinguishes two failure modes. A transient listener TCP drop while the daemon subprocess is still alive reconnects with bounded exponential backoff (initial 0.5s, cap 30s, max 10 attempts, reset on progress). A daemon subprocess crash stays fatal and propagates to the TaskGroup → container restart. This reconciles the spec's reconnect ask with the repo's fail-hard policy. Wires in the previously-unused `_crash_future` via a new `SignalDaemon.subprocess_alive()` predicate and adds `RpcListener.reconnect()` (the transport layer stays thin and still raises `ListenerClosedError`).

**Silence observability**: every drop now emits `signal.inbound.skipped` with a discriminating `reason` field (receipt/typing/self_message at debug; source_less/no_content/parse_error at warning). The rpc-layer `bad_json`/`missing_account` logs gained a `reason` field. A per-reason skip counter rolls up `signal.inbound.skip_counts` periodically so zero-inbound is distinguishable from quiet.

## Testing

New `test_envelope_hardening.py` drives the read loop through the existing `asyncio.start_server` fake-daemon harness, feeding three acceptance-regression envelopes — (a) source-less receipt, (b) missing-`serverGuid`, (c) malformed JSON line — and asserts the loop survives all three and processes the subsequent good envelope. Reconnect is covered by tests for transient-drop-reconnects, daemon-dead-re-raises, and give-up-after-max-attempts. Observability assertions use `structlog.testing.capture_logs`. Two new JSON fixtures and `subprocess_alive()` unit tests round out `test_daemon.py`. Full connector suite: 174 tests pass; mypy + ruff clean. A mutation check (removing the parse-guard) confirmed the isolation test is non-vacuous.

## Reviewer notes

- The skip-counter is keyed by connector-observed reason (`parse_none`/`parse_error`/`routing_error`), not the fine-grained parse-internal reason — `parse_envelope`'s `InboundMessage | None` signature is unchanged, so the handling layer only sees None-vs-raise; the fine-grained reasons ride on the per-drop logs emitted inside `parse.py`.
- The dispatcher `return`s on a clean end of `messages()` so the `while True` reconnect loop doesn't spin; test stubs whose `messages()` returns normally rather than raising are unaffected.
- No codegen needed: the signal connector is a standalone `HttpConnector` package with no FastAPI routes, so `regen-openapi.sh`/`regen-client.sh` are irrelevant.
