### PR TITLE
fix: detect half-open connector SSE streams (heartbeat)

### DIFF
--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -866,3 +866,91 @@ class TestWaitConnectionServed:
 
         assert "conn_direct" in c._connection_served
         assert c._connection_served["conn_direct"].is_set()
+
+
+class TestDiscoveryLoopReconnectsOnStaleStream:
+    """A silently half-open discovery stream surfaces ``httpx.ReadTimeout``
+    (an ``httpx.HTTPError``); the loop must reconnect and re-process the
+    backfill rather than wedging forever (aios#962).
+
+    The connector SDK now sets a bounded read timeout so a zombied stream
+    raises instead of blocking; the loop's existing ``except
+    httpx.HTTPError`` retry path is what restores correctness — its
+    reconnect replays the backfill, which surfaces any connection created
+    while the stream was dead.
+    """
+
+    @staticmethod
+    def _added_msg(connection_id: str):
+        from aios_sdk import SseMessage
+
+        return SseMessage(
+            event="connection",
+            data=json.dumps(
+                {
+                    "event": "added",
+                    "connection_id": connection_id,
+                    "external_account_id": "acct_x",
+                }
+            ),
+        )
+
+    async def test_read_timeout_triggers_reconnect_and_backfill_replay(self) -> None:
+        c = _ProbeConnector()
+        added: list[str] = []
+
+        async def _fake_added(tg: Any, connection_id: str, external_account_id: str) -> None:
+            del tg, external_account_id
+            added.append(connection_id)
+
+        c._on_connection_added = _fake_added  # type: ignore[method-assign]
+
+        attempts = {"n": 0}
+
+        async def _fake_stream(httpx_client: Any, connector: str):
+            del httpx_client, connector
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                # First connection goes silently half-open: the bounded
+                # read timeout fires after a stretch of no events / no
+                # heartbeat.
+                raise httpx.ReadTimeout("stream stalled")
+            # Reconnect: backfill replays the connection that was created
+            # while the stream was dead.
+            yield self._added_msg("conn_late")
+            await asyncio.Event().wait()  # then idle (live tail)
+
+        sleeps: list[float] = []
+        _real_sleep = asyncio.sleep
+
+        async def _fake_sleep(delay: float) -> None:
+            # Record the backoff but collapse the wait to a real zero-delay
+            # yield so the test doesn't actually sleep for ``delay`` seconds
+            # while still ceding control to the event loop.
+            sleeps.append(delay)
+            await _real_sleep(0)
+
+        with (
+            patch("aios_connector_http.runner.stream_connection_discovery", new=_fake_stream),
+            patch("aios_connector_http.runner.asyncio.sleep", new=_fake_sleep),
+        ):
+            mock_tg = MagicMock()
+            loop_task = asyncio.create_task(c._discovery_loop(mock_tg))
+            try:
+                # Spin the event loop until the reconnect has replayed the
+                # backfilled connection.
+                for _ in range(100):
+                    await _real_sleep(0)
+                    if added:
+                        break
+            finally:
+                loop_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await loop_task
+
+        # The loop reconnected after the ReadTimeout and processed the
+        # connection that appeared while the stream was zombied.
+        assert added == ["conn_late"]
+        # It backed off between the failed attempt and the reconnect
+        # (rather than busy-looping).
+        assert sleeps and sleeps[0] >= 1.0

--- a/packages/aios-sdk/aios_sdk/streaming.py
+++ b/packages/aios-sdk/aios_sdk/streaming.py
@@ -29,6 +29,25 @@ import httpx
 
 from aios_sdk._generated import AuthenticatedClient
 
