### PR TITLE
Add composite secret-chain FK backstops

### DIFF
--- a/migrations/versions/0093_composite_fk_backstop.py
+++ b/migrations/versions/0093_composite_fk_backstop.py
@@ -1,0 +1,115 @@
+"""Composite tenant FKs for secret-bearing chains.
+
+Revision ID: 0093
+Revises: 0092
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0093"
+down_revision: str = "0092"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PARENT_UNIQUES: Sequence[tuple[str, str]] = (
+    ("vaults", "vaults_id_account_id_key"),
+    ("sessions", "sessions_id_account_id_key"),
+    ("wf_runs", "wf_runs_id_account_id_key"),
+)
+
+_BARE_FKS: Sequence[tuple[str, str]] = (
+    ("session_vaults", "session_vaults_session_id_fkey"),
+    ("session_vaults", "session_vaults_vault_id_fkey"),
+    ("wf_run_vaults", "wf_run_vaults_run_id_fkey"),
+    ("wf_run_vaults", "wf_run_vaults_vault_id_fkey"),
+    ("vault_credentials", "vault_credentials_vault_id_fkey"),
+    ("oauth_flows", "oauth_flows_vault_id_fkey"),
+)
+
+_COMPOSITE_FKS: Sequence[tuple[str, str, str]] = (
+    (
+        "session_vaults",
+        "session_vaults_session_account_id_fkey",
+        "FOREIGN KEY (session_id, account_id) REFERENCES sessions(id, account_id) ON DELETE CASCADE",
+    ),
+    (
+        "session_vaults",
+        "session_vaults_vault_account_id_fkey",
+        "FOREIGN KEY (vault_id, account_id) REFERENCES vaults(id, account_id)",
+    ),
+    (
+        "wf_run_vaults",
+        "wf_run_vaults_run_account_id_fkey",
+        "FOREIGN KEY (run_id, account_id) REFERENCES wf_runs(id, account_id) ON DELETE CASCADE",
+    ),
+    (
+        "wf_run_vaults",
+        "wf_run_vaults_vault_account_id_fkey",
+        "FOREIGN KEY (vault_id, account_id) REFERENCES vaults(id, account_id)",
+    ),
+    (
+        "vault_credentials",
+        "vault_credentials_vault_account_id_fkey",
+        "FOREIGN KEY (vault_id, account_id) REFERENCES vaults(id, account_id)",
+    ),
+    (
+        "oauth_flows",
+        "oauth_flows_vault_account_id_fkey",
+        "FOREIGN KEY (vault_id, account_id) REFERENCES vaults(id, account_id) ON DELETE CASCADE",
+    ),
+)
+
+
+def upgrade() -> None:
+    for table, constraint in _PARENT_UNIQUES:
+        op.execute(
+            f"ALTER TABLE {table} ADD CONSTRAINT {constraint} UNIQUE (id, account_id)"
+        )
+
+    for table, constraint in _BARE_FKS:
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {constraint}")
+
+    for table, constraint, definition in _COMPOSITE_FKS:
+        op.execute(
+            f"ALTER TABLE {table} ADD CONSTRAINT {constraint} {definition} NOT VALID"
+        )
+
+    for table, constraint, _definition in _COMPOSITE_FKS:
+        op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")
+
+
+def downgrade() -> None:
+    for table, constraint, _definition in reversed(_COMPOSITE_FKS):
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {constraint}")
+
+    op.execute(
+        "ALTER TABLE session_vaults ADD CONSTRAINT session_vaults_session_id_fkey "
+        "FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE"
+    )
+    op.execute(
+        "ALTER TABLE session_vaults ADD CONSTRAINT session_vaults_vault_id_fkey "
+        "FOREIGN KEY (vault_id) REFERENCES vaults(id)"
+    )
+    op.execute(
+        "ALTER TABLE wf_run_vaults ADD CONSTRAINT wf_run_vaults_run_id_fkey "
+        "FOREIGN KEY (run_id) REFERENCES wf_runs(id) ON DELETE CASCADE"
+    )
+    op.execute(
+        "ALTER TABLE wf_run_vaults ADD CONSTRAINT wf_run_vaults_vault_id_fkey "
+        "FOREIGN KEY (vault_id) REFERENCES vaults(id)"
+    )
+    op.execute(
+        "ALTER TABLE vault_credentials ADD CONSTRAINT vault_credentials_vault_id_fkey "
+        "FOREIGN KEY (vault_id) REFERENCES vaults(id) ON DELETE CASCADE"
+    )
+    op.execute(
+        "ALTER TABLE oauth_flows ADD CONSTRAINT oauth_flows_vault_id_fkey "
+        "FOREIGN KEY (vault_id) REFERENCES vaults(id) ON DELETE CASCADE"
+    )
+
+    for table, constraint in reversed(_PARENT_UNIQUES):
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {constraint}")

--- a/migrations/versions/0093_composite_fk_backstop.py
+++ b/migrations/versions/0093_composite_fk_backstop.py
@@ -54,7 +54,7 @@ _COMPOSITE_FKS: Sequence[tuple[str, str, str]] = (
     (
         "vault_credentials",
         "vault_credentials_vault_account_id_fkey",
-        "FOREIGN KEY (vault_id, account_id) REFERENCES vaults(id, account_id)",
+        "FOREIGN KEY (vault_id, account_id) REFERENCES vaults(id, account_id) ON DELETE CASCADE",
     ),
     (
         "oauth_flows",

--- a/tests/integration/test_composite_fk_backstop.py
+++ b/tests/integration/test_composite_fk_backstop.py
@@ -30,9 +30,18 @@ async def _seed_two_tenant_secret_chains(conn: asyncpg.Connection[Any]) -> None:
         INSERT INTO workflows (id, account_id, name, script)
         VALUES ('wf_a', 'acc_a', 'wf-a', 'async def main(i):\n    return i\n'),
                ('wf_b', 'acc_b', 'wf-b', 'async def main(i):\n    return i\n');
-        INSERT INTO wf_runs (id, workflow_id, account_id, script, script_sha, status, host_semantics_epoch)
-        VALUES ('run_a', 'wf_a', 'acc_a', 'async def main(i):\n    return i\n', 'sha-a', 'pending', 1),
-               ('run_b', 'wf_b', 'acc_b', 'async def main(i):\n    return i\n', 'sha-b', 'pending', 1);
+        INSERT INTO wf_runs (
+            id, workflow_id, account_id, environment_id,
+            script, script_sha, status, host_semantics_epoch
+        )
+        VALUES (
+            'run_a', 'wf_a', 'acc_a', 'env_a',
+            'async def main(i):\n    return i\n', 'sha-a', 'pending', 1
+        ),
+        (
+            'run_b', 'wf_b', 'acc_b', 'env_b',
+            'async def main(i):\n    return i\n', 'sha-b', 'pending', 1
+        );
         INSERT INTO vaults (id, display_name, account_id)
         VALUES ('vault_a', 'vault-a', 'acc_a'),
                ('vault_b', 'vault-b', 'acc_b');

--- a/tests/integration/test_composite_fk_backstop.py
+++ b/tests/integration/test_composite_fk_backstop.py
@@ -1,0 +1,131 @@
+"""Raw-SQL proofs for composite tenant FK backstops on secret-bearing chains."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+async def _seed_two_tenant_secret_chains(conn: asyncpg.Connection[Any]) -> None:
+    await conn.execute(
+        """
+        INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+        VALUES ('acc_root', NULL, TRUE, 'root'),
+               ('acc_a', 'acc_root', FALSE, 'tenant-a'),
+               ('acc_b', 'acc_root', FALSE, 'tenant-b')
+        ON CONFLICT DO NOTHING;
+        INSERT INTO environments (id, name, account_id)
+        VALUES ('env_a', 'env-a', 'acc_a'),
+               ('env_b', 'env-b', 'acc_b');
+        INSERT INTO agents (id, name, model, account_id)
+        VALUES ('agent_a', 'agent-a', 'test/model', 'acc_a'),
+               ('agent_b', 'agent-b', 'test/model', 'acc_b');
+        INSERT INTO sessions (id, agent_id, environment_id, workspace_volume_path, account_id)
+        VALUES ('sess_a', 'agent_a', 'env_a', '/tmp/ws-a', 'acc_a'),
+               ('sess_b', 'agent_b', 'env_b', '/tmp/ws-b', 'acc_b');
+        INSERT INTO workflows (id, account_id, name, script)
+        VALUES ('wf_a', 'acc_a', 'wf-a', 'async def main(i):\n    return i\n'),
+               ('wf_b', 'acc_b', 'wf-b', 'async def main(i):\n    return i\n');
+        INSERT INTO wf_runs (id, workflow_id, account_id, script, script_sha, status, host_semantics_epoch)
+        VALUES ('run_a', 'wf_a', 'acc_a', 'async def main(i):\n    return i\n', 'sha-a', 'pending', 1),
+               ('run_b', 'wf_b', 'acc_b', 'async def main(i):\n    return i\n', 'sha-b', 'pending', 1);
+        INSERT INTO vaults (id, display_name, account_id)
+        VALUES ('vault_a', 'vault-a', 'acc_a'),
+               ('vault_b', 'vault-b', 'acc_b');
+        """
+    )
+
+
+async def _assert_fk_violation(conn: asyncpg.Connection[Any], sql: str) -> None:
+    with pytest.raises(asyncpg.ForeignKeyViolationError):
+        await conn.execute(sql)
+
+
+async def test_session_vaults_rejects_foreign_vault_and_session(
+    conn_two_accounts: asyncpg.Connection[Any],
+) -> None:
+    conn = conn_two_accounts
+    await _seed_two_tenant_secret_chains(conn)
+
+    await _assert_fk_violation(
+        conn,
+        """
+        INSERT INTO session_vaults (session_id, vault_id, rank, account_id)
+        VALUES ('sess_a', 'vault_b', 0, 'acc_a')
+        """,
+    )
+    await _assert_fk_violation(
+        conn,
+        """
+        INSERT INTO session_vaults (session_id, vault_id, rank, account_id)
+        VALUES ('sess_b', 'vault_a', 0, 'acc_a')
+        """,
+    )
+
+
+async def test_wf_run_vaults_rejects_foreign_vault_and_run(
+    conn_two_accounts: asyncpg.Connection[Any],
+) -> None:
+    conn = conn_two_accounts
+    await _seed_two_tenant_secret_chains(conn)
+
+    await _assert_fk_violation(
+        conn,
+        """
+        INSERT INTO wf_run_vaults (run_id, vault_id, rank, account_id)
+        VALUES ('run_a', 'vault_b', 0, 'acc_a')
+        """,
+    )
+    await _assert_fk_violation(
+        conn,
+        """
+        INSERT INTO wf_run_vaults (run_id, vault_id, rank, account_id)
+        VALUES ('run_b', 'vault_a', 0, 'acc_a')
+        """,
+    )
+
+
+async def test_vault_credentials_rejects_foreign_vault(
+    conn_two_accounts: asyncpg.Connection[Any],
+) -> None:
+    conn = conn_two_accounts
+    await _seed_two_tenant_secret_chains(conn)
+
+    await _assert_fk_violation(
+        conn,
+        """
+        INSERT INTO vault_credentials (
+            id, vault_id, display_name, target_url, auth_type,
+            ciphertext, nonce, account_id
+        )
+        VALUES (
+            'cred_cross', 'vault_b', 'cross', 'https://example.invalid/mcp',
+            'bearer_header', '\\x01'::bytea, '\\x02'::bytea, 'acc_a'
+        )
+        """,
+    )
+
+
+async def test_oauth_flows_rejects_foreign_vault(
+    conn_two_accounts: asyncpg.Connection[Any],
+) -> None:
+    conn = conn_two_accounts
+    await _seed_two_tenant_secret_chains(conn)
+
+    await _assert_fk_violation(
+        conn,
+        """
+        INSERT INTO oauth_flows (
+            id, account_id, vault_id, target_url, state,
+            redirect_uri, ciphertext, nonce, expires_at
+        )
+        VALUES (
+            'flow_cross', 'acc_a', 'vault_b', 'https://example.invalid/mcp', 'state-cross',
+            'https://callback.invalid/oauth', '\\x01'::bytea, '\\x02'::bytea, now() + interval '5 minutes'
+        )
+        """,
+    )

