### PR TITLE
fix(workflows): name the noun in attenuation rejection copy

### DIFF
--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -84,7 +84,7 @@ async def _enforce_surface_attenuation(
     effective = attenuation_service.clamp(declared, surface_of(agent))
     if effective != expected:
         raise ForbiddenError(
-            "workflow surface exceeds the acting agent's",
+            "workflow surface exceeds the acting agent's permissions",
             detail={"exceeds": surface_diff(expected, effective)},
         )
 

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -268,7 +268,7 @@ async def test_create_time_attenuation(vault_pool: asyncpg.Pool[Any]) -> None:
 
     # Declares a server the creator lacks → ForbiddenError, no workflow row leaks.
     before = await _workflow_count(pool)
-    with pytest.raises(ForbiddenError):
+    with pytest.raises(ForbiddenError, match=r"exceeds the acting agent's permissions"):
         await wf_service.create_workflow(
             pool,
             account_id=ACC,


### PR DESCRIPTION
The create/update_workflow attenuation rejection read as a truncated sentence — a dangling possessive with no noun:

```
workflow surface exceeds the acting agent's ({"exceeds": {"tools": ["http_request"]}})
```

## Change

`src/aios/services/workflows.py`: the prose now completes the clause.

- Before: `workflow surface exceeds the acting agent's`
- After: `workflow surface exceeds the acting agent's permissions`

The structured `detail={"exceeds": surface_diff(...)}` payload — which names the offending tools/servers/routes — is unchanged. Only the dangling prose was fixed.

## Sibling check

The sibling vault-attenuation message in `src/aios/workflows/service.py` ("run requested vaults the launching agent does not hold") was deliberately left untouched: it is grammatically complete and does not share the dangling-possessive defect.

## Tests

Added a `match=r"exceeds the acting agent's permissions"` regression assertion to the existing `pytest.raises(ForbiddenError)` in `test_create_time_attenuation` (`tests/integration/test_wf_run_vaults.py`).

Strict TDD: the assertion was confirmed RED against unmodified source (the regex did not match the old truncated message), then GREEN after the fix, with a mutation check confirming it is non-vacuous. ruff + mypy clean. No generated artifacts affected (runtime exception body, not an API schema field).

Closes #929