### PR TITLE
Add sandbox runtime flag for runsc (#1014)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -225,6 +225,13 @@ class Settings(BaseSettings):
         "Emergency rollback ONLY: set AIOS_SANDBOX_SECCOMP_PROFILE=unconfined to "
         "disable seccomp filtering. Never defaults to unconfined; the flag is always emitted.",
     )
+    sandbox_runtime: str | None = Field(
+        default=None,
+        description="Optional Docker container runtime for sandboxes and their "
+        "network-lockdown sidecars. Unset (or Docker's configured default, normally "
+        "runc) preserves local/CI behavior; set AIOS_SANDBOX_RUNTIME=runsc to run "
+        "containers under gVisor where the host has runsc installed.",
+    )
     bash_default_timeout_seconds: int = Field(
         default=120,
         ge=1,

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -463,6 +463,7 @@ class SandboxBackend(Protocol):
         script: str,
         timeout_seconds: int,
         max_output_bytes: int,
+        runtime: str | None = None,
     ) -> CommandResult:
         """Run ``script`` in an ephemeral sidecar joined to a sandbox's netns.
 
@@ -472,7 +473,11 @@ class SandboxBackend(Protocol):
         its iptables edits apply to the sandbox's traffic, and is removed on
         exit. The sandbox itself holds no ``NET_ADMIN``, so root-in-sandbox
         can neither flush its own lockdown nor poison the binaries that apply
-        it. Returns the script's :class:`CommandResult`; raises
+        it. ``runtime`` (#1014) selects the backend-specific container runtime
+        for the sidecar (e.g. ``runsc``); ``None`` leaves the backend default.
+        Callers pass it explicitly — pinned to the target sandbox's spec —
+        because the backend layer never reads ambient config. Returns the
+        script's :class:`CommandResult`; raises
         :class:`SandboxBackendError` on infra failure / timeout.
         """
         ...

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -140,6 +140,10 @@ class SandboxSpec:
     # profile is never silently shipped. The default below is a fallback for
     # bare test construction only; production always sets it from settings.
     seccomp_profile: str = "unconfined"
+    # Optional backend-specific container runtime (#1014). ``None`` leaves Docker's
+    # default runtime in place (local/CI no-op); DockerBackend translates a value
+    # such as ``runsc`` into ``docker run --runtime runsc``.
+    runtime: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 
+from aios.config import get_settings
 from aios.logging import get_logger
 from aios.sandbox._subprocess import (
     run_docker_cli,
@@ -196,6 +197,9 @@ class DockerBackend:
         # The value is a host path the docker CLI reads, or the literal "unconfined"
         # (emergency rollback via AIOS_SANDBOX_SECCOMP_PROFILE only).
         argv.extend(["--security-opt", f"seccomp={spec.seccomp_profile}"])
+
+        if spec.runtime:
+            argv.extend(["--runtime", spec.runtime])
 
         # Keep stdin open so the container doesn't exit on empty stdin.
         argv.append("--interactive")
@@ -719,11 +723,18 @@ class DockerBackend:
             f"container:{target_sandbox_id}",
             "--cap-add",
             "NET_ADMIN",
-            image,
-            "bash",
-            "-c",
-            script,
         ]
+        runtime = get_settings().sandbox_runtime
+        if runtime:
+            argv.extend(["--runtime", runtime])
+        argv.extend(
+            [
+                image,
+                "bash",
+                "-c",
+                script,
+            ]
+        )
         rc, stdout_bytes, stderr_bytes, timed_out = await run_subprocess_with_timeout(
             argv, timeout_s=float(timeout_seconds)
         )

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import json
 
-from aios.config import get_settings
 from aios.logging import get_logger
 from aios.sandbox._subprocess import (
     run_docker_cli,
@@ -705,6 +704,7 @@ class DockerBackend:
         script: str,
         timeout_seconds: int,
         max_output_bytes: int,
+        runtime: str | None = None,
     ) -> CommandResult:
         """Apply/verify the network lockdown from an ephemeral operator-image sidecar.
 
@@ -713,7 +713,9 @@ class DockerBackend:
         ``--rm`` removes it on exit (the rules persist in the netns, held by
         the sandbox). No restrictive seccomp is applied — this is an
         operator-trusted, short-lived container, and iptables needs the
-        syscalls the default profile permits.
+        syscalls the default profile permits. ``runtime`` (#1014) selects the
+        container runtime (e.g. ``runsc``) — passed by the caller, pinned to
+        the target sandbox's spec; the backend never reads ambient config.
         """
         argv = [
             "docker",
@@ -724,7 +726,6 @@ class DockerBackend:
             "--cap-add",
             "NET_ADMIN",
         ]
