### PR TITLE
fix(workflows): fail child requests on archive/delete (#904)

### DIFF
--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -631,12 +631,13 @@ async def list_run_ids_needing_step(
     - a stale inflight call: an ``agent`` past the wall-clock deadline (the step
       must force-resolve its timeout — this clause DRIVES that backstop) or a
       ``tool`` past the re-dispatch horizon (its task crashed without a signal).
-      A ``gate`` maps to NULL — resume-driven only, never stale. The agent
-      deadline is also the (deliberately slow) backstop for a child archived or
-      deleted BEFORE answering: that path writes no signal, so the run waits out
-      the deadline before the harvest resolves ``child_gone`` — acceptable for a
-      rare operator action, but a recall mode this filter covers only at the
-      horizon, not within a tick.
+      A ``gate`` maps to NULL — resume-driven only, never stale. Operator
+      archive/delete of a child BEFORE it answers now COMPLETES the open request
+      EAGERLY (the service layer fails it ``child_gone`` and writes a ``child_done``
+      signal atomically with the archive/delete, like every other completion), so
+      it is recalled via the unharvested-signal clause above within a tick — not
+      this deadline. The agent deadline remains only the backstop for a genuinely
+      stuck or non-responding LIVE child.
 
     (No ``account_id``: ``defer_run_wake`` needs none and appends no journal span.)
     """

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -59,6 +59,20 @@ from aios.services import triggers as triggers_service
 from aios.services.await_completion import await_completion
 
 
+async def defer_run_wake(run_id: str, *, batch: bool = False) -> None:
+    """Module-level wrapper over :func:`aios.services.wake.defer_run_wake`.
+
+    ``wake`` imports this module at top level, so a top-level
+    ``from aios.services.wake import defer_run_wake`` here would be a circular
+    import. This thin wrapper imports it lazily at call time, and — being a real
+    attribute of this module — stays the single patch point for tests that stub the
+    archive/delete run-wake (``aios.services.sessions.defer_run_wake``).
+    """
+    from aios.services.wake import defer_run_wake as _defer_run_wake
+
+    await _defer_run_wake(run_id, batch=batch)
+
+
 async def load_session_account_id(pool: asyncpg.Pool[Any], session_id: str) -> str:
     """Bootstrap helper: load ``account_id`` for a session by id, no scoping.
 
@@ -760,6 +774,53 @@ async def write_child_response(
     return wrote
 
 
+async def fail_open_child_requests_conn(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    error: dict[str, Any],
+) -> str | None:
+    """Conn-level twin of ``workflow_completion.fail_all_open_requests``: fail every
+    still-open request on a workflow child through the fused :func:`write_child_response`
+    seam, INSIDE the caller's open transaction, so the ``child_gone`` response + its
+    ``child_done`` signal commit atomically with the archive/delete that terminates the
+    child. Returns the ``parent_run_id`` to wake when at least one response was written
+    (so the pool-level caller can ``defer_run_wake`` after commit), else ``None`` — a
+    no-op for non-child sessions (``parent_run_id`` is None) and children that owe
+    nothing.
+
+    The pool-level ``fail_all_open_requests`` is the harness-erroring path (the model
+    failed past its retry budget) and acquires its own connection + wakes itself; this
+    twin instead joins the caller's transaction so the failure is fused with the
+    terminating archive/delete — there is no point at which the child is gone but its
+    callers still hung.
+    """
+    ctx = await queries.get_session_workflow_context(conn, session_id)
+    if ctx is None:
+        return None
+    _account_id, parent_run_id = ctx
+    if parent_run_id is None:
+        return None  # not a workflow child — nothing owes a request
+    open_ids = await queries.get_open_request_ids(conn, session_id, account_id=account_id)
+    if not open_ids:
+        return None
+    wrote_any = False
+    for request_id in open_ids:
+        wrote = await write_child_response(
+            conn,
+            session_id,
+            account_id=account_id,
+            parent_run_id=parent_run_id,
+            request_id=request_id,
+            is_error=True,
+            result=None,
+            error=error,
+        )
+        wrote_any |= wrote
+    return parent_run_id if wrote_any else None
+
+
 async def append_assistant_and_guard_quiescence(
     pool: asyncpg.Pool[Any],
     session_id: str,
@@ -1078,15 +1139,25 @@ async def increment_usage(
 
 
 async def archive_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> Session:
-    # Enrich vault_ids / resources / triggers so the API response
-    # shape matches GET /sessions/{id}. Archive itself is a single column
-    # flip; the lists are read post-update to surface any concurrent
-    # mutation that committed before archive landed.
-    async with pool.acquire() as conn:
+    # Archiving a workflow child that still owes its agent() response is a
+    # COMPLETION: fail its open requests through write_child_response (error
+    # child_gone) FIRST — before the archived_at flip, because append_event is
+    # fenced by ``archived_at IS NULL`` and raises NotFoundError on an archived
+    # row — so the child_gone response + its child_done signal commit atomically
+    # with the archive. The run is then sweep-visible within a tick (#904) instead
+    # of waiting out the 1h agent deadline. Enrich vault_ids / resources / triggers
+    # so the API response shape matches GET /sessions/{id}; the lists are read
+    # post-update to surface any concurrent mutation that committed before archive.
+    async with pool.acquire() as conn, conn.transaction():
+        parent_run_id = await fail_open_child_requests_conn(
+            conn, session_id, account_id=account_id, error={"kind": "child_gone"}
+        )
         session = await queries.archive_session(conn, session_id, account_id=account_id)
         vault_ids = await queries.get_session_vault_ids(conn, session_id, account_id=account_id)
         echoes = await _list_all_echoes(conn, session_id, account_id=account_id)
         trigger_echoes = await queries.list_triggers(conn, session_id, account_id=account_id)
+    if parent_run_id is not None:
+        await defer_run_wake(parent_run_id, batch=True)
     return session.model_copy(
         update={
             "vault_ids": vault_ids,
@@ -1123,8 +1194,20 @@ async def clone_session(
 
 
 async def delete_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> None:
-    async with pool.acquire() as conn:
+    # Deleting a workflow child that still owes its agent() response is a
+    # COMPLETION (#904): fail its open requests through write_child_response (error
+    # child_gone) FIRST — before delete_session's cascade wipes the child's events —
+    # so the child_gone response + its child_done signal commit atomically with the
+    # delete. The child_done signal lives in wf_run_signals (NOT the child's events),
+    # so it survives the cascade and makes the run sweep-visible within a tick rather
+    # than waiting out the 1h agent deadline.
+    async with pool.acquire() as conn, conn.transaction():
+        parent_run_id = await fail_open_child_requests_conn(
+            conn, session_id, account_id=account_id, error={"kind": "child_gone"}
+        )
         await queries.delete_session(conn, session_id, account_id=account_id)
+    if parent_run_id is not None:
+        await defer_run_wake(parent_run_id, batch=True)
 
 
 async def update_session(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -785,10 +785,17 @@ async def fail_open_child_requests_conn(
     still-open request on a workflow child through the fused :func:`write_child_response`
     seam, INSIDE the caller's open transaction, so the ``child_gone`` response + its
     ``child_done`` signal commit atomically with the archive/delete that terminates the
-    child. Returns the ``parent_run_id`` to wake when at least one response was written
-    (so the pool-level caller can ``defer_run_wake`` after commit), else ``None`` — a
-    no-op for non-child sessions (``parent_run_id`` is None) and children that owe
-    nothing.
+    child. What actually *survives* differs by caller: archive only flips ``archived_at``,
+    so the ``request_response`` event persists and ``derive_response`` returns the written
+    ``child_gone``; delete's cascade erases that event, leaving the ``child_done`` signal
+    (in ``wf_run_signals``, keyed by ``run_id`` — a separate table) as the sole survivor
+    that keeps the run sweep-visible, while ``derive_response`` resolves ``child_gone`` via
+    its liveness fallback (the session row is gone). Routing both paths through the seam is
+    deliberate: it keeps the single response-writer/signal chokepoint — the erased delete-path
+    event is the harmless cost of one uniform seam, not a bug. Returns the ``parent_run_id``
+    to wake when at least one response was written (so the pool-level caller can
+    ``defer_run_wake`` after commit), else ``None`` — a no-op for non-child sessions
+    (``parent_run_id`` is None) and children that owe nothing.
 
     The pool-level ``fail_all_open_requests`` is the harness-erroring path (the model
     failed past its retry budget) and acquires its own connection + wakes itself; this
@@ -1196,11 +1203,14 @@ async def clone_session(
 async def delete_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> None:
     # Deleting a workflow child that still owes its agent() response is a
     # COMPLETION (#904): fail its open requests through write_child_response (error
-    # child_gone) FIRST — before delete_session's cascade wipes the child's events —
-    # so the child_gone response + its child_done signal commit atomically with the
-    # delete. The child_done signal lives in wf_run_signals (NOT the child's events),
-    # so it survives the cascade and makes the run sweep-visible within a tick rather
-    # than waiting out the 1h agent deadline.
+    # child_gone) FIRST — same single response-writer/signal seam as archive. The
+    # cascade then wipes the child's events, INCLUDING the child_gone request_response
+    # this just wrote — that erasure is harmless (routing through the one seam is the
+    # point; see fail_open_child_requests_conn). What carries the completion is the
+    # child_done signal, which lives in wf_run_signals (keyed by run_id, NOT the child's
+    # events), so it survives the cascade and makes the run sweep-visible within a tick
+    # rather than waiting out the 1h agent deadline; derive_response resolves child_gone
+    # via its liveness fallback once the session row is gone.
     async with pool.acquire() as conn, conn.transaction():
         parent_run_id = await fail_open_child_requests_conn(
             conn, session_id, account_id=account_id, error={"kind": "child_gone"}

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -77,6 +77,9 @@ async def wf_runtime(
             # The fire-and-forget tool task's own wake — patch it too, else it enqueues a
             # real wake_workflow job against the test DB (the harvest is driven manually).
             mock.patch("aios.workflows.run_tools.defer_run_wake", new=AsyncMock()),
+            # The service-level archive/delete now eagerly fail open child requests and
+            # defer a run wake after commit — patch it so they don't enqueue a real job.
+            mock.patch("aios.services.sessions.defer_run_wake", new=AsyncMock()),
         ):
             yield pool
     finally:
@@ -1443,8 +1446,10 @@ async def test_operator_archived_child_resolves_run_as_child_gone(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     """An operator archiving a *running* child before it answers must not hang the
-    run: derive_response sees the child is no longer live and resolves the call as a
-    catchable AgentError(child_gone)."""
+    run. The service-level archive EAGERLY fails the child's open request through the
+    write_child_response seam (error child_gone) + writes its child_done signal, so the
+    run is sweep-visible within a tick — no waiting out the 1h agent deadline. The
+    harvest then resolves the call as a catchable AgentError(child_gone)."""
     pool = wf_runtime
     script = (
         "async def main(input):\n"
@@ -1456,8 +1461,24 @@ async def test_operator_archived_child_resolves_run_as_child_gone(
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     child_id = await _child_id_of(pool, run_id)
-    async with pool.acquire() as conn:  # operator archives the child mid-flight
-        await db_queries.archive_session(conn, child_id, account_id="acc_wf")
+    request_id = await _open_request_id(pool, child_id)  # capture BEFORE archiving
+
+    # Suspended, no signal, not past the agent deadline → not yet sweep-visible.
+    assert run_id not in await _needing(pool)
+
+    # Operator archives the child mid-flight, via the SERVICE-level path under test.
+    await sessions_service.archive_session(pool, child_id, account_id="acc_wf")
+
+    # CORE #904 ASSERTION: the eager child_done signal makes the run sweep-visible
+    # WITHOUT aging the wall-clock — it appears in the needs-step set immediately.
+    assert run_id in await _needing(pool)
+
+    # The request was failed immediately, before any further step ran.
+    async with pool.acquire() as conn:
+        resolved = await db_queries.derive_response(
+            conn, child_id, account_id="acc_wf", request_id=request_id
+        )
+    assert resolved == {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
 
     await run_workflow_step(run_id)  # harvest -> child_gone -> AgentError -> caught
     async with pool.acquire() as conn:
@@ -1469,8 +1490,12 @@ async def test_operator_archived_child_resolves_run_as_child_gone(
 async def test_operator_deleted_child_resolves_run_as_child_gone(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
-    """Same totality guarantee when the child is hard-deleted (its events are gone):
-    the run resolves from the child's absence, not a written response."""
+    """Same totality guarantee when the child is hard-deleted. The service-level
+    delete EAGERLY fails the open request through write_child_response FIRST (so its
+    child_gone response + child_done signal commit before the cascade wipes the child's
+    events), making the run sweep-visible within a tick. The signal survives the
+    cascade (it lives in wf_run_signals, not the child's events); the harvest resolves
+    child_gone from the signal, not a re-read of the now-absent child."""
     pool = wf_runtime
     script = (
         "async def main(input):\n"
@@ -1482,13 +1507,60 @@ async def test_operator_deleted_child_resolves_run_as_child_gone(
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     child_id = await _child_id_of(pool, run_id)
+    request_id = await _open_request_id(pool, child_id)  # the agent call_key; capture BEFORE delete
+
+    assert run_id not in await _needing(pool)
+
+    await sessions_service.delete_session(pool, child_id, account_id="acc_wf")
+
+    # Eagerness: the child_done signal makes the run sweep-visible immediately.
+    assert run_id in await _needing(pool)
+
     async with pool.acquire() as conn:
-        await db_queries.delete_session(conn, child_id, account_id="acc_wf")
+        # The child_done signal survived the events cascade (lives in wf_run_signals).
+        signal = await wf_queries.read_run_signal(conn, run_id, request_id)
+        # The child session row is gone.
+        with pytest.raises(NotFoundError):
+            await db_queries.get_session_bare(conn, child_id, account_id="acc_wf")
+    assert signal is not None and signal.kind == "child_done"
 
     await run_workflow_step(run_id)  # harvest -> child_gone -> AgentError -> caught
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "completed" and run.output == "child_gone"
+
+
+async def test_archive_child_commits_response_and_child_done_atomically(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """Acceptance #3: the child_gone response, its child_done signal, and the
+    archived_at flip all commit in ONE transaction — observable together afterward."""
+    pool = wf_runtime
+    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # spawn + suspend
+    child_id = await _child_id_of(pool, run_id)
+    request_id = await _open_request_id(pool, child_id)
+
+    await sessions_service.archive_session(pool, child_id, account_id="acc_wf")
+
+    async with pool.acquire() as conn:
+        # (a) the request_response lifecycle event was written with error child_gone.
+        response = await db_queries.read_request_response(
+            conn, child_id, account_id="acc_wf", request_id=request_id
+        )
+        # (b) the child_done signal exists for (run_id, request_id).
+        signal = await wf_queries.read_run_signal(conn, run_id, request_id)
+        # (c) the session's archived_at is set.
+        archived_at = await conn.fetchval(
+            "SELECT archived_at FROM sessions WHERE id = $1 AND account_id = $2",
+            child_id,
+            "acc_wf",
+        )
+    assert response is not None and response["is_error"] is True
+    assert response["error"] == {"kind": "child_gone"}
+    assert signal is not None and signal.kind == "child_done"
+    assert archived_at is not None
 
 
 # ─── G — parallel() spawns a child fan-out and collects results ───────────────


### PR DESCRIPTION
## Summary

Closes #904. Part of the #777 workflow series; this gap was surfaced by the #780 post-implementation review.

Archiving or deleting a workflow child that still owed an `agent()` response left no sweep-visible state. The caller run sat `suspended` until the agent wall-clock deadline (`workflow_agent_deadline_seconds`, default 1h) finally tripped the stale-agent clause. Before #780's `list_run_ids_needing_step` filter, a blanket every-run sweep healed this within ~30s; the #780 filter's recall contract covers every *completion* loss mode within one tick (the `child_done` marker commits atomically with every response write), but child *termination* wrote no response — so this mode fell through to the deadline horizon.

## Fix

Child termination is now a completion. A new `fail_open_child_requests_conn` helper fails every open request on a workflow child via the existing `write_child_response` seam (setting `error={"kind": "child_gone"}`), inside the archive/delete transaction. The `child_gone` response and its `child_done` signal commit atomically with the `archived_at` flip / row cascade; after commit the service defers a run wake. The caller harvests `child_gone` within one sweep tick (via the unharvested-signal clause) instead of at the agent deadline.

**Ordering constraint:** the helper runs first in both transactions — `append_event` is fenced by `archived_at IS NULL` and the delete cascade wipes the child's events, so the `request_response` write must precede both. The `child_done` signal lives in `wf_run_signals` (keyed by `run_id`) and survives the delete cascade.

**Blast radius for ordinary sessions is zero:** the helper short-circuits to a no-op when `parent_run_id` is None.

**Circular import:** `sessions.py` → `wake.py` → `sessions.py` is a hard cycle. Resolved with a thin lazy-delegating `defer_run_wake` wrapper in `sessions.py`, which keeps `aios.services.sessions.defer_run_wake` as the exact patchable symbol used by existing test fixtures.

## Files changed

- `src/aios/services/sessions.py` — `fail_open_child_requests_conn` helper; `archive_session` and `delete_session` rewritten to call it first inside a single transaction and defer a run wake after commit; lazy `defer_run_wake` wrapper.
- `src/aios/db/queries/workflows.py` — updated `list_run_ids_needing_step` docstring (removes the now-closed lazy-exception note).
- `tests/integration/test_wf_step.py` — three lazy-semantics tests converted to the eager shape; new atomicity test added; timeout-window TOCTOU re-verified under the new write site.

## Testing

All tests run under Docker (Postgres testcontainer): 4/4 target tests pass, `test_wf_step.py` 82/82, plus `test_wf_sweep.py` / `test_wake.py` / archived-session integration tests green. Full `scripts/run-checks.sh` clean: mypy (541 files), ruff, 2349 unit tests. Mutation check confirmed the core eagerness assertion is non-vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
