### PR TITLE
fix(sandbox): reap docker pipeline children on outer cancellation

### DIFF
--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -173,6 +173,22 @@ async def run_docker_pipeline(
                 f"docker pipeline timed out after {timeout_s}s: "
                 f"{' '.join(producer_argv)} | {' '.join(consumer_argv)}"
             ) from timeout_err
+        except BaseException:
+            # CancelledError is a BaseException, not a TimeoutError, so an
+            # outer cancel (caller's job deadline, worker SIGTERM mid
+            # multi-GB export) skips the timeout branch above — both
+            # children keep running and their parent-side pipe FDs leak.
+            # Mirror run_subprocess_with_timeout: SIGKILL both and close
+            # their transports before propagating. (The timeout branch
+            # needs no close — the loop reclaims each transport on the
+            # killed child's pipe EOF — but a propagating cancel returns
+            # immediately, so it must release them here.)
+            for proc in (producer, consumer):
+                if proc is not None:
+                    with contextlib.suppress(ProcessLookupError):
+                        proc.kill()
+                    proc._transport.close()  # type: ignore[attr-defined]  # typeshed omits Process._transport
+            raise
 
         if producer.returncode != 0:
             raise SandboxBackendError(

--- a/tests/unit/sandbox/test_subprocess.py
+++ b/tests/unit/sandbox/test_subprocess.py
@@ -1,27 +1,29 @@
-"""The double-timeout give-up path must close the subprocess transport.
+"""The SIGKILL cleanup paths in ``_subprocess`` must release the
+parent-side pipe FDs.
 
-When the post-SIGKILL drain in ``run_subprocess_with_timeout`` also
-times out (a child wedged in uninterruptible D-state — ``docker``
-against a flapping daemon, ``git`` on a dead mount), the give-up branch
-must close ``proc._transport`` so the cancelled ``communicate()``
-doesn't strand the parent-side stdout/stderr pipe FDs. Every container
-provision and host git-clone funnels through this runner; pre-fix,
-repeated wedges exhaust the worker's FD ceiling and starve both
-connection pools. The mechanism is documented at the fix site in
-``_subprocess.py``.
+When a child is killed but its transport isn't closed — the
+double-timeout give-up path, or an outer ``CancelledError`` that skips
+the timeout branch — the cancelled ``communicate()`` strands the
+parent-side stdout/stderr pipe FDs. Every container provision, host
+git-clone, and snapshot flatten funnels through this module; pre-fix,
+repeated wedges/cancellations exhaust the worker's FD ceiling and starve
+both connection pools (and, for the ``docker export | docker import``
+flatten pipeline, orphan multi-GB subprocesses). The mechanism is
+documented at each fix site in ``_subprocess.py``.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from aios.sandbox import _subprocess
-from aios.sandbox._subprocess import run_subprocess_with_timeout
+from aios.sandbox._subprocess import run_docker_pipeline, run_subprocess_with_timeout
 
 
 class _WedgedProc:
@@ -94,3 +96,46 @@ async def test_outer_cancellation_kills_and_closes_transport(
 
     assert proc._transport.kill.called
     proc._transport.close.assert_called_once()
+
+
+async def test_pipeline_outer_cancel_kills_and_closes_both(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Outer cancellation of the flatten pipeline must SIGKILL *both*
+    docker children and close *both* pipe transports before propagating.
+
+    ``CancelledError`` is a ``BaseException``, not a ``TimeoutError``, so
+    it skips ``run_docker_pipeline``'s timeout branch — the same gap the
+    sibling ``run_subprocess_with_timeout`` closes. Without it, a worker
+    SIGTERM or job-deadline cancel mid ``docker export | docker import``
+    leaves both children running and strands their parent-side pipe
+    FDs."""
+    producer = _WedgedProc()
+    consumer = _WedgedProc()
+    spawned = iter((producer, consumer))
+
+    async def _fake_spawn(*_argv: Any, **_kwargs: Any) -> _WedgedProc:
+        return next(spawned)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+    # Keep the pipe plumbing hermetic — no real host FDs are created or closed.
+    monkeypatch.setattr(os, "pipe", lambda: (100, 101))
+    monkeypatch.setattr(os, "close", lambda _fd: None)
+
+    # Generous timeout so the wait_for itself never fires — outer
+    # cancellation is what we're testing.
+    task = asyncio.create_task(
+        run_docker_pipeline(
+            ["docker", "export", "x"], ["docker", "import", "-", "tag"], timeout_s=60.0
+        )
+    )
+    # Let the task reach `await asyncio.wait_for(_drain(), ...)`.
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    assert producer._transport.kill.called
+    assert consumer._transport.kill.called
+    producer._transport.close.assert_called_once()
+    consumer._transport.close.assert_called_once()


### PR DESCRIPTION
## Summary

- `run_docker_pipeline` (the `docker export | docker import` snapshot-flatten path in `sandbox/_subprocess.py`) had only an `except TimeoutError` branch. A `CancelledError` — a `BaseException`, **not** a `TimeoutError` — from a worker SIGTERM or a procrastinate job-deadline firing mid multi-GB `docker export` skipped that branch and fell through to the `finally`, which closes only the host pipe fds (already `-1`). **Both docker subprocesses kept running and their parent-side pipe transports leaked.** Repeated across deploys this exhausts the worker FD ceiling (the exact failure the module docstring warns about) and orphans GB-moving processes.
- The fix adds the symmetric `except BaseException` that the sibling `run_subprocess_with_timeout` in the same module already has: SIGKILL both children (suppressing `ProcessLookupError`) and close both transports before re-raising.
- It is a **sibling** to `except TimeoutError`, scoped to the drain await — so the `SandboxBackendError` deliberately raised on the timeout / producer-nonzero paths is unaffected (those need no transport-close: the loop reclaims each transport on the killed child's pipe EOF; a *propagating cancel* returns immediately, so it must release them inline).

## How it was found

Surfaced by an adversarial bug-hunt audit. The verify pass **refuted** the finder's companion claim that the *timeout* branch also leaks (measured: 30 timed-out pipelines → FD delta 0), narrowing the fix to the outer-cancellation prong only — which is why no redundant close was added to the timeout path.

## Test plan

- [x] New regression test `test_pipeline_outer_cancel_kills_and_closes_both` — RED before the fix (`producer._transport.kill` never called on cancel), GREEN after. Asserts both children killed + both transports closed once.
- [x] `mypy src tests` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/unit` — 2602 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)