### PR TITLE
Add generic workflow subagents for #787

### DIFF
--- a/migrations/versions/0095_generic_workflow_children.py
+++ b/migrations/versions/0095_generic_workflow_children.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
     op.execute("ALTER TABLE wf_runs ADD COLUMN default_child_model text")
     op.execute(
         "ALTER TABLE sessions ADD CONSTRAINT sessions_agent_version_pair_ck "
-        "CHECK ((agent_id IS NULL) = (agent_version IS NULL))"
+        "CHECK (parent_run_id IS NULL OR ((agent_id IS NULL) = (agent_version IS NULL)))"
     )
     op.execute(
         "ALTER TABLE sessions ADD CONSTRAINT sessions_agentless_workflow_child_ck "

--- a/migrations/versions/0095_generic_workflow_children.py
+++ b/migrations/versions/0095_generic_workflow_children.py
@@ -1,0 +1,40 @@
+"""Generic workflow children and default child model.
+
+Revision ID: 0095
+Revises: 0094
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0095"
+down_revision: str = "0094"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sessions ALTER COLUMN agent_id DROP NOT NULL")
+    op.execute("ALTER TABLE sessions ALTER COLUMN agent_version DROP NOT NULL")
+    op.execute("ALTER TABLE sessions ADD COLUMN model text")
+    op.execute("ALTER TABLE wf_runs ADD COLUMN default_child_model text")
+    op.execute(
+        "ALTER TABLE sessions ADD CONSTRAINT sessions_agent_version_pair_ck "
+        "CHECK ((agent_id IS NULL) = (agent_version IS NULL))"
+    )
+    op.execute(
+        "ALTER TABLE sessions ADD CONSTRAINT sessions_agentless_workflow_child_ck "
+        "CHECK (agent_id IS NOT NULL OR (parent_run_id IS NOT NULL AND model IS NOT NULL))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP CONSTRAINT sessions_agentless_workflow_child_ck")
+    op.execute("ALTER TABLE sessions DROP CONSTRAINT sessions_agent_version_pair_ck")
+    op.execute("ALTER TABLE wf_runs DROP COLUMN default_child_model")
+    op.execute("ALTER TABLE sessions DROP COLUMN model")
+    op.execute("ALTER TABLE sessions ALTER COLUMN agent_version SET NOT NULL")
+    op.execute("ALTER TABLE sessions ALTER COLUMN agent_id SET NOT NULL")

--- a/openapi.json
+++ b/openapi.json
@@ -13368,7 +13368,14 @@
             "title": "Id"
           },
           "agent_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Agent Id"
           },
           "environment_id": {
@@ -13385,6 +13392,17 @@
               }
             ],
             "title": "Agent Version"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
           },
           "title": {
             "anyOf": [
@@ -16167,6 +16185,17 @@
             ],
             "title": "Budget Usd"
           },
+          "default_child_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Child Model"
+          },
           "last_event_seq": {
             "type": "integer",
             "title": "Last Event Seq"
@@ -16244,6 +16273,18 @@
             ],
             "title": "Budget Usd",
             "description": "Optional shared USD spend ceiling for this run's direct agent() children."
+          },
+          "default_child_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Child Model",
+            "description": "Optional model used by generic agent() children when they omit model=."
           }
         },
         "additionalProperties": false,
@@ -16695,7 +16736,7 @@
           "script": {
             "type": "string",
             "title": "Script",
-            "description": "Workflow script contract:\n- Entry point: define `async def main(input)`. A run's output is the value returned by\n  `main`.\n- Injected capability API, available without imports:\n  - `agent(agent_id, input, output_schema=None)`: invoke an agent and await its result.\n  - `tool(name, input)`: invoke a declared tool; tool errors are returned, not raised.\n  - `gate()`: suspend until an external resume delivers a value.\n  - `budget()`: read this run's shared child-spend budget, or None when unset.\n  - `parallel(thunks)`: run zero-argument callables concurrently (for example,\n    `lambda: agent(...)`). A failed agent branch yields `None` at the barrier instead\n    of raising. Fan-out width is capped by `MAX_PARALLEL_FANOUT` (currently 1000).\n  - `pipeline(items, *stages)`: run each item through staged transforms concurrently.\n  - `log(msg)`: record progress on the run journal.\n- Shell execution: `tool('bash', {\"command\": str, \"timeout_seconds\": float | None})` runs the\n  command in a per-run sandbox (provisioned lazily on first use, in the run's\n  environment). `bash` must be a member of the workflow's declared tools or the call\n  resolves to a `{\"error\": ...}` value. Result: `{exit_code, stdout, stderr, timed_out,\n  truncated}` \u2014 a nonzero exit or in-command timeout is a successful result to branch\n  on, not an error.\n- Crash semantics: at-least-once at the call boundary. A capability call interrupted by\n  a crash re-runs on resume; completed calls never re-run. The sandbox filesystem is\n  ephemeral scratch \u2014 write re-run-tolerant commands (e.g. `rm -rf dir && git clone ...`).\n- Irreversible external effects (a POST that charges, sends, or publishes): the bash\n  environment exposes `$AIOS_IDEMPOTENCY_KEY` (stable across crash re-runs of the same\n  call, distinct per call) \u2014 pass it to the external service as an idempotency key so\n  the service drops a re-fired duplicate, or knowingly accept at-least-once.\n- Partition rule: put re-run-tolerant mechanical work in `tool('bash')`; put work whose\n  uncertain completion needs judgment to resolve inside `agent(...)`.\n- Environment: the SCRIPT runs in a deterministic, credential-free, isolated child\n  process \u2014 imports restricted to a curated stdlib allowlist, no network or filesystem\n  access from script code itself; all effects go through the capability API. The\n  `tool('bash')` sandbox is different: it has a filesystem (ephemeral scratch) and\n  network egress per the run's ENVIRONMENT network policy (Unrestricted, or Limited to\n  the environment's allowed hosts) \u2014 commands can curl, clone, and install within that\n  policy.\n\nMinimal example:\n```python\nasync def main(input):\n    result = await agent(\n        input[\"agent_id\"],\n        {\"task\": input[\"task\"]},\n        None,\n    )\n    return result\n```\n"
+            "description": "Workflow script contract:\n- Entry point: define `async def main(input)`. A run's output is the value returned by\n  `main`.\n- Injected capability API, available without imports:\n  - `agent(input, *, agent_id=None, output_schema=None, model=None, label=None)`: invoke a generic or named agent and await its result.\n  - `tool(name, input)`: invoke a declared tool; tool errors are returned, not raised.\n  - `gate()`: suspend until an external resume delivers a value.\n  - `budget()`: read this run's shared child-spend budget, or None when unset.\n  - `parallel(thunks)`: run zero-argument callables concurrently (for example,\n    `lambda: agent(...)`). A failed agent branch yields `None` at the barrier instead\n    of raising. Fan-out width is capped by `MAX_PARALLEL_FANOUT` (currently 1000).\n  - `pipeline(items, *stages)`: run each item through staged transforms concurrently.\n  - `log(msg)`: record progress on the run journal.\n- Shell execution: `tool('bash', {\"command\": str, \"timeout_seconds\": float | None})` runs the\n  command in a per-run sandbox (provisioned lazily on first use, in the run's\n  environment). `bash` must be a member of the workflow's declared tools or the call\n  resolves to a `{\"error\": ...}` value. Result: `{exit_code, stdout, stderr, timed_out,\n  truncated}` \u2014 a nonzero exit or in-command timeout is a successful result to branch\n  on, not an error.\n- Crash semantics: at-least-once at the call boundary. A capability call interrupted by\n  a crash re-runs on resume; completed calls never re-run. The sandbox filesystem is\n  ephemeral scratch \u2014 write re-run-tolerant commands (e.g. `rm -rf dir && git clone ...`).\n- Irreversible external effects (a POST that charges, sends, or publishes): the bash\n  environment exposes `$AIOS_IDEMPOTENCY_KEY` (stable across crash re-runs of the same\n  call, distinct per call) \u2014 pass it to the external service as an idempotency key so\n  the service drops a re-fired duplicate, or knowingly accept at-least-once.\n- Partition rule: put re-run-tolerant mechanical work in `tool('bash')`; put work whose\n  uncertain completion needs judgment to resolve inside `agent(...)`.\n- Environment: the SCRIPT runs in a deterministic, credential-free, isolated child\n  process \u2014 imports restricted to a curated stdlib allowlist, no network or filesystem\n  access from script code itself; all effects go through the capability API. The\n  `tool('bash')` sandbox is different: it has a filesystem (ephemeral scratch) and\n  network egress per the run's ENVIRONMENT network policy (Unrestricted, or Limited to\n  the environment's allowed hosts) \u2014 commands can curl, clone, and install within that\n  policy.\n\nMinimal example:\n```python\nasync def main(input):\n    result = await agent(\n        {\"task\": input[\"task\"]},\n        agent_id=input[\"agent_id\"],\n    )\n    return result\n```\n"
           },
           "input_schema": {
             "anyOf": [
@@ -16792,7 +16833,7 @@
               }
             ],
             "title": "Script",
-            "description": "Workflow script contract:\n- Entry point: define `async def main(input)`. A run's output is the value returned by\n  `main`.\n- Injected capability API, available without imports:\n  - `agent(agent_id, input, output_schema=None)`: invoke an agent and await its result.\n  - `tool(name, input)`: invoke a declared tool; tool errors are returned, not raised.\n  - `gate()`: suspend until an external resume delivers a value.\n  - `budget()`: read this run's shared child-spend budget, or None when unset.\n  - `parallel(thunks)`: run zero-argument callables concurrently (for example,\n    `lambda: agent(...)`). A failed agent branch yields `None` at the barrier instead\n    of raising. Fan-out width is capped by `MAX_PARALLEL_FANOUT` (currently 1000).\n  - `pipeline(items, *stages)`: run each item through staged transforms concurrently.\n  - `log(msg)`: record progress on the run journal.\n- Shell execution: `tool('bash', {\"command\": str, \"timeout_seconds\": float | None})` runs the\n  command in a per-run sandbox (provisioned lazily on first use, in the run's\n  environment). `bash` must be a member of the workflow's declared tools or the call\n  resolves to a `{\"error\": ...}` value. Result: `{exit_code, stdout, stderr, timed_out,\n  truncated}` \u2014 a nonzero exit or in-command timeout is a successful result to branch\n  on, not an error.\n- Crash semantics: at-least-once at the call boundary. A capability call interrupted by\n  a crash re-runs on resume; completed calls never re-run. The sandbox filesystem is\n  ephemeral scratch \u2014 write re-run-tolerant commands (e.g. `rm -rf dir && git clone ...`).\n- Irreversible external effects (a POST that charges, sends, or publishes): the bash\n  environment exposes `$AIOS_IDEMPOTENCY_KEY` (stable across crash re-runs of the same\n  call, distinct per call) \u2014 pass it to the external service as an idempotency key so\n  the service drops a re-fired duplicate, or knowingly accept at-least-once.\n- Partition rule: put re-run-tolerant mechanical work in `tool('bash')`; put work whose\n  uncertain completion needs judgment to resolve inside `agent(...)`.\n- Environment: the SCRIPT runs in a deterministic, credential-free, isolated child\n  process \u2014 imports restricted to a curated stdlib allowlist, no network or filesystem\n  access from script code itself; all effects go through the capability API. The\n  `tool('bash')` sandbox is different: it has a filesystem (ephemeral scratch) and\n  network egress per the run's ENVIRONMENT network policy (Unrestricted, or Limited to\n  the environment's allowed hosts) \u2014 commands can curl, clone, and install within that\n  policy.\n\nMinimal example:\n```python\nasync def main(input):\n    result = await agent(\n        input[\"agent_id\"],\n        {\"task\": input[\"task\"]},\n        None,\n    )\n    return result\n```\n"
+            "description": "Workflow script contract:\n- Entry point: define `async def main(input)`. A run's output is the value returned by\n  `main`.\n- Injected capability API, available without imports:\n  - `agent(input, *, agent_id=None, output_schema=None, model=None, label=None)`: invoke a generic or named agent and await its result.\n  - `tool(name, input)`: invoke a declared tool; tool errors are returned, not raised.\n  - `gate()`: suspend until an external resume delivers a value.\n  - `budget()`: read this run's shared child-spend budget, or None when unset.\n  - `parallel(thunks)`: run zero-argument callables concurrently (for example,\n    `lambda: agent(...)`). A failed agent branch yields `None` at the barrier instead\n    of raising. Fan-out width is capped by `MAX_PARALLEL_FANOUT` (currently 1000).\n  - `pipeline(items, *stages)`: run each item through staged transforms concurrently.\n  - `log(msg)`: record progress on the run journal.\n- Shell execution: `tool('bash', {\"command\": str, \"timeout_seconds\": float | None})` runs the\n  command in a per-run sandbox (provisioned lazily on first use, in the run's\n  environment). `bash` must be a member of the workflow's declared tools or the call\n  resolves to a `{\"error\": ...}` value. Result: `{exit_code, stdout, stderr, timed_out,\n  truncated}` \u2014 a nonzero exit or in-command timeout is a successful result to branch\n  on, not an error.\n- Crash semantics: at-least-once at the call boundary. A capability call interrupted by\n  a crash re-runs on resume; completed calls never re-run. The sandbox filesystem is\n  ephemeral scratch \u2014 write re-run-tolerant commands (e.g. `rm -rf dir && git clone ...`).\n- Irreversible external effects (a POST that charges, sends, or publishes): the bash\n  environment exposes `$AIOS_IDEMPOTENCY_KEY` (stable across crash re-runs of the same\n  call, distinct per call) \u2014 pass it to the external service as an idempotency key so\n  the service drops a re-fired duplicate, or knowingly accept at-least-once.\n- Partition rule: put re-run-tolerant mechanical work in `tool('bash')`; put work whose\n  uncertain completion needs judgment to resolve inside `agent(...)`.\n- Environment: the SCRIPT runs in a deterministic, credential-free, isolated child\n  process \u2014 imports restricted to a curated stdlib allowlist, no network or filesystem\n  access from script code itself; all effects go through the capability API. The\n  `tool('bash')` sandbox is different: it has a filesystem (ephemeral scratch) and\n  network egress per the run's ENVIRONMENT network policy (Unrestricted, or Limited to\n  the environment's allowed hosts) \u2014 commands can curl, clone, and install within that\n  policy.\n\nMinimal example:\n```python\nasync def main(input):\n    result = await agent(\n        {\"task\": input[\"task\"]},\n        agent_id=input[\"agent_id\"],\n    )\n    return result\n```\n"
           },
           "input_schema": {
             "anyOf": [

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -38,7 +38,7 @@ class Session:
 
         Attributes:
             id (str):
-            agent_id (str):
+            agent_id (None | str):
             environment_id (str):
             agent_version (int | None):
             title (None | str):
@@ -48,6 +48,7 @@ class Session:
             last_event_seq (int):
             created_at (datetime.datetime):
             updated_at (datetime.datetime):
+            model (None | str | Unset):
             awaiting (list[AwaitingToolCall] | Unset):
             vault_ids (list[str] | Unset):
             usage (SessionUsage | Unset): Cumulative token usage across all model calls in a session.
@@ -64,7 +65,7 @@ class Session:
     """
 
     id: str
-    agent_id: str
+    agent_id: None | str
     environment_id: str
     agent_version: int | None
     title: None | str
@@ -74,6 +75,7 @@ class Session:
     last_event_seq: int
     created_at: datetime.datetime
     updated_at: datetime.datetime
+    model: None | str | Unset = UNSET
     awaiting: list[AwaitingToolCall] | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
     usage: SessionUsage | Unset = UNSET
@@ -97,6 +99,7 @@ class Session:
 
         id = self.id
 
+        agent_id: None | str
         agent_id = self.agent_id
 
         environment_id = self.environment_id
@@ -122,6 +125,12 @@ class Session:
         created_at = self.created_at.isoformat()
 
         updated_at = self.updated_at.isoformat()
+
+        model: None | str | Unset
+        if isinstance(self.model, Unset):
+            model = UNSET
+        else:
+            model = self.model
 
         awaiting: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.awaiting, Unset):