-        runtime = get_settings().sandbox_runtime
         if runtime:
             argv.extend(["--runtime", runtime])
         argv.extend(

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -653,6 +653,10 @@ class SandboxRegistry:
             extra_host_ports=extra_host_ports,
             dnat_hosts=dnat_hosts,
             dnat_target=dnat_target,
+            # Pin the lockdown sidecar to the same container runtime as the
+            # sandbox it locks down (#1014) — sourced from the sandbox's own
+            # provisioning spec, never ambient config.
+            runtime=plan.spec.runtime,
         )
 
     async def _stop_proxy_silently(

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -314,11 +314,18 @@ async def apply_network_lockdown(
     extra_host_ports: Sequence[tuple[str, int]] = (),
     dnat_hosts: Sequence[str] = (),
     dnat_target: tuple[str, int] | None = None,
+    runtime: str | None = None,
 ) -> None:
     """Apply + verify iptables egress rules via an ephemeral operator-image sidecar.
 
     Called after package installation so ``pip install`` etc. can reach
     registries before the lockdown takes effect.
+
+    ``runtime`` (#1014) is the container runtime for the sidecar (e.g.
+    ``runsc``), threaded by the registry from the sandbox's own provisioning
+    spec so the sidecar always runs under the same runtime as the sandbox it
+    locks down. The backend layer takes it as an explicit parameter — it never
+    reads ambient config.
 
     ``dnat_hosts`` + ``dnat_target`` are threaded into
     :func:`build_iptables_script` to DNAT credential-host :443 egress through
@@ -368,6 +375,7 @@ async def apply_network_lockdown(
             script=apply_script,
             timeout_seconds=30,
             max_output_bytes=settings.bash_max_output_bytes,
+            runtime=runtime,
         )
     except SandboxBackendError:
         # Don't swallow an infra failure into a wide-open sandbox: a Limited
@@ -396,6 +404,7 @@ async def apply_network_lockdown(
             script=_LOCKDOWN_VERIFY_SCRIPT,
             timeout_seconds=15,
             max_output_bytes=settings.bash_max_output_bytes,
+            runtime=runtime,
         )
     except SandboxBackendError:
         log.warning("sandbox.network_lockdown_verify_error", owner_id=handle.owner_id)

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -963,6 +963,9 @@ def _assemble_plan(
         # the deny-list profile by default; the literal "unconfined" only
         # appears via the AIOS_SANDBOX_SECCOMP_PROFILE emergency override.
         seccomp_profile=settings.sandbox_seccomp_profile,
+        # Optional sandbox runtime (#1014). ``None`` leaves Docker's default in
+        # place; operators can select gVisor with AIOS_SANDBOX_RUNTIME=runsc.
+        runtime=settings.sandbox_runtime,
     )
 
     return ProvisioningPlan(

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -235,6 +235,7 @@ class FakeBackend:
         script: str,
         timeout_seconds: int,
         max_output_bytes: int,
+        runtime: str | None = None,
     ) -> CommandResult:
         self.calls.append(
             (
@@ -244,6 +245,7 @@ class FakeBackend:
                     "image": image,
                     "script": script,
                     "timeout_seconds": timeout_seconds,
+                    "runtime": runtime,
                 },
             )
         )

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -351,6 +351,7 @@ def patch_build_spec_deps(
     settings.sandbox_memory_bytes = None
     settings.sandbox_pids_limit = None
     settings.sandbox_seccomp_profile = "/app/docker/seccomp-sandbox.json"
+    settings.sandbox_runtime = None
     settings.tool_broker_socket_path = None
 
     if tool_broker is None:

--- a/tests/unit/sandbox/test_docker_runtime_argv.py
+++ b/tests/unit/sandbox/test_docker_runtime_argv.py
@@ -72,7 +72,7 @@ async def test_create_emits_configured_runtime(monkeypatch: pytest.MonkeyPatch) 
     assert _runtime_values(calls[0]) == ["runsc"]
 
 
-async def test_netns_sidecar_emits_configured_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_netns_sidecar_emits_runtime_when_passed(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[list[str]] = []
 
     async def fake_run(argv: list[str], *, timeout_s: float) -> tuple[int, bytes, bytes, bool]:
@@ -80,11 +80,7 @@ async def test_netns_sidecar_emits_configured_runtime(monkeypatch: pytest.Monkey
         calls.append(list(argv))
         return 0, b"", b"", False
 
-    class Settings:
-        sandbox_runtime = "runsc"
-
     monkeypatch.setattr(docker_backend, "run_subprocess_with_timeout", fake_run)
-    monkeypatch.setattr(docker_backend, "get_settings", lambda: Settings())
 
     await DockerBackend().run_netns_sidecar(
         "sandbox123",
@@ -92,16 +88,16 @@ async def test_netns_sidecar_emits_configured_runtime(monkeypatch: pytest.Monkey
         script="true",
         timeout_seconds=5,
         max_output_bytes=1024,
+        runtime="runsc",
     )
 
     assert _runtime_values(calls[0]) == ["runsc"]
-    assert calls[0][calls[0].index("--runtime") : calls[0].index("--runtime") + 2] == [
-        "--runtime",
-        "runsc",
-    ]
+    # The flag lands before the image (i.e. on the docker run options, not
+    # inside the in-container command).
+    assert calls[0].index("--runtime") < calls[0].index("aios-sandbox:test")
 
 
-async def test_netns_sidecar_omits_runtime_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_netns_sidecar_omits_runtime_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[list[str]] = []
 
     async def fake_run(argv: list[str], *, timeout_s: float) -> tuple[int, bytes, bytes, bool]:
@@ -109,11 +105,7 @@ async def test_netns_sidecar_omits_runtime_by_default(monkeypatch: pytest.Monkey
         calls.append(list(argv))
         return 0, b"", b"", False
 
-    class Settings:
-        sandbox_runtime = None
-
     monkeypatch.setattr(docker_backend, "run_subprocess_with_timeout", fake_run)
-    monkeypatch.setattr(docker_backend, "get_settings", lambda: Settings())
 
     await DockerBackend().run_netns_sidecar(
         "sandbox123",

--- a/tests/unit/sandbox/test_docker_runtime_argv.py
+++ b/tests/unit/sandbox/test_docker_runtime_argv.py
@@ -1,0 +1,126 @@
+"""Docker runtime flag plumbing for gVisor/runsc selection (#1014)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aios.sandbox.backends import docker as docker_backend
+from aios.sandbox.backends.base import (
+    INSTANCE_LABEL_KEY,
+    MANAGED_LABEL_KEY,
+    MANAGED_LABEL_VALUE,
+    SESSION_LABEL_KEY,
+    Mount,
+    SandboxSpec,
+    Unrestricted,
+)
+from aios.sandbox.backends.docker import DockerBackend
+
+
+def _spec(*, runtime: str | None = None) -> SandboxSpec:
+    return SandboxSpec(
+        session_id="sess_runtime",
+        instance_id="inst_runtime",
+        workspace=Mount(host_path=Path("/tmp/ws"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={
+            MANAGED_LABEL_KEY: MANAGED_LABEL_VALUE,
+            INSTANCE_LABEL_KEY: "inst_runtime",
+            SESSION_LABEL_KEY: "sess_runtime",
+        },
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image="aios-sandbox:test",
+        runtime=runtime,
+    )
+
+
+def _runtime_values(argv: list[str]) -> list[str]:
+    return [argv[i + 1] for i, tok in enumerate(argv) if tok == "--runtime"]
+
+
+async def test_create_omits_runtime_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+        del timeout_s
+        calls.append(list(argv))
+        return 0, b"deadbeefcafe\n", b""
+
+    monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
+
+    await DockerBackend().create(_spec())
+
+    assert _runtime_values(calls[0]) == []
+
+
+async def test_create_emits_configured_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+        del timeout_s
+        calls.append(list(argv))
+        return 0, b"deadbeefcafe\n", b""
+
+    monkeypatch.setattr(docker_backend, "run_docker_cli", fake_run)
+
+    await DockerBackend().create(_spec(runtime="runsc"))
+
+    assert _runtime_values(calls[0]) == ["runsc"]
+
+
+async def test_netns_sidecar_emits_configured_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(argv: list[str], *, timeout_s: float) -> tuple[int, bytes, bytes, bool]:
+        del timeout_s
+        calls.append(list(argv))
+        return 0, b"", b"", False
+
+    class Settings:
+        sandbox_runtime = "runsc"
+
+    monkeypatch.setattr(docker_backend, "run_subprocess_with_timeout", fake_run)
+    monkeypatch.setattr(docker_backend, "get_settings", lambda: Settings())
+
+    await DockerBackend().run_netns_sidecar(
+        "sandbox123",
+        image="aios-sandbox:test",
+        script="true",
+        timeout_seconds=5,
+        max_output_bytes=1024,
+    )
+
+    assert _runtime_values(calls[0]) == ["runsc"]
+    assert calls[0][calls[0].index("--runtime") : calls[0].index("--runtime") + 2] == [
+        "--runtime",
+        "runsc",
+    ]
+
+
+async def test_netns_sidecar_omits_runtime_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_run(argv: list[str], *, timeout_s: float) -> tuple[int, bytes, bytes, bool]:
+        del timeout_s
+        calls.append(list(argv))
+        return 0, b"", b"", False
+
+    class Settings:
+        sandbox_runtime = None
+
+    monkeypatch.setattr(docker_backend, "run_subprocess_with_timeout", fake_run)
+    monkeypatch.setattr(docker_backend, "get_settings", lambda: Settings())
+
+    await DockerBackend().run_netns_sidecar(
+        "sandbox123",
+        image="aios-sandbox:test",
+        script="true",
+        timeout_seconds=5,
+        max_output_bytes=1024,
+    )
+
+    assert _runtime_values(calls[0]) == []

--- a/tests/unit/sandbox/test_spec_per_env_controls.py
+++ b/tests/unit/sandbox/test_spec_per_env_controls.py
@@ -117,12 +117,24 @@ class TestAssemblePlanImageAndBudget:
         sandbox-cap attributes the constructor reads."""
         settings = MagicMock()
         settings.sandbox_seccomp_profile = "/x/seccomp.json"
+        settings.sandbox_runtime = None
         settings.sandbox_cpu_quota = None
         settings.sandbox_memory_bytes = None
         settings.sandbox_pids_limit = None
         with patch("aios.sandbox.spec.get_settings", return_value=settings):
             plan = _call_assemble()
         assert plan.spec.seccomp_profile == "/x/seccomp.json"
+
+    def test_runtime_from_settings_lands_on_spec(self) -> None:
+        settings = MagicMock()
+        settings.sandbox_seccomp_profile = "/x/seccomp.json"
+        settings.sandbox_runtime = "runsc"
+        settings.sandbox_cpu_quota = None
+        settings.sandbox_memory_bytes = None
+        settings.sandbox_pids_limit = None
+        with patch("aios.sandbox.spec.get_settings", return_value=settings):
+            plan = _call_assemble()
+        assert plan.spec.runtime == "runsc"
 
 
 # ── build_spec_from_session resolution (#724 image, snapshot budget) ─────────

--- a/tests/unit/sandbox/test_spec_run_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_run_env_var_credentials.py
@@ -61,6 +61,7 @@ def _patch_run_spec_deps(
     settings.sandbox_memory_bytes = None
     settings.sandbox_pids_limit = None
     settings.sandbox_seccomp_profile = "/app/docker/seccomp-sandbox.json"
+    settings.sandbox_runtime = None
     settings.tool_broker_socket_path = None
     if broker is None:
         broker = MagicMock()
@@ -118,6 +119,7 @@ async def test_run_placeholder_lands_in_env_secret_never_does() -> None:
         plan = await build_spec_from_run(_RUN_ID)
 
     assert plan.spec.environment["PW_DEV_GATE_PASSWORD"] == _CRED.placeholder
+    assert plan.spec.runtime is None
     assert _SENTINEL_SECRET not in str(plan.spec)
     assert _SENTINEL_SECRET not in " ".join(plan.spec.environment.values())
     assert plan.env_var_credentials == (_CRED,)

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -466,6 +466,31 @@ class TestApplyNetworkLockdown:
         assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in script
         assert "getent ahosts api.secret.com" in script
 
+    @pytest.mark.asyncio
+    async def test_runtime_threaded_to_both_sidecar_calls(self) -> None:
+        """The sandbox's container runtime (#1014) reaches BOTH sidecar
+        invocations (apply and read-back verify) so the lockdown runs under
+        the same runtime as the sandbox it locks down."""
+        backend = FakeBackend()
+        handle = make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        await apply_network_lockdown(backend, handle, networking, runtime="runsc")
+
+        runtimes = [c[1]["runtime"] for c in backend.calls if c[0] == "run_netns_sidecar"]
+        assert runtimes == ["runsc", "runsc"]
+
+    @pytest.mark.asyncio
+    async def test_runtime_defaults_to_none(self) -> None:
+        backend = FakeBackend()
+        handle = make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        await apply_network_lockdown(backend, handle, networking)
+
+        runtimes = [c[1]["runtime"] for c in backend.calls if c[0] == "run_netns_sidecar"]
+        assert runtimes == [None, None]
+
 
 # ── lockdown fails closed (security gate, not best-effort) ─────────────────────
 


### PR DESCRIPTION
Adds config-selected Docker runtime plumbing for sandboxes without changing the default local/CI behavior.

What changed:
- Added `AIOS_SANDBOX_RUNTIME` / `settings.sandbox_runtime`.
- Added `runtime` to `SandboxSpec`.
- Propagated the runtime through session and workflow-run spec assembly.
- Emits `docker run --runtime <value>` for sandbox containers when configured.
- Emits the same runtime flag for netns lockdown sidecars.
- Added unit coverage for default omission, `runsc` emission, and spec propagation.

Validation:
- `ruff check src tests`
- `ruff format --check src tests`
- `mypy src tests`
- `pytest tests/unit -q`
- pre-commit hook checks, including connector unit tests
- `scripts/regen-client.sh`
- `scripts/regen-openapi.sh`

Closes #1014