+# Connector discovery / calls / management streams sit idle for long
+# stretches (a connector with zero connections sees zero events for
+# hours).  The server emits an SSE heartbeat comment (``: ping``) every
+# ``SSE_SERVER_PING_SECONDS`` so a healthy idle stream still produces a
+# steady trickle of bytes — see ``aios.api.sse.make_sse_response``.
+#
+# An ``httpx`` read timeout is the gap allowed BETWEEN consecutive bytes,
+# so it is reset by each heartbeat on a live stream but fires when a proxy
+# or server silently drops the connection without a FIN (Traefik idle
+# timeout on a quiet SSE response is the documented culprit — aios#962).
+# We set it to a small multiple of the ping interval so two consecutive
+# missed heartbeats trip the timeout: the consuming loop then surfaces
+# ``httpx.ReadTimeout`` (an ``httpx.HTTPError``) and reconnects with
+# backoff, and the reconnect's backfill restores correctness.  Without a
+# bounded read timeout a half-open stream blocks forever and connections
+# created in the meantime are invisible until the container restarts.
+SSE_SERVER_PING_SECONDS = 15.0
+CONNECTOR_STREAM_READ_TIMEOUT = 3 * SSE_SERVER_PING_SECONDS
+
 
 @dataclass(frozen=True, slots=True)
 class SseMessage:
@@ -197,7 +216,11 @@ async def _stream_sse(httpx_client: httpx.AsyncClient, path: str) -> AsyncIterat
         "GET",
         path,
         headers={"Accept": "text/event-stream"},
-        timeout=httpx.Timeout(60.0, read=None),
+        # Bounded read timeout (NOT ``read=None``): a healthy idle stream
+        # is kept alive by the server's ``: ping`` heartbeat, so this only
+        # fires when the stream has gone silently half-open — see
+        # ``CONNECTOR_STREAM_READ_TIMEOUT`` (aios#962).
+        timeout=httpx.Timeout(60.0, read=CONNECTOR_STREAM_READ_TIMEOUT),
     ) as response:
         response.raise_for_status()
         # Synthetic open marker so HttpConnector loops can mark themselves

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -50,12 +50,24 @@ log = get_logger("aios.api.sse")
 # (issue #376). Anything else bubbles as an unhandled 500.
 SSE_PREFLIGHT_EXCEPTIONS = (asyncpg.PostgresError, OSError)
 
