### PR TITLE
fix: supervise worker background tasks

### DIFF
--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -88,13 +88,18 @@ suite).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import asyncpg
 
-from aios.db.pool import listener_application_name, normalize_dsn
+from aios.db.pool import (
+    LISTENER_TCP_KEEPALIVE_SETTINGS,
+    listener_application_name,
+    normalize_dsn,
+)
 from aios.db.sse_lock import acquire_subscriber_lock
 from aios.logging import get_logger
 
@@ -116,7 +121,10 @@ async def _connect_listener(db_url: str) -> asyncpg.Connection[object]:
     """
     return await asyncpg.connect(
         normalize_dsn(db_url),
-        server_settings={"application_name": listener_application_name()},
+        server_settings={
+            "application_name": listener_application_name(),
+            **LISTENER_TCP_KEEPALIVE_SETTINGS,
+        },
     )
 
 
@@ -524,7 +532,16 @@ SESSION_INTERRUPT_CHANNEL = "aios_session_interrupt"
 async def listen_for_session_interrupts(
     db_url: str,
 ) -> AsyncIterator[asyncio.Queue[str]]:
-    """Yield a queue of session_id payloads from the interrupt channel."""
+    """Yield session_id payloads from the interrupt channel.
+
+    Interrupt NOTIFY delivery is fire-and-forget: an interrupt emitted while
+    this dedicated LISTEN connection is disconnected or reconnecting is lost,
+    because there is no durable interrupt row to backfill from. Silent drops
+    are made detectable by TCP keepalive settings on the listener connection
+    plus a termination listener that wakes the consumer; the worker-level
+    reconnect loop then re-enters LISTEN after its backoff, and interrupts
+    issued after reconnect dispatch normally.
+    """
     conn = await _connect_listener(db_url)
     try:
         queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1024)
@@ -540,6 +557,11 @@ async def listen_for_session_interrupts(
             except asyncio.QueueFull:
                 log.warning("listen.session_interrupt_queue_full")
 
+        def _termination_callback(_conn: asyncpg.Connection[object]) -> None:
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait("")
+
+        conn.add_termination_listener(_termination_callback)
         await conn.add_listener(SESSION_INTERRUPT_CHANNEL, _callback)
         yield queue
     finally:

--- a/src/aios/db/pool.py
+++ b/src/aios/db/pool.py
@@ -17,6 +17,14 @@ from aios.logging import get_logger
 _KNOWN_POOL_COUNT = 2  # API pool + worker pool (production call sites)
 log = get_logger("aios.db.pool")
 
+LISTENER_TCP_KEEPALIVE_SETTINGS = {
+    "tcp_keepalives_idle": "60",
+    "tcp_keepalives_interval": "10",
+    "tcp_keepalives_count": "5",
+}
+
+_POOL_TCP_KEEPALIVE_SETTINGS = LISTENER_TCP_KEEPALIVE_SETTINGS
+
 
 def normalize_dsn(db_url: str) -> str:
     """Strip SQLAlchemy/alembic driver prefixes; asyncpg wants bare ``postgresql://``."""
@@ -56,9 +64,7 @@ async def create_pool(db_url: str, *, min_size: int = 1, max_size: int = 8) -> a
         server_settings={
             "statement_timeout": "30000",
             "idle_in_transaction_session_timeout": "60000",
-            "tcp_keepalives_idle": "60",
-            "tcp_keepalives_interval": "10",
-            "tcp_keepalives_count": "5",
+            **_POOL_TCP_KEEPALIVE_SETTINGS,
         },
     )
     if pool is None:

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -28,7 +28,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import asyncpg
 
@@ -41,7 +41,7 @@ from aios.harness import runtime
 from aios.harness.attachment_gc import sweep_orphan_attachments
 from aios.harness.exit_diagnostics import install_exit_diagnostics
 from aios.harness.procrastinate_app import app as procrastinate_app
