### PR TITLE
fix(harness): keep a non-empty tail in read_windowed_events

### DIFF
--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -1492,6 +1492,19 @@ async def read_windowed_events(
 
     drop = math.ceil(drop_effective / ratio)
 
+    # Never drop the entire window. ``select_window`` keeps a non-empty tail
+    # because it requires ``min_tokens >= 1``; here ``events_window_min`` can
+    # clamp to 0 when overhead exceeds ``window_min`` (above), and the
+    # asymmetric ceil back-conversion can then push ``drop`` up to ``total`` —
+    # the retained scan (``cumulative_tokens > drop``) would match zero rows
+    # while the omission complement still matches every row. That pairing
+    # (empty events + a non-None omission) crashes ``build_messages``, which
+    # reads ``events[0].created_at`` to anchor the omission marker and relies
+    # on the inverse invariant. Clamp so the most recent event always survives
+    # (its ``cumulative_tokens == total``), matching select_window's
+    # retain-the-tail-even-when-oversized guarantee.
+    drop = min(drop, total - 1)
+
     # Bounded range scan: only events past the boundary.
     rows = await conn.fetch(
         "SELECT * FROM events "

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -265,3 +265,64 @@ async def test_ceil_div_never_overshoots_window(
     assert remaining_effective <= window_max, (
         f"post-drop {remaining_effective} exceeds window_max={window_max}"
     )
+
+
+@pytest.mark.asyncio
+async def test_overhead_clamp_never_drops_entire_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The windower must never drop the *entire* window.
+
+    When per-step overhead exceeds ``window_min``, ``events_window_min``
+    clamps to its 0 floor (events.py) — losing the floor that normally
+    guarantees a non-empty tail (cf. ``select_window``, which requires
+    ``min_tokens >= 1``). The chunked snap then drops in full-window chunks,
+    and the asymmetric ``ceil(drop_effective / ratio)`` back-conversion can
+    push ``drop`` up to ``total``. The retained scan (``cumulative_tokens >
+    drop``) then matches ZERO rows while the omission complement
+    (``<= drop``) matches every row — so ``read_windowed_events`` returns an
+    empty event list paired with a non-None omission. ``build_messages``
+    relies on the inverse invariant and reads ``events[0].created_at`` to
+    anchor the omission marker, crashing with IndexError — and since
+    ``build_messages`` is pure replay, the session wedges permanently.
+
+    The boundary must keep ``drop < total`` so the most recent event always
+    survives (the last event's ``cumulative_tokens == total``; the scan is
+    ``> drop``).
+    """
+    account_id = "acc_test_stub"
+    ratio = 1.2
+    total_local = 534
+    window_min, window_max, overhead_local = 1_000, 2_000, 1_400
+    # overhead_effective = round(1400*1.2) = 1680 → events_window_max = 320,
+    # events_window_min = max(0, 1000-1680) = 0; total_effective =
+    # round(534*1.2) = 641 > 320 → drop_effective = tokens_to_drop(641,
+    # min=0, max=320) = 640 → ceil(640/1.2) = 534 == total (drops everything).
+    monkeypatch.setattr(queries, "model_token_ratio", AsyncMock(return_value=ratio))
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=total_local)
+    conn.fetchrow = AsyncMock(  # omission complement matches every row here
+        return_value={"began_at": _BEGAN_AT, "omitted_messages": 7}
+    )
+    captured: dict[str, int] = {}
+
+    async def _fetch(_sql: str, *args: Any) -> list[Any]:
+        captured["drop_local"] = args[1]
+        return []
+
+    conn.fetch = _fetch
+    await queries.read_windowed_events(
+        conn,
+        "sess_x",
+        window_min=window_min,
+        window_max=window_max,
+        model="m",
+        overhead_local=overhead_local,
+        account_id=account_id,
+    )
+    drop_local = captured["drop_local"]
+    assert drop_local < total_local, (
+        f"drop_local={drop_local} >= total={total_local} drops the entire "
+        "window, leaving an empty retained scan paired with a non-None "
+        "omission — which crashes build_messages on events[0]"
+    )


### PR DESCRIPTION
## Summary

- **Bug:** `read_windowed_events` could return an **empty event list paired with a non-None `WindowOmission`**. `build_messages` relies on the inverse invariant — it reads `events[0].created_at` to anchor the omission marker — so it raised `IndexError`. Because `build_messages` is pure replay over the immutable window, the crash recurred on **every wake and permanently wedged the session**.
- **Root cause:** `select_window` guarantees a non-empty tail because it requires `min_tokens >= 1`. `read_windowed_events` loses that floor: when per-step overhead (system prompt + tool schemas) exceeds `window_min`, `events_window_min` clamps to **0**, the chunked snap drops in full-window chunks, and the asymmetric `ceil(drop_effective / ratio)` back-conversion can push `drop` up to `total`. The retained scan (`cumulative_tokens > drop`) then matches **zero** rows while the omission complement (`<= drop`) matches **every** row.
- **Reachability:** `window_min` / `window_max` are `Field(ge=1)` with no cross-validation, so a small-window agent is creatable, and overhead easily exceeds a small `window_min`.
- **Fix:** `drop = min(drop, total - 1)` so the most recent event (whose `cumulative_tokens == total`) always survives — restoring `select_window`'s retain-the-tail invariant and the producer→consumer contract that `omission != None` ⟹ non-empty window.

## Why this altitude

Fixed at the **producer**, not by guarding `events[0]` in `build_messages`: a consumer guard would silently return a **broken (empty) context** — the model called with only the system prompt, unable to see the user's latest message — trading a loud crash for a silent failure. The producer fix keeps the latest turn and the omission marker (graceful, visible degradation), matching how `select_window` retains an oversized tail.

## Verification

- Failing test written first (`test_overhead_clamp_never_drops_entire_window`), confirmed red: `drop_local=534 >= total=534`.
- The clamp is provably a **no-op in every healthy regime** (`drop <= total - 2` there); existing windowing tests' drop assertions (1000 / 667 / 7300) are unchanged.
- Adversarial review attacked 5 vectors (off-by-one/still-empty, prefix-cache/monotonicity regression, fires-when-it-shouldn't, omission-complement consistency, `remaining_effective <= window_max`) — none reproduced.

## Test plan

- [x] `test_overhead_clamp_never_drops_entire_window` (red→green)
- [x] windowing + window + context suites (178 passed); full unit suite 2607 passed
- [x] mypy clean · ruff check + format clean
- [ ] CI runs e2e / integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)