+# Heartbeat interval (seconds) for every SSE response built here.
+# sse-starlette emits an SSE comment (``: ping``) every ``ping`` seconds
+# when the generator is idle, which keeps proxies (Traefik) from
+# classifying a quiet stream as dead AND lets the client distinguish a
+# healthy-idle stream from a silently half-open one.  The connector SDK's
+# read timeout (``CONNECTOR_STREAM_READ_TIMEOUT`` in
+# ``aios_sdk.streaming``) is sized as a multiple of this interval, so the
+# two MUST stay in sync — a connection created while a connector's
+# discovery stream is zombied is otherwise invisible until the container
+# restarts (aios#962).
+SSE_PING_SECONDS = 15
+
 
 def make_sse_response(
     subscription: ListenSubscription,
     content: AsyncIterator[ServerSentEvent],
     *,
-    ping: int = 15,
+    ping: int = SSE_PING_SECONDS,
 ) -> EventSourceResponse:
     """Build an ``EventSourceResponse`` whose ``ListenSubscription`` is
     cleaned up even on paths that never iterate the wrapped generator.

--- a/tests/unit/test_sdk_streaming_heartbeat.py
+++ b/tests/unit/test_sdk_streaming_heartbeat.py
@@ -1,0 +1,147 @@
+"""SSE half-open detection for the connector SDK streams (aios#962).
+
+The connector discovery / calls / management SSE streams can go silently
+half-open: a proxy (Traefik) or the server drops the connection without a
+FIN, and a client with no read timeout blocks forever — every connection
+created in the meantime is invisible until the container restarts.
+
+The fix is a bounded read timeout on :func:`aios_sdk.streaming._stream_sse`,
+sized as a multiple of the server's ``: ping`` heartbeat interval so a
+healthy idle stream (kept alive by heartbeats) never trips it, but a
+silently dropped stream surfaces ``httpx.ReadTimeout`` (an
+``httpx.HTTPError``) — which the connector loops already treat as a
+reconnect trigger.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from aios_sdk import streaming
+from aios_sdk.streaming import (
+    CONNECTOR_STREAM_READ_TIMEOUT,
+    SSE_SERVER_PING_SECONDS,
+    _stream_sse,
+)
+
+
+def test_read_timeout_tolerates_healthy_idle_heartbeat() -> None:
+    """The read timeout must exceed the server ping interval.
+
+    A healthy idle stream produces a ``: ping`` every
+    ``SSE_SERVER_PING_SECONDS``; each heartbeat resets httpx's read
+    timeout.  If the timeout were <= the ping interval, a healthy idle
+    stream would be torn down on every quiet window — exactly the
+    flapping the heartbeat exists to prevent.
+    """
+    assert CONNECTOR_STREAM_READ_TIMEOUT > SSE_SERVER_PING_SECONDS
+    # A single missed heartbeat is jitter, not death — require headroom
+    # for at least two ping intervals before declaring the stream stale.
+    assert CONNECTOR_STREAM_READ_TIMEOUT >= 2 * SSE_SERVER_PING_SECONDS
+
+
+def test_server_ping_interval_matches_api_heartbeat() -> None:
+    """The SDK's assumed ping interval must equal the server's actual one.
+
+    If the API's ``SSE_PING_SECONDS`` drifts above the SDK's assumption,
+    a healthy idle stream could miss the read-timeout window and reconnect
+    needlessly; if it drifts well below, staleness detection lags.  Pin
+    them together so the two halves of the heartbeat contract stay in sync.
+    """
+    from aios.api.sse import SSE_PING_SECONDS
+
+    assert float(SSE_PING_SECONDS) == SSE_SERVER_PING_SECONDS
+
+
+class _RecordingStreamClient:
+    """Captures the ``timeout`` ``_stream_sse`` hands to ``.stream(...)``.
+
+    httpx only enforces read timeouts inside its real network transport
+    (a custom ``AsyncBaseTransport`` bypasses that machinery), so we can't
+    provoke a genuine ``ReadTimeout`` deterministically in-process.  We
+    instead assert the bounded timeout is wired through to the request —
+    httpx's own test suite owns the "this timeout raises ReadTimeout"
+    contract.  The body yields nothing, so the stream ends cleanly after
+    the synthetic ``_open`` marker.
+    """
+
+    def __init__(self) -> None:
+        self.captured_timeout: httpx.Timeout | None = None
+
+    @asynccontextmanager
+    async def stream(self, method: str, path: str, **kwargs: Any) -> AsyncIterator[httpx.Response]:
+        del method, path
+        timeout = kwargs.get("timeout")
+        assert isinstance(timeout, httpx.Timeout)
+        self.captured_timeout = timeout
+        response = httpx.Response(200, headers={"content-type": "text/event-stream"})
+
+        async def _empty() -> AsyncIterator[str]:
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        def _ok() -> httpx.Response:
+            return response
+
+        response.aiter_lines = _empty  # type: ignore[method-assign]
+        response.raise_for_status = _ok  # type: ignore[method-assign]
+        yield response
+
+
+async def test_stream_sse_uses_bounded_read_timeout() -> None:
+    """``_stream_sse`` opens the stream with a finite read timeout.
+
+    ``read=None`` is the bug (blocks forever on a half-open stream); the
+    fix is ``read=CONNECTOR_STREAM_READ_TIMEOUT``.
+    """
+    client = _RecordingStreamClient()
+    events = [msg.event async for msg in _stream_sse(client, "/v1/connectors/connections")]  # type: ignore[arg-type]
+
+    assert events == ["_open"]
+    assert client.captured_timeout is not None
+    # The bug regressions on a None read timeout; the fix is a finite one.
+    assert client.captured_timeout.read == CONNECTOR_STREAM_READ_TIMEOUT
+    assert client.captured_timeout.read is not None
+
+
+def test_read_timeout_is_an_http_error() -> None:
+    """``httpx.ReadTimeout`` is an ``httpx.HTTPError``.
+
+    The connector loops catch ``httpx.HTTPError`` to reconnect with
+    backoff; this is what turns a tripped read timeout into a recovery
+    instead of an unhandled crash.  Pin the relationship so the recovery
+    path can't silently break if httpx's exception hierarchy shifts.
+    """
+    assert issubclass(httpx.ReadTimeout, httpx.HTTPError)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/connectors/connections",
+        "/v1/connectors/runtime/calls",
+        "/v1/connectors/runtime/management-calls",
+    ],
+)
+async def test_all_connector_streams_bounded(path: str) -> None:
+    """Every connector SSE stream goes through the bounded-timeout path.
+
+    Discovery, tool-call, and management-call streams all share
+    ``_stream_sse`` (per the spec: the management/tool streams share the
+    SSE/long-poll pattern and the same half-open risk), so all three get
+    the read timeout.
+    """
+    client = _RecordingStreamClient()
+    _ = [msg async for msg in _stream_sse(client, path)]  # type: ignore[arg-type]
+    assert client.captured_timeout is not None
+    assert client.captured_timeout.read == CONNECTOR_STREAM_READ_TIMEOUT
+
+
+def test_streaming_module_constant_default() -> None:
+    """Sanity-check the production default is unchanged by monkeypatching."""
+    assert streaming.CONNECTOR_STREAM_READ_TIMEOUT == 3 * SSE_SERVER_PING_SECONDS


