### PR TITLE
fix(workflows): match http_servers by identity in authoring gate

### DIFF
--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -360,9 +360,12 @@ def attenuate(
     """The lattice meet: ``declared`` clamped to never exceed ``launcher``.
 
     Per identity key in ``declared``: absent from ``launcher`` → drop; present → the
-    per-dimension meet, dropping if it bottoms out. Servers survive only on an exact
-    key match and are emitted **launcher-verbatim** (parent-wins-frozen: routes and
-    headers come from the launcher; the child narrows only by dropping whole servers).
+    per-dimension meet, dropping if it bottoms out. Servers survive only on a key match
+    and are emitted **launcher-verbatim** (parent-wins-frozen: routes and headers come
+    from the launcher; the child narrows only by dropping whole servers). http servers
+    survive on a ``base_url`` key and are emitted launcher-verbatim — the child's declared
+    routes are inert here, consistent with the authoring gate, which now admits http
+    servers by identity (``(name, base_url)``) and inherits the launcher's frozen routes.
     MCP servers key on the joint ``(name, url)`` — a re-pointed name is a different key
     and drops. Output is canonical (``attenuate(d, l)`` is a fixpoint of ``canonicalize``).
     """
@@ -410,6 +413,12 @@ def surface_diff(expected: Surface, actual: Surface) -> dict[str, list[str]]:
     ``expected`` is ``canonicalize(declared)``; ``actual`` is ``attenuate(declared,
     launcher)``. Used to build the author-edge ``ForbiddenError`` detail — names the
     exact tools/servers the declared surface exceeded the actor on.
+
+    Tools and mcp_servers are full-equality keyed checks (the value must match, not just
+    the key) — a widened per-tool policy or a re-pointed server is flagged. http_servers
+    are identity-keyed on ``(name, base_url)`` (membership only): a server is flagged iff
+    its identity is absent from ``actual``, never for a route/field divergence — the
+    authoring gate inherits the launcher's frozen routes, so identity is the whole test.
     """
     out: dict[str, list[str]] = {}
 
@@ -427,8 +436,8 @@ def surface_diff(expected: Surface, actual: Surface) -> dict[str, list[str]]:
     if bad_mcp:
         out["mcp_servers"] = bad_mcp
 
-    actual_http = {s.base_url: s for s in actual.http_servers}
-    bad_http = [s.name for s in expected.http_servers if actual_http.get(s.base_url) != s]
+    actual_ids = {(s.name, s.base_url) for s in actual.http_servers}
+    bad_http = [s.name for s in expected.http_servers if (s.name, s.base_url) not in actual_ids]
     if bad_http:
         out["http_servers"] = bad_http
 

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -63,17 +63,25 @@ async def _enforce_surface_attenuation(
     tools: list[ToolSpec],
     mcp_servers: list[McpServerSpec],
     http_servers: list[HttpServerSpec],
-) -> None:
-    """Raise ``ForbiddenError`` unless the declared surface is a fixpoint of the meet
-    against the acting agent's surface — i.e. it grants nothing the agent lacks.
+) -> Surface:
+    """Raise ``ForbiddenError`` unless the declared surface is admissible against the acting
+    agent's; return the effective (clamped) surface for storage.
 
     Serves both create (the creator's declared surface) and update (the editor's merged
-    final surface). The predicate is ``attenuate(declared, actor) ==
-    canonicalize(declared)``: equal iff the meet did not have to narrow anything, which
-    is exactly "``declared`` ≤ ``actor``" on every axis — membership *and* per-tool
-    permission/transport, MCP server identity (joint name+url), and http routes (which
-    are parent-wins-frozen, so the agent's must be declared verbatim; R1). The HTTP path
-    passes no actor and skips this — operator authority.
+    final surface). The predicate is per-dimension:
+
+    * tools / mcp_servers — byte-equality of ``clamp(declared, actor)`` against
+      ``canonicalize(declared)``: equal iff the meet did not narrow anything, which is
+      exactly "``declared`` ≤ ``actor``" on membership *and* per-tool permission/transport
+      and MCP server identity (joint name+url).
+    * http_servers — identity survival: every declared ``(name, base_url)`` must appear in
+      the clamp's http servers. The agent's routes/fields are inherited launcher-frozen
+      into storage (the returned ``effective``), so a workflow need only name the server,
+      not reproduce its routes byte-perfect.
+
+    http servers remain parent-wins-frozen at run-time (run-launch clamps to
+    launcher-verbatim) — only the AUTHORING gate relaxes to identity, which grants no new
+    run-time authority. The HTTP/operator path passes no actor and skips this entirely.
     """
     session = await sessions_service.get_session_basic(
         pool, actor_session_id, account_id=account_id
@@ -82,11 +90,18 @@ async def _enforce_surface_attenuation(
     declared = Surface(tools, mcp_servers, http_servers)
     expected = attenuation_service.normalize(declared)
     effective = attenuation_service.clamp(declared, surface_of(agent))
-    if effective != expected:
+    surviving_http = {(s.name, s.base_url) for s in effective.http_servers}
+    exceeds = (
+        effective.tools != expected.tools
+        or effective.mcp_servers != expected.mcp_servers
+        or any((s.name, s.base_url) not in surviving_http for s in expected.http_servers)
+    )
+    if exceeds:
         raise ForbiddenError(
             "workflow surface exceeds the acting agent's permissions",
             detail={"exceeds": surface_diff(expected, effective)},
         )
+    return effective
 
 
 async def create_workflow(
@@ -108,11 +123,14 @@ async def create_workflow(
     **Create-time attenuation:** when ``creator_session_id`` is set (an agent authoring
     the workflow), the declared surface (``tools``/``mcp_servers``/``http_servers``) must
     be a subset of the creating agent's own — an agent cannot grant a workflow a tool or
-    server it does not itself have; a breach raises :class:`ForbiddenError`. With no
-    creator (the HTTP/operator path) any surface may be declared, account-scoped.
+    server it does not itself have; a breach raises :class:`ForbiddenError`. http servers
+    are admitted by identity (name + base_url) and their routes inherited launcher-frozen
+    into storage. With no creator (the HTTP/operator path) any surface may be declared
+    verbatim, account-scoped.
     """
+    effective: Surface | None = None
     if creator_session_id is not None:
-        await _enforce_surface_attenuation(
+        effective = await _enforce_surface_attenuation(
             pool,
             account_id=account_id,
             actor_session_id=creator_session_id,
@@ -120,6 +138,9 @@ async def create_workflow(
             mcp_servers=mcp_servers or [],
             http_servers=http_servers or [],
         )
+    # Agent-authored: store the agent's launcher-frozen http routes (inherited by identity).
+    # Operator path: store the declared http servers verbatim.
+    http_to_store = effective.http_servers if effective is not None else http_servers
     async with pool.acquire() as conn:
         return await wf_queries.insert_workflow(
             conn,
@@ -131,7 +152,7 @@ async def create_workflow(
             description=description,
             tools=tools,
             mcp_servers=mcp_servers,
-            http_servers=http_servers,
+            http_servers=http_to_store,
         )
 
 
@@ -162,7 +183,11 @@ async def update_workflow(
 
     In-flight runs are unaffected: a run snapshots ``script`` + the declared surface at
     launch; only runs created after the update see the new definition.
+
+    http servers are admitted by identity and their routes inherited launcher-frozen into
+    storage (mirroring create); the operator path stores declared http verbatim.
     """
+    effective: Surface | None = None
     if actor_session_id is not None:
         current = await get_workflow(pool, workflow_id, account_id=account_id)
         if current.version != expected_version:
@@ -180,7 +205,7 @@ async def update_workflow(
                     "id": workflow_id,
                 },
             )
-        await _enforce_surface_attenuation(
+        effective = await _enforce_surface_attenuation(
             pool,
             account_id=account_id,
             actor_session_id=actor_session_id,
@@ -188,6 +213,14 @@ async def update_workflow(
             mcp_servers=mcp_servers if mcp_servers is not None else current.mcp_servers,
             http_servers=http_servers if http_servers is not None else current.http_servers,
         )
+    # Agent-actor touching http: store the inherited launcher-frozen routes. Operator path,
+    # or an edit that didn't touch http (``http_servers is None`` → query preserves current):
+    # pass the original argument through unchanged.
+    http_to_store = (
+        effective.http_servers
+        if (effective is not None and http_servers is not None)
+        else http_servers
+    )
     async with pool.acquire() as conn:
         return await wf_queries.update_workflow(
             conn,
@@ -201,7 +234,7 @@ async def update_workflow(
             description=description,
             tools=tools,
             mcp_servers=mcp_servers,
-            http_servers=http_servers,
+            http_servers=http_to_store,
         )
 
 

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -32,7 +32,14 @@ from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, ForbiddenError, NotFoundError, RateLimitedError
 from aios.harness import runtime
 from aios.mcp.client import resolve_auth_for_target_url_run
-from aios.models.agents import Agent, HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.agents import (
+    Agent,
+    HttpPermissionPolicy,
+    HttpRouteSpec,
+    HttpServerSpec,
+    McpServerSpec,
+    ToolSpec,
+)
 from aios.models.attenuation import surface_of
 from aios.models.vaults import VaultCredentialCreate
 from aios.services import agents as agents_service
@@ -346,6 +353,151 @@ async def test_declared_surface_round_trips(vault_pool: asyncpg.Pool[Any]) -> No
     fetched = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
     assert [m.url for m in fetched.mcp_servers] == ["https://s.example"]
     assert [h.base_url for h in fetched.http_servers] == ["https://h.example"]
+
+
+# ─── #939: http_servers admitted by identity, inherited launcher-frozen ──────
+#
+# The authoring gate matches http_servers on identity (name + base_url) like tools/mcp,
+# and INHERITS the agent's frozen routes into workflow storage — so a workflow declaring
+# the right server but partial/empty routes is admitted and stored with the agent's full
+# routes. Membership still gates: a server the agent lacks is still forbidden. Run-time
+# stays parent-wins-frozen (run-launch clamps to launcher-verbatim), so relaxing the
+# AUTHORING gate grants no new run-time authority.
+
+
+async def test_create_time_http_identity_inherits_frozen_routes(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Create-time: a workflow declaring the agent's http server by identity (partial/empty
+    routes) is admitted, and stores the agent's full routes launcher-frozen."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(
+        name="api",
+        base_url="https://api",
+        routes=[
+            HttpRouteSpec(
+                path_pattern="/v1/**",
+                permission_policy=HttpPermissionPolicy(type="always_ask"),
+            )
+        ],
+    )
+    agent = await _make_agent(pool, "http-creator", http_servers=[agent_http])
+    creator = await _make_session(pool, agent)
+
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-http-ct",
+        script=_SCRIPT,
+        http_servers=[HttpServerSpec(name="api", base_url="https://api", routes=[])],
+        creator_session_id=creator,
+    )
+    fetched = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    # Routes inherited launcher-frozen — equals the agent's full spec, NOT the declared
+    # empty-routes one.
+    assert fetched.http_servers == [agent_http]
+
+
+async def test_create_time_http_missing_server_still_forbidden(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Create-time: a server the agent lacks (different identity) is still forbidden — the
+    identity relaxation is membership-keyed, not a blanket admit. No workflow row leaks."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(name="api", base_url="https://api")
+    agent = await _make_agent(pool, "http-creator-2", http_servers=[agent_http])
+    creator = await _make_session(pool, agent)
+
+    before = await _workflow_count(pool)
+    with pytest.raises(ForbiddenError, match=r"exceeds the acting agent's permissions") as ei:
+        await wf_service.create_workflow(
+            pool,
+            account_id=ACC,
+            name="w-http-missing",
+            script=_SCRIPT,
+            http_servers=[HttpServerSpec(name="other", base_url="https://other")],
+            creator_session_id=creator,
+        )
+    assert ei.value.detail["exceeds"]["http_servers"] == ["other"]
+    assert await _workflow_count(pool) == before
+
+
+async def test_update_time_http_identity_inherits_frozen_routes(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Update-time: an actor re-declaring the agent's http server by identity (empty routes)
+    is admitted and the stored routes stay the agent's full, launcher-frozen spec."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(
+        name="api",
+        base_url="https://api",
+        routes=[
+            HttpRouteSpec(
+                path_pattern="/v1/**",
+                permission_policy=HttpPermissionPolicy(type="always_ask"),
+            )
+        ],
+    )
+    agent = await _make_agent(pool, "http-updater", http_servers=[agent_http])
+    actor = await _make_session(pool, agent)
+    # Operator-create a workflow storing the server with EMPTY routes verbatim (operator
+    # path), version 1 — so the actor's inherited-frozen update is a genuine change.
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-http-up",
+        script=_SCRIPT,
+        http_servers=[HttpServerSpec(name="api", base_url="https://api", routes=[])],
+    )
+    assert wf.http_servers == [HttpServerSpec(name="api", base_url="https://api", routes=[])]
+
+    updated = await wf_service.update_workflow(
+        pool,
+        wf.id,
+        account_id=ACC,
+        expected_version=1,
+        http_servers=[HttpServerSpec(name="api", base_url="https://api", routes=[])],
+        actor_session_id=actor,
+    )
+    assert updated.version == 2
+    fetched = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    # The actor declared empty routes but the agent's full routes are inherited frozen.
+    assert fetched.http_servers == [agent_http]
+
+
+async def test_update_time_http_missing_server_still_forbidden(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Update-time: re-pointing to a server the agent lacks is still forbidden; the workflow
+    stays at version 1 (no write)."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(
+        name="api",
+        base_url="https://api",
+        routes=[
+            HttpRouteSpec(
+                path_pattern="/v1/**",
+                permission_policy=HttpPermissionPolicy(type="always_ask"),
+            )
+        ],
+    )
+    agent = await _make_agent(pool, "http-updater-2", http_servers=[agent_http])
+    actor = await _make_session(pool, agent)
+    wf = await wf_service.create_workflow(
+        pool, account_id=ACC, name="w-http-ghost", script=_SCRIPT, http_servers=[agent_http]
+    )
+
+    with pytest.raises(ForbiddenError, match=r"exceeds the acting agent's permissions"):
+        await wf_service.update_workflow(
+            pool,
+            wf.id,
+            account_id=ACC,
+            expected_version=1,
+            http_servers=[HttpServerSpec(name="ghost", base_url="https://ghost")],
+            actor_session_id=actor,
+        )
+    fetched = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    assert fetched.version == 1
 
 
 async def test_run_cannot_bind_foreign_or_missing_vault(vault_pool: asyncpg.Pool[Any]) -> None:

--- a/tests/unit/test_attenuation.py
+++ b/tests/unit/test_attenuation.py
@@ -183,6 +183,49 @@ class TestServerSurvival:
         assert out.http_servers == []
 
 
+class TestSurfaceDiffHttpIdentity:
+    """#939: ``surface_diff``'s http section is keyed on identity ``(name, base_url)``,
+    not full-spec equality — so a route/field divergence on an identically-identified
+    server is NOT flagged (the authoring gate inherits the launcher's frozen routes).
+    Contrast tools/mcp, which stay full-equality keyed checks.
+    """
+
+    def test_surface_diff_http_ignores_route_divergence_when_identity_matches(self) -> None:
+        expected = canon(
+            Surface(
+                [],
+                [],
+                [
+                    HttpServerSpec(
+                        name="api",
+                        base_url="https://api",
+                        routes=[
+                            HttpRouteSpec(
+                                path_pattern="/v1/**",
+                                permission_policy=HttpPermissionPolicy(type="always_ask"),
+                            )
+                        ],
+                    )
+                ],
+            )
+        )
+        # Same (name, base_url) identity, but routes diverge (here: empty).
+        actual = canon(
+            Surface([], [], [HttpServerSpec(name="api", base_url="https://api", routes=[])])
+        )
+        assert surface_diff(expected, actual) == {}
+
+    def test_surface_diff_http_flags_absent_base_url(self) -> None:
+        expected = canon(Surface([], [], [HttpServerSpec(name="api", base_url="https://api")]))
+        actual = canon(Surface([], [], []))
+        assert surface_diff(expected, actual) == {"http_servers": ["api"]}
+
+    def test_surface_diff_http_flags_renamed_server_same_base_url(self) -> None:
+        expected = canon(Surface([], [], [HttpServerSpec(name="api", base_url="https://api")]))
+        actual = canon(Surface([], [], [HttpServerSpec(name="api2", base_url="https://api")]))
+        assert surface_diff(expected, actual) == {"http_servers": ["api"]}
+
+
 # ── MCP toolset normal form ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

Workflow authors who held an `http_server` grant via their agent couldn't create workflows that used that server. The authoring permission gate in `_enforce_surface_attenuation` compared declared `http_servers` using whole-object structural equality — requiring every field (routes list, each route's `path_pattern`, `description`, `enabled`, `permission_policy`, `base_url` normalisation) to match byte-perfect. Any field divergence caused the whole server to be rejected.

The error payload named the offending server but not the diverging field, so the author had no way to converge. Ironically, calling `http_request(server_ref='davenant')` directly worked fine — tools match by identity. `http_servers` were the odd one out.

Closes eumemic/eumemic-ops#301

## Fix

**`src/aios/models/attenuation.py` — `surface_diff`**

The `http_servers` branch now keys on `(name, base_url)` identity membership instead of full-object equality. The `exceeds.http_servers` list now names only servers the agent genuinely lacks (or a server renamed at the same `base_url`), not false-positives from route-field divergence. This makes Ask 2 (field-level diff) moot — the error only fires on true identity failures.

`tools` and `mcp_servers` comparisons are unchanged.

**`src/aios/services/workflows.py` — `_enforce_surface_attenuation`**

Switched from whole-surface equality (`effective != expected`) to a per-dimension predicate: tools and `mcp_servers` keep byte-equality; `http_servers` require identity survival — every declared `(name, base_url)` must appear in the clamped effective surface. The function now returns the clamped `effective` Surface.

**`create_workflow` / `update_workflow`**

On the agent-actor path, `effective.http_servers` (the launcher-frozen, verbatim routes from the agent) are persisted in place of the workflow's declared entries. The declared `http_server` entries act as identity references; the stored spec is the agent's frozen one (routes inherited). The operator/HTTP path (no session) is unchanged — declared specs stored verbatim. `update_workflow` only rewrites stored `http_servers` when the caller explicitly passed `http_servers`; passing `None` preserves the current stored spec.

Docstrings in `_enforce_surface_attenuation` and `attenuate` updated to reflect the new semantics: "declared by identity (name + base_url); routes/fields inherited launcher-frozen".

## Why this is safe

`http_servers` remain parent-wins-frozen at run-time. Run launch already clamps the snapshot against the launching agent and stores the effective (launcher-verbatim) specs. Run-time `server_ref` resolution matches by name. Relaxing the **authoring** gate to identity-match grants no new run-time authority — a workflow can still only ever exercise routes the launching agent actually holds.

Out of scope: Ask 3 (names-only `http_servers: ["davenant"]` API sugar) — a follow-up will be filed if still wanted.

## Testing

- **Unit** (`tests/unit/test_attenuation.py`, new `TestSurfaceDiffHttpIdentity`): `surface_diff` does not flag an `http_server` whose `(name, base_url)` matches but whose routes/`permission_policy`/`enabled` diverge; still flags a server absent from actual; flags a renamed server at the same `base_url`. 64/64 pass.
- **Integration** (`tests/integration/test_wf_run_vaults.py`): `create_workflow` and `update_workflow` with an `http_server` matching the agent by `(name, base_url)` but with partial/divergent routes now succeed, and the stored workflow's `http_servers` equal the agent's frozen spec (routes inherited); naming a server the agent lacks still raises `ForbiddenError` with `exceeds.http_servers` naming it; existing run-launch snapshot and creator-lacks-server regression tests stay green. 26/26 pass.
- mypy clean, ruff check + format clean. No OpenAPI/SDK codegen drift (internal service/model logic only).
- **Mutation check**: reverting the `surface_diff` http branch to old structural-equality makes the identity-match test fail; restoring makes it pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
