### PR TITLE
refactor(services): delete dead list_session_echoes wrappers

### DIFF
--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -154,18 +154,6 @@ async def detach_all_from_session(
     return bool(old_ids)
 
 
-async def list_session_echoes(
-    pool: asyncpg.Pool[Any],
-    session_id: str,
-    *,
-    account_id: str,
-) -> list[GithubRepositoryResourceEcho]:
-    async with pool.acquire() as conn:
-        return await queries.list_session_github_repo_echoes(
-            conn, session_id, account_id=account_id
-        )
-
-
 async def get_resource(
     pool: asyncpg.Pool[Any],
     session_id: str,

--- a/src/aios/services/memory_stores.py
+++ b/src/aios/services/memory_stores.py
@@ -27,7 +27,6 @@ from aios.models.memory_stores import (
     MemoryPrefix,
     MemoryStore,
     MemoryStoreResource,
-    MemoryStoreResourceEcho,
     MemoryVersion,
 )
 from aios.sandbox.atomic_mirror import atomic_delete, atomic_write
@@ -346,21 +345,6 @@ async def redact_version(
             actor_type=actor_type,
             actor_ref=actor_ref,
             account_id=account_id,
-        )
-
-
-# ── session bridge (used by sessions service) ──────────────────────────────
-
-
-async def list_session_echoes(
-    pool: asyncpg.Pool[Any],
-    session_id: str,
-    *,
-    account_id: str,
-) -> list[MemoryStoreResourceEcho]:
-    async with pool.acquire() as conn:
-        return await queries.list_session_memory_store_echoes(
-            conn, session_id, account_id=account_id
         )
 
 


### PR DESCRIPTION
## Summary

- `services/github_repositories.py` and `services/memory_stores.py` each defined
  an `async list_session_echoes()` that just forwarded to
  `queries.list_session_*_echoes`. **Both have zero callers** anywhere in
  src/tests/packages — every real consumer (`services/sessions.py`,
  `harness/loop.py`, `sandbox/spec.py`, `api/routers/sessions.py`) calls the
  query directly.
- The `memory_stores` copy even carried a provably-false
  `# session bridge (used by sessions service)` comment.
- Delete both wrappers + the stale comment; drop the now-unused
  `MemoryStoreResourceEcho` import. Underlying queries untouched. **−28 LOC, pure
  dead-code removal, no behavior change.**

Surfaced by a `/kaizen` re-audit (dead-code dimension, highest-confidence target).

## Test plan
- [x] `grep` — zero references to `list_session_echoes` remain
- [x] `mypy src` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] Unit suite (service/memory/github/echo) — 145 passed; full unit suite via pre-commit hook — green
- [ ] CI runs e2e/integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)