--- a/tests/integration/test_env_var_credential_resolution.py
+++ b/tests/integration/test_env_var_credential_resolution.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.integration
 ACC = "acc_envvar"
 ACC_OTHER = "acc_envvar_other"
 ENV = "env_envvar"
+ENV_OTHER = "env_envvar_other"
 
 
 @pytest.fixture
@@ -60,9 +61,12 @@ async def vault_pool(
             )
             await conn.execute(
                 "INSERT INTO environments (id, name, config, account_id) "
-                "VALUES ($1, 'envvar-env', '{}'::jsonb, $2)",
+                "VALUES ($1, 'envvar-env', '{}'::jsonb, $2), "
+                "($3, 'envvar-env-other', '{}'::jsonb, $4)",
                 ENV,
                 ACC,
+                ENV_OTHER,
+                ACC_OTHER,
             )
         yield pool
     finally:
@@ -86,7 +90,11 @@ async def _make_agent(pool: asyncpg.Pool[Any], *, account_id: str = ACC) -> Any:
 
 
 async def _make_session(
-    pool: asyncpg.Pool[Any], *, vault_ids: list[str] | None = None, account_id: str = ACC
+    pool: asyncpg.Pool[Any],
+    *,
+    vault_ids: list[str] | None = None,
+    account_id: str = ACC,
+    environment_id: str = ENV,
 ) -> str:
     agent = await _make_agent(pool, account_id=account_id)
     async with pool.acquire() as conn:
