### PR TITLE
fix(sandbox): absolute-path keepalive to survive PATH breakage

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -28,7 +28,9 @@
 # `docker run --label`, so the worker's orphan reaper can find containers
 # started by previous worker processes.
 #
-# Entry point is `tail -f /dev/null` — the container stays alive between
+# Entry point is `/usr/bin/tail -f /dev/null` (absolute path — PATH-regression
+# defense-in-depth after #925; bare `tail` fails at OCI init on an empty PATH).
+# The container stays alive between
 # `docker exec` calls. Each bash/read/write/edit/glob/grep tool invocation
 # is a fresh `docker exec`, so shell state does not persist across calls
 # (one-shot exec model, see aios_v1_decisions.md).
@@ -66,7 +68,7 @@ RUN chmod 0755 /usr/local/bin/tool
 # Named non-root user `aios` (uid:gid 1000:1000) with a writable home.
 #
 # DELIBERATELY no top-level `USER aios` directive. The image runs on a
-# one-shot-exec model: `CMD ["tail","-f","/dev/null"]` keeps the
+# one-shot-exec model: `CMD ["/usr/bin/tail","-f","/dev/null"]` keeps the
 # container alive as **root**, and every tool call is a separate
 # `docker exec`. The agent uid is supplied per-exec via
 # `docker exec --user 1000:1000 ...` (follow-up seam issue), never as the
@@ -95,4 +97,4 @@ WORKDIR /workspace
 
 # Keep the container alive until we remove it. Each tool call is a
 # `docker exec`, not a `docker run`.
-CMD ["tail", "-f", "/dev/null"]
+CMD ["/usr/bin/tail", "-f", "/dev/null"]

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -571,14 +571,16 @@ class DockerBackend:
         Flatten applies overlay whiteouts (so "delete files to shrink" finally
         works) and strips ALL baked config (the definitive secret scrub). Import
         loses the base image's config, so restore ``WORKDIR``/``HOME``/``CMD``
-        and re-stamp the managed labels. ``PATH`` is deliberately NOT restored
-        — Docker injects its default for a config with no PATH, which is what
-        keeps the restored ``CMD`` execable (an empty PATH would break it). The
-        resumed container's env is re-injected fresh via ``docker run --env``
-        regardless, so config env doesn't affect runtime — only the artifact.
+        and re-stamp the managed labels. ``PATH`` is deliberately NOT restored.
+        The restored ``CMD`` invokes ``tail`` by absolute path
+        (``/usr/bin/tail``), so it no longer depends on PATH resolution — a
+        PATH regression can't break container init (defense-in-depth after
+        #925). The resumed container's env is re-injected fresh via
+        ``docker run --env`` regardless, so config env doesn't affect runtime
+        — only the artifact.
         """
         changes = [
-            'CMD ["tail","-f","/dev/null"]',
+            'CMD ["/usr/bin/tail","-f","/dev/null"]',
             "WORKDIR /workspace",
             "ENV HOME=/home/aios",
             f"LABEL {MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -11,6 +11,7 @@ no Postgres, no async. They require only a Docker daemon.
 
 from __future__ import annotations
 
+import json
 import os
 import platform
 import re
@@ -129,6 +130,26 @@ def test_tail_at_absolute_path(pulled_image: str) -> None:
     not at container init with an opaque `exec` failure (#925, #938)."""
     r = _docker_run(pulled_image, "test", "-x", "/usr/bin/tail")
     assert r.returncode == 0, f"/usr/bin/tail not executable in image: {r.stderr}"
