### PR TITLE
Fix singleton worker lock monitoring

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -707,24 +707,22 @@ def _group_tool_call_ids(rows: list[Any]) -> dict[str, set[str]]:
 
 
 async def reap_stalled_jobs(job_manager: Any) -> int:
-    """Mark stalled procrastinate jobs as failed.
+    """Mark predecessor-owned in-flight procrastinate jobs as failed.
 
-    Procrastinate runs a heartbeat lease: workers update
-    ``procrastinate_workers.last_heartbeat`` every
-    ``update_heartbeat_interval`` (default 10s).  A dead worker
-    (laptop sleep, OOM, ungraceful shutdown) stops heartbeating; its
-    row is pruned at any other worker's startup, leaving its
-    in-flight job at ``status='doing'`` with ``worker_id`` either
-    NULL (post-prune) or pointing at the missing row.  Either way the
-    job's ``lock`` (``"{session_id}"`` for aios) stays held — every
-    subsequent wake for that session sits behind it forever.
+    This is a boot-only recovery step. It runs after the worker
+    singleton advisory lock has handed off, proving the predecessor is
+    gone, and before this process starts consuming jobs. At that point
+    every ``doing`` job in procrastinate is orphaned by construction;
+    there is no live in-process job for a heartbeat-age filter to
+    protect.
 
     :meth:`procrastinate.manager.JobManager.get_stalled_jobs` is the
-    blessed query for this state.  Its SQL covers both shapes
-    (``worker_id IS NULL`` plus the membership join on
-    ``procrastinate_workers``), and the threshold is configurable per
-    call — we use 60s, comfortably above procrastinate's 10s
-    heartbeat interval and 30s default ``stalled_worker_timeout``.
+    blessed query for this state. Calling it with a zero-second
+    heartbeat threshold returns every ``doing`` job, including rows
+    with ``worker_id IS NULL`` and rows whose worker heartbeat is merely
+    in the past. Failing those jobs releases their procrastinate locks
+    so the startup wake sweep can re-enqueue the affected sessions in
+    the same pass.
 
     Takes a ``job_manager`` rather than an ``App`` so tests can build
     a fresh manager pointed at the testcontainer DB without depending
@@ -736,7 +734,7 @@ async def reap_stalled_jobs(job_manager: Any) -> int:
     """
     from procrastinate.jobs import Status
 
-    stalled = list(await job_manager.get_stalled_jobs(seconds_since_heartbeat=60))
+    stalled = list(await job_manager.get_stalled_jobs(seconds_since_heartbeat=0))
     for job in stalled:
         if job.id is None:
             continue

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -36,7 +36,7 @@ import aios.tools  # noqa: F401  — side-effect: register built-in tools
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db.listen import listen_for_session_interrupts
-from aios.db.pool import create_pool, normalize_dsn
+from aios.db.pool import LISTENER_TCP_KEEPALIVE_SETTINGS, create_pool, normalize_dsn
 from aios.harness import runtime
 from aios.harness.attachment_gc import sweep_orphan_attachments
 from aios.harness.exit_diagnostics import install_exit_diagnostics
@@ -137,6 +137,30 @@ def _supervise(
     task.add_done_callback(_done)
 
 
+def _make_advisory_lock_termination_listener(
+    *,
+    latch: asyncio.Event,
+    fatal: _SupervisedTaskFailure,
+) -> Any:
+    """Return a fail-stop callback for singleton lock connection termination."""
+
+    def _terminated(_conn: asyncpg.Connection[Any]) -> None:
+        if latch.is_set():
+            return
+        exc = RuntimeError("singleton advisory lock connection lost")
+        log = get_logger("aios.worker")
+        log.error(
+            "worker.advisory_lock_lost",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        with contextlib.suppress(OSError):
+            _HEARTBEAT_FILE.unlink(missing_ok=True)
+        fatal["exception"] = exc
+        latch.set()
+
+    return _terminated
+
+
 async def _cancel_and_drain(task: asyncio.Task[Any]) -> None:
     """Cancel a background task and suppress prior task exceptions after logging."""
     task.cancel()
@@ -191,6 +215,12 @@ async def worker_main() -> None:
     scheduler_task: asyncio.Task[None] | None = None
     supervised_latch = asyncio.Event()
     supervised_failure: _SupervisedTaskFailure = {"exception": None}
+    lock_conn.add_termination_listener(
+        _make_advisory_lock_termination_listener(
+            latch=supervised_latch,
+            fatal=supervised_failure,
+        )
+    )
 
     try:
         pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
@@ -247,10 +277,11 @@ async def worker_main() -> None:
         )
 
         # Startup sweep:
-        #   1. Reap stalled procrastinate jobs (workers that died without
-        #      releasing their session lock — laptop sleep, OOM, crash).
-        #      Must run BEFORE the wake sweep so freshly-unblocked sessions
-        #      get re-enqueued in the same pass.
+        #   1. Reap every in-flight procrastinate job left by a predecessor.
+        #      The singleton lock has handed off, so the previous worker is
+        #      gone, and this process has not consumed any job yet. Must run
+        #      BEFORE the wake sweep so freshly-unblocked sessions get
+        #      re-enqueued in the same pass.
         #   2. Repair tool-call ghosts and wake sessions needing inference.
         await reap_stalled_jobs(procrastinate_app.job_manager)
         sweep = await wake_sessions_needing_inference(pool, task_registry)
@@ -288,7 +319,7 @@ async def worker_main() -> None:
 
         # Start periodic sweep (every 30s).
         sweep_task = asyncio.create_task(
-            _periodic_sweep(pool, task_registry, procrastinate_app.job_manager, interval=30),
+            _periodic_sweep(pool, task_registry, interval=30),
             name="periodic_sweep",
         )
         _supervise(sweep_task, latch=supervised_latch, fatal=supervised_failure)
@@ -427,7 +458,7 @@ async def _acquire_worker_lock(
     locks and silently drops the guarantee.
     """
     dsn = normalize_dsn(db_url)