@@ -94,7 +102,7 @@ async def _make_session(
             conn,
             account_id=account_id,
             agent_id=agent.id,
-            environment_id=ENV,
+            environment_id=environment_id,
             agent_version=agent.version,
             title=None,
             metadata={},
@@ -104,25 +112,33 @@ async def _make_session(
     return session.id
 
 
-async def _make_run(pool: asyncpg.Pool[Any], *, vault_ids: list[str] | None = None) -> str:
+async def _make_run(
+    pool: asyncpg.Pool[Any],
+    *,
+    vault_ids: list[str] | None = None,
+    account_id: str = ACC,
+    environment_id: str = ENV,
+) -> str:
     async with pool.acquire() as conn:
         wf = await db_queries.workflows.insert_workflow(
             conn,
-            account_id=ACC,
+            account_id=account_id,
             name=f"envvar-wf-{os.urandom(4).hex()}",
             script="async def main(input):\n    return input\n",
         )
         run = await db_queries.workflows.insert_wf_run(
             conn,
-            account_id=ACC,
+            account_id=account_id,
             workflow_id=wf.id,
-            environment_id=ENV,
+            environment_id=environment_id,
             script=wf.script,
             host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             script_sha=hashlib.sha256(wf.script.encode("utf-8")).hexdigest(),
         )
         if vault_ids:
-            await db_queries.workflows.set_run_vaults(conn, run.id, vault_ids, account_id=ACC)
+            await db_queries.workflows.set_run_vaults(
+                conn, run.id, vault_ids, account_id=account_id
+            )
     return run.id
 
 
@@ -302,49 +318,47 @@ async def test_run_placeholders_deterministic_owner_distinct(
 async def test_other_tenants_credentials_invisible(
     vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
 ) -> None:
+    # A cross-tenant session_vaults row is now unrepresentable — the composite FK
+    # proof lives in tests/integration/test_composite_fk_backstop.py. Here we keep
+    # the read-side guarantee on representable data: the resolver's account_id
+    # filter excludes another tenant's fully consistent chain.
     pool = vault_pool
     theirs = await _make_vault(pool, "their-vault", account_id=ACC_OTHER)
     await _make_env_cred(pool, crypto_box, theirs, "API_KEY", "their-secret", account_id=ACC_OTHER)
+    their_session_id = await _make_session(
+        pool, vault_ids=[theirs], account_id=ACC_OTHER, environment_id=ENV_OTHER
+    )
     mine = await _make_vault(pool, "my-vault")
     await _make_env_cred(pool, crypto_box, mine, "OTHER_KEY", "my-secret")
-
     session_id = await _make_session(pool, vault_ids=[mine])
-    async with pool.acquire() as conn:
-        await conn.execute(
-            "INSERT INTO session_vaults (session_id, vault_id, rank, account_id) "
-            "VALUES ($1, $2, $3, $4)",
-            session_id,
-            theirs,
-            1,
-            ACC,
-        )
+
     resolved = await _resolve(pool, crypto_box, session_id)
 
     assert [(r.secret_name, r.secret_value) for r in resolved] == [("OTHER_KEY", "my-secret")]
+    # Their session id under my account: the dual account_id filter yields nothing.
+    assert await _resolve(pool, crypto_box, their_session_id, account_id=ACC) == []
 
 
 async def test_run_other_tenants_credentials_invisible(
     vault_pool: asyncpg.Pool[Any], crypto_box: CryptoBox
 ) -> None:
+    # Run twin of the session test above; unrepresentability of cross-tenant
+    # wf_run_vaults rows is proven in tests/integration/test_composite_fk_backstop.py.
     pool = vault_pool
     theirs = await _make_vault(pool, "their-run-vault", account_id=ACC_OTHER)
     await _make_env_cred(pool, crypto_box, theirs, "API_KEY", "their-secret", account_id=ACC_OTHER)
+    their_run_id = await _make_run(
+        pool, vault_ids=[theirs], account_id=ACC_OTHER, environment_id=ENV_OTHER
+    )
     mine = await _make_vault(pool, "my-run-vault")
     await _make_env_cred(pool, crypto_box, mine, "OTHER_KEY", "my-secret")
-
     run_id = await _make_run(pool, vault_ids=[mine])
-    async with pool.acquire() as conn:
-        await conn.execute(
-            "INSERT INTO wf_run_vaults (run_id, vault_id, rank, account_id) "
-            "VALUES ($1, $2, $3, $4)",
-            run_id,
-            theirs,
-            1,
-            ACC,
-        )
+
     resolved = await _resolve_run(pool, crypto_box, run_id)
 
     assert [(r.secret_name, r.secret_value) for r in resolved] == [("OTHER_KEY", "my-secret")]
+    # Their run id under my account: the dual account_id filter yields nothing.
+    assert await _resolve_run(pool, crypto_box, their_run_id, account_id=ACC) == []
 
 
 async def test_vaultless_session_resolves_empty(

--- a/tests/integration/test_migrations_0093_composite_fk_backstop.py
+++ b/tests/integration/test_migrations_0093_composite_fk_backstop.py
@@ -1,0 +1,77 @@
+"""Migration 0093 adds composite tenant FKs for secret-bearing chains."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+_CHAIN_SQL = """
+INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+VALUES ('acc_root', NULL, TRUE, 'root'),
+       ('acc_a', 'acc_root', FALSE, 'tenant-a'),
+       ('acc_b', 'acc_root', FALSE, 'tenant-b');
+INSERT INTO environments (id, name, account_id)
+VALUES ('env_a', 'env-a', 'acc_a');
+INSERT INTO agents (id, name, model, account_id)
+VALUES ('agent_a', 'agent-a', 'test/model', 'acc_a');
+INSERT INTO sessions (id, agent_id, environment_id, workspace_volume_path, account_id)
+VALUES ('sess_a', 'agent_a', 'env_a', '/tmp/ws-a', 'acc_a');
+INSERT INTO vaults (id, display_name, account_id)
+VALUES ('vault_b', 'foreign vault', 'acc_b');
+"""
+
+_LEGACY_CROSS_TENANT_SESSION_VAULT_SQL = """
+INSERT INTO session_vaults (session_id, vault_id, rank, account_id)
+VALUES ('sess_a', 'vault_b', 0, 'acc_a');
+"""
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    """Fresh function-scoped Postgres; each test mutates alembic_version."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _execute(db_url: str, sql: str) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+def test_clean_database_upgrades_to_composite_fk_backstop(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "head"], db_url)
+
+    assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
+
+
+@needs_docker
+@pytest.mark.integration
+def test_legacy_cross_tenant_session_vault_fails_validation(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "0092"], db_url)
+    assert up.returncode == 0, f"upgrade to 0092 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_execute(db_url, _CHAIN_SQL + _LEGACY_CROSS_TENANT_SESSION_VAULT_SQL))
+
+    up = _run_alembic(["upgrade", "head"], db_url)
+
+    assert up.returncode != 0, f"upgrade should have failed loud:\n{up.stdout}"
+    output = up.stderr + up.stdout
+    assert "session_vaults_vault_account_id_fkey" in output

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0092``."""
+    """The migration ladder has exactly one head: ``0093``."""
     script = _script_directory()
-    assert script.get_heads() == ["0092"]
+    assert script.get_heads() == ["0093"]
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
Adds migration 0093 to make tenant isolation storage-enforced across the four FK-able secret-bearing chains.

What changed:
- Adds parent composite UNIQUE constraints for `vaults`, `sessions`, and `wf_runs` on `(id, account_id)`.
- Drops the six superseded bare-id FKs.
- Adds six composite `(resource_id, account_id)` FKs using `NOT VALID` then `VALIDATE CONSTRAINT`, preserving existing ON DELETE semantics.
- Adds migration-tier coverage for clean upgrades and legacy cross-tenant row validation failure.
- Adds raw-SQL integration proofs that cross-tenant inserts fail for:
  - `session_vaults` in both directions
  - `wf_run_vaults` in both directions
  - `vault_credentials`
  - `oauth_flows`
- Updates the migration-chain head test to `0093`.

Validation:
- `uv run mypy src tests`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest tests/unit -q`
- Targeted integration tests were collected but skipped locally because Docker/testcontainers are unavailable in this sandbox.
- Repository pre-commit hook passed.

#426-pattern grep:
- Reviewed functions accepting `account_id` in `src/aios/db/queries/vaults.py` and `src/aios/db/queries/workflows.py`.
- Bucket 1 real cross-tenant leaks: none found.
- Bucket 2 defense-in-depth shortfalls: none found.
- Bucket 3 intentionally global: none in these two chain query modules.

Closes #857