### PR TITLE
fix(sandbox): make the over-limit snapshot notice best-effort

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -802,10 +802,27 @@ class SandboxRegistry:
         if outcome.image_id is not None:
             # Edge-trigger the over-limit notice only on the crossing — read
             # the prior bytes only when we're actually over budget (rare).
+            # The notice (this read + the append below) is BEST-EFFORT: the
+            # snapshot verb and pointer write are the durable outcome, so a DB
+            # hiccup on the informational notice must not propagate. If it did,
+            # it would skip ``backend.destroy`` in the caller and surface as a
+            # harness_error retry — undoing a successful snapshot, which the
+            # no-propagate contract on ``_snapshot_and_remove`` forbids. A
+            # failed read loses the edge signal, so skip the notice rather than
+            # emit a possibly-spurious one.
             prev_bytes: int | None = None
             over_now = disk_limit_bytes is not None and outcome.unique_bytes > disk_limit_bytes
             if over_now:
-                prev_bytes = await self._read_snapshot_bytes(session_id)
+                try:
+                    prev_bytes = await self._read_snapshot_bytes(session_id)
+                except Exception as err:
+                    log.warning(
+                        "sandbox.over_limit_notice_read_failed",
+                        session_id=session_id,
+                        container_id=sandbox_id[:12],
+                        error=str(err),
+                    )
+                    over_now = False
             try:
                 await self._write_snapshot_pointer(session_id, tag, outcome.unique_bytes)
             except Exception as err:
@@ -821,11 +838,19 @@ class SandboxRegistry:
                 and over_now
                 and (prev_bytes is None or prev_bytes <= disk_limit_bytes)
             ):