-from aios.harness.scheduler import event_driven_scheduler
+from aios.harness.scheduler import _LISTEN_RECONNECT_BACKOFF_SECONDS, event_driven_scheduler
 from aios.harness.sweep import (
     reap_stalled_jobs,
     wake_sessions_needing_inference,
@@ -101,6 +101,56 @@ def _resolve_heartbeat_path() -> Path:
 _HEARTBEAT_FILE = _resolve_heartbeat_path()
 
 
+class _SupervisedTaskFailure(TypedDict):
+    exception: BaseException | None
+
+
+def _supervise(
+    task: asyncio.Task[Any],
+    *,
+    latch: asyncio.Event,
+    fatal: _SupervisedTaskFailure,
+) -> None:
+    """Attach fail-stop supervision to one long-lived worker task."""
+
+    def _done(done: asyncio.Task[Any]) -> None:
+        if latch.is_set() or done.cancelled():
+            return
+        task_name = done.get_name()
+        try:
+            exc = done.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is None:
+            exc = RuntimeError(f"supervised task {task_name!r} returned cleanly")
+        log = get_logger("aios.worker")
+        log.error(
+            "worker.supervised_task_died",
+            task_name=task_name,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        with contextlib.suppress(OSError):
+            _HEARTBEAT_FILE.unlink(missing_ok=True)
+        fatal["exception"] = exc
+        latch.set()
+
+    task.add_done_callback(_done)
+
+
+async def _cancel_and_drain(task: asyncio.Task[Any]) -> None:
+    """Cancel a background task and suppress prior task exceptions after logging."""
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        get_logger("aios.worker").exception(
+            "worker.teardown_task_error",
+            task_name=task.get_name(),
+        )
+
+
 def _make_worker_id() -> str:
     from ulid import ULID
 
@@ -139,6 +189,8 @@ async def worker_main() -> None:
     interrupt_task: asyncio.Task[None] | None = None
     heartbeat_task: asyncio.Task[None] | None = None
     scheduler_task: asyncio.Task[None] | None = None
+    supervised_latch = asyncio.Event()
+    supervised_failure: _SupervisedTaskFailure = {"exception": None}
 
     try:
         pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
@@ -149,6 +201,8 @@ async def worker_main() -> None:
         await ensure_sandbox_network()
         tool_broker = ToolBroker(socket_path=settings.tool_broker_socket_path)
         await tool_broker.start()
+        for broker_task in tool_broker.serve_tasks():
+            _supervise(broker_task, latch=supervised_latch, fatal=supervised_failure)
 
         # Register the connector subsystem's ToolProvider impl against the
         # Protocol slot from PR 3 (#328). The harness reaches the
@@ -219,22 +273,31 @@ async def worker_main() -> None:
         # pointers against store truth, then repeats hourly. Boot is not
         # blocked — a session waking mid-reconcile salvages its own corpse
         # inline under its own lock.
-        sandbox_registry.start_gc(pool)
+        sandbox_gc_task = sandbox_registry.start_gc(pool)
+        _supervise(sandbox_gc_task, latch=supervised_latch, fatal=supervised_failure)
 
         # Start container + MCP-pool idle-TTL reapers.
-        sandbox_registry.start_reaper(idle_timeout=settings.container_idle_timeout_seconds)
-        mcp_session_pool.start_reaper(idle_timeout=settings.mcp_pool_idle_timeout_seconds)
+        sandbox_reaper_task = sandbox_registry.start_reaper(
+            idle_timeout=settings.container_idle_timeout_seconds
+        )
+        _supervise(sandbox_reaper_task, latch=supervised_latch, fatal=supervised_failure)
+        mcp_reaper_task = mcp_session_pool.start_reaper(
+            idle_timeout=settings.mcp_pool_idle_timeout_seconds
+        )
+        _supervise(mcp_reaper_task, latch=supervised_latch, fatal=supervised_failure)
 
         # Start periodic sweep (every 30s).
         sweep_task = asyncio.create_task(
             _periodic_sweep(pool, task_registry, procrastinate_app.job_manager, interval=30),
             name="periodic_sweep",
         )
+        _supervise(sweep_task, latch=supervised_latch, fatal=supervised_failure)
 
         interrupt_task = asyncio.create_task(
             _run_interrupt_listener(settings.db_url, task_registry),
             name="interrupt_listener",
         )
+        _supervise(interrupt_task, latch=supervised_latch, fatal=supervised_failure)
 
         # Start event-driven scheduler. Sleeps until the next due
         # ``next_fire``, woken early by NOTIFY on
@@ -246,6 +309,7 @@ async def worker_main() -> None:
             event_driven_scheduler(pool, settings.db_url),
             name="scheduler",
         )
+        _supervise(scheduler_task, latch=supervised_latch, fatal=supervised_failure)
 
         # Start liveness heartbeat AFTER all critical resources are up,
         # so the healthcheck can't go green until the worker is fully
@@ -257,18 +321,42 @@ async def worker_main() -> None:
             _periodic_heartbeat(interval=_HEARTBEAT_INTERVAL_SECONDS),
             name="heartbeat",
         )
