### PR TITLE
feat(workflows): journaled log()/phase() progress for workflow runs

### DIFF
--- a/migrations/versions/0085_wf_run_events_annotation_type.py
+++ b/migrations/versions/0085_wf_run_events_annotation_type.py
@@ -1,0 +1,43 @@
+"""Widen ``wf_run_events.type`` CHECK to include ``annotation``.
+
+``log()`` and ``phase()`` become journaled progress events: a new ``annotation``
+row in each run's journal, branch-local-keyed so the memo
+``UNIQUE NULLS NOT DISTINCT (run_id, call_key, type)`` makes them emit-once across
+replays. The inline CHECK from 0064 enumerated only the four capability/bookend
+types, so it must be widened or every annotation insert raises.
+
+Drop + re-add of the inline CHECK (PG-default name ``wf_run_events_type_check``
+from 0064), exactly as 0074 widened ``wf_run_signals_kind_check``. Additive and
+backward-compatible: existing rows are unaffected, and pre-deploy code never
+writes the new type — so deploy ordering is unconstrained.
+
+Revision ID: 0085
+Revises: 0084
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0085"
+down_revision: str = "0084"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE wf_run_events DROP CONSTRAINT wf_run_events_type_check")
+    op.execute(
+        "ALTER TABLE wf_run_events ADD CONSTRAINT wf_run_events_type_check "
+        "CHECK (type IN ('run_started','call_started','call_result','run_completed','annotation'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE wf_run_events DROP CONSTRAINT wf_run_events_type_check")
+    op.execute(
+        "ALTER TABLE wf_run_events ADD CONSTRAINT wf_run_events_type_check "
+        "CHECK (type IN ('run_started','call_started','call_result','run_completed'))"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -15764,7 +15764,8 @@
               "run_started",
               "call_started",
               "call_result",
-              "run_completed"
+              "run_completed",
+              "annotation"
             ],
             "title": "Type"
           },
@@ -15800,7 +15801,7 @@
           "created_at"
         ],
         "title": "WfRunEvent",
-        "description": "One row of a run's append-only journal (the replay-with-memo source).\n\n``call_key`` is set for ``call_started``/``call_result`` (the memo key) and\n``None`` for the ``run_started``/``run_completed`` bookends."
+        "description": "One row of a run's append-only journal (the replay-with-memo source).\n\n``call_key`` is set for ``call_started``/``call_result`` (the memo key) and for\n``annotation`` (the branch-local dedup key that makes ``log()``/``phase()``\nemit-once across replays); it is ``None`` for the ``run_started``/``run_completed``\nbookends. An ``annotation`` is a journaled progress marker (``payload`` =\n``{\"kind\": \"log\" | \"phase\", \"text\": ...}``), not a capability call."
       },
       "WfRunWaitResponse": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event.py
@@ -22,8 +22,11 @@ T = TypeVar("T", bound="WfRunEvent")
 class WfRunEvent:
     """One row of a run's append-only journal (the replay-with-memo source).
 
-    ``call_key`` is set for ``call_started``/``call_result`` (the memo key) and
-    ``None`` for the ``run_started``/``run_completed`` bookends.
+    ``call_key`` is set for ``call_started``/``call_result`` (the memo key) and for
+    ``annotation`` (the branch-local dedup key that makes ``log()``/``phase()``
+    emit-once across replays); it is ``None`` for the ``run_started``/``run_completed``
+    bookends. An ``annotation`` is a journaled progress marker (``payload`` =
+    ``{"kind": "log" | "phase", "text": ...}``), not a capability call.
 
         Attributes:
             id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event_type.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event_type.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class WfRunEventType(str, Enum):
+    ANNOTATION = "annotation"
     CALL_RESULT = "call_result"
     CALL_STARTED = "call_started"
     RUN_COMPLETED = "run_completed"

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -22,7 +22,9 @@ from pydantic import BaseModel, ConfigDict, Field
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
 
 WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored", "cancelled"]
-WfRunEventType = Literal["run_started", "call_started", "call_result", "run_completed"]
+WfRunEventType = Literal[
+    "run_started", "call_started", "call_result", "run_completed", "annotation"
+]
 WfRunSignalKind = Literal["gate_resume", "child_done", "cancel", "tool_result"]
 
 # The terminal run statuses — monotonic: once here, a run never leaves. The one source for
@@ -89,8 +91,11 @@ class WfRun(BaseModel):
 class WfRunEvent(BaseModel):
     """One row of a run's append-only journal (the replay-with-memo source).
 
-    ``call_key`` is set for ``call_started``/``call_result`` (the memo key) and
-    ``None`` for the ``run_started``/``run_completed`` bookends.
+    ``call_key`` is set for ``call_started``/``call_result`` (the memo key) and for
+    ``annotation`` (the branch-local dedup key that makes ``log()``/``phase()``
+    emit-once across replays); it is ``None`` for the ``run_started``/``run_completed``
+    bookends. An ``annotation`` is a journaled progress marker (``payload`` =
+    ``{"kind": "log" | "phase", "text": ...}``), not a capability call.
     """
 
     id: str

--- a/src/aios/workflows/_protocol.py
+++ b/src/aios/workflows/_protocol.py
@@ -5,12 +5,15 @@ Wire format: a 4-byte big-endian length prefix followed by that many bytes of
 UTF-8 JSON. Stdlib-only — imported by the credential-free child, so it must never
 pull in anything from ``aios.harness``/``aios.db``/``aios.crypto``.
 
