### PR TITLE
fix: pin workflow host semantics epoch

### DIFF
--- a/migrations/versions/0092_wf_run_host_semantics_epoch.py
+++ b/migrations/versions/0092_wf_run_host_semantics_epoch.py
@@ -1,0 +1,31 @@
+"""Pin workflow runs to a host-semantics epoch.
+
+Revision ID: 0092
+Revises: 0091
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0092"
+down_revision: str = "0091"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+HOST_SEMANTICS_EPOCH = 1
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE wf_runs ADD COLUMN host_semantics_epoch integer "
+        f"NOT NULL DEFAULT {HOST_SEMANTICS_EPOCH}"
+    )
+    op.execute("ALTER TABLE wf_runs ALTER COLUMN host_semantics_epoch DROP DEFAULT")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE wf_runs DROP COLUMN host_semantics_epoch")

--- a/openapi.json
+++ b/openapi.json
@@ -16113,6 +16113,10 @@
             "type": "string",
             "title": "Script Sha"
           },
+          "host_semantics_epoch": {
+            "type": "integer",
+            "title": "Host Semantics Epoch"
+          },
           "tools": {
             "items": {
               "$ref": "#/components/schemas/ToolSpec"
@@ -16198,6 +16202,7 @@
           "environment_id",
           "script",
           "script_sha",
+          "host_semantics_epoch",
           "status",
           "last_event_seq",
           "created_at",

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -39,6 +39,7 @@ class WfRun:
             environment_id (str):
             script (str):
             script_sha (str):
+            host_semantics_epoch (int):
             status (WfRunStatus):
             last_event_seq (int):
             created_at (datetime.datetime):
@@ -60,6 +61,7 @@ class WfRun:
     environment_id: str
     script: str
     script_sha: str
+    host_semantics_epoch: int
     status: WfRunStatus
     last_event_seq: int
     created_at: datetime.datetime
@@ -87,6 +89,8 @@ class WfRun:
         script = self.script
 
         script_sha = self.script_sha
+
+        host_semantics_epoch = self.host_semantics_epoch
 
         status = self.status.value
 
@@ -157,6 +161,7 @@ class WfRun:
                 "environment_id": environment_id,
                 "script": script,
                 "script_sha": script_sha,
+                "host_semantics_epoch": host_semantics_epoch,
                 "status": status,
                 "last_event_seq": last_event_seq,
                 "created_at": created_at,
@@ -202,6 +207,8 @@ class WfRun:
         script = d.pop("script")
 
         script_sha = d.pop("script_sha")
+
+        host_semantics_epoch = d.pop("host_semantics_epoch")
 
         status = WfRunStatus(d.pop("status"))
 
@@ -295,6 +302,7 @@ class WfRun:
             environment_id=environment_id,
             script=script,
             script_sha=script_sha,
+            host_semantics_epoch=host_semantics_epoch,
             status=status,
             last_event_seq=last_event_seq,
             created_at=created_at,

--- a/scripts/regen-replay-semantics-fingerprint.py
+++ b/scripts/regen-replay-semantics-fingerprint.py
@@ -1,26 +1,66 @@
 #!/usr/bin/env python3
-"""Regenerate the workflow replay-semantics fingerprint snapshots."""
+"""Regenerate the workflow replay-semantics fingerprint snapshot.
+
+The snapshot is an epoch-stamped canary: it may only change together with a
+``HOST_SEMANTICS_EPOCH`` bump in ``src/aios/workflows/determinism.py``.  This
+script therefore loads the existing fixture first and refuses to overwrite it
+when the rebuilt content differs while the epoch still equals the stored one —
+silently regenerating in that state would mask a replay-semantics change.
+
+Permitted regens: rebuilt content identical to the existing fixture
+(idempotent re-run), epoch differing from the stored one (legitimate bump), or
+fixture file absent (bootstrap).
+"""
 
 from __future__ import annotations
 
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "src"))
 
-from tests.unit.replay_semantics_fingerprint_fixture import build_snapshot
+from tests.unit.replay_semantics_fingerprint_fixture import build_snapshot  # noqa: E402
 
 OUT = ROOT / "tests" / "fixtures" / "replay_semantics_fingerprint.json"
 
 
-def main() -> None:
-    snapshot = build_snapshot()
-    OUT.parent.mkdir(parents=True, exist_ok=True)
-    OUT.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+class EpochNotBumpedError(Exception):
+    """Rebuilt snapshot differs but ``HOST_SEMANTICS_EPOCH`` was not bumped."""
+
+
+def check_regen_allowed(existing: dict[str, Any] | None, rebuilt: dict[str, Any]) -> None:
+    """Raise :class:`EpochNotBumpedError` when overwriting would mask a change.
+
+    Permitted: fixture absent (bootstrap), rebuilt identical to existing
+    (idempotent re-run), or rebuilt epoch differing from the stored epoch
+    (legitimate bump).  Refused: content differs while the epoch matches.
+    """
+    if existing is None or rebuilt == existing or rebuilt["epoch"] != existing["epoch"]:
+        return
+    raise EpochNotBumpedError(
+        "replay-semantics fingerprint content changed but HOST_SEMANTICS_EPOCH "
+        f"is still {existing['epoch']}. Replay semantics may only change together "
+        "with an epoch bump: bump HOST_SEMANTICS_EPOCH in "
+        "src/aios/workflows/determinism.py first, then re-run this script."
+    )
+
+
+def main(out: Path = OUT) -> int:
+    rebuilt = build_snapshot()
+    existing = json.loads(out.read_text()) if out.exists() else None
+    try:
+        check_regen_allowed(existing, rebuilt)
+    except EpochNotBumpedError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(rebuilt, indent=2, sort_keys=True) + "\n")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/regen-replay-semantics-fingerprint.py
+++ b/scripts/regen-replay-semantics-fingerprint.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Regenerate the workflow replay-semantics fingerprint snapshots."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from tests.unit.replay_semantics_fingerprint_fixture import build_snapshot
+
+OUT = ROOT / "tests" / "fixtures" / "replay_semantics_fingerprint.json"
+
+
+def main() -> None:
+    snapshot = build_snapshot()
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -70,6 +70,7 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         launcher_session_id=row["launcher_session_id"],
         script=row["script"],
         script_sha=row["script_sha"],
+        host_semantics_epoch=row["host_semantics_epoch"],
         tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
         mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
         http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
@@ -406,6 +407,7 @@ async def insert_wf_run(
     environment_id: str,
     script: str,
     script_sha: str,
+    host_semantics_epoch: int,
     input: Any = None,
     parent_run_id: str | None = None,
     launcher_session_id: str | None = None,
@@ -423,10 +425,10 @@ async def insert_wf_run(
             """
             INSERT INTO wf_runs
                 (id, workflow_id, account_id, environment_id, parent_run_id,
-                 launcher_session_id, script, script_sha, status, input,
+                 launcher_session_id, script, script_sha, host_semantics_epoch, status, input,
                  tools, mcp_servers, http_servers, budget_total_microusd)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'pending', $9::jsonb,
