### PR TITLE
feat(sandbox): materialize env-var credential placeholders into the container (#874)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10459,7 +10459,7 @@
               }
             ],
             "title": "Env",
-            "description": "Environment variables injected into every session container using this environment.  Per-session env overrides these."
+            "description": "Environment variables injected into every session container using this environment.  Per-session env overrides these. A vaulted environment_variable credential whose secret_name matches a key \u2014 here or in the per-session env \u2014 outranks both: that key resolves to the credential's opaque placeholder, not the value set here."
           },
           "disk_bytes": {
             "anyOf": [
@@ -13346,7 +13346,7 @@
             },
             "type": "object",
             "title": "Env",
-            "description": "Environment variables injected into the sandbox container."
+            "description": "Environment variables injected into the sandbox container. A vaulted environment_variable credential whose secret_name matches a key here takes precedence: that key resolves to the credential's opaque placeholder, not the value set here."
           },
           "initial_message": {
             "anyOf": [

--- a/packages/aios-sdk/aios_sdk/_generated/models/environment_config.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/environment_config.py
@@ -34,7 +34,9 @@ class EnvironmentConfig:
         networking (LimitedNetworking | None | UnrestrictedNetworking | Unset): Network access rules.  None or {"type":
             "unrestricted"} for full access; {"type": "limited", "allowed_hosts": [...]} to restrict.
         env (EnvironmentConfigEnvType0 | None | Unset): Environment variables injected into every session container
-            using this environment.  Per-session env overrides these.
+            using this environment.  Per-session env overrides these. A vaulted environment_variable credential whose
+            secret_name matches a key — here or in the per-session env — outranks both: that key resolves to the
+            credential's opaque placeholder, not the value set here.
         disk_bytes (int | None | Unset): Maximum writable-layer size, in bytes, for sandbox containers bound to this
             environment. When unset, falls back to the worker's global ``settings.sandbox_disk_bytes`` (itself unbounded by
             default). Translates to ``docker run --storage-opt size=`` so a heavy dev build can't fill the host disk and

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
@@ -36,7 +36,9 @@ class SessionCreate:
         workspace_path (None | str | Unset): Absolute host path to use as the session workspace. If omitted, defaults to
             workspace_root/<account_id>/<session_id>. Must resolve within the account's workspace subdirectory. The
             directory must exist; aios will not create it.
-        env (SessionCreateEnv | Unset): Environment variables injected into the sandbox container.
+        env (SessionCreateEnv | Unset): Environment variables injected into the sandbox container. A vaulted
+            environment_variable credential whose secret_name matches a key here takes precedence: that key resolves to the
+            credential's opaque placeholder, not the value set here.
         initial_message (None | str | Unset): Convenience: when set, the server appends a user.message event with this
             content immediately after creating the session and enqueues a wake job. Equivalent to a follow-up POST
             /messages.

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_create_env.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_create_env.py
@@ -11,7 +11,11 @@ T = TypeVar("T", bound="SessionCreateEnv")
 
 @_attrs_define
 class SessionCreateEnv:
-    """Environment variables injected into the sandbox container."""
+    """Environment variables injected into the sandbox container. A vaulted environment_variable credential whose
+    secret_name matches a key here takes precedence: that key resolves to the credential's opaque placeholder, not the
+    value set here.
+
+    """
 
     additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
 

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -126,7 +126,11 @@ class EnvironmentConfig(BaseModel):
         default=None,
         description=(
             "Environment variables injected into every session container "
-            "using this environment.  Per-session env overrides these."
+            "using this environment.  Per-session env overrides these. A "
+            "vaulted environment_variable credential whose secret_name "
+            "matches a key — here or in the per-session env — outranks "
+            "both: that key resolves to the credential's opaque "
+            "placeholder, not the value set here."
         ),
     )
     disk_bytes: int | None = Field(

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -168,7 +168,12 @@ class SessionCreate(BaseModel):
     )
     env: dict[str, str] = Field(
         default_factory=dict,
-        description="Environment variables injected into the sandbox container.",
+        description=(
+            "Environment variables injected into the sandbox container. A "
+            "vaulted environment_variable credential whose secret_name "
+            "matches a key here takes precedence: that key resolves to the "
+            "credential's opaque placeholder, not the value set here."
+        ),
     )
     initial_message: str | None = Field(
         default=None,

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -511,15 +511,41 @@ def _assemble_plan(
         session_repo_working_tree_dir,
     )
 
-    merged_env: dict[str, str] = {
-        **WORKSPACE_RUNTIME_ENV,
-        # Trust-store defaults precede env_config.env/session_env so a
-        # custom image (#724) with a non-Debian CA layout can override
-        # them; vault credential secret_names can't claim them either
-        # way (RESERVED_SANDBOX_ENV_KEYS).
-        **TRUST_STORE_ENV,
+    # Operator-supplied env as one layer (environment config + per-session
+    # overrides, session winning) so the vault placeholders below can be
+    # checked against it for shadowing.
+    operator_env = {
         **(env_config.env if env_config and env_config.env else {}),
         **session_env,
+    }
+    # Vault env-var credential placeholders (#874): the session's
+    # ``environment_variable`` secrets surface in the container as
+    # ``secret_name=<opaque placeholder>``. ONLY the placeholder enters
+    # the container — the decrypted secret stays on
+    # ``plan.env_var_credentials`` in worker memory for the egress swap
+    # (#876) and never touches ``merged_env``, the spec, or any log.
+    # A vaulted secret outranks an operator/session var of the same name:
+    # a deliberate credential beats a loose env var, and it keeps a
+    # plaintext value an operator mistakenly set under that name out of
+    # the container. The clash is logged so the override is never silent.
+    placeholder_env = {cred.secret_name: cred.placeholder for cred in env_var_credentials}
+    shadowed = sorted(operator_env.keys() & placeholder_env.keys())
+    if shadowed:
+        log.warning(
+            "sandbox.vault_placeholder_shadows_env",
+            session_id=session_id,
+            secret_names=shadowed,
+        )
+
+    merged_env: dict[str, str] = {
+        **WORKSPACE_RUNTIME_ENV,
+        # Trust-store defaults precede operator env so a custom image
+        # (#724) with a non-Debian CA layout can override them.
+        **TRUST_STORE_ENV,
+        **operator_env,
+        **placeholder_env,
+        # Trailers last so nothing shadows them — a placeholder can't reach
+        # them anyway (secret_name can't be a reserved key, models/vaults.py).
         "TOOL_BROKER_URL": tool_broker_url,
         "TOOL_BROKER_SECRET": tool_broker_secret,
         # Scheduled-tasks escalation (#636): bash inside a cron sandbox

--- a/tests/e2e/test_env_var_placeholder_materialized.py
+++ b/tests/e2e/test_env_var_placeholder_materialized.py
@@ -1,0 +1,79 @@
+"""E2E: a session's env-var vault credential surfaces in the real
+sandbox container as ``SECRET_NAME=<placeholder>`` (#874).
+
+The C1 safe-foundation acceptance: ``printenv`` inside a provisioned
+sandbox shows the opaque placeholder; the decrypted secret never does.
+This drives the whole chain the unit tests mock out — resolver → mint →
+merged_env → ``docker run --env`` → ``docker exec`` — so it proves the
+placeholder reaches a real container's environment, not just the spec
+dict. Nothing swaps the placeholder yet (that is #876).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import SecretStr
+
+from aios.db import queries
+from aios.harness import runtime
+from aios.models.vaults import VaultCredentialCreate
+from aios.services import vaults as vaults_service
+from aios.services.vaults import mint_secret_placeholder
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant, bash, first_tool_result
+
+pytestmark = pytest.mark.docker
+
+_ACCOUNT_ID = "acc_test_stub"
+_SECRET_NAME = "GITHUB_TOKEN"
+_SENTINEL_SECRET = "ghp_SENTINEL_PLAINTEXT_DO_NOT_LEAK"
+
+
+@needs_docker
+async def test_placeholder_visible_in_container_secret_absent(docker_harness: Harness) -> None:
+    pool = docker_harness._pool
+    crypto_box = runtime.require_crypto_box()
+
+    vault = await vaults_service.create_vault(
+        pool, account_id=_ACCOUNT_ID, display_name="envvar-e2e", metadata={}
+    )
+    cred = await vaults_service.create_vault_credential(
+        pool,
+        crypto_box,
+        account_id=_ACCOUNT_ID,
+        vault_id=vault.id,
+        body=VaultCredentialCreate(
+            auth_type="environment_variable",
+            secret_name=_SECRET_NAME,
+            secret_value=SecretStr(_SENTINEL_SECRET),
+            allowed_hosts=["api.github.com"],
+        ),
+    )
+
+    # The placeholder is deterministic per (session, credential), so we
+    # can compute the exact string the container must show.
+    docker_harness.script_model(
+        [
+            assistant(tool_calls=[bash(f'printf "%s" "${_SECRET_NAME}"')]),
+            assistant("Done."),
+        ]
+    )
+    session = await docker_harness.start("test", tools=["bash"])
+    # Bind the vault before the first bash call provisions the sandbox.
+    async with pool.acquire() as conn:
+        await queries.set_session_vaults(conn, session.id, [vault.id], account_id=_ACCOUNT_ID)
+
+    expected = mint_secret_placeholder(
+        crypto_box.derive_account_subkey(_ACCOUNT_ID), session.id, cred.id
+    )
+
+    await docker_harness.run_until_idle(session.id)
+
+    content = str(first_tool_result(await docker_harness.events(session.id)).get("content", ""))
+    # The bash tool result is a JSON envelope; the placeholder is the
+    # command's stdout. Assert the EXACT minted placeholder reached the
+    # container env, and the decrypted secret appears nowhere.
+    assert json.loads(content)["stdout"].strip() == expected
+    assert _SENTINEL_SECRET not in content

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -140,6 +140,7 @@ _assert_protocol(FakeBackend())
 def patch_build_spec_deps(
     *,
     env_config: Any = None,
+    session_env: dict[str, str] | None = None,
     docker_image: str = "ghcr.io/eumemic/aios-sandbox:latest",
     sandbox_disk_bytes: int | None = None,
     env_var_credentials: Any = None,
@@ -150,10 +151,10 @@ def patch_build_spec_deps(
     ``build_spec_from_session`` so it runs to the ``_assemble_plan`` call
     with synthetic settings.
 
-    The three keyword overrides let a test install its OWN mock for a
-    materializer or the tool broker — each target is patched exactly
-    once, so the mock a test asserts on is unambiguously the installed
-    one (no nested re-patching).
+    The keyword overrides let a test install its OWN mock for a
+    materializer, the tool broker, or the per-session env — each target
+    is patched exactly once, so the mock a test asserts on is
+    unambiguously the installed one (no nested re-patching).
     """
     from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -181,8 +182,8 @@ def patch_build_spec_deps(
         ),
         patch(
             "aios.sandbox.spec._load_session_provisioning",
-            # (workspace_path, env, spec_version) since #713.
-            AsyncMock(return_value=("/tmp/w", {}, 0)),
+            # (workspace_path, session_env, spec_version) since #713.
+            AsyncMock(return_value=("/tmp/w", session_env or {}, 0)),
         ),
         # ``build_spec_from_session`` imports these function-locally from
         # ``aios.sandbox.volumes`` (deferred import to avoid a cycle), so

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -1,41 +1,51 @@
-"""Env-var credentials on the provisioning plan (#873).
+"""Env-var credential materialization into the sandbox env (#873 + #874).
 
-Two properties of ``build_spec_from_session``:
+Three properties of ``build_spec_from_session``:
 
-* the resolved credential set rides ``plan.env_var_credentials`` while
-  the container env stays untouched — materialization is the next slice
-  (#874), so in this one the placeholder must NOT appear anywhere in
-  ``spec.environment``;
-* credential resolution runs BEFORE the github-clones step by design —
-  its deliberate fail-hard (one corrupt blob aborts the provision) must
-  raise while no GitProxy is running and no broker secret is registered,
+* #874: a session's ``environment_variable`` secret surfaces in the
+  container env as ``secret_name=<opaque placeholder>``; the decrypted
+  secret reaches neither the env nor anywhere else on the spec;
+* #874: the placeholder WINS over an operator/session env var of the
+  same name — the security-load-bearing precedence (a plaintext value an
+  operator set under that name must not reach the container);
+* #873: credential resolution runs BEFORE the github-clones step, so its
+  deliberate fail-hard (one corrupt blob aborts the provision) raises
+  while no GitProxy is running and no broker secret is registered —
   otherwise every failed provision would leak a live proxy.
 """
 
 from __future__ import annotations
 
 import contextlib
+import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from aios.errors import CryptoDecryptError
+from aios.models.environments import EnvironmentConfig
+from aios.models.vaults import RESERVED_SANDBOX_ENV_KEYS
 from aios.sandbox.spec import build_spec_from_session
 from aios.services.vaults import ResolvedEnvVarCredential
 from tests.helpers.sandbox import patch_build_spec_deps
 
+# A distinctive sentinel rather than a real-looking token, so a leak is
+# unambiguous in any diff (and never a plausible credential in CI logs).
+_SENTINEL_SECRET = "SENTINEL_PLAINTEXT_DO_NOT_LEAK"
 _CRED = ResolvedEnvVarCredential(
     credential_id="vcred_01TEST",
     secret_name="GITHUB_TOKEN",
-    secret_value="ghp_secret",
+    secret_value=_SENTINEL_SECRET,
     allowed_hosts=("api.github.com",),
     updated_at=datetime(2026, 6, 10, tzinfo=UTC),
     placeholder="AIOS_SECRET_PLACEHOLDER_" + "ab" * 16,
 )
 
 
-async def test_plan_carries_resolved_creds_but_injects_nothing() -> None:
+async def test_placeholder_lands_in_env_secret_never_does() -> None:
+    """The credential's ``secret_name`` surfaces set to its opaque
+    placeholder; the decrypted secret appears nowhere on the spec."""
     with contextlib.ExitStack() as stack:
         for ctx in patch_build_spec_deps(
             env_var_credentials=AsyncMock(return_value=(_CRED,)),
@@ -43,13 +53,70 @@ async def test_plan_carries_resolved_creds_but_injects_nothing() -> None:
             stack.enter_context(ctx)
         plan = await build_spec_from_session("sess_01TEST")
 
+    # The placeholder IS the value of the secret_name key...
+    assert plan.spec.environment["GITHUB_TOKEN"] == _CRED.placeholder
+    # ...and the key set is exactly the reserved keys plus the injected
+    # secret_name — nothing extra leaked into it, and the secret_name is
+    # disjoint from the reserved set (blocked from claiming one at create).
+    assert set(plan.spec.environment) == {*RESERVED_SANDBOX_ENV_KEYS, "GITHUB_TOKEN"}
+    # The decrypted secret reaches NOTHING on the spec. Membership, not
+    # dataclass ``==``: secret_value is repr=False, but an equality diff
+    # across differing secrets would still render the plaintext.
+    assert _SENTINEL_SECRET not in str(plan.spec)
+    assert _SENTINEL_SECRET not in " ".join(plan.spec.environment.values())
+    # The decrypted creds still ride the plan for #876's egress swap
+    # (the secret is off the spec but must remain in worker memory).
     assert plan.env_var_credentials == (_CRED,)
-    # Nothing is materialized into the container in this slice: neither
-    # the placeholder nor (ever) the secret may reach the env.
-    env_blob = " ".join([*plan.spec.environment.keys(), *plan.spec.environment.values()])
-    assert _CRED.placeholder not in env_blob
-    assert _CRED.secret_value not in env_blob
-    assert "GITHUB_TOKEN" not in plan.spec.environment
+
+
+@pytest.mark.parametrize("layer", ["env_config", "session_env"])
+async def test_vault_placeholder_wins_over_operator_env(
+    layer: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The security-load-bearing precedence: a plaintext value an operator
+    set under the same name as a vault ``secret_name`` must NOT reach the
+    container — the opaque placeholder wins, and the override is logged.
+
+    Both operator-env layers are checked: the environment config's
+    ``env`` and the per-session ``env`` override (they merge into one
+    ``operator_env`` layer that the placeholder shadows)."""
+    leak = "operator-plaintext-leak-do-not-ship"
+    env_config = EnvironmentConfig(env={"GITHUB_TOKEN": leak}) if layer == "env_config" else None
+    session_env = {"GITHUB_TOKEN": leak} if layer == "session_env" else None
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_config=env_config,
+            session_env=session_env,
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
+        ):
+            stack.enter_context(ctx)
+        with caplog.at_level(logging.WARNING):
+            plan = await build_spec_from_session("sess_01TEST")
+
+    assert plan.spec.environment["GITHUB_TOKEN"] == _CRED.placeholder
+    assert leak not in str(plan.spec)
+    # The override is logged — the colliding KEY name, never the operator's
+    # plaintext value (which is itself a secret an operator may have set).
+    shadow_log = next(
+        r.getMessage()
+        for r in caplog.records
+        if "sandbox.vault_placeholder_shadows_env" in r.getMessage()
+    )
+    assert "GITHUB_TOKEN" in shadow_log
+    assert leak not in shadow_log
+
+
+async def test_no_creds_leaves_env_untouched() -> None:
+    """The empty case is byte-identical to a no-vault provision: the env
+    is exactly the reserved keys, nothing injected."""
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_var_credentials=AsyncMock(return_value=()),
+        ):
+            stack.enter_context(ctx)
+        plan = await build_spec_from_session("sess_01TEST")
+
+    assert set(plan.spec.environment) == RESERVED_SANDBOX_ENV_KEYS
 
 
 async def test_resolve_failure_aborts_before_git_proxy_or_broker_exist() -> None:


### PR DESCRIPTION
Closes #874. Part of epic #871 — **lands the C1 safe-foundation milestone**: `$VAR` exists in the sandbox as an opaque placeholder, never the real value, safe in the transcript. Nothing swaps yet (that's #876).

## The change

One layer in `_assemble_plan`'s `merged_env`: a dict comprehension over the already-resolved `env_var_credentials` (threaded onto the plan by #873), slotted after the operator env (`env_config.env` + `session_env`) and before the load-bearing `TOOL_BROKER_*`/`AIOS_SESSION_ID` trailers. **Only `secret_name → placeholder` is read** — the decrypted `secret_value` is never touched in `_assemble_plan`; it stays on `plan.env_var_credentials` in worker memory for #876's egress swap.

## Precedence decision (settled, red-teamed)

**The vault placeholder wins over an operator/session env var of the same name** — chosen over error-on-clash:

- **Security-preserving.** If operator env won, a plaintext value an operator set under that name would leak into the container *and the model would see it* — exactly what the epic prevents. Vault-wins guarantees the opaque placeholder lands.
- **Not silent.** Erroring would brick the whole provision over a name collision (a bowels-of-system failure the model can't fix and the operator isn't in the request loop for). Instead the shadow is logged — `sandbox.vault_placeholder_shadows_env`, **key names only, never values** — so the override is visible without being fatal.
- **Documented operator-facing.** The precedence is stated on the `EnvironmentConfig.env` and `SessionCreate.env` field descriptions (openapi.json + SDK regenerated).
- **Vault-before-trailers is regression-insurance, not a live guard** (called out honestly in the comment): `secret_name` is validated against `RESERVED_SANDBOX_ENV_KEYS` at create and is immutable after, so a placeholder can never reach a reserved/trailer key — the drift-pin test enforces that the reserved set equals the harness-injected key set.

## Flagged for sign-off

- **The shadow warning re-fires per cold provision** (no dedup) when an operator keeps a clashing key. The review verifier and I both land on *accept as-is*: an operator misconfig should stay visible, and dedup state is exactly the complexity the project avoids. Ops-log only, not model-visible.

## Tests

- **Unit** (`test_spec_env_var_credentials.py`): placeholder *is* the value; `keys == RESERVED ∪ {secret_name}` (proves injection + nothing extra leaked into the key set + disjointness); secret absent from the *whole* stringified spec via **membership, never dataclass `==`** (which would render plaintext in a pytest diff even with `repr=False`); **vault-wins precedence parametrized over BOTH operator layers** (`env_config.env` and `session_env` — the helper gained a `session_env` knob so the session layer is proven, not just asserted in prose); empty-creds case unperturbed. The #873 test that pinned the *no-injection* state is flipped in place.
- **Drift pin** (`test_reserved_env_keys.py`): stays green (empty-creds case is byte-identical).
- **E2E (docker)**: the full chain — resolver → mint → `docker run --env` → `docker exec` `printenv` — shows the **exact deterministic placeholder** in a real container's env and never the sentinel secret. Closes the gap the unit tests can't (they mock the backend).

## Lifecycle / handoff notes (confirmed, no code needed)

- Injection runs on cold provision **and every recycle** (both call `_assemble_plan`); warm-hits reuse the already-injected deterministic placeholder — no re-injection hook needed, no lifecycle hole.
- `#876` builds its request-time `placeholder→secret` map from `plan.env_var_credentials` (untouched here). `#806`'s uid-1000 drop must use env-preserving `docker exec --user` (not a login-shell/`su` that scrubs env) — the only way it could break visibility.

## Review process

Plan red-teamed by 5 lenses pre-code (the precedence decision confirmed correct and load-bearing; the must-flip #873 test caught by 3 lenses independently); diff reviewed by a 25-agent simplify + code-review pass (the session_env coverage gap and `str(plan.spec)` tightening folded; the reserved-key-coverage, layering, and "Pure"-docstring concerns all correctly REFUTED by the drift-pin test + create-time validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)