### PR TITLE
feat(vaults): session env-var cred resolver + deterministic placeholder mint (#873)

### DIFF
--- a/migrations/versions/0082_session_vaults_spec_version_trigger.py
+++ b/migrations/versions/0082_session_vaults_spec_version_trigger.py
@@ -1,0 +1,51 @@
+"""Bump ``sessions.spec_version`` on ``session_vaults`` changes (#873).
+
+Migration 0077 deliberately excluded ``session_vaults`` from the
+spec-version bump triggers because vault bindings reached the agent only
+via the MCP pool — they didn't feed ``build_spec_from_session``. Since
+#873 that premise is false: ``environment_variable`` credentials resolve
+through a session's bound vaults into the provisioning plan, so a vault
+attach/detach changes what the spec builder produces. Per 0077's own
+rule ("only the tables that actually feed build_spec_from_session get a
+bump trigger" — and every table that does, must), ``session_vaults`` now
+joins ``session_memory_stores`` / ``session_github_repositories``.
+
+Without this, the Layer-1 write-path eviction is the only cover and it
+is a no-op in the API process — where ``PUT /sessions/:id`` (the only
+``session_vaults`` write path) actually runs. A live sandbox would keep
+a stale credential set until an unrelated resource change recycled it.
+
+Credential-LEVEL drift (rotation, create/archive within a still-bound
+vault) is not a ``session_vaults`` write and stays uncovered here —
+that's the recycle-on-rotation drift key (#877).
+
+Reuses 0077's ``bump_session_spec_version()`` trigger function.
+
+Revision ID: 0082
+Revises: 0081
+Create Date: 2026-06-10
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0082"
+down_revision: str = "0081"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TRIGGER session_vaults_bump_spec_version
+        AFTER INSERT OR UPDATE OR DELETE ON session_vaults
+        FOR EACH ROW
+        EXECUTE FUNCTION bump_session_spec_version()
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS session_vaults_bump_spec_version ON session_vaults")

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -4156,9 +4156,8 @@ class EnvVarCredentialRow(NamedTuple):
     """
 
     credential_id: str
-    vault_id: str
     secret_name: str
-    allowed_hosts: list[str]
+    allowed_hosts: tuple[str, ...]
     blob: EncryptedBlob
     updated_at: datetime
 
@@ -4183,7 +4182,7 @@ async def list_session_env_var_credentials(
     rows = await conn.fetch(
         """
         SELECT DISTINCT ON (vc.secret_name)
-               vc.id, vc.vault_id, vc.secret_name, vc.allowed_hosts,
+               vc.id, vc.secret_name, vc.allowed_hosts,
                vc.ciphertext, vc.nonce, vc.updated_at
           FROM session_vaults sv
           JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
@@ -4200,9 +4199,8 @@ async def list_session_env_var_credentials(
     return [
         EnvVarCredentialRow(
             credential_id=str(row["id"]),
-            vault_id=str(row["vault_id"]),
             secret_name=str(row["secret_name"]),
-            allowed_hosts=list(row["allowed_hosts"]),
+            allowed_hosts=tuple(row["allowed_hosts"]),
             blob=EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"])),
             updated_at=row["updated_at"],
         )

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -4145,6 +4145,71 @@ async def resolve_run_credential(
     )
 
 
+class EnvVarCredentialRow(NamedTuple):
+    """One ``environment_variable`` credential resolved for a session.
+
+    ``updated_at`` rides along for the recycle-on-rotation drift key
+    (#877); ``allowed_hosts`` entries are the stored canonical
+    ``host[/path-prefix]`` strings — consumers parse them with
+    :func:`aios.models.vaults.parse_allowed_host_entry`, the single
+    grammar authority.
+    """
+
+    credential_id: str
+    vault_id: str
+    secret_name: str
+    allowed_hosts: list[str]
+    blob: EncryptedBlob
+    updated_at: datetime
+
+
+async def list_session_env_var_credentials(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+) -> list[EnvVarCredentialRow]:
+    """All active ``environment_variable`` credentials across a session's
+    bound vaults — a *list*, unlike the single-``target_url`` lookup above.
+
+    Duplicate ``secret_name`` across two attached vaults resolves
+    first-vault-wins: ``DISTINCT ON (secret_name)`` keeps the lowest
+    ``session_vaults.rank`` row (within one vault duplicates are
+    impossible — the partial unique index on ``(vault_id, secret_name)``).
+    Rank uniqueness per session is an ``enumerate()`` artifact of
+    ``set_session_vaults``, the same invariant ``resolve_session_credential``
+    already leans on.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT DISTINCT ON (vc.secret_name)
+               vc.id, vc.vault_id, vc.secret_name, vc.allowed_hosts,
+               vc.ciphertext, vc.nonce, vc.updated_at
+          FROM session_vaults sv
+          JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
+         WHERE sv.session_id = $1
+           AND vc.auth_type = 'environment_variable'
+           AND vc.archived_at IS NULL
+           AND sv.account_id = $2
+           AND vc.account_id = $2
+         ORDER BY vc.secret_name, sv.rank
+        """,
+        session_id,
+        account_id,
+    )
+    return [
+        EnvVarCredentialRow(
+            credential_id=str(row["id"]),
+            vault_id=str(row["vault_id"]),
+            secret_name=str(row["secret_name"]),
+            allowed_hosts=list(row["allowed_hosts"]),
+            blob=EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"])),
+            updated_at=row["updated_at"],
+        )
+        for row in rows
+    ]
+
+
 # ─── skills ──────────────────────────────────────────────────────────────────
 
 

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -56,6 +56,7 @@ from aios.sandbox.github_clone import (
 from aios.sandbox.network import WORKER_NETWORK_ALIAS, is_running_in_container
 from aios.sandbox.setup import WORKSPACE_RUNTIME_ENV
 from aios.services import sessions as sessions_service
+from aios.services.vaults import ResolvedEnvVarCredential, resolve_session_env_var_credentials
 
 log = get_logger("aios.sandbox.spec")
 
@@ -114,6 +115,13 @@ class ProvisioningPlan:
     memory_echoes: list[MemoryStoreResourceEcho]
     github_echoes: list[GithubRepositoryResourceEcho]
     git_proxy: GitProxy | None
+    # Decrypted env-var credentials + minted placeholders (#873). Alive
+    # only for the provision call — the plan is dropped after
+    # ``_provision`` consumes it. Materialization (placeholder env
+    # injection) and the request-time placeholder→secret map are the
+    # follow-up slices (#874, #876). Defaulted so plan-shape-agnostic
+    # constructors stay valid.
+    env_var_credentials: tuple[ResolvedEnvVarCredential, ...] = ()
 
 
 def mount_snapshot_from_echoes(
@@ -223,6 +231,30 @@ async def _materialize_memory_mounts(
                 conn, store_id=echo.memory_store_id, account_id=account_id
             )
     return list(echoes)
+
+
+async def _materialize_env_var_credentials(
+    session_id: str,
+    *,
+    account_id: str,
+) -> tuple[ResolvedEnvVarCredential, ...]:
+    """Resolve + decrypt the session's env-var credentials and mint their
+    placeholders (#873).
+
+    Runs BEFORE :func:`_materialize_github_clones` in
+    :func:`build_spec_from_session` by design: this step holds no
+    host-side resources, so its deliberate fail-hard on a corrupt blob
+    (one bad credential aborts the provision) raises while there is
+    nothing to clean up — after the clones step a raise would have to
+    unwind a running GitProxy.
+    """
+    pool = runtime.require_pool()
+    crypto_box = runtime.require_crypto_box()
+    async with pool.acquire() as conn:
+        resolved = await resolve_session_env_var_credentials(
+            conn, crypto_box, session_id, account_id=account_id
+        )
+    return tuple(resolved)
 
 
 async def _materialize_github_clones(
@@ -380,6 +412,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id, account_id=account_id)
     memory_echoes = await _materialize_memory_mounts(session_id, account_id=account_id)
+    env_var_credentials = await _materialize_env_var_credentials(session_id, account_id=account_id)
     github_echoes, git_proxy = await _materialize_github_clones(session_id, account_id=account_id)
 
     tool_broker = runtime.require_tool_broker()
@@ -426,6 +459,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             tool_broker_secret=tool_broker_secret,
             tool_socket_host_path=tool_socket_host_path,
             spec_version=spec_version,
+            env_var_credentials=env_var_credentials,
         )
     except BaseException:
         # Both proxies hold worker-process state (ports, token maps,
@@ -462,6 +496,7 @@ def _assemble_plan(
     tool_socket_host_path: Path | None = None,
     disk_bytes: int | None = None,
     spec_version: int = 0,
+    env_var_credentials: tuple[ResolvedEnvVarCredential, ...] = (),
 ) -> ProvisioningPlan:
     """Pure assembly of the plan from already-materialized inputs.
 
@@ -618,4 +653,5 @@ def _assemble_plan(
         memory_echoes=memory_echoes,
         github_echoes=github_echoes,
         git_proxy=git_proxy,
+        env_var_credentials=env_var_credentials,
     )

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -119,9 +119,8 @@ class ProvisioningPlan:
     # only for the provision call — the plan is dropped after
     # ``_provision`` consumes it. Materialization (placeholder env
     # injection) and the request-time placeholder→secret map are the
-    # follow-up slices (#874, #876). Defaulted so plan-shape-agnostic
-    # constructors stay valid.
-    env_var_credentials: tuple[ResolvedEnvVarCredential, ...] = ()
+    # follow-up slices (#874, #876).
+    env_var_credentials: tuple[ResolvedEnvVarCredential, ...]
 
 
 def mount_snapshot_from_echoes(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -142,16 +142,17 @@ def _evict_sandbox_for_resource_change(session_id: str) -> None:
 
     Memory-store and github-repository bindings feed build_spec_from_session
     and MUST evict. Vault session-bindings feed it too since #873
-    (environment_variable credentials resolve into the provisioning plan),
-    so the Layer-1 eviction here covers them; header-style credentials
-    still reach the agent via the MCP pool, keyed on (url, vault_id).
-    In-place vault credential rotation (refresh_credential / ciphertext
-    overwrite) does NOT evict: the pool keys on (url, vault_id) and a
-    rotation overwrites the row contents, so the stable key already serves
-    the new secret — and a live sandbox keeps its already-materialized
-    env-var set until #877's drift handling lands. Layer 2's spec_version
-    triggers are deliberately NOT placed on vault/connection tables —
-    this Layer1/Layer2 asymmetry is intentional.
+    (environment_variable credentials resolve into the provisioning plan) —
+    but this Layer-1 eviction is a no-op for them in practice, because
+    update_session runs in the API process; their real cover is the
+    session_vaults spec_version bump trigger (migration 0082). Header-style
+    credentials still reach the agent via the MCP pool, keyed on
+    (url, vault_id). In-place vault credential rotation (refresh_credential
+    / ciphertext overwrite) does NOT evict: the pool keys on (url, vault_id)
+    and a rotation overwrites the row contents, so the stable key already
+    serves the new secret — and a live sandbox keeps its already-
+    materialized env-var set until #877's drift handling lands. Layer 2's
+    triggers stay off the connection tables — that asymmetry is intentional.
     """
     from aios.harness import runtime
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -141,16 +141,17 @@ def _evict_sandbox_for_resource_change(session_id: str) -> None:
     cleanly on the next step.
 
     Memory-store and github-repository bindings feed build_spec_from_session
-    and MUST evict. Vault session-bindings do NOT feed the sandbox spec (they
-    reach the agent via the MCP pool, keyed on (url, vault_id)); we evict
-    anyway as defense-in-depth so 'any session-resource mutation forces a
-    clean re-read' holds — harmless, one extra cold-start. In-place vault
-    credential rotation (refresh_credential / ciphertext overwrite) does NOT
-    evict: the pool keys on (url, vault_id) and a rotation overwrites the row
-    contents, so the stable key already serves the new secret. Layer 2's
-    spec_version triggers are deliberately NOT placed on vault/connection
-    tables (they don't change the spec) — this Layer1/Layer2 asymmetry is
-    intentional.
+    and MUST evict. Vault session-bindings feed it too since #873
+    (environment_variable credentials resolve into the provisioning plan),
+    so the Layer-1 eviction here covers them; header-style credentials
+    still reach the agent via the MCP pool, keyed on (url, vault_id).
+    In-place vault credential rotation (refresh_credential / ciphertext
+    overwrite) does NOT evict: the pool keys on (url, vault_id) and a
+    rotation overwrites the row contents, so the stable key already serves
+    the new secret — and a live sandbox keeps its already-materialized
+    env-var set until #877's drift handling lands. Layer 2's spec_version
+    triggers are deliberately NOT placed on vault/connection tables —
+    this Layer1/Layer2 asymmetry is intentional.
     """
     from aios.harness import runtime
 

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -13,19 +13,20 @@ mutations here (:func:`refresh_credential`, :func:`update_vault_credential`,
 :func:`create_vault_credential`, and credential archive/delete) do NOT
 evict any sandbox: the MCP pool keys on ``(url, vault_id)`` and a rotation
 overwrites the row contents under that stable key, so the existing key
-already serves the new secret. Vault tables are also deliberately excluded
-from Layer 2's ``spec_version`` triggers. Since #873,
-``environment_variable`` credentials DO feed the sandbox spec builder
-(:func:`resolve_session_env_var_credentials` below) — drift handling for
-live sandboxes (rotation, attach/archive) is deferred to #877.
+already serves the new secret. Since #873, ``environment_variable``
+credentials DO feed the sandbox spec builder
+(:func:`resolve_session_env_var_credentials` below): vault BINDING
+changes now bump ``spec_version`` (migration 0082) so a live sandbox
+recycles, while credential-LEVEL drift in a still-bound vault (rotation,
+create/archive) stays invisible to a live sandbox until #877's drift
+key.
 """
 
 from __future__ import annotations
 
-import dataclasses
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import Any, assert_never
+from typing import Any, assert_never, cast
 
 import asyncpg
 import httpx
@@ -361,18 +362,18 @@ def _extract_auth_payload(body: VaultCredentialCreate) -> dict[str, Any]:
         )
 
     payload: dict[str, Any] = {}
-    for field in _fields_for(body.auth_type):
-        val = getattr(body, field)
+    for field_name in _fields_for(body.auth_type):
+        val = getattr(body, field_name)
         if val is None:
             continue
-        if field == "token_endpoint_auth":
-            payload[field] = _serialize_token_endpoint_auth(val)
+        if field_name == "token_endpoint_auth":
+            payload[field_name] = _serialize_token_endpoint_auth(val)
         elif hasattr(val, "get_secret_value"):
-            payload[field] = val.get_secret_value()
+            payload[field_name] = val.get_secret_value()
         elif hasattr(val, "isoformat"):
-            payload[field] = val.isoformat()
+            payload[field_name] = val.isoformat()
         else:
-            payload[field] = val
+            payload[field_name] = val
     return payload
 
 
@@ -394,20 +395,20 @@ def _merge_auth_payload(
     """
     fields = _fields_for(auth_type)
     merged = dict(existing)
-    for field in fields:
-        if field not in body.model_fields_set:
+    for field_name in fields:
+        if field_name not in body.model_fields_set:
             continue
-        val = getattr(body, field)
+        val = getattr(body, field_name)
         if val is None:
-            merged.pop(field, None)
-        elif field == "token_endpoint_auth":
-            merged[field] = _serialize_token_endpoint_auth(val)
+            merged.pop(field_name, None)
+        elif field_name == "token_endpoint_auth":
+            merged[field_name] = _serialize_token_endpoint_auth(val)
         elif hasattr(val, "get_secret_value"):
-            merged[field] = val.get_secret_value()
+            merged[field_name] = val.get_secret_value()
         elif hasattr(val, "isoformat"):
-            merged[field] = val.isoformat()
+            merged[field_name] = val.isoformat()
         else:
-            merged[field] = val
+            merged[field_name] = val
     _validate_required_in_payload(merged, auth_type)
     return merged
 
@@ -586,16 +587,17 @@ class ResolvedEnvVarCredential:
     """A decrypted ``environment_variable`` credential plus its minted
     placeholder, as consumed by sandbox materialization.
 
-    ``secret_value`` is excluded from ``repr`` so a logged plan or a
-    pytest assertion diff never prints the plaintext. ``allowed_hosts``
-    holds the stored canonical entries; parse with
+    ``secret_value`` is excluded from ``repr`` so a logged plan never
+    prints the plaintext (an equality-assertion diff in pytest still
+    drills into it — don't assert equality across differing secrets).
+    ``allowed_hosts`` holds the stored canonical entries; parse with
     :func:`aios.models.vaults.parse_allowed_host_entry`.
+    ``updated_at`` feeds the recycle-on-rotation drift key (#877).
     """
 
     credential_id: str
-    vault_id: str
     secret_name: str
-    secret_value: str = dataclasses.field(repr=False)
+    secret_value: str = field(repr=False)
     allowed_hosts: tuple[str, ...]
     updated_at: datetime
     placeholder: str
@@ -623,16 +625,15 @@ async def resolve_session_env_var_credentials(
     partial credential set.
     """
     rows = await queries.list_session_env_var_credentials(conn, session_id, account_id=account_id)
-    if not rows:
-        return []
     subkey = crypto_box.derive_account_subkey(account_id)
     return [
         ResolvedEnvVarCredential(
             credential_id=row.credential_id,
-            vault_id=row.vault_id,
             secret_name=row.secret_name,
-            secret_value=str(subkey.decrypt_dict(row.blob)["secret_value"]),
-            allowed_hosts=tuple(row.allowed_hosts),
+            # The write path stores SecretStr.get_secret_value() — always
+            # a str; cast records that contract without a masking str().
+            secret_value=cast(str, subkey.decrypt_dict(row.blob)["secret_value"]),
+            allowed_hosts=row.allowed_hosts,
             updated_at=row.updated_at,
             placeholder=mint_secret_placeholder(subkey, session_id, row.credential_id),
         )

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -14,12 +14,16 @@ mutations here (:func:`refresh_credential`, :func:`update_vault_credential`,
 evict any sandbox: the MCP pool keys on ``(url, vault_id)`` and a rotation
 overwrites the row contents under that stable key, so the existing key
 already serves the new secret. Vault tables are also deliberately excluded
-from Layer 2's ``spec_version`` triggers — they don't change the sandbox
-spec.
+from Layer 2's ``spec_version`` triggers. Since #873,
+``environment_variable`` credentials DO feed the sandbox spec builder
+(:func:`resolve_session_env_var_credentials` below) — drift handling for
+live sandboxes (rotation, attach/archive) is deferred to #877.
 """
 
 from __future__ import annotations
 
+import dataclasses
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, assert_never
 
@@ -563,3 +567,74 @@ async def delete_vault_credential(
 ) -> None:
     async with pool.acquire() as conn:
         await queries.delete_vault_credential(conn, vault_id, credential_id, account_id=account_id)
+
+
+# ─── environment_variable resolution (#873) ──────────────────────────────────
+
+# The opaque per-(session, credential) stand-in for an env-var secret.
+# Same shape as the probed CMA reference (ANTHROPIC_SECRET_PLACEHOLDER_<32
+# hex>): a distinctive greppable prefix plus 128 bits derived via HKDF from
+# the account subkey — deterministic, so it survives container recycles
+# (anything the agent persisted into /workspace keeps working) and is
+# identical across workers, with zero stored state. Not derived from the
+# secret; worthless outside this session's egress proxy.
+SECRET_PLACEHOLDER_PREFIX = "AIOS_SECRET_PLACEHOLDER_"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedEnvVarCredential:
+    """A decrypted ``environment_variable`` credential plus its minted
+    placeholder, as consumed by sandbox materialization.
+
+    ``secret_value`` is excluded from ``repr`` so a logged plan or a
+    pytest assertion diff never prints the plaintext. ``allowed_hosts``
+    holds the stored canonical entries; parse with
+    :func:`aios.models.vaults.parse_allowed_host_entry`.
+    """
+
+    credential_id: str
+    vault_id: str
+    secret_name: str
+    secret_value: str = dataclasses.field(repr=False)
+    allowed_hosts: tuple[str, ...]
+    updated_at: datetime
+    placeholder: str
+
+
+def mint_secret_placeholder(subkey: CryptoBox, session_id: str, credential_id: str) -> str:
+    """The placeholder for ``credential_id`` in ``session_id`` — a pure
+    function of the account subkey and the two ids."""
+    digest = subkey.derive_subkey_bytes(f"aios-secret-placeholder-{session_id}-{credential_id}")
+    return SECRET_PLACEHOLDER_PREFIX + digest[:16].hex()
+
+
+async def resolve_session_env_var_credentials(
+    conn: asyncpg.Connection[Any],
+    crypto_box: CryptoBox,
+    session_id: str,
+    *,
+    account_id: str,
+) -> list[ResolvedEnvVarCredential]:
+    """Decrypt every active env-var credential bound to ``session_id``.
+
+    First-vault-wins on duplicate ``secret_name`` comes from the query
+    (rank-ordered ``DISTINCT ON``). Decrypt failures propagate — one
+    corrupt blob aborts the provision loudly rather than materializing a
+    partial credential set.
+    """
+    rows = await queries.list_session_env_var_credentials(conn, session_id, account_id=account_id)
+    if not rows:
+        return []
+    subkey = crypto_box.derive_account_subkey(account_id)
+    return [
+        ResolvedEnvVarCredential(
+            credential_id=row.credential_id,
+            vault_id=row.vault_id,
+            secret_name=row.secret_name,
+            secret_value=str(subkey.decrypt_dict(row.blob)["secret_value"]),
+            allowed_hosts=tuple(row.allowed_hosts),
+            updated_at=row.updated_at,
+            placeholder=mint_secret_placeholder(subkey, session_id, row.credential_id),
+        )
+        for row in rows
+    ]

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -135,3 +135,90 @@ def _assert_protocol(backend: SandboxBackend) -> None:
 
 
 _assert_protocol(FakeBackend())
+
+
+def patch_build_spec_deps(
+    *,
+    env_config: Any = None,
+    docker_image: str = "ghcr.io/eumemic/aios-sandbox:latest",
+    sandbox_disk_bytes: int | None = None,
+    env_var_credentials: Any = None,
+    github_clones: Any = None,
+    tool_broker: Any = None,
+) -> tuple[Any, ...]:
+    """Context-manager bundle stubbing every external dependency of
+    ``build_spec_from_session`` so it runs to the ``_assemble_plan`` call
+    with synthetic settings.
+
+    The three keyword overrides let a test install its OWN mock for a
+    materializer or the tool broker — each target is patched exactly
+    once, so the mock a test asserts on is unambiguously the installed
+    one (no nested re-patching).
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    settings = MagicMock()
+    settings.docker_image = docker_image
+    settings.sandbox_disk_bytes = sandbox_disk_bytes
+    settings.instance_id = "inst_TEST"
+    settings.sandbox_cpu_quota = None
+    settings.sandbox_memory_bytes = None
+    settings.sandbox_pids_limit = None
+    settings.sandbox_seccomp_profile = "/app/docker/seccomp-sandbox.json"
+    settings.tool_broker_socket_path = None
+
+    if tool_broker is None:
+        tool_broker = MagicMock()
+        tool_broker.port = 54321
+        tool_broker.register_session = MagicMock()
+        tool_broker.unregister_session = MagicMock()
+
+    return (
+        patch("aios.sandbox.spec.get_settings", return_value=settings),
+        patch(
+            "aios.sandbox.spec.sessions_service.load_session_account_id",
+            AsyncMock(return_value="acct_x"),
+        ),
+        patch(
+            "aios.sandbox.spec._load_session_provisioning",
+            # (workspace_path, env, spec_version) since #713.
+            AsyncMock(return_value=("/tmp/w", {}, 0)),
+        ),
+        # ``build_spec_from_session`` imports these function-locally from
+        # ``aios.sandbox.volumes`` (deferred import to avoid a cycle), so
+        # patch them at the source module, not on ``aios.sandbox.spec``.
+        patch("aios.sandbox.volumes.validate_workspace_path", MagicMock()),
+        patch(
+            "aios.sandbox.volumes.ensure_workspace_path",
+            MagicMock(return_value=Path("/tmp/w")),
+        ),
+        patch(
+            "aios.sandbox.spec._load_environment_config",
+            AsyncMock(return_value=env_config),
+        ),
+        patch(
+            "aios.sandbox.spec._materialize_memory_mounts",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "aios.sandbox.spec._materialize_env_var_credentials",
+            env_var_credentials or AsyncMock(return_value=()),
+        ),
+        patch(
+            "aios.sandbox.spec._materialize_github_clones",
+            github_clones or AsyncMock(return_value=([], None)),
+        ),
+        patch("aios.sandbox.spec.runtime.require_pool", MagicMock()),
+        patch(
+            "aios.sandbox.spec.runtime.require_tool_broker",
+            MagicMock(return_value=tool_broker),
+        ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_attachments_dir",
+            return_value=Path("/tmp/a"),
+        ),
+        patch(
+            "aios.sandbox.volumes.ensure_session_uploads_dir",
+            return_value=Path("/tmp/u"),
+        ),
+    )

--- a/tests/integration/test_env_var_credential_resolution.py
+++ b/tests/integration/test_env_var_credential_resolution.py
@@ -1,0 +1,270 @@
+"""Session-scoped ``environment_variable`` credential resolution (#873).
+
+Against a real Postgres: the rank-ordered ``DISTINCT ON`` list query +
+the decrypt/mint service tail. The properties that matter:
+
+* a session resolves exactly the active env-var creds across its bound
+  vaults — header-style creds and archived rows never appear;
+* duplicate ``secret_name`` across two vaults → the lower-rank vault
+  wins (and flipping the binding order flips the winner);
+* placeholders are deterministic per (session, credential) — stable
+  across repeated resolution (so a recycle re-derives the same value)
+  and distinct across sessions;
+* tenant isolation: an identically-named credential in another
+  account's vault is invisible;
+* decrypt failures propagate (fail-hard) rather than yielding a
+  partial credential set.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+from pydantic import SecretStr
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries as db_queries
+from aios.db.pool import create_pool
+from aios.errors import CryptoDecryptError
+from aios.harness import runtime
+from aios.models.vaults import VaultCredentialCreate
+from aios.services import agents as agents_service
+from aios.services import vaults as vaults_service
+from aios.services.vaults import (
+    SECRET_PLACEHOLDER_PREFIX,
+    resolve_session_env_var_credentials,
+)
+
+pytestmark = pytest.mark.integration
+
+ACC = "acc_envvar"
+ACC_OTHER = "acc_envvar_other"
+ENV = "env_envvar"
+
+
+@pytest.fixture
+def crypto_box() -> CryptoBox:
+    return CryptoBox(os.urandom(32))
+
+
+@pytest.fixture
+async def vault_pool(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    """A pool on ``runtime.pool`` + seeded accounts and an environment."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = pool
+    try:
+        async with pool.acquire() as conn:
+            # Only one active root account is allowed; the second tenant
+            # is a child of the first (tenant isolation is account_id
+            # scoping, not tree position).
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                "display_name) VALUES ($1, NULL, TRUE, 'envvar-root')",
+                ACC,
+            )
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                "display_name) VALUES ($1, $2, FALSE, 'envvar-other')",
+                ACC_OTHER,
+                ACC,
+            )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ($1, 'envvar-env', '{}'::jsonb, $2)",
+                ENV,
+                ACC,
+            )
+        yield pool
+    finally:
+        runtime.pool = prev
+        await pool.close()
+
+
+async def _make_session(
+    pool: asyncpg.Pool[Any], *, vault_ids: list[str] | None = None, account_id: str = ACC
+) -> str:
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=account_id,
+        name=f"envvar-agent-{os.urandom(4).hex()}",
+        model="test/dummy",
+        system="x",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=1000,
+        window_max=100000,
+    )
+    async with pool.acquire() as conn:
+        session = await db_queries.insert_session(
+            conn,
+            account_id=account_id,
+            agent_id=agent.id,
+            environment_id=ENV,
+            agent_version=agent.version,
+            title=None,
+            metadata={},
+        )
+        if vault_ids:
+            await db_queries.set_session_vaults(conn, session.id, vault_ids, account_id=account_id)
+    return session.id
+
+
+async def _make_vault(pool: asyncpg.Pool[Any], name: str, *, account_id: str = ACC) -> str:
+    vault = await vaults_service.create_vault(
+        pool, account_id=account_id, display_name=name, metadata={}
+    )
+    return vault.id
+
+
+async def _make_env_cred(
+    pool: asyncpg.Pool[Any],
+    crypto_box: CryptoBox,
+    vault_id: str,
+    secret_name: str,
+    secret_value: str,
+    *,
+    account_id: str = ACC,
+) -> str:
+    cred = await vaults_service.create_vault_credential(
+        pool,
+        crypto_box,
+        account_id=account_id,
+        vault_id=vault_id,
+        body=VaultCredentialCreate(
+            auth_type="environment_variable",
+            secret_name=secret_name,
+            secret_value=SecretStr(secret_value),
+            allowed_hosts=["api.example.com/v1", "files.example.com"],
+        ),
+    )
+    return cred.id
+
+
+async def _resolve(
+    pool: asyncpg.Pool[Any], crypto_box: CryptoBox, session_id: str, *, account_id: str = ACC
+) -> list[vaults_service.ResolvedEnvVarCredential]:
+    async with pool.acquire() as conn:
+        return await resolve_session_env_var_credentials(
+            conn, crypto_box, session_id, account_id=account_id
+        )
+
+
+async def test_resolves_the_set_across_ranked_vaults(
+    vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+) -> None:
+    pool = vault_pool
+    v1, v2 = await _make_vault(pool, "v1"), await _make_vault(pool, "v2")
+    await _make_env_cred(pool, crypto_box, v1, "GITHUB_TOKEN", "ghp_one")
+    await _make_env_cred(pool, crypto_box, v1, "STRIPE_KEY", "sk_two")
+    await _make_env_cred(pool, crypto_box, v2, "TAVILY_KEY", "tvly_three")
+    # Noise that must NOT resolve: a header credential in the same vault
+    # (the auth_type filter is the only thing excluding it) and an
+    # archived env-var credential.
+    await vaults_service.create_vault_credential(
+        pool,
+        crypto_box,
+        account_id=ACC,
+        vault_id=v1,
+        body=VaultCredentialCreate(
+            target_url="https://api.example/mcp",
+            auth_type="bearer_header",
+            token=SecretStr("tok-x"),
+        ),
+    )
+    archived_id = await _make_env_cred(pool, crypto_box, v1, "DEAD_KEY", "gone")
+    await vaults_service.archive_vault_credential(
+        pool, vault_id=v1, credential_id=archived_id, account_id=ACC
+    )
+
+    session_id = await _make_session(pool, vault_ids=[v1, v2])
+    resolved = await _resolve(pool, crypto_box, session_id)
+
+    assert {(r.secret_name, r.secret_value) for r in resolved} == {
+        ("GITHUB_TOKEN", "ghp_one"),
+        ("STRIPE_KEY", "sk_two"),
+        ("TAVILY_KEY", "tvly_three"),
+    }
+    for r in resolved:
+        assert r.placeholder.startswith(SECRET_PLACEHOLDER_PREFIX)
+        assert len(r.placeholder) == len(SECRET_PLACEHOLDER_PREFIX) + 32
+        assert r.allowed_hosts == ("api.example.com/v1", "files.example.com")
+        # The plaintext never leaks through the dataclass repr.
+        assert r.secret_value not in repr(r)
+    assert len({r.placeholder for r in resolved}) == 3
+
+
+async def test_duplicate_secret_name_first_vault_wins(
+    vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+) -> None:
+    pool = vault_pool
+    v1, v2 = await _make_vault(pool, "v1"), await _make_vault(pool, "v2")
+    await _make_env_cred(pool, crypto_box, v1, "API_KEY", "from-v1")
+    await _make_env_cred(pool, crypto_box, v2, "API_KEY", "from-v2")
+
+    forward = await _resolve(pool, crypto_box, await _make_session(pool, vault_ids=[v1, v2]))
+    reverse = await _resolve(pool, crypto_box, await _make_session(pool, vault_ids=[v2, v1]))
+
+    assert [r.secret_value for r in forward] == ["from-v1"]
+    assert [r.secret_value for r in reverse] == ["from-v2"]
+
+
+async def test_placeholders_deterministic_per_session_distinct_across(
+    vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+) -> None:
+    pool = vault_pool
+    vault_id = await _make_vault(pool, "v1")
+    await _make_env_cred(pool, crypto_box, vault_id, "API_KEY", "val")
+    s1 = await _make_session(pool, vault_ids=[vault_id])
+    s2 = await _make_session(pool, vault_ids=[vault_id])
+
+    (first,) = await _resolve(pool, crypto_box, s1)
+    (again,) = await _resolve(pool, crypto_box, s1)
+    (other,) = await _resolve(pool, crypto_box, s2)
+
+    # Stable across re-resolution (a container recycle re-derives the
+    # same placeholder, so anything persisted into /workspace survives)…
+    assert first.placeholder == again.placeholder
+    # …but unique per session, and never the secret.
+    assert first.placeholder != other.placeholder
+    assert "val" not in first.placeholder
+
+
+async def test_other_tenants_credentials_invisible(
+    vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+) -> None:
+    pool = vault_pool
+    theirs = await _make_vault(pool, "their-vault", account_id=ACC_OTHER)
+    await _make_env_cred(pool, crypto_box, theirs, "API_KEY", "their-secret", account_id=ACC_OTHER)
+    mine = await _make_vault(pool, "my-vault")
+    await _make_env_cred(pool, crypto_box, mine, "API_KEY", "my-secret")
+
+    session_id = await _make_session(pool, vault_ids=[mine])
+    resolved = await _resolve(pool, crypto_box, session_id)
+
+    assert [r.secret_value for r in resolved] == ["my-secret"]
+
+
+async def test_vaultless_session_resolves_empty(
+    vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+) -> None:
+    session_id = await _make_session(vault_pool)
+    assert await _resolve(vault_pool, crypto_box, session_id) == []
+
+
+async def test_wrong_key_fails_hard(vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox) -> None:
+    """One undecryptable blob aborts resolution loudly — no partial set."""
+    pool = vault_pool
+    vault_id = await _make_vault(pool, "v1")
+    await _make_env_cred(pool, crypto_box, vault_id, "API_KEY", "val")
+    session_id = await _make_session(pool, vault_ids=[vault_id])
+
+    with pytest.raises(CryptoDecryptError):
+        await _resolve(pool, CryptoBox(os.urandom(32)), session_id)

--- a/tests/integration/test_env_var_credential_resolution.py
+++ b/tests/integration/test_env_var_credential_resolution.py
@@ -240,16 +240,21 @@ async def test_placeholders_deterministic_per_session_distinct_across(
 async def test_other_tenants_credentials_invisible(
     vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
 ) -> None:
+    """The query's ``vc.account_id`` filter is load-bearing, so construct
+    the state where ONLY it excludes the foreign row: bind the other
+    tenant's vault directly into this session (``set_session_vaults``
+    FK-checks vault existence, not ownership, so the binding goes
+    through) and assert the foreign credential still never resolves."""
     pool = vault_pool
     theirs = await _make_vault(pool, "their-vault", account_id=ACC_OTHER)
     await _make_env_cred(pool, crypto_box, theirs, "API_KEY", "their-secret", account_id=ACC_OTHER)
     mine = await _make_vault(pool, "my-vault")
-    await _make_env_cred(pool, crypto_box, mine, "API_KEY", "my-secret")
+    await _make_env_cred(pool, crypto_box, mine, "OTHER_KEY", "my-secret")
 
-    session_id = await _make_session(pool, vault_ids=[mine])
+    session_id = await _make_session(pool, vault_ids=[theirs, mine])
     resolved = await _resolve(pool, crypto_box, session_id)
 
-    assert [r.secret_value for r in resolved] == ["my-secret"]
+    assert [(r.secret_name, r.secret_value) for r in resolved] == [("OTHER_KEY", "my-secret")]
 
 
 async def test_vaultless_session_resolves_empty(
@@ -268,3 +273,27 @@ async def test_wrong_key_fails_hard(vault_pool: asyncpg.Pool[Any], crypto_box: C
 
     with pytest.raises(CryptoDecryptError):
         await _resolve(pool, CryptoBox(os.urandom(32)), session_id)
+
+
+async def test_materializer_resolves_through_worker_runtime(
+    vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
+) -> None:
+    """Execute the real ``_materialize_env_var_credentials`` (everything
+    else patches it out): it pulls pool + crypto box from the worker
+    runtime and returns the resolved tuple the plan carries."""
+    from aios.sandbox.spec import _materialize_env_var_credentials
+
+    pool = vault_pool
+    vault_id = await _make_vault(pool, "v1")
+    await _make_env_cred(pool, crypto_box, vault_id, "API_KEY", "val")
+    session_id = await _make_session(pool, vault_ids=[vault_id])
+
+    prev = runtime.crypto_box
+    runtime.crypto_box = crypto_box
+    try:
+        resolved = await _materialize_env_var_credentials(session_id, account_id=ACC)
+    finally:
+        runtime.crypto_box = prev
+
+    assert [(r.secret_name, r.secret_value) for r in resolved] == [("API_KEY", "val")]
+    assert resolved[0].placeholder.startswith(SECRET_PLACEHOLDER_PREFIX)

--- a/tests/integration/test_session_resource_eviction.py
+++ b/tests/integration/test_session_resource_eviction.py
@@ -17,16 +17,17 @@ Coverage:
 
 - memory-store and github-repository resource changes via
   ``update_session`` evict (they feed the spec).
-- vault session-BINDING changes via ``update_session`` evict as
-  defense-in-depth (they do NOT feed the spec, but Layer 1 evicts on any
-  session-resource mutation).
+- vault session-BINDING changes via ``update_session`` evict (since
+  #873 they feed the spec — env-var credentials resolve into the
+  provisioning plan; migration 0082 also bumps ``spec_version``).
 - a title-only ``update_session`` and ``create_session`` do NOT evict.
 - an idempotent re-PUT (same memory resources, same vault ids, or an
   empty list on an empty session) writes nothing: no eviction AND no
   ``spec_version`` bump, so neither layer recycles the sandbox.
 - connection attach/detach evict the bound session (defense-in-depth).
 - in-place vault credential rotation does NOT evict (the MCP pool keys on
-  ``(url, vault_id)`` and the row contents are overwritten in place).
+  ``(url, vault_id)`` and the row contents are overwritten in place; a
+  live sandbox keeps its materialized env-var set until #877's drift key).
 """
 
 from __future__ import annotations

--- a/tests/integration/test_spec_version_triggers.py
+++ b/tests/integration/test_spec_version_triggers.py
@@ -233,14 +233,14 @@ async def test_scheduled_task_insert_does_not_bump_spec_version(
     assert await _spec_version(pool, session_id) == before
 
 
-async def test_vault_binding_insert_does_not_bump_spec_version(
+async def test_vault_binding_insert_bumps_spec_version(
     pool_and_session: tuple[asyncpg.Pool[Any], str],
 ) -> None:
-    """Vault session-bindings deliberately have no bump trigger: header
-    credentials reach the agent via the MCP pool, and the env-var
-    credentials that DO feed the spec builder (#873) are covered by
-    Layer 1's eviction on the same update_session write path (Layer 2
-    stays silent here by design; live-sandbox drift is #877)."""
+    """Since #873 env-var credentials resolve through a session's bound
+    vaults into the provisioning plan, so vault bindings feed the spec
+    builder and get a bump trigger (migration 0082) — the Layer-1
+    eviction can't cover them (``update_session`` runs in the API
+    process, where eviction is a no-op)."""
     pool, session_id = pool_and_session
     vault = await vaults_service.create_vault(
         pool, account_id=_ACCOUNT_ID, display_name="creds", metadata={}
@@ -256,4 +256,4 @@ async def test_vault_binding_insert_does_not_bump_spec_version(
             _ACCOUNT_ID,
         )
 
-    assert await _spec_version(pool, session_id) == before
+    assert await _spec_version(pool, session_id) > before

--- a/tests/integration/test_spec_version_triggers.py
+++ b/tests/integration/test_spec_version_triggers.py
@@ -236,9 +236,11 @@ async def test_scheduled_task_insert_does_not_bump_spec_version(
 async def test_vault_binding_insert_does_not_bump_spec_version(
     pool_and_session: tuple[asyncpg.Pool[Any], str],
 ) -> None:
-    """Vault session-bindings reach the agent via the MCP pool, not the
-    sandbox spec — deliberately no bump trigger (Layer 1 still evicts as
-    defense-in-depth; Layer 2 stays silent here by design)."""
+    """Vault session-bindings deliberately have no bump trigger: header
+    credentials reach the agent via the MCP pool, and the env-var
+    credentials that DO feed the spec builder (#873) are covered by
+    Layer 1's eviction on the same update_session write path (Layer 2
+    stays silent here by design; live-sandbox drift is #877)."""
     pool, session_id = pool_and_session
     vault = await vaults_service.create_vault(
         pool, account_id=_ACCOUNT_ID, display_name="creds", metadata={}

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -16,18 +16,17 @@ from __future__ import annotations
 
 import contextlib
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from aios.errors import CryptoDecryptError
 from aios.sandbox.spec import build_spec_from_session
 from aios.services.vaults import ResolvedEnvVarCredential
-from tests.unit.sandbox.test_spec_per_env_controls import _patch_build_spec_deps
+from tests.helpers.sandbox import patch_build_spec_deps
 
 _CRED = ResolvedEnvVarCredential(
     credential_id="vcred_01TEST",
-    vault_id="vault_01TEST",
     secret_name="GITHUB_TOKEN",
     secret_value="ghp_secret",
     allowed_hosts=("api.github.com",),
@@ -38,18 +37,10 @@ _CRED = ResolvedEnvVarCredential(
 
 async def test_plan_carries_resolved_creds_but_injects_nothing() -> None:
     with contextlib.ExitStack() as stack:
-        for ctx in _patch_build_spec_deps(
-            env_config=None,
-            docker_image="aios-sandbox:test",
-            sandbox_disk_bytes=None,
+        for ctx in patch_build_spec_deps(
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
         ):
             stack.enter_context(ctx)
-        stack.enter_context(
-            patch(
-                "aios.sandbox.spec._materialize_env_var_credentials",
-                AsyncMock(return_value=(_CRED,)),
-            )
-        )
         plan = await build_spec_from_session("sess_01TEST")
 
     assert plan.env_var_credentials == (_CRED,)
@@ -63,23 +54,15 @@ async def test_plan_carries_resolved_creds_but_injects_nothing() -> None:
 
 async def test_resolve_failure_aborts_before_git_proxy_or_broker_exist() -> None:
     clones = AsyncMock(return_value=([], None))
+    broker = MagicMock()
+    broker.port = 54321
     with contextlib.ExitStack() as stack:
-        for ctx in _patch_build_spec_deps(
-            env_config=None,
-            docker_image="aios-sandbox:test",
-            sandbox_disk_bytes=None,
+        for ctx in patch_build_spec_deps(
+            env_var_credentials=AsyncMock(side_effect=CryptoDecryptError("corrupt blob")),
+            github_clones=clones,
+            tool_broker=broker,
         ):
             stack.enter_context(ctx)
-        stack.enter_context(patch("aios.sandbox.spec._materialize_github_clones", clones))
-        stack.enter_context(
-            patch(
-                "aios.sandbox.spec._materialize_env_var_credentials",
-                AsyncMock(side_effect=CryptoDecryptError("corrupt blob")),
-            )
-        )
-        broker = stack.enter_context(
-            patch("aios.sandbox.spec.runtime.require_tool_broker")
-        ).return_value
 
         with pytest.raises(CryptoDecryptError):
             await build_spec_from_session("sess_01TEST")

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -1,0 +1,90 @@
+"""Env-var credentials on the provisioning plan (#873).
+
+Two properties of ``build_spec_from_session``:
+
+* the resolved credential set rides ``plan.env_var_credentials`` while
+  the container env stays untouched — materialization is the next slice
+  (#874), so in this one the placeholder must NOT appear anywhere in
+  ``spec.environment``;
+* credential resolution runs BEFORE the github-clones step by design —
+  its deliberate fail-hard (one corrupt blob aborts the provision) must
+  raise while no GitProxy is running and no broker secret is registered,
+  otherwise every failed provision would leak a live proxy.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aios.errors import CryptoDecryptError
+from aios.sandbox.spec import build_spec_from_session
+from aios.services.vaults import ResolvedEnvVarCredential
+from tests.unit.sandbox.test_spec_per_env_controls import _patch_build_spec_deps
+
+_CRED = ResolvedEnvVarCredential(
+    credential_id="vcred_01TEST",
+    vault_id="vault_01TEST",
+    secret_name="GITHUB_TOKEN",
+    secret_value="ghp_secret",
+    allowed_hosts=("api.github.com",),
+    updated_at=datetime(2026, 6, 10, tzinfo=UTC),
+    placeholder="AIOS_SECRET_PLACEHOLDER_" + "ab" * 16,
+)
+
+
+async def test_plan_carries_resolved_creds_but_injects_nothing() -> None:
+    with contextlib.ExitStack() as stack:
+        for ctx in _patch_build_spec_deps(
+            env_config=None,
+            docker_image="aios-sandbox:test",
+            sandbox_disk_bytes=None,
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(
+            patch(
+                "aios.sandbox.spec._materialize_env_var_credentials",
+                AsyncMock(return_value=(_CRED,)),
+            )
+        )
+        plan = await build_spec_from_session("sess_01TEST")
+
+    assert plan.env_var_credentials == (_CRED,)
+    # Nothing is materialized into the container in this slice: neither
+    # the placeholder nor (ever) the secret may reach the env.
+    env_blob = " ".join([*plan.spec.environment.keys(), *plan.spec.environment.values()])
+    assert _CRED.placeholder not in env_blob
+    assert _CRED.secret_value not in env_blob
+    assert "GITHUB_TOKEN" not in plan.spec.environment
+
+
+async def test_resolve_failure_aborts_before_git_proxy_or_broker_exist() -> None:
+    clones = AsyncMock(return_value=([], None))
+    with contextlib.ExitStack() as stack:
+        for ctx in _patch_build_spec_deps(
+            env_config=None,
+            docker_image="aios-sandbox:test",
+            sandbox_disk_bytes=None,
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(patch("aios.sandbox.spec._materialize_github_clones", clones))
+        stack.enter_context(
+            patch(
+                "aios.sandbox.spec._materialize_env_var_credentials",
+                AsyncMock(side_effect=CryptoDecryptError("corrupt blob")),
+            )
+        )
+        broker = stack.enter_context(
+            patch("aios.sandbox.spec.runtime.require_tool_broker")
+        ).return_value
+
+        with pytest.raises(CryptoDecryptError):
+            await build_spec_from_session("sess_01TEST")
+
+    # The fail-hard fired while nothing needed cleanup: no proxy was
+    # started, no broker secret registered.
+    clones.assert_not_awaited()
+    broker.register_session.assert_not_called()

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -30,6 +30,7 @@ from aios.sandbox.spec import (
     _assemble_plan,
     resolve_bash_timeout_ceiling,
 )
+from tests.helpers.sandbox import patch_build_spec_deps
 
 
 def _call_assemble(
@@ -102,81 +103,6 @@ class TestAssemblePlanImageAndDisk:
 # ── build_spec_from_session resolution (#724 image, #725 disk) ───────────────
 
 
-def _patch_build_spec_deps(
-    *,
-    env_config: EnvironmentConfig | None,
-    docker_image: str,
-    sandbox_disk_bytes: int | None,
-) -> tuple[Any, ...]:
-    """Context manager bundle that stubs every external dependency of
-    ``build_spec_from_session`` so it runs to the ``_assemble_plan`` call
-    with a synthetic environment config and synthetic settings."""
-    settings = MagicMock()
-    settings.docker_image = docker_image
-    settings.sandbox_disk_bytes = sandbox_disk_bytes
-    settings.instance_id = "inst_TEST"
-    settings.sandbox_cpu_quota = None
-    settings.sandbox_memory_bytes = None
-    settings.sandbox_pids_limit = None
-    settings.sandbox_seccomp_profile = "/app/docker/seccomp-sandbox.json"
-    settings.tool_broker_socket_path = None
-
-    tool_broker = MagicMock()
-    tool_broker.port = 54321
-    tool_broker.register_session = MagicMock()
-    tool_broker.unregister_session = MagicMock()
-
-    return (
-        patch("aios.sandbox.spec.get_settings", return_value=settings),
-        patch(
-            "aios.sandbox.spec.sessions_service.load_session_account_id",
-            AsyncMock(return_value="acct_x"),
-        ),
-        patch(
-            "aios.sandbox.spec._load_session_provisioning",
-            # (workspace_path, env, spec_version) since #713.
-            AsyncMock(return_value=("/tmp/w", {}, 0)),
-        ),
-        # ``build_spec_from_session`` imports these function-locally from
-        # ``aios.sandbox.volumes`` (deferred import to avoid a cycle), so
-        # patch them at the source module, not on ``aios.sandbox.spec``.
-        patch("aios.sandbox.volumes.validate_workspace_path", MagicMock()),
-        patch(
-            "aios.sandbox.volumes.ensure_workspace_path",
-            MagicMock(return_value=Path("/tmp/w")),
-        ),
-        patch(
-            "aios.sandbox.spec._load_environment_config",
-            AsyncMock(return_value=env_config),
-        ),
-        patch(
-            "aios.sandbox.spec._materialize_memory_mounts",
-            AsyncMock(return_value=[]),
-        ),
-        patch(
-            "aios.sandbox.spec._materialize_env_var_credentials",
-            AsyncMock(return_value=()),
-        ),
-        patch(
-            "aios.sandbox.spec._materialize_github_clones",
-            AsyncMock(return_value=([], None)),
-        ),
-        patch("aios.sandbox.spec.runtime.require_pool", MagicMock()),
-        patch(
-            "aios.sandbox.spec.runtime.require_tool_broker",
-            MagicMock(return_value=tool_broker),
-        ),
-        patch(
-            "aios.sandbox.volumes.ensure_session_attachments_dir",
-            return_value=Path("/tmp/a"),
-        ),
-        patch(
-            "aios.sandbox.volumes.ensure_session_uploads_dir",
-            return_value=Path("/tmp/u"),
-        ),
-    )
-
-
 async def _build_with(
     *,
     env_config: EnvironmentConfig | None,
@@ -188,7 +114,7 @@ async def _build_with(
     from aios.sandbox.spec import build_spec_from_session
 
     with ExitStack() as stack:
-        for cm in _patch_build_spec_deps(
+        for cm in patch_build_spec_deps(
             env_config=env_config,
             docker_image=docker_image,
             sandbox_disk_bytes=sandbox_disk_bytes,

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -154,6 +154,10 @@ def _patch_build_spec_deps(
             AsyncMock(return_value=[]),
         ),
         patch(
+            "aios.sandbox.spec._materialize_env_var_credentials",
+            AsyncMock(return_value=()),
+        ),
+        patch(
             "aios.sandbox.spec._materialize_github_clones",
             AsyncMock(return_value=([], None)),
         ),

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0081``."""
+    """The migration ladder has exactly one head: ``0082``."""
     script = _script_directory()
-    assert script.get_heads() == ["0081"]
+    assert script.get_heads() == ["0082"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_sandbox_provision_span.py
+++ b/tests/unit/test_sandbox_provision_span.py
@@ -36,6 +36,7 @@ def _make_plan() -> ProvisioningPlan:
         memory_echoes=[],
         github_echoes=[],
         git_proxy=None,
+        env_var_credentials=(),
     )
 
 

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -160,6 +160,7 @@ class TestReleaseIfMountsChanged:
                 memory_echoes=[],
                 github_echoes=[],
                 git_proxy=None,
+                env_var_credentials=(),
             )
 
         # Force a cache miss so get_or_provision contends for the lock.
@@ -359,6 +360,7 @@ def _provisioning_plan(session_id: str) -> ProvisioningPlan:
         memory_echoes=[],
         github_echoes=[],
         git_proxy=None,
+        env_var_credentials=(),
     )
 
 
@@ -388,6 +390,7 @@ def _provisioning_plan_limited(session_id: str) -> ProvisioningPlan:
         memory_echoes=[],
         github_echoes=[],
         git_proxy=None,
+        env_var_credentials=(),
     )
 
 
@@ -799,6 +802,7 @@ class TestSpecVersionDrift:
             memory_echoes=plan.memory_echoes,
             github_echoes=plan.github_echoes,
             git_proxy=plan.git_proxy,
+            env_var_credentials=(),
         )
 
         with (

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -1009,6 +1009,36 @@ class TestDeriveAccountSubkey:
         assert master.derive_subkey_bytes("ctx-one") == master.derive_subkey_bytes("ctx-one")
 
 
+class TestMintSecretPlaceholder:
+    """``mint_secret_placeholder`` — the opaque per-(session, credential)
+    stand-in (#873). Deterministic by design: it must survive container
+    recycles and re-derive identically on any worker sharing the vault
+    key, while staying unique per session and unlinkable to the secret."""
+
+    def _subkey(self) -> CryptoBox:
+        return CryptoBox(b"\xcd" * 32).derive_account_subkey("acc_alpha")
+
+    def test_format(self) -> None:
+        from aios.services.vaults import SECRET_PLACEHOLDER_PREFIX, mint_secret_placeholder
+
+        placeholder = mint_secret_placeholder(self._subkey(), "sess_A", "vcred_1")
+        assert placeholder.startswith(SECRET_PLACEHOLDER_PREFIX)
+        suffix = placeholder.removeprefix(SECRET_PLACEHOLDER_PREFIX)
+        assert len(suffix) == 32
+        assert all(c in "0123456789abcdef" for c in suffix)
+
+    def test_deterministic_and_distinct_per_input(self) -> None:
+        from aios.services.vaults import mint_secret_placeholder
+
+        subkey = self._subkey()
+        base = mint_secret_placeholder(subkey, "sess_A", "vcred_1")
+        assert mint_secret_placeholder(subkey, "sess_A", "vcred_1") == base
+        assert mint_secret_placeholder(subkey, "sess_B", "vcred_1") != base
+        assert mint_secret_placeholder(subkey, "sess_A", "vcred_2") != base
+        other_subkey = CryptoBox(b"\xee" * 32).derive_account_subkey("acc_alpha")
+        assert mint_secret_placeholder(other_subkey, "sess_A", "vcred_1") != base
+
+
 class TestServiceWiringIsAccountScoped:
     """End-to-end integration: a vault_credential blob written by the service
     under ``account_a`` must NOT be decryptable when fetched under ``account_b``.

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -27,9 +27,11 @@ from aios.models.vaults import (
 from aios.services import vaults as vaults_service
 from aios.services.vaults import (
     REFRESH_SKEW_SECONDS,
+    SECRET_PLACEHOLDER_PREFIX,
     _extract_auth_payload,
     _merge_auth_payload,
     is_expiring,
+    mint_secret_placeholder,
     refresh_credential,
 )
 from tests.unit.conftest import fake_pool_yielding_conn
@@ -1019,8 +1021,6 @@ class TestMintSecretPlaceholder:
         return CryptoBox(b"\xcd" * 32).derive_account_subkey("acc_alpha")
 
     def test_format(self) -> None:
-        from aios.services.vaults import SECRET_PLACEHOLDER_PREFIX, mint_secret_placeholder
-
         placeholder = mint_secret_placeholder(self._subkey(), "sess_A", "vcred_1")
         assert placeholder.startswith(SECRET_PLACEHOLDER_PREFIX)
         suffix = placeholder.removeprefix(SECRET_PLACEHOLDER_PREFIX)
@@ -1028,8 +1028,6 @@ class TestMintSecretPlaceholder:
         assert all(c in "0123456789abcdef" for c in suffix)
 
     def test_deterministic_and_distinct_per_input(self) -> None:
-        from aios.services.vaults import mint_secret_placeholder
-
         subkey = self._subkey()
         base = mint_secret_placeholder(subkey, "sess_A", "vcred_1")
         assert mint_secret_placeholder(subkey, "sess_A", "vcred_1") == base


### PR DESCRIPTION
Closes #873. Part of epic #871 (C1 middle slice). **Stacked on #911** (`feat/875-egress-ca`) — shares `CryptoBox.derive_subkey_bytes`. Retarget to `master` after #911 merges (do NOT squash-merge into the sibling branch).

A session's `environment_variable` credentials now resolve — decrypted, with minted placeholders — onto the `ProvisioningPlan`. Nothing reaches the container yet: #874 injects `{secret_name: placeholder}` into the env; #876's per-session proxy becomes the request-time placeholder→secret map (the `GitProxy._auth_headers` analog). Scope notes posted on #873 (map → #876, run mirrors → #781 with rationale).

## Design

- **List resolver**: `list_session_env_var_credentials` — rank-ordered `DISTINCT ON (secret_name)`, so duplicate names across two attached vaults resolve first-vault-wins *by construction* (within one vault the partial unique index already forbids duplicates). The row carries the `EncryptedBlob` and `updated_at` (for #877's drift key).
- **Deterministic placeholder mint** (signed off in-session; deviates from the issue's literal "freshly-minted"): `AIOS_SECRET_PLACEHOLDER_` + 128 bits of HKDF from the account subkey over `(session_id, credential_id)`. Rationale: `/workspace` survives container recycles, so a random-per-provision placeholder an agent persisted into a file would go stale and the literal string would hit the wire once swapping lands; deterministic minting keeps it valid across recycles and workers with zero stored state — matching the probed CMA stability. Still per-session-unique, still worthless outside this session's proxy. `secret_value` is `repr`-excluded.
- **Fail-hard decrypt**: one corrupt blob aborts the provision rather than materializing a partial set. The materializer runs **before** `_materialize_github_clones` by design — the raise happens while no GitProxy is running and no broker secret is registered (every provision retry would otherwise leak a live proxy; a unit test pins the ordering). All five pre-implementation red-team lenses converged on this one.
- **`session_vaults` joins the spec-version triggers (migration 0082).** The review pass caught that the natural story — "Layer-1 eviction covers vault bindings" — is false: `update_session` runs in the API process where eviction is a no-op. #873 makes vault bindings feed `build_spec_from_session`, and 0077's own rule is that every spec-feeding table gets a bump trigger. The trigger test is inverted accordingly. Credential-*level* drift in a still-bound vault (rotation, create/archive) remains #877 (membership-aware drift key — noted on the issue).

## Flagged substrate gap (pre-existing, not fixed here)

`set_session_vaults` FK-checks vault *existence* but not *ownership* — tenant A can bind tenant B's `vault_id` into A's session (`create_session` ownership-validates the environment but not vaults). The resolver's `vc.account_id` filter is the guard that holds, and the tenant-isolation test now constructs exactly that adversarial state (the review caught the original test passing vacuously). Fits the `account_id`-audit bucket "defense-in-depth shortfall" — happy to file/fix separately.

## Review process

Plan red-teamed by 10 lenses pre-code (GitProxy-leak ordering, test blast radius, `EncryptedBlob` layer contract, repr hygiene, drift-gap mapping); implementation reviewed by a 43-agent find→verify pass — 28 verified findings folded in the second commit (the 0082 trigger + honest docs, the de-vacuoused tenant test, fully-immutable row type, dead `vault_id` rider dropped, `cast` over masking `str()`, helper promoted to `tests/helpers` with override kwargs, real execution coverage for the materializer).

## Tests

- Integration (Postgres): resolves the right set across ranked vaults (bearer + archived noise excluded), first-vault-wins flips with binding order, placeholder determinism across re-resolution + uniqueness across sessions, adversarial cross-tenant binding, vaultless → `[]`, wrong-key → `CryptoDecryptError`, real `_materialize_env_var_credentials` through the worker runtime, vault-binding insert bumps `spec_version`.
- Unit: mint format/determinism/distinctness; plan carries creds while the env stays untouched (placeholder + secret + name all absent); fail-hard ordering leaves no proxy/broker state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)