### PR TITLE
Warn on signal daemon stdout exceptions

### DIFF
--- a/connectors/signal/src/aios_signal/daemon.py
+++ b/connectors/signal/src/aios_signal/daemon.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import signal
 from dataclasses import dataclass
 from pathlib import Path
@@ -55,6 +56,8 @@ READY_POLL_INTERVAL_S = 0.2
 READY_POLL_TIMEOUT_S = 2.0
 
 SHUTDOWN_GRACE_S = 5.0
+
+daemon_exception_count = 0
 
 
 class SignalDaemon:
@@ -451,8 +454,33 @@ async def _drain(reader: asyncio.StreamReader, log_event: str) -> None:
             line = await reader.readline()
             if not line:
                 return
-            log.info(log_event, line=line.rstrip(b"\n").decode("utf-8", errors="replace"))
+            decoded = line.rstrip(b"\n").decode("utf-8", errors="replace")
+            log.info(log_event, line=decoded)
+            if log_event == "signal.daemon.stdout":
+                _log_daemon_exception(decoded)
     except asyncio.CancelledError:
         raise
     except Exception as e:
         log.warning(f"{log_event}.read_error", error=str(e))
+
+
+def _log_daemon_exception(line: str) -> None:
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return
+    if not isinstance(payload, dict) or "exception" not in payload:
+        return
+
+    exception = payload["exception"]
+    if not isinstance(exception, dict):
+        return
+
+    global daemon_exception_count
+    daemon_exception_count += 1
+    log.warning(
+        "signal.daemon.exception",
+        exception_type=exception.get("type"),
+        exception_message=exception.get("message"),
+        count=daemon_exception_count,
+    )

--- a/connectors/signal/tests/test_daemon.py
+++ b/connectors/signal/tests/test_daemon.py
@@ -14,11 +14,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import MutableMapping
 from pathlib import Path
 from typing import Any
 
 import pytest
+from structlog.testing import capture_logs
 
+from aios_signal import daemon as daemon_module
 from aios_signal.daemon import SignalDaemon
 from aios_signal.errors import BotAccountNotFoundError, DaemonCrashError
 
@@ -147,3 +150,55 @@ async def test_subprocess_alive_false_after_exit(tmp_path: Path) -> None:
     assert d.subprocess_alive() is False
     # Consume the exception so the test doesn't emit a "never retrieved" warning.
     assert fut.exception() is not None
+
+
+# ── daemon stdout observability ────────────────────────────────────────
+
+
+async def _drain_lines(*lines: bytes) -> list[MutableMapping[str, Any]]:
+    reader = asyncio.StreamReader()
+    for line in lines:
+        reader.feed_data(line)
+    reader.feed_eof()
+
+    with capture_logs() as logs:
+        await daemon_module._drain(reader, "signal.daemon.stdout")
+    return logs
+
+
+async def test_daemon_stdout_exception_logs_warning_with_fields() -> None:
+    daemon_module.daemon_exception_count = 0
+    line = {
+        "error": {
+            "code": -32603,
+            "message": 'Unexpected error: Cannot invoke "org.whispersystems.signalservice.api.push.ServiceId.toString()" because the return value of "org.asamk.signal.manager.api.MessageEnvelope.getServerGuid()" is null',
+        },
+        "exception": {
+            "type": "java.lang.NullPointerException",
+            "message": 'Cannot invoke "org.whispersystems.signalservice.api.push.ServiceId.toString()" because the return value of "org.asamk.signal.manager.api.MessageEnvelope.getServerGuid()" is null',
+        },
+    }
+
+    logs = await _drain_lines(json.dumps(line).encode() + b"\n")
+
+    assert any(e["event"] == "signal.daemon.stdout" and e["log_level"] == "info" for e in logs)
+    warnings = [e for e in logs if e["event"] == "signal.daemon.exception"]
+    assert warnings == [
+        {
+            "event": "signal.daemon.exception",
+            "log_level": "warning",
+            "exception_type": "java.lang.NullPointerException",
+            "exception_message": 'Cannot invoke "org.whispersystems.signalservice.api.push.ServiceId.toString()" because the return value of "org.asamk.signal.manager.api.MessageEnvelope.getServerGuid()" is null',
+            "count": 1,
+        }
+    ]
+    assert daemon_module.daemon_exception_count == 1
+
+
+async def test_daemon_stdout_normal_json_line_does_not_log_warning() -> None:
+    daemon_module.daemon_exception_count = 0
+    logs = await _drain_lines(b'{"jsonrpc":"2.0","method":"receive","params":{}}\n')
+
+    assert any(e["event"] == "signal.daemon.stdout" and e["log_level"] == "info" for e in logs)
+    assert [e for e in logs if e["event"] == "signal.daemon.exception"] == []
+    assert daemon_module.daemon_exception_count == 0


### PR DESCRIPTION
Adds observability for signal-cli daemon stdout JSON lines that include an `exception` object.

Changes:
- Keeps the existing raw `signal.daemon.stdout` INFO log.
- Emits a structured WARNING event `signal.daemon.exception`.
- Includes `exception_type`, `exception_message`, and a process-lifetime `count`.
- Adds regression coverage for the getServerGuid NPE shape and a normal stdout line.

Validation:
- `pytest connectors/signal/tests -q`
- `ruff check/format --check connectors/signal/src connectors/signal/tests`
- `mypy connectors/signal/src connectors/signal/tests`

Closes eumemic/aios#918