### PR TITLE
Surface workflow author exception details

### DIFF
--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -148,7 +148,7 @@ class WfRunWaitResponse(BaseModel):
     done: bool  # run_status in TERMINAL_RUN_STATUSES (completed/errored/cancelled)
     output: Any = None  # the run's return value (on completed; None otherwise)
     is_error: bool = False  # run_status == errored
-    error: dict[str, Any] | None = None  # the run_completed event's {kind} (on errored)
+    error: dict[str, Any] | None = None  # the run_completed event's {kind,message,traceback}
 
 
 # ─── request models (the public HTTP surface) ────────────────────────────────

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -129,6 +129,7 @@ class HostOutcome:
     annotations: list[EmittedAnnotation] = field(default_factory=list)
     value: Any = None
     error_repr: str | None = None
+    error_traceback: str | None = None
     error_kind: HostErrorKind | None = None
     # The child's real stderr — crash diagnostics only (a host-crash traceback, an
     # rlimit message). log()/phase() no longer route through here; they are journaled
@@ -202,6 +203,7 @@ def _outcome_from_frames(
         emitted=emitted,
         annotations=annotations,
         error_repr=terminal.get("repr"),
+        error_traceback=terminal.get("traceback"),
         # The host stamps a specific kind on structural failures it detects itself
         # (e.g. the fan-out cap); an uncaught author exception carries none → generic.
         error_kind=terminal.get("kind") or "author_exception",

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -476,7 +476,12 @@ async def _run_workflow_step_body(
                 # sweep re-wakes the (still non-terminal) run when capacity returns.
                 raise RuntimeError(f"workflow {run_id}: {outcome.error_repr}")
             await _complete_run(
-                conn, run, output=outcome.error_repr, is_error=True, error_kind=outcome.error_kind
+                conn,
+                run,
+                output=outcome.error_repr,
+                is_error=True,
+                error_kind=outcome.error_kind,
+                error_traceback=outcome.error_traceback,
             )
             return
 
@@ -936,6 +941,7 @@ async def _complete_run(
     output: Any,
     is_error: bool,
     error_kind: str | None = None,
+    error_traceback: str | None = None,
 ) -> None:
     """Append ``run_completed`` + flip status (+ store output) atomically.
 
@@ -957,13 +963,18 @@ async def _complete_run(
         "duration_ms": max(0, int((datetime.now(UTC) - run.created_at).total_seconds() * 1000)),
     }
     if error_kind is not None:
-        payload["error"] = {"kind": error_kind}
+        error: dict[str, Any] = {"kind": error_kind}
+        if output is not None:
+            error["message"] = str(output)
+        if error_traceback:
+            error["traceback"] = error_traceback
+        payload["error"] = error
     await _commit_terminal_and_dispatch(
         conn,
         run,
         status="errored" if is_error else "completed",
         payload=payload,
-        output=None if is_error else output,
+        output=output,
     )
 
 

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -521,7 +521,9 @@ def _author_traceback(exc: BaseException) -> str:
     internals). The script itself is author-visible by definition, so keep its
     filename/line/function/code entries plus the exception type/message footer.
     """
-    frames = [frame for frame in traceback.extract_tb(exc.__traceback__) if frame.filename == "<workflow>"]
+    frames = [
+        frame for frame in traceback.extract_tb(exc.__traceback__) if frame.filename == "<workflow>"
+    ]
     if not frames:
         return ""
     lines = ["Traceback (most recent call last):\n"]

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import builtins
 import contextlib
 import inspect
+import linecache
 import os
 import sys
 import traceback
@@ -498,18 +499,35 @@ def _build_coroutine(source: str, input_value: Any) -> Any:
     # breaks dataclasses' ClassVar/InitVar detection. Compiled clean, annotations
     # are live objects, evaluated eagerly against the script's own namespace.
     code = compile(source, "<workflow>", "exec", dont_inherit=True)
+    linecache.cache["<workflow>"] = (len(source), None, source.splitlines(True), "<workflow>")
     exec(code, namespace)
     entry = namespace.get("main")
     if entry is None or not callable(entry):
         raise WorkflowScriptError("workflow script must define `async def main(input)`")
     coro = entry(input_value)
     if not hasattr(coro, "send"):
-        raise WorkflowScriptError("`main` must be an async function (`async def main(input)`)")
+        raise WorkflowScriptError("workflow script must define `async def main(input)`")
     return coro
 
 
 def _exc_repr(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {exc}"
+
+
+def _author_traceback(exc: BaseException) -> str:
+    """Return an author-facing traceback containing only workflow source frames.
+
+    The subprocess host stack is implementation detail (and may include sandbox
+    internals). The script itself is author-visible by definition, so keep its
+    filename/line/function/code entries plus the exception type/message footer.
+    """
+    frames = [frame for frame in traceback.extract_tb(exc.__traceback__) if frame.filename == "<workflow>"]
+    if not frames:
+        return ""
+    lines = ["Traceback (most recent call last):\n"]
+    lines.extend(traceback.format_list(frames))
+    lines.extend(traceback.format_exception_only(type(exc), exc))
+    return "".join(lines)
 
 
 def _emit_error(emit: Any, repr_: str, tb: str = "", *, kind: str | None = None) -> None:
@@ -522,7 +540,7 @@ def _emit_error(emit: Any, repr_: str, tb: str = "", *, kind: str | None = None)
 
 
 def _emit_raised(emit: Any, exc: BaseException) -> None:
-    _emit_error(emit, _exc_repr(exc), traceback.format_exc())
+    _emit_error(emit, _exc_repr(exc), _author_traceback(exc))
 
 
 _AGENT_ERROR_DEFAULT_MESSAGES: dict[str | None, str] = {

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -151,6 +151,22 @@ async def test_author_exception_is_terminal_raised() -> None:
     assert "ValueError: boom" in (out.error_repr or "")
 
 
+async def test_author_exception_traceback_is_author_sanitized() -> None:
+    out = await _run(
+        "async def main(input):\n"
+        "    x = 1\n"
+        "    raise RuntimeError('kapow')\n"
+        "    return x\n"
+    )
+    assert out.kind == "raised"
+    assert out.error_repr == "RuntimeError: kapow"
+    assert out.error_traceback is not None
+    assert 'File "<workflow>", line 3, in main' in out.error_traceback
+    assert "raise RuntimeError('kapow')" in out.error_traceback
+    assert "RuntimeError: kapow" in out.error_traceback
+    assert "wf_script_host.py" not in out.error_traceback
+
+
 async def test_agent_emits_a_frontier_for_block2() -> None:
     out = await _run("async def main(input):\n    return await agent('a1', input={'p': 1})")
     assert out.kind == "suspended"

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -153,10 +153,7 @@ async def test_author_exception_is_terminal_raised() -> None:
 
 async def test_author_exception_traceback_is_author_sanitized() -> None:
     out = await _run(
-        "async def main(input):\n"
-        "    x = 1\n"
-        "    raise RuntimeError('kapow')\n"
-        "    return x\n"
+        "async def main(input):\n    x = 1\n    raise RuntimeError('kapow')\n    return x\n"
     )
     assert out.kind == "raised"
     assert out.error_repr == "RuntimeError: kapow"

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -2614,7 +2614,8 @@ async def test_epoch_mismatch_errors_before_replay(wf_runtime: asyncpg.Pool[Any]
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
     assert run is not None and run.status == "errored"
-    assert run.output is None
+    # Errored runs persist the author-facing error message as output (#926).
+    assert "engine semantics changed" in (run.output or "")
     assert [event.type for event in events] == ["run_completed"]
     assert events[-1].payload["is_error"] is True
     assert events[-1].payload["error"]["kind"] == "engine_semantics_changed"
@@ -3396,10 +3397,7 @@ async def test_await_run_surfaces_runtime_author_traceback_line(
     pool = wf_runtime
     run_id = await _make_run(
         pool,
-        "async def main(input):\n"
-        "    x = 1\n"
-        "    raise ValueError('boom')\n"
-        "    return x\n",
+        "async def main(input):\n    x = 1\n    raise ValueError('boom')\n    return x\n",
     )
     await run_workflow_step(run_id)  # raise → errored
     resp = await wf_service.await_run(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -3369,19 +3369,51 @@ async def test_await_run_returns_when_already_completed(
     assert resp.output == 1 and resp.is_error is False and resp.error is None
 
 
-async def test_await_run_surfaces_error_kind(
+async def test_await_run_surfaces_sync_def_author_error_message(
     wf_runtime: asyncpg.Pool[Any], migrated_db_url: str
 ) -> None:
-    """An errored run returns ``is_error`` + the ``error.kind`` lifted from the
-    ``run_completed`` payload (``author_exception`` for an uncaught script raise)."""
+    """A malformed workflow entrypoint returns the host's author-facing diagnostic,
+    not just an opaque ``author_exception`` kind."""
     pool = wf_runtime
-    run_id = await _make_run(pool, "async def main(input):\n    raise ValueError('boom')")
+    run_id = await _make_run(pool, "def main(input):\n    return 1")
+    await run_workflow_step(run_id)  # sync def → errored
+    resp = await wf_service.await_run(
+        pool, migrated_db_url, run_id, account_id="acc_wf", timeout_seconds=5
+    )
+    assert resp.done is True and resp.run_status == "errored" and resp.is_error is True
+    assert resp.output == "WorkflowScriptError: workflow script must define `async def main(input)`"
+    assert resp.error == {
+        "kind": "author_exception",
+        "message": "WorkflowScriptError: workflow script must define `async def main(input)`",
+    }
+
+
+async def test_await_run_surfaces_runtime_author_traceback_line(
+    wf_runtime: asyncpg.Pool[Any], migrated_db_url: str
+) -> None:
+    """A mid-script raise carries type, message, and author-visible line number while
+    host implementation frames are sanitized out."""
+    pool = wf_runtime
+    run_id = await _make_run(
+        pool,
+        "async def main(input):\n"
+        "    x = 1\n"
+        "    raise ValueError('boom')\n"
+        "    return x\n",
+    )
     await run_workflow_step(run_id)  # raise → errored
     resp = await wf_service.await_run(
         pool, migrated_db_url, run_id, account_id="acc_wf", timeout_seconds=5
     )
     assert resp.done is True and resp.run_status == "errored" and resp.is_error is True
-    assert resp.error == {"kind": "author_exception"}
+    assert resp.output == "ValueError: boom"
+    assert resp.error is not None
+    assert resp.error["kind"] == "author_exception"
+    assert resp.error["message"] == "ValueError: boom"
+    tb = resp.error["traceback"]
+    assert 'File "<workflow>", line 3, in main' in tb
+    assert "raise ValueError('boom')" in tb
+    assert "wf_script_host.py" not in tb
 
 
 async def test_await_run_times_out_on_non_terminal_run(


### PR DESCRIPTION
Propagates workflow author exception messages and sanitized author tracebacks from the script host through run completion payloads, errored run output, and await_run responses.

What changed:
- Captures author-visible traceback frames from `<workflow>` only, excluding host-side implementation frames.
- Includes `message` and optional `traceback` alongside `error.kind` in run completion errors.
- Stores errored run output as the author-facing error message so await_run/run representations are diagnosable.
- Adds coverage for sync `def main` diagnostics and runtime exception tracebacks with line numbers.

Validation:
- `python -m pytest tests/integration/test_wf_host.py tests/unit/test_workflow_management.py`
- `python -m ruff check ...`
- await_run integration tests were collected but skipped because Docker is unavailable in this sandbox.

Closes #926