### PR TITLE
Archive and unarchive workflows

### DIFF
--- a/migrations/versions/0089_workflow_archive.py
+++ b/migrations/versions/0089_workflow_archive.py
@@ -1,0 +1,37 @@
+"""Soft-archive workflows and release archived names.
+
+Workflow definitions follow the never-delete lifecycle: archived rows stay
+addressable by id, disappear from lists, and no longer claim their tenant/name.
+
+Revision ID: 0089
+Revises: 0088
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0089"
+down_revision: str = "0088"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE workflows ADD COLUMN archived_at timestamptz")
+    op.execute("ALTER TABLE workflows DROP CONSTRAINT workflows_account_id_name_key")
+    op.execute(
+        "CREATE UNIQUE INDEX workflows_account_id_name_key "
+        "ON workflows (account_id, name) WHERE archived_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX workflows_account_id_name_key")
+    op.execute(
+        "ALTER TABLE workflows ADD CONSTRAINT workflows_account_id_name_key "
+        "UNIQUE (account_id, name)"
+    )
+    op.execute("ALTER TABLE workflows DROP COLUMN archived_at")

--- a/openapi.json
+++ b/openapi.json
@@ -14594,6 +14594,8 @@
                   "trigger_list",
                   "create_workflow",
                   "update_workflow",
+                  "archive_workflow",
+                  "unarchive_workflow",
                   "create_run",
                   "await_run",
                   "cancel_run",

--- a/openapi.json
+++ b/openapi.json
@@ -8600,6 +8600,127 @@
         }
       }
     },
+    "/v1/workflows/{workflow_id}/archive": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "Archive Workflow",
+        "operationId": "archive_workflow",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workflow"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen": {
+          "mcp": {
+            "destructiveHint": true
+          }
+        }
+      }
+    },
+    "/v1/workflows/{workflow_id}/unarchive": {
+      "post": {
+        "tags": [
+          "workflows"
+        ],
+        "summary": "Unarchive Workflow",
+        "operationId": "unarchive_workflow",
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workflow"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/runs": {
       "post": {
         "tags": [
@@ -16364,6 +16485,18 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
           }
         },
         "type": "object",

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/archive_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/archive_workflow.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.workflow import Workflow
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    workflow_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/workflows/{workflow_id}/archive".format(
+            workflow_id=quote(str(workflow_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Workflow | None:
+    if response.status_code == 200:
+        response_200 = Workflow.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Workflow]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Archive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Archive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return sync_detailed(
+        workflow_id=workflow_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Archive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Archive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return (
+        await asyncio_detailed(
+            workflow_id=workflow_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/workflows/unarchive_workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/workflows/unarchive_workflow.py
@@ -1,0 +1,179 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.workflow import Workflow
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    workflow_id: str,
+    *,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/workflows/{workflow_id}/unarchive".format(
+            workflow_id=quote(str(workflow_id), safe=""),
+        ),
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | Workflow | None:
+    if response.status_code == 200:
+        response_200 = Workflow.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | Workflow]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Unarchive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Unarchive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return sync_detailed(
+        workflow_id=workflow_id,
+        client=client,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | Workflow]:
+    """Unarchive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | Workflow]
+    """
+
+    kwargs = _get_kwargs(
+        workflow_id=workflow_id,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    workflow_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | Workflow | None:
+    """Unarchive Workflow
+
+    Args:
+        workflow_id (str):
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | Workflow
+    """
+
+    return (
+        await asyncio_detailed(
+            workflow_id=workflow_id,
+            client=client,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/tool_spec_type_type_0.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class ToolSpecTypeType0(str, Enum):
+    ARCHIVE_WORKFLOW = "archive_workflow"
     AWAIT_RUN = "await_run"
     BASH = "bash"
     CANCEL = "cancel"
@@ -25,6 +26,7 @@ class ToolSpecTypeType0(str, Enum):
     TRIGGER_LIST = "trigger_list"
     TRIGGER_REMOVE = "trigger_remove"
     TRIGGER_UPDATE = "trigger_update"
+    UNARCHIVE_WORKFLOW = "unarchive_workflow"
     UPDATE_WORKFLOW = "update_workflow"
     WAKE_SELF = "wake_self"
     WAKE_SESSION = "wake_session"

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow.py
@@ -39,6 +39,7 @@ class Workflow:
         tools (list[ToolSpec] | Unset):
         mcp_servers (list[McpServerSpec] | Unset):
         http_servers (list[HttpServerSpec] | Unset):
+        archived_at (datetime.datetime | None | Unset):
     """
 
     id: str
