### PR TITLE
feat(sandbox): wire SecretEgressProxy into provisioning + recycle-on-rotation

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -4224,6 +4224,27 @@ class EnvVarCredentialEcho(NamedTuple):
     updated_at: datetime
 
 
+# Shared FROM/WHERE/ORDER-BY body for the two session env-var credential
+# queries below. The account-scoping (``sv.account_id``/``vc.account_id =
+# $2``), archival (``archived_at IS NULL``), DISTINCT-ON-rank predicate and
+# first-vault-wins ordering live here ONCE so the provision-set
+# (:func:`list_session_env_var_credentials`) and the per-step drift echo-set
+# (:func:`list_session_env_var_credential_echoes`) can NEVER silently diverge:
+# a future account-scoping or security fix to this body applies to both. The
+# two queries differ ONLY in their SELECT columns (and return type). ``$1`` is
+# the session id, ``$2`` the account id.
+_SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE = """
+          FROM session_vaults sv
+          JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
+         WHERE sv.session_id = $1
+           AND vc.auth_type = 'environment_variable'
+           AND vc.archived_at IS NULL
+           AND sv.account_id = $2
+           AND vc.account_id = $2
+         ORDER BY vc.secret_name, sv.rank
+""".strip()
+
+
 async def list_session_env_var_credentials(
     conn: asyncpg.Connection[Any],
     session_id: str,
@@ -4240,20 +4261,17 @@ async def list_session_env_var_credentials(
     Rank uniqueness per session is an ``enumerate()`` artifact of
     ``set_session_vaults``, the same invariant ``resolve_session_credential``
     already leans on.
+
+    Shares its account-scoped FROM/WHERE/ORDER-BY body with
+    :func:`list_session_env_var_credential_echoes` via
+    ``_SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE`` so the two sets can't diverge.
     """
     rows = await conn.fetch(
-        """
+        f"""
         SELECT DISTINCT ON (vc.secret_name)
                vc.id, vc.secret_name, vc.allowed_hosts,
                vc.ciphertext, vc.nonce, vc.updated_at
-          FROM session_vaults sv
-          JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
-         WHERE sv.session_id = $1
-           AND vc.auth_type = 'environment_variable'
-           AND vc.archived_at IS NULL
-           AND sv.account_id = $2
-           AND vc.account_id = $2
-         ORDER BY vc.secret_name, sv.rank
+        {_SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE}
         """,
         session_id,
         account_id,
@@ -4281,20 +4299,16 @@ async def list_session_env_var_credential_echoes(
     Selects ONLY ``(id, updated_at)`` — never the ciphertext — under the SAME
     ``DISTINCT ON (secret_name)`` / ``archived_at IS NULL`` / rank-order filter
     as :func:`list_session_env_var_credentials`, so the resolved set (provision)
-    and the echo set (step) have IDENTICAL membership. Mirrors
+    and the echo set (step) have IDENTICAL membership. That parity is enforced
+    structurally: both queries embed the SAME
+    ``_SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE`` body, so an account-scoping or
+    archival change touches both at once. Mirrors
     :func:`list_session_github_repo_echoes`.
     """
     rows = await conn.fetch(
-        """
+        f"""
         SELECT DISTINCT ON (vc.secret_name) vc.id, vc.updated_at
-          FROM session_vaults sv
-          JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
-         WHERE sv.session_id = $1
-           AND vc.auth_type = 'environment_variable'
-           AND vc.archived_at IS NULL
-           AND sv.account_id = $2
-           AND vc.account_id = $2
-         ORDER BY vc.secret_name, sv.rank
+        {_SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE}
         """,
         session_id,
         account_id,

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -4211,6 +4211,19 @@ class EnvVarCredentialRow(NamedTuple):
     updated_at: datetime
 
 
+class EnvVarCredentialEcho(NamedTuple):
+    """Metadata-only drift echo for a session's env-var credentials (#877).
+
+    The per-step recycle-on-rotation probe needs ONLY the (id, updated_at)
+    set membership — never the ciphertext. INTERNAL type (not a pydantic
+    model, never on Session.resources or any API response), so the FastAPI
+    surface is unchanged.
+    """
+
+    credential_id: str
+    updated_at: datetime
+
+
 async def list_session_env_var_credentials(
     conn: asyncpg.Connection[Any],
     session_id: str,
@@ -4253,6 +4266,41 @@ async def list_session_env_var_credentials(
             blob=EncryptedBlob(ciphertext=bytes(row["ciphertext"]), nonce=bytes(row["nonce"])),
             updated_at=row["updated_at"],
         )
+        for row in rows
+    ]
+
+
+async def list_session_env_var_credential_echoes(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+) -> list[EnvVarCredentialEcho]:
+    """Metadata-only env-var credential echoes for the per-step drift probe (#877).
+
+    Selects ONLY ``(id, updated_at)`` — never the ciphertext — under the SAME
+    ``DISTINCT ON (secret_name)`` / ``archived_at IS NULL`` / rank-order filter
+    as :func:`list_session_env_var_credentials`, so the resolved set (provision)
+    and the echo set (step) have IDENTICAL membership. Mirrors
+    :func:`list_session_github_repo_echoes`.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT DISTINCT ON (vc.secret_name) vc.id, vc.updated_at
+          FROM session_vaults sv
+          JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
+         WHERE sv.session_id = $1
+           AND vc.auth_type = 'environment_variable'
+           AND vc.archived_at IS NULL
+           AND sv.account_id = $2
+           AND vc.account_id = $2
+         ORDER BY vc.secret_name, sv.rank
+        """,
+        session_id,
+        account_id,
+    )
+    return [
+        EnvVarCredentialEcho(credential_id=str(row["id"]), updated_at=row["updated_at"])
         for row in rows
     ]
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -127,8 +127,10 @@ async def refresh_session_mount_state(
     """Refresh the cached resource echoes and the sandbox drift check.
 
     Returns the memory echoes (used downstream for prompt augmentation).
-    Github echoes are cached and fed into the registry's drift check but
-    not returned — no current caller in the step body needs them.
+    Github echoes and env-var credential echoes are fed into the registry's
+    drift check but not returned — no current caller in the step body needs
+    them. The env-var echoes carry ``updated_at`` so a credential rotation
+    recycles the sandbox (#877), exactly like github token rotation.
     """
     from aios.db import queries
 
@@ -139,10 +141,13 @@ async def refresh_session_mount_state(
         github_echoes = await queries.list_session_github_repo_echoes(
             conn, session_id, account_id=account_id
         )
+        env_var_echoes = await queries.list_session_env_var_credential_echoes(
+            conn, session_id, account_id=account_id
+        )
     runtime.set_session_memory_mounts(session_id, memory_echoes)
     if runtime.sandbox_registry is not None:
         await runtime.sandbox_registry.release_if_mounts_changed(
-            session_id, memory_echoes, github_echoes
+            session_id, memory_echoes, github_echoes, env_var_echoes
         )
     return memory_echoes
 

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -518,10 +518,29 @@ class SandboxRegistry:
             await proxy.stop()
         except Exception as err:
             log.warning(
-                f"sandbox.{kind}_stop_failed",
+                "sandbox.proxy_stop_failed",
+                kind=kind,
                 session_id=session_id,
                 error=str(err),
             )
+
+    def _spawn_evict_proxy_stop(
+        self, proxy: GitProxy | SecretEgressProxy, session_id: str, *, kind: str
+    ) -> None:
+        """Fire-and-forget stop of an evicted proxy, holding a strong ref.
+
+        ``evict`` is on a retry path and can't block on ``stop()``'s up-to-5s
+        graceful drain, so the stop runs as a detached task. asyncio only
+        weak-refs tasks, so the task is parked in ``_evict_proxy_stop_tasks``
+        (cleared via a done-callback) to keep it alive until ``stop()`` unwinds
+        the proxy's uvicorn server, httpx client and bound TCP port.
+        """
+        task = asyncio.create_task(
+            self._stop_proxy_silently(proxy, session_id, kind=kind),
+            name=f"sandbox-evict-{kind}-stop:{session_id}",
+        )
+        self._evict_proxy_stop_tasks.add(task)
+        task.add_done_callback(self._evict_proxy_stop_tasks.discard)
 
     def _release_tool_broker_secret(self, session_id: str) -> None:
         """Drop the per-session entry from the tool broker's secret map.
@@ -983,22 +1002,12 @@ class SandboxRegistry:
         # from the next provision pass. Both stops are fire-and-forget
         # (the caller is on a retry path) and share the strong-ref set so
         # neither task is GC'd before stop() unwinds its server/port.
-        proxy = self._git_proxies.pop(session_id, None)
-        if proxy is not None:
-            task = asyncio.create_task(
-                self._stop_proxy_silently(proxy, session_id, kind="git_proxy"),
-                name=f"sandbox-evict-proxy-stop:{session_id}",
-            )
-            self._evict_proxy_stop_tasks.add(task)
-            task.add_done_callback(self._evict_proxy_stop_tasks.discard)
+        git_proxy = self._git_proxies.pop(session_id, None)
+        if git_proxy is not None:
+            self._spawn_evict_proxy_stop(git_proxy, session_id, kind="git_proxy")
         secret_proxy = self._secret_proxies.pop(session_id, None)
         if secret_proxy is not None:
-            secret_task = asyncio.create_task(
-                self._stop_proxy_silently(secret_proxy, session_id, kind="secret_proxy"),
-                name=f"sandbox-evict-secret-proxy-stop:{session_id}",
-            )
-            self._evict_proxy_stop_tasks.add(secret_task)
-            secret_task.add_done_callback(self._evict_proxy_stop_tasks.discard)
+            self._spawn_evict_proxy_stop(secret_proxy, session_id, kind="secret_proxy")
         # Same story for the tool broker secret: drop it immediately; a
         # fresh sandbox will get a fresh secret from the next provision.
         self._release_tool_broker_secret(session_id)

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -446,10 +446,10 @@ class SandboxRegistry:
             # Drop all so their ports + token/secret maps don't leak.
             self._git_proxies.pop(session_id, None)
             if plan.git_proxy is not None:
-                await self._stop_proxy_silently(plan.git_proxy, session_id)
+                await self._stop_proxy_silently(plan.git_proxy, session_id, kind="git_proxy")
             self._secret_proxies.pop(session_id, None)
             if plan.secret_proxy is not None:
-                await self._stop_proxy_silently(plan.secret_proxy, session_id)
+                await self._stop_proxy_silently(plan.secret_proxy, session_id, kind="secret_proxy")
             self._release_tool_broker_secret(session_id)
             raise
 
@@ -504,19 +504,21 @@ class SandboxRegistry:
         )
 
     async def _stop_proxy_silently(
-        self, proxy: GitProxy | SecretEgressProxy, session_id: str
+        self, proxy: GitProxy | SecretEgressProxy, session_id: str, *, kind: str
     ) -> None:
         """Stop ``proxy``, log + swallow any error.
 
         Used by every cleanup path; a stuck proxy must never block
         sandbox teardown or propagate a secondary exception over a
-        primary one.
+        primary one. ``kind`` (``"git_proxy"`` / ``"secret_proxy"``)
+        names the proxy type in the failure log so a secret-egress stop
+        failure isn't mis-attributed to the git proxy in logs/alerts.
         """
         try:
             await proxy.stop()
         except Exception as err:
             log.warning(
-                "sandbox.git_proxy_stop_failed",
+                f"sandbox.{kind}_stop_failed",
                 session_id=session_id,
                 error=str(err),
             )
@@ -570,10 +572,10 @@ class SandboxRegistry:
             )
         proxy = self._git_proxies.pop(session_id, None)
         if proxy is not None:
-            await self._stop_proxy_silently(proxy, session_id)
+            await self._stop_proxy_silently(proxy, session_id, kind="git_proxy")
         secret_proxy = self._secret_proxies.pop(session_id, None)
         if secret_proxy is not None:
-            await self._stop_proxy_silently(secret_proxy, session_id)
+            await self._stop_proxy_silently(secret_proxy, session_id, kind="secret_proxy")
         self._release_tool_broker_secret(session_id)
 
     # ── durable-session-sandbox lifecycle helpers (§5.2-§5.4) ───────────────
@@ -880,9 +882,9 @@ class SandboxRegistry:
         secret_proxy = self._secret_proxies.pop(session_id, None)
 
         if proxy is not None:
-            await self._stop_proxy_silently(proxy, session_id)
+            await self._stop_proxy_silently(proxy, session_id, kind="git_proxy")
         if secret_proxy is not None:
-            await self._stop_proxy_silently(secret_proxy, session_id)
+            await self._stop_proxy_silently(secret_proxy, session_id, kind="secret_proxy")
         self._release_tool_broker_secret(session_id)
         runtime.clear_session_memory_mounts(session_id)
         runtime.clear_session_read_shas(session_id)
@@ -984,7 +986,7 @@ class SandboxRegistry:
         proxy = self._git_proxies.pop(session_id, None)
         if proxy is not None:
             task = asyncio.create_task(
-                self._stop_proxy_silently(proxy, session_id),
+                self._stop_proxy_silently(proxy, session_id, kind="git_proxy"),
                 name=f"sandbox-evict-proxy-stop:{session_id}",
             )
             self._evict_proxy_stop_tasks.add(task)
@@ -992,7 +994,7 @@ class SandboxRegistry:
         secret_proxy = self._secret_proxies.pop(session_id, None)
         if secret_proxy is not None:
             secret_task = asyncio.create_task(
-                self._stop_proxy_silently(secret_proxy, session_id),
+                self._stop_proxy_silently(secret_proxy, session_id, kind="secret_proxy"),
                 name=f"sandbox-evict-secret-proxy-stop:{session_id}",
             )
             self._evict_proxy_stop_tasks.add(secret_task)
@@ -1044,6 +1046,18 @@ class SandboxRegistry:
             for _p, result in zip(all_proxies, proxy_results, strict=True):
                 if isinstance(result, BaseException):
                     log.warning("sandbox.stop_all_proxy_error", error=str(result))
+
+        # Drain any evict-triggered fire-and-forget proxy-stop tasks still in
+        # flight: evict() pops the proxy out of ``_git_proxies`` /
+        # ``_secret_proxies`` (so the gather above can't see it) and stops it in
+        # the background. Without awaiting them here, shutdown would abandon an
+        # in-progress teardown, leaking the proxy's server/port past worker
+        # exit. Snapshot first — each task removes itself from the set via its
+        # done-callback. These tasks already log+swallow internally, so
+        # ``return_exceptions=True`` is belt-and-suspenders.
+        evict_tasks = list(self._evict_proxy_stop_tasks)
+        if evict_tasks:
+            await asyncio.gather(*evict_tasks, return_exceptions=True)
 
         if not handles:
             return

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -72,8 +72,17 @@ from aios.sandbox.spec import (
 if TYPE_CHECKING:
     import asyncpg
 
+    from aios.db.queries import EnvVarCredentialEcho
     from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
+
+    # Type-only: a runtime top-level import would pull in ``aios.tools`` (via
+    # ``secret_egress_proxy`` → ``url_safety``), whose package ``__init__``
+    # imports ``bash`` → back into ``aios.sandbox.spec`` — a cycle. The
+    # registry only ever annotates with this type (it constructs the proxy in
+    # ``spec.build_spec_from_session`` and receives it on the plan), so a
+    # TYPE_CHECKING import is sufficient.
+    from aios.sandbox.secret_egress_proxy import SecretEgressProxy
 
 log = get_logger("aios.sandbox.registry")
 
@@ -215,6 +224,7 @@ class SandboxRegistry:
         self._store: SnapshotStore = LocalDaemonStore(backend)
         self._handles: dict[str, SandboxHandle] = {}
         self._git_proxies: dict[str, GitProxy] = {}
+        self._secret_proxies: dict[str, SecretEgressProxy] = {}
         self._last_used: dict[str, float] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._reaper_task: asyncio.Task[None] | None = None
@@ -421,20 +431,25 @@ class SandboxRegistry:
         # to None (cold start) on a detected reset.
         spec = await self._resolve_snapshot(session_id, plan.spec)
 
-        # Record the GitProxy before backend.create so a failure midway
-        # has us in a state where release() will find and stop it.
+        # Record the proxies before backend.create so a failure midway
+        # has us in a state where release() will find and stop them.
         if plan.git_proxy is not None:
             self._git_proxies[session_id] = plan.git_proxy
+        if plan.secret_proxy is not None:
+            self._secret_proxies[session_id] = plan.secret_proxy
 
         try:
             handle = await self._backend.create(spec)
         except BaseException:
-            # Spec was built (proxy may be running, broker secret is
+            # Spec was built (proxies may be running, broker secret is
             # registered) but the backend couldn't create the sandbox.
-            # Drop both so their port + token map + secret map don't leak.
+            # Drop all so their ports + token/secret maps don't leak.
             self._git_proxies.pop(session_id, None)
             if plan.git_proxy is not None:
                 await self._stop_proxy_silently(plan.git_proxy, session_id)
+            self._secret_proxies.pop(session_id, None)
+            if plan.secret_proxy is not None:
+                await self._stop_proxy_silently(plan.secret_proxy, session_id)
             self._release_tool_broker_secret(session_id)
             raise
 
@@ -478,6 +493,9 @@ class SandboxRegistry:
         ]
         if plan.git_proxy is not None:
             extra_host_ports.append((WORKER_NETWORK_ALIAS, plan.git_proxy.port))
+        # The secret-egress proxy port is intentionally NOT opened here: it is
+        # inert until #878 wires nat DNAT egress routing through it. Opening a
+        # host port with no consumer would be wrong; #878 adds it.
         await apply_network_lockdown(
             self._backend,
             handle,
@@ -485,7 +503,9 @@ class SandboxRegistry:
             extra_host_ports=extra_host_ports,
         )
 
-    async def _stop_proxy_silently(self, proxy: GitProxy, session_id: str) -> None:
+    async def _stop_proxy_silently(
+        self, proxy: GitProxy | SecretEgressProxy, session_id: str
+    ) -> None:
         """Stop ``proxy``, log + swallow any error.
 
         Used by every cleanup path; a stuck proxy must never block
@@ -551,6 +571,9 @@ class SandboxRegistry:
         proxy = self._git_proxies.pop(session_id, None)
         if proxy is not None:
             await self._stop_proxy_silently(proxy, session_id)
+        secret_proxy = self._secret_proxies.pop(session_id, None)
+        if secret_proxy is not None:
+            await self._stop_proxy_silently(secret_proxy, session_id)
         self._release_tool_broker_secret(session_id)
 
     # ── durable-session-sandbox lifecycle helpers (§5.2-§5.4) ───────────────
@@ -854,9 +877,12 @@ class SandboxRegistry:
         # eventual restart clears; the race is unacceptable.
         # ``stop_all()`` clears the whole dict at teardown.
         proxy = self._git_proxies.pop(session_id, None)
+        secret_proxy = self._secret_proxies.pop(session_id, None)
 
         if proxy is not None:
             await self._stop_proxy_silently(proxy, session_id)
+        if secret_proxy is not None:
+            await self._stop_proxy_silently(secret_proxy, session_id)
         self._release_tool_broker_secret(session_id)
         runtime.clear_session_memory_mounts(session_id)
         runtime.clear_session_read_shas(session_id)
@@ -874,6 +900,7 @@ class SandboxRegistry:
         session_id: str,
         memory_echoes: list[MemoryStoreResourceEcho],
         github_echoes: list[GithubRepositoryResourceEcho],
+        env_var_credential_echoes: list[EnvVarCredentialEcho],
     ) -> None:
         """Release the cached sandbox if its mount snapshot has drifted.
 
@@ -881,15 +908,19 @@ class SandboxRegistry:
         can't race with the release via ``get_or_provision``.
 
         Drift includes: memory store attachments added/removed, github
-        repos added/removed, github token rotated (the ``updated_at``
-        timestamp on the github echo is part of the snapshot key, see
-        :func:`mount_snapshot_from_echoes`).
+        repos added/removed, github token rotated, and env-var credentials
+        added/removed/rotated (the ``updated_at`` timestamp on the github
+        echo and the env-var echo are part of the snapshot key, see
+        :func:`mount_snapshot_from_echoes`). The secret-egress proxy is
+        stopped via the delegated ``release()`` call.
         """
         async with self._lock_for(session_id):
             handle = self._handles.get(session_id)
             if handle is None:
                 return
-            if handle.mount_snapshot == mount_snapshot_from_echoes(memory_echoes, github_echoes):
+            if handle.mount_snapshot == mount_snapshot_from_echoes(
+                memory_echoes, github_echoes, env_var_credential_echoes
+            ):
                 return
             log.info(
                 "sandbox.released_for_mount_change",
@@ -946,8 +977,10 @@ class SandboxRegistry:
         # broker secret, wedging the new sandbox.
         if self._handles.pop(session_id, None) is not None:
             log.info("sandbox.evicted", session_id=session_id)
-        # Drop the proxy too — a fresh sandbox will get a fresh proxy
-        # from the next provision pass.
+        # Drop the proxies too — a fresh sandbox will get fresh proxies
+        # from the next provision pass. Both stops are fire-and-forget
+        # (the caller is on a retry path) and share the strong-ref set so
+        # neither task is GC'd before stop() unwinds its server/port.
         proxy = self._git_proxies.pop(session_id, None)
         if proxy is not None:
             task = asyncio.create_task(
@@ -956,6 +989,14 @@ class SandboxRegistry:
             )
             self._evict_proxy_stop_tasks.add(task)
             task.add_done_callback(self._evict_proxy_stop_tasks.discard)
+        secret_proxy = self._secret_proxies.pop(session_id, None)
+        if secret_proxy is not None:
+            secret_task = asyncio.create_task(
+                self._stop_proxy_silently(secret_proxy, session_id),
+                name=f"sandbox-evict-secret-proxy-stop:{session_id}",
+            )
+            self._evict_proxy_stop_tasks.add(secret_task)
+            secret_task.add_done_callback(self._evict_proxy_stop_tasks.discard)
         # Same story for the tool broker secret: drop it immediately; a
         # fresh sandbox will get a fresh secret from the next provision.
         self._release_tool_broker_secret(session_id)
@@ -983,6 +1024,7 @@ class SandboxRegistry:
         """
         handles = list(self._handles.values())
         proxies = list(self._git_proxies.values())
+        secret_proxies = list(self._secret_proxies.values())
         # Drop the per-session tool broker secret (and its on-disk ``.secret``
         # file when UDS transport is in use) for every active session, matching
         # the cleanup path in ``release()``/``evict()``.
@@ -992,12 +1034,14 @@ class SandboxRegistry:
         self._last_used.clear()
         self._locks.clear()
         self._git_proxies.clear()
+        self._secret_proxies.clear()
 
-        if proxies:
+        all_proxies: list[GitProxy | SecretEgressProxy] = [*proxies, *secret_proxies]
+        if all_proxies:
             proxy_results = await asyncio.gather(
-                *(p.stop() for p in proxies), return_exceptions=True
+                *(p.stop() for p in all_proxies), return_exceptions=True
             )
-            for _p, result in zip(proxies, proxy_results, strict=True):
+            for _p, result in zip(all_proxies, proxy_results, strict=True):
                 if isinstance(result, BaseException):
                     log.warning("sandbox.stop_all_proxy_error", error=str(result))
 

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -425,25 +425,29 @@ class SandboxRegistry:
         await self._reconcile_pointer_from_local(session_id)
 
         plan = await build_spec_from_session(session_id)
-        # Resolve the snapshot pointer through the store: verified-negative
-        # existence, base-image drift, missing-snapshot detection. Returns the
-        # spec to run from — snapshot tag resolved to a local image, or cleared
-        # to None (cold start) on a detected reset.
-        spec = await self._resolve_snapshot(session_id, plan.spec)
-
-        # Record the proxies before backend.create so a failure midway
-        # has us in a state where release() will find and stop them.
+        # Record the proxies before anything else fallible runs: once
+        # build_spec_from_session returns, its proxies are RUNNING and the
+        # broker secret is REGISTERED, so a raise from _resolve_snapshot (below)
+        # would otherwise escape with the proxies absent from these dicts —
+        # release/evict/stop_all could never find them. Storing here keeps the
+        # whole span through backend.create leak-safe via the cleanup below.
         if plan.git_proxy is not None:
             self._git_proxies[session_id] = plan.git_proxy
         if plan.secret_proxy is not None:
             self._secret_proxies[session_id] = plan.secret_proxy
 
         try:
+            # Resolve the snapshot pointer through the store: verified-negative
+            # existence, base-image drift, missing-snapshot detection. Returns
+            # the spec to run from — snapshot tag resolved to a local image, or
+            # cleared to None (cold start) on a detected reset.
+            spec = await self._resolve_snapshot(session_id, plan.spec)
             handle = await self._backend.create(spec)
         except BaseException:
-            # Spec was built (proxies may be running, broker secret is
-            # registered) but the backend couldn't create the sandbox.
-            # Drop all so their ports + token/secret maps don't leak.
+            # Spec was built (proxies are running, broker secret is registered)
+            # but resolution or backend.create failed before the sandbox
+            # exists. Drop all so their ports + token/secret maps don't leak.
+            # No backend.destroy here — there is no sandbox yet.
             self._git_proxies.pop(session_id, None)
             if plan.git_proxy is not None:
                 await self._stop_proxy_silently(plan.git_proxy, session_id, kind="git_proxy")
@@ -1047,14 +1051,17 @@ class SandboxRegistry:
         self._git_proxies.clear()
         self._secret_proxies.clear()
 
-        all_proxies: list[GitProxy | SecretEgressProxy] = [*proxies, *secret_proxies]
-        if all_proxies:
+        kinded_proxies: list[tuple[str, GitProxy | SecretEgressProxy]] = [
+            *(("git_proxy", p) for p in proxies),
+            *(("secret_proxy", p) for p in secret_proxies),
+        ]
+        if kinded_proxies:
             proxy_results = await asyncio.gather(
-                *(p.stop() for p in all_proxies), return_exceptions=True
+                *(p.stop() for _kind, p in kinded_proxies), return_exceptions=True
             )
-            for _p, result in zip(all_proxies, proxy_results, strict=True):
+            for (kind, _p), result in zip(kinded_proxies, proxy_results, strict=True):
                 if isinstance(result, BaseException):
-                    log.warning("sandbox.stop_all_proxy_error", error=str(result))
+                    log.warning("sandbox.stop_all_proxy_error", kind=kind, error=str(result))
 
         # Drain any evict-triggered fire-and-forget proxy-stop tasks still in
         # flight: evict() pops the proxy out of ``_git_proxies`` /

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -453,10 +453,14 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     repos are attached), mints a per-session MCP-broker secret, then
     assembles the :class:`SandboxSpec` and related artifacts.
 
-    On any failure after the GitProxy is started or the broker secret
-    is registered, both are cleaned up before the exception propagates
-    so the port, token map, and secret map don't leak for the worker's
-    lifetime.
+    On any failure after the first host resource is allocated — the
+    GitProxy started by the clones step, the secret-egress proxy, or the
+    broker secret — every allocation made so far is cleaned up before the
+    exception propagates so the ports, token map, and secret map don't
+    leak for the worker's lifetime. A single ``try`` envelope spans from
+    the clones step through plan assembly so no allocation sits in an
+    unguarded window (the reserved-image gate and broker registration
+    both raise inside it).
     """
     from aios.harness import runtime
     from aios.sandbox.volumes import ensure_workspace_path, validate_workspace_path
@@ -481,61 +485,72 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     workspace_path = ensure_workspace_path(raw_path)
     env_config = await _load_environment_config(session_id, account_id=account_id)
     memory_echoes = await _materialize_memory_mounts(session_id, account_id=account_id)
+    # Resolve + decrypt env-var credentials BEFORE any host resource is
+    # allocated (#873): a corrupt blob fails hard here with nothing to
+    # clean up, so this step stays OUTSIDE the cleanup envelope below.
     env_var_credentials = await _materialize_env_var_credentials(session_id, account_id=account_id)
-    github_echoes, git_proxy = await _materialize_github_clones(session_id, account_id=account_id)
-    # Start the per-session secret-egress proxy when the session has env-var
-    # credentials (#877). Inert until #878 routes egress through it; the
-    # registry owns its lifecycle from the returned plan, mirroring git_proxy.
-    # Started AFTER the clones step so its failure-exposure window matches
-    # git_proxy's: a raise from here on is caught by the try/except below
-    # (which stops both proxies); a clones failure unwinds itself before this.
-    secret_proxy: SecretEgressProxy | None = None
-    if env_var_credentials:
-        secret_proxy = SecretEgressProxy(env_var_credentials)
-        await secret_proxy.start()
 
     tool_broker = runtime.require_tool_broker()
-    tool_broker_secret = secrets.token_urlsafe(32)
-    tool_broker.register_session(session_id, tool_broker_secret)
-    # Prefer the UDS transport when the operator configured one: it
-    # works in deployments where the worker's TCP port isn't reachable
-    # from the sandbox network (e.g. Coolify production). Otherwise
-    # fall back to the ephemeral TCP URL.
     tool_socket_host_path = settings.tool_broker_socket_path
-    if tool_socket_host_path is not None:
-        tool_broker_url = f"unix://{TOOL_BROKER_SOCKET_SANDBOX_PATH}"
-    else:
-        tool_broker_url = f"http://{WORKER_NETWORK_ALIAS}:{tool_broker.port}"
-
-    # Per-environment image override (#724): a session bound to an
-    # environment with ``image`` set provisions from that image; unset
-    # falls back to the worker-global ``settings.docker_image``. This is
-    # the only resolution point — everything downstream (backend create,
-    # the --pull decision) consumes ``spec.image`` blindly.
-    image = env_config.image if (env_config and env_config.image) else settings.docker_image
-    # Cross-tenant snapshot gate (durable session sandboxes, §5.8): this is
-    # the spec-build choke point ALL writers traverse, including direct SQL —
-    # the boundary layer of the two-layer gate (the other being the pydantic
-    # ``image`` validator). Reject any image in the reserved snapshot
-    # namespace so a tenant can't point ``env_config.image`` at another
-    # session's snapshot tag (``aios-sbx-<victim>``) and mount its root FS +
-    # baked secrets. Case-insensitive (Docker lowercases refs).
-    if image.lower().startswith(RESERVED_SANDBOX_IMAGE_PREFIX):
-        raise ValueError(
-            f"environment image {image!r} uses the reserved "
-            f"{RESERVED_SANDBOX_IMAGE_PREFIX!r} prefix (reserved for per-session "
-            "snapshot images); refusing to provision"
-        )
-    # Per-session snapshot budget (durable session sandboxes, §5.7):
-    # environment override wins; otherwise the worker-global default
-    # (4 GiB unless the operator set AIOS_SANDBOX_SNAPSHOT_BUDGET_BYTES).
-    snapshot_budget_bytes = (
-        env_config.snapshot_budget_bytes
-        if (env_config and env_config.snapshot_budget_bytes is not None)
-        else settings.sandbox_snapshot_budget_bytes
-    )
-
+    # Initialized to None before the cleanup envelope so the ``except``
+    # can reference them whether or not they were allocated when a raise
+    # fired. ``git_proxy`` is assigned by the clones step (first host
+    # allocation), ``secret_proxy`` shortly after.
+    git_proxy: GitProxy | None = None
+    secret_proxy: SecretEgressProxy | None = None
+    broker_registered = False
     try:
+        github_echoes, git_proxy = await _materialize_github_clones(
+            session_id, account_id=account_id
+        )
+        # Start the per-session secret-egress proxy when the session has
+        # env-var credentials (#877). Inert until #878 routes egress through
+        # it; the registry owns its lifecycle from the returned plan,
+        # mirroring git_proxy.
+        if env_var_credentials:
+            secret_proxy = SecretEgressProxy(env_var_credentials)
+            await secret_proxy.start()
+
+        tool_broker_secret = secrets.token_urlsafe(32)
+        tool_broker.register_session(session_id, tool_broker_secret)
+        broker_registered = True
+        # Prefer the UDS transport when the operator configured one: it
+        # works in deployments where the worker's TCP port isn't reachable
+        # from the sandbox network (e.g. Coolify production). Otherwise
+        # fall back to the ephemeral TCP URL.
+        if tool_socket_host_path is not None:
+            tool_broker_url = f"unix://{TOOL_BROKER_SOCKET_SANDBOX_PATH}"
+        else:
+            tool_broker_url = f"http://{WORKER_NETWORK_ALIAS}:{tool_broker.port}"
+
+        # Per-environment image override (#724): a session bound to an
+        # environment with ``image`` set provisions from that image; unset
+        # falls back to the worker-global ``settings.docker_image``. This is
+        # the only resolution point — everything downstream (backend create,
+        # the --pull decision) consumes ``spec.image`` blindly.
+        image = env_config.image if (env_config and env_config.image) else settings.docker_image
+        # Cross-tenant snapshot gate (durable session sandboxes, §5.8): this is
+        # the spec-build choke point ALL writers traverse, including direct SQL —
+        # the boundary layer of the two-layer gate (the other being the pydantic
+        # ``image`` validator). Reject any image in the reserved snapshot
+        # namespace so a tenant can't point ``env_config.image`` at another
+        # session's snapshot tag (``aios-sbx-<victim>``) and mount its root FS +
+        # baked secrets. Case-insensitive (Docker lowercases refs).
+        if image.lower().startswith(RESERVED_SANDBOX_IMAGE_PREFIX):
+            raise ValueError(
+                f"environment image {image!r} uses the reserved "
+                f"{RESERVED_SANDBOX_IMAGE_PREFIX!r} prefix (reserved for per-session "
+                "snapshot images); refusing to provision"
+            )
+        # Per-session snapshot budget (durable session sandboxes, §5.7):
+        # environment override wins; otherwise the worker-global default
+        # (4 GiB unless the operator set AIOS_SANDBOX_SNAPSHOT_BUDGET_BYTES).
+        snapshot_budget_bytes = (
+            env_config.snapshot_budget_bytes
+            if (env_config and env_config.snapshot_budget_bytes is not None)
+            else settings.sandbox_snapshot_budget_bytes
+        )
+
         return _assemble_plan(
             session_id=session_id,
             instance_id=settings.instance_id,
@@ -556,12 +571,14 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             secret_proxy=secret_proxy,
         )
     except BaseException:
-        # All proxies hold worker-process state (ports, token maps,
-        # secret-to-session bindings). Anything that raises before we
-        # hand back a plan must clean up everything on the way out,
-        # otherwise state leaks for the worker's lifetime.
-        tool_broker.unregister_session(session_id)
-        cleanup_session_secret_file(session_id, tool_socket_host_path)
+        # Every host resource allocated above holds worker-process state
+        # (ports, token maps, secret-to-session bindings). Anything that
+        # raises before we hand back a plan must clean up everything
+        # allocated so far on the way out, otherwise state leaks for the
+        # worker's lifetime.
+        if broker_registered:
+            tool_broker.unregister_session(session_id)
+            cleanup_session_secret_file(session_id, tool_socket_host_path)
         if git_proxy is not None:
             try:
                 await git_proxy.stop()

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -27,9 +27,8 @@ import os
 import secrets
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING
 
 from aios.config import get_settings
 from aios.db import queries
@@ -68,6 +67,14 @@ from aios.services import sessions as sessions_service
 from aios.services.vaults import ResolvedEnvVarCredential, resolve_session_env_var_credentials
 
 if TYPE_CHECKING:
+    # Type-only: the step-time drift probe folds these through
+    # ``mount_snapshot_from_echoes``. A runtime import isn't needed — the param
+    # is only used structurally (``.credential_id`` / ``.updated_at``) — so a
+    # TYPE_CHECKING import keeps the annotation honest without coupling.
+    # (``aios.db.queries`` is already imported at module level, so this is no
+    # new dependency edge regardless.)
+    from aios.db.queries import EnvVarCredentialEcho
+
     # Imported for typing only at module level: a runtime top-level import
     # would pull in ``aios.tools`` (via ``secret_egress_proxy`` →
     # ``url_safety``) whose package ``__init__`` imports ``bash``, which
@@ -167,25 +174,10 @@ class ProvisioningPlan:
     secret_proxy: SecretEgressProxy | None = None
 
 
-class _EnvVarCredentialLike(Protocol):
-    """The structural shape the env-var drift fold needs from a credential.
-
-    Provision passes :class:`ResolvedEnvVarCredential`; the per-step probe
-    passes :class:`aios.db.queries.EnvVarCredentialEcho`. Both satisfy this,
-    so :func:`mount_snapshot_from_echoes` folds them identically (constraint A).
-    """
-
-    @property
-    def credential_id(self) -> str: ...
-
-    @property
-    def updated_at(self) -> datetime: ...
-
-
 def mount_snapshot_from_echoes(
     memory_echoes: list[MemoryStoreResourceEcho] | tuple[MemoryStoreResourceEcho, ...],
     github_echoes: list[GithubRepositoryResourceEcho] | tuple[GithubRepositoryResourceEcho, ...],
-    env_var_credentials: Sequence[_EnvVarCredentialLike] = (),
+    env_var_credentials: Sequence[ResolvedEnvVarCredential | EnvVarCredentialEcho] = (),
 ) -> frozenset[tuple[str, ...]]:
     """The set of inputs that determines the spec's mount/credential surface.
 
@@ -195,12 +187,12 @@ def mount_snapshot_from_echoes(
     include ``updated_at`` so a token/secret rotation (which bumps
     ``updated_at``) propagates to a sandbox recycle (#877).
 
-    ``env_var_credentials`` is structural — provision passes
-    :class:`ResolvedEnvVarCredential`, the per-step drift probe passes
-    :class:`aios.db.queries.EnvVarCredentialEcho`. Both fold to the SAME
-    ``(VAULT_CREDENTIAL, credential_id, updated_at)`` element, so the
-    provision-time snapshot stamped on the handle matches the step-time
-    echo set (no spurious first-step recycle).
+    ``env_var_credentials`` is a closed union of exactly the two co-located
+    credential shapes — provision passes :class:`ResolvedEnvVarCredential`, the
+    per-step drift probe passes :class:`aios.db.queries.EnvVarCredentialEcho`.
+    Both fold to the SAME ``(VAULT_CREDENTIAL, credential_id, updated_at)``
+    element, so the provision-time snapshot stamped on the handle matches the
+    step-time echo set (no spurious first-step recycle).
     """
     from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE, VAULT_CREDENTIAL
 
@@ -507,9 +499,19 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
         # env-var credentials (#877). Inert until #878 routes egress through
         # it; the registry owns its lifecycle from the returned plan,
         # mirroring git_proxy.
+        #
+        # Construct + start into a LOCAL, and only publish to the outer
+        # ``secret_proxy`` once ``start()`` has returned cleanly. ``start()``
+        # self-cleans on failure (its own ``except`` calls ``await self.stop()``
+        # then re-raises), so a start failure must leave ``secret_proxy`` None —
+        # otherwise the outer cleanup below would stop an already-closed proxy a
+        # SECOND time. This mirrors git_proxy, whose ref comes from
+        # ``_materialize_github_clones``'s return value (only set on a clean
+        # start).
         if env_var_credentials:
-            secret_proxy = SecretEgressProxy(env_var_credentials)
-            await secret_proxy.start()
+            proxy = SecretEgressProxy(env_var_credentials)
+            await proxy.start()
+            secret_proxy = proxy
 
         tool_broker_secret = secrets.token_urlsafe(32)
         tool_broker.register_session(session_id, tool_broker_secret)

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -25,8 +25,11 @@ from __future__ import annotations
 
 import os
 import secrets
+from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
 
 from aios.config import get_settings
 from aios.db import queries
@@ -63,6 +66,15 @@ from aios.sandbox.network import WORKER_NETWORK_ALIAS, is_running_in_container
 from aios.sandbox.setup import WORKSPACE_RUNTIME_ENV
 from aios.services import sessions as sessions_service
 from aios.services.vaults import ResolvedEnvVarCredential, resolve_session_env_var_credentials
+
+if TYPE_CHECKING:
+    # Imported for typing only at module level: a runtime top-level import
+    # would pull in ``aios.tools`` (via ``secret_egress_proxy`` →
+    # ``url_safety``) whose package ``__init__`` imports ``bash``, which
+    # imports back from this module — a cycle. The concrete class is bound
+    # at module bottom (after every def runs) so it's still a patchable
+    # ``aios.sandbox.spec.SecretEgressProxy`` attribute.
+    from aios.sandbox.secret_egress_proxy import SecretEgressProxy
 
 log = get_logger("aios.sandbox.spec")
 
@@ -147,26 +159,58 @@ class ProvisioningPlan:
     # injection) and the request-time placeholder→secret map are the
     # follow-up slices (#874, #876).
     env_var_credentials: tuple[ResolvedEnvVarCredential, ...]
+    # Per-session :class:`SecretEgressProxy` (#877), started here when the
+    # session has env-var credentials. Like ``git_proxy``, the registry owns
+    # its lifecycle: it records the proxy at provision time and stops it on
+    # release / recycle. ``None`` when the session has no env-var creds.
+    # INERT until #878 wires nat DNAT egress routing into it.
+    secret_proxy: SecretEgressProxy | None = None
+
+
+class _EnvVarCredentialLike(Protocol):
+    """The structural shape the env-var drift fold needs from a credential.
+
+    Provision passes :class:`ResolvedEnvVarCredential`; the per-step probe
+    passes :class:`aios.db.queries.EnvVarCredentialEcho`. Both satisfy this,
+    so :func:`mount_snapshot_from_echoes` folds them identically (constraint A).
+    """
+
+    @property
+    def credential_id(self) -> str: ...
+
+    @property
+    def updated_at(self) -> datetime: ...
 
 
 def mount_snapshot_from_echoes(
     memory_echoes: list[MemoryStoreResourceEcho] | tuple[MemoryStoreResourceEcho, ...],
     github_echoes: list[GithubRepositoryResourceEcho] | tuple[GithubRepositoryResourceEcho, ...],
+    env_var_credentials: Sequence[_EnvVarCredentialLike] = (),
 ) -> frozenset[tuple[str, ...]]:
-    """The set of inputs that determines the spec's mount list.
+    """The set of inputs that determines the spec's mount/credential surface.
 
     Order-independent so rank reorders don't trigger spurious recycles.
-    Each tuple is type-prefixed so memory and github namespaces can't
-    collide. The github tuple includes ``updated_at`` so token rotation
-    (which bumps ``updated_at``) propagates to a sandbox recycle.
+    Each tuple is type-prefixed so memory, github, and vault-credential
+    namespaces can't collide. Both the github tuple and the env-var tuple
+    include ``updated_at`` so a token/secret rotation (which bumps
+    ``updated_at``) propagates to a sandbox recycle (#877).
+
+    ``env_var_credentials`` is structural — provision passes
+    :class:`ResolvedEnvVarCredential`, the per-step drift probe passes
+    :class:`aios.db.queries.EnvVarCredentialEcho`. Both fold to the SAME
+    ``(VAULT_CREDENTIAL, credential_id, updated_at)`` element, so the
+    provision-time snapshot stamped on the handle matches the step-time
+    echo set (no spurious first-step recycle).
     """
-    from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE
+    from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE, VAULT_CREDENTIAL
 
     items: set[tuple[str, ...]] = set()
     for m in memory_echoes:
         items.add((MEMORY_STORE, m.memory_store_id, m.name, m.access))
     for g in github_echoes:
         items.add((GITHUB_REPOSITORY, g.id, g.mount_path, g.updated_at.isoformat()))
+    for c in env_var_credentials:
+        items.add((VAULT_CREDENTIAL, c.credential_id, c.updated_at.isoformat()))
     return frozenset(items)
 
 
@@ -439,6 +483,16 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     memory_echoes = await _materialize_memory_mounts(session_id, account_id=account_id)
     env_var_credentials = await _materialize_env_var_credentials(session_id, account_id=account_id)
     github_echoes, git_proxy = await _materialize_github_clones(session_id, account_id=account_id)
+    # Start the per-session secret-egress proxy when the session has env-var
+    # credentials (#877). Inert until #878 routes egress through it; the
+    # registry owns its lifecycle from the returned plan, mirroring git_proxy.
+    # Started AFTER the clones step so its failure-exposure window matches
+    # git_proxy's: a raise from here on is caught by the try/except below
+    # (which stops both proxies); a clones failure unwinds itself before this.
+    secret_proxy: SecretEgressProxy | None = None
+    if env_var_credentials:
+        secret_proxy = SecretEgressProxy(env_var_credentials)
+        await secret_proxy.start()
 
     tool_broker = runtime.require_tool_broker()
     tool_broker_secret = secrets.token_urlsafe(32)
@@ -499,12 +553,13 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             tool_socket_host_path=tool_socket_host_path,
             spec_version=spec_version,
             env_var_credentials=env_var_credentials,
+            secret_proxy=secret_proxy,
         )
     except BaseException:
-        # Both proxies hold worker-process state (ports, token maps,
+        # All proxies hold worker-process state (ports, token maps,
         # secret-to-session bindings). Anything that raises before we
-        # hand back a plan must clean up both on the way out, otherwise
-        # state leaks for the worker's lifetime.
+        # hand back a plan must clean up everything on the way out,
+        # otherwise state leaks for the worker's lifetime.
         tool_broker.unregister_session(session_id)
         cleanup_session_secret_file(session_id, tool_socket_host_path)
         if git_proxy is not None:
@@ -513,6 +568,15 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             except Exception as cleanup_err:
                 log.warning(
                     "sandbox.git_proxy_cleanup_after_spec_failure",
+                    session_id=session_id,
+                    error=str(cleanup_err),
+                )
+        if secret_proxy is not None:
+            try:
+                await secret_proxy.stop()
+            except Exception as cleanup_err:
+                log.warning(
+                    "sandbox.secret_proxy_cleanup_after_spec_failure",
                     session_id=session_id,
                     error=str(cleanup_err),
                 )
@@ -537,6 +601,7 @@ def _assemble_plan(
     snapshot_budget_bytes: int | None = None,
     spec_version: int = 0,
     env_var_credentials: tuple[ResolvedEnvVarCredential, ...] = (),
+    secret_proxy: SecretEgressProxy | None = None,
 ) -> ProvisioningPlan:
     """Pure assembly of the plan from already-materialized inputs.
 
@@ -689,7 +754,7 @@ def _assemble_plan(
         BASE_IMAGE_LABEL_KEY: image,
     }
 
-    snapshot = mount_snapshot_from_echoes(memory_echoes, github_echoes)
+    snapshot = mount_snapshot_from_echoes(memory_echoes, github_echoes, env_var_credentials)
     settings = get_settings()
     spec = SandboxSpec(
         session_id=session_id,
@@ -739,4 +804,12 @@ def _assemble_plan(
         github_echoes=github_echoes,
         git_proxy=git_proxy,
         env_var_credentials=env_var_credentials,
+        secret_proxy=secret_proxy,
     )
+
+
+# Runtime binding for ``SecretEgressProxy`` (see the TYPE_CHECKING note at the
+# top). Imported at module bottom — after every def has run — so it resolves
+# the spec↔tools cycle while still exposing a patchable
+# ``aios.sandbox.spec.SecretEgressProxy`` attribute for unit tests.
+from aios.sandbox.secret_egress_proxy import SecretEgressProxy  # noqa: E402

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -347,6 +347,7 @@ def patch_build_spec_deps(
     # symbol AFTER entering the bundle, so their mock wins (last patch binds).
     secret_proxy_instance = MagicMock()
     secret_proxy_instance.start = AsyncMock()
+    secret_proxy_instance.stop = AsyncMock()
 
     return (
         patch("aios.sandbox.spec.get_settings", return_value=settings),

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -341,8 +341,19 @@ def patch_build_spec_deps(
         tool_broker.register_session = MagicMock()
         tool_broker.unregister_session = MagicMock()
 
+    # Stub the SecretEgressProxy (#877) so a provision with env-var creds
+    # doesn't boot a real TLS server / reach for the egress CA (which needs a
+    # worker-context crypto_box). Tests asserting on the proxy re-patch this
+    # symbol AFTER entering the bundle, so their mock wins (last patch binds).
+    secret_proxy_instance = MagicMock()
+    secret_proxy_instance.start = AsyncMock()
+
     return (
         patch("aios.sandbox.spec.get_settings", return_value=settings),
+        patch(
+            "aios.sandbox.spec.SecretEgressProxy",
+            MagicMock(return_value=secret_proxy_instance),
+        ),
         patch(
             "aios.sandbox.spec.sessions_service.load_session_account_id",
             AsyncMock(return_value="acct_x"),

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -19,15 +19,17 @@ from __future__ import annotations
 import contextlib
 import logging
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aios.crypto.vault import CryptoBox
 from aios.errors import CryptoDecryptError
+from aios.ids import VAULT_CREDENTIAL
 from aios.models.environments import EnvironmentConfig
 from aios.models.vaults import RESERVED_SANDBOX_ENV_KEYS
 from aios.sandbox.spec import build_spec_from_session
-from aios.services.vaults import ResolvedEnvVarCredential
+from aios.services.vaults import ResolvedEnvVarCredential, mint_secret_placeholder
 from tests.helpers.sandbox import patch_build_spec_deps
 
 # A distinctive sentinel rather than a real-looking token, so a leak is
@@ -138,3 +140,83 @@ async def test_resolve_failure_aborts_before_git_proxy_or_broker_exist() -> None
     # started, no broker secret registered.
     clones.assert_not_awaited()
     broker.register_session.assert_not_called()
+
+
+# ── SecretEgressProxy lifecycle (#877) ───────────────────────────────────────
+
+
+async def test_secret_proxy_constructed_and_started_when_creds_present() -> None:
+    """A provision with env-var creds constructs the per-session
+    ``SecretEgressProxy`` with those creds, awaits its ``start()``, and hands
+    the live instance back on ``plan.secret_proxy`` for the registry to own."""
+    proxy_instance = MagicMock()
+    proxy_instance.start = AsyncMock()
+    proxy_cls = MagicMock(return_value=proxy_instance)
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(patch("aios.sandbox.spec.SecretEgressProxy", proxy_cls))
+        plan = await build_spec_from_session("sess_01TEST")
+
+    # Constructed with the resolved creds and started exactly once.
+    proxy_cls.assert_called_once_with((_CRED,))
+    proxy_instance.start.assert_awaited_once()
+    assert plan.secret_proxy is proxy_instance
+
+
+async def test_secret_proxy_not_constructed_when_no_creds() -> None:
+    """No env-var creds ⇒ the proxy is never constructed and the plan carries
+    ``secret_proxy is None`` (the inert empty case)."""
+    proxy_cls = MagicMock()
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_var_credentials=AsyncMock(return_value=()),
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(patch("aios.sandbox.spec.SecretEgressProxy", proxy_cls))
+        plan = await build_spec_from_session("sess_01TEST")
+
+    proxy_cls.assert_not_called()
+    assert plan.secret_proxy is None
+
+
+async def test_provision_time_fold_lands_cred_on_mount_snapshot() -> None:
+    """The provision-time half of constraint A: the resolved cred's
+    ``(VAULT_CREDENTIAL, credential_id, updated_at)`` tuple lands on
+    ``plan.spec.mount_snapshot`` so the handle the backend stamps it onto
+    matches the step-time echo set."""
+    proxy_instance = MagicMock()
+    proxy_instance.start = AsyncMock()
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(
+            patch("aios.sandbox.spec.SecretEgressProxy", MagicMock(return_value=proxy_instance))
+        )
+        plan = await build_spec_from_session("sess_01TEST")
+
+    assert (
+        VAULT_CREDENTIAL,
+        _CRED.credential_id,
+        _CRED.updated_at.isoformat(),
+    ) in plan.spec.mount_snapshot
+
+
+def test_placeholder_is_stable_across_recycle() -> None:
+    """The placeholder is a pure function of ``(subkey, session_id,
+    credential_id)`` — two mints with the same ids are equal.
+
+    This locks the piece-4 reconstruction invariant: a recycled sandbox
+    re-derives the SAME placeholder, so anything the agent persisted into
+    /workspace keeps resolving through the fresh proxy. Already deterministic
+    — no production change; this test documents/guards it.
+    """
+    box = CryptoBox(bytes(range(32)))
+    subkey = box.derive_account_subkey("acct_x")
+    first = mint_secret_placeholder(subkey, "sess_01TEST", "vcr_01")
+    second = mint_secret_placeholder(subkey, "sess_01TEST", "vcr_01")
+    assert first == second

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -250,6 +250,50 @@ async def test_failure_after_proxy_starts_stops_both_proxies() -> None:
     broker.unregister_session.assert_called_once_with("sess_01TEST")
 
 
+async def test_secret_proxy_start_failure_does_not_double_stop() -> None:
+    """``SecretEgressProxy.start()`` self-cleans on failure (its own ``except``
+    calls ``await self.stop()`` then re-raises). The outer cleanup envelope must
+    NOT stop the proxy a SECOND time — a double ``stop()`` re-closes an
+    already-closed httpx client and mis-logs a spurious cleanup failure.
+
+    Modelled faithfully: the mock's ``start()`` calls its own ``stop()`` then
+    raises, mirroring the real self-clean. ``stop`` is therefore expected
+    exactly once (the self-clean); a second call would mean the outer ``except``
+    re-stopped a proxy it should never have tracked.
+    """
+    secret_proxy = MagicMock()
+    secret_proxy.stop = AsyncMock()
+
+    async def _start_then_self_clean() -> None:
+        # Mirror the real start(): on a bind failure it awaits self.stop()
+        # before re-raising, so the caller must never call stop() again.
+        await secret_proxy.stop()
+        raise RuntimeError("bind failed")
+
+    secret_proxy.start = AsyncMock(side_effect=_start_then_self_clean)
+    broker = MagicMock()
+    broker.port = 54321
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
+            github_clones=AsyncMock(return_value=([], None)),
+            tool_broker=broker,
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(
+            patch("aios.sandbox.spec.SecretEgressProxy", MagicMock(return_value=secret_proxy))
+        )
+        with pytest.raises(RuntimeError, match="bind failed"):
+            await build_spec_from_session("sess_01TEST")
+
+    # Exactly once: the self-clean inside start(). The outer cleanup must NOT
+    # re-stop it (secret_proxy was never published past the failed start).
+    secret_proxy.stop.assert_awaited_once()
+    # The start failure fired before the broker secret was registered, so the
+    # broker is never touched on this path either.
+    broker.register_session.assert_not_called()
+
+
 def test_placeholder_is_stable_across_recycle() -> None:
     """The placeholder is a pure function of ``(subkey, session_id,
     credential_id)`` — two mints with the same ids are equal.

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -206,6 +206,50 @@ async def test_provision_time_fold_lands_cred_on_mount_snapshot() -> None:
     ) in plan.spec.mount_snapshot
 
 
+async def test_failure_after_proxy_starts_stops_both_proxies() -> None:
+    """A raise in the post-proxy-start span (here the reserved-image gate)
+    must tear down BOTH the git proxy and the secret-egress proxy.
+
+    Both proxies and the broker secret are allocated BEFORE the spec is
+    assembled; a single cleanup envelope must cover all of them so a
+    failed provision can't leak a live proxy for the worker's lifetime.
+    """
+    git_proxy = MagicMock()
+    git_proxy.stop = AsyncMock()
+    secret_proxy = MagicMock()
+    secret_proxy.start = AsyncMock()
+    secret_proxy.stop = AsyncMock()
+    broker = MagicMock()
+    broker.port = 54321
+    broker.register_session = MagicMock()
+    broker.unregister_session = MagicMock()
+    # A reserved-prefix image trips the cross-tenant snapshot gate's
+    # ValueError after both proxies have started and the broker secret is
+    # registered. ``MagicMock`` env_config bypasses the pydantic ``image``
+    # validator so the gate (not construction) is what raises.
+    env_config = MagicMock()
+    env_config.image = "aios-sbx-victim"
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_config=env_config,
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
+            github_clones=AsyncMock(return_value=([], git_proxy)),
+            tool_broker=broker,
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(
+            patch("aios.sandbox.spec.SecretEgressProxy", MagicMock(return_value=secret_proxy))
+        )
+        with pytest.raises(ValueError, match="reserved"):
+            await build_spec_from_session("sess_01TEST")
+
+    # Everything allocated before the failure is torn down: both proxies
+    # stopped and the broker secret unregistered.
+    git_proxy.stop.assert_awaited_once()
+    secret_proxy.stop.assert_awaited_once()
+    broker.unregister_session.assert_called_once_with("sess_01TEST")
+
+
 def test_placeholder_is_stable_across_recycle() -> None:
     """The placeholder is a pure function of ``(subkey, session_id,
     credential_id)`` — two mints with the same ids are equal.

--- a/tests/unit/sandbox/test_spec_mount_snapshot.py
+++ b/tests/unit/sandbox/test_spec_mount_snapshot.py
@@ -1,0 +1,93 @@
+"""Pure-function tests for ``mount_snapshot_from_echoes`` env-var fold (#877).
+
+The mount snapshot is computed at TWO sites with IDENTICAL membership:
+``_assemble_plan`` (provision time, folding ``ResolvedEnvVarCredential``)
+and ``release_if_mounts_changed`` (step time, folding
+``EnvVarCredentialEcho``). If the two folds diverged, every session with
+env-var creds would spuriously recycle on its first step. These tests pin
+the fold as a pure function of ``(credential_id, updated_at)`` and prove
+the structural symmetry between the two input shapes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from aios.db.queries import EnvVarCredentialEcho
+from aios.ids import VAULT_CREDENTIAL
+from aios.sandbox.spec import mount_snapshot_from_echoes
+from aios.services.vaults import ResolvedEnvVarCredential
+
+_TS_V1 = datetime(2026, 6, 10, tzinfo=UTC)
+_TS_V2 = datetime(2026, 6, 11, tzinfo=UTC)
+
+
+def _resolved(credential_id: str, updated_at: datetime) -> ResolvedEnvVarCredential:
+    return ResolvedEnvVarCredential(
+        credential_id=credential_id,
+        secret_name="GITHUB_TOKEN",
+        secret_value="SENTINEL_DO_NOT_LEAK",
+        allowed_hosts=("api.github.com",),
+        updated_at=updated_at,
+        placeholder="AIOS_SECRET_PLACEHOLDER_" + "ab" * 16,
+    )
+
+
+def _echo(credential_id: str, updated_at: datetime) -> EnvVarCredentialEcho:
+    return EnvVarCredentialEcho(credential_id=credential_id, updated_at=updated_at)
+
+
+def test_env_var_cred_folds_into_snapshot() -> None:
+    """An env-var cred contributes exactly ``(VAULT_CREDENTIAL, id, ts)``."""
+    snapshot = mount_snapshot_from_echoes([], [], [_resolved("vcr_01", _TS_V1)])
+    assert (VAULT_CREDENTIAL, "vcr_01", _TS_V1.isoformat()) in snapshot
+
+
+def test_rotation_changes_snapshot() -> None:
+    """Same credential_id, bumped updated_at ⇒ different frozenset (a rotation
+    propagates to a recycle, mirroring the github ``updated_at`` fold)."""
+    before = mount_snapshot_from_echoes([], [], [_resolved("vcr_01", _TS_V1)])
+    after = mount_snapshot_from_echoes([], [], [_resolved("vcr_01", _TS_V2)])
+    assert before != after
+
+
+def test_adding_a_cred_changes_snapshot() -> None:
+    before = mount_snapshot_from_echoes([], [], [_resolved("vcr_01", _TS_V1)])
+    after = mount_snapshot_from_echoes(
+        [], [], [_resolved("vcr_01", _TS_V1), _resolved("vcr_02", _TS_V1)]
+    )
+    assert before != after
+
+
+def test_removing_a_cred_changes_snapshot() -> None:
+    """Archiving/removing a cred drops its echo ⇒ different frozenset."""
+    before = mount_snapshot_from_echoes(
+        [], [], [_resolved("vcr_01", _TS_V1), _resolved("vcr_02", _TS_V1)]
+    )
+    after = mount_snapshot_from_echoes([], [], [_resolved("vcr_01", _TS_V1)])
+    assert before != after
+
+
+def test_reorder_is_order_independent() -> None:
+    """The fold is set membership — reordering the cred list is a no-op."""
+    a = mount_snapshot_from_echoes(
+        [], [], [_resolved("vcr_01", _TS_V1), _resolved("vcr_02", _TS_V2)]
+    )
+    b = mount_snapshot_from_echoes(
+        [], [], [_resolved("vcr_02", _TS_V2), _resolved("vcr_01", _TS_V1)]
+    )
+    assert a == b
+
+
+def test_resolved_and_echo_fold_identically() -> None:
+    """Constraint A: a ``ResolvedEnvVarCredential`` (provision) and an
+    ``EnvVarCredentialEcho`` (step) with the SAME ``(credential_id,
+    updated_at)`` produce the SAME frozenset element.
+
+    If they diverged, a session would recycle on its first step because the
+    provision-time snapshot stamped on the handle would never match the
+    step-time echo set.
+    """
+    provision = mount_snapshot_from_echoes([], [], [_resolved("vcr_01", _TS_V1)])
+    step = mount_snapshot_from_echoes([], [], [_echo("vcr_01", _TS_V1)])
+    assert provision == step

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -25,6 +25,7 @@ import pytest
 
 from aios.db.queries import EnvVarCredentialEcho
 from aios.harness import runtime
+from aios.ids import VAULT_CREDENTIAL
 from aios.models.memory_stores import Access, MemoryStoreResourceEcho
 from aios.sandbox.backends.base import (
     CommandResult,
@@ -958,6 +959,52 @@ class TestSecretProxyLifecycle:
 
         assert registry._secret_proxies["sess_X"] is cast(Any, proxy)
 
+    async def test_provision_failure_after_build_spec_stops_both_proxies(self) -> None:
+        """A raise from ``_resolve_snapshot`` — after ``build_spec_from_session``
+        has started the proxies and registered the broker secret, but before the
+        sandbox exists — must stop BOTH proxies exactly once, unregister the
+        broker, and leave neither proxy in the registry dicts. Without the
+        cleanup span covering resolution, the proxies leak (their ports + the
+        broker secret outlive the worker) (#877)."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        git_proxy = FakeSecretProxy()
+        secret_proxy = FakeSecretProxy()
+        plan = _provisioning_plan("sess_X")
+        plan = ProvisioningPlan(
+            spec=plan.spec,
+            env_config=plan.env_config,
+            memory_echoes=plan.memory_echoes,
+            github_echoes=plan.github_echoes,
+            git_proxy=cast(Any, git_proxy),
+            env_var_credentials=(),
+            secret_proxy=cast(Any, secret_proxy),
+        )
+        broker = MagicMock()
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=plan),
+            ),
+            patch.object(
+                registry,
+                "_resolve_snapshot",
+                AsyncMock(side_effect=RuntimeError("store probe indeterminate")),
+            ),
+            patch("aios.harness.runtime.require_tool_broker", return_value=broker),
+            pytest.raises(RuntimeError, match="store probe indeterminate"),
+        ):
+            await registry.get_or_provision("sess_X")
+
+        git_proxy.stop.assert_awaited_once()
+        secret_proxy.stop.assert_awaited_once()
+        broker.unregister_session.assert_called_once_with("sess_X")
+        assert "sess_X" not in registry._git_proxies
+        assert "sess_X" not in registry._secret_proxies
+        # No sandbox was ever created — teardown must not destroy a phantom.
+        assert [c for c in backend.calls if c[0] in ("create", "destroy")] == []
+
 
 class TestEnvVarCredentialDrift:
     """The step-time half of constraint A: an env-var credential rotation
@@ -988,7 +1035,7 @@ class TestEnvVarCredentialDrift:
     ) -> None:
         backend = FakeBackend()
         registry = SandboxRegistry(backend=backend)
-        snapshot = frozenset([("vcr", "vcr_01", self._TS_V1.isoformat())])
+        snapshot = frozenset([(VAULT_CREDENTIAL, "vcr_01", self._TS_V1.isoformat())])
         handle = _seed(registry, "sess_X", snapshot)
 
         await registry.release_if_mounts_changed("sess_X", [], [], current_echoes)

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -16,12 +16,14 @@ from __future__ import annotations
 import asyncio
 import gc
 from collections.abc import Iterator
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aios.db.queries import EnvVarCredentialEcho
 from aios.harness import runtime
 from aios.models.memory_stores import Access, MemoryStoreResourceEcho
 from aios.sandbox.backends.base import (
@@ -63,6 +65,20 @@ def _echo(
     )
 
 
+def _env_echo(credential_id: str, updated_at: datetime) -> EnvVarCredentialEcho:
+    return EnvVarCredentialEcho(credential_id=credential_id, updated_at=updated_at)
+
+
+class FakeSecretProxy:
+    """Stand-in for ``SecretEgressProxy`` — records ``stop()`` calls and
+    exposes a fake ``port`` so registry lifecycle paths can be exercised
+    without booting a real TLS server (#877)."""
+
+    def __init__(self, port: int = 49152) -> None:
+        self.port = port
+        self.stop = AsyncMock()
+
+
 def _seed(
     registry: SandboxRegistry,
     session_id: str,
@@ -78,7 +94,7 @@ class TestReleaseIfMountsChanged:
     async def test_no_cached_handle_is_noop(self) -> None:
         backend = FakeBackend()
         registry = SandboxRegistry(backend=backend)
-        await registry.release_if_mounts_changed("sess_NONE", [_echo("memstore_a", "a")], [])
+        await registry.release_if_mounts_changed("sess_NONE", [_echo("memstore_a", "a")], [], [])
         destroys = [c for c in backend.calls if c[0] == "destroy"]
         assert destroys == []
 
@@ -88,7 +104,7 @@ class TestReleaseIfMountsChanged:
         snapshot = frozenset([("memstore", "memstore_a", "a", "read_write")])
         _seed(registry, "sess_X", snapshot)
 
-        await registry.release_if_mounts_changed("sess_X", [_echo("memstore_a", "a")], [])
+        await registry.release_if_mounts_changed("sess_X", [_echo("memstore_a", "a")], [], [])
 
         destroys = [c for c in backend.calls if c[0] == "destroy"]
         assert destroys == []
@@ -108,6 +124,7 @@ class TestReleaseIfMountsChanged:
         await registry.release_if_mounts_changed(
             "sess_X",
             [_echo("memstore_b", "b", "read_only"), _echo("memstore_a", "a")],
+            [],
             [],
         )
 
@@ -133,7 +150,7 @@ class TestReleaseIfMountsChanged:
         snapshot = frozenset([("memstore", "memstore_a", "a", "read_write")])
         handle = _seed(registry, "sess_X", snapshot)
 
-        await registry.release_if_mounts_changed("sess_X", current_echoes, [])
+        await registry.release_if_mounts_changed("sess_X", current_echoes, [], [])
 
         destroys = [c for c in backend.calls if c[0] == "destroy"]
         assert len(destroys) == 1
@@ -192,7 +209,7 @@ class TestReleaseIfMountsChanged:
             await provision_started.wait()
 
             release_task = asyncio.create_task(
-                registry.release_if_mounts_changed("sess_X", [_echo("memstore_b", "b")], [])
+                registry.release_if_mounts_changed("sess_X", [_echo("memstore_b", "b")], [], [])
             )
             # release_task is blocked on the lock provision_task is holding.
             await asyncio.sleep(0)
@@ -838,3 +855,149 @@ class TestSpecVersionDrift:
         handle = registry.peek("sess_X")
         assert handle is not None
         assert handle.spec_version == 7
+
+
+class TestSecretProxyLifecycle:
+    """The per-session ``SecretEgressProxy`` is owned by the registry, not the
+    handle (mirroring ``GitProxy``): stopped on release, mount-drift release,
+    evict, and stop_all, and stored at provision time (#877).
+
+    LIFECYCLE-ONLY and inert until #878 wires egress routing — these tests
+    never drive a secret swap, only the start/store/stop bookkeeping.
+    """
+
+    async def test_release_stops_secret_proxy(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        _seed(registry, "sess_X")
+        proxy = FakeSecretProxy()
+        registry._secret_proxies["sess_X"] = cast(Any, proxy)
+
+        await registry.release("sess_X")
+
+        proxy.stop.assert_awaited_once()
+        assert "sess_X" not in registry._secret_proxies
+
+    async def test_release_if_mounts_changed_stops_secret_proxy(self) -> None:
+        """A diverged echo set fires release(), which stops the secret proxy."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        snapshot = frozenset([("memstore", "memstore_a", "a", "read_write")])
+        _seed(registry, "sess_X", snapshot)
+        proxy = FakeSecretProxy()
+        registry._secret_proxies["sess_X"] = cast(Any, proxy)
+
+        # Detach all memory stores → snapshot diverges → release fires.
+        await registry.release_if_mounts_changed("sess_X", [], [], [])
+
+        proxy.stop.assert_awaited_once()
+        assert "sess_X" not in registry._secret_proxies
+
+    async def test_evict_stops_secret_proxy(self) -> None:
+        """``evict`` stops the secret proxy in the background (reusing the
+        evict task-keepalive set); await the tracked task to observe it."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        registry._handles["sess_X"] = make_handle(session_id="sess_X")
+        registry._last_used["sess_X"] = 0.0
+        proxy = FakeSecretProxy()
+        registry._secret_proxies["sess_X"] = cast(Any, proxy)
+
+        registry.evict("sess_X")
+        assert "sess_X" not in registry._secret_proxies
+        # The stop is fire-and-forget — drain the tracked tasks.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        proxy.stop.assert_awaited_once()
+
+    async def test_stop_all_stops_all_secret_proxies(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        _seed(registry, "sess_X")
+        _seed(registry, "sess_Y")
+        proxy_x = FakeSecretProxy()
+        proxy_y = FakeSecretProxy()
+        registry._secret_proxies["sess_X"] = cast(Any, proxy_x)
+        registry._secret_proxies["sess_Y"] = cast(Any, proxy_y)
+
+        await registry.stop_all()
+
+        proxy_x.stop.assert_awaited_once()
+        proxy_y.stop.assert_awaited_once()
+        assert registry._secret_proxies == {}
+
+    async def test_provision_stores_secret_proxy(self) -> None:
+        """A cold provision whose plan carries a non-None ``secret_proxy``
+        stores it on ``registry._secret_proxies`` (mirrors
+        ``test_handle_carries_spec_version_from_spec``)."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        proxy = FakeSecretProxy()
+        plan = _provisioning_plan("sess_X")
+        plan = ProvisioningPlan(
+            spec=plan.spec,
+            env_config=plan.env_config,
+            memory_echoes=plan.memory_echoes,
+            github_echoes=plan.github_echoes,
+            git_proxy=plan.git_proxy,
+            env_var_credentials=(),
+            secret_proxy=cast(Any, proxy),
+        )
+
+        with (
+            patch(
+                "aios.sandbox.registry.build_spec_from_session",
+                AsyncMock(return_value=plan),
+            ),
+            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
+            patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),
+        ):
+            await registry.get_or_provision("sess_X")
+
+        assert registry._secret_proxies["sess_X"] is cast(Any, proxy)
+
+
+class TestEnvVarCredentialDrift:
+    """The step-time half of constraint A: an env-var credential rotation
+    (bumped ``updated_at``), add, or remove diverges the mount snapshot and
+    recycles the cached sandbox; an identical echo set does not (#877)."""
+
+    _TS_V1 = datetime(2026, 6, 10, tzinfo=UTC)
+    _TS_V2 = datetime(2026, 6, 11, tzinfo=UTC)
+
+    @pytest.mark.parametrize(
+        "current_echoes,description,expect_release",
+        [
+            ([_env_echo("vcr_01", _TS_V2)], "rotated (updated_at bumped)", True),
+            (
+                [_env_echo("vcr_01", _TS_V1), _env_echo("vcr_02", _TS_V1)],
+                "added a cred",
+                True,
+            ),
+            ([], "removed the cred", True),
+            ([_env_echo("vcr_01", _TS_V1)], "identical", False),
+        ],
+    )
+    async def test_env_var_drift(
+        self,
+        current_echoes: list[EnvVarCredentialEcho],
+        description: str,
+        expect_release: bool,
+    ) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        snapshot = frozenset([("vcr", "vcr_01", self._TS_V1.isoformat())])
+        handle = _seed(registry, "sess_X", snapshot)
+
+        await registry.release_if_mounts_changed("sess_X", [], [], current_echoes)
+
+        destroys = [c for c in backend.calls if c[0] == "destroy"]
+        if expect_release:
+            assert len(destroys) == 1, f"{description!r} should recycle the sandbox"
+            assert destroys[0][1]["sandbox_id"] == handle.sandbox_id
+            assert registry.peek("sess_X") is None
+        else:
+            assert destroys == [], f"{description!r} must not recycle the sandbox"
+            assert registry.peek("sess_X") is not None


### PR DESCRIPTION
## Summary

Wires the `SecretEgressProxy` (built in #876) into the sandbox provisioning lifecycle and adds a rotation-triggered container recycle for env-var credentials.

This is **lifecycle-only and inert** until #878 adds nat DNAT egress routing — there is no end-to-end secret-swap behavior yet, and no e2e test by design.

Closes #877

## What's implemented

**1. Construct + start on provision**
`build_spec_from_session` in `sandbox/spec.py` builds and starts a `SecretEgressProxy(plan.env_var_credentials)` whenever the session has env-var credentials. Start is placed after the github-clones step so the leak-exposure window on provisioning failure matches git_proxy's.

**2. Registry holds + stops it**
A per-session `_secret_proxies` dict mirrors `_git_proxies`. The proxy is stopped on `release`, `release_if_mounts_changed`, `evict`, `stop_all`, `_destroy_quietly`, and the provision create-failure path.

**3. Recycle-on-rotation drift key**
`mount_snapshot_from_echoes` now folds the full set of `(credential_id, updated_at)` pairs for the session's env-var creds into the mount snapshot (set membership). Rotating, creating, or archiving a cred in a bound vault all trigger a container recycle. The fold runs identically at provision time and per-step drift-check time — no spurious recycles.

**4. Placeholder ⇄ recycle invariant**
Placeholders are deterministic per `(session, credential)` and stable across recycles. A rotation-triggered recycle rebuilds the proxy from freshly-resolved creds, so a placeholder the agent persisted to `/workspace` resolves behind the same token with the new secret value.

## Implementation notes

- A new internal `EnvVarCredentialEcho` NamedTuple and `list_session_env_var_credential_echoes` metadata-only query (no ciphertext) feed the per-step drift probe. Both are worker-internal — not on any API response model — so the FastAPI surface is unchanged and no openapi/SDK codegen is needed.
- The echo query reuses the exact same `DISTINCT ON (secret_name)` / `archived_at IS NULL` / rank filter as the credential resolver, ensuring the resolved set (provision) and echo set (step) have identical membership. This prevents spurious first-step recycles.
- `SecretEgressProxy` is imported into `spec.py` via a `TYPE_CHECKING` annotation + a bottom-of-module runtime import to break a `spec → aios.tools → spec` circular import that git_proxy doesn't hit, while keeping `aios.sandbox.spec.SecretEgressProxy` a patchable module attribute for tests.
- The secret-proxy host port is intentionally not opened in the network lockdown path yet — that lands with #878's egress routing.

## Tests

- New `tests/unit/sandbox/test_spec_mount_snapshot.py`: pure-function tests of the env-var fold — rotation/add/archive change the snapshot; reorder does not; provision-time `ResolvedEnvVarCredential` and step-time `EnvVarCredentialEcho` with the same `(id, updated_at)` fold identically.
- Extended `tests/unit/test_sandbox_registry.py`: proxy stored on provision; stopped on release/evict/stop_all; env-var drift (rotate/add/remove → recycle, identical → no recycle).
- Extended `tests/unit/sandbox/test_spec_env_var_credentials.py`: proxy started when creds present / not when absent; snapshot includes creds; placeholder stable across recycle.
- All 2339 unit tests pass; mypy + ruff clean. Mutation check confirmed the rotation-drift test is non-vacuous (red when the fold is removed, green when restored).

## Cleanup envelope (updated)

An earlier revision of this description claimed the proxy-leak window between proxy start and `_assemble_plan` was left as a pre-existing limitation. The final diff **does** widen the cleanup envelope: in `build_spec_from_session` a single `try` now spans from the clones step through plan assembly, so a raise anywhere in that span stops both git_proxy and secret_proxy. Covered by `tests/unit/sandbox/test_spec_env_var_credentials.py::test_failure_after_proxy_starts_stops_both_proxies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)