-Message flow (the child emits zero or more frontier capabilities, then a terminal;
-a single-coroutine run emits at most one, a ``parallel``/``pipeline`` fan-out emits
-one EMIT per open branch capability before the terminal):
+Message flow (the child emits zero or more ANNOTATION + frontier-capability frames,
+then a terminal; a single-coroutine run emits at most one EMIT, a
+``parallel``/``pipeline`` fan-out emits one EMIT per open branch capability before
+the terminal; ANNOTATION frames — ``log()``/``phase()`` progress — interleave freely,
+fire-and-forget, in execution order):
 
     parent → child:  INIT {source, input, memo}
-    child  → parent: EMIT {capability_id, call_key, spec} *  (zero or more)
+    child  → parent: ANNOTATION {call_key, payload} *  (zero or more, interleaved)
+                     EMIT {capability_id, call_key, spec} *  (zero or more)
                      then exactly one of SUSPENDED | RETURNED {value} | RAISED {repr, traceback}
 """
 
@@ -26,6 +29,7 @@ MAX_FRAME_BYTES = 64 * 1024 * 1024  # guard against a corrupt/oversized length p
 # message "type" tags
 INIT = "init"
 EMIT = "emit"
+ANNOTATION = "annotation"
 SUSPENDED = "suspended"
 RETURNED = "returned"
 RAISED = "raised"

--- a/src/aios/workflows/determinism.py
+++ b/src/aios/workflows/determinism.py
@@ -96,6 +96,19 @@ def validate_value(x: Any, *, path: str = "input") -> None:
     )
 
 
+def storable_text(text: str) -> str:
+    """Neutralize the two byte classes :func:`validate_value` rejects — NUL and unpaired
+    surrogates (Postgres jsonb cannot store either) — so the result is always storable.
+
+    The sanitize-sibling of :func:`validate_value`'s reject, over the same domain: a
+    capability input fails loudly on an unstorable byte (it is the author's data), but a
+    *diagnostic* string (``log()``/``phase()`` text) must be total — a progress line can
+    never fail the run — so it is neutralized instead. Lossless for ordinary text: only
+    the rejected bytes are replaced (NUL survives the UTF-8 round-trip, so it needs its
+    own pass)."""
+    return text.encode("utf-8", "replace").decode("utf-8").replace("\x00", "�")
+
+
 def _canon(x: Any) -> Any:
     """Collapse integer-valued floats (``1.0`` → ``1``) and tuples (→ lists) so
     equal content produces the same JSON token whichever form the author built."""

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from aios.workflows._protocol import (
+    ANNOTATION,
     EMIT,
     INIT,
     RAISED,
@@ -109,14 +110,30 @@ class EmittedCapability:
 
 
 @dataclass(frozen=True)
+class EmittedAnnotation:
+    """One ``log()``/``phase()`` progress line the child emitted this wake. ``call_key``
+    is the branch-local annotation key; ``payload`` is ``{"kind": "log"|"phase", "text"}``.
+    The step journals these as ``annotation`` events; the memo UNIQUE makes a replay's
+    re-emission a no-op (emit-once)."""
+
+    call_key: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
 class HostOutcome:
     """The result of driving one wake of the author script in the subprocess."""
 
     kind: HostOutcomeKind
     emitted: list[EmittedCapability] = field(default_factory=list)
+    annotations: list[EmittedAnnotation] = field(default_factory=list)
     value: Any = None
     error_repr: str | None = None
     error_kind: HostErrorKind | None = None
+    # CRASH DIAGNOSTICS ONLY — the child's real stderr (a Python traceback from a host
+    # crash, an rlimit message). log()/phase() no longer route through here (they are
+    # journaled annotation frames on stdout); the step never reads this field. It exists
+    # solely so a host crash/timeout leaves an attributable diagnostic in the worker log.
     stderr: str = ""
 
 
@@ -144,6 +161,15 @@ def _outcome_from_frames(
         for f in frames
         if f.get("type") == EMIT
     ]
+    # Progress annotations (log()/phase()), in stream/execution order. Carried on every
+    # outcome — including a no-terminal crash below — so a script that logged before
+    # dying is still journaled. (A timeout/spawn failure returns earlier with none: its
+    # frames are discarded, which is exactly the zero-growth bound for a runaway loop.)
+    annotations = [
+        EmittedAnnotation(call_key=f["call_key"], payload=f["payload"])
+        for f in frames
+        if f.get("type") == ANNOTATION
+    ]
     terminal = next(
         (f for f in reversed(frames) if f.get("type") in (SUSPENDED, RETURNED, RAISED)), None
     )
@@ -151,20 +177,28 @@ def _outcome_from_frames(
         return HostOutcome(
             kind="raised",
             emitted=emitted,
+            annotations=annotations,
             error_kind="script_host_crash",
             error_repr=f"script host exited (rc={returncode}) without a terminal frame",
             stderr=stderr,
         )
     kind = terminal["type"]
     if kind == SUSPENDED:
-        return HostOutcome(kind="suspended", emitted=emitted, stderr=stderr)
+        return HostOutcome(
+            kind="suspended", emitted=emitted, annotations=annotations, stderr=stderr
+        )
     if kind == RETURNED:
         return HostOutcome(
-            kind="returned", emitted=emitted, value=terminal.get("value"), stderr=stderr
+            kind="returned",
+            emitted=emitted,
+            annotations=annotations,
+            value=terminal.get("value"),
+            stderr=stderr,
         )
     return HostOutcome(
         kind="raised",
         emitted=emitted,
+        annotations=annotations,
         error_repr=terminal.get("repr"),
         # The host stamps a specific kind on structural failures it detects itself
         # (e.g. the fan-out cap); an uncaught author exception carries none → generic.

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -130,10 +130,12 @@ class HostOutcome:
     value: Any = None
     error_repr: str | None = None
     error_kind: HostErrorKind | None = None
-    # CRASH DIAGNOSTICS ONLY — the child's real stderr (a Python traceback from a host
-    # crash, an rlimit message). log()/phase() no longer route through here (they are
-    # journaled annotation frames on stdout); the step never reads this field. It exists
-    # solely so a host crash/timeout leaves an attributable diagnostic in the worker log.
+    # The child's real stderr — crash diagnostics only (a host-crash traceback, an
+    # rlimit message). log()/phase() no longer route through here; they are journaled
+    # annotation frames on stdout. The step deliberately does NOT consume this field:
+    # capturing-at-the-boundary-then-dropping is the "explicitly dropped" disposition the
+    # design calls for — it is never plumbed into the run journal (author-visible output
+    # is the annotations now), and is here for a host-crash post-mortem path to read.
     stderr: str = ""
 
 

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -313,6 +313,23 @@ async def _run_workflow_step_body(
     # the txn commits (below), so call_started is visible before a task can signal+wake.
     tools_to_launch: list[tuple[str, str, Any]] = []
     async with pool.acquire() as conn:
+        # Journal this wake's progress annotations (log()/phase()) FIRST — before the
+        # raised/returned/suspended dispatch — so a line emitted just before a crash or
+        # a return is durably captured, ordered ahead of this wake's call_started /
+        # run_completed. The run is still 'running' here (the lease flip above), so the
+        # append's status guard admits them. Emit-once across replays is the memo's job:
+        # a re-emitted annotation hits ON CONFLICT (run_id, call_key, type) — type
+        # 'annotation' — and no-ops, preserving the original seq.
+        for ann in outcome.annotations:
+            await wf_queries.append_run_event(
+                conn,
+                account_id=account_id,
+                run_id=run_id,
+                type="annotation",
+                call_key=ann.call_key,
+                payload=ann.payload,
+            )
+
         if outcome.kind == "raised":
             if outcome.error_kind == "script_host_spawn_failed":
                 # Failure to *spawn* the host (EAGAIN/ENOMEM at fork) is a transient

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -44,7 +44,12 @@ from aios.workflows._protocol import (
     read_frame_sync,
     write_frame_sync,
 )
-from aios.workflows.determinism import CallKeyer, canonical_schema_json, validate_value
+from aios.workflows.determinism import (
+    CallKeyer,
+    canonical_schema_json,
+    storable_text,
+    validate_value,
+)
 
 
 class WorkflowScriptError(Exception):
@@ -220,26 +225,18 @@ def pipeline(items: Any, *stages: Any) -> _ParallelAwait:
 _pending: list[tuple[str, str]] = []
 
 
-def _storable(text: str) -> str:
-    """Neutralize the two byte classes Postgres jsonb (and the call_key validator)
-    reject — NUL and unpaired surrogates — so a progress line can never fail the run.
-    ``log()``/``phase()`` are diagnostics: total by construction, the way their
-    pre-journal stderr form never crashed. Lossless for ordinary text (only the
-    rejected bytes are replaced)."""
-    return text.encode("utf-8", "replace").decode("utf-8").replace("\x00", "�")
-
-
 def log(*args: Any) -> None:
     """Record a progress line on the run's journal (a durable ``annotation`` event,
     surfaced in the run stream). Space-joined like ``print``; re-runs on every replay