@@ -54,6 +55,7 @@ class Workflow:
     tools: list[ToolSpec] | Unset = UNSET
     mcp_servers: list[McpServerSpec] | Unset = UNSET
     http_servers: list[HttpServerSpec] | Unset = UNSET
+    archived_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -117,6 +119,14 @@ class Workflow:
                 http_servers_item = http_servers_item_data.to_dict()
                 http_servers.append(http_servers_item)
 
+        archived_at: None | str | Unset
+        if isinstance(self.archived_at, Unset):
+            archived_at = UNSET
+        elif isinstance(self.archived_at, datetime.datetime):
+            archived_at = self.archived_at.isoformat()
+        else:
+            archived_at = self.archived_at
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -142,6 +152,8 @@ class Workflow:
             field_dict["mcp_servers"] = mcp_servers
         if http_servers is not UNSET:
             field_dict["http_servers"] = http_servers
+        if archived_at is not UNSET:
+            field_dict["archived_at"] = archived_at
 
         return field_dict
 
@@ -242,6 +254,23 @@ class Workflow:
 
                 http_servers.append(http_servers_item)
 
+        def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                archived_at_type_0 = isoparse(data)
+
+                return archived_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
+
         workflow = cls(
             id=id,
             account_id=account_id,
@@ -256,6 +285,7 @@ class Workflow:
             tools=tools,
             mcp_servers=mcp_servers,
             http_servers=http_servers,
+            archived_at=archived_at,
         )
 
         workflow.additional_properties = d

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -120,6 +120,20 @@ async def get_workflow(workflow_id: str, pool: PoolDep, account_id: AccountIdDep
     return await service.get_workflow(pool, workflow_id, account_id=account_id)
 
 
+@router.post(
+    "/{workflow_id}/archive",
+    operation_id="archive_workflow",
+    openapi_extra={"x-codegen": {"mcp": {"destructiveHint": True}}},
+)
+async def archive_workflow(workflow_id: str, pool: PoolDep, account_id: AccountIdDep) -> Workflow:
+    return await service.archive_workflow(pool, workflow_id, account_id=account_id)
+
+
+@router.post("/{workflow_id}/unarchive", operation_id="unarchive_workflow")
+async def unarchive_workflow(workflow_id: str, pool: PoolDep, account_id: AccountIdDep) -> Workflow:
+    return await service.unarchive_workflow(pool, workflow_id, account_id=account_id)
+
+
 # ─── /v1/runs (execution instances) ──────────────────────────────────────────
 
 

--- a/src/aios/cli/commands/workflows.py
+++ b/src/aios/cli/commands/workflows.py
@@ -30,9 +30,11 @@ from aios_sdk._generated.api.runs import (
     resume_gate,
 )
 from aios_sdk._generated.api.workflows import (
+    archive_workflow,
     create_workflow,
     get_workflow,
     list_workflows,
+    unarchive_workflow,
     update_workflow,
 )
 from aios_sdk._generated.models.gate_resume import GateResume
@@ -122,6 +124,24 @@ def update_workflow_(
         body = WorkflowUpdate.from_dict(payload)
         call_single(ctx, update_workflow.sync_detailed, workflow_id=workflow_id, body=body)
         return None
+
+    run_or_die(_run)
+
+
+@app.command("archive", help="Archive a workflow (hidden from lists; updates/new runs 409).")
+@covers("archive_workflow")
+def archive_workflow_(ctx: typer.Context, workflow_id: str) -> None:
+    def _run() -> None:
+        call_single(ctx, archive_workflow.sync_detailed, workflow_id=workflow_id)
+
+    run_or_die(_run)
+
+
+@app.command("unarchive", help="Restore an archived workflow.")
+@covers("unarchive_workflow")
+def unarchive_workflow_(ctx: typer.Context, workflow_id: str) -> None:
+    def _run() -> None:
+        call_single(ctx, unarchive_workflow.sync_detailed, workflow_id=workflow_id)
 
     run_or_die(_run)
 

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import asyncpg
 
-from aios.db.queries import _get_scoped, _list_scoped, parse_jsonb
+from aios.db.queries import _archive_scoped, _get_scoped, _list_scoped, parse_jsonb
 from aios.errors import ConflictError, NotFoundError
 from aios.ids import WORKFLOW, WORKFLOW_EVENT, WORKFLOW_RUN, make_id
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
@@ -56,6 +56,7 @@ def _row_to_workflow(row: asyncpg.Record) -> Workflow:
         http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
+        archived_at=row["archived_at"],
     )
 
 
@@ -177,6 +178,8 @@ async def update_workflow(
     exactly one of two racing writers matches, the other gets a clean 409.
     """
     current = await get_workflow(conn, workflow_id, account_id=account_id)
+    if current.archived_at is not None:
+        raise ConflictError(f"workflow {workflow_id} is archived", detail={"id": workflow_id})
     if expected_version != current.version:
         # Validate the token up front so the contract is uniform — without this, the
         # write-free no-op path below would return 200 for a stale token + identical
@@ -222,7 +225,7 @@ async def update_workflow(
                    input_schema = $5::jsonb, output_schema = $6::jsonb, description = $7,
                    tools = $8::jsonb, mcp_servers = $9::jsonb, http_servers = $10::jsonb,
                    updated_at = now()
-             WHERE id = $1 AND account_id = $2 AND version = $11
+             WHERE id = $1 AND account_id = $2 AND archived_at IS NULL AND version = $11
             RETURNING *
             """,
             workflow_id,
@@ -280,23 +283,55 @@ async def list_workflows(
     after: str | None = None,
     name: str | None = None,
 ) -> list[Workflow]:
-    """Keyset-paginated list of an account's workflows, newest first.
+    return await _list_scoped(
+        conn,
+        table="workflows",
+        account_id=account_id,
+        row=_row_to_workflow,
+        limit=limit,
+        after=after,
+        filters=[("name", name)],
+    )
 
-    Hand-written (not ``_list_scoped``) because the ``workflows`` table has no
-    ``archived_at`` column — workflows are never archived. One row per name
-    (``UNIQUE(account_id, name)``); ``version`` bumps in place on update.
-    """
-    args: list[Any] = [account_id]
-    where = ["account_id = $1"]
-    if name is not None:
-        args.append(name)
-        where.append(f"name = ${len(args)}")
-    if after is not None:
-        args.append(after)
-        where.append(f"id < ${len(args)}")
-    args.append(limit)
-    sql = f"SELECT * FROM workflows WHERE {' AND '.join(where)} ORDER BY id DESC LIMIT ${len(args)}"
-    return [_row_to_workflow(r) for r in await conn.fetch(sql, *args)]
+
+async def archive_workflow(
+    conn: asyncpg.Connection[Any], workflow_id: str, *, account_id: str
+) -> Workflow:
+    row = await _archive_scoped(
+        conn,
+        table="workflows",
+        id_=workflow_id,
+        account_id=account_id,
+        noun="workflow",
+    )
+    return _row_to_workflow(row)
+
+
+async def unarchive_workflow(
+    conn: asyncpg.Connection[Any], workflow_id: str, *, account_id: str
+) -> Workflow:
+    try:
+        row = await conn.fetchrow(
+            """
+            UPDATE workflows
+               SET archived_at = NULL, updated_at = now()
+             WHERE id = $1 AND account_id = $2 AND archived_at IS NOT NULL
+            RETURNING *
+            """,
+            workflow_id,
+            account_id,
+        )
+    except asyncpg.UniqueViolationError as exc:
+        current = await get_workflow(conn, workflow_id, account_id=account_id)
+        raise ConflictError(
+            f"workflow {current.name!r} already exists",
+            detail={"name": current.name},
+        ) from exc
+    if row is None:
+        raise NotFoundError(
+            f"workflow {workflow_id} not found or not archived", detail={"id": workflow_id}
+        )
+    return _row_to_workflow(row)
 
 
 # ─── wf_runs (execution instances) ───────────────────────────────────────────

--- a/src/aios/harness/trigger_runner.py
+++ b/src/aios/harness/trigger_runner.py
@@ -515,9 +515,10 @@ async def _run_workflow(
     (outstanding caps; deliberately an error, never ``skipped`` — a
     cap-saturated trigger must trip auto-disable, not drop fires silently),
     ``WorkflowRunDepthExceededError`` (a reactive cascade or self-fire loop
-    hit the depth cap — the loop's structural bound), and ``NotFoundError``
+    hit the depth cap — the loop's structural bound), ``ConflictError``
+    (workflow version drift or an archived target workflow), and ``NotFoundError``
     (a vault in ``action.vault_ids`` was deleted, or the owner session was
-    deleted mid-fire; workflows and environments have no delete path).
+    deleted mid-fire; workflows and environments have no hard-delete path).
     """
     # Lazy: aios.workflows.service transitively imports the tools package,
     # which imports services.workflows, which imports back into

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -39,6 +39,8 @@ BuiltinToolType = Literal[
     "trigger_list",
     "create_workflow",
     "update_workflow",
+    "archive_workflow",
+    "unarchive_workflow",
     "create_run",
     "await_run",
     "cancel_run",

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -57,6 +57,7 @@ class Workflow(BaseModel):
     http_servers: list[HttpServerSpec] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
+    archived_at: datetime | None = None
 
 
 class WfRun(BaseModel):

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -37,6 +37,7 @@ from aios.services.wake import defer_run_wake
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
+    "archive_workflow",
     "await_run",
     "cancel_run",
     "create_run",
@@ -48,6 +49,7 @@ __all__ = [
     "list_workflows",
     "resume_gate",
     "resume_gate_by_nonce",
+    "unarchive_workflow",
     "update_workflow",
 ]
 
@@ -241,6 +243,16 @@ async def update_workflow(
 async def get_workflow(pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str) -> Workflow:
     async with pool.acquire() as conn:
         return await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
+
+
+async def archive_workflow(pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str) -> Workflow:
+    async with pool.acquire() as conn:
+        return await wf_queries.archive_workflow(conn, workflow_id, account_id=account_id)
+
+
+async def unarchive_workflow(pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str) -> Workflow:
+    async with pool.acquire() as conn:
+        return await wf_queries.unarchive_workflow(conn, workflow_id, account_id=account_id)
 
 
 async def list_workflows(

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -245,12 +245,16 @@ async def get_workflow(pool: asyncpg.Pool[Any], workflow_id: str, *, account_id:
         return await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
 
 
-async def archive_workflow(pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str) -> Workflow:
+async def archive_workflow(
+    pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str
+) -> Workflow:
     async with pool.acquire() as conn:
         return await wf_queries.archive_workflow(conn, workflow_id, account_id=account_id)
 
 
-async def unarchive_workflow(pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str) -> Workflow:
+async def unarchive_workflow(
+    pool: asyncpg.Pool[Any], workflow_id: str, *, account_id: str
+) -> Workflow:
     async with pool.acquire() as conn:
         return await wf_queries.unarchive_workflow(conn, workflow_id, account_id=account_id)
 

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -80,6 +80,12 @@ class _UpdateWorkflowArgs(WorkflowUpdate):
     workflow_id: str
 
 
+class _WorkflowIdArgs(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_id: str
+
+
 class _CreateRunArgs(BaseModel):
     """``create_run`` arguments. No ``environment_id`` — the run always inherits the
     caller session's env (a caller-chosen env id would be a cross-tenant attack surface)."""
@@ -110,10 +116,8 @@ class _CancelRunArgs(BaseModel):
     run_id: str
 
 
-class _GetWorkflowArgs(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    workflow_id: str
+class _GetWorkflowArgs(_WorkflowIdArgs):
+    pass
 
 
 class _ListWorkflowsArgs(BaseModel):
@@ -211,6 +215,22 @@ async def update_workflow_handler(session_id: str, arguments: dict[str, Any]) ->
         http_servers=args.http_servers,
         actor_session_id=session_id,
     )
+    return wf.model_dump(mode="json", exclude=_WORKFLOW_ECHO_EXCLUDE)
+
+
+async def archive_workflow_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    args = _parse(_WorkflowIdArgs, arguments)
+    wf = await wf_service.archive_workflow(pool, args.workflow_id, account_id=account_id)
+    return wf.model_dump(mode="json", exclude=_WORKFLOW_ECHO_EXCLUDE)
+
+
+async def unarchive_workflow_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    pool = runtime.require_pool()
+    account_id = await sessions_service.load_session_account_id(pool, session_id)
+    args = _parse(_WorkflowIdArgs, arguments)
+    wf = await wf_service.unarchive_workflow(pool, args.workflow_id, account_id=account_id)
     return wf.model_dump(mode="json", exclude=_WORKFLOW_ECHO_EXCLUDE)
 
 
@@ -332,8 +352,19 @@ UPDATE_WORKFLOW_DESCRIPTION = (
     "Update one of your workflows in place, bumping its version. Pass the current "
     "'version' as an optimistic-concurrency token (a stale token is rejected — re-read "
     "with get_workflow and retry). Omitted fields are preserved. The resulting tool/server "
-    "surface must still be a subset of your own. In-flight runs are unaffected (a run pins "
-    "its workflow's script + surface at launch)."
+    "surface must still be a subset of your own. Archived workflows cannot be updated; "
+    "unarchive first. In-flight runs are unaffected (a run pins its workflow's script + "
+    "surface at launch)."
+)
+ARCHIVE_WORKFLOW_DESCRIPTION = (
+    "Archive one of your workflows. Archived workflows disappear from list_workflows and "
+    "refuse new create_run launches, but remain fetchable by id and keep their run/journal "
+    "history. Archiving releases the workflow name for a fresh create_workflow."
+)
+UNARCHIVE_WORKFLOW_DESCRIPTION = (
+    "Restore an archived workflow so it appears in list_workflows and can launch new runs "
+    "again. If another live workflow has reclaimed the same name, unarchive is rejected; "
+    "rename or archive the conflicting live workflow first."
 )
 CREATE_RUN_DESCRIPTION = (
     "Launch a run of a workflow you can access. The run executes with the workflow's "
@@ -400,6 +431,20 @@ def _register() -> None:
         description=UPDATE_WORKFLOW_DESCRIPTION,
         parameters_schema=_UpdateWorkflowArgs.model_json_schema(),
         handler=update_workflow_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name="archive_workflow",
+        description=ARCHIVE_WORKFLOW_DESCRIPTION,
+        parameters_schema=_WorkflowIdArgs.model_json_schema(),
+        handler=archive_workflow_handler,
+        transport="agent_tool",
+    )
+    registry.register(
+        name="unarchive_workflow",
+        description=UNARCHIVE_WORKFLOW_DESCRIPTION,
+        parameters_schema=_WorkflowIdArgs.model_json_schema(),
+        handler=unarchive_workflow_handler,
         transport="agent_tool",
     )
     registry.register(

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -96,6 +96,8 @@ async def create_run(
     async with pool.acquire() as conn, conn.transaction():
         await get_environment(conn, environment_id, account_id=account_id)  # 404s foreign/absent
         workflow = await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
+        if workflow.archived_at is not None:
+            raise ConflictError(f"workflow {workflow_id} is archived", detail={"id": workflow_id})
         if expected_version is not None and workflow.version != expected_version:
             raise ConflictError(
                 f"workflow version drift: pinned {expected_version}, current {workflow.version}",

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0088``."""
+    """The migration ladder has exactly one head: ``0089``."""
     script = _script_directory()
-    assert script.get_heads() == ["0088"]
+    assert script.get_heads() == ["0089"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -125,6 +125,20 @@ class TestSchemaRejectsInjectedTrustedIds:
                 "ses_1", "cancel_run", {"run_id": "wfr_1", "canceller_session_id": "ses_victim"}
             )
 
+    async def test_archive_workflow_account_id_rejected(self) -> None:
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1", "archive_workflow", {"workflow_id": "wf_1", "account_id": "acc_victim"}
+            )
+
+    async def test_unarchive_workflow_account_id_rejected(self) -> None:
+        with pytest.raises(ToolBail):
+            await invoke_builtin(
+                "ses_1",
+                "unarchive_workflow",
+                {"workflow_id": "wf_1", "account_id": "acc_victim"},
+            )
+
     async def test_get_run_account_id_rejected(self) -> None:
         with pytest.raises(ToolBail):
             await invoke_builtin(
@@ -211,6 +225,26 @@ class TestReturnShape:
         out = await wm.create_workflow_handler("ses_1", {"name": "w", "script": "SECRET"})
         assert out["name"] == "w" and out["version"] == 1
         assert "script" not in out  # heavy snapshot field trimmed
+
+    async def test_archive_workflow_calls_service_and_returns_archived_at(self, monkeypatch: Any) -> None:
+        archived = datetime(2026, 1, 2, tzinfo=UTC)
+        mock_archive = AsyncMock(return_value=_workflow(archived_at=archived))
+        monkeypatch.setattr("aios.services.workflows.archive_workflow", mock_archive)
+        out = await wm.archive_workflow_handler("ses_1", {"workflow_id": "wf_1"})
+        assert out["id"] == "wf_1"
+        assert out["archived_at"] == archived.isoformat().replace("+00:00", "Z")
+        assert "script" not in out
+        assert mock_archive.call_args.args[1] == "wf_1"
+        assert mock_archive.call_args.kwargs["account_id"] == "acc_x"
+
+    async def test_unarchive_workflow_calls_service_and_returns_live_row(self, monkeypatch: Any) -> None:
+        mock_unarchive = AsyncMock(return_value=_workflow(archived_at=None))
+        monkeypatch.setattr("aios.services.workflows.unarchive_workflow", mock_unarchive)
+        out = await wm.unarchive_workflow_handler("ses_1", {"workflow_id": "wf_1"})
+        assert out["id"] == "wf_1"
+        assert out["archived_at"] is None
+        assert mock_unarchive.call_args.args[1] == "wf_1"
+        assert mock_unarchive.call_args.kwargs["account_id"] == "acc_x"
 
     async def test_await_run_passes_settings_db_url(self, monkeypatch: Any) -> None:
         mock_await = AsyncMock(

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -226,7 +226,9 @@ class TestReturnShape:
         assert out["name"] == "w" and out["version"] == 1
         assert "script" not in out  # heavy snapshot field trimmed
 
-    async def test_archive_workflow_calls_service_and_returns_archived_at(self, monkeypatch: Any) -> None:
+    async def test_archive_workflow_calls_service_and_returns_archived_at(
+        self, monkeypatch: Any
+    ) -> None:
         archived = datetime(2026, 1, 2, tzinfo=UTC)
         mock_archive = AsyncMock(return_value=_workflow(archived_at=archived))
         monkeypatch.setattr("aios.services.workflows.archive_workflow", mock_archive)
@@ -237,7 +239,9 @@ class TestReturnShape:
         assert mock_archive.call_args.args[1] == "wf_1"
         assert mock_archive.call_args.kwargs["account_id"] == "acc_x"
 
-    async def test_unarchive_workflow_calls_service_and_returns_live_row(self, monkeypatch: Any) -> None:
+    async def test_unarchive_workflow_calls_service_and_returns_live_row(
+        self, monkeypatch: Any
+    ) -> None:
         mock_unarchive = AsyncMock(return_value=_workflow(archived_at=None))
         monkeypatch.setattr("aios.services.workflows.unarchive_workflow", mock_unarchive)
         out = await wm.unarchive_workflow_handler("ses_1", {"workflow_id": "wf_1"})


### PR DESCRIPTION
Adds the workflow soft-archive lifecycle requested in eumemic/aios#927.

What changed:
- Adds `workflows.archived_at` and swaps name uniqueness to a partial live-only unique index.
- Adds REST routes:
  - `POST /v1/workflows/{workflow_id}/archive`
  - `POST /v1/workflows/{workflow_id}/unarchive`
- Adds agent builtins `archive_workflow` and `unarchive_workflow`.
- Filters archived workflows out of list views while keeping get-by-id available.
- Refuses update/run launch for archived workflows with `ConflictError`.
- Regenerates OpenAPI and SDK client artifacts.
- Updates trigger runner launch-error docs to include archived workflow refusal.

Validation:
- `uv run pytest tests/unit/test_workflow_management.py -q`
- `uv run ruff check ...`
- `python3 -m compileall -q src/aios migrations/versions/0089_workflow_archive.py`
- Mutation check confirmed archive builtin test fails when production handler is intentionally broken and passes after restore.

Note: DB-backed integration tests were not run in this sandbox because no Docker/testcontainer Postgres environment was available.

Closes eumemic/aios#927