### PR TITLE
refactor(db): extract _row_to_active_binding mapper

### DIFF
--- a/src/aios/db/queries/connections.py
+++ b/src/aios/db/queries/connections.py
@@ -82,6 +82,16 @@ class ActiveBinding(NamedTuple):
     session_template_id: str | None
 
 
+def _row_to_active_binding(row: asyncpg.Record) -> ActiveBinding:
+    return ActiveBinding(
+        id=row["id"],
+        connection_id=row["connection_id"],
+        mode=row["mode"],
+        session_id=row["session_id"],
+        session_template_id=row["session_template_id"],
+    )
+
+
 async def get_active_binding(
     conn: asyncpg.Connection[Any],
     connection_id: str,
@@ -107,13 +117,7 @@ async def get_active_binding(
     )
     if row is None:
         return None
-    return ActiveBinding(
-        id=row["id"],
-        connection_id=row["connection_id"],
-        mode=row["mode"],
-        session_id=row["session_id"],
-        session_template_id=row["session_template_id"],
-    )
+    return _row_to_active_binding(row)
 
 
 async def insert_binding(
@@ -201,13 +205,7 @@ async def archive_active_binding(
     )
     if row is None:
         return None
-    return ActiveBinding(
-        id=row["id"],
-        connection_id=row["connection_id"],
-        mode=row["mode"],
-        session_id=row["session_id"],
-        session_template_id=row["session_template_id"],
-    )
+    return _row_to_active_binding(row)
 
 
 async def _raise_for_failed_binding_insert(


### PR DESCRIPTION
## Summary

- `get_active_binding` and `archive_active_binding` each constructed `ActiveBinding` field-by-field from a `Record`, while every sibling resource in the `db/queries` package uses a `_row_to_X(row)` mapper (`_row_to_connection`, `_row_to_event`, `_row_to_account`, …).
- Add `_row_to_active_binding` and route both `Record` sites through it. `insert_binding` builds from locals (not a `Record`) and correctly stays inline.
- Net **−2 LOC**; removes the inconsistency with the package's dominant row→model precedent.

## Test plan

- [x] mypy — clean
- [x] ruff check + format-check — clean
- [x] Unit suite (pre-commit full gate) — passed; connection/binding tests (63) green
- [x] Runtime check — mapper builds the tuple non-recursively
- [ ] CI runs e2e/integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)