### PR TITLE
Fix streaming model deadline usage recording

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -24,7 +24,7 @@ from aios.models.vaults import OAuthProviderApp
 # mode is a config validator that no longer matches reality, not a
 # crash. ``test_github_clone_session_timeout_below_step_budget``
 # cross-checks the two values stay aligned.
-_HARNESS_STEP_TIMEOUT_S: float = 300.0
+_HARNESS_STEP_TIMEOUT_S: float = 960.0
 
 
 class Settings(BaseSettings):
@@ -248,13 +248,21 @@ class Settings(BaseSettings):
         "after the multipart body is drained so the client sees a clean "
         "response rather than a transport reset.",
     )
+    model_call_deadline_s: float = Field(
+        default=900.0,
+        ge=1.0,
+        description="Total-duration deadline for a single model call, in seconds. "
+        "Must stay strictly below the harness step timeout so job-level "
+        "cancellation remains a final safety net instead of the normal model "
+        "budget.",
+    )
     github_clone_session_timeout_seconds: float = Field(
         default=30.0,
         ge=1.0,
         description="Wall-clock bound on each per-session "
         "``git clone --reference --dissociate`` (and the short admin ops "
         "around it: ``remote set-url``, ``config user.*``). Must stay "
-        "well below the 300s harness step timeout — otherwise a hung "
+        "well below the 960s harness step timeout — otherwise a hung "
         "clone burns a whole user turn before the step-level cap fires. "
         "See issue #697.",
     )
@@ -549,6 +557,16 @@ class Settings(BaseSettings):
                 "API and worker processes resolve relative paths against their own CWD, "
                 "producing diverging session workspace_path values and ForbiddenError "
                 "on tool calls."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _model_call_deadline_under_step_budget(self) -> Settings:
+        if self.model_call_deadline_s >= _HARNESS_STEP_TIMEOUT_S:
+            raise ValueError(
+                f"AIOS_MODEL_CALL_DEADLINE_S={self.model_call_deadline_s} must be "
+                f"strictly less than the harness step budget "
+                f"({_HARNESS_STEP_TIMEOUT_S}s, aios.harness.loop._JOB_TIMEOUT_S)."
             )
         return self
 

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 import litellm
 
+from aios.config import get_settings
 from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT
 
 # Anthropic rejects empty text blocks that some OpenRouter models emit on
@@ -79,6 +80,24 @@ except (ImportError, AttributeError):  # pragma: no cover - litellm layout drift
 _REQUEST_TIMEOUT_S = 300.0
 _STREAM_TTFT_TIMEOUT_S = 300.0
 _STREAM_INTER_CHUNK_TIMEOUT_S = 60.0