-    but the journal keeps it emit-once."""
-    _pending.append(("log", _storable(" ".join(str(a) for a in args))))
+    but the journal keeps it emit-once. ``storable_text`` keeps it total — a diagnostic
+    never fails the run, even on NUL/surrogate bytes in arbitrary logged output."""
+    _pending.append(("log", storable_text(" ".join(str(a) for a in args))))
 
 
 def phase(title: Any) -> None:
     """Record a phase marker on the run's journal (a durable ``annotation`` event) —
     a lightweight progress label, not a step boundary. Emit-once across replays."""
-    _pending.append(("phase", _storable(str(title))))
+    _pending.append(("phase", storable_text(str(title))))
 
 
 def _flush_annotations(branch: _Branch, emit: Any) -> None:
@@ -251,7 +248,7 @@ def _flush_annotations(branch: _Branch, emit: Any) -> None:
     ``type`` discriminator keeps an annotation distinct from a same-keyed capability).
     Drained right after the producing step so attribution to the branch is exact.
 
-    Total by construction: ``_storable`` already made every text jsonb-storable, so
+    Total by construction: ``storable_text`` already made every text jsonb-storable, so
     ``keyer.next`` (which validates against that same domain) cannot raise here — a
     raise would propagate out of the driver's inner ``finally`` and wrongly error the
     run (or mask a clean return)."""

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -228,8 +228,11 @@ _pending: list[tuple[str, str]] = []
 def log(*args: Any) -> None:
     """Record a progress line on the run's journal (a durable ``annotation`` event,
     surfaced in the run stream). Space-joined like ``print``; re-runs on every replay
