### PR TITLE
fix(connectors): stamp resolved channel onto send tool results

### DIFF
--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -489,6 +489,10 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         # *before* issuing the RPC closes the race where the echo
         # could arrive before we're listening.
         chat_type, _ = decode_chat_id(chat_id)
+        # Stamp the resolved focal channel + chat_type onto the result so
+        # external observers read the send target directly off the
+        # tool_result event instead of reconstructing focal heuristically.
+        base = {"channel": self.focal_channel(state.bot_uuid, chat_id), "chat_type": chat_type}
         echo_future: asyncio.Future[int] | None = None
         if chat_type == "group":
             echo_future = asyncio.get_running_loop().create_future()
@@ -509,7 +513,7 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
                         phone=state.phone,
                         chat_id=chat_id,
                     )
-            return {"sent_at_ms": ts} if ts is not None else {"status": "ok"}
+            return {"sent_at_ms": ts, **base} if ts is not None else {"status": "ok", **base}
         finally:
             # Cancel any unresolved future so the drain-stale logic in
             # ``_maybe_resolve_self_echo`` prunes it before the NEXT

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -50,14 +50,50 @@ def test_build_params_with_attachments() -> None:
 # ── signal_send: direct method calls with already-resolved paths ─────
 
 
-async def test_signal_send_text_only(connector: SignalConnector) -> None:
+async def test_signal_send_dm_result_carries_channel_and_chat_type(
+    connector: SignalConnector,
+) -> None:
     result = await connector.signal_send(
         text="hello there", chat_id=ALICE_UUID, connection_id=CONNECTION_ID
     )
-    assert result == {"status": "ok"}
+    # The result stamps the resolved focal channel + chat_type so
+    # external observers don't have to reconstruct focal heuristically.
+    # The connector fixture's bot_uuid is the literal "bot-uuid".
+    assert result == {
+        "status": "ok",
+        "channel": f"signal/bot-uuid/{ALICE_UUID}",
+        "chat_type": "dm",
+    }
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["message"] == "hello there"
     assert "attachments" not in sent_params