-                    $10::jsonb, $11::jsonb, $12::jsonb, $13)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending', $10::jsonb,
+                    $11::jsonb, $12::jsonb, $13::jsonb, $14)
             RETURNING *
             """,
             new_id,
@@ -437,6 +439,7 @@ async def insert_wf_run(
             launcher_session_id,
             script,
             script_sha,
+            host_semantics_epoch,
             json.dumps(input) if input is not None else None,
             json.dumps([t.model_dump() for t in (tools or [])]),
             json.dumps([s.model_dump() for s in (mcp_servers or [])]),

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -86,6 +86,7 @@ class WfRun(BaseModel):
     launcher_session_id: str | None = None
     script: str
     script_sha: str
+    host_semantics_epoch: int
     tools: list[ToolSpec] = Field(default_factory=list)
     mcp_servers: list[McpServerSpec] = Field(default_factory=list)
     http_servers: list[HttpServerSpec] = Field(default_factory=list)

--- a/src/aios/workflows/determinism.py
+++ b/src/aios/workflows/determinism.py
@@ -36,6 +36,12 @@ import json
 import math
 from typing import Any
 
+# Epoch of the host-side workflow replay semantics. A run pins this at creation;
+# workers fail honest at wake time instead of replaying an in-flight journal under
+# silently changed keying/interpreter/capability semantics. Bump only for knowingly
+# replay-breaking changes; replay-additive changes should keep the epoch.
+HOST_SEMANTICS_EPOCH = 1
+
 
 class WorkflowInputTypeError(TypeError):
     """A capability input contains a type not permitted in a workflow.

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -20,6 +20,7 @@ from aios.models.workflows import WfRun
 from aios.services import agents as agents_service
 from aios.services import attenuation as attenuation_service
 from aios.services.wake import defer_run_wake
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
 # Vertical recursion bound: how deep a chain of runs (a run whose agent() child
 # launches a sub-run, and so on) may nest. Mirrors WAKE_SESSION_MAX_DEPTH — bounds
