### PR TITLE
fix: evict MCP pool sessions on operator credential rotation (#1030)

### DIFF
--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -568,6 +568,55 @@ async def listen_for_session_interrupts(
         conn.terminate()
 
 
+MCP_EVICT_VAULT_CHANNEL = "aios_mcp_evict_vault"
+
+
+@asynccontextmanager
+async def listen_for_mcp_evict_vault(
+    db_url: str,
+) -> AsyncIterator[asyncio.Queue[str]]:
+    """Yield ``vault_id`` payloads from the MCP-pool eviction channel.
+
+    An operator credential mutation (PUT/archive/delete on a vault
+    credential, plus vault archive/delete) runs in the API process and
+    fires a NOTIFY on this channel; the worker — which owns the MCP session
+    pool — LISTENs here and evicts the pooled sessions keyed on that vault
+    so the rotated secret propagates immediately instead of waiting out the
+    900s idle TTL that active use defeats (#1030).
+
+    Delivery is fire-and-forget (no durable backfill row), exactly like
+    :func:`listen_for_session_interrupts`: an eviction emitted while this
+    dedicated LISTEN connection is reconnecting is lost, but the idle reaper
+    remains the safety net and a subsequent mutation re-fires. Silent drops
+    are made detectable by TCP keepalive plus a termination listener that
+    wakes the consumer into the worker-level reconnect loop.
+    """
+    conn = await _connect_listener(db_url)
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1024)
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning("listen.mcp_evict_vault_queue_full")
+
+        def _termination_callback(_conn: asyncpg.Connection[object]) -> None:
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait("")
+
+        conn.add_termination_listener(_termination_callback)
+        await conn.add_listener(MCP_EVICT_VAULT_CHANNEL, _callback)
+        yield queue
+    finally:
+        conn.terminate()
+
+
 # Channel VALUE is byte-identical across the #818 rename (the underlying
 # Postgres NOTIFY trigger function ``notify_scheduled_tasks_due`` and its
 # channel string stay put — renaming buys nothing and opens a deploy window

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -35,7 +35,7 @@ import asyncpg
 import aios.tools  # noqa: F401  — side-effect: register built-in tools
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
-from aios.db.listen import listen_for_session_interrupts
+from aios.db.listen import listen_for_mcp_evict_vault, listen_for_session_interrupts
 from aios.db.pool import LISTENER_TCP_KEEPALIVE_SETTINGS, create_pool, normalize_dsn
 from aios.harness import runtime
 from aios.harness.attachment_gc import sweep_orphan_attachments
@@ -211,6 +211,7 @@ async def worker_main() -> None:
     procrastinate_opened = False
     sweep_task: asyncio.Task[None] | None = None
     interrupt_task: asyncio.Task[None] | None = None
+    mcp_evict_task: asyncio.Task[None] | None = None
     heartbeat_task: asyncio.Task[None] | None = None
     scheduler_task: asyncio.Task[None] | None = None
     supervised_latch = asyncio.Event()
@@ -330,6 +331,15 @@ async def worker_main() -> None:
         )
         _supervise(interrupt_task, latch=supervised_latch, fatal=supervised_failure)
 
+        # Listen for operator credential-rotation NOTIFYs and evict the
+        # rotated vault's pooled MCP sessions so the new secret propagates
+        # immediately, instead of waiting out the idle TTL (#1030).
+        mcp_evict_task = asyncio.create_task(
+            _run_mcp_evict_listener(settings.db_url),
+            name="mcp_evict_listener",
+        )
+        _supervise(mcp_evict_task, latch=supervised_latch, fatal=supervised_failure)
+
         # Start event-driven scheduler. Sleeps until the next due
         # ``next_fire``, woken early by NOTIFY on
         # ``aios_scheduled_tasks_due`` (insert/delete or
@@ -401,6 +411,8 @@ async def worker_main() -> None:
             await _cancel_and_drain(sweep_task)
         if interrupt_task is not None:
             await _cancel_and_drain(interrupt_task)
+        if mcp_evict_task is not None:
+            await _cancel_and_drain(mcp_evict_task)
         if scheduler_task is not None:
             await _cancel_and_drain(scheduler_task)
         if sandbox_registry is not None:
@@ -579,4 +591,51 @@ async def _run_interrupt_listener(
             raise
         except Exception:
             log.exception("interrupt_listener.listen_failed_will_retry")
+            await asyncio.sleep(_LISTEN_RECONNECT_BACKOFF_SECONDS)
+
+
+async def _run_mcp_evict_listener(db_url: str) -> None:
+    """Drain pg_notify on the MCP-pool eviction channel and evict pooled
+    sessions for the rotated vault.
+
+    An operator credential mutation (PUT/archive/delete on a vault
+    credential, plus vault archive/delete) runs in the API process and
+    NOTIFYs ``aios_mcp_evict_vault`` with the ``vault_id``. The worker owns
+    the MCP session pool, so it LISTENs here and calls
+    :meth:`McpSessionPool.evict_by_vault` — discarding idle sessions and
+    flagging in-use ones for discard-on-release so the rotated secret
+    propagates immediately, instead of waiting out the 900s idle TTL that
+    active polling defeats (#1030).
+
+    Mirrors :func:`_run_interrupt_listener`'s survivability contract: the
+    dispatch try/except is nested INSIDE ``while True`` so a transient
+    eviction failure doesn't disable the listener for the worker's lifetime;
+    LISTEN-connection failures escape to the outer reconnect loop.
+    ``CancelledError`` propagates so worker shutdown stays clean.
+    """
+    log = get_logger("aios.worker.mcp_evict_listener")
+    while True:
+        try:
+            async with listen_for_mcp_evict_vault(db_url) as queue:
+                while True:
+                    try:
+                        vault_id = await queue.get()
+                        if vault_id == "":
+                            raise ConnectionError("mcp evict LISTEN connection terminated")
+                        pool = runtime.mcp_session_pool
+                        if pool is None:
+                            # Pool not yet initialized (startup race) or already
+                            # torn down — nothing to evict; the idle reaper and
+                            # a fresh pool cover the gap.
+                            continue
+                        await pool.evict_by_vault(vault_id)
+                        log.info("mcp_evict_listener.dispatch", vault_id=vault_id)
+                    except ConnectionError:
+                        raise
+                    except Exception:
+                        log.exception("mcp_evict_listener.dispatch_failed")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("mcp_evict_listener.listen_failed_will_retry")
             await asyncio.sleep(_LISTEN_RECONNECT_BACKOFF_SECONDS)

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -161,6 +161,11 @@ class _Entry:
         # vector (a vault whose tenant never returns) — defense-in-depth
         # signed off in #459's planning round, not silent accretion.
         self.last_used = last_used
+        # Set by :meth:`McpSessionPool.evict_by_vault` when an operator rotates
+        # the vault credential while this entry is checked out. The entry's live
+        # ClientSession baked in the OLD bearer at open time, so it must not
+        # return to idle for reuse: :meth:`release` discards it instead (#1030).
+        self.discard_on_release = False
 
     async def close(self) -> None:
         """Signal the owner task to exit its contexts and await its completion.
@@ -322,7 +327,16 @@ class McpSessionPool:
         application-level HTTP error (the transport is unaffected). Stamps
         ``last_used`` (the reaper's staleness signal) and notifies one waiter
         that a slot is free.
+
+        Exception: if :meth:`evict_by_vault` flagged this entry mid-checkout
+        (an operator rotated the vault credential), the entry's live session
+        still carries the OLD bearer, so it is DISCARDED here instead of being
+        returned to idle — the next acquire then opens a fresh session on the
+        rotated secret (#1030).
         """
+        if entry.discard_on_release:
+            await self.discard(url, vault_id, headers_key, entry)
+            return
         entry.last_used = time.monotonic()
         key: _PoolKey = (url, vault_id, headers_key)
         cond = self._condition_for(key)
@@ -352,6 +366,61 @@ class McpSessionPool:
         self._close_tasks.add(task)
         task.add_done_callback(self._close_tasks.discard)
         log.info("mcp_pool.discarded", url=url)
+
+    async def evict_by_vault(self, vault_id: str) -> None:
+        """Discard every pooled session keyed on ``vault_id`` — an operator
+        rotated (PUT/archive/delete) this vault's credential (#1030).
+
+        The resolved bearer is baked into each live ``ClientSession`` at open
+        time and the pool key is stable across token changes (by design, for
+        OAuth-refresh reuse), so a rotated ``secret_value`` would otherwise keep
+        serving the OLD token until the 900s idle reaper — which active polling
+        defeats. This is the explicit eviction signal that closes that gap.
+
+        Idle entries are closed and dropped immediately. In-use (checked-out)
+        entries can't be torn down under their owner — closing mid-call would
+        cancel the in-flight transport — so they are FLAGGED
+        (``discard_on_release``); :meth:`release` then discards instead of
+        returning them to idle. Either way no stale-token session survives to a
+        later acquire.
+
+        Fired cross-process: the credential mutation runs in the API process,
+        the pool lives in the worker, so the worker's evict-listener invokes
+        this on a NOTIFY (see ``MCP_EVICT_VAULT_CHANNEL`` /
+        ``_run_mcp_evict_listener``). Unconditional — no config knob.
+        """
+        idle_closed = 0
+        flagged = 0
+        # Snapshot the matching idle entries under each key's Condition, then
+        # close them outside the lock (close awaits the owner task, which the
+        # Condition holder must not block on). Mirrors the reaper's TOCTOU
+        # shape: re-check membership under the lock before removing.
+        for key in [k for k in self._idle if k[1] == vault_id]:
+            cond = self._condition_for(key)
+            to_close: list[_Entry] = []
+            async with cond:
+                idle = self._idle.get(key)
+                if idle is None:
+                    continue
+                to_close = list(idle)
+                del self._idle[key]
+            for entry in to_close:
+                idle_closed += 1
+                await entry.close()
+        # Flag in-use entries so their release discards them.
+        for key in [k for k in self._in_use if k[1] == vault_id]:
+            cond = self._condition_for(key)
+            async with cond:
+                for entry in self._in_use.get(key, set()):
+                    entry.discard_on_release = True
+                    flagged += 1
+        if idle_closed or flagged:
+            log.info(
+                "mcp_pool.evict_by_vault",
+                vault_id=vault_id,
+                idle_closed=idle_closed,
+                in_use_flagged=flagged,
+            )
 
     async def _reap_idle_once(self, *, idle_timeout: float, now: float) -> None:
         """Close idle entries unused longer than ``idle_timeout`` seconds.

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -8,12 +8,25 @@ fields and enforces limits.
 Sandbox eviction (#713): session-BINDING changes (which vaults a session
 can reach) flow through :func:`aios.db.queries.set_session_vaults` from
 :func:`aios.services.sessions.update_session`, which fires the post-commit
-sandbox-eviction hook as defense-in-depth. The in-place credential
-mutations here (:func:`refresh_credential`, :func:`update_vault_credential`,
-:func:`create_vault_credential`, and credential archive/delete) do NOT
-evict any sandbox: the MCP pool keys on ``(url, vault_id)`` and a rotation
-overwrites the row contents under that stable key, so the existing key
-already serves the new secret. Since #873, ``environment_variable``
+sandbox-eviction hook as defense-in-depth.
+
+MCP-pool eviction (#1030): the in-place credential mutations here overwrite
+the credential row under a pool key that is stable across token changes
+(``(url, vault_id, headers_key)`` — by design, for OAuth-refresh reuse).
+But the resolved bearer is baked into the live ``ClientSession`` at open
+time, so an operator rotation would otherwise keep serving the OLD token
+until the 900s idle reaper — which active polling defeats. So a credential
+mutation (:func:`update_vault_credential`, :func:`archive_vault_credential`,
+:func:`delete_vault_credential`) — and a vault-level archive/delete that
+retires its credentials — fires a NOTIFY on ``MCP_EVICT_VAULT_CHANNEL`` with
+the ``vault_id``. The worker (which owns the pool, in a separate process)
+LISTENs and calls :meth:`McpSessionPool.evict_by_vault`. The automated
+:func:`refresh_credential` path is deliberately NOT evicted: it is the OAuth
+case the idle reaper already covers (#459). ``create_vault_credential`` adds
+a brand-new credential (a new ``target_url`` with no pooled session yet), so
+it needs no eviction either.
+
+Since #873, ``environment_variable``
 credentials DO feed the sandbox spec builder
 (:func:`resolve_session_env_var_credentials` below): vault BINDING
 changes now bump ``spec_version`` (migration 0082) so a live sandbox
@@ -34,6 +47,7 @@ import httpx
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
+from aios.db.listen import MCP_EVICT_VAULT_CHANNEL
 from aios.errors import NotFoundError, OAuthRefreshError, ValidationError
 from aios.logging import get_logger
 from aios.models.environments import EnvironmentConfig, LimitedNetworking
@@ -59,6 +73,22 @@ REFRESH_SKEW_SECONDS = 30
 _REFRESH_HTTP_TIMEOUT_SECONDS = 30
 
 log = get_logger("aios.services.vaults")
+
+
+async def _notify_evict_vault(pool: asyncpg.Pool[Any], vault_id: str) -> None:
+    """Signal the worker's MCP session pool to evict every pooled session keyed
+    on ``vault_id`` after an operator credential mutation (#1030).
+
+    The mutation runs in the API process; the pool lives in the worker. This
+    fires a ``pg_notify`` on ``MCP_EVICT_VAULT_CHANNEL`` (function form, never
+    literal NOTIFY — our ids carry uppercase) which the worker's
+    ``_run_mcp_evict_listener`` drains and dispatches to
+    :meth:`McpSessionPool.evict_by_vault`. Fire-and-forget, like the session
+    interrupt signal: a notification lost during a listener reconnect falls
+    back to the idle reaper, and the next mutation re-fires.
+    """
+    await pool.execute("SELECT pg_notify($1, $2)", MCP_EVICT_VAULT_CHANNEL, vault_id)
+
 
 # Fields that go into the encrypted payload for each auth type. The
 # ``token_endpoint_auth`` field is a discriminated Pydantic union and gets
@@ -340,12 +370,18 @@ async def update_vault(
 
 async def archive_vault(pool: asyncpg.Pool[Any], vault_id: str, *, account_id: str) -> Vault:
     async with pool.acquire() as conn:
-        return await queries.archive_vault(conn, vault_id, account_id=account_id)
+        archived = await queries.archive_vault(conn, vault_id, account_id=account_id)
+    # Archiving a vault retires (zeroes) all its credentials' secrets, so the
+    # pooled MCP sessions keyed on this vault must be evicted too (#1030).
+    await _notify_evict_vault(pool, vault_id)
+    return archived
 
 
 async def delete_vault(pool: asyncpg.Pool[Any], vault_id: str, *, account_id: str) -> None:
     async with pool.acquire() as conn:
         await queries.delete_vault(conn, vault_id, account_id=account_id)
+    # Deleting a vault cascades to its credentials, so evict pooled sessions (#1030).
+    await _notify_evict_vault(pool, vault_id)
 
 
 # ── vault credential CRUD ──────────────────────────────────────────────────
@@ -538,7 +574,7 @@ async def update_vault_credential(
         merged = _merge_auth_payload(existing_payload, body, cred.auth_type)
         new_blob = subkey.encrypt_dict(merged)
 
-        return await queries.update_vault_credential(
+        updated = await queries.update_vault_credential(
             conn,
             vault_id,
             credential_id,
@@ -547,6 +583,10 @@ async def update_vault_credential(
             metadata=body.metadata if "metadata" in body.model_fields_set else ...,
             account_id=account_id,
         )
+    # NOTIFY after commit (invariant 6) so the worker evicts the pooled MCP
+    # session that still carries the pre-rotation secret (#1030).
+    await _notify_evict_vault(pool, vault_id)
+    return updated
 
 
 async def archive_vault_credential(
@@ -557,9 +597,12 @@ async def archive_vault_credential(
     account_id: str,
 ) -> VaultCredential:
     async with pool.acquire() as conn:
-        return await queries.archive_vault_credential(
+        archived = await queries.archive_vault_credential(
             conn, vault_id, credential_id, account_id=account_id
         )
+    # Evict the pooled MCP session: the credential's secret is now retired (#1030).
+    await _notify_evict_vault(pool, vault_id)
+    return archived
 
 
 async def delete_vault_credential(
@@ -571,6 +614,8 @@ async def delete_vault_credential(
 ) -> None:
     async with pool.acquire() as conn:
         await queries.delete_vault_credential(conn, vault_id, credential_id, account_id=account_id)
+    # Evict the pooled MCP session: the credential row is gone (#1030).
+    await _notify_evict_vault(pool, vault_id)
 
 
 # ─── environment_variable resolution (#873) ──────────────────────────────────

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -101,6 +101,9 @@ def fake_pool_yielding_conn(conn: Any, **kwargs: Any) -> Any:
     cm.__aenter__ = AsyncMock(return_value=conn)
     cm.__aexit__ = AsyncMock(return_value=None)
     pool.acquire.return_value = cm
+    # ``asyncpg.Pool.execute`` is awaitable — used directly (no acquire) by
+    # post-commit ``pg_notify`` call sites; keep the stand-in faithful.
+    pool.execute = AsyncMock()
     return pool
 
 

--- a/tests/unit/test_mcp_evict_listener.py
+++ b/tests/unit/test_mcp_evict_listener.py
@@ -1,0 +1,183 @@
+"""Unit coverage for :func:`aios.harness.worker._run_mcp_evict_listener`.
+
+The MCP-pool eviction listener is one long-lived background task in the
+worker. An operator credential mutation fires a NOTIFY on
+``aios_mcp_evict_vault`` (from the API process); this listener drains it
+and calls :meth:`McpSessionPool.evict_by_vault` so the rotated secret
+propagates immediately instead of waiting out the idle TTL (#1030).
+
+It pins the same survivability contract as the interrupt listener: a
+per-payload dispatch exception is isolated (try INSIDE while True) and a
+LISTEN-connection failure escapes to the outer reconnect loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.harness import runtime
+from aios.harness.worker import _run_mcp_evict_listener
+from aios.mcp.pool import McpSessionPool
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def _restore_runtime_pool() -> Iterator[None]:
+    saved = runtime.mcp_session_pool
+    yield
+    runtime.mcp_session_pool = saved
+
+
+async def test_listener_evicts_on_notify(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_pool: None
+) -> None:
+    """A vault_id payload drives ``evict_by_vault(vault_id)`` on the pool."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_mcp_evict_vault", fake_listen)
+
+    pool = MagicMock(spec=McpSessionPool)
+    evicted = asyncio.Event()
+
+    async def evict_by_vault(_vault_id: str) -> None:
+        evicted.set()
+
+    pool.evict_by_vault.side_effect = evict_by_vault
+    runtime.mcp_session_pool = pool
+
+    task = asyncio.create_task(_run_mcp_evict_listener("postgresql://stub"))
+    try:
+        await queue.put("vlt_rotated")
+        await asyncio.wait_for(evicted.wait(), timeout=1.0)
+        pool.evict_by_vault.assert_awaited_with("vlt_rotated")
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_listener_noop_when_pool_unset(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_pool: None
+) -> None:
+    """If the pool global isn't set yet, a NOTIFY is a harmless no-op and the
+    listener survives to process the next one."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_mcp_evict_vault", fake_listen)
+    runtime.mcp_session_pool = None
+
+    pool = MagicMock(spec=McpSessionPool)
+    second_evicted = asyncio.Event()
+
+    async def evict_by_vault(_vault_id: str) -> None:
+        second_evicted.set()
+
+    pool.evict_by_vault.side_effect = evict_by_vault
+
+    task = asyncio.create_task(_run_mcp_evict_listener("postgresql://stub"))
+    try:
+        # First NOTIFY arrives while the pool is None — must not crash.
+        await queue.put("vlt_early")
+        await asyncio.sleep(0)
+        # Now the pool is up; the next NOTIFY dispatches.
+        runtime.mcp_session_pool = pool
+        await queue.put("vlt_later")
+        await asyncio.wait_for(second_evicted.wait(), timeout=1.0)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_listener_survives_dispatch_exception(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_pool: None
+) -> None:
+    """One exception in dispatch must not disable the listener."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_mcp_evict_vault", fake_listen)
+
+    pool = MagicMock(spec=McpSessionPool)
+    first = asyncio.Event()
+    second = asyncio.Event()
+    calls = 0
+
+    async def evict_by_vault(_vault_id: str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first.set()
+            raise RuntimeError("simulated transient evict failure")
+        second.set()
+
+    pool.evict_by_vault.side_effect = evict_by_vault
+    runtime.mcp_session_pool = pool
+
+    task = asyncio.create_task(_run_mcp_evict_listener("postgresql://stub"))
+    try:
+        await queue.put("vlt_one")
+        await asyncio.wait_for(first.wait(), timeout=1.0)
+        await queue.put("vlt_two")
+        try:
+            await asyncio.wait_for(second.wait(), timeout=1.0)
+        except TimeoutError as exc:
+            raise AssertionError(
+                "listener did not process second eviction — it died on the first"
+            ) from exc
+        assert calls == 2
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_listener_reconnects_after_termination(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_pool: None
+) -> None:
+    """An empty-string payload (termination sentinel) tears down the inner loop
+    and the outer loop re-enters LISTEN."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    attempts = 0
+    second_entered = asyncio.Event()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 2:
+            second_entered.set()
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_mcp_evict_vault", fake_listen)
+    monkeypatch.setattr("aios.harness.worker._LISTEN_RECONNECT_BACKOFF_SECONDS", 0)
+    runtime.mcp_session_pool = MagicMock(spec=McpSessionPool)
+    runtime.mcp_session_pool.evict_by_vault = AsyncMock()
+
+    task = asyncio.create_task(_run_mcp_evict_listener("postgresql://stub"))
+    try:
+        await queue.put("")  # termination sentinel
+        await asyncio.wait_for(second_entered.wait(), timeout=1.0)
+        assert attempts == 2
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -414,6 +414,101 @@ class TestMcpSessionPool:
         assert a2 is a1, "A's session is reused across rotation"
         assert b1.session is not a1.session, "tenants hold distinct entries"
 
+    async def test_evict_by_vault_closes_idle_entries(self) -> None:
+        """evict_by_vault closes every IDLE entry keyed on the vault_id and
+        drops them from the idle pool, so the next acquire opens a fresh
+        session on the rotated credential (#1030)."""
+        s1, s2 = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s1, s2])),
+        ):
+            pool = McpSessionPool()
+            e1 = await pool.acquire(URL, "vault_a", EMPTY_KEY, {"Authorization": "Bearer old"})
+            await pool.release(URL, "vault_a", EMPTY_KEY, e1)  # → idle
+            assert pool._idle[(URL, "vault_a", EMPTY_KEY)] == [e1]
+
+            await pool.evict_by_vault("vault_a")
+
+            assert e1._owner_task.done(), "evicted idle entry's owner task must be closed"
+            assert (URL, "vault_a", EMPTY_KEY) not in pool._idle
+            # Next acquire opens a brand-new session (no stale reuse).
+            e2 = await pool.acquire(URL, "vault_a", EMPTY_KEY, {"Authorization": "Bearer new"})
+            assert e2 is not e1
+            assert e2.session is not e1.session
+
+    async def test_evict_by_vault_only_targets_matching_vault(self) -> None:
+        """evict_by_vault leaves entries for OTHER vault_ids untouched — only
+        the rotated vault's pooled sessions are discarded."""
+        s_a, s_b = _make_mock_session(), _make_mock_session()
+        url = "https://shared.example/"
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s_a, s_b])),
+        ):
+            pool = McpSessionPool()
+            a1 = await pool.acquire(url, "vault_A", EMPTY_KEY, {})
+            b1 = await pool.acquire(url, "vault_B", EMPTY_KEY, {})
+            await pool.release(url, "vault_A", EMPTY_KEY, a1)
+            await pool.release(url, "vault_B", EMPTY_KEY, b1)
+
+            await pool.evict_by_vault("vault_A")
+
+            assert a1._owner_task.done(), "vault_A's idle entry is closed"
+            assert (url, "vault_A", EMPTY_KEY) not in pool._idle
+            assert not b1._owner_task.done(), "vault_B's idle entry is untouched"
+            assert pool._idle[(url, "vault_B", EMPTY_KEY)] == [b1]
+
+    async def test_evict_by_vault_flags_in_use_then_release_discards(self) -> None:
+        """evict_by_vault flags an IN-USE entry so the subsequent release
+        DISCARDS it (closes + drops) instead of returning it to idle — the
+        old token never gets reused by a later acquire (#1030)."""
+        s1, s2 = _make_mock_session(), _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx_seq([s1, s2])),
+        ):
+            pool = McpSessionPool()
+            e1 = await pool.acquire(URL, "vault_a", EMPTY_KEY, {"Authorization": "Bearer old"})
+            # Rotation lands while the entry is checked out.
+            await pool.evict_by_vault("vault_a")
+            assert not e1._owner_task.done(), "in-use entry stays open until release"
+            assert (URL, "vault_a", EMPTY_KEY) in pool._in_use
+
+            await pool.release(URL, "vault_a", EMPTY_KEY, e1)
+            # release routes a flagged entry through discard (fire-and-forget
+            # close) — let the close task run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            assert e1._owner_task.done(), "flagged entry must be CLOSED on release"
+            # Not returned to idle — a stale-token session must never be reused.
+            assert (URL, "vault_a", EMPTY_KEY) not in pool._idle
+            assert (URL, "vault_a", EMPTY_KEY) not in pool._in_use
+
+            e2 = await pool.acquire(URL, "vault_a", EMPTY_KEY, {"Authorization": "Bearer new"})
+            assert e2 is not e1
+            assert e2.session is not e1.session
+
+    async def test_evict_by_vault_unknown_vault_is_noop(self) -> None:
+        """Evicting a vault with no pooled entries is a harmless no-op."""
+        pool = McpSessionPool()
+        await pool.evict_by_vault("nonexistent")  # must not raise
+
+    async def test_release_without_flag_still_returns_to_idle(self) -> None:
+        """A normal release (no eviction flag) returns the entry to idle — the
+        flag path must not regress warm reuse."""
+        session = _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            pool = McpSessionPool()
+            e1 = await pool.acquire(URL, "vault_a", EMPTY_KEY, {})
+            await pool.release(URL, "vault_a", EMPTY_KEY, e1)
+            assert pool._idle[(URL, "vault_a", EMPTY_KEY)] == [e1]
+            assert not e1._owner_task.done()
+
     async def test_contexts_exit_in_same_task_they_entered(self) -> None:
         """Cross-task close — regression for #425. The transport's __aenter__ and
         __aexit__ must run in the SAME task (the owner-task model guarantees it;

--- a/tests/unit/test_vault_evict_notify.py
+++ b/tests/unit/test_vault_evict_notify.py
@@ -1,0 +1,171 @@
+"""The vault credential-mutation service paths fire the MCP-pool eviction
+NOTIFY (#1030).
+
+An operator rotating/retiring a vault credential runs in the API process,
+but the live MCP ``ClientSession`` baked in the OLD bearer lives in the
+worker's pool. These tests pin that each mutation path emits a
+``pg_notify`` on ``aios_mcp_evict_vault`` with the ``vault_id`` so the
+worker evicts the stale session instead of waiting out the idle TTL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.crypto.vault import KEY_BYTES, CryptoBox
+from aios.db import queries
+from aios.db.listen import MCP_EVICT_VAULT_CHANNEL
+from aios.models.vaults import Vault, VaultCredential, VaultCredentialUpdate
+from aios.services import vaults as vaults_service
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def crypto_box() -> CryptoBox:
+    return CryptoBox(os.urandom(KEY_BYTES))
+
+
+def _fake_pool_with_conn(conn: Any) -> Any:
+    """Pool whose ``acquire()`` yields *conn* and whose ``execute`` (the NOTIFY
+    call site) is an awaitable spy."""
+    pool = MagicMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    pool.acquire.return_value = cm
+    pool.execute = AsyncMock()
+    return pool
+
+
+def _conn_with_transaction() -> MagicMock:
+    conn = MagicMock()
+    txn_cm = MagicMock()
+    txn_cm.__aenter__ = AsyncMock(return_value=None)
+    txn_cm.__aexit__ = AsyncMock(return_value=None)
+    conn.transaction = MagicMock(return_value=txn_cm)
+    return conn
+
+
+def _credential() -> VaultCredential:
+    return VaultCredential(
+        id="vc_1",
+        vault_id="vlt_1",
+        display_name="orig",
+        target_url="https://mcp.example.com",
+        auth_type="bearer_header",
+        metadata={},
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _vault() -> Vault:
+    return Vault(
+        id="vlt_1",
+        display_name="v",
+        metadata={},
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+def _assert_notified(pool: Any, vault_id: str) -> None:
+    pool.execute.assert_awaited_once()
+    args = pool.execute.await_args.args
+    assert args[0] == "SELECT pg_notify($1, $2)"
+    assert args[1] == MCP_EVICT_VAULT_CHANNEL
+    assert args[2] == vault_id
+
+
+async def test_update_credential_fires_evict_notify(crypto_box: CryptoBox) -> None:
+    account_id = "acc_1"
+    blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps({"token": "old"}))
+    conn = _conn_with_transaction()
+    pool = _fake_pool_with_conn(conn)
+
+    with (
+        patch.object(
+            queries,
+            "get_vault_credential_with_blob",
+            AsyncMock(return_value=(_credential(), blob)),
+        ),
+        patch.object(queries, "update_vault_credential", AsyncMock(return_value=_credential())),
+    ):
+        await vaults_service.update_vault_credential(
+            pool,
+            crypto_box,
+            account_id=account_id,
+            vault_id="vlt_1",
+            credential_id="vc_1",
+            body=VaultCredentialUpdate(token="new"),
+        )
+
+    _assert_notified(pool, "vlt_1")
+
+
+async def test_archive_credential_fires_evict_notify() -> None:
+    conn = MagicMock()
+    pool = _fake_pool_with_conn(conn)
+    with patch.object(queries, "archive_vault_credential", AsyncMock(return_value=_credential())):
+        await vaults_service.archive_vault_credential(pool, "vlt_1", "vc_1", account_id="acc_1")
+    _assert_notified(pool, "vlt_1")
+
+
+async def test_delete_credential_fires_evict_notify() -> None:
+    conn = MagicMock()
+    pool = _fake_pool_with_conn(conn)
+    with patch.object(queries, "delete_vault_credential", AsyncMock(return_value=None)):
+        await vaults_service.delete_vault_credential(pool, "vlt_1", "vc_1", account_id="acc_1")
+    _assert_notified(pool, "vlt_1")
+
+
+async def test_archive_vault_fires_evict_notify() -> None:
+    conn = MagicMock()
+    pool = _fake_pool_with_conn(conn)
+    with patch.object(queries, "archive_vault", AsyncMock(return_value=_vault())):
+        await vaults_service.archive_vault(pool, "vlt_1", account_id="acc_1")
+    _assert_notified(pool, "vlt_1")
+
+
+async def test_delete_vault_fires_evict_notify() -> None:
+    conn = MagicMock()
+    pool = _fake_pool_with_conn(conn)
+    with patch.object(queries, "delete_vault", AsyncMock(return_value=None)):
+        await vaults_service.delete_vault(pool, "vlt_1", account_id="acc_1")
+    _assert_notified(pool, "vlt_1")
+
+
+async def test_create_credential_does_not_fire_evict_notify(crypto_box: CryptoBox) -> None:
+    """A brand-new credential has no pooled session yet — no eviction needed,
+    so create must NOT fire the NOTIFY (scope discipline)."""
+    from aios.models.vaults import VaultCredentialCreate
+
+    conn = _conn_with_transaction()
+    conn.fetchrow = AsyncMock(return_value={"?column?": 1})
+    pool = _fake_pool_with_conn(conn)
+
+    with (
+        patch.object(queries, "count_active_vault_credentials", AsyncMock(return_value=0)),
+        patch.object(queries, "insert_vault_credential", AsyncMock(return_value=_credential())),
+    ):
+        await vaults_service.create_vault_credential(
+            pool,
+            crypto_box,
+            account_id="acc_1",
+            vault_id="vlt_1",
+            body=VaultCredentialCreate(
+                display_name="new",
+                target_url="https://new.example.com",
+                auth_type="bearer_header",
+                token="tok",
+            ),
+        )
+
+    pool.execute.assert_not_awaited()


### PR DESCRIPTION
## Problem

The MCP session pool keys on `(url, vault_id, headers_key)` where the key is intentionally stable across token changes (for OAuth-refresh reuse), but the resolved bearer is baked into the live `ClientSession` at open time. When an operator rotates a vault credential's `secret_value` (PUT/archive/delete), the pooled connection kept serving the **old** token. The only eviction was the 900s idle reaper — and active polling resets `last_used`, so the rotated secret never propagated until the worker restarted.

## Change

Add an explicit eviction signal, unconditional on credential mutation (no new config knob):

- **`McpSessionPool.evict_by_vault(vault_id)`** — closes idle entries keyed on the vault and flags in-use ones (`_Entry.discard_on_release`) so `release()` discards them instead of returning them to idle. No stale-token session survives to a later acquire.
- **Cross-process signal** — credential mutations run in the API process; the pool lives in the worker. The mutation service path fires `pg_notify` on a new `aios_mcp_evict_vault` channel (mirroring the existing session-interrupt NOTIFY/LISTEN pattern). The worker's new `_run_mcp_evict_listener` drains it and calls `evict_by_vault`.
- Fired (after commit) from `update_vault_credential`, `archive_vault_credential`, `delete_vault_credential`, and vault `archive`/`delete`. `create_vault_credential` (no pooled session yet) and the automated OAuth-refresh path (the idle-reaper case from #459) are deliberately not evicted.

## Topology decision

The escalation contract flagged the API-vs-worker topology and NOTIFY choice. Both were settled by the existing `aios_session_interrupt` listener — the same shape (API NOTIFYs, worker acts on in-memory state) — so no escalation was needed.

## Tests

- Pool unit: idle close, in-use flag → release discards, only-matching-vault, unknown-vault no-op, no-regression on normal release.
- Worker listener: dispatches on NOTIFY, no-op when pool unset, survives dispatch exception, reconnects after termination.
- Service producer: each mutation path fires NOTIFY with the right channel + vault_id; create does not.
- Mutation check verified the in-use/release test fails when the flag handling is removed.

Closes #1030