### PR TITLE
refactor(harness): collapse 4 terminal-error latches into one helper

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1053,6 +1053,52 @@ async def _append_model_request_error_span(
     )
 
 
+async def _latch_errored_turn(
+    pool: Any,
+    session_id: str,
+    *,
+    error_kind: str,
+    stop_message: str | None = None,
+    finish_reason: str | None = None,
+    account_id: str,
+) -> None:
+    """Land a session in the terminal ``errored`` state (#353).
+
+    Runs the fixed three-step latch in order: fail every open request on the
+    session's behalf, set the ``error`` stop_reason, then append the
+    ``turn_ended``/``errored`` lifecycle event. The lifecycle event puts the
+    session in the derived ``errored`` state, which the sweep skips (see
+    ``sweep.ERRORED_SESSIONS_SQL``); any in-flight tool task that completes
+    after this point sits unreaped until a user message recovers the session
+    (its seq overtakes the error event).
+
+    The ordering is load-bearing. ``fail_all_open_requests`` MUST land BEFORE
+    the lifecycle latch. A workflow child whose turn errored can no longer
+    answer the requests it was invoked with, so each is failed with a monotonic
+    response and its invoking run resolves (and can raise ``AgentError``)
+    instead of hanging forever on a dead child (no-op for a non-child / nothing
+    owed). Because the latch makes the sweep skip the session, a crash after
+    latching-but-before-responding would strand the child errored-and-unanswered
+    with no path to ever resolve its callers. Responses-before-latch means a
+    crash instead leaves the child un-latched and recoverable — the sweep
+    re-wakes it, it re-errors, and the now-written responses no-op.
+    """
+    await fail_all_open_requests(
+        pool, session_id, account_id=account_id, error={"kind": error_kind}
+    )
+    stop_reason: dict[str, Any] = {"type": "error"}
+    if stop_message is not None:
+        stop_reason["message"] = stop_message
+    if finish_reason is not None:
+        stop_reason["finish_reason"] = finish_reason
+    await sessions_service.set_session_stop_reason(
+        pool, session_id, stop_reason, account_id=account_id
+    )
+    await _append_lifecycle(
+        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
+    )
+
+
 async def _handle_streaming_model_deadline(
     pool: Any,
     session_id: str,
@@ -1093,20 +1139,15 @@ async def _handle_streaming_model_deadline(
         account_id=account_id,
     )
     deadline_s = get_settings().model_call_deadline_s
-    await fail_all_open_requests(
-        pool, session_id, account_id=account_id, error={"kind": "model_call_deadline"}
-    )
-    await sessions_service.set_session_stop_reason(
+    await _latch_errored_turn(
         pool,
         session_id,
-        {
-            "type": "error",
-            "message": f"model call exceeded its {deadline_s:.0f}s total deadline while still streaming; partial token usage was recorded",
-        },
+        error_kind="model_call_deadline",
+        stop_message=(
+            f"model call exceeded its {deadline_s:.0f}s total deadline while still "
+            "streaming; partial token usage was recorded"
+        ),
         account_id=account_id,
-    )
-    await _append_lifecycle(
-        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
     )
 
 
@@ -1134,30 +1175,10 @@ async def _apply_retry_or_failure(pool: Any, session_id: str, *, account_id: str
             account_id=account_id,
         )
         return delay
-    # Terminal landing pad (#353): the ``turn_ended``/``error`` lifecycle event
-    # appended below puts the session in the derived ``errored`` state, which
-    # the sweep skips (see ``sweep.ERRORED_SESSIONS_SQL``); any in-flight tool
-    # task that completes after this point sits unreaped until a user message
-    # recovers the session (its seq overtakes the error event).
-    #
-    # A workflow child whose model errored past its retry budget can no longer
-    # answer the requests it was invoked with. Error every one on its behalf with a
-    # monotonic response so each invoking run resolves (and can raise AgentError)
-    # instead of hanging forever on a dead child (no-op for a non-child / nothing
-    # owed). This MUST land BEFORE the error latch below: the latch makes the sweep
-    # skip the session, so a crash after latching-but-before-responding would strand
-    # the child errored-and-unanswered, with no path to ever resolve its callers.
-    # Responses-before-latch means a crash leaves the child un-latched (recoverable —
-    # the sweep re-wakes it, it re-errors, and the now-written responses no-op).
-    await fail_all_open_requests(
-        pool, session_id, account_id=account_id, error={"kind": "child_errored"}
-    )
-    await sessions_service.set_session_stop_reason(
-        pool, session_id, {"type": "error"}, account_id=account_id
-    )
-    await _append_lifecycle(
-        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
-    )
+    # Terminal landing pad (#353): the retry budget is spent, so land the
+    # session in the errored state. See ``_latch_errored_turn`` for the
+    # responses-before-latch ordering invariant this relies on.
+    await _latch_errored_turn(pool, session_id, error_kind="child_errored", account_id=account_id)
     return None
 
 
@@ -1182,17 +1203,12 @@ async def _handle_spend_cap(
         },
         account_id=account_id,
     )
-    await fail_all_open_requests(
-        pool, session_id, account_id=account_id, error={"kind": "spend_cap_exceeded"}
-    )
-    await sessions_service.set_session_stop_reason(
+    await _latch_errored_turn(
         pool,
         session_id,
-        {"type": "error", "message": _SPEND_CAP_STOP_REASON_MESSAGE},
+        error_kind="spend_cap_exceeded",
+        stop_message=_SPEND_CAP_STOP_REASON_MESSAGE,
         account_id=account_id,
-    )
-    await _append_lifecycle(
-        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
     )
 
 
@@ -1211,8 +1227,8 @@ async def _handle_refusal(
     truncated). The partial content/tool_calls are stashed on a ``span`` event
     for debugging — ``build_messages`` only replays ``kind == "message"`` events,
     so the span never re-enters context. The session then lands in the terminal
-    ``errored`` state via the same surface as the retry-budget-exhausted path
-    (see ``_apply_retry_or_failure``): a workflow child's open requests are
+    ``errored`` state via the shared latch used by every terminal-error handler
+    (see ``_latch_errored_turn``): a workflow child's open requests are
     failed so its callers resolve, the stop_reason latches to ``error`` (drives
     the console "Errored" pill), and the error lifecycle event bumps
     ``last_error_seq`` so the sweep parks the session until a user message
@@ -1232,24 +1248,13 @@ async def _handle_refusal(
         },
         account_id=account_id,
     )
-    # Mirror the terminal branch of ``_apply_retry_or_failure``: resolve a
-    # workflow child's open requests BEFORE latching the error (the latch makes
-    # the sweep skip the session — see the ordering note there).
-    await fail_all_open_requests(
-        pool, session_id, account_id=account_id, error={"kind": "model_refusal"}
-    )
-    await sessions_service.set_session_stop_reason(
+    await _latch_errored_turn(
         pool,
         session_id,
-        {
-            "type": "error",
-            "message": _REFUSAL_STOP_REASON_MESSAGE,
-            "finish_reason": finish_reason,
-        },
+        error_kind="model_refusal",
+        stop_message=_REFUSAL_STOP_REASON_MESSAGE,
+        finish_reason=finish_reason,
         account_id=account_id,
-    )
-    await _append_lifecycle(
-        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
     )
 
 


### PR DESCRIPTION
## Summary

- Extracts `_latch_errored_turn(...)` in `harness/loop.py`, collapsing the
  fail_all_open_requests → set_session_stop_reason(`{"type":"error"}`) →
  `turn_ended`/`errored` lifecycle sequence that was copy-pasted across **four**
  terminal-error handlers (`_handle_streaming_model_deadline`, the terminal
  branch of `_apply_retry_or_failure`, `_handle_spend_cap`, `_handle_refusal`).
- The load-bearing **responses-before-latch** ordering invariant (#353) — a
  crash between latching and responding strands a workflow child
  errored-and-unanswered — was previously re-documented in prose at two sites.
  It now lives once, **correct-by-construction**: the helper bakes in
  `{"type":"error"}` so a non-error latch cannot be expressed, and callers
  supply only the per-site `error_kind` and optional `stop_message`/`finish_reason`.
- Pure structural refactor, **no behavior change**. `_handle_step_timeout` is
  covered transitively via `_apply_retry_or_failure`; the `sessions.py`
  `fail_open_child_requests_conn` archive/delete seam is deliberately distinct
  (no stop_reason+lifecycle latch) and intentionally left untouched.

Surfaced by a `/kaizen` audit — flagged by 3 of 6 independent audit dimensions
(smell-words, corrective-pipelines, craftsmanship) as the top-scored target.

## Behavior equivalence (verified)

Per-site `stop_reason` dicts, `error_kind` strings, and the fail→stop→lifecycle
call ordering are byte-for-byte preserved. The `child_errored` path still emits
exactly `{"type":"error"}` (the `is not None` guards never insert `message:null`);
the deadline message's implicit string concatenation reproduces the original
f-string exactly.

## Test plan

- [x] `mypy src tests` — clean (595 files)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Unit suite — 2601 passed; connector/SDK suites — 538 passed
- [x] Targeted: `test_loop_retry`, `test_loop_spend_gate`, `test_completion_timeouts`, `test_error_events` — green
- [ ] CI runs e2e/integration (incl. `test_refusal`, `test_errored_session_sweep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)