### PR TITLE
test: fix master unit breakage — #955/#951 cross-PR collision (stale monkeypatch)

### DIFF
--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -941,7 +941,6 @@ class TestSecretProxyLifecycle:
                 "aios.sandbox.registry.build_spec_from_session",
                 AsyncMock(return_value=plan),
             ),
-            patch("aios.sandbox.registry.ensure_workspace_runtime_dirs", AsyncMock()),
             patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
             patch("aios.sandbox.registry.install_packages", AsyncMock()),
             patch("aios.sandbox.registry.apply_network_lockdown", AsyncMock()),


### PR DESCRIPTION
Master's unit suite is red since ~21:49Z: #955's `TestSecretProxyLifecycle` monkeypatches `registry.ensure_workspace_runtime_dirs`, which #951 deleted — both merged green individually in the same pass. One-line removal; suite passes (36/36 locally).

Process followup lands in the release-train doc: during multi-PR merge passes, gate each merge on the previous one's master CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)