### PR TITLE
fix(workflows): make spawn failures catchable; add pipeline arity

### DIFF
--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -309,6 +309,13 @@ async def _run_workflow_step_body(
     outcome = await run_script_host(source=run.script, input=run.input, memo=memo)
 
     needs_rewake = False
+    # A spawn rejection journaled this wake (a catchable agent() error). The run owes one
+    # more drive so the replay throws the AgentError at the await — so we DON'T settle into
+    # a quiet 'suspended' (which the next wake's quiet-wake guard would early-exit), we hand
+    # the lease back as 'running' and let the guaranteed self-wake (needs_rewake) drive it.
+    # One-shot by construction: a rejected call lands in memo, so its capability is skipped
+    # on replay (never re-journaled), and the driven wake re-suspends/completes normally.
+    rejected_any = False
     # (call_key, tool_name, input) for tool frontiers opened this wake — launched AFTER
     # the txn commits (below), so call_started is visible before a task can signal+wake.
     tools_to_launch: list[tuple[str, str, Any]] = []
@@ -418,10 +425,14 @@ async def _run_workflow_step_body(
                     needs_rewake = True
             elif cap.capability_id == "agent":
                 spawn = await _open_agent_capability(conn, pool, run, cap)
+                # rejected: this call's catchable error was journaled — self-wake so the
+                # run replays and throws the AgentError at the await. A spawn error on ONE
+                # capability must NOT abort spawning the others, so continue the loop.
+                # needs_rewake (C1'/C4): a re-attached child already has its marker.
+                if spawn.rejected or spawn.needs_rewake:
+                    needs_rewake = True
                 if spawn.rejected:
-                    return  # the frontier was terminally rejected (bad call) — run errored
-                if spawn.needs_rewake:
-                    needs_rewake = True  # C1'/C4: harvest the already-present marker next step
+                    rejected_any = True
             elif cap.capability_id == "tool":
                 spec = cap.spec if isinstance(cap.spec, dict) else {}
                 tool_name = spec.get("tool_name")
@@ -461,7 +472,12 @@ async def _run_workflow_step_body(
                     error_kind="not_implemented",
                 )
                 return
-        await wf_queries.set_run_status(conn, run_id, "suspended", account_id=account_id)
+        # Hand the lease back. A reject journaled this wake leaves the run 'running' (a
+        # drive is owed: the self-wake replays and throws the catchable AgentError);
+        # otherwise park as a settled 'suspended'.
+        await wf_queries.set_run_status(
+            conn, run_id, "running" if rejected_any else "suspended", account_id=account_id
+        )
 
     # Outside the txn (after the suspend commits): launch this wake's tool tasks — now
     # that their call_started rows are committed, a task that signals+wakes lands a step
@@ -478,7 +494,8 @@ async def _run_workflow_step_body(
 class _SpawnResult(NamedTuple):
     """Outcome of opening one ``agent()`` frontier."""
 
-    rejected: bool  # the call was terminally rejected (run errored) — stop the step
+    # this call's catchable error was journaled — self-wake so the run replays and throws
+    rejected: bool
     needs_rewake: bool  # a re-attached child already has its marker — self-wake to harvest
 
 
@@ -496,8 +513,10 @@ async def _open_agent_capability(
     ``call_started`` dedups on the memo. On replay the child id already exists →
     re-attach, journaling the *row's* pinned version (not a re-resolved one).
 
-    Returns ``rejected=True`` iff the call was terminally rejected (the run was
-    errored — the caller should stop the step). ``defer_wake`` fires **only on
+    Returns ``rejected=True`` iff this call was rejected and its catchable error was
+    journaled (a ``call_result`` error for ``cap.call_key``): the caller self-wakes so
+    the run replays and ``_agent_error_from`` throws an ``AgentError`` at the
+    ``await``, where the author can catch it. ``defer_wake`` fires **only on
     first spawn** (``created``): on a re-attach the child is already sweep-wakeable
     via its own first user message and may even be terminal, so appending a wake
     span to it would crash. ``needs_rewake=True`` asks the caller for a self-wake
@@ -506,6 +525,24 @@ async def _open_agent_capability(
     — which only sees inflight ``call_started`` events — missed it).
     """
     account_id = run.account_id
+
+    async def _reject(kind: str, message: str) -> _SpawnResult:
+        # Journal the rejection as a CATCHABLE call_result error for this call_key —
+        # the same channel every other agent failure uses — instead of terminally
+        # erroring the run. The descriptive ``message`` is the author's only source
+        # (``_AGENT_ERROR_DEFAULT_MESSAGES`` has no entry for these kinds), so it is
+        # preserved verbatim. The caller self-wakes; the next step's replay throws
+        # ``_agent_error_from`` at the ``await``, where the author can try/except it.
+        await wf_queries.append_run_event(
+            conn,
+            account_id=account_id,
+            run_id=run.id,
+            type="call_result",
+            call_key=cap.call_key,
+            payload={"result": None, "is_error": True, "error": {"kind": kind, "message": message}},
+        )
+        return _SpawnResult(rejected=True, needs_rewake=False)
+
     spec = cap.spec if isinstance(cap.spec, dict) else {}
     # agent() carries output_schema as a canonical JSON *string* (so a schema's floats
     # survive the call_key hash); reconstruct the dict. None means no schema demanded.
@@ -538,24 +575,12 @@ async def _open_agent_capability(
                         "(references must resolve within the schema; remote refs are unsupported)"
                     )
         if schema_error is not None:
-            await _complete_run(
-                conn,
-                run,
-                output=f"agent() {schema_error}",
-                is_error=True,
-                error_kind="bad_agent_call",
-            )
-            return _SpawnResult(rejected=True, needs_rewake=False)
+            return await _reject("bad_agent_call", f"agent() {schema_error}")
     agent_id = spec.get("agent_id")
     if not isinstance(agent_id, str):
-        await _complete_run(
-            conn,
-            run,
-            output=f"agent() requires a string agent_id, got {agent_id!r}",
-            is_error=True,
-            error_kind="bad_agent_call",
+        return await _reject(
+            "bad_agent_call", f"agent() requires a string agent_id, got {agent_id!r}"
         )
-        return _SpawnResult(rejected=True, needs_rewake=False)
 
     child_id = child_session_id(run.id, cap.call_key)
     try:
@@ -563,14 +588,7 @@ async def _open_agent_capability(
         # which the run clamps. One query, same NotFoundError contract as before.
         agent = await db_queries.get_agent(conn, agent_id, account_id=account_id)
     except NotFoundError:
-        await _complete_run(
-            conn,
-            run,
-            output=f"agent {agent_id!r} not found",
-            is_error=True,
-            error_kind="agent_not_found",
-        )
-        return _SpawnResult(rejected=True, needs_rewake=False)
+        return await _reject("agent_not_found", f"agent {agent_id!r} not found")
     pinned = agent.version
     # #794: the child wields agent ∩ run, frozen at spawn; its vaults are the run's.
     child_surface = attenuation_service.clamp(surface_of(agent), surface_of(run))

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -427,7 +427,7 @@ async def _run_workflow_step_body(
                         run,
                         output=(
                             f"workflow exceeded the {max_agent_calls}-agent call cap "
-                            f"({prior_agent_calls} started before this step)"
+                            f"({agent_spawns + 1} total agent calls attempted)"
                         ),
                         is_error=True,
                         error_kind="too_many_agents",

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -372,36 +372,25 @@ async def _run_workflow_step_body(
             return
 
         # Lifetime agent-call cap (H1): bound a runaway that spawns children in an
-        # unbounded loop. Counted from the monotonic call_started journal plus this
-        # step's new agent frontier, checked BEFORE any spawn so an over-cap step
-        # errors atomically — never leaving a partial fan-out of orphan children.
-        # (A single parallel()'s width is bounded separately in the host.) Gated on
-        # there BEING new spawns: a harvest-only re-suspend (no new agents) must never
-        # error — else lowering the cap mid-flight would retroactively kill a run whose
-        # children are already all inflight, orphaning them. H1 blocks NEW spawns only.
-        new_agent_caps = [
-            cap
-            for cap in outcome.emitted
-            if cap.capability_id == "agent"
-            and cap.call_key not in memo
-            and cap.call_key not in inflight
-        ]
+        # unbounded loop. Counted from the monotonic call_started journal (prior real
+        # spawns) plus each child this step ACTUALLY creates — enforced per-spawn at the
+        # gate (see ``_open_agent_capability``), the moment before a child is created, so
+        # the over-cap child is never created. Per-spawn (not a batch pre-count) because a
+        # rejected cap (agent_not_found / bad_agent_call) spawns no child and consumes no
+        # slot, so it must NOT count toward the cap: a batch count over the frontier would
+        # pessimistically tip the quota on caps that never spawn, terminating a run whose
+        # only real over-cap pressure is illusory. (Good children spawned earlier in an
+        # over-cap frontier do persist as orphans the quiescence sweep reclaims — same
+        # terminal outcome, no correctness cost.) A harvest-only re-suspend (no new spawns)
+        # thus naturally never errors — H1 gates NEW real spawns only, so lowering the cap
+        # mid-flight can't retroactively kill a run whose children are already all inflight.
+        # (parallel()'s width is bounded separately in the host.)
         prior_agent_calls = sum(
             1 for e in events if e.type == "call_started" and e.payload.get("capability") == "agent"
         )
         max_agent_calls = get_settings().workflow_max_agent_calls
-        if new_agent_caps and prior_agent_calls + len(new_agent_caps) > max_agent_calls:
-            await _complete_run(
-                conn,
-                run,
-                output=(
-                    f"workflow exceeded the {max_agent_calls}-agent call cap "
-                    f"({prior_agent_calls} started, {len(new_agent_caps)} more requested)"
-                ),
-                is_error=True,
-                error_kind="too_many_agents",
-            )
-            return
+        # The running tally of real agent children: prior journaled spawns + this step's.
+        agent_spawns = prior_agent_calls
 
         # Suspended: open any *new* frontier capability, then park.
         for cap in outcome.emitted:
@@ -424,7 +413,26 @@ async def _run_workflow_step_body(
                 if cap.call_key in signals:
                     needs_rewake = True
             elif cap.capability_id == "agent":
-                spawn = await _open_agent_capability(conn, pool, run, cap)
+                spawn = await _open_agent_capability(
+                    conn, pool, run, cap, agent_spawns=agent_spawns, max_agent_calls=max_agent_calls
+                )
+                # Lifetime cap hit (H1): this cap passed every rejection gate and WOULD
+                # create a real child, but that child would exceed the cap — terminate the
+                # run (terminal, not catchable). Checked at the spawn point, before the
+                # child exists, so no orphan is created; any good children already spawned
+                # earlier in this frontier share the run's terminal outcome.
+                if spawn.quota_exceeded:
+                    await _complete_run(
+                        conn,
+                        run,
+                        output=(
+                            f"workflow exceeded the {max_agent_calls}-agent call cap "
+                            f"({prior_agent_calls} started before this step)"
+                        ),
+                        is_error=True,
+                        error_kind="too_many_agents",
+                    )
+                    return
                 # rejected: this call's catchable error was journaled — self-wake so the
                 # run replays and throws the AgentError at the await. A spawn error on ONE
                 # capability must NOT abort spawning the others, so continue the loop.
@@ -433,6 +441,8 @@ async def _run_workflow_step_body(
                     needs_rewake = True
                 if spawn.rejected:
                     rejected_any = True
+                else:
+                    agent_spawns += 1  # a real child was created (or re-attached) — it counts
             elif cap.capability_id == "tool":
                 spec = cap.spec if isinstance(cap.spec, dict) else {}
                 tool_name = spec.get("tool_name")
@@ -497,6 +507,9 @@ class _SpawnResult(NamedTuple):
     # this call's catchable error was journaled — self-wake so the run replays and throws
     rejected: bool
     needs_rewake: bool  # a re-attached child already has its marker — self-wake to harvest
+    # the cap passed every rejection gate but creating its child would exceed the lifetime
+    # agent-call cap — the caller terminates the run (``too_many_agents``); no child created
+    quota_exceeded: bool = False
 
 
 async def _open_agent_capability(
@@ -504,6 +517,9 @@ async def _open_agent_capability(
     pool: asyncpg.Pool[Any],
     run: WfRun,
     cap: EmittedCapability,
+    *,
+    agent_spawns: int,
+    max_agent_calls: int,
 ) -> _SpawnResult:
     """Spawn (or, on replay/C1', re-attach) the ``agent()`` child for a frontier,
     then journal ``call_started{child_session_id, child_agent_version}``.
@@ -523,6 +539,13 @@ async def _open_agent_capability(
     when a re-attached child *already* has its completion marker (C1'/C4: it
     finished before this wake journaled ``call_started``, so the pre-replay harvest
     — which only sees inflight ``call_started`` events — missed it).
+
+    The lifetime agent-call cap (H1) is enforced here, at the spawn point: ``agent_spawns``
+    is the count of real children already created (prior journaled + this step's so far).
+    A cap is checked AFTER its rejection gates and BEFORE ``create_child_session`` — a
+    rejected cap creates no child and never counts, and a cap that would create the
+    (``max_agent_calls`` + 1)-th child returns ``quota_exceeded=True`` so the caller
+    terminates the run before that child exists.
     """
     account_id = run.account_id
 
@@ -554,28 +577,29 @@ async def _open_agent_capability(
         # Structured output: the child must return a value matching this schema (the
         # return tool enforces it; see workflow_completion). Reject a bad schema here —
         # author-facing — rather than letting it brick the child when it applies the
-        # schema. Three author-facing failures: a non-object schema (a bare boolean is
-        # valid JSON Schema, but `false` rejects every value and `true` disables
-        # enforcement), a structurally-invalid schema, and one with an unresolvable
-        # reference (passes check_schema but raises at validation time).
-        schema_error: str | None = None
+        # schema. Three sequentially-dependent author-facing failures, each an early
+        # reject: a non-object schema (a bare boolean is valid JSON Schema, but `false`
+        # rejects every value and `true` disables enforcement), a structurally-invalid
+        # schema, and one with an unresolvable reference (passes check_schema but raises
+        # at validation time).
         if not isinstance(output_schema, dict):
-            schema_error = (
-                f"output_schema must be a JSON object schema, got {type(output_schema).__name__}"
+            return await _reject(
+                "bad_agent_call",
+                f"agent() output_schema must be a JSON object schema, "
+                f"got {type(output_schema).__name__}",
             )
-        else:
-            try:
-                jsonschema.Draft202012Validator.check_schema(output_schema)
-            except jsonschema.SchemaError as exc:
-                schema_error = f"output_schema is not a valid JSON Schema: {exc.message}"
-            else:
-                if (bad_ref := _unresolvable_ref(output_schema)) is not None:
-                    schema_error = (
-                        f"output_schema has an unresolvable reference {bad_ref!r} "
-                        "(references must resolve within the schema; remote refs are unsupported)"
-                    )
-        if schema_error is not None:
-            return await _reject("bad_agent_call", f"agent() {schema_error}")
+        try:
+            jsonschema.Draft202012Validator.check_schema(output_schema)
+        except jsonschema.SchemaError as exc:
+            return await _reject(
+                "bad_agent_call", f"agent() output_schema is not a valid JSON Schema: {exc.message}"
+            )
+        if (bad_ref := _unresolvable_ref(output_schema)) is not None:
+            return await _reject(
+                "bad_agent_call",
+                f"agent() output_schema has an unresolvable reference {bad_ref!r} "
+                "(references must resolve within the schema; remote refs are unsupported)",
+            )
     agent_id = spec.get("agent_id")
     if not isinstance(agent_id, str):
         return await _reject(
@@ -589,6 +613,11 @@ async def _open_agent_capability(
         agent = await db_queries.get_agent(conn, agent_id, account_id=account_id)
     except NotFoundError:
         return await _reject("agent_not_found", f"agent {agent_id!r} not found")
+    # Lifetime cap (H1) enforced HERE — past every rejection gate, before the child is
+    # created — so only caps that genuinely spawn count. ``agent_spawns`` already excludes
+    # rejected caps; this child would be the (agent_spawns + 1)-th, so cap it on strict ``>``.
+    if agent_spawns + 1 > max_agent_calls:
+        return _SpawnResult(rejected=False, needs_rewake=False, quota_exceeded=True)
     pinned = agent.version
     # #794: the child wields agent ∩ run, frozen at spawn; its vaults are the run's.
     child_surface = attenuation_service.clamp(surface_of(agent), surface_of(run))

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import builtins
 import contextlib
+import inspect
 import os
 import sys
 import traceback
@@ -65,9 +66,11 @@ class AgentError(Exception):
     (the bubble). ``kind`` distinguishes the failure mode: ``None`` for an explicit
     ``error()`` from the child, ``"child_errored"`` for a model failure,
     ``"child_gone"`` if the child was archived/deleted before answering,
-    ``"timeout"`` if the call outran its wall-clock budget without responding, and
+    ``"timeout"`` if the call outran its wall-clock budget without responding,
     ``"no_return"`` for an idle-without-responding child (see
-    :class:`AgentNoReturnError`).
+    :class:`AgentNoReturnError`), ``"agent_not_found"`` if the named agent does not
+    exist, and ``"bad_agent_call"`` for a malformed call (a non-string ``agent_id``
+    or an invalid ``output_schema``).
     """
 
     def __init__(self, message: str, *, kind: str | None = None) -> None:
@@ -140,8 +143,10 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
     ``input`` is **required and must not be None** — the child needs a real first
     message to act on (a child born with no user message would sit idle forever and
     poison the totality backstop). Pass a ``str`` (delivered verbatim) or any
-    JSON-serialisable value (delivered as canonical JSON). The error surfaces as a
-    normal exception in the author's script, so a bad call fails the run loudly.
+    JSON-serialisable value (delivered as canonical JSON). A missing agent or a
+    malformed call (non-string ``agent_id`` / invalid ``output_schema``) surfaces as
+    a catchable :class:`AgentError` at the ``await`` — ``try/except`` it like any
+    other agent failure, or let it propagate to fail the run / ``None`` the branch.
     """
     if input is None:
         raise ValueError("agent() requires a non-None input (the child's first message)")
@@ -194,11 +199,34 @@ def parallel(thunks: Any) -> _ParallelAwait:
     return _ParallelAwait([_branch(t) for t in thunks])
 
 
-def _pipeline_thunk(item: Any, stages: tuple[Any, ...]) -> Any:
+def _stage_arity(stage: Any) -> int:
+    """How many of ``(prev, item, index)`` to hand ``stage`` — inspected once at
+    construction. A ``*args`` stage opts into all three; a plain stage gets its count
+    of positional parameters, clamped to ``[1, 3]`` (so a 0-param stage still receives
+    ``prev``, a >3 stage gets the three available). A callable whose signature can't be
+    inspected (e.g. a C builtin) falls back to the legacy 1-arg (prev-only) call."""
+    try:
+        params = inspect.signature(stage).parameters.values()
+    except (ValueError, TypeError):
+        return 1  # non-inspectable callable (e.g. C builtin) → legacy 1-arg (prev only)
+    if any(p.kind is inspect.Parameter.VAR_POSITIONAL for p in params):
+        return 3  # *args → all three (prev, item, index)
+    n = sum(
+        1
+        for p in params
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    )
+    return min(max(n, 1), 3)  # clamp: 0-param → 1, >3 → 3
+
+
+def _pipeline_thunk(
+    item: Any, index: int, stages: tuple[Any, ...], arities: tuple[int, ...]
+) -> Any:
     async def run() -> Any:
         value = item
-        for stage in stages:
-            produced = stage(value)
+        for stage, arity in zip(stages, arities, strict=True):
+            args = (value, item, index)[:arity]
+            produced = stage(*args)
             value = await produced if hasattr(produced, "__await__") else produced
         return value
 
@@ -210,10 +238,20 @@ def pipeline(items: Any, *stages: Any) -> _ParallelAwait:
     chain advances on its own, with no barrier between stages. Returns a list of
     final values, one per item in order (``None`` for an item whose chain failed with
     an :class:`AgentError`; any other exception fails the whole run, per
-    :func:`parallel`). Each stage is ``stage(value) -> awaitable | value``; a
-    non-awaitable return is used as-is (a sync transform). Composition over
-    :func:`parallel`."""
-    return parallel([_pipeline_thunk(item, stages) for item in items])
+    :func:`parallel`).
+
+    Each stage may declare 1, 2, or 3 of ``(prev, item, index)``: ``prev`` is the
+    previous stage's output (the item itself for the first stage), ``item`` is the
+    original element, and ``index`` is its position in ``items``. A stage's arity is
+    inspected once at construction. A ``*args`` stage receives all three; a callable
+    whose signature can't be inspected receives only ``prev`` (the legacy 1-arg
+    shape); every stage must accept at least ``prev``. A stage returns
+    ``awaitable | value`` — a non-awaitable return is used as-is (a sync transform).
+    Composition over :func:`parallel`."""
+    arities = tuple(_stage_arity(s) for s in stages)
+    return parallel(
+        [_pipeline_thunk(item, index, stages, arities) for index, item in enumerate(items)]
+    )
 
 
 # Annotations (log/phase) produced during the branch step currently being driven.

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -489,6 +489,62 @@ async def test_pipeline_runs_each_item_through_stages() -> None:
     assert out.value == ["a", "b"]
 
 
+async def test_pipeline_stage_receives_item_and_index() -> None:
+    """A three-arg stage gets ``(prev, item, index)``: for the FIRST stage ``prev``
+    equals the item itself, and ``index`` is the element's position in ``items``."""
+    out = await _run(
+        "async def main(input):\n"
+        "    return await pipeline([10, 20], lambda p, it, ix: {'p': p, 'it': it, 'ix': ix})"
+    )
+    assert out.kind == "returned"
+    assert out.value == [
+        {"p": 10, "it": 10, "ix": 0},
+        {"p": 20, "it": 20, "ix": 1},
+    ]
+
+
+async def test_pipeline_two_arg_stage_gets_prev_and_item() -> None:
+    """A two-arg stage gets ``(prev, item)``; for the first stage prev == item, so
+    ``p + it`` is ``5 + 5``."""
+    out = await _run("async def main(input):\n    return await pipeline([5], lambda p, it: p + it)")
+    assert out.kind == "returned"
+    assert out.value == [10]
+
+
+async def test_pipeline_var_positional_stage_gets_all_three() -> None:
+    """A ``*args`` stage opts into all three positional values ``(prev, item, index)``."""
+    out = await _run("async def main(input):\n    return await pipeline([7], lambda *a: list(a))")
+    assert out.kind == "returned"
+    assert out.value == [[7, 7, 0]]
+
+
+async def test_pipeline_non_inspectable_stage_defaults_to_one_arg() -> None:
+    """A callable whose ``inspect.signature`` raises (``str`` is one such builtin in
+    CPython 3.13) falls back to the legacy 1-arg (prev-only) call — so ``str`` is a
+    valid single-argument transform."""
+    out = await _run("async def main(input):\n    return await pipeline([42], str)")
+    assert out.kind == "returned"
+    assert out.value == ["42"]
+
+
+async def test_pipeline_none_short_circuit_on_agent_error() -> None:
+    """An item whose chain raises AgentError at an early stage skips the remaining
+    stages and lands None in its slot — the downstream multi-arg stage never runs.
+    (PIN: this already works via the parallel barrier; the arity rewrite must not
+    regress it.)"""
+    src = (
+        "async def main(input):\n"
+        "    return await pipeline([1, 2], lambda x: agent('s', x),"
+        " lambda prev, item, index: prev + 1)"
+    )
+    first = await _run(src)
+    assert first.kind == "suspended"
+    k0, k1 = (e.call_key for e in first.emitted)
+    out = await _run(src, memo={k0: {"ok": 10}, k1: {"error": {"kind": "child_errored"}}})
+    assert out.kind == "returned"
+    assert out.value == [11, None]  # item 1: 10 -> +1 -> 11; item 2: chain raised -> None
+
+
 async def test_parallel_call_keys_are_replay_stable() -> None:
     """The scheduler's fixed creation-order sweep makes the per-branch call_keys
     identical across drives — the basis of replay-with-memo for parallel."""

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1854,7 +1854,9 @@ async def test_lowering_cap_mid_flight_does_not_kill_a_harvest_only_step(
     with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
         await workflow_completion.return_handler(children[0], {"request_id": rid0, "value": "r0"})
 
-    await run_workflow_step(run_id)  # harvest child0; child1 inflight; new_agent_caps == []
+    await run_workflow_step(
+        run_id
+    )  # harvest child0; child1 still inflight; no new agent spawns this step
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "suspended"  # NOT errored — no new spawns

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -602,18 +602,211 @@ async def test_agent_spawn_idempotent_on_replay(
     assert user_msgs == 1  # input delivered exactly once across replays
 
 
-async def test_agent_not_found_errors_the_run(wf_runtime: asyncpg.Pool[Any]) -> None:
+async def test_agent_not_found_is_catchable(wf_runtime: asyncpg.Pool[Any]) -> None:
+    """A missing agent surfaces as a catchable ``AgentError`` at the ``await``, not an
+    uncatchable terminal run error. Wake 1 journals a ``call_result`` error (and
+    self-wakes); wake 2 replays and throws the AgentError where the script catches it
+    and completes. No child is ever spawned for the bad call."""
     pool = wf_runtime
-    run_id = await _make_run(
-        pool, "async def main(input):\n    return await agent('agent_nope', 'x')\n"
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        "        await agent('agent_nope', 'x')\n"
+        "    except AgentError as e:\n"
+        "        return {'caught': True, 'kind': e.kind, 'msg': str(e)}\n"
+        "    return {'caught': False}\n"
     )
-    await run_workflow_step(run_id)
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # wake 1: journal the catchable error + self-wake
+    await run_workflow_step(run_id)  # wake 2: replay -> throw AgentError -> caught -> return
+
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
-    assert run is not None and run.status == "errored"
-    assert events[-1].type == "run_completed"
-    assert events[-1].payload["error"]["kind"] == "agent_not_found"
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert run is not None and run.status == "completed"
+    assert run.output == {
+        "caught": True,
+        "kind": "agent_not_found",
+        "msg": "agent 'agent_nope' not found",
+    }
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["is_error"] is True
+    assert cr.payload["error"] == {
+        "kind": "agent_not_found",
+        "message": "agent 'agent_nope' not found",
+    }
+    assert children == 0  # the rejected call never spawned a child
+
+
+async def test_bad_agent_call_invalid_schema_is_catchable(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A structurally-invalid ``output_schema`` surfaces as a catchable
+    ``AgentError(kind='bad_agent_call')`` at the await, preserving the descriptive
+    schema message. Two wakes; no child is spawned."""
+    pool = wf_runtime
+    bad_schema = {"type": "not-a-real-type"}
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'hi', output_schema={bad_schema!r})\n"
+        "    except AgentError as e:\n"
+        "        return {'caught': True, 'kind': e.kind, 'msg': str(e)}\n"
+        "    return {'caught': False}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert run is not None and run.status == "completed"
+    assert run.output["caught"] is True
+    assert run.output["kind"] == "bad_agent_call"
+    assert run.output["msg"].startswith("agent() output_schema is not a valid JSON Schema")
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["is_error"] is True
+    assert cr.payload["error"]["kind"] == "bad_agent_call"
+    assert cr.payload["error"]["message"].startswith(
+        "agent() output_schema is not a valid JSON Schema"
+    )
+    assert children == 0
+
+
+async def test_bad_agent_call_non_string_agent_id_is_catchable(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A non-string ``agent_id`` (here an int) reaches the parent's
+    ``not isinstance(agent_id, str)`` branch and surfaces as a catchable
+    ``AgentError(kind='bad_agent_call')`` with the exact descriptive message. No child."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        "        await agent(123, 'hi')\n"
+        "    except AgentError as e:\n"
+        "        return {'caught': True, 'kind': e.kind, 'msg': str(e)}\n"
+        "    return {'caught': False}\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    assert run is not None and run.status == "completed"
+    assert run.output == {
+        "caught": True,
+        "kind": "bad_agent_call",
+        "msg": "agent() requires a string agent_id, got 123",
+    }
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["error"] == {
+        "kind": "bad_agent_call",
+        "message": "agent() requires a string agent_id, got 123",
+    }
+    assert children == 0
+
+
+async def test_one_bad_branch_in_fanout_does_not_terminate_the_run(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """HEADLINE: a spawn error on ONE branch of a fan-out journals that branch's
+    catchable error and must NOT abort spawning the others. After wake 1 the run is
+    NOT terminated — the two good children are spawned and exactly one error is
+    journaled; it owes one drive ('running'), and a self-wake re-suspends it on the two
+    good children. After they answer, the barrier returns ``[None, r_a, r_b]``."""
+    from aios.tools import workflow_completion
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    return await parallel([\n"
+        "        lambda: agent('agent_nope', 'x'),\n"
+        f"        lambda: agent({wf_agent_id!r}, 'a'),\n"
+        f"        lambda: agent({wf_agent_id!r}, 'b'),\n"
+        "    ])\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # wake 1: spawn the 2 good children, journal 1 error
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    # NOT terminated by the bad branch — it owes a drive (the catchable error replay).
+    assert run is not None and run.status == "running"
+    started = [e for e in events if e.type == "call_started"]
+    assert len(started) == 2  # exactly the two good children spawned
+    errors = [e for e in events if e.type == "call_result" and e.payload.get("is_error")]
+    assert len(errors) == 1  # exactly one journaled spawn error
+    assert errors[0].payload["error"]["kind"] == "agent_not_found"
+    children = await _children_of(pool, run_id)
+    assert len(children) == 2
+
+    await run_workflow_step(run_id)  # owed drive: replay throws the caught error → re-suspend
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "suspended"  # settled on the two good children
+    assert len([e for e in events if e.type == "call_started"]) == 2  # no new spawns on replay
+    assert len([e for e in events if e.type == "call_result" and e.payload.get("is_error")]) == 1
+
+    # Answer the two good children, then drive again: barrier returns with the bad
+    # branch's None in its (first) slot.
+    for cid, value in zip(children, ["r_a", "r_b"], strict=True):
+        rid = await _open_request_id(pool, cid)
+        with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+            await workflow_completion.return_handler(cid, {"request_id": rid, "value": value})
+
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == [None, "r_a", "r_b"]
+
+
+async def test_spawn_error_call_result_has_no_paired_call_started(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """The journaled spawn error is a bare ``call_result`` for the bad call_key with NO
+    paired ``call_started`` — and the replay-prefix check (which asserts every inflight
+    ``call_started`` is re-emitted) never trips ``nondeterministic_replay``, because the
+    bad call has no open ``call_started`` to orphan."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        "        await agent('agent_nope', 'x')\n"
+        "    except AgentError:\n"
+        "        return 'caught'\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # wake 1: journal the error, self-wake
+
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+    error_keys = {
+        e.call_key for e in events if e.type == "call_result" and e.payload.get("is_error")
+    }
+    started_keys = {e.call_key for e in events if e.type == "call_started"}
+    assert len(error_keys) == 1
+    assert error_keys.isdisjoint(started_keys)  # the bad call_result has no call_started
+    # The run did not error (least of all with nondeterministic_replay).
+    completed = [e for e in events if e.type == "run_completed"]
+    assert all(
+        e.payload.get("error", {}).get("kind") != "nondeterministic_replay" for e in completed
+    )
 
 
 # ─── B2.D — return()/error() completion tools + injection gate ────────────────
@@ -2303,15 +2496,20 @@ async def test_return_enforces_output_schema(
 async def test_malformed_output_schema_errors_the_run(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
-    """A malformed output_schema fails the run cleanly (author-facing bad_agent_call)
-    and never spawns a child."""
+    """A malformed output_schema surfaces as a catchable ``AgentError(bad_agent_call)``
+    at the await (preserving the schema message) and never spawns a child."""
     pool = wf_runtime
     bad_schema = {"type": "not-a-real-type"}
     script = (
-        f"async def main(input):\n"
-        f"    return await agent({wf_agent_id!r}, 'hi', output_schema={bad_schema!r})\n"
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'hi', output_schema={bad_schema!r})\n"
+        "    except AgentError as e:\n"
+        "        return {'kind': e.kind, 'msg': str(e)}\n"
+        "    return {'caught': False}\n"
     )
     run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
@@ -2319,9 +2517,11 @@ async def test_malformed_output_schema_errors_the_run(
         children = await conn.fetchval(
             "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
         )
-    assert run is not None and run.status == "errored"
-    completed = [e for e in events if e.type == "run_completed"]
-    assert completed and completed[0].payload["error"]["kind"] == "bad_agent_call"
+    assert run is not None and run.status == "completed"
+    assert run.output["kind"] == "bad_agent_call"
+    assert run.output["msg"].startswith("agent() output_schema is not a valid JSON Schema")
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["error"]["kind"] == "bad_agent_call"
     assert children == 0  # rejected before any spawn
 
 
@@ -2330,11 +2530,19 @@ async def test_non_object_output_schema_errors_the_run(
 ) -> None:
     """A non-object output_schema (a bare boolean — valid JSON Schema, but ``false``
     rejects every value and ``true`` disables enforcement) is a degenerate author input:
-    fail the run cleanly as bad_agent_call rather than spawn a child that can never
-    return (or one with no enforcement)."""
+    surface a catchable ``AgentError(bad_agent_call)`` rather than spawn a child that can
+    never return (or one with no enforcement)."""
     pool = wf_runtime
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi', output_schema=False)\n"
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'hi', output_schema=False)\n"
+        "    except AgentError as e:\n"
+        "        return {'kind': e.kind, 'msg': str(e)}\n"
+        "    return {'caught': False}\n"
+    )
     run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
@@ -2342,10 +2550,11 @@ async def test_non_object_output_schema_errors_the_run(
         children = await conn.fetchval(
             "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
         )
-    assert run is not None and run.status == "errored"
-    completed = [e for e in events if e.type == "run_completed"]
-    assert completed and completed[0].payload["error"]["kind"] == "bad_agent_call"
-    assert "object schema" in completed[0].payload["output"]
+    assert run is not None and run.status == "completed"
+    assert run.output["kind"] == "bad_agent_call"
+    assert "object schema" in run.output["msg"]
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["error"]["kind"] == "bad_agent_call"
     assert children == 0  # rejected before any spawn
 
 
@@ -2471,11 +2680,20 @@ async def test_dangling_ref_output_schema_errors_the_run(
 ) -> None:
     """A schema whose ``$ref`` doesn't resolve passes check_schema but would raise at
     the child's validation time (bricking it until the deadline). Reject it
-    author-facing at the spawn gate, before any child spawns."""
+    author-facing at the spawn gate (a catchable ``AgentError``), before any child
+    spawns."""
     pool = wf_runtime
     schema = {"type": "object", "properties": {"a": {"$ref": "#/$defs/missing"}}, "required": ["a"]}
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'x', output_schema={schema!r})\n"
+    script = (
+        "async def main(input):\n"
+        "    try:\n"
+        f"        await agent({wf_agent_id!r}, 'x', output_schema={schema!r})\n"
+        "    except AgentError as e:\n"
+        "        return {'kind': e.kind, 'msg': str(e)}\n"
+        "    return {'caught': False}\n"
+    )
     run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
@@ -2483,10 +2701,11 @@ async def test_dangling_ref_output_schema_errors_the_run(
         children = await conn.fetchval(
             "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
         )
-    assert run is not None and run.status == "errored"
-    completed = [e for e in events if e.type == "run_completed"]
-    assert completed and completed[0].payload["error"]["kind"] == "bad_agent_call"
-    assert "reference" in completed[0].payload["output"].lower()
+    assert run is not None and run.status == "completed"
+    assert run.output["kind"] == "bad_agent_call"
+    assert "reference" in run.output["msg"].lower()
+    cr = next(e for e in events if e.type == "call_result")
+    assert cr.payload["error"]["kind"] == "bad_agent_call"
     assert children == 0  # rejected before any spawn
 
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1047,6 +1047,10 @@ async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
     from aios.workflows.host_launcher import EmittedCapability
     from aios.workflows.step import _open_agent_capability
 
+    # A cap high enough that the lifetime quota never trips — this test exercises the
+    # re-attach / self-wake arm, not H1.
+    _SPAWN_KW = {"agent_spawns": 0, "max_agent_calls": 1000}
+
     pool = wf_runtime
     script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
     run_id = await _make_run(pool, script)
@@ -1060,12 +1064,12 @@ async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
         assert run is not None
         # First spawn: created → defer_wake fires once.
         with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as w1:
-            r1 = await _open_agent_capability(conn, pool, run, cap)
+            r1 = await _open_agent_capability(conn, pool, run, cap, **_SPAWN_KW)
         assert not r1.rejected and not r1.needs_rewake
         w1.assert_awaited_once()
         # Re-attach, no marker yet → no defer_wake, no self-wake.
         with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as w2:
-            r2 = await _open_agent_capability(conn, pool, run, cap)
+            r2 = await _open_agent_capability(conn, pool, run, cap, **_SPAWN_KW)
         assert not r2.rejected and not r2.needs_rewake
         w2.assert_not_awaited()
 
@@ -1079,7 +1083,7 @@ async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
         run = await wf_queries.get_run_for_step(conn, run_id)
         assert run is not None
         with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as w3:
-            r3 = await _open_agent_capability(conn, pool, run, cap)
+            r3 = await _open_agent_capability(conn, pool, run, cap, **_SPAWN_KW)
         assert not r3.rejected and r3.needs_rewake  # marker present → self-wake to harvest
         w3.assert_not_awaited()
 
@@ -1759,11 +1763,16 @@ async def test_parallel_barrier_yields_none_for_an_errored_child(
 # ─── H — runaway caps + the per-call wall-clock deadline ──────────────────────
 
 
-async def test_lifetime_agent_cap_errors_atomically_before_spawning(
+async def test_lifetime_agent_cap_errors_at_the_over_cap_spawn(
     monkeypatch: pytest.MonkeyPatch, wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
-    """A fan-out that would push the run past its lifetime agent-call cap errors
-    BEFORE spawning any of that step's children — no partial fan-out of orphans."""
+    """A fan-out that would push the run past its lifetime agent-call cap errors with
+    ``too_many_agents`` AT the over-cap child: the cap is enforced per-spawn (so a
+    rejected cap never tips it), checked just before each ``create_child_session``. The
+    children up to the cap are spawned, but the (cap + 1)-th child is NEVER created — the
+    run errors the moment that spawn is attempted. Those at-cap children are orphans the
+    quiescence sweep reclaims (idle, no sandbox until used); the over-cap child does not
+    exist."""
     from aios.config import get_settings
 
     capped = get_settings().model_copy(update={"workflow_max_agent_calls": 2})
@@ -1775,17 +1784,18 @@ async def test_lifetime_agent_cap_errors_atomically_before_spawning(
         f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(3)])\n"
     )
     run_id = await _make_run(pool, script)
-    await run_workflow_step(run_id)  # 3 > cap 2 → error, nothing spawned
+    await run_workflow_step(run_id)  # 3 > cap 2 → error AT the 3rd spawn
 
-    assert await _children_of(pool, run_id) == []  # no call_started journaled
+    # The cap-many children spawned (call_started journaled); the over-cap one did not.
+    assert len(await _children_of(pool, run_id)) == 2  # exactly max_agent_calls, never the 3rd
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
         events = await wf_queries.list_run_events(conn, run_id)
-        # the invariant at its real surface: no child session rows exist for the run
-        orphans = await conn.fetchval(
+        # The over-cap child is never created — at most max_agent_calls session rows exist.
+        spawned = await conn.fetchval(
             "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
         )
-    assert orphans == 0  # atomic: no partial fan-out of orphan children
+    assert spawned == 2  # the (cap + 1)-th child was never created
     assert run is not None and run.status == "errored"
     assert events[-1].type == "run_completed"
     assert events[-1].payload["error"]["kind"] == "too_many_agents"
@@ -1848,6 +1858,106 @@ async def test_lowering_cap_mid_flight_does_not_kill_a_harvest_only_step(
     async with pool.acquire() as conn:
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "suspended"  # NOT errored — no new spawns
+
+
+async def test_rejected_agent_cap_does_not_count_toward_quota(
+    monkeypatch: pytest.MonkeyPatch, wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A cap the spawn gate REJECTS (agent_not_found / bad_agent_call) spawns no child
+    and must NOT count toward ``max_agent_calls``. With cap 2 and one prior real spawn,
+    a ``parallel([agent('nope'), agent(real)])`` frontier has only ONE real spawn left
+    (the good branch) — so the run must NOT trip ``too_many_agents``: the bad branch
+    surfaces a catchable AgentError (→ barrier slot None) and the good branch completes.
+    The buggy pre-count saw 2 new caps (1 prior + 2 > 2) and terminated the run."""
+    from aios.config import get_settings
+    from aios.tools import workflow_completion
+
+    capped = get_settings().model_copy(update={"workflow_max_agent_calls": 2})
+    monkeypatch.setattr("aios.workflows.step.get_settings", lambda: capped)
+
+    pool = wf_runtime
+    # One prior real spawn, THEN the bad+good fan-out: prior=1, one real spawn left.
+    script = (
+        "async def main(input):\n"
+        f"    await agent({wf_agent_id!r}, 'first')\n"
+        "    return await parallel([\n"
+        "        lambda: agent('agent_nope', 'x'),\n"
+        f"        lambda: agent({wf_agent_id!r}, 'y'),\n"
+        "    ])\n"
+    )
+    run_id = await _make_run(pool, script)
+
+    # Wake 1: spawn `first`, suspend. Answer it so the next wake replays to the parallel.
+    await run_workflow_step(run_id)
+    first_child = (await _children_of(pool, run_id))[0]
+    rid_first = await _open_request_id(pool, first_child)
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(
+            first_child, {"request_id": rid_first, "value": "r_first"}
+        )
+
+    # Wake 2: harvest `first` → replay to the parallel frontier. prior=1, new caps={nope, y}.
+    # The good 'y' is the only real spawn (count 2 ≤ 2 OK); 'nope' is rejected, NOT counted.
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    # NOT terminated by too_many_agents — the rejected cap did not tip the quota.
+    assert run is not None and run.status == "running"  # owes the catchable-error drive
+    assert not any(
+        e.type == "run_completed" and e.payload.get("error", {}).get("kind") == "too_many_agents"
+        for e in events
+    )
+    errors = [e for e in events if e.type == "call_result" and e.payload.get("is_error")]
+    assert len(errors) == 1 and errors[0].payload["error"]["kind"] == "agent_not_found"
+    # Two real children total: `first` (harvested) + `y` (just spawned).
+    children = await _children_of(pool, run_id)
+    assert len(children) == 2
+
+    # Drive the owed replay (throws the caught AgentError → re-suspend on `y`), then
+    # answer `y` and complete. The bad branch is None; the good branch is `y`'s value.
+    await run_workflow_step(run_id)
+    y_child = children[1]
+    rid_y = await _open_request_id(pool, y_child)
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        await workflow_completion.return_handler(y_child, {"request_id": rid_y, "value": "r_y"})
+
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output == [None, "r_y"]  # bad branch → None, good branch → its value
+
+
+async def test_real_overquota_fanout_still_errors_too_many_agents(
+    monkeypatch: pytest.MonkeyPatch, wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The guard still fires for genuine over-quota REAL spawns (it isn't disabled by the
+    per-spawn counting): a fan-out of three real agents with cap 2 terminates the run with
+    ``too_many_agents`` and the over-cap child is never created."""
+    from aios.config import get_settings
+
+    capped = get_settings().model_copy(update={"workflow_max_agent_calls": 2})
+    monkeypatch.setattr("aios.workflows.step.get_settings", lambda: capped)
+
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        "    return await parallel([\n"
+        f"        lambda: agent({wf_agent_id!r}, 'a'),\n"
+        f"        lambda: agent({wf_agent_id!r}, 'b'),\n"
+        f"        lambda: agent({wf_agent_id!r}, 'c'),\n"
+        "    ])\n"
+    )
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)  # 3 real > cap 2 → too_many_agents
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "errored"
+    assert events[-1].type == "run_completed"
+    assert events[-1].payload["error"]["kind"] == "too_many_agents"
 
 
 async def test_agent_call_times_out_when_child_never_responds(


### PR DESCRIPTION
Closes #779

## Motivation

Two unrelated gaps in the workflow script host produced the same class of problem: a single bad configuration or future branch could silently kill an entire run without giving the workflow author a chance to handle it. This PR closes both gaps.

---

## Fix 1 — Spawn-time failures are now catchable `AgentError`s

### The problem

Every _runtime_ agent failure (timeout, crash, archival, no-return) was already delivered as a catchable `AgentError` at the `await agent(...)` site, through a journaled `call_result` error-result event. Spawn-time failures were the inconsistent exception:

- An unknown or archived `agent_id` → `_complete_run(is_error=True)`
- A non-string `agent_id` or invalid `output_schema` → same

One bad branch in a `parallel()` or `pipeline()` fan-out killed the entire run. A configuration slip could turn a long-lived heartbeat workflow into a permanently dead durable loop, with no recovery path short of archiving the run.

### The fix

Both spawn rejections now flow through the same journaled error-result channel used by every other agent failure. The spawn function journals a `call_result` error for the call key, carrying `{kind: "agent_not_found" | "bad_agent_call", message: <text>}`; on replay, `_agent_error_from` raises a catchable `AgentError` at the await site. Caught → the script continues. Uncaught → the branch becomes `None` like any other agent failure, and the run is not terminated.

One error-delivery channel, correct by construction.

**Replay subtlety:** when a rejection is journaled, the step returns its lease as `running` (not `suspended`) so the already-deferred re-wake drives replay past the quiet-wake early-exit guard. Without this, the harvest would find nothing new (the spawn error has no paired `call_started`), and the replay that raises the `AgentError` would never run. This is one-shot by construction: the rejected call lands in memo and its capability is skipped on every subsequent replay.

**Already-errored runs are unaffected** — the terminal path is still used where the error is not attributable to a specific call.

---

## Fix 2 — `pipeline()` stages may now declare `(prev, item, index)`

### The problem

`pipeline(items, *stages)` threaded each item through each stage with a single argument: `stage(prev)`. Later stages had no direct access to the original item — you had to thread it through every return value yourself, which is boilerplate and obscures intent (e.g. a verify stage that needs to name the file it's verifying).

### The fix

Stages may declare 1, 2, or 3 positional parameters of `(prev, item, index)`. `pipeline()` inspects each stage's parameter count once at construction and calls it with that many arguments from the front of `[prev, item, index]`. For the first stage, `prev` is the item itself.

Edge cases:
- A `*args` stage receives all three.
- A callable whose signature cannot be inspected (e.g. a C builtin) receives only `prev` — the conservative, legacy-compatible default.

Per-stage inspection and deterministic dispatch make this replay-stable. Existing one-arg stage definitions and in-flight runs are untouched; Python cannot silently drop extra args the way JavaScript does, so adaptive arity is the deliberate calling convention here rather than always passing all three.

The `None` short-circuit — an item whose chain raises `AgentError` yields `None` and skips its remaining stages — is preserved and now pinned by a dedicated test.

---

## Tests

- **Host-tier** (subprocess script host, no DB): arity 1/2/3 stages, `*args` receiving all three, non-inspectable builtin falling back to `prev`-only, `None` short-circuit.
- **Step-tier** (Postgres testcontainer): catchable `agent_not_found`, catchable `bad_agent_call` (both invalid `output_schema` and non-string `agent_id`, with message text verified), and the headline case — a `parallel()` fan-out where one branch has a bad agent: the run is **not** terminated, other branches spawn and complete, and the bad branch resolves to `None`.
- Four existing tests that pinned the old "run completes errored" semantics were rewritten to the catchable shape.
- mypy clean (541 files), ruff clean, host tier 55 passed, step tier 85 passed.

---

## Scope

No migration, no API/OpenAPI/SDK-model change — the journal rows reuse the existing error-result shape. `parallel()` error semantics are otherwise unchanged: deterministic author bugs (`KeyError`, `TypeError`) still fail the run loudly.

Part of #777. Consolidates #827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
