### PR TITLE
ci: add master-push migration-chain canary (#956)

### DIFF
--- a/.github/workflows/migration-chain-canary.yml
+++ b/.github/workflows/migration-chain-canary.yml
@@ -1,0 +1,120 @@
+name: Migration chain canary
+
+# Post-merge guard against a forked alembic revision chain reaching master.
+#
+# The pinned-head assertion in tests/unit/test_migration_chain.py forces a
+# *textual* git conflict when two PRs claim DIFFERENT revision numbers — that
+# is the PR-time defense. It does NOT conflict when two PRs claim the SAME
+# number with an identical head edit: git sees no textual conflict, branch
+# protection is strict:false, and stale-green checks let the second merge in.
+# Alembic's duplicate-revision load error covers that case, but only when the
+# test runs against the true merged master tree. A real merge queue would
+# prevent this structurally, but requires an org-owned repo (eumemic is a User
+# account). Hence this canary: run the chain test on master immediately after
+# every migration-touching merge, and shout within a minute if it broke.
+#
+# Security note: this workflow does not interpolate any untrusted ${{ }}
+# expression (issue/PR titles, head_ref, commit messages) into run: commands.
+# The issue title and label are workflow-authored constants; only trusted
+# contexts (secrets.GITHUB_TOKEN in env:, github.server_url / github.repository
+# / github.run_id / github.sha) are referenced, and those are used as quoted
+# shell values, never eval'd.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - migrations/**
+      - tests/unit/test_migration_chain.py
+      - .github/workflows/migration-chain-canary.yml
+
+# Serialize per-ref. cancel-in-progress:false is load-bearing: this is the
+# authoritative "did master's chain break" verdict — a later push must not
+# cancel an in-flight canary whose failure-issue creation is still running.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Parse-only defaults: get_settings() runs at import for some unit modules.
+    # tests/conftest.py already os.environ.setdefault()s these, so the chain
+    # test passes without them; set them explicitly anyway so the canary never
+    # depends on conftest's default values staying in place.
+    env:
+      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
+      AIOS_API_KEY: test-key-for-ci
+      AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Migration chain check
+        # ONLY this file — pure-Python, no DB/Docker, ~seconds. Running the
+        # whole suite here would be slow and would couple the canary's verdict
+        # to unrelated test flakes; the point is a fast, specific signal.
+        run: uv run pytest tests/unit/test_migration_chain.py -q
+
+      - name: Open or update incident issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          TITLE="ALEMBIC CHAIN BROKEN on master"
+
+          # The incident label may not exist yet; create it idempotently so
+          # `gh issue create --label incident` can't fail on a missing label.
+          gh label create incident \
+            --color B60205 \
+            --description "Production-impacting break that needs immediate attention" \
+            2>/dev/null || true
+
+          BODY=$(printf '%s\n' \
+            "The alembic migration chain is broken on \`master\`." \
+            "" \
+            "\`tests/unit/test_migration_chain.py\` failed on the merged master tree." \
+            "This usually means two migration PRs claimed the same revision number, or the chain forked / lost its single head." \
+            "" \
+            "- Commit: \`${COMMIT_SHA}\`" \
+            "- Run: ${RUN_URL}" \
+            "" \
+            "Fix forward by renumbering the duplicate/forked revision so the ladder is a single linear chain, then re-run this workflow.")
+
+          # Create-or-update via gh (no github-script, matching repo idiom).
+          EXISTING=$(gh issue list \
+            --search "\"${TITLE}\" in:title" \
+            --state open \
+            --json number,title \
+            --jq "[.[] | select(.title == \"${TITLE}\")][0].number // empty")
+
+          if [ -n "${EXISTING}" ]; then
+            echo "Updating existing incident issue #${EXISTING}."
+            gh issue comment "${EXISTING}" --body "${BODY}"
+          else
+            echo "Creating new incident issue."
+            gh issue create \
+              --title "${TITLE}" \
+              --label incident \
+              --body "${BODY}"
+          fi

--- a/.github/workflows/migration-chain-canary.yml
+++ b/.github/workflows/migration-chain-canary.yml
@@ -99,12 +99,15 @@ jobs:
           # eventually-consistent search index) and exact-match the title in jq,
           # so rapid consecutive failures update the one issue instead of
           # spawning duplicates.
+          # `set -e` would abort this step on a transient `gh issue list`
+          # failure before any issue is filed; fall through to creating one
+          # instead (mirrors the `|| true` on the label create above).
           EXISTING=$(gh issue list \
             --label incident \
             --state open \
             --limit 100 \
             --json number,title \
-            --jq "[.[] | select(.title == \"${TITLE}\")][0].number // empty")
+            --jq "[.[] | select(.title == \"${TITLE}\")][0].number // empty" || echo "")
 
           if [ -n "${EXISTING}" ]; then
             echo "Updating existing incident issue #${EXISTING}."

