### PR TITLE
fix(ci): gVisor archive key URL (release.key 404 → gvisor.dev/archive.key)

### DIFF
--- a/.github/workflows/gvisor-validation.yml
+++ b/.github/workflows/gvisor-validation.yml
@@ -24,7 +24,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y ca-certificates curl gnupg
-          curl -fsSL https://storage.googleapis.com/gvisor/releases/release.key \
+          curl -fsSL https://gvisor.dev/archive.key \
             | sudo gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
           arch="$(dpkg --print-architecture)"
           echo "deb [arch=${arch} signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" \


### PR DESCRIPTION
First `gvisor-validation` run ([27441239005](https://github.com/eumemic/aios/actions/runs/27441239005)) died at **Install runsc**: `curl: (22) 404` on `storage.googleapis.com/gvisor/releases/release.key` → `gpg: no valid OpenPGP data found`. Canonical key URL is `https://gvisor.dev/archive.key` (verified 200, serves the PGP block). One-line swap; the apt source line was already correct. Workflow structure tests pass (4/4).

Re-trigger of the battery follows merge — ops#160 acceptance still pending a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)