### PR TITLE
Add launcher gate resume builtin for #782

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -14649,6 +14649,7 @@
                   "create_run",
                   "await_run",
                   "cancel_run",
+                  "resume_gate",
                   "get_workflow",
                   "list_workflows",
                   "get_run",

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
@@ -20,6 +20,7 @@ class ToolSpecTypeType0(str, Enum):
     LIST_RUN_EVENTS = "list_run_events"
     LIST_WORKFLOWS = "list_workflows"
     READ = "read"
+    RESUME_GATE = "resume_gate"
     SCHEDULE_WAKE = "schedule_wake"
     SEARCH_EVENTS = "search_events"
     TRIGGER_CREATE = "trigger_create"

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -44,6 +44,7 @@ BuiltinToolType = Literal[
     "create_run",
     "await_run",
     "cancel_run",
+    "resume_gate",
     "get_workflow",
     "list_workflows",
     "get_run",

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -777,6 +777,32 @@ def _nudge_content(request_ids: list[str]) -> str:
     )
 
 
+async def write_gate_opened(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    request_id: str,
+    run_id: str,
+    gate_nonce: str,
+) -> bool:
+    """Deliver a ``gate_opened`` notification to a run's launcher exactly once.
+
+    ``request_id`` is the gate ``call_key``: replaying the same open gate attempts the
+    same ledger slot, so ``write_response_if_absent``'s first-writer-wins guard dedupes
+    without consuming any sibling request's response slot.
+    """
+    return await queries.write_response_if_absent(
+        conn,
+        session_id,
+        account_id=account_id,
+        request_id=request_id,
+        is_error=False,
+        result={"event": "gate_opened", "run_id": run_id, "gate_nonce": gate_nonce},
+        error=None,
+    )
+
+
 async def write_child_response(
     conn: asyncpg.Connection[Any],
     session_id: str,

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -374,7 +374,8 @@ async def resume_gate_by_nonce(
     account_id: str,
     gate_nonce: str,
     result: Any,
-) -> None:
+    resumer_session_id: str | None = None,
+) -> WfRun:
     """Deliver an external resume to the gate identified by its capability ``nonce``.
 
     The HTTP-facing gate resume: account-scope the run first (the internal
@@ -384,11 +385,18 @@ async def resume_gate_by_nonce(
     one whose payload carries that nonce. Only an OPEN gate (no ``call_result`` yet)
     matches — a nonce for an already-resolved gate (or any gate on a terminal run)
     raises ``NotFoundError`` rather than writing an orphaned signal nothing harvests.
-    ``insert_run_signal`` is idempotent, so a concurrent double-resume of a
-    still-open gate is a no-op.
+    ``resumer_session_id`` applies the agent builtin's launcher attenuation: when
+    present, only the session that launched the run may resume its gates. The HTTP
+    operator path leaves it unset and remains account-scoped. ``insert_run_signal``
+    is idempotent, so a concurrent double-resume of a still-open gate is a no-op.
     """
     async with pool.acquire() as conn:
-        await wf_queries.get_wf_run(conn, run_id, account_id=account_id)  # 404s cross-tenant
+        run = await wf_queries.get_wf_run(conn, run_id, account_id=account_id)  # 404s cross-tenant
+        if resumer_session_id is not None and run.launcher_session_id != resumer_session_id:
+            raise ForbiddenError(
+                "run was not launched by this session; only the launcher can resume its gates",
+                detail={"run_id": run_id},
+            )
         call_key = await wf_queries.find_open_gate_call_key(conn, run_id, gate_nonce=gate_nonce)
         if call_key is None:
             raise NotFoundError(
@@ -398,6 +406,7 @@ async def resume_gate_by_nonce(
             conn, run_id=run_id, call_key=call_key, kind="gate_resume", result=result
         )
     await defer_run_wake(run_id)
+    return run
 
 
 async def cancel_run(

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -166,6 +166,8 @@ class _ListRunEventsArgs(BaseModel):
     run_id: str
     after_seq: int = Field(default=0, ge=0)
     limit: int = Field(default=200, ge=1, le=500)
+
+
 class _ResumeGateArgs(BaseModel):
     """``resume_gate`` arguments. The resumer is the trusted executing session;
     it may resume only gates in runs it launched."""
@@ -358,6 +360,8 @@ async def list_run_events_handler(session_id: str, arguments: dict[str, Any]) ->
     )
     # payloads returned in full; paging is via after_seq/limit
     return {"events": [e.model_dump(mode="json") for e in events]}
+
+
 async def resume_gate_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -18,6 +18,8 @@ session id** the harness supplies (``invoke_builtin(session_id, …)``,
 * ``cancel_run`` — cancel-time attenuation: a session may cancel only runs *it
   launched* (the self-service escape for the fan-out cap; operator-launched runs
   need the operator).
+* ``resume_gate`` — gate-resume attenuation: a session may resume only gates in
+  runs *it launched*; operator-launched runs stay on the operator HTTP plane.
 
 **Identity is load-bearing, so two invariants hold (see F1 in the review):**
 1. The trusted ids (``creator_session_id``/``actor_session_id``/``launcher_session_id``,
@@ -164,6 +166,15 @@ class _ListRunEventsArgs(BaseModel):
     run_id: str
     after_seq: int = Field(default=0, ge=0)
     limit: int = Field(default=200, ge=1, le=500)
+class _ResumeGateArgs(BaseModel):
+    """``resume_gate`` arguments. The resumer is the trusted executing session;
+    it may resume only gates in runs it launched."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    gate_nonce: str
+    result: Any = None
 
 
 # ─── handler plumbing ────────────────────────────────────────────────────────
@@ -347,6 +358,19 @@ async def list_run_events_handler(session_id: str, arguments: dict[str, Any]) ->
     )
     # payloads returned in full; paging is via after_seq/limit
     return {"events": [e.model_dump(mode="json") for e in events]}
+async def resume_gate_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    args = _parse(_ResumeGateArgs, arguments)
+    run = await wf_service.resume_gate_by_nonce(
+        pool,
+        run_id=args.run_id,
+        account_id=account_id,
+        gate_nonce=args.gate_nonce,
+        result=args.result,
+        resumer_session_id=session_id,  # resume only gates in runs this session launched
+    )
+    return run.model_dump(mode="json", exclude=_RUN_ECHO_EXCLUDE)
 
 
 # ─── descriptions + registration ─────────────────────────────────────────────
@@ -427,6 +451,11 @@ LIST_RUN_EVENTS_DESCRIPTION = (
     "markers a workflow emits — so you can watch a mid-flight run advance. Page forward "
     "with 'after_seq' (the last seq seen); a full page means call again. Event payloads "
     "are returned in full — the journal text is never clipped."
+)
+RESUME_GATE_DESCRIPTION = (
+    "Resume an open gate in a run YOU launched, using the gate_nonce delivered to you "
+    "by the gate_opened notification. You cannot resume gates in runs launched by other "
+    "sessions or by the operator. The run continues on its next wake."
 )
 
 
@@ -513,6 +542,13 @@ def _register() -> None:
         description=LIST_RUN_EVENTS_DESCRIPTION,
         parameters_schema=_ListRunEventsArgs.model_json_schema(),
         handler=list_run_events_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name="resume_gate",
+        description=RESUME_GATE_DESCRIPTION,
+        parameters_schema=_ResumeGateArgs.model_json_schema(),
+        handler=resume_gate_handler,
         transport="agent_tool",
     )
 

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -48,7 +48,11 @@ from aios.logging import get_logger
 from aios.models.attenuation import surface_of
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent
 from aios.services import attenuation as attenuation_service
-from aios.services.sessions import create_child_session, fail_open_child_requests_conn
+from aios.services.sessions import (
+    create_child_session,
+    fail_open_child_requests_conn,
+    write_gate_opened,
+)
 from aios.services.wake import defer_run_wake, defer_trigger_fire, defer_wake
 from aios.tools.registry import tool_executes_class
 from aios.workflows import run_sandbox, run_tools
@@ -589,6 +593,15 @@ async def _run_workflow_step_body(
                     call_key=cap.call_key,
                     payload={"capability": "gate", "gate_nonce": nonce},
                 )
+                if run.launcher_session_id is not None:
+                    await write_gate_opened(
+                        conn,
+                        run.launcher_session_id,
+                        account_id=account_id,
+                        request_id=cap.call_key,
+                        run_id=run_id,
+                        gate_nonce=nonce,
+                    )
                 # A resume signal can land before this call_started is journaled
                 # (the call_key is derivable); the pre-replay harvest only sees
                 # gates already inflight, so a self-wake harvests this freshly

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -27,7 +27,7 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries as db_queries
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
-from aios.errors import NotFoundError
+from aios.errors import ForbiddenError, NotFoundError
 from aios.harness import runtime
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.attenuation import Surface
@@ -111,6 +111,17 @@ async def _make_run(pool: asyncpg.Pool[Any], script: str, *, input: Any = None) 
         pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf", input=input
     )
     return run.id
+
+
+async def _make_launcher_session(pool: asyncpg.Pool[Any], agent_id: str):
+    return await sessions_service.create_session(
+        pool,
+        account_id="acc_wf",
+        agent_id=agent_id,
+        environment_id="env_wf",
+        title=None,
+        metadata={},
+    )
 
 
 @pytest.fixture
@@ -278,6 +289,111 @@ async def test_gate_suspend_resume_replay_roundtrip(wf_runtime: asyncpg.Pool[Any
         "call_result",
         "run_completed",
     ]
+
+
+async def test_launcher_receives_gate_opened_and_resume_gate_happy_path(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    launcher = await _make_launcher_session(pool, wf_agent_id)
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT)
+    run = await service.create_run(
+        pool,
+        account_id="acc_wf",
+        workflow_id=wf.id,
+        environment_id="env_wf",
+        launcher_session_id=launcher.id,
+    )
+
+    await run_workflow_step(run.id)
+    async with pool.acquire() as conn:
+        gate_event = next(e for e in await wf_queries.list_run_events(conn, run.id) if e.type == "call_started")
+        delivered = await db_queries.read_request_response(
+            conn, launcher.id, account_id="acc_wf", request_id=gate_event.call_key or ""
+        )
+    assert delivered is not None
+    assert delivered["is_error"] is False
+    assert delivered["result"] == {
+        "event": "gate_opened",
+        "run_id": run.id,
+        "gate_nonce": gate_event.payload["gate_nonce"],
+    }
+
+    returned = await wf_service.resume_gate_by_nonce(
+        pool,
+        run_id=run.id,
+        account_id="acc_wf",
+        gate_nonce=gate_event.payload["gate_nonce"],
+        result="yes",
+        resumer_session_id=launcher.id,
+    )
+    assert returned.id == run.id and returned.status == "suspended"
+    await run_workflow_step(run.id)
+    async with pool.acquire() as conn:
+        completed = await wf_queries.get_run_for_step(conn, run.id)
+    assert completed is not None and completed.status == "completed" and completed.output == {"answer": "yes"}
+
+
+async def test_gate_opened_delivery_dedupes_by_call_key_on_replay(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    launcher = await _make_launcher_session(pool, wf_agent_id)
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT)
+    run = await service.create_run(
+        pool,
+        account_id="acc_wf",
+        workflow_id=wf.id,
+        environment_id="env_wf",
+        launcher_session_id=launcher.id,
+    )
+
+    await run_workflow_step(run.id)
+    await run_workflow_step(run.id)  # re-drive while still suspended at the same gate
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_response'",
+            launcher.id,
+            "acc_wf",
+        )
+    assert len(rows) == 1
+    assert db_queries.parse_jsonb(rows[0]["data"])["result"]["event"] == "gate_opened"
+
+
+async def test_non_launcher_cannot_resume_gate(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    launcher = await _make_launcher_session(pool, wf_agent_id)
+    other = await _make_launcher_session(pool, wf_agent_id)
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT)
+    run = await service.create_run(
+        pool,
+        account_id="acc_wf",
+        workflow_id=wf.id,
+        environment_id="env_wf",
+        launcher_session_id=launcher.id,
+    )
+
+    await run_workflow_step(run.id)
+    async with pool.acquire() as conn:
+        gate_event = next(e for e in await wf_queries.list_run_events(conn, run.id) if e.type == "call_started")
+    with pytest.raises(ForbiddenError):
+        await wf_service.resume_gate_by_nonce(
+            pool,
+            run_id=run.id,
+            account_id="acc_wf",
+            gate_nonce=gate_event.payload["gate_nonce"],
+            result="nope",
+            resumer_session_id=other.id,
+        )
+
+
 
 
 async def test_terminal_run_and_double_resume_are_noops(wf_runtime: asyncpg.Pool[Any]) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -31,6 +31,7 @@ from aios.errors import ForbiddenError, NotFoundError
 from aios.harness import runtime
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.attenuation import Surface
+from aios.models.sessions import Session
 from aios.models.vaults import VaultCredentialCreate
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
@@ -113,7 +114,7 @@ async def _make_run(pool: asyncpg.Pool[Any], script: str, *, input: Any = None) 
     return run.id
 
 
-async def _make_launcher_session(pool: asyncpg.Pool[Any], agent_id: str):
+async def _make_launcher_session(pool: asyncpg.Pool[Any], agent_id: str) -> Session:
     return await sessions_service.create_session(
         pool,
         account_id="acc_wf",
@@ -297,7 +298,9 @@ async def test_launcher_receives_gate_opened_and_resume_gate_happy_path(
     pool = wf_runtime
     launcher = await _make_launcher_session(pool, wf_agent_id)
     async with pool.acquire() as conn:
-        wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT)
+        wf = await wf_queries.insert_workflow(
+            conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT
+        )
     run = await service.create_run(
         pool,
         account_id="acc_wf",
@@ -308,7 +311,9 @@ async def test_launcher_receives_gate_opened_and_resume_gate_happy_path(
 
     await run_workflow_step(run.id)
     async with pool.acquire() as conn:
-        gate_event = next(e for e in await wf_queries.list_run_events(conn, run.id) if e.type == "call_started")
+        gate_event = next(
+            e for e in await wf_queries.list_run_events(conn, run.id) if e.type == "call_started"
+        )
         delivered = await db_queries.read_request_response(
             conn, launcher.id, account_id="acc_wf", request_id=gate_event.call_key or ""
         )
@@ -332,7 +337,11 @@ async def test_launcher_receives_gate_opened_and_resume_gate_happy_path(
     await run_workflow_step(run.id)
     async with pool.acquire() as conn:
         completed = await wf_queries.get_run_for_step(conn, run.id)
-    assert completed is not None and completed.status == "completed" and completed.output == {"answer": "yes"}
+    assert (
+        completed is not None
+        and completed.status == "completed"
+        and completed.output == {"answer": "yes"}
+    )
 
 
 async def test_gate_opened_delivery_dedupes_by_call_key_on_replay(
@@ -341,7 +350,9 @@ async def test_gate_opened_delivery_dedupes_by_call_key_on_replay(
     pool = wf_runtime
     launcher = await _make_launcher_session(pool, wf_agent_id)
     async with pool.acquire() as conn:
-        wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT)
+        wf = await wf_queries.insert_workflow(
+            conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT
+        )
     run = await service.create_run(
         pool,
         account_id="acc_wf",
@@ -371,7 +382,9 @@ async def test_non_launcher_cannot_resume_gate(
     launcher = await _make_launcher_session(pool, wf_agent_id)
     other = await _make_launcher_session(pool, wf_agent_id)
     async with pool.acquire() as conn:
-        wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT)
+        wf = await wf_queries.insert_workflow(
+            conn, account_id="acc_wf", name="w-gate", script=_GATE_SCRIPT
+        )
     run = await service.create_run(
         pool,
         account_id="acc_wf",
@@ -382,7 +395,9 @@ async def test_non_launcher_cannot_resume_gate(
 
     await run_workflow_step(run.id)
     async with pool.acquire() as conn:
-        gate_event = next(e for e in await wf_queries.list_run_events(conn, run.id) if e.type == "call_started")
+        gate_event = next(
+            e for e in await wf_queries.list_run_events(conn, run.id) if e.type == "call_started"
+        )
     with pytest.raises(ForbiddenError):
         await wf_service.resume_gate_by_nonce(
             pool,
@@ -392,8 +407,6 @@ async def test_non_launcher_cannot_resume_gate(
             result="nope",
             resumer_session_id=other.id,
         )
-
-
 
 
 async def test_terminal_run_and_double_resume_are_noops(wf_runtime: asyncpg.Pool[Any]) -> None:

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -214,6 +214,19 @@ class TestSchemaRejectsInjectedTrustedIds:
                 {"account_wide": True, "launcher_session_id": "ses_victim"},
             )
 
+    async def test_resume_gate_resumer_session_id_rejected(self) -> None:
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1",
+                "resume_gate",
+                {
+                    "run_id": "wfr_1",
+                    "gate_nonce": "nonce",
+                    "result": "ok",
+                    "resumer_session_id": "ses_victim",
+                },
+            )
+
 
 class TestErrorPropagation:
     async def test_pydantic_semantic_error_becomes_toolbail(self) -> None:
@@ -309,6 +322,24 @@ class TestReturnShape:
         pos = mock_await.call_args.args
         assert pos[1] == "postgres://test-db"
         assert mock_await.call_args.kwargs["timeout_seconds"] == 7
+
+    async def test_resume_gate_passes_launcher_session_id_and_trims_run(
+        self, monkeypatch: Any
+    ) -> None:
+        mock_resume = AsyncMock(return_value=_run(status="suspended"))
+        monkeypatch.setattr("aios.services.workflows.resume_gate_by_nonce", mock_resume)
+        out = await wm.resume_gate_handler(
+            "ses_1", {"run_id": "wfr_1", "gate_nonce": "nonce", "result": {"ok": True}}
+        )
+        assert out["id"] == "wfr_1" and out["status"] == "suspended"
+        assert "script" not in out
+        assert mock_resume.call_args.kwargs == {
+            "run_id": "wfr_1",
+            "account_id": "acc_x",
+            "gate_nonce": "nonce",
+            "result": {"ok": True},
+            "resumer_session_id": "ses_1",
+        }
 
 
 class TestReadHandlers:


### PR DESCRIPTION
Implements agent-plane gate discovery and resume for launcher-owned workflow runs.

What changed:
- Sends a `gate_opened` notification to the launching session via the existing exactly-once request-response ledger when a gate opens.
- Adds launcher-attenuated `resume_gate` builtin using the delivered `gate_nonce`.
- Enforces that only the launching session can resume gates through the builtin path; HTTP/operator resume remains account-scoped.
- Adds unit and integration coverage for registration/argument hardening, notification dedupe, happy-path resume, and non-launcher denial.

Validation:
- `python3 -m compileall ...` passed.
- `git diff --check` passed.
- Could not run pytest in this sandbox because `uv` and `pytest` are unavailable.

Closes #782