--- a/.github/workflows/migration-chain-canary.yml
+++ b/.github/workflows/migration-chain-canary.yml
@@ -44,15 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # Parse-only defaults: get_settings() runs at import for some unit modules.
-    # tests/conftest.py already os.environ.setdefault()s these, so the chain
-    # test passes without them; set them explicitly anyway so the canary never
-    # depends on conftest's default values staying in place.
-    env:
-      AIOS_DB_URL: postgresql://aios:aios@localhost:5432/aios_test
-      AIOS_API_KEY: test-key-for-ci
-      AIOS_VAULT_KEY: 5Uvx6pICqEEpPDl+1f5SrKyXOoQA5j0XcYD590hZH/Y=
-
+    # The chain test is pure-Python and needs no env (tests/conftest.py
+    # os.environ.setdefault()s the parse-only settings it imports).
     steps:
       - uses: actions/checkout@v4
 
@@ -102,9 +95,14 @@ jobs:
             "Fix forward by renumbering the duplicate/forked revision so the ladder is a single linear chain, then re-run this workflow.")
 
           # Create-or-update via gh (no github-script, matching repo idiom).
+          # List by label (REST list is immediately consistent, unlike the
+          # eventually-consistent search index) and exact-match the title in jq,
+          # so rapid consecutive failures update the one issue instead of
+          # spawning duplicates.
           EXISTING=$(gh issue list \
-            --search "\"${TITLE}\" in:title" \
+            --label incident \
             --state open \
+            --limit 100 \
             --json number,title \
             --jq "[.[] | select(.title == \"${TITLE}\")][0].number // empty")
 