@@ -188,6 +189,7 @@ async def create_run(
             launcher_session_id=launcher_session_id,
             script=workflow.script,
             script_sha=script_sha,
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             input=input,
             # Snapshot the launch-clamped surface (like script), so a later
             # update_workflow never shifts this run's tool-authority.

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -48,11 +48,12 @@ from aios.logging import get_logger
 from aios.models.attenuation import surface_of
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent
 from aios.services import attenuation as attenuation_service
-from aios.services.sessions import create_child_session
+from aios.services.sessions import create_child_session, fail_open_child_requests_conn
 from aios.services.wake import defer_run_wake, defer_trigger_fire, defer_wake
 from aios.tools.registry import tool_executes_class
 from aios.workflows import run_sandbox, run_tools
 from aios.workflows.child_id import child_session_id
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 from aios.workflows.host_launcher import EmittedCapability, run_script_host
 
 log = get_logger("aios.workflows.step")
@@ -292,6 +293,21 @@ async def _run_workflow_step_body(
         # natural terminal already returned at the ``TERMINAL_RUN_STATUSES`` guard above.
         if (cancel_sig := signals.get(wf_queries.CANCEL_SIGNAL_CALL_KEY)) is not None:
             await _cancel_run(conn, run, reason=cancel_sig.result)
+            return
+
+        if run.host_semantics_epoch != HOST_SEMANTICS_EPOCH:
+            await _complete_run(
+                conn,
+                run,
+                output=(
+                    "engine semantics changed: this run was created under "
+                    f"host-semantics epoch {run.host_semantics_epoch} but the worker now "
+                    f"runs epoch {HOST_SEMANTICS_EPOCH}; relaunch the workflow to run it "
+                    "under the current engine"
+                ),
+                is_error=True,
+                error_kind="engine_semantics_changed",
+            )
             return
 
         memo: dict[str, Any] = {
@@ -968,6 +984,24 @@ async def _cancel_run(conn: asyncpg.Connection[Any], run: WfRun, *, reason: Any 
     await _commit_terminal_and_dispatch(conn, run, status="cancelled", payload=payload, output=None)
 
 
+async def _fail_child_requests_for_terminal_error(
+    conn: asyncpg.Connection[Any], run: WfRun, *, error_kind: str
+) -> None:
+    rows = await conn.fetch(
+        "SELECT id FROM sessions "
+        "WHERE parent_run_id = $1 AND account_id = $2 AND archived_at IS NULL",
+        run.id,
+        run.account_id,
+    )
+    for row in rows:
+        await fail_open_child_requests_conn(
+            conn,
+            row["id"],
+            account_id=run.account_id,
+            error={"kind": error_kind},
+        )
+
+
 async def _commit_terminal_and_dispatch(
     conn: asyncpg.Connection[Any],
     run: WfRun,
@@ -994,6 +1028,10 @@ async def _commit_terminal_and_dispatch(
         inserted = await wf_queries.append_run_event(
             conn, account_id=run.account_id, run_id=run.id, type="run_completed", payload=payload
         )
+        if status == "errored" and (error := payload.get("error")) is not None:
+            kind = error.get("kind")
+            if kind in {"engine_semantics_changed", "nondeterministic_replay"}:
+                await _fail_child_requests_for_terminal_error(conn, run, error_kind=kind)
         await wf_queries.set_run_terminal(
             conn, run.id, status=status, output=output, account_id=run.account_id
         )

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -237,6 +237,7 @@ async def test_runs_parent_run_id_filter(http_client: httpx.AsyncClient, pool: A
     spawned internally (a nested ``workflow()``), so seed one via the query layer and
     assert only it comes back for the parent."""
     from aios.db.queries import workflows as wf_queries
+    from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
     env_id = await _create_env(http_client)
     wf = (
@@ -253,6 +254,7 @@ async def test_runs_parent_run_id_filter(http_client: httpx.AsyncClient, pool: A
             environment_id=env_id,
             script=_SCRIPT,
             script_sha="sha",
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             parent_run_id=parent["id"],
         )
     # An unrelated (parentless) run that must be excluded.

--- a/tests/fixtures/replay_semantics_fingerprint.json
+++ b/tests/fixtures/replay_semantics_fingerprint.json
@@ -1,0 +1,133 @@
+{
+  "call_keys": {
+    "base": [
+      "sha:0aca7f5613d6d7c341368af9a870ba8738d96dc241b4c10834c3172367747c59#0",
+      "sha:c3b7c0a87f3a4c93055e63f6465942d700d53cc78532cb76082935cc503479ec#0",
+      "sha:eaa50e7f02c439677e4194c4c6ee929bf60adc5109a443284ce47d1f38122066#0",
+      "sha:eaa50e7f02c439677e4194c4c6ee929bf60adc5109a443284ce47d1f38122066#1",
+      "sha:9665b5e91aec5f3f4b2a36bda3ea7dc513aa30511cbeefbfd0b3982357f7d81b#0"
+    ],
+    "parallel_branch": [
+      "0.1/sha:744f2ac661468c49fb80aad7fd56b5fd12463fc650533aafece435eb37a7795d#0",
+      "0.1/sha:f58823ec8c5a90ca9badad8eed3d250ff67410ed77d833d0ae5a64a002ab4307#0"
+    ]
+  },
+  "canonical_json": {
+    "int_float_tuple_order": "{\"a\":{\"a\":true,\"b\":2},\"z\":[1,1.5]}",
+    "sanitized_text": "nul\ufffdsurrogate?",
+    "unicode": "{\"text\":\"snowman \\u2603 and slash /\"}"
+  },
+  "canonical_schema_json": "{\"description\":\"float literals stay verbatim\",\"minimum\":1.0,\"multipleOf\":0.25,\"type\":\"number\"}",
+  "child_session_ids": [
+    {
+      "call_key": "sha:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#0",
+      "run_id": "run_01J00000000000000000000000",
+      "session_id": "sess_5HGH3KAY8P7P65FQ614DAHWM3H"
+    },
+    {
+      "call_key": "0.1/sha:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb#2",
+      "run_id": "run_01J00000000000000000000000",
+      "session_id": "sess_6NB6RKY6R8JZWHWAJDAGB7GR87"
+    }
+  ],
+  "epoch": 1,
+  "surface": {
+    "importable_modules": [
+      "base64",
+      "collections",
+      "dataclasses",
+      "functools",
+      "hashlib",
+      "itertools",
+      "json",
+      "math",
+      "re",
+      "statistics",
+      "string",
+      "textwrap",
+      "urllib.parse"
+    ],
+    "namespace": [
+      "AgentError",
+      "AgentNoReturnError",
+      "agent",
+      "budget",
+      "gate",
+      "log",
+      "parallel",
+      "phase",
+      "pipeline",
+      "tool"
+    ],
+    "safe_builtins": [
+      "ArithmeticError",
+      "AssertionError",
+      "AttributeError",
+      "BaseException",
+      "Ellipsis",
+      "Exception",
+      "ImportError",
+      "IndexError",
+      "KeyError",
+      "LookupError",
+      "NotImplemented",
+      "NotImplementedError",
+      "RuntimeError",
+      "StopIteration",
+      "TypeError",
+      "ValueError",
+      "ZeroDivisionError",
+      "abs",
+      "all",
+      "any",
+      "ascii",
+      "bin",
+      "bool",
+      "bytes",
+      "callable",
+      "chr",
+      "classmethod",
+      "dict",
+      "divmod",
+      "enumerate",
+      "filter",
+      "float",
+      "format",
+      "frozenset",
+      "getattr",
+      "hasattr",
+      "hash",
+      "hex",
+      "int",
+      "isinstance",
+      "issubclass",
+      "iter",
+      "len",
+      "list",
+      "map",
+      "max",
+      "min",
+      "next",
+      "object",
+      "oct",
+      "ord",
+      "pow",
+      "property",
+      "range",
+      "repr",
+      "reversed",
+      "round",
+      "set",
+      "setattr",
+      "slice",
+      "sorted",
+      "staticmethod",
+      "str",
+      "sum",
+      "super",
+      "tuple",
+      "type",
+      "zip"
+    ]
+  }
+}

--- a/tests/integration/test_env_var_credential_resolution.py
+++ b/tests/integration/test_env_var_credential_resolution.py
@@ -24,6 +24,7 @@ from aios.services.vaults import (
     resolve_run_env_var_credentials,
     resolve_session_env_var_credentials,
 )
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
 pytestmark = pytest.mark.integration
 
@@ -117,6 +118,7 @@ async def _make_run(pool: asyncpg.Pool[Any], *, vault_ids: list[str] | None = No
             workflow_id=wf.id,
             environment_id=ENV,
             script=wf.script,
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             script_sha=hashlib.sha256(wf.script.encode("utf-8")).hexdigest(),
         )
         if vault_ids:

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -20,6 +20,7 @@ from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, NotFoundError
 from aios.models.agents import ToolSpec
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
 
 @pytest.fixture
@@ -52,6 +53,7 @@ async def _seed_run(conn: asyncpg.Connection[Any]) -> str:
         workflow_id=wf.id,
         environment_id="env_root",
         script=wf.script,
+        host_semantics_epoch=HOST_SEMANTICS_EPOCH,
         script_sha="deadbeef",
     )
     return run.id
@@ -88,6 +90,7 @@ async def test_insert_run_snapshots_script(wf_conn: asyncpg.Connection[Any]) -> 
         workflow_id=wf.id,
         environment_id="env_root",
         script=wf.script,
+        host_semantics_epoch=HOST_SEMANTICS_EPOCH,
         script_sha="sha-v1",
     )
     assert run.id.startswith("wfr_")
@@ -451,6 +454,7 @@ async def test_list_wf_runs_filters_by_launcher_session(wf_conn: asyncpg.Connect
             environment_id="env_root",
             script=wf.script,
             script_sha="sha",
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             launcher_session_id=launcher,
         )
         return run.id

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -38,7 +38,7 @@ from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
 from aios.workflows import run_tools, service
 from aios.workflows.child_id import child_session_id
-from aios.workflows.determinism import CallKeyer
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH, CallKeyer
 from aios.workflows.host_launcher import HostOutcome
 from aios.workflows.step import run_workflow_step
 
@@ -530,6 +530,7 @@ async def test_children_listable_by_parent_run_id(
             environment_id="env_wf",
             script="async def main(i):\n    return 1",
             script_sha="sha",
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             parent_run_id=parent_id,
         )
         child_runs = await wf_queries.list_wf_runs(
@@ -2588,6 +2589,124 @@ async def test_divergent_replay_is_caught(wf_runtime: asyncpg.Pool[Any]) -> None
     assert run is not None and run.status == "errored"
     assert events[-1].type == "run_completed"
     assert events[-1].payload["error"]["kind"] == "nondeterministic_replay"
+
+
+async def test_create_run_stamps_host_semantics_epoch(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+    assert run is not None
+    assert run.host_semantics_epoch == HOST_SEMANTICS_EPOCH
+
+
+async def test_epoch_mismatch_errors_before_replay(wf_runtime: asyncpg.Pool[Any]) -> None:
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_runs SET host_semantics_epoch = $1 WHERE id = $2",
+            HOST_SEMANTICS_EPOCH - 1,
+            run_id,
+        )
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        events = await wf_queries.list_run_events(conn, run_id)
+    assert run is not None and run.status == "errored"
+    assert run.output is None
+    assert [event.type for event in events] == ["run_completed"]
+    assert events[-1].payload["is_error"] is True
+    assert events[-1].payload["error"]["kind"] == "engine_semantics_changed"
+    assert "engine semantics changed" in events[-1].payload["output"]
+
+
+async def test_epoch_mismatch_fails_child_open_requests(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi')\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    children = await _children_of(pool, run_id)
+    assert len(children) == 1
+    child_id = children[0]
+    request_id = (await _events(pool, run_id))[1][2]
+    assert request_id is not None
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_runs SET host_semantics_epoch = $1 WHERE id = $2",
+            HOST_SEMANTICS_EPOCH - 1,
+            run_id,
+        )
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        response = await db_queries.read_request_response(
+            conn, child_id, account_id="acc_wf", request_id=request_id
+        )
+        signals = await wf_queries.list_run_signals(conn, run_id)
+    assert response is not None
+    assert response["is_error"] is True
+    assert response["error"] == {"kind": "engine_semantics_changed"}
+    assert any(s.call_key == request_id and s.kind == "child_done" for s in signals)
+
+
+async def test_nondeterministic_replay_fails_child_open_requests(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    pool = wf_runtime
+    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi')\n"
+    run_id = await _make_run(pool, script)
+    await run_workflow_step(run_id)
+    children = await _children_of(pool, run_id)
+    assert len(children) == 1
+    child_id = children[0]
+    request_id = (await _events(pool, run_id))[1][2]
+    assert request_id is not None
+
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_runs SET script = $1, status = 'running' WHERE id = $2",
+            "async def main(input):\n    return 1",
+            run_id,
+        )
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        response = await db_queries.read_request_response(
+            conn, child_id, account_id="acc_wf", request_id=request_id
+        )
+    assert run is not None and run.status == "errored"
+    assert response is not None
+    assert response["is_error"] is True
+    assert response["error"] == {"kind": "nondeterministic_replay"}
+
+
+async def test_gate_parked_run_detects_epoch_mismatch_on_next_wake(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    pool = wf_runtime
+    run_id = await _make_run(pool, _GATE_SCRIPT)
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        suspended = await wf_queries.get_run_for_step(conn, run_id)
+        await conn.execute(
+            "UPDATE wf_runs SET host_semantics_epoch = $1 WHERE id = $2",
+            HOST_SEMANTICS_EPOCH - 1,
+            run_id,
+        )
+    assert suspended is not None and suspended.status == "suspended"
+
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        completed = await wf_queries.get_run_completed_event(conn, run_id)
+    assert run is not None and run.status == "errored"
+    assert completed is not None
+    assert completed.payload["error"]["kind"] == "engine_semantics_changed"
 
 
 async def test_host_crash_on_suspended_gate_is_not_divergence(

--- a/tests/integration/test_wf_sweep.py
+++ b/tests/integration/test_wf_sweep.py
@@ -20,6 +20,7 @@ import pytest
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.models.workflows import WfRunSignalKind
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 from aios.workflows.sweep import wake_runs_needing_step
 
 pytestmark = pytest.mark.integration
@@ -69,6 +70,7 @@ async def _make_run(pool: asyncpg.Pool[Any], *, status: str = "suspended") -> st
             workflow_id=wf.id,
             environment_id="env_sw",
             script="x",
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             script_sha="x",
         )
         if status != "pending":

--- a/tests/unit/replay_semantics_fingerprint_fixture.py
+++ b/tests/unit/replay_semantics_fingerprint_fixture.py
@@ -1,0 +1,88 @@
+"""Fixture builder for the workflow replay-semantics fingerprint test."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.workflows.child_id import child_session_id
+from aios.workflows.determinism import (
+    HOST_SEMANTICS_EPOCH,
+    CallKeyer,
+    canonical_json,
+    canonical_schema_json,
+    storable_text,
+)
+from aios.workflows.wf_script_host import _IMPORTABLE_MODULES, _SAFE_BUILTIN_NAMES
+
+# Deadline/frame/workspace-survivability constants are deliberately excluded: they can
+# make a wake live or die, but they do not alter replay equality or call_key derivation.
+# Sandbox filesystem resume policy is likewise outside today's keyer; a future
+# resume-health decision may choose to bump the epoch if that axis becomes replay-visible.
+
+
+def _keys_for(prefix: str, specs: list[tuple[str, Any]]) -> list[str]:
+    keyer = CallKeyer()
+    return [prefix + keyer.next(capability_id, spec) for capability_id, spec in specs]
+
+
+def build_snapshot() -> dict[str, Any]:
+    repeated_spec = ("agent", {"agent_id": "ag_1", "input": {"same": True}})
+    base_specs: list[tuple[str, Any]] = [
+        ("gate", {"b": 1.0, "a": ("tuple", {"z": [3.25, 2.0]})}),
+        ("tool", {"tool_name": "web", "input": {"nested": {"y": 2, "x": 1.0}}}),
+        repeated_spec,
+        repeated_spec,
+        ("agent", {"agent_id": "ag_2", "input": storable_text("nul\x00surrogate\ud800")}),
+    ]
+    branch_specs = [
+        ("agent", {"agent_id": "ag_branch", "input": {"items": (1.0, 1.5)}}),
+        ("gate", {"branch": "two"}),
+    ]
+    child_inputs = [
+        ("run_01J00000000000000000000000", "sha:" + "a" * 64 + "#0"),
+        ("run_01J00000000000000000000000", "0.1/sha:" + "b" * 64 + "#2"),
+    ]
+    return {
+        "epoch": HOST_SEMANTICS_EPOCH,
+        "canonical_json": {
+            "int_float_tuple_order": canonical_json({"z": (1.0, 1.5), "a": {"b": 2.0, "a": True}}),
+            "unicode": canonical_json({"text": "snowman ☃ and slash /"}),
+            "sanitized_text": storable_text("nul\x00surrogate\ud800"),
+        },
+        "canonical_schema_json": canonical_schema_json(
+            {
+                "type": "number",
+                "minimum": 1.0,
+                "multipleOf": 0.25,
+                "description": "float literals stay verbatim",
+            }
+        ),
+        "call_keys": {
+            "base": _keys_for("", base_specs),
+            "parallel_branch": _keys_for("0.1/", branch_specs),
+        },
+        "surface": {
+            "namespace": [
+                "AgentError",
+                "AgentNoReturnError",
+                "agent",
+                "budget",
+                "gate",
+                "log",
+                "parallel",
+                "phase",
+                "pipeline",
+                "tool",
+            ],
+            "safe_builtins": sorted(_SAFE_BUILTIN_NAMES),
+            "importable_modules": sorted(_IMPORTABLE_MODULES),
+        },
+        "child_session_ids": [
+            {
+                "run_id": run_id,
+                "call_key": call_key,
+                "session_id": child_session_id(run_id, call_key),
+            }
+            for run_id, call_key in child_inputs
+        ],
+    }

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0091``."""
+    """The migration ladder has exactly one head: ``0092``."""
     script = _script_directory()
-    assert script.get_heads() == ["0091"]
+    assert script.get_heads() == ["0092"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_replay_semantics_fingerprint.py
+++ b/tests/unit/test_replay_semantics_fingerprint.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
+from types import ModuleType
+
+import pytest
 
 from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 from tests.unit.replay_semantics_fingerprint_fixture import build_snapshot
@@ -11,9 +15,81 @@ from tests.unit.replay_semantics_fingerprint_fixture import build_snapshot
 SNAPSHOT_PATH = (
     Path(__file__).resolve().parents[1] / "fixtures" / "replay_semantics_fingerprint.json"
 )
+_REGEN_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "regen-replay-semantics-fingerprint.py"
+)
+
+
+def _load_regen_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_regen_fingerprint", _REGEN_SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_replay_semantics_fingerprint_matches_epoch_snapshot() -> None:
     snapshot = json.loads(SNAPSHOT_PATH.read_text())
     assert snapshot["epoch"] == HOST_SEMANTICS_EPOCH
     assert build_snapshot() == snapshot
+
+
+def test_regen_refuses_content_change_without_epoch_bump() -> None:
+    regen = _load_regen_script()
+    existing = {"epoch": 1, "surface": "old"}
+    rebuilt = {"epoch": 1, "surface": "new"}
+    with pytest.raises(regen.EpochNotBumpedError, match="HOST_SEMANTICS_EPOCH"):
+        regen.check_regen_allowed(existing, rebuilt)
+
+
+def test_regen_refusal_message_points_at_determinism_module() -> None:
+    regen = _load_regen_script()
+    with pytest.raises(regen.EpochNotBumpedError, match=r"determinism\.py"):
+        regen.check_regen_allowed({"epoch": 3, "k": "a"}, {"epoch": 3, "k": "b"})
+
+
+def test_regen_permits_identical_content() -> None:
+    regen = _load_regen_script()
+    snapshot = {"epoch": 1, "surface": "same"}
+    regen.check_regen_allowed(snapshot, dict(snapshot))
+
+
+def test_regen_permits_epoch_bump() -> None:
+    regen = _load_regen_script()
+    regen.check_regen_allowed({"epoch": 1, "surface": "old"}, {"epoch": 2, "surface": "new"})
+
+
+def test_regen_permits_bootstrap_when_fixture_absent() -> None:
+    regen = _load_regen_script()
+    regen.check_regen_allowed(None, {"epoch": 1, "surface": "new"})
+
+
+def test_regen_main_bootstraps_then_is_idempotent_then_refuses(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    regen = _load_regen_script()
+    out = tmp_path / "fixtures" / "replay_semantics_fingerprint.json"
+
+    # Bootstrap: fixture absent → written.
+    assert regen.main(out) == 0
+    written = json.loads(out.read_text())
+    assert written == build_snapshot()
+
+    # Idempotent re-run: identical content → still permitted.
+    assert regen.main(out) == 0
+    assert json.loads(out.read_text()) == written
+
+    # Same-epoch content drift → refused, fixture untouched.
+    tampered = dict(written)
+    tampered["surface"] = "tampered"
+    out.write_text(json.dumps(tampered, indent=2, sort_keys=True) + "\n")
+    assert regen.main(out) == 1
+    assert "HOST_SEMANTICS_EPOCH" in capsys.readouterr().err
+    assert json.loads(out.read_text()) == tampered
+
+    # Stored epoch differing from the rebuilt one → legitimate bump, rewritten.
+    bumped = dict(written)
+    bumped["epoch"] = written["epoch"] - 1
+    out.write_text(json.dumps(bumped, indent=2, sort_keys=True) + "\n")
+    assert regen.main(out) == 0
+    assert json.loads(out.read_text()) == written

--- a/tests/unit/test_replay_semantics_fingerprint.py
+++ b/tests/unit/test_replay_semantics_fingerprint.py
@@ -1,0 +1,19 @@
+"""Workflow replay-semantics epoch fingerprint canary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
+from tests.unit.replay_semantics_fingerprint_fixture import build_snapshot
+
+SNAPSHOT_PATH = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "replay_semantics_fingerprint.json"
+)
+
+
+def test_replay_semantics_fingerprint_matches_epoch_snapshot() -> None:
+    snapshot = json.loads(SNAPSHOT_PATH.read_text())
+    assert snapshot["epoch"] == HOST_SEMANTICS_EPOCH
+    assert build_snapshot() == snapshot

--- a/tests/unit/test_triggers_slice2_models.py
+++ b/tests/unit/test_triggers_slice2_models.py
@@ -51,6 +51,7 @@ def _wf_run(**overrides: Any) -> WfRun:
         "environment_id": "env_t",
         "script": "async def main(input): ...",
         "script_sha": "x" * 64,
+        "host_semantics_epoch": 1,
         "status": "completed",
         "output": {"rows": 3},
         "last_event_seq": 2,

--- a/tests/unit/test_workflow_management.py
+++ b/tests/unit/test_workflow_management.py
@@ -79,6 +79,7 @@ def _run(**over: Any) -> WfRun:
         environment_id="env_x",
         script="SECRET",
         script_sha="sha",
+        host_semantics_epoch=1,
         status="running",
         last_event_seq=0,
         budget_usd=None,

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -190,6 +190,7 @@ def test_wf_run_budget_usd_round_trip() -> None:
         environment_id="env_1",
         script="async def main(input): return None",
         script_sha="sha",
+        host_semantics_epoch=1,
         status="pending",
         last_event_seq=0,
         created_at=__import__("datetime").datetime.now(__import__("datetime").UTC),


### PR DESCRIPTION
Adds host-semantics epoch pinning for workflow runs so in-flight journals fail honestly instead of replaying under silently changed engine semantics.

What changed:
- Added `HOST_SEMANTICS_EPOCH = 1` and stamps `wf_runs.host_semantics_epoch` at run creation.
- Added migration `0092` with default backfill then default drop; updated migration chain head.
- Added wake-time epoch mismatch handling before replay, terminaling with `engine_semantics_changed`.
- Retrofitted child open-request failure for both `engine_semantics_changed` and existing `nondeterministic_replay` terminal paths.
- Added replay-semantics fingerprint snapshot test and regen script.
- Regenerated OpenAPI and SDK artifacts for the new run field.
- Added integration coverage for epoch mismatch, child notification, nondeterministic child notification, gate-parked detection, and stamp checks.

Validation:
- `uv run mypy src tests`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest tests/unit -q`
- pre-commit hook suite passed at commit time, including connector tests

Notes:
- Docker-backed integration tests were selected but skipped locally because Docker is unavailable in this sandbox.
- Mutation check was performed against the new fingerprint unit test by bumping the epoch constant and confirming the test failed, then restoring it.

Closes #795