-                await self._append_fs_event(
-                    session_id,
-                    SANDBOX_FS_OVER_LIMIT_EVENT,
-                    {"unique_bytes": outcome.unique_bytes, "limit_bytes": disk_limit_bytes},
-                )
+                try:
+                    await self._append_fs_event(
+                        session_id,
+                        SANDBOX_FS_OVER_LIMIT_EVENT,
+                        {"unique_bytes": outcome.unique_bytes, "limit_bytes": disk_limit_bytes},
+                    )
+                except Exception as err:
+                    log.warning(
+                        "sandbox.over_limit_notice_append_failed",
+                        session_id=session_id,
+                        container_id=sandbox_id[:12],
+                        error=str(err),
+                    )
 
         log.info(
             "sandbox.snapshot",

--- a/tests/unit/sandbox/test_snapshot_pointer.py
+++ b/tests/unit/sandbox/test_snapshot_pointer.py
@@ -9,12 +9,14 @@ first-commit crash heal, and the reset clear-plus-event — all without Docker.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
 
 from aios.harness import runtime
+from aios.sandbox.backends.base import SandboxHandle, SnapshotOutcome
 from aios.sandbox.registry import SandboxRegistry
 from tests.helpers.sandbox import FakeBackend, FakePool, make_handle
 
@@ -220,3 +222,71 @@ async def test_resolve_snapshot_missing_resets(
 
     assert resolved.snapshot_image is None
     assert ("fs_event", "sandbox_fs_reset", "snapshot_missing") in timeline
+
+
+def _over_budget_handle() -> SandboxHandle:
+    """A handle whose snapshot will exceed its disk limit (drives the
+    over-limit notice path: the FakeBackend outcome reports 2000 unique
+    bytes against a 1000-byte budget)."""
+    return SandboxHandle(
+        owner_id="sess_x",
+        sandbox_id="abc123def456abc123def456",
+        workspace_path=Path("/tmp/w"),
+        disk_limit_bytes=1_000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_over_limit_notice_read_failure_does_not_propagate(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The over-limit notice is best-effort. A DB failure reading the prior
+    snapshot bytes (the edge-trigger probe) must NOT propagate: the snapshot
+    verb and pointer write already succeeded, so the corpse must still be
+    removed. Propagating skips ``backend.destroy`` and burns a harness retry,
+    violating the docstring's no-propagate contract (§5.2)."""
+    registry, backend, timeline = harness
+    backend.next_snapshot_outcome = SnapshotOutcome(
+        kind="flattened", image_id="img", unique_bytes=2_000, depth=1
+    )
+
+    async def _boom(*_a: Any, **_k: Any) -> int | None:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("aios.sandbox.registry.queries.unscoped_get_session_snapshot_bytes", _boom)
+    registry._handles["sess_x"] = _over_budget_handle()
+    registry._last_used["sess_x"] = 0.0
+
+    await registry.release("sess_x")  # must not raise
+
+    kinds = [t[0] for t in timeline]
+    assert "pointer_set" in kinds, "snapshot + pointer succeeded"
+    assert "destroy" in kinds, "corpse must still be removed despite the notice read failure"
+
+
+@pytest.mark.asyncio
+async def test_over_limit_notice_append_failure_does_not_propagate(
+    harness: tuple[SandboxRegistry, FakeBackend, list[Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The over-limit fs-event append is best-effort too: a DB failure
+    emitting the model-visible notice must NOT propagate (same contract).
+    Prior bytes default to None (harness) → crossing edge → append fires."""
+    registry, backend, timeline = harness
+    backend.next_snapshot_outcome = SnapshotOutcome(
+        kind="flattened", image_id="img", unique_bytes=2_000, depth=1
+    )
+
+    async def _boom(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("aios.services.sessions.append_event", _boom)
+    registry._handles["sess_x"] = _over_budget_handle()
+    registry._last_used["sess_x"] = 0.0
+
+    await registry.release("sess_x")  # must not raise
+
+    kinds = [t[0] for t in timeline]
+    assert "pointer_set" in kinds, "snapshot + pointer succeeded"
+    assert "destroy" in kinds, "corpse must still be removed despite the notice append failure"


### PR DESCRIPTION
## Summary

- **Bug:** `_snapshot_and_record` (`sandbox/registry.py`) ran two over-budget-only DB calls **unguarded** *after* the (guarded) snapshot verb and pointer write — `_read_snapshot_bytes` (the edge-trigger probe) and `_append_fs_event` (the model-visible over-limit notice). Either raising propagated through `_snapshot_and_remove` (no guard) → `release()` → `run_session_step`'s generic `except`, surfacing as a **harness_error retry that skips `backend.destroy`** — leaving the container corpse and burning a retry slot.
- **Contract violated:** `_snapshot_and_remove`'s docstring states *"a snapshot failure here must not propagate."* A successful snapshot + pointer write must not be undone by a failed, purely-informational notice.
- **Fix:** Wrap each notice call in a best-effort `try/except` + `log.warning`, mirroring the adjacent snapshot-verb and pointer-write guards. The pointer-write guard is untouched — a pointer-write failure still `return False` (corpse retained, converges via salvage), **distinct** from a notice failure (swallow, `return True`, `destroy` runs).

## Why swallowing is correct here (not a "fail-hard" violation)

The swallowed calls are not the durable outcome — the snapshot verb + pointer write are, and they keep their own guards. The notice is an informational, teardown-time, model-not-consciously-initiated operation; its failure is logged to the ops log. This is the documented best-effort/no-propagate contract, not a silent suppression of a model-visible error.

## Design note (surfaced by adversarial review, sub-threshold)

On a prev-bytes **read** failure the fix sets `over_now=False`, skipping the notice for that cycle. This is deliberate: the over-limit notice is **edge-triggered** (fires once on `prev <= limit < now`), so when a read failure makes the crossing undeterminable, *not* firing is more faithful to the once-per-crossing semantics than emitting a possibly-spurious notice (the alternative would re-fire on every DB hiccup during an already-over-budget session). Trade-off: a read failure coinciding exactly with the crossing cycle misses that one advisory; the flattening behavior itself is unaffected.

## Verification

- Two failing tests written first (read-path and append-path), confirmed red: `RuntimeError: db down` propagates out of `release()` from `registry.py:808`.
- Adversarial review attacked 6 vectors (happy-path semantics, masked-failure, `over_now=False` choice, pointer-guard integrity, exception breadth, promote-gate isolation) — no actionable findings.

## Test plan

- [x] `test_over_limit_notice_read_failure_does_not_propagate`, `test_over_limit_notice_append_failure_does_not_propagate` (red→green; assert `release()` doesn't raise and the corpse is still removed)
- [x] full snapshot-pointer suite (9 passed); full unit suite 2618 passed
- [x] mypy clean · ruff check + format clean
- [ ] CI runs e2e / integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)