### PR TITLE
refactor(db): extract _row_to_memory_store_echo row mapper

### DIFF
--- a/src/aios/db/queries/memory_stores.py
+++ b/src/aios/db/queries/memory_stores.py
@@ -826,6 +826,17 @@ async def attach_memory_stores_to_session(
         )
 
 
+def _row_to_memory_store_echo(row: asyncpg.Record) -> MemoryStoreResourceEcho:
+    return MemoryStoreResourceEcho(
+        memory_store_id=row["memory_store_id"],
+        access=row["access"],
+        instructions=row["instructions"],
+        name=row["name_at_attach"],
+        description=row["description_at_attach"],
+        mount_path=f"/mnt/memory/{row['name_at_attach']}",
+    )
+
+
 async def list_session_memory_store_echoes(
     conn: asyncpg.Connection[Any],
     session_id: str,
@@ -837,17 +848,7 @@ async def list_session_memory_store_echoes(
         session_id,
         account_id,
     )
-    return [
-        MemoryStoreResourceEcho(
-            memory_store_id=r["memory_store_id"],
-            access=r["access"],
-            instructions=r["instructions"],
-            name=r["name_at_attach"],
-            description=r["description_at_attach"],
-            mount_path=f"/mnt/memory/{r['name_at_attach']}",
-        )
-        for r in rows
-    ]
+    return [_row_to_memory_store_echo(r) for r in rows]
 
 
 # GitHub repository attachments ────────────────────────────────────────────
@@ -937,16 +938,7 @@ async def batch_list_session_memory_store_echoes(
     )
     result: dict[str, list[MemoryStoreResourceEcho]] = {sid: [] for sid in session_ids}
     for r in rows:
-        result[r["session_id"]].append(
-            MemoryStoreResourceEcho(
-                memory_store_id=r["memory_store_id"],
-                access=r["access"],
-                instructions=r["instructions"],
-                name=r["name_at_attach"],
-                description=r["description_at_attach"],
-                mount_path=f"/mnt/memory/{r['name_at_attach']}",
-            )
-        )
+        result[r["session_id"]].append(_row_to_memory_store_echo(r))
     return result
 
 


### PR DESCRIPTION
## Summary

- `list_session_memory_store_echoes` and `batch_list_session_memory_store_echoes` each inlined an identical `MemoryStoreResourceEcho(...)` construction (same six fields, including the `mount_path=f"/mnt/memory/{name_at_attach}"` literal).
- Extract a module-level `_row_to_memory_store_echo(row)` and call it from both, mirroring the existing `_row_to_github_repo_echo` mapper used across the github-repo echo functions in the same file. Net **−8 LOC**.
- Pure structural change, zero behavior change: the helper reads only columns both queries already select (`SELECT *` and the explicit 5-column batch select).

## Test plan

- [x] mypy — clean
- [x] ruff check + format-check — clean
- [x] Unit suite (pre-commit full gate) — passed; memory-store tests (52) green
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)