-    conn = await asyncpg.connect(dsn)
+    conn = await asyncpg.connect(dsn, server_settings=LISTENER_TCP_KEEPALIVE_SETTINGS)
     deadline = time.monotonic() + timeout_seconds
     waiting_logged = False
     try:
@@ -486,7 +517,6 @@ async def _periodic_heartbeat(*, interval: int = _HEARTBEAT_INTERVAL_SECONDS) ->
 async def _periodic_sweep(
     pool: asyncpg.Pool[Any],
     task_registry: TaskRegistry,
-    job_manager: Any,
     *,
     interval: int = 30,
 ) -> None:
@@ -495,9 +525,6 @@ async def _periodic_sweep(
     while True:
         await asyncio.sleep(interval)
         try:
-            # Reap stalled jobs first so any unblocked sessions get re-enqueued
-            # in the same tick (mirrors worker_main's startup sequence).
-            await reap_stalled_jobs(job_manager)
             sweep = await wake_sessions_needing_inference(pool, task_registry)
             if sweep.woken_sessions or sweep.repaired_ghosts:
                 log.info(

--- a/tests/e2e/test_reap_stalled_jobs.py
+++ b/tests/e2e/test_reap_stalled_jobs.py
@@ -1,14 +1,12 @@
-"""E2E tests for the stalled-procrastinate-job reaper.
+"""E2E tests for the boot-time procrastinate-job reaper.
 
-A worker process can die mid-job (laptop sleep, OOM, ungraceful shutdown)
-leaving the row at ``status='doing'``. Procrastinate's heartbeat lease
-(``procrastinate_workers.last_heartbeat``) is what we lean on to detect
-this — :meth:`procrastinate.manager.JobManager.get_stalled_jobs` returns
-``doing`` jobs whose worker has been silent for longer than the
-threshold (we use 60s).
+After the singleton worker lock hands off and before the new worker consumes
+jobs, every ``doing`` procrastinate row belongs to the dead predecessor. The
+boot reaper therefore fails all ``doing`` jobs unconditionally so their locks
+are released before the startup wake sweep.
 
-These tests pin the lease semantics end-to-end against a real
-procrastinate schema so a refactor can't quietly break recovery.
+These tests pin that contract end-to-end against a real procrastinate schema
+so a refactor can't quietly break recovery.
 """
 
 from __future__ import annotations
@@ -59,8 +57,8 @@ async def job_manager(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[Any]
 async def _insert_worker(conn: Any, *, stale_seconds: int = 0) -> int:
     """Insert a procrastinate_workers row.
 
-    ``stale_seconds`` controls the heartbeat age — 0 means fresh,
-    >60 means past our reap threshold.
+    ``stale_seconds`` controls the heartbeat age; the boot reaper treats
+    fresh and stale heartbeats the same.
     """
     return int(
         await conn.fetchval(
@@ -146,21 +144,23 @@ class TestReapStalledJobs:
                 await conn.execute("DELETE FROM procrastinate_jobs WHERE id=$1", jid)
                 await conn.execute("DELETE FROM procrastinate_workers WHERE id=$1", wid)
 
-    async def test_leaves_doing_with_live_worker_alone(self, pool: Any, job_manager: Any) -> None:
-        """A live worker's in-flight job MUST NOT be reaped.
+    async def test_reaps_doing_with_fresh_worker_heartbeat(
+        self, pool: Any, job_manager: Any
+    ) -> None:
+        """A fresh heartbeat still belongs to the dead predecessor at boot.
 
-        The safety case — under normal load, jobs sit at
-        ``status='doing'`` while their worker is processing. The
-        lease check on ``last_heartbeat`` distinguishes legitimate
-        live work from genuinely abandoned jobs.
+        Startup recovery runs after singleton lock handoff and before this
+        process consumes jobs, so every ``doing`` row is orphaned even when
+        its recorded heartbeat is recent.
         """
         async with pool.acquire() as conn:
             wid = await _insert_worker(conn, stale_seconds=0)
             jid = await _insert_job(conn, status="doing", worker_id=wid)
             try:
-                await reap_stalled_jobs(job_manager)
+                reaped = await reap_stalled_jobs(job_manager)
                 row = await conn.fetchrow("SELECT status FROM procrastinate_jobs WHERE id=$1", jid)
-                assert row["status"] == "doing"
+                assert reaped >= 1
+                assert row["status"] == "failed"
             finally:
                 await conn.execute("DELETE FROM procrastinate_jobs WHERE id=$1", jid)
                 await conn.execute("DELETE FROM procrastinate_workers WHERE id=$1", wid)

--- a/tests/integration/test_worker_lock.py
+++ b/tests/integration/test_worker_lock.py
@@ -19,7 +19,12 @@ from typing import Any
 import asyncpg
 import pytest
 
-from aios.harness.worker import _acquire_worker_lock
+from aios.db.pool import LISTENER_TCP_KEEPALIVE_SETTINGS
+from aios.harness.worker import (
+    _acquire_worker_lock,
+    _make_advisory_lock_termination_listener,
+    _SupervisedTaskFailure,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -91,3 +96,36 @@ class TestAcquireWorkerLock:
             assert "worker.duplicate_instance_refused" in event_names
         finally:
             await holder.close()
+
+    async def test_lock_connection_uses_tcp_keepalive_settings(
+        self, db_url: str, log: _FakeLog
+    ) -> None:
+        conn = await _acquire_worker_lock(db_url, log, timeout_seconds=2.0)
+        assert conn is not None
+        try:
+            for key, expected in LISTENER_TCP_KEEPALIVE_SETTINGS.items():
+                assert await conn.fetchval(f"SHOW {key}") == expected
+        finally:
+            await conn.close()
+
+    async def test_backend_termination_trips_lock_listener(
+        self, db_url: str, log: _FakeLog
+    ) -> None:
+        conn = await _acquire_worker_lock(db_url, log, timeout_seconds=2.0)
+        assert conn is not None
+        latch = asyncio.Event()
+        fatal: _SupervisedTaskFailure = {"exception": None}
+        conn.add_termination_listener(
+            _make_advisory_lock_termination_listener(latch=latch, fatal=fatal)
+        )
+        terminator = await asyncpg.connect(db_url)
+        try:
+            pid = conn.get_server_pid()
+            terminated = await terminator.fetchval("SELECT pg_terminate_backend($1)", pid)
+            assert terminated is True
+            await asyncio.wait_for(latch.wait(), timeout=5.0)
+            assert isinstance(fatal["exception"], RuntimeError)
+        finally:
+            await terminator.close()
+            if not conn.is_closed():
+                await conn.close()

--- a/tests/unit/test_reap_stalled_jobs.py
+++ b/tests/unit/test_reap_stalled_jobs.py
@@ -1,0 +1,56 @@
+"""Unit tests for the boot-time stalled procrastinate job reaper."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from aios.harness.sweep import reap_stalled_jobs
+
+
+@dataclass
+class _FakeJob:
+    id: int | None
+
+
+class _FakeJobManager:
+    def __init__(self, jobs: list[_FakeJob]) -> None:
+        self.jobs = jobs
+        self.stalled_thresholds: list[int] = []
+        self.finished: list[dict[str, Any]] = []
+
+    async def get_stalled_jobs(self, *, seconds_since_heartbeat: int) -> list[_FakeJob]:
+        self.stalled_thresholds.append(seconds_since_heartbeat)
+        return self.jobs
+
+    async def finish_job_by_id_async(self, **kwargs: Any) -> None:
+        self.finished.append(kwargs)
+
+
+async def test_reaps_every_stalled_job_unconditionally(caplog: pytest.LogCaptureFixture) -> None:
+    manager = _FakeJobManager([_FakeJob(id=101), _FakeJob(id=102)])
+
+    with caplog.at_level(logging.WARNING):
+        count = await reap_stalled_jobs(manager)
+
+    assert count == 2
+    assert manager.stalled_thresholds == [0]
+    assert [call["job_id"] for call in manager.finished] == [101, 102]
+    assert {call["status"].name for call in manager.finished} == {"FAILED"}
+    assert all(call["delete_job"] is False for call in manager.finished)
+    assert any("sweep.reaped_stalled_jobs" in record.getMessage() for record in caplog.records)
+
+
+async def test_returns_zero_without_warning_when_no_jobs(caplog: pytest.LogCaptureFixture) -> None:
+    manager = _FakeJobManager([])
+
+    with caplog.at_level(logging.WARNING):
+        count = await reap_stalled_jobs(manager)
+
+    assert count == 0
+    assert manager.stalled_thresholds == [0]
+    assert manager.finished == []
+    assert not any("sweep.reaped_stalled_jobs" in record.getMessage() for record in caplog.records)

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -302,14 +302,7 @@ class TestPeriodicSweepEmitsNoSpan:
             patch("aios.services.sessions.append_event", append_event),
             pytest.raises(StopAsyncIteration),
         ):
-            # MagicMock for the procrastinate app — `_periodic_sweep` calls
-            # `reap_stalled_jobs` first, which the test's patch list doesn't
-            # cover; an `AsyncMock`-backed `MagicMock().job_manager.get_stalled_jobs`
-            # returns a coroutine yielding the mock itself, which iterates
-            # empty. That's enough to make the call a no-op for this test.
-            app_mock = MagicMock()
-            app_mock.job_manager.get_stalled_jobs = AsyncMock(return_value=[])
-            await _periodic_sweep(MagicMock(), MagicMock(), app_mock, interval=30)
+            await _periodic_sweep(MagicMock(), MagicMock(), interval=30)
 
         # The periodic sweep must not emit any sweep_start/sweep_end spans.
         for call in append_event.await_args_list:

--- a/tests/unit/test_worker_lock_monitor.py
+++ b/tests/unit/test_worker_lock_monitor.py
@@ -1,0 +1,51 @@
+"""Unit tests for advisory-lock connection loss handling."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aios.harness import worker as worker_mod
+
+
+async def test_advisory_lock_loss_trips_fail_stop_latch(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    heartbeat = tmp_path / "alive"
+    heartbeat.touch()
+    latch = asyncio.Event()
+    fatal: worker_mod._SupervisedTaskFailure = {"exception": None}
+    callback = worker_mod._make_advisory_lock_termination_listener(latch=latch, fatal=fatal)
+
+    with patch.object(worker_mod, "_HEARTBEAT_FILE", heartbeat), caplog.at_level(logging.ERROR):
+        callback(object())
+
+    assert latch.is_set()
+    assert isinstance(fatal["exception"], RuntimeError)
+    assert "singleton advisory lock connection lost" in str(fatal["exception"])
+    assert not heartbeat.exists()
+    assert any("worker.advisory_lock_lost" in record.getMessage() for record in caplog.records)
+
+
+async def test_advisory_lock_loss_listener_is_silent_when_latch_set(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    heartbeat = tmp_path / "alive"
+    heartbeat.touch()
+    latch = asyncio.Event()
+    latch.set()
+    fatal: worker_mod._SupervisedTaskFailure = {"exception": None}
+    callback = worker_mod._make_advisory_lock_termination_listener(latch=latch, fatal=fatal)
+
+    with patch.object(worker_mod, "_HEARTBEAT_FILE", heartbeat), caplog.at_level(logging.ERROR):
+        callback(object())
+
+    assert fatal["exception"] is None
+    assert heartbeat.exists()
+    assert not any("worker.advisory_lock_lost" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
This updates the worker singleton recovery paths for WP-17.

Changes:
- Makes stalled procrastinate job reaping startup-only by removing the periodic reap call and `_periodic_sweep` job manager dependency.
- Makes the boot reap unconditional by querying stalled jobs with `seconds_since_heartbeat=0`.
- Adds keepalive server settings to the dedicated advisory-lock connection using the shared pool/listener keepalive constant.
- Adds an advisory-lock termination listener that trips the existing fail-stop latch, logs `worker.advisory_lock_lost`, unlinks the heartbeat file, and exits through ordered teardown.
- Adds unit coverage for the lock listener and unconditional reap contract, updates sweep instrumentation tests, and extends integration/e2e coverage for lock keepalives, backend termination, and fresh-heartbeat reaping.

Validation:
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src tests`
- `uv run pytest tests/unit -q`
- `DOCKER_HOST=unix:///Users/tom/.docker/run/docker.sock uv run pytest tests/integration/test_worker_lock.py tests/e2e/test_reap_stalled_jobs.py -q` (skipped in sandbox: Docker unavailable)
- `bash scripts/regen-client.sh`
- `bash scripts/regen-openapi.sh`

Closes #856