@@ -212,6 +221,8 @@ class Session:
                 "updated_at": updated_at,
             }
         )
+        if model is not UNSET:
+            field_dict["model"] = model
         if awaiting is not UNSET:
             field_dict["awaiting"] = awaiting
         if vault_ids is not UNSET:
@@ -256,7 +267,12 @@ class Session:
         d = dict(src_dict)
         id = d.pop("id")
 
-        agent_id = d.pop("agent_id")
+        def _parse_agent_id(data: object) -> None | str:
+            if data is None:
+                return data
+            return cast(None | str, data)
+
+        agent_id = _parse_agent_id(d.pop("agent_id"))
 
         environment_id = d.pop("environment_id")
 
@@ -298,6 +314,15 @@ class Session:
         created_at = isoparse(d.pop("created_at"))
 
         updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_model(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        model = _parse_model(d.pop("model", UNSET))
 
         _awaiting = d.pop("awaiting", UNSET)
         awaiting: list[AwaitingToolCall] | Unset = UNSET
@@ -432,6 +457,7 @@ class Session:
             last_event_seq=last_event_seq,
             created_at=created_at,
             updated_at=updated_at,
+            model=model,
             awaiting=awaiting,
             vault_ids=vault_ids,
             usage=usage,

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -52,6 +52,7 @@ class WfRun:
             input_ (Any | Unset):
             output (Any | Unset):
             budget_usd (float | None | Unset):
+            default_child_model (None | str | Unset):
             archived_at (datetime.datetime | None | Unset):
     """
 
@@ -74,6 +75,7 @@ class WfRun:
     input_: Any | Unset = UNSET
     output: Any | Unset = UNSET
     budget_usd: float | None | Unset = UNSET
+    default_child_model: None | str | Unset = UNSET
     archived_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -143,6 +145,12 @@ class WfRun:
         else:
             budget_usd = self.budget_usd
 
+        default_child_model: None | str | Unset
+        if isinstance(self.default_child_model, Unset):
+            default_child_model = UNSET
+        else:
+            default_child_model = self.default_child_model
+
         archived_at: None | str | Unset
         if isinstance(self.archived_at, Unset):
             archived_at = UNSET
@@ -184,6 +192,8 @@ class WfRun:
             field_dict["output"] = output
         if budget_usd is not UNSET:
             field_dict["budget_usd"] = budget_usd
+        if default_child_model is not UNSET:
+            field_dict["default_child_model"] = default_child_model
         if archived_at is not UNSET:
             field_dict["archived_at"] = archived_at
 
@@ -278,6 +288,17 @@ class WfRun:
 
         budget_usd = _parse_budget_usd(d.pop("budget_usd", UNSET))
 
+        def _parse_default_child_model(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        default_child_model = _parse_default_child_model(
+            d.pop("default_child_model", UNSET)
+        )
+
         def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -315,6 +336,7 @@ class WfRun:
             input_=input_,
             output=output,
             budget_usd=budget_usd,
+            default_child_model=default_child_model,
             archived_at=archived_at,
         )
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_create.py
@@ -26,6 +26,7 @@ class WfRunCreate:
             vault_ids (list[str] | Unset): Vault ids to bind to the run for credential resolution. When an agent launches
                 the run, these must be a subset of the launcher's own vaults; the HTTP path is unattenuated operator authority.
             budget_usd (float | None | Unset): Optional shared USD spend ceiling for this run's direct agent() children.
+            default_child_model (None | str | Unset): Optional model used by generic agent() children when they omit model=.
     """
 
     workflow_id: str
@@ -33,6 +34,7 @@ class WfRunCreate:
     input_: Any | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
     budget_usd: float | None | Unset = UNSET
+    default_child_model: None | str | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         workflow_id = self.workflow_id
@@ -51,6 +53,12 @@ class WfRunCreate:
         else:
             budget_usd = self.budget_usd
 
+        default_child_model: None | str | Unset
+        if isinstance(self.default_child_model, Unset):
+            default_child_model = UNSET
+        else:
+            default_child_model = self.default_child_model
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -65,6 +73,8 @@ class WfRunCreate:
             field_dict["vault_ids"] = vault_ids
         if budget_usd is not UNSET:
             field_dict["budget_usd"] = budget_usd
+        if default_child_model is not UNSET:
+            field_dict["default_child_model"] = default_child_model
 
         return field_dict
 
@@ -88,12 +98,24 @@ class WfRunCreate:
 
         budget_usd = _parse_budget_usd(d.pop("budget_usd", UNSET))
 
+        def _parse_default_child_model(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        default_child_model = _parse_default_child_model(
+            d.pop("default_child_model", UNSET)
+        )
+
         wf_run_create = cls(
             workflow_id=workflow_id,
             environment_id=environment_id,
             input_=input_,
             vault_ids=vault_ids,
             budget_usd=budget_usd,
+            default_child_model=default_child_model,
         )
 
         return wf_run_create

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
@@ -32,7 +32,8 @@ class WorkflowCreate:
             - Entry point: define `async def main(input)`. A run's output is the value returned by
               `main`.
             - Injected capability API, available without imports:
-              - `agent(agent_id, input, output_schema=None)`: invoke an agent and await its result.
+              - `agent(input, *, agent_id=None, output_schema=None, model=None, label=None)`: invoke a generic or named
+            agent and await its result.
               - `tool(name, input)`: invoke a declared tool; tool errors are returned, not raised.
               - `gate()`: suspend until an external resume delivers a value.
               - `budget()`: read this run's shared child-spend budget, or None when unset.
@@ -68,9 +69,8 @@ class WorkflowCreate:
             ```python
             async def main(input):
                 result = await agent(
-                    input["agent_id"],
                     {"task": input["task"]},
-                    None,
+                    agent_id=input["agent_id"],
                 )
                 return result
             ```

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_update.py
@@ -41,7 +41,8 @@ class WorkflowUpdate:
                 - Entry point: define `async def main(input)`. A run's output is the value returned by
                   `main`.
                 - Injected capability API, available without imports:
-                  - `agent(agent_id, input, output_schema=None)`: invoke an agent and await its result.
+                  - `agent(input, *, agent_id=None, output_schema=None, model=None, label=None)`: invoke a generic or named
+                agent and await its result.
                   - `tool(name, input)`: invoke a declared tool; tool errors are returned, not raised.
                   - `gate()`: suspend until an external resume delivers a value.
                   - `budget()`: read this run's shared child-spend budget, or None when unset.
@@ -77,9 +78,8 @@ class WorkflowUpdate:
                 ```python
                 async def main(input):
                     result = await agent(
-                        input["agent_id"],
                         {"task": input["task"]},
-                        None,
+                        agent_id=input["agent_id"],
                     )
                     return result
                 ```

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -152,6 +152,7 @@ async def create_run(body: WfRunCreate, pool: PoolDep, account_id: AccountIdDep)
         input=body.input,
         vault_ids=body.vault_ids,
         budget_usd=body.budget_usd,
+        default_child_model=body.default_child_model,
     )
 
 

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -421,6 +421,10 @@ class Settings(BaseSettings):
         "single-``parallel()`` fan-out width is bounded separately, in the "
         "host (``wf_script_host.MAX_PARALLEL_FANOUT``).",
     )
