### PR TITLE
Add deep-research workflow fixture for #792

### DIFF
--- a/src/aios/workflows/deep_research.py
+++ b/src/aios/workflows/deep_research.py
@@ -1,0 +1,331 @@
+"""Reference deep-research workflow script templates.
+
+The exported builders return workflow source code that is authored into the
+workflow runtime.  The full script is the issue #792 live-demo workload; tests use
+``build_deep_research_fixture_script`` to exercise the same strange-loop shape
+with a small deterministic fan-out and simulated child returns.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+SCOUT_ANGLES: tuple[str, ...] = (
+    "direct-factual",
+    "recent-developments",
+    "primary-source",
+    "contrarian-counter-evidence",
+    "academic",
+    "statistical",
+    "historical-context",
+    "stakeholder",
+    "technical-deep-dive",
+    "regulatory-legal",
+)
+
+
+def build_deep_research_script(
+    *,
+    scout_agent_id: str = "scout",
+    reader_agent_id: str = "reader",
+    synthesis_agent_id: str = "synthesis",
+    critic_agent_id: str = "critic",
+    angles: tuple[str, ...] = SCOUT_ANGLES,
+    top_k: int = 16,
+    supplementary_limit: int = 4,
+    failing_agent_id: str = "scout_nonexistent_deep_research_parity",
+) -> str:
+    """Return the full deep-research parity workflow source.
+
+    The defaults match the resource names used in the live demo.  Tests pass real
+    generated agent ids while preserving the script shape.
+    """
+
+    return _render_script(
+        scout_agent_id=scout_agent_id,
+        reader_agent_id=reader_agent_id,
+        synthesis_agent_id=synthesis_agent_id,
+        critic_agent_id=critic_agent_id,
+        angles=angles,
+        top_k=top_k,
+        supplementary_limit=supplementary_limit,
+        failing_agent_id=failing_agent_id,
+    )
+
+
+def build_deep_research_fixture_script(
+    *,
+    scout_agent_id: str,
+    reader_agent_id: str,
+    synthesis_agent_id: str,
+    critic_agent_id: str,
+    failing_agent_id: str = "scout_nonexistent_fixture",
+) -> str:
+    """Return the CI fixture variant: 2 scouts, 2 readers, no deferral."""
+
+    return _render_script(
+        scout_agent_id=scout_agent_id,
+        reader_agent_id=reader_agent_id,
+        synthesis_agent_id=synthesis_agent_id,
+        critic_agent_id=critic_agent_id,
+        angles=("direct-factual", "contrarian-counter-evidence"),
+        top_k=2,
+        supplementary_limit=0,
+        failing_agent_id=failing_agent_id,
+    )
+
+
+def _render_script(
+    *,
+    scout_agent_id: str,
+    reader_agent_id: str,
+    synthesis_agent_id: str,
+    critic_agent_id: str,
+    angles: tuple[str, ...],
+    top_k: int,
+    supplementary_limit: int,
+    failing_agent_id: str,
+) -> str:
+    return dedent(
+        f'''
+        import hashlib
+        import json
+        import urllib.parse
+
+        SCOUT_AGENT_ID = {scout_agent_id!r}
+        READER_AGENT_ID = {reader_agent_id!r}
+        SYNTHESIS_AGENT_ID = {synthesis_agent_id!r}
+        CRITIC_AGENT_ID = {critic_agent_id!r}
+        FAILING_AGENT_ID = {failing_agent_id!r}
+        ANGLES = {list(angles)!r}
+        TOP_K = {top_k!r}
+        SUPPLEMENTARY_LIMIT = {supplementary_limit!r}
+
+        SCOUT_SCHEMA = {{
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["angle", "findings", "dead_ends"],
+            "properties": {{
+                "angle": {{"type": "string"}},
+                "findings": {{
+                    "type": "array",
+                    "items": {{
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["claim", "source_url", "source_title", "confidence"],
+                        "properties": {{
+                            "claim": {{"type": "string"}},
+                            "source_url": {{"type": "string"}},
+                            "source_title": {{"type": "string"}},
+                            "confidence": {{"type": "number", "minimum": 0, "maximum": 1}},
+                        }},
+                    }},
+                }},
+                "dead_ends": {{"type": "array", "items": {{"type": "string"}}}},
+            }},
+        }}
+
+        READER_SCHEMA = {{
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["source_url", "credibility", "key_facts"],
+            "properties": {{
+                "source_url": {{"type": "string"}},
+                "credibility": {{"type": "number", "minimum": 0, "maximum": 1}},
+                "key_facts": {{
+                    "type": "array",
+                    "items": {{
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["fact", "confidence"],
+                        "properties": {{
+                            "fact": {{"type": "string"}},
+                            "quote": {{"type": "string"}},
+                            "confidence": {{"type": "number", "minimum": 0, "maximum": 1}},
+                        }},
+                    }},
+                }},
+            }},
+        }}
+
+        SYNTHESIS_SCHEMA = {{
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["report_markdown", "citations", "open_questions"],
+            "properties": {{
+                "report_markdown": {{"type": "string"}},
+                "citations": {{
+                    "type": "array",
+                    "items": {{
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["n", "url", "title"],
+                        "properties": {{
+                            "n": {{"type": "integer"}},
+                            "url": {{"type": "string"}},
+                            "title": {{"type": "string"}},
+                        }},
+                    }},
+                }},
+                "open_questions": {{"type": "array", "items": {{"type": "string"}}}},
+            }},
+        }}
+
+        CRITIC_SCHEMA = {{
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["verdict", "gaps"],
+            "properties": {{
+                "verdict": {{"type": "string", "enum": ["complete", "gaps"]}},
+                "gaps": {{
+                    "type": "array",
+                    "items": {{
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["description", "suggested_angle"],
+                        "properties": {{
+                            "description": {{"type": "string"}},
+                            "suggested_angle": {{"type": "string"}},
+                        }},
+                    }},
+                }},
+            }},
+        }}
+
+        OUTPUT_SCHEMA = {{
+            "type": "object",
+            "required": ["report", "citations", "critic_verdict", "stats"],
+            "properties": {{
+                "report": {{"type": "string"}},
+                "citations": {{"type": "array"}},
+                "critic_verdict": {{"type": "object"}},
+                "stats": {{"type": "object"}},
+            }},
+        }}
+
+        def normalize_url(url):
+            parsed = urllib.parse.urlparse(url or "")
+            scheme = (parsed.scheme or "https").lower()
+            netloc = parsed.netloc.lower()
+            if netloc.startswith("www."):
+                netloc = netloc[4:]
+            path = parsed.path.rstrip("/") or "/"
+            query = urllib.parse.urlencode(sorted(urllib.parse.parse_qsl(parsed.query)))
+            return urllib.parse.urlunparse((scheme, netloc, path, "", query, ""))
+
+        def claim_key(text):
+            normalized = " ".join((text or "").lower().split())
+            return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+        def merge_scout_results(results):
+            sources = {{}}
+            claims = {{}}
+            for result in results:
+                if not result:
+                    continue
+                for finding in result.get("findings", []):
+                    url = normalize_url(finding.get("source_url", ""))
+                    if not url:
+                        continue
+                    source = sources.setdefault(url, {{
+                        "url": url,
+                        "title": finding.get("source_title") or url,
+                        "confidence_total": 0.0,
+                        "corroboration": 0,
+                        "claims": [],
+                    }})
+                    source["confidence_total"] += float(finding.get("confidence") or 0)
+                    source["corroboration"] += 1
+                    key = claim_key(finding.get("claim", ""))
+                    if key not in claims:
+                        claims[key] = finding.get("claim", "")
+                        source["claims"].append(claims[key])
+            ranked = sorted(
+                sources.values(),
+                key=lambda s: (s["confidence_total"] * max(1, s["corroboration"]), s["url"]),
+                reverse=True,
+            )
+            return ranked, claims
+
+        async def failed_scout():
+            try:
+                await agent(FAILING_AGENT_ID, {{"expected_failure": True}}, output_schema=SCOUT_SCHEMA)
+            except AgentError as e:
+                log(f"scout failed (expected): {{e}}")
+                return None
+            return None
+
+        def scout_thunk(angle):
+            return lambda: agent(SCOUT_AGENT_ID, {{"question": QUESTION, "angle": angle}}, output_schema=SCOUT_SCHEMA)
+
+        def read_stage(source):
+            return agent(READER_AGENT_ID, {{"question": QUESTION, "source": source}}, output_schema=READER_SCHEMA)
+
+        def normalize_stage(reading, source, index):
+            if not reading:
+                return None
+            reading["source_url"] = normalize_url(reading.get("source_url") or source.get("url"))
+            reading["rank"] = index + 1
+            return reading
+
+        async def synthesize(question, sources, readings):
+            return await agent(
+                SYNTHESIS_AGENT_ID,
+                {{"question": question, "sources": sources, "readings": readings}},
+                output_schema=SYNTHESIS_SCHEMA,
+            )
+
+        async def critique(question, draft):
+            return await agent(CRITIC_AGENT_ID, {{"question": question, "draft": draft}}, output_schema=CRITIC_SCHEMA)
+
+        async def supplementary_scout(gap):
+            return await agent(
+                SCOUT_AGENT_ID,
+                {{"question": QUESTION, "angle": gap.get("suggested_angle", "supplementary"), "gap": gap}},
+                output_schema=SCOUT_SCHEMA,
+            )
+
+        async def main(input):
+            global QUESTION
+            QUESTION = input["question"]
+            stats = {{"scouts": 0, "sources": 0, "readers": 0, "supplementary_scouts": 0}}
+
+            phase("Phase 1: sweep")
+            scout_results = await parallel([scout_thunk(angle) for angle in ANGLES] + [failed_scout])
+            stats["scouts"] = len([r for r in scout_results if r])
+            sources, claims = merge_scout_results(scout_results)
+            stats["sources"] = len(sources)
+            log("deduped", len(claims), "claims from", len(sources), "sources")
+
+            phase("Phase 2: deep read")
+            survivors = sources[:TOP_K]
+            readings = [r for r in await pipeline(survivors, read_stage, normalize_stage) if r]
+            stats["readers"] = len(readings)
+            log("read", len(readings), "sources")
+
+            phase("Phase 3: synthesis")
+            draft = await synthesize(QUESTION, survivors, readings)
+            verdict = await critique(QUESTION, draft)
+
+            if input.get("pause_for_review"):
+                review = await gate({{"draft_report": draft, "gaps": verdict.get("gaps", [])}})
+                if isinstance(review, dict) and review.get("veto_supplementary"):
+                    verdict = {{"verdict": verdict.get("verdict", "gaps"), "gaps": [], "review": review}}
+
+            gaps = verdict.get("gaps", [])[:SUPPLEMENTARY_LIMIT]
+            if gaps:
+                extra = await parallel([lambda gap=gap: supplementary_scout(gap) for gap in gaps])
+                stats["supplementary_scouts"] = len([r for r in extra if r])
+                extra_sources, _extra_claims = merge_scout_results(extra)
+                sources = sources + [s for s in extra_sources if s["url"] not in {{src["url"] for src in sources}}]
+                draft = await synthesize(QUESTION, sources[:TOP_K], readings)
+                verdict = await critique(QUESTION, draft)
+
+            return {{
+                "report": draft.get("report_markdown", ""),
+                "citations": draft.get("citations", []),
+                "critic_verdict": verdict,
+                "stats": stats,
+            }}
+        '''
+    ).strip() + "\n"

--- a/src/aios/workflows/deep_research.py
+++ b/src/aios/workflows/deep_research.py
@@ -86,8 +86,9 @@ def _render_script(
     supplementary_limit: int,
     failing_agent_id: str,
 ) -> str:
-    return dedent(
-        f'''
+    return (
+        dedent(
+            f"""
         import hashlib
         import json
         import urllib.parse
@@ -327,5 +328,7 @@ def _render_script(
                 "critic_verdict": verdict,
                 "stats": stats,
             }}
-        '''
-    ).strip() + "\n"
+        """
+        ).strip()
+        + "\n"
+    )

--- a/tests/integration/test_wf_deep_research_fixture.py
+++ b/tests/integration/test_wf_deep_research_fixture.py
@@ -1,0 +1,232 @@
+"""Deep-research reference workflow fixture (#792).
+
+The live demo runs the width-10 script against real web-capable agents.  This CI
+fixture drives the same workflow shape directly against Postgres with a tiny fan-out
+and simulated child returns: sweep -> restart/replay -> deep read pipeline ->
+synthesis -> critic -> complete.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.db import queries as db_queries
+from aios.db.queries import workflows as wf_queries
+from aios.services import agents as agents_service
+from aios.tools import workflow_completion
+from aios.workflows.deep_research import build_deep_research_fixture_script
+from aios.workflows.step import run_workflow_step
+from tests.integration.test_wf_step import _make_run, _open_request_id
+
+pytestmark = pytest.mark.integration
+pytest_plugins = ["tests.integration.test_wf_step"]
+
+
+@pytest.fixture
+async def deep_research_agents(wf_runtime: asyncpg.Pool[Any]) -> dict[str, str]:
+    ids: dict[str, str] = {}
+    for role in ("scout", "reader", "synthesis", "critic"):
+        agent = await agents_service.create_agent(
+            wf_runtime,
+            account_id="acc_wf",
+            name=f"deep-research-{role}",
+            model="test/dummy",
+            system=f"test {role}",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=1000,
+            window_max=100000,
+        )
+        ids[role] = agent.id
+    return ids
+
+
+async def _events(pool: asyncpg.Pool[Any], run_id: str):
+    async with pool.acquire() as conn:
+        return await wf_queries.list_run_events(conn, run_id)
+
+
+async def _children_by_payload(pool: asyncpg.Pool[Any], run_id: str) -> dict[str, str]:
+    children: dict[str, str] = {}
+    for event in await _events(pool, run_id):
+        if event.type != "call_started" or event.payload.get("capability") != "agent":
+            continue
+        child_id = event.payload["child_session_id"]
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT data FROM events WHERE session_id = $1 AND account_id = $2 "
+                "AND kind = 'message' AND role = 'user' ORDER BY seq ASC LIMIT 1",
+                child_id,
+                "acc_wf",
+            )
+        request = db_queries.parse_jsonb(row["data"])
+        children[request["content"]] = child_id
+    return children
+
+
+async def _return_child(pool: asyncpg.Pool[Any], child_id: str, value: Any) -> None:
+    request_id = await _open_request_id(pool, child_id)
+    with mock.patch("aios.tools.workflow_completion.defer_run_wake", new=AsyncMock()):
+        result = await workflow_completion.return_handler(
+            child_id, {"request_id": request_id, "value": value}
+        )
+    assert result == {"status": "returned"}
+
+
+async def test_deep_research_fixture_survives_replay_and_completes(
+    wf_runtime: asyncpg.Pool[Any], deep_research_agents: dict[str, str]
+) -> None:
+    pool = wf_runtime
+    script = build_deep_research_fixture_script(
+        scout_agent_id=deep_research_agents["scout"],
+        reader_agent_id=deep_research_agents["reader"],
+        synthesis_agent_id=deep_research_agents["synthesis"],
+        critic_agent_id=deep_research_agents["critic"],
+    )
+    run_id = await _make_run(pool, script, input={"question": "What changed in AIOS?"})
+
+    await run_workflow_step(run_id)  # Phase 1: two scouts + one catchable missing scout
+    events_after_spawn = await _events(pool, run_id)
+    assert [e.payload for e in events_after_spawn if e.type == "annotation" and e.call_key == "phase"] == [
+        {"message": "Phase 1: sweep"}
+    ]
+    assert len([e for e in events_after_spawn if e.type == "call_started"]) == 2
+    assert len([e for e in events_after_spawn if e.type == "frontier_deferred"]) == 0
+    assert len([e for e in events_after_spawn if e.type == "call_result" and e.payload.get("is_error")]) == 1
+
+    # Simulated restart/replay before all Phase-1 children return: no duplicate starts
+    # and the expected AgentError catch log is emitted exactly once.
+    children = await _children_by_payload(pool, run_id)
+    first_scout = next(cid for content, cid in children.items() if '"angle": "direct-factual"' in content)
+    await _return_child(
+        pool,
+        first_scout,
+        {
+            "angle": "direct-factual",
+            "findings": [
+                {
+                    "claim": "AIOS has a durable workflow runtime.",
+                    "source_url": "https://example.com/a?b=2&a=1",
+                    "source_title": "AIOS A",
+                    "confidence": 0.8,
+                }
+            ],
+            "dead_ends": [],
+        },
+    )
+    await run_workflow_step(run_id)
+    replay_events = await _events(pool, run_id)
+    assert len([e for e in replay_events if e.type == "call_started"]) == 2
+    assert len(
+        [
+            e
+            for e in replay_events
+            if e.type == "annotation"
+            and e.call_key == "log"
+            and "scout failed (expected)" in e.payload["message"]
+        ]
+    ) == 1
+
+    children = await _children_by_payload(pool, run_id)
+    second_scout = next(
+        cid for content, cid in children.items() if '"angle": "contrarian-counter-evidence"' in content
+    )
+    await _return_child(
+        pool,
+        second_scout,
+        {
+            "angle": "contrarian-counter-evidence",
+            "findings": [
+                {
+                    "claim": "AIOS has a durable workflow runtime.",
+                    "source_url": "https://www.example.com/a?a=1&b=2/",
+                    "source_title": "Duplicate AIOS A",
+                    "confidence": 0.7,
+                },
+                {
+                    "claim": "Workflow scripts can fan out to agents.",
+                    "source_url": "https://example.com/b",
+                    "source_title": "AIOS B",
+                    "confidence": 0.6,
+                },
+            ],
+            "dead_ends": [],
+        },
+    )
+    await run_workflow_step(run_id)  # Phase 2 reader pipeline spawns two readers
+    phase2_events = await _events(pool, run_id)
+    assert [e.payload["message"] for e in phase2_events if e.type == "annotation" and e.call_key == "phase"] == [
+        "Phase 1: sweep",
+        "Phase 2: deep read",
+    ]
+    assert len([e for e in phase2_events if e.type == "call_started"]) == 4
+
+    children = await _children_by_payload(pool, run_id)
+    reader_children = [cid for content, cid in children.items() if '"source"' in content]
+    assert len(reader_children) == 2
+    await _return_child(
+        pool,
+        reader_children[0],
+        {
+            "source_url": "https://example.com/a?a=1&b=2",
+            "credibility": 0.9,
+            "key_facts": [{"fact": "Runtime is durable", "quote": "durable", "confidence": 0.8}],
+        },
+    )
+    await _return_child(
+        pool,
+        reader_children[1],
+        {
+            "source_url": "https://example.com/b",
+            "credibility": 0.7,
+            "key_facts": [{"fact": "Scripts fan out", "confidence": 0.7}],
+        },
+    )
+    await run_workflow_step(run_id)  # synthesis
+
+    children = await _children_by_payload(pool, run_id)
+    synthesis_child = next(cid for content, cid in children.items() if '"readings"' in content)
+    await _return_child(
+        pool,
+        synthesis_child,
+        {
+            "report_markdown": "# Report\nAIOS workflow runtime works [1].",
+            "citations": [{"n": 1, "url": "https://example.com/a?a=1&b=2", "title": "AIOS A"}],
+            "open_questions": [],
+        },
+    )
+    await run_workflow_step(run_id)  # critic
+
+    children = await _children_by_payload(pool, run_id)
+    critic_child = next(cid for content, cid in children.items() if '"draft"' in content)
+    await _return_child(
+        pool,
+        critic_child,
+        {"verdict": "complete", "gaps": []},
+    )
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None and run.status == "completed"
+    assert run.output["report"].startswith("# Report")
+    assert run.output["citations"] == [{"n": 1, "url": "https://example.com/a?a=1&b=2", "title": "AIOS A"}]
+    assert run.output["critic_verdict"] == {"verdict": "complete", "gaps": []}
+    assert run.output["stats"] == {"scouts": 2, "sources": 2, "readers": 2, "supplementary_scouts": 0}
+
+    final_events = await _events(pool, run_id)
+    assert [e.payload["message"] for e in final_events if e.type == "annotation" and e.call_key == "phase"] == [
+        "Phase 1: sweep",
+        "Phase 2: deep read",
+        "Phase 3: synthesis",
+    ]
+    call_keys = [e.call_key for e in final_events if e.type == "call_started"]
+    assert len(call_keys) == len(set(call_keys)) == 6
+    result_keys = [e.call_key for e in final_events if e.type == "call_result" and not e.payload.get("is_error")]
+    assert len(result_keys) == len(set(result_keys)) == 6

--- a/tests/integration/test_wf_deep_research_fixture.py
+++ b/tests/integration/test_wf_deep_research_fixture.py
@@ -8,6 +8,7 @@ synthesis -> critic -> complete.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock
@@ -16,16 +17,65 @@ import asyncpg
 import pytest
 
 from aios.db import queries as db_queries
+from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
+from aios.harness import runtime
 from aios.models.workflows import WfRunEvent
 from aios.services import agents as agents_service
 from aios.tools import workflow_completion
+from aios.workflows import run_tools, service
 from aios.workflows.deep_research import build_deep_research_fixture_script
 from aios.workflows.step import run_workflow_step
-from tests.integration.test_wf_step import _make_run, _open_request_id
 
 pytestmark = pytest.mark.integration
-pytest_plugins = ["tests.integration.test_wf_step"]
+
+
+@pytest.fixture
+async def wf_runtime(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = pool
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ('acc_wf', NULL, TRUE, 'wf-root')"
+            )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ('env_wf', 'wf-env', '{}'::jsonb, 'acc_wf')"
+            )
+        run_tools._INFLIGHT.clear()
+        with (
+            mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.workflows.step.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()),
+            mock.patch("aios.workflows.run_tools.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.sessions.defer_run_wake", new=AsyncMock()),
+        ):
+            yield pool
+    finally:
+        run_tools._INFLIGHT.clear()
+        runtime.pool = prev
+        await pool.close()
+
+
+async def _make_run(pool: asyncpg.Pool[Any], script: str, *, input: Any = None) -> str:
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(conn, account_id="acc_wf", name="w", script=script)
+    run = await service.create_run(
+        pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf", input=input
+    )
+    return run.id
+
+
+async def _open_request_id(pool: asyncpg.Pool[Any], session_id: str) -> str:
+    async with pool.acquire() as conn:
+        ids = await db_queries.get_open_request_ids(conn, session_id, account_id="acc_wf")
+    return ids[0]
 
 
 @pytest.fixture

--- a/tests/integration/test_wf_deep_research_fixture.py
+++ b/tests/integration/test_wf_deep_research_fixture.py
@@ -17,6 +17,7 @@ import pytest
 
 from aios.db import queries as db_queries
 from aios.db.queries import workflows as wf_queries
+from aios.models.workflows import WfRunEvent
 from aios.services import agents as agents_service
 from aios.tools import workflow_completion
 from aios.workflows.deep_research import build_deep_research_fixture_script
@@ -47,7 +48,7 @@ async def deep_research_agents(wf_runtime: asyncpg.Pool[Any]) -> dict[str, str]:
     return ids
 
 
-async def _events(pool: asyncpg.Pool[Any], run_id: str):
+async def _events(pool: asyncpg.Pool[Any], run_id: str) -> list[WfRunEvent]:
     async with pool.acquire() as conn:
         return await wf_queries.list_run_events(conn, run_id)
 
@@ -93,17 +94,24 @@ async def test_deep_research_fixture_survives_replay_and_completes(
 
     await run_workflow_step(run_id)  # Phase 1: two scouts + one catchable missing scout
     events_after_spawn = await _events(pool, run_id)
-    assert [e.payload for e in events_after_spawn if e.type == "annotation" and e.call_key == "phase"] == [
-        {"message": "Phase 1: sweep"}
-    ]
+    assert [
+        e.payload for e in events_after_spawn if e.type == "annotation" and e.call_key == "phase"
+    ] == [{"message": "Phase 1: sweep"}]
     assert len([e for e in events_after_spawn if e.type == "call_started"]) == 2
     assert len([e for e in events_after_spawn if e.type == "frontier_deferred"]) == 0
-    assert len([e for e in events_after_spawn if e.type == "call_result" and e.payload.get("is_error")]) == 1
+    assert (
+        len(
+            [e for e in events_after_spawn if e.type == "call_result" and e.payload.get("is_error")]
+        )
+        == 1
+    )
 
     # Simulated restart/replay before all Phase-1 children return: no duplicate starts
     # and the expected AgentError catch log is emitted exactly once.
     children = await _children_by_payload(pool, run_id)
-    first_scout = next(cid for content, cid in children.items() if '"angle": "direct-factual"' in content)
+    first_scout = next(
+        cid for content, cid in children.items() if '"angle": "direct-factual"' in content
+    )
     await _return_child(
         pool,
         first_scout,
@@ -123,19 +131,24 @@ async def test_deep_research_fixture_survives_replay_and_completes(
     await run_workflow_step(run_id)
     replay_events = await _events(pool, run_id)
     assert len([e for e in replay_events if e.type == "call_started"]) == 2
-    assert len(
-        [
-            e
-            for e in replay_events
-            if e.type == "annotation"
-            and e.call_key == "log"
-            and "scout failed (expected)" in e.payload["message"]
-        ]
-    ) == 1
+    assert (
+        len(
+            [
+                e
+                for e in replay_events
+                if e.type == "annotation"
+                and e.call_key == "log"
+                and "scout failed (expected)" in e.payload["message"]
+            ]
+        )
+        == 1
+    )
 
     children = await _children_by_payload(pool, run_id)
     second_scout = next(
-        cid for content, cid in children.items() if '"angle": "contrarian-counter-evidence"' in content
+        cid
+        for content, cid in children.items()
+        if '"angle": "contrarian-counter-evidence"' in content
     )
     await _return_child(
         pool,
@@ -161,7 +174,11 @@ async def test_deep_research_fixture_survives_replay_and_completes(
     )
     await run_workflow_step(run_id)  # Phase 2 reader pipeline spawns two readers
     phase2_events = await _events(pool, run_id)
-    assert [e.payload["message"] for e in phase2_events if e.type == "annotation" and e.call_key == "phase"] == [
+    assert [
+        e.payload["message"]
+        for e in phase2_events
+        if e.type == "annotation" and e.call_key == "phase"
+    ] == [
         "Phase 1: sweep",
         "Phase 2: deep read",
     ]
@@ -216,17 +233,32 @@ async def test_deep_research_fixture_survives_replay_and_completes(
         run = await wf_queries.get_run_for_step(conn, run_id)
     assert run is not None and run.status == "completed"
     assert run.output["report"].startswith("# Report")
-    assert run.output["citations"] == [{"n": 1, "url": "https://example.com/a?a=1&b=2", "title": "AIOS A"}]
+    assert run.output["citations"] == [
+        {"n": 1, "url": "https://example.com/a?a=1&b=2", "title": "AIOS A"}
+    ]
     assert run.output["critic_verdict"] == {"verdict": "complete", "gaps": []}
-    assert run.output["stats"] == {"scouts": 2, "sources": 2, "readers": 2, "supplementary_scouts": 0}
+    assert run.output["stats"] == {
+        "scouts": 2,
+        "sources": 2,
+        "readers": 2,
+        "supplementary_scouts": 0,
+    }
 
     final_events = await _events(pool, run_id)
-    assert [e.payload["message"] for e in final_events if e.type == "annotation" and e.call_key == "phase"] == [
+    assert [
+        e.payload["message"]
+        for e in final_events
+        if e.type == "annotation" and e.call_key == "phase"
+    ] == [
         "Phase 1: sweep",
         "Phase 2: deep read",
         "Phase 3: synthesis",
     ]
     call_keys = [e.call_key for e in final_events if e.type == "call_started"]
     assert len(call_keys) == len(set(call_keys)) == 6
-    result_keys = [e.call_key for e in final_events if e.type == "call_result" and not e.payload.get("is_error")]
+    result_keys = [
+        e.call_key
+        for e in final_events
+        if e.type == "call_result" and not e.payload.get("is_error")
+    ]
     assert len(result_keys) == len(set(result_keys)) == 6

--- a/tests/integration/test_wf_deep_research_fixture.py
+++ b/tests/integration/test_wf_deep_research_fixture.py
@@ -145,8 +145,10 @@ async def test_deep_research_fixture_survives_replay_and_completes(
     await run_workflow_step(run_id)  # Phase 1: two scouts + one catchable missing scout
     events_after_spawn = await _events(pool, run_id)
     assert [
-        e.payload for e in events_after_spawn if e.type == "annotation" and e.call_key == "phase"
-    ] == [{"message": "Phase 1: sweep"}]
+        e.payload["text"]
+        for e in events_after_spawn
+        if e.type == "annotation" and e.payload["kind"] == "phase"
+    ] == ["Phase 1: sweep"]
     assert len([e for e in events_after_spawn if e.type == "call_started"]) == 2
     assert len([e for e in events_after_spawn if e.type == "frontier_deferred"]) == 0
     assert (
@@ -187,8 +189,8 @@ async def test_deep_research_fixture_survives_replay_and_completes(
                 e
                 for e in replay_events
                 if e.type == "annotation"
-                and e.call_key == "log"
-                and "scout failed (expected)" in e.payload["message"]
+                and e.payload["kind"] == "log"
+                and "scout failed (expected)" in e.payload["text"]
             ]
         )
         == 1
@@ -208,7 +210,7 @@ async def test_deep_research_fixture_survives_replay_and_completes(
             "findings": [
                 {
                     "claim": "AIOS has a durable workflow runtime.",
-                    "source_url": "https://www.example.com/a?a=1&b=2/",
+                    "source_url": "https://www.example.com/a/?a=1&b=2",
                     "source_title": "Duplicate AIOS A",
                     "confidence": 0.7,
                 },
@@ -225,9 +227,9 @@ async def test_deep_research_fixture_survives_replay_and_completes(
     await run_workflow_step(run_id)  # Phase 2 reader pipeline spawns two readers
     phase2_events = await _events(pool, run_id)
     assert [
-        e.payload["message"]
+        e.payload["text"]
         for e in phase2_events
-        if e.type == "annotation" and e.call_key == "phase"
+        if e.type == "annotation" and e.payload["kind"] == "phase"
     ] == [
         "Phase 1: sweep",
         "Phase 2: deep read",
@@ -296,9 +298,9 @@ async def test_deep_research_fixture_survives_replay_and_completes(
 
     final_events = await _events(pool, run_id)
     assert [
-        e.payload["message"]
+        e.payload["text"]
         for e in final_events
-        if e.type == "annotation" and e.call_key == "phase"
+        if e.type == "annotation" and e.payload["kind"] == "phase"
     ] == [
         "Phase 1: sweep",
         "Phase 2: deep read",


### PR DESCRIPTION
Adds the deep-research reference workload script builder and a CI-sized integration fixture.

What changed:
- Added `aios.workflows.deep_research` with the full width-10 parity script builder and a shrunken fixture builder.
- The script exercises:
  - curated stdlib imports (`json`, `hashlib`, `urllib.parse`)
  - `parallel()` sweep fan-out plus catchable `AgentError`
  - plain-code URL/claim deduplication
  - `pipeline()` reader stage with sync normalization
  - four `agent(..., output_schema=...)` schemas
  - journaled `phase()` and `log()`
  - optional review `gate()`
  - bounded supplementary synthesis path
- Added `tests/integration/test_wf_deep_research_fixture.py`, a model-free fixture that simulates child returns and checks replay/no-duplicate-start behavior, annotations, expected catch log, and final output shape.

Validation:
- `uv run ruff check src/aios/workflows/deep_research.py tests/integration/test_wf_deep_research_fixture.py`
- `uv run pytest tests/integration/test_wf_deep_research_fixture.py -q` collected the fixture but skipped because Docker is unavailable in this sandbox.
- Ran declared codegen scripts:
  - `bash scripts/regen-client.sh`
  - `bash scripts/regen-openapi.sh`

Closes #792