### PR TITLE
refactor(db): extract shared version-history query helpers

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -104,6 +104,72 @@ async def _list_scoped[T](
     return [row(r) for r in await conn.fetch(sql, *args)]
 
 
+async def _get_versioned[T](
+    conn: asyncpg.Connection[Any],
+    *,
+    table: str,
+    parent_column: str,
+    parent_id: str,
+    version: int,
+    account_id: str,
+    row: Callable[[asyncpg.Record], T],
+    noun: str,
+) -> T:
+    """``SELECT * FROM <table> WHERE <parent_column>=$1 AND version=$2 AND account_id=$3``.
+
+    Raise NotFound on miss. ``table``/``parent_column``/``noun`` are static
+    literals from the calling module — never user input.
+    """
+    rec = await conn.fetchrow(
+        f"SELECT * FROM {table} WHERE {parent_column} = $1 AND version = $2 AND account_id = $3",
+        parent_id,
+        version,
+        account_id,
+    )
+    if rec is None:
+        raise NotFoundError(
+            f"{noun} {parent_id} version {version} not found",
+            detail={parent_column: parent_id, "version": version},
+        )
+    return row(rec)
+
+
+async def _list_versioned[T](
+    conn: asyncpg.Connection[Any],
+    *,
+    table: str,
+    parent_column: str,
+    parent_id: str,
+    account_id: str,
+    row: Callable[[asyncpg.Record], T],
+    limit: int = 50,
+    after: int | None = None,
+) -> list[T]:
+    """List a parent's versions newest-first (``version DESC``), keyset-paginated by ``after``.
+
+    ``table``/``parent_column`` are static literals from the calling module —
+    never user input.
+    """
+    if after is None:
+        rows = await conn.fetch(
+            f"SELECT * FROM {table} WHERE {parent_column} = $1 AND account_id = $2 "
+            "ORDER BY version DESC LIMIT $3",
+            parent_id,
+            account_id,
+            limit,
+        )
+    else:
+        rows = await conn.fetch(
+            f"SELECT * FROM {table} WHERE {parent_column} = $1 AND version < $2 "
+            "AND account_id = $3 ORDER BY version DESC LIMIT $4",
+            parent_id,
+            after,
+            account_id,
+            limit,
+        )
+    return [row(r) for r in rows]
+
+
 async def _archive_scoped(
     conn: asyncpg.Connection[Any],
     *,

--- a/src/aios/db/queries/agents.py
+++ b/src/aios/db/queries/agents.py
@@ -15,12 +15,13 @@ import asyncpg
 from aios.db.queries import (
     _archive_scoped,
     _get_scoped,
+    _get_versioned,
     _list_scoped,
+    _list_versioned,
     parse_jsonb,
 )
 from aios.errors import (
     ConflictError,
-    NotFoundError,
     ValidationError,
 )
 from aios.ids import (
@@ -389,18 +390,16 @@ async def get_agent_version(
     *,
     account_id: str,
 ) -> AgentVersion:
-    row = await conn.fetchrow(
-        "SELECT * FROM agent_versions WHERE agent_id = $1 AND version = $2 AND account_id = $3",
-        agent_id,
-        version,
-        account_id,
+    return await _get_versioned(
+        conn,
+        table="agent_versions",
+        parent_column="agent_id",
+        parent_id=agent_id,
+        version=version,
+        account_id=account_id,
+        row=_row_to_agent_version,
+        noun="agent",
     )
-    if row is None:
-        raise NotFoundError(
-            f"agent {agent_id} version {version} not found",
-            detail={"agent_id": agent_id, "version": version},
-        )
-    return _row_to_agent_version(row)
 
 
 async def list_agent_versions(
@@ -412,21 +411,13 @@ async def list_agent_versions(
     after: int | None = None,
 ) -> list[AgentVersion]:
     """List versions in descending order (newest first)."""
-    if after is None:
-        rows = await conn.fetch(
-            "SELECT * FROM agent_versions WHERE agent_id = $1 AND account_id = $2 "
-            "ORDER BY version DESC LIMIT $3",
-            agent_id,
-            account_id,
-            limit,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM agent_versions WHERE agent_id = $1 AND version < $2 "
-            "AND account_id = $3 ORDER BY version DESC LIMIT $4",
-            agent_id,
-            after,
-            account_id,
-            limit,
-        )
-    return [_row_to_agent_version(r) for r in rows]
+    return await _list_versioned(
+        conn,
+        table="agent_versions",
+        parent_column="agent_id",
+        parent_id=agent_id,
+        account_id=account_id,
+        row=_row_to_agent_version,
+        limit=limit,
+        after=after,
+    )

--- a/src/aios/db/queries/skills.py
+++ b/src/aios/db/queries/skills.py
@@ -15,7 +15,9 @@ import asyncpg
 from aios.db.queries import (
     _archive_scoped,
     _get_scoped,
+    _get_versioned,
     _list_scoped,
+    _list_versioned,
     parse_jsonb,
 )
 from aios.errors import (
@@ -189,18 +191,16 @@ async def get_skill_version(
     *,
     account_id: str,
 ) -> SkillVersion:
-    row = await conn.fetchrow(
-        "SELECT * FROM skill_versions WHERE skill_id = $1 AND version = $2 AND account_id = $3",
-        skill_id,
-        version,
-        account_id,
+    return await _get_versioned(
+        conn,
+        table="skill_versions",
+        parent_column="skill_id",
+        parent_id=skill_id,
+        version=version,
+        account_id=account_id,
+        row=_row_to_skill_version,
+        noun="skill",
     )
-    if row is None:
-        raise NotFoundError(
-            f"skill {skill_id} version {version} not found",
-            detail={"skill_id": skill_id, "version": version},
-        )
-    return _row_to_skill_version(row)
 
 
 async def get_latest_skill_version(
@@ -231,24 +231,16 @@ async def list_skill_versions(
     after: int | None = None,
 ) -> list[SkillVersion]:
     """List versions in descending order (newest first)."""
-    if after is None:
-        rows = await conn.fetch(
-            "SELECT * FROM skill_versions WHERE skill_id = $1 AND account_id = $2 "
-            "ORDER BY version DESC LIMIT $3",
-            skill_id,
-            account_id,
-            limit,
-        )
-    else:
-        rows = await conn.fetch(
-            "SELECT * FROM skill_versions WHERE skill_id = $1 AND version < $2 "
-            "AND account_id = $3 ORDER BY version DESC LIMIT $4",
-            skill_id,
-            after,
-            account_id,
-            limit,
-        )
-    return [_row_to_skill_version(r) for r in rows]
+    return await _list_versioned(
+        conn,
+        table="skill_versions",
+        parent_column="skill_id",
+        parent_id=skill_id,
+        account_id=account_id,
+        row=_row_to_skill_version,
+        limit=limit,
+        after=after,
+    )
 
 
 async def resolve_skill_refs(


### PR DESCRIPTION
## Summary

- `get_agent_version`/`list_agent_versions` and `get_skill_version`/`list_skill_versions`
  were near-identical — the `get_*` pair differs only in table, parent column,
  `NotFoundError` noun, and row mapper; the `list_*` pair adds only those same
  substitutions over an identical `after`-is-None keyset (`ORDER BY version DESC`).
- Extract `_get_versioned`/`_list_versioned` into `db/queries/__init__.py`,
  **mirroring the existing `_get_scoped`/`_list_scoped` helpers**, and reduce the
  four functions to thin delegations. The version tables were the only resource
  queries not yet using the shared-helper idiom; this completes it, making the
  version-query SQL (and its tenant scoping) a single source of truth so the
  agent and skill paths can no longer drift.
- `memory_versions` is intentionally left inline — it has a distinct
  `created_at`/`seq DESC` tiebreaker, not a twin.

### Note on LOC
Net is **slightly positive** (+49): the per-call kwargs plus two helper
docstrings cost more lines than the inline bodies removed. This is a
consolidation / idiom-consistency win, **not a deletion** — accepted
deliberately. (Surfaced by a `/kaizen` audit, duplication dimension.)

## Behavior equivalence (verified)
SQL, parameter order, `account_id` scoping, `NotFoundError` message + detail-dict
keys, row mappers, and pagination defaults are byte-for-byte identical per site
(adversarial code review + the agents/skills unit tests). `get_latest_skill_version`
and `memory_versions` are untouched.

## Test plan
- [x] `mypy src tests` — clean (593 files)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Unit suite — 2602 passed
- [ ] CI runs e2e/integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)