### PR TITLE
fix(windowing): surface FS-loss sandbox notices to the model

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -365,6 +365,7 @@ from .events import (  # noqa: E402
     model_token_ratio,
     read_events,
     read_message_events,
+    read_windowed_context_events,
     read_windowed_events,
 )
 from .files import (  # noqa: E402
@@ -771,6 +772,7 @@ __all__ = [
     "read_message_events",
     "read_request_response",
     "read_session_watermarks",
+    "read_windowed_context_events",
     "read_windowed_events",
     "reclaim_session_if_idle",
     "record_trigger_fire",

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -29,7 +29,7 @@ from aios.ids import (
     EVENT,
     make_id,
 )
-from aios.models.events import Event, EventKind
+from aios.models.events import MODEL_VISIBLE_LIFECYCLE_EVENTS, Event, EventKind
 
 # ─── events ───────────────────────────────────────────────────────────────────
 
@@ -1384,6 +1384,71 @@ async def list_session_channels(
     return [str(r["channel"]) for r in rows]
 
 
+async def read_windowed_context_events(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    drop: int | None = None,
+) -> list[Event]:
+    """Events the context builder needs, in seq order: message events plus
+    the model-visible FS-loss notices (``kind='lifecycle'`` whose ``event``
+    is in :data:`MODEL_VISIBLE_LIFECYCLE_EVENTS`).
+
+    ``drop=None`` loads the full log. ``drop=N`` keeps messages with
+    ``cumulative_tokens > N`` plus notices past the dropped-message prefix
+    (``seq`` greater than the max seq among dropped messages). The notices
+    carry NULL ``cumulative_tokens``, so they window out by *seq* alongside
+    their surrounding messages, not by the token boundary — a notice scrolls
+    out of context exactly when the messages around its reset point do.
+
+    ``read_message_events`` stays message-only (its other callers — e.g.
+    ``confirm_tool_deny`` — must not see lifecycle rows); this is the
+    windowing-specific read that feeds :func:`build_messages`.
+    """
+    allowlist = list(MODEL_VISIBLE_LIFECYCLE_EVENTS)
+    # UNION ALL (not an OR across kinds) so each arm keeps its own index plan:
+    # the message arm stays a clean ``cumulative_tokens`` partial-index range
+    # scan. An ``OR`` spanning both kinds would defeat that index on every
+    # windowed wake, even for the common session with no FS-loss notices. The
+    # arms are disjoint by ``kind``, so ALL (no dedup) is correct and cheaper.
+    if drop is None:
+        rows = await conn.fetch(
+            "SELECT * FROM events "
+            "WHERE session_id = $1 AND account_id = $2 AND kind = 'message' "
+            "UNION ALL "
+            "SELECT * FROM events "
+            "WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'lifecycle' AND data->>'event' = ANY($3) "
+            "ORDER BY seq ASC",
+            session_id,
+            account_id,
+            allowlist,
+        )
+    else:
+        # Notices are seq-bounded, not token-bounded: include those past the
+        # last dropped message (COALESCE handles "nothing dropped" → seq > 0).
+        rows = await conn.fetch(
+            "SELECT * FROM events "
+            "WHERE session_id = $1 AND account_id = $3 "
+            "AND kind = 'message' AND cumulative_tokens > $2 "
+            "UNION ALL "
+            "SELECT * FROM events "
+            "WHERE session_id = $1 AND account_id = $3 "
+            "AND kind = 'lifecycle' AND data->>'event' = ANY($4) "
+            "AND seq > COALESCE("
+            "    (SELECT max(seq) FROM events "
+            "     WHERE session_id = $1 AND account_id = $3 "
+            "     AND kind = 'message' AND cumulative_tokens <= $2), 0) "
+            "ORDER BY seq ASC",
+            session_id,
+            drop,
+            account_id,
+            allowlist,
+        )
+    return [_row_to_event(r) for r in rows]
+
+
 async def read_windowed_events(
     conn: asyncpg.Connection[Any],
     session_id: str,
@@ -1449,7 +1514,9 @@ async def read_windowed_events(
     # Fallback: no cumulative data yet — load everything.
     if total is None:
         return WindowedEvents(
-            events=await queries.read_message_events(conn, session_id, account_id=account_id),
+            events=await queries.read_windowed_context_events(
+                conn, session_id, account_id=account_id
+            ),
             omission=None,
         )
 
@@ -1470,7 +1537,9 @@ async def read_windowed_events(
     total_effective = round(total * ratio)
     if total_effective <= events_window_max:
         return WindowedEvents(
-            events=await queries.read_message_events(conn, session_id, account_id=account_id),
+            events=await queries.read_windowed_context_events(
+                conn, session_id, account_id=account_id
+            ),
             omission=None,
         )
 
@@ -1486,7 +1555,9 @@ async def read_windowed_events(
     )
     if drop_effective == 0:
         return WindowedEvents(
-            events=await queries.read_message_events(conn, session_id, account_id=account_id),
+            events=await queries.read_windowed_context_events(
+                conn, session_id, account_id=account_id
+            ),
             omission=None,
         )
 
@@ -1505,16 +1576,11 @@ async def read_windowed_events(
     # retain-the-tail-even-when-oversized guarantee.
     drop = min(drop, total - 1)
 
-    # Bounded range scan: only events past the boundary.
-    rows = await conn.fetch(
-        "SELECT * FROM events "
-        "WHERE session_id = $1 AND account_id = $3 AND kind = 'message' "
-        "AND cumulative_tokens > $2 "
-        "ORDER BY seq ASC",
-        session_id,
-        drop,
-        account_id,
-    )
+    # Bounded range scan: messages past the boundary, plus the FS-loss
+    # notices past the dropped-message prefix. Bare call (not via ``queries``)
+    # so the fallback stub on the package attribute does not intercept the
+    # retained-window read — keeping the unit FakeConn path exercised.
+    events = await read_windowed_context_events(conn, session_id, account_id=account_id, drop=drop)
 
     # The omitted complement: same boundary expression as the retained
     # scan (``<=`` vs ``>``), and a seq-prefix of the log — so its
@@ -1542,4 +1608,4 @@ async def read_windowed_events(
         if omission_row["began_at"] is not None
         else None
     )
-    return WindowedEvents(events=[_row_to_event(r) for r in rows], omission=omission)
+    return WindowedEvents(events=events, omission=omission)

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -49,7 +49,7 @@ from aios.harness.vision import (
 )
 from aios.harness.window import WindowOmission
 from aios.logging import get_logger
-from aios.models.events import Event
+from aios.models.events import MODEL_VISIBLE_LIFECYCLE_EVENTS, Event
 from aios.sandbox.volumes import resolve_to_host_path
 
 log = get_logger("aios.harness.context")
@@ -67,16 +67,6 @@ _ALLOWED_FIELDS: dict[str, frozenset[str]] = {
 # Anthropic's contract: thinking blocks must be preserved across turns
 # for the model to use them as continuation context.
 _THINKING_FIELDS: frozenset[str] = frozenset({"thinking_blocks", "reasoning_content"})
-
-# Durable-session-sandbox FS-loss notices (§5.9): the only non-``message``
-# events ``build_messages`` renders. They are append-only (each at its seq
-# position, so monotonicity holds) and NOT stimulus-bearing — they never
-# advance ``reacting_to`` and so never, on their own, wake the session; the
-# notice is read at the next genuine wake. Event text is runtime-vocabulary
-# only (no repo/PR/issue refs — the agent can't act on those).
-_MODEL_VISIBLE_LIFECYCLE: frozenset[str] = frozenset(
-    {"sandbox_fs_reset", "sandbox_fs_expired", "sandbox_fs_over_limit"}
-)
 
 # Unaffected-resources tail shared by the reset/expired notices.
 _FS_UNAFFECTED = (
@@ -923,7 +913,7 @@ def build_messages(
         # NOT stimulus-bearing — deliberately does not touch max_stimulus_seq,
         # so a GC/reset append never advances ``reacting_to`` or wakes the
         # session; the model reads the notice at its next genuine wake.
-        if e.kind == "lifecycle" and e.data.get("event") in _MODEL_VISIBLE_LIFECYCLE:
+        if e.kind == "lifecycle" and e.data.get("event") in MODEL_VISIBLE_LIFECYCLE_EVENTS:
             messages.append({"role": "user", "content": _render_fs_lifecycle_notice(e.data)})
             continue
         if e.kind != "message":

--- a/src/aios/models/events.py
+++ b/src/aios/models/events.py
@@ -25,6 +25,16 @@ from pydantic import BaseModel, Field
 
 EventKind = Literal["message", "lifecycle", "span", "interrupt"]
 
+# Durable-session-sandbox FS-loss notices (§5.9): the only non-``message``
+# events the context builder renders, and so the only non-``message`` events
+# the windowing read must carry through to it. Defined here, the lowest layer,
+# so both the harness renderer (``harness/context.py``) and the db read
+# (``db/queries/events.py``: ``read_windowed_context_events``) can name the same
+# allowlist without the db layer importing the harness.
+MODEL_VISIBLE_LIFECYCLE_EVENTS: frozenset[str] = frozenset(
+    {"sandbox_fs_reset", "sandbox_fs_expired", "sandbox_fs_over_limit"}
+)
+
 
 class Event(BaseModel):
     """Read view of a single event from the session log."""

--- a/tests/integration/test_windowed_fs_lifecycle.py
+++ b/tests/integration/test_windowed_fs_lifecycle.py
@@ -1,0 +1,148 @@
+"""Integration: the windowing read carries model-visible FS-loss notices.
+
+``read_windowed_events`` feeds ``build_messages``, which renders the §5.9
+sandbox FS-loss notices (``sandbox_fs_reset`` / ``_expired`` /
+``_over_limit``, appended as ``kind='lifecycle'``). But every windowing
+read path filtered ``kind='message'``, so the notices were stripped at the
+SQL layer and never reached the model — the feature was dead in
+production. These tests pin that the allowlisted lifecycle events survive
+the read, and that they window out by *seq* (not the token boundary, which
+they have no part in — they carry NULL ``cumulative_tokens``) so a notice
+scrolls out of context alongside the messages around its reset point.
+
+The bug lives in the SQL kind filter, so it is not unit-reachable: the
+``read_windowed_events`` unit FakeConn dispatches on SQL text and never
+models real rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.harness.context import build_messages
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def pool_and_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ('acc_fsnotice', NULL, TRUE, 'fsnotice-test')"
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_fsnotice", prefix="fsnotice-test"
+        )
+        yield pool, "acc_fsnotice", session.id
+    finally:
+        await pool.close()
+
+
+async def _msg(
+    conn: asyncpg.Connection[Any], account_id: str, session_id: str, content: str
+) -> Any:
+    return await queries.append_event(
+        conn,
+        account_id=account_id,
+        session_id=session_id,
+        kind="message",
+        data={"role": "user", "content": content},
+    )
+
+
+async def _notice(
+    conn: asyncpg.Connection[Any], account_id: str, session_id: str, reason: str
+) -> Any:
+    return await queries.append_event(
+        conn,
+        account_id=account_id,
+        session_id=session_id,
+        kind="lifecycle",
+        data={"event": "sandbox_fs_reset", "reason": reason},
+    )
+
+
+async def test_windowed_read_includes_and_renders_fs_notice(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """Small session (everything fits → full-log path): a sandbox_fs_reset
+    notice survives the windowing read, and build_messages renders it as a
+    user-role notice the model can act on."""
+    pool, account_id, session_id = pool_and_session
+    async with pool.acquire() as conn:
+        await _msg(conn, account_id, session_id, "install numpy")
+        await _notice(conn, account_id, session_id, "snapshot_missing")
+
+        windowed = await queries.read_windowed_events(
+            conn,
+            session_id,
+            account_id=account_id,
+            window_min=1_000,
+            window_max=8_000,
+            model="openrouter/test",
+            overhead_local=0,
+        )
+
+    # The lifecycle notice is present in the windowed events (RED pre-fix:
+    # stripped by the kind='message' filter).
+    assert any(
+        e.kind == "lifecycle" and e.data.get("event") == "sandbox_fs_reset" for e in windowed.events
+    )
+
+    # End-to-end: build_messages renders it as a user-role notice.
+    result = build_messages(windowed.events, system_prompt=None)
+    assert any(
+        m["role"] == "user"
+        and isinstance(m.get("content"), str)
+        and "fresh base filesystem" in m["content"]
+        for m in result.messages
+    )
+
+
+async def test_windowed_context_events_seq_bounds_notices(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """Range-scan path: notices window out by seq with their surrounding
+    messages. A notice in the dropped prefix is excluded; one in the
+    retained window is kept. Driven by calling read_windowed_context_events
+    with an explicit drop so the bound is exact, not token-math-dependent."""
+    pool, account_id, session_id = pool_and_session
+    async with pool.acquire() as conn:
+        # Log order: m1, notice_a, m2, m3, notice_b, m4.
+        m1 = await _msg(conn, account_id, session_id, "one")
+        notice_a = await _notice(conn, account_id, session_id, "snapshot_missing")
+        m2 = await _msg(conn, account_id, session_id, "two")
+        m3 = await _msg(conn, account_id, session_id, "three")
+        notice_b = await _notice(conn, account_id, session_id, "environment_image_changed")
+        m4 = await _msg(conn, account_id, session_id, "four")
+
+        # Drop boundary at m2's cumulative_tokens: messages with
+        # cumulative_tokens <= drop (m1, m2) are dropped; m3, m4 retained.
+        # max dropped-message seq is m2.seq.
+        drop_row = await conn.fetchrow("SELECT cumulative_tokens FROM events WHERE id = $1", m2.id)
+        drop = drop_row["cumulative_tokens"]
+
+        events = await queries.read_windowed_context_events(
+            conn, session_id, account_id=account_id, drop=drop
+        )
+
+    seqs = {e.seq for e in events}
+    # Retained messages present, dropped messages absent.
+    assert m3.seq in seqs and m4.seq in seqs
+    assert m1.seq not in seqs and m2.seq not in seqs
+    # notice_a (seq <= m2.seq, in the dropped prefix) is excluded.
+    assert notice_a.seq not in seqs
+    # notice_b (seq > m2.seq, in the retained window) is included.
+    assert notice_b.seq in seqs

--- a/tests/unit/test_context_fs_lifecycle.py
+++ b/tests/unit/test_context_fs_lifecycle.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from aios.harness.context import build_messages
+from aios.harness.window import WindowOmission
 from aios.models.events import Event
 
 _AT = datetime(2026, 6, 10, tzinfo=UTC)
@@ -129,3 +130,29 @@ def test_non_allowlisted_lifecycle_event_is_skipped() -> None:
     ]
     result = build_messages(events, system_prompt=None)
     assert all("boom" not in (m.get("content") or "") for m in result.messages)
+
+
+def test_omission_marker_anchors_on_leading_notice() -> None:
+    """Now that the windowing read carries FS-loss notices, the first retained
+    event can be a notice — one in the gap between the last dropped message and
+    the first retained message. The head omission marker anchors on
+    ``events[0].created_at`` (#1044's non-empty-window invariant), which must
+    hold whether ``events[0]`` is a message or a notice — accessing
+    ``created_at`` on a lifecycle event must not raise. Pins that this no longer
+    assumes a leading message."""
+    events = [
+        _lifecycle(7, {"event": "sandbox_fs_reset", "reason": "snapshot_missing"}),
+        _msg(8, "user", "still here?"),
+    ]
+    omission = WindowOmission(began_at=datetime(2026, 6, 9, tzinfo=UTC), omitted_messages=4)
+
+    # Must not raise: events[0] is a lifecycle notice, not a message.
+    result = build_messages(events, system_prompt=None, omission=omission)
+
+    # The head omission marker landed, and the notice itself still renders.
+    assert result.messages[0]["role"] == "user"
+    assert "messages" in result.messages[0]["content"]
+    assert any(
+        isinstance(m.get("content"), str) and "fresh base filesystem" in m["content"]
+        for m in result.messages
+    )

--- a/tests/unit/test_queries_package_split.py
+++ b/tests/unit/test_queries_package_split.py
@@ -106,10 +106,12 @@ def test_internal_callers_route_patched_fns_through_package() -> None:
     assert "queries.get_session_template(" in update_template_src
 
     # ``read_windowed_events`` (events.py) internally calls two functions that
-    # tests patch at the package attribute — ``read_message_events`` (fallback
-    # load-all path) and ``model_token_ratio`` (test_windowed_ratio.py). Both
-    # live in events.py too, so the same-module calls must route through the
-    # package or the monkeypatch is bypassed.
+    # tests patch at the package attribute — ``read_windowed_context_events``
+    # (fallback load-all path) and ``model_token_ratio`` (test_windowed_ratio.py).
+    # Both live in events.py too, so the same-module calls must route through the
+    # package or the monkeypatch is bypassed. (The retained-window range scan
+    # calls ``read_windowed_context_events`` bare on purpose, so the fallback
+    # stub does not intercept it — that bare call is not asserted here.)
     windowed_src = inspect.getsource(events.read_windowed_events)
-    assert "queries.read_message_events(" in windowed_src
+    assert "queries.read_windowed_context_events(" in windowed_src
     assert "queries.model_token_ratio(" in windowed_src

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -67,14 +67,19 @@ class _FakeConn:
 
 
 @pytest.fixture(autouse=True)
-def _stub_read_message_events(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> None:
-    """Short-circuit ``read_message_events`` so no real DB is hit when the
-    code path falls back to 'load everything'.  We sentinel its return so
-    tests can detect the fallback."""
+def _stub_read_context_events(monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> None:
+    """Short-circuit the fallback ``read_windowed_context_events`` so no real
+    DB is hit when the code path falls back to 'load everything'.  We sentinel
+    its return so tests can detect the fallback.
+
+    Only the fallback paths call it via the package attribute; the retained
+    range scan calls it bare (module-global), so this stub leaves that path
+    to hit ``_FakeConn.fetch`` — which is what the drop-boundary assertions
+    rely on."""
     queries._clear_model_token_ratio_cache()
     monkeypatch.setattr(
         queries,
-        "read_message_events",
+        "read_windowed_context_events",
         AsyncMock(return_value=_FALLBACK_SENTINEL),
     )
 


### PR DESCRIPTION
## Summary

- **Bug:** durable-sandbox FS-loss notices (`sandbox_fs_reset` / `_expired` / `_over_limit`) are appended as `kind='lifecycle'` events and `build_messages` renders the allowlisted ones — but `read_windowed_events` filtered `kind='message'` in **every** read path (the 3 `read_message_events` fallbacks + the `cumulative_tokens` range scan), so the notices were stripped at the SQL layer and never reached the model. The §5.9 model-visible-notice feature was **dead in production**: after a sandbox FS reset the model kept believing its installed packages survived, then hit unexplained "command not found".
- **Fix (read-side, seq-bounded):** new `read_windowed_context_events` returns message events **plus** the allowlisted lifecycle notices, in seq order. `read_message_events` stays message-only (its `confirm_tool_deny` / channel callers must not see lifecycle rows). Notices carry NULL `cumulative_tokens`, so in the windowed case they're bounded by **seq** (`> max seq among dropped messages`) — a notice scrolls out of context exactly when the messages around its reset point do.
- **Index-preserving:** built as a `UNION ALL` of a message arm and a lifecycle arm, so the message arm keeps its `cumulative_tokens` partial-index range scan; an `OR` across kinds would defeat that index on every windowed wake even for sessions with no notices.
- `MODEL_VISIBLE_LIFECYCLE_EVENTS` moves `harness/context.py` → `models/events.py` (lowest layer) so the db read and the harness renderer share one source of truth without `db → harness` import inversion.

## Interaction with #1044 (rebased in)
This composes with #1044's `drop = min(drop, total - 1)` clamp: the clamp guarantees a non-empty message tail, and `build_messages` anchors the omission marker on `events[0].created_at` — which now tolerates a **leading lifecycle notice** (a notice in the gap between the last dropped message and the first retained message). Covered by `test_omission_marker_anchors_on_leading_notice`.

## How it was found
Adversarial bug-hunt audit; the verify pass confirmed the read path strips lifecycle rows and that the existing unit test passed only by feeding `build_messages` directly (bypassing the windowing SQL) — false confidence.

## Residual (out of scope, noted by /simplify)
The `sandbox_fs_*` event names are spelled in three places (registry constants, the models allowlist literals, `build_messages` render dispatch). Unifying would force `models → sandbox` imports; awaits a registry-side refactor.

## Test plan
- [x] New integration tests (`tests/integration/test_windowed_fs_lifecycle.py`): full-log path RED→GREEN (notice reaches the model + renders) and an explicit-`drop` test pinning the seq bound (dropped-prefix notice excluded, retained-window notice included).
- [x] New unit test for the leading-notice + omission interaction.
- [x] `test_windowed_ratio` (stub repointed) + `test_queries_package_split` (assertion updated) still pin the arithmetic + patchability contract.
- [x] `mypy` clean · `ruff` check + format clean · `pytest tests/unit` — 2617 passed
- [ ] CI runs e2e / integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)