### PR DESCRIPTION
## Problem

`POST /v1/connections` for a new connection could be silently ignored by a running connector — no `connector.connection.added`, management calls returning `no_active_connection` indefinitely — until a container restart let boot-time backfill serve it.

Root cause: the connector's discovery SSE stream (and the sibling calls/management streams) went **silently half-open**. A proxy (Traefik idle timeout on a quiet stream) or the server dropped the connection without a FIN, and the SDK consumer opened the stream with `read=None` (unbounded read timeout), so it blocked forever waiting for bytes that would never come. Any connection created while the stream was zombied was invisible until restart.

## Fix

The server **already** emits an SSE heartbeat (`: ping` every 15s, via sse-starlette's `EventSourceResponse`) on every connector stream — that keeps proxies treating the stream as live and gives the client a steady trickle of bytes to distinguish "healthy idle" from "dead."

This PR wires up the missing client half:

- **`aios_sdk.streaming._stream_sse`** now opens connector streams with a **bounded read timeout** (`CONNECTOR_STREAM_READ_TIMEOUT = 3 × ping interval = 45s`) instead of `read=None`. A live stream is kept under the threshold by heartbeats; a half-open stream (no events **and** no heartbeat for the window) raises `httpx.ReadTimeout` — an `httpx.HTTPError` the connector loops (`_discovery_loop` / `_tool_loop` / `_management_call_loop`) already catch and reconnect on with backoff. The reconnect replays the backfill, which restores correctness. This covers all three connector streams since they share `_stream_sse`.
- **`aios.api.sse.SSE_PING_SECONDS`** centralizes the server's previously-inline `ping=15`, and a cross-package test pins it to the SDK's assumed interval so the two halves of the heartbeat contract can't silently drift.

## Tests

- `tests/unit/test_sdk_streaming_heartbeat.py`: the read timeout is finite, exceeds the ping interval with ≥2× headroom, is wired through to every connector stream path, equals the server's ping interval, and `httpx.ReadTimeout ⊂ httpx.HTTPError`. (httpx only enforces read timeouts in its real network transport, so the test asserts the timeout is wired through rather than provoking a real timeout in-process.)
- `TestDiscoveryLoopReconnectsOnStaleStream` in the connector-http suite: a `ReadTimeout` mid-stream makes the loop reconnect, back off, and replay the backfilled connection that appeared while the stream was dead.

Mutation-checked: reverting to `read=None` fails the bounded-timeout test. Full lint/type/unit suite green via the repo pre-commit hook. No OpenAPI/SDK codegen drift (no API surface change).

Closes #962