+    workflow_default_child_model: str | None = Field(
+        default=None,
+        description="Default model for generic workflow agent() children launched via operator/HTTP runs when no per-run or per-call model is supplied.",
+    )
     workflow_max_inflight_children_per_run: int = Field(
         default=8,
         ge=1,

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -86,6 +86,7 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         agent_id=row["agent_id"],
         environment_id=row["environment_id"],
         agent_version=row["agent_version"],
+        model=row.get("model"),
         title=row["title"],
         metadata=metadata,
         # ``status`` is derived ({active, idle}) from the event log via
@@ -204,9 +205,10 @@ async def insert_child_session(
     *,
     session_id: str,
     account_id: str,
-    agent_id: str,
+    agent_id: str | None,
     environment_id: str,
-    agent_version: int,
+    agent_version: int | None,
+    model: str | None,
     parent_run_id: str,
     tools: list[ToolSpec],
     mcp_servers: list[McpServerSpec],
@@ -232,14 +234,14 @@ async def insert_child_session(
         row = await conn.fetchrow(
             """
             INSERT INTO sessions (
-                id, agent_id, environment_id, agent_version, title, metadata,
+                id, agent_id, environment_id, agent_version, model, title, metadata,
                 workspace_volume_path, env, focal_channel, focal_locked,
                 account_id, parent_run_id, origin, archive_when_idle,
                 tools, mcp_servers, http_servers, surface_frozen
             )
-            VALUES ($1, $2, $3, $4, NULL, '{}'::jsonb, $5, '{}'::jsonb,
-                    NULL, FALSE, $6, $7, 'background', TRUE,
-                    $8::jsonb, $9::jsonb, $10::jsonb, TRUE)
+            VALUES ($1, $2, $3, $4, $5, NULL, '{}'::jsonb, $6, '{}'::jsonb,
+                    NULL, FALSE, $7, $8, 'background', TRUE,
+                    $9::jsonb, $10::jsonb, $11::jsonb, TRUE)
             ON CONFLICT (id) DO NOTHING
             RETURNING *
             """,
@@ -247,6 +249,7 @@ async def insert_child_session(
             agent_id,
             environment_id,
             agent_version,
+            model,
             workspace_path,
             account_id,
             parent_run_id,
@@ -888,16 +891,17 @@ async def get_session_model(
     """
     row = await conn.fetchrow(
         """
-        SELECT COALESCE(av.model, a.model) AS model
+        SELECT COALESCE(s.model, av.model, a.model) AS model
           FROM sessions s
-          JOIN agents a ON a.id = s.agent_id
+     LEFT JOIN agents a
+            ON a.id = s.agent_id
+           AND a.account_id = $2
      LEFT JOIN agent_versions av
             ON av.agent_id = s.agent_id
            AND av.version = s.agent_version
            AND av.account_id = $2
          WHERE s.id = $1
            AND s.account_id = $2
-           AND a.account_id = $2
         """,
         session_id,
         account_id,

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -906,7 +906,7 @@ async def get_session_model(
         session_id,
         account_id,
     )
-    if row is None:
+    if row is None or row["model"] is None:
         raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
     return str(row["model"])
 

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -82,6 +82,7 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
             if row.get("budget_total_microusd") is not None
             else None
         ),
+        default_child_model=row.get("default_child_model"),
         last_event_seq=row["last_event_seq"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -415,6 +416,7 @@ async def insert_wf_run(
     mcp_servers: list[McpServerSpec] | None = None,
     http_servers: list[HttpServerSpec] | None = None,
     budget_usd: float | None = None,
+    default_child_model: str | None = None,
 ) -> WfRun:
     """Insert a fresh ``pending`` run that snapshots ``script`` (+ ``script_sha``) and the
     declared tool surface (``tools``/``mcp_servers``/``http_servers``) — pinned at launch.
@@ -426,9 +428,9 @@ async def insert_wf_run(
             INSERT INTO wf_runs
                 (id, workflow_id, account_id, environment_id, parent_run_id,
                  launcher_session_id, script, script_sha, host_semantics_epoch, status, input,
-                 tools, mcp_servers, http_servers, budget_total_microusd)
+                 tools, mcp_servers, http_servers, budget_total_microusd, default_child_model)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending', $10::jsonb,
-                    $11::jsonb, $12::jsonb, $13::jsonb, $14)
+                    $11::jsonb, $12::jsonb, $13::jsonb, $14, $15)
             RETURNING *
             """,
             new_id,
@@ -445,6 +447,7 @@ async def insert_wf_run(
             json.dumps([s.model_dump() for s in (mcp_servers or [])]),
             json.dumps([s.model_dump() for s in (http_servers or [])]),
             round(budget_usd * 1_000_000) if budget_usd is not None else None,
+            default_child_model,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -266,9 +266,10 @@ class Session(BaseModel):
     """
 
     id: str
-    agent_id: str
+    agent_id: str | None
     environment_id: str
     agent_version: int | None
+    model: str | None = None
     title: str | None
     metadata: dict[str, Any]
     status: SessionStatus

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -94,6 +94,7 @@ class WfRun(BaseModel):
     input: Any = None  # arbitrary JSON: a workflow's input need not be an object
     output: Any = None  # arbitrary JSON: the script's return value
     budget_usd: float | None = None
+    default_child_model: str | None = None
     last_event_seq: int
     created_at: datetime
     updated_at: datetime
@@ -157,7 +158,7 @@ WORKFLOW_SCRIPT_CONTRACT = """Workflow script contract:
 - Entry point: define `async def main(input)`. A run's output is the value returned by
   `main`.
 - Injected capability API, available without imports:
-  - `agent(agent_id, input, output_schema=None)`: invoke an agent and await its result.
+  - `agent(input, *, agent_id=None, output_schema=None, model=None, label=None)`: invoke a generic or named agent and await its result.
   - `tool(name, input)`: invoke a declared tool; tool errors are returned, not raised.
   - `gate()`: suspend until an external resume delivers a value.
   - `budget()`: read this run's shared child-spend budget, or None when unset.
@@ -193,9 +194,8 @@ Minimal example:
 ```python
 async def main(input):
     result = await agent(
-        input["agent_id"],
         {"task": input["task"]},
-        None,
+        agent_id=input["agent_id"],
     )
     return result
 ```
@@ -282,6 +282,10 @@ class WfRunCreate(BaseModel):
         default=None,
         gt=0,
         description="Optional shared USD spend ceiling for this run's direct agent() children.",
+    )
+    default_child_model: str | None = Field(
+        default=None,
+        description="Optional model used by generic agent() children when they omit model=.",
     )
 
 

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -23,6 +23,7 @@ from aios.models.agents import (
 )
 from aios.models.skills import AgentSkillRef
 from aios.services import skills as skills_service
+from aios.workflows.generic_child import GENERIC_CHILD_SYSTEM
 
 
 async def create_agent(
@@ -156,18 +157,32 @@ async def _load_for_session_conn(
                 f"workflow child {session.id} has no frozen surface snapshot "
                 "(parent_run_id set but surface_frozen is false)"
             )
-        # A workflow child always pins a concrete agent_version at spawn
-        # (insert_child_session requires the int), so this is never a "latest" read.
+        if session.agent_id is None:
+            return AgentVersion(
+                agent_id="",
+                version=0,
+                model=session.model,
+                system=GENERIC_CHILD_SYSTEM.format(model=session.model),
+                tools=frozen.tools,
+                skills=[],
+                mcp_servers=frozen.mcp_servers,
+                http_servers=frozen.http_servers,
+                litellm_extra={},
+                window_min=50_000,
+                window_max=150_000,
+                created_at=session.created_at,
+            )
         version = await queries.get_agent_version(
             conn, session.agent_id, session.agent_version, account_id=account_id
         )
-        return version.model_copy(
-            update={
-                "tools": frozen.tools,
-                "mcp_servers": frozen.mcp_servers,
-                "http_servers": frozen.http_servers,
-            }
-        )
+        updates: dict[str, Any] = {
+            "tools": frozen.tools,
+            "mcp_servers": frozen.mcp_servers,
+            "http_servers": frozen.http_servers,
+        }
+        if session.model is not None:
+            updates["model"] = session.model
+        return version.model_copy(update=updates)
     if session.agent_version is not None:
         return await queries.get_agent_version(
             conn, session.agent_id, session.agent_version, account_id=account_id

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -347,9 +347,10 @@ async def create_child_session(
     *,
     session_id: str,
     account_id: str,
-    agent_id: str,
+    agent_id: str | None,
     environment_id: str,
-    agent_version: int,
+    agent_version: int | None,
+    model: str | None,
     parent_run_id: str,
     surface: Surface,
     vault_ids: list[str],
@@ -394,6 +395,7 @@ async def create_child_session(
             agent_id=agent_id,
             environment_id=environment_id,
             agent_version=agent_version,
+            model=model,
             parent_run_id=parent_run_id,
             tools=surface.tools,
             mcp_servers=surface.mcp_servers,
@@ -496,13 +498,13 @@ async def compute_awaiting(
     # run-attenuated surface (#794), so two children of the same agent/version under
     # different runs would collide on the old key and misclassify authority — they key
     # per-session instead.
-    agent_cache: dict[str | tuple[str, int | None], Agent | AgentVersion] = {}
+    agent_cache: dict[str | tuple[str | None, int | None], Agent | AgentVersion] = {}
     out: dict[str, list[AwaitingToolCall]] = {}
     for session in sessions:
         unresolved = unresolved_by_sid.get(session.id)
         if not unresolved:
             continue
-        key: str | tuple[str, int | None] = (
+        key: str | tuple[str | None, int | None] = (
             session.id
             if session.parent_run_id is not None
             else (session.agent_id, session.agent_version)

--- a/src/aios/workflows/deep_research.py
+++ b/src/aios/workflows/deep_research.py
@@ -250,17 +250,17 @@ def _render_script(
 
         async def failed_scout():
             try:
-                await agent(FAILING_AGENT_ID, {{"expected_failure": True}}, output_schema=SCOUT_SCHEMA)
+                await agent({{"expected_failure": True}}, agent_id=FAILING_AGENT_ID, output_schema=SCOUT_SCHEMA)
             except AgentError as e:
                 log(f"scout failed (expected): {{e}}")
                 return None
             return None
 
         def scout_thunk(angle):
-            return lambda: agent(SCOUT_AGENT_ID, {{"question": QUESTION, "angle": angle}}, output_schema=SCOUT_SCHEMA)
+            return lambda: agent({{"question": QUESTION, "angle": angle}}, agent_id=SCOUT_AGENT_ID, output_schema=SCOUT_SCHEMA)
 
         def read_stage(source):
-            return agent(READER_AGENT_ID, {{"question": QUESTION, "source": source}}, output_schema=READER_SCHEMA)
+            return agent({{"question": QUESTION, "source": source}}, agent_id=READER_AGENT_ID, output_schema=READER_SCHEMA)
 
         def normalize_stage(reading, source, index):
             if not reading:
@@ -271,18 +271,18 @@ def _render_script(
 
         async def synthesize(question, sources, readings):
             return await agent(
-                SYNTHESIS_AGENT_ID,
                 {{"question": question, "sources": sources, "readings": readings}},
+                agent_id=SYNTHESIS_AGENT_ID,
                 output_schema=SYNTHESIS_SCHEMA,
             )
 
         async def critique(question, draft):
-            return await agent(CRITIC_AGENT_ID, {{"question": question, "draft": draft}}, output_schema=CRITIC_SCHEMA)
+            return await agent({{"question": question, "draft": draft}}, agent_id=CRITIC_AGENT_ID, output_schema=CRITIC_SCHEMA)
 
         async def supplementary_scout(gap):
             return await agent(
-                SCOUT_AGENT_ID,
                 {{"question": QUESTION, "angle": gap.get("suggested_angle", "supplementary"), "gap": gap}},
+                agent_id=SCOUT_AGENT_ID,
                 output_schema=SCOUT_SCHEMA,
             )
 

--- a/src/aios/workflows/determinism.py
+++ b/src/aios/workflows/determinism.py
@@ -40,7 +40,7 @@ from typing import Any
 # workers fail honest at wake time instead of replaying an in-flight journal under
 # silently changed keying/interpreter/capability semantics. Bump only for knowingly
 # replay-breaking changes; replay-additive changes should keep the epoch.
-HOST_SEMANTICS_EPOCH = 1
+HOST_SEMANTICS_EPOCH = 2
 
 
 class WorkflowInputTypeError(TypeError):

--- a/src/aios/workflows/generic_child.py
+++ b/src/aios/workflows/generic_child.py
@@ -1,0 +1,20 @@
+"""Generic workflow subagent prompt.
+
+Leaf module with no aios imports so services can load it without cycles.
+"""
+
+from __future__ import annotations
+
+GENERIC_CHILD_SYSTEM = """You are a subagent executing a single request for an automated workflow.
+The request is your first message; everything you need is in it.
+
+Your result is delivered only by calling the `return` tool: its `value` IS
+the result the workflow receives. The caller is a program, not a person —
+do not narrate progress, do not ask questions (nothing can answer them),
+and do not send any wrap-up message after returning. If the request shows
+a JSON Schema, `value` must conform to it. If you cannot complete the
+request, call the `error` tool with the reason instead of returning a
+best guess.
+
+You are running on the model {model}.
+"""

--- a/src/aios/workflows/host_launcher.py
+++ b/src/aios/workflows/host_launcher.py
@@ -107,6 +107,7 @@ class EmittedCapability:
     # ("0.0/sha:<hex>#<ordinal>"). Treated as an opaque, deterministic key.
     call_key: str
     spec: Any
+    annotations: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -159,6 +160,7 @@ def _outcome_from_frames(
             capability_id=f["capability_id"],
             call_key=f["call_key"],
             spec=f.get("spec"),
+            annotations=f.get("annotations") or {},
         )
         for f in frames
         if f.get("type") == EMIT

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -48,6 +48,7 @@ async def create_run(
     parent_run_id: str | None = None,
     expected_version: int | None = None,
     budget_usd: float | None = None,
+    default_child_model: str | None = None,
 ) -> WfRun:
     """Create a run that snapshots the workflow's current script, then wake it.
 
@@ -95,6 +96,7 @@ async def create_run(
     # snapshots the workflow verbatim. Threading `conn` (vs a second pool.acquire())
     # keeps the whole path single-connection, so it is safe on a size-1 pool.
     launcher_surface: Surface | None = None
+    run_default_child_model = default_child_model or get_settings().workflow_default_child_model
     async with pool.acquire() as conn, conn.transaction():
         await get_environment(conn, environment_id, account_id=account_id)  # 404s foreign/absent
         workflow = await wf_queries.get_workflow(conn, workflow_id, account_id=account_id)
@@ -118,6 +120,7 @@ async def create_run(
                 pool, launcher_session, account_id=account_id, conn=conn
             )
             launcher_surface = surface_of(launcher_agent)
+            run_default_child_model = launcher_agent.model
         # Clamp the snapshot to the launcher's surface (sub-runs compose for free: a
         # child launcher's load_for_session already returns its frozen clamp).
         effective = (
@@ -197,6 +200,7 @@ async def create_run(
             mcp_servers=effective.mcp_servers,
             http_servers=effective.http_servers,
             budget_usd=budget_usd,
+            default_child_model=run_default_child_model,
         )
         if requested:
             await wf_queries.set_run_vaults(conn, run.id, requested, account_id=account_id)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -848,26 +848,41 @@ async def _open_agent_capability(
                 "(references must resolve within the schema; remote refs are unsupported)",
             )
     agent_id = spec.get("agent_id")
-    if not isinstance(agent_id, str):
+    if agent_id is not None and not isinstance(agent_id, str):
         return await _reject(
-            "bad_agent_call", f"agent() requires a string agent_id, got {agent_id!r}"
+            "bad_agent_call", f"agent() requires agent_id to be a string or None, got {agent_id!r}"
         )
+    model = spec.get("model")
+    if model is not None and not isinstance(model, str):
+        return await _reject("bad_agent_call", f"agent() model must be a string, got {model!r}")
 
     child_id = child_session_id(run.id, cap.call_key)
-    try:
-        # The full agent (head row) — both the pinned version AND its declared surface,
-        # which the run clamps. One query, same NotFoundError contract as before.
-        agent = await db_queries.get_agent(conn, agent_id, account_id=account_id)
-    except NotFoundError:
-        return await _reject("agent_not_found", f"agent {agent_id!r} not found")
+    pinned: int | None
+    stamped_model: str | None = model
+    if agent_id is None:
+        pinned = None
+        stamped_model = model or run.default_child_model
+        if stamped_model is None:
+            return await _reject(
+                "bad_agent_call",
+                "generic agent() call has no model: pass model= or set the run's default child model",
+            )
+        child_surface = surface_of(run)
+    else:
+        try:
+            # The full agent (head row) — both the pinned version AND its declared surface,
+            # which the run clamps. One query, same NotFoundError contract as before.
+            agent = await db_queries.get_agent(conn, agent_id, account_id=account_id)
+        except NotFoundError:
+            return await _reject("agent_not_found", f"agent {agent_id!r} not found")
+        pinned = agent.version
+        # #794: named children wield agent ∩ run, frozen at spawn; vaults are the run's.
+        child_surface = attenuation_service.clamp(surface_of(agent), surface_of(run))
     # Lifetime cap (H1) enforced HERE — past every rejection gate, before the child is
     # created — so only caps that genuinely spawn count. ``agent_spawns`` already excludes
     # rejected caps; this child would be the (agent_spawns + 1)-th, so cap it on strict ``>``.
     if agent_spawns + 1 > max_agent_calls:
         return _SpawnResult(rejected=False, needs_rewake=False, quota_exceeded=True)
-    pinned = agent.version
-    # #794: the child wields agent ∩ run, frozen at spawn; its vaults are the run's.
-    child_surface = attenuation_service.clamp(surface_of(agent), surface_of(run))
     run_vaults = await wf_queries.get_run_vault_ids(conn, run.id, account_id=account_id)
 
     created = await create_child_session(
@@ -877,6 +892,7 @@ async def _open_agent_capability(
         agent_id=agent_id,
         environment_id=run.environment_id,
         agent_version=pinned,
+        model=stamped_model,
         parent_run_id=run.id,
         surface=child_surface,
         vault_ids=run_vaults,
@@ -910,6 +926,8 @@ async def _open_agent_capability(
         "child_session_id": child_id,
         "child_agent_version": child_version,
     }
+    if "label" in cap.annotations:
+        cap_payload["label"] = cap.annotations["label"]
     if output_schema is not None:
         cap_payload["output_schema"] = output_schema  # audit: the shape this call demanded
     await wf_queries.append_run_event(

--- a/src/aios/workflows/wf_script_host.py
+++ b/src/aios/workflows/wf_script_host.py
@@ -93,22 +93,28 @@ class AgentNoReturnError(AgentError):
 class _Yield:
     """The single value every workflow ``await`` yields up to the driver."""
 
-    __slots__ = ("capability_id", "spec")
+    __slots__ = ("annotations", "capability_id", "spec")
 
-    def __init__(self, capability_id: str, spec: Any) -> None:
+    def __init__(
+        self, capability_id: str, spec: Any, annotations: dict[str, Any] | None = None
+    ) -> None:
         self.capability_id = capability_id
         self.spec = spec
+        self.annotations = annotations or {}
 
 
 class _Capability:
-    __slots__ = ("_capability_id", "_spec")
+    __slots__ = ("_annotations", "_capability_id", "_spec")
 
-    def __init__(self, capability_id: str, spec: Any) -> None:
+    def __init__(
+        self, capability_id: str, spec: Any, annotations: dict[str, Any] | None = None
+    ) -> None:
         self._capability_id = capability_id
         self._spec = spec
+        self._annotations = annotations or {}
 
     def __await__(self) -> Any:
-        result = yield _Yield(self._capability_id, self._spec)
+        result = yield _Yield(self._capability_id, self._spec, self._annotations)
         return result
 
 
@@ -139,17 +145,20 @@ def gate(spec: Any = None) -> _Capability:
     return _Capability("gate", spec)
 
 
-def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
-    """Invoke an agent: spawn a child session with ``input`` as its first user
-    message and await its ``return``/``error`` result.
+def agent(
+    input: Any,
+    *,
+    agent_id: str | None = None,
+    output_schema: Any = None,
+    model: str | None = None,
+    label: str | None = None,
+) -> _Capability:
+    """Invoke an agent child and await its ``return``/``error`` result.
 
-    ``input`` is **required and must not be None** — the child needs a real first
-    message to act on (a child born with no user message would sit idle forever and
-    poison the totality backstop). Pass a ``str`` (delivered verbatim) or any
-    JSON-serialisable value (delivered as canonical JSON). A missing agent or a
-    malformed call (non-string ``agent_id`` / invalid ``output_schema``) surfaces as
-    a catchable :class:`AgentError` at the ``await`` — ``try/except`` it like any
-    other agent failure, or let it propagate to fail the run / ``None`` the branch.
+    ``agent_id`` omitted spawns the generic workflow subagent over the run's frozen
+    surface. ``agent_id`` supplied spawns that named agent. ``input`` is required and
+    must not be None; ``model`` is a per-call model override; ``label`` is an
+    observability annotation and does not enter the call key.
     """
     if input is None:
         raise ValueError("agent() requires a non-None input (the child's first message)")
@@ -158,6 +167,9 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
     # integer-valued floats (1.0 → 1), which would alter schema constraints like
     # "minimum": 1.0. A schema is metadata, not workflow data. The worker
     # reconstructs the dict with json.loads. None stays None (no schema demanded).
+    annotations: dict[str, Any] = {}
+    if label is not None:
+        annotations["label"] = label
     return _Capability(
         "agent",
         {
@@ -166,7 +178,9 @@ def agent(agent_id: str, input: Any, output_schema: Any = None) -> _Capability:
             "output_schema": None
             if output_schema is None
             else canonical_schema_json(output_schema),
+            "model": model,
         },
+        annotations,
     )
 
 
@@ -775,6 +789,7 @@ def _drive(root_coro: Any, memo: dict[str, Any], emit: Any) -> None:
                 "capability_id": yielded.capability_id,
                 "call_key": call_key,
                 "spec": yielded.spec,
+                "annotations": yielded.annotations,
             }
         )
     emit({"type": SUSPENDED})

--- a/tests/e2e/test_step_model.py
+++ b/tests/e2e/test_step_model.py
@@ -956,6 +956,7 @@ class TestSessionVersionBinding:
         await harness.run_until_idle(session.id)
 
         # Update the agent's system prompt
+        assert session.agent_id is not None
         agent = await agents_service.get_agent(
             harness._pool, session.agent_id, account_id=account_id
         )
@@ -998,6 +999,7 @@ class TestSessionVersionBinding:
         )
 
         # Update agent to version 2
+        assert session.agent_id is not None
         agent = await agents_service.get_agent(
             harness._pool, session.agent_id, account_id=account_id
         )

--- a/tests/fixtures/replay_semantics_fingerprint.json
+++ b/tests/fixtures/replay_semantics_fingerprint.json
@@ -30,7 +30,7 @@
       "session_id": "sess_6NB6RKY6R8JZWHWAJDAGB7GR87"
     }
   ],
-  "epoch": 1,
+  "epoch": 2,
   "surface": {
     "importable_modules": [
       "base64",

--- a/tests/integration/test_trigger_event_fires.py
+++ b/tests/integration/test_trigger_event_fires.py
@@ -281,6 +281,7 @@ async def test_timer_fire_threads_owner_lineage(trig_runtime: asyncpg.Pool[Any])
         agent_id=agent.id,
         environment_id=env.id,
         agent_version=agent.version,
+        model=None,
         parent_run_id=parent_run.id,
         surface=Surface([], [], []),
         vault_ids=[],

--- a/tests/integration/test_wf_host.py
+++ b/tests/integration/test_wf_host.py
@@ -82,7 +82,7 @@ async def test_memoized_result_fast_forwards() -> None:
 async def test_memoized_error_outcome_throws_agent_error() -> None:
     """An {"error"} memo outcome is thrown at the await as AgentError; uncaught, it
     propagates out of main and terminates the run (the bubble)."""
-    src = "async def main(input):\n    return await agent('a1', 'go')"
+    src = "async def main(input):\n    return await agent('go', agent_id='a1')"
     first = await _run(src)
     key = first.emitted[0].call_key
     out = await _run(src, memo={key: {"error": {"message": "boom"}}})
@@ -96,7 +96,7 @@ async def test_memoized_error_outcome_is_catchable() -> None:
     src = (
         "async def main(input):\n"
         "    try:\n"
-        "        await agent('a1', 'go')\n"
+        "        await agent('go', agent_id='a1')\n"
         "    except AgentError as e:\n"
         "        return {'caught': True, 'kind': e.kind}\n"
         "    return {'caught': False}"
@@ -114,7 +114,7 @@ async def test_no_return_outcome_raises_agent_no_return_subtype() -> None:
     catch_base = (
         "async def main(input):\n"
         "    try:\n"
-        "        await agent('a1', 'go')\n"
+        "        await agent('go', agent_id='a1')\n"
         "    except AgentError as e:\n"
         "        return isinstance(e, AgentNoReturnError)"
     )
@@ -152,19 +152,49 @@ async def test_author_exception_is_terminal_raised() -> None:
 
 
 async def test_agent_emits_a_frontier_for_block2() -> None:
-    out = await _run("async def main(input):\n    return await agent('a1', input={'p': 1})")
+    out = await _run(
+        "async def main(input):\n    return await agent(input={'p': 1}, agent_id='a1')"
+    )
     assert out.kind == "suspended"
     assert out.emitted[0].capability_id == "agent"
+
+
+async def test_generic_agent_spec_has_four_keys() -> None:
+    out = await _run("async def main(input):\n    return await agent({'p': 1})")
+    assert out.kind == "suspended"
+    assert out.emitted[0].spec == {
+        "agent_id": None,
+        "input": {"p": 1},
+        "output_schema": None,
+        "model": None,
+    }
+
+
+async def test_agent_label_excluded_from_call_key_model_included() -> None:
+    a = await _run("async def main(input):\n    return await agent('go', label='one')")
+    b = await _run("async def main(input):\n    return await agent('go', label='two')")
+    c = await _run("async def main(input):\n    return await agent('go', model='m')")
+    assert a.emitted[0].call_key == b.emitted[0].call_key
+    assert a.emitted[0].call_key != c.emitted[0].call_key
+    assert a.emitted[0].annotations == {"label": "one"}
+
+
+async def test_old_positional_agent_form_raises_typeerror() -> None:
+    out = await _run("async def main(input):\n    return await agent('a1', {'p': 1})")
+    assert out.kind == "raised"
+    assert "TypeError" in (out.error_repr or "")
 
 
 async def test_agent_requires_non_none_input() -> None:
     # input is required: a child born with no first user message would sit idle
     # forever. A bad call raises in the author's script → terminal RAISED.
-    missing = await _run("async def main(input):\n    return await agent('a1')")
+    missing = await _run("async def main(input):\n    return await agent(agent_id='a1')")
     assert missing.kind == "raised"
     assert "input" in (missing.error_repr or "")  # TypeError: missing required 'input'
 
-    explicit_none = await _run("async def main(input):\n    return await agent('a1', None)")
+    explicit_none = await _run(
+        "async def main(input):\n    return await agent(None, agent_id='a1')"
+    )
     assert explicit_none.kind == "raised"
     assert "non-None input" in (explicit_none.error_repr or "")
 
@@ -363,7 +393,7 @@ async def test_non_json_return_is_an_author_error_not_a_host_crash() -> None:
 
 _PARALLEL_SRC = (
     "async def main(input):\n"
-    "    return await parallel([lambda: agent('a', '1'), lambda: agent('b', '2')])"
+    "    return await parallel([lambda: agent('1', agent_id='a'), lambda: agent('2', agent_id='b')])"
 )
 
 
@@ -406,10 +436,10 @@ async def test_parallel_branch_can_catch_agent_error() -> None:
         "async def main(input):\n"
         "    async def safe():\n"
         "        try:\n"
-        "            return await agent('a', '1')\n"
+        "            return await agent('1', agent_id='a')\n"
         "        except AgentError:\n"
         "            return 'fallback'\n"
-        "    return await parallel([safe, lambda: agent('b', '2')])"
+        "    return await parallel([safe, lambda: agent('2', agent_id='b')])"
     )
     first = await _run(src)
     k0, k1 = (e.call_key for e in first.emitted)
@@ -426,7 +456,7 @@ async def test_parallel_non_agent_error_fails_the_run() -> None:
         "async def main(input):\n"
         "    async def boom():\n"
         "        raise ValueError('author bug in a branch')\n"
-        "    return await parallel([boom, lambda: agent('b', '2')])"
+        "    return await parallel([boom, lambda: agent('2', agent_id='b')])"
     )
     out = await _run(src)
     assert out.kind == "raised"
@@ -445,7 +475,7 @@ async def test_parallel_absorbs_author_raised_agent_error() -> None:
         "async def main(input):\n"
         "    async def manual():\n"
         "        raise AgentError('treat as a failed agent')\n"
-        "    return await parallel([manual, lambda: agent('b', '2')])"
+        "    return await parallel([manual, lambda: agent('2', agent_id='b')])"
     )
     first = await _run(src)
     assert first.kind == "suspended"
@@ -468,7 +498,7 @@ async def test_parallel_fanout_over_cap_raises_before_spawning() -> None:
     n = MAX_PARALLEL_FANOUT + 1
     src = (
         "async def main(input):\n"
-        f"    return await parallel([(lambda: agent('a', 'x')) for _ in range({n})])"
+        f"    return await parallel([(lambda: agent('x', agent_id='a')) for _ in range({n})])"
     )
     out = await _run(src)
     assert out.kind == "raised"
@@ -484,7 +514,7 @@ async def test_parallel_fanout_at_cap_is_allowed() -> None:
     n = MAX_PARALLEL_FANOUT
     src = (
         "async def main(input):\n"
-        f"    return await parallel([(lambda: agent('a', str(i))) for i in range({n})])"
+        f"    return await parallel([(lambda: agent(str(i), agent_id='a')) for i in range({n})])"
     )
     out = await _run(src)
     assert out.kind == "suspended"
@@ -496,7 +526,7 @@ async def test_pipeline_runs_each_item_through_stages() -> None:
     leaf) independently; all items fan out at once."""
     src = (
         "async def main(input):\n"
-        "    return await pipeline([1, 10], lambda x: x + 1, lambda x: agent('s', x))"
+        "    return await pipeline([1, 10], lambda x: x + 1, lambda x: agent(x, agent_id='s'))"
     )
     first = await _run(src)
     assert first.kind == "suspended"
@@ -552,7 +582,7 @@ async def test_pipeline_none_short_circuit_on_agent_error() -> None:
     regress it.)"""
     src = (
         "async def main(input):\n"
-        "    return await pipeline([1, 2], lambda x: agent('s', x),"
+        "    return await pipeline([1, 2], lambda x: agent(x, agent_id='s'),"
         " lambda prev, item, index: prev + 1)"
     )
     first = await _run(src)
@@ -582,9 +612,9 @@ async def test_parallel_keys_are_branch_local_under_asymmetric_depth() -> None:
         "async def main(input):\n"
         "    async def b0():\n"
         "        await gate('g')\n"
-        "        return await agent('p', 'x')\n"
+        "        return await agent('x', agent_id='p')\n"
         "    async def b1():\n"
-        "        return await agent('p', 'x')\n"
+        "        return await agent('x', agent_id='p')\n"
         "    return await parallel([b0, b1])"
     )
     # Drive 1 (empty memo): b0 blocks on its gate; b1 emits the shared agent.

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -499,6 +499,13 @@ async def test_run_children_usage_sums_direct_children_and_includes_archived(
     await wf_conn.execute(
         "INSERT INTO agents (id, name, model, system, account_id) VALUES ('agent_usage', 'usage-agent', 'm', 's', 'acc_root')"
     )
+    # Named workflow children must carry a pinned agent_version (0095's
+    # sessions_agent_version_pair_ck: a child with agent_id set requires a
+    # non-NULL agent_version); seed the matching agent_versions row.
+    await wf_conn.execute(
+        "INSERT INTO agent_versions (agent_id, version, model, system, account_id) "
+        "VALUES ('agent_usage', 1, 'm', 's', 'acc_root')"
+    )
     await wf_conn.execute(
         """
         INSERT INTO sessions (
@@ -506,8 +513,8 @@ async def test_run_children_usage_sums_direct_children_and_includes_archived(
             workspace_volume_path, account_id, parent_run_id, input_tokens, output_tokens,
             cache_read_input_tokens, cache_creation_input_tokens, cost_microusd, archived_at
         ) VALUES
-            ('ses_child_a', 'agent_usage', 'env_root', NULL, NULL, '{}'::jsonb, '/tmp/a', 'acc_root', $1, 10, 20, 3, 4, 123456, NULL),
-            ('ses_child_b', 'agent_usage', 'env_root', NULL, NULL, '{}'::jsonb, '/tmp/b', 'acc_root', $1, 1, 2, 5, 6, 654321, now())
+            ('ses_child_a', 'agent_usage', 'env_root', 1, NULL, '{}'::jsonb, '/tmp/a', 'acc_root', $1, 10, 20, 3, 4, 123456, NULL),
+            ('ses_child_b', 'agent_usage', 'env_root', 1, NULL, '{}'::jsonb, '/tmp/b', 'acc_root', $1, 1, 2, 5, 6, 654321, now())
         """,
         run_id,
     )

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -862,6 +862,7 @@ async def _spawn_child(
         agent_id=agent.id,
         environment_id=ENV,
         agent_version=agent.version,
+        model=None,
         parent_run_id=run_id,
         surface=surface,
         vault_ids=vault_ids or [],

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -4370,9 +4370,15 @@ async def test_over_budget_agent_refusal_is_catchable(
         await conn.execute(
             "INSERT INTO agents (id, name, model, system, account_id) VALUES ('agent_cost_seed', 'cost-seed', 'm', 's', 'acc_wf')"
         )
+        # Named workflow children must carry a pinned agent_version (0095's
+        # sessions_agent_version_pair_ck); seed the matching agent_versions row.
+        await conn.execute(
+            "INSERT INTO agent_versions (agent_id, version, model, system, account_id) "
+            "VALUES ('agent_cost_seed', 1, 'm', 's', 'acc_wf')"
+        )
         await conn.execute(
             "INSERT INTO sessions (id, agent_id, environment_id, agent_version, title, metadata, workspace_volume_path, account_id, parent_run_id, cost_microusd) "
-            "VALUES ('ses_cost_seed', 'agent_cost_seed', 'env_wf', NULL, NULL, '{}'::jsonb, '/tmp/cost', 'acc_wf', $1, 1000000)",
+            "VALUES ('ses_cost_seed', 'agent_cost_seed', 'env_wf', 1, NULL, '{}'::jsonb, '/tmp/cost', 'acc_wf', $1, 1000000)",
             run.id,
         )
     await run_workflow_step(run.id)

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -148,6 +148,7 @@ async def _spawn_child(
         agent_id=agent_id,
         environment_id="env_wf",
         agent_version=1,
+        model=None,
         parent_run_id=run_id,
         surface=Surface([], [], []),
         vault_ids=[],
@@ -175,6 +176,7 @@ async def test_create_child_session_idempotent(
         agent_id=wf_agent_id,
         environment_id="env_wf",
         agent_version=1,
+        model=None,
         parent_run_id=run_id,
         surface=Surface([], [], []),
         vault_ids=[],
@@ -190,6 +192,7 @@ async def test_create_child_session_idempotent(
         agent_id=wf_agent_id,
         environment_id="env_wf",
         agent_version=1,
+        model=None,
         parent_run_id=run_id,
         surface=Surface([], [], []),
         vault_ids=[],
@@ -550,7 +553,7 @@ async def test_agent_spawn_creates_child_and_suspends(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     pool = wf_runtime
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, {{'task': 'go'}})\n"
+    script = f"async def main(input):\n    return await agent({{'task': 'go'}}, agent_id={wf_agent_id!r})\n"
     run_id = await _make_run(pool, script)
     with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as child_wake:
         await run_workflow_step(run_id)
@@ -578,12 +581,45 @@ async def test_agent_spawn_creates_child_and_suspends(
     child_wake.assert_awaited_once()  # prompt wake of the child
 
 
+async def test_generic_agent_spawn_creates_agentless_child_with_run_surface(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    pool = wf_runtime
+    script = "async def main(input):\n    return await agent({'task': 'go'}, model='test/generic', label='generic')\n"
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(
+            conn,
+            account_id="acc_wf",
+            name="generic-w",
+            script=script,
+            tools=[ToolSpec(type="web_search")],
+        )
+    run = await service.create_run(
+        pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf"
+    )
+    await run_workflow_step(run.id)
+
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run.id)
+        started = next(e for e in events if e.type == "call_started")
+        child = await db_queries.get_session_bare(
+            conn, started.payload["child_session_id"], account_id="acc_wf"
+        )
+        frozen = await db_queries.get_session_frozen_surface(conn, child.id, account_id="acc_wf")
+    assert started.payload["label"] == "generic"
+    assert started.payload["child_agent_version"] is None
+    assert child.agent_id is None
+    assert child.agent_version is None
+    assert child.model == "test/generic"
+    assert frozen == Surface(tools=[ToolSpec(type="web_search")], mcp_servers=[], http_servers=[])
+
+
 async def test_agent_spawn_idempotent_on_replay(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     """C1/C2/C6: a re-step (crash replay) must NOT double-spawn or re-deliver input."""
     pool = wf_runtime
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi')\n"
+    script = f"async def main(input):\n    return await agent('hi', agent_id={wf_agent_id!r})\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # wake 1: spawn
     await run_workflow_step(run_id)  # wake 2: replay — re-emits the same frontier
@@ -615,7 +651,7 @@ async def test_agent_not_found_is_catchable(wf_runtime: asyncpg.Pool[Any]) -> No
     script = (
         "async def main(input):\n"
         "    try:\n"
-        "        await agent('agent_nope', 'x')\n"
+        "        await agent('x', agent_id='agent_nope')\n"
         "    except AgentError as e:\n"
         "        return {'caught': True, 'kind': e.kind, 'msg': str(e)}\n"
         "    return {'caught': False}\n"
@@ -656,7 +692,7 @@ async def test_bad_agent_call_invalid_schema_is_catchable(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'hi', output_schema={bad_schema!r})\n"
+        f"        await agent('hi', output_schema={bad_schema!r}, agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'caught': True, 'kind': e.kind, 'msg': str(e)}\n"
         "    return {'caught': False}\n"
@@ -694,7 +730,7 @@ async def test_bad_agent_call_non_string_agent_id_is_catchable(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        "        await agent(123, 'hi')\n"
+        "        await agent('hi', agent_id=123)\n"
         "    except AgentError as e:\n"
         "        return {'caught': True, 'kind': e.kind, 'msg': str(e)}\n"
         "    return {'caught': False}\n"
@@ -713,12 +749,12 @@ async def test_bad_agent_call_non_string_agent_id_is_catchable(
     assert run.output == {
         "caught": True,
         "kind": "bad_agent_call",
-        "msg": "agent() requires a string agent_id, got 123",
+        "msg": "agent() requires agent_id to be a string or None, got 123",
     }
     cr = next(e for e in events if e.type == "call_result")
     assert cr.payload["error"] == {
         "kind": "bad_agent_call",
-        "message": "agent() requires a string agent_id, got 123",
+        "message": "agent() requires agent_id to be a string or None, got 123",
     }
     assert children == 0
 
@@ -737,9 +773,9 @@ async def test_one_bad_branch_in_fanout_does_not_terminate_the_run(
     script = (
         "async def main(input):\n"
         "    return await parallel([\n"
-        "        lambda: agent('agent_nope', 'x'),\n"
-        f"        lambda: agent({wf_agent_id!r}, 'a'),\n"
-        f"        lambda: agent({wf_agent_id!r}, 'b'),\n"
+        "        lambda: agent('x', agent_id='agent_nope'),\n"
+        f"        lambda: agent('a', agent_id={wf_agent_id!r}),\n"
+        f"        lambda: agent('b', agent_id={wf_agent_id!r}),\n"
         "    ])\n"
     )
     run_id = await _make_run(pool, script)
@@ -791,7 +827,7 @@ async def test_spawn_error_call_result_has_no_paired_call_started(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        "        await agent('agent_nope', 'x')\n"
+        "        await agent('x', agent_id='agent_nope')\n"
         "    except AgentError:\n"
         "        return 'caught'\n"
     )
@@ -1056,7 +1092,7 @@ async def test_reattach_skips_defer_wake_and_self_wakes_on_marker(
     _SPAWN_KW = {"agent_spawns": 0, "max_agent_calls": 1000}
 
     pool = wf_runtime
-    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    script = f"async def main(input):\n    await agent('go', agent_id={wf_agent_id!r})\n    return 'done'\n"
     run_id = await _make_run(pool, script)
     spec = {"agent_id": wf_agent_id, "input": "go", "output_schema": None}
     call_key = CallKeyer().next("agent", spec)
@@ -1114,7 +1150,7 @@ async def test_agent_round_trip_harvest_completes_run(
     from aios.tools import workflow_completion
 
     pool = wf_runtime
-    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    script = f"async def main(input):\n    await agent('go', agent_id={wf_agent_id!r})\n    return 'done'\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     child_id = await _child_id_of(pool, run_id)
@@ -1150,7 +1186,7 @@ async def test_uncaught_agent_error_bubbles_and_errors_the_run(
     from aios.tools import workflow_completion
 
     pool = wf_runtime
-    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    script = f"async def main(input):\n    await agent('go', agent_id={wf_agent_id!r})\n    return 'done'\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     child_id = await _child_id_of(pool, run_id)
@@ -1181,7 +1217,7 @@ async def test_workflow_try_except_agent_error_continues(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'go')\n"
+        f"        await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'caught': True, 'kind': e.kind}\n"
         "    return {'caught': False}\n"
@@ -1209,7 +1245,7 @@ async def test_workflow_uses_agent_return_value(
     from aios.tools import workflow_completion
 
     pool = wf_runtime
-    script = f"async def main(input):\n    r = await agent({wf_agent_id!r}, 'go')\n    return {{'got': r}}\n"
+    script = f"async def main(input):\n    r = await agent('go', agent_id={wf_agent_id!r})\n    return {{'got': r}}\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     child_id = await _child_id_of(pool, run_id)
@@ -1235,7 +1271,7 @@ async def test_model_failure_writes_error_response_and_run_resolves(
     from aios.harness import loop
 
     pool = wf_runtime
-    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    script = f"async def main(input):\n    await agent('go', agent_id={wf_agent_id!r})\n    return 'done'\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     child_id = await _child_id_of(pool, run_id)
@@ -1427,7 +1463,7 @@ async def test_non_answering_child_resolves_run_via_agent_no_return_error(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'go')\n"
+        f"        await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentNoReturnError:\n"
         "        return 'gave-up'\n"
     )
@@ -1652,7 +1688,7 @@ async def test_operator_archived_child_resolves_run_as_child_gone(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'go')\n"
+        f"        await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'caught': True, 'kind': e.kind}\n"
     )
@@ -1698,7 +1734,7 @@ async def test_operator_deleted_child_resolves_run_as_child_gone(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'go')\n"
+        f"        await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return e.kind\n"
     )
@@ -1734,7 +1770,7 @@ async def test_archive_child_commits_response_and_child_done_atomically(
     """Acceptance #3: the child_gone response, its child_done signal, and the
     archived_at flip all commit in ONE transaction — observable together afterward."""
     pool = wf_runtime
-    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    script = f"async def main(input):\n    await agent('go', agent_id={wf_agent_id!r})\n    return 'done'\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     child_id = await _child_id_of(pool, run_id)
@@ -1782,8 +1818,8 @@ async def test_parallel_spawns_fanout_and_collects_results_in_order(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, 'a'),"
-        f" lambda: agent({wf_agent_id!r}, 'b')])\n"
+        f"    return await parallel([lambda: agent('a', agent_id={wf_agent_id!r}),"
+        f" lambda: agent('b', agent_id={wf_agent_id!r})])\n"
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # drive parallel -> spawn both children + suspend
@@ -1812,8 +1848,8 @@ async def test_parallel_barrier_yields_none_for_an_errored_child(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, 'a'),"
-        f" lambda: agent({wf_agent_id!r}, 'b')])\n"
+        f"    return await parallel([lambda: agent('a', agent_id={wf_agent_id!r}),"
+        f" lambda: agent('b', agent_id={wf_agent_id!r})])\n"
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
@@ -1854,7 +1890,7 @@ async def test_lifetime_agent_cap_errors_at_the_over_cap_spawn(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(3)])\n"
+        f"    return await parallel([lambda: agent(str(i), agent_id={wf_agent_id!r}) for i in range(3)])\n"
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # 3 > cap 2 → error AT the 3rd spawn
@@ -1888,7 +1924,7 @@ async def test_agent_cap_at_boundary_is_allowed(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(3)])\n"
+        f"    return await parallel([lambda: agent(str(i), agent_id={wf_agent_id!r}) for i in range(3)])\n"
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # 3 == cap 3 → allowed
@@ -1912,7 +1948,7 @@ async def test_lowering_cap_mid_flight_does_not_kill_a_harvest_only_step(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(2)])\n"
+        f"    return await parallel([lambda: agent(str(i), agent_id={wf_agent_id!r}) for i in range(2)])\n"
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn 2 under the default (high) cap
@@ -1954,10 +1990,10 @@ async def test_rejected_agent_cap_does_not_count_toward_quota(
     # One prior real spawn, THEN the bad+good fan-out: prior=1, one real spawn left.
     script = (
         "async def main(input):\n"
-        f"    await agent({wf_agent_id!r}, 'first')\n"
+        f"    await agent('first', agent_id={wf_agent_id!r})\n"
         "    return await parallel([\n"
-        "        lambda: agent('agent_nope', 'x'),\n"
-        f"        lambda: agent({wf_agent_id!r}, 'y'),\n"
+        "        lambda: agent('x', agent_id='agent_nope'),\n"
+        f"        lambda: agent('y', agent_id={wf_agent_id!r}),\n"
         "    ])\n"
     )
     run_id = await _make_run(pool, script)
@@ -2019,9 +2055,9 @@ async def test_real_overquota_fanout_still_errors_too_many_agents(
     script = (
         "async def main(input):\n"
         "    return await parallel([\n"
-        f"        lambda: agent({wf_agent_id!r}, 'a'),\n"
-        f"        lambda: agent({wf_agent_id!r}, 'b'),\n"
-        f"        lambda: agent({wf_agent_id!r}, 'c'),\n"
+        f"        lambda: agent('a', agent_id={wf_agent_id!r}),\n"
+        f"        lambda: agent('b', agent_id={wf_agent_id!r}),\n"
+        f"        lambda: agent('c', agent_id={wf_agent_id!r}),\n"
         "    ])\n"
     )
     run_id = await _make_run(pool, script)
@@ -2096,7 +2132,7 @@ async def test_wave_admits_in_waves_as_children_resolve(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(5)])\n"
+        f"    return await parallel([lambda: agent(str(i), agent_id={wf_agent_id!r}) for i in range(5)])\n"
     )
     run_id = await _make_run(pool, script)
     # Each admitted child returns a value derived from ITS call_key, so the final
@@ -2175,7 +2211,7 @@ async def test_harvest_only_resuspend_with_deferred_outstanding_no_error(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(3)])\n"
+        f"    return await parallel([lambda: agent(str(i), agent_id={wf_agent_id!r}) for i in range(3)])\n"
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # 2 admitted, 1 deferred
@@ -2220,7 +2256,7 @@ async def test_wave_gate_does_not_mask_or_false_trip_lifetime_cap(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(5)])\n"
+        f"    return await parallel([lambda: agent(str(i), agent_id={wf_agent_id!r}) for i in range(5)])\n"
     )
     run_id = await _make_run(pool, script)
 
@@ -2302,7 +2338,7 @@ async def test_frontier_deferred_marker_is_idempotent_and_seq_gapless(
     pool = wf_runtime
     script = (
         "async def main(input):\n"
-        f"    return await parallel([lambda: agent({wf_agent_id!r}, str(i)) for i in range(4)])\n"
+        f"    return await parallel([lambda: agent(str(i), agent_id={wf_agent_id!r}) for i in range(4)])\n"
     )
     run_id = await _make_run(pool, script)
 
@@ -2353,7 +2389,7 @@ async def test_agent_call_times_out_when_child_never_responds(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        f"        return await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'timed_out': e.kind}\n"
     )
@@ -2397,7 +2433,7 @@ async def test_past_deadline_child_that_already_responded_keeps_its_real_respons
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        f"        return await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'timed_out': e.kind}\n"
     )
@@ -2438,7 +2474,7 @@ async def test_past_deadline_gone_child_resolves_as_child_gone_not_timeout(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        f"        return await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'kind': e.kind}\n"
     )
@@ -2473,7 +2509,7 @@ async def test_child_archived_in_timeout_write_window_resolves_as_child_gone(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        return await agent({wf_agent_id!r}, 'go')\n"
+        f"        return await agent('go', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'kind': e.kind}\n"
     )
@@ -2511,7 +2547,7 @@ async def test_agent_stays_suspended_until_marker(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     pool = wf_runtime
-    script = f"async def main(input):\n    await agent({wf_agent_id!r}, 'go')\n    return 'done'\n"
+    script = f"async def main(input):\n    await agent('go', agent_id={wf_agent_id!r})\n    return 'done'\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
     await run_workflow_step(run_id)  # marker absent -> stays suspended, no call_result
@@ -2625,7 +2661,7 @@ async def test_epoch_mismatch_fails_child_open_requests(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     pool = wf_runtime
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi')\n"
+    script = f"async def main(input):\n    return await agent('hi', agent_id={wf_agent_id!r})\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     children = await _children_of(pool, run_id)
@@ -2657,7 +2693,7 @@ async def test_nondeterministic_replay_fails_child_open_requests(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:
     pool = wf_runtime
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'hi')\n"
+    script = f"async def main(input):\n    return await agent('hi', agent_id={wf_agent_id!r})\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     children = await _children_of(pool, run_id)
@@ -3113,7 +3149,7 @@ async def test_malformed_output_schema_errors_the_run(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'hi', output_schema={bad_schema!r})\n"
+        f"        await agent('hi', output_schema={bad_schema!r}, agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'kind': e.kind, 'msg': str(e)}\n"
         "    return {'caught': False}\n"
@@ -3146,7 +3182,7 @@ async def test_non_object_output_schema_errors_the_run(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'hi', output_schema=False)\n"
+        f"        await agent('hi', output_schema=False, agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'kind': e.kind, 'msg': str(e)}\n"
         "    return {'caught': False}\n"
@@ -3180,7 +3216,7 @@ async def test_agent_output_schema_end_to_end(
     pool = wf_runtime
     script = (
         f"async def main(input):\n"
-        f"    return await agent({wf_agent_id!r}, 'task', output_schema={_OBJ_SCHEMA!r})\n"
+        f"    return await agent('task', output_schema={_OBJ_SCHEMA!r}, agent_id={wf_agent_id!r})\n"
     )
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)  # spawn + suspend
@@ -3230,7 +3266,7 @@ async def test_float_bearing_output_schema_spawns_and_enforces(
 
     pool = wf_runtime
     schema = {"type": "number", "minimum": 1.5, "maximum": 9.5}
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'pick', output_schema={schema!r})\n"
+    script = f"async def main(input):\n    return await agent('pick', output_schema={schema!r}, agent_id={wf_agent_id!r})\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
 
@@ -3273,7 +3309,7 @@ async def test_valid_local_ref_output_schema_spawns(
         "properties": {"name": {"$ref": "#/$defs/Name"}},
         "required": ["name"],
     }
-    script = f"async def main(input):\n    return await agent({wf_agent_id!r}, 'x', output_schema={schema!r})\n"
+    script = f"async def main(input):\n    return await agent('x', output_schema={schema!r}, agent_id={wf_agent_id!r})\n"
     run_id = await _make_run(pool, script)
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
@@ -3297,7 +3333,7 @@ async def test_dangling_ref_output_schema_errors_the_run(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'x', output_schema={schema!r})\n"
+        f"        await agent('x', output_schema={schema!r}, agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'kind': e.kind, 'msg': str(e)}\n"
         "    return {'caught': False}\n"
@@ -4069,8 +4105,8 @@ async def test_bash_dispatches_while_agent_frontier_deferred(
     script = (
         "async def main(input):\n"
         "    return await parallel([\n"
-        f"        lambda: agent({wf_agent_id!r}, 'a'),\n"
-        f"        lambda: agent({wf_agent_id!r}, 'b'),\n"
+        f"        lambda: agent('a', agent_id={wf_agent_id!r}),\n"
+        f"        lambda: agent('b', agent_id={wf_agent_id!r}),\n"
         "        lambda: tool('bash', {'command': 'echo hi'}),\n"
         "    ])\n"
     )
@@ -4319,7 +4355,7 @@ async def test_over_budget_agent_refusal_is_catchable(
     script = (
         "async def main(input):\n"
         "    try:\n"
-        f"        await agent({wf_agent_id!r}, 'x')\n"
+        f"        await agent('x', agent_id={wf_agent_id!r})\n"
         "    except AgentError as e:\n"
         "        return {'kind': e.kind, 'msg': str(e)}\n"
     )

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0094``."""
+    """The migration ladder has exactly one head: ``0095``."""
     script = _script_directory()
-    assert script.get_heads() == ["0094"]
+    assert script.get_heads() == ["0095"]
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
Implements the generic workflow subagent path and reshapes `agent()` to the new input-first signature.

What changed:
- Adds `agent(input, *, agent_id=None, output_schema=None, model=None, label=None)` in the workflow host.
- Supports generic agent-less workflow children with nullable `sessions.agent_id` / `agent_version`, stamped `sessions.model`, and frozen run surface copied verbatim.
- Adds `GENERIC_CHILD_SYSTEM` with the fixed return-contract prompt.
- Adds per-call model override and call-start label journaling while keeping labels out of call keys.
- Adds `wf_runs.default_child_model`, HTTP/operator launch default handling, config fallback, and launcher-model snapshotting.
- Updates session model resolution and agent loading for generic children and named children with model overrides.
- Bumps `HOST_SEMANTICS_EPOCH` and regenerates replay fingerprint.
- Adds migration `0095_generic_workflow_children.py`.
- Regenerates OpenAPI and SDK models.

Validation:
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src tests`
- `uv run pytest tests/unit -q`
- Targeted workflow-host tests for generic spec, label/model key split, and old positional TypeError
- Pre-commit hook also ran ruff, mypy, unit tests, and connector tests successfully.

Mutation check:
- Temporarily removed the `model` key contribution from the workflow host spec; the new model-vs-label call-key test failed, then passed after restoring.

Closes #787