### PR TITLE
Reject duplicate HTTP server base URLs

### DIFF
--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -240,6 +240,20 @@ class HttpServerSpec(BaseModel):
     routes: list[HttpRouteSpec] = Field(default_factory=list)
 
 
+def validate_http_servers(servers: list[HttpServerSpec]) -> None:
+    """Cross-item invariants for ingress ``http_servers`` lists.
+
+    ``base_url`` is the credential-resolution key and the attenuation key, so
+    each authored surface must contain it at most once.  Equality is exact
+    string equality, matching run-time resolution and attenuation semantics.
+    """
+    seen: set[str] = set()
+    for server in servers:
+        if server.base_url in seen:
+            raise ValueError(f"duplicate base_url {server.base_url!r}")
+        seen.add(server.base_url)
+
+
 # ── Tool declaration ──────────────────────────────────────────────────────────
 
 
@@ -332,6 +346,11 @@ class AgentCreate(BaseModel):
     window_min: int = Field(default=50_000, ge=1)
     window_max: int = Field(default=150_000, ge=1)
 
+    @model_validator(mode="after")
+    def _validate_http_servers(self) -> AgentCreate:
+        validate_http_servers(self.http_servers)
+        return self
+
 
 class AgentUpdate(BaseModel):
     """Request body for ``PUT /v1/agents/{id}``.
@@ -357,6 +376,12 @@ class AgentUpdate(BaseModel):
     litellm_extra: dict[str, Any] | None = None
     window_min: int | None = Field(default=None, ge=1)
     window_max: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_http_servers(self) -> AgentUpdate:
+        if self.http_servers is not None:
+            validate_http_servers(self.http_servers)
+        return self
 
 
 class Agent(BaseModel):

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, validate_http_servers
 
 WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored", "cancelled"]
 WfRunEventType = Literal[
@@ -163,6 +163,11 @@ class WorkflowCreate(BaseModel):
     mcp_servers: list[McpServerSpec] = Field(default_factory=list)
     http_servers: list[HttpServerSpec] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def _validate_http_servers(self) -> WorkflowCreate:
+        validate_http_servers(self.http_servers)
+        return self
+
 
 class WorkflowUpdate(BaseModel):
     """Request body for ``PUT /v1/workflows/{id}`` — update in place, bumping ``version``.
@@ -187,6 +192,12 @@ class WorkflowUpdate(BaseModel):
     tools: list[ToolSpec] | None = None
     mcp_servers: list[McpServerSpec] | None = None
     http_servers: list[HttpServerSpec] | None = None
+
+    @model_validator(mode="after")
+    def _validate_http_servers(self) -> WorkflowUpdate:
+        if self.http_servers is not None:
+            validate_http_servers(self.http_servers)
+        return self
 
 
 class WfRunCreate(BaseModel):

