### PR TITLE
fix: list run-spawned agent() children with status and usage

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1693,6 +1693,7 @@
           "sessions"
         ],
         "summary": "List ",
+        "description": "List sessions, newest first, keyset-paginated.\n\nSoft-archived sessions are hidden by default. Two filters surface them so a\nworkflow run's spent ``agent()`` children stay enumerable with their terminal\nstatus and token usage (#831): ``?parent_run_id=`` lists a run's children\n(alive or archived), and ``?status=archived`` lists the terminal ones. Each\nrow carries the derived ``status`` ({active, idle, archived}) and cumulative\n``usage``.",
         "operationId": "list_sessions",
         "parameters": [
           {
@@ -1736,7 +1737,8 @@
                 {
                   "enum": [
                     "active",
-                    "idle"
+                    "idle",
+                    "archived"
                   ],
                   "type": "string"
                 },
@@ -13424,7 +13426,8 @@
             "type": "string",
             "enum": [
               "active",
-              "idle"
+              "idle",
+              "archived"
             ],
             "title": "Status"
           },
@@ -16023,7 +16026,8 @@
             "type": "string",
             "enum": [
               "active",
-              "idle"
+              "idle",
+              "archived"
             ],
             "title": "Session Status"
           },

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_sessions.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_sessions.py
@@ -117,6 +117,15 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | ListResponseSession]:
     """List
 
+     List sessions, newest first, keyset-paginated.
+
+    Soft-archived sessions are hidden by default. Two filters surface them so a
+    workflow run's spent ``agent()`` children stay enumerable with their terminal
+    status and token usage (#831): ``?parent_run_id=`` lists a run's children
+    (alive or archived), and ``?status=archived`` lists the terminal ones. Each
+    row carries the derived ``status`` ({active, idle, archived}) and cumulative
+    ``usage``.
+
     Args:
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
@@ -161,6 +170,15 @@ def sync(
 ) -> HTTPValidationError | ListResponseSession | None:
     """List
 