--- a/tests/unit/test_migration_chain_canary_workflow.py
+++ b/tests/unit/test_migration_chain_canary_workflow.py
@@ -1,0 +1,176 @@
+"""Load-bearing-property checks for the migration-chain canary workflow.
+
+``.github/workflows/migration-chain-canary.yml`` is a post-merge guard: it
+runs ``tests/unit/test_migration_chain.py`` on every migration-touching push to
+``master`` and opens an incident issue if the alembic chain broke (see the
+issue title constant below). This module pins the canary's load-bearing
+properties so a careless future edit can't silently disable it — e.g. dropping
+the ``master`` trigger, broadening the run to the whole suite (coupling the
+verdict to unrelated flakes), or removing the failure-path issue creation.
+
+Pure-Python: parses the workflow YAML with PyYAML; no DB, no Docker, no CI.
+
+PyYAML gotcha: the bare mapping key ``on:`` parses as the boolean ``True`` (the
+"Norway problem"), so the trigger mapping is resolved via ``doc.get(True)``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]  # types-PyYAML not in the dep set
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WF = _REPO_ROOT / ".github" / "workflows" / "migration-chain-canary.yml"
+
+_ISSUE_TITLE = "ALEMBIC CHAIN BROKEN on master"
+_CHAIN_TEST_PATH = "tests/unit/test_migration_chain.py"
+
+
+def _doc() -> dict[Any, Any]:
+    # Keys are `str`, except `on:` which PyYAML parses as the bool `True` (the
+    # Norway problem) — hence an `Any`-keyed mapping rather than `dict[str, ...]`.
+    doc: dict[Any, Any] = yaml.safe_load(_WF.read_text())
+    return doc
+
+
+def _triggers(doc: dict[Any, Any]) -> dict[str, Any]:
+    # Resolve the trigger mapping under either the string key or the bool True.
+    # A missing mapping fails the calling test loudly when it indexes the result.
+    triggers = doc.get("on", doc.get(True))
+    assert isinstance(triggers, dict), f"{_WF} has no `on:` trigger mapping; resolved {triggers!r}."
+    return triggers
+
+
+def _run_steps(doc: dict[Any, Any]) -> list[str]:
+    return [s["run"] for s in doc["jobs"]["canary"]["steps"] if "run" in s]
+
+
+def test_workflow_parses_to_nonempty_dict() -> None:
+    """The canary workflow exists and parses to a non-empty mapping."""
+    assert _WF.exists(), (
+        f"{_WF} is missing; the migration-chain canary workflow must exist so a "
+        f"broken alembic chain on master is caught post-merge."
+    )
+    doc = _doc()
+    assert isinstance(doc, dict) and doc, f"{_WF} did not parse to a non-empty dict."
+
+
+def test_triggers_on_push_to_master() -> None:
+    """The canary must run on pushes to master (post-merge verdict)."""
+    triggers = _triggers(_doc())
+    branches = triggers["push"]["branches"]
+    assert "master" in branches, (
+        f"{_WF} on.push.branches must include 'master' so the chain test runs after "
+        f"every merge; found {branches!r}."
+    )
+
+
+def test_paths_filter_includes_migrations() -> None:
+    """The trigger paths filter must include 'migrations/**'."""
+    paths = _triggers(_doc())["push"]["paths"]
+    assert "migrations/**" in paths, (
+        f"{_WF} on.push.paths must include 'migrations/**' so a migration merge fires "
+        f"the canary; found {paths!r}."
+    )
+
+
+def test_paths_filter_includes_test_and_self() -> None:
+    """The paths filter must include the chain test AND the canary workflow itself.
+
+    A change to either the chain test or this workflow must re-run the canary so
+    the guard can't be quietly weakened without an immediate verdict.
+    """
+    paths = _triggers(_doc())["push"]["paths"]
+    assert _CHAIN_TEST_PATH in paths, (
+        f"{_WF} on.push.paths must include {_CHAIN_TEST_PATH!r}; found {paths!r}."
+    )
+    self_path = ".github/workflows/migration-chain-canary.yml"
+    assert self_path in paths, (
+        f"{_WF} on.push.paths must include {self_path!r} so edits to the canary re-run it; "
+        f"found {paths!r}."
+    )
+
+
+def test_permissions_are_minimal_and_sufficient() -> None:
+    """Permissions: issues:write (to open the incident) and contents:read."""
+    doc = _doc()
+    perms = doc["permissions"]
+    assert perms["issues"] == "write", (
+        f"{_WF} permissions.issues must be 'write' so the failure path can open the "
+        f"incident issue; found {perms.get('issues')!r}."
+    )
+    assert perms["contents"] == "read", (
+        f"{_WF} permissions.contents must be 'read'; found {perms.get('contents')!r}."
+    )
+
+
+def test_runs_only_the_chain_test_not_the_suite() -> None:
+    """Exactly the chain test runs — never the whole ``tests/unit`` suite.
+
+    Mutation-resistant core: broadening the run to ``pytest tests/unit`` would
+    couple the canary's verdict to unrelated test flakes and slow it down. We
+    assert (a) some step runs the specific chain-test file, and (b) NO run step
+    invokes the suite broadly (``pytest tests/unit`` followed by whitespace).
+
+    The suite-level regex ``pytest\\s+tests/unit\\s`` requires whitespace
+    immediately after ``unit``; the chain-test path has ``/`` there, so it does
+    not match ``pytest tests/unit/test_migration_chain.py``.
+    """
+    run_steps = _run_steps(_doc())
+    assert any(f"pytest {_CHAIN_TEST_PATH}" in run for run in run_steps), (
+        f"{_WF} must have a step running 'pytest {_CHAIN_TEST_PATH}'; run steps were {run_steps!r}."
+    )
+    suite_re = re.compile(r"pytest\s+tests/unit\s")
+    offenders = [run for run in run_steps if suite_re.search(run)]
+    assert not offenders, (
+        f"{_WF} must NOT run the whole tests/unit suite (couples the canary to unrelated "
+        f"flakes); offending run step(s): {offenders!r}."
+    )
+
+
+def test_issue_title_constant_present() -> None:
+    """The exact incident issue title appears in a run step."""
+    run_steps = _run_steps(_doc())
+    assert any(_ISSUE_TITLE in run for run in run_steps), (
+        f"{_WF} must reference the incident title {_ISSUE_TITLE!r} in a run step so the "
+        f"opened issue is recognizable and de-duplicated."
+    )
+
+
+def test_incident_label_used_and_created() -> None:
+    """The incident is labeled, and the label is created idempotently first."""
+    run_steps = _run_steps(_doc())
+    assert any("--label incident" in run for run in run_steps), (
+        f"{_WF} must pass '--label incident' when creating the issue; run steps were {run_steps!r}."
+    )
+    assert any("gh label create incident" in run for run in run_steps), (
+        f"{_WF} must 'gh label create incident' (idempotent guard) so issue creation "
+        f"can't fail on a missing label; run steps were {run_steps!r}."
+    )
+
+
+def test_issue_step_runs_only_on_failure() -> None:
+    """The step that creates the incident must be gated on ``failure()``."""
+    doc = _doc()
+    steps = doc["jobs"]["canary"]["steps"]
+    title_steps = [s for s in steps if "run" in s and _ISSUE_TITLE in s["run"]]
+    assert title_steps, f"{_WF} has no step whose run contains the incident title {_ISSUE_TITLE!r}."
+    for step in title_steps:
+        assert step.get("if") == "failure()", (
+            f"{_WF}: the incident-creating step must have if: failure() (else it runs on "
+            f"green and spams issues); found if={step.get('if')!r}."
+        )
+
+
+def test_incident_body_is_actionable() -> None:
+    """The workflow references the run id and commit sha for an actionable issue."""
+    text = _WF.read_text()
+    assert "github.run_id" in text, (
+        f"{_WF} must reference github.run_id so the incident issue links the failing run."
+    )
+    assert "github.sha" in text, (
+        f"{_WF} must reference github.sha so the incident issue names the offending commit."
+    )

--- a/tests/unit/test_migration_chain_canary_workflow.py
+++ b/tests/unit/test_migration_chain_canary_workflow.py
@@ -112,22 +112,18 @@ def test_runs_only_the_chain_test_not_the_suite() -> None:
 
     Mutation-resistant core: broadening the run to ``pytest tests/unit`` would
     couple the canary's verdict to unrelated test flakes and slow it down. We
-    assert (a) some step runs the specific chain-test file, and (b) NO run step
-    invokes the suite broadly (``pytest tests/unit`` followed by whitespace).
+    assert there is exactly one pytest step and the set of test paths it names
+    is precisely ``{tests/unit/test_migration_chain.py}`` — nothing more.
 
-    The suite-level regex ``pytest\\s+tests/unit\\s`` requires whitespace
-    immediately after ``unit``; the chain-test path has ``/`` there, so it does
-    not match ``pytest tests/unit/test_migration_chain.py``.
+    This exact-token-set check fails for end-of-line ``tests/unit`` (no trailing
+    whitespace), for the whole suite, and for any extra test file added to the
+    invocation.
     """