-    but the journal keeps it emit-once. ``storable_text`` keeps it total — a diagnostic
-    never fails the run, even on NUL/surrogate bytes in arbitrary logged output."""
+    but the journal keeps it emit-once. ``storable_text`` neutralizes the NUL/unpaired-
+    surrogate bytes that arbitrary logged output may carry, so the annotation's key
+    derivation can't reject it — a stray control byte never fails the run. (A value so
+    huge its frame exceeds the protocol's MAX_FRAME_BYTES is the one exception, and the
+    same pre-existing cap that bounds every frame — not specific to annotations.)"""
     _pending.append(("log", storable_text(" ".join(str(a) for a in args))))
 
 

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -35,6 +35,7 @@ import types
 from typing import Any
 
 from aios.workflows._protocol import (
+    ANNOTATION,
     EMIT,
     INIT,
     RAISED,
@@ -210,13 +211,58 @@ def pipeline(items: Any, *stages: Any) -> _ParallelAwait:
     return parallel([_pipeline_thunk(item, stages) for item in items])
 
 
-def log(*args: Any) -> None:
-    """Emit a diagnostic to stderr (never stdout — that's the frame stream).
+# Annotations (log/phase) produced during the branch step currently being driven.
+# A synchronous log()/phase() cannot reach the driver's per-branch keyer directly,
+# so it buffers here; the driver drains this right after each branch step, keying
+# every entry through THAT branch's keyer+path (see _flush_annotations). The host is
+# single-threaded and drives exactly one branch at a time, so a module list is the
+# whole of the ambient context.
+_pending: list[tuple[str, str]] = []
 
-    Re-fires on every replay; kept to stderr so it can't corrupt the protocol or
-    the journal.
-    """
-    sys.stderr.write(" ".join(str(a) for a in args) + "\n")
+
+def _storable(text: str) -> str:
+    """Neutralize the two byte classes Postgres jsonb (and the call_key validator)
+    reject — NUL and unpaired surrogates — so a progress line can never fail the run.
+    ``log()``/``phase()`` are diagnostics: total by construction, the way their
+    pre-journal stderr form never crashed. Lossless for ordinary text (only the
+    rejected bytes are replaced)."""
+    return text.encode("utf-8", "replace").decode("utf-8").replace("\x00", "�")
+
+
+def log(*args: Any) -> None:
+    """Record a progress line on the run's journal (a durable ``annotation`` event,
+    surfaced in the run stream). Space-joined like ``print``; re-runs on every replay
+    but the journal keeps it emit-once."""
+    _pending.append(("log", _storable(" ".join(str(a) for a in args))))
+
+
+def phase(title: Any) -> None:
+    """Record a phase marker on the run's journal (a durable ``annotation`` event) —
+    a lightweight progress label, not a step boundary. Emit-once across replays."""
+    _pending.append(("phase", _storable(str(title))))
+
+
+def _flush_annotations(branch: _Branch, emit: Any) -> None:
+    """Emit the annotations buffered during ``branch``'s just-finished step, keying
+    each through the BRANCH's own keyer+path — the identical derivation a capability
+    call uses. That makes every annotation's call_key branch-local and replay-stable:
+    ``parallel()`` branches never collide, and a replay re-emits the identical key,
+    which the journal's ``UNIQUE (run_id, call_key, type)`` folds to one row (the
+    ``type`` discriminator keeps an annotation distinct from a same-keyed capability).
+    Drained right after the producing step so attribution to the branch is exact.
+
+    Total by construction: ``_storable`` already made every text jsonb-storable, so
+    ``keyer.next`` (which validates against that same domain) cannot raise here — a
+    raise would propagate out of the driver's inner ``finally`` and wrongly error the
+    run (or mask a clean return)."""
+    if not _pending:
+        return
+    buffered = _pending[:]
+    _pending.clear()
+    for kind, text in buffered:
+        payload = {"kind": kind, "text": text}
+        call_key = branch.path + branch.keyer.next(ANNOTATION, payload)
+        emit({"type": ANNOTATION, "call_key": call_key, "payload": payload})
 
 
 # ─── restricted builtins + curated imports (footgun aids, NOT the boundary) ──
@@ -374,6 +420,7 @@ def _build_coroutine(source: str, input_value: Any) -> Any:
             "parallel": parallel,
             "pipeline": pipeline,
             "log": log,
+            "phase": phase,
             # The agent() failure type lives with its capability in the author API
             # (not SAFE_BUILTINS), so `try/except AgentError` resolves it as a global.
             "AgentError": AgentError,
@@ -534,12 +581,21 @@ def _drive(root_coro: Any, memo: dict[str, Any], emit: Any) -> None:
             if branch.done or branch.blocked:
                 continue
             try:
-                # A journaled error outcome is delivered as a throw AT the await, so
-                # the author's try/except sees it; everything else is a resume value.
-                if branch.throw is not None:
-                    yielded = branch.coro.throw(branch.throw)
-                else:
-                    yielded = branch.coro.send(branch.send)
+                try:
+                    # A journaled error outcome is delivered as a throw AT the await, so
+                    # the author's try/except sees it; everything else is a resume value.
+                    if branch.throw is not None:
+                        yielded = branch.coro.throw(branch.throw)
+                    else:
+                        yielded = branch.coro.send(branch.send)
+                finally:
+                    # Drain log()/phase() buffered during THIS step, keyed by THIS
+                    # branch — before the outcome is handled, so annotation frames
+                    # precede the step's EMIT/terminal in the stream, and the live
+                    # exception (if the send raised) is still bound for the outer
+                    # handlers' traceback capture. _flush_annotations is total, so it
+                    # can never replace that exception.
+                    _flush_annotations(branch, emit)
             except StopIteration as stop:
                 progressed = True
                 if branch is root:

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -19,8 +19,8 @@ from typing import Any
 import pytest
 
 from aios.workflows.determinism import content_hash
-from aios.workflows.host_launcher import HostOutcome, run_script_host
-from aios.workflows.wf_script_host import MAX_PARALLEL_FANOUT
+from aios.workflows.host_launcher import EmittedAnnotation, HostOutcome, run_script_host
+from aios.workflows.wf_script_host import MAX_PARALLEL_FANOUT, _storable
 
 
 async def _run(
@@ -686,13 +686,118 @@ async def test_cpu_rlimit_derives_from_the_scaled_deadline() -> None:
     assert 61 <= int(big.value) <= 62  # int(0.01 + ~2*30) + 1
 
 
-async def test_log_goes_to_stderr_not_the_frame_stream() -> None:
-    out = await _run("async def main(input):\n    log('diagnostic')\n    return 7")
-    assert out.kind == "returned"
-    assert out.value == 7  # stdout frame stream parsed cleanly despite the log()
-    assert "diagnostic" in out.stderr
-
-
 async def test_print_is_unavailable_so_author_cannot_corrupt_stdout() -> None:
     out = await _run("async def main(input):\n    print('x')\n    return 1")
     assert out.kind == "raised"  # print is not in SAFE_BUILTINS
+
+
+# ─── log() / phase() as journaled annotations (B-783) ────────────────────────
+
+
+def _ann_key(kind: str, text: str, *, path: str = "") -> str:
+    """The branch-local annotation call_key the host derives — ``path`` is the
+    parallel branch prefix ("" for root, "0.0/" for the first child)."""
+    return f"{path}sha:{content_hash('annotation', {'kind': kind, 'text': text})}#0"
+
+
+async def test_log_is_a_journaled_annotation_not_stderr() -> None:
+    # The stderr reversion: log() no longer writes stderr — it emits a journaled
+    # annotation frame, keyed branch-locally so the journal can dedup it across replays.
+    out = await _run("async def main(input):\n    log('diagnostic')\n    return 7")
+    assert out.kind == "returned"
+    assert out.value == 7
+    assert "diagnostic" not in out.stderr  # stderr is crash-diagnostics-only now
+    assert out.annotations == [
+        EmittedAnnotation(
+            call_key=_ann_key("log", "diagnostic"),
+            payload={"kind": "log", "text": "diagnostic"},
+        )
+    ]
+
+
+async def test_phase_is_a_journaled_annotation() -> None:
+    out = await _run("async def main(input):\n    phase('build')\n    return 1")
+    assert out.kind == "returned"
+    assert out.annotations == [
+        EmittedAnnotation(
+            call_key=_ann_key("phase", "build"), payload={"kind": "phase", "text": "build"}
+        )
+    ]
+
+
+async def test_log_space_joins_args_like_print() -> None:
+    out = await _run("async def main(input):\n    log('a', 1, True)\n    return 1")
+    assert out.annotations[0].payload == {"kind": "log", "text": "a 1 True"}
+
+
+async def test_annotations_emit_in_order_before_the_frontier() -> None:
+    # phase() then log() then a suspending gate: both annotations are emitted (in
+    # execution order) alongside the one frontier capability.
+    out = await _run(
+        "async def main(input):\n    phase('p')\n    log('l')\n    return await gate(1)"
+    )
+    assert out.kind == "suspended"
+    assert [(a.payload["kind"], a.payload["text"]) for a in out.annotations] == [
+        ("phase", "p"),
+        ("log", "l"),
+    ]
+    assert len(out.emitted) == 1  # the gate frontier
+
+
+async def test_annotation_call_key_is_stable_across_replays() -> None:
+    # The host re-emits annotations on EVERY wake with the IDENTICAL call_key; emit-once
+    # is the journal's job (ON CONFLICT), so stability of the key across wakes is what
+    # the host must guarantee.
+    src = "async def main(input):\n    log('once')\n    r = await gate(1)\n    return r"
+    first = await _run(src)
+    assert [a.payload["text"] for a in first.annotations] == ["once"]
+    gate_key = first.emitted[0].call_key
+    second = await _run(src, memo={gate_key: {"ok": "v"}})
+    assert second.kind == "returned"
+    assert second.value == "v"
+    assert second.annotations[0].call_key == first.annotations[0].call_key
+
+
+_PARALLEL_LOG_SRC = """
+    async def main(input):
+        def mk(n):
+            async def run():
+                log('hi')
+                return await gate(n)
+            return run
+        return await parallel([mk(1), mk(2)])
+"""
+
+
+async def test_parallel_branches_key_annotations_locally() -> None:
+    # Both branches log the identical text 'hi'. Branch-local keying (path prefix)
+    # makes the two annotations DISTINCT call_keys — they neither collide nor dedupe
+    # each other — which is exactly why annotations route through the branch keyer.
+    out = await _run(_PARALLEL_LOG_SRC)
+    assert out.kind == "suspended"
+    assert len(out.annotations) == 2
+    assert all(a.payload == {"kind": "log", "text": "hi"} for a in out.annotations)
+    assert {a.call_key for a in out.annotations} == {
+        _ann_key("log", "hi", path="0.0/"),
+        _ann_key("log", "hi", path="0.1/"),
+    }
+
+
+async def test_log_with_unstorable_text_does_not_kill_the_run() -> None:
+    # NUL / unpaired surrogate is common in logged tool output (decoded bytes, JSON with
+    # control chars). A diagnostic must never fail the run, so the host sanitizes the
+    # text rather than letting the call_key validator raise (which would error the run).
+    out = await _run(
+        "async def main(input):\n    log('a' + chr(0) + chr(0xD800) + 'b')\n    return 9"
+    )
+    assert out.kind == "returned"
+    assert out.value == 9
+    text = out.annotations[0].payload["text"]
+    assert "\x00" not in text
+    text.encode("utf-8")  # storable: raises if a lone surrogate survived
+
+
+def test_storable_neutralizes_nul_and_surrogates_losslessly() -> None:
+    assert _storable("ordinary text — é 🎉") == "ordinary text — é 🎉"
+    assert "\x00" not in _storable("a\x00b")
+    _storable("x" + chr(0xD800)).encode("utf-8")  # no raise → storable

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -18,9 +18,9 @@ from typing import Any
 
 import pytest
 
-from aios.workflows.determinism import content_hash
+from aios.workflows.determinism import content_hash, storable_text
 from aios.workflows.host_launcher import EmittedAnnotation, HostOutcome, run_script_host
-from aios.workflows.wf_script_host import MAX_PARALLEL_FANOUT, _storable
+from aios.workflows.wf_script_host import MAX_PARALLEL_FANOUT
 
 
 async def _run(
@@ -798,6 +798,6 @@ async def test_log_with_unstorable_text_does_not_kill_the_run() -> None:
 
 
 def test_storable_neutralizes_nul_and_surrogates_losslessly() -> None:
-    assert _storable("ordinary text — é 🎉") == "ordinary text — é 🎉"
-    assert "\x00" not in _storable("a\x00b")
-    _storable("x" + chr(0xD800)).encode("utf-8")  # no raise → storable
+    assert storable_text("ordinary text — é 🎉") == "ordinary text — é 🎉"
+    assert "\x00" not in storable_text("a\x00b")
+    storable_text("x" + chr(0xD800)).encode("utf-8")  # no raise → storable

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -293,6 +293,131 @@ async def test_terminal_run_and_double_resume_are_noops(wf_runtime: asyncpg.Pool
     assert await _events(pool, run_id) == before  # journal unchanged
 
 
+# ─── annotations — log()/phase() journaling (B-783) ──────────────────────────
+
+
+async def _typed(pool: asyncpg.Pool[Any], run_id: str) -> list[tuple[str, str | None, str | None]]:
+    """The journal as ``(type, kind, text)`` — ``kind``/``text`` are an annotation's
+    payload, ``None`` for every other event type."""
+    async with pool.acquire() as conn:
+        rows = await wf_queries.list_run_events(conn, run_id)
+    return [
+        (e.type, e.payload.get("kind"), e.payload.get("text"))
+        if e.type == "annotation"
+        else (e.type, None, None)
+        for e in rows
+    ]
+
+
+_ANN_SCRIPT = (
+    "async def main(input):\n"
+    "    phase('start')\n"
+    "    log('before', 'gate')\n"
+    "    r = await gate({'q': 'ok?'})\n"
+    "    log('after gate')\n"
+    "    return r\n"
+)
+
+
+async def test_annotations_journaled_in_execution_order(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    run_id = await _make_run(pool, _ANN_SCRIPT)
+
+    # Wake 1: phase() + log() emit before the gate frontier.
+    await run_workflow_step(run_id)
+    assert [(t, k is not None) for _s, t, k in await _events(pool, run_id)] == [
+        ("run_started", False),
+        ("annotation", True),
+        ("annotation", True),
+        ("call_started", True),
+    ]
+    gate_key = next(k for _s, t, k in await _events(pool, run_id) if t == "call_started")
+    assert gate_key is not None
+    await service.resume_gate(pool, run_id=run_id, call_key=gate_key, result="yes")
+
+    # Wake 2: replay re-emits the first two annotations (deduped by the memo), harvests
+    # the gate, then emits the post-gate log (new) — so the journal stays in execution
+    # order with NO duplicate annotation rows.
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert await _typed(pool, run_id) == [
+        ("run_started", None, None),
+        ("annotation", "phase", "start"),
+        ("annotation", "log", "before gate"),  # log(*args) space-joined
+        ("call_started", None, None),
+        ("call_result", None, None),
+        ("annotation", "log", "after gate"),
+        ("run_completed", None, None),
+    ]
+
+
+async def test_replay_does_not_duplicate_annotations(wf_runtime: asyncpg.Pool[Any]) -> None:
+    # Re-driving the suspended run WITHOUT resolving the gate would quiet-wake (no
+    # re-emit); instead force a real replay by resolving the gate, and assert the two
+    # pre-gate annotations each appear exactly once though wake 2 re-emitted them.
+    pool = wf_runtime
+    run_id = await _make_run(pool, _ANN_SCRIPT)
+    await run_workflow_step(run_id)
+    gate_key = next(k for _s, t, k in await _events(pool, run_id) if t == "call_started")
+    assert gate_key is not None
+    await service.resume_gate(pool, run_id=run_id, call_key=gate_key, result="yes")
+    await run_workflow_step(run_id)
+    annotations = [(k, txt) for typ, k, txt in await _typed(pool, run_id) if typ == "annotation"]
+    assert annotations == [("phase", "start"), ("log", "before gate"), ("log", "after gate")]
+
+
+async def test_annotation_write_once_first_text_wins(wf_runtime: asyncpg.Pool[Any]) -> None:
+    # The memo UNIQUE (run_id, call_key, type) makes annotation text write-once per
+    # call_key: a replay that re-emits the SAME key with edited text is a no-op, and the
+    # original row stands (correct under replay — a deterministic script can't change a
+    # position's text, but a hand-edited script source must never rewrite history).
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    async with pool.acquire() as conn:
+        first = await wf_queries.append_run_event(
+            conn,
+            account_id="acc_wf",
+            run_id=run_id,
+            type="annotation",
+            call_key="sha:ann#0",
+            payload={"kind": "log", "text": "first"},
+        )
+        second = await wf_queries.append_run_event(
+            conn,
+            account_id="acc_wf",
+            run_id=run_id,
+            type="annotation",
+            call_key="sha:ann#0",
+            payload={"kind": "log", "text": "EDITED"},
+        )
+    assert first is not None
+    assert second is None  # ON CONFLICT (run_id, call_key, type) → no-op, no seq consumed
+    annotations = [(k, txt) for typ, k, txt in await _typed(pool, run_id) if typ == "annotation"]
+    assert annotations == [("log", "first")]
+
+
+async def test_annotation_before_crash_is_captured(wf_runtime: asyncpg.Pool[Any]) -> None:
+    # The debuggability payoff: a log() just before an author exception is journaled
+    # AHEAD of the run_completed(errored) bookend, so an operator can see how far a
+    # crashing run got.
+    pool = wf_runtime
+    run_id = await _make_run(
+        pool,
+        "async def main(input):\n    log('about to fail')\n    raise ValueError('boom')\n",
+    )
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "errored"
+    assert await _typed(pool, run_id) == [
+        ("run_started", None, None),
+        ("annotation", "log", "about to fail"),
+        ("run_completed", None, None),
+    ]
+
+
 # ─── cancel — user-requested termination via the cancel signal ───────────────
 
 

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0084``."""
+    """The migration ladder has exactly one head: ``0085``."""
     script = _script_directory()
-    assert script.get_heads() == ["0084"]
+    assert script.get_heads() == ["0085"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_wf_run_event_stream_terminal.py
+++ b/tests/unit/test_wf_run_event_stream_terminal.py
@@ -71,6 +71,45 @@ async def test_terminal_status_drains_catch_up_tail_then_done() -> None:
     subscription._conn.terminate.assert_called_once()
 
 
+async def test_annotation_event_surfaces_in_the_stream() -> None:
+    """A ``log()``/``phase()`` annotation row streams as a normal event frame — the
+    serializer is type-agnostic — in seq order ahead of the ``run_completed`` terminal.
+    This is the SSE half of the journaled-progress contract."""
+    annotation_row = {
+        "id": "wfe_a",
+        "run_id": "wfr_X",
+        "seq": 1,
+        "type": "annotation",
+        "call_key": "sha:ann#0",
+        "payload": json.dumps({"kind": "phase", "text": "build"}),
+        "created_at": datetime(2024, 1, 1, tzinfo=UTC),
+    }
+    run_completed_row = {
+        "id": "wfe_z",
+        "run_id": "wfr_X",
+        "seq": 2,
+        "type": "run_completed",
+        "call_key": None,
+        "payload": json.dumps({"output": None, "is_error": False}),
+        "created_at": datetime(2024, 1, 1, tzinfo=UTC),
+    }
+    conn = MagicMock()
+    # Backfill carries both rows; the loop yields the annotation, then closes on the
+    # run_completed (no catch-up fetch needed).
+    conn.fetch = AsyncMock(side_effect=[[annotation_row, run_completed_row]])
+    pool = _mk_pool(conn)
+    subscription = _mk_subscription()
+
+    messages = [msg async for msg in wf_run_event_stream(subscription, pool, "wfr_X", after_seq=0)]
+    events = [json.loads(str(msg.data)) for msg in messages if msg.event == "event"]
+
+    assert [msg.event for msg in messages] == ["event", "event", "done"]
+    assert events[0]["type"] == "annotation"
+    assert events[0]["payload"] == {"kind": "phase", "text": "build"}
+    assert events[1]["type"] == "run_completed"
+    subscription._conn.terminate.assert_called_once()
+
+
 async def test_terminal_status_empty_catch_up_falls_through_to_done() -> None:
     """The genuine reconnect-past-terminal case: empty backfill + status terminal +
     nothing past the cursor ⇒ a single done frame (no hang, no spurious event)."""


### PR DESCRIPTION
## What

`log()` and a new `phase()` become **journaled, run-correlated progress events** on
a workflow run's journal — a new `annotation` event kind in `wf_run_events` —
visible in order via `GET /v1/runs/{id}/events` and the SSE `/stream`.

Before: `log()` wrote to the subprocess stderr, which `host_launcher` captured into
`HostOutcome.stderr` and `step.py` then **silently discarded** — and it re-fired on
every replay. `phase()` didn't exist. A run had no observable progress between
agent calls, so debugging a stuck/misbehaving workflow was blind.

Closes #783. Part of the workflows-parity epic #777.

## Mechanism

- **`log(*args)` / `phase(title)` stay synchronous** (CC parity) and append to a
  module-level buffer in the script host. The driver `_drive` wraps each branch step
  in an inner `try/finally` that drains the buffer through **that branch's
  keyer+path** — the identical derivation a capability call uses:
  `call_key = branch.path + branch.keyer.next("annotation", {kind, text})`. So every
  annotation gets a **branch-local, replay-stable** key: `parallel()` branches never
  collide, and a replay re-emits the identical key.
- **Emit-once across replays** rides the existing memo `UNIQUE NULLS NOT DISTINCT
  (run_id, call_key, type)` + `ON CONFLICT DO NOTHING` — a re-emitted annotation
  folds to one row, original `seq` preserved. `"annotation"` is a **disjoint
  content-hash bucket** from `agent`/`gate`/`tool`, so capability `call_key`s are
  bit-identical with or without annotations interleaved (no replay perturbation).
- **`storable_text()`** (co-located with `validate_value` in `determinism.py`)
  neutralizes the NUL / unpaired-surrogate bytes Postgres jsonb rejects, so the key
  derivation can't reject arbitrary logged output and the producer stays total.
- **`step.py`** journals `outcome.annotations` as the first writes of the wake, before
  the raised/returned/suspended dispatch — so a `log()` just before a crash or a
  return is durably captured, ordered ahead of `call_started`/`run_completed`.
- **`HostOutcome.stderr` reverts to crash-diagnostics-only** (the issue's other half):
  `log()` no longer routes through it; the field is captured-at-the-boundary then
  dropped, never plumbed into the journal — with a comment saying so.
- **Migration 0085** widens the `wf_run_events.type` CHECK to include `annotation`
  (additive, backward-compatible; pre-deploy code never writes the new type).
- No router/SSE change needed: the events page, `list_run_events`, and the stream all
  read every event by `seq` and serialize generically (terminating only on
  `run_completed`), so annotations surface in order for free.

## Process / provenance

Shipped through the adversarial pipeline (plan → red-team the plan → implement →
/simplify → /code-review → fold):

- **Pre-code red-team** (5 lenses) caught the load-bearing bug before any code: a
  NUL / unpaired surrogate in logged text would make the keyer **raise inside the
  driver's `finally`** and terminally error the run (even masking a clean return).
  Fixed by `storable_text` totality at the producer + a regression test.
- **/simplify** co-located `storable_text` with `validate_value` (one home for the
  "what jsonb rejects" domain) and made the `HostOutcome.stderr` comment honest
  (nothing reads it — it's the "explicitly dropped" disposition).
- **/code-review** (5 finders + verify + gap sweep) surfaced one moderate doc-claim
  issue (the frame-cap residual below); folded into an honest comment.

## Tests

- Host: stderr reversion, `phase()`, arg join, in-order emission before the frontier,
  call_key stability across replays, **branch-local keying under `parallel()`** (two
  branches logging identical text get distinct keys), and the **unstorable-text
  totality regression** (NUL + surrogate must not kill the run).
- Step (real Postgres): execution-order journaling across a gate round-trip,
  replay-does-not-duplicate, **write-once text** per call_key, and **pre-crash
  capture** (a `log()` before an exception lands ahead of `run_completed(errored)`).
- SSE: an annotation row streams through `wf_run_event_stream` in order before the
  terminal.
- Migration-chain head pin updated to `0085`.

## Residuals — for explicit sign-off

1. **No journal-growth cap** (operator-confirmed). `while True: log()` is already
   zero-growth (wall-clock timeout discards frames); await-interleaved loops are
   bounded by `workflow_max_agent_calls`. A finite log-heavy pre-await loop can bloat
   one run's journal — accepted.
2. **No replay-compat special handling for in-flight runs** (operator-confirmed).
   Annotations are a disjoint keyer bucket, so a run mid-flight at deploy replays
   under bit-identical capability keys and simply gains annotations from that wake on.
3. **Single >64MB-frame log line** (code-review, **new — please confirm**). A single
   logged value so large its frame exceeds the protocol's pre-existing
   `MAX_FRAME_BYTES` (64MB) errors the run via the parent's frame parser — the same
   cap that bounds every frame (a giant `agent()` spec/return crashes identically),
   not specific to annotations. Resolved consistent with residual #1 ("rely on
   existing bounds"): the docstring is scoped to the truth and **no per-line
   truncation cap was added** (that would be the cap the project rejects + a silent-
   truncation footgun). Flagging in case you'd prefer log/phase to be size-total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)