### PR TITLE
fix(sessions): close write-side cross-tenant resource binds

### DIFF
--- a/src/aios/db/queries/vaults.py
+++ b/src/aios/db/queries/vaults.py
@@ -603,27 +603,45 @@ async def set_session_vaults(
     *,
     account_id: str,
 ) -> None:
-    """Replace the session's vault bindings. Order is preserved via rank."""
+    """Replace the session's vault bindings, rank-ordered (first-match
+    credential resolution). Each vault must exist AND belong to ``account_id``
+    — a foreign or unknown id raises ``NotFoundError`` before any insert, so a
+    session can never bind another account's vault. The ``vault_id`` FK alone
+    checks existence, not ownership; mirrors ``set_run_vaults``. Duplicate ids
+    are de-duplicated. Order is preserved via rank.
+    """
+    deduped = list(dict.fromkeys(vault_ids))
     async with conn.transaction():
         await conn.execute(
             "DELETE FROM session_vaults WHERE session_id = $1 AND account_id = $2",
             session_id,
             account_id,
         )
-        for rank, vault_id in enumerate(vault_ids):
-            try:
-                await conn.execute(
-                    "INSERT INTO session_vaults (session_id, vault_id, rank, account_id) VALUES ($1, $2, $3, $4)",
-                    session_id,
-                    vault_id,
-                    rank,
-                    account_id,
-                )
-            except asyncpg.ForeignKeyViolationError as exc:
-                raise NotFoundError(
-                    f"vault {vault_id} not found",
-                    detail={"vault_id": vault_id},
-                ) from exc
+        if not deduped:
+            return
+        owned = {
+            str(r["id"])
+            for r in await conn.fetch(
+                "SELECT id FROM vaults WHERE id = ANY($1) AND account_id = $2",
+                deduped,
+                account_id,
+            )
+        }
+        missing = [v for v in deduped if v not in owned]
+        if missing:
+            raise NotFoundError(
+                f"vault(s) not found in this account: {missing}",
+                detail={"vault_ids": missing},
+            )
+        for rank, vault_id in enumerate(deduped):
+            await conn.execute(
+                "INSERT INTO session_vaults (session_id, vault_id, rank, account_id) "
+                "VALUES ($1, $2, $3, $4)",
+                session_id,
+                vault_id,
+                rank,
+                account_id,
+            )
 
 
 async def get_session_vault_ids(

--- a/src/aios/services/session_templates.py
+++ b/src/aios/services/session_templates.py
@@ -34,6 +34,15 @@ async def create_session_template(
         # image / env-vars / networking into spawned sessions — mirrors
         # create_session / create_run (issue #755).
         await queries.get_environment(conn, environment_id, account_id=account_id)
+        # Validate every referenced resource is account-owned before binding.
+        # agent_id/environment_id have existence-only FKs (no ownership);
+        # vault_ids/memory_store_ids are plain text[] with NO FK at all, so a
+        # foreign id would silently bind. Mirror the #755 env guard (issue #851).
+        await queries.get_agent(conn, agent_id, account_id=account_id)
+        for vault_id in vault_ids:
+            await queries.get_vault(conn, vault_id, account_id=account_id)
+        for store_id in memory_store_ids:
+            await queries.get_memory_store(conn, store_id, account_id=account_id)
         return await queries.insert_session_template(
             conn,
             name=name,

--- a/src/aios/services/session_templates.py
+++ b/src/aios/services/session_templates.py
@@ -1,7 +1,8 @@
 """Business logic for session templates.
 
-Thin wrapper over :mod:`aios.db.queries` — no business rules beyond
-what the schema enforces.
+Thin wrapper over :mod:`aios.db.queries` — the only business rule beyond
+the schema is account-scoped ownership validation of every referenced
+resource (agent, environment, vaults, memory stores) on create/update.
 """
 
 from __future__ import annotations

--- a/src/aios/services/session_templates.py
+++ b/src/aios/services/session_templates.py
@@ -88,11 +88,23 @@ async def update_session_template(
     archive_when_idle: bool | None = None,
 ) -> SessionTemplate:
     async with pool.acquire() as conn, conn.transaction():
-        # Validate ownership only when the caller supplies a new env — omitting
-        # it preserves the current binding, so no check is needed there. A bare
-        # FK would accept another tenant's env id (issue #755).
+        # Validate ownership only when the caller supplies a new value — omitting
+        # a field preserves the current binding, so no check is needed there.
+        # Without these guards the create-clean-then-update-dirty path bypasses
+        # the create_session_template checks: agent_id has an existence-only FK,
+        # and vault_ids/memory_store_ids are plain text[] with no FK at all, so a
+        # foreign id would silently rebind. Mirrors create_session_template and
+        # the #755 env guard (issue #851).
         if environment_id is not None:
             await queries.get_environment(conn, environment_id, account_id=account_id)
+        if agent_id is not None:
+            await queries.get_agent(conn, agent_id, account_id=account_id)
+        if vault_ids is not None:
+            for vault_id in vault_ids:
+                await queries.get_vault(conn, vault_id, account_id=account_id)
+        if memory_store_ids is not None:
+            for store_id in memory_store_ids:
+                await queries.get_memory_store(conn, store_id, account_id=account_id)
         return await queries.update_session_template(
             conn,
             template_id,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1276,6 +1276,13 @@ async def update_session(
     # One transaction so a 4xx from resource attach (e.g. name collision)
     # rolls back the earlier title/agent/vault writes.
     async with pool.acquire() as conn, conn.transaction():
+        # Validate agent ownership before rebinding — only when a new agent_id
+        # is supplied (omitting it preserves the current binding). The bare FK
+        # on agent_id checks existence, not ownership, so a foreign agent id
+        # would silently rebind another tenant's model/surface. Mirrors the
+        # create_session guard (issue #851).
+        if agent_id is not None:
+            await queries.get_agent(conn, agent_id, account_id=account_id)
         session = await queries.update_session(
             conn,
             session_id,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -250,6 +250,11 @@ async def create_session(
         # it. A bare FK would accept another tenant's env id and leak its image /
         # env-vars / networking into this session — mirrors create_run (issue #755).
         await queries.get_environment(conn, environment_id, account_id=account_id)
+        # Validate the agent is account-owned before binding the session to it.
+        # The bare FK on agent_id checks existence, not ownership — a foreign
+        # agent id would silently bind another tenant's model/surface into the
+        # session. Mirrors the environment guard above (issue #755 / #851).
+        await queries.get_agent(conn, agent_id, account_id=account_id)
         session = await queries.insert_session(
             conn,
             agent_id=agent_id,

--- a/tests/e2e/test_tenant_isolation.py
+++ b/tests/e2e/test_tenant_isolation.py
@@ -445,6 +445,240 @@ class TestTwoTenantIsolation:
         )
         assert name_only.status_code == 200, name_only.text
 
+    async def test_session_create_cross_tenant_agent_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """POST /v1/sessions binding tenant B's agent_id as tenant A must 404.
+
+        ``services.sessions.create_session`` validated only the environment as
+        account-owned; ``agent_id`` was FK-only (existence, not ownership), so
+        tenant A could bind tenant B's agent (its model / surface) into a
+        session. Match the env guard's posture (issue #851). NotFound, not a
+        cross-tenant binding.
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-sessag-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-sessag-b")
+
+        # Tenant B owns agent_b.
+        agent_b = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(kb),
+            json={"name": "sessag-agent-b", "model": "openrouter/test"},
+        )
+        assert agent_b.status_code == 201, agent_b.text
+        agent_b_id = agent_b.json()["id"]
+
+        # Tenant A owns the environment.
+        env_a = await http_client.post(
+            "/v1/environments", headers=_bearer(ka), json={"name": "sessag-env-a"}
+        )
+        assert env_a.status_code == 201, env_a.text
+        env_a_id = env_a.json()["id"]
+
+        # Tenant A targets tenant B's agent_id; expected 404, not a bound session.
+        cross = await http_client.post(
+            "/v1/sessions",
+            headers=_bearer(ka),
+            json={"agent_id": agent_b_id, "environment_id": env_a_id},
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Same-tenant control: tenant A's own agent still binds a session (201).
+        agent_a = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(ka),
+            json={"name": "sessag-agent-a", "model": "openrouter/test"},
+        )
+        assert agent_a.status_code == 201, agent_a.text
+        ok = await http_client.post(
+            "/v1/sessions",
+            headers=_bearer(ka),
+            json={"agent_id": agent_a.json()["id"], "environment_id": env_a_id},
+        )
+        assert ok.status_code == 201, ok.text
+
+    async def test_session_template_create_cross_tenant_agent_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """POST /v1/session-templates binding tenant B's agent as tenant A must 404.
+
+        ``create_session_template`` validated only the environment; ``agent_id``
+        was FK-only. Tenant A could bind tenant B's agent into a template. Match
+        the env guard's posture (issue #851).
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplag-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplag-b")
+
+        # Tenant B owns agent_b.
+        agent_b = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(kb),
+            json={"name": "tmplag-agent-b", "model": "openrouter/test"},
+        )
+        assert agent_b.status_code == 201, agent_b.text
+        agent_b_id = agent_b.json()["id"]
+
+        # Tenant A owns the environment.
+        env_a = await http_client.post(
+            "/v1/environments", headers=_bearer(ka), json={"name": "tmplag-env-a"}
+        )
+        assert env_a.status_code == 201, env_a.text
+        env_a_id = env_a.json()["id"]
+
+        # Tenant A targets tenant B's agent_id; expected 404, not a bound template.
+        cross = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmplag-cross",
+                "agent_id": agent_b_id,
+                "environment_id": env_a_id,
+            },
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Same-tenant control: tenant A's own agent still binds a template (201).
+        agent_a = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(ka),
+            json={"name": "tmplag-agent-a", "model": "openrouter/test"},
+        )
+        assert agent_a.status_code == 201, agent_a.text
+        ok = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmplag-own",
+                "agent_id": agent_a.json()["id"],
+                "environment_id": env_a_id,
+            },
+        )
+        assert ok.status_code == 201, ok.text
+
+    async def test_session_template_create_cross_tenant_vault_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """POST /v1/session-templates with tenant B's vault_id as tenant A must 404.
+
+        ``vault_ids`` is a plain ``text[]`` column with NO FK — a foreign id
+        would silently bind. The ownership guard rejects it (issue #851).
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplvt-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplvt-b")
+
+        # Tenant A owns its agent + env.
+        agent_a = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(ka),
+            json={"name": "tmplvt-agent-a", "model": "openrouter/test"},
+        )
+        assert agent_a.status_code == 201, agent_a.text
+        agent_a_id = agent_a.json()["id"]
+        env_a = await http_client.post(
+            "/v1/environments", headers=_bearer(ka), json={"name": "tmplvt-env-a"}
+        )
+        assert env_a.status_code == 201, env_a.text
+        env_a_id = env_a.json()["id"]
+
+        # Tenant B owns vault_b.
+        vault_b = await http_client.post(
+            "/v1/vaults", headers=_bearer(kb), json={"display_name": "tmplvt-vault-b"}
+        )
+        assert vault_b.status_code == 201, vault_b.text
+        vault_b_id = vault_b.json()["id"]
+
+        # Tenant A targets tenant B's vault_id; expected 404.
+        cross = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmplvt-cross",
+                "agent_id": agent_a_id,
+                "environment_id": env_a_id,
+                "vault_ids": [vault_b_id],
+            },
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Same-tenant control: tenant A's own vault binds a template (201).
+        vault_a = await http_client.post(
+            "/v1/vaults", headers=_bearer(ka), json={"display_name": "tmplvt-vault-a"}
+        )
+        assert vault_a.status_code == 201, vault_a.text
+        ok = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmplvt-own",
+                "agent_id": agent_a_id,
+                "environment_id": env_a_id,
+                "vault_ids": [vault_a.json()["id"]],
+            },
+        )
+        assert ok.status_code == 201, ok.text
+
+    async def test_session_template_create_cross_tenant_memory_store_404(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """POST /v1/session-templates with tenant B's memory_store_id as tenant A must 404.
+
+        ``memory_store_ids`` is a plain ``text[]`` column with NO FK — a foreign
+        id would silently bind. The ownership guard rejects it (issue #851).
+        """
+        ka = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplms-a")
+        kb = await _mint_tenant(http_client, aios_env["AIOS_API_KEY"], "iso-tmplms-b")
+
+        # Tenant A owns its agent + env.
+        agent_a = await http_client.post(
+            "/v1/agents",
+            headers=_bearer(ka),
+            json={"name": "tmplms-agent-a", "model": "openrouter/test"},
+        )
+        assert agent_a.status_code == 201, agent_a.text
+        agent_a_id = agent_a.json()["id"]
+        env_a = await http_client.post(
+            "/v1/environments", headers=_bearer(ka), json={"name": "tmplms-env-a"}
+        )
+        assert env_a.status_code == 201, env_a.text
+        env_a_id = env_a.json()["id"]
+
+        # Tenant B owns store_b.
+        store_b = await http_client.post(
+            "/v1/memory-stores", headers=_bearer(kb), json={"name": "tmplms-store-b"}
+        )
+        assert store_b.status_code == 201, store_b.text
+        store_b_id = store_b.json()["id"]
+
+        # Tenant A targets tenant B's memory_store_id; expected 404.
+        cross = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmplms-cross",
+                "agent_id": agent_a_id,
+                "environment_id": env_a_id,
+                "memory_store_ids": [store_b_id],
+            },
+        )
+        assert cross.status_code == 404, cross.text
+
+        # Same-tenant control: tenant A's own store binds a template (201).
+        store_a = await http_client.post(
+            "/v1/memory-stores", headers=_bearer(ka), json={"name": "tmplms-store-a"}
+        )
+        assert store_a.status_code == 201, store_a.text
+        ok = await http_client.post(
+            "/v1/session-templates",
+            headers=_bearer(ka),
+            json={
+                "name": "tmplms-own",
+                "agent_id": agent_a_id,
+                "environment_id": env_a_id,
+                "memory_store_ids": [store_a.json()["id"]],
+            },
+        )
+        assert ok.status_code == 201, ok.text
+
     async def test_keys_isolated(
         self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
     ) -> None:

--- a/tests/integration/test_env_var_credential_resolution.py
+++ b/tests/integration/test_env_var_credential_resolution.py
@@ -241,17 +241,34 @@ async def test_other_tenants_credentials_invisible(
     vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
 ) -> None:
     """The query's ``vc.account_id`` filter is load-bearing, so construct
-    the state where ONLY it excludes the foreign row: bind the other
-    tenant's vault directly into this session (``set_session_vaults``
-    FK-checks vault existence, not ownership, so the binding goes
-    through) and assert the foreign credential still never resolves."""
+    the state where ONLY it excludes the foreign row: force a cross-tenant
+    ``session_vaults`` binding and assert the foreign credential still
+    never resolves.
+
+    ``set_session_vaults`` now validates vault ownership (issue #851), so a
+    foreign bind can no longer be created through it — the row below is
+    injected via direct SQL INSERT to model a pre-validation legacy/forced
+    bad row that the read-side ``vc.account_id`` filter must still exclude.
+    Mirrors the direct-INSERT idiom in
+    ``test_session_cross_tenant_isolation.py``."""
     pool = vault_pool
     theirs = await _make_vault(pool, "their-vault", account_id=ACC_OTHER)
     await _make_env_cred(pool, crypto_box, theirs, "API_KEY", "their-secret", account_id=ACC_OTHER)
     mine = await _make_vault(pool, "my-vault")
     await _make_env_cred(pool, crypto_box, mine, "OTHER_KEY", "my-secret")
 
-    session_id = await _make_session(pool, vault_ids=[theirs, mine])
+    # Bind only the owned vault through the (now-validating) helper; force the
+    # foreign vault in directly. Column list matches set_session_vaults' INSERT.
+    session_id = await _make_session(pool, vault_ids=[mine])
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO session_vaults (session_id, vault_id, rank, account_id) "
+            "VALUES ($1, $2, $3, $4)",
+            session_id,
+            theirs,
+            1,
+            ACC,
+        )
     resolved = await _resolve(pool, crypto_box, session_id)
 
     assert [(r.secret_name, r.secret_value) for r in resolved] == [("OTHER_KEY", "my-secret")]

--- a/tests/integration/test_session_template_ownership.py
+++ b/tests/integration/test_session_template_ownership.py
@@ -140,3 +140,76 @@ async def test_create_template_with_own_resources_succeeds(
     )
     assert tmpl.vault_ids == [own_vault.id]
     assert tmpl.memory_store_ids == [own_store.id]
+
+
+async def _own_template(pool: asyncpg.Pool[Any]) -> str:
+    """Create a clean acc_a-owned template and return its id (the clean half
+    of the create-clean-then-update-dirty bypass these tests pin shut)."""
+    agent_a, env_a, _s = await seed_agent_env_session(pool, account_id="acc_a", prefix="stu")
+    tmpl = await session_templates_service.create_session_template(
+        pool,
+        account_id="acc_a",
+        name="tmpl-update-base",
+        agent_id=agent_a.id,
+        environment_id=env_a.id,
+        agent_version=None,
+        vault_ids=[],
+        memory_store_ids=[],
+        metadata={},
+    )
+    return tmpl.id
+
+
+async def test_update_template_rejects_foreign_agent(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """Updating a clean acc_a template to bind acc_b's agent → NotFoundError."""
+    pool = pool_three_accounts
+    template_id = await _own_template(pool)
+    agent_b, _env_b, _sb = await seed_agent_env_session(pool, account_id="acc_b", prefix="stub")
+
+    with pytest.raises(NotFoundError):
+        await session_templates_service.update_session_template(
+            pool,
+            template_id,
+            account_id="acc_a",
+            agent_id=agent_b.id,
+        )
+
+
+async def test_update_template_rejects_foreign_vault(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """Updating a clean acc_a template to bind acc_b's vault → NotFoundError."""
+    pool = pool_three_accounts
+    template_id = await _own_template(pool)
+    vault_b = await vaults_service.create_vault(
+        pool, account_id="acc_b", display_name="b-vault", metadata={}
+    )
+
+    with pytest.raises(NotFoundError):
+        await session_templates_service.update_session_template(
+            pool,
+            template_id,
+            account_id="acc_a",
+            vault_ids=[vault_b.id],
+        )
+
+
+async def test_update_template_rejects_foreign_memory_store(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """Updating a clean acc_a template to bind acc_b's store → NotFoundError."""
+    pool = pool_three_accounts
+    template_id = await _own_template(pool)
+    store_b = await memory_stores_service.create_store(
+        pool, account_id="acc_b", name="b-store", description="", metadata={}
+    )
+
+    with pytest.raises(NotFoundError):
+        await session_templates_service.update_session_template(
+            pool,
+            template_id,
+            account_id="acc_a",
+            memory_store_ids=[store_b.id],
+        )

--- a/tests/integration/test_session_template_ownership.py
+++ b/tests/integration/test_session_template_ownership.py
@@ -1,0 +1,142 @@
+"""Integration tests: ``create_session_template`` must validate that every
+referenced resource (agent, vault, memory store) is account-owned.
+
+``environment_id`` already gets a #755 ownership guard, but ``agent_id`` was
+FK-only and ``vault_ids`` / ``memory_store_ids`` are plain ``text[]`` columns
+with NO FK at all — a foreign id would silently bind. These tests pin the
+ownership guards added in issue #851.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError
+from aios.services import memory_stores as memory_stores_service
+from aios.services import session_templates as session_templates_service
+from aios.services import vaults as vaults_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_three_accounts(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    """A pool seeded with one root + two child tenants (``acc_a``, ``acc_b``)."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ('acc_root', NULL, TRUE, 'root'), "
+                "('acc_a', 'acc_root', FALSE, 'a'), "
+                "('acc_b', 'acc_root', FALSE, 'b')"
+            )
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def test_create_template_rejects_foreign_agent(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """acc_b's agent + acc_a's own env → NotFoundError (agent ownership guard)."""
+    pool = pool_three_accounts
+    _agent_a, env_a, _s = await seed_agent_env_session(pool, account_id="acc_a", prefix="st")
+    agent_b, _env_b, _sb = await seed_agent_env_session(pool, account_id="acc_b", prefix="stb")
+
+    with pytest.raises(NotFoundError):
+        await session_templates_service.create_session_template(
+            pool,
+            account_id="acc_a",
+            name="tmpl-foreign-agent",
+            agent_id=agent_b.id,
+            environment_id=env_a.id,
+            agent_version=None,
+            vault_ids=[],
+            memory_store_ids=[],
+            metadata={},
+        )
+
+
+async def test_create_template_rejects_foreign_vault(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """acc_a agent+env, vault_ids=[acc_b vault] → NotFoundError (vault ownership guard)."""
+    pool = pool_three_accounts
+    agent_a, env_a, _s = await seed_agent_env_session(pool, account_id="acc_a", prefix="st")
+    vault_b = await vaults_service.create_vault(
+        pool, account_id="acc_b", display_name="b-vault", metadata={}
+    )
+
+    with pytest.raises(NotFoundError):
+        await session_templates_service.create_session_template(
+            pool,
+            account_id="acc_a",
+            name="tmpl-foreign-vault",
+            agent_id=agent_a.id,
+            environment_id=env_a.id,
+            agent_version=None,
+            vault_ids=[vault_b.id],
+            memory_store_ids=[],
+            metadata={},
+        )
+
+
+async def test_create_template_rejects_foreign_memory_store(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """acc_a agent+env, memory_store_ids=[acc_b store] → NotFoundError (store ownership guard)."""
+    pool = pool_three_accounts
+    agent_a, env_a, _s = await seed_agent_env_session(pool, account_id="acc_a", prefix="st")
+    store_b = await memory_stores_service.create_store(
+        pool, account_id="acc_b", name="b-store", description="", metadata={}
+    )
+
+    with pytest.raises(NotFoundError):
+        await session_templates_service.create_session_template(
+            pool,
+            account_id="acc_a",
+            name="tmpl-foreign-store",
+            agent_id=agent_a.id,
+            environment_id=env_a.id,
+            agent_version=None,
+            vault_ids=[],
+            memory_store_ids=[store_b.id],
+            metadata={},
+        )
+
+
+async def test_create_template_with_own_resources_succeeds(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """Control: all acc_a-owned ids → a template that round-trips its bindings."""
+    pool = pool_three_accounts
+    agent_a, env_a, _s = await seed_agent_env_session(pool, account_id="acc_a", prefix="st")
+    own_vault = await vaults_service.create_vault(
+        pool, account_id="acc_a", display_name="a-vault", metadata={}
+    )
+    own_store = await memory_stores_service.create_store(
+        pool, account_id="acc_a", name="a-store", description="", metadata={}
+    )
+
+    tmpl = await session_templates_service.create_session_template(
+        pool,
+        account_id="acc_a",
+        name="tmpl-own",
+        agent_id=agent_a.id,
+        environment_id=env_a.id,
+        agent_version=None,
+        vault_ids=[own_vault.id],
+        memory_store_ids=[own_store.id],
+        metadata={},
+    )
+    assert tmpl.vault_ids == [own_vault.id]
+    assert tmpl.memory_store_ids == [own_store.id]

--- a/tests/integration/test_session_vaults_binding.py
+++ b/tests/integration/test_session_vaults_binding.py
@@ -131,3 +131,29 @@ async def test_create_session_rejects_foreign_agent(
             metadata={},
         )
     assert await _acc_a_session_count() == before
+
+
+async def test_update_session_rejects_foreign_agent(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """``update_session`` rebinding acc_a's session to acc_b's agent raises
+    NotFoundError — the agent FK proves existence, not ownership — and the
+    session keeps its original agent (the create-clean-then-update-dirty
+    bypass this guard closes)."""
+    pool = pool_three_accounts
+    agent_a, _env_a, session = await seed_agent_env_session(pool, account_id="acc_a", prefix="sv")
+    agent_b, _env_b, _session_b = await seed_agent_env_session(
+        pool, account_id="acc_b", prefix="svb"
+    )
+
+    with pytest.raises(NotFoundError):
+        await sessions_service.update_session(
+            pool,
+            session.id,
+            account_id="acc_a",
+            agent_id=agent_b.id,
+        )
+
+    async with pool.acquire() as conn:
+        current = await queries.get_session(conn, session.id, account_id="acc_a")
+    assert current.agent_id == agent_a.id

--- a/tests/integration/test_session_vaults_binding.py
+++ b/tests/integration/test_session_vaults_binding.py
@@ -1,0 +1,133 @@
+"""Integration tests: the session-vault binding write path must validate
+vault OWNERSHIP, and ``create_session`` must validate agent ownership.
+
+``set_session_vaults`` stamps the caller's ``account_id`` onto each bind row
+but the ``vault_id`` FK alone proves only existence, not ownership — a
+foreign-but-existing vault would bind, a secret-injection vector. ``create_session``
+likewise bound ``agent_id`` by FK only. These tests pin the ownership guards
+(issue #851), the run analog of ``test_wf_run_vaults.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError
+from aios.services import sessions as sessions_service
+from aios.services import vaults as vaults_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_three_accounts(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    """A pool seeded with one root + two child tenants (``acc_a``, ``acc_b``)."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ('acc_root', NULL, TRUE, 'root'), "
+                "('acc_a', 'acc_root', FALSE, 'a'), "
+                "('acc_b', 'acc_root', FALSE, 'b')"
+            )
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def _session_vault_count(pool: asyncpg.Pool[Any], session_id: str) -> int:
+    async with pool.acquire() as conn:
+        return int(
+            await conn.fetchval(
+                "SELECT count(*) FROM session_vaults WHERE session_id = $1", session_id
+            )
+        )
+
+
+async def test_set_session_vaults_rejects_foreign_vault(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """Binding acc_b's (existing) vault to acc_a's session raises NotFoundError —
+    the FK alone would accept it; the ownership guard rejects it, no row leaks."""
+    pool = pool_three_accounts
+    _agent, _env, session = await seed_agent_env_session(pool, account_id="acc_a", prefix="sv")
+    vault_b = await vaults_service.create_vault(
+        pool, account_id="acc_b", display_name="b-vault", metadata={}
+    )
+
+    async with pool.acquire() as conn:
+        with pytest.raises(NotFoundError):
+            await queries.set_session_vaults(conn, session.id, [vault_b.id], account_id="acc_a")
+    assert await _session_vault_count(pool, session.id) == 0
+
+
+async def test_set_session_vaults_rejects_nonexistent_vault(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """A plainly nonexistent vault id is likewise NotFound, with no bind row."""
+    pool = pool_three_accounts
+    _agent, _env, session = await seed_agent_env_session(pool, account_id="acc_a", prefix="sv")
+
+    async with pool.acquire() as conn:
+        with pytest.raises(NotFoundError):
+            await queries.set_session_vaults(
+                conn, session.id, ["vlt_does_not_exist"], account_id="acc_a"
+            )
+    assert await _session_vault_count(pool, session.id) == 0
+
+
+async def test_set_session_vaults_binds_own_vault(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """Control: binding acc_a's own vault succeeds and reads back."""
+    pool = pool_three_accounts
+    _agent, _env, session = await seed_agent_env_session(pool, account_id="acc_a", prefix="sv")
+    own = await vaults_service.create_vault(
+        pool, account_id="acc_a", display_name="a-vault", metadata={}
+    )
+
+    async with pool.acquire() as conn:
+        await queries.set_session_vaults(conn, session.id, [own.id], account_id="acc_a")
+        bound = await queries.get_session_vault_ids(conn, session.id, account_id="acc_a")
+    assert bound == [own.id]
+
+
+async def test_create_session_rejects_foreign_agent(
+    pool_three_accounts: asyncpg.Pool[Any],
+) -> None:
+    """``create_session`` for acc_a binding acc_b's agent (with acc_a's own env)
+    raises NotFoundError — the agent FK proves existence, not ownership — and no
+    acc_a session row is created."""
+    pool = pool_three_accounts
+    _agent_a, env_a, _session = await seed_agent_env_session(pool, account_id="acc_a", prefix="sv")
+    agent_b, _env_b, _session_b = await seed_agent_env_session(
+        pool, account_id="acc_b", prefix="svb"
+    )
+
+    async def _acc_a_session_count() -> int:
+        async with pool.acquire() as conn:
+            return int(
+                await conn.fetchval("SELECT count(*) FROM sessions WHERE account_id = 'acc_a'")
+            )
+
+    before = await _acc_a_session_count()
+    with pytest.raises(NotFoundError):
+        await sessions_service.create_session(
+            pool,
+            account_id="acc_a",
+            agent_id=agent_b.id,
+            environment_id=env_a.id,
+            title=None,
+            metadata={},
+        )
+    assert await _acc_a_session_count() == before


### PR DESCRIPTION
## What changed

The session create path skipped the ownership checks the workflow run path already enforced, letting a caller bind **another tenant's resources by id**. This closes three write-side multi-tenant gaps (June 2026 production-readiness audit, severity HIGH):

1. **`set_session_vaults` (db/queries/vaults.py)** stamped the caller's `account_id` onto bind rows but never checked the vault *belonged* to that account. The bare `vault_id` FK only proves existence, so a foreign-but-existing vault id bound successfully — a cross-tenant secret-injection vector, since `session_vaults` rows feed credential resolution and (via #873) sandbox secret materialization, so a foreign bind can materialize another tenant's credentials into your sandbox env. Now mirrors `set_run_vaults`: de-dupes ids, pre-SELECTs requested ids scoped by `account_id`, and raises `NotFoundError` on any missing/foreign id before inserting (replacing a per-row FK-violation catch that only proved existence).
2. **`create_session` (services/sessions.py)** never validated `agent_id` ownership — a foreign agent id would bind another tenant's model/surface. Now guarded by an account-scoped `get_agent` inside the create transaction, mirroring the existing #755 environment guard.
3. **`create_session_template` (services/session_templates.py)** validated only `environment_id`. `agent_id` had an existence-only FK; `vault_ids`/`memory_store_ids` were plain `text[]` with no FK at all. Now guarded by per-id account-scoped `get_agent`/`get_vault`/`get_memory_store` checks inside the create transaction.

## Why this layering

- **Vault binds validate at the queries layer** (inside `set_session_vaults`), so the fix covers both `create_session` and `update_session` — both call it — for free.
- **Create-path refs** (agent_id; template vault/memory refs) validate at the **service layer** inside the create txn, mirroring the #755 `get_environment(account_id=...)` pattern.
- **`create_child_session` is intentionally unchanged** — its caller in `workflows/step.py` already validates `agent_id` before calling it.
- **Cross-tenant access returns 404** (`NotFoundError`), not 403 — consistent with the repo convention: the resource genuinely doesn't exist from the unauthorized tenant's view.

## Tests

- New integration: `tests/integration/test_session_vaults_binding.py` (foreign + nonexistent vault on `set_session_vaults` with rollback assertion; foreign agent on `create_session`; own-resource control) and `tests/integration/test_session_template_ownership.py` (foreign agent/vault/memory-store on `create_session_template`; own-resource control).
- New e2e: 4 methods added to `tests/e2e/test_tenant_isolation.py` asserting HTTP 404 for cross-tenant session/template create (agent, vault, memory-store) with same-tenant 201 controls.
- Existing read-side legacy-row defenses (`test_session_cross_tenant_isolation.py`, `set_run_vaults` tests) untouched and still pass.
- mypy + ruff clean; targeted integration/e2e + regression suites green; no openapi/SDK codegen drift (pure internal validation raising the existing `NotFoundError`).

## Notes for reviewers

- The `set_session_vaults` rewrite changes binding semantics slightly: it now **de-duplicates** vault ids (a binding is a set), matching `set_run_vaults`. Previously duplicates were each ranked.
- Pairs with #857 (WP-18 composite `(id, account_id)` FK backstop — the schema-layer complement).

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)