+
+
+def test_image_cmd_uses_absolute_tail(pulled_image: str) -> None:
+    """The image's configured CMD must invoke tail by absolute path.
+
+    test_tail_at_absolute_path proves the binary exists at /usr/bin/tail;
+    this proves the image is actually configured to *use* it. Together they
+    catch both a base-image swap that relocates tail and a regression that
+    reverts the CMD to bare `tail` (PATH-dependent, the #938/#925 failure)."""
+    r = subprocess.run(
+        ["docker", "inspect", "--format", "{{json .Config.Cmd}}", pulled_image],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert r.returncode == 0, f"docker inspect failed: {r.stderr}"
+    assert json.loads(r.stdout) == ["/usr/bin/tail", "-f", "/dev/null"], (
+        f"image CMD is {r.stdout.strip()}, expected absolute-path tail keepalive"
+    )
 
 
 # -- runtime behaviour ---------------------------------------------------------

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -103,7 +103,7 @@ def _docker_run(
         "tool",  # sandbox-native broker CLI (baked from repo bin/tool; #635)
         "node",  # so agents can run npm packages without first apt-installing the runtime
         "npm",
-        "tail",  # the image CMD is `tail -f /dev/null`
+        "tail",  # the image CMD is `/usr/bin/tail -f /dev/null`
         "cat",
         "head",
         "grep",
@@ -120,6 +120,15 @@ def test_binary_available(pulled_image: str, binary: str) -> None:
     """
     r = _docker_run(pulled_image, "which", binary)
     assert r.returncode == 0, f"{binary!r} not found: {r.stderr}"
+
+
+def test_tail_at_absolute_path(pulled_image: str) -> None:
+    """The image CMD is `/usr/bin/tail -f /dev/null` (absolute path — see
+    docker/Dockerfile.sandbox and DockerBackend._flatten). Pin the binary at
+    that exact path so a base-image swap relocating `tail` is caught in CI,
+    not at container init with an opaque `exec` failure (#925, #938)."""
+    r = _docker_run(pulled_image, "test", "-x", "/usr/bin/tail")
+    assert r.returncode == 0, f"/usr/bin/tail not executable in image: {r.stderr}"
 
 
 # -- runtime behaviour ---------------------------------------------------------

--- a/tests/e2e/test_sandbox_persistence.py
+++ b/tests/e2e/test_sandbox_persistence.py
@@ -268,6 +268,16 @@ async def test_resume_integrity_path_home_pwd(
     )
     await backend.destroy(h1)
 
+    if flatten:
+        # The flattened image's baked CMD is the keepalive set by ``_flatten``'s
+        # ``--change`` — assert docker's actual ``--change`` parse produced the
+        # absolute-path form (#925/#938), not just that we emitted the string.
+        rc, out, err = await _docker(["image", "inspect", "--format", "{{json .Config.Cmd}}", tag])
+        assert rc == 0, err
+        assert out.strip() == '["/usr/bin/tail","-f","/dev/null"]', (
+            f"flattened image CMD not the absolute-path keepalive: {out.strip()!r}"
+        )
+
     h2 = await backend.create(
         _spec(
             instance_id=instance_id, session_id=session_id, workspace=workspace, snapshot_image=tag

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -277,8 +277,9 @@ class TestFlattenConfigRestore:
         self, fake_docker: _FakeDocker
     ) -> None:
         """Import strips all config; flatten restores WORKDIR/HOME/CMD and
-        re-stamps labels, but deliberately NOT PATH (Docker injects a default,
-        which keeps the restored CMD execable). §5.2."""
+        re-stamps labels, but deliberately NOT PATH. The restored CMD invokes
+        ``tail`` by absolute path (``/usr/bin/tail``), so it no longer depends
+        on PATH resolution at all. §5.2."""
         fake_docker.container_labels = {
             "aios.base_image": "ghcr.io/eumemic/aios-sandbox:latest",
             "aios.session_id": "sess_x",

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -294,7 +294,7 @@ class TestFlattenConfigRestore:
         joined = " ".join(consumer)
         assert "WORKDIR /workspace" in joined
         assert "ENV HOME=/home/aios" in joined
-        assert 'CMD ["tail","-f","/dev/null"]' in joined
+        assert 'CMD ["/usr/bin/tail","-f","/dev/null"]' in joined
         assert "aios.flattened=true" in joined
         assert "aios.base_image=ghcr.io/eumemic/aios-sandbox:latest" in joined
         # PATH is NOT restored.


### PR DESCRIPTION
Closes #938

## Problem

The sandbox keepalive was `CMD ["tail", "-f", "/dev/null"]` — bare `tail`, resolved at OCI container init via PATH. The #925 outage showed that a missing or empty PATH causes this to fail with an opaque `exec: "tail": executable file not found` before the container is running, producing an init crashloop that is invisible from inside the container and very hard to diagnose.

The `_flatten` export/import path in `DockerBackend` deliberately does not restore PATH (Docker injects its own default PATH for normal image builds, but the flatten path bypasses that). This makes the keepalive especially fragile to any PATH regression on that path.

## Fix

Replace the bare binary with its absolute path: `CMD ["/usr/bin/tail", "-f", "/dev/null"]`. The keepalive no longer depends on PATH resolution at container init. A PATH regression now degrades gracefully — the container starts, and any subsequent tool failure is diagnosable from inside rather than an opaque crashloop.

`/usr/bin/tail` is correct for the base image (`python:3.13-slim-bookworm`, Debian usrmerge), where coreutils lives under `/usr/bin`. The e2e image contract test already pins `tail` as a required binary; a new assertion locks the absolute path as well.

## What changed

- `src/aios/sandbox/backends/docker.py` — `_flatten` now emits `CMD ["/usr/bin/tail","-f","/dev/null"]`; docstring updated to reflect that the absolute path removes the PATH dependency entirely
- `docker/Dockerfile.sandbox` — CMD updated to absolute path; comments explain the PATH-regression defense and reference #925
- `tests/unit/sandbox/test_snapshot_verb.py` — flatten assertion updated to expect the absolute-path CMD (this is the merge gate)
- `tests/e2e/test_sandbox_image_contract.py` — new `test_tail_at_absolute_path` contract test asserts `/usr/bin/tail` is executable at that exact path, so a future base-image swap that relocates tail is caught in CI rather than at container init

## Testing

Unit sandbox suite, mypy, and ruff all green. Mutation check confirmed the unit assertion fails when the production CMD is reverted to bare `tail` and passes when fixed. The new e2e contract test ensures any future base-image change that relocates `tail` is caught before it reaches a running container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
