### PR TITLE
feat(harness): head omission marker when the window drops transcript (#738)

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -645,8 +645,11 @@ async def get_context(
     bind-mount source from the session row, not a worker-only sandbox
     handle.
     """
-    from aios.harness.step_context import compose_step_context, compute_step_prelude
-    from aios.harness.tokens import approx_tokens
+    from aios.harness.step_context import (
+        compose_step_context,
+        compute_step_prelude,
+        prelude_overhead_local,
+    )
     from aios.services import agents as agents_service
     from aios.services.channels import list_session_channels
 
@@ -670,21 +673,13 @@ async def get_context(
         channels=channels,
         memory_store_echoes=memory_echoes,
     )
-    overhead_local = (
-        approx_tokens(
-            [{"role": "system", "content": prelude.system_prompt}],
-            tools=prelude.tools,
-        )
-        + prelude.tail_block_upper_bound_local
-    )
-
-    events = await service.read_windowed_events(
+    windowed = await service.read_windowed_events(
         pool,
         session_id,
         window_min=agent.window_min,
         window_max=agent.window_max,
         model=agent.model,
-        overhead_local=overhead_local,
+        overhead_local=prelude_overhead_local(prelude),
         account_id=account_id,
     )
 
@@ -699,7 +694,8 @@ async def get_context(
         agent=agent,
         channels=channels,
         prelude=prelude,
-        events=events,
+        events=windowed.events,
+        omission=windowed.omission,
     )
     return ContextResponse(
         session_id=session_id,

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -32,6 +32,7 @@ from aios.errors import (
     NotFoundError,
     ValidationError,
 )
+from aios.harness.window import WindowedEvents, WindowOmission
 from aios.ids import (
     ACCOUNT,
     ACCOUNT_KEY,
@@ -3306,7 +3307,7 @@ async def read_windowed_events(
     window_max: int,
     model: str,
     overhead_local: int,
-) -> list[Event]:
+) -> WindowedEvents:
     """Read message events for the session's trailing context window.
 
     Uses the ``cumulative_tokens`` column to compute the chunked-window
@@ -3350,13 +3351,21 @@ async def read_windowed_events(
     Falls back to :func:`read_message_events` (loading all events) when
     cumulative data is not available (pre-backfill sessions or rolling
     deploys) or when the entire session fits within ``window_max``.
+
+    When the boundary excludes message events, the result carries a
+    :class:`~aios.harness.window.WindowOmission` (issue #738), computed
+    against the same ``cumulative_tokens`` boundary as the retained scan
+    — exact complements.  Cache-stability rationale lives on the class.
     """
     # Index seek: total cumulative tokens from the latest message event.
     total = await _latest_cumulative_tokens(conn, session_id)
 
     # Fallback: no cumulative data yet — load everything.
     if total is None:
-        return await read_message_events(conn, session_id, account_id=account_id)
+        return WindowedEvents(
+            events=await read_message_events(conn, session_id, account_id=account_id),
+            omission=None,
+        )
 
     ratio = await model_token_ratio(conn, model, account_id=account_id)
 
@@ -3374,7 +3383,10 @@ async def read_windowed_events(
 
     total_effective = round(total * ratio)
     if total_effective <= events_window_max:
-        return await read_message_events(conn, session_id, account_id=account_id)
+        return WindowedEvents(
+            events=await read_message_events(conn, session_id, account_id=account_id),
+            omission=None,
+        )
 
     from aios.harness.tokens import tokens_to_drop
 
@@ -3387,7 +3399,10 @@ async def read_windowed_events(
         total_effective, window_min=events_window_min, window_max=events_window_max
     )
     if drop_effective == 0:
-        return await read_message_events(conn, session_id, account_id=account_id)
+        return WindowedEvents(
+            events=await read_message_events(conn, session_id, account_id=account_id),
+            omission=None,
+        )
 
     drop = math.ceil(drop_effective / ratio)
 
@@ -3401,7 +3416,34 @@ async def read_windowed_events(
         drop,
         account_id,
     )
-    return [_row_to_event(r) for r in rows]
+
+    # The omitted complement: same boundary expression as the retained
+    # scan (``<=`` vs ``>``), and a seq-prefix of the log — so its
+    # ``min(created_at)`` IS the conversation start, and NULL means the
+    # boundary excludes nothing (oversized first event straddling it).
+    # The aggregate re-scans the omitted span each windowed step; if it
+    # ever profiles hot, the escape hatch is a ``cumulative_messages``
+    # counter column (the ``cumulative_tokens`` mechanism).
+    omission_row = await conn.fetchrow(
+        "SELECT min(created_at) AS began_at, "
+        "count(*) FILTER (WHERE role IN ('user', 'assistant')) AS omitted_messages "
+        "FROM events "
+        "WHERE session_id = $1 AND account_id = $3 AND kind = 'message' "
+        "AND cumulative_tokens <= $2",
+        session_id,
+        drop,
+        account_id,
+    )
+    assert omission_row is not None  # aggregate query always returns one row
+    omission = (
+        WindowOmission(
+            began_at=omission_row["began_at"],
+            omitted_messages=omission_row["omitted_messages"],
+        )
+        if omission_row["began_at"] is not None
+        else None
+    )
+    return WindowedEvents(events=[_row_to_event(r) for r in rows], omission=omission)
 
 
 # ─── vaults ─────────────────────────────────────────────────────────────────

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -47,6 +47,7 @@ from aios.harness.vision import (
     make_image_url_part,
     text_marker,
 )
+from aios.harness.window import WindowOmission
 from aios.logging import get_logger
 from aios.models.events import Event
 from aios.sandbox.volumes import resolve_to_host_path
@@ -738,6 +739,61 @@ def _quarantine_placeholder(seq: int) -> dict[str, Any]:
     return {"role": "user", "content": f"[unrenderable event seq={seq} — quarantined]"}
 
 
+# Upper bound (local approx_tokens units) reserved in the window budget for
+# the omission marker, mirroring ``tail_block_upper_bound_local``: the marker
+# is appended after windowing runs, so without a reserve it would push the
+# send-time payload past ``window_max`` (the PR #165 full-payload invariant).
+# Reserved unconditionally — like the tail block, which also may not render.
+# ``TestOmissionMarker`` pins a worst-case render under this bound.
+OMISSION_MARKER_UPPER_BOUND_LOCAL = 128
+
+
+def _approx_count(n: int) -> str:
+    """Round ``n`` down to two significant figures, comma-grouped.
+
+    Deterministic (pure floor, no banker's rounding ambiguity) so the
+    omission marker it feeds stays byte-stable across rebuilds.
+    """
+    if n >= 100:
+        magnitude = 10 ** (len(str(n)) - 2)
+        n -= n % magnitude
+    return f"{n:,}"
+
+
+def _omission_marker(omission: WindowOmission, boundary: datetime, tz_name: str) -> dict[str, Any]:
+    """Head marker telling the model the window omits transcript (#738).
+
+    Byte-stable within a snap chunk — see :class:`WindowOmission` for the
+    cache-stability rationale.  The boundary timestamp reuses
+    :func:`_format_received` so it renders identically to the
+    ``received=`` envelope headers; the start date uses the same account
+    timezone, date-only.  ``_prune_leading_orphans`` may hide a few more
+    rendered messages at/after the boundary — "everything before" remains
+    true regardless, so the claim direction is safe.
+    """
+    began = omission.began_at.astimezone(ZoneInfo(tz_name)).date().isoformat()
+    before = _format_received(boundary, tz_name)
+    if omission.omitted_messages > 0:
+        scrolled = (
+            f"Everything before {before} — about "
+            f"{_approx_count(omission.omitted_messages)} messages, including your own — "
+            "has scrolled out of view."
+        )
+    else:
+        # Degenerate: the omitted span holds only tool results.
+        scrolled = f"Everything before {before} has scrolled out of view."
+    return {
+        "role": "user",
+        "content": (
+            f"[history: this conversation began {began}. {scrolled} "
+            "Nothing is lost: the full transcript remains queryable with search_events. "
+            "What seems unfamiliar is usually forgotten, not new: when in doubt about "
+            "anything that's referred to, search first rather than fill the gap by "
+            "assumption.]"
+        ),
+    }
+
+
 def build_messages(
     events: list[Event],
     *,
@@ -747,6 +803,7 @@ def build_messages(
     workspace_path: Path | None = None,
     in_flight_tool_call_ids: frozenset[str] = frozenset(),
     tz_name: str = "UTC",
+    omission: WindowOmission | None = None,
 ) -> ContextResult:
     """Assemble a chat-completions message list from pre-windowed events.
 
@@ -942,6 +999,15 @@ def build_messages(
     # leaving orphan tool results or an assistant with missing paired
     # results.
     messages = _prune_leading_orphans(messages)
+
+    # Head omission marker (#738): when the window omits transcript, tell
+    # the model how much and how to recall it. After the prune (so it can't
+    # be pruned), before the system insert (so it lands at messages[1]).
+    # ``read_windowed_events`` guarantees a non-empty window whenever it
+    # reports an omission (drop < total by construction), so ``events[0]``
+    # is the first retained event — the boundary.
+    if omission is not None:
+        messages.insert(0, _omission_marker(omission, events[0].created_at, tz_name))
 
     if system_prompt:
         messages.insert(0, {"role": "system", "content": system_prompt})

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -30,7 +30,11 @@ from structlog.contextvars import bind_contextvars, clear_contextvars
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
 from aios.harness.completion import call_litellm, stream_litellm
-from aios.harness.step_context import compose_step_context, compute_step_prelude
+from aios.harness.step_context import (
+    compose_step_context,
+    compute_step_prelude,
+    prelude_overhead_local,
+)
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
@@ -352,24 +356,17 @@ async def _run_session_step_body(
         channels=channels,
         memory_store_echoes=memory_echoes,
     )
-    overhead_local = (
-        approx_tokens(
-            [{"role": "system", "content": prelude.system_prompt}],
-            tools=prelude.tools,
-        )
-        + prelude.tail_block_upper_bound_local
-    )
-
     # Read windowed message events for this session.
-    events = await sessions_service.read_windowed_events(
+    windowed = await sessions_service.read_windowed_events(
         pool,
         session_id,
         window_min=agent.window_min,
         window_max=agent.window_max,
         model=agent.model,
-        overhead_local=overhead_local,
+        overhead_local=prelude_overhead_local(prelude),
         account_id=account_id,
     )
+    events = windowed.events
 
     # Check for confirmed-but-undispatched tool calls (always_ask → allow).
     # The sweep's case (c) ensures we passed the guard above.
@@ -424,6 +421,7 @@ async def _run_session_step_body(
             prelude=prelude,
             events=events,
             in_flight_tool_call_ids=frozenset(task_registry.in_flight_tool_call_ids(session_id)),
+            omission=windowed.omission,
         )
     except Exception:
         await sessions_service.append_event(

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -30,11 +30,14 @@ from typing import TYPE_CHECKING, Any
 
 from aios.harness._text import join_blocks
 from aios.harness.context import (
+    OMISSION_MARKER_UPPER_BOUND_LOCAL,
     build_messages,
     merge_adjacent_user_messages,
     message_is_notification_marker,
     stub_missing_reasoning_content,
 )
+from aios.harness.tokens import approx_tokens
+from aios.harness.window import WindowOmission
 from aios.tools.registry import to_openai_tools
 
 if TYPE_CHECKING:
@@ -125,6 +128,26 @@ class StepPrelude:
     tools: list[dict[str, Any]]
     skill_versions: list[SkillVersion]
     tail_block_upper_bound_local: int
+
+
+def prelude_overhead_local(prelude: StepPrelude) -> int:
+    """Token cost the composer adds on top of the windowed events, in
+    local (``approx_tokens``) units — the ``overhead_local`` argument to
+    ``read_windowed_events``.
+
+    System prompt + tool schemas, plus the reserved upper bounds for the
+    two post-windowing additions: the channels tail block and the
+    omission marker (#738). Both are reserved unconditionally — either
+    may not render, but the budget must hold when they do.
+    """
+    return (
+        approx_tokens(
+            [{"role": "system", "content": prelude.system_prompt}],
+            tools=prelude.tools,
+        )
+        + prelude.tail_block_upper_bound_local
+        + OMISSION_MARKER_UPPER_BOUND_LOCAL
+    )
 
 
 @dataclass(frozen=True)
@@ -307,6 +330,7 @@ async def compose_step_context(
     prelude: StepPrelude,
     events: list[Event],
     in_flight_tool_call_ids: frozenset[str] = frozenset(),
+    omission: WindowOmission | None = None,
 ) -> StepContext:
     """Compose the chat-completions payload for a step.
 
@@ -353,6 +377,7 @@ async def compose_step_context(
         workspace_path=workspace_path,
         in_flight_tool_call_ids=in_flight_tool_call_ids,
         tz_name=tz_name,
+        omission=omission,
     )
 
     # Tail block lives *after* build_messages so its per-step mutations

--- a/src/aios/harness/window.py
+++ b/src/aios/harness/window.py
@@ -32,8 +32,45 @@ output, no side effects.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
 
 from aios.harness.tokens import tokens_to_drop as _tokens_to_drop
+from aios.models.events import Event
+
+
+@dataclass(frozen=True, slots=True)
+class WindowOmission:
+    """Facts about the transcript a window omits (issue #738) — the
+    inputs to the head omission marker.
+
+    ``began_at`` is the ``created_at`` of the session's first message
+    event; ``omitted_messages`` counts omitted user+assistant events
+    only (tool results would dominate tool-heavy sessions without
+    conveying conversational depth).
+
+    Cache-stability rationale (canonical home — other sites reference
+    this): both fields are pure functions of the drop boundary over the
+    immutable log, so the marker rendered from them is byte-identical
+    within a snap chunk and re-renders exactly when the boundary moves —
+    a snap, when the head changes anyway.  Producer:
+    :func:`~aios.db.queries.read_windowed_events`; consumer:
+    :func:`~aios.harness.context.build_messages`.
+    """
+
+    began_at: datetime
+    omitted_messages: int
+
+
+@dataclass(frozen=True, slots=True)
+class WindowedEvents:
+    """A context window over a session log: the retained trailing slate,
+    plus facts about what the drop boundary excluded.  ``omission`` is
+    ``None`` when nothing is excluded — the whole transcript fits, or an
+    oversized first event straddles the boundary."""
+
+    events: list[Event]
+    omission: WindowOmission | None
 
 
 def select_window[T](

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -28,6 +28,7 @@ from aios.errors import (
     RateLimitedError,
     ValidationError,
 )
+from aios.harness.window import WindowedEvents
 from aios.models.agents import (
     Agent,
     AgentVersion,
@@ -1002,7 +1003,7 @@ async def read_windowed_events(
     window_max: int,
     model: str,
     overhead_local: int,
-) -> list[Event]:
+) -> WindowedEvents:
     async with pool.acquire() as conn:
         return await queries.read_windowed_events(
             conn,

--- a/tests/e2e/test_windowing_overhead.py
+++ b/tests/e2e/test_windowing_overhead.py
@@ -89,6 +89,14 @@ class TestWindowingOverhead:
             f"tools={len(call.get('tools') or [])})"
         )
 
+        # The forced drop must surface the omission marker (#738) — its
+        # reserved budget is part of the invariant this asserts, so a
+        # payload without it would pass vacuously.
+        assert any(
+            isinstance(m.get("content"), str) and m["content"].startswith("[history: ")
+            for m in call["messages"]
+        ), "expected the omission marker in a windowed payload"
+
     async def test_full_payload_fits_window_max_with_tail_block(self, harness: Harness) -> None:
         """Same invariant, but with channel bindings active so
         :func:`~aios.harness.channels.build_channels_tail_block` emits

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -14,6 +14,7 @@ import pytest
 
 from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
+    _approx_count,
     _concat_user_messages,
     _is_degenerate_empty_assistant,
     _quarantine_placeholder,
@@ -22,6 +23,7 @@ from aios.harness.context import (
     render_user_event,
     stub_missing_reasoning_content,
 )
+from aios.harness.window import WindowOmission
 from aios.models.events import Event
 
 
@@ -2149,3 +2151,166 @@ class TestPoisonEventQuarantine:
         ctx = build_messages([e], system_prompt=None)
         assert len(ctx.messages) == 1
         assert ctx.messages[0] == _quarantine_placeholder(5)
+
+
+# ─── omission marker (#738) ──────────────────────────────────────────────────
+
+
+_BEGAN_AT = datetime(2025, 11, 5, 14, 30, tzinfo=UTC)
+
+_MARKER_TAIL = (
+    "Nothing is lost: the full transcript remains queryable with search_events. "
+    "What seems unfamiliar is usually forgotten, not new: when in doubt about "
+    "anything that's referred to, search first rather than fill the gap by "
+    "assumption.]"
+)
+
+
+class TestOmissionMarker:
+    """Head marker rendered when the window omits transcript (#738).
+
+    The load-bearing property is prompt-cache stability: the marker is a
+    pure function of (omission, boundary event, tz) — byte-identical
+    across rebuilds while the drop boundary is unchanged, changing only
+    when the boundary moves (a snap, when the head changes anyway).
+    """
+
+    def _omission(self, *, omitted_messages: int = 9_837) -> WindowOmission:
+        return WindowOmission(began_at=_BEGAN_AT, omitted_messages=omitted_messages)
+
+    def test_exact_marker_text_and_placement(self) -> None:
+        events = [_evt(50, "user", content="hi")]
+        ctx = build_messages(events, system_prompt="SYS", omission=self._omission())
+        assert ctx.messages[0] == {"role": "system", "content": "SYS"}
+        assert ctx.messages[1] == {
+            "role": "user",
+            "content": (
+                f"[history: this conversation began 2025-11-05. "
+                f"Everything before {RECEIVED} — about 9,800 messages, "
+                f"including your own — has scrolled out of view. " + _MARKER_TAIL
+            ),
+        }
+
+    def test_no_omission_no_marker(self) -> None:
+        events = [_evt(1, "user", content="hi")]
+        ctx = build_messages(events, system_prompt="SYS")
+        assert ctx.messages == [
+            {"role": "system", "content": "SYS"},
+            {"role": "user", "content": f"[received={RECEIVED}]\nhi"},
+        ]
+
+    def test_marker_first_when_no_system_prompt(self) -> None:
+        events = [_evt(50, "user", content="hi")]
+        ctx = build_messages(events, system_prompt=None, omission=self._omission())
+        assert ctx.messages[0]["content"].startswith("[history: ")
+
+    def test_byte_stable_while_context_grows_within_chunk(self) -> None:
+        """Appending tail events with an unchanged boundary must not perturb
+        a single byte of the marker — the prompt-cache invariant."""
+        omission = self._omission()
+        head = [_evt(50, "user", content="hi"), _evt(51, "assistant", content="yo")]
+        grown = [*head, _evt(52, "user", content="more"), _evt(53, "assistant", content="ok")]
+        ctx_before = build_messages(head, system_prompt="SYS", omission=omission)
+        ctx_after = build_messages(grown, system_prompt="SYS", omission=omission)
+        _assert_prefix(ctx_before.messages, ctx_after.messages)
+
+    def test_marker_changes_when_boundary_moves(self) -> None:
+        """After a snap the head event differs → the marker re-renders with
+        the new boundary timestamp (and changes exactly then, with the rest
+        of the head)."""
+        omission = self._omission()
+        before_snap = [_evt(50, "user", content="a")]
+        after_snap = [
+            _evt(
+                150,
+                "user",
+                content="b",
+                created_at=datetime(2026, 1, 9, 12, 0, tzinfo=UTC),
+            )
+        ]
+        m1 = build_messages(before_snap, system_prompt=None, omission=omission).messages[0]
+        m2 = build_messages(after_snap, system_prompt=None, omission=omission).messages[0]
+        assert "2026-01-02T03:04:05+00:00" in m1["content"]
+        assert "2026-01-09T12:00:00+00:00" in m2["content"]
+
+    def test_zero_message_count_drops_count_clause(self) -> None:
+        """An omitted span holding only tool results renders without the
+        'about N messages' clause rather than claiming 'about 0 messages'."""
+        events = [_evt(50, "user", content="hi")]
+        ctx = build_messages(
+            events, system_prompt=None, omission=self._omission(omitted_messages=0)
+        )
+        content = ctx.messages[0]["content"]
+        assert f"Everything before {RECEIVED} has scrolled out of view." in content
+        assert "— about" not in content
+        assert "including your own" not in content
+
+    def test_account_timezone_applies_to_both_timestamps(self) -> None:
+        """Boundary uses _format_received in the account tz; the began date
+        is the account-tz calendar date (here UTC 2025-11-06 04:00 is still
+        Nov 5 in Los Angeles)."""
+        omission = WindowOmission(
+            began_at=datetime(2025, 11, 6, 4, 0, tzinfo=UTC), omitted_messages=3
+        )
+        events = [_evt(50, "user", content="hi")]
+        ctx = build_messages(
+            events, system_prompt=None, omission=omission, tz_name="America/Los_Angeles"
+        )
+        content = ctx.messages[0]["content"]
+        assert "began 2025-11-05." in content
+        # November → PST (-08:00).
+        assert "Everything before 2026-01-01T19:04:05-08:00 (America/Los_Angeles)" in content
+
+    def test_upper_bound_covers_worst_case_render(self) -> None:
+        """The window budget reserves OMISSION_MARKER_UPPER_BOUND_LOCAL for
+        the marker (PR #165 full-payload invariant); a worst-case render —
+        eight-digit count, longest-form IANA zone — must fit under it.
+        Fails when someone fattens the marker text without bumping the
+        reserve."""
+        from aios.harness.context import OMISSION_MARKER_UPPER_BOUND_LOCAL
+        from aios.harness.tokens import approx_tokens
+
+        omission = WindowOmission(
+            began_at=datetime(2025, 11, 5, 14, 30, tzinfo=UTC),
+            omitted_messages=98_765_432,
+        )
+        marker = build_messages(
+            [_evt(50, "user", content="x")],
+            system_prompt=None,
+            omission=omission,
+            tz_name="America/Argentina/ComodRivadavia",
+        ).messages[0]
+        assert approx_tokens([marker]) <= OMISSION_MARKER_UPPER_BOUND_LOCAL
+
+    def test_marker_merges_with_leading_user_inbound(self) -> None:
+        """On the wire the user-role marker merges with a leading user
+        inbound (Anthropic requires alternating roles); both parts are
+        byte-stable so the merged turn is too."""
+        events = [_evt(50, "user", content="hi")]
+        ctx = build_messages(events, system_prompt=None, omission=self._omission())
+        merged = merge_adjacent_user_messages(ctx.messages)
+        assert len(merged) == 1
+        content = merged[0]["content"]
+        assert content.startswith("[history: ")
+        assert content.endswith(f"[received={RECEIVED}]\nhi")
+
+
+class TestApproxCount:
+    """Floor-to-two-significant-figures rendering for the omission marker."""
+
+    @pytest.mark.parametrize(
+        ("n", "expected"),
+        [
+            (1, "1"),
+            (7, "7"),
+            (97, "97"),
+            (99, "99"),
+            (100, "100"),
+            (123, "120"),
+            (9_837, "9,800"),
+            (10_000, "10,000"),
+            (1_234_567, "1,200,000"),
+        ],
+    )
+    def test_rounding(self, n: int, expected: str) -> None:
+        assert _approx_count(n) == expected

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -22,6 +22,7 @@ from aios.harness.loop import (
     _retry_delay_for_attempt,
     run_session_step,
 )
+from aios.harness.window import WindowedEvents
 
 
 class TestRetryDelayForAttempt:
@@ -180,7 +181,7 @@ def mock_step_dependencies() -> Any:
         ),
         patch(
             "aios.harness.loop.sessions_service.read_windowed_events",
-            AsyncMock(return_value=[]),
+            AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
         ),
         patch(
             "aios.harness.loop._dispatch_confirmed_tools",

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -22,6 +22,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aios.harness.window import WindowedEvents
+
 
 def _span_events(append_event: AsyncMock) -> list[dict[str, object]]:
     """Extract every span payload (the 4th positional arg) in order."""
@@ -187,7 +189,7 @@ class TestEntrySweepSpan:
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
             ),
             patch(
                 "aios.harness.loop._dispatch_confirmed_tools",

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -19,6 +19,8 @@ import pytest
 from procrastinate import App
 from procrastinate.testing import InMemoryConnector
 
+from aios.harness.window import WindowedEvents
+
 
 class TestE2EConftestMockSignatures:
     """The e2e conftest installs a no-op mock in place of ``defer_wake``.
@@ -239,7 +241,7 @@ class TestStepStartEndSpans:
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
             ),
             patch(
                 "aios.harness.loop._dispatch_confirmed_tools",
@@ -342,7 +344,7 @@ class TestStepStartEndSpans:
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
             ),
             patch(
                 "aios.harness.loop._dispatch_confirmed_tools",
@@ -451,7 +453,7 @@ class TestStepStartEndSpans:
             patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
             ),
             patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
             patch(
@@ -549,7 +551,7 @@ class TestStepStartEndSpans:
             patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
             ),
             patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
             patch(
@@ -648,7 +650,7 @@ class TestStepStartEndSpans:
             ),
             patch(
                 "aios.harness.loop.sessions_service.read_windowed_events",
-                AsyncMock(return_value=[]),
+                AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
             ),
             patch(
                 "aios.harness.loop._dispatch_confirmed_tools",
@@ -737,7 +739,8 @@ async def _harness_with_guard(
         patch("aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)),
         patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
         patch(
-            "aios.harness.loop.sessions_service.read_windowed_events", AsyncMock(return_value=[])
+            "aios.harness.loop.sessions_service.read_windowed_events",
+            AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
         ),
         patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
         patch(

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -9,12 +9,20 @@ layer.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from aios.db import queries
+from aios.harness.window import WindowOmission
+
+_BEGAN_AT = datetime(2026, 2, 19, 9, 0, 0, tzinfo=UTC)
+
+# ``list[Any]`` so equality checks against ``WindowedEvents.events``
+# (statically ``list[Event]``) don't trip mypy's comparison-overlap.
+_FALLBACK_SENTINEL: list[Any] = ["_fallback_sentinel"]
 
 
 class _FakeConn:
@@ -22,7 +30,8 @@ class _FakeConn:
 
     ``fetchval`` serves ``_latest_cumulative_tokens`` (total local tokens).
     ``fetchrow`` serves ``model_token_ratio`` (the lifetime calibration
-    aggregate row).  ``fetch`` captures the bounded range scan's args so
+    aggregate row) and the omission-complement aggregate, dispatched on
+    the SQL text.  ``fetch`` captures the bounded range scan's args so
     tests can assert the computed ``drop_local``.
     """
 
@@ -32,15 +41,24 @@ class _FakeConn:
         total_local: int | None,
         ratio_n: int,
         ratio_mean: float,
+        omission_row: dict[str, Any] | None = None,
     ) -> None:
         self.total_local = total_local
         self.ratio_row = {"n": ratio_n, "mean_ratio": ratio_mean}
+        self.omission_row = omission_row or {
+            "began_at": _BEGAN_AT,
+            "omitted_messages": 7,
+        }
         self.fetch_calls: list[tuple[Any, ...]] = []
+        self.omission_calls: list[tuple[Any, ...]] = []
 
     async def fetchval(self, _sql: str, *_args: Any) -> int | None:
         return self.total_local
 
-    async def fetchrow(self, _sql: str, *_args: Any) -> dict[str, Any]:
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        if "began_at" in sql:
+            self.omission_calls.append(args)
+            return self.omission_row
         return self.ratio_row
 
     async def fetch(self, _sql: str, *args: Any) -> list[Any]:
@@ -57,7 +75,7 @@ def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) ->
     monkeypatch.setattr(
         queries,
         "read_message_events",
-        AsyncMock(return_value=["_fallback_sentinel"]),
+        AsyncMock(return_value=_FALLBACK_SENTINEL),
     )
 
 
@@ -65,7 +83,7 @@ def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) ->
 async def test_no_cumulative_falls_back_to_full_read() -> None:
     account_id = "acc_test_stub"  # PR 3 scaffolding
     conn = _FakeConn(total_local=None, ratio_n=0, ratio_mean=0.0)
-    result: list[Any] = await queries.read_windowed_events(
+    result = await queries.read_windowed_events(
         conn,
         "sess_x",
         window_min=1_000,
@@ -74,8 +92,9 @@ async def test_no_cumulative_falls_back_to_full_read() -> None:
         overhead_local=0,
         account_id=account_id,
     )
-    # Fallback short-circuit — ratio never consulted.
-    assert result == ["_fallback_sentinel"]
+    # Fallback short-circuit — ratio never consulted, no omission.
+    assert result.events == _FALLBACK_SENTINEL
+    assert result.omission is None
 
 
 @pytest.mark.asyncio
@@ -139,7 +158,7 @@ async def test_ratio_below_1_drops_fewer() -> None:
     """ratio=0.5 deflates total_effective below window_max → no drop."""
     account_id = "acc_test_stub"  # PR 3 scaffolding
     conn = _FakeConn(total_local=3_000, ratio_n=5, ratio_mean=0.5)
-    result: list[Any] = await queries.read_windowed_events(
+    result = await queries.read_windowed_events(
         conn,
         "sess_x",
         window_min=1_000,
@@ -149,8 +168,58 @@ async def test_ratio_below_1_drops_fewer() -> None:
         account_id=account_id,
     )
     # total_effective = 1500 < 2000 → drop_effective = 0 → fallback.
-    assert result == ["_fallback_sentinel"]
+    assert result.events == _FALLBACK_SENTINEL
+    assert result.omission is None
     assert not conn.fetch_calls
+
+
+# ─── omission metadata (#738) ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_windowed_read_reports_omission() -> None:
+    """A real drop returns the omitted-span facts, queried against the
+    SAME boundary value as the retained range scan (exact complements)."""
+    account_id = "acc_test_stub"
+    conn = _FakeConn(total_local=3_000, ratio_n=4, ratio_mean=0.0)
+    result = await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=1_000,
+        window_max=2_000,
+        model="m",
+        overhead_local=0,
+        account_id=account_id,
+    )
+    assert result.omission == WindowOmission(began_at=_BEGAN_AT, omitted_messages=7)
+    # Complement check: both queries saw the same drop boundary.
+    assert conn.omission_calls, "expected the omission aggregate to be queried"
+    _sid, retained_drop, *_ = conn.fetch_calls[-1]
+    _sid2, omitted_drop, *_ = conn.omission_calls[-1]
+    assert retained_drop == omitted_drop
+
+
+@pytest.mark.asyncio
+async def test_empty_complement_reports_no_omission() -> None:
+    """drop > 0 but the boundary excludes nothing (oversized first event
+    straddling it) → omission is None, not a zero-count marker."""
+    account_id = "acc_test_stub"
+    conn = _FakeConn(
+        total_local=3_000,
+        ratio_n=4,
+        ratio_mean=0.0,
+        omission_row={"began_at": None, "omitted_messages": 0},
+    )
+    result = await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=1_000,
+        window_max=2_000,
+        model="m",
+        overhead_local=0,
+        account_id=account_id,
+    )
+    assert result.omission is None
 
 
 @pytest.mark.asyncio
@@ -170,6 +239,9 @@ async def test_ceil_div_never_overshoots_window(
     )
     conn = MagicMock()
     conn.fetchval = AsyncMock(return_value=total_local)
+    conn.fetchrow = AsyncMock(  # serves the omission-complement aggregate
+        return_value={"began_at": None, "omitted_messages": 0}
+    )
 
     captured: dict[str, int] = {}
 


### PR DESCRIPTION
Closes #738.

## What

When the context window omits transcript (`drop > 0`), `build_messages` renders a synthetic head marker telling the model what it's missing and how to recall it:

> `[history: this conversation began 2026-02-19. Everything before 2026-06-08T14:32:11-07:00 (America/Los_Angeles) — about 9,800 messages, including your own — has scrolled out of view. Nothing is lost: the full transcript remains queryable with search_events. What seems unfamiliar is usually forgotten, not new: when in doubt about anything that's referred to, search first rather than fill the gap by assumption.]`

This is the cognitive-legibility half of the no-compaction design: storage was already lossless and addressable; now the model *knows* a forget happened, so it can choose to recall. Marker text was workshopped on the issue — see the [amendment comment](https://github.com/eumemic/aios/issues/738#issuecomment-4677772427) for the content decisions (no token counts, no seq ranges; participant-meaningful data only; inverted-prior guidance sentence).

## How

- **`read_windowed_events` → `WindowedEvents`** (`events` + optional `WindowOmission`): the omitted complement is computed against the same `cumulative_tokens` boundary as the retained scan — exact complements by construction. Because the omitted set is a seq-prefix of the log, `min(created_at)` over it doubles as the conversation start *and* the emptiness signal (oversized straddling first event → `NULL` → no marker). Counts use the physical `role` column (migration 0023's pattern), index-supported by `events_session_cumtokens_idx`.
- **Render in `build_messages`** (`harness/context.py`): inserted after `_prune_leading_orphans` (can't be pruned), before the system insert (lands at `messages[1]`). Boundary timestamp reuses `_format_received` byte-identically to the `received=` envelope headers; start date is account-tz, date-only; count floored to two significant figures; the count clause drops out entirely for a tool-results-only span. User-role, so it merges with a leading user inbound under `merge_adjacent_user_messages`.
- **Budget honesty**: `OMISSION_MARKER_UPPER_BOUND_LOCAL` (128 local tokens) reserved unconditionally in the window budget, mirroring `tail_block_upper_bound_local` (PR #165 full-payload invariant). The previously-duplicated overhead expression in `loop.py` and the context-preview route is consolidated into `prelude_overhead_local()`.
- **No tool injection, no conditional variants** (per design ruling on the issue): an agent without `search_events` sees the marker, hits the missing tool, and surfaces it to its operator — standard "model sees the raw error" stance.

## Cache stability (the load-bearing invariant)

Every marker datum is a pure function of the drop boundary over the immutable log: start date immutable, boundary timestamp + count fixed until the cut moves. The marker is byte-identical across rebuilds within a snap chunk and re-renders exactly when the head changes anyway (snap, or a rare `model_token_ratio` recalibration that moves the boundary regardless). Canonical rationale lives on `WindowOmission`'s docstring.

## Tests

- `TestOmissionMarker` (unit): exact text pin, placement, byte-stability across tail growth (prefix assertion), boundary-move re-render, zero-count variant, account-tz on both timestamps, merge interplay, worst-case render under the budget reserve (fails if the text fattens without bumping the constant).
- `TestApproxCount` (unit): floor-to-2-sig-figs cases.
- `test_windowed_ratio.py` (unit): omission metadata populated on real drops, same boundary value for both scans (complement check), `None` on all fallback paths and on the empty complement.
- `test_windowing_overhead.py` (e2e, real Postgres + forced drop): omission SQL exercised end-to-end; payload still fits `window_max` with the marker present, and the marker's presence is now asserted so the budget check can't pass vacuously.

## Residuals

- The omission aggregate re-scans the omitted span once per windowed step (physical `role` column, index-supported range — no JSONB detoast). If it ever profiles hot, the named escape hatch is a `cumulative_messages` counter column maintained like `cumulative_tokens`.
- `_omission_marker` takes the boundary from `events[0]`; the "omission ⇒ non-empty window" invariant is guaranteed by `read_windowed_events` (drop < total by construction) and documented at the consumer. Reviewers floated duplicating the boundary into `WindowOmission` — rejected as redundant state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
