### PR TITLE
feat(sandbox): durable session sandboxes — full-filesystem persistence

### DIFF
--- a/docs/design/durable-session-sandboxes.md
+++ b/docs/design/durable-session-sandboxes.md
@@ -1,0 +1,913 @@
+# Durable session sandboxes: full-filesystem persistence
+
+**Status**: design recommendation, pre-implementation (2026-06-10)
+**Recommendation**: Mechanism B — disposable containers + commit-snapshot — with the
+amendments in §5, the production prerequisites and durability/scale decision in §9, and
+the sign-off items in §11. Horizontal scale (a second worker, host
+replacement/rebalancing) is a stated requirement and is carried by the design from v1.
+
+---
+
+## 1. Summary
+
+Make the whole sandbox root filesystem survive idle reclaim: every *planned* teardown
+becomes **stop → `docker commit` to a per-session local image → rm**, and every resume is
+the **existing cold-start provision path** running from that image instead of the base.
+Containers stay disposable; the filesystem becomes the durable artifact. Drop `--rm`, so
+*unplanned* deaths (crash, OOM, daemon restart) leave a stopped corpse that is salvaged
+(committed) before the session's next container starts — container death stops losing data
+entirely, which is strictly better than today.
+
+Horizontal scale — a second worker, and/or host replacement/rebalancing — is a **stated
+requirement**, so durable state splits cleanly: **the DB carries a snapshot pointer
+(`snapshot_ref` / `snapshot_host` / `snapshot_bytes` / `snapshot_updated_at` — location
+and existence), while the daemon/store remains the source of truth for artifact content
+and lineage.** Snapshot transport sits behind a `SnapshotStore` seam whose v1
+implementation (`LocalDaemonStore`) is an identity wrapper over the local daemon —
+today's behavior exactly — so multi-host is configuration plus a second store
+implementation, not redesign (§5.11). The migration drops the dead
+`sessions.container_id` and adds the pointer columns. The artifact itself is a
+deterministic local tag in v1 (a host-independent store ref under a remote store); GC
+metadata rides on image labels; a single retain-rule
+reconciler replaces `reap_orphans` and doubles as the convergence authority that corrects
+pointer drift.
+
+Two facts discovered on the production host are prerequisites, not details (§9): Server B
+runs an **hourly `docker image prune -af --filter until=48h` cron** that would silently
+delete every snapshot idle >48h (a lockstep eumemic-ops change must exempt
+`aios.managed=true` images *and* introduce a snapshot disk budget, because the exemption
+removes the only bound that exists today), and prod runs the **containerd image store**,
+not the overlay2 graphdriver every Docker experiment in this design was verified on — the
+verification battery must be re-run there before implementation.
+
+## 2. Corrections to the brief (verified against code)
+
+The brief's current-state sketch was mostly right. Four corrections:
+
+1. **The lease columns are gone.** `lease_worker_id` / `lease_expires_at` were dropped in
+   migration `0002` (Phase 5 replaced the DB-lease protocol with procrastinate's `lock`).
+   Only `sessions.container_id` (migration 0001) survives, and it is dead — zero SQL
+   reads/writes anywhere. It should be **dropped**, not repurposed.
+2. **`reclaim_session_if_idle` (loop.py:256) is not the sandbox idle hook.** It is
+   archive-on-quiescence for `archive_when_idle` workflow sessions (a conditional
+   `UPDATE sessions SET archived_at = now()`). The sandbox idle path is the registry's
+   own reaper: `_reap_idle_once` → `release()` → `docker rm --force`
+   (registry.py:631-657).
+3. **There are six teardown/loss sites, not one**: idle reaper; mount-snapshot drift
+   (`release_if_mounts_changed`); `spec_version` drift recycle inside `get_or_provision`
+   (Postgres trigger from migration 0077 bumps it on memory-store / github-repo
+   attach/detach/token-rotate); `evict()` on tool failure; `release_all()` at worker
+   shutdown; `reap_orphans()` at worker boot. Persistence must hook all of them.
+4. **Host topology in the code today**: the worker is a Postgres advisory-lock-enforced
+   **singleton per database** (worker.py:301) — one worker, one Docker daemon (DooD
+   socket mount), one host. Horizontal scale (a stated requirement) therefore takes one
+   of two shapes (§9.3): **shard-by-DB**, which preserves the singleton invariant per
+   shard, or an **elastic worker pool**, which lifts the advisory lock while
+   procrastinate's per-session `lock` — a DB-level lock — continues to serialize steps
+   across workers. Either way, a resuming worker must be able to *find* a snapshot that
+   another daemon produced, which is what forces the DB snapshot pointer (§5.1).
+
+Also verified and load-bearing: prod has **no working `--storage-opt` quota** (the flag
+requires overlay2-on-xfs+pquota; `AIOS_SANDBOX_DISK_BYTES` defaults to None and would be
+rejected at `docker run` on this daemon), so any quota story must work without it.
+
+## 3. The persistence contract (validated, two amendments)
+
+**Persists** (via the snapshot image): the entire writable root FS — `/root`, `/etc`,
+`/usr`, `/var`, `/opt`, `/home`, **`/tmp`** (a normal overlay dir, not tmpfs), global
+apt/pip/npm installs, and deletions of base-image files (`docker commit` captures
+overlayfs whiteouts — verified).
+
+**Persists** (via host bind mounts, exactly as today, *not* via the snapshot):
+`/workspace`, `/mnt/attachments`, `/mnt/uploads`, `/mnt/memory/*`, github working trees.
+`docker commit` excludes bind-mount contents (verified), so there is no duplication and no
+interaction between snapshot GC and workspace data.
+
+**Does not persist**: processes, fds, locks, sockets, netns/iptables state, `/dev/shm`
+(tmpfs), the container IP. Resume = fresh process tree on the persisted disk.
+
+This contract is the natural semantics of disk persistence — a fresh boot on a persisted
+disk — and the strongest version of it aios can honestly promise. **Process persistence
+is rejected decisively**: Docker checkpoint/CRIU is experimental, bridge-network restore
+is structurally broken since Docker 28 (moby#50750, open), and the `criu` package is
+absent from Ubuntu 24.04 LTS entirely. Even a hypothetical working process snapshot
+cannot preserve live TCP connections or other kernel-held resources, so the marginal
+value over disk-only does not justify the machinery.
+
+Two deliberate amendments to the proposed contract, both strengths:
+
+- **Environment variables do not persist.** Resume re-derives env from the *current*
+  spec. The committed image config is actively scrubbed (§5.2) so a secret removed from
+  `env_config.env` cannot resurrect inside a resumed container.
+- **Security posture does not persist.** seccomp profile, no-new-privileges, resource
+  caps, and the network lockdown are re-applied from *current* settings at every resume.
+  A session parked across a security-hardening deploy resumes with the new flags. (This
+  is the structural advantage over mechanism A's frozen stopped containers.)
+
+**Two containerd-image-store amendments (verified on the production store, which OVERRIDE
+the overlay2-verified §5.2/§5.6 pseudocode and are what the implementation ships):**
+
+- **Skip-empty threshold is a byte floor, not `== 0`.** A no-write container reports
+  `SizeRw == 4096`, not 0, on the containerd image store. The identity short-circuit fires
+  on `SizeRw <= sandbox_snapshot_empty_floor_bytes` (default 8 KiB), so read/chat-only
+  sessions never grow a chain (§5.7's premise). An `== 0` test would never fire in prod.
+- **Flatten is budget-driven; the layer wall does not exist.** The overlay2 ~125-layer
+  commit wall is absent on the containerd store (a chain ran cleanly through 250 layers).
+  Flatten is therefore driven by the per-session unique-bytes budget (storage), with layer
+  depth as a *soft* performance guard at a generous ceiling (`_FLATTEN_DEPTH_CEILING = 200`,
+  below the kernel overlayfs lower-layer max), not a hard-wall dodge. The rest of the
+  containerd verification battery (label inheritance through commit, `rmi` parent-chain
+  cascade, `images -a` residue visibility, `export|import` flatten + config strip, the
+  `prune --filter 'label!='` exemption) confirmed the design unchanged.
+
+## 4. Mechanism decision
+
+**Preserve the disposable-instance model; persist the filesystem as an image.** The whole
+codebase is built around containers being recreatable at any moment (six teardown sites,
+spec rebuilt fresh each provision, secrets re-minted, lockdown re-applied). Mechanism B
+is the only option where resume *is* the existing provision path — every drift problem
+(env, mounts, secrets, seccomp, broker URL, iptables) dissolves structurally because
+resume is a cold start that happens to run from a persisted rootfs.
+
+| | **B: disposable + commit (chosen)** | A: durable stopped container | C: overlay-upper / podman `--rootfs` |
+|---|---|---|---|
+| Resume path | existing provision, unchanged shape | new `docker start` path + adoption logic | existing shape, new runtime |
+| Config/mount/secret drift while idle | dissolves (fresh `docker run` from snapshot) | **fatal flaw**: env/mounts/seccomp frozen at create; broker secret 401s; needs commit machinery anyway as drift escape hatch → two resume paths | dissolves (artifact carries zero config) |
+| `spec_version` recycle (a today-feature) | FS preserved | **loses entire FS** (pure A) or imports B's machinery (hybrid) | FS preserved |
+| Snapshot cost per idle cycle | 0.3–15 s commit, delta-sized (fresh container ⇒ empty layer ⇒ per-cycle delta) | ~0 (stop) | ~0 (structural) |
+| Failure surface | lineage gate + salvage + flatten + image GC + pointer/store reconciliation | smallest | smallest (no snapshot step exists) |
+| Layer/chain management | flatten on the unique-bytes budget (depth ≥ 200 soft guard — §3); flattened image duplicates base (~466 MB) | none | none |
+| Quota on prod ext4 | commit-time accounting (`SizeRw`, image sizes) | `SizeRw` scan | **best**: per-session loopback ext4 = kernel ENOSPC at write time |
+| Deployment change | none beyond the §9 prune-cron/budget lockstep (shard shape); elastic pool adds a registry/object store (§9.3) | same as B | privileged worker + podman/netavark/crun in the worker image; macOS dev can't run it (two backends, flagship behavior untestable locally) |
+| Security posture refresh at resume | **yes** (current flags) | no (frozen) | yes |
+| Future fork/replay of sandboxes | natural (immutable image artifacts) | requires committing anyway | natural (CoW dirs) |
+| Verified mechanics | live-verified (on overlay2 — §9 caveat) | live-verified | documented, unverified spikes needed |
+
+A's steelman conceded that the hybrid needed to match B's preservation guarantees is
+*more* total mechanism than B alone. C's steelman conceded that at aios's per-host
+scale (one daemon per host/shard, tens-to-hundreds of sessions each) the failure surface
+C deletes is mostly surface aios won't hit, while its deployment cost is concrete and
+immediate; C's case only wins if write-time disk quotas get promoted to a hard
+requirement. No researched platform ships commit-based per-idle persistence at scale —
+but the published cautionary tale against whole-filesystem serialization (O(size) per
+*change*, at hyperscale) doesn't transfer to per-*idle*, delta-sized commits at this
+deployment's scale, and unlike every alternative, B needs no new container backend and
+no privileged deployment change — its ops footprint is the §9 prune-cron/budget
+lockstep.
+
+Horizontal scale is a stated requirement and is carried *within* B: snapshot transport
+sits behind a `SnapshotStore` seam (§5.2) — local-daemon in v1, registry/object-store as
+a drop-in — and snapshot location lives in the DB (§5.1), so a second worker or a host
+replacement is configuration plus a store implementation, not redesign (§5.11). If aios
+later needs write-time disk quotas or sandbox forking as a product feature, the
+C/microVM per-session-rootfs-artifact remains the successor design for the *backend*;
+the store seam and the DB pointer carry over unchanged.
+
+## 5. The design
+
+### 5.1 Identity and state: deterministic tag, image labels, DB snapshot pointer
+
+**Tag**: `aios-sbx-{instance_id}-{session_id.lower()}:latest`. ULID lowercasing is
+bijective; the single-path-component form means `_is_registry_image()` returns False, so
+the existing `--pull always` logic never touches the registry for snapshots (verified
+against docker.py:352-377). `instance_id` isolates concurrent dev worktrees on one daemon.
+
+**State splits: DB = location + existence; store/daemon = content + lineage.**
+Single-host, the daemon alone was a defensible source of truth — a DB column would have
+been a cache with no consumer able to trust it over the local probe (the original draft's
+position). With horizontal scale a requirement, the column gains the consumer no daemon
+probe can replace: *where does this session's snapshot live?* A worker resuming a session
+whose snapshot another daemon produced is blind without it. Sessions carry a pointer:
+
+```
+snapshot_ref         text         -- artifact identity: a deterministic, host-independent name
+                                  -- (the local tag string in v1; each store maps it into its
+                                  -- own namespace, §5.2); NULL = none
+snapshot_host        text         -- owning worker/daemon/host id; NULL = none
+snapshot_bytes       bigint       -- last-known unique size; reporting only, never an
+                                  -- enforcement input (§5.7)
+snapshot_updated_at  timestamptz
+```
+
+**Drift discipline** (the answer to "a cache that lies in every failure mode"): the
+pointer is written **inside the snapshot critical section — after commit success, before
+`rm` — under the per-session lock**, so it never claims a snapshot that wasn't committed.
+The GC reconciler (§5.5) is the convergence authority: each tick re-derives truth from
+its own store and corrects the pointer (commit-succeeded/DB-write-failed crash residue,
+operator `rmi`, manual mess). The pointer is a reconciled routing hint, never blindly
+trusted — but unlike the rejected single-host cache, removing it would leave multi-host
+resume with no way to function at all. Content truth — the lineage gate, labels, sizes —
+stays local to the owning daemon, unchanged. The worker-side daemon-enumerating sweep is
+still structurally required (session delete runs in the API process, which has no Docker
+socket); the pointer doesn't replace it, it routes around its locality.
+
+`snapshot_host` is `settings.instance_id` in v1 (one worker, so trivially unique).
+Multi-worker shapes need a per-worker host-id setting **distinct from `instance_id`**:
+the tag/ref namespace must stay deployment-stable while host identity varies — if each
+worker minted refs from its own id, every cross-host handoff would change the session's
+ref and reopen the first-commit crash window (§5.3). Invariant (§5.11): `snapshot_ref`
+is a pure function of (deployment, session), never of which worker committed. The four
+columns are internal — not exposed on the session wire shape, the same stance the dead
+`container_id` had.
+
+**Labels** (all stamped at `docker run`, inherited into committed images automatically —
+verified):
+
+- `aios.managed=true`, `aios.instance_id`, `aios.session_id` — exist today.
+- `aios.env_keys=<comma-separated names>` — **new**: the names (never values) of every
+  run-injected env var. Makes any corpse self-describing for the commit-time ENV scrub
+  (§5.2) without any DB lookup, including corpses salvaged after a crash when the
+  original spec is gone.
+- `aios.base_image=<resolved spec.image ref>` — **new**: which base this session's chain
+  is rooted on. Drives both base-drift detection (§5.3) and accurate accounting (§5.7).
+- `aios.flattened=true` — **new**, applied via `--change` at import only: marks images
+  that no longer share layers with the base, so accounting charges them full size (§5.7).
+
+No `aios.account_id` label: it would let any daemon-local reader enumerate the
+tenant graph. The GC's existing batch DB query maps session→account where needed.
+
+### 5.2 The snapshot operation
+
+Drop `--rm` from `DockerBackend.create`. One new backend verb performs:
+
+```
+docker stop -t 5 <id>                          # idempotent on stopped corpses
+docker inspect <id>          → .Image (parent), .Config.Env, labels
+docker image inspect <tag>   → .Id, layer depth, .Size      # absent → first snapshot
+LINEAGE GATE: proceed iff tag absent OR tag.Id == corpse.Image   # else skipped_stale
+docker inspect --size <id>   → SizeRw
+SizeRw <= empty_floor → skipped_empty          # identity short-circuit (containerd no-write == 4096; §3)
+flatten? (unique-bytes over per-session budget [primary], or depth+1 ≥ 200 [soft guard] — §3)
+  COMMIT:  docker commit --change 'ENV K='  (per key in aios.env_keys ONLY)  <id> <tag>
+  FLATTEN: docker export <id> | docker import
+             --change 'CMD ["tail","-f","/dev/null"]'
+             --change 'WORKDIR /workspace'
+             --change 'ENV HOME=/home/aios'
+             --change 'LABEL …'  (managed/instance/session/env_keys/base_image/flattened)
+             - <tag>
+```
+
+The caller then runs the existing `force_remove`. **Ordering invariant: the container is
+removed only after the snapshot verb succeeds.** On failure the stopped corpse is
+retained and the error goes to the ops log; convergence is the salvage rule (§5.4).
+
+Adversarial-review corrections folded in (three of these were verified failures in the
+original spec):
+
+- **ENV scrub scope** (was a verified container-bricker): scrub *exactly* the
+  `aios.env_keys` set. Scrubbing all of `.Config.Env` empties `PATH`/`HOME` inherited
+  from the base image config, and Docker does not re-inject a default `PATH` when the
+  key is present-but-empty — the snapshot's CMD then fails `exec` lookup and **every
+  resumed container fails to start** (reproduced live). Key-set diffing against the
+  parent image is also wrong: at generation ≥2 the parent already carries scrubbed keys
+  as `K=`, so a diff would skip re-scrubbing and leak fresh secret values. The label is
+  the only sound source. Known wart: `ENV K=` empties rather than unsets; removed vars
+  read as empty strings until the next flatten strips config entirely.
+- **No `rmi` inside the flatten path** (was a deterministic failure): the corpse being
+  flattened was created *from* the old chain's image, and a container — even stopped —
+  blocks `rmi`, so an in-verb cleanup is refused 100% of the time and, under the
+  corpse-retained-on-failure rule, would wedge the session in a permanent release/salvage
+  loop. Snapshot success = new tag exists, nothing else; the orphaned old chain is
+  collected by the GC retain rule on the next tick, after the corpse is gone. One
+  reconciler, not two.
+- **Size-derived timeout** (was a permanent-brick path): a fixed 300 s commit timeout
+  turns a ~110 GB writable layer into an infinite retry loop (commit times out → corpse
+  retained → salvage times out → provision fails → forever). Timeout = constant floor +
+  per-byte budget at ~10× measured throughput, derived from the `SizeRw` already read in
+  the sequence — fires only on a genuinely hung daemon, never on size.
+- **Restore `WORKDIR` and `HOME` at flatten** (was a silent behavior shift): import
+  strips all config; without these, post-flatten sessions exec with cwd=`/` and
+  `HOME=/root`. `PATH` is deliberately *not* restored so Docker injects its default.
+- **`skipped_stale` is for content-equal crash residue only**: under the salvage-
+  before-provision invariant, the only reachable corpse-with-newer-tag states are
+  crash-between-commit-and-rm and crash-between-import-and-cleanup, both content-equal to
+  the tag. The gate never discards live data; assert that as a unit-tested invariant.
+- **Skip-commit-if-`SizeRw==0`** is included as an identity short-circuit, not
+  belt-and-suspenders: a zero-byte layer produces content identical to the existing tag.
+  It is what keeps chat-only and read-only sessions from ever growing a chain, and what
+  makes deploy-time salvage commits free for unchanged sessions.
+
+Protocol additions (`backends/base.py`): `snapshot(sandbox_id, tag, *,
+flatten_if_unique_bytes_over) -> SnapshotOutcome` (the depth wall is backend-internal),
+`stop(sandbox_id)`, `list_managed_images(instance_id)`, `remove_image(ref) -> bool`
+(rmi-no-force; False when refused), `image_size(image)`. `SandboxSpec` and
+`SandboxHandle` gain `snapshot_image: str | None`; the handle gains
+`disk_limit_bytes: int | None`. `ManagedSandboxRef` gains `running: bool`
+(`list_managed` switches to `docker ps --all`).
+
+**`SnapshotStore` seam** (`sandbox/snapshot_store.py`) — transport is pluggable; the
+lifecycle/salvage/lineage/flatten/GC-classify logic above never sees it:
+
+```python
+class SnapshotStore(Protocol):
+    async def put(self, local_image_tag: str, ref: str) -> str: ...  # persist a just-committed local image; returns stored ref
+    async def get(self, ref: str) -> str: ...                        # make ref locally runnable (pull/load if remote); returns local tag
+    async def exists(self, ref: str) -> bool: ...                    # verified-negative semantics; indeterminate raises
+    async def remove(self, ref: str) -> bool: ...
+    async def size(self, ref: str) -> int: ...
+```
+
+v1 **`LocalDaemonStore`**: `put`/`get` are identity (the image is already local),
+`exists` = `docker image inspect` under the §5.3 verified-negative rule, `remove` =
+`rmi`, `size` = image size — exactly today's behavior, now behind the seam. A future
+`RegistryStore`/`ObjectStore` (`put` = push or `save | upload`, `get` = pull or
+`download | load`) drops in with no lifecycle changes.
+
+**Refs are host-independent names**, a pure function of (deployment, session); each
+store maps the name into its own namespace deterministically (`LocalDaemonStore`: the
+name *is* the local tag; a `RegistryStore` prefixes its configured registry path). The
+pointer therefore never needs rewriting after a push, and the shard+async-push
+configuration is a *hybrid* store: `get` prefers local, falls back to the remote
+namespace. Digest-pinned refs are possible only under the elastic pointer-after-`put`
+ordering (the digest doesn't exist when a pointer-before-push write happens).
+
+Two boundaries attach to the snapshot verb without changing its internals: the **DB
+pointer write** (`snapshot_ref/host/bytes/updated_at`) happens after the verb succeeds
+and before `force_remove`, in the same critical section — and a **failed pointer write
+is treated identically to a failed snapshot verb**: corpse retained, no `rm`, ops-log
+error, convergence via salvage. When durable transport is enabled (§9.3), an **async
+`store.put` is enqueued after the pointer write** — never on the release critical path.
+In the elastic-pool shape the pointer is instead written only after `put` returns, so it
+never routes a peer to an artifact it cannot fetch; `put` then sits inside the critical
+section and obeys the same size-derived timeout rule as commit/flatten.
+
+### 5.3 Resume
+
+Resolution runs through the store: `sessions.snapshot_ref` set → `store.get(ref)` → run
+from the returned local tag; else the base path (env override → `settings.docker_image`)
+with today's pull logic. With `LocalDaemonStore`, `get` is an inspect of the
+deterministic local tag — today's behavior exactly. Rules:
+
+- **Verified-negative only, extended to the store** (was a silent double-data-loss path):
+  only a *verified* not-found from `get`/`exists` selects the base path. Any
+  indeterminate result (daemon or registry hiccup, timeout) raises and fails the
+  provision — treating an indeterminate probe as absence would silently cold-start the
+  session and then, at the next idle, the lineage gate would discard all post-hiccup
+  work as `skipped_stale`.
+- **Snapshot-missing is detected, not silent**: pointer set + store verified-not-found
+  can only mean external mutation (operator `rmi`, image-store loss, host replacement
+  without transport). The provision clears the pointer, appends a model-visible
+  `sandbox_fs_reset {reason: "snapshot_missing"}`, and cold-starts from base. (This was
+  the original draft's one accepted silent case; the pointer makes detection free, so
+  silence is no longer defensible.)
+- **Base-image drift is detected, never silent** (was a textbook silent fallback): if the
+  snapshot resolves but its `aios.base_image` label ≠ the currently resolved
+  `spec.image` *ref*, the operator deliberately redefined the environment's image. The
+  snapshot is discarded — **`store.remove(ref)` + pointer cleared, in the same provision
+  step** (the artifact must actually be gone: a surviving tag would be re-pointered by
+  GC pass 4, and the next idle's lineage gate would see a corpse rooted on the new base
+  against the old tag and discard live post-drift work as `skipped_stale`) — a
+  model-visible `sandbox_fs_reset {reason: "environment_image_changed"}` lifecycle event
+  is appended, and the session cold-starts on the new image. (Content changes under the *same* ref — base rebuilds, `:stable`
+  promotes — do not trigger this; parked chains keep their pinned base until reset or
+  expiry.) Keep-the-FS-instead is a defensible alternative semantic; the event is the
+  non-negotiable part — sign-off item §11.
+- **First-commit crash heal**: the salvage preamble (§5.4), already under the per-session
+  lock, also reconciles the pointer against local truth — a crash after the first-ever
+  commit but before the pointer write leaves `snapshot_ref` NULL while the local
+  canonical tag exists; the preamble sets the pointer before resolution runs, closing
+  the only window where resolution could miss a local snapshot. (Later commits rewrite
+  the same ref value in v1, so the window is first-commit-only; the GC tick covers the
+  same case out-of-band.)
+
+After resolution, the provision path runs **unchanged**: fresh env from current config,
+fresh broker secret, fresh netns, lockdown re-applied (§5.8), `install_packages`
+reconciling current package config idempotently onto the persisted FS.
+
+### 5.4 Lifecycle: all six sites
+
+Two registry helpers under the existing per-session `asyncio.Lock`:
+`_snapshot_and_remove(...)` (§5.2 sequence) and `_salvage_session_corpses(session_id)`
+(list this session's containers → stop if running-and-uncached → lineage-gated snapshot →
+remove).
+
+| Site | Today | New behavior |
+|---|---|---|
+| Idle reap | `docker rm --force` | snapshot → rm. The main snapshot point. |
+| Mount-drift release | destroy | snapshot → rm; resume rebuilds current mounts on the persisted FS. |
+| `spec_version` recycle | destroy mid-step | snapshot → rm; the immediately following provision resolves the just-written tag — an FS-preserving reboot. |
+| `evict()` (tool failure) | drop cache (`--rm` self-removes) | **code unchanged**; the corpse now persists and is salvaged by the session's next provision or the GC tick, whichever first. |
+| **Provision preamble (new)** | — | `_provision` starts with `_salvage_session_corpses` under the lock, then reconciles the snapshot pointer against local truth (§5.3). **Container death no longer loses data.** Salvage failure fails the provision — raw error into the tool result, model-actionable; never a silent resume from the stale tag. |
+| Worker shutdown | destroy all | `stop_all()`: parallel `docker stop -t 5` under one overall `wait_for` (~8 s) so a hung daemon can't eat the SIGTERM grace; no commits (unbounded). Per-container failures are ops-log noise — the boot tick converges regardless. |
+| Worker boot | `reap_orphans` removes all | **deleted**, replaced by the GC sweep's immediate first tick as a background task. Boot is not blocked; a session waking mid-reconcile salvages its own corpse inline under its own lock. |
+
+**Worker crash**: containers keep running; the advisory lock frees when the dead worker's
+PG connection drops; the returning worker's first GC tick stops + salvages.
+(Singleton/shard shapes. In an elastic pool the crashed worker's host retains its corpses
+until *its own* worker returns — peers cannot reach that daemon, which is the §9.3
+async-push motivation.) **Daemon restart/host reboot**: running → stopped corpses
+(restart policy stays `no`) → salvaged. The worker is a container on the same daemon, so
+"daemon restarted but worker didn't" is structurally impossible (live-restore=false,
+verified).
+
+**Concurrency** (one container ever runs per session): three locks at three scopes — the
+DB advisory lock (one worker per database; singleton/shard shapes — lifted in the
+elastic pool, where procrastinate's DB-level per-session lock carries cross-worker *step*
+exclusion but not host co-location, see §8/§9.3), the procrastinate per-session lock
+(one step), and the registry per-session asyncio lock (provision / release / salvage /
+GC-per-corpse mutually exclusive within the worker). The lineage gate makes the residual
+crash windows content-equal no-ops.
+
+### 5.5 GC: one retain-rule reconciler
+
+`start_gc(pool, ...)` — background loop, hourly tick, immediate first tick at boot:
+
+1. **Corpse pass** — per corpse, under `_lock_for(session_id)`: **consult the retain rule
+   first** (a deleted or TTL-expired session's corpse is removed *without* paying the
+   commit), then salvage (lineage-gated) and remove.
+2. **Image pass** — `docker images -a` (with `--filter label=aios.managed`); the `-a` is
+   load-bearing: untagged crash residue is invisible without it (verified). Untagged
+   interiors of live chains are skipped **structurally** — exclude any image that is the
+   `.Parent` of another listed image — rather than leaning on rmi-refusal churn. Then the
+   single rule: **an image is retained iff it is the canonical tag of an existing session
+   whose last activity is within the TTL** (`sandbox_snapshot_ttl_seconds`, default 30
+   days, keyed on session dormancy via the `(session_id, last_event_seq)` event row — a
+   point probe, not `MAX(events.created_at)`). Everything else managed-and-mine is
+   removed: crash residue, flatten leftovers, deleted sessions (this *is* the delete
+   hook — ≤1 h lag), and dormant sessions (the latter with a model-visible
+   `sandbox_fs_expired {reason: "retention_ttl"}` event). Archived sessions follow the
+   same dormancy rule (unarchive exists; immediate deletion would strand it).
+3. **Pool-budget pass** — if this host's snapshot total exceeds
+   `sandbox_snapshot_pool_bytes` (§5.7), evict **most-dormant sessions first** (by the
+   same `last_event_at` the tick already fetched — *not* image `.Created`, which
+   skip-empty pins and which would evict the most-active session first), each with
+   `sandbox_fs_expired {reason: "disk_pressure"}`.
+4. **Pointer reconciliation** — the tick writes/clears
+   `snapshot_ref/host/bytes/updated_at` to match what its own store actually holds:
+   every removal of a *canonical* artifact in passes 2–3 clears the pointer in the same
+   per-session lock scope; a canonical tag present with a NULL or stale pointer (crash
+   residue) gets the pointer set. The DB never ends a tick claiming something the owning
+   store disowns. **Pointer writes and clears are ownership-gated**: a tick touches
+   `sessions.snapshot_*` only for sessions whose `snapshot_host` is this host (or NULL,
+   for the crash heal) — evicting a local *cache* of another host's artifact never
+   touches the canonical pointer. On multi-host shapes, pointer advancement (salvage, GC
+   heal) is additionally **compare-and-swap** — `UPDATE … WHERE snapshot_host = <this
+   host> AND snapshot_updated_at = <value read at tick start>` — so a session that moved
+   to another host can never be clobbered by a returning host's stale corpse; a CAS
+   failure demotes the local corpse/tag to non-canonical residue, removed without
+   commit. When async push is enabled, the tick also reconciles the store against the
+   local canonical tag (re-enqueue `put` on digest mismatch), so a crash-dropped push
+   converges instead of leaving unbounded staleness.
+
+**Ownership across hosts**: each host GCs only its own store. For a deleted/expired
+session whose `snapshot_host` is another host, the non-owning tick **skips** — the DB
+pointer tells it not to reach across; the owning host's tick removes. On multi-host
+shapes the retain rule gains an ownership clause: a local image whose session's
+`snapshot_host` is elsewhere is a transport cache, reclaimable once unreferenced, never
+the canonical copy. With a `RegistryStore`, registry-artifact GC is keyed on the DB
+pointers (the registry has no session knowledge) — run by a **single designated
+ticker** (config), with an age grace period exceeding the put→pointer window so a
+just-pushed artifact is never collected before its pointer lands. A **permanently
+decommissioned host** is an explicit operator action: clear `sessions.snapshot_*` for
+that `snapshot_host`, which converts future resumes into detected resets and fixes
+global accounting — without it, never-waking sessions' pointers (and their
+`snapshot_bytes`) leak indefinitely, since non-owning ticks skip by design. All of this
+is vacuous single-host.
+
+**Every per-session image removal in passes 2–3 takes `_lock_for(session_id)` and
+re-checks under the lock** (cached handle present → skip; condition re-verified). Without
+this, the TTL/budget pass can race a waking session in the window between
+corpse-salvage and `docker run`, when no container references the tag and `rmi` would
+succeed against a just-salvaged snapshot (a verified-constructible interleaving).
+
+`docker rmi` of a tag cascade-deletes the entire untagged parent chain down to the first
+still-referenced image (verified on overlay2; re-verify on containerd, §9) — GC of an
+arbitrarily long session history is one command. Each tick logs a one-line summary
+(images retained/removed, bytes, top sessions by usage) so "why is the disk full" is
+answerable from logs.
+
+### 5.6 Flatten policy
+
+Each nonzero idle cycle adds one layer. On the overlay2 graphdriver commits hard-fail at
+a ~125-layer wall; the production **containerd image store has no such wall** (a chain ran
+cleanly through 250 layers — §3), so flatten is driven primarily by the per-session
+**unique-bytes budget**, with layer depth as a *soft* performance guard. Flatten
+(`export | import`) when unique bytes exceed the per-session budget, or when `depth+1 ≥
+200` (a generous backstop below the kernel overlayfs lower-layer max) — flatten applies
+whiteouts, so it is also what makes "delete files to
+shrink" actually work, and it strips baked config entirely (the definitive secret-residue
+scrub). Cost honesty: a flattened image is a standalone rootfs that stops sharing the
+466 MB base — acceptable at this scale, and rare once the idle-TTL change (§5.10) cuts
+cycle counts by an order of magnitude.
+
+### 5.7 Quotas and accounting (must work on ext4)
+
+- **Delete the `--storage-opt` emission entirely** and **delete `sandbox_disk_bytes`**,
+  introducing `sandbox_snapshot_budget_bytes` (per-session, finite default ~4 GB; env
+  override keeps working through `EnvironmentConfig`). Silently repurposing a deployed
+  env var's semantics is the config-surface version of the shim "don't deprecate,
+  delete" forbids.
+- **Metric**: unique bytes = `tag.Size − base.Size` where base is the image named by the
+  chain's own `aios.base_image` label (not `settings.docker_image` — per-env overrides
+  would otherwise be billed ~1.5 GB they never wrote, triggering wrongful evictions);
+  `aios.flattened=true` images charge full `.Size` (they share nothing — subtracting the
+  base would hide ~466 MB per flattened session from the very accounting that must see
+  the host filling). Computed at read time from the owning daemon, which stays
+  authoritative for enforcement; the figure is also written to `sessions.snapshot_bytes`
+  at each commit so cross-host reporting needs no daemon round-trips.
+  **`snapshot_bytes` is reporting-only — never an enforcement input**: enforcement
+  always derives from the owning store's live enumeration (the column can be one
+  generation stale in a crash window; a future bytes-based eviction reading it would
+  silently break this).
+- **Per-session enforcement**: commit-and-flag, never refuse (refusal destroys the
+  agent's work as punishment for a state it wasn't awake to prevent). Over budget →
+  flatten instead of commit; if still over, append `sandbox_fs_over_limit` —
+  **edge-triggered** on the crossing (previous size ≤ limit < new size), not re-fired
+  every cycle.
+- **Pool budgets** (`sandbox_snapshot_pool_bytes`, operator-set): the load-bearing
+  bound. Required in v1 because the prune-cron exemption (§9) removes the only existing
+  disk control; on a 75 GB host at 76% with a documented full-disk → Postgres-PANIC →
+  11-app-cascade incident, shipping unbounded retention is not an option. Enforced
+  **per-host** by GC pass 3 from local enumeration; the **global** cross-host total is
+  computed by summing `sessions.snapshot_bytes` pointers. v1 enforces per-host and
+  reports global.
+- **Per-account caps** (`accounts.config.sandbox_snapshot_bytes`): **deferred to a
+  follow-up.** The eviction engine is the most intricate code in the design and would
+  ship dead (no account will have a cap set); v1 ships per-account *usage* as a read-time
+  ops metric only. (Ethos review; consistent with the no-belt-and-suspenders rule.)
+- **Stated residual**: nothing bounds the *live* writable layer between commits on ext4 —
+  prod's status quo today. Host disk monitoring (plus the eumemic-ops audit extension,
+  §9) is the mitigation; a write-time quota requires xfs+pquota or mechanism C.
+
+### 5.8 Security
+
+**Network lockdown moves off the tenant-writable filesystem (blocker, and a pre-existing
+hole).** Today `apply_network_lockdown` runs `bash`/`iptables`/`getent` *inside* the
+sandbox via `docker exec` — i.e., from the container's own root FS — and grants the
+sandbox `--cap-add NET_ADMIN`. Under persistence this is a working bypass: a tenant
+replaces `/usr/sbin/iptables` with `exit 0` in an Unrestricted session, the snapshot
+persists it, and when the environment later flips to Limited the fail-closed gate
+trusts the poisoned binary's exit 0 — open egress, no audit artifact. (It is *already* a
+hole today in milder form: a root agent holding NET_ADMIN can simply `iptables -F` its
+own lockdown.) Fix, using only the docker CLI: apply the lockdown from an **ephemeral
+sidecar** — `docker run --rm --cap-add NET_ADMIN --network container:<sandbox>
+<settings.docker_image> bash -c <script>` — which joins the sandbox's netns but executes
+the *operator-trusted* image's binaries (never `env_config.image`, which is
+tenant-controlled), then verifies `-P OUTPUT DROP` through the same sidecar. The sandbox
+itself **loses `--cap-add NET_ADMIN` entirely**: root-in-sandbox can no longer modify
+netfilter at all. This closes both the persisted-FS bypass and the pre-existing
+flush-your-own-lockdown hole, and hardens the Limited profile beyond today's.
+
+**Cross-tenant snapshot isolation (blocker).** `spec.snapshot_image` is derived only from
+the session row the worker is stepping. But `env_config.image` is a free-form
+tenant-writable string, snapshot tags are single-component (no pull → resolved locally),
+and `instance_id` is `default` in prod — so `image: aios-sbx-default-<victim-ulid>:latest`
+would mount another session's entire root FS and its baked secrets. ULIDs are not
+secrets (they appear in URLs, logs, events). **Gate**: reject any `env_config.image`
+matching the reserved `aios-sbx-` prefix (case-insensitive) in `build_spec_from_session`
+— the choke point all writers traverse, including direct SQL — **plus** a
+`field_validator` on `EnvironmentConfig.image` returning a 422 at the API boundary. The
+two layers cover different writer sets (deliberate, flagged: the validator is UX +
+window-shrinking; the spec gate is the boundary).
+
+**Secrets.** Run-injected env (which can include operator API keys in `env_config.env`)
+is scrubbed from image config via the `aios.env_keys` label (§5.2); flatten strips config
+entirely. What remains: secrets the agent itself wrote to disk (`~/.netrc`,
+`~/.aws/credentials`) are in the snapshot *filesystem* — the same exposure class as
+`/workspace` on host disk today, but now also readable by anything with daemon access
+(`docker save`, image inspect of FS layers). **Accepted threat-model boundary requiring
+sign-off**: daemon access ≈ host root, already a near-total compromise; the marginal
+regression is retention duration, bounded by TTL/budget.
+
+**Deferred hardening, dispositioned rather than re-deferred**: `--read-only` is
+**permanently incompatible** with this contract (the contract *is* a writable persistent
+root) — close it as superseded, don't re-defer it. `--cap-drop=ALL` stays deferred
+(apt/dpkg interaction unchanged by this design), but this design already removes
+NET_ADMIN, the largest grant. The resume-fresh-flags property means any future hardening
+retrofits every parked session automatically.
+
+**Supply-chain accumulation**: agent-installed software re-executes at every resume —
+inherent to persistent disk. Bounds: dormancy TTL, budgets,
+fresh security flags each resume, and the sidecar fix removing the worst consequence
+(lockdown subversion). `install_packages` still runs tenant-FS package managers at
+resume; with the lockdown gate moved off the sandbox FS, a poisoned pip/apt harms only
+the tenant's own sandbox — unchanged from the agent running them directly.
+
+### 5.9 Agent observability
+
+`build_messages` skips all non-`message` events today, so loss events need a render path:
+a minimal allowlist in context.py (`sandbox_fs_expired`, `sandbox_fs_over_limit`,
+`sandbox_fs_reset`) rendered as bracketed user-role notices at their seq position —
+append-only in, append-only out (monotonicity holds), **not** stimulus-bearing
+(`find_sessions_needing_inference` ignores them, so a GC append never wakes a session or
+costs a model call; the notice is read at the next genuine wake). Event text uses runtime
+vocabulary only, e.g.: *"The persisted sandbox filesystem for this session was discarded
+(retention limit). The next command runs on a fresh base filesystem; /workspace and
+mounted directories are unaffected."*
+
+Saves are silent in the session log (model-consciousness: loss is actionable, routine
+saves are noise). The existing `sandbox_provision_*` span gains the resolved image ref +
+chain depth + size, so "why did this session cold-start" is answerable after the fact
+(consecutive spans flipping snapshot→base expose even operator-caused wipes).
+
+The original draft accepted one silent case — operator `rmi`, host migration — because
+zero DB state made "never snapshotted" and "externally removed" indistinguishable. The
+snapshot pointer (§5.1) reverses that: external loss is now detected at resume (pointer
+set, store verified-not-found) and surfaced as `sandbox_fs_reset {reason:
+"snapshot_missing"}` (§5.3). Every FS-loss path the model can encounter is now evented.
+
+### 5.10 Idle-TTL economics (the constant this design inverts)
+
+`container_idle_timeout_seconds=300` was tuned when teardown was a free `docker rm`.
+Under B, teardown costs a commit, a layer, and eventual flatten — keeping an idle
+container alive is now the *cheap* option (a parked `tail -f` container is ~1 MB RSS).
+At 300 s, a daily-driver session commits 20–80×/day and a 15-minute cron-trigger session
+~96×/day, hitting the flatten wall in days and turning the design's cost model into
+fiction. **Raise the default to 1800 s (30 min) in the same change**, with the rationale
+in the field description. A 15-min cron session then never idles out at all (zero
+commits until it stops); a conversational session commits a handful of times a day.
+Re-run the §5.6/§5.7 arithmetic at both values in the PR description.
+
+### 5.11 Cross-host invariants (hold even when deployed single-host)
+
+1. A session's snapshot is addressable by `(snapshot_ref, snapshot_host)` from the DB
+   alone — no daemon enumeration required to *find* it.
+2. Resume on a non-owning host goes through `store.get(ref)` or fails loud — never a
+   silent cold start on an indeterminate probe.
+3. GC removes only artifacts its host owns; local images of sessions owned elsewhere are
+   transport caches, and a non-owning tick skips rather than reaches across.
+4. The DB pointer is written after commit success and before `rm`, under the per-session
+   lock, and is reconciled by GC against store truth every tick.
+5. Lineage/content truth (the lineage gate, labels, sizes) stays local to the owning
+   daemon; the DB holds location and last-known size, never content claims —
+   `snapshot_bytes` is reporting-only, never an enforcement input.
+6. Pointer writes and clears are ownership-gated (only the `snapshot_host` owner — or
+   the NULL-heal — touches `sessions.snapshot_*`), and multi-host pointer advancement is
+   compare-and-swap, so a moved-on session is never clobbered by a stale host.
+7. `snapshot_ref` is a pure function of (deployment, session_id) — never of which worker
+   performed the commit. Host identity lives only in `snapshot_host`.
+
+A pointer whose owning host no longer exists converges only via operator decommission or
+session wake — a stated leak, not a discovered one (§5.5).
+
+A single-host v1 with `LocalDaemonStore` satisfies all seven trivially — which is the
+point: nothing in the lifecycle assumes one host. The **shard-by-DB** rollout is
+configuration plus a store implementation; the **elastic pool** additionally requires
+the §9.3 prerequisites (wake→host affinity while a session has a live container or
+uncommitted state) — stated there as a named follow-on, not hand-waved here.
+
+## 6. Schema and settings
+
+**Migration 0080** (raw `op.execute`, repo style; the entire migration):
+
+```python
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE sessions
+            ADD COLUMN snapshot_ref        text,
+            ADD COLUMN snapshot_host       text,
+            ADD COLUMN snapshot_bytes      bigint,
+            ADD COLUMN snapshot_updated_at timestamptz;
+        """
+    )
+    op.execute("ALTER TABLE sessions DROP COLUMN container_id;")
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE sessions
+            DROP COLUMN snapshot_ref,
+            DROP COLUMN snapshot_host,
+            DROP COLUMN snapshot_bytes,
+            DROP COLUMN snapshot_updated_at;
+        """
+    )
+    op.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS container_id text;")
+```
+
+All four new columns are nullable with NULL = no snapshot — zero backfill, metadata-only
+DDL. They are internal (excluded from the session wire shape), so no openapi/SDK churn
+from this migration itself.
+
+**Settings** (config.py): `sandbox_snapshot_ttl_seconds: int = 2_592_000` (30 d);
+`sandbox_snapshot_budget_bytes: int = 4 GiB` (per-session; per-env override via a **new**
+`EnvironmentConfig` field replacing `disk_bytes` — never a silent semantic rename of the
+existing field, per §5.7's own no-repurposing rule); `sandbox_snapshot_pool_bytes: int | None = None` with the eumemic-ops
+deploy setting it (§9); **delete** `sandbox_disk_bytes`; raise
+`container_idle_timeout_seconds` default to 1800. The snapshot store implementation is
+selected in code (`LocalDaemonStore` in v1 — a settings knob arrives with the second
+store implementation, not before). `EnvironmentConfig` model changes flow
+through FastAPI introspection → run `./scripts/regen-openapi.sh && ./scripts/regen-client.sh`.
+
+## 7. Code touchpoints
+
+- `sandbox/backends/base.py` — `SnapshotOutcome`, new label-key constants, Protocol +=
+  `snapshot/stop/list_managed_images/remove_image/image_size`; `SandboxSpec/Handle +=
+  snapshot_image`, handle `disk_limit_bytes`; `ManagedSandboxRef += running`.
+- `sandbox/backends/docker.py` — drop `--rm`; delete `--storage-opt` block; remove
+  `--cap-add NET_ADMIN`; `create()` runs from the locally-resolved tag (resolution
+  itself lives in the provision path, below); the five new verbs (lineage gate, env-keys
+  scrub, skip-empty, flatten with full config restore, size-derived timeouts) plus a
+  label-inspect primitive for the drift check; `list_managed --all`.
+- `sandbox/_subprocess.py` — `run_docker_pipeline` (export|import over an `os.pipe()` fd
+  pair; no host shell).
+- `sandbox/snapshot_store.py` — **new**: `SnapshotStore` protocol + `LocalDaemonStore`
+  (§5.2); the only module a future `RegistryStore` touches.
+- `sandbox/setup.py` — `apply_network_lockdown` rewritten to the sidecar invocation
+  (new backend verb or a dedicated `run_in_netns_sidecar` helper); same fail-closed
+  semantics plus the `-P OUTPUT DROP` verification readback.
+- `sandbox/spec.py` — pure `snapshot_tag()` (the ref mint); reserved-prefix gate at
+  image resolution; `aios.env_keys`/`aios.base_image` labels in `_assemble_plan`;
+  populate `spec.snapshot_image` from the session row's pointer (NULL → unset).
+- `sandbox/registry.py` — `release()` → snapshot-then-remove **+ DB pointer write in the
+  same critical section** (host-side cleanup sequencing unchanged); drift-recycle path
+  uses the same helper; `_provision` salvage preamble **+ pointer reconcile + snapshot
+  resolution via `store.get`** (verified-negative rule, base-label drift check, pointer
+  clears and `sandbox_fs_reset` events — store consumption and event appends live at
+  this layer, not in the Docker backend);
+  `release_all` → `stop_all` (bounded); `reap_orphans` deleted; `start_gc` / `_gc_once`
+  with a pure `_classify_images()` for table-driven unit tests, pass-4 pointer
+  reconciliation, and the ownership clause; per-session budget policy reads
+  `handle.disk_limit_bytes`; registry holds the pool (events and pointer writes from the
+  reaper path need it).
+- `harness/worker.py` — boot: `start_gc(...)` replaces awaited `reap_orphans`; shutdown:
+  `stop_all()`.
+- `harness/context.py` — `_MODEL_VISIBLE_LIFECYCLE` allowlist + render branch.
+- `models/environments.py` — `image` field validator (reserved prefix).
+- `db/queries/__init__.py` — GC freshness query keyed on the `(session_id,
+  last_event_seq)` event row; `unscoped_set_session_snapshot` /
+  `unscoped_clear_session_snapshot` (worker-side, per the unscoped naming convention);
+  the GC batch query gains the pointer fields; `get_session_provisioning` returns
+  `snapshot_ref/host` so `build_spec_from_session` can populate the spec.
+- `config.py`, migration 0080, openapi/SDK regen as §6.
+- `harness/tool_dispatch.py` — **no changes** (evict semantics preserved).
+
+## 8. Failure-mode analysis (consolidated)
+
+| Failure | Outcome |
+|---|---|
+| Worker crash mid-commit | Tag still at S_n; corpse parent == S_n → lineage passes → recommitted at salvage. Untagged partial image = GC residue, swept. |
+| Crash between commit and rm | Tag at S_n+1 (child of corpse's image) → `skipped_stale` → corpse removed; content already captured. |
+| Crash (or DB failure) between commit and pointer write | Treated like a failed snapshot verb: corpse retained (no rm), and the preamble/GC pointer-reconcile sets the ref from local truth. First-commit-only window for *ref resolution* in v1 (later commits rewrite the same ref value; a gen≥2 crash leaves only `snapshot_bytes/updated_at` stale ≤1 tick — harmless, the column is reporting-only). |
+| Crash between flatten-import and corpse rm | New tag exists; old chain orphaned-untagged → swept by retain rule next tick (visible only under `images -a`, which the sweep uses). |
+| Daemon restart / host reboot | Running containers → stopped corpses (`--restart no`); worker dies with daemon (same host), boot tick salvages. |
+| Double resume / concurrent workers | Single-host/shard: impossible (advisory singleton + procrastinate per-session lock + registry asyncio lock). Elastic pool: procrastinate's DB-level per-session `lock` serializes *steps* across workers but does not co-locate them — live containers, fire-and-forget tool tasks, and the in-process reaper outlive a step on the host that ran it, so the elastic shape additionally requires wake→host affinity while a session has a live container or uncommitted state (§9.3); without it, consecutive wakes hopping hosts produce silent stale resumes and two live containers per session. |
+| Disk full during commit | Snapshot verb fails → corpse retained, ops-log error, pointer untouched; session's next provision retries salvage and fails loud (model-actionable raw error). Operator remediation: GC budgets + audit canary (§9). |
+| Snapshot missing at resume (operator rmi / image-store loss) | **Detected**: pointer set + store verified-not-found → pointer cleared + model-visible `sandbox_fs_reset {reason: "snapshot_missing"}` + cold start (§5.3); provision span records the resolution. |
+| Host loss | Detected at resume via the pointer (reset event), but the data is unrecoverable until a host-independent store exists — the §9.3 argument for the async `put`. With async push enabled: the replacement host's `store.get` falls back to the **last successful push** (a crash-dropped push is re-enqueued by the GC's push reconciliation, §5.5, so the lag is bounded by one tick in steady state). Elastic shape: the store is authoritative; loss bounded to unpushed deltas. |
+| Env image ref changed while parked | Detected via `aios.base_image` label → snapshot discarded (`store.remove` + pointer cleared) + `sandbox_fs_reset` event + cold start (§5.3). |
+| Mid-commit wake | Waking step blocks on the per-session lock ≤ commit duration (+ `put` duration in the elastic shape — both size-bounded), then provisions from the fresh tag. |
+| Giant layer (100 GB) | Size-derived timeout admits it; budget enforcement flattens/evicts via GC; never an infinite retry loop. |
+| Session deleted while corpse/image exist | API can't touch Docker; GC removes both within ≤1 h (corpse pass checks retain rule before salvaging — no wasted commit). |
+
+## 9. Deployment prerequisites (eumemic-ops, lockstep)
+
+1. **Prune-cron exemption + budget interlock (blocker, verified live).** Server B's
+   hourly `docker-retention-prune` runs `docker image prune -af --filter "until=48h"` —
+   it would silently delete every snapshot parked >48 h (and skip-empty pins `.Created`,
+   so even daily-active read-only sessions get wiped). Lockstep change: add
+   `--filter "label!=aios.managed=true"` to the cron and to
+   `disk-fill-recovery.md` step 2; never enable Coolify's `force_docker_cleanup`. The
+   exemption removes the only existing disk bound → it must land together with
+   `sandbox_snapshot_pool_bytes` set to real host headroom (~15 GB on Server B), and the
+   eumemic-ops `disk-usage` audit gains a label-filtered snapshot total so the canary
+   fires before Postgres PANICs (the 2026-05-14 incident shape).
+2. **Containerd-store verification battery (blocker for implementation, not direction).**
+   Prod runs the containerd image store (`io.containerd.snapshotter.v1`, verified via
+   `docker info`), while every Docker experiment behind this design ran on
+   overlay2/graphdriver. Re-verify on a containerd-store daemon (half a day): label
+   inheritance through commit, retag-in-place residue and its `images -a` visibility,
+   `rmi` cascade semantics, prune `label!=` filtering, `SizeRw` probe cost at high file
+   counts, the layer-depth wall, commit/flatten latency. Divergences are design input.
+3. **Durability timing × scale shape (decision).** Until a host-independent store
+   exists, **host loss = loss of that host's snapshots** — the DB pointer makes it
+   *detectable* (reset events at resume, §5.3), not recoverable. The transport timing
+   follows the scale shape (sign-off, §11):
+   - **Elastic worker pool** (any worker resumes any session): requires **both** a
+     host-independent `RegistryStore`/`ObjectStore` (a peer cannot find a daemon-local
+     image; the pointer is written only after `put` returns; `snapshot_host` becomes
+     advisory) **and wake→host affinity while a session has a live container or
+     uncommitted local state** — procrastinate's per-session lock serializes steps but
+     does not co-locate them, and tool tasks plus the idle reaper hold the container
+     *between* steps; without affinity, consecutive wakes hopping hosts silently resume
+     from the last committed generation while the previous host's container still holds
+     newer state. The affinity mechanism (live-handle owner gating on the wake claim, or
+     commit-per-step semantics) is a **named follow-on design**, not specified here:
+     choosing this shape means designing it first.
+   - **Shard-by-DB** (per-DB singleton worker, sessions pinned to their shard): affinity
+     makes resume host-stable, so the registry store is **deferrable** — v1 runs
+     `LocalDaemonStore`; `snapshot_host` records the home host for GC and future
+     migration/rebalancing.
+
+   **Recommended regardless of shape**: an async, off-critical-path `store.put` after
+   each successful commit (commit local → pointer write → rm → enqueue background push;
+   resume prefers local, falls back to `get` — the hybrid store of §5.2). Commit and
+   resume latency stay local while a dying host stops erasing a user's invested
+   environment — staleness bounded by the **last successful push**, with the GC tick
+   re-enqueueing dropped pushes (§5.5) so the bound is one tick in steady state. The
+   explicit sign-off: **async push in v1** (recommended) vs **seam-ready, defer the
+   second store**.
+
+   Backup reality: local snapshots live in `/var/lib/docker` — covered by whole-disk
+   backups; a DB-only restore now yields *detected* resets rather than silent cold
+   starts. Add the row to the eumemic-ops topology backup table either way.
+
+## 10. Verification plan
+
+E2E (`docker_harness`, gated by the existing `needs_docker` marker; force idle via
+`registry._reap_idle_once(0.0)` or direct `release()`):
+
+- **Contract positive/negative** (`test_sandbox_persistence.py`): write `/root/marker`,
+  `/etc/marker`, `/tmp/marker`, `/dev/shm/marker`; start `sleep 1000 &`; release; assert
+  tag exists; resume → first three markers present, `/dev/shm` marker **absent**,
+  `pgrep sleep` empty. `apt-get install -y figlet` variant → `dpkg -l figlet` survives a
+  second cycle. Zero-write release → image id unchanged (`skipped_empty`). Run the tag
+  directly → `/workspace` empty (bind mounts excluded from snapshot).
+- **Drift dissolution** (the headline claim): write `/root/marker` → attach a memory
+  store mid-session (spec_version bump → recycle) → next tool call → marker present AND
+  new mount visible.
+- **Resume integrity**: resumed container has non-empty `$PATH`, `pwd`==/workspace,
+  `HOME=/home/aios` — both after a plain commit and after a flatten round-trip with the
+  depth threshold monkeypatched to 1 (this test catches both historical blockers).
+- **Secrets**: `docker image inspect .Config.Env` on the committed tag → the
+  `env_config.env` secret *value* absent; env-removal variant → removed key reads empty,
+  not the old value, in the resumed container.
+- **Salvage** (`test_sandbox_salvage.py`): out-of-band `docker stop` (simulated crash) →
+  `evict()` → next tool call sees the pre-crash marker; stale-corpse variant never
+  regresses tag content.
+- **GC** (`test_sandbox_snapshot_gc.py`): session delete → `_gc_once` → image gone;
+  TTL=0 → image gone + `sandbox_fs_expired` in the event log; orphaned-chain residue
+  (crash-between-import-and-rm shape) collected; pool budget evicts most-dormant first.
+- **Lockdown sidecar** (`test_networking.py` extension): Limited env on a *resumed*
+  snapshot whose `/usr/sbin/iptables` was replaced by `exit 0` pre-idle → lockdown still
+  enforced (curl to unlisted host fails); sandbox cannot `iptables -F` (no NET_ADMIN).
+- **Pointer discipline** (unit, FakeBackend + fake store): pointer written after
+  snapshot success and before `force_remove`; never written on snapshot failure;
+  salvage-preamble reconcile heals a NULL pointer when the local canonical tag exists;
+  GC pass 4 clears the pointer on every removal.
+- **Missing-snapshot detection** (e2e): commit → out-of-band `docker rmi` → resume →
+  cold start + `sandbox_fs_reset {reason: "snapshot_missing"}` in the event log +
+  pointer cleared.
+- **Store seam** (unit): `LocalDaemonStore` verified-negative semantics (not-found vs
+  indeterminate raises); snapshot transport/lookup (`put`/`get`/`exists`/`remove`/`size`
+  of session artifacts) goes only through `SnapshotStore` — daemon *enumeration* stays
+  on backend verbs; registry code never shells to docker directly.
+- **Base-image drift** (e2e): commit → change the environment's image ref → resume →
+  cold start on the new base + `sandbox_fs_reset {reason: "environment_image_changed"}`
+  in the log + pointer cleared + old tag removed (the next idle commits fresh — no
+  `skipped_stale`).
+- Unit: `FakeBackend` grows the five verbs; snapshot-before-remove ordering;
+  snapshot-failure ⇒ no `force_remove` but host-side cleanup still runs; lineage-gate
+  truth table; `_classify_images` table-driven; tag derivation + `_is_registry_image`
+  false; reserved-prefix gate (spec + pydantic); context allowlist rendering without
+  watermark movement.
+
+Docker availability: e2e requires real Docker (`DOCKER_HOST` per conftest); CI as today.
+
+## 11. Decisions requiring sign-off
+
+1. **DB snapshot pointer ships** (reverses the original draft's zero-DB-state stance,
+   forced by the horizontal-scale requirement): the DB is source of truth for snapshot
+   *location/existence* (`snapshot_ref/host/bytes/updated_at`), the store/daemon for
+   *content/lineage*, with the GC reconciler as convergence authority. The
+   previously-accepted silent operator-caused loss is now detected and evented (§5.3).
+2. **Scale shape — elastic worker pool vs shard-by-DB**: decides whether the
+   host-independent store is mandatory in v1 or deferrable, and whether `snapshot_host`
+   is advisory or load-bearing (§9.3). Note the elastic shape carries a second
+   prerequisite beyond the store: wake→host affinity for live containers (§9.3) — a
+   named follow-on design. Shard-by-DB is the shape this document fully specifies.
+   Needed to finalize §5.5/§9.3.
+3. **Durability timing — async `store.put` in v1 (recommended) vs seam-ready-defer**:
+   whether each commit is pushed to a host-independent store off the critical path, so
+   host loss stops being data loss (§9.3).
+4. **Base-image-ref drift semantics**: discard-snapshot + event (operator intent wins) vs
+   keep-snapshot + event. Recommended: discard. The event is non-negotiable either way.
+5. **Daemon-access threat boundary**: snapshot filesystems (and any agent-written
+   secrets in them) are readable by anything with Docker-socket/host-root access for the
+   retention duration — same trust domain as workspace dirs, longer retention. Accept +
+   document. (An async-push store extends the same boundary to the registry/bucket —
+   scope its ACLs with the sign-off.)
+6. **Two-layer image-prefix gate**: spec-build gate (the boundary) + pydantic 422 (UX).
+   Deliberate near-redundancy across different writer sets.
+7. **Idle-TTL default 300 s → 1800 s**: operator-visible behavior change shipped inside
+   this feature because the feature inverts the constant's economics.
+8. **Per-account caps deferred** (usage metric ships, eviction engine doesn't);
+   **`--read-only` closed as incompatible** rather than re-deferred; **`--cap-drop=ALL`
+   stays deferred** (NET_ADMIN removal ships now via the lockdown sidecar).
+9. **Optional rollback knob** (not in the design, flag only): `sandbox_snapshot_ttl_seconds=0`
+   could degenerate to today's destroy-on-idle if a kill switch is wanted for the rollout.
+
+---
+
+*Provenance: produced via two orchestrated workflows — (1) 9 agents verifying the brief
+against the codebase and live Docker/podman/prior-art research (incl. live experiments:
+commit whiteouts/latency/layer-wall, stop/start netns semantics, GC cascade); (2) a
+design panel (full mechanism-B design + genuine A/C steelmen) followed by four
+adversarial reviewers (security, crash/concurrency, ops, simplicity) — the ops reviewer
+probed the production host directly (prune cron, disk headroom, containerd store). All
+blockers and majors are folded into §5/§9; nothing in this document is unreviewed
+first-draft material.*
+
+*Revised 2026-06-10: horizontal scale promoted from "later" to stated requirement —
+reverses the zero-DB-state decision (snapshot pointer columns, §5.1/§6), introduces the
+`SnapshotStore` transport seam (§5.2), store-routed resume with detected snapshot loss
+(§5.3), cross-host GC ownership (§5.5), the durability-timing × scale-shape decision
+(§9.3), and the cross-host invariants (§5.11). Mechanism B, the snapshot sequence
+internals, salvage, lineage gate, flatten, lockdown sidecar, prefix gate, idle-TTL
+raise, and the containerd verification battery are unchanged. The revision was itself
+adversarially checked (a residue sweep + a cross-host correctness attack) and those
+findings — including the drift-discard artifact-removal fix, ownership-gated/CAS pointer
+writes, the elastic-shape affinity prerequisite, host-independent ref naming, push
+reconciliation, and the decommission procedure — are folded in above.*

--- a/migrations/versions/0084_session_snapshot_pointer.py
+++ b/migrations/versions/0084_session_snapshot_pointer.py
@@ -1,0 +1,76 @@
+"""The DB snapshot pointer for durable session sandboxes (#…).
+
+Under durable persistence the daemon/store remains the source of truth for
+snapshot *content and lineage*, but horizontal scale (a second worker, host
+replacement/rebalancing — a stated requirement) needs the DB to answer the
+one question no daemon probe can: *where does this session's snapshot live?*
+A worker resuming a session whose snapshot another daemon produced is blind
+without it. So ``sessions`` carries a reconciled routing pointer:
+
+* ``snapshot_ref``  — artifact identity: a deterministic, host-independent
+  name (the local snapshot tag in v1). NULL = no snapshot.
+* ``snapshot_host`` — owning worker/daemon/host id. NULL = none. Equals
+  ``settings.instance_id`` in v1 (one worker), kept conceptually distinct
+  from the deployment namespace that derives ``snapshot_ref`` so a future
+  multi-host deployment never changes a session's ref on handoff.
+* ``snapshot_bytes`` — last-known unique size; reporting only, NEVER an
+  enforcement input (enforcement always derives from the owning store's
+  live enumeration; this column can be one generation stale in a crash
+  window).
+* ``snapshot_updated_at`` — last pointer write (the compare-and-swap key on
+  multi-host shapes; vacuous single-host).
+
+The pointer is written inside the snapshot critical section (after commit
+success, before ``rm``, under the per-session lock) and reconciled against
+store truth by the GC tick, so it never claims a snapshot that wasn't
+committed. All four columns are internal — excluded from the session wire
+shape, exactly as the dead ``container_id`` was — so there is no
+openapi/SDK churn from this migration.
+
+The same migration **drops the dead ``container_id``** (migration 0001):
+zero SQL reads/writes anywhere, superseded by the snapshot pointer.
+
+``sessions`` is not the hot ``events`` table, and every column here is
+nullable with NULL = "no snapshot", so this is metadata-only DDL — no
+backfill, no table rewrite.
+
+Revision ID: 0084
+Revises: 0083
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0084"
+down_revision: str = "0083"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE sessions
+            ADD COLUMN snapshot_ref        text,
+            ADD COLUMN snapshot_host       text,
+            ADD COLUMN snapshot_bytes      bigint,
+            ADD COLUMN snapshot_updated_at timestamptz;
+        """
+    )
+    op.execute("ALTER TABLE sessions DROP COLUMN container_id;")
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE sessions
+            DROP COLUMN snapshot_ref,
+            DROP COLUMN snapshot_host,
+            DROP COLUMN snapshot_bytes,
+            DROP COLUMN snapshot_updated_at;
+        """
+    )
+    op.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS container_id text;")

--- a/openapi.json
+++ b/openapi.json
@@ -10461,7 +10461,7 @@
             "title": "Env",
             "description": "Environment variables injected into every session container using this environment.  Per-session env overrides these. A vaulted environment_variable credential whose secret_name matches a key \u2014 here or in the per-session env \u2014 outranks both: that key resolves to the credential's opaque placeholder, not the value set here."
           },
-          "disk_bytes": {
+          "snapshot_budget_bytes": {
             "anyOf": [
               {
                 "type": "integer",
@@ -10471,8 +10471,8 @@
                 "type": "null"
               }
             ],
-            "title": "Disk Bytes",
-            "description": "Maximum writable-layer size, in bytes, for sandbox containers bound to this environment. When unset, falls back to the worker's global ``settings.sandbox_disk_bytes`` (itself unbounded by default). Translates to ``docker run --storage-opt size=`` so a heavy dev build can't fill the host disk and take down the worker. Only honored by storage drivers that support per-container quotas; on an unsupported driver Docker rejects the flag at create time. Minimum 10 MiB (issue #725)."
+            "title": "Snapshot Budget Bytes",
+            "description": "Per-session snapshot budget in **unique** bytes for sessions bound to this environment (durable session sandboxes). When unset, falls back to the worker's global ``settings.sandbox_snapshot_budget_bytes`` (4 GiB). When a session's unique snapshot bytes would exceed this at teardown, the snapshot flattens (collapse + whiteout) instead of growing another layer \u2014 commit-and-flag, never a refusal. Replaces the former ``disk_bytes`` writable-layer cap, which required overlay2+pquota and never worked on prod ext4. Minimum 10 MiB."
           },
           "bash_timeout_seconds": {
             "anyOf": [

--- a/packages/aios-sdk/aios_sdk/_generated/models/environment_config.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/environment_config.py
@@ -37,11 +37,12 @@ class EnvironmentConfig:
             using this environment.  Per-session env overrides these. A vaulted environment_variable credential whose
             secret_name matches a key — here or in the per-session env — outranks both: that key resolves to the
             credential's opaque placeholder, not the value set here.
-        disk_bytes (int | None | Unset): Maximum writable-layer size, in bytes, for sandbox containers bound to this
-            environment. When unset, falls back to the worker's global ``settings.sandbox_disk_bytes`` (itself unbounded by
-            default). Translates to ``docker run --storage-opt size=`` so a heavy dev build can't fill the host disk and
-            take down the worker. Only honored by storage drivers that support per-container quotas; on an unsupported
-            driver Docker rejects the flag at create time. Minimum 10 MiB (issue #725).
+        snapshot_budget_bytes (int | None | Unset): Per-session snapshot budget in **unique** bytes for sessions bound
+            to this environment (durable session sandboxes). When unset, falls back to the worker's global
+            ``settings.sandbox_snapshot_budget_bytes`` (4 GiB). When a session's unique snapshot bytes would exceed this at
+            teardown, the snapshot flattens (collapse + whiteout) instead of growing another layer — commit-and-flag, never
+            a refusal. Replaces the former ``disk_bytes`` writable-layer cap, which required overlay2+pquota and never
+            worked on prod ext4. Minimum 10 MiB.
         bash_timeout_seconds (int | None | Unset): Ceiling, in seconds, for a single bash tool call in sessions bound to
             this environment. When unset, falls back to the worker's global ``settings.bash_default_timeout_seconds``
             (120s). Lets heavy dev workloads run >120s commands without raising the global default for every session on the
@@ -53,7 +54,7 @@ class EnvironmentConfig:
     packages: EnvironmentConfigPackagesType0 | None | Unset = UNSET
     networking: LimitedNetworking | None | UnrestrictedNetworking | Unset = UNSET
     env: EnvironmentConfigEnvType0 | None | Unset = UNSET
-    disk_bytes: int | None | Unset = UNSET
+    snapshot_budget_bytes: int | None | Unset = UNSET
     bash_timeout_seconds: int | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
@@ -96,11 +97,11 @@ class EnvironmentConfig:
         else:
             env = self.env
 
-        disk_bytes: int | None | Unset
-        if isinstance(self.disk_bytes, Unset):
-            disk_bytes = UNSET
+        snapshot_budget_bytes: int | None | Unset
+        if isinstance(self.snapshot_budget_bytes, Unset):
+            snapshot_budget_bytes = UNSET
         else:
-            disk_bytes = self.disk_bytes
+            snapshot_budget_bytes = self.snapshot_budget_bytes
 
         bash_timeout_seconds: int | None | Unset
         if isinstance(self.bash_timeout_seconds, Unset):
@@ -119,8 +120,8 @@ class EnvironmentConfig:
             field_dict["networking"] = networking
         if env is not UNSET:
             field_dict["env"] = env
-        if disk_bytes is not UNSET:
-            field_dict["disk_bytes"] = disk_bytes
+        if snapshot_budget_bytes is not UNSET:
+            field_dict["snapshot_budget_bytes"] = snapshot_budget_bytes
         if bash_timeout_seconds is not UNSET:
             field_dict["bash_timeout_seconds"] = bash_timeout_seconds
 
@@ -209,14 +210,16 @@ class EnvironmentConfig:
 
         env = _parse_env(d.pop("env", UNSET))
 
-        def _parse_disk_bytes(data: object) -> int | None | Unset:
+        def _parse_snapshot_budget_bytes(data: object) -> int | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
             return cast(int | None | Unset, data)
 
-        disk_bytes = _parse_disk_bytes(d.pop("disk_bytes", UNSET))
+        snapshot_budget_bytes = _parse_snapshot_budget_bytes(
+            d.pop("snapshot_budget_bytes", UNSET)
+        )
 
         def _parse_bash_timeout_seconds(data: object) -> int | None | Unset:
             if data is None:
@@ -234,7 +237,7 @@ class EnvironmentConfig:
             packages=packages,
             networking=networking,
             env=env,
-            disk_bytes=disk_bytes,
+            snapshot_budget_bytes=snapshot_budget_bytes,
             bash_timeout_seconds=bash_timeout_seconds,
         )
 

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -146,22 +146,53 @@ class Settings(BaseSettings):
         "Translates to ``docker run --pids-limit``. Mitigates fork-bomb "
         "denial-of-service; ``None`` leaves the host's default in place.",
     )
-    sandbox_disk_bytes: int | None = Field(
-        default=None,
+    sandbox_snapshot_budget_bytes: int | None = Field(
+        default=4 * 1024 * 1024 * 1024,
         ge=10 * 1024 * 1024,
-        description="Maximum writable-layer size a sandbox container can "
-        "grow to, in bytes. Translates to ``docker run --storage-opt "
-        "size=`` so a heavy build (``npm ci``, large test artifacts) "
-        "can't fill the host disk and take down the worker + sibling "
-        "sandboxes. ``None`` leaves the host's default (unbounded) in "
-        "place. NOTE: ``--storage-opt size=`` is only honored by storage "
-        "drivers that support per-container quotas (``overlay2`` on an "
-        "``xfs``/``btrfs`` backing filesystem with ``pquota``, or "
-        "``devicemapper``); on an unsupported driver Docker rejects the "
-        "flag at ``create`` time, surfacing as a SandboxBackendError "
-        "rather than a silent no-op. Minimum 10 MiB to stay above the "
-        "image's own base size. Per-environment overridable via "
-        "``EnvironmentConfig.disk_bytes`` (issue #725).",
+        description="Per-session snapshot budget in **unique** bytes (durable "
+        "session sandboxes, §5.7). When a session's unique snapshot bytes "
+        "would exceed this at idle/teardown, the snapshot verb FLATTENS "
+        "(collapse + whiteout, the definitive secret scrub) instead of "
+        "committing another layer; commit-and-flag, never refuse (refusal "
+        "would destroy the agent's work as punishment for a state it wasn't "
+        "awake to prevent). Replaces the dead ``sandbox_disk_bytes`` "
+        "writable-layer cap, which required overlay2-on-xfs+pquota and never "
+        "worked on prod ext4. ``None`` ⇒ unbounded (the depth backstop still "
+        "applies). Per-environment overridable via "
+        "``EnvironmentConfig.snapshot_budget_bytes``.",
+    )
+    sandbox_snapshot_ttl_seconds: int = Field(
+        default=2_592_000,  # 30 days
+        ge=60,
+        description="Dormancy TTL for a persisted session snapshot. The GC "
+        "reconciler removes a snapshot whose session's last activity is older "
+        "than this (appending a model-visible ``sandbox_fs_expired`` notice), "
+        "keyed on the session's ``(session_id, last_event_seq)`` event row. "
+        "Bounds supply-chain accumulation (agent-installed software re-executes "
+        "at every resume) and unbounded snapshot retention.",
+    )
+    sandbox_snapshot_pool_bytes: int | None = Field(
+        default=None,
+        ge=0,
+        description="Per-host snapshot disk budget in bytes (durable session "
+        "sandboxes, §5.7) — the load-bearing pool bound. When this host's "
+        "total snapshot bytes exceed it, the GC evicts the MOST-DORMANT "
+        "sessions first (``sandbox_fs_expired {disk_pressure}``). Required in "
+        "production once the eumemic-ops prune-cron exemption lands (that "
+        "exemption removes the only existing disk control). ``None`` ⇒ "
+        "unbounded retention (dev default); operators MUST set real host "
+        "headroom in production. v1 enforces per-host and reports global.",
+    )
+    sandbox_snapshot_empty_floor_bytes: int = Field(
+        default=8192,
+        ge=0,
+        description="Writable-layer byte floor at/below which a snapshot is "
+        "treated as a no-write identity (``skipped_empty`` — no new image, no "
+        "chain growth). NOT zero: on the production **containerd image store** "
+        "a no-write container reports ``SizeRw == 4096``, not 0, so an "
+        "``== 0`` test would never fire in prod and chat-only / read-only "
+        "sessions would grow a chain every idle. The floor (default 8 KiB) is "
+        "what keeps them from ever snapshotting.",
     )
     sandbox_seccomp_profile: str = Field(
         default=str(Path(__file__).resolve().parents[2] / "docker" / "seccomp-sandbox.json"),
@@ -233,10 +264,17 @@ class Settings(BaseSettings):
 
     # ── container lifecycle ────────────────────────────────────────────────
     container_idle_timeout_seconds: int = Field(
-        default=300,
+        default=1800,
         ge=30,
         description="Seconds of inactivity before a session's sandbox container "
-        "is released. The idle reaper checks every 60s.",
+        "is released. The idle reaper checks every 60s. Raised from 300 to 1800 "
+        "(30 min) for durable session sandboxes (§5.10): teardown now costs a "
+        "commit + a layer + eventual flatten, so keeping an idle ``tail -f`` "
+        "container alive (~1 MB RSS) is the cheap option. At 300s a daily-driver "
+        "session would commit 20-80x/day and a 15-min cron-trigger session "
+        "~96x/day, hitting the flatten wall in days; at 1800s a 15-min cron "
+        "session never idles out (zero commits until it stops) and a "
+        "conversational session commits a handful of times a day.",
     )
     mcp_pool_idle_timeout_seconds: int = Field(
         default=900,

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import math
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from types import EllipsisType
 from typing import Any, NamedTuple, NoReturn, cast
@@ -1419,16 +1419,19 @@ async def get_session_provisioning(
     session_id: str,
     *,
     account_id: str,
-) -> tuple[str, dict[str, str], int]:
-    """Return ``(workspace_volume_path, env, spec_version)`` for provisioning
-    a session's container.
+) -> tuple[str, dict[str, str], int, str | None]:
+    """Return ``(workspace_volume_path, env, spec_version, snapshot_ref)`` for
+    provisioning a session's container.
 
     ``spec_version`` (issue #713) is the snapshot the backend stamps onto
     the :class:`SandboxHandle` so the registry can detect drift on a warm
-    hit and recycle the cached sandbox.
+    hit and recycle the cached sandbox. ``snapshot_ref`` (durable session
+    sandboxes) is the DB snapshot pointer the provision path resolves
+    through the store to decide resume-source vs cold-start; ``None`` ⇒ no
+    snapshot.
     """
     row = await conn.fetchrow(
-        "SELECT workspace_volume_path, env, spec_version "
+        "SELECT workspace_volume_path, env, spec_version, snapshot_ref "
         "FROM sessions WHERE id = $1 AND account_id = $2",
         session_id,
         account_id,
@@ -1437,7 +1440,7 @@ async def get_session_provisioning(
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
     raw_env = row["env"]
     env: dict[str, str] = parse_jsonb(raw_env)
-    return row["workspace_volume_path"], env, row["spec_version"]
+    return row["workspace_volume_path"], env, row["spec_version"], row["snapshot_ref"]
 
 
 async def list_sessions(
@@ -7362,6 +7365,113 @@ async def unscoped_get_session_spec_version(conn: asyncpg.Connection[Any], sessi
     if row is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
     return int(row["spec_version"])
+
+
+# ─── durable session sandboxes: snapshot pointer (§5.1) ───────────────────────
+#
+# Worker-side, unscoped (per the ``unscoped_`` convention): the snapshot
+# lifecycle runs entirely worker-internal, keyed only by the session_id the
+# worker already holds. The pointer is written inside the snapshot critical
+# section (after commit success, before ``rm``) and reconciled by the GC tick.
+# v1 is single-host, so writes are direct; the §5.5 multi-host compare-and-swap
+# and ownership-gating refinements are deferred (the ``snapshot_host`` column
+# is the seam that makes them additive).
+
+
+async def unscoped_set_session_snapshot(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    ref: str,
+    host: str,
+    snapshot_bytes: int,
+) -> None:
+    """Point a session at a just-committed snapshot. ``snapshot_updated_at`` = now()."""
+    await conn.execute(
+        """
+        UPDATE sessions
+           SET snapshot_ref = $2,
+               snapshot_host = $3,
+               snapshot_bytes = $4,
+               snapshot_updated_at = now()
+         WHERE id = $1
+        """,
+        session_id,
+        ref,
+        host,
+        snapshot_bytes,
+    )
+
+
+async def unscoped_get_session_snapshot_bytes(
+    conn: asyncpg.Connection[Any], session_id: str
+) -> int | None:
+    """The session's last-recorded ``snapshot_bytes`` (``None`` if no snapshot).
+
+    Read by the release path to edge-trigger the ``sandbox_fs_over_limit``
+    notice only on the crossing (previous ≤ limit < new), not every cycle.
+    """
+    row = await conn.fetchrow("SELECT snapshot_bytes FROM sessions WHERE id = $1", session_id)
+    if row is None:
+        return None
+    value = row["snapshot_bytes"]
+    return int(value) if value is not None else None
+
+
+async def unscoped_clear_session_snapshot(conn: asyncpg.Connection[Any], session_id: str) -> None:
+    """Clear a session's snapshot pointer (all four columns NULL).
+
+    Used on a detected reset (snapshot-missing / base-image drift) and by the
+    GC pass-4 reconcile when a canonical artifact is removed.
+    """
+    await conn.execute(
+        """
+        UPDATE sessions
+           SET snapshot_ref = NULL,
+               snapshot_host = NULL,
+               snapshot_bytes = NULL,
+               snapshot_updated_at = now()
+         WHERE id = $1
+        """,
+        session_id,
+    )
+
+
+async def gc_snapshot_session_states(
+    conn: asyncpg.Connection[Any], session_ids: Sequence[str]
+) -> list[asyncpg.Record]:
+    """Batch-load the GC's per-session decision inputs for ``session_ids``.
+
+    Returns one row per *existing* session (a deleted session is simply
+    absent — its snapshot is collectible). Columns:
+
+    * ``id`` / ``account_id`` / ``archived_at``
+    * ``last_event_at`` — the dormancy probe: the ``created_at`` of the event
+      at ``seq == sessions.last_event_seq``. A **point probe** on the
+      ``(session_id, seq)`` primary key (NOT ``MAX(events.created_at)``, which
+      has no index), so the retain rule stays cheap over arbitrarily large
+      sessions.
+    * ``snapshot_ref`` / ``snapshot_host`` / ``snapshot_bytes`` — the pointer,
+      for the ownership-gated pass-4 reconcile.
+    """
+    if not session_ids:
+        return []
+    rows: list[asyncpg.Record] = await conn.fetch(
+        """
+        SELECT s.id,
+               s.account_id,
+               s.archived_at,
+               s.snapshot_ref,
+               s.snapshot_host,
+               s.snapshot_bytes,
+               (SELECT e.created_at FROM events e
+                 WHERE e.session_id = s.id AND e.seq = s.last_event_seq) AS last_event_at
+          FROM sessions s
+         WHERE s.id = ANY($1::text[])
+        """,
+        list(session_ids),
+    )
+    return rows
 
 
 # ─── account management (#367 PR 7) ───────────────────────────────────────────

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -67,6 +67,62 @@ _ALLOWED_FIELDS: dict[str, frozenset[str]] = {
 # for the model to use them as continuation context.
 _THINKING_FIELDS: frozenset[str] = frozenset({"thinking_blocks", "reasoning_content"})
 
+# Durable-session-sandbox FS-loss notices (§5.9): the only non-``message``
+# events ``build_messages`` renders. They are append-only (each at its seq
+# position, so monotonicity holds) and NOT stimulus-bearing — they never
+# advance ``reacting_to`` and so never, on their own, wake the session; the
+# notice is read at the next genuine wake. Event text is runtime-vocabulary
+# only (no repo/PR/issue refs — the agent can't act on those).
+_MODEL_VISIBLE_LIFECYCLE: frozenset[str] = frozenset(
+    {"sandbox_fs_reset", "sandbox_fs_expired", "sandbox_fs_over_limit"}
+)
+
+# Unaffected-resources tail shared by the reset/expired notices.
+_FS_UNAFFECTED = (
+    " /workspace and mounted directories (memory stores, uploads, attachments, "
+    "github working trees) are unaffected."
+)
+
+
+def _render_fs_lifecycle_notice(data: dict[str, Any]) -> str:
+    """Render an FS-loss lifecycle event as a bracketed user-role notice.
+
+    Total by contract — a pure function of ``data`` that never raises (an
+    unknown event/reason falls back to a generic line), since it runs inside
+    the per-wake replay where a raise would brick the session.
+    """
+    event = data.get("event")
+    reason = data.get("reason")
+    if event == "sandbox_fs_over_limit":
+        return (
+            "[The persisted sandbox filesystem for this session exceeded its size budget. "
+            "Installed packages and files are retained, but older write history may be "
+            "collapsed to reclaim space; keep the persistent footprint small — large data "
+            "belongs in /workspace, which is unaffected.]"
+        )
+    if event == "sandbox_fs_expired":
+        cause = (
+            "to reclaim disk space"
+            if reason == "disk_pressure"
+            else "after a period of inactivity (retention limit)"
+        )
+        return (
+            f"[The persisted sandbox filesystem for this session was discarded {cause}. "
+            f"The next command runs on a fresh base filesystem;{_FS_UNAFFECTED}]"
+        )
+    # sandbox_fs_reset (or any other allowlisted reset-shaped event).
+    if reason == "environment_image_changed":
+        detail = "the environment's base image was changed"
+    elif reason == "snapshot_missing":
+        detail = "the persisted filesystem could no longer be found"
+    else:
+        detail = "the persisted filesystem was reset"
+    return (
+        f"[The sandbox filesystem for this session was reset because {detail}. "
+        f"The next command runs on a fresh base filesystem;{_FS_UNAFFECTED}]"
+    )
+
+
 # Notification markers truncate the source content to this many chars
 # (plus an ellipsis when truncated) so a busy non-focal channel
 # contributes O(tens-of-tokens) per inbound to the context — cheap
@@ -801,6 +857,14 @@ def build_messages(
     max_stimulus_seq: int = 0
 
     for e in events:
+        # Durable-session-sandbox FS-loss notices (§5.9): the only non-message
+        # events that render. Append-only at this seq position (monotonic) and
+        # NOT stimulus-bearing — deliberately does not touch max_stimulus_seq,
+        # so a GC/reset append never advances ``reacting_to`` or wakes the
+        # session; the model reads the notice at its next genuine wake.
+        if e.kind == "lifecycle" and e.data.get("event") in _MODEL_VISIBLE_LIFECYCLE:
+            messages.append({"role": "user", "content": _render_fs_lifecycle_notice(e.data)})
+            continue
         if e.kind != "message":
             continue
         # Quarantine backstop (#686): build_messages is a pure replay over

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -203,10 +203,14 @@ async def worker_main() -> None:
         if woken_runs:
             log.info("worker.startup_sweep.workflows", woken_runs=woken_runs)
 
-        # Reap orphaned sandbox containers from prior worker runs.
-        reaped = await sandbox_registry.reap_orphans()
-        if reaped:
-            log.info("worker.reaped_orphan_containers", count=reaped)
+        # Start the snapshot GC reconciler (durable session sandboxes). Its
+        # immediate first tick replaces the old boot-time orphan reap: rather
+        # than removing every managed container at boot (which lost their
+        # filesystems), it salvages crash corpses and reconciles images +
+        # pointers against store truth, then repeats hourly. Boot is not
+        # blocked — a session waking mid-reconcile salvages its own corpse
+        # inline under its own lock.
+        sandbox_registry.start_gc(pool)
 
         # Start container + MCP-pool idle-TTL reapers.
         sandbox_registry.start_reaper(idle_timeout=settings.container_idle_timeout_seconds)
@@ -281,10 +285,14 @@ async def worker_main() -> None:
                 await scheduler_task
         if sandbox_registry is not None:
             sandbox_registry.stop_reaper()
+            sandbox_registry.stop_gc()
         if task_registry is not None:
             await task_registry.shutdown()
         if sandbox_registry is not None:
-            await sandbox_registry.release_all()
+            # Durable session sandboxes: STOP (don't destroy) every container
+            # so their filesystems survive; the next worker's boot GC tick
+            # salvages the stopped corpses.
+            await sandbox_registry.stop_all()
         if mcp_session_pool is not None:
             mcp_session_pool.stop_reaper()
             await mcp_session_pool.close_all()

--- a/src/aios/models/environments.py
+++ b/src/aios/models/environments.py
@@ -89,6 +89,18 @@ NetworkingConfig = Annotated[
 
 # ── environment config ────────────────────────────────────────────────────────
 
+# Reserved prefix for per-session snapshot images (durable session sandboxes,
+# §5.8). Snapshot tags are ``aios-sbx-{instance}-{session}:latest`` — single
+# path component, so they resolve locally with no registry pull. Because
+# persistence makes another session's snapshot mountable via a free-form
+# ``image`` string, a tenant-supplied image starting with this prefix would
+# mount a victim session's entire root FS (and its baked secrets); ULIDs are
+# not secrets (they appear in URLs/logs). The cross-tenant gate rejects it at
+# two layers covering different writer sets: this pydantic validator (422 at
+# the API boundary, UX + window-shrinking) and the spec-build choke point all
+# writers traverse including direct SQL (``build_spec_from_session``).
+RESERVED_SANDBOX_IMAGE_PREFIX = "aios-sbx-"
+
 
 class EnvironmentConfig(BaseModel):
     """Container configuration for an environment."""
@@ -133,19 +145,19 @@ class EnvironmentConfig(BaseModel):
             "placeholder, not the value set here."
         ),
     )
-    disk_bytes: int | None = Field(
+    snapshot_budget_bytes: int | None = Field(
         default=None,
         ge=10 * 1024 * 1024,
         description=(
-            "Maximum writable-layer size, in bytes, for sandbox containers "
-            "bound to this environment. When unset, falls back to the "
-            "worker's global ``settings.sandbox_disk_bytes`` (itself "
-            "unbounded by default). Translates to ``docker run "
-            "--storage-opt size=`` so a heavy dev build can't fill the host "
-            "disk and take down the worker. Only honored by storage drivers "
-            "that support per-container quotas; on an unsupported driver "
-            "Docker rejects the flag at create time. Minimum 10 MiB (issue "
-            "#725)."
+            "Per-session snapshot budget in **unique** bytes for sessions "
+            "bound to this environment (durable session sandboxes). When "
+            "unset, falls back to the worker's global "
+            "``settings.sandbox_snapshot_budget_bytes`` (4 GiB). When a "
+            "session's unique snapshot bytes would exceed this at teardown, "
+            "the snapshot flattens (collapse + whiteout) instead of growing "
+            "another layer — commit-and-flag, never a refusal. Replaces the "
+            "former ``disk_bytes`` writable-layer cap, which required "
+            "overlay2+pquota and never worked on prod ext4. Minimum 10 MiB."
         ),
     )
     bash_timeout_seconds: int | None = Field(
@@ -161,6 +173,25 @@ class EnvironmentConfig(BaseModel):
             "is the maximum it is capped to (issue #725)."
         ),
     )
+
+    @field_validator("image", mode="after")
+    @classmethod
+    def _reject_reserved_image_prefix(cls, v: str | None) -> str | None:
+        """Reject the reserved per-session-snapshot image prefix (422).
+
+        Persistence makes another session's snapshot mountable via this
+        free-form string; the prefix is reserved so a tenant can't point an
+        environment at ``aios-sbx-<victim>`` and mount its root FS + baked
+        secrets. Case-insensitive (Docker lowercases image refs). This is the
+        UX/window-shrinking layer; ``build_spec_from_session`` is the boundary
+        gate that also catches direct-SQL writers.
+        """
+        if v is not None and v.lower().startswith(RESERVED_SANDBOX_IMAGE_PREFIX):
+            raise ValueError(
+                f"image may not use the reserved {RESERVED_SANDBOX_IMAGE_PREFIX!r} prefix "
+                "(reserved for per-session snapshot images)"
+            )
+        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 
 from aios.sandbox.backends.base import SandboxBackendError
 
@@ -98,3 +99,94 @@ async def run_docker_cli(
     if timed_out:
         raise SandboxBackendError(f"docker cli timed out after {timeout_s}s: {' '.join(argv)}")
     return rc, stdout_bytes, stderr_bytes
+
+
+async def run_docker_pipeline(
+    producer_argv: list[str],
+    consumer_argv: list[str],
+    *,
+    timeout_s: float,
+) -> tuple[int, bytes, bytes]:
+    """Run ``producer_argv | consumer_argv`` joined by an ``os.pipe()`` fd pair.
+
+    Used for the flatten path ``docker export <id> | docker import - <tag>``
+    without a host shell: both argvs go straight to ``execve`` and are
+    connected at the OS level, so no shell metacharacter interpretation
+    happens on the host (same security posture as
+    :func:`run_subprocess_with_timeout`). Returns the **consumer's**
+    ``(returncode, stdout, stderr)`` — ``docker import`` prints the new
+    image id to stdout — so the caller can read the flattened image id.
+
+    Raises :class:`SandboxBackendError` on launch failure, on timeout
+    (both children are SIGKILLed), or when the **producer** exits nonzero
+    (a failed ``export`` would otherwise feed the consumer a truncated
+    stream that imports as a silently-corrupt image). The consumer's own
+    nonzero exit is returned for the caller to interpret, mirroring
+    :func:`run_docker_cli`.
+    """
+    rd, wr = os.pipe()
+    producer: asyncio.subprocess.Process | None = None
+    consumer: asyncio.subprocess.Process | None = None
+    try:
+        try:
+            producer = await asyncio.create_subprocess_exec(
+                *producer_argv, stdout=wr, stderr=asyncio.subprocess.PIPE
+            )
+        except (OSError, FileNotFoundError) as host_err:
+            raise SandboxBackendError(
+                f"failed to launch {producer_argv[0]}: {host_err}"
+            ) from host_err
+        # The producer now holds the only writer; the parent must drop its
+        # copy so the consumer sees EOF when the producer exits.
+        os.close(wr)
+        wr = -1
+        try:
+            consumer = await asyncio.create_subprocess_exec(
+                *consumer_argv,
+                stdin=rd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, FileNotFoundError) as host_err:
+            raise SandboxBackendError(
+                f"failed to launch {consumer_argv[0]}: {host_err}"
+            ) from host_err
+        os.close(rd)
+        rd = -1
+
+        async def _drain() -> tuple[tuple[bytes, bytes], tuple[bytes, bytes]]:
+            # Drive both concurrently so neither stderr/stdout pipe can
+            # fill and deadlock the other. Both are non-None here (assigned
+            # above before _drain is ever awaited).
+            return await asyncio.gather(consumer.communicate(), producer.communicate())
+
+        try:
+            (cons_out, cons_err), (_prod_out, prod_err) = await asyncio.wait_for(
+                _drain(), timeout=timeout_s
+            )
+        except TimeoutError as timeout_err:
+            for proc in (producer, consumer):
+                if proc is not None:
+                    with contextlib.suppress(ProcessLookupError):
+                        proc.kill()
+            raise SandboxBackendError(
+                f"docker pipeline timed out after {timeout_s}s: "
+                f"{' '.join(producer_argv)} | {' '.join(consumer_argv)}"
+            ) from timeout_err
+
+        if producer.returncode != 0:
+            raise SandboxBackendError(
+                f"{producer_argv[0]} export failed (exit {producer.returncode}): "
+                f"{prod_err.decode('utf-8', errors='replace').strip()}"
+            )
+        return (
+            consumer.returncode if consumer.returncode is not None else -1,
+            cons_out,
+            cons_err,
+        )
+    finally:
+        # Close any fd we still own (launch-failure / early-raise paths).
+        for fd in (rd, wr):
+            if fd != -1:
+                with contextlib.suppress(OSError):
+                    os.close(fd)

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,12 +58,14 @@ class Unrestricted(NetworkPolicy):
 class Limited(NetworkPolicy):
     """Allow outbound only to ``allowed_hosts`` (resolved at apply time).
 
-    The Docker backend interprets this as ``--cap-add NET_ADMIN`` on
-    create, with the actual iptables script applied separately via
-    :func:`aios.sandbox.setup.apply_network_lockdown` after create
-    returns. The script-application path is shared logic, not a backend
-    concern, so backends that can't enforce it surface failures the same
-    way as backends that can.
+    The sandbox itself is granted NO ``NET_ADMIN`` (durable session
+    sandboxes, §5.8). The iptables lockdown is applied + read-back verified
+    separately via :func:`aios.sandbox.setup.apply_network_lockdown` after
+    create returns, from an ephemeral operator-image sidecar that joins the
+    sandbox's netns — so a tenant can neither poison the binaries that apply
+    the lockdown nor flush it from inside. The application path is shared
+    logic, not a backend concern, so backends that can't enforce it surface
+    failures the same way as backends that can.
     """
 
     allowed_hosts: frozenset[str]
@@ -99,6 +101,15 @@ class SandboxSpec:
     network_policy: NetworkPolicy
     host_gateway_alias: str | None
     image: str
+    # Resume source (durable session sandboxes): the locally-resolved
+    # snapshot tag a resuming session runs from, set by the registry's
+    # provision path after it resolves ``sessions.snapshot_ref`` through
+    # the store (verified-negative, base-drift checked). ``None`` ⇒ cold
+    # start from ``image``. The backend runs from ``snapshot_image or
+    # image``; everything else (env, mounts, lockdown) is re-derived fresh
+    # so resume is structurally a cold start that happens to run on a
+    # persisted rootfs.
+    snapshot_image: str | None = None
     mount_snapshot: frozenset[tuple[str, ...]] = frozenset()
     # ``sessions.spec_version`` snapshot at build time (issue #713). Bumped
     # by Postgres triggers on the resource tables that feed this spec
@@ -112,12 +123,16 @@ class SandboxSpec:
     cpu_quota: float | None = None
     memory_bytes: int | None = None
     pids_limit: int | None = None
-    # Writable-layer disk cap (issue #725). ``None`` leaves the host's
-    # default (unbounded) in place. The spec builder resolves this from
-    # the environment's ``disk_bytes`` override, falling back to the
-    # global ``settings.sandbox_disk_bytes``; the backend injects
-    # ``--storage-opt size=`` when set.
-    disk_bytes: int | None = None
+    # Per-session snapshot budget in unique bytes (durable session
+    # sandboxes, §5.7). Drives the release-time flatten trigger: when a
+    # session's unique snapshot bytes would exceed this, the snapshot verb
+    # flattens (collapse + whiteout) instead of committing another layer.
+    # The backend stamps it onto the handle as ``disk_limit_bytes`` so the
+    # release path (which only holds the handle) can pass it back. ``None``
+    # ⇒ unbounded (never flatten on budget; the depth backstop still
+    # applies). Replaces the dead ``--storage-opt size=`` writable-layer
+    # cap, which never worked on prod ext4.
+    snapshot_budget_bytes: int | None = None
     # Authored seccomp profile (#807). Always set by the spec builder to the
     # configured path (a host filesystem path the docker CLI reads), or the
     # literal "unconfined" for emergency rollback. The backend ALWAYS emits
@@ -154,6 +169,15 @@ class SandboxHandle:
     workspace_path: Path
     mount_snapshot: frozenset[tuple[str, ...]] = frozenset()
     spec_version: int = 0
+    # The locally-resolved snapshot tag this container was created from
+    # (durable session sandboxes), or ``None`` for a cold start from base.
+    # Stamped from ``spec.snapshot_image`` so the provision span can record
+    # whether a resume ran from a snapshot or cold-started.
+    snapshot_image: str | None = None
+    # Per-session snapshot budget in unique bytes (§5.7), copied from
+    # ``spec.snapshot_budget_bytes``. The release path passes it back to
+    # ``backend.snapshot`` as the flatten trigger. ``None`` ⇒ unbounded.
+    disk_limit_bytes: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,18 +193,86 @@ class CommandResult:
 
 @dataclass(frozen=True, slots=True)
 class ManagedSandboxRef:
-    """A reference to a sandbox the orphan reaper wants to inspect.
+    """A reference to a managed sandbox container the GC/salvage paths inspect.
 
-    The reaper compares each ``session_id`` against the worker's set of
-    active session ids; sandboxes whose session is no longer active are
-    removed via ``force_remove``. ``session_id`` is ``None`` when the
-    backend can't recover it (e.g. a Docker container missing the
-    ``aios.session_id`` label, which shouldn't happen but the reaper is
-    defensive).
+    The GC corpse pass compares each ``session_id`` against the worker's
+    set of active session ids; a corpse whose session is dormant/deleted
+    is salvaged then removed. ``session_id`` is ``None`` when the backend
+    can't recover it (a container missing the ``aios.session_id`` label,
+    which shouldn't happen but the sweep is defensive).
+
+    ``running`` distinguishes a live container from a stopped corpse —
+    the salvage path only ``stop``s the former, and a still-running
+    container for a session this worker isn't stepping is a crash
+    survivor that the GC tick stops + salvages. Populated from ``docker
+    ps --all`` (the listing now includes stopped containers — under
+    persistence a corpse is salvageable, not just removable).
     """
 
     sandbox_id: str
     session_id: str | None
+    running: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedImage:
+    """A managed snapshot image (or untagged residue) the GC image pass classifies.
+
+    Enumerated by :meth:`SandboxBackend.list_managed_images` via ``docker
+    images -a`` so untagged crash/flatten residue is visible (it is
+    invisible without ``-a`` — verified). ``parent_id`` is the image's
+    ``.Parent`` (``None`` when absent); the GC excludes any image that is
+    the parent of another listed image so it never removes the untagged
+    interior of a live chain. On the containerd image store ``.Parent``
+    can be empty even for genuine chains — the structural skip then
+    no-ops and the ``remove_image`` refusal (a child still references the
+    layer) is the safety net, which is correct, just noisier.
+
+    ``repo_tags`` is empty for untagged residue. ``labels`` carries the
+    ``aios.*`` metadata (``session_id``, ``base_image``, ``flattened``)
+    the classifier keys on without any DB lookup.
+    """
+
+    image_id: str
+    repo_tags: tuple[str, ...]
+    parent_id: str | None
+    size_bytes: int
+    labels: dict[str, str]
+
+
+# Outcome of a single snapshot verb (``SandboxBackend.snapshot``).
+SnapshotKind = Literal["committed", "flattened", "skipped_empty", "skipped_stale"]
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotOutcome:
+    """What a :meth:`SandboxBackend.snapshot` call did to the canonical tag.
+
+    - ``committed`` — a new layer was committed onto the chain.
+    - ``flattened`` — the chain was collapsed to a single standalone layer
+      (``export | import``), stripping baked config (the definitive secret
+      scrub) and re-rooting off the base.
+    - ``skipped_empty`` — the writable layer was at/below the empty floor
+      (identity short-circuit), so no new image; the prior tag, if any,
+      stays canonical. ``image_id`` is ``None`` only when no prior tag
+      existed (a chat/read-only session that never wrote).
+    - ``skipped_stale`` — the corpse's parent is a *child* of the existing
+      tag (content-equal crash residue under the salvage-before-provision
+      invariant); the corpse is discarded without a commit and the
+      existing newer tag stays canonical.
+
+    ``image_id`` is the winning canonical image id after the op (``None``
+    iff no snapshot exists). ``unique_bytes`` is the accounting figure
+    written to ``sessions.snapshot_bytes`` (tag size minus base size, or
+    full size for a flattened/standalone image). ``depth`` is the chain
+    depth of the canonical image after the op (0 when ``image_id`` is
+    ``None``) — surfaced for the provision span and the flatten tests.
+    """
+
+    kind: SnapshotKind
+    image_id: str | None
+    unique_bytes: int
+    depth: int
 
 
 class SandboxBackendError(Exception):
@@ -244,15 +336,133 @@ class SandboxBackend(Protocol):
         """
         ...
 
-    async def list_managed(self, *, instance_id: str) -> list[ManagedSandboxRef]:
-        """List sandboxes belonging to this aios instance.
+    async def list_managed(
+        self, *, instance_id: str, session_id: str | None = None
+    ) -> list[ManagedSandboxRef]:
+        """List managed sandbox containers belonging to this aios instance.
 
-        Used by the worker's orphan reaper at startup. ``instance_id``
-        scopes the list to this deployment so a reaper can't kill
-        sandboxes belonging to a concurrent worker on the same machine.
+        Includes **stopped** containers (``docker ps --all``): under
+        durable persistence a crashed corpse is salvageable, not merely
+        removable, so the GC corpse pass and the provision-preamble
+        salvage must see stopped containers too. Each ref's ``running``
+        flag distinguishes a live container from a corpse.
+
+        ``instance_id`` scopes the list to this deployment so a sweep
+        can't touch a concurrent worker's containers. ``session_id``, when
+        given, narrows to one session's containers (the salvage preamble
+        targets a single session).
 
         Raises :class:`SandboxBackendError` if the backend cannot
         enumerate (e.g. Docker daemon unreachable).
+        """
+        ...
+
+    async def snapshot(
+        self,
+        sandbox_id: str,
+        tag: str,
+        *,
+        empty_floor_bytes: int,
+        flatten_if_unique_bytes_over: int | None,
+    ) -> SnapshotOutcome:
+        """Commit (or flatten) a container's writable rootfs to ``tag``.
+
+        The planned-teardown verb of durable session sandboxes (§5.2):
+        ``stop -t 5`` → inspect → **lineage gate** (proceed iff ``tag``
+        absent or ``tag.Id == corpse.Image``; else ``skipped_stale``) →
+        ``SizeRw <= empty_floor_bytes`` short-circuit (``skipped_empty``)
+        → commit-or-flatten. The container is **not** removed — the caller
+        removes it only after this returns successfully.
+
+        Flatten (``export | import``, collapsing the chain to one
+        standalone layer and stripping baked config — the definitive
+        secret scrub) fires when the chain depth would cross the backend's
+        soft ceiling, or when ``flatten_if_unique_bytes_over`` is not
+        ``None`` and the projected unique bytes exceed it. Commit scrubs
+        exactly the ``aios.env_keys`` label's named vars from the image
+        config (``ENV K=``); ``base_image``/``env_keys`` are read from the
+        container's labels so a salvaged crash corpse needs no spec.
+
+        Raises :class:`SandboxBackendError` on infra failure (daemon down,
+        commit/export timeout) — the caller then retains the corpse and
+        converges via salvage; it never removes a container whose snapshot
+        verb failed.
+        """
+        ...
+
+    async def stop(self, sandbox_id: str) -> None:
+        """``docker stop -t 5`` a container. Idempotent on a stopped corpse.
+
+        Logs but does not raise on a missing container (already gone).
+        Raises :class:`SandboxBackendError` on a hung/unreachable daemon.
+        """
+        ...
+
+    async def list_managed_images(self, *, instance_id: str) -> list[ManagedImage]:
+        """Enumerate this instance's managed snapshot images via ``docker images -a``.
+
+        The ``-a`` is load-bearing: untagged crash/flatten residue is
+        invisible without it. Each :class:`ManagedImage` carries the
+        ``.Parent`` (for the GC's structural skip of live-chain interiors),
+        size, repo tags, and ``aios.*`` labels.
+
+        Raises :class:`SandboxBackendError` if the backend cannot enumerate.
+        """
+        ...
+
+    async def remove_image(self, ref: str) -> bool:
+        """``docker rmi`` (no ``--force``) ``ref``. Returns success.
+
+        ``True`` when the image was removed or was already gone
+        (idempotent goal-state). ``False`` when the daemon **refused** —
+        a container or child image still references it; the GC treats a
+        refusal as "retained this tick, retry next tick" rather than
+        forcing. Removing a tag cascade-deletes its untagged parent chain
+        down to the first still-referenced image.
+
+        Raises :class:`SandboxBackendError` only on infra failure
+        (daemon unreachable / timeout).
+        """
+        ...
+
+    async def image_size(self, image: str) -> int:
+        """Return ``image``'s ``.Size`` in bytes.
+
+        Raises :class:`SandboxBackendError` if the image is absent or the
+        daemon is unreachable (callers that tolerate absence catch it).
+        """
+        ...
+
+    async def image_labels(self, image: str) -> dict[str, str] | None:
+        """Return ``image``'s ``.Config.Labels``, or ``None`` if absent.
+
+        Verified-negative: a confirmed not-found returns ``None``; an
+        indeterminate probe (daemon hiccup, timeout) raises
+        :class:`SandboxBackendError` so the caller fails loud rather than
+        treating a hiccup as "no labels". Used by the resume path's
+        base-image drift check.
+        """
+        ...
+
+    async def run_netns_sidecar(
+        self,
+        target_sandbox_id: str,
+        *,
+        image: str,
+        script: str,
+        timeout_seconds: int,
+        max_output_bytes: int,
+    ) -> CommandResult:
+        """Run ``script`` in an ephemeral sidecar joined to a sandbox's netns.
+
+        The network-lockdown apply/verify path (§5.8). The sidecar runs the
+        **operator-trusted** ``image`` (never the tenant ``env_config.image``)
+        with ``NET_ADMIN``, joins ``target_sandbox_id``'s network namespace so
+        its iptables edits apply to the sandbox's traffic, and is removed on
+        exit. The sandbox itself holds no ``NET_ADMIN``, so root-in-sandbox
+        can neither flush its own lockdown nor poison the binaries that apply
+        it. Returns the script's :class:`CommandResult`; raises
+        :class:`SandboxBackendError` on infra failure / timeout.
         """
         ...
 
@@ -297,3 +507,21 @@ MANAGED_LABEL_KEY = "aios.managed"
 MANAGED_LABEL_VALUE = "true"
 INSTANCE_LABEL_KEY = "aios.instance_id"
 SESSION_LABEL_KEY = "aios.session_id"
+
+# ── Durable-session-sandbox labels (§5.1) ───────────────────────────────────
+#
+# All stamped at ``docker run`` and inherited into committed images
+# automatically (verified). They make a container/image self-describing so
+# the commit-time scrub and the GC/accounting work off labels alone — no DB
+# lookup, including for a crash corpse salvaged after its spec is gone.
+#
+# ``ENV_KEYS_LABEL_KEY`` carries the comma-separated NAMES (never values) of
+# every run-injected env var; the snapshot commit scrubs exactly that set
+# from the image config. ``BASE_IMAGE_LABEL_KEY`` records which base ref the
+# chain is rooted on (drives resume base-drift detection and unique-bytes
+# accounting). ``FLATTENED_LABEL_KEY`` marks standalone export|import images
+# that share no layers with the base, so accounting charges them full size.
+ENV_KEYS_LABEL_KEY = "aios.env_keys"
+BASE_IMAGE_LABEL_KEY = "aios.base_image"
+FLATTENED_LABEL_KEY = "aios.flattened"
+FLATTENED_LABEL_VALUE = "true"

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -20,19 +20,30 @@ expected to run arbitrary shell inside the sandbox.
 
 from __future__ import annotations
 
+import json
+
 from aios.logging import get_logger
-from aios.sandbox._subprocess import run_docker_cli, run_subprocess_with_timeout
+from aios.sandbox._subprocess import (
+    run_docker_cli,
+    run_docker_pipeline,
+    run_subprocess_with_timeout,
+)
 from aios.sandbox.backends.base import (
+    BASE_IMAGE_LABEL_KEY,
+    ENV_KEYS_LABEL_KEY,
+    FLATTENED_LABEL_KEY,
+    FLATTENED_LABEL_VALUE,
     INSTANCE_LABEL_KEY,
     MANAGED_LABEL_KEY,
     MANAGED_LABEL_VALUE,
     SESSION_LABEL_KEY,
     CommandResult,
-    Limited,
+    ManagedImage,
     ManagedSandboxRef,
     SandboxBackendError,
     SandboxHandle,
     SandboxSpec,
+    SnapshotOutcome,
 )
 from aios.sandbox.network import SANDBOX_NETWORK_NAME
 
@@ -50,6 +61,26 @@ _HOST_BACKSTOP_MARGIN_S = 5
 # code to ``timed_out``: our invocation never yields the 124 (TERM-path) code
 # from a timeout, and a command that exits 124 on its own is not a timeout.
 _CONTAINER_TIMEOUT_EXIT_CODE = 137
+
+# Chain-depth backstop for the snapshot verb. The overlay2 graphdriver
+# hard-fails ``docker commit`` at ~125 stacked layers; the production
+# **containerd image store** has no such wall (a chain committed and ran
+# cleanly through 250 layers in the verification battery). So flatten is
+# driven primarily by the per-session unique-bytes budget (§5.6); this
+# depth ceiling is only a *soft* performance guard, kept generously below
+# the kernel overlayfs lower-layer max so a budget-less session can't grow
+# an unbounded chain. NOT a hard-wall dodge on the prod store.
+_FLATTEN_DEPTH_CEILING = 200
+
+# Constant floor + per-byte budget for the commit/flatten/export timeout,
+# derived from the writable-layer ``SizeRw`` already read in the snapshot
+# sequence. A fixed timeout would turn a genuinely huge writable layer into
+# a permanent-brick retry loop (commit times out -> corpse retained ->
+# salvage times out -> forever); a size-derived bound fires only on a
+# genuinely hung daemon, never merely on size. ~10x a conservative
+# 50 MB/s measured commit throughput => 20 ns/byte.
+_SNAPSHOT_TIMEOUT_FLOOR_S = 60.0
+_SNAPSHOT_TIMEOUT_NS_PER_BYTE = 20e-9
 
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
@@ -76,7 +107,11 @@ class DockerBackend:
             "docker",
             "run",
             "--detach",
-            "--rm",
+            # NB: NO ``--rm`` (durable session sandboxes). An unplanned death
+            # (crash, OOM, daemon restart) must leave a stopped corpse that
+            # the next provision / GC tick salvages (commits) — container
+            # death stops losing data. Planned teardown snapshots then
+            # removes explicitly.
             # Workspace bind mount.
             "--volume",
             _format_volume(
@@ -97,10 +132,13 @@ class DockerBackend:
 
         argv.extend(["--network", SANDBOX_NETWORK_NAME])
 
-        # Limited policy needs NET_ADMIN so the iptables script (applied
-        # later by the registry via aios.sandbox.setup) can install rules.
-        if isinstance(spec.network_policy, Limited):
-            argv.extend(["--cap-add", "NET_ADMIN"])
+        # NB: the sandbox is NOT granted ``--cap-add NET_ADMIN`` (durable
+        # session sandboxes, §5.8). The Limited-policy iptables lockdown is
+        # applied from an ephemeral operator-image sidecar that joins this
+        # container's netns (see ``aios.sandbox.setup.apply_network_lockdown``),
+        # so root-in-sandbox can no longer modify netfilter at all — closing
+        # both the persisted-poisoned-iptables bypass and the pre-existing
+        # ``iptables -F your own lockdown`` hole.
 
         # WS0 phase-1 hardening: two flags safe to land before the exec-user
         # seam is in place.
@@ -146,17 +184,12 @@ class DockerBackend:
             argv.extend(["--memory-swap", str(spec.memory_bytes)])
         if spec.pids_limit is not None:
             argv.extend(["--pids-limit", str(spec.pids_limit)])
-        if spec.disk_bytes is not None:
-            # Bound the container's writable layer so a heavy build can't
-            # fill the host disk and take the worker + sibling sandboxes
-            # down (issue #725). Only honored by storage drivers that
-            # support per-container quotas (overlay2 on xfs/btrfs with
-            # pquota, or devicemapper). On an unsupported driver Docker
-            # rejects this at ``docker run`` time — surfaced below as a
-            # SandboxBackendError on the nonzero exit, NOT silently
-            # dropped, so a misconfigured host fails loud rather than
-            # leaving the cap un-enforced.
-            argv.extend(["--storage-opt", f"size={spec.disk_bytes}"])
+        # NB: NO ``--storage-opt size=`` (durable session sandboxes, §5.7).
+        # The writable-layer quota required overlay2-on-xfs+pquota and was
+        # rejected at ``docker run`` on prod's ext4 daemon — it never
+        # worked. Disk pressure is now bounded by the snapshot pool budget
+        # (GC eviction) instead; the live writable layer between commits
+        # stays unbounded on ext4, same as today's status quo.
 
         # Authored seccomp deny-list (#807). ALWAYS emitted — never conditional —
         # so a misconfiguration can't silently fall back to Docker's default profile.
@@ -171,10 +204,17 @@ class DockerBackend:
         for key, value in spec.environment.items():
             argv.extend(["--env", f"{key}={value}"])
 
-        # Only pull from registry for remote images; local/bare tags (dev builds) have no registry prefix
-        if _is_registry_image(spec.image):
+        # Resume source: run from the resolved snapshot tag when set
+        # (durable session sandboxes), else the cold-start base image. The
+        # registry's provision path does the verified resolution and sets
+        # ``spec.snapshot_image`` to a locally-runnable tag; here we run it
+        # blindly. A snapshot tag is single-component (``_is_registry_image``
+        # False), so ``--pull always`` is correctly skipped for it — the
+        # snapshot is local by construction and a registry lookup would fail.
+        run_image = spec.snapshot_image or spec.image
+        if _is_registry_image(run_image):
             argv.extend(["--pull", "always"])
-        argv.append(spec.image)
+        argv.append(run_image)
 
         rc, stdout_bytes, stderr_bytes = await run_docker_cli(argv)
         if rc != 0:
@@ -193,6 +233,8 @@ class DockerBackend:
             workspace_path=spec.workspace.host_path,
             mount_snapshot=spec.mount_snapshot,
             spec_version=spec.spec_version,
+            snapshot_image=spec.snapshot_image,
+            disk_limit_bytes=spec.snapshot_budget_bytes,
         )
 
     async def exec(
@@ -280,17 +322,27 @@ class DockerBackend:
             container_id=handle.sandbox_id[:12],
         )
 
-    async def list_managed(self, *, instance_id: str) -> list[ManagedSandboxRef]:
-        """List ``aios.managed=true`` containers for ``instance_id``."""
+    async def list_managed(
+        self, *, instance_id: str, session_id: str | None = None
+    ) -> list[ManagedSandboxRef]:
+        """List managed containers (running AND stopped) for ``instance_id``.
+
+        ``--all`` so stopped corpses are visible to the salvage/GC paths.
+        ``session_id`` narrows to one session's containers (the salvage
+        preamble). Each ref carries ``running`` from ``.State.Running``.
+        """
         ps_argv = [
             "docker",
             "ps",
+            "--all",
             "--quiet",
             "--filter",
             f"label={MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",
             "--filter",
             f"label={INSTANCE_LABEL_KEY}={instance_id}",
         ]
+        if session_id is not None:
+            ps_argv.extend(["--filter", f"label={SESSION_LABEL_KEY}={session_id}"])
         rc, stdout_bytes, stderr_bytes = await run_docker_cli(ps_argv)
         if rc != 0:
             raise SandboxBackendError(
@@ -303,7 +355,7 @@ class DockerBackend:
         if not container_ids:
             return []
 
-        fmt = '{{.Id}}\t{{index .Config.Labels "' + SESSION_LABEL_KEY + '"}}'
+        fmt = '{{.Id}}\t{{.State.Running}}\t{{index .Config.Labels "' + SESSION_LABEL_KEY + '"}}'
         inspect_argv = ["docker", "inspect", "--format", fmt, *container_ids]
         rc, stdout_bytes, stderr_bytes = await run_docker_cli(inspect_argv)
         if rc != 0:
@@ -315,10 +367,11 @@ class DockerBackend:
         for line in stdout_bytes.decode("utf-8").splitlines():
             if not line.strip():
                 continue
-            parts = line.split("\t", 1)
+            parts = line.split("\t", 2)
             cid = parts[0].strip()
-            sid = parts[1].strip() if len(parts) > 1 else ""
-            out.append(ManagedSandboxRef(sandbox_id=cid, session_id=sid or None))
+            running = len(parts) > 1 and parts[1].strip() == "true"
+            sid = parts[2].strip() if len(parts) > 2 else ""
+            out.append(ManagedSandboxRef(sandbox_id=cid, session_id=sid or None, running=running))
         return out
 
     async def force_remove(self, sandbox_id: str) -> None:
@@ -374,8 +427,8 @@ class DockerBackend:
             )
             return False
         if rc != 0:
-            # Most common case: container was removed (--rm after exit), which
-            # Docker reports as a nonzero exit + "No such container" on stderr.
+            # A container removed out of band (crash/OOM that left no corpse,
+            # or an operator rm) reports nonzero + "No such container".
             log.info(
                 "sandbox.is_alive_inspect_nonzero",
                 session_id=handle.session_id,
@@ -384,6 +437,461 @@ class DockerBackend:
             )
             return False
         return stdout_bytes.decode("utf-8", errors="replace").strip() == "true"
+
+    # ── durable-session-sandbox verbs (§5.2) ────────────────────────────────
+
+    async def stop(self, sandbox_id: str) -> None:
+        """``docker stop -t 5``. Idempotent on a stopped corpse / missing container."""
+        argv = ["docker", "stop", "-t", "5", sandbox_id]
+        rc, _stdout, stderr_bytes = await run_docker_cli(argv)
+        if rc != 0:
+            stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+            if _is_no_such_container(stderr):
+                return
+            log.warning("sandbox.stop_nonzero", container_id=sandbox_id[:12], stderr=stderr)
+
+    async def snapshot(
+        self,
+        sandbox_id: str,
+        tag: str,
+        *,
+        empty_floor_bytes: int,
+        flatten_if_unique_bytes_over: int | None,
+    ) -> SnapshotOutcome:
+        """Commit (or flatten) ``sandbox_id``'s rootfs to ``tag`` (§5.2)."""
+        # 1. Stop (idempotent — the corpse may already be stopped).
+        await self.stop(sandbox_id)
+
+        # 2. Inspect the corpse: parent image, writable-layer bytes, labels.
+        parent_image, size_rw, labels = await self._inspect_container_for_snapshot(sandbox_id)
+        env_keys = _split_label_list(labels.get(ENV_KEYS_LABEL_KEY))
+        base_ref = labels.get(BASE_IMAGE_LABEL_KEY)
+
+        # 3. Inspect the existing tag (absent → first snapshot).
+        tag_fields = await self._inspect_image_fields(tag)
+
+        # 4. LINEAGE GATE: proceed iff the tag is absent, or the tag is exactly
+        #    the image this corpse was created from. A tag that has moved past
+        #    the corpse's parent is content-equal crash residue (commit-then-
+        #    crash-before-rm under the salvage-before-provision invariant) — the
+        #    corpse carries nothing newer than the tag, so discard it.
+        if tag_fields is not None and tag_fields[0] != parent_image:
+            return SnapshotOutcome(
+                kind="skipped_stale",
+                image_id=tag_fields[0],
+                unique_bytes=await self._unique_bytes(tag_fields, base_ref),
+                depth=tag_fields[2],
+            )
+
+        # 5. Identity short-circuit: a writable layer at/below the empty floor
+        #    produces content identical to the existing tag. On the containerd
+        #    image store a no-write container reports SizeRw == 4096 (NOT 0),
+        #    so the floor — not an == 0 test — is what keeps chat-only and
+        #    read-only sessions from ever growing a chain.
+        if size_rw is not None and size_rw <= empty_floor_bytes:
+            if tag_fields is None:
+                return SnapshotOutcome(kind="skipped_empty", image_id=None, unique_bytes=0, depth=0)
+            return SnapshotOutcome(
+                kind="skipped_empty",
+                image_id=tag_fields[0],
+                unique_bytes=await self._unique_bytes(tag_fields, base_ref),
+                depth=tag_fields[2],
+            )
+
+        # 6. Decide commit vs flatten. Depth is a soft performance backstop
+        #    (no hard layer wall on the containerd store); the per-session
+        #    unique-bytes budget is the primary trigger.
+        base_size = await self._image_size_or_zero(base_ref)
+        parent_fields = await self._inspect_image_fields(parent_image)
+        parent_size = parent_fields[1] if parent_fields else 0
+        parent_depth = parent_fields[2] if parent_fields else 1
+        rw = size_rw if size_rw is not None else 0
+        projected_unique = max(0, parent_size - base_size) + rw
+        over_budget = (
+            flatten_if_unique_bytes_over is not None
+            and projected_unique > flatten_if_unique_bytes_over
+        )
+        # Timeout scales with the bytes the daemon must move (resulting image
+        # for commit; whole rootfs for export) so a huge layer never wedges
+        # the worker in a permanent retry loop, while a hung daemon still trips.
+        timeout_s = _SNAPSHOT_TIMEOUT_FLOOR_S + (parent_size + rw) * _SNAPSHOT_TIMEOUT_NS_PER_BYTE
+
+        if parent_depth + 1 >= _FLATTEN_DEPTH_CEILING or over_budget:
+            return await self._flatten(sandbox_id, tag, labels, timeout_s=timeout_s)
+        return await self._commit(sandbox_id, tag, env_keys, base_ref, timeout_s=timeout_s)
+
+    async def _commit(
+        self,
+        sandbox_id: str,
+        tag: str,
+        env_keys: list[str],
+        base_ref: str | None,
+        *,
+        timeout_s: float,
+    ) -> SnapshotOutcome:
+        """``docker commit`` one layer, scrubbing exactly the run-injected env keys.
+
+        Scrub scope is the ``aios.env_keys`` set ONLY (``ENV K=``). Scrubbing
+        all of ``.Config.Env`` empties the base image's ``PATH``/``HOME`` and
+        bricks every resumed container (Docker won't re-inject a default PATH
+        for a present-but-empty key — verified). ``ENV K=`` empties rather than
+        unsets; removed vars read as ``""`` until the next flatten strips
+        config entirely.
+        """
+        argv = ["docker", "commit"]
+        for key in env_keys:
+            argv.extend(["--change", f"ENV {key}="])
+        argv.extend([sandbox_id, tag])
+        rc, _stdout, stderr_bytes = await run_docker_cli(argv, timeout_s=timeout_s)
+        if rc != 0:
+            raise SandboxBackendError(
+                f"docker commit failed (exit {rc}) for {tag}: "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+        new = await self._inspect_image_fields(tag)
+        if new is None:
+            raise SandboxBackendError(f"committed image {tag} not found after commit")
+        return SnapshotOutcome(
+            kind="committed",
+            image_id=new[0],
+            unique_bytes=await self._unique_bytes(new, base_ref),
+            depth=new[2],
+        )
+
+    async def _flatten(
+        self,
+        sandbox_id: str,
+        tag: str,
+        labels: dict[str, str],
+        *,
+        timeout_s: float,
+    ) -> SnapshotOutcome:
+        """``docker export | docker import`` — collapse the chain to one layer.
+
+        Flatten applies overlay whiteouts (so "delete files to shrink" finally
+        works) and strips ALL baked config (the definitive secret scrub). Import
+        loses the base image's config, so restore ``WORKDIR``/``HOME``/``CMD``
+        and re-stamp the managed labels. ``PATH`` is deliberately NOT restored
+        — Docker injects its default for a config with no PATH, which is what
+        keeps the restored ``CMD`` execable (an empty PATH would break it). The
+        resumed container's env is re-injected fresh via ``docker run --env``
+        regardless, so config env doesn't affect runtime — only the artifact.
+        """
+        changes = [
+            'CMD ["tail","-f","/dev/null"]',
+            "WORKDIR /workspace",
+            "ENV HOME=/home/aios",
+            f"LABEL {MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",
+            f"LABEL {FLATTENED_LABEL_KEY}={FLATTENED_LABEL_VALUE}",
+        ]
+        for key in (
+            INSTANCE_LABEL_KEY,
+            SESSION_LABEL_KEY,
+            ENV_KEYS_LABEL_KEY,
+            BASE_IMAGE_LABEL_KEY,
+        ):
+            value = labels.get(key)
+            if value is not None:
+                changes.append(f"LABEL {key}={value}")
+        consumer = ["docker", "import"]
+        for change in changes:
+            consumer.extend(["--change", change])
+        consumer.extend(["-", tag])
+        await run_docker_pipeline(["docker", "export", sandbox_id], consumer, timeout_s=timeout_s)
+        new = await self._inspect_image_fields(tag)
+        if new is None:
+            raise SandboxBackendError(f"flattened image {tag} not found after import")
+        # A flattened image is standalone — it shares no layers with the base,
+        # so it is charged its FULL size (subtracting a base it doesn't share
+        # would hide ~hundreds of MB from the accounting that must see the host
+        # filling).
+        return SnapshotOutcome(kind="flattened", image_id=new[0], unique_bytes=new[1], depth=new[2])
+
+    async def list_managed_images(self, *, instance_id: str) -> list[ManagedImage]:
+        """Enumerate managed images (incl. untagged residue) via ``docker images -a``."""
+        ls_argv = [
+            "docker",
+            "images",
+            "--all",
+            "--no-trunc",
+            "--quiet",
+            "--filter",
+            f"label={MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",
+            "--filter",
+            f"label={INSTANCE_LABEL_KEY}={instance_id}",
+        ]
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(ls_argv)
+        if rc != 0:
+            raise SandboxBackendError(
+                f"docker images failed (exit {rc}): "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+        # ``docker images -q`` repeats an id once per tag; dedupe preserving order.
+        seen: set[str] = set()
+        image_ids: list[str] = []
+        for line in stdout_bytes.decode("utf-8").splitlines():
+            iid = line.strip()
+            if iid and iid not in seen:
+                seen.add(iid)
+                image_ids.append(iid)
+        if not image_ids:
+            return []
+
+        # Whole-Config form for labels — see ``_inspect_image_fields`` on why a
+        # direct ``{{json .Config.Labels}}`` errors on label-less images under
+        # Docker inspect's ``missingkey=error``.
+        fmt = "{{.Id}}\t{{.Parent}}\t{{.Size}}\t{{json .RepoTags}}\t{{json .Config}}"
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(
+            ["docker", "image", "inspect", "--format", fmt, *image_ids]
+        )
+        if rc != 0:
+            raise SandboxBackendError(
+                f"docker image inspect failed (exit {rc}): "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+        out: list[ManagedImage] = []
+        for line in stdout_bytes.decode("utf-8").splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t", 4)
+            image_id = parts[0].strip()
+            parent = parts[1].strip() if len(parts) > 1 else ""
+            size = int(parts[2]) if len(parts) > 2 and parts[2].strip().isdigit() else 0
+            repo_tags = _parse_json_str_list(parts[3]) if len(parts) > 3 else ()
+            img_labels = _labels_from_config_json(parts[4]) if len(parts) > 4 else {}
+            out.append(
+                ManagedImage(
+                    image_id=image_id,
+                    repo_tags=repo_tags,
+                    parent_id=parent or None,
+                    size_bytes=size,
+                    labels=img_labels,
+                )
+            )
+        return out
+
+    async def remove_image(self, ref: str) -> bool:
+        """``docker rmi`` (no force). True on removed/already-gone, False on refusal."""
+        rc, _stdout, stderr_bytes = await run_docker_cli(["docker", "rmi", ref])
+        if rc == 0:
+            return True
+        stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+        if _is_no_such_image(stderr):
+            return True  # idempotent: goal state (image gone) already reached
+        log.info("sandbox.rmi_refused", ref=ref, stderr=stderr)
+        return False
+
+    async def image_size(self, image: str) -> int:
+        fields = await self._inspect_image_fields(image)
+        if fields is None:
+            raise SandboxBackendError(f"image not found: {image}")
+        return fields[1]
+
+    async def image_labels(self, image: str) -> dict[str, str] | None:
+        fields = await self._inspect_image_fields(image)
+        return None if fields is None else fields[3]
+
+    async def run_netns_sidecar(
+        self,
+        target_sandbox_id: str,
+        *,
+        image: str,
+        script: str,
+        timeout_seconds: int,
+        max_output_bytes: int,
+    ) -> CommandResult:
+        """Apply/verify the network lockdown from an ephemeral operator-image sidecar.
+
+        ``--network container:<id>`` shares the sandbox's netns; ``--cap-add
+        NET_ADMIN`` lets the sidecar edit netfilter in that shared namespace;
+        ``--rm`` removes it on exit (the rules persist in the netns, held by
+        the sandbox). No restrictive seccomp is applied — this is an
+        operator-trusted, short-lived container, and iptables needs the
+        syscalls the default profile permits.
+        """
+        argv = [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            f"container:{target_sandbox_id}",
+            "--cap-add",
+            "NET_ADMIN",
+            image,
+            "bash",
+            "-c",
+            script,
+        ]
+        rc, stdout_bytes, stderr_bytes, timed_out = await run_subprocess_with_timeout(
+            argv, timeout_s=float(timeout_seconds)
+        )
+        if timed_out:
+            raise SandboxBackendError(
+                f"network-lockdown sidecar timed out after {timeout_seconds}s for "
+                f"{target_sandbox_id[:12]}"
+            )
+        stdout_str, out_truncated = _decode_and_truncate(stdout_bytes, max_output_bytes)
+        stderr_str, err_truncated = _decode_and_truncate(stderr_bytes, max_output_bytes)
+        return CommandResult(
+            exit_code=rc,
+            stdout=stdout_str,
+            stderr=stderr_str,
+            timed_out=False,
+            truncated=out_truncated or err_truncated,
+        )
+
+    # ── snapshot-verb helpers ───────────────────────────────────────────────
+
+    async def _inspect_container_for_snapshot(
+        self, sandbox_id: str
+    ) -> tuple[str, int | None, dict[str, str]]:
+        """Return ``(parent_image_id, size_rw, labels)`` for a container.
+
+        ``size_rw`` is ``None`` only when the daemon reports an unparseable
+        value — the snapshot path then declines the empty short-circuit
+        (commit rather than risk losing data).
+        """
+        fmt = "{{.Image}}\t{{.SizeRw}}\t{{json .Config.Labels}}"
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(
+            ["docker", "inspect", "--size", "--format", fmt, sandbox_id]
+        )
+        if rc != 0:
+            raise SandboxBackendError(
+                f"docker inspect (container) failed (exit {rc}) for {sandbox_id[:12]}: "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+        parts = stdout_bytes.decode("utf-8").rstrip("\n").split("\t", 2)
+        parent_image = parts[0].strip()
+        raw_rw = parts[1].strip() if len(parts) > 1 else ""
+        size_rw = int(raw_rw) if raw_rw.isdigit() else None
+        labels = _parse_json_labels(parts[2]) if len(parts) > 2 else {}
+        return parent_image, size_rw, labels
+
+    async def _inspect_image_fields(self, ref: str) -> tuple[str, int, int, dict[str, str]] | None:
+        """Return ``(image_id, size_bytes, layer_depth, labels)`` or ``None`` if absent.
+
+        Verified-negative: a confirmed "No such image" returns ``None``; any
+        other nonzero exit raises (an indeterminate probe must not read as
+        absence).
+
+        Labels are extracted from the whole ``{{json .Config}}`` object rather
+        than ``{{json .Config.Labels}}``: Docker's inspect applies
+        ``missingkey=error`` to multi-action templates, so a direct
+        ``.Config.Labels`` access errors on an image with NO labels (the base
+        image) — ``map has no entry for key "Labels"`` — while the whole-Config
+        form is safe for labeled and unlabeled images alike (verified).
+        """
+        fmt = "{{.Id}}\t{{.Size}}\t{{len .RootFS.Layers}}\t{{json .Config}}"
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(
+            ["docker", "image", "inspect", "--format", fmt, ref]
+        )
+        if rc != 0:
+            stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+            if _is_no_such_image(stderr):
+                return None
+            raise SandboxBackendError(f"docker image inspect failed for {ref}: {stderr}")
+        parts = stdout_bytes.decode("utf-8").rstrip("\n").split("\t", 3)
+        image_id = parts[0].strip()
+        size = int(parts[1]) if len(parts) > 1 and parts[1].strip().isdigit() else 0
+        depth = int(parts[2]) if len(parts) > 2 and parts[2].strip().isdigit() else 1
+        labels = _labels_from_config_json(parts[3]) if len(parts) > 3 else {}
+        return image_id, size, depth, labels
+
+    async def _image_size_or_zero(self, ref: str | None) -> int:
+        """Base size for accounting; 0 when the base ref is unknown/absent.
+
+        Over-counting (charging full size when the base can't be resolved) is
+        safe for budget enforcement — it never under-reports the host filling.
+        """
+        if not ref:
+            return 0
+        try:
+            return await self.image_size(ref)
+        except SandboxBackendError:
+            return 0
+
+    async def _unique_bytes(
+        self, image_fields: tuple[str, int, int, dict[str, str]], base_ref: str | None
+    ) -> int:
+        """Unique bytes for the accounting pointer: full size for a flattened
+        (standalone) image, else ``tag.Size - base.Size``."""
+        _image_id, size, _depth, labels = image_fields
+        if labels.get(FLATTENED_LABEL_KEY) == FLATTENED_LABEL_VALUE:
+            return size
+        return max(0, size - await self._image_size_or_zero(base_ref))
+
+
+def _split_label_list(value: str | None) -> list[str]:
+    """Parse a comma-separated label value (e.g. ``aios.env_keys``) into names."""
+    if not value:
+        return []
+    return [item for item in (part.strip() for part in value.split(",")) if item]
+
+
+def _parse_json_labels(raw: str) -> dict[str, str]:
+    """Parse a ``{{json .Config.Labels}}`` field into a label map.
+
+    Docker emits ``null`` for an image/container with no labels and
+    ``<no value>`` when the field is entirely absent — both map to ``{}``.
+    """
+    raw = raw.strip()
+    if not raw or raw in ("null", "<no value>"):
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): str(v) for k, v in parsed.items()}
+
+
+def _labels_from_config_json(raw: str) -> dict[str, str]:
+    """Extract ``.Config.Labels`` from a ``{{json .Config}}`` field.
+
+    Used instead of ``{{json .Config.Labels}}`` for IMAGE inspects: Docker's
+    inspect applies ``missingkey=error`` to multi-action templates, so a direct
+    ``.Config.Labels`` access errors on a label-less image (the base) with
+    ``map has no entry for key "Labels"``. The whole-Config form is safe for
+    both labeled and unlabeled images; ``Labels`` may be absent or ``null``,
+    both of which map to ``{}``.
+    """
+    raw = raw.strip()
+    if not raw or raw in ("null", "<no value>"):
+        return {}
+    try:
+        config = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(config, dict):
+        return {}
+    labels = config.get("Labels")
+    if not isinstance(labels, dict):
+        return {}
+    return {str(k): str(v) for k, v in labels.items()}
+
+
+def _parse_json_str_list(raw: str) -> tuple[str, ...]:
+    """Parse a ``{{json .RepoTags}}`` field into a tuple of tags (``()`` if none)."""
+    raw = raw.strip()
+    if not raw or raw in ("null", "<no value>"):
+        return ()
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    return tuple(str(item) for item in parsed)
+
+
+def _is_no_such_container(stderr: str) -> bool:
+    return "no such container" in stderr.lower()
+
+
+def _is_no_such_image(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return "no such image" in lowered or "no such object" in lowered
 
 
 def _is_registry_image(image: str) -> bool:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -16,8 +16,11 @@ torn down.
 Sandbox lifecycle is decoupled from step lifecycle via an idle-TTL
 reaper. Sandboxes stay alive across consecutive steps for the same
 session and are released when idle for longer than
-``container_idle_timeout_seconds``. Worker shutdown calls
-:meth:`release_all` to clean up everything.
+``container_idle_timeout_seconds`` (which now snapshots the rootfs before
+removing — durable session sandboxes). Worker shutdown calls
+:meth:`stop_all`, which STOPS every container (leaving its filesystem in a
+stopped corpse for the next worker's GC tick to salvage) rather than
+destroying them.
 
 The registry owns the per-session :class:`GitProxy`, not the handle —
 the proxy is a host-side process whose lifetime tracks the session, not
@@ -28,12 +31,27 @@ addition to destroying the sandbox.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import time
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Literal
 
+from aios.config import get_settings
 from aios.db import queries
 from aios.logging import get_logger
-from aios.sandbox.backends.base import CommandResult, SandboxBackend, SandboxHandle
+from aios.sandbox.backends.base import (
+    BASE_IMAGE_LABEL_KEY,
+    FLATTENED_LABEL_KEY,
+    FLATTENED_LABEL_VALUE,
+    SESSION_LABEL_KEY,
+    CommandResult,
+    ManagedImage,
+    SandboxBackend,
+    SandboxBackendError,
+    SandboxHandle,
+    SandboxSpec,
+)
 from aios.sandbox.git_proxy import GitProxy
 from aios.sandbox.network import WORKER_NETWORK_ALIAS
 from aios.sandbox.setup import (
@@ -42,11 +60,13 @@ from aios.sandbox.setup import (
     install_egress_ca,
     install_packages,
 )
+from aios.sandbox.snapshot_store import LocalDaemonStore, SnapshotStore
 from aios.sandbox.spec import (
     ProvisioningPlan,
     build_spec_from_session,
     cleanup_session_secret_file,
     mount_snapshot_from_echoes,
+    snapshot_tag,
 )
 
 if TYPE_CHECKING:
@@ -56,6 +76,125 @@ if TYPE_CHECKING:
     from aios.models.memory_stores import MemoryStoreResourceEcho
 
 log = get_logger("aios.sandbox.registry")
+
+# Model-visible FS-loss lifecycle events (durable session sandboxes, §5.9).
+# Appended append-only and NON-stimulus-bearing (a GC append never wakes a
+# session); rendered by ``harness.context`` as bracketed user-role notices.
+SANDBOX_FS_RESET_EVENT = "sandbox_fs_reset"
+SANDBOX_FS_EXPIRED_EVENT = "sandbox_fs_expired"
+SANDBOX_FS_OVER_LIMIT_EVENT = "sandbox_fs_over_limit"
+
+# Overall deadline for the worker-shutdown ``stop_all`` (durable session
+# sandboxes, §5.4): a hung daemon must not eat the SIGTERM grace.
+_STOP_ALL_TIMEOUT_S = 8.0
+
+# GC reconciler tick interval (durable session sandboxes, §5.5): hourly, with
+# an immediate first tick at boot (replacing the old boot-time orphan reap).
+_GC_INTERVAL_SECONDS = 3600.0
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSnapshotState:
+    """The GC's per-session decision inputs (one existing session row).
+
+    A session *absent* from the GC's state map is **deleted** — its snapshot
+    is collectible without an event (the model is gone). ``last_event_at`` is
+    the dormancy probe (the ``created_at`` of the event at ``last_event_seq``);
+    ``None`` only on the should-not-happen no-events edge, treated as *not*
+    dormant (conservative — never wipe on a missing probe).
+    """
+
+    session_id: str
+    account_id: str
+    archived: bool
+    last_event_at: datetime | None
+    snapshot_ref: str | None
+    snapshot_host: str | None
+    snapshot_bytes: int | None
+
+
+_GcVerdict = Literal["retain", "remove"]
+_GcReason = Literal["live", "retention_ttl", "deleted", "residue"]
+
+
+@dataclass(frozen=True, slots=True)
+class GcImageVerdict:
+    """A classified managed image and what the GC should do with it."""
+
+    image: ManagedImage
+    session_id: str | None
+    is_canonical: bool
+    removal_ref: str  # the tag for a canonical image (cascade-deletes the chain), else the image id
+    verdict: _GcVerdict
+    reason: _GcReason
+
+
+def _is_session_dormant(state: SessionSnapshotState, now: datetime, ttl_seconds: int) -> bool:
+    """A session is dormant iff its last activity is older than the TTL.
+
+    Archived sessions follow the same rule (unarchive exists; immediate
+    deletion would strand it). A missing dormancy probe reads as *not* dormant.
+    """
+    if state.last_event_at is None:
+        return False
+    return (now - state.last_event_at).total_seconds() > ttl_seconds
+
+
+def _classify_images(
+    images: list[ManagedImage],
+    states: dict[str, SessionSnapshotState],
+    *,
+    now: datetime,
+    ttl_seconds: int,
+    this_host: str,
+) -> list[GcImageVerdict]:
+    """Pure retain-rule classifier for the GC image pass (§5.5), table-driven.
+
+    The single rule: **an image is retained iff it is the canonical tag of an
+    existing session whose last activity is within the TTL.** Everything else
+    managed-and-mine is removed — crash residue, flatten leftovers, deleted
+    sessions (the delete hook), and dormant sessions (the latter flagged
+    ``retention_ttl`` so the caller emits ``sandbox_fs_expired``).
+
+    Untagged interiors of *live* chains are skipped **structurally** — any
+    image that is the ``.Parent`` of another listed image is excluded (the
+    leaf's removal cascade-deletes the chain; removing an interior directly
+    would be refused anyway). On the containerd store ``.Parent`` may be empty;
+    the structural skip then no-ops and the ``remove_image`` refusal is the
+    safety net.
+    """
+    parent_ids = {img.parent_id for img in images if img.parent_id}
+    verdicts: list[GcImageVerdict] = []
+    for img in images:
+        # Structural skip: interior of a (possibly live) chain.
+        if img.image_id in parent_ids:
+            continue
+        sid = img.labels.get(SESSION_LABEL_KEY)
+        canonical_tag = snapshot_tag(this_host, sid) if sid else None
+        is_canonical = canonical_tag is not None and canonical_tag in img.repo_tags
+        removal_ref = canonical_tag if (is_canonical and canonical_tag) else img.image_id
+        state = states.get(sid) if sid else None
+
+        if is_canonical and state is not None and not _is_session_dormant(state, now, ttl_seconds):
+            verdict: _GcVerdict = "retain"
+            reason: _GcReason = "live"
+        elif is_canonical and state is not None:
+            verdict, reason = "remove", "retention_ttl"  # dormant → emit expired event
+        elif is_canonical and state is None:
+            verdict, reason = "remove", "deleted"  # session deleted → no event
+        else:
+            verdict, reason = "remove", "residue"  # crash/flatten leftover, non-canonical
+        verdicts.append(
+            GcImageVerdict(
+                image=img,
+                session_id=sid,
+                is_canonical=is_canonical,
+                removal_ref=removal_ref,
+                verdict=verdict,
+                reason=reason,
+            )
+        )
+    return verdicts
 
 
 class SandboxRegistry:
@@ -70,11 +209,16 @@ class SandboxRegistry:
 
     def __init__(self, backend: SandboxBackend) -> None:
         self._backend = backend
+        # Snapshot transport seam (durable session sandboxes). v1 is the
+        # identity store over the local daemon; multi-host is a drop-in
+        # replacement here with no lifecycle changes.
+        self._store: SnapshotStore = LocalDaemonStore(backend)
         self._handles: dict[str, SandboxHandle] = {}
         self._git_proxies: dict[str, GitProxy] = {}
         self._last_used: dict[str, float] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._reaper_task: asyncio.Task[None] | None = None
+        self._gc_task: asyncio.Task[None] | None = None
         # Strong refs for evict()'s fire-and-forget proxy-stop tasks.
         # asyncio only weak-refs tasks, so without this the task can be
         # GC'd before stop() unwinds the proxy's uvicorn server, httpx
@@ -119,10 +263,11 @@ class SandboxRegistry:
         a ``pool`` is supplied (the cold-start span path already passes
         one) and is best-effort — a transient DB error returns the live
         handle rather than churning a healthy sandbox. A drifted version
-        triggers a recycle: the alive container is explicitly destroyed
-        via ``_destroy_quietly`` before re-provisioning so it doesn't
-        run until the next worker restart the way a dead-container evict
-        would.
+        triggers a recycle: the alive container is SNAPSHOT then removed
+        via ``_snapshot_and_remove`` before re-provisioning (durable session
+        sandboxes — the FS survives the recycle so the immediately-following
+        provision resolves the just-written tag, an FS-preserving reboot onto
+        the current mounts).
 
         Best-effort, not a hard guarantee. The probe runs lock-free, so a
         container can still die between the probe and the caller's use,
@@ -162,14 +307,18 @@ class SandboxRegistry:
                 return current
             if current is not None:
                 if spec_version_drifted:
-                    # Container is still alive — must destroy it, not just
-                    # evict (evict drops the cache entry but skips
-                    # backend.destroy, which is correct for dead containers
-                    # but would leak a live one). _destroy_quietly is
-                    # best-effort so a Docker hiccup doesn't block
-                    # re-provisioning (#713).
+                    # Container is still alive — SNAPSHOT then remove (durable
+                    # session sandboxes, §5.4): the FS must survive the recycle
+                    # so the immediately-following provision resolves the
+                    # just-written snapshot tag — an FS-preserving reboot onto
+                    # the current mounts. ``evict`` drops the cache/proxy/secret
+                    # (the snapshot reads the container's labels, not the cache);
+                    # ``_snapshot_and_remove`` stops + commits + writes the
+                    # pointer + removes. On snapshot failure the corpse is
+                    # retained and the following provision's salvage preamble
+                    # recovers it.
                     self.evict(session_id, unload_session_caches=False)
-                    await self._destroy_quietly(current, session_id)
+                    await self._snapshot_and_remove(session_id, current)
                 else:
                     log.warning(
                         "sandbox.stale_handle_recycling",
@@ -247,8 +396,30 @@ class SandboxRegistry:
             )
 
     async def _provision(self, session_id: str) -> SandboxHandle:
-        """Build the plan, ask the backend to create the sandbox, run setup."""
+        """Salvage corpses, resolve the snapshot, create the sandbox, run setup.
+
+        Runs under the per-session lock (held by :meth:`get_or_provision`), so
+        the salvage preamble's stop/commit/remove is serialized against
+        release and the idle reaper.
+        """
+        # Provision preamble (durable session sandboxes, §5.4): salvage any
+        # crash corpse for this session BEFORE provisioning — container death
+        # no longer loses data. Salvage failure fails the provision loud (raw
+        # error into the tool result, model-actionable); never a silent resume
+        # from a stale tag.
+        await self._salvage_session_corpses(session_id)
+        # First-commit crash heal (§5.3): a commit that succeeded but whose
+        # pointer write crashed leaves a canonical tag with a NULL pointer.
+        # Reconcile it from local truth so resolution below can't miss a local
+        # snapshot (the GC tick covers the same case out-of-band).
+        await self._reconcile_pointer_from_local(session_id)
+
         plan = await build_spec_from_session(session_id)
+        # Resolve the snapshot pointer through the store: verified-negative
+        # existence, base-image drift, missing-snapshot detection. Returns the
+        # spec to run from — snapshot tag resolved to a local image, or cleared
+        # to None (cold start) on a detected reset.
+        spec = await self._resolve_snapshot(session_id, plan.spec)
 
         # Record the GitProxy before backend.create so a failure midway
         # has us in a state where release() will find and stop it.
@@ -256,7 +427,7 @@ class SandboxRegistry:
             self._git_proxies[session_id] = plan.git_proxy
 
         try:
-            handle = await self._backend.create(plan.spec)
+            handle = await self._backend.create(spec)
         except BaseException:
             # Spec was built (proxy may be running, broker secret is
             # registered) but the backend couldn't create the sandbox.
@@ -286,6 +457,11 @@ class SandboxRegistry:
             workspace_path=str(handle.workspace_path),
             backend=self._backend.name,
             networking=type(plan.spec.network_policy).__name__,
+            # Whether this was a snapshot resume or a cold start — so
+            # "why did this session cold-start" is answerable after the fact
+            # (consecutive provisions flipping snapshot→base expose even
+            # operator-caused wipes). §5.9.
+            resumed_from_snapshot=handle.snapshot_image is not None,
         )
         return handle
 
@@ -377,6 +553,245 @@ class SandboxRegistry:
             await self._stop_proxy_silently(proxy, session_id)
         self._release_tool_broker_secret(session_id)
 
+    # ── durable-session-sandbox lifecycle helpers (§5.2-§5.4) ───────────────
+
+    async def _snapshot_and_remove(self, session_id: str, handle: SandboxHandle) -> None:
+        """Snapshot ``handle``'s rootfs → write the pointer → remove the container.
+
+        **Ordering invariant**: the container is removed only after the
+        snapshot verb AND the pointer write both succeed. On failure the
+        stopped corpse is retained (no ``rm``) — the next provision's salvage
+        preamble or the GC tick converges. Best-effort by contract: a snapshot
+        failure here must not propagate (release/recycle callers continue).
+        """
+        if await self._snapshot_and_record(
+            session_id, handle.sandbox_id, disk_limit_bytes=handle.disk_limit_bytes
+        ):
+            await self._backend.destroy(handle)
+
+    async def _snapshot_and_record(
+        self, session_id: str, sandbox_id: str, *, disk_limit_bytes: int | None
+    ) -> bool:
+        """Run the snapshot verb and write the DB pointer for ``sandbox_id``.
+
+        Returns ``True`` iff the container may now be removed (snapshot verb
+        and pointer write both succeeded). A failed pointer write is treated
+        identically to a failed snapshot verb (§5.2): corpse retained, return
+        ``False``, converge via salvage.
+        """
+        settings = get_settings()
+        tag = snapshot_tag(settings.instance_id, session_id)
+        try:
+            outcome = await self._backend.snapshot(
+                sandbox_id,
+                tag,
+                empty_floor_bytes=settings.sandbox_snapshot_empty_floor_bytes,
+                flatten_if_unique_bytes_over=disk_limit_bytes,
+            )
+        except Exception as err:
+            log.warning(
+                "sandbox.snapshot_failed_corpse_retained",
+                session_id=session_id,
+                container_id=sandbox_id[:12],
+                error=str(err),
+            )
+            return False
+
+        # ``image_id is None`` ⇒ skipped_empty with no prior tag (a session
+        # that never wrote): nothing to point at, leave the pointer NULL.
+        if outcome.image_id is not None:
+            # Edge-trigger the over-limit notice only on the crossing — read
+            # the prior bytes only when we're actually over budget (rare).
+            prev_bytes: int | None = None
+            over_now = disk_limit_bytes is not None and outcome.unique_bytes > disk_limit_bytes
+            if over_now:
+                prev_bytes = await self._read_snapshot_bytes(session_id)
+            try:
+                await self._write_snapshot_pointer(session_id, tag, outcome.unique_bytes)
+            except Exception as err:
+                log.warning(
+                    "sandbox.snapshot_pointer_write_failed_corpse_retained",
+                    session_id=session_id,
+                    container_id=sandbox_id[:12],
+                    error=str(err),
+                )
+                return False
+            if (
+                disk_limit_bytes is not None
+                and over_now
+                and (prev_bytes is None or prev_bytes <= disk_limit_bytes)
+            ):
+                await self._append_fs_event(
+                    session_id,
+                    SANDBOX_FS_OVER_LIMIT_EVENT,
+                    {"unique_bytes": outcome.unique_bytes, "limit_bytes": disk_limit_bytes},
+                )
+
+        log.info(
+            "sandbox.snapshot",
+            session_id=session_id,
+            container_id=sandbox_id[:12],
+            kind=outcome.kind,
+            unique_bytes=outcome.unique_bytes,
+            depth=outcome.depth,
+        )
+        return True
+
+    async def _salvage_session_corpses(self, session_id: str) -> None:
+        """Provision preamble: snapshot + remove every corpse of ``session_id``.
+
+        Container death no longer loses data — a crash/OOM/daemon-restart
+        corpse is committed here before the session's next container starts.
+        **Salvage failure fails the provision** (raw error, model-actionable):
+        a retained corpse must never be silently bypassed into a stale-tag
+        resume. Per-corpse budget falls back to the global default (a crash
+        corpse has no spec/handle to carry a per-env override).
+        """
+        settings = get_settings()
+        refs = await self._backend.list_managed(
+            instance_id=settings.instance_id, session_id=session_id
+        )
+        for ref in refs:
+            removable = await self._snapshot_and_record(
+                session_id,
+                ref.sandbox_id,
+                disk_limit_bytes=settings.sandbox_snapshot_budget_bytes,
+            )
+            if not removable:
+                raise SandboxBackendError(
+                    f"salvage of corpse {ref.sandbox_id[:12]} for session {session_id} "
+                    "failed (snapshot or pointer write); refusing to provision over "
+                    "unrecovered state"
+                )
+            await self._backend.force_remove(ref.sandbox_id)
+
+    async def _reconcile_pointer_from_local(self, session_id: str) -> None:
+        """First-commit crash heal (§5.3): if the canonical tag exists locally,
+        ensure the pointer points at it.
+
+        Closes the window where a commit succeeded but its pointer write
+        crashed (and the container was already removed), leaving a tag with a
+        NULL pointer that resolution would otherwise miss. Idempotent — a
+        no-op when the pointer already matches. ``snapshot_bytes`` is set to
+        the full image size here (reporting-only; the next real commit writes
+        the accurate unique figure).
+        """
+        tag = snapshot_tag(get_settings().instance_id, session_id)
+        try:
+            if not await self._store.exists(tag):
+                return
+            size = await self._store.size(tag)
+        except SandboxBackendError as err:
+            log.warning(
+                "sandbox.pointer_reconcile_probe_failed", session_id=session_id, error=str(err)
+            )
+            return
+        await self._write_snapshot_pointer(session_id, tag, size)
+
+    async def _resolve_snapshot(self, session_id: str, spec: SandboxSpec) -> SandboxSpec:
+        """Resolve the DB snapshot pointer to a runnable spec (§5.3).
+
+        ``spec.snapshot_image`` arrives as the raw pointer ref. Returns a spec
+        whose ``snapshot_image`` is the locally-runnable tag for a valid
+        resume, or ``None`` (cold start) on a detected reset. Verified-negative
+        throughout: an indeterminate store probe raises and fails the provision
+        rather than silently cold-starting (which the next idle's lineage gate
+        would then punish as ``skipped_stale``).
+        """
+        ref = spec.snapshot_image
+        if ref is None:
+            return spec  # cold start — no pointer
+
+        # Verified-negative existence through the store (raises on indeterminate).
+        if not await self._store.exists(ref):
+            # Pointer set + store verified-not-found ⇒ external mutation
+            # (operator rmi, image-store loss, host replacement w/o transport).
+            await self._reset_snapshot(session_id, reason="snapshot_missing")
+            return dataclasses.replace(spec, snapshot_image=None)
+
+        # Base-image drift: the snapshot's recorded base vs the currently
+        # resolved env image. A mismatch means the operator deliberately
+        # redefined the environment image.
+        snap_labels = await self._backend.image_labels(ref)
+        if snap_labels is None:
+            # The image was removed between the existence probe and here (an
+            # operator rmi racing resume). That's the snapshot-missing case, not
+            # base drift — record the right reason and cold-start; nothing to
+            # remove (it's already gone).
+            await self._reset_snapshot(session_id, reason="snapshot_missing")
+            return dataclasses.replace(spec, snapshot_image=None)
+        snap_base = snap_labels.get(BASE_IMAGE_LABEL_KEY)
+        if snap_base != spec.image:
+            # Discard — the artifact must actually be GONE: a surviving tag
+            # would be re-pointered by GC pass 4, and the next idle's lineage
+            # gate would see a corpse rooted on the new base against the old
+            # tag and discard live post-drift work as skipped_stale. remove +
+            # clear + event, in the same step.
+            await self._store.remove(ref)
+            await self._reset_snapshot(session_id, reason="environment_image_changed")
+            return dataclasses.replace(spec, snapshot_image=None)
+
+        # Valid resume: make the ref locally runnable (identity for v1).
+        local_tag = await self._store.get(ref)
+        return dataclasses.replace(spec, snapshot_image=local_tag)
+
+    async def _reset_snapshot(self, session_id: str, *, reason: str) -> None:
+        """Clear the snapshot pointer and append a model-visible reset notice."""
+        from aios.harness import runtime
+
+        pool = runtime.require_pool()
+        async with pool.acquire() as conn:
+            await queries.unscoped_clear_session_snapshot(conn, session_id)
+        await self._append_fs_event(session_id, SANDBOX_FS_RESET_EVENT, {"reason": reason})
+        log.info("sandbox.fs_reset", session_id=session_id, reason=reason)
+
+    async def _write_snapshot_pointer(self, session_id: str, ref: str, unique_bytes: int) -> None:
+        """Write the DB snapshot pointer under the deployment's host id.
+
+        ``snapshot_host`` is ``settings.instance_id`` in v1 (one worker), kept
+        distinct from the deployment namespace that derives ``ref`` so a future
+        multi-host deployment never changes a session's ref on handoff (§5.11).
+        """
+        from aios.harness import runtime
+
+        pool = runtime.require_pool()
+        async with pool.acquire() as conn:
+            await queries.unscoped_set_session_snapshot(
+                conn,
+                session_id,
+                ref=ref,
+                host=get_settings().instance_id,
+                snapshot_bytes=unique_bytes,
+            )
+
+    async def _read_snapshot_bytes(self, session_id: str) -> int | None:
+        from aios.harness import runtime
+
+        pool = runtime.require_pool()
+        async with pool.acquire() as conn:
+            return await queries.unscoped_get_session_snapshot_bytes(conn, session_id)
+
+    async def _append_fs_event(self, session_id: str, event: str, payload: dict[str, Any]) -> None:
+        """Append a model-visible FS-loss lifecycle event (§5.9).
+
+        Append-only and **not** stimulus-bearing — ``append_event`` only
+        advances ``last_stimulus_seq`` for user/tool roles, and a lifecycle
+        event carries no role, so a GC/reset append never wakes the session or
+        costs a model call; the notice is read at the next genuine wake.
+        """
+        from aios.harness import runtime
+        from aios.services import sessions as sessions_service
+
+        pool = runtime.require_pool()
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "lifecycle",
+            {"event": event, **payload},
+            account_id=account_id,
+        )
+
     async def exec(
         self,
         handle: SandboxHandle,
@@ -437,7 +852,7 @@ class SandboxRegistry:
         # new sandbox.  The accumulation of one ``asyncio.Lock`` per
         # ever-touched session is a bounded leak that the worker's
         # eventual restart clears; the race is unacceptable.
-        # ``release_all()`` clears the whole dict at teardown.
+        # ``stop_all()`` clears the whole dict at teardown.
         proxy = self._git_proxies.pop(session_id, None)
 
         if proxy is not None:
@@ -447,7 +862,12 @@ class SandboxRegistry:
         runtime.clear_session_read_shas(session_id)
         if handle is None:
             return
-        await self._backend.destroy(handle)
+        # Durable session sandboxes: snapshot the rootfs → write the DB
+        # pointer → remove (instead of a bare destroy). On snapshot/pointer
+        # failure the corpse is retained and converges via the next
+        # provision's salvage preamble or the GC tick. Host-side cleanup above
+        # already ran, so a retained corpse never leaves a stale proxy/secret.
+        await self._snapshot_and_remove(session_id, handle)
 
     async def release_if_mounts_changed(
         self,
@@ -497,7 +917,7 @@ class SandboxRegistry:
         The per-session :class:`GitProxy` is stopped in the background:
         the caller is on a retry path and can't block on stop()'s up-to-5s
         graceful drain. Skipping stop() entirely would strand the proxy's
-        uvicorn server, httpx client and bound TCP port — ``release_all``
+        uvicorn server, httpx client and bound TCP port — ``stop_all``
         only sees ``_git_proxies`` (which we've popped here), so without
         the background stop the proxy leaks for the worker's lifetime.
 
@@ -548,15 +968,24 @@ class SandboxRegistry:
             runtime.clear_session_memory_mounts(session_id)
             runtime.clear_session_read_shas(session_id)
 
-    async def release_all(self) -> None:
-        """Tear down every sandbox + proxy. Called at worker shutdown."""
+    async def stop_all(self) -> None:
+        """Worker shutdown: bounded parallel STOP (no commits) + host cleanup.
+
+        Under durable persistence, shutdown does NOT commit — a commit per
+        container is unbounded and could eat the SIGTERM grace. It stops the
+        containers under one overall ``wait_for`` so a hung daemon can't wedge
+        teardown, leaving stopped corpses (``--restart no``) that the next
+        worker's immediate first GC tick salvages. Per-container stop failures
+        are ops-log noise; the boot tick converges regardless.
+
+        Replaces the old destroy-everything ``release_all`` — destroying at
+        shutdown would lose every active session's filesystem.
+        """
         handles = list(self._handles.values())
         proxies = list(self._git_proxies.values())
-        # Drop the per-session tool broker secret (and its on-disk
-        # ``.secret`` file when UDS transport is in use) for every active
-        # session, matching the cleanup path in ``release()``/``evict()``.
-        # Without this, ``.secret`` files leak on every clean worker
-        # shutdown.
+        # Drop the per-session tool broker secret (and its on-disk ``.secret``
+        # file when UDS transport is in use) for every active session, matching
+        # the cleanup path in ``release()``/``evict()``.
         for h in handles:
             self._release_tool_broker_secret(h.session_id)
         self._handles.clear()
@@ -570,63 +999,30 @@ class SandboxRegistry:
             )
             for _p, result in zip(proxies, proxy_results, strict=True):
                 if isinstance(result, BaseException):
-                    log.warning(
-                        "sandbox.release_all_proxy_error",
-                        error=str(result),
-                    )
+                    log.warning("sandbox.stop_all_proxy_error", error=str(result))
 
         if not handles:
             return
-        log.info("sandbox.release_all", count=len(handles))
-        results = await asyncio.gather(
-            *(self._backend.destroy(h) for h in handles), return_exceptions=True
-        )
+        log.info("sandbox.stop_all", count=len(handles))
+        try:
+            results = await asyncio.wait_for(
+                asyncio.gather(
+                    *(self._backend.stop(h.sandbox_id) for h in handles),
+                    return_exceptions=True,
+                ),
+                timeout=_STOP_ALL_TIMEOUT_S,
+            )
+        except TimeoutError:
+            log.warning("sandbox.stop_all_timeout", count=len(handles), timeout=_STOP_ALL_TIMEOUT_S)
+            return
         for h, result in zip(handles, results, strict=True):
             if isinstance(result, BaseException):
                 log.warning(
-                    "sandbox.release_all_error",
+                    "sandbox.stop_all_error",
                     session_id=h.session_id,
                     container_id=h.sandbox_id[:12],
                     error=str(result),
                 )
-
-    async def reap_orphans(self) -> int:
-        """At startup, remove every sandbox we manage.
-
-        Called once per worker boot, before any step or tool task runs;
-        the worker's ``task_registry`` is empty by construction, so every
-        managed container is a corpse from a prior run. Sessions that
-        resume on this worker will spawn fresh containers on their next
-        step.
-        """
-        from aios.config import get_settings
-
-        instance_id = get_settings().instance_id
-        try:
-            managed = await self._backend.list_managed(instance_id=instance_id)
-        except Exception as err:
-            log.warning("sandbox.reap_list_failed", error=str(err))
-            return 0
-        if not managed:
-            return 0
-
-        removed = 0
-        for ref in managed:
-            log.info(
-                "sandbox.reap_orphan",
-                container_id=ref.sandbox_id[:12],
-                session_id=ref.session_id or "<no-label>",
-            )
-            try:
-                await self._backend.force_remove(ref.sandbox_id)
-                removed += 1
-            except Exception as err:
-                log.warning(
-                    "sandbox.reap_remove_failed",
-                    container_id=ref.sandbox_id[:12],
-                    error=str(err),
-                )
-        return removed
 
     # ── idle-TTL reaper ──────────────────────────────────────────────────
 
@@ -691,3 +1087,333 @@ class SandboxRegistry:
         if self._reaper_task is not None:
             self._reaper_task.cancel()
             self._reaper_task = None
+
+    # ── GC: one retain-rule reconciler (§5.5) ───────────────────────────────
+
+    def start_gc(self, pool: asyncpg.Pool[Any]) -> None:
+        """Start the snapshot GC reconciler (hourly, immediate first tick).
+
+        Replaces the old boot-time ``reap_orphans``: instead of removing every
+        managed container at boot, the first tick salvages crash corpses and
+        reconciles images/pointers against store truth, then repeats hourly.
+        Boot is not blocked — a session waking mid-reconcile salvages its own
+        corpse inline under its own lock.
+        """
+        if self._gc_task is not None:
+            return
+        self._gc_task = asyncio.create_task(self._gc_loop(pool), name="sandbox-snapshot-gc")
+
+    def stop_gc(self) -> None:
+        """Cancel the GC reconciler."""
+        if self._gc_task is not None:
+            self._gc_task.cancel()
+            self._gc_task = None
+
+    async def _gc_loop(self, pool: asyncpg.Pool[Any]) -> None:
+        """Background loop: immediate first tick, then hourly.
+
+        The try/except is nested INSIDE the loop (mirroring the idle reaper):
+        a Docker/DB hiccup in one tick must not silently disable the GC for the
+        worker's lifetime. ``CancelledError`` is not an ``Exception``, so
+        ``stop_gc()`` still exits cleanly.
+        """
+        first = True
+        while True:
+            try:
+                if not first:
+                    await asyncio.sleep(_GC_INTERVAL_SECONDS)
+                first = False
+                await self._gc_once(pool)
+            except Exception:
+                log.exception("sandbox.gc_tick_failed")
+
+    async def _gc_once(self, pool: asyncpg.Pool[Any]) -> None:
+        """One GC tick: corpse pass, image pass, pool-budget pass, pointer reconcile."""
+        settings = get_settings()
+        instance_id = settings.instance_id
+        now = datetime.now(UTC)
+
+        # Pass 1 — corpses (may commit + remove, so it runs before the image enum).
+        containers = await self._backend.list_managed(instance_id=instance_id)
+        corpse_states = await self._load_gc_states(
+            pool, {c.session_id for c in containers if c.session_id}
+        )
+        await self._gc_corpse_pass(containers, corpse_states, now, settings, instance_id)
+
+        # Pass 2 — images (enumerated AFTER the corpse pass settled).
+        images = await self._backend.list_managed_images(instance_id=instance_id)
+        image_states = await self._load_gc_states(
+            pool,
+            {sid for img in images if (sid := img.labels.get(SESSION_LABEL_KEY)) is not None},
+        )
+        verdicts = _classify_images(
+            images,
+            image_states,
+            now=now,
+            ttl_seconds=settings.sandbox_snapshot_ttl_seconds,
+            this_host=instance_id,
+        )
+        retained = await self._gc_image_pass(
+            verdicts, image_states, now, settings.sandbox_snapshot_ttl_seconds, instance_id
+        )
+
+        # Pass 3 — per-host pool budget.
+        await self._gc_pool_budget_pass(
+            retained, image_states, settings.sandbox_snapshot_pool_bytes, instance_id
+        )
+
+        # Pass 4 — pointer reconciliation against local store truth.
+        await self._gc_reconcile_pointers(retained, image_states, instance_id)
+
+        log.info(
+            "sandbox.gc_tick",
+            corpses=len(containers),
+            images=len(images),
+            retained=len(retained),
+            removed=len(verdicts) - len(retained),
+        )
+
+    async def _load_gc_states(
+        self, pool: asyncpg.Pool[Any], session_ids: set[str]
+    ) -> dict[str, SessionSnapshotState]:
+        """Batch-load per-session GC inputs; absent ⇒ deleted (collectible)."""
+        if not session_ids:
+            return {}
+        async with pool.acquire() as conn:
+            rows = await queries.gc_snapshot_session_states(conn, list(session_ids))
+        return {
+            row["id"]: SessionSnapshotState(
+                session_id=row["id"],
+                account_id=row["account_id"],
+                archived=row["archived_at"] is not None,
+                last_event_at=row["last_event_at"],
+                snapshot_ref=row["snapshot_ref"],
+                snapshot_host=row["snapshot_host"],
+                snapshot_bytes=row["snapshot_bytes"],
+            )
+            for row in rows
+        }
+
+    async def _fresh_session_state(self, session_id: str) -> SessionSnapshotState | None:
+        """Re-read one session's GC state — the **condition re-verify** the
+        retain rule needs under the per-session lock (§5.5).
+
+        The tick-start ``states`` snapshot can be stale for a session that woke
+        (or crossed back under the TTL) between the load and a drop decision;
+        re-deriving dormancy from a fresh single-row read under the lock is what
+        keeps the GC from force-removing a just-woke session's corpse without
+        salvage, or removing its canonical snapshot a tick too early. ``None``
+        ⇒ the session is genuinely gone (deleted), still collectible.
+        """
+        from aios.harness import runtime
+
+        states = await self._load_gc_states(runtime.require_pool(), {session_id})
+        return states.get(session_id)
+
+    async def _gc_corpse_pass(
+        self,
+        containers: list[Any],
+        states: dict[str, SessionSnapshotState],
+        now: datetime,
+        settings: Any,
+        instance_id: str,
+    ) -> None:
+        """Salvage (or drop) every managed container that isn't a live cached handle.
+
+        Retain rule first: a deleted/dormant session's corpse is removed
+        WITHOUT paying a commit; a live-within-TTL corpse is salvaged (commit)
+        then removed. Best-effort — a snapshot failure leaves the corpse for
+        the next tick (the GC never raises). Each corpse is handled under the
+        per-session lock with the cached-handle re-check.
+        """
+        for ref in containers:
+            sid = ref.session_id
+            if sid is None:
+                # Unlabeled container — can't salvage without a session; drop it.
+                await self._backend.force_remove(ref.sandbox_id)
+                continue
+            async with self._lock_for(sid):
+                cached = self._handles.get(sid)
+                if cached is not None and cached.sandbox_id == ref.sandbox_id:
+                    continue  # the live, in-use container — never touch it
+                ttl = settings.sandbox_snapshot_ttl_seconds
+                state = states.get(sid)
+                keep_fs = state is not None and not _is_session_dormant(state, now, ttl)
+                if not keep_fs:
+                    # Drop candidate (deleted/dormant per the tick-start snapshot)
+                    # — re-verify dormancy under the lock (§5.5). A session that
+                    # woke since the load must be salvaged, not dropped without a
+                    # commit. (Only the drop direction can be wrong: a session
+                    # can't grow MORE dormant within one tick.)
+                    fresh = await self._fresh_session_state(sid)
+                    keep_fs = fresh is not None and not _is_session_dormant(fresh, now, ttl)
+                if keep_fs:
+                    removable = await self._snapshot_and_record(
+                        sid, ref.sandbox_id, disk_limit_bytes=settings.sandbox_snapshot_budget_bytes
+                    )
+                    if removable:
+                        await self._backend.force_remove(ref.sandbox_id)
+                    # else: snapshot failed — leave the corpse for the next tick.
+                else:
+                    # Deleted/dormant: remove without paying a commit.
+                    await self._backend.force_remove(ref.sandbox_id)
+
+    async def _gc_image_pass(
+        self,
+        verdicts: list[GcImageVerdict],
+        states: dict[str, SessionSnapshotState],
+        now: datetime,
+        ttl_seconds: int,
+        instance_id: str,
+    ) -> list[GcImageVerdict]:
+        """Remove every non-retained image (under per-session locks); return the retained."""
+        retained: list[GcImageVerdict] = []
+        for v in verdicts:
+            if v.verdict == "retain":
+                retained.append(v)
+                continue
+            sid = v.session_id
+            if sid is None:
+                # Residue with no session label — remove directly.
+                await self._backend.remove_image(v.removal_ref)
+                continue
+            async with self._lock_for(sid):
+                # Re-check under the lock: a waking session may now hold a
+                # cached handle (raced between corpse-salvage and docker run);
+                # never rmi a just-salvaged snapshot out from under it.
+                if self._handles.get(sid) is not None:
+                    retained.append(v)
+                    continue
+                # Condition re-verify (§5.5): a TTL-expiry removal is decided
+                # from the tick-start snapshot — re-read dormancy under the lock
+                # so a session that woke since the load keeps its canonical
+                # snapshot instead of being expired a tick early. (Deleted /
+                # residue verdicts can't flip back within a tick.)
+                if v.reason == "retention_ttl":
+                    fresh = await self._fresh_session_state(sid)
+                    if fresh is not None and not _is_session_dormant(fresh, now, ttl_seconds):
+                        retained.append(v)
+                        continue
+                removed = await self._backend.remove_image(v.removal_ref)
+                if not removed:
+                    # Refused (a child still references it) — retain this tick.
+                    retained.append(v)
+                    continue
+                if v.reason == "retention_ttl":
+                    await self._append_fs_event(
+                        sid, SANDBOX_FS_EXPIRED_EVENT, {"reason": "retention_ttl"}
+                    )
+                if v.is_canonical:
+                    await self._clear_pointer_if_owned(sid, instance_id, states)
+        return retained
+
+    async def _gc_pool_budget_pass(
+        self,
+        retained: list[GcImageVerdict],
+        states: dict[str, SessionSnapshotState],
+        pool_bytes: int | None,
+        instance_id: str,
+    ) -> None:
+        """Evict most-dormant sessions first while this host is over its pool budget."""
+        if pool_bytes is None:
+            return
+        base_sizes: dict[str, int] = {}
+        sized: list[tuple[GcImageVerdict, int]] = []
+        total = 0
+        for v in retained:
+            if not v.is_canonical:
+                continue
+            ub = await self._unique_bytes_for_image(v.image, base_sizes)
+            total += ub
+            sized.append((v, ub))
+        if total <= pool_bytes:
+            return
+
+        def _dormancy_key(item: tuple[GcImageVerdict, int]) -> datetime:
+            st = item[0].session_id and states.get(item[0].session_id)
+            if st and st.last_event_at is not None:
+                return st.last_event_at
+            return datetime.min.replace(tzinfo=UTC)  # unknown dormancy ⇒ evict first
+
+        for v, ub in sorted(sized, key=_dormancy_key):
+            if total <= pool_bytes:
+                break
+            sid = v.session_id
+            if sid is None:
+                continue
+            async with self._lock_for(sid):
+                if self._handles.get(sid) is not None:
+                    continue  # waking — skip
+                if await self._backend.remove_image(v.removal_ref):
+                    total -= ub
+                    await self._append_fs_event(
+                        sid, SANDBOX_FS_EXPIRED_EVENT, {"reason": "disk_pressure"}
+                    )
+                    await self._clear_pointer_if_owned(sid, instance_id, states)
+
+    async def _gc_reconcile_pointers(
+        self,
+        retained: list[GcImageVerdict],
+        states: dict[str, SessionSnapshotState],
+        instance_id: str,
+    ) -> None:
+        """Heal a NULL/stale pointer for a retained canonical tag (§5.5 pass 4).
+
+        Ownership-gated: a tick touches ``sessions.snapshot_*`` only for
+        sessions whose ``snapshot_host`` is this host (or NULL, for the crash
+        heal). Multi-host compare-and-swap is deferred — the ``snapshot_host``
+        column is the seam that makes it additive.
+        """
+        base_sizes: dict[str, int] = {}  # shared across the pass (sessions share a base)
+        for v in retained:
+            if not v.is_canonical:
+                continue
+            sid = v.session_id
+            if sid is None:
+                continue
+            st = states.get(sid)
+            if st is None:
+                continue
+            if st.snapshot_host not in (None, instance_id):
+                continue  # owned by another host — never reach across
+            if st.snapshot_ref == v.removal_ref:
+                continue  # already correct
+            async with self._lock_for(sid):
+                if self._handles.get(sid) is not None:
+                    continue  # active; its own commit owns the pointer
+                ub = await self._unique_bytes_for_image(v.image, base_sizes)
+                await self._write_snapshot_pointer(sid, v.removal_ref, ub)
+
+    async def _unique_bytes_for_image(self, image: ManagedImage, base_sizes: dict[str, int]) -> int:
+        """Unique bytes for accounting: full size for a flattened (standalone)
+        image, else ``tag.Size - base.Size``. ``base_sizes`` caches base lookups."""
+        if image.labels.get(FLATTENED_LABEL_KEY) == FLATTENED_LABEL_VALUE:
+            return image.size_bytes
+        base_ref = image.labels.get(BASE_IMAGE_LABEL_KEY)
+        if not base_ref:
+            return image.size_bytes
+        if base_ref not in base_sizes:
+            try:
+                base_sizes[base_ref] = await self._backend.image_size(base_ref)
+            except SandboxBackendError:
+                base_sizes[base_ref] = 0  # over-count is safe; never under-report
+        return max(0, image.size_bytes - base_sizes[base_ref])
+
+    async def _clear_pointer_if_owned(
+        self, session_id: str, instance_id: str, states: dict[str, SessionSnapshotState]
+    ) -> None:
+        """Clear a session's pointer when removing its canonical artifact.
+
+        Ownership-gated: skip when the pointer is owned by another host (a
+        local cache of a peer's artifact, never the canonical copy). A deleted
+        session (absent from ``states``) is cleared unconditionally — the
+        ``UPDATE`` is a harmless no-op against the vanished row.
+        """
+        st = states.get(session_id)
+        if st is not None and st.snapshot_host not in (None, instance_id):
+            return
+        from aios.harness import runtime
+
+        pool = runtime.require_pool()
+        async with pool.acquire() as conn:
+            await queries.unscoped_clear_session_snapshot(conn, session_id)

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -11,12 +11,15 @@ bring it to a usable state:
    into the sandbox trust store (issue #875).
 3. :func:`install_packages` — runs the apt/pip/npm/cargo/gem/go
    commands the environment config asked for.
-4. :func:`apply_network_lockdown` — installs the iptables script that
-   restricts outbound traffic when the network policy is
-   :class:`Limited`.
+4. :func:`apply_network_lockdown` — applies (and read-back verifies) the
+   iptables egress rules when the network policy is :class:`Limited`, from
+   an ephemeral operator-image sidecar joined to the sandbox's netns (§5.8)
+   — NOT from the tenant-writable sandbox filesystem.
 
-Each step calls ``await backend.exec(handle, ...)`` rather than touching
-Docker directly, so they work uniformly across backends.
+The first two steps call ``await backend.exec(handle, ...)`` rather than
+touching Docker directly, so they work uniformly across backends; the
+lockdown goes through :func:`SandboxBackend.run_netns_sidecar` (the sandbox
+holds no ``NET_ADMIN``, so it cannot apply or subvert its own lockdown).
 
 The first three steps are best-effort enrichments — a nonzero exit is
 logged, never raised; the model can retry or work around missing tooling.
@@ -278,6 +281,21 @@ def build_iptables_script(
     return "\n".join(lines)
 
 
+# Docker's embedded DNS, served inside every user-defined-network netns (the
+# sandbox runs on the ``aios-sandbox`` user-defined bridge). The lockdown
+# sidecar joins that netns but inherits the operator image's (typically empty)
+# ``/etc/resolv.conf`` — Docker does NOT manage resolv.conf for a
+# netns-joining container — so the sidecar script points itself at the
+# embedded resolver before ``getent`` resolves the allowed hosts. A DNS miss
+# fails CLOSED (the host gets no ACCEPT rule → blocked), never a bypass.
+_EMBEDDED_DNS_ADDRESS = "127.0.0.11"
+
+# Read-back assertion that the default OUTPUT policy is DROP — proves the
+# lockdown actually took effect in the shared netns, not just that the apply
+# script exited 0.
+_LOCKDOWN_VERIFY_SCRIPT = "iptables -S OUTPUT | grep -qx -- '-P OUTPUT DROP'"
+
+
 async def apply_network_lockdown(
     backend: SandboxBackend,
     handle: SandboxHandle,
@@ -285,40 +303,53 @@ async def apply_network_lockdown(
     *,
     extra_host_ports: Sequence[tuple[str, int]] = (),
 ) -> None:
-    """Apply iptables rules to restrict outbound traffic.
+    """Apply + verify iptables egress rules via an ephemeral operator-image sidecar.
 
-    Called after package installation so that ``pip install`` etc. can
-    reach registries before the lockdown takes effect.
+    Called after package installation so ``pip install`` etc. can reach
+    registries before the lockdown takes effect.
 
-    **Fails closed.** For a :class:`Limited` policy the lockdown *is* the
-    network boundary, not a best-effort enrichment. If the iptables
-    script exits nonzero — missing ``iptables``/``getent`` (e.g. a
-    pared-down per-env image, #724), no ``NET_ADMIN``, a partial flush —
-    the sandbox would otherwise stay up with *unrestricted* outbound
-    traffic, silently bypassing the operator's :class:`Limited` intent.
-    So a nonzero exit (or a backend exec that itself errors) raises
-    :class:`SandboxBackendError`; the caller
-    (:meth:`SandboxRegistry._provision`) tears the sandbox down and
-    aborts the provision rather than handing back an open box.
+    **Off the tenant-writable filesystem (§5.8).** Under durable persistence,
+    running the lockdown *inside* the sandbox (its own ``iptables``/``getent``)
+    was a bypass: a tenant could replace ``/usr/sbin/iptables`` with ``exit 0``
+    in an Unrestricted session, persist it in the snapshot, and have the
+    fail-closed gate trust the poisoned binary's exit 0 when the environment
+    later flipped to Limited. So the lockdown is applied from an **ephemeral
+    sidecar** that joins the sandbox's netns but executes the *operator-trusted*
+    image's binaries (:func:`SandboxBackend.run_netns_sidecar`), and the sandbox
+    holds no ``NET_ADMIN`` — root-in-sandbox can no longer touch netfilter at
+    all. This also closes the pre-existing ``iptables -F your own lockdown``
+    hole.
+
+    **Fails closed.** A Limited policy whose apply OR read-back verification
+    fails (sidecar errors, nonzero exit, or ``OUTPUT`` policy not ``DROP``)
+    raises :class:`SandboxBackendError`; the caller
+    (:meth:`SandboxRegistry._provision`) tears the sandbox down and aborts the
+    provision rather than handing back an open box.
     """
     allowed: set[str] = set(networking.allowed_hosts)
     if networking.allow_package_managers:
         allowed |= PACKAGE_REGISTRY_HOSTS
 
-    script = build_iptables_script(allowed, extra_host_ports=extra_host_ports)
+    iptables_script = build_iptables_script(allowed, extra_host_ports=extra_host_ports)
+    # Point the sidecar at the netns's embedded resolver before getent runs.
+    apply_script = (
+        f"printf 'nameserver {_EMBEDDED_DNS_ADDRESS}\\n' > /etc/resolv.conf 2>/dev/null || true\n"
+        f"{iptables_script}"
+    )
     settings = get_settings()
+
     try:
-        result = await backend.exec(
-            handle, script, timeout_seconds=30, max_output_bytes=settings.bash_max_output_bytes
+        result = await backend.run_netns_sidecar(
+            handle.sandbox_id,
+            image=settings.docker_image,
+            script=apply_script,
+            timeout_seconds=30,
+            max_output_bytes=settings.bash_max_output_bytes,
         )
     except SandboxBackendError:
-        # Don't swallow an infra failure into a wide-open sandbox: a
-        # Limited policy whose lockdown couldn't even run must fail the
-        # provision. Re-raise so the registry tears the box down.
-        log.warning(
-            "sandbox.network_lockdown_exec_error",
-            session_id=handle.session_id,
-        )
+        # Don't swallow an infra failure into a wide-open sandbox: a Limited
+        # policy whose lockdown couldn't even run must fail the provision.
+        log.warning("sandbox.network_lockdown_sidecar_error", session_id=handle.session_id)
         raise
 
     if result.exit_code != 0:
@@ -328,13 +359,34 @@ async def apply_network_lockdown(
             exit_code=result.exit_code,
             stderr=result.stderr[:500],
         )
-        # Fail closed: a Limited sandbox without a successful lockdown is
-        # a silent unrestricted-networking bypass. Aborting the provision
-        # (sandbox torn down by the caller) is the safe outcome.
         raise SandboxBackendError(
             f"network lockdown failed (exit {result.exit_code}) for session "
             f"{handle.session_id}; refusing to run a Limited sandbox with "
             f"unrestricted networking"
+        )
+
+    # Read-back verify the DROP policy actually landed in the shared netns.
+    try:
+        verify = await backend.run_netns_sidecar(
+            handle.sandbox_id,
+            image=settings.docker_image,
+            script=_LOCKDOWN_VERIFY_SCRIPT,
+            timeout_seconds=15,
+            max_output_bytes=settings.bash_max_output_bytes,
+        )
+    except SandboxBackendError:
+        log.warning("sandbox.network_lockdown_verify_error", session_id=handle.session_id)
+        raise
+    if verify.exit_code != 0:
+        log.warning(
+            "sandbox.network_lockdown_verify_failed",
+            session_id=handle.session_id,
+            exit_code=verify.exit_code,
+        )
+        raise SandboxBackendError(
+            f"network lockdown verification failed for session {handle.session_id}: "
+            "OUTPUT policy is not DROP after apply; refusing to run a Limited "
+            "sandbox with unverified networking"
         )
 
     log.info(

--- a/src/aios/sandbox/snapshot_store.py
+++ b/src/aios/sandbox/snapshot_store.py
@@ -1,0 +1,102 @@
+"""The snapshot-transport seam for durable session sandboxes (§5.2).
+
+Horizontal scale — a second worker, host replacement/rebalancing — is a
+stated requirement, so snapshot *transport* sits behind a small Protocol:
+the lifecycle/salvage/lineage/flatten/GC-classify logic in
+:mod:`aios.sandbox.registry` never sees how a snapshot is moved between
+hosts. v1 ships :class:`LocalDaemonStore` only — an identity wrapper over
+the local Docker daemon (today's behaviour exactly, now behind the seam),
+so multi-host is *configuration plus a second store implementation*, not a
+redesign.
+
+A ``ref`` is a **host-independent name** — a pure function of (deployment,
+session), never of which worker committed it. Each store maps the name
+into its own namespace deterministically: ``LocalDaemonStore``'s name *is*
+the local tag; a future ``RegistryStore`` would prefix its configured
+registry path. The DB snapshot pointer therefore never needs rewriting
+after a push.
+
+**Verified-negative semantics** are load-bearing on :meth:`exists`/
+:meth:`get`: only a *confirmed* not-found selects the resume cold-start
+path. An indeterminate probe (daemon hiccup, timeout) raises rather than
+reading as absence — treating a hiccup as "gone" would silently cold-start
+a session and then let the next idle's lineage gate discard all post-hiccup
+work as ``skipped_stale``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from aios.sandbox.backends.base import SandboxBackend, SandboxBackendError
+
+
+@runtime_checkable
+class SnapshotStore(Protocol):
+    """Pluggable transport for a session's canonical snapshot artifact."""
+
+    async def put(self, local_image_tag: str, ref: str) -> str:
+        """Persist a just-committed local image under ``ref``; return the stored ref.
+
+        Identity for a local-only store (the image is already addressable);
+        a remote store pushes/uploads here and returns the durable ref.
+        """
+        ...
+
+    async def get(self, ref: str) -> str:
+        """Make ``ref`` locally runnable and return the local tag to run.
+
+        Pulls/loads for a remote store; identity for a local one. Raises on a
+        ref that has vanished (callers gate with :meth:`exists` first).
+        """
+        ...
+
+    async def exists(self, ref: str) -> bool:
+        """Verified-negative existence: ``False`` only on a *confirmed*
+        not-found; an indeterminate probe raises."""
+        ...
+
+    async def remove(self, ref: str) -> bool:
+        """Remove the artifact. ``True`` on removed/already-gone, ``False`` on refusal."""
+        ...
+
+    async def size(self, ref: str) -> int:
+        """Stored size in bytes (reporting only)."""
+        ...
+
+
+class LocalDaemonStore:
+    """v1 identity store over the local Docker daemon.
+
+    The committed image is already local under ``ref`` (the deterministic
+    tag), so :meth:`put`/:meth:`get` are identity. ``exists``/``remove``/
+    ``size`` map onto the backend's image verbs. A future
+    ``RegistryStore``/``ObjectStore`` implements the same five methods with
+    push/pull and drops in with no lifecycle changes.
+    """
+
+    def __init__(self, backend: SandboxBackend) -> None:
+        self._backend = backend
+
+    async def put(self, local_image_tag: str, ref: str) -> str:
+        # Image is already local under ``ref``; nothing to transport in v1.
+        return ref
+
+    async def get(self, ref: str) -> str:
+        if not await self.exists(ref):
+            # Should-never-happen: callers verify existence first. A vanish
+            # between the check and here is a race, not a silent base fallback.
+            raise SandboxBackendError(f"snapshot ref vanished during resolve: {ref}")
+        return ref
+
+    async def exists(self, ref: str) -> bool:
+        # ``image_labels`` is verified-negative at the backend boundary
+        # (``None`` ⇒ confirmed-absent, indeterminate ⇒ raises), which is
+        # exactly the semantics this seam promises.
+        return await self._backend.image_labels(ref) is not None
+
+    async def remove(self, ref: str) -> bool:
+        return await self._backend.remove_image(ref)
+
+    async def size(self, ref: str) -> int:
+        return await self._backend.image_size(ref)

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -32,10 +32,16 @@ from aios.config import get_settings
 from aios.db import queries
 from aios.harness import runtime
 from aios.logging import get_logger
-from aios.models.environments import EnvironmentConfig, LimitedNetworking
+from aios.models.environments import (
+    RESERVED_SANDBOX_IMAGE_PREFIX,
+    EnvironmentConfig,
+    LimitedNetworking,
+)
 from aios.models.github_repositories import GithubRepositoryResourceEcho
 from aios.models.memory_stores import MemoryStoreResourceEcho
 from aios.sandbox.backends.base import (
+    BASE_IMAGE_LABEL_KEY,
+    ENV_KEYS_LABEL_KEY,
     INSTANCE_LABEL_KEY,
     MANAGED_LABEL_KEY,
     MANAGED_LABEL_VALUE,
@@ -73,6 +79,26 @@ TOOL_BROKER_SOCKET_SANDBOX_PATH = "/var/run/aios/tool-broker.sock"
 # transport is in use. The in-sandbox ``bin/tool`` CLI reads this file
 # as a fallback when ``TOOL_BROKER_SECRET`` isn't in the environment.
 TOOL_BROKER_SECRET_SANDBOX_PATH = "/var/run/aios/tool-broker-secret"
+
+
+def snapshot_tag(deployment: str, session_id: str) -> str:
+    """The deterministic snapshot ref for a session (durable session sandboxes).
+
+    ``aios-sbx-{deployment}-{session_id.lower()}:latest`` — a single path
+    component, so ``_is_registry_image`` returns False and the ``--pull
+    always`` logic never reaches the registry for a snapshot. ULID lowercasing
+    is bijective, so the mapping is collision-free.
+
+    ``deployment`` is the **deployment namespace** (the ``instance_id`` in v1),
+    kept conceptually distinct from the *host id* (``snapshot_host``): the ref
+    must be a pure function of (deployment, session), NEVER of which worker
+    committed it. If a future multi-host deployment minted refs from a
+    per-worker id, every cross-host handoff would change a session's ref and
+    reopen the first-commit crash window (§5.11 invariant 7). The reserved
+    prefix this produces (``aios-sbx-``) is gated against tenant ``image``
+    overrides at the API boundary and the spec-build choke point.
+    """
+    return f"{RESERVED_SANDBOX_IMAGE_PREFIX}{deployment}-{session_id.lower()}:latest"
 
 
 def cleanup_session_secret_file(session_id: str, tool_socket_host_path: Path | None) -> None:
@@ -197,9 +223,9 @@ async def resolve_bash_timeout_ceiling(session_id: str) -> int:
 
 async def _load_session_provisioning(
     session_id: str, *, account_id: str
-) -> tuple[str, dict[str, str], int]:
-    """Load workspace path, env, and ``spec_version`` from the session row
-    in one query (issue #713 adds ``spec_version`` to the tuple)."""
+) -> tuple[str, dict[str, str], int, str | None]:
+    """Load workspace path, env, ``spec_version``, and the snapshot pointer
+    (``snapshot_ref``) from the session row in one query."""
 
     pool = runtime.require_pool()
     async with pool.acquire() as conn:
@@ -393,7 +419,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
 
     settings = get_settings()
     account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
-    raw_path, session_env, spec_version = await _load_session_provisioning(
+    raw_path, session_env, spec_version, snapshot_ref = await _load_session_provisioning(
         session_id, account_id=account_id
     )
     # Re-validate at the bind-mount boundary: ``validate_workspace_path``
@@ -433,13 +459,26 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     # the only resolution point — everything downstream (backend create,
     # the --pull decision) consumes ``spec.image`` blindly.
     image = env_config.image if (env_config and env_config.image) else settings.docker_image
-    # Per-environment writable-layer disk cap (#725): environment
-    # override wins; otherwise the worker-global default (which is itself
-    # ``None`` = unbounded unless the operator set AIOS_SANDBOX_DISK_BYTES).
-    disk_bytes = (
-        env_config.disk_bytes
-        if (env_config and env_config.disk_bytes is not None)
-        else settings.sandbox_disk_bytes
+    # Cross-tenant snapshot gate (durable session sandboxes, §5.8): this is
+    # the spec-build choke point ALL writers traverse, including direct SQL —
+    # the boundary layer of the two-layer gate (the other being the pydantic
+    # ``image`` validator). Reject any image in the reserved snapshot
+    # namespace so a tenant can't point ``env_config.image`` at another
+    # session's snapshot tag (``aios-sbx-<victim>``) and mount its root FS +
+    # baked secrets. Case-insensitive (Docker lowercases refs).
+    if image.lower().startswith(RESERVED_SANDBOX_IMAGE_PREFIX):
+        raise ValueError(
+            f"environment image {image!r} uses the reserved "
+            f"{RESERVED_SANDBOX_IMAGE_PREFIX!r} prefix (reserved for per-session "
+            "snapshot images); refusing to provision"
+        )
+    # Per-session snapshot budget (durable session sandboxes, §5.7):
+    # environment override wins; otherwise the worker-global default
+    # (4 GiB unless the operator set AIOS_SANDBOX_SNAPSHOT_BUDGET_BYTES).
+    snapshot_budget_bytes = (
+        env_config.snapshot_budget_bytes
+        if (env_config and env_config.snapshot_budget_bytes is not None)
+        else settings.sandbox_snapshot_budget_bytes
     )
 
     try:
@@ -448,7 +487,8 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             instance_id=settings.instance_id,
             image=image,
             workspace_path=workspace_path,
-            disk_bytes=disk_bytes,
+            snapshot_ref=snapshot_ref,
+            snapshot_budget_bytes=snapshot_budget_bytes,
             env_config=env_config,
             session_env=session_env,
             memory_echoes=memory_echoes,
@@ -493,7 +533,8 @@ def _assemble_plan(
     tool_broker_url: str,
     tool_broker_secret: str,
     tool_socket_host_path: Path | None = None,
-    disk_bytes: int | None = None,
+    snapshot_ref: str | None = None,
+    snapshot_budget_bytes: int | None = None,
     spec_version: int = 0,
     env_var_credentials: tuple[ResolvedEnvVarCredential, ...] = (),
 ) -> ProvisioningPlan:
@@ -635,6 +676,17 @@ def _assemble_plan(
         MANAGED_LABEL_KEY: MANAGED_LABEL_VALUE,
         INSTANCE_LABEL_KEY: instance_id,
         SESSION_LABEL_KEY: session_id,
+        # Durable session sandboxes (§5.1), inherited into committed images.
+        # ``env_keys`` lists the NAMES of every run-injected env var so the
+        # commit-time scrub empties exactly that set (never the base image's
+        # PATH/HOME — those aren't here). Every name listed is re-injected via
+        # ``docker run --env`` at resume, so emptying it in the image config
+        # only sanitizes the artifact (no value leaks to ``docker save`` /
+        # layer inspect) without affecting the resumed runtime. ``base_image``
+        # records the chain root for resume base-drift detection and
+        # unique-bytes accounting.
+        ENV_KEYS_LABEL_KEY: ",".join(sorted(merged_env)),
+        BASE_IMAGE_LABEL_KEY: image,
     }
 
     snapshot = mount_snapshot_from_echoes(memory_echoes, github_echoes)
@@ -649,6 +701,12 @@ def _assemble_plan(
         network_policy=_network_policy_from_config(env_config),
         host_gateway_alias=None if is_running_in_container() else WORKER_NETWORK_ALIAS,
         image=image,
+        # Resume source (durable session sandboxes): the raw DB snapshot
+        # pointer. The registry's provision path resolves it through the store
+        # (verified-negative, base-drift checked) and replaces it with the
+        # locally-runnable tag — or clears it to None on a detected reset —
+        # before ``backend.create``. ``None`` ⇒ cold start.
+        snapshot_image=snapshot_ref,
         mount_snapshot=snapshot,
         # Provision-time ``sessions.spec_version`` snapshot (issue #713):
         # the backend copies it onto the handle so the registry's warm-hit
@@ -661,10 +719,12 @@ def _assemble_plan(
         cpu_quota=settings.sandbox_cpu_quota,
         memory_bytes=settings.sandbox_memory_bytes,
         pids_limit=settings.sandbox_pids_limit,
-        # Writable-layer disk cap (#725): already resolved by the caller
-        # (environment override → global default), so pass it straight
-        # through rather than re-reading settings here.
-        disk_bytes=disk_bytes,
+        # Per-session snapshot budget (durable session sandboxes, §5.7):
+        # already resolved by the caller (environment override → global
+        # default). The backend stamps it onto the handle as
+        # ``disk_limit_bytes``; the release path passes it back to
+        # ``backend.snapshot`` as the flatten trigger.
+        snapshot_budget_bytes=snapshot_budget_bytes,
         # Authored seccomp deny-list (#807). Always set from settings (never
         # left at the dataclass "unconfined" fallback) so the backend ships
         # the deny-list profile by default; the literal "unconfined" only

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -393,7 +393,9 @@ async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
         runtime.tool_provider,
     ) = prev
     await task_reg.shutdown()
-    await sandbox_reg.release_all()
+    from tests.helpers.sandbox import purge_all_sandboxes
+
+    await purge_all_sandboxes(sandbox_reg)
     await tool_broker.stop()
     await pool.close()
 

--- a/tests/e2e/test_memory_cross_session_sync.py
+++ b/tests/e2e/test_memory_cross_session_sync.py
@@ -168,7 +168,9 @@ async def shared_docker_harness(
             runtime.tool_provider,
         ) = prev
         await task_reg.shutdown()
-        await sandbox_reg.release_all()
+        from tests.helpers.sandbox import purge_all_sandboxes
+
+        await purge_all_sandboxes(sandbox_reg)
         await tool_broker.stop()
         await pool.close()
         get_settings.cache_clear()
@@ -188,7 +190,9 @@ async def _reset_memory_test_state(shared_docker_harness: Harness, migrated_db_u
     survive between tests.
     """
     sandbox = runtime.require_sandbox_registry()
-    await sandbox.release_all()
+    from tests.helpers.sandbox import purge_all_sandboxes
+
+    await purge_all_sandboxes(sandbox)
 
     conn = await asyncpg.connect(migrated_db_url)
     try:
@@ -634,10 +638,19 @@ class TestMountUpdateRecyclesContainer:
         )
         sandbox = runtime.require_sandbox_registry()
         await sandbox.get_or_provision(session.id, pool=shared_docker_harness._pool)
+        # Write a sentinel into the mounted store so the post-detach check can
+        # assert the store's CONTENT is unmounted, not merely that a directory
+        # name vanished.
         before = await bash_handler(
-            session.id, {"command": "ls -d /mnt/memory/detach-mount && echo OK"}
+            session.id,
+            {
+                "command": (
+                    "echo data > /mnt/memory/detach-mount/sentinel "
+                    "&& cat /mnt/memory/detach-mount/sentinel"
+                )
+            },
         )
-        assert "OK" in before["stdout"], before
+        assert "data" in before["stdout"], before
 
         await sessions_service.update_session(
             shared_docker_harness._pool, session.id, resources=[], account_id=account_id
@@ -646,8 +659,17 @@ class TestMountUpdateRecyclesContainer:
             shared_docker_harness._pool, session.id, account_id="acc_test_stub"
         )
 
-        after = await bash_handler(session.id, {"command": "ls /mnt/memory 2>&1; true"})
-        assert "detach-mount" not in after["stdout"]
+        # The store is unmounted: its content is gone from the container. Under
+        # durable session sandboxes the recycled container resumes from the
+        # snapshot (not a fresh base), so the now-empty mountpoint DIRECTORY may
+        # linger in the persisted root FS — a harmless cosmetic artifact, not a
+        # data leak (the bind-mounted store content is excluded from the
+        # snapshot). Assert the meaningful property: the store's content is no
+        # longer accessible.
+        after = await bash_handler(
+            session.id, {"command": "cat /mnt/memory/detach-mount/sentinel 2>&1; true"}
+        )
+        assert "data" not in after["stdout"], after
 
     async def test_idempotent_update_does_not_recycle(self, shared_docker_harness: Harness) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding

--- a/tests/e2e/test_sandbox_persistence.py
+++ b/tests/e2e/test_sandbox_persistence.py
@@ -1,0 +1,357 @@
+"""E2E: the durable-session-sandbox persistence contract on a REAL daemon (§10).
+
+Exercises the snapshot verb + resume against the production-shaped flow
+(``backend.snapshot`` → ``backend.create`` from the resulting tag) so the
+containerd-store mechanics the design depends on are validated end to end:
+
+  * the writable rootfs (``/root``, ``/etc``, ``/tmp``, global installs)
+    survives a release/resume cycle; ``/dev/shm`` (tmpfs) and processes do NOT;
+  * bind mounts are excluded from the snapshot;
+  * a no-write release is ``skipped_empty`` (the containerd SizeRw floor);
+  * run-injected secret VALUES are scrubbed from the committed image config;
+  * resume integrity (non-empty PATH, HOME, pwd) holds after a plain commit
+    AND after a flatten round-trip.
+
+These tests run real ``docker`` and pull/run the sandbox image; they are
+``needs_docker`` + ``docker``-marked and skipped on hosts without a daemon.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from aios.sandbox.backends.base import (
+    BASE_IMAGE_LABEL_KEY,
+    ENV_KEYS_LABEL_KEY,
+    INSTANCE_LABEL_KEY,
+    MANAGED_LABEL_KEY,
+    MANAGED_LABEL_VALUE,
+    SESSION_LABEL_KEY,
+    Mount,
+    SandboxHandle,
+    SandboxSpec,
+    Unrestricted,
+)
+from aios.sandbox.backends.docker import DockerBackend
+from aios.sandbox.network import ensure_sandbox_network
+from aios.sandbox.spec import snapshot_tag
+from tests.conftest import needs_docker
+
+pytestmark = [needs_docker, pytest.mark.docker]
+
+IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
+SECRET_VALUE = "s3cr3t-do-not-leak-DEADBEEF"
+SECCOMP_PROFILE = str(Path(__file__).parents[2] / "docker" / "seccomp-sandbox.json")
+
+
+def _spec(
+    *,
+    instance_id: str,
+    session_id: str,
+    workspace: Path,
+    snapshot_image: str | None = None,
+    env: dict[str, str] | None = None,
+) -> SandboxSpec:
+    environment = {"PATH": "/usr/local/bin:/usr/bin:/bin", **(env or {})}
+    return SandboxSpec(
+        session_id=session_id,
+        instance_id=instance_id,
+        workspace=Mount(host_path=workspace, sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment=environment,
+        labels={
+            MANAGED_LABEL_KEY: MANAGED_LABEL_VALUE,
+            INSTANCE_LABEL_KEY: instance_id,
+            SESSION_LABEL_KEY: session_id,
+            ENV_KEYS_LABEL_KEY: ",".join(sorted(environment)),
+            BASE_IMAGE_LABEL_KEY: IMAGE,
+        },
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image=IMAGE,
+        snapshot_image=snapshot_image,
+        seccomp_profile=SECCOMP_PROFILE,
+    )
+
+
+@pytest.fixture
+async def daemon(tmp_path: Path) -> AsyncIterator[tuple[DockerBackend, str, str, Path]]:
+    """A backend + a unique (instance, session, workspace) plus image cleanup."""
+    await ensure_sandbox_network()
+    backend = DockerBackend()
+    instance_id = f"test_{uuid.uuid4().hex[:8]}"
+    session_id = f"sess_{uuid.uuid4().hex[:8]}"
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    try:
+        yield backend, instance_id, session_id, workspace
+    finally:
+        # Remove any containers + the snapshot image this test produced.
+        for ref in await backend.list_managed(instance_id=instance_id):
+            await backend.force_remove(ref.sandbox_id)
+        await backend.remove_image(snapshot_tag(instance_id, session_id))
+
+
+async def _run(backend: DockerBackend, handle: SandboxHandle, cmd: str) -> tuple[int, str]:
+    res = await backend.exec(handle, cmd, timeout_seconds=120, max_output_bytes=200_000)
+    return res.exit_code, res.stdout + res.stderr
+
+
+async def _write_substantial(backend: DockerBackend, handle: SandboxHandle) -> None:
+    """Write well over the empty-floor (8 KiB) so the release commits a real
+    layer — a no-write / sub-floor session is intentionally ``skipped_empty``
+    (the identity short-circuit), which is covered by its own test."""
+    await _run(backend, handle, "head -c 65536 /dev/zero > /root/blob")
+
+
+async def test_filesystem_persists_processes_and_shm_do_not(
+    daemon: tuple[DockerBackend, str, str, Path],
+) -> None:
+    backend, instance_id, session_id, workspace = daemon
+    tag = snapshot_tag(instance_id, session_id)
+
+    # Cycle 1: write markers across the persistent rootfs + tmpfs, start a proc.
+    h1 = await backend.create(
+        _spec(instance_id=instance_id, session_id=session_id, workspace=workspace)
+    )
+    await _run(backend, h1, "echo root > /root/marker")
+    await _run(backend, h1, "echo etc > /etc/marker")
+    await _run(backend, h1, "echo tmp > /tmp/marker")
+    await _run(backend, h1, "mkdir -p /usr/local/persist && echo glob > /usr/local/persist/marker")
+    await _run(backend, h1, "echo shm > /dev/shm/marker")
+    await _run(backend, h1, "nohup sleep 1000 >/dev/null 2>&1 &")
+    await _run(backend, h1, "echo workspace-only > /workspace/in_ws")  # bind mount — excluded
+    await _write_substantial(backend, h1)
+
+    out = await backend.snapshot(
+        h1.sandbox_id, tag, empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+    )
+    assert out.kind == "committed", f"expected a committed snapshot, got {out.kind}"
+    await backend.destroy(h1)
+    assert await backend.image_labels(tag) is not None, "snapshot tag must exist after commit"
+
+    # Cycle 2: resume from the snapshot on a FRESH workspace dir.
+    fresh_ws = workspace.parent / "ws2"
+    fresh_ws.mkdir()
+    h2 = await backend.create(
+        _spec(
+            instance_id=instance_id, session_id=session_id, workspace=fresh_ws, snapshot_image=tag
+        )
+    )
+    try:
+        # Persistent rootfs survives.
+        for path in ("/root/marker", "/etc/marker", "/tmp/marker", "/usr/local/persist/marker"):
+            rc, _ = await _run(backend, h2, f"test -f {path}")
+            assert rc == 0, f"{path} did not survive the snapshot/resume cycle"
+        # /dev/shm (tmpfs) does NOT survive.
+        rc, _ = await _run(backend, h2, "test -f /dev/shm/marker")
+        assert rc != 0, "/dev/shm marker survived — tmpfs must not persist"
+        # The process is dead (resume = fresh process tree).
+        rc, out_txt = await _run(backend, h2, "pgrep -x sleep || echo NONE")
+        assert "NONE" in out_txt, "the background process survived — resume must be a fresh boot"
+        # Bind-mounted /workspace is excluded from the snapshot (fresh dir is empty).
+        rc, _ = await _run(backend, h2, "test -f /workspace/in_ws")
+        assert rc != 0, "bind-mount content leaked into the snapshot"
+
+        # Second cycle: re-snapshot → resume → first-cycle markers still survive.
+        out2 = await backend.snapshot(
+            h2.sandbox_id, tag, empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out2.kind in ("committed", "skipped_empty")
+    finally:
+        await backend.destroy(h2)
+
+    h3 = await backend.create(
+        _spec(
+            instance_id=instance_id, session_id=session_id, workspace=fresh_ws, snapshot_image=tag
+        )
+    )
+    try:
+        rc, _ = await _run(backend, h3, "test -f /root/marker")
+        assert rc == 0, "/root/marker lost across two snapshot cycles"
+    finally:
+        await backend.destroy(h3)
+
+
+async def test_zero_write_release_is_skipped_empty(
+    daemon: tuple[DockerBackend, str, str, Path],
+) -> None:
+    """A read/chat-only session (no writes) snapshots as ``skipped_empty`` — the
+    containerd-store SizeRw floor (a no-write container reports 4096, not 0)."""
+    backend, instance_id, session_id, workspace = daemon
+    tag = snapshot_tag(instance_id, session_id)
+
+    h1 = await backend.create(
+        _spec(instance_id=instance_id, session_id=session_id, workspace=workspace)
+    )
+    await _run(backend, h1, "true")  # no filesystem writes
+    out = await backend.snapshot(
+        h1.sandbox_id, tag, empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+    )
+    await backend.destroy(h1)
+    assert out.kind == "skipped_empty", (
+        f"a no-write release must be skipped_empty on the floor, got {out.kind}"
+    )
+
+
+async def test_secret_value_absent_from_committed_image_config(
+    daemon: tuple[DockerBackend, str, str, Path],
+) -> None:
+    """Run-injected secret VALUES are scrubbed from the committed image config
+    (a ``docker save`` / image-inspect exposure); the resumed container still
+    gets the secret via ``docker run --env`` at runtime."""
+    backend, instance_id, session_id, workspace = daemon
+    tag = snapshot_tag(instance_id, session_id)
+
+    h1 = await backend.create(
+        _spec(
+            instance_id=instance_id,
+            session_id=session_id,
+            workspace=workspace,
+            env={"OPENAI_API_KEY": SECRET_VALUE},
+        )
+    )
+    await _write_substantial(backend, h1)  # force a non-empty committed layer
+    await backend.snapshot(
+        h1.sandbox_id, tag, empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+    )
+    await backend.destroy(h1)
+
+    # Inspect the committed image's baked Config.Env — the secret value must be gone.
+    rc, out, err = await _docker(["image", "inspect", "--format", "{{json .Config.Env}}", tag])
+    assert rc == 0, err
+    assert SECRET_VALUE not in out, "the secret VALUE leaked into the committed image config"
+
+
+@pytest.mark.parametrize("flatten", [False, True], ids=["plain_commit", "flatten"])
+async def test_resume_integrity_path_home_pwd(
+    daemon: tuple[DockerBackend, str, str, Path], flatten: bool
+) -> None:
+    """A resumed container has a non-empty PATH and pwd ==/workspace, and a
+    correct HOME — both after a plain commit AND after a flatten round-trip
+    (the historical container-bricker + the config-strip regression).
+
+    A plain commit PRESERVES the base image's HOME (so the resumed value equals
+    a fresh base container's HOME); flatten strips all config and RESTORES the
+    sandbox's canonical ``/home/aios``. (In a current deployment the base sets
+    HOME=/home/aios, so both are /home/aios; capturing the base HOME keeps the
+    test robust to base-image build variance.)"""
+    backend, instance_id, session_id, workspace = daemon
+    tag = snapshot_tag(instance_id, session_id)
+
+    # The base image's HOME, as the daemon yields it for a fresh container.
+    base_h = await backend.create(
+        _spec(instance_id=instance_id, session_id=f"{session_id}base", workspace=workspace)
+    )
+    try:
+        _rc, base_home = await _run(backend, base_h, 'printf %s "$HOME"')
+        base_home = base_home.strip()
+    finally:
+        await backend.destroy(base_h)
+
+    h1 = await backend.create(
+        _spec(instance_id=instance_id, session_id=session_id, workspace=workspace)
+    )
+    await _run(backend, h1, "echo x > /root/marker")
+    await _write_substantial(backend, h1)
+    # flatten_if_unique_bytes_over=0 forces the flatten path on any nonzero layer.
+    await backend.snapshot(
+        h1.sandbox_id,
+        tag,
+        empty_floor_bytes=8192,
+        flatten_if_unique_bytes_over=0 if flatten else None,
+    )
+    await backend.destroy(h1)
+
+    h2 = await backend.create(
+        _spec(
+            instance_id=instance_id, session_id=session_id, workspace=workspace, snapshot_image=tag
+        )
+    )
+    try:
+        rc, path = await _run(backend, h2, 'printf %s "$PATH"')
+        assert rc == 0 and path.strip(), "resumed container has an empty PATH (CMD would not exec)"
+        rc, home = await _run(backend, h2, 'printf %s "$HOME"')
+        expected_home = "/home/aios" if flatten else base_home
+        assert home.strip() == expected_home, (
+            f"HOME mismatch: got {home!r}, expected {expected_home!r} (flatten={flatten})"
+        )
+        rc, pwd = await _run(backend, h2, "pwd")
+        assert pwd.strip() == "/workspace", f"pwd not /workspace: {pwd!r}"
+        # The marker survived the (possibly flattened) round-trip.
+        rc, _ = await _run(backend, h2, "test -f /root/marker")
+        assert rc == 0
+    finally:
+        await backend.destroy(h2)
+
+
+async def test_lockdown_survives_poisoned_iptables_on_resume(
+    daemon: tuple[DockerBackend, str, str, Path],
+) -> None:
+    """The §5.8 security fix on a real daemon: a tenant poisons the sandbox's
+    own ``iptables`` (replaces it with ``exit 0``), the snapshot persists it,
+    and on resume the Limited lockdown STILL applies + read-back verifies —
+    because it runs from the operator-image sidecar, not the tenant FS — and the
+    sandbox holds no ``NET_ADMIN`` to flush it.
+    """
+    from aios.models.environments import LimitedNetworking
+    from aios.sandbox.setup import apply_network_lockdown
+
+    backend, instance_id, session_id, workspace = daemon
+    tag = snapshot_tag(instance_id, session_id)
+
+    # Cycle 1: poison the in-sandbox iptables (the persisted-bypass vector).
+    h1 = await backend.create(
+        _spec(instance_id=instance_id, session_id=session_id, workspace=workspace)
+    )
+    await _run(
+        backend,
+        h1,
+        "printf '#!/bin/sh\\nexit 0\\n' > /usr/sbin/iptables && chmod +x /usr/sbin/iptables",
+    )
+    await _write_substantial(backend, h1)
+    await backend.snapshot(
+        h1.sandbox_id, tag, empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+    )
+    await backend.destroy(h1)
+
+    # Cycle 2: resume from the poisoned snapshot.
+    h2 = await backend.create(
+        _spec(
+            instance_id=instance_id, session_id=session_id, workspace=workspace, snapshot_image=tag
+        )
+    )
+    try:
+        # Sanity: the sandbox's own iptables is the poisoned no-op.
+        rc, _ = await _run(backend, h2, "test -x /usr/sbin/iptables")
+        assert rc == 0
+
+        # Apply the Limited lockdown. With the OLD in-sandbox approach this
+        # would trust the poisoned ``exit 0`` and leave egress open; the sidecar
+        # applies + read-back verifies REAL rules, so this returns (no raise)
+        # only because the DROP policy actually landed.
+        await apply_network_lockdown(
+            backend,
+            h2,
+            LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
+        )
+
+        # The sandbox holds no NET_ADMIN (capability bit 12) — it cannot touch
+        # netfilter to flush its own lockdown.
+        rc, capeff = await _run(backend, h2, "grep CapEff /proc/self/status | awk '{print $2}'")
+        caps = int(capeff.strip(), 16)
+        assert not (caps >> 12) & 1, f"sandbox must not hold NET_ADMIN; CapEff={capeff.strip()}"
+    finally:
+        await backend.destroy(h2)
+
+
+async def _docker(args: list[str]) -> tuple[int, str, str]:
+    from aios.sandbox._subprocess import run_docker_cli
+
+    rc, out, err = await run_docker_cli(["docker", *args])
+    return rc, out.decode("utf-8", "replace"), err.decode("utf-8", "replace")

--- a/tests/e2e/test_sandbox_salvage.py
+++ b/tests/e2e/test_sandbox_salvage.py
@@ -1,0 +1,134 @@
+"""E2E: crash-corpse salvage on a real daemon (durable session sandboxes, §5.4).
+
+The headline guarantee — *container death stops losing data* — is validated by
+leaving a stopped corpse (the no-``--rm`` path) and driving the registry's
+salvage preamble (``_salvage_session_corpses``) directly: it commits the corpse
+to the session's snapshot tag and removes it, so a subsequent resume recovers
+the pre-crash filesystem. The DB pointer write is stubbed (a fake pool) — pointer
+discipline is unit-covered; this exercises the real stop→commit→rm integration.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import runtime
+from aios.sandbox.backends.base import (
+    BASE_IMAGE_LABEL_KEY,
+    ENV_KEYS_LABEL_KEY,
+    INSTANCE_LABEL_KEY,
+    MANAGED_LABEL_KEY,
+    MANAGED_LABEL_VALUE,
+    SESSION_LABEL_KEY,
+    Mount,
+    SandboxSpec,
+    Unrestricted,
+)
+from aios.sandbox.backends.docker import DockerBackend
+from aios.sandbox.network import ensure_sandbox_network
+from aios.sandbox.registry import SandboxRegistry
+from aios.sandbox.spec import snapshot_tag
+from tests.conftest import needs_docker
+from tests.helpers.sandbox import FakePool
+
+pytestmark = [needs_docker, pytest.mark.docker]
+
+IMAGE = os.environ.get("AIOS_DOCKER_IMAGE", "ghcr.io/eumemic/aios-sandbox:latest")
+SECCOMP_PROFILE = str(Path(__file__).parents[2] / "docker" / "seccomp-sandbox.json")
+
+
+@pytest.fixture
+def fake_pool() -> Iterator[None]:
+    prev = runtime.pool
+    runtime.pool = cast(Any, FakePool())
+    try:
+        yield
+    finally:
+        runtime.pool = prev
+
+
+@pytest.fixture
+async def daemon(tmp_path: Path) -> AsyncIterator[tuple[DockerBackend, str, Path]]:
+    await ensure_sandbox_network()
+    backend = DockerBackend()
+    instance_id = get_settings().instance_id
+    session_id = f"sess_{uuid.uuid4().hex[:8]}"
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    try:
+        yield backend, session_id, workspace
+    finally:
+        for ref in await backend.list_managed(instance_id=instance_id, session_id=session_id):
+            await backend.force_remove(ref.sandbox_id)
+        await backend.remove_image(snapshot_tag(instance_id, session_id))
+
+
+def _spec(session_id: str, workspace: Path) -> SandboxSpec:
+    instance_id = get_settings().instance_id
+    environment = {"PATH": "/usr/local/bin:/usr/bin:/bin"}
+    return SandboxSpec(
+        session_id=session_id,
+        instance_id=instance_id,
+        workspace=Mount(host_path=workspace, sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment=environment,
+        labels={
+            MANAGED_LABEL_KEY: MANAGED_LABEL_VALUE,
+            INSTANCE_LABEL_KEY: instance_id,
+            SESSION_LABEL_KEY: session_id,
+            ENV_KEYS_LABEL_KEY: ",".join(sorted(environment)),
+            BASE_IMAGE_LABEL_KEY: IMAGE,
+        },
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image=IMAGE,
+        seccomp_profile=SECCOMP_PROFILE,
+    )
+
+
+async def test_crash_corpse_is_salvaged_then_resumed(
+    daemon: tuple[DockerBackend, str, Path], fake_pool: None
+) -> None:
+    backend, session_id, workspace = daemon
+    instance_id = get_settings().instance_id
+    tag = snapshot_tag(instance_id, session_id)
+    registry = SandboxRegistry(backend=backend)
+
+    # Provision a container, write a marker + a substantial layer, then simulate
+    # a crash: stop it out of band WITHOUT removing it (the no-``--rm`` corpse).
+    handle = await backend.create(_spec(session_id, workspace))
+    await backend.exec(
+        handle,
+        "echo pre-crash > /root/survivor && head -c 65536 /dev/zero > /root/blob",
+        timeout_seconds=60,
+        max_output_bytes=10_000,
+    )
+    await backend.stop(handle.sandbox_id)  # crash: corpse remains, no snapshot yet
+    assert await backend.image_labels(tag) is None, "no snapshot should exist before salvage"
+
+    # The salvage preamble commits the corpse to the snapshot tag and removes it.
+    await registry._salvage_session_corpses(session_id)
+    assert await backend.image_labels(tag) is not None, "salvage must commit the corpse's FS"
+    assert not await backend.list_managed(instance_id=instance_id, session_id=session_id), (
+        "salvage must remove the corpse after committing it"
+    )
+
+    # Resume from the salvaged snapshot → the pre-crash marker survives.
+    resumed = await backend.create(
+        dataclasses.replace(_spec(session_id, workspace), snapshot_image=tag)
+    )
+    try:
+        res = await backend.exec(
+            resumed, "cat /root/survivor", timeout_seconds=60, max_output_bytes=10_000
+        )
+        assert "pre-crash" in res.stdout, "the pre-crash marker did not survive salvage+resume"
+    finally:
+        await backend.destroy(resumed)

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -18,10 +18,13 @@ from typing import Any
 
 from aios.sandbox.backends.base import (
     CommandResult,
+    ManagedImage,
     ManagedSandboxRef,
     SandboxBackend,
+    SandboxBackendError,
     SandboxHandle,
     SandboxSpec,
+    SnapshotOutcome,
 )
 
 
@@ -67,6 +70,24 @@ class FakeBackend:
     # Default-empty so existing tests behave as before; tests covering
     # the stale-handle path (#691) populate this.
     dead_sandbox_ids: set[str] = field(default_factory=set)
+    # ── durable-session-sandbox surface (drives registry lifecycle tests
+    #    without Docker) ──────────────────────────────────────────────────
+    # The outcome ``snapshot`` returns (default: a committed layer). Set to
+    # exercise skip/flatten paths; set ``snapshot_raises`` to simulate an
+    # infra failure (corpse retained, no rm).
+    next_snapshot_outcome: SnapshotOutcome | None = None
+    snapshot_raises: bool = False
+    managed_images: list[ManagedImage] = field(default_factory=list)
+    # In-memory image table the store seam reads through (image ref → labels);
+    # ``None`` value models "absent" for verified-negative ``image_labels``.
+    image_labels_by_ref: dict[str, dict[str, str] | None] = field(default_factory=dict)
+    image_sizes_by_ref: dict[str, int] = field(default_factory=dict)
+    # Refs ``remove_image`` should refuse (return False) rather than remove.
+    refuse_remove_refs: set[str] = field(default_factory=set)
+    removed_image_refs: list[str] = field(default_factory=list)
+    # Results ``run_netns_sidecar`` returns, popped in order (apply, verify);
+    # default exit-0 when drained. Set to exercise lockdown apply/verify paths.
+    sidecar_results: list[CommandResult] = field(default_factory=list)
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         self.calls.append(("create", {"session_id": spec.session_id}))
@@ -76,6 +97,8 @@ class FakeBackend:
             workspace_path=spec.workspace.host_path,
             mount_snapshot=spec.mount_snapshot,
             spec_version=spec.spec_version,
+            snapshot_image=spec.snapshot_image,
+            disk_limit_bytes=spec.snapshot_budget_bytes,
         )
 
     async def is_alive(self, handle: SandboxHandle) -> bool:
@@ -121,12 +144,156 @@ class FakeBackend:
             ("destroy", {"session_id": handle.session_id, "sandbox_id": handle.sandbox_id})
         )
 
-    async def list_managed(self, *, instance_id: str) -> list[ManagedSandboxRef]:
-        self.calls.append(("list_managed", {"instance_id": instance_id}))
-        return list(self.managed)
+    async def list_managed(
+        self, *, instance_id: str, session_id: str | None = None
+    ) -> list[ManagedSandboxRef]:
+        self.calls.append(("list_managed", {"instance_id": instance_id, "session_id": session_id}))
+        if session_id is None:
+            return list(self.managed)
+        return [ref for ref in self.managed if ref.session_id == session_id]
 
     async def force_remove(self, sandbox_id: str) -> None:
         self.calls.append(("force_remove", {"sandbox_id": sandbox_id}))
+
+    async def stop(self, sandbox_id: str) -> None:
+        self.calls.append(("stop", {"sandbox_id": sandbox_id}))
+
+    async def snapshot(
+        self,
+        sandbox_id: str,
+        tag: str,
+        *,
+        empty_floor_bytes: int,
+        flatten_if_unique_bytes_over: int | None,
+    ) -> SnapshotOutcome:
+        self.calls.append(
+            (
+                "snapshot",
+                {
+                    "sandbox_id": sandbox_id,
+                    "tag": tag,
+                    "empty_floor_bytes": empty_floor_bytes,
+                    "flatten_if_unique_bytes_over": flatten_if_unique_bytes_over,
+                },
+            )
+        )
+        if self.snapshot_raises:
+            raise SandboxBackendError("fake snapshot failure")
+        if self.next_snapshot_outcome is not None:
+            return self.next_snapshot_outcome
+        return SnapshotOutcome(
+            kind="committed", image_id=f"sha256:{tag}", unique_bytes=1024, depth=1
+        )
+
+    async def list_managed_images(self, *, instance_id: str) -> list[ManagedImage]:
+        self.calls.append(("list_managed_images", {"instance_id": instance_id}))
+        return list(self.managed_images)
+
+    async def remove_image(self, ref: str) -> bool:
+        self.calls.append(("remove_image", {"ref": ref}))
+        if ref in self.refuse_remove_refs:
+            return False
+        self.removed_image_refs.append(ref)
+        self.image_labels_by_ref.pop(ref, None)
+        self.image_sizes_by_ref.pop(ref, None)
+        return True
+
+    async def image_size(self, image: str) -> int:
+        self.calls.append(("image_size", {"image": image}))
+        if image not in self.image_sizes_by_ref:
+            raise SandboxBackendError(f"fake image not found: {image}")
+        return self.image_sizes_by_ref[image]
+
+    async def image_labels(self, image: str) -> dict[str, str] | None:
+        self.calls.append(("image_labels", {"image": image}))
+        # Absent key OR explicit None value ⇒ verified-not-found.
+        return self.image_labels_by_ref.get(image)
+
+    async def run_netns_sidecar(
+        self,
+        target_sandbox_id: str,
+        *,
+        image: str,
+        script: str,
+        timeout_seconds: int,
+        max_output_bytes: int,
+    ) -> CommandResult:
+        self.calls.append(
+            (
+                "run_netns_sidecar",
+                {
+                    "target_sandbox_id": target_sandbox_id,
+                    "image": image,
+                    "script": script,
+                    "timeout_seconds": timeout_seconds,
+                },
+            )
+        )
+        # Each call pops the next queued result (apply, then verify); default
+        # exit-0 once the queue is drained.
+        if self.sidecar_results:
+            return self.sidecar_results.pop(0)
+        return CommandResult(exit_code=0, stdout="", stderr="", timed_out=False, truncated=False)
+
+
+async def purge_all_sandboxes(registry: Any) -> None:
+    """Hard test-teardown for a real-Docker registry (durable session sandboxes).
+
+    ``stop_all`` only STOPS containers (their filesystems are meant to survive
+    for the next worker's GC tick) and never touches snapshot images, so a test
+    that truncates the sessions table would leak stopped corpses + snapshot
+    images across runs. This removes both for the test instance so each test
+    starts from a clean daemon. Refused image removals (a child still
+    references the layer) are ignored — the leaf's removal cascades.
+    """
+    from aios.config import get_settings
+
+    await registry.stop_all()
+    backend = registry._backend
+    instance_id = get_settings().instance_id
+    for ref in await backend.list_managed(instance_id=instance_id):
+        await backend.force_remove(ref.sandbox_id)
+    for img in await backend.list_managed_images(instance_id=instance_id):
+        removal_ref = img.repo_tags[0] if img.repo_tags else img.image_id
+        await backend.remove_image(removal_ref)
+
+
+class _FakeConn:
+    """Minimal asyncpg-conn stand-in for the snapshot-pointer queries the
+    registry runs (``execute``/``fetchrow``/``fetchval``). Reads return benign
+    defaults; ``fetchval`` returns a stub account id for ``load_session_account_id``."""
+
+    async def execute(self, *args: Any, **kwargs: Any) -> str:
+        return "OK"
+
+    async def fetchrow(self, *args: Any, **kwargs: Any) -> Any:
+        return None
+
+    async def fetchval(self, *args: Any, **kwargs: Any) -> Any:
+        return "acct_test"
+
+    async def fetch(self, *args: Any, **kwargs: Any) -> list[Any]:
+        return []
+
+
+class _FakeAcquire:
+    async def __aenter__(self) -> _FakeConn:
+        return _FakeConn()
+
+    async def __aexit__(self, *args: Any) -> bool:
+        return False
+
+
+class FakePool:
+    """A fake asyncpg pool whose ``acquire()`` yields a no-op :class:`_FakeConn`.
+
+    Lets registry snapshot/pointer code that calls ``runtime.require_pool()``
+    run under unit tests without a real database (the pointer writes are
+    no-op ``execute``s). Set ``runtime.pool`` to an instance and restore it.
+    """
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire()
 
 
 # Static check that FakeBackend satisfies the Protocol.
@@ -142,7 +309,7 @@ def patch_build_spec_deps(
     env_config: Any = None,
     session_env: dict[str, str] | None = None,
     docker_image: str = "ghcr.io/eumemic/aios-sandbox:latest",
-    sandbox_disk_bytes: int | None = None,
+    sandbox_snapshot_budget_bytes: int | None = None,
     env_var_credentials: Any = None,
     github_clones: Any = None,
     tool_broker: Any = None,
@@ -160,7 +327,7 @@ def patch_build_spec_deps(
 
     settings = MagicMock()
     settings.docker_image = docker_image
-    settings.sandbox_disk_bytes = sandbox_disk_bytes
+    settings.sandbox_snapshot_budget_bytes = sandbox_snapshot_budget_bytes
     settings.instance_id = "inst_TEST"
     settings.sandbox_cpu_quota = None
     settings.sandbox_memory_bytes = None
@@ -182,8 +349,8 @@ def patch_build_spec_deps(
         ),
         patch(
             "aios.sandbox.spec._load_session_provisioning",
-            # (workspace_path, session_env, spec_version) since #713.
-            AsyncMock(return_value=("/tmp/w", session_env or {}, 0)),
+            # (workspace_path, session_env, spec_version, snapshot_ref).
+            AsyncMock(return_value=("/tmp/w", session_env or {}, 0, None)),
         ),
         # ``build_spec_from_session`` imports these function-locally from
         # ``aios.sandbox.volumes`` (deferred import to avoid a cycle), so

--- a/tests/integration/test_environment_sandbox_controls_persist.py
+++ b/tests/integration/test_environment_sandbox_controls_persist.py
@@ -2,7 +2,7 @@
 through the ``environments.config`` JSONB column without any schema
 migration.
 
-``image``, ``disk_bytes``, and ``bash_timeout_seconds`` are stored
+``image``, ``snapshot_budget_bytes``, and ``bash_timeout_seconds`` are stored
 inside the existing schemaless JSONB ``config`` column (added by
 migration 0004), so adding them to :class:`EnvironmentConfig` is purely
 additive at the DB layer. These tests prove an insert carrying the new
@@ -48,13 +48,13 @@ async def pool_with_account(
 async def test_new_fields_round_trip_through_jsonb(
     pool_with_account: tuple[asyncpg.Pool[Any], str],
 ) -> None:
-    """An environment created with image + disk + bash-timeout overrides
+    """An environment created with image + snapshot-budget + bash-timeout overrides
     reads back with all three intact — no migration required."""
     pool, account_id = pool_with_account
 
     config = EnvironmentConfig(
         image="ghcr.io/eumemic/aios-dev-env:pinned",
-        disk_bytes=8 * 1024 * 1024 * 1024,
+        snapshot_budget_bytes=8 * 1024 * 1024 * 1024,
         bash_timeout_seconds=600,
         packages={"pip": ["pytest"]},
     )
@@ -62,7 +62,7 @@ async def test_new_fields_round_trip_through_jsonb(
         pool, account_id=account_id, name="dev-env", config=config
     )
     assert created.config.image == "ghcr.io/eumemic/aios-dev-env:pinned"
-    assert created.config.disk_bytes == 8 * 1024 * 1024 * 1024
+    assert created.config.snapshot_budget_bytes == 8 * 1024 * 1024 * 1024
     assert created.config.bash_timeout_seconds == 600
 
     # Read back through a fresh query to confirm the JSONB persisted, not
@@ -86,7 +86,7 @@ async def test_unset_fields_persist_as_none(
     )
     fetched = await environments_service.get_environment(pool, created.id, account_id=account_id)
     assert fetched.config.image is None
-    assert fetched.config.disk_bytes is None
+    assert fetched.config.snapshot_budget_bytes is None
     assert fetched.config.bash_timeout_seconds is None
 
 
@@ -95,12 +95,12 @@ async def test_get_environment_config_for_session_carries_new_fields(
 ) -> None:
     """The session-scoped read used by the sandbox spec builder surfaces
     the new fields, so ``build_spec_from_session`` can resolve the
-    per-env image / disk / bash-timeout overrides (issues #724, #725)."""
+    per-env image / snapshot-budget / bash-timeout overrides."""
     pool, account_id = pool_with_account
 
     config = EnvironmentConfig(
         image="ghcr.io/eumemic/aios-dev-env:pinned",
-        disk_bytes=4 * 1024 * 1024 * 1024,
+        snapshot_budget_bytes=4 * 1024 * 1024 * 1024,
         bash_timeout_seconds=300,
     )
     env = await environments_service.create_environment(
@@ -137,5 +137,5 @@ async def test_get_environment_config_for_session_carries_new_fields(
 
     assert loaded is not None
     assert loaded.image == "ghcr.io/eumemic/aios-dev-env:pinned"
-    assert loaded.disk_bytes == 4 * 1024 * 1024 * 1024
+    assert loaded.snapshot_budget_bytes == 4 * 1024 * 1024 * 1024
     assert loaded.bash_timeout_seconds == 300

--- a/tests/unit/sandbox/test_gc_classify.py
+++ b/tests/unit/sandbox/test_gc_classify.py
@@ -1,0 +1,137 @@
+"""Table-driven coverage for the GC retain-rule classifier (durable session
+sandboxes, §5.5). ``_classify_images`` is pure, so it needs no Docker or DB.
+
+The single rule: an image is RETAINED iff it is the canonical tag of an
+existing session whose last activity is within the TTL. Everything else
+managed-and-mine is removed — crash/flatten residue, deleted sessions (the
+delete hook), and dormant sessions (flagged ``retention_ttl``). Untagged
+interiors of live chains are skipped structurally.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from aios.sandbox.backends.base import SESSION_LABEL_KEY, ManagedImage
+from aios.sandbox.registry import SessionSnapshotState, _classify_images
+from aios.sandbox.spec import snapshot_tag
+
+_HOST = "default"
+_TTL = 30 * 24 * 3600
+_NOW = datetime(2026, 6, 10, tzinfo=UTC)
+
+
+def _image(
+    *,
+    image_id: str,
+    session_id: str | None,
+    canonical: bool,
+    parent_id: str | None = None,
+    flattened: bool = False,
+) -> ManagedImage:
+    labels: dict[str, str] = {"aios.managed": "true"}
+    if session_id is not None:
+        labels[SESSION_LABEL_KEY] = session_id
+    if flattened:
+        labels["aios.flattened"] = "true"
+    repo_tags = (snapshot_tag(_HOST, session_id),) if (canonical and session_id) else ()
+    return ManagedImage(
+        image_id=image_id,
+        repo_tags=repo_tags,
+        parent_id=parent_id,
+        size_bytes=1_000_000,
+        labels=labels,
+    )
+
+
+def _state(session_id: str, *, dormant: bool) -> SessionSnapshotState:
+    last = _NOW - timedelta(days=40 if dormant else 1)
+    return SessionSnapshotState(
+        session_id=session_id,
+        account_id="acct",
+        archived=False,
+        last_event_at=last,
+        snapshot_ref=snapshot_tag(_HOST, session_id),
+        snapshot_host=_HOST,
+        snapshot_bytes=1_000_000,
+    )
+
+
+def _classify(
+    images: list[ManagedImage], states: dict[str, SessionSnapshotState]
+) -> dict[str, tuple[str, str]]:
+    verdicts = _classify_images(images, states, now=_NOW, ttl_seconds=_TTL, this_host=_HOST)
+    return {v.image.image_id: (v.verdict, v.reason) for v in verdicts}
+
+
+def test_live_canonical_is_retained() -> None:
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    out = _classify([img], {"sess_a": _state("sess_a", dormant=False)})
+    assert out["img_a"] == ("retain", "live")
+
+
+def test_dormant_canonical_is_removed_with_ttl_reason() -> None:
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    out = _classify([img], {"sess_a": _state("sess_a", dormant=True)})
+    assert out["img_a"] == ("remove", "retention_ttl")
+
+
+def test_deleted_session_canonical_is_removed_no_event() -> None:
+    """A session absent from the state map is deleted → remove, reason 'deleted'
+    (no model-visible event; the session is gone)."""
+    img = _image(image_id="img_a", session_id="sess_gone", canonical=True)
+    out = _classify([img], {})  # session not present
+    assert out["img_a"] == ("remove", "deleted")
+
+
+def test_untagged_residue_is_removed() -> None:
+    """An untagged (non-canonical) leaf — flatten leftover / crash residue —
+    is removed even for a live session."""
+    img = _image(image_id="img_resid", session_id="sess_a", canonical=False)
+    out = _classify([img], {"sess_a": _state("sess_a", dormant=False)})
+    assert out["img_resid"] == ("remove", "residue")
+
+
+def test_structural_parent_skip_excludes_live_chain_interior() -> None:
+    """An image that is the parent of another listed image (a live chain
+    interior) is excluded — its leaf's removal cascade-deletes it."""
+    leaf = _image(
+        image_id="img_leaf", session_id="sess_a", canonical=True, parent_id="img_interior"
+    )
+    interior = _image(image_id="img_interior", session_id="sess_a", canonical=False)
+    out = _classify([leaf, interior], {"sess_a": _state("sess_a", dormant=False)})
+    assert "img_interior" not in out, "live-chain interior must be skipped, not classified"
+    assert out["img_leaf"] == ("retain", "live")
+
+
+def test_archived_session_within_ttl_is_retained() -> None:
+    """Archived sessions follow the same dormancy rule (unarchive exists)."""
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    state = SessionSnapshotState(
+        session_id="sess_a",
+        account_id="acct",
+        archived=True,
+        last_event_at=_NOW - timedelta(days=1),
+        snapshot_ref=snapshot_tag(_HOST, "sess_a"),
+        snapshot_host=_HOST,
+        snapshot_bytes=1,
+    )
+    out = _classify([img], {"sess_a": state})
+    assert out["img_a"] == ("retain", "live")
+
+
+def test_missing_dormancy_probe_is_not_dormant() -> None:
+    """A session with no last_event_at (the should-not-happen no-events edge)
+    reads as NOT dormant — conservative, never wipe on a missing probe."""
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    state = SessionSnapshotState(
+        session_id="sess_a",
+        account_id="acct",
+        archived=False,
+        last_event_at=None,
+        snapshot_ref=snapshot_tag(_HOST, "sess_a"),
+        snapshot_host=_HOST,
+        snapshot_bytes=1,
+    )
+    out = _classify([img], {"sess_a": state})
+    assert out["img_a"] == ("retain", "live")

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -1,0 +1,176 @@
+"""The GC passes' under-lock dormancy RE-VERIFY (durable session sandboxes, §5.5).
+
+The retain rule is decided from a ``states`` snapshot loaded once per tick, but
+the design requires the condition to be **re-verified under the per-session
+lock**: a session that wakes (or crosses back under the TTL) between the load
+and a drop decision must keep its filesystem. These tests drive the impure
+corpse/image passes with a stale-dormant tick-start state and a fresh-read that
+says active, and assert the woke session is salvaged / retained — not dropped.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.config import get_settings
+from aios.harness import runtime
+from aios.sandbox.backends.base import ManagedImage, ManagedSandboxRef
+from aios.sandbox.registry import GcImageVerdict, SandboxRegistry, SessionSnapshotState
+from aios.sandbox.spec import snapshot_tag
+from tests.helpers.sandbox import FakeBackend, FakePool
+
+_NOW = datetime(2026, 6, 10, tzinfo=UTC)
+_TTL = 30 * 24 * 3600
+
+
+@pytest.fixture
+def fake_pool() -> Iterator[None]:
+    prev = runtime.pool
+    runtime.pool = cast(Any, FakePool())
+    try:
+        yield
+    finally:
+        runtime.pool = prev
+
+
+def _state(session_id: str, *, dormant: bool) -> SessionSnapshotState:
+    return SessionSnapshotState(
+        session_id=session_id,
+        account_id="acct",
+        archived=False,
+        last_event_at=_NOW - timedelta(days=40 if dormant else 1),
+        snapshot_ref=snapshot_tag(get_settings().instance_id, session_id),
+        snapshot_host=get_settings().instance_id,
+        snapshot_bytes=1_000_000,
+    )
+
+
+def _row(session_id: str, *, dormant: bool) -> dict[str, Any]:
+    """A ``gc_snapshot_session_states`` row shape (the fresh re-read)."""
+    return {
+        "id": session_id,
+        "account_id": "acct",
+        "archived_at": None,
+        "last_event_at": _NOW - timedelta(days=40 if dormant else 1),
+        "snapshot_ref": snapshot_tag(get_settings().instance_id, session_id),
+        "snapshot_host": get_settings().instance_id,
+        "snapshot_bytes": 1_000_000,
+    }
+
+
+def _patch_fresh_read(
+    monkeypatch: pytest.MonkeyPatch, *, dormant: bool, deleted: bool = False
+) -> None:
+    rows = [] if deleted else [_row("sess_x", dormant=dormant)]
+    monkeypatch.setattr(
+        "aios.sandbox.registry.queries.gc_snapshot_session_states",
+        AsyncMock(return_value=rows),
+    )
+
+
+@pytest.mark.asyncio
+async def test_corpse_pass_salvages_session_that_woke_since_tick_start(
+    fake_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tick-start state says dormant, but a fresh read under the lock says active
+    (the session woke) → the corpse is SALVAGED (committed), not dropped."""
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    _patch_fresh_read(monkeypatch, dormant=False)  # woke: fresh read is active
+    container = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+
+    await registry._gc_corpse_pass(
+        [container],
+        {"sess_x": _state("sess_x", dormant=True)},  # stale tick-start snapshot
+        _NOW,
+        get_settings(),
+        get_settings().instance_id,
+    )
+
+    assert any(c[0] == "snapshot" for c in backend.calls), (
+        "a session that woke since the tick-start load must have its corpse salvaged"
+    )
+
+
+@pytest.mark.asyncio
+async def test_corpse_pass_drops_still_dormant_session_without_commit(
+    fake_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tick-start dormant AND fresh read still dormant → drop without a commit."""
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    _patch_fresh_read(monkeypatch, dormant=True)
+    container = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+
+    await registry._gc_corpse_pass(
+        [container],
+        {"sess_x": _state("sess_x", dormant=True)},
+        _NOW,
+        get_settings(),
+        get_settings().instance_id,
+    )
+
+    assert not any(c[0] == "snapshot" for c in backend.calls), (
+        "a still-dormant corpse must be dropped without paying a commit"
+    )
+    assert any(c[0] == "force_remove" for c in backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_corpse_pass_drops_deleted_session(
+    fake_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fresh read returns no row (session deleted) → drop without a commit."""
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    _patch_fresh_read(monkeypatch, dormant=True, deleted=True)
+    container = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+
+    await registry._gc_corpse_pass(
+        [container],
+        {},  # absent at tick start too
+        _NOW,
+        get_settings(),
+        get_settings().instance_id,
+    )
+
+    assert not any(c[0] == "snapshot" for c in backend.calls)
+    assert any(c[0] == "force_remove" for c in backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_image_pass_retains_ttl_removal_for_session_that_woke(
+    fake_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retention_ttl removal verdict is re-verified under the lock — a session
+    that woke since the tick-start load keeps its canonical snapshot image."""
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    _patch_fresh_read(monkeypatch, dormant=False)  # woke
+    tag = snapshot_tag(get_settings().instance_id, "sess_x")
+    verdict = GcImageVerdict(
+        image=ManagedImage(
+            image_id="img", repo_tags=(tag,), parent_id=None, size_bytes=1, labels={}
+        ),
+        session_id="sess_x",
+        is_canonical=True,
+        removal_ref=tag,
+        verdict="remove",
+        reason="retention_ttl",
+    )
+
+    retained = await registry._gc_image_pass(
+        [verdict],
+        {"sess_x": _state("sess_x", dormant=True)},
+        _NOW,
+        _TTL,
+        get_settings().instance_id,
+    )
+
+    assert retained == [verdict], "a woke session's snapshot must not be expired a tick early"
+    assert not any(c[0] == "remove_image" for c in backend.calls)

--- a/tests/unit/sandbox/test_snapshot_pointer.py
+++ b/tests/unit/sandbox/test_snapshot_pointer.py
@@ -1,0 +1,222 @@
+"""Pointer-discipline coverage for the registry's snapshot lifecycle (§5.1-§5.4).
+
+Drives ``release`` / salvage-reconcile / reset against a ``FakeBackend`` with
+the snapshot-pointer queries patched, so we can assert the ordering invariant
+(pointer written after snapshot success and BEFORE rm; never on failure), the
+first-commit crash heal, and the reset clear-plus-event — all without Docker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.harness import runtime
+from aios.sandbox.registry import SandboxRegistry
+from tests.helpers.sandbox import FakeBackend, FakePool, make_handle
+
+
+@pytest.fixture
+def harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[SandboxRegistry, FakeBackend, list[Any]]]:
+    """A registry over a FakeBackend with the pointer queries patched.
+
+    ``timeline`` records pointer-set / pointer-clear / destroy / fs-event in the
+    order they happen so the after-success-before-rm invariant is assertable.
+    """
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    timeline: list[Any] = []
+
+    async def _set(
+        _conn: Any, session_id: str, *, ref: str, host: str, snapshot_bytes: int
+    ) -> None:
+        timeline.append(("pointer_set", ref, snapshot_bytes))
+
+    async def _clear(_conn: Any, session_id: str) -> None:
+        timeline.append(("pointer_clear", session_id))
+
+    monkeypatch.setattr("aios.sandbox.registry.queries.unscoped_set_session_snapshot", _set)
+    monkeypatch.setattr("aios.sandbox.registry.queries.unscoped_clear_session_snapshot", _clear)
+    monkeypatch.setattr(
+        "aios.sandbox.registry.queries.unscoped_get_session_snapshot_bytes",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "aios.services.sessions.load_session_account_id", AsyncMock(return_value="acct")
+    )
+
+    async def _append(
+        pool: Any, session_id: str, kind: str, data: dict[str, Any], **k: Any
+    ) -> None:
+        timeline.append(("fs_event", data.get("event"), data.get("reason")))
+
+    monkeypatch.setattr("aios.services.sessions.append_event", _append)
+
+    # Record destroy in the same timeline so ordering vs the pointer is visible.
+    orig_destroy = backend.destroy
+
+    async def _destroy(handle: Any) -> None:
+        timeline.append(("destroy", handle.sandbox_id))
+        await orig_destroy(handle)
+
+    backend.destroy = _destroy  # type: ignore[method-assign]
+
+    prev_pool = runtime.pool
+    runtime.pool = cast(Any, FakePool())
+    try:
+        yield registry, backend, timeline
+    finally:
+        runtime.pool = prev_pool
+
+
+@pytest.mark.asyncio
+async def test_release_writes_pointer_before_rm(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+) -> None:
+    registry, _backend, timeline = harness
+    registry._handles["sess_x"] = make_handle(session_id="sess_x")
+    registry._last_used["sess_x"] = 0.0
+
+    await registry.release("sess_x")
+
+    kinds = [t[0] for t in timeline]
+    assert "pointer_set" in kinds, "release must write the snapshot pointer"
+    assert "destroy" in kinds, "release must remove the container after snapshotting"
+    assert kinds.index("pointer_set") < kinds.index("destroy"), (
+        "the pointer must be written AFTER snapshot success and BEFORE rm"
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_failure_retains_corpse_no_pointer(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+) -> None:
+    registry, backend, timeline = harness
+    backend.snapshot_raises = True
+    registry._handles["sess_x"] = make_handle(session_id="sess_x")
+    registry._last_used["sess_x"] = 0.0
+
+    await registry.release("sess_x")
+
+    kinds = [t[0] for t in timeline]
+    assert "pointer_set" not in kinds, "a failed snapshot must not write a pointer"
+    assert "destroy" not in kinds, "a failed snapshot must retain the corpse (no rm)"
+
+
+@pytest.mark.asyncio
+async def test_pointer_write_failure_treated_as_snapshot_failure(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, _backend, timeline = harness
+
+    async def _boom(*a: Any, **k: Any) -> None:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("aios.sandbox.registry.queries.unscoped_set_session_snapshot", _boom)
+    registry._handles["sess_x"] = make_handle(session_id="sess_x")
+    registry._last_used["sess_x"] = 0.0
+
+    await registry.release("sess_x")
+
+    # A failed pointer write is treated identically to a failed snapshot verb:
+    # corpse retained, no rm.
+    assert ("destroy", "abc123def456abc123def456") not in timeline
+
+
+@pytest.mark.asyncio
+async def test_salvage_preamble_heals_null_pointer(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+) -> None:
+    """First-commit crash heal (§5.3): the canonical tag exists locally but the
+    pointer is NULL → the preamble reconcile sets it before resolution runs."""
+    registry, backend, timeline = harness
+    from aios.config import get_settings
+    from aios.sandbox.spec import snapshot_tag
+
+    tag = snapshot_tag(get_settings().instance_id, "sess_x")
+    backend.image_labels_by_ref[tag] = {}  # tag exists locally
+    backend.image_sizes_by_ref[tag] = 500_000
+
+    await registry._reconcile_pointer_from_local("sess_x")
+
+    pointer_sets = [t for t in timeline if t[0] == "pointer_set"]
+    assert pointer_sets, "the heal must set the pointer when the canonical tag exists"
+    assert pointer_sets[0][1] == tag
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_pointer_and_events(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+) -> None:
+    registry, _backend, timeline = harness
+
+    await registry._reset_snapshot("sess_x", reason="snapshot_missing")
+
+    assert ("pointer_clear", "sess_x") in timeline
+    assert ("fs_event", "sandbox_fs_reset", "snapshot_missing") in timeline
+
+
+@pytest.mark.asyncio
+async def test_resolve_base_drift_removes_and_resets(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+) -> None:
+    """Base-image drift (§5.3): the snapshot's recorded base != the current env
+    image → discard (store.remove + pointer clear + event), cold start."""
+    registry, backend, timeline = harness
+    from aios.sandbox.backends.base import Mount, SandboxSpec, Unrestricted
+
+    ref = "aios-sbx-default-sess_x:latest"
+    backend.image_labels_by_ref[ref] = {"aios.base_image": "OLD-IMAGE"}
+    spec = SandboxSpec(
+        session_id="sess_x",
+        instance_id="default",
+        workspace=Mount(host_path=cast(Any, "/tmp/w"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={},
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image="NEW-IMAGE",  # differs from the snapshot's base_image
+        snapshot_image=ref,
+    )
+
+    resolved = await registry._resolve_snapshot("sess_x", spec)
+
+    assert resolved.snapshot_image is None, "drift must clear the resume source (cold start)"
+    assert ref in backend.removed_image_refs, "the stale snapshot artifact must actually be removed"
+    assert ("pointer_clear", "sess_x") in timeline
+    assert ("fs_event", "sandbox_fs_reset", "environment_image_changed") in timeline
+
+
+@pytest.mark.asyncio
+async def test_resolve_snapshot_missing_resets(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+) -> None:
+    """Pointer set + store verified-not-found → snapshot_missing reset + cold start."""
+    registry, _backend, timeline = harness
+    from aios.sandbox.backends.base import Mount, SandboxSpec, Unrestricted
+
+    ref = "aios-sbx-default-sess_x:latest"  # not in image_labels_by_ref ⇒ absent
+    spec = SandboxSpec(
+        session_id="sess_x",
+        instance_id="default",
+        workspace=Mount(host_path=cast(Any, "/tmp/w"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={},
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image="NEW-IMAGE",
+        snapshot_image=ref,
+    )
+
+    resolved = await registry._resolve_snapshot("sess_x", spec)
+
+    assert resolved.snapshot_image is None
+    assert ("fs_event", "sandbox_fs_reset", "snapshot_missing") in timeline

--- a/tests/unit/sandbox/test_snapshot_store.py
+++ b/tests/unit/sandbox/test_snapshot_store.py
@@ -1,0 +1,93 @@
+"""Unit coverage for the ``SnapshotStore`` seam (durable session sandboxes, §5.2).
+
+``LocalDaemonStore`` is the v1 identity wrapper over the local daemon: put/get
+are identity, exists/remove/size map onto the backend's image verbs. The
+load-bearing property under test is **verified-negative** existence — a
+confirmed not-found returns False, an indeterminate probe raises (never reads
+as absence, which would silently cold-start a session and then let the next
+idle's lineage gate discard its post-hiccup work).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.sandbox.backends.base import SandboxBackendError
+from aios.sandbox.snapshot_store import LocalDaemonStore
+from tests.helpers.sandbox import FakeBackend
+
+
+class TestLocalDaemonStore:
+    @pytest.mark.asyncio
+    async def test_put_is_identity(self) -> None:
+        store = LocalDaemonStore(FakeBackend())
+        assert await store.put("local-tag:latest", "ref:latest") == "ref:latest"
+
+    @pytest.mark.asyncio
+    async def test_exists_true_when_present(self) -> None:
+        backend = FakeBackend()
+        backend.image_labels_by_ref["ref:latest"] = {"aios.managed": "true"}
+        store = LocalDaemonStore(backend)
+        assert await store.exists("ref:latest") is True
+
+    @pytest.mark.asyncio
+    async def test_exists_true_even_with_empty_labels(self) -> None:
+        """An image with no labels still exists ({} is not None)."""
+        backend = FakeBackend()
+        backend.image_labels_by_ref["ref:latest"] = {}
+        store = LocalDaemonStore(backend)
+        assert await store.exists("ref:latest") is True
+
+    @pytest.mark.asyncio
+    async def test_exists_false_on_verified_not_found(self) -> None:
+        backend = FakeBackend()  # ref absent ⇒ image_labels returns None
+        store = LocalDaemonStore(backend)
+        assert await store.exists("missing:latest") is False
+
+    @pytest.mark.asyncio
+    async def test_exists_raises_on_indeterminate_probe(self) -> None:
+        """A daemon hiccup must propagate, never read as absence."""
+        backend = FakeBackend()
+        backend.image_labels = AsyncMock(  # type: ignore[method-assign]
+            side_effect=SandboxBackendError("daemon hiccup")
+        )
+        store = LocalDaemonStore(backend)
+        with pytest.raises(SandboxBackendError, match="daemon hiccup"):
+            await store.exists("ref:latest")
+
+    @pytest.mark.asyncio
+    async def test_get_returns_ref_when_present(self) -> None:
+        backend = FakeBackend()
+        backend.image_labels_by_ref["ref:latest"] = {}
+        store = LocalDaemonStore(backend)
+        assert await store.get("ref:latest") == "ref:latest"
+
+    @pytest.mark.asyncio
+    async def test_get_raises_when_vanished(self) -> None:
+        store = LocalDaemonStore(FakeBackend())
+        with pytest.raises(SandboxBackendError, match="vanished"):
+            await store.get("missing:latest")
+
+    @pytest.mark.asyncio
+    async def test_remove_delegates_to_backend(self) -> None:
+        backend = FakeBackend()
+        backend.image_labels_by_ref["ref:latest"] = {}
+        store = LocalDaemonStore(backend)
+        assert await store.remove("ref:latest") is True
+        assert "ref:latest" in backend.removed_image_refs
+
+    @pytest.mark.asyncio
+    async def test_remove_reports_refusal(self) -> None:
+        backend = FakeBackend()
+        backend.refuse_remove_refs.add("ref:latest")
+        store = LocalDaemonStore(backend)
+        assert await store.remove("ref:latest") is False
+
+    @pytest.mark.asyncio
+    async def test_size_delegates_to_backend(self) -> None:
+        backend = FakeBackend()
+        backend.image_sizes_by_ref["ref:latest"] = 12345
+        store = LocalDaemonStore(backend)
+        assert await store.size("ref:latest") == 12345

--- a/tests/unit/sandbox/test_snapshot_tag.py
+++ b/tests/unit/sandbox/test_snapshot_tag.py
@@ -1,0 +1,53 @@
+"""Unit coverage for the snapshot ref mint + the cross-tenant prefix gate (§5.1, §5.8)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios.models.environments import RESERVED_SANDBOX_IMAGE_PREFIX, EnvironmentConfig
+from aios.sandbox.backends.docker import _is_registry_image
+from aios.sandbox.spec import snapshot_tag
+
+
+class TestSnapshotTag:
+    def test_shape_and_lowercasing(self) -> None:
+        # ULIDs are uppercase; the tag lowercases the session id (bijective).
+        tag = snapshot_tag("default", "sess_01HXYZ")
+        assert tag == "aios-sbx-default-sess_01hxyz:latest"
+
+    def test_is_not_a_registry_image(self) -> None:
+        """Single path component ⇒ ``_is_registry_image`` False ⇒ the
+        ``--pull always`` logic never reaches the registry for a snapshot."""
+        tag = snapshot_tag("default", "sess_01HXYZ")
+        assert _is_registry_image(tag) is False
+
+    def test_pure_function_of_deployment_and_session(self) -> None:
+        """The ref is a pure function of (deployment, session) — NEVER of which
+        worker committed it (§5.11 invariant 7), so a multi-host handoff can't
+        change a session's ref."""
+        assert snapshot_tag("deploy_a", "sess_x") == snapshot_tag("deploy_a", "sess_x")
+        assert snapshot_tag("deploy_a", "sess_x") != snapshot_tag("deploy_b", "sess_x")
+
+    def test_uses_reserved_prefix(self) -> None:
+        assert snapshot_tag("default", "sess_x").startswith(RESERVED_SANDBOX_IMAGE_PREFIX)
+
+
+class TestReservedImagePrefixValidator:
+    """The pydantic 422 layer of the two-layer cross-tenant gate (§5.8)."""
+
+    def test_rejects_reserved_prefix(self) -> None:
+        with pytest.raises(ValidationError, match="reserved"):
+            EnvironmentConfig(image="aios-sbx-default-sess_victim:latest")
+
+    def test_rejects_reserved_prefix_case_insensitive(self) -> None:
+        """Docker lowercases image refs, so the gate is case-insensitive."""
+        with pytest.raises(ValidationError, match="reserved"):
+            EnvironmentConfig(image="AIOS-SBX-default-sess_victim:latest")
+
+    def test_allows_normal_images(self) -> None:
+        cfg = EnvironmentConfig(image="ghcr.io/eumemic/aios-sandbox:latest")
+        assert cfg.image == "ghcr.io/eumemic/aios-sandbox:latest"
+
+    def test_allows_none(self) -> None:
+        assert EnvironmentConfig(image=None).image is None

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -1,0 +1,301 @@
+"""Unit coverage for ``DockerBackend.snapshot`` (durable session sandboxes, §5.2).
+
+Drives the snapshot verb against a fake ``docker`` CLI dispatcher so the
+lineage gate, the skip-empty floor (with the production containerd
+``SizeRw == 4096`` no-write value), the flatten triggers (budget + depth),
+and the env-keys scrub are all exercised without a real daemon.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from aios.sandbox.backends.docker import _FLATTEN_DEPTH_CEILING, DockerBackend
+
+
+class _FakeDocker:
+    """A canned ``docker`` CLI + pipeline keyed on the subcommand.
+
+    Models one container-under-snapshot (``parent_image`` / ``size_rw`` /
+    ``container_labels``) and an image table (ref → id/size/depth/labels).
+    ``commit`` and the flatten ``import`` both materialize the tag.
+    """
+
+    def __init__(self) -> None:
+        self.parent_image = "img_S1"
+        self.size_rw = 1_000_000
+        self.container_labels: dict[str, str] = {}
+        self.images: dict[str, dict[str, Any]] = {}
+        self.calls: list[list[str]] = []
+        self.pipelines: list[tuple[list[str], list[str]]] = []
+
+    async def cli(self, argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+        self.calls.append(argv)
+        sub = argv[1]
+        if sub == "stop":
+            return 0, b"cid\n", b""
+        if sub == "inspect" and "--size" in argv:
+            out = f"{self.parent_image}\t{self.size_rw}\t{json.dumps(self.container_labels)}"
+            return 0, out.encode(), b""
+        if sub == "image" and len(argv) > 2 and argv[2] == "inspect":
+            ref = argv[-1]
+            img = self.images.get(ref)
+            if img is None:
+                return 1, b"", f"Error: No such image: {ref}".encode()
+            # Real code inspects ``{{json .Config}}`` (the whole config), then
+            # extracts ``.Labels`` — so emit a Config object, not bare labels.
+            config = json.dumps({"Labels": img.get("labels", {})})
+            out = f"{img['id']}\t{img['size']}\t{img['depth']}\t{config}"
+            return 0, out.encode(), b""
+        if sub == "commit":
+            tag = argv[-1]
+            self.images[tag] = {
+                "id": "committed",
+                "size": self.size_rw + 100_000,
+                "depth": 2,
+                "labels": dict(self.container_labels),
+            }
+            return 0, b"sha256:committed\n", b""
+        raise AssertionError(f"unexpected docker cli: {argv}")
+
+    async def pipeline(
+        self, producer: list[str], consumer: list[str], *, timeout_s: float
+    ) -> tuple[int, bytes, bytes]:
+        self.pipelines.append((producer, consumer))
+        tag = consumer[-1]
+        self.images[tag] = {
+            "id": "flattened",
+            "size": 466_000_000,
+            "depth": 1,
+            "labels": {"aios.flattened": "true"},
+        }
+        return 0, b"sha256:flattened\n", b""
+
+
+@pytest.fixture
+def fake_docker(monkeypatch: pytest.MonkeyPatch) -> _FakeDocker:
+    fd = _FakeDocker()
+    monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", fd.cli)
+    monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_pipeline", fd.pipeline)
+    return fd
+
+
+def _committed(fd: _FakeDocker) -> bool:
+    return any(c[1] == "commit" for c in fd.calls)
+
+
+# ── skip-empty floor (the containerd-store amendment) ────────────────────────
+
+
+class TestSkipEmptyFloor:
+    @pytest.mark.asyncio
+    async def test_containerd_no_write_sizerw_4096_is_skipped(
+        self, fake_docker: _FakeDocker
+    ) -> None:
+        """The production containerd image store reports ``SizeRw == 4096`` for
+        a no-write container, NOT 0. With the default 8 KiB floor this must
+        short-circuit to ``skipped_empty`` — otherwise read/chat-only sessions
+        grow a chain every idle (§5.7)."""
+        fake_docker.size_rw = 4096  # containerd no-write value
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "skipped_empty"
+        assert out.image_id is None
+        assert not _committed(fake_docker), "a no-write layer must not grow a chain"
+
+    @pytest.mark.asyncio
+    async def test_exactly_at_floor_is_skipped(self, fake_docker: _FakeDocker) -> None:
+        fake_docker.size_rw = 8192
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "skipped_empty"
+        assert not _committed(fake_docker)
+
+    @pytest.mark.asyncio
+    async def test_above_floor_commits(self, fake_docker: _FakeDocker) -> None:
+        fake_docker.size_rw = 8193
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "committed"
+        assert _committed(fake_docker)
+
+    @pytest.mark.asyncio
+    async def test_skip_empty_preserves_existing_tag(self, fake_docker: _FakeDocker) -> None:
+        """A no-write release on a session that already has a snapshot keeps the
+        prior tag canonical (image_id set), so the pointer heals to it."""
+        fake_docker.size_rw = 4096
+        fake_docker.images["tag:latest"] = {
+            "id": "img_S1",  # == parent → lineage gate passes before the skip
+            "size": 500_000,
+            "depth": 2,
+            "labels": {},
+        }
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "skipped_empty"
+        assert out.image_id == "img_S1"
+        assert not _committed(fake_docker)
+
+
+# ── lineage gate truth table ─────────────────────────────────────────────────
+
+
+class TestLineageGate:
+    @pytest.mark.asyncio
+    async def test_tag_absent_commits_first_snapshot(self, fake_docker: _FakeDocker) -> None:
+        # No tag in the image table → first snapshot → commit.
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "committed"
+
+    @pytest.mark.asyncio
+    async def test_tag_id_equals_corpse_parent_commits(self, fake_docker: _FakeDocker) -> None:
+        """The corpse is a direct child of the current tag → committing advances
+        the chain (the normal second-and-later idle cycle)."""
+        fake_docker.parent_image = "img_S1"
+        fake_docker.images["tag:latest"] = {
+            "id": "img_S1",
+            "size": 500_000,
+            "depth": 2,
+            "labels": {},
+        }
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "committed"
+        assert _committed(fake_docker)
+
+    @pytest.mark.asyncio
+    async def test_tag_moved_past_corpse_is_skipped_stale(self, fake_docker: _FakeDocker) -> None:
+        """The tag is a child of the corpse's parent (crash-between-commit-and-rm,
+        content-equal residue) → discard the corpse without a commit."""
+        fake_docker.parent_image = "img_S1"
+        fake_docker.images["tag:latest"] = {
+            "id": "img_S2",  # tag has moved past the corpse's parent
+            "size": 700_000,
+            "depth": 3,
+            "labels": {},
+        }
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "skipped_stale"
+        assert out.image_id == "img_S2"
+        assert not _committed(fake_docker), "skipped_stale must never commit live-discarding work"
+
+
+# ── flatten triggers ─────────────────────────────────────────────────────────
+
+
+class TestFlattenTriggers:
+    @pytest.mark.asyncio
+    async def test_over_budget_flattens_not_commits(self, fake_docker: _FakeDocker) -> None:
+        """Projected unique bytes over the per-session budget → flatten
+        (the primary trigger on the containerd store, §1/§5.6)."""
+        fake_docker.size_rw = 5_000_000_000  # 5 GB written
+        out = await DockerBackend().snapshot(
+            "cid",
+            "tag:latest",
+            empty_floor_bytes=8192,
+            flatten_if_unique_bytes_over=4 * 1024 * 1024 * 1024,
+        )
+        assert out.kind == "flattened"
+        assert fake_docker.pipelines, "flatten must run export|import"
+        assert not _committed(fake_docker)
+
+    @pytest.mark.asyncio
+    async def test_depth_ceiling_flattens(self, fake_docker: _FakeDocker) -> None:
+        """The soft depth backstop fires at the ceiling even under budget."""
+        fake_docker.images["img_S1"] = {
+            "id": "img_S1",
+            "size": 500_000,
+            "depth": _FLATTEN_DEPTH_CEILING - 1,  # +1 hits the ceiling
+            "labels": {},
+        }
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "flattened"
+        assert fake_docker.pipelines
+
+    @pytest.mark.asyncio
+    async def test_under_budget_commits(self, fake_docker: _FakeDocker) -> None:
+        fake_docker.size_rw = 1_000_000
+        out = await DockerBackend().snapshot(
+            "cid",
+            "tag:latest",
+            empty_floor_bytes=8192,
+            flatten_if_unique_bytes_over=4 * 1024 * 1024 * 1024,
+        )
+        assert out.kind == "committed"
+        assert not fake_docker.pipelines
+
+
+# ── env-keys scrub scope (the verified container-bricker guard) ──────────────
+
+
+class TestEnvKeysScrub:
+    @pytest.mark.asyncio
+    async def test_commit_scrubs_exactly_the_env_keys_label(self, fake_docker: _FakeDocker) -> None:
+        """Commit emits ``--change 'ENV K='`` for exactly the names in
+        ``aios.env_keys`` (read from the container labels), never the whole
+        ``.Config.Env`` — scrubbing the base PATH/HOME bricks resume."""
+        fake_docker.container_labels = {"aios.env_keys": "OPENAI_API_KEY,TOOL_BROKER_SECRET"}
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        commit = next(c for c in fake_docker.calls if c[1] == "commit")
+        assert "ENV OPENAI_API_KEY=" in commit
+        assert "ENV TOOL_BROKER_SECRET=" in commit
+        # Only the labelled keys are scrubbed — no blanket PATH/HOME wipe.
+        assert "ENV PATH=" not in commit
+        assert "ENV HOME=" not in commit
+
+    @pytest.mark.asyncio
+    async def test_no_env_keys_label_means_plain_commit(self, fake_docker: _FakeDocker) -> None:
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        commit = next(c for c in fake_docker.calls if c[1] == "commit")
+        assert "--change" not in commit
+
+
+# ── flatten config restore ───────────────────────────────────────────────────
+
+
+class TestFlattenConfigRestore:
+    @pytest.mark.asyncio
+    async def test_flatten_restores_workdir_home_cmd_not_path(
+        self, fake_docker: _FakeDocker
+    ) -> None:
+        """Import strips all config; flatten restores WORKDIR/HOME/CMD and
+        re-stamps labels, but deliberately NOT PATH (Docker injects a default,
+        which keeps the restored CMD execable). §5.2."""
+        fake_docker.container_labels = {
+            "aios.base_image": "ghcr.io/eumemic/aios-sandbox:latest",
+            "aios.session_id": "sess_x",
+        }
+        fake_docker.size_rw = 5_000_000_000
+        await DockerBackend().snapshot(
+            "cid",
+            "tag:latest",
+            empty_floor_bytes=8192,
+            flatten_if_unique_bytes_over=1,  # force flatten
+        )
+        _producer, consumer = fake_docker.pipelines[0]
+        joined = " ".join(consumer)
+        assert "WORKDIR /workspace" in joined
+        assert "ENV HOME=/home/aios" in joined
+        assert 'CMD ["tail","-f","/dev/null"]' in joined
+        assert "aios.flattened=true" in joined
+        assert "aios.base_image=ghcr.io/eumemic/aios-sandbox:latest" in joined
+        # PATH is NOT restored.
+        assert "ENV PATH=" not in joined

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -1,17 +1,18 @@
-"""Per-environment sandbox controls: image override, disk cap, and the
-bash-timeout ceiling resolver (issues #724, #725).
+"""Per-environment sandbox controls: image override, snapshot budget, and the
+bash-timeout ceiling resolver (issues #724, #725; durable session sandboxes).
 
-#724 adds an optional :attr:`EnvironmentConfig.image`; #725 adds a
-per-environment writable-layer disk cap and a per-environment bash
-timeout ceiling. All three default to current behavior when unset:
+#724 adds an optional :attr:`EnvironmentConfig.image`; durable session
+sandboxes replace the former writable-layer ``disk_bytes`` cap with a
+per-session ``snapshot_budget_bytes`` (over budget at teardown → flatten,
+never refuse). All three default to current behavior when unset:
 
 - ``image`` unset → the worker-global ``settings.docker_image``.
-- ``disk_bytes`` unset → the worker-global ``settings.sandbox_disk_bytes``
-  (itself ``None`` = unbounded by default).
+- ``snapshot_budget_bytes`` unset → the worker-global
+  ``settings.sandbox_snapshot_budget_bytes`` (4 GiB by default).
 - ``bash_timeout_seconds`` unset → the worker-global
   ``settings.bash_default_timeout_seconds``.
 
-The image/disk resolution lives in ``build_spec_from_session``; the
+The image/budget resolution lives in ``build_spec_from_session``; the
 plumbing onto the spec lives in ``_assemble_plan``; the bash ceiling
 lives in ``resolve_bash_timeout_ceiling``. These tests pin each.
 """
@@ -36,7 +37,8 @@ from tests.helpers.sandbox import patch_build_spec_deps
 def _call_assemble(
     *,
     image: str = "aios-sandbox:test",
-    disk_bytes: int | None = None,
+    snapshot_budget_bytes: int | None = None,
+    snapshot_ref: str | None = None,
     env_config: EnvironmentConfig | None = None,
 ) -> ProvisioningPlan:
     # ``_assemble_plan`` imports its volume helpers function-locally, so
@@ -65,25 +67,48 @@ def _call_assemble(
             tool_broker_url="http://aios-worker:54321",
             tool_broker_secret="secret123",
             tool_socket_host_path=None,
-            disk_bytes=disk_bytes,
+            snapshot_ref=snapshot_ref,
+            snapshot_budget_bytes=snapshot_budget_bytes,
         )
 
 
-class TestAssemblePlanImageAndDisk:
-    """``_assemble_plan`` copies the resolved image + disk cap onto the
-    spec verbatim — it does not itself read settings for these."""
+class TestAssemblePlanImageAndBudget:
+    """``_assemble_plan`` copies the resolved image + snapshot budget + pointer
+    onto the spec verbatim — it does not itself read settings for these."""
 
     def test_image_lands_on_spec(self) -> None:
         plan = _call_assemble(image="ghcr.io/eumemic/aios-sandbox:pinned")
         assert plan.spec.image == "ghcr.io/eumemic/aios-sandbox:pinned"
 
-    def test_disk_bytes_lands_on_spec_when_set(self) -> None:
-        plan = _call_assemble(disk_bytes=2 * 1024 * 1024 * 1024)
-        assert plan.spec.disk_bytes == 2 * 1024 * 1024 * 1024
+    def test_snapshot_budget_lands_on_spec_when_set(self) -> None:
+        plan = _call_assemble(snapshot_budget_bytes=2 * 1024 * 1024 * 1024)
+        assert plan.spec.snapshot_budget_bytes == 2 * 1024 * 1024 * 1024
 
-    def test_disk_bytes_none_by_default(self) -> None:
+    def test_snapshot_budget_none_by_default(self) -> None:
         plan = _call_assemble()
-        assert plan.spec.disk_bytes is None
+        assert plan.spec.snapshot_budget_bytes is None
+
+    def test_snapshot_ref_lands_on_spec_image(self) -> None:
+        """The DB snapshot pointer arrives on the spec as ``snapshot_image``;
+        the registry resolves it through the store before ``backend.create``."""
+        plan = _call_assemble(snapshot_ref="aios-sbx-inst_test-sess_01test:latest")
+        assert plan.spec.snapshot_image == "aios-sbx-inst_test-sess_01test:latest"
+
+    def test_snapshot_ref_none_by_default(self) -> None:
+        plan = _call_assemble()
+        assert plan.spec.snapshot_image is None
+
+    def test_env_keys_and_base_image_labels_stamped(self) -> None:
+        """Durable session sandboxes stamp ``aios.env_keys`` (the names of every
+        run-injected env var) and ``aios.base_image`` (the chain root) so the
+        commit-time scrub and accounting work off labels alone."""
+        plan = _call_assemble(image="ghcr.io/eumemic/aios-sandbox:pinned")
+        labels = plan.spec.labels
+        assert labels["aios.base_image"] == "ghcr.io/eumemic/aios-sandbox:pinned"
+        env_keys = set(labels["aios.env_keys"].split(","))
+        # The names (never values) of the run-injected env — includes the broker
+        # secret's KEY but the scrub only ever empties it, never reads a value.
+        assert {"PATH", "TOOL_BROKER_SECRET", "AIOS_SESSION_ID"} <= env_keys
 
     def test_seccomp_profile_from_settings_lands_on_spec(self) -> None:
         """#807: ``_assemble_plan`` copies ``settings.sandbox_seccomp_profile``
@@ -100,14 +125,14 @@ class TestAssemblePlanImageAndDisk:
         assert plan.spec.seccomp_profile == "/x/seccomp.json"
 
 
-# ── build_spec_from_session resolution (#724 image, #725 disk) ───────────────
+# ── build_spec_from_session resolution (#724 image, snapshot budget) ─────────
 
 
 async def _build_with(
     *,
     env_config: EnvironmentConfig | None,
     docker_image: str = "ghcr.io/eumemic/aios-sandbox:latest",
-    sandbox_disk_bytes: int | None = None,
+    sandbox_snapshot_budget_bytes: int | None = None,
 ) -> ProvisioningPlan:
     from contextlib import ExitStack
 
@@ -117,7 +142,7 @@ async def _build_with(
         for cm in patch_build_spec_deps(
             env_config=env_config,
             docker_image=docker_image,
-            sandbox_disk_bytes=sandbox_disk_bytes,
+            sandbox_snapshot_budget_bytes=sandbox_snapshot_budget_bytes,
         ):
             stack.enter_context(cm)
         return await build_spec_from_session("sess_01TEST")
@@ -152,33 +177,45 @@ class TestBuildSpecImageResolution:
         )
         assert plan.spec.image == "ghcr.io/eumemic/aios-sandbox:latest"
 
+    @pytest.mark.asyncio
+    async def test_reserved_prefix_image_is_rejected(self) -> None:
+        """Cross-tenant gate (§5.8): the spec-build choke point rejects a
+        tenant ``image`` in the reserved per-session-snapshot namespace, so a
+        tenant can't mount another session's snapshot (and its baked secrets)."""
+        with pytest.raises(ValueError, match="reserved"):
+            await _build_with(
+                env_config=EnvironmentConfig.model_construct(
+                    image="aios-sbx-default-sess_victim:latest"
+                ),
+            )
 
-class TestBuildSpecDiskResolution:
-    """#725: per-env ``disk_bytes`` wins; else the global default; else None."""
+
+class TestBuildSpecSnapshotBudgetResolution:
+    """Per-env ``snapshot_budget_bytes`` wins; else the global default; else None."""
 
     @pytest.mark.asyncio
-    async def test_env_disk_overrides_global(self) -> None:
+    async def test_env_budget_overrides_global(self) -> None:
         plan = await _build_with(
-            env_config=EnvironmentConfig(disk_bytes=8 * 1024 * 1024 * 1024),
-            sandbox_disk_bytes=2 * 1024 * 1024 * 1024,
+            env_config=EnvironmentConfig(snapshot_budget_bytes=8 * 1024 * 1024 * 1024),
+            sandbox_snapshot_budget_bytes=2 * 1024 * 1024 * 1024,
         )
-        assert plan.spec.disk_bytes == 8 * 1024 * 1024 * 1024
+        assert plan.spec.snapshot_budget_bytes == 8 * 1024 * 1024 * 1024
 
     @pytest.mark.asyncio
-    async def test_unset_env_disk_falls_back_to_global(self) -> None:
+    async def test_unset_env_budget_falls_back_to_global(self) -> None:
         plan = await _build_with(
             env_config=EnvironmentConfig(packages={"pip": ["x"]}),
-            sandbox_disk_bytes=2 * 1024 * 1024 * 1024,
+            sandbox_snapshot_budget_bytes=2 * 1024 * 1024 * 1024,
         )
-        assert plan.spec.disk_bytes == 2 * 1024 * 1024 * 1024
+        assert plan.spec.snapshot_budget_bytes == 2 * 1024 * 1024 * 1024
 
     @pytest.mark.asyncio
     async def test_both_unset_is_none(self) -> None:
         plan = await _build_with(
             env_config=None,
-            sandbox_disk_bytes=None,
+            sandbox_snapshot_budget_bytes=None,
         )
-        assert plan.spec.disk_bytes is None
+        assert plan.spec.snapshot_budget_bytes is None
 
 
 # ── resolve_bash_timeout_ceiling (#725) ──────────────────────────────────────

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -179,46 +179,62 @@ def test_github_clone_session_timeout_mirror_matches_harness_constant(
     assert _HARNESS_STEP_TIMEOUT_S == _JOB_TIMEOUT_S
 
 
-def test_sandbox_disk_bytes_default_is_none(
+def test_sandbox_snapshot_budget_bytes_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The disk cap (issue #725) defaults to ``None`` so current behavior
-    (host default, unbounded) is unchanged unless the operator opts in."""
+    """The per-session snapshot budget (durable session sandboxes) defaults to
+    4 GiB — over budget at teardown triggers flatten, never a refusal."""
     from aios.config import Settings
 
     secrets = tmp_path / "secrets.env"
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
-    monkeypatch.delenv("AIOS_SANDBOX_DISK_BYTES", raising=False)
+    monkeypatch.delenv("AIOS_SANDBOX_SNAPSHOT_BUDGET_BYTES", raising=False)
 
     s = Settings(_env_file=(str(secrets),))
-    assert s.sandbox_disk_bytes is None
+    assert s.sandbox_snapshot_budget_bytes == 4 * 1024 * 1024 * 1024
 
 
-def test_sandbox_disk_bytes_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``AIOS_SANDBOX_DISK_BYTES`` sets the global writable-layer cap."""
+def test_sandbox_snapshot_budget_bytes_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``AIOS_SANDBOX_SNAPSHOT_BUDGET_BYTES`` sets the global per-session budget."""
     from aios.config import Settings
 
     secrets = tmp_path / "secrets.env"
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
-    monkeypatch.setenv("AIOS_SANDBOX_DISK_BYTES", str(4 * 1024 * 1024 * 1024))
+    monkeypatch.setenv("AIOS_SANDBOX_SNAPSHOT_BUDGET_BYTES", str(8 * 1024 * 1024 * 1024))
 
     s = Settings(_env_file=(str(secrets),))
-    assert s.sandbox_disk_bytes == 4 * 1024 * 1024 * 1024
+    assert s.sandbox_snapshot_budget_bytes == 8 * 1024 * 1024 * 1024
 
 
-def test_sandbox_disk_bytes_rejects_below_floor(
+def test_sandbox_snapshot_budget_bytes_rejects_below_floor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Below the 10 MiB floor the cap can't fit the image's own base size,
-    so Settings construction rejects it loudly rather than provisioning a
-    container that can't start."""
+    """Below the 10 MiB floor the budget can't fit the image's base, so
+    Settings construction rejects it loudly."""
     from pydantic import ValidationError
 
     from aios.config import Settings
 
     secrets = tmp_path / "secrets.env"
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
-    monkeypatch.setenv("AIOS_SANDBOX_DISK_BYTES", "1024")
+    monkeypatch.setenv("AIOS_SANDBOX_SNAPSHOT_BUDGET_BYTES", "1024")
 
     with pytest.raises(ValidationError):
         Settings(_env_file=(str(secrets),))
+
+
+def test_container_idle_timeout_default_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Durable session sandboxes raise the idle default 300 → 1800 (§5.10):
+    teardown now costs a commit, so keeping an idle container alive is cheap."""
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_CONTAINER_IDLE_TIMEOUT_SECONDS", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))
+    assert s.container_idle_timeout_seconds == 1800

--- a/tests/unit/test_context_fs_lifecycle.py
+++ b/tests/unit/test_context_fs_lifecycle.py
@@ -1,0 +1,131 @@
+"""Coverage for the FS-loss lifecycle notices in the context builder (§5.9).
+
+The durable-session-sandbox loss events (``sandbox_fs_reset`` /
+``sandbox_fs_expired`` / ``sandbox_fs_over_limit``) are the only non-``message``
+events ``build_messages`` renders. They must:
+  * render as a bracketed user-role notice at their seq position,
+  * NOT advance the ``reacting_to`` watermark (they are not stimulus-bearing,
+    so a GC/reset append never, on its own, wakes the session), and
+  * leave other lifecycle events skipped (the allowlist is minimal).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from aios.harness.context import build_messages
+from aios.models.events import Event
+
+_AT = datetime(2026, 6, 10, tzinfo=UTC)
+
+
+def _msg(seq: int, role: str, content: str) -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="message",
+        data={"role": role, "content": content},
+        created_at=_AT,
+        orig_channel=None,
+        focal_channel_at_arrival=None,
+    )
+
+
+def _lifecycle(seq: int, data: dict[str, Any]) -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="lifecycle",
+        data=data,
+        created_at=_AT,
+        orig_channel=None,
+        focal_channel_at_arrival=None,
+    )
+
+
+def test_reset_event_renders_as_user_notice() -> None:
+    events = [
+        _msg(1, "user", "hello"),
+        _lifecycle(2, {"event": "sandbox_fs_reset", "reason": "snapshot_missing"}),
+    ]
+    result = build_messages(events, system_prompt=None)
+    notices = [
+        m
+        for m in result.messages
+        if m["role"] == "user" and isinstance(m["content"], str) and "filesystem" in m["content"]
+    ]
+    assert len(notices) == 1
+    assert notices[0]["content"].startswith("[")
+    assert "fresh base filesystem" in notices[0]["content"]
+    assert "/workspace" in notices[0]["content"]
+
+
+def test_notice_does_not_advance_reacting_to() -> None:
+    """The notice is NOT stimulus-bearing: the watermark stays at the last real
+    stimulus (the user message), so the event never wakes the session."""
+    events = [
+        _msg(1, "user", "hello"),
+        _lifecycle(5, {"event": "sandbox_fs_expired", "reason": "retention_ttl"}),
+    ]
+    result = build_messages(events, system_prompt=None)
+    assert result.reacting_to == 1, "an FS-loss notice must not advance reacting_to"
+
+
+def test_reset_reasons_render_distinctly() -> None:
+    missing = build_messages(
+        [
+            _msg(1, "user", "x"),
+            _lifecycle(2, {"event": "sandbox_fs_reset", "reason": "snapshot_missing"}),
+        ],
+        system_prompt=None,
+    ).messages[-1]["content"]
+    image_changed = build_messages(
+        [
+            _msg(1, "user", "x"),
+            _lifecycle(2, {"event": "sandbox_fs_reset", "reason": "environment_image_changed"}),
+        ],
+        system_prompt=None,
+    ).messages[-1]["content"]
+    assert "could no longer be found" in missing
+    assert "base image was changed" in image_changed
+
+
+def test_expired_disk_pressure_vs_ttl_render_distinctly() -> None:
+    ttl = build_messages(
+        [
+            _msg(1, "user", "x"),
+            _lifecycle(2, {"event": "sandbox_fs_expired", "reason": "retention_ttl"}),
+        ],
+        system_prompt=None,
+    ).messages[-1]["content"]
+    pressure = build_messages(
+        [
+            _msg(1, "user", "x"),
+            _lifecycle(2, {"event": "sandbox_fs_expired", "reason": "disk_pressure"}),
+        ],
+        system_prompt=None,
+    ).messages[-1]["content"]
+    assert "inactivity" in ttl
+    assert "reclaim disk space" in pressure
+
+
+def test_over_limit_renders() -> None:
+    msg = build_messages(
+        [_msg(1, "user", "x"), _lifecycle(2, {"event": "sandbox_fs_over_limit"})],
+        system_prompt=None,
+    ).messages[-1]["content"]
+    assert "size budget" in msg
+
+
+def test_non_allowlisted_lifecycle_event_is_skipped() -> None:
+    """A lifecycle event outside the allowlist (e.g. a github clone failure)
+    is NOT rendered — the allowlist is deliberately minimal."""
+    events = [
+        _msg(1, "user", "hello"),
+        _lifecycle(2, {"event": "github_clone_failed", "message": "boom"}),
+    ]
+    result = build_messages(events, system_prompt=None)
+    assert all("boom" not in (m.get("content") or "") for m in result.messages)

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0083``."""
+    """The migration ladder has exactly one head: ``0084``."""
     script = _script_directory()
-    assert script.get_heads() == ["0083"]
+    assert script.get_heads() == ["0084"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -178,13 +178,15 @@ class TestDockerBackendArgs:
     """The DockerBackend translates SandboxSpec.network_policy to the right argv."""
 
     @pytest.mark.asyncio
-    async def test_limited_adds_cap_net_admin(self) -> None:
+    async def test_limited_does_not_add_cap_net_admin(self) -> None:
+        """Durable session sandboxes (§5.8): the sandbox holds NO ``NET_ADMIN``
+        even under Limited networking — the lockdown is applied from an
+        ephemeral operator-image sidecar joined to the netns, so root-in-sandbox
+        can neither poison nor flush its own lockdown."""
         argv = await _capture_docker_argv(
             _make_spec(Limited(allowed_hosts=frozenset({"example.com"})))
         )
-        assert "--cap-add" in argv
-        cap_idx = argv.index("--cap-add")
-        assert argv[cap_idx + 1] == "NET_ADMIN"
+        assert "NET_ADMIN" not in argv
 
     @pytest.mark.asyncio
     async def test_unrestricted_no_cap_net_admin(self) -> None:
@@ -300,21 +302,35 @@ class TestDockerBackendIsAlive:
 
 
 class TestApplyNetworkLockdown:
-    """apply_network_lockdown builds the script and runs it via backend.exec."""
+    """apply_network_lockdown builds the script and applies + verifies it via
+    the operator-image netns sidecar (durable session sandboxes, §5.8)."""
+
+    @staticmethod
+    def _sidecar_scripts(backend: FakeBackend) -> list[str]:
+        return [c[1]["script"] for c in backend.calls if c[0] == "run_netns_sidecar"]
 
     @pytest.mark.asyncio
-    async def test_calls_backend_exec_with_script(self) -> None:
+    async def test_applies_and_verifies_via_sidecar(self) -> None:
         backend = FakeBackend()
         handle = make_handle()
         networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
 
         await apply_network_lockdown(backend, handle, networking)
 
-        exec_calls = [c for c in backend.calls if c[0] == "exec"]
-        assert len(exec_calls) == 1
-        script = exec_calls[0][1]["command"]
-        assert "iptables -P OUTPUT DROP" in script
-        assert "getent ahosts api.example.com" in script
+        scripts = self._sidecar_scripts(backend)
+        # Two sidecar invocations: apply, then read-back verify.
+        assert len(scripts) == 2
+        apply_script, verify_script = scripts
+        assert "iptables -P OUTPUT DROP" in apply_script
+        assert "getent ahosts api.example.com" in apply_script
+        # The sidecar inherits the operator image's (empty) resolv.conf, so the
+        # apply script points itself at the netns embedded DNS before getent.
+        assert "127.0.0.11" in apply_script
+        assert "OUTPUT DROP" in verify_script
+        # The sidecar runs the OPERATOR image, never env_config.image.
+        sidecar_call = next(c for c in backend.calls if c[0] == "run_netns_sidecar")
+        assert sidecar_call[1]["image"].endswith("aios-sandbox:latest")
+        assert sidecar_call[1]["target_sandbox_id"] == handle.sandbox_id
 
     @pytest.mark.asyncio
     async def test_includes_package_registries_when_enabled(self) -> None:
@@ -328,7 +344,7 @@ class TestApplyNetworkLockdown:
 
         await apply_network_lockdown(backend, handle, networking)
 
-        script = backend.calls[0][1]["command"]
+        script = self._sidecar_scripts(backend)[0]
         assert "pypi.org" in script
         assert "registry.npmjs.org" in script
         assert "api.example.com" in script
@@ -345,7 +361,7 @@ class TestApplyNetworkLockdown:
 
         await apply_network_lockdown(backend, handle, networking)
 
-        script = backend.calls[0][1]["command"]
+        script = self._sidecar_scripts(backend)[0]
         assert "pypi.org" not in script
         assert "api.example.com" in script
 
@@ -362,7 +378,7 @@ class TestApplyNetworkLockdown:
             extra_host_ports=[("aios-worker", 8765)],
         )
 
-        script = backend.calls[0][1]["command"]
+        script = self._sidecar_scripts(backend)[0]
         assert "aios-worker:8765" in script
 
 
@@ -370,24 +386,25 @@ class TestApplyNetworkLockdown:
 
 
 class TestApplyNetworkLockdownFailsClosed:
-    """A :class:`Limited` sandbox whose iptables lockdown didn't apply is a
-    silent unrestricted-networking bypass — especially dangerous combined
-    with the per-environment image override (#724), where a tenant-supplied
-    image might lack ``iptables``/``getent``. The lockdown is a security
-    gate, so a nonzero exit (or a backend exec error) must raise rather than
-    log-and-continue, letting the registry tear the sandbox down.
+    """A :class:`Limited` sandbox whose lockdown didn't apply (or whose DROP
+    policy didn't verify) is a silent unrestricted-networking bypass. The
+    lockdown is a security gate, so a nonzero apply, a failed read-back verify,
+    or a sidecar infra error must raise rather than log-and-continue, letting
+    the registry tear the sandbox down.
     """
 
     @pytest.mark.asyncio
-    async def test_nonzero_exit_raises_sandbox_backend_error(self) -> None:
+    async def test_nonzero_apply_raises_sandbox_backend_error(self) -> None:
         backend = FakeBackend()
-        backend.next_result = CommandResult(
-            exit_code=3,
-            stdout="",
-            stderr="iptables: command not found",
-            timed_out=False,
-            truncated=False,
-        )
+        backend.sidecar_results = [
+            CommandResult(
+                exit_code=3,
+                stdout="",
+                stderr="iptables: command not found",
+                timed_out=False,
+                truncated=False,
+            )
+        ]
         handle = make_handle()
         networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
 
@@ -395,12 +412,26 @@ class TestApplyNetworkLockdownFailsClosed:
             await apply_network_lockdown(backend, handle, networking)
 
     @pytest.mark.asyncio
-    async def test_backend_exec_error_propagates(self) -> None:
-        """An infra failure to even run the lockdown script must not be
+    async def test_failed_verify_raises(self) -> None:
+        """Apply succeeds but the read-back shows the OUTPUT policy is not DROP
+        (the lockdown didn't actually land) → fail closed."""
+        backend = FakeBackend()
+        ok = CommandResult(exit_code=0, stdout="", stderr="", timed_out=False, truncated=False)
+        bad = CommandResult(exit_code=1, stdout="", stderr="", timed_out=False, truncated=False)
+        backend.sidecar_results = [ok, bad]  # apply ok, verify fails
+        handle = make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        with pytest.raises(SandboxBackendError, match="verification failed"):
+            await apply_network_lockdown(backend, handle, networking)
+
+    @pytest.mark.asyncio
+    async def test_sidecar_error_propagates(self) -> None:
+        """An infra failure to even run the lockdown sidecar must not be
         swallowed into a wide-open sandbox — it propagates so the provision
         aborts."""
         backend = FakeBackend()
-        backend.exec = AsyncMock(  # type: ignore[method-assign]
+        backend.run_netns_sidecar = AsyncMock(  # type: ignore[method-assign]
             side_effect=SandboxBackendError("daemon hiccup")
         )
         handle = make_handle()
@@ -411,8 +442,8 @@ class TestApplyNetworkLockdownFailsClosed:
 
     @pytest.mark.asyncio
     async def test_zero_exit_does_not_raise(self) -> None:
-        """The happy path (exit 0) is unchanged — no exception."""
-        backend = FakeBackend()  # default exec returns exit 0
+        """The happy path (apply + verify both exit 0) is unchanged — no exception."""
+        backend = FakeBackend()  # default sidecar returns exit 0 for both calls
         handle = make_handle()
         networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
 

--- a/tests/unit/test_sandbox_reaper.py
+++ b/tests/unit/test_sandbox_reaper.py
@@ -27,7 +27,12 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-from aios.sandbox.backends.base import SandboxBackend, SandboxBackendError, SandboxHandle
+from aios.sandbox.backends.base import (
+    SandboxBackend,
+    SandboxBackendError,
+    SandboxHandle,
+    SnapshotOutcome,
+)
 from aios.sandbox.registry import SandboxRegistry
 
 
@@ -43,6 +48,14 @@ def _backend_with_destroy(destroy: Any) -> SandboxBackend:
     backend = MagicMock(spec=SandboxBackend)
     backend.destroy = destroy
     backend.name = "stub"
+    # Durable session sandboxes: ``release()`` snapshots before destroying.
+    # These reaper tests are about loop resilience + locking, not snapshot
+    # content, so the snapshot is a no-write ``skipped_empty`` (image_id=None)
+    # — that path writes NO DB pointer, so the reaper needs no ``runtime.pool``
+    # and still proceeds to the ``destroy`` the tests assert on.
+    backend.snapshot = AsyncMock(
+        return_value=SnapshotOutcome(kind="skipped_empty", image_id=None, unique_bytes=0, depth=0)
+    )
     return backend
 
 

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -32,7 +33,21 @@ from aios.sandbox.backends.base import (
 )
 from aios.sandbox.registry import SandboxRegistry
 from aios.sandbox.spec import ProvisioningPlan
-from tests.helpers.sandbox import FakeBackend, make_handle
+from tests.helpers.sandbox import FakeBackend, FakePool, make_handle
+
+
+@pytest.fixture(autouse=True)
+def _fake_runtime_pool() -> Iterator[None]:
+    """Provide a fake ``runtime.pool`` so ``release()``'s snapshot-pointer write
+    succeeds — otherwise ``require_pool()`` raises, the pointer write is treated
+    as a snapshot failure, and ``backend.destroy`` is never reached (which would
+    hang the blocking-destroy test and fail the mount-drift destroy assertions)."""
+    prev = runtime.pool
+    runtime.pool = cast(Any, FakePool())
+    try:
+        yield
+    finally:
+        runtime.pool = prev
 
 
 def _echo(
@@ -194,7 +209,7 @@ class TestReleaseIfMountsChanged:
 
 class TestLocksDictCleanup:
     """``SandboxRegistry._locks`` is reclaimed at registry teardown
-    (``release_all``) only.  Both ``release()`` and ``evict()``
+    (``stop_all``) only.  Both ``release()`` and ``evict()``
     deliberately keep the per-session entry so a concurrent
     ``get_or_provision`` (or one already in-flight) serializes via
     the same lock instance — popping while another task is mid-
@@ -204,7 +219,7 @@ class TestLocksDictCleanup:
     that the worker's eventual restart clears; the race is
     unacceptable."""
 
-    async def test_release_all_clears_locks(self) -> None:
+    async def test_stop_all_clears_locks(self) -> None:
         backend = FakeBackend()
         registry = SandboxRegistry(backend=backend)
         _seed(registry, "sess_X")
@@ -213,7 +228,7 @@ class TestLocksDictCleanup:
         _ = registry._lock_for("sess_Y")
         assert set(registry._locks) == {"sess_X", "sess_Y"}
 
-        await registry.release_all()
+        await registry.stop_all()
 
         assert registry._locks == {}
 
@@ -401,16 +416,19 @@ class TestLockdownFailsClosed:
 
     async def test_lockdown_failure_destroys_sandbox_and_raises(self) -> None:
         backend = FakeBackend()
-        # The post-create setup execs all route through backend.exec; make
-        # the lockdown script (the only exec the cold path runs here, since
-        # the other setup steps are patched out) return nonzero.
-        backend.next_result = CommandResult(
-            exit_code=2,
-            stdout="",
-            stderr="iptables: not found",
-            timed_out=False,
-            truncated=False,
-        )
+        # Durable session sandboxes: the lockdown is applied from the netns
+        # sidecar, not backend.exec. Make the apply sidecar return nonzero so
+        # the fail-closed gate fires (a poisoned/missing iptables in the
+        # sidecar's operator image, or a partial flush).
+        backend.sidecar_results = [
+            CommandResult(
+                exit_code=2,
+                stdout="",
+                stderr="iptables: not found",
+                timed_out=False,
+                truncated=False,
+            )
+        ]
         registry = SandboxRegistry(backend=backend)
 
         broker = MagicMock()

--- a/tests/unit/test_sandbox_resource_caps.py
+++ b/tests/unit/test_sandbox_resource_caps.py
@@ -102,13 +102,12 @@ class TestResourceCapFlags:
         assert argv[i + 1] == "512"
 
     @pytest.mark.asyncio
-    async def test_disk_bytes_emits_storage_opt_size(self) -> None:
-        """A disk cap flips ``--storage-opt size=<bytes>`` (issue #725) so a
-        heavy build can't grow the container's writable layer past the cap."""
-        argv = await _capture_argv(_spec(disk_bytes=2 * 1024 * 1024 * 1024))
-        assert "--storage-opt" in argv
-        i = argv.index("--storage-opt")
-        assert argv[i + 1] == f"size={2 * 1024 * 1024 * 1024}"
+    async def test_no_storage_opt_ever_emitted(self) -> None:
+        """Durable session sandboxes deleted the ``--storage-opt size=`` cap
+        (§5.7): it required overlay2+pquota and never worked on prod ext4.
+        Disk pressure is now bounded by the snapshot pool budget (GC eviction)."""
+        argv = await _capture_argv(_spec(snapshot_budget_bytes=2 * 1024 * 1024 * 1024))
+        assert "--storage-opt" not in argv
 
     @pytest.mark.asyncio
     async def test_no_caps_emits_no_resource_flags(self) -> None:
@@ -130,13 +129,28 @@ class TestResourceCapFlags:
                 cpu_quota=2.0,
                 memory_bytes=128 * 1024 * 1024,
                 pids_limit=64,
-                disk_bytes=512 * 1024 * 1024,
             )
         )
         assert "--cpus" in argv
         assert "--memory" in argv
         assert "--memory-swap" in argv
         assert "--pids-limit" in argv
-        assert "--storage-opt" in argv
-        i = argv.index("--storage-opt")
-        assert argv[i + 1] == f"size={512 * 1024 * 1024}"
+        # The writable-layer cap is gone — never emitted.
+        assert "--storage-opt" not in argv
+
+    @pytest.mark.asyncio
+    async def test_sandbox_has_no_net_admin(self) -> None:
+        """Durable session sandboxes strip ``--cap-add NET_ADMIN`` from the
+        sandbox (§5.8) — even a Limited-networking spec; the lockdown is
+        applied from an ephemeral operator-image sidecar instead."""
+        from aios.sandbox.backends.base import Limited
+
+        argv = await _capture_argv(_spec(network_policy=Limited(allowed_hosts=frozenset({"x"}))))
+        assert "NET_ADMIN" not in argv
+
+    @pytest.mark.asyncio
+    async def test_no_rm_flag(self) -> None:
+        """No ``--rm`` (durable session sandboxes): an unplanned death must
+        leave a stopped corpse for the next provision / GC tick to salvage."""
+        argv = await _capture_argv(_spec())
+        assert "--rm" not in argv


### PR DESCRIPTION
Makes the whole sandbox root filesystem survive idle reclaim. Every *planned* teardown becomes **stop → `docker commit` to a per-session local image → rm**; every resume is the existing cold-start provision path running from that image. Containers stay disposable; the filesystem becomes the durable artifact. Dropping `--rm` means *unplanned* deaths (crash, OOM, daemon restart) leave a stopped corpse that the next provision's salvage preamble (or the GC tick) commits before the session's next container starts — **container death stops losing data entirely**.

Implements Mechanism B from `docs/design/durable-session-sandboxes.md` (committed here). Horizontal scale is designed-for but **v1 ships the lightest single-host shape**: the DB snapshot-pointer columns and the `SnapshotStore` seam are the only hinges, making either scaling path a later *additive* change, not a rewrite.

## What's here
- **Backend snapshot verb** (`stop` → lineage gate → `SizeRw` skip-empty → commit-or-flatten, env-keys scrub from the `aios.env_keys` label, size-derived timeout) + the **`SnapshotStore` seam** (`LocalDaemonStore` identity wrapper) + `run_docker_pipeline` for the `export|import` flatten.
- **DB snapshot pointer** — migration **0080** adds `snapshot_ref/host/bytes/updated_at`, drops the dead `container_id`. Written inside the snapshot critical section (after commit success, **before `rm`**, under the per-session lock); a failed pointer write is treated like a failed snapshot verb. A **GC reconciler** replaces `reap_orphans` (corpse → retain-rule image pass → per-host pool budget → pointer reconcile), immediate first tick at boot.
- **Resume** resolves the pointer through the store, **verified-negative only**. Snapshot-missing and base-image drift are *detected* (`store.remove` + pointer clear) and surfaced as model-visible `sandbox_fs_reset` events — never a silent base fallback.
- **Security (ships in v1):** the network lockdown moves off the tenant-writable sandbox FS to an **ephemeral operator-image netns sidecar** that applies + read-back-verifies the rules; the sandbox **loses `NET_ADMIN` entirely**. A **two-layer reserved-prefix gate** (`build_spec_from_session` choke point + an `EnvironmentConfig.image` 422 validator) blocks mounting another session's snapshot via `env_config.image`.
- **Observability:** `sandbox_fs_reset/expired/over_limit` render as bracketed user-role notices in the context builder — append-only and **not stimulus-bearing** (a GC append never wakes a session).
- **Settings:** idle timeout default **300 → 1800**; add snapshot TTL / per-session budget / per-host pool budget / empty floor; **delete** the dead `--storage-opt` `sandbox_disk_bytes` path (never worked on prod ext4).

## Two containerd-image-store amendments (override the overlay2-verified doc)
1. **Skip-empty is a byte floor, not `== 0`.** A no-write container reports `SizeRw == 4096` on the production containerd image store, so the short-circuit fires on `SizeRw <= sandbox_snapshot_empty_floor_bytes` (default 8 KiB). An `== 0` test would never fire in prod and read/chat-only sessions would grow a chain every idle.
2. **Flatten is budget-driven; the layer wall is absent.** The overlay2 ~125-layer commit wall does not exist on the containerd store (a chain ran cleanly through 250 layers). Flatten is driven by the per-session unique-bytes **budget**, with layer depth as a *soft* guard (`_FLATTEN_DEPTH_CEILING = 200`).

The §10 e2e suite, run against a live daemon, caught and fixed **two real issues**: a Docker template `missingkey` error on `{{json .Config.Labels}}` for label-less base images (now parsed from `{{json .Config}}`), and the floor semantics.

## v1 scope — deferred (the columns + seam keep these additive)
- `RegistryStore`/`ObjectStore` + async durability `put` (v1 is `LocalDaemonStore` only; documented single-host "host loss = data loss" interim).
- Wake→host affinity routing; lifting the singleton-per-DB worker.
- Cross-host GC designated-ticker, registry-artifact GC, host-decommission procedure.
- Compare-and-swap / ownership-gating *refinements* on pointer writes (single-host writes the pointer directly; the `snapshot_host` column is the multi-host seam).
- Per-account snapshot-cap eviction engine (ships the per-account *usage* read-time metric only).

## Verification
- **Unit:** lineage-gate truth table, skip-empty floor pin, `_classify_images` table-driven, pointer discipline (after-success-before-rm / failed-pointer-as-failed-snapshot / reset / drift / missing), `SnapshotStore` verified-negative semantics, tag derivation + reserved-prefix gate (spec + pydantic), context allowlist render without watermark movement. **2050 unit tests green.**
- **E2E (real daemon):** persistence contract (markers in `/root`,`/etc`,`/tmp`,global survive; `/dev/shm` + processes do not; bind mounts excluded), skip-empty floor, secret-value scrub, resume integrity (PATH/HOME/pwd after commit **and** flatten), crash-corpse salvage, lockdown sidecar on a resumed snapshot whose `iptables` was poisoned.
- **Integration:** migration 0080 + `snapshot_budget_bytes` round-trip through the JSONB config.
- mypy + ruff + format clean; `openapi.json` + SDK regenerated.
- **Adversarial multi-dimension review** (crash/concurrency, security, containerd amendments, pointer/GC, simplicity): **zero must-fix issues** — the highest-severity concurrency findings were verified false positives (the entire `_provision` body, incl. resolve/create/`_handles` assignment, and every per-session GC op run under the same per-session lock with a cached-handle re-check).

## ⚠️ Release prerequisite (separate eumemic-ops PR — NOT in this repo)
Before promoting: exempt `aios.managed=true` images from Server B's hourly `docker image prune -af --filter until=48h` cron (and `disk-fill-recovery.md`), and set `AIOS_SANDBOX_SNAPSHOT_POOL_BYTES` to real host headroom (~15 GB on Server B). The exemption removes the only existing disk bound, so the pool budget must land with it. The setting ships here so ops can wire it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)