+
+
+async def test_signal_send_group_result_carries_channel_and_chat_type(
+    connector: SignalConnector,
+) -> None:
+    connector.state[CONNECTION_ID].groups = [
+        GroupInfo(id=GROUP_CHAT_ID, name="Tea Party", member_uuids=[ALICE_UUID, BOB_UUID])
+    ]
+    result = await connector.signal_send(
+        text="hello group", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
+    )
+    assert result["channel"] == f"signal/bot-uuid/{GROUP_CHAT_ID}"
+    assert result["chat_type"] == "group"
+
+
+async def test_signal_send_sent_at_ms_branch_carries_channel(
+    connector: SignalConnector,
+) -> None:
+    # When signal-cli returns a timestamp inline (DM path), the result
+    # still stamps channel + chat_type alongside ``sent_at_ms``.
+    connector._daemon.rpc.call.return_value = {"timestamp": 1700000000000}  # type: ignore[union-attr]
+    result = await connector.signal_send(text="hi", chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
+    assert result == {
+        "sent_at_ms": 1700000000000,
+        "channel": f"signal/bot-uuid/{ALICE_UUID}",
+        "chat_type": "dm",
+    }
 
 
 async def test_signal_send_with_resolved_attachments(

--- a/connectors/signal/tests/test_signal_send_echo.py
+++ b/connectors/signal/tests/test_signal_send_echo.py
@@ -196,7 +196,11 @@ async def test_signal_send_group_returns_sent_at_ms_from_echo(
         text="hello", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
     )
 
-    assert result == {"sent_at_ms": sent_ts}
+    assert result == {
+        "sent_at_ms": sent_ts,
+        "channel": f"signal/{BOT_UUID}/{GROUP_CHAT_ID}",
+        "chat_type": "group",
+    }
 
 
 async def test_signal_send_group_falls_back_when_echo_times_out(
@@ -212,7 +216,11 @@ async def test_signal_send_group_falls_back_when_echo_times_out(
         text="silence", chat_id=GROUP_CHAT_ID, connection_id=CONNECTION_ID
     )
 
-    assert result == {"status": "ok"}
+    assert result == {
+        "status": "ok",
+        "channel": f"signal/{BOT_UUID}/{GROUP_CHAT_ID}",
+        "chat_type": "group",
+    }
 
 
 async def test_inbound_dispatcher_resolves_echo_on_peer_account_stream(
@@ -289,5 +297,9 @@ async def test_signal_send_dm_does_not_register_echo_future(
 
     result = await connector.signal_send(text="dm", chat_id=ALICE_UUID, connection_id=CONNECTION_ID)
 
-    assert result == {"sent_at_ms": 999}
+    assert result == {
+        "sent_at_ms": 999,
+        "channel": f"signal/{BOT_UUID}/{ALICE_UUID}",
+        "chat_type": "dm",
+    }
     assert (PHONE, ALICE_UUID) not in connector._pending_echoes

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -438,6 +438,14 @@ class TelegramConnector(HttpConnector):
         """
         state = self.state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
+        # Stamp the resolved focal channel + chat_type onto the result so
+        # external observers read the send target directly off the
+        # tool_result event.  Build the channel from the ORIGINAL chat_id
+        # string so the segment is byte-identical to inbound/focal form.
+        base = {
+            "channel": self.focal_channel(str(state.bot_id), chat_id),
+            "chat_type": _chat_type_from_chat_id(chat_id_int),
+        }
 
         body, ptb_parse_mode = _prepare_text(text, parse_mode)
         host_paths: list[Path] = list(attachments or [])
@@ -454,7 +462,7 @@ class TelegramConnector(HttpConnector):
                 parse_mode=ptb_parse_mode,
                 **reply_kwargs,
             )
-            return {"message_id": sent.message_id}
+            return {"message_id": sent.message_id, **base}
 
         if len(host_paths) == 1:
             single = await _send_single_media(
@@ -465,14 +473,14 @@ class TelegramConnector(HttpConnector):
                 parse_mode=ptb_parse_mode,
                 reply_to_message_id=reply_to_message_id,
             )
-            return {"message_id": single.message_id}
+            return {"message_id": single.message_id, **base}
 
         sent_group = await bot.send_media_group(
             chat_id=chat_id_int,
             media=_build_media_group(host_paths, caption=body or None, parse_mode=ptb_parse_mode),
             **reply_kwargs,
         )
-        return {"message_ids": [m.message_id for m in sent_group]}
+        return {"message_ids": [m.message_id for m in sent_group], **base}
 
     @tool()
     async def telegram_typing(
@@ -635,6 +643,13 @@ def _coerce_chat_id(chat_id: str) -> int:
         return int(chat_id)
     except ValueError as e:
         raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
+
+
+def _chat_type_from_chat_id(chat_id_int: int) -> Literal["dm", "group"]:
+    # Telegram's chat-id sign convention: positive ids are private chats
+    # (dm); negative ids are groups/supergroups/channels (the -100...
+    # prefix marks supergroups/channels, still negative → group).
+    return "dm" if chat_id_int >= 0 else "group"
 
 
 def _prepare_text(text: str, parse_mode: str) -> tuple[str, str | None]:

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -69,6 +69,7 @@ from .parse import (
     Attachment,
     InboundMessage,
     InboundReaction,
+    _chat_kind,
     parse_message,
     parse_reaction,
 )
@@ -438,14 +439,17 @@ class TelegramConnector(HttpConnector):
         """
         state = self.state[connection_id]
         chat_id_int = _coerce_chat_id(chat_id)
-        # Stamp the resolved focal channel + chat_type onto the result so
-        # external observers read the send target directly off the
-        # tool_result event.  Build the channel from the ORIGINAL chat_id
-        # string so the segment is byte-identical to inbound/focal form.
-        base = {
-            "channel": self.focal_channel(str(state.bot_id), chat_id),
-            "chat_type": _chat_type_from_chat_id(chat_id_int),
-        }
+        # Stamp the resolved focal channel onto the result so external
+        # observers read the send target directly off the tool_result
+        # event.  Build the channel from the ORIGINAL chat_id string so
+        # the segment is byte-identical to inbound/focal form.  ``chat_type``
+        # is derived below from the chat object the send API returns,
+        # through the SAME ``_chat_kind`` helper inbound uses — so a
+        # supergroup reads ``"supergroup"`` outbound exactly as it does
+        # inbound, instead of being flattened to ``"group"`` by guessing
+        # from the chat_id sign (which can't tell group from supergroup
+        # from channel).
+        channel = self.focal_channel(str(state.bot_id), chat_id)
 
         body, ptb_parse_mode = _prepare_text(text, parse_mode)
         host_paths: list[Path] = list(attachments or [])
@@ -462,7 +466,11 @@ class TelegramConnector(HttpConnector):
                 parse_mode=ptb_parse_mode,
                 **reply_kwargs,
             )
-            return {"message_id": sent.message_id, **base}
+            return {
+                "message_id": sent.message_id,
+                "channel": channel,
+                "chat_type": _chat_kind(sent.chat.type),
+            }
 
         if len(host_paths) == 1:
             single = await _send_single_media(
@@ -473,14 +481,22 @@ class TelegramConnector(HttpConnector):
                 parse_mode=ptb_parse_mode,
                 reply_to_message_id=reply_to_message_id,
             )
-            return {"message_id": single.message_id, **base}
+            return {
+                "message_id": single.message_id,
+                "channel": channel,
+                "chat_type": _chat_kind(single.chat.type),
+            }
 
         sent_group = await bot.send_media_group(
             chat_id=chat_id_int,
             media=_build_media_group(host_paths, caption=body or None, parse_mode=ptb_parse_mode),
             **reply_kwargs,
         )
-        return {"message_ids": [m.message_id for m in sent_group], **base}
+        return {
+            "message_ids": [m.message_id for m in sent_group],
+            "channel": channel,
+            "chat_type": _chat_kind(sent_group[0].chat.type),
+        }
 
     @tool()
     async def telegram_typing(
@@ -643,13 +659,6 @@ def _coerce_chat_id(chat_id: str) -> int:
         return int(chat_id)
     except ValueError as e:
         raise ValueError(f"telegram chat_id must be an integer; got {chat_id!r}") from e
-
-
-def _chat_type_from_chat_id(chat_id_int: int) -> Literal["dm", "group"]:
-    # Telegram's chat-id sign convention: positive ids are private chats
-    # (dm); negative ids are groups/supergroups/channels (the -100...
-    # prefix marks supergroups/channels, still negative → group).
-    return "dm" if chat_id_int >= 0 else "group"
 
 
 def _prepare_text(text: str, parse_mode: str) -> tuple[str, str | None]:

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -25,10 +25,22 @@ from telegram import InputFile
 from aios_telegram.connector import (
     TelegramConnector,
     _build_media_group,
-    _chat_type_from_chat_id,
     _classify,
 )
 from tests.conftest import BOT_ID, CONNECTION_ID
+
+
+def _sent(message_id: int, chat_type: str = "private") -> MagicMock:
+    """Build a mock PTB ``Message`` return value for a send_* call.
+
+    ``telegram_send`` derives the result's ``chat_type`` from the
+    returned message's ``.chat.type`` via the same ``_chat_kind`` helper
+    inbound uses, so the mock must carry a realistic Telegram chat-type
+    string ("private"/"group"/"supergroup"/"channel").
+    """
+    m = MagicMock(message_id=message_id)
+    m.chat.type = chat_type
+    return m
 
 
 def test_classify_extensions() -> None:
@@ -91,18 +103,13 @@ def test_telegram_connector_subclasses_http_connector() -> None:
 @pytest.fixture
 def bot() -> Any:
     b = MagicMock()
-    b.send_message = AsyncMock(return_value=MagicMock(message_id=42))
-    b.send_photo = AsyncMock(return_value=MagicMock(message_id=43))
-    b.send_voice = AsyncMock(return_value=MagicMock(message_id=44))
-    b.send_video = AsyncMock(return_value=MagicMock(message_id=45))
-    b.send_audio = AsyncMock(return_value=MagicMock(message_id=46))
-    b.send_document = AsyncMock(return_value=MagicMock(message_id=47))
-    b.send_media_group = AsyncMock(
-        return_value=[
-            MagicMock(message_id=100),
-            MagicMock(message_id=101),
-        ]
-    )
+    b.send_message = AsyncMock(return_value=_sent(42))
+    b.send_photo = AsyncMock(return_value=_sent(43))
+    b.send_voice = AsyncMock(return_value=_sent(44))
+    b.send_video = AsyncMock(return_value=_sent(45))
+    b.send_audio = AsyncMock(return_value=_sent(46))
+    b.send_document = AsyncMock(return_value=_sent(47))
+    b.send_media_group = AsyncMock(return_value=[_sent(100), _sent(101)])
     return b
 
 
@@ -111,8 +118,9 @@ def bot() -> Any:
 
 async def test_telegram_send_text_only(connector: TelegramConnector, bot: Any) -> None:
     result = await connector.telegram_send(text="hello", chat_id="123", connection_id=CONNECTION_ID)
-    # Result stamps the resolved focal channel + chat_type.  chat_id
-    # "123" is positive → dm per Telegram's sign convention.
+    # Result stamps the resolved focal channel + chat_type.  ``chat_type``
+    # is derived from the chat the send API returned (``.chat.type ==
+    # "private"``) via the same ``_chat_kind`` helper inbound uses → "dm".
     assert result == {
         "message_id": 42,
         "channel": f"telegram/{BOT_ID}/123",
@@ -121,22 +129,37 @@ async def test_telegram_send_text_only(connector: TelegramConnector, bot: Any) -
     bot.send_message.assert_awaited_once_with(chat_id=123, text="hello", parse_mode=None)
 
 
-def test_chat_type_from_chat_id() -> None:
-    assert _chat_type_from_chat_id(123) == "dm"
-    assert _chat_type_from_chat_id(0) == "dm"
-    assert _chat_type_from_chat_id(-987654321) == "group"
-    # Supergroups/channels use the -100... prefix — still negative → group.
-    assert _chat_type_from_chat_id(-1001234567890) == "group"
-
-
 async def test_telegram_send_group_result_chat_type_group(
     connector: TelegramConnector, bot: Any
 ) -> None:
+    """A legacy ``group`` chat reports ``chat_type == "group"`` — derived
+    from the returned message's ``.chat.type``, matching inbound's
+    ``_chat_kind`` mapping."""
+    bot.send_message = AsyncMock(return_value=_sent(42, chat_type="group"))
     result = await connector.telegram_send(
         text="hello group", chat_id="-987654321", connection_id=CONNECTION_ID
     )
     assert result["channel"] == f"telegram/{BOT_ID}/-987654321"
     assert result["chat_type"] == "group"
+
+
+async def test_telegram_send_supergroup_result_chat_type_supergroup(
+    connector: TelegramConnector, bot: Any
+) -> None:
+    """Regression for #943: a supergroup (chat_id with the ``-100…``
+    prefix) MUST report ``chat_type == "supergroup"`` outbound, exactly
+    as inbound stamps it.  The old ``_chat_type_from_chat_id`` guessed
+    from the chat_id sign and flattened every negative id to "group",
+    so a supergroup recorded ``"supergroup"`` inbound but ``"group"``
+    outbound — breaking inbound↔outbound correlation.  Deriving from the
+    returned ``.chat.type`` via ``_chat_kind`` makes the two byte-identical.
+    """
+    bot.send_message = AsyncMock(return_value=_sent(42, chat_type="supergroup"))
+    result = await connector.telegram_send(
+        text="hello supergroup", chat_id="-1001234567890", connection_id=CONNECTION_ID
+    )
+    assert result["channel"] == f"telegram/{BOT_ID}/-1001234567890"
+    assert result["chat_type"] == "supergroup"
 
 
 async def test_telegram_send_reply_to_message_id_threads_through(

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -25,9 +25,10 @@ from telegram import InputFile
 from aios_telegram.connector import (
     TelegramConnector,
     _build_media_group,
+    _chat_type_from_chat_id,
     _classify,
 )
-from tests.conftest import CONNECTION_ID
+from tests.conftest import BOT_ID, CONNECTION_ID
 
 
 def test_classify_extensions() -> None:
@@ -110,8 +111,32 @@ def bot() -> Any:
 
 async def test_telegram_send_text_only(connector: TelegramConnector, bot: Any) -> None:
     result = await connector.telegram_send(text="hello", chat_id="123", connection_id=CONNECTION_ID)
-    assert result == {"message_id": 42}
+    # Result stamps the resolved focal channel + chat_type.  chat_id
+    # "123" is positive → dm per Telegram's sign convention.
+    assert result == {
+        "message_id": 42,
+        "channel": f"telegram/{BOT_ID}/123",
+        "chat_type": "dm",
+    }
     bot.send_message.assert_awaited_once_with(chat_id=123, text="hello", parse_mode=None)
+
+
+def test_chat_type_from_chat_id() -> None:
+    assert _chat_type_from_chat_id(123) == "dm"
+    assert _chat_type_from_chat_id(0) == "dm"
+    assert _chat_type_from_chat_id(-987654321) == "group"
+    # Supergroups/channels use the -100... prefix — still negative → group.
+    assert _chat_type_from_chat_id(-1001234567890) == "group"
+
+
+async def test_telegram_send_group_result_chat_type_group(
+    connector: TelegramConnector, bot: Any
+) -> None:
+    result = await connector.telegram_send(
+        text="hello group", chat_id="-987654321", connection_id=CONNECTION_ID
+    )
+    assert result["channel"] == f"telegram/{BOT_ID}/-987654321"
+    assert result["chat_type"] == "group"
 
 
 async def test_telegram_send_reply_to_message_id_threads_through(
@@ -153,7 +178,11 @@ async def test_telegram_send_single_photo_routes_to_send_photo(
         text="look", attachments=[photo], chat_id="123", connection_id=CONNECTION_ID
     )
 
-    assert result == {"message_id": 43}
+    assert result == {
+        "message_id": 43,
+        "channel": f"telegram/{BOT_ID}/123",
+        "chat_type": "dm",
+    }
     bot.send_photo.assert_awaited_once()
     kwargs = bot.send_photo.call_args.kwargs
     assert kwargs["chat_id"] == 123
@@ -251,7 +280,11 @@ async def test_telegram_send_multi_media_uses_send_media_group(
         connection_id=CONNECTION_ID,
     )
 
-    assert result == {"message_ids": [100, 101]}
+    assert result == {
+        "message_ids": [100, 101],
+        "channel": f"telegram/{BOT_ID}/123",
+        "chat_type": "dm",
+    }
     bot.send_media_group.assert_awaited_once()
     bot.send_photo.assert_not_awaited()
     media = bot.send_media_group.call_args.kwargs["media"]

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -12,7 +12,7 @@ import mimetypes
 import socket
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import structlog
 from aios_connector_http import HttpConnector, SandboxPath, iso_from_ms, tool
@@ -283,7 +283,14 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
         result = await state.daemon.rpc.call("sendMessage", params)
         if not isinstance(result, dict):
             raise RuntimeError(f"sendMessage returned non-dict: {result!r}")
-        return result
+        # Stamp the resolved focal channel + chat_type onto the result so
+        # external observers read the send target directly off the
+        # tool_result event instead of reconstructing focal heuristically.
+        return {
+            **result,
+            "channel": self.focal_channel(state.phone, chat_id),
+            "chat_type": _chat_type_from_jid(chat_id),
+        }
 
     @tool()
     async def whatsapp_react(
@@ -512,6 +519,12 @@ def _phone_from_jid(jid: str) -> str:
     if not sep or host != "s.whatsapp.net" or not local.isdigit():
         return jid
     return "+" + local
+
+
+def _chat_type_from_jid(jid: str) -> Literal["dm", "group"]:
+    # WhatsApp group JIDs carry the ``@g.us`` suffix; 1:1 chats use
+    # ``@s.whatsapp.net`` (or a ``@lid`` privacy alias) → dm.
+    return "group" if jid.endswith("@g.us") else "dm"
 
 
 def _attachment_params(host_path: Path) -> dict[str, str]:

--- a/connectors/whatsapp/tests/test_whatsapp_send.py
+++ b/connectors/whatsapp/tests/test_whatsapp_send.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 import pytest
 
-from aios_whatsapp.connector import WhatsappConnector
+from aios_whatsapp.connector import WhatsappConnector, _chat_type_from_jid
 
-from .conftest import CONNECTION_ID, GROUP_JID, PEER_JID
+from .conftest import CONNECTION_ID, GROUP_JID, PEER_JID, PHONE
 
 
 async def test_whatsapp_send_dm_calls_send_message_rpc(connector: WhatsappConnector) -> None:
@@ -25,7 +25,19 @@ async def test_whatsapp_send_dm_calls_send_message_rpc(connector: WhatsappConnec
         "sendMessage",
         {"jid": PEER_JID, "text": "hello peer"},
     )
-    assert result == {"message_id": "3EB0NEW", "timestamp_ms": 1700000100000}
+    # Result stamps the resolved focal channel + chat_type.  PEER_JID
+    # ends with @s.whatsapp.net → dm.
+    assert result == {
+        "message_id": "3EB0NEW",
+        "timestamp_ms": 1700000100000,
+        "channel": f"whatsapp/{PHONE}/{PEER_JID}",
+        "chat_type": "dm",
+    }
+
+
+def test_chat_type_from_jid() -> None:
+    assert _chat_type_from_jid(PEER_JID) == "dm"
+    assert _chat_type_from_jid(GROUP_JID) == "group"
 
 
 async def test_whatsapp_send_group_passes_group_jid(connector: WhatsappConnector) -> None:
@@ -33,7 +45,7 @@ async def test_whatsapp_send_group_passes_group_jid(connector: WhatsappConnector
         "message_id": "3EB0GRP",
         "timestamp_ms": 1700000200000,
     }
-    await connector.whatsapp_send(
+    result = await connector.whatsapp_send(
         text="hello group",
         connection_id=CONNECTION_ID,
         chat_id=GROUP_JID,
@@ -42,6 +54,9 @@ async def test_whatsapp_send_group_passes_group_jid(connector: WhatsappConnector
         "sendMessage",
         {"jid": GROUP_JID, "text": "hello group"},
     )
+    # GROUP_JID ends with @g.us → group.
+    assert result["channel"] == f"whatsapp/{PHONE}/{GROUP_JID}"
+    assert result["chat_type"] == "group"
 
 
 async def test_whatsapp_send_raises_on_non_dict_result(connector: WhatsappConnector) -> None:
@@ -86,7 +101,12 @@ async def test_whatsapp_send_forwards_attachments(
             "attachments": [{"path": str(img), "mimetype": "image/jpeg", "filename": "photo.jpg"}],
         },
     )
-    assert result == {"message_id": "3EB0IMG", "timestamp_ms": 1700000200000}
+    assert result == {
+        "message_id": "3EB0IMG",
+        "timestamp_ms": 1700000200000,
+        "channel": f"whatsapp/{PHONE}/{PEER_JID}",
+        "chat_type": "dm",
+    }
 
 
 async def test_whatsapp_send_unknown_mimetype_falls_back_to_octet_stream(

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -433,6 +434,168 @@ class TestSignalMultiConnection:
             await harness.run_step(session_a.id)
             events = await harness.events(session_a.id)
             assert last_assistant_content(events) == "done"
+        finally:
+            connector_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await connector_task
+
+    async def test_outbound_send_result_stamps_channel(
+        self,
+        harness: Harness,
+        live_server: str,
+        aios_env: dict[str, str],
+        mocked_signal_daemon: dict[str, Any],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The persisted ``signal_send`` tool_result stamps the RESOLVED
+        focal channel + chat_type directly onto its payload (#943), so an
+        external observer reads the send target off the tool event alone —
+        no heuristic reconstruction from prior events.
+
+        Drives the full ``switch_channel`` → ``signal_send`` path: an
+        inbound stamps a bound channel on session A, the model switches
+        focal to it, then calls ``signal_send`` WITHOUT an explicit
+        ``chat_id``.  The runtime injects ``chat_id`` from the switched
+        focal, and the connector echoes the same channel back in the
+        result — proving the stamped channel tracks focal, not the call
+        args.
+        """
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        from aios_signal.config import Settings
+        from aios_signal.connector import SignalConnector
+
+        from aios.services import agents as agents_service
+        from aios.services import connections as connections_service
+        from aios.services import environments as env_svc
+        from aios.services import sessions as sess_svc
+
+        target_channel = f"signal/{BOT_UUID_A}/{ALICE_UUID}"
+
+        agent = await agents_service.create_agent(
+            harness._pool,
+            name=f"sig-stamp-{id(self)}",
+            model="fake/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+            account_id=account_id,
+        )
+        env = await env_svc.create_environment(
+            harness._pool, name=f"env-stamp-{id(self)}", account_id=account_id
+        )
+        session_a = await sess_svc.create_session(
+            harness._pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title=None,
+            metadata={},
+            account_id=account_id,
+        )
+
+        api_key = aios_env["AIOS_API_KEY"]
+        conn_a = await _create_signal_connection(
+            api_key, live_server, PHONE_A + "-stamp", {"phone": PHONE_A}
+        )
+        await connections_service.attach_connection(
+            harness._pool, conn_a, session_id=session_a.id, account_id=account_id
+        )
+        await _publish_signal_tools_schema(harness)
+        token = await issue_runtime_token(api_key, live_server, "signal")
+
+        monkeypatch.setenv("AIOS_URL", live_server)
+        monkeypatch.setenv("AIOS_RUNTIME_TOKEN", token)
+        cfg = Settings(config_dir=tmp_path / "cfg", cli_bin="/usr/bin/signal-cli")
+        connector = SignalConnector(cfg)
+
+        # Inbound on the target channel makes it a bound, switchable
+        # channel (list_session_channels derives from the event log's
+        # ``channel`` column, stamped from this message's metadata).
+        await sess_svc.append_user_message(
+            harness._pool,
+            session_a.id,
+            "hi from alice",
+            metadata={"channel": target_channel},
+            account_id=account_id,
+        )
+
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[
+                        tool_call(
+                            "switch_channel",
+                            {"channel_id": target_channel},
+                            call_id="call_switch",
+                        )
+                    ]
+                ),
+                # No explicit chat_id — the runtime injects it from the
+                # switched focal channel.
+                assistant(
+                    tool_calls=[
+                        tool_call(
+                            "signal_send",
+                            {"text": "ack"},
+                            call_id="call_send",
+                        )
+                    ]
+                ),
+                assistant("done"),
+            ]
+        )
+
+        connector_task = asyncio.create_task(connector.run())
+        rpc_call: AsyncMock = mocked_signal_daemon["rpc_call"]
+        try:
+            await connector.wait_connection_served(conn_a)
+
+            # Step 1: switch_channel (in-process built-in) mutates focal.
+            await harness.run_step(session_a.id)
+            await harness.wait_for_tools(session_a.id)
+            session = await harness.session(session_a.id)
+            assert session.focal_channel == target_channel
+
+            # Step 2: signal_send — the connector executes it out-of-process.
+            await harness.run_step(session_a.id)
+
+            async def _signal_send_called() -> bool:
+                return any(c.args and c.args[0] == "send" for c in rpc_call.call_args_list)
+
+            deadline = asyncio.get_running_loop().time() + 10.0
+            while not await _signal_send_called():
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError("signal_send never reached the daemon RPC")
+                await asyncio.sleep(0.1)
+
+            # Poll for the SEND result specifically — the switch_channel
+            # tool_result is also ``role="tool"`` and lands first, so a
+            # bare "any tool result" predicate would race ahead of the
+            # connector's out-of-process signal_send POST.
+            async def _send_results() -> list[Any]:
+                msgs = await harness.events(session_a.id)
+                return [
+                    e
+                    for e in msgs
+                    if e.data.get("role") == "tool" and e.data.get("tool_call_id") == "call_send"
+                ]
+
+            deadline = asyncio.get_running_loop().time() + 5.0
+            while not await _send_results():
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError("signal_send tool_result event never persisted")
+                await asyncio.sleep(0.1)
+
+            # Read the connector's signal_send tool_result and assert the
+            # stamped channel + chat_type WITHOUT scanning prior events.
+            send_results = await _send_results()
+            assert len(send_results) == 1
+            payload = json.loads(send_results[0].data["content"])
+            assert payload["channel"] == target_channel
+            assert payload["chat_type"] == "dm"
         finally:
             connector_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):


### PR DESCRIPTION
## Why

Outbound send tools (`signal_send`, `telegram_send`, `whatsapp_send`) recorded a result event containing only the bare delivery confirmation — `{"status": "ok"}`, `{"message_id": ...}`, `{"sent_at_ms": ...}` — with no record of which channel the message was actually sent to. The resolved target lived only as transient focal-channel session state.

Any external consumer of the events log — conversation monitors, audit trails, dashboards, future operator tooling — had to reconstruct the target by scanning backwards for the nearest channel hint. That heuristic breaks when an inbound on a different channel lands mid-turn, causing misattribution.

## What changed

Each send-class connector tool now stamps the resolved `channel` and `chat_type` onto its result dict before returning. For example:

```json
{"status": "ok"}
```
becomes:
```json
{"status": "ok", "channel": "signal/<account>/<chat>", "chat_type": "dm"}
```

The connector already has the resolved target at send time — it must, to deliver. This change only persists what was already computed.

No schema migration, no API change, no codegen: the payload flows into `events.data` (jsonb) as-is.

## Implementation details

- Channel strings are built via the shared `HttpConnector.focal_channel(external_account_id, chat_id)` helper, so they are byte-identical to the inbound and focal-channel forms used everywhere else in the log.
- `chat_type` derivation is per-platform: Signal via `decode_chat_id`, Telegram via the chat_id sign convention (positive = dm, negative = group/supergroup/channel), WhatsApp via the `@g.us` JID suffix.
- Applied uniformly across all three connectors.

## Tests

- Unit tests per connector asserting the result dict carries the correct `channel` and `chat_type` for both dm and group targets, across all return shapes.
- E2E test (`tests/e2e/test_signal_connector.py::test_outbound_send_result_stamps_channel`) drives a live `SignalConnector` through inbound-focus + `switch_channel` → `signal_send` and asserts the persisted `tool_result` payload carries the resolved channel without scanning prior events.

**Reviewer note on the e2e test:** the poll had to match against the specific `signal_send` tool_call_id rather than "any tool result" — `switch_channel` also emits a `role=="tool"` result that lands first and would otherwise race. The `switch_channel`→`signal_send` leg calls `signal_send` with no explicit `chat_id` to prove the stamped channel tracks the resolved focal, not the call arguments; `_inject_focal_kwargs` parses `chat_id` out of the live `sessions.focal_channel` column written by `switch_channel`.

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