--- a/tests/unit/test_agents_models.py
+++ b/tests/unit/test_agents_models.py
@@ -1,0 +1,84 @@
+"""Pydantic validation for agent request models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios.models.agents import AgentCreate, AgentUpdate
+
+
+def _http_server(name: str, base_url: str) -> dict[str, str]:
+    return {"name": name, "base_url": base_url}
+
+
+class TestAgentCreateHttpServers:
+    def test_rejects_duplicate_base_url_with_different_names(self) -> None:
+        with pytest.raises(
+            ValidationError, match=r"duplicate base_url 'https://api\.example\.com'"
+        ):
+            AgentCreate.model_validate(
+                {
+                    "name": "agent",
+                    "model": "gpt-4",
+                    "http_servers": [
+                        _http_server("primary", "https://api.example.com"),
+                        _http_server("secondary", "https://api.example.com"),
+                    ],
+                }
+            )
+
+    def test_accepts_duplicate_names_with_distinct_base_urls(self) -> None:
+        agent = AgentCreate.model_validate(
+            {
+                "name": "agent",
+                "model": "gpt-4",
+                "http_servers": [
+                    _http_server("api", "https://one.example.com"),
+                    _http_server("api", "https://two.example.com"),
+                ],
+            }
+        )
+
+        assert [server.base_url for server in agent.http_servers] == [
+            "https://one.example.com",
+            "https://two.example.com",
+        ]
+
+
+class TestAgentUpdateHttpServers:
+    def test_rejects_duplicate_base_url_with_different_names(self) -> None:
+        with pytest.raises(
+            ValidationError, match=r"duplicate base_url 'https://api\.example\.com'"
+        ):
+            AgentUpdate.model_validate(
+                {
+                    "version": 1,
+                    "http_servers": [
+                        _http_server("primary", "https://api.example.com"),
+                        _http_server("secondary", "https://api.example.com"),
+                    ],
+                }
+            )
+
+    def test_accepts_duplicate_names_with_distinct_base_urls(self) -> None:
+        update = AgentUpdate.model_validate(
+            {
+                "version": 1,
+                "http_servers": [
+                    _http_server("api", "https://one.example.com"),
+                    _http_server("api", "https://two.example.com"),
+                ],
+            }
+        )
+
+        assert update.http_servers is not None
+        assert [server.base_url for server in update.http_servers] == [
+            "https://one.example.com",
+            "https://two.example.com",
+        ]
+
+    def test_accepts_omitted_http_servers(self) -> None:
+        update = AgentUpdate.model_validate({"version": 1})
+
+        assert update.http_servers is None

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -11,6 +11,10 @@ from pydantic import ValidationError
 from aios.models.workflows import GateResume, WfRunCreate, WorkflowCreate, WorkflowUpdate
 
 
+def _http_server(name: str, base_url: str) -> dict[str, str]:
+    return {"name": name, "base_url": base_url}
+
+
 class TestWorkflowCreate:
     def test_minimal(self) -> None:
         wf = WorkflowCreate.model_validate(
@@ -55,6 +59,38 @@ class TestWorkflowCreate:
         with pytest.raises(ValidationError):
             WorkflowCreate.model_validate({"script": "x"})
 
+    def test_rejects_duplicate_http_server_base_url_with_different_names(self) -> None:
+        with pytest.raises(
+            ValidationError, match=r"duplicate base_url 'https://api\.example\.com'"
+        ):
+            WorkflowCreate.model_validate(
+                {
+                    "name": "w",
+                    "script": "async def main(i): return 1",
+                    "http_servers": [
+                        _http_server("primary", "https://api.example.com"),
+                        _http_server("secondary", "https://api.example.com"),
+                    ],
+                }
+            )
+
+    def test_accepts_duplicate_http_server_names_with_distinct_base_urls(self) -> None:
+        workflow = WorkflowCreate.model_validate(
+            {
+                "name": "w",
+                "script": "async def main(i): return 1",
+                "http_servers": [
+                    _http_server("api", "https://one.example.com"),
+                    _http_server("api", "https://two.example.com"),
+                ],
+            }
+        )
+
+        assert [server.base_url for server in workflow.http_servers] == [
+            "https://one.example.com",
+            "https://two.example.com",
+        ]
+
 
 class TestWorkflowUpdate:
     def test_version_required_fields_optional(self) -> None:
@@ -63,6 +99,42 @@ class TestWorkflowUpdate:
         assert upd.name is None and upd.tools is None  # omitted = preserved
         with pytest.raises(ValidationError):
             WorkflowUpdate.model_validate({"script": "x"})  # version is mandatory
+
+    def test_rejects_duplicate_http_server_base_url_with_different_names(self) -> None:
+        with pytest.raises(
+            ValidationError, match=r"duplicate base_url 'https://api\.example\.com'"
+        ):
+            WorkflowUpdate.model_validate(
+                {
+                    "version": 3,
+                    "http_servers": [
+                        _http_server("primary", "https://api.example.com"),
+                        _http_server("secondary", "https://api.example.com"),
+                    ],
+                }
+            )
+
+    def test_accepts_duplicate_http_server_names_with_distinct_base_urls(self) -> None:
+        update = WorkflowUpdate.model_validate(
+            {
+                "version": 3,
+                "http_servers": [
+                    _http_server("api", "https://one.example.com"),
+                    _http_server("api", "https://two.example.com"),
+                ],
+            }
+        )
+
+        assert update.http_servers is not None
+        assert [server.base_url for server in update.http_servers] == [
+            "https://one.example.com",
+            "https://two.example.com",
+        ]
+
+    def test_accepts_omitted_http_servers(self) -> None:
+        update = WorkflowUpdate.model_validate({"version": 3})
+
+        assert update.http_servers is None
 
 
 class TestWfRunCreate:


### PR DESCRIPTION
Adds ingress validation for `http_servers` on agent and workflow create/update request models. Duplicate `base_url` entries now raise normal Pydantic/FastAPI validation errors while read models remain unvalidated, preserving readability of any existing stored rows.

Tests cover:
- duplicate `base_url` rejection for `AgentCreate`, `AgentUpdate`, `WorkflowCreate`, and `WorkflowUpdate`
- duplicate `name` acceptance when `base_url`s differ
- omitted `http_servers` acceptance on update models
- existing attenuation tests remain unchanged

Closes #954