+        _supervise(heartbeat_task, latch=supervised_latch, fatal=supervised_failure)
 
-        await procrastinate_app.run_worker_async(
-            queues=["sessions", "connectors", "workflows"],
-            concurrency=settings.worker_concurrency,
-            wait=True,
-            install_signal_handlers=True,
-            # procrastinate defaults to NEVER deleting finished jobs, so
-            # ``procrastinate_jobs`` would grow one row per wake forever.
-            # Reap successful jobs; keep failures around for triage.
-            delete_jobs="successful",
+        worker_task = asyncio.create_task(
+            procrastinate_app.run_worker_async(
+                queues=["sessions", "connectors", "workflows"],
+                concurrency=settings.worker_concurrency,
+                wait=True,
+                install_signal_handlers=True,
+                # procrastinate defaults to NEVER deleting finished jobs, so
+                # ``procrastinate_jobs`` would grow one row per wake forever.
+                # Reap successful jobs; keep failures around for triage.
+                delete_jobs="successful",
+            ),
+            name="procrastinate-worker",
         )
+        latch_task = asyncio.create_task(supervised_latch.wait(), name="worker-supervision-latch")
+        try:
+            done, _pending = await asyncio.wait(
+                {worker_task, latch_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if latch_task in done:
+                worker_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await worker_task
+            else:
+                latch_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await latch_task
+                await worker_task
+        finally:
+            latch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await latch_task
     finally:
+        supervised_latch.set()
         log.info("worker.shutdown")
         # Drop the heartbeat file BEFORE other teardown so the healthcheck
         # flips to unhealthy as soon as shutdown begins — orchestrators
@@ -277,21 +365,13 @@ async def worker_main() -> None:
         with contextlib.suppress(OSError):
             _HEARTBEAT_FILE.unlink(missing_ok=True)
         if heartbeat_task is not None:
-            heartbeat_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await heartbeat_task
+            await _cancel_and_drain(heartbeat_task)
         if sweep_task is not None:
-            sweep_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await sweep_task
+            await _cancel_and_drain(sweep_task)
         if interrupt_task is not None:
-            interrupt_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await interrupt_task
+            await _cancel_and_drain(interrupt_task)
         if scheduler_task is not None:
-            scheduler_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await scheduler_task
+            await _cancel_and_drain(scheduler_task)
         if sandbox_registry is not None:
             sandbox_registry.stop_reaper()
             sandbox_registry.stop_gc()
@@ -316,6 +396,8 @@ async def worker_main() -> None:
         # would still get refused while we tear down).
         with contextlib.suppress(asyncpg.PostgresError, OSError):
             await lock_conn.close()
+        if supervised_failure["exception"] is not None:
+            raise supervised_failure["exception"]
 
 
 async def _acquire_worker_lock(
@@ -440,24 +522,34 @@ async def _run_interrupt_listener(
 ) -> None:
     """Drain pg_notify on the session-interrupt channel and cancel matching steps.
 
-    The try/except is nested INSIDE ``while True`` (mirroring
-    :func:`_periodic_sweep`): a transient failure dispatching one
-    interrupt must not silently disable the listener for the worker's
-    lifetime. ``CancelledError`` is not an :class:`Exception` subclass
-    and propagates through, so worker shutdown still exits cleanly.
+    Dispatch exceptions are isolated per payload. LISTEN connection failures
+    or termination escape to the outer reconnect loop, which mirrors the
+    scheduler: log, wait one backoff, and re-enter LISTEN indefinitely.
+    ``CancelledError`` propagates so worker shutdown remains clean.
     """
     log = get_logger("aios.worker.interrupt_listener")
-    async with listen_for_session_interrupts(db_url) as queue:
-        while True:
-            try:
-                session_id = await queue.get()
-                step_cancelled = task_registry.cancel_step(session_id)
-                tools_cancelled = task_registry.cancel_session(session_id)
-                log.info(
-                    "interrupt_listener.dispatch",
-                    session_id=session_id,
-                    step_cancelled=step_cancelled,
-                    tools_cancelled=tools_cancelled,
-                )
-            except Exception:
-                log.exception("interrupt_listener.dispatch_failed")
+    while True:
+        try:
+            async with listen_for_session_interrupts(db_url) as queue:
+                while True:
+                    try:
+                        session_id = await queue.get()
+                        if session_id == "":
+                            raise ConnectionError("session interrupt LISTEN connection terminated")
+                        step_cancelled = task_registry.cancel_step(session_id)
+                        tools_cancelled = task_registry.cancel_session(session_id)
+                        log.info(
+                            "interrupt_listener.dispatch",
+                            session_id=session_id,
+                            step_cancelled=step_cancelled,
+                            tools_cancelled=tools_cancelled,
+                        )
+                    except ConnectionError:
+                        raise
+                    except Exception:
+                        log.exception("interrupt_listener.dispatch_failed")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("interrupt_listener.listen_failed_will_retry")
+            await asyncio.sleep(_LISTEN_RECONNECT_BACKOFF_SECONDS)

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -406,14 +406,15 @@ class McpSessionPool:
             except Exception:
                 log.exception("mcp_pool.reap_idle_loop_failed")
 
-    def start_reaper(self, idle_timeout: float) -> None:
-        """Start the idle-TTL reaper background task."""
+    def start_reaper(self, idle_timeout: float) -> asyncio.Task[None]:
+        """Start the idle-TTL reaper background task and return its handle."""
         if self._reaper_task is not None:
-            return
+            return self._reaper_task
         self._reaper_task = asyncio.create_task(
             self._reap_idle_loop(idle_timeout),
             name="mcp-pool-idle-reaper",
         )
+        return self._reaper_task
 
     def stop_reaper(self) -> None:
         """Cancel the idle-TTL reaper."""

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -1319,14 +1319,15 @@ class SandboxRegistry:
             except Exception:
                 log.exception("sandbox.reap_idle_loop_failed")
 
-    def start_reaper(self, idle_timeout: float = 300.0) -> None:
-        """Start the idle-TTL reaper background task."""
+    def start_reaper(self, idle_timeout: float = 300.0) -> asyncio.Task[None]:
+        """Start the idle-TTL reaper background task and return its handle."""
         if self._reaper_task is not None:
-            return
+            return self._reaper_task
         self._reaper_task = asyncio.create_task(
             self._reap_idle_loop(idle_timeout),
             name="sandbox-idle-reaper",
         )
+        return self._reaper_task
 
     def stop_reaper(self) -> None:
         """Cancel the idle-TTL reaper."""
@@ -1336,7 +1337,7 @@ class SandboxRegistry:
 
     # ── GC: one retain-rule reconciler (§5.5) ───────────────────────────────
 
-    def start_gc(self, pool: asyncpg.Pool[Any]) -> None:
+    def start_gc(self, pool: asyncpg.Pool[Any]) -> asyncio.Task[None]:
         """Start the snapshot GC reconciler (hourly, immediate first tick).
 
         Replaces the old boot-time ``reap_orphans``: instead of removing every
@@ -1346,8 +1347,9 @@ class SandboxRegistry:
         corpse inline under its own lock.
         """
         if self._gc_task is not None:
-            return
+            return self._gc_task
         self._gc_task = asyncio.create_task(self._gc_loop(pool), name="sandbox-snapshot-gc")
+        return self._gc_task
 
     def stop_gc(self) -> None:
         """Cancel the GC reconciler."""

--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -364,6 +364,15 @@ class ToolBroker:
             await self.stop()
             raise
 
+    def serve_tasks(self) -> tuple[asyncio.Task[object], ...]:
+        """Return uvicorn serve task handles created by :meth:`start`."""
+        tasks: list[asyncio.Task[object]] = []
+        if self._serve_task is not None:
+            tasks.append(self._serve_task)
+        if self._uds_serve_task is not None:
+            tasks.append(self._uds_serve_task)
+        return tuple(tasks)
+
     async def stop(self) -> None:
         try:
             # Graceful drain only matters once the server actually

--- a/tests/integration/test_interrupt_listener_reconnect.py
+++ b/tests/integration/test_interrupt_listener_reconnect.py
@@ -1,0 +1,107 @@
+"""Integration coverage for worker interrupt-listener reconnect."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+from unittest.mock import MagicMock
+
+import asyncpg
+import pytest
+
+from aios.db.listen import SESSION_INTERRUPT_CHANNEL
+from aios.db.pool import listener_application_name
+from aios.harness.worker import _run_interrupt_listener
+from tests.conftest import needs_docker
+
+pytestmark = [pytest.mark.integration, needs_docker]
+
+
+class _FakeTaskRegistry:
+    def __init__(self) -> None:
+        self.cancelled: asyncio.Queue[str] = asyncio.Queue()
+
+    def cancel_step(self, session_id: str) -> bool:
+        self.cancelled.put_nowait(session_id)
+        return True
+
+    def cancel_session(self, session_id: str) -> int:
+        return 0
+
+
+async def _listener_backend_pid(db_url: str) -> int:
+    app_name = listener_application_name()
+    observer = await asyncpg.connect(db_url)
+    try:
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while True:
+            pid = await observer.fetchval(
+                "SELECT pid FROM pg_stat_activity "
+                "WHERE datname = current_database() "
+                "AND application_name = $1 "
+                "AND pid <> pg_backend_pid() "
+                "ORDER BY backend_start DESC LIMIT 1",
+                app_name,
+            )
+            if pid is not None:
+                return int(pid)
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError("interrupt listener backend did not appear")
+            await asyncio.sleep(0.1)
+    finally:
+        await observer.close()
+
+
+async def _notify_interrupt(db_url: str, session_id: str) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute("SELECT pg_notify($1, $2)", SESSION_INTERRUPT_CHANNEL, session_id)
+    finally:
+        await conn.close()
+
+
+async def test_interrupt_listener_reconnects_after_backend_termination(
+    migrated_db_url: str,
+    _reset_db_state: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("aios.harness.worker._LISTEN_RECONNECT_BACKOFF_SECONDS", 0.1)
+    fake_registry = _FakeTaskRegistry()
+    registry = MagicMock()
+    registry.cancel_step.side_effect = fake_registry.cancel_step
+    registry.cancel_session.side_effect = fake_registry.cancel_session
+    listener_task = asyncio.create_task(
+        _run_interrupt_listener(migrated_db_url, registry),
+        name="test-interrupt-listener",
+    )
+
+    killer: asyncpg.Connection[Any] | None = None
+    try:
+        first_pid = await _listener_backend_pid(migrated_db_url)
+        killer = await asyncpg.connect(migrated_db_url)
+        terminated = await killer.fetchval("SELECT pg_terminate_backend($1)", first_pid)
+        assert terminated is True
+
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while True:
+            new_pid = await _listener_backend_pid(migrated_db_url)
+            if new_pid != first_pid:
+                break
+            if asyncio.get_running_loop().time() > deadline:
+                raise AssertionError(
+                    "interrupt listener did not reconnect after backend termination"
+                )
+            await asyncio.sleep(0.1)
+
+        await _notify_interrupt(migrated_db_url, "sess_after_reconnect")
+        assert (
+            await asyncio.wait_for(fake_registry.cancelled.get(), timeout=5.0)
+            == "sess_after_reconnect"
+        )
+    finally:
+        if killer is not None:
+            await killer.close()
+        listener_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await listener_task

--- a/tests/unit/test_interrupt_listener.py
+++ b/tests/unit/test_interrupt_listener.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Generator
 from contextlib import asynccontextmanager
 from unittest.mock import MagicMock
 
@@ -95,3 +95,63 @@ async def test_listener_survives_dispatch_exception(
         listener_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await listener_task
+
+
+async def test_listener_reconnects_after_context_acquisition_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_enter_attempted = asyncio.Event()
+    second_entered = asyncio.Event()
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    attempts = 0
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            first_enter_attempted.set()
+            raise RuntimeError("listener connect failed")
+        second_entered.set()
+        yield queue
+
+    monkeypatch.setattr(
+        "aios.harness.worker.listen_for_session_interrupts",
+        fake_listen,
+    )
+    monkeypatch.setattr("aios.harness.worker._LISTEN_RECONNECT_BACKOFF_SECONDS", 0)
+
+    registry = MagicMock(spec=TaskRegistry)
+    listener_task = asyncio.create_task(_run_interrupt_listener("postgresql://stub", registry))
+    try:
+        await asyncio.wait_for(first_enter_attempted.wait(), timeout=1.0)
+        await asyncio.wait_for(second_entered.wait(), timeout=1.0)
+        assert attempts == 2
+    finally:
+        listener_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await listener_task
+
+
+async def test_listener_cancelled_error_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        class CancelOnEnter:
+            def __await__(self) -> Generator[None]:
+                yield
+                raise asyncio.CancelledError
+
+        await CancelOnEnter()
+        yield asyncio.Queue()
+
+    monkeypatch.setattr(
+        "aios.harness.worker.listen_for_session_interrupts",
+        fake_listen,
+    )
+    monkeypatch.setattr("aios.harness.worker._LISTEN_RECONNECT_BACKOFF_SECONDS", 0)
+
+    registry = MagicMock(spec=TaskRegistry)
+    with pytest.raises(asyncio.CancelledError):
+        await _run_interrupt_listener("postgresql://stub", registry)

--- a/tests/unit/test_worker_supervision.py
+++ b/tests/unit/test_worker_supervision.py
@@ -1,0 +1,106 @@
+"""Unit coverage for worker fail-stop supervision helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aios.harness import worker as worker_mod
+
+
+async def _wait_until_done_callbacks_run() -> None:
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+async def test_supervisor_records_raising_task_and_unlinks_heartbeat(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    heartbeat = tmp_path / "alive"
+    heartbeat.touch()
+    latch = asyncio.Event()
+    fatal: worker_mod._SupervisedTaskFailure = {"exception": None}
+
+    async def boom() -> None:
+        raise RuntimeError("worker background task exploded")
+
+    task = asyncio.create_task(boom(), name="fake-supervised")
+    with patch.object(worker_mod, "_HEARTBEAT_FILE", heartbeat), caplog.at_level(logging.ERROR):
+        worker_mod._supervise(task, latch=latch, fatal=fatal)
+        with pytest.raises(RuntimeError):
+            await task
+        await _wait_until_done_callbacks_run()
+
+    assert latch.is_set()
+    assert isinstance(fatal["exception"], RuntimeError)
+    assert not heartbeat.exists()
+    assert any("worker.supervised_task_died" in record.getMessage() for record in caplog.records)
+
+
+async def test_supervisor_ignores_cancelled_task(tmp_path: Path) -> None:
+    heartbeat = tmp_path / "alive"
+    heartbeat.touch()
+    latch = asyncio.Event()
+    fatal: worker_mod._SupervisedTaskFailure = {"exception": None}
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(wait_forever(), name="fake-cancelled")
+    with patch.object(worker_mod, "_HEARTBEAT_FILE", heartbeat):
+        worker_mod._supervise(task, latch=latch, fatal=fatal)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await _wait_until_done_callbacks_run()
+
+    assert not latch.is_set()
+    assert fatal["exception"] is None
+    assert heartbeat.exists()
+
+
+async def test_supervisor_ignores_when_latch_already_set(tmp_path: Path) -> None:
+    heartbeat = tmp_path / "alive"
+    heartbeat.touch()
+    latch = asyncio.Event()
+    latch.set()
+    fatal: worker_mod._SupervisedTaskFailure = {"exception": None}
+
+    async def boom() -> None:
+        raise RuntimeError("already shutting down")
+
+    task = asyncio.create_task(boom(), name="fake-latched")
+    with patch.object(worker_mod, "_HEARTBEAT_FILE", heartbeat):
+        worker_mod._supervise(task, latch=latch, fatal=fatal)
+        with pytest.raises(RuntimeError):
+            await task
+        await _wait_until_done_callbacks_run()
+
+    assert fatal["exception"] is None
+    assert heartbeat.exists()
+
+
+async def test_supervisor_treats_clean_return_as_death(tmp_path: Path) -> None:
+    heartbeat = tmp_path / "alive"
+    heartbeat.touch()
+    latch = asyncio.Event()
+    fatal: worker_mod._SupervisedTaskFailure = {"exception": None}
+
+    async def returns_cleanly() -> None:
+        return None
+
+    task = asyncio.create_task(returns_cleanly(), name="fake-returned")
+    with patch.object(worker_mod, "_HEARTBEAT_FILE", heartbeat):
+        worker_mod._supervise(task, latch=latch, fatal=fatal)
+        await task
+        await _wait_until_done_callbacks_run()
+
+    assert latch.is_set()
+    assert isinstance(fatal["exception"], RuntimeError)
+    assert "fake-returned" in str(fatal["exception"])
+    assert not heartbeat.exists()

--- a/tests/unit/test_worker_teardown.py
+++ b/tests/unit/test_worker_teardown.py
@@ -1,0 +1,66 @@
+"""Unit coverage for worker background-task teardown draining."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from aios.harness.worker import _cancel_and_drain
+
+
+async def test_cancel_and_drain_cancels_running_task() -> None:
+    cancelled = asyncio.Event()
+
+    async def wait_forever() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    task = asyncio.create_task(wait_forever(), name="healthy-task")
+    await asyncio.sleep(0)
+
+    await _cancel_and_drain(task)
+
+    assert task.cancelled()
+    assert cancelled.is_set()
+
+
+async def test_cancel_and_drain_logs_pre_dead_task_without_raising(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def boom() -> None:
+        raise RuntimeError("died before teardown")
+
+    task = asyncio.create_task(boom(), name="pre-dead-task")
+    await asyncio.sleep(0)
+
+    with caplog.at_level(logging.ERROR):
+        await _cancel_and_drain(task)
+
+    assert any("worker.teardown_task_error" in record.getMessage() for record in caplog.records)
+
+
+async def test_pre_dead_task_does_not_stop_later_drains() -> None:
+    second_cancelled = asyncio.Event()
+
+    async def boom() -> None:
+        raise RuntimeError("first task died")
+
+    async def wait_forever() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            second_cancelled.set()
+
+    first = asyncio.create_task(boom(), name="first-pre-dead")
+    second = asyncio.create_task(wait_forever(), name="second-running")
+    await asyncio.sleep(0)
+
+    await _cancel_and_drain(first)
+    await _cancel_and_drain(second)
+
+    assert second.cancelled()
+    assert second_cancelled.is_set()


### PR DESCRIPTION
Implements fail-stop supervision for long-lived worker background tasks and hardens the interrupt LISTEN path.

What changed:
- Adds worker-side supervision callbacks for periodic sweep, interrupt listener, scheduler, heartbeat, sandbox reapers/GC, MCP reaper, and tool broker serve tasks.
- A supervised task that raises or returns cleanly now logs `worker.supervised_task_died`, unlinks the heartbeat file, drains shutdown in order, and re-raises for non-zero process exit.
- Adds teardown draining helper so pre-dead background tasks log `worker.teardown_task_error` without aborting later cleanup.
- Wraps the interrupt listener in a scheduler-style reconnect loop.
- Applies shared TCP keepalive settings to dedicated LISTEN connections.
- Adds termination wakeup for session-interrupt LISTEN so silent connection termination reconnects instead of blocking forever.
- Exposes subsystem-owned background task handles for worker-owned supervision policy.
- Adds unit tests for supervision, teardown, and listener reconnect behavior, plus an integration test for reconnect after terminating the listener backend.

Validation:
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src tests`
- `uv run pytest tests/unit -q`
- targeted unit tests for new supervision/listener coverage
- codegen scripts run: `scripts/regen-openapi.sh`, `scripts/regen-client.sh`

Closes #853