### PR TITLE
fix(triggers): heal NULL next_fire on cron re-enable

### DIFF
--- a/src/aios/services/triggers.py
+++ b/src/aios/services/triggers.py
@@ -2,8 +2,16 @@
 
 Thin pool-acquiring wrappers around the queries in
 :mod:`aios.db.queries`. Owns the business logic around when to recompute
-``next_fire`` — on add, on source change, on re-enable — and exposes
-granular add/remove/update/list operations to the API + tool layers.
+``next_fire`` — on add, on source change, on re-enable, and (#957) as a
+defense-in-depth heal whenever an already-enabled row is found with
+``next_fire`` NULL — and exposes granular add/remove/update/list operations
+to the API + tool layers.
+
+Healing invariant (#957): an enabled schedulable trigger always has a
+non-NULL ``next_fire``. ``update_trigger`` re-arms a NULL on ANY update whose
+final state is enabled — closing the gap the #925 incident's manual
+``UPDATE … SET enabled=true`` opened, and complementing the startup-reconcile
+(#940 / PR #950). run_completion rows stay NULL by design.
 
 Deliberately no whole-list-replace primitive; per #270, the only mutation
 surface is granular ops.
@@ -207,6 +215,12 @@ async def update_trigger(
     - Source replaced on a row whose final state is enabled: recomputes
       ``next_fire`` (no cap re-check — an already-enabled row holds its
       slot), with the same past-``fire_at`` rejection.
+    - Healing (#957): an already-enabled row found with ``next_fire`` NULL has
+      ``next_fire`` recomputed from the merged source on ANY update whose final
+      state is enabled — no cap re-check, no failure-counter reset;
+      run_completion rows stay NULL by design; defense-in-depth with the
+      startup-reconcile (#940 / PR #950). Invariant: an enabled schedulable
+      trigger always has non-NULL ``next_fire``.
     - action / metadata / no-op: ``next_fire`` untouched.
 
     ``updated_at`` always bumps (handled in the query layer) so a no-op
@@ -243,10 +257,31 @@ async def update_trigger(
 
         next_fire: datetime | None | EllipsisType = ...  # ... = leave alone
         reenabled = new_enabled and not current.enabled
+        # Healing (#957): re-arm next_fire when the post-update state is enabled
+        # but next_fire is NULL — the state a manual `UPDATE … SET enabled=true`
+        # (the #925 incident anti-pattern) leaves a cron row in. heal_next_fire
+        # means "this is a cron row whose next_fire is NULL and therefore needs
+        # re-arming"; the enabled requirement is applied at the use site (the
+        # `elif new_enabled and (...)` gate below), so this flag is True for BOTH
+        # a genuine re-enable (a disabled row has next_fire=NULL) and a pure heal
+        # of an already-enabled row — it does not by itself distinguish them. The
+        # per-account cap re-check and the consecutive-failures reset are gated
+        # SEPARATELY on `not current.enabled` / `reenabled` below, so they apply
+        # only to a genuine false->true re-enable, never to a pure heal.
+        #
+        # Scoped to CRON sources only: the invariant is "an enabled CRON trigger
+        # always has non-NULL next_fire". One-shot rows (fire-and-delete; the
+        # existing past-fire_at guard owns their re-arm contract) and run_completion
+        # rows (NULL by design) are intentionally NOT healed — re-arming them
+        # requires an explicit source. This keeps a metadata-only or enabled=true
+        # PATCH on a stale one-shot from raising a spurious 422. (When a source IS
+        # provided, the source_provided branch below handles every source type
+        # unchanged.) Defense-in-depth with the startup-reconcile (#940 / PR #950).
+        heal_next_fire = current.next_fire is None and isinstance(current.source, CronSource)
         if not new_enabled and current.enabled:
             # Disabling: clear next_fire.
             next_fire = None
-        elif new_enabled and (source_provided or not current.enabled):
+        elif new_enabled and (source_provided or not current.enabled or heal_next_fire):
             # Re-enabling, or replacing the source on a row whose final
             # state is enabled: recompute next_fire from the merged source.
             if not current.enabled:

--- a/src/aios/services/triggers.py
+++ b/src/aios/services/triggers.py
@@ -7,11 +7,20 @@ defense-in-depth heal whenever an already-enabled row is found with
 ``next_fire`` NULL — and exposes granular add/remove/update/list operations
 to the API + tool layers.
 
-Healing invariant (#957): an enabled schedulable trigger always has a
+Healing invariant (#957): an enabled schedulable (cron) trigger always has a
 non-NULL ``next_fire``. ``update_trigger`` re-arms a NULL on ANY update whose
 final state is enabled — closing the gap the #925 incident's manual
-``UPDATE … SET enabled=true`` opened, and complementing the startup-reconcile
-(#940 / PR #950). run_completion rows stay NULL by design.
+``UPDATE … SET enabled=true`` opened. This heal is the SOLE recovery path for
+an incident-state row (``enabled=true, next_fire=NULL``): nothing re-arms such
+a row on its own. The scheduler's claim/MIN queries both filter
+``next_fire IS NOT NULL`` (see ``fetch_and_claim_due_triggers`` /
+``fetch_next_trigger_event`` in :mod:`aios.db.queries`), so a NULL row is
+invisible to the scheduler and never fires. #940 / PR #950 is NOT a reconcile:
+it only broadened ``notify_scheduled_tasks_due()`` to NOTIFY on any
+``next_fire`` change and lowered the scheduler heartbeat, which is what makes
+the scheduler REACT promptly to the re-armed schedule this heal produces.
+Removing this heal would therefore leave incident-state rows with no recovery
+at all. run_completion rows stay NULL by design.
 
 Deliberately no whole-list-replace primitive; per #270, the only mutation
 surface is granular ops.
@@ -218,8 +227,10 @@ async def update_trigger(
     - Healing (#957): an already-enabled row found with ``next_fire`` NULL has
       ``next_fire`` recomputed from the merged source on ANY update whose final
       state is enabled — no cap re-check, no failure-counter reset;
-      run_completion rows stay NULL by design; defense-in-depth with the
-      startup-reconcile (#940 / PR #950). Invariant: an enabled schedulable
+      run_completion rows stay NULL by design. This recompute is the SOLE
+      producer of a non-NULL ``next_fire`` for such a row; #940 / PR #950 only
+      broadened the NOTIFY gate and lowered the heartbeat so the scheduler
+      REACTS to the re-armed schedule. Invariant: an enabled schedulable
       trigger always has non-NULL ``next_fire``.
     - action / metadata / no-op: ``next_fire`` untouched.
 
@@ -276,7 +287,12 @@ async def update_trigger(
         # requires an explicit source. This keeps a metadata-only or enabled=true
         # PATCH on a stale one-shot from raising a spurious 422. (When a source IS
         # provided, the source_provided branch below handles every source type
-        # unchanged.) Defense-in-depth with the startup-reconcile (#940 / PR #950).
+        # unchanged.) This recompute is the SOLE producer of a non-NULL next_fire
+        # for an incident-state row (enabled=true, next_fire=NULL): the scheduler's
+        # claim/MIN queries both filter `next_fire IS NOT NULL`, so such a row never
+        # fires and nothing else re-arms it. #940 / PR #950 is not a reconcile — it
+        # only broadened the NOTIFY gate and lowered the heartbeat so the scheduler
+        # REACTS to the re-armed next_fire this heal writes.
         heal_next_fire = current.next_fire is None and isinstance(current.source, CronSource)
         if not new_enabled and current.enabled:
             # Disabling: clear next_fire.

--- a/src/aios/tools/trigger_update.py
+++ b/src/aios/tools/trigger_update.py
@@ -35,7 +35,12 @@ TRIGGER_UPDATE_DESCRIPTION = (
     "`source` and `action`, when provided, REPLACE the stored object "
     "wholesale — send the complete object (fetch the current values via "
     "`trigger_list`). Toggling `enabled` true→false pauses the trigger "
-    "(clears next_fire); false→true resumes it (recomputes next_fire)."
+    "(clears next_fire); false→true resumes it (recomputes next_fire). "
+    "Any update whose resulting state is an enabled cron trigger always "
+    "yields a recomputed (non-NULL) next_fire, so a cron trigger that "
+    "somehow became enabled with a cleared schedule is automatically "
+    "re-armed by any update (e.g. just re-enabling it) without re-sending "
+    "`source`; one-shot and run_completion triggers are not re-armed this way."
 )
 
 _SOURCE_SCHEMA: dict[str, Any] = {

--- a/tests/e2e/test_triggers.py
+++ b/tests/e2e/test_triggers.py
@@ -1744,6 +1744,205 @@ class TestNotifyTrigger:
                 pytest.fail("next_fire-only update did not produce a NOTIFY within 2s")
 
 
+class TestReEnableNextFireInvariant:
+    """The invariant "an enabled schedulable trigger has non-NULL next_fire"
+    across re-enable. Groups two cohesive cases:
+
+    - The clean-path re-enable baseline (ground truth, green PRE-fix): the
+      service auto-disable→re-enable (false→true) path already re-arms
+      next_fire and NOTIFYs — pre-existing behavior, not the #957 fix.
+    - The #957 heal cases: cron rows that reach enabled+next_fire=NULL out of
+      band (the #925 incident-recovery anti-pattern's manual
+      `UPDATE … SET enabled=true`) are re-armed on ANY update whose final state
+      is enabled, and the NULL→non-NULL re-arm NOTIFYs so the scheduler
+      relearns its sleep — while run_completion and one-shot rows are left
+      NULL by design.
+    """
+
+    async def test_reenable_after_service_auto_disable_rearms_next_fire(
+        self, pool: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """Clean path (ground truth): the service auto-disable flips enabled
+        false and clears next_fire; a plain re-enable (false→true) re-arms
+        next_fire and NOTIFYs. Passes even before the #957 fix."""
+        import asyncio as _asyncio
+
+        from aios.config import get_settings
+        from aios.db.listen import listen_for_triggers_due
+        from aios.harness import runtime, trigger_runner
+
+        env_id, agent_id = env_and_agent
+        sid = await _create_session(pool, env_id, agent_id)
+        account_id = "acc_test_stub"
+
+        echo = await trig_service.add_trigger(pool, sid, _spec("ultron"), account_id=account_id)
+
+        # Drive auto-disable through the SERVICE fire path: a failing run on the
+        # 5th consecutive failure trips the breaker (MAX_CONSECUTIVE_FAILURES).
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE triggers SET consecutive_failures = 4, running_since = $1 WHERE id = $2",
+                datetime.now(UTC),
+                echo.id,
+            )
+
+        async def _fail_run(_self: object, _handle: object, _cmd: str, **_kw: Any) -> Any:
+            return mock.MagicMock(exit_code=2, timed_out=False, stderr="boom: cron failed")
+
+        registry = _make_fake_sandbox_registry(_fail_run)
+        prev_pool = runtime.pool
+        prev_registry = runtime.sandbox_registry
+        runtime.pool = pool
+        runtime.sandbox_registry = registry
+        with mock.patch("aios.harness.trigger_runner.defer_wake", new_callable=mock.AsyncMock):
+            try:
+                await trigger_runner.run_trigger_step(echo.id)
+            finally:
+                runtime.pool = prev_pool
+                runtime.sandbox_registry = prev_registry
+
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT enabled, consecutive_failures, next_fire FROM triggers WHERE id = $1",
+                echo.id,
+            )
+        assert row is not None
+        assert row["enabled"] is False
+        assert row["consecutive_failures"] == 5
+        assert row["next_fire"] is None
+
+        # Re-enable (false→true): re-arms next_fire AND NOTIFYs (enabled flip).
+        async with listen_for_triggers_due(get_settings().db_url) as event:
+            event.clear()
+            re_enabled = await trig_service.update_trigger(
+                pool,
+                sid,
+                "ultron",
+                TriggerUpdate.model_validate({"enabled": True}),
+                account_id=account_id,
+            )
+            assert re_enabled.enabled is True
+            assert re_enabled.next_fire is not None
+            try:
+                await _asyncio.wait_for(event.wait(), timeout=2.0)
+            except TimeoutError:
+                pytest.fail("re-enable did not produce a NOTIFY within 2s")
+
+    async def test_reenable_already_enabled_null_next_fire_heals(
+        self, pool: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """Contaminated path (#957 RED before fix): a row that is ALREADY
+        enabled but has next_fire NULL is healed on a no-source enabled update —
+        next_fire is recomputed and the NULL→non-NULL re-arm NOTIFYs."""
+        import asyncio as _asyncio
+
+        from aios.config import get_settings
+        from aios.db.listen import listen_for_triggers_due
+
+        env_id, agent_id = env_and_agent
+        sid = await _create_session(pool, env_id, agent_id)
+        account_id = "acc_test_stub"
+
+        echo = await trig_service.add_trigger(pool, sid, _spec("ultron"), account_id=account_id)
+        # Reproduces the #957/#925 incident state: the manual `UPDATE … enabled=
+        # true` left next_fire NULL and suppressed the false→true transition the
+        # service keys recompute on.
+        async with pool.acquire() as conn:
+            await conn.execute("UPDATE triggers SET next_fire = NULL WHERE id = $1", echo.id)
+
+        async with listen_for_triggers_due(get_settings().db_url) as event:
+            event.clear()
+            healed = await trig_service.update_trigger(
+                pool,
+                sid,
+                "ultron",
+                TriggerUpdate.model_validate({"enabled": True}),
+                account_id=account_id,
+            )
+            assert healed.enabled is True
+            assert healed.next_fire is not None  # heal recomputed next_fire
+            try:
+                await _asyncio.wait_for(event.wait(), timeout=2.0)
+            except TimeoutError:
+                pytest.fail("heal (NULL→non-NULL next_fire) did not produce a NOTIFY within 2s")
+
+    async def test_heal_leaves_run_completion_next_fire_null(
+        self, pool: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """Invariant guard: healing a run_completion-source row (correctly at
+        enabled=true, next_fire=NULL) must keep next_fire NULL —
+        compute_initial_next_fire returns None for RunCompletionSource, so the
+        heal is a no-op and the triggers_run_completion_no_next_fire DB guard is
+        never violated."""
+        env_id, agent_id = env_and_agent
+        sid = await _create_session(pool, env_id, agent_id)
+        account_id = "acc_test_stub"
+        wf_id = await _make_workflow_e2e(pool)
+
+        echo = await trig_service.add_trigger(
+            pool, sid, _watch_spec("watcher", wf_id), account_id=account_id
+        )
+        assert echo.next_fire is None  # reactive row: NULL by design
+
+        healed = await trig_service.update_trigger(
+            pool,
+            sid,
+            "watcher",
+            TriggerUpdate.model_validate({"enabled": True}),
+            account_id=account_id,
+        )
+        assert healed.enabled is True
+        assert healed.next_fire is None  # heal is a no-op for run_completion
+
+        # The DB guard held (the row would not have UPDATEd otherwise).
+        async with pool.acquire() as conn:
+            col = await conn.fetchval("SELECT next_fire FROM triggers WHERE id = $1", echo.id)
+        assert col is None
+
+    async def test_heal_skips_one_shot_source(
+        self, pool: Any, env_and_agent: tuple[str, str]
+    ) -> None:
+        """#957 regression: the heal is scoped to CRON sources, so an enabled
+        one-shot row contaminated to next_fire=NULL is NOT healed on a no-source
+        enabled=true PATCH — and (the actual bug) the recompute branch is never
+        entered, so the one-shot past-fire_at guard does NOT raise a spurious 422.
+        One-shots are fire-and-delete; their re-arm contract is owned by an
+        explicit source replacement, not the heal."""
+        env_id, agent_id = env_and_agent
+        sid = await _create_session(pool, env_id, agent_id)
+        account_id = "acc_test_stub"
+
+        # Enabled one-shot with a fire_at in the PAST relative to the heal call:
+        # add_trigger accepts any fire_at, so seed it in the past directly. The
+        # 422 bug needed a past fire_at to trip the one-shot guard once the broad
+        # heal wrongly entered the recompute branch.
+        past_fire = datetime.now(UTC) - timedelta(days=1)
+        echo = await trig_service.add_trigger(
+            pool, sid, _one_shot_spec("stale_oneshot", past_fire), account_id=account_id
+        )
+        assert echo.next_fire is not None  # enabled one-shot armed to fire_at
+        # Reproduce the contaminated state (enabled=true, next_fire=NULL) the #925
+        # manual edit left, but on a one-shot row this time.
+        async with pool.acquire() as conn:
+            await conn.execute("UPDATE triggers SET next_fire = NULL WHERE id = $1", echo.id)
+
+        # No raise (the pre-fix broad heal would have hit the one-shot past-fire_at
+        # guard and 422'd here), and next_fire stays NULL — only crons are healed.
+        healed = await trig_service.update_trigger(
+            pool,
+            sid,
+            "stale_oneshot",
+            TriggerUpdate.model_validate({"enabled": True}),
+            account_id=account_id,
+        )
+        assert healed.enabled is True
+        assert healed.next_fire is None  # one-shot is not healed
+
+        async with pool.acquire() as conn:
+            col = await conn.fetchval("SELECT next_fire FROM triggers WHERE id = $1", echo.id)
+        assert col is None
+
+
 class TestAdvisoryLockSerializesCapCheck:
     async def test_concurrent_add_at_cap_serialized(
         self, pool: Any, env_and_agent: tuple[str, str], monkeypatch: Any


### PR DESCRIPTION
Closes #957

## Problem

Re-enabling an auto-disabled trigger via `trigger_update(enabled=true)` could leave `next_fire=NULL` — a trigger that appears re-armed but never fires. Ultron (first production trigger user) hit this after being auto-disabled by the #925 incident: `enabled=true` alone did not restore scheduling; he had to also re-send `source` to force a reschedule.

## Verify-first finding

The report had a complicating factor: during incident recovery the CEO manually `UPDATE … SET enabled=true` on some rows, which itself suppresses the `false→true` transition the service keys `next_fire` recomputation on. So we established ground truth on the clean path before fixing anything.

- **Clean path** (auto-disable via the service fire path, then `enabled=true` re-enable): already re-armed `next_fire` and fired NOTIFY before any fix — it's a genuine `false→true` transition. Added as a regression guard; green pre-fix.
- **Contaminated path** (cron row already at `enabled=true, next_fire=NULL`, then `enabled=true`/metadata update with no source): `next_fire` stayed NULL. This is the real bug.

## Root cause

`update_trigger()` recomputed `next_fire` only when `new_enabled and (source_provided or not current.enabled)`. That correctly handles the normal `false→true` transition, but a row already at `enabled=true, next_fire=NULL` — exactly what a manual `UPDATE` or other out-of-band write leaves behind — has `not current.enabled` evaluate False with no source change, so `next_fire` was never touched. Enabled-but-never-fires: monitoring that looks re-armed but isn't, the worst failure shape.

## Fix — service-boundary heal (this PR)

Recompute `next_fire` on any update whose final state is enabled when the current row is a **cron** source with `next_fire IS NULL`. Because this is not a `false→true` transition, it does **not** re-check the per-account active-trigger cap (the row already holds its slot) and does **not** reset `consecutive_failures` — both remain gated on `not current.enabled` / `reenabled`. Invariant established at the service boundary: **an enabled cron trigger always has non-NULL `next_fire`, regardless of how the row got into its prior state.**

Scoped deliberately to cron:
- **One-shot** sources own their re-arm contract via the existing past-`fire_at` guard; healing them would spuriously raise a 422 ("set a fresh fire_at before enabling") on a metadata-only PATCH of an already-enabled stale one-shot. Left untouched.
- **`run_completion`** rows are NULL by design (`compute_initial_next_fire` returns `None`). Not healed.

## Scheduler re-arm is handled upstream (#940 / #950)

The other half — making the NOTIFY-driven scheduler *hear* a newly re-armed schedule — already landed on master via PR #940 / #950 (migration `0087_notify_next_fire`), which broadened `notify_scheduled_tasks_due()` to NOTIFY on any `next_fire` change. So a healed row (`next_fire` NULL→slot) wakes the scheduler immediately. **This PR carries no migration** — it was rebased onto that work, and the two form defense-in-depth: #940 makes the scheduler hear a re-armed schedule; #957 makes the service produce one.

## Tests (e2e, `tests/e2e/test_triggers.py`, class `TestReEnableNextFireInvariant`)

- `test_reenable_after_service_auto_disable_rearms_next_fire` — clean-path ground-truth baseline (drives `consecutive_failures` to threshold through `run_trigger_step`; green pre-fix)
- `test_reenable_already_enabled_null_next_fire_heals` — contaminated-path repro (the real bug; red pre-fix, including the NOTIFY assertion now satisfied by master's #940 clause)
- `test_heal_leaves_run_completion_next_fire_null` — reactive-row invariant guard
- `test_heal_skips_one_shot_source` — one-shot is not healed and does not 422

Mutation-checked: removing `or heal_next_fire` turns the heal assertion red. Full e2e triggers suite (86 tests, incl. master's `test_next_fire_only_update_emits_notify` and `test_action_only_update_does_not_notify`), unit suite, mypy and ruff all green. No codegen change (service recompute-timing only; no API/pydantic surface touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
