### PR TITLE
fix: notify session listeners on mid-flight archive (#906)

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -27,6 +27,7 @@ from aios.api.deps import (
 from aios.api.sse import SSE_PREFLIGHT_EXCEPTIONS, make_sse_response, sse_event_stream
 from aios.db import queries
 from aios.db.listen import (
+    EVENTS_ARCHIVED_NOTIFY,
     SESSION_INTERRUPT_CHANNEL,
     listen_for_events,
     open_listen_for_events,
@@ -806,6 +807,12 @@ async def wait_for_events(
                     break
                 if payload.startswith("{"):
                     continue
+                # Archive poke (#906): the session was archived mid-poll. It
+                # appends no event, so re-reading would find nothing and the
+                # client would block out the full timeout; instead return
+                # promptly so the caller observes the now-archived session.
+                if payload == EVENTS_ARCHIVED_NOTIFY:
+                    break
                 events = await service.read_events(
                     pool, session_id, after_seq=after, account_id=account_id
                 )

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -35,6 +35,7 @@ import asyncpg
 from sse_starlette import EventSourceResponse, ServerSentEvent
 
 from aios.db import queries
+from aios.db.listen import EVENTS_ARCHIVED_NOTIFY
 from aios.logging import get_logger
 from aios.models.workflows import TERMINAL_RUN_STATUSES
 
@@ -176,6 +177,15 @@ async def sse_event_stream(
             if notification.startswith("{"):
                 yield ServerSentEvent(data=notification, event="delta")
                 continue
+
+            # Archive poke (#906): the session was archived mid-stream. An
+            # archived session is permanently gone — terminal, just like a
+            # ``lifecycle: terminated`` event — so end the stream cleanly
+            # rather than treat the sentinel as a (missing) event id and log
+            # a spurious ``sse.event_not_found`` warning.
+            if notification == EVENTS_ARCHIVED_NOTIFY:
+                yield ServerSentEvent(data="{}", event="done")
+                return
 
             event_id = notification
             async with pool.acquire() as conn:

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -108,6 +108,17 @@ if TYPE_CHECKING:
 
 log = get_logger("aios.db.listen")
 
+# Sentinel payload fired on ``events_<session_id>`` when a session is archived
+# mid-flight (see :func:`aios.services.sessions.archive_session`). The
+# ``events_`` channel otherwise carries committed-event ids (``evt_…``) and
+# transient streaming-delta JSON (``{"delta": …}``); this sentinel is neither —
+# it's a content-free wake poke so consumers blocked on the channel (the
+# ``await`` primitive, the long-poll ``wait`` endpoint, the SSE ``/stream``)
+# re-read and observe the archive instead of sitting until their own timeout.
+# It deliberately does NOT start with ``{`` so it's distinguishable from a
+# delta payload, and isn't an ``evt_`` id so consumers don't try to fetch a row.
+EVENTS_ARCHIVED_NOTIFY = "archived"
+
 
 async def _connect_listener(db_url: str) -> asyncpg.Connection[object]:
     """Open a dedicated (non-pooled) asyncpg connection tagged with this

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -19,7 +19,7 @@ import asyncpg
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
-from aios.db.listen import open_listen_for_events
+from aios.db.listen import EVENTS_ARCHIVED_NOTIFY, open_listen_for_events
 from aios.db.queries import workflows as wf_queries
 from aios.errors import (
     ConflictError,
@@ -1266,6 +1266,16 @@ async def archive_session(pool: asyncpg.Pool[Any], session_id: str, *, account_i
         )
         session = await queries.archive_session(conn, session_id, account_id=account_id)
         session = await _enrich_session(conn, session, account_id=account_id)
+    # Wake any consumer LISTENing on this session's events channel (#906): the
+    # await primitive, the long-poll /wait endpoint, the SSE /stream. Archival
+    # appends no event of its own (it only flips ``archived_at``, and
+    # ``append_event`` is fenced by ``archived_at IS NULL``), so without this
+    # poke a mid-flight listener sits until its own timeout. Fired AFTER the
+    # transaction commits — the NOTIFY-after-commit invariant (a subscriber
+    # must never see a payload for state that isn't yet committed); the bare
+    # ``EVENTS_ARCHIVED_NOTIFY`` sentinel is neither an ``evt_`` id nor a
+    # ``{"delta": …}`` payload, so each consumer recognizes it on its own terms.
+    await pool.execute("SELECT pg_notify($1, $2)", f"events_{session_id}", EVENTS_ARCHIVED_NOTIFY)
     if parent_run_id is not None:
         await defer_run_wake(parent_run_id, batch=True)
     return session

--- a/tests/integration/test_archive_session_notify.py
+++ b/tests/integration/test_archive_session_notify.py
@@ -1,0 +1,129 @@
+"""Integration tests: ``archive_session`` fires a NOTIFY so mid-flight
+session listeners wake (issue #906).
+
+``db/queries/sessions.archive_session`` only flips ``archived_at`` — it appends
+no event, so before this fix any consumer blocked on ``events_<session_id>``
+(the ``await`` primitive, the long-poll ``/wait`` endpoint, the SSE ``/stream``)
+got no wake signal on mid-flight archival and sat until its own timeout.
+
+The service-layer ``archive_session`` now fires a bare
+``EVENTS_ARCHIVED_NOTIFY`` poke on ``events_<session_id>`` AFTER the archive
+transaction commits (the NOTIFY-after-commit invariant). These tests verify:
+
+* the raw poke lands on the channel after commit, and
+* a Mode-1 (request_id) ``await_session`` blocked mid-flight wakes on the poke
+  and returns ``child_gone`` promptly — well before its own timeout.
+
+DB-backed (testcontainer Postgres).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.listen import EVENTS_ARCHIVED_NOTIFY, open_listen_for_events
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError
+from aios.services import sessions as service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_and_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a fresh session."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_arch_notify', NULL, TRUE, 'archive-notify-test')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_arch_notify", prefix="archive-notify-test"
+        )
+        yield pool, "acc_arch_notify", session.id
+    finally:
+        await pool.close()
+
+
+async def test_archive_fires_notify_on_events_channel(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    """A subscriber LISTENing on ``events_<id>`` receives the archive sentinel
+    after the archive commits."""
+    pool, account_id, session_id = pool_and_session
+
+    subscription = await open_listen_for_events(migrated_db_url, session_id, acquire_lock=False)
+    try:
+        await service.archive_session(pool, session_id, account_id=account_id)
+        payload = await asyncio.wait_for(subscription.queue.get(), timeout=5)
+        assert payload == EVENTS_ARCHIVED_NOTIFY
+    finally:
+        subscription.terminate()
+
+
+async def test_mode1_await_wakes_promptly_on_mid_flight_archive(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    """A Mode-1 await blocked on an unresolved request wakes on the archive
+    poke and returns ``child_gone`` — without sitting out its full timeout."""
+    pool, account_id, session_id = pool_and_session
+
+    async def archive_late() -> None:
+        await asyncio.sleep(0.2)
+        await service.archive_session(pool, session_id, account_id=account_id)
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    resp, _ = await asyncio.gather(
+        service.await_session(
+            pool,
+            migrated_db_url,
+            session_id,
+            account_id=account_id,
+            request_id="req_archived",
+            watermark=None,
+            timeout_seconds=30,
+        ),
+        archive_late(),
+    )
+    elapsed = loop.time() - start
+
+    assert resp.done is True
+    assert resp.is_error is True
+    assert resp.error == {"kind": "child_gone"}
+    # The poke woke the await; it must not have waited out the 30s timeout.
+    assert elapsed < 10
+
+
+async def test_archive_already_archived_does_not_fire_second_poke(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    migrated_db_url: str,
+) -> None:
+    """Re-archiving an already-archived session raises NotFound (the query is
+    fenced by ``archived_at IS NULL``) BEFORE the poke — so no spurious poke
+    fires for a no-op archive."""
+    pool, account_id, session_id = pool_and_session
+    await service.archive_session(pool, session_id, account_id=account_id)
+
+    subscription = await open_listen_for_events(migrated_db_url, session_id, acquire_lock=False)
+    try:
+        with pytest.raises(NotFoundError):
+            await service.archive_session(pool, session_id, account_id=account_id)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(subscription.queue.get(), timeout=0.5)
+    finally:
+        subscription.terminate()

--- a/tests/unit/test_sse_archived_poke.py
+++ b/tests/unit/test_sse_archived_poke.py
@@ -1,0 +1,73 @@
+"""Unit tests: the SSE ``/stream`` generator ends cleanly on an archive poke.
+
+``archive_session`` fires a content-free ``EVENTS_ARCHIVED_NOTIFY`` sentinel on
+``events_<session_id>`` after commit (issue #906). The sentinel is neither an
+``evt_`` id nor a ``{"delta": …}`` payload, so the SSE tail must recognize it
+and terminate the stream (an archived session is permanently gone — equivalent
+to the ``lifecycle: terminated`` terminal) rather than log a spurious
+``sse.event_not_found`` warning while trying to fetch a non-existent row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from sse_starlette import ServerSentEvent
+
+from aios.api.sse import sse_event_stream
+from aios.db.listen import EVENTS_ARCHIVED_NOTIFY, ListenSubscription
+
+
+def _mk_subscription(queue: asyncio.Queue[str]) -> ListenSubscription:
+    return ListenSubscription(queue=queue, _conn=MagicMock())
+
+
+def _mk_pool_empty_backfill() -> MagicMock:
+    """Pool whose backfill ``conn.fetch`` returns no rows and whose
+    per-notify ``conn.fetchrow`` returns None (the archived session has no
+    new event row — only the sentinel poke)."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchrow = AsyncMock(return_value=None)
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool
+
+
+async def _drain(gen: Any) -> list[ServerSentEvent]:
+    return [item async for item in gen]
+
+
+async def test_sse_terminates_on_archive_poke() -> None:
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    queue.put_nowait(EVENTS_ARCHIVED_NOTIFY)
+    pool = _mk_pool_empty_backfill()
+    sub = _mk_subscription(queue)
+
+    out = await _drain(sse_event_stream(sub, pool, "sess_x", after_seq=0))
+
+    # Exactly one item: the terminal ``done`` SSE event.
+    assert len(out) == 1
+    assert out[0].event == "done"
+    # The archive poke must NOT have triggered a per-notify row fetch
+    # (which would have logged sse.event_not_found on the None result).
+    pool.acquire.return_value.__aenter__.return_value.fetchrow.assert_not_called()
+
+
+async def test_sse_archive_poke_is_distinct_from_delta() -> None:
+    """A real delta payload (``{"delta": …}``) still streams as a delta and
+    does NOT terminate; only the archive sentinel terminates."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    queue.put_nowait('{"delta": "hi"}')
+    queue.put_nowait(EVENTS_ARCHIVED_NOTIFY)
+    pool = _mk_pool_empty_backfill()
+    sub = _mk_subscription(queue)
+
+    out = await _drain(sse_event_stream(sub, pool, "sess_x", after_seq=0))
+
+    assert [item.event for item in out] == ["delta", "done"]


### PR DESCRIPTION
## Problem

`archive_session` only flipped `archived_at` and issued no `pg_notify` on `events_<session_id>`. Any consumer blocked on that session's LISTEN channel — the `await` primitive, the long-poll `/wait` endpoint, the SSE `/stream` — got no wake signal when the session was archived mid-flight, so it sat until its own timeout.

## Fix

Fire a bare `EVENTS_ARCHIVED_NOTIFY` sentinel on `events_<session_id>` **after the archive transaction commits** (honoring the repo's NOTIFY-after-commit invariant). Archival appends no event of its own — it only flips `archived_at`, and `append_event` is fenced by `archived_at IS NULL` — so a content-free poke is the right shape rather than a synthetic lifecycle event.

The sentinel is neither an `evt_` event id nor a `{"delta": …}` payload, so each of the three listener paths recognizes it on its own terms:

- **await primitive** — any queue item triggers a re-read; Mode 1 now wakes promptly and `derive_response` returns `child_gone` instead of waiting out the full timeout.
- **long-poll `/wait`** — returns promptly so the caller observes the now-archived session rather than blocking out the timeout on a no-op re-read.
- **SSE `/stream`** — treats the poke as terminal (an archived session is permanently gone, like a `lifecycle: terminated` event) and ends the stream cleanly instead of logging a spurious `sse.event_not_found`.

## Tests

- `tests/unit/test_sse_archived_poke.py` — SSE terminates on the archive poke without a stray row fetch; the sentinel stays distinct from a real delta. (Mutation-checked: breaking the SSE handling makes the test hang/fail.)
- `tests/integration/test_archive_session_notify.py` — the poke lands on the channel after commit; a Mode-1 await blocked mid-flight wakes and returns `child_gone` well before its 30s timeout; re-archiving raises `NotFound` before any spurious second poke.

## Validation

`ruff check`, `ruff format --check`, `mypy`, and the full unit suite (2604 passed) are green. Both codegen scripts (`regen-openapi.sh`, `regen-client.sh`) were run and produced no drift (no API surface changed). Integration tests need a Docker testcontainer Postgres (unavailable in the sandbox) and were verified by collection.

Closes #906