-    run_steps = _run_steps(_doc())
-    assert any(f"pytest {_CHAIN_TEST_PATH}" in run for run in run_steps), (
-        f"{_WF} must have a step running 'pytest {_CHAIN_TEST_PATH}'; run steps were {run_steps!r}."
-    )
-    suite_re = re.compile(r"pytest\s+tests/unit\s")
-    offenders = [run for run in run_steps if suite_re.search(run)]
-    assert not offenders, (
-        f"{_WF} must NOT run the whole tests/unit suite (couples the canary to unrelated "
-        f"flakes); offending run step(s): {offenders!r}."
+    pytest_steps = [r for r in _run_steps(_doc()) if "pytest" in r]
+    assert len(pytest_steps) == 1, f"expected exactly one pytest step, found {len(pytest_steps)}"
+    test_paths = set(re.findall(r"tests/\S+", pytest_steps[0]))
+    assert test_paths == {_CHAIN_TEST_PATH}, (
+        f"canary must run ONLY the chain test; found test paths {test_paths}"
     )
 
 
@@ -166,11 +162,32 @@ def test_issue_step_runs_only_on_failure() -> None:
 
 
 def test_incident_body_is_actionable() -> None:
-    """The workflow references the run id and commit sha for an actionable issue."""
-    text = _WF.read_text()
-    assert "github.run_id" in text, (
-        f"{_WF} must reference github.run_id so the incident issue links the failing run."
+    """The failure step wires run id and commit sha into its ``env:`` mapping.
+
+    Structural (not text-substring): the failure step is the step whose ``run``
+    contains the issue title. Asserting against its ``env:`` mapping can't be
+    satisfied by the top-of-file security comment that merely mentions these
+    contexts — the env wiring must actually be present.
+    """
+    doc = _doc()
+    steps = doc["jobs"]["canary"]["steps"]
+    fail_step = next(s for s in steps if "run" in s and _ISSUE_TITLE in s["run"])
+    env = fail_step.get("env", {})
+    assert "github.run_id" in env.get("RUN_URL", ""), (
+        "failure step must wire RUN_URL to github.run_id"
     )
-    assert "github.sha" in text, (
-        f"{_WF} must reference github.sha so the incident issue names the offending commit."
+    assert "github.sha" in env.get("COMMIT_SHA", ""), (
+        "failure step must wire COMMIT_SHA to github.sha"
+    )
+
+
+def test_concurrency_does_not_cancel_in_progress() -> None:
+    """``cancel-in-progress`` must stay false (load-bearing per the workflow).
+
+    PyYAML parses the unquoted ``false`` as Python ``False``.
+    """
+    doc = _doc()
+    assert doc["concurrency"]["cancel-in-progress"] is False, (
+        "cancel-in-progress must stay false so a later push can't cancel an "
+        "in-flight canary mid-issue-creation"
     )

--- a/tests/unit/test_migration_chain_canary_workflow.py
+++ b/tests/unit/test_migration_chain_canary_workflow.py
@@ -48,6 +48,31 @@ def _run_steps(doc: dict[Any, Any]) -> list[str]:
     return [s["run"] for s in doc["jobs"]["canary"]["steps"] if "run" in s]
 
 
+def _failure_step(doc: dict[Any, Any]) -> dict[str, Any]:
+    """The step whose ``run`` body contains the incident title — i.e. the
+    failure-path step that opens/updates the incident issue."""
+    steps = doc["jobs"]["canary"]["steps"]
+    return next(s for s in steps if "run" in s and _ISSUE_TITLE in s["run"])
+
+
+def _failure_step_run(doc: dict[Any, Any]) -> str:
+    """The ``run`` string of the failure-path step."""
+    run = _failure_step(doc)["run"]
+    assert isinstance(run, str)
+    return run
+
+
+def _logical_commands(run: str) -> list[str]:
+    """Join shell line-continuations and drop comment lines, yielding one
+    string per logical command."""
+    joined = run.replace("\\\n", " ")
+    return [
+        line.strip()
+        for line in joined.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
 def test_workflow_parses_to_nonempty_dict() -> None:
     """The canary workflow exists and parses to a non-empty mapping."""
     assert _WF.exists(), (
@@ -136,16 +161,30 @@ def test_issue_title_constant_present() -> None:
     )
 
 
-def test_incident_label_used_and_created() -> None:
-    """The incident is labeled, and the label is created idempotently first."""
-    run_steps = _run_steps(_doc())
-    assert any("--label incident" in run for run in run_steps), (
-        f"{_WF} must pass '--label incident' when creating the issue; run steps were {run_steps!r}."
+def test_incident_issue_is_created_with_the_incident_label() -> None:
+    """The incident is labeled, and the label is created idempotently first.
+
+    Pinning ``--label incident`` on the ``gh issue create`` command specifically
+    (not merely somewhere in the run) is load-bearing: ``--label incident`` also
+    appears in a comment and in the ``gh issue list --label incident`` lookup, so
+    a future edit that drops it from ``gh issue create`` alone would leave new
+    issues unlabeled — and the label-based lookup would then never find them,
+    spawning a fresh duplicate on every failure.
+    """
+    doc = _doc()
+    fail_run = _failure_step_run(doc)  # the run of the step whose body contains TITLE
+    commands = _logical_commands(fail_run)
+
+    # The label must be created idempotently before use.
+    assert any(c.startswith("gh label create incident") for c in commands), (
+        "failure step must idempotently create the incident label"
     )
-    assert any("gh label create incident" in run for run in run_steps), (
-        f"{_WF} must 'gh label create incident' (idempotent guard) so issue creation "
-        f"can't fail on a missing label; run steps were {run_steps!r}."
-    )
+
+    # The CREATE command specifically must carry --label incident, else new
+    # issues are unlabeled and the label-based lookup spawns duplicates.
+    create_cmds = [c for c in commands if c.startswith("gh issue create")]
+    assert len(create_cmds) == 1, f"expected one `gh issue create`, found {len(create_cmds)}"
+    assert "--label incident" in create_cmds[0], "gh issue create must apply the incident label"
 
 
 def test_issue_step_runs_only_on_failure() -> None:
@@ -170,8 +209,7 @@ def test_incident_body_is_actionable() -> None:
     contexts — the env wiring must actually be present.
     """
     doc = _doc()
-    steps = doc["jobs"]["canary"]["steps"]
-    fail_step = next(s for s in steps if "run" in s and _ISSUE_TITLE in s["run"])
+    fail_step = _failure_step(doc)
     env = fail_step.get("env", {})
     assert "github.run_id" in env.get("RUN_URL", ""), (
         "failure step must wire RUN_URL to github.run_id"
@@ -190,4 +228,8 @@ def test_concurrency_does_not_cancel_in_progress() -> None:
     assert doc["concurrency"]["cancel-in-progress"] is False, (
         "cancel-in-progress must stay false so a later push can't cancel an "
         "in-flight canary mid-issue-creation"
+    )
+    assert doc["concurrency"]["group"] == "${{ github.workflow }}-${{ github.ref }}", (
+        "concurrency group must serialize per-ref (workflow + ref), else "
+        "cancel-in-progress:false no longer guarantees one canary per ref"
     )


### PR DESCRIPTION
Closes #956

Two migration PRs can independently claim the same revision number and merge cleanly — git sees no textual conflict when both pick the *same* number, and the existing pinned-head assertion in `test_migration_chain.py` only forces a conflict when they pick *different* ones. Alembic's own duplicate-revision load error would catch the bad state, but only against the true merged tree. This landed as a real near-miss on 2026-06-11 and was caught manually.

This PR closes that gap with a post-merge canary.

**What's added**

- `.github/workflows/migration-chain-canary.yml` — triggers on push to `master`, paths-filtered to `migrations/**` (plus the chain test and workflow file itself). Runs only `tests/unit/test_migration_chain.py` — pure Python, no DB or Docker, takes seconds. On failure, idempotently creates or updates a GitHub issue titled "ALEMBIC CHAIN BROKEN on master" with an `incident` label (created first if absent), the commit SHA, and a run URL. Uses `gh` CLI, matching the create-or-update idiom in `release-aios-sdk.yml`. No `${{ }}` interpolation of untrusted input into shell. Permissions are `contents: read` + `issues: write`. Concurrency uses `cancel-in-progress: false` so a later push can't silently cancel an in-flight verdict.

- `tests/unit/test_migration_chain_canary_workflow.py` — parses the canary workflow YAML and asserts its load-bearing properties: triggers on push to master, paths include `migrations/**`, `permissions.issues == write`, the run step is scoped to the chain test file (not broadened to the whole suite), and the failure path references the exact issue title, `incident` label, and `if: failure()` gating. Lives under `tests/unit/` so it runs in normal CI — the canary guards itself against a future edit that would silently disable it.

**What's not changed**

`tests/unit/test_migration_chain.py` is untouched — the canary just runs it. No production code or codegen artifacts are modified.

**Verification**

The guard test was built with strict TDD; a mutation check confirmed the file-scoped-run assertion is non-vacuous (broadening the workflow's run line to `pytest tests/unit` makes the guard fail; restoring it returns green). The live workflow behavior — issue creation on a real master breakage — can only be fully exercised once deployed, per the issue's test strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