+     List sessions, newest first, keyset-paginated.
+
+    Soft-archived sessions are hidden by default. Two filters surface them so a
+    workflow run's spent ``agent()`` children stay enumerable with their terminal
+    status and token usage (#831): ``?parent_run_id=`` lists a run's children
+    (alive or archived), and ``?status=archived`` lists the terminal ones. Each
+    row carries the derived ``status`` ({active, idle, archived}) and cumulative
+    ``usage``.
+
     Args:
         cursor (None | str | Unset):
         agent_id (None | str | Unset):
@@ -199,6 +217,15 @@ async def asyncio_detailed(
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseSession]:
     """List
+
+     List sessions, newest first, keyset-paginated.
+
+    Soft-archived sessions are hidden by default. Two filters surface them so a
+    workflow run's spent ``agent()`` children stay enumerable with their terminal
+    status and token usage (#831): ``?parent_run_id=`` lists a run's children
+    (alive or archived), and ``?status=archived`` lists the terminal ones. Each
+    row carries the derived ``status`` ({active, idle, archived}) and cumulative
+    ``usage``.
 
     Args:
         cursor (None | str | Unset):
@@ -241,6 +268,15 @@ async def asyncio(
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseSession | None:
     """List
+
+     List sessions, newest first, keyset-paginated.
+
+    Soft-archived sessions are hidden by default. Two filters surface them so a
+    workflow run's spent ``agent()`` children stay enumerable with their terminal
+    status and token usage (#831): ``?parent_run_id=`` lists a run's children
+    (alive or archived), and ``?status=archived`` lists the terminal ones. Each
+    row carries the derived ``status`` ({active, idle, archived}) and cumulative
+    ``usage``.
 
     Args:
         cursor (None | str | Unset):

--- a/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/list_sessions_status_type_0.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class ListSessionsStatusType0(str, Enum):
     ACTIVE = "active"
+    ARCHIVED = "archived"
     IDLE = "idle"
 
     def __str__(self) -> str:

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_status.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class SessionStatus(str, Enum):
     ACTIVE = "active"
+    ARCHIVED = "archived"
     IDLE = "idle"
 
     def __str__(self) -> str:

--- a/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wait_response_session_status.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class WaitResponseSessionStatus(str, Enum):
     ACTIVE = "active"
+    ARCHIVED = "archived"
     IDLE = "idle"
 
     def __str__(self) -> str:

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -120,6 +120,15 @@ async def list_(
     parent_run_id: str | None = None,
     limit: Annotated[int | None, Query(ge=1, le=200)] = None,
 ) -> ListResponse[Session]:
+    """List sessions, newest first, keyset-paginated.
+
+    Soft-archived sessions are hidden by default. Two filters surface them so a
+    workflow run's spent ``agent()`` children stay enumerable with their terminal
+    status and token usage (#831): ``?parent_run_id=`` lists a run's children
+    (alive or archived), and ``?status=archived`` lists the terminal ones. Each
+    row carries the derived ``status`` ({active, idle, archived}) and cumulative
+    ``usage``.
+    """
     st = page_cursor(
         cursor,
         {

--- a/src/aios/cli/commands/sessions.py
+++ b/src/aios/cli/commands/sessions.py
@@ -38,7 +38,7 @@ def list_(
     agent_id: Annotated[str | None, typer.Option("--agent-id")] = None,
     status_filter: Annotated[
         str | None,
-        typer.Option("--status", help="Filter by status: active, idle."),
+        typer.Option("--status", help="Filter by status: active, idle, archived."),
     ] = None,
     limit: Annotated[int, typer.Option("--limit", min=1, max=200)] = 50,
     all_: Annotated[bool, typer.Option("--all")] = False,

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -77,8 +77,10 @@ async def _list_scoped[T](
     after: str | None = None,
     filters: list[tuple[str, Any]] | None = None,
     extra_select: str | None = None,
+    include_archived: bool = False,
 ) -> list[T]:
-    """Keyset-paginated SELECT scoped by ``account_id`` + ``archived_at IS NULL``.
+    """Keyset-paginated SELECT scoped by ``account_id`` (+ ``archived_at IS NULL``
+    unless ``include_archived``).
 
     ``filters`` is a list of ``(column, value)`` equality predicates;
     entries whose ``value`` is ``None`` are skipped (mirrors the per-arg
@@ -87,9 +89,14 @@ async def _list_scoped[T](
 
     ``extra_select`` is an optional SQL expression (a static literal from
     this module, never user input) appended to the projection — e.g. a
-    correlated subquery that derives a column the base table doesn't store."""
+    correlated subquery that derives a column the base table doesn't store.
+
+    ``include_archived`` drops the default ``archived_at IS NULL`` clause so
+    soft-archived rows are visible — e.g. enumerating a workflow run's spent
+    ``agent()`` children (#831). The default keeps every other resource listing
+    archive-blind, as before."""
     args: list[Any] = [account_id]
-    where = ["archived_at IS NULL", "account_id = $1"]
+    where = ["account_id = $1"] if include_archived else ["archived_at IS NULL", "account_id = $1"]
     for column, value in filters or []:
         if value is None:
             continue

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -73,7 +73,17 @@ _SESSION_ACTIVE_EXPR = (
     f" AND NOT {_SESSION_ERRORED_EXPR})"
 )
 
-_SESSION_STATUS_EXPR = f"CASE WHEN {_SESSION_ACTIVE_EXPR} THEN 'active' ELSE 'idle' END"
+# Read-path status label ({active, idle, archived}). ``archived`` is terminal
+# and DOMINATES the active/idle derivation: a soft-archived session
+# (``archived_at`` set) — e.g. a workflow ``agent()`` child that reclaimed itself
+# on idle (``archive_when_idle``, #831) — never wakes again, so reporting it as
+# ``active``/``idle`` would be a lie. This wraps, but does NOT alter,
+# ``_SESSION_ACTIVE_EXPR``: the sweep's candidate filter uses that predicate
+# directly under its own ``archived_at IS NULL`` WHERE clause and is untouched.
+_SESSION_STATUS_EXPR = (
+    "CASE WHEN sessions.archived_at IS NOT NULL THEN 'archived' "
+    f"WHEN {_SESSION_ACTIVE_EXPR} THEN 'active' ELSE 'idle' END"
+)
 
 
 def _row_to_session(row: asyncpg.Record) -> Session:
@@ -719,7 +729,18 @@ async def list_sessions(
     ``parent_run_id`` is a plain column filter (the session is a workflow run's
     ``agent()`` child) — the session-side analog of filtering runs by their
     parent, so a run can list the agent sessions it spawned.
+
+    Soft-archived rows are normally invisible, but a workflow ``agent()`` child
+    reclaims itself on idle (``archive_when_idle``), so an account could never
+    enumerate its spent judgment nodes or sum their token spend (#831). Two
+    listings therefore drop the ``archived_at IS NULL`` clause: filtering by
+    ``parent_run_id`` (a run enumerating its children, alive or terminal) and
+    ``status="archived"`` (the explicit terminal-status query). All other
+    listings stay archive-blind. The ``({_SESSION_STATUS_EXPR})`` filter then
+    matches ``'archived'`` like any other status, so ``status="archived"``
+    returns exactly the archived rows.
     """
+    include_archived = parent_run_id is not None or status == "archived"
     return await _list_scoped(
         conn,
         table="sessions",
@@ -727,6 +748,7 @@ async def list_sessions(
         row=_row_to_session,
         limit=limit,
         after=after,
+        include_archived=include_archived,
         filters=[
             ("agent_id", agent_id),
             (f"({_SESSION_STATUS_EXPR})", status),

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -72,9 +72,9 @@ def _validate_session_resources(resources: list[SessionResource]) -> None:
     _validate_github_resources(github)
 
 
-SessionStatus = Literal["active", "idle"]
-"""Derived session activity, computed from the event log at read time (there is
-no persisted status column).
+SessionStatus = Literal["active", "idle", "archived"]
+"""Derived session activity, computed from the event log + ``archived_at`` at
+read time (there is no persisted status column).
 
 * ``active`` — the session has owed/in-flight work that will advance WITHOUT a
   new unprompted user message: an unreacted user/tool stimulus, or an unresolved
@@ -82,6 +82,10 @@ no persisted status column).
   custom-tool result — see :class:`AwaitingToolCall`).
 * ``idle`` — quiescent: nothing is owed; only a new unprompted user message (or
   an armed timer firing) will move it. ``idle`` implies ``awaiting == []``.
+* ``archived`` — terminal: the session has been soft-archived (``archived_at``
+  set), e.g. a workflow ``agent()`` child that reclaimed itself on idle
+  (``archive_when_idle``). It will never wake again. This dominates the
+  active/idle derivation so a listing can report a run's spent judgment nodes.
 
 An *errored* session (model-call retry budget exhausted, not yet recovered) is a
 special case of ``idle``: it reads ``idle`` with ``stop_reason.type == "error"``

--- a/tests/integration/test_list_sessions_run_children.py
+++ b/tests/integration/test_list_sessions_run_children.py
@@ -1,0 +1,159 @@
+"""Integration test: run-spawned ``agent()`` children are listable by run_id,
+even after they soft-archive on idle, with a terminal ``archived`` status and
+their token usage.
+
+Regression for #831: ``agent()`` children (``origin=background``,
+``archive_when_idle=True``) are recovered only via journal-scraping because
+``list_sessions`` hardcoded ``archived_at IS NULL`` and the derived status was
+only ``{active, idle}``. An account running workflows must be able to enumerate
+its judgment nodes and sum their token spend as a first-class query.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.db.queries import workflows as wf_queries
+from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+async def _seed_run(conn: asyncpg.Connection[Any], account_id: str) -> str:
+    wf = await wf_queries.insert_workflow(
+        conn,
+        account_id=account_id,
+        name="demo",
+        script="async def main(input):\n    return 1\n",
+    )
+    run = await wf_queries.insert_wf_run(
+        conn,
+        account_id=account_id,
+        workflow_id=wf.id,
+        environment_id="env_lsrc",
+        script=wf.script,
+        host_semantics_epoch=HOST_SEMANTICS_EPOCH,
+        script_sha="deadbeef",
+    )
+    return run.id
+
+
+class TestListSessionsRunChildren:
+    async def test_archived_children_listable_by_run_id_with_status_and_usage(
+        self, migrated_db_url: str, _reset_db_state: None
+    ) -> None:
+        pool: asyncpg.Pool[Any] = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                    "display_name) VALUES ('acc_lsrc', NULL, TRUE, 'run-children-test')"
+                )
+                await conn.execute(
+                    "INSERT INTO environments (id, name, config, account_id) "
+                    "VALUES ('env_lsrc', 'lsrc-env', '{}'::jsonb, 'acc_lsrc')"
+                )
+
+            agent, _env, _parent = await seed_agent_env_session(
+                pool, account_id="acc_lsrc", prefix="lsrc"
+            )
+
+            async with pool.acquire() as conn:
+                run_id = await _seed_run(conn, "acc_lsrc")
+                child = await queries.insert_child_session(
+                    conn,
+                    session_id="ses_lsrc_child",
+                    account_id="acc_lsrc",
+                    agent_id=agent.id,
+                    environment_id="env_lsrc",
+                    agent_version=1,
+                    model="openrouter/test",
+                    parent_run_id=run_id,
+                    tools=[],
+                    mcp_servers=[],
+                    http_servers=[],
+                )
+                assert child is not None
+                # Record token spend (the per-beat cost the v0 PoC had to scrape).
+                await queries.increment_session_usage(
+                    conn,
+                    child.id,
+                    account_id="acc_lsrc",
+                    input_tokens=12_010,
+                    output_tokens=5_133,
+                )
+
+            # While alive, the child lists by run_id (status active/idle).
+            async with pool.acquire() as conn:
+                live = await queries.list_sessions(
+                    conn, account_id="acc_lsrc", parent_run_id=run_id
+                )
+            assert [s.id for s in live] == [child.id]
+
+            # The child reclaims itself on idle (archive_when_idle).
+            async with pool.acquire() as conn:
+                archived = await queries.reclaim_session_if_idle(
+                    conn, child.id, account_id="acc_lsrc"
+                )
+            assert archived is True
+
+            # The archived child STILL lists by run_id, with terminal status and usage.
+            async with pool.acquire() as conn:
+                after = await queries.list_sessions(
+                    conn, account_id="acc_lsrc", parent_run_id=run_id
+                )
+            assert [s.id for s in after] == [child.id]
+            got = after[0]
+            assert got.status == "archived"
+            assert got.archived_at is not None
+            assert got.usage.input_tokens == 12_010
+            assert got.usage.output_tokens == 5_133
+
+        finally:
+            await pool.close()
+
+    async def test_status_archived_filter_includes_archived_only(
+        self, migrated_db_url: str, _reset_db_state: None
+    ) -> None:
+        pool: asyncpg.Pool[Any] = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                    "display_name) VALUES ('acc_lsrc2', NULL, TRUE, 'run-children-test2')"
+                )
+            # One live foreground session...
+            _agent, _env, live = await seed_agent_env_session(
+                pool, account_id="acc_lsrc2", prefix="lsrc2"
+            )
+            # ...and one archived session.
+            _agent2, _env2, gone = await seed_agent_env_session(
+                pool, account_id="acc_lsrc2", prefix="lsrc2b"
+            )
+            async with pool.acquire() as conn:
+                await queries.archive_session(conn, gone.id, account_id="acc_lsrc2")
+
+            # Default listing omits the archived session.
+            async with pool.acquire() as conn:
+                default = await queries.list_sessions(conn, account_id="acc_lsrc2")
+            default_ids = {s.id for s in default}
+            assert live.id in default_ids
+            assert gone.id not in default_ids
+
+            # status=archived returns the archived session, not the live one.
+            async with pool.acquire() as conn:
+                archived = await queries.list_sessions(
+                    conn, account_id="acc_lsrc2", status="archived"
+                )
+            archived_ids = {s.id for s in archived}
+            assert gone.id in archived_ids
+            assert live.id not in archived_ids
+            assert all(s.status == "archived" for s in archived)
+        finally:
+            await pool.close()

--- a/tests/integration/test_list_sessions_run_children.py
+++ b/tests/integration/test_list_sessions_run_children.py
@@ -25,7 +25,7 @@ from tests.integration.conftest import seed_agent_env_session
 pytestmark = pytest.mark.integration
 
 
-async def _seed_run(conn: asyncpg.Connection[Any], account_id: str) -> str:
+async def _seed_run(conn: asyncpg.Connection[Any], account_id: str, environment_id: str) -> str:
     wf = await wf_queries.insert_workflow(
         conn,
         account_id=account_id,
@@ -36,7 +36,7 @@ async def _seed_run(conn: asyncpg.Connection[Any], account_id: str) -> str:
         conn,
         account_id=account_id,
         workflow_id=wf.id,
-        environment_id="env_lsrc",
+        environment_id=environment_id,
         script=wf.script,
         host_semantics_epoch=HOST_SEMANTICS_EPOCH,
         script_sha="deadbeef",
@@ -55,24 +55,20 @@ class TestListSessionsRunChildren:
                     "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
                     "display_name) VALUES ('acc_lsrc', NULL, TRUE, 'run-children-test')"
                 )
-                await conn.execute(
-                    "INSERT INTO environments (id, name, config, account_id) "
-                    "VALUES ('env_lsrc', 'lsrc-env', '{}'::jsonb, 'acc_lsrc')"
-                )
 
-            agent, _env, _parent = await seed_agent_env_session(
+            agent, env, _parent = await seed_agent_env_session(
                 pool, account_id="acc_lsrc", prefix="lsrc"
             )
 
             async with pool.acquire() as conn:
-                run_id = await _seed_run(conn, "acc_lsrc")
+                run_id = await _seed_run(conn, "acc_lsrc", env.id)
                 child = await queries.insert_child_session(
                     conn,
                     session_id="ses_lsrc_child",
                     account_id="acc_lsrc",
                     agent_id=agent.id,
-                    environment_id="env_lsrc",
-                    agent_version=1,
+                    environment_id=env.id,
+                    agent_version=agent.version,
                     model="openrouter/test",
                     parent_run_id=run_id,
                     tools=[],

--- a/tests/unit/test_list_sessions_include_archived.py
+++ b/tests/unit/test_list_sessions_include_archived.py
@@ -1,0 +1,51 @@
+"""Unit test: ``list_sessions`` drops the ``archived_at IS NULL`` clause exactly
+when enumerating a workflow run's children (``parent_run_id``) or asking for the
+terminal ``status="archived"`` query (#831), and keeps it otherwise.
+
+Exercised against a fake asyncpg connection that captures the emitted SQL, so it
+runs without a database. The status-derivation correctness (archived dominating
+active/idle) is covered by the integration test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios.db.queries import sessions as session_queries
+
+
+class _CapturingConn:
+    """Captures the SQL the query emits; returns no rows."""
+
+    def __init__(self) -> None:
+        self.sql: str | None = None
+
+    async def fetch(self, sql: str, *args: Any) -> list[Any]:
+        self.sql = sql
+        return []
+
+
+class TestListSessionsIncludeArchived:
+    @pytest.mark.parametrize(
+        ("kwargs", "expect_archived_filter"),
+        [
+            ({}, True),  # default listing stays archive-blind
+            ({"status": "idle"}, True),  # a non-archived status filter stays blind
+            ({"agent_id": "agt_x"}, True),  # plain agent filter stays blind
+            ({"parent_run_id": "wfr_x"}, False),  # run children: archived visible
+            ({"status": "archived"}, False),  # terminal-status query: archived visible
+            # parent_run_id wins even with a live-status filter (still drops clause;
+            # the status filter then narrows the visible set).
+            ({"parent_run_id": "wfr_x", "status": "idle"}, False),
+        ],
+    )
+    async def test_archived_clause_applied_only_when_blind(
+        self, kwargs: dict[str, Any], expect_archived_filter: bool
+    ) -> None:
+        conn = _CapturingConn()
+        await session_queries.list_sessions(conn, account_id="acc_x", **kwargs)
+        assert conn.sql is not None
+        has_clause = "archived_at IS NULL" in conn.sql
+        assert has_clause is expect_archived_filter


### PR DESCRIPTION
## Problem

Workflow `agent()` children (`origin=background`, `archive_when_idle`) soft-archive themselves the first time they go idle. Because `list_sessions` hardcoded `archived_at IS NULL` (via `_list_scoped`) and the derived `SessionStatus` was only `{active, idle}`, those children were invisible to **every** `/v1/sessions` listing — default and `?status=archived` alike. An account running workflows could not enumerate its own judgment nodes or sum their token spend without scraping the run journal (the v0 PoC had to journal-scrape to measure per-beat cost). Issue #831.

## Change

- **Terminal status**: added `archived` to `SessionStatus`. `_SESSION_STATUS_EXPR` now returns `'archived'` (terminal, dominating the active/idle derivation) when `archived_at IS NOT NULL`. The separate `_SESSION_ACTIVE_EXPR` the sweep uses for its candidate filter is untouched, so wake semantics are unchanged.
- **Archive-visible listings**: `_list_scoped` gains an `include_archived` flag that drops the default `archived_at IS NULL` clause. `list_sessions` sets it when filtering by `parent_run_id` (a run enumerating its children, alive or terminal) or when `status="archived"` (the explicit terminal-status query). Every other resource listing stays archive-blind, as before.
- Usage was already present on `Session.usage`; the gap was purely visibility + a terminal status label.
- Route docstring and CLI `--status` help updated; regenerated `openapi.json` and the `aios-sdk` client for the new enum value.

## Tests

- `tests/integration/test_list_sessions_run_children.py` — an `agent()` child lists by `run_id` while alive, then still lists after `reclaim_session_if_idle` archives it, reporting `status="archived"` and its recorded token usage; `status="archived"` returns archived sessions and excludes live ones; the default listing omits archived.
- `tests/unit/test_list_sessions_include_archived.py` — runnable without a DB (fake conn capturing SQL), asserts the `archived_at IS NULL` clause is dropped exactly for `parent_run_id` / `status="archived"` and kept otherwise. Mutation-checked: forcing `include_archived=False` fails the three archive-visible cases.

Note: no Docker in the sandbox, so the integration test was not run locally; the unit test + full mypy/ruff/unit suite (via the pre-commit hook) are green.

Closes #831