### PR TITLE
fix(harness): exclude the caller's own task from cancel_session

### DIFF
--- a/src/aios/harness/task_registry.py
+++ b/src/aios/harness/task_registry.py
@@ -48,12 +48,24 @@ class TaskRegistry:
         return True
 
     def cancel_session(self, session_id: str) -> int:
-        """Cancel all in-flight tool tasks for a session. Returns count cancelled."""
+        """Cancel all in-flight tool tasks for a session. Returns count cancelled.
+
+        Skips the caller's own task. The in-band ``cancel`` tool runs as a
+        registered task in this session's set, so cancelling indiscriminately
+        would cancel itself — inflating the count and letting a
+        ``CancelledError`` raised at its post-handler await overwrite the
+        tool's real result with a generic ``"cancelled"`` error. The
+        interrupt-listener caller (``worker.py``) runs from a non-registered
+        listener task, so the skip is a no-op there.
+        """
         session_tasks = self._tasks.get(session_id)
         if not session_tasks:
             return 0
+        current = asyncio.current_task()
         count = 0
         for _tool_call_id, task in list(session_tasks.items()):
+            if task is current:
+                continue
             if not task.done():
                 task.cancel()
                 count += 1

--- a/tests/unit/test_cancel_handler.py
+++ b/tests/unit/test_cancel_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 
 import pytest
@@ -61,3 +62,38 @@ class TestCancelAllTasks:
         result = await cancel_handler("sess_01TEST", {})
         assert result["cancelled"] is True
         assert result["count"] == 0
+
+    async def test_cancel_excludes_own_running_task(self, task_reg: TaskRegistry) -> None:
+        """The in-band cancel tool runs as a registered task in its own
+        session set, so cancel-all must skip it. If it cancels itself the
+        count is inflated by one and a CancelledError fired at the
+        post-handler await overwrites the tool's real {cancelled, count}
+        result with a generic "cancelled" error. The interrupt-listener
+        caller runs from a non-registered task, so it is unaffected."""
+        sid = "sess_01TEST"
+        sibling = asyncio.create_task(_sleeper())
+        task_reg.add(sid, "call_bash", sibling)
+
+        captured: dict[str, Any] = {}
+
+        async def run_cancel() -> None:
+            # Mirrors dispatch: this coroutine *is* the registered cancel
+            # task, so asyncio.current_task() inside the handler is the
+            # call_cancel entry in the session set.
+            captured["result"] = await cancel_handler(sid, {})
+            # The post-handler await where a self-inflicted cancel lands.
+            await asyncio.sleep(0)
+            captured["reached"] = True
+
+        own = asyncio.create_task(run_cancel())
+        task_reg.add(sid, "call_cancel", own)
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await own
+        with contextlib.suppress(asyncio.CancelledError):
+            await sibling
+
+        assert not own.cancelled()  # the cancel tool must not cancel itself
+        assert captured.get("reached") is True  # ran past the post-handler await
+        assert captured["result"] == {"cancelled": True, "count": 1}  # sibling only
+        assert sibling.cancelled()  # the real target is still cancelled


### PR DESCRIPTION
## Summary

- The in-band `cancel` tool runs as a **registered task** in its own session's `TaskRegistry` set. `cancel_session` (invoked when `cancel` is called with no `tool_call_id`) cancelled *every* registered task — including the cancel tool's own running task.
- Two defects followed: (1) the returned `count` was inflated by one; (2) the `CancelledError` scheduled by the self-`cancel()` fired at the handler's post-result `await`, so `_tool_lifecycle`'s `except CancelledError` overwrote the real `{"cancelled": true, "count": N}` result with a generic `{"error": "cancelled"}` — **the tool reported failure when it had succeeded**, and the count never reached the model.
- Fix: `cancel_session` captures `asyncio.current_task()` and skips the task that `is` it (exact identity). The interrupt-listener caller (`worker.py:579`) runs from a non-registered listener task, so the skip is a no-op there; outside any task `current_task()` is `None` and the skip degrades to the prior cancel-all behavior.

## How it was found

Adversarial bug-hunt audit. The verify pass confirmed the real harm (wrong result surfaced, not just an off-by-one) and validated the root-cause site is the shared `cancel_session` primitive, not `cancel_handler`.

## Test plan

- [x] New regression test `test_cancel_excludes_own_running_task` — invokes `cancel_handler({})` from *inside* the registered cancel task; RED pre-fix (`own.cancelled()` True, count 2, result overwritten), GREEN after (own not cancelled, count 1, real result, sibling still cancelled). Existing `test_cancel_all` (unregistered caller) still returns count 2.
- [x] `mypy src tests` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/unit` — 2603 passed
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)