### PR TITLE
feat: surface rotated WhatsApp QR codes during pairing (#967)

### DIFF
--- a/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
+++ b/connectors/whatsapp/daemon/cmd/whatsapp-daemon/main.go
@@ -117,6 +117,10 @@ func (a *clientPairAdapter) StartPairing(ctx context.Context) (string, error) {
 	return a.client.StartPairing(ctx)
 }
 
+func (a *clientPairAdapter) GetPairingCode(ctx context.Context) (string, int, error) {
+	return a.client.GetPairingCode(ctx)
+}
+
 func (a *clientPairAdapter) ConfirmPairing(ctx context.Context) (handler.PairingOutcome, error) {
 	outcome, err := a.client.ConfirmPairing(ctx)
 	if err != nil {

--- a/connectors/whatsapp/daemon/internal/handler/pair.go
+++ b/connectors/whatsapp/daemon/internal/handler/pair.go
@@ -12,6 +12,7 @@ import (
 // decoupled from whatsmeow types so tests can stub it.
 type Pairer interface {
 	StartPairing(ctx context.Context) (string, error)
+	GetPairingCode(ctx context.Context) (string, int, error)
 	ConfirmPairing(ctx context.Context) (PairingOutcome, error)
 	Unpair(ctx context.Context) error
 }
@@ -30,6 +31,11 @@ type startPairingResult struct {
 	Code string `json:"code"`
 }
 
+type getPairingCodeResult struct {
+	Code        string `json:"code"`
+	RotationSeq int    `json:"rotation_seq"`
+}
+
 type confirmPairingResult struct {
 	Status   string `json:"status"`
 	JID      string `json:"jid,omitempty"`
@@ -45,6 +51,13 @@ func RegisterPairing(reg *Registry, p Pairer) {
 			return nil, &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
 		}
 		return startPairingResult{Code: code}, nil
+	})
+	reg.Register("getPairingCode", func(ctx context.Context, _ json.RawMessage) (any, *rpc.Error) {
+		code, seq, err := p.GetPairingCode(ctx)
+		if err != nil {
+			return nil, &rpc.Error{Code: rpc.ErrCodeServerError, Message: err.Error()}
+		}
+		return getPairingCodeResult{Code: code, RotationSeq: seq}, nil
 	})
 	reg.Register("confirmPairing", func(ctx context.Context, _ json.RawMessage) (any, *rpc.Error) {
 		outcome, err := p.ConfirmPairing(ctx)

--- a/connectors/whatsapp/daemon/internal/wameow/pair.go
+++ b/connectors/whatsapp/daemon/internal/wameow/pair.go
@@ -34,6 +34,17 @@ type PairingOutcome struct {
 type pairAttempt struct {
 	done    chan struct{}
 	outcome PairingOutcome
+
+	// code is the QR string currently displayed to the operator;
+	// rotationSeq increments each time whatsmeow rotates it (~every
+	// 20s).  Both are written under c.pair.mu by recordQRCode — the
+	// first code at StartPairing time (seq 0) and each subsequent
+	// "code" refresh in drainQRChannel.  GetPairingCode snapshots
+	// them under the same lock so a polling operator can re-render on
+	// seq change.  done being closed means the attempt terminated and
+	// no live code remains.
+	code        string
+	rotationSeq int
 }
 
 // pairing tracks the current or most recent pairing attempt.  attempt
@@ -87,6 +98,7 @@ func (c *Client) StartPairing(ctx context.Context) (string, error) {
 			c.completeFromQRItem(item)
 			return "", fmt.Errorf("pairing failed before first code: %s", item.Event)
 		}
+		c.recordQRCode(attempt, item.Code, 0)
 		go c.drainQRChannel(qrChan)
 		return item.Code, nil
 	case <-ctx.Done():
@@ -120,6 +132,58 @@ func (c *Client) ConfirmPairing(ctx context.Context) (PairingOutcome, error) {
 	case <-ctx.Done():
 		return PairingOutcome{}, ctx.Err()
 	}
+}
+
+// GetPairingCode returns the QR code currently displayed for the
+// in-flight attempt plus its rotationSeq.  Operators poll this every
+// few seconds and re-render when rotationSeq changes — surfacing the
+// rotated codes whatsmeow emits ~every 20s rather than just the first.
+//
+// Errors if no attempt has been started, if Unpair forgot the cache,
+// or if the attempt has already terminated (done closed): a terminated
+// attempt has no live code, and returning a stale one would invite the
+// operator to scan a dead QR.  The snapshot is taken under c.pair.mu so
+// a concurrent recordQRRefresh can't tear the {code, seq} pair.
+func (c *Client) GetPairingCode(ctx context.Context) (string, int, error) {
+	c.pair.mu.Lock()
+	defer c.pair.mu.Unlock()
+	if c.pair.attempt == nil {
+		return "", 0, errors.New("no pairing in progress")
+	}
+	if !c.pair.inProgress {
+		return "", 0, errors.New("pairing attempt already terminated")
+	}
+	return c.pair.attempt.code, c.pair.attempt.rotationSeq, nil
+}
+
+// recordQRCode stores the QR code + rotationSeq for attempt under
+// c.pair.mu.  Used for the first code (seq 0) at StartPairing time;
+// recordQRRefresh handles subsequent rotations.  Guarded against a
+// concurrent terminal: if the attempt is no longer current (Unpair or
+// completePair already swapped/cleared it), the write is dropped so a
+// late code can't resurrect a finished attempt's live-code state.
+func (c *Client) recordQRCode(attempt *pairAttempt, code string, seq int) {
+	c.pair.mu.Lock()
+	defer c.pair.mu.Unlock()
+	if c.pair.attempt != attempt {
+		return
+	}
+	attempt.code = code
+	attempt.rotationSeq = seq
+}
+
+// recordQRRefresh stores a rotated QR code on the current attempt,
+// incrementing rotationSeq.  No-op if no attempt is in progress (a late
+// refresh arriving after the attempt terminated): a terminated attempt
+// has no live code to update.
+func (c *Client) recordQRRefresh(code string) {
+	c.pair.mu.Lock()
+	defer c.pair.mu.Unlock()
+	if !c.pair.inProgress || c.pair.attempt == nil {
+		return
+	}
+	c.pair.attempt.code = code
+	c.pair.attempt.rotationSeq++
 }
 
 // Unpair unlinks the device server-side, deletes the local store, and
@@ -209,7 +273,11 @@ func (c *Client) drainQRChannel(qrChan <-chan whatsmeow.QRChannelItem) {
 	for item := range qrChan {
 		switch item.Event {
 		case "code":
-			// QR refresh; a future PR may surface these.
+			// QR refresh: whatsmeow rotates the code ~every 20s.
+			// Retain it (incrementing rotationSeq) so a polling
+			// operator can re-render the live code mid-attempt
+			// instead of being stuck on the first ~20s window.
+			c.recordQRRefresh(item.Code)
 			continue
 		case "scanned-without-multidevice":
 			// Per whatsmeow this is non-terminal: the QR session

--- a/connectors/whatsapp/daemon/internal/wameow/pair_test.go
+++ b/connectors/whatsapp/daemon/internal/wameow/pair_test.go
@@ -373,3 +373,75 @@ func TestCompleteFromQRItemSuccessLeavesPushNameEmpty(t *testing.T) {
 	}
 }
 
+func TestGetPairingCodeErrorsWhenNoAttempt(t *testing.T) {
+	c := &Client{log: discardLogger()}
+
+	_, _, err := c.GetPairingCode(context.Background())
+	if err == nil {
+		t.Fatal("expected error when no pairing has been started")
+	}
+}
+
+func TestGetPairingCodeReturnsCurrentCode(t *testing.T) {
+	c, attempt := newPairing()
+	c.recordQRCode(attempt, "2@first", 0)
+
+	code, seq, err := c.GetPairingCode(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != "2@first" {
+		t.Errorf("code = %q, want '2@first'", code)
+	}
+	if seq != 0 {
+		t.Errorf("rotationSeq = %d, want 0", seq)
+	}
+}
+
+func TestGetPairingCodeErrorsAfterTermination(t *testing.T) {
+	c, attempt := newPairing()
+	c.recordQRCode(attempt, "2@first", 0)
+	c.completePair(PairingOutcome{Status: "timeout"})
+
+	_, _, err := c.GetPairingCode(context.Background())
+	if err == nil {
+		t.Fatal("expected error after the attempt terminated (no live code)")
+	}
+}
+
+func TestDrainQRChannelRecordsRotatedCodes(t *testing.T) {
+	c, attempt := newPairing()
+	c.recordQRCode(attempt, "2@first", 0)
+
+	ch := make(chan whatsmeow.QRChannelItem, 3)
+	ch <- whatsmeow.QRChannelItem{Event: "code", Code: "2@second"}
+	ch <- whatsmeow.QRChannelItem{Event: "code", Code: "2@third"}
+	close(ch)
+
+	c.drainQRChannel(ch)
+
+	// Channel closed without a terminal event, so the attempt ends in
+	// error and GetPairingCode now refuses.  Assert on the captured
+	// state directly: the last rotated code is retained at seq 2.
+	if attempt.code != "2@third" {
+		t.Errorf("attempt.code = %q, want '2@third'", attempt.code)
+	}
+	if attempt.rotationSeq != 2 {
+		t.Errorf("attempt.rotationSeq = %d, want 2 (first=0, +2 refreshes)", attempt.rotationSeq)
+	}
+}
+
+func TestRecordQRRefreshIsNoOpAfterTermination(t *testing.T) {
+	c, attempt := newPairing()
+	c.recordQRCode(attempt, "2@first", 0)
+	c.completePair(PairingOutcome{Status: "success", JID: "alice@s.whatsapp.net"})
+
+	c.recordQRRefresh("2@late")
+
+	if attempt.code != "2@first" {
+		t.Errorf("late refresh mutated a terminated attempt: code = %q, want '2@first'", attempt.code)
+	}
+	if attempt.rotationSeq != 0 {
+		t.Errorf("late refresh bumped seq on a terminated attempt: %d, want 0", attempt.rotationSeq)
+	}
+}

--- a/connectors/whatsapp/src/aios_whatsapp/daemon.py
+++ b/connectors/whatsapp/src/aios_whatsapp/daemon.py
@@ -123,6 +123,18 @@ class WhatsappDaemon:
         result = await self.rpc.call("startPairing")
         return result if isinstance(result, dict) else {}
 
+    async def get_pairing_code(self) -> dict[str, Any]:
+        """Fetch the QR code currently displayed for the in-flight attempt.
+
+        Returns ``{"code": "...", "rotation_seq": N}``.  whatsmeow rotates
+        the code ~every 20 s; operators poll this and re-render when
+        ``rotation_seq`` changes.  The daemon errors (surfaced as an RPC
+        error) if no attempt is in progress or it has already terminated —
+        there is no live code to show in that case.
+        """
+        result = await self.rpc.call("getPairingCode")
+        return result if isinstance(result, dict) else {}
+
     async def confirm_pairing(self) -> dict[str, Any]:
         """Block until the in-flight pairing terminates.
 

--- a/connectors/whatsapp/src/aios_whatsapp/management.py
+++ b/connectors/whatsapp/src/aios_whatsapp/management.py
@@ -71,6 +71,39 @@ class WhatsappManagementMixin:
         return {"external_account_id": external_account_id, "code": code}
 
     @management_handler()
+    async def getPairingCode(self, *, external_account_id: str) -> dict[str, Any]:
+        """Return the rotated QR code currently live for the in-flight attempt.
+
+        whatsmeow rotates the code ~every 20 s over a ~100 s attempt;
+        :meth:`startPairing` surfaces only the first.  Operators poll this
+        every few seconds and re-render when ``rotation_seq`` changes so
+        each ~20 s window is scannable, not just the first.
+
+        Returns ``{external_account_id, code, rotation_seq}``.  Raises
+        :class:`ManagementHandlerError` if the daemon returns an empty code
+        (no live attempt / already terminated) so the AIOS server route can
+        surface a 404/502 rather than 200 OK with a blank QR.
+        """
+        state = self._state_for_phone(external_account_id)
+        result = await state.daemon.get_pairing_code()
+        code = result.get("code")
+        if not code:
+            raise ManagementHandlerError(
+                {
+                    "status": "error",
+                    "external_account_id": external_account_id,
+                    "reason": "daemon returned empty pairing code",
+                }
+            )
+        return {
+            "external_account_id": external_account_id,
+            "code": code,
+            # rotation_seq defaults to 0 (the first code) when the daemon
+            # omits it — a missing seq means no rotation has happened yet.
+            "rotation_seq": result.get("rotation_seq", 0),
+        }
+
+    @management_handler()
     async def confirmPairing(self, *, external_account_id: str) -> dict[str, Any]:
         """Block until pairing terminates.
 

--- a/connectors/whatsapp/tests/test_management.py
+++ b/connectors/whatsapp/tests/test_management.py
@@ -92,6 +92,54 @@ async def test_start_pairing_empty_code_raises_structured_error(
     assert "empty pairing code" in ei.value.payload["reason"]
 
 
+async def test_get_pairing_code_returns_code_and_rotation_seq(
+    connector: WhatsappConnector,
+) -> None:
+    """getPairingCode surfaces the rotated code + its rotation_seq so a
+    polling operator can re-render when the code changes mid-attempt."""
+    connector.state[CONNECTION_ID].daemon.get_pairing_code = (  # type: ignore[attr-defined]
+        _async_return({"code": "2@rotated-qr", "rotation_seq": 3})
+    )
+    result = await connector.getPairingCode(external_account_id=PHONE)
+    connector.state[CONNECTION_ID].daemon.get_pairing_code.assert_awaited_once()  # type: ignore[attr-defined]
+    assert result == {
+        "external_account_id": PHONE,
+        "code": "2@rotated-qr",
+        "rotation_seq": 3,
+    }
+
+
+async def test_get_pairing_code_defaults_rotation_seq_to_zero(
+    connector: WhatsappConnector,
+) -> None:
+    """A daemon that omits rotation_seq (first code, no rotation yet)
+    defaults to 0 rather than dropping the field."""
+    connector.state[CONNECTION_ID].daemon.get_pairing_code = (  # type: ignore[attr-defined]
+        _async_return({"code": "2@first-qr"})
+    )
+    result = await connector.getPairingCode(external_account_id=PHONE)
+    assert result == {
+        "external_account_id": PHONE,
+        "code": "2@first-qr",
+        "rotation_seq": 0,
+    }
+
+
+async def test_get_pairing_code_empty_code_raises_structured_error(
+    connector: WhatsappConnector,
+) -> None:
+    """No live attempt (or one already terminated) yields an empty code;
+    surface a structured error, not a 200 OK with a blank QR."""
+    connector.state[CONNECTION_ID].daemon.get_pairing_code = (  # type: ignore[attr-defined]
+        _async_return({"code": ""})
+    )
+    with pytest.raises(ManagementHandlerError) as ei:
+        await connector.getPairingCode(external_account_id=PHONE)
+    assert ei.value.payload["status"] == "error"
+    assert ei.value.payload["external_account_id"] == PHONE
+    assert "empty pairing code" in ei.value.payload["reason"]
+
+
 async def test_confirm_pairing_empty_status_falls_back_to_error(
     connector: WhatsappConnector,
 ) -> None:

--- a/openapi.json
+++ b/openapi.json
@@ -7828,6 +7828,66 @@
         }
       }
     },
+    "/v1/connectors/whatsapp/pairing-code": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Post Whatsapp Pairing Code",
+        "description": "Return the QR code currently live for the in-flight pairing\nattempt.  whatsmeow rotates the code ~every 20 s over the ~100 s\nattempt; ``/start-pairing`` surfaces only the first.  Operators poll\nthis every few seconds and re-render when ``rotation_seq`` changes so\neach rotation is scannable, not just the first window.  404s when no\nattempt is live (none started, or already terminated).",
+        "operationId": "post_connector_whatsapp_pairing_code",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WhatsappPairingCodeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WhatsappPairingCodeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/connectors/whatsapp/confirm-pairing": {
       "post": {
         "tags": [
@@ -16474,6 +16534,44 @@
         ],
         "title": "WhatsappConfirmPairingResponse",
         "description": "``status`` is the terminal pairing outcome; ``jid`` / ``push_name``\nare populated on success, ``reason`` on error / timeout."
+      },
+      "WhatsappPairingCodeRequest": {
+        "properties": {
+          "external_account_id": {
+            "type": "string",
+            "title": "External Account Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "external_account_id"
+        ],
+        "title": "WhatsappPairingCodeRequest"
+      },
+      "WhatsappPairingCodeResponse": {
+        "properties": {
+          "external_account_id": {
+            "type": "string",
+            "title": "External Account Id"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "rotation_seq": {
+            "type": "integer",
+            "title": "Rotation Seq"
+          }
+        },
+        "type": "object",
+        "required": [
+          "external_account_id",
+          "code",
+          "rotation_seq"
+        ],
+        "title": "WhatsappPairingCodeResponse",
+        "description": "The QR code currently live for the in-flight pairing attempt.\n\n``rotation_seq`` increments each time whatsmeow rotates the code\n(~every 20 s); operators poll this endpoint every few seconds and\nre-render the QR when ``rotation_seq`` changes."
       },
       "WhatsappStartPairingRequest": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_whatsapp_pairing_code.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_whatsapp_pairing_code.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.whatsapp_pairing_code_request import WhatsappPairingCodeRequest
+from ...models.whatsapp_pairing_code_response import WhatsappPairingCodeResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: WhatsappPairingCodeRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connectors/whatsapp/pairing-code",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | WhatsappPairingCodeResponse | None:
+    if response.status_code == 200:
+        response_200 = WhatsappPairingCodeResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | WhatsappPairingCodeResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WhatsappPairingCodeRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WhatsappPairingCodeResponse]:
+    """Post Whatsapp Pairing Code
+
+     Return the QR code currently live for the in-flight pairing
+    attempt.  whatsmeow rotates the code ~every 20 s over the ~100 s
+    attempt; ``/start-pairing`` surfaces only the first.  Operators poll
+    this every few seconds and re-render when ``rotation_seq`` changes so
+    each rotation is scannable, not just the first window.  404s when no
+    attempt is live (none started, or already terminated).
+
+    Args:
+        authorization (None | str | Unset):
+        body (WhatsappPairingCodeRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WhatsappPairingCodeResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WhatsappPairingCodeRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WhatsappPairingCodeResponse | None:
+    """Post Whatsapp Pairing Code
+
+     Return the QR code currently live for the in-flight pairing
+    attempt.  whatsmeow rotates the code ~every 20 s over the ~100 s
+    attempt; ``/start-pairing`` surfaces only the first.  Operators poll
+    this every few seconds and re-render when ``rotation_seq`` changes so
+    each rotation is scannable, not just the first window.  404s when no
+    attempt is live (none started, or already terminated).
+
+    Args:
+        authorization (None | str | Unset):
+        body (WhatsappPairingCodeRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WhatsappPairingCodeResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WhatsappPairingCodeRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | WhatsappPairingCodeResponse]:
+    """Post Whatsapp Pairing Code
+
+     Return the QR code currently live for the in-flight pairing
+    attempt.  whatsmeow rotates the code ~every 20 s over the ~100 s
+    attempt; ``/start-pairing`` surfaces only the first.  Operators poll
+    this every few seconds and re-render when ``rotation_seq`` changes so
+    each rotation is scannable, not just the first window.  404s when no
+    attempt is live (none started, or already terminated).
+
+    Args:
+        authorization (None | str | Unset):
+        body (WhatsappPairingCodeRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | WhatsappPairingCodeResponse]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: WhatsappPairingCodeRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | WhatsappPairingCodeResponse | None:
+    """Post Whatsapp Pairing Code
+
+     Return the QR code currently live for the in-flight pairing
+    attempt.  whatsmeow rotates the code ~every 20 s over the ~100 s
+    attempt; ``/start-pairing`` surfaces only the first.  Operators poll
+    this every few seconds and re-render when ``rotation_seq`` changes so
+    each rotation is scannable, not just the first window.  404s when no
+    attempt is live (none started, or already terminated).
+
+    Args:
+        authorization (None | str | Unset):
+        body (WhatsappPairingCodeRequest):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | WhatsappPairingCodeResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -250,6 +250,8 @@ from .whatsapp_confirm_pairing_response import WhatsappConfirmPairingResponse
 from .whatsapp_confirm_pairing_response_status import (
     WhatsappConfirmPairingResponseStatus,
 )
+from .whatsapp_pairing_code_request import WhatsappPairingCodeRequest
+from .whatsapp_pairing_code_response import WhatsappPairingCodeResponse
 from .whatsapp_start_pairing_request import WhatsappStartPairingRequest
 from .whatsapp_start_pairing_response import WhatsappStartPairingResponse
 from .whatsapp_unpair_request import WhatsappUnpairRequest
@@ -502,6 +504,8 @@ __all__ = (
     "WhatsappConfirmPairingRequest",
     "WhatsappConfirmPairingResponse",
     "WhatsappConfirmPairingResponseStatus",
+    "WhatsappPairingCodeRequest",
+    "WhatsappPairingCodeResponse",
     "WhatsappStartPairingRequest",
     "WhatsappStartPairingResponse",
     "WhatsappUnpairRequest",

--- a/packages/aios-sdk/aios_sdk/_generated/models/whatsapp_pairing_code_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/whatsapp_pairing_code_request.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="WhatsappPairingCodeRequest")
+
+
+@_attrs_define
+class WhatsappPairingCodeRequest:
+    """
+    Attributes:
+        external_account_id (str):
+    """
+
+    external_account_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        external_account_id = self.external_account_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "external_account_id": external_account_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        external_account_id = d.pop("external_account_id")
+
+        whatsapp_pairing_code_request = cls(
+            external_account_id=external_account_id,
+        )
+
+        return whatsapp_pairing_code_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/whatsapp_pairing_code_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/whatsapp_pairing_code_response.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="WhatsappPairingCodeResponse")
+
+
+@_attrs_define
+class WhatsappPairingCodeResponse:
+    """The QR code currently live for the in-flight pairing attempt.
+
+    ``rotation_seq`` increments each time whatsmeow rotates the code
+    (~every 20 s); operators poll this endpoint every few seconds and
+    re-render the QR when ``rotation_seq`` changes.
+
+        Attributes:
+            external_account_id (str):
+            code (str):
+            rotation_seq (int):
+    """
+
+    external_account_id: str
+    code: str
+    rotation_seq: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        external_account_id = self.external_account_id
+
+        code = self.code
+
+        rotation_seq = self.rotation_seq
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "external_account_id": external_account_id,
+                "code": code,
+                "rotation_seq": rotation_seq,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        external_account_id = d.pop("external_account_id")
+
+        code = d.pop("code")
+
+        rotation_seq = d.pop("rotation_seq")
+
+        whatsapp_pairing_code_response = cls(
+            external_account_id=external_account_id,
+            code=code,
+            rotation_seq=rotation_seq,
+        )
+
+        whatsapp_pairing_code_response.additional_properties = d
+        return whatsapp_pairing_code_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -858,6 +858,24 @@ class WhatsappStartPairingResponse(BaseModel):
     code: str
 
 
+class WhatsappPairingCodeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    external_account_id: str
+
+
+class WhatsappPairingCodeResponse(BaseModel):
+    """The QR code currently live for the in-flight pairing attempt.
+
+    ``rotation_seq`` increments each time whatsmeow rotates the code
+    (~every 20 s); operators poll this endpoint every few seconds and
+    re-render the QR when ``rotation_seq`` changes."""
+
+    external_account_id: str
+    code: str
+    rotation_seq: int
+
+
 class WhatsappConfirmPairingRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -950,6 +968,45 @@ async def post_whatsapp_start_pairing(
     return WhatsappStartPairingResponse(
         external_account_id=body.external_account_id,
         code=str(code),
+    )
+
+
+@router.post(
+    "/whatsapp/pairing-code",
+    operation_id="post_connector_whatsapp_pairing_code",
+)
+async def post_whatsapp_pairing_code(
+    body: WhatsappPairingCodeRequest,
+    db_url: DbUrlDep,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+) -> WhatsappPairingCodeResponse:
+    """Return the QR code currently live for the in-flight pairing
+    attempt.  whatsmeow rotates the code ~every 20 s over the ~100 s
+    attempt; ``/start-pairing`` surfaces only the first.  Operators poll
+    this every few seconds and re-render when ``rotation_seq`` changes so
+    each rotation is scannable, not just the first window.  404s when no
+    attempt is live (none started, or already terminated)."""
+    result = await _whatsapp_management_call(
+        db_url,
+        pool,
+        account_id=account_id,
+        method="getPairingCode",
+        params=body.model_dump(exclude_none=True),
+        timeout_s=30.0,
+    )
+    code = result.get("code") if isinstance(result, dict) else None
+    if not code:
+        # Fail loud rather than 200 OK with an empty QR — see
+        # post_whatsapp_start_pairing for the rationale.
+        raise ConnectorCallFailedError(
+            "whatsapp connector getPairingCode returned no code",
+            detail={"method": "getPairingCode", "connector_result": result},
+        )
+    return WhatsappPairingCodeResponse(
+        external_account_id=body.external_account_id,
+        code=str(code),
+        rotation_seq=int(result.get("rotation_seq", 0)),
     )
 
 

--- a/src/aios/cli/commands/whatsapp.py
+++ b/src/aios/cli/commands/whatsapp.py
@@ -1,4 +1,4 @@
-"""``aios whatsapp {start-pairing, confirm-pairing, unpair}`` — operator pairing ops."""
+"""``aios whatsapp {start-pairing, pairing-code, confirm-pairing, unpair}`` — operator pairing ops."""
 
 from __future__ import annotations
 
@@ -12,11 +12,15 @@ from aios.cli.output import print_note
 from aios.cli.runtime import get_state, run_or_die
 from aios_sdk._generated.api.connectors import (
     post_connector_whatsapp_confirm_pairing,
+    post_connector_whatsapp_pairing_code,
     post_connector_whatsapp_start_pairing,
     post_connector_whatsapp_unpair,
 )
 from aios_sdk._generated.models.whatsapp_confirm_pairing_request import (
     WhatsappConfirmPairingRequest,
+)
+from aios_sdk._generated.models.whatsapp_pairing_code_request import (
+    WhatsappPairingCodeRequest,
 )
 from aios_sdk._generated.models.whatsapp_start_pairing_request import (
     WhatsappStartPairingRequest,
@@ -25,7 +29,7 @@ from aios_sdk._generated.models.whatsapp_unpair_request import WhatsappUnpairReq
 
 app = typer.Typer(
     name="whatsapp",
-    help="WhatsApp management operations (pair, confirm-pairing, unpair).",
+    help="WhatsApp management operations (pair, pairing-code, confirm-pairing, unpair).",
     no_args_is_help=True,
 )
 
@@ -65,6 +69,33 @@ def start_pairing(
         )
         if payload:
             render_single(payload)
+
+    run_or_die(_run)
+
+
+@app.command("pairing-code")
+@covers("post_connector_whatsapp_pairing_code")
+def pairing_code(
+    ctx: typer.Context,
+    phone: Annotated[str, typer.Argument(help="E.164 phone of the WhatsApp connection.")],
+) -> None:
+    """Fetch the QR code currently live for the in-flight pairing attempt.
+
+    whatsmeow rotates the code ~every 20 s over the ~100 s attempt;
+    ``start-pairing`` returns only the first.  Poll this every few
+    seconds and re-render the QR whenever ``rotation_seq`` changes so the
+    operator always has a scannable code, not just the first ~20 s window.
+    Fails if no attempt is live (none started, or already terminated).
+    """
+
+    def _run() -> None:
+        with get_state(ctx).sdk_client() as client:
+            body = WhatsappPairingCodeRequest(external_account_id=phone)
+            result = unwrap(
+                post_connector_whatsapp_pairing_code.sync_detailed(client=client, body=body)
+            )
+        payload = result.to_dict() if result is not None else {}
+        render_single(payload)
 
     run_or_die(_run)
 


### PR DESCRIPTION
## Problem

WhatsApp pairing v1 surfaced only the **first** QR code, but whatsmeow rotates codes ~every 20s over a ~100s attempt. The daemon drained those refreshes without retaining them, so operators got a single ~20s scan window per ~100s attempt — pairing on 2026-06-11 took three attempts purely from this.

## Approach

Implements **option 1 (poll-current-code)** from the design issue — the cheapest shape that fits the existing request/response management plane (operator API → management-call queue → connector handler → daemon RPC). No new streaming channel needed.

The daemon now retains the live code and a `rotation_seq` on the in-flight attempt; a new `getPairingCode` RPC surfaces it. Clients poll every few seconds and re-render the QR whenever `rotation_seq` changes.

## Changes

- **Daemon (Go)**: `pairAttempt` retains `{code, rotationSeq}`. `recordQRCode` sets the first code (seq 0) at `StartPairing`; `recordQRRefresh` bumps the seq on each `"code"` rotation in `drainQRChannel` (previously a no-op `continue`). New `GetPairingCode` snapshots both under the pair mutex and errors if no attempt is live or it has already terminated (no stale/dead QR). `getPairingCode` RPC added to the handler + `clientPairAdapter`.
- **Connector (Python)**: `DaemonClient.get_pairing_code()` + `WhatsappManagementMixin.getPairingCode` (fail-loud on empty code, `rotation_seq` defaults to 0).
- **API**: `POST /v1/connectors/whatsapp/pairing-code` → `{external_account_id, code, rotation_seq}`; 404 when no live attempt.
- **CLI**: `aios whatsapp pairing-code <phone>`.
- **Codegen**: regenerated `openapi.json` and the aios-sdk `_generated/` client (new operation + request/response models), committed together.

## Testing

- Go: new tests for `GetPairingCode` (no attempt / live code / post-termination), rotation capture in `drainQRChannel`, and late-refresh no-op after termination. `go build`/`go vet`/`go test` green.
- Python: management-handler tests for code+seq passthrough, `rotation_seq` default, and empty-code structured error.
- Mutation-checked one Go and one Python test (both fail when the production code is broken, pass when restored).
- Full pre-commit suite (ruff, mypy, unit + all connector suites) passed.

Notes for reviewers: a CLI command was required beyond the obvious plumbing because the repo's `test_cli_coverage` invariant fails any new OpenAPI operation lacking a `@covers` CLI command or allowlist entry — a `pairing-code` command fit the operator workflow better than an allowlist entry.

Closes #967