### PR TITLE
fix(harness): prune mid-list orphan tool results in build_messages

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -827,7 +827,7 @@ def _omission_marker(omission: WindowOmission, boundary: datetime, tz_name: str)
     cache-stability rationale.  The boundary timestamp reuses
     :func:`_format_received` so it renders identically to the
     ``received=`` envelope headers; the start date uses the same account
-    timezone, date-only.  ``_prune_leading_orphans`` may hide a few more
+    timezone, date-only.  ``_prune_orphans`` may hide a few more
     rendered messages at/after the boundary — "everything before" remains
     true regardless, so the claim direction is safe.
     """
@@ -1033,6 +1033,18 @@ def build_messages(
                     max_stimulus_seq = max(max_stimulus_seq, real_result_seqs[inj_tcid])
 
             elif role == "tool":
+                # Reaching this branch means NO in-window assistant declared
+                # this tcid — the assistant branch above records every id it
+                # emits in ``emitted_tcids``, so a standalone tool event here
+                # is always a structural orphan (its issuing assistant was
+                # windowed out). We still advance ``max_stimulus_seq``: the
+                # result is a real stimulus the watermark must count
+                # (``reacting_to`` = f(log)), and under-counting it risks
+                # re-waking on an already-consumed event. The structurally
+                # invalid message itself is removed downstream by
+                # ``_prune_orphans`` (message list = f(structural validity)) —
+                # do NOT "correct-by-construction" this by skipping the append
+                # here, which would entangle the two and regress the watermark.
                 tcid = e.data.get("tool_call_id")
                 if tcid and tcid not in emitted_tcids:
                     messages.append(e.data)
@@ -1066,7 +1078,7 @@ def build_messages(
     # windowing can cut in the middle of an assistant+tool_result group,
     # leaving orphan tool results or an assistant with missing paired
     # results.
-    messages = _prune_leading_orphans(messages)
+    messages = _prune_orphans(messages)
 
     # Head omission marker (#738): when the window omits transcript, tell
     # the model how much and how to recall it. After the prune (so it can't
@@ -1135,19 +1147,38 @@ def _is_degenerate_empty_assistant(msg: dict[str, Any]) -> bool:
 # ─── helpers ─────────────────────────────────────────────────────────────────
 
 
-def _prune_leading_orphans(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Drop messages from the front until we reach a clean conversation start.
+def _prune_orphans(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop structurally-orphaned messages produced by window cuts.
 
-    Windowing can cut in the middle of an assistant + tool_result group,
-    leaving orphan tool results at the start (no preceding assistant with
-    matching tool_calls) or an assistant whose paired results were
-    partially dropped.
+    DB-level windowing slices the event log at a token budget and can cut
+    through an assistant + tool_result group, leaving an invalid
+    chat-completions sequence that strict providers (Anthropic / Bedrock)
+    reject. Because :func:`build_messages` is pure replay over the
+    immutable window, that rejection recurs on every wake and permanently
+    wedges the session — so the structure must be repaired here. Two
+    orphan shapes arise:
 
-    Walk forward and drop until we find a ``user`` message or an
-    ``assistant`` without ``tool_calls`` — both are valid starts. An
-    ``assistant`` with ``tool_calls`` is valid only if ALL its
-    tool_call_ids have matching tool results later in the list.
+    * **Incomplete leading assistant** — an ``assistant`` at the front
+      whose ``tool_calls`` ids are not all matched by following ``tool``
+      results (a paired result was dropped by the boundary, or a
+      ``tool_call`` carries no ``id``). The whole leading group is dropped.
+    * **Orphan tool result** — a ``tool`` message whose ``tool_call_id``
+      has no preceding ``assistant`` ``tool_calls`` declaring it (the
+      issuing assistant was dropped). This sits at the FRONT of the
+      window, or MID-list: the blind-spot race appends a late tool result
+      after an interleaved user message (assistant < user < result in seq
+      order), and a boundary that drops the assistant but keeps the user
+      and the result strands the result *after* a clean ``user`` start.
+      Such orphans are dropped at ANY position.
+
+    The leading scan stops at the first clean start (a ``user`` or a
+    complete ``assistant``), so it alone cannot reach a mid-list orphan;
+    the position-independent sweep that follows is what catches those.
     """
+    # Leading scan: establish a clean conversation start by dropping a
+    # leading incomplete-assistant group (and any orphan tool results
+    # ahead of it). Walk forward until a ``user`` or an ``assistant``
+    # whose tool_calls are all paired — both are valid starts.
     start = 0
     while start < len(messages):
         msg = messages[start]
@@ -1177,7 +1208,26 @@ def _prune_leading_orphans(messages: list[dict[str, Any]]) -> list[dict[str, Any
         # tool or anything else at the front — orphan, drop.
         start += 1
 
-    return messages[start:]
+    messages = messages[start:]
+
+    # Position-independent sweep: drop any tool result whose tool_call_id
+    # was never declared by a preceding in-window assistant. Catches the
+    # mid-list orphan the leading scan stops short of (the interleaved-user
+    # window cut above); a no-op on lists the leading scan already cleaned.
+    declared: set[str] = set()
+    pruned: list[dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant":
+            declared.update(tc["id"] for tc in (msg.get("tool_calls") or []) if tc.get("id"))
+            pruned.append(msg)
+        elif role == "tool":
+            if msg.get("tool_call_id") in declared:
+                pruned.append(msg)
+            # else: orphan result with no declaring assistant — drop
+        else:
+            pruned.append(msg)
+    return pruned
 
 
 def stub_missing_reasoning_content(

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -331,6 +331,45 @@ class TestBuildMessages:
         assert msgs[0]["content"] == f"[received={RECEIVED}]\nnext question"
         assert msgs[1]["role"] == "assistant"
 
+    def test_prune_orphan_tool_result_after_interleaved_user(self) -> None:
+        """A window cut between an assistant's tool_call and a LATER
+        interleaved user message leaves a MID-list orphan tool result.
+
+        The blind-spot race (CLAUDE.md): an assistant emits a tool_call,
+        a user message arrives DURING inference (higher seq), then the
+        tool completes and appends its result (higher seq still) — log
+        order assistant < user < result. When the token-budget window
+        boundary drops the tool_call assistant but keeps the interleaved
+        user message and the late result, the result is an orphan sitting
+        AFTER a clean ``user`` start, which the leading-only prune stops
+        before ever reaching. The emitted ``role=="tool"`` message then
+        has no preceding ``tool_calls`` declaring it — an invalid
+        chat-completions sequence that strict providers (Anthropic /
+        Bedrock) reject, permanently wedging the session since
+        ``build_messages`` is pure replay over the immutable window.
+        """
+        events = [
+            _evt(11, "user", content="are you there?"),
+            _evt(12, "tool", tool_call_id="bash_1", content="output"),
+            _evt(13, "assistant", content="yes done"),
+        ]
+        events[2].data["reacting_to"] = 11
+        msgs = build_messages(events, system_prompt=None).messages
+        # Every tool result must be preceded by an assistant whose
+        # tool_calls declare its id (same invariant asserted by
+        # test_prune_partial_assistant_tool_group).
+        for m in msgs:
+            if m.get("role") == "tool":
+                tc_id = m.get("tool_call_id")
+                has_parent = any(
+                    tc_id in {tc["id"] for tc in prior.get("tool_calls") or []}
+                    for prior in msgs[: msgs.index(m)]
+                    if prior.get("role") == "assistant"
+                )
+                assert has_parent, (
+                    f"orphan tool result {tc_id!r}; roles={[mm.get('role') for mm in msgs]}"
+                )
+
     def test_user_metadata_excluded_from_messages(self) -> None:
         """Metadata on user message events must not leak into the
         chat-completions message list sent to the model."""


### PR DESCRIPTION
## Summary

- **Bug:** When DB windowing dropped a tool-call assistant but kept an *interleaved* user message plus the late tool result (the documented blind-spot race — `assistant < user < result` in seq order), `build_messages` emitted a `role=="tool"` message with no preceding assistant `tool_calls` declaring it. Strict providers (Anthropic/Bedrock) reject *"tool_result without a preceding tool_use"*, and because `build_messages` is pure replay over the immutable window, the rejection recurs on **every wake** — permanently wedging the session with no path for the model to recover.
- **Root cause:** `_prune_leading_orphans` only stripped orphans at the **front** of the window; it `break`s on the first clean start (the interleaved `user` message), so the mid-list orphan sitting *after* it was never reached.
- **Fix:** Generalized the helper (now `_prune_orphans`) with a **position-independent** sweep that drops any tool result whose `tool_call_id` was not declared by a preceding in-window assistant — at any position. The leading scan is retained for its distinct job (dropping a leading incomplete-assistant group).
- The assembly walk and `max_stimulus_seq`/`reacting_to` watermark are **left untouched**: the orphan's seq still counts as stimulus (watermark = f(log)); only the structurally-invalid message is trimmed from the list (message list = f(structural validity)) — exactly as *leading* orphans already behaved. A WHY comment at the standalone `tool` branch documents this split so it isn't naively "corrected" in the walk (which would regress the watermark).

## Discovery & verification

- Found via a hypothesis-driven audit; the failing test was written first and confirmed red for the predicted reason (`orphan tool result 'bash_1'; roles=['user', 'tool', 'assistant']`) before the fix.
- Adversarial correctness review attacked 5 vectors (drops a valid tool message / leaves a dangling assistant call / drops a pending placeholder / watermark desync / post-prune index math) — none reproduced; `declared` is always populated before the sweep visits a legitimate result.

## Test plan

- [x] `test_prune_orphan_tool_result_after_interleaved_user` — new regression test (red→green)
- [x] Existing prune tests unchanged: `test_prune_orphan_tool_results_at_start`, `test_prune_partial_assistant_tool_group`, `test_prune_handles_leading_assistant_with_malformed_tool_call`
- [x] mypy — clean (1048 files)
- [x] ruff check + format — clean
- [x] Unit suite — 2602 passed; connector suites — 538 passed
- [ ] CI runs e2e / integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)