+
+
+class ModelCallDeadlineError(Exception):
+    """The model call exceeded the configured total-duration deadline."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        usage: dict[str, int],
+        cost_usd: float | None,
+        chunks_seen: int,
+    ) -> None:
+        super().__init__(message)
+        self.usage = usage
+        self.cost_usd = cost_usd
+        self.chunks_seen = chunks_seen
+
 
 if TYPE_CHECKING:
     import asyncpg
@@ -516,7 +535,16 @@ async def call_litellm(
         session_id=session_id,
         stream=False,
     )
-    response = await litellm.acompletion(**kwargs)
+    deadline_s = get_settings().model_call_deadline_s
+    try:
+        response = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=deadline_s)
+    except TimeoutError as exc:
+        raise ModelCallDeadlineError(
+            f"model call exceeded its {deadline_s:.0f}s total deadline before returning",
+            usage={},
+            cost_usd=None,
+            chunks_seen=0,
+        ) from exc
     return _unpack_litellm_response(response, source="litellm.acompletion")
 
 
@@ -552,6 +580,9 @@ async def stream_litellm(
         session_id=session_id,
         stream=True,
     )
+    deadline_s = get_settings().model_call_deadline_s
+    loop = asyncio.get_running_loop()
+    deadline_at = loop.time() + deadline_s
     response = await litellm.acompletion(**kwargs)
 
     # Per-chunk inactivity guard. The ``stream_timeout`` kwarg above is
@@ -580,9 +611,28 @@ async def stream_litellm(
     saw_content_filter = False
     try:
         while True:
-            timeout = _STREAM_TTFT_TIMEOUT_S if first else _STREAM_INTER_CHUNK_TIMEOUT_S
+            guard_timeout = _STREAM_TTFT_TIMEOUT_S if first else _STREAM_INTER_CHUNK_TIMEOUT_S
+            remaining_deadline_s = deadline_at - loop.time()
+            timeout = min(guard_timeout, remaining_deadline_s)
             try:
                 chunk = await asyncio.wait_for(aiter.__anext__(), timeout=timeout)
+            except TimeoutError as exc:
+                if loop.time() >= deadline_at:
+                    usage: dict[str, int] = {}
+                    cost: float | None = None
+                    if chunks:
+                        partial_assembled: Any = litellm.stream_chunk_builder(chunks=chunks)
+                        if partial_assembled is not None:
+                            _, usage, cost, _ = _unpack_litellm_response(
+                                partial_assembled, source="stream_chunk_builder"
+                            )
+                    raise ModelCallDeadlineError(
+                        f"model call exceeded its {deadline_s:.0f}s total deadline while still streaming",
+                        usage=usage,
+                        cost_usd=cost,
+                        chunks_seen=len(chunks),
+                    ) from exc
+                raise
             except StopAsyncIteration:
                 break
             first = False

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -27,9 +27,10 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from structlog.contextvars import bind_contextvars, clear_contextvars
 
+from aios.config import get_settings
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
-from aios.harness.completion import call_litellm, stream_litellm
+from aios.harness.completion import ModelCallDeadlineError, call_litellm, stream_litellm
 from aios.harness.step_context import (
     compose_step_context,
     compute_step_prelude,
@@ -64,11 +65,10 @@ _RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
 # Wall-clock cap on a single ``run_session_step`` invocation. The harness's
 # zero-hang guarantee: per-call timeouts (LiteLLM, MCP, tool dispatch, etc.)
 # are the precise instruments, but if any future code path bypasses them
-# this cap fires and forces a clean rescheduling. Sized to fit the longest
-# legitimate single-turn use (300s = matches the ``_REQUEST_TIMEOUT_S`` in
-# ``completion.py`` so the model call alone can occupy almost the whole
-# budget).
-_JOB_TIMEOUT_S = 300.0
+# this cap fires and forces a clean rescheduling. Sized as the default 900s
+# model-call deadline plus 60s of headroom for prologue, context-build, and
+# epilogue work that no longer compete with the model budget.
+_JOB_TIMEOUT_S = 960.0
 
 # litellm's standardized ``finish_reason`` for a safety refusal. Anthropic's
 # ``stop_reason: "refusal"`` maps here; OpenAI/Azure ``content_filter`` lands
@@ -503,20 +503,30 @@ async def _run_session_step_body(
                 extra=agent.litellm_extra or None,
                 session_id=session_id,
             )
+    except ModelCallDeadlineError as exc:
+        log.exception(
+            "step.model_call_deadline", session_id=session_id, chunks_seen=exc.chunks_seen
+        )
+        if exc.chunks_seen > 0:
+            await _handle_streaming_model_deadline(
+                pool,
+                session_id,
+                start_event_id=start_event.id,
+                usage=exc.usage,
+                cost_usd=exc.cost_usd,
+                account_id=account_id,
+            )
+            return _StepResult()
+        await _append_model_request_error_span(
+            pool, session_id, start_event_id=start_event.id, account_id=account_id
+        )
+        return _StepResult(
+            retry_delay=await _apply_retry_or_failure(pool, session_id, account_id=account_id)
+        )
     except Exception:
         log.exception("step.litellm_failed", session_id=session_id)
-        await sessions_service.append_event(
-            pool,
-            session_id,
-            "span",
-            {
-                "event": "model_request_end",
-                "model_request_start_id": start_event.id,
-                "is_error": True,
-                "model_usage": {},
-                "cost_usd": None,
-            },
-            account_id=account_id,
+        await _append_model_request_error_span(
+            pool, session_id, start_event_id=start_event.id, account_id=account_id
         )
         return _StepResult(
             retry_delay=await _apply_retry_or_failure(pool, session_id, account_id=account_id)
@@ -964,6 +974,77 @@ async def _dispatch_confirmed_tools(
         return []
     in_flight = task_registry.in_flight_tool_call_ids(session_id)
     return [tc for tc in dispatchable if tc.get("id") not in in_flight]
+
+
+async def _append_model_request_error_span(
+    pool: Any,
+    session_id: str,
+    *,
+    start_event_id: str,
+    account_id: str,
+) -> None:
+    await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {
+            "event": "model_request_end",
+            "model_request_start_id": start_event_id,
+            "is_error": True,
+            "model_usage": {},
+            "cost_usd": None,
+        },
+        account_id=account_id,
+    )
+
+
+async def _handle_streaming_model_deadline(
+    pool: Any,
+    session_id: str,
+    *,
+    start_event_id: str,
+    usage: dict[str, int],
+    cost_usd: float | None,
+    account_id: str,
+) -> None:
+    await sessions_service.append_event(
+        pool,
+        session_id,
+        "span",
+        {
+            "event": "model_request_end",
+            "model_request_start_id": start_event_id,
+            "is_error": True,
+            "model_usage": usage,
+            "cost_usd": cost_usd,
+        },
+        account_id=account_id,
+    )
+    await sessions_service.increment_usage(
+        pool,
+        session_id,
+        input_tokens=usage.get("input_tokens", 0),
+        output_tokens=usage.get("output_tokens", 0),
+        cache_read_input_tokens=usage.get("cache_read_input_tokens", 0),
+        cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
+        account_id=account_id,
+    )
+    deadline_s = get_settings().model_call_deadline_s
+    await fail_all_open_requests(
+        pool, session_id, account_id=account_id, error={"kind": "model_call_deadline"}
+    )
+    await sessions_service.set_session_stop_reason(
+        pool,
+        session_id,
+        {
+            "type": "error",
+            "message": f"model call exceeded its {deadline_s:.0f}s total deadline while still streaming; partial token usage was recorded",
+        },
+        account_id=account_id,
+    )
+    await _append_lifecycle(
+        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
+    )
 
 
 async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str) -> float | None:

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -17,6 +17,7 @@ from typing import Any
 import litellm
 import pytest
 
+from aios.config import Settings
 from aios.harness import completion
 
 
@@ -137,6 +138,76 @@ async def test_stream_litellm_raises_timeout_on_stalled_stream(
         )
 
     assert resp.aclose_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_litellm_raises_deadline_with_salvaged_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(completion, "get_settings", lambda: Settings(model_call_deadline_s=1.0))
+    monkeypatch.setattr(completion, "_STREAM_TTFT_TIMEOUT_S", 1.0)
+    monkeypatch.setattr(completion, "_STREAM_INTER_CHUNK_TIMEOUT_S", 1.0)
+
+    resp = _RecordingResponse([_make_chunk("hello")], stall=True)
+
+    async def fake_acompletion(**kwargs: object) -> _RecordingResponse:
+        return resp
+
+    def fake_builder(chunks: list[object], **kwargs: object) -> dict[str, object]:
+        assert len(chunks) == 1
+        return {
+            "usage": {
+                "prompt_tokens": 11,
+                "completion_tokens": 22,
+                "cache_read_input_tokens": 3,
+                "cache_creation_input_tokens": 4,
+            },
+            "choices": [{"message": {"role": "assistant", "content": "hello"}}],
+        }
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "stream_chunk_builder", fake_builder)
+
+    with pytest.raises(completion.ModelCallDeadlineError) as excinfo:
+        await completion.stream_litellm(
+            model="anthropic/claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "ping"}],
+            pool=_StubPool(),
+            session_id="sess_test",
+        )
+
+    assert excinfo.value.chunks_seen == 1
+    assert excinfo.value.usage == {
+        "input_tokens": 11,
+        "output_tokens": 22,
+        "cache_read_input_tokens": 3,
+        "cache_creation_input_tokens": 4,
+    }
+    assert excinfo.value.cost_usd is None
+    assert resp.aclose_count == 1
+
+
+@pytest.mark.asyncio
+async def test_call_litellm_deadline_raises_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(completion, "get_settings", lambda: Settings(model_call_deadline_s=1.0))
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    with pytest.raises(completion.ModelCallDeadlineError) as excinfo:
+        await completion.call_litellm(
+            model="anthropic/claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "ping"}],
+        )
+
+    assert excinfo.value.chunks_seen == 0
+    assert excinfo.value.usage == {}
+    assert excinfo.value.cost_usd is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -114,12 +114,39 @@ def test_github_clone_cache_timeout_default(
     assert s.github_clone_cache_timeout_seconds == 300.0
 
 
+def test_model_call_deadline_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_MODEL_CALL_DEADLINE_S", raising=False)
+
+    s = Settings(_env_file=(str(secrets),))
+    assert s.model_call_deadline_s == 900.0
+
+
+def test_model_call_deadline_rejects_step_budget_or_above(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pydantic import ValidationError
+
+    from aios.config import Settings
+    from aios.harness.loop import _JOB_TIMEOUT_S
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_MODEL_CALL_DEADLINE_S", str(_JOB_TIMEOUT_S))
+
+    with pytest.raises(ValidationError, match="AIOS_MODEL_CALL_DEADLINE_S"):
+        Settings(_env_file=(str(secrets),))
+
+
 def test_github_clone_session_timeout_below_step_budget(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The whole point of issue #697: the per-session clone budget must
     fit strictly inside the harness step budget so a hung clone doesn't
-    burn the full 5-minute turn.
+    burn the full harness turn.
     """
     from aios.config import Settings
     from aios.harness.loop import _JOB_TIMEOUT_S
@@ -160,7 +187,7 @@ def test_github_clone_session_timeout_rejects_above_step_budget(
 
     secrets = tmp_path / "secrets.env"
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_DB_URL=postgresql://x/y\n")
-    monkeypatch.setenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", "400")
+    monkeypatch.setenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", "960")
 
     with pytest.raises(ValidationError, match="must be strictly less than"):
         Settings(_env_file=(str(secrets),))

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -17,6 +17,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
+from aios.harness.completion import ModelCallDeadlineError
 from aios.harness.loop import (
     _count_consecutive_rescheduling,
     _retry_delay_for_attempt,
@@ -210,7 +211,11 @@ def mock_step_dependencies() -> Any:
         patch(
             "aios.harness.loop.stream_litellm",
             AsyncMock(side_effect=RuntimeError("provider boom")),
-        ),
+        ) as stream_litellm_mock,
+        patch(
+            "aios.harness.loop.sessions_service.increment_usage",
+            AsyncMock(),
+        ) as increment_usage_mock,
         patch(
             "aios.harness.loop.defer_wake",
             AsyncMock(),
@@ -229,6 +234,8 @@ def mock_step_dependencies() -> Any:
             append_event=append_event,
             defer_wake=defer_wake_mock,
             fail_all_open_requests=fail_all_open_requests_mock,
+            stream_litellm=stream_litellm_mock,
+            increment_usage=increment_usage_mock,
         )
 
 
@@ -287,3 +294,96 @@ class TestRunSessionStepOnModelError:
         mock_step_dependencies.fail_all_open_requests.assert_awaited_once_with(
             ANY, "sess_x", account_id=ANY, error={"kind": "child_errored"}
         )
+
+    async def test_streaming_deadline_records_usage_and_parks_without_retry(
+        self, mock_step_dependencies: Any
+    ) -> None:
+        usage = {
+            "input_tokens": 11,
+            "output_tokens": 22,
+            "cache_read_input_tokens": 3,
+            "cache_creation_input_tokens": 4,
+        }
+        mock_step_dependencies.stream_litellm.side_effect = ModelCallDeadlineError(
+            "deadline",
+            usage=usage,
+            cost_usd=1.25,
+            chunks_seen=2,
+        )
+
+        await run_session_step("sess_x")
+
+        mock_step_dependencies.defer_wake.assert_not_awaited()
+        mock_step_dependencies.increment_usage.assert_awaited_once_with(
+            ANY,
+            "sess_x",
+            input_tokens=11,
+            output_tokens=22,
+            cache_read_input_tokens=3,
+            cache_creation_input_tokens=4,
+            account_id=ANY,
+        )
+        mock_step_dependencies.fail_all_open_requests.assert_awaited_once_with(
+            ANY, "sess_x", account_id=ANY, error={"kind": "model_call_deadline"}
+        )
+        stop_reasons = [
+            call.args[2] for call in mock_step_dependencies.set_stop_reason.call_args_list
+        ]
+        assert any(
+            reason.get("type") == "error"
+            and "partial token usage was recorded" in reason.get("message", "")
+            for reason in stop_reasons
+        )
+        span_payloads = [
+            call.args[3]
+            for call in mock_step_dependencies.append_event.call_args_list
+            if call.args[2] == "span"
+        ]
+        assert {
+            "event": "model_request_end",
+            "model_request_start_id": "ev_start",
+            "is_error": True,
+            "model_usage": usage,
+            "cost_usd": 1.25,
+        } in span_payloads
+        lifecycle_payloads = [
+            call.args[3]
+            for call in mock_step_dependencies.append_event.call_args_list
+            if call.args[2] == "lifecycle"
+        ]
+        assert any(payload.get("stop_reason") == "error" for payload in lifecycle_payloads)
+        assert not any(
+            payload.get("stop_reason") == "rescheduling" for payload in lifecycle_payloads
+        )
+
+    async def test_zero_chunk_deadline_uses_retry_path(self, mock_step_dependencies: Any) -> None:
+        mock_step_dependencies.stream_litellm.side_effect = ModelCallDeadlineError(
+            "deadline",
+            usage={},
+            cost_usd=None,
+            chunks_seen=0,
+        )
+
+        with patch(
+            "aios.harness.loop._count_consecutive_rescheduling",
+            AsyncMock(return_value=0),
+        ):
+            await run_session_step("sess_x")
+
+        mock_step_dependencies.defer_wake.assert_awaited_once_with(
+            ANY, "sess_x", cause="reschedule", delay_seconds=2, account_id=ANY
+        )
+        mock_step_dependencies.increment_usage.assert_not_awaited()
+        mock_step_dependencies.fail_all_open_requests.assert_not_awaited()
+        span_payloads = [
+            call.args[3]
+            for call in mock_step_dependencies.append_event.call_args_list
+            if call.args[2] == "span"
+        ]
+        assert {
+            "event": "model_request_end",
+            "model_request_start_id": "ev_start",
+            "is_error": True,
+            "model_usage": {},
+            "cost_usd": None,
+        } in span_payloads


### PR DESCRIPTION
Adds a configured total-duration model-call deadline below the raised harness job cap and handles deadline expiry in-band so cancellations no longer bypass model_request_end recording.

What changed:
- Added `AIOS_MODEL_CALL_DEADLINE_S` defaulting to 900s with startup validation that it stays strictly below the 960s harness step cap.
- Raised the session step cap to 960s and updated related config comments/tests.
- Added `ModelCallDeadlineError` for streamed and non-streamed LiteLLM wrappers.
- Enforced streaming deadline per chunk while preserving existing TTFT/inter-chunk stall behavior.
- Salvages streamed partial usage/cost on deadline expiry and records it on an errored `model_request_end` span plus cumulative usage counters.
- Parks legitimately-long streaming deadline turns as terminal errored turns without retrying.
- Keeps zero-chunk/non-streamed deadline expiry on the existing retry path with an error span.
- Extended unit coverage for completion deadlines, loop retry discriminator behavior, and config validation.

Validation:
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest tests/unit/test_completion_timeouts.py tests/unit/test_loop_retry.py tests/unit/test_config.py -q`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/e2e/test_litellm_502_recovery.py -q` (skipped: Docker not running)
- pre-commit hooks passed, including unit and connector suites
- `bash scripts/regen-client.sh`
- `bash scripts/regen-openapi.sh`

Closes #852