### PR TITLE
feat: method scoping for HttpRouteSpec read/write attenuation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11175,6 +11175,27 @@
                 "type": "null"
               }
             ]
+          },
+          "methods": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "GET",
+                    "POST",
+                    "PUT",
+                    "DELETE",
+                    "PATCH"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Methods"
           }
         },
         "additionalProperties": false,
@@ -11183,7 +11204,7 @@
           "path_pattern"
         ],
         "title": "HttpRouteSpec",
-        "description": "One entry in an ``HttpServerSpec.routes`` allowlist.\n\n``path_pattern`` is a glob against the request path (``*`` matches one\nsegment, ``**`` matches any number of segments).  ``description`` is\noperator-authored prose rendered into the system prompt so the agent\nknows what the route does and how to call it.  ``permission_policy``\ngates *invocation*: ``always_ask`` leaves the call unresolved in the\nevent log until the client confirms via\n``POST /sessions/:id/tool-confirmations``."
+        "description": "One entry in an ``HttpServerSpec.routes`` allowlist.\n\n``path_pattern`` is a glob against the request path (``*`` matches one\nsegment, ``**`` matches any number of segments).  ``description`` is\noperator-authored prose rendered into the system prompt so the agent\nknows what the route does and how to call it.  ``permission_policy``\ngates *invocation*: ``always_ask`` leaves the call unresolved in the\nevent log until the client confirms via\n``POST /sessions/:id/tool-confirmations``.\n\n``methods`` scopes the route to a set of HTTP verbs so a surface can\nexpress read/write attenuation structurally \u2014 e.g. ``GET`` everywhere\nbut ``POST`` only on a sandbox path (#828).  ``None`` (the default)\nmeans *all* methods are allowed (the method-dimension lattice top;\nbackward-compatible with routes authored before method scoping).  A\nnon-empty list restricts the route to exactly those verbs.  An empty\nlist (``[]``) is *deny-all* \u2014 the method-dimension lattice bottom, and\nthe natural result of intersecting two disjoint method sets during\nattenuation; it matches nothing.  The capability meet\n(:mod:`aios.models.attenuation`) intersects ``methods`` per route, so a\nchild surface can narrow a parent route's verbs but never widen them.\n\nGraphQL caveat \u2014 **REST-only discipline for attenuated surfaces.**\nMethod scoping confines REST read/write because the verb encodes the\nsemantics.  A GraphQL endpoint serves both queries (reads) and\nmutations (writes) over a single ``POST`` path, so method scoping\n*cannot* separate read from write there, and the broker does not\ninspect request bodies.  An operator who needs to confine writes on a\nGraphQL surface must place reads and writes behind distinct\n``base_url`` servers (each with its own credential/route allowlist) or\naccept that granting ``POST`` grants both."
       },
       "HttpServerSpec": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -62,6 +62,7 @@ from .github_repository_update import GithubRepositoryUpdate
 from .http_permission_policy import HttpPermissionPolicy
 from .http_permission_policy_type import HttpPermissionPolicyType
 from .http_route_spec import HttpRouteSpec
+from .http_route_spec_methods_type_0_item import HttpRouteSpecMethodsType0Item
 from .http_server_spec import HttpServerSpec
 from .http_validation_error import HTTPValidationError
 from .limited_networking import LimitedNetworking
@@ -328,6 +329,7 @@ __all__ = (
     "HttpPermissionPolicy",
     "HttpPermissionPolicyType",
     "HttpRouteSpec",
+    "HttpRouteSpecMethodsType0Item",
     "HttpServerSpec",
     "HTTPValidationError",
     "LimitedNetworking",

--- a/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
+from ..models.http_route_spec_methods_type_0_item import HttpRouteSpecMethodsType0Item
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -26,17 +27,41 @@ class HttpRouteSpec:
     event log until the client confirms via
     ``POST /sessions/:id/tool-confirmations``.
 
+    ``methods`` scopes the route to a set of HTTP verbs so a surface can
+    express read/write attenuation structurally — e.g. ``GET`` everywhere
+    but ``POST`` only on a sandbox path (#828).  ``None`` (the default)
+    means *all* methods are allowed (the method-dimension lattice top;
+    backward-compatible with routes authored before method scoping).  A
+    non-empty list restricts the route to exactly those verbs.  An empty
+    list (``[]``) is *deny-all* — the method-dimension lattice bottom, and
+    the natural result of intersecting two disjoint method sets during
+    attenuation; it matches nothing.  The capability meet
+    (:mod:`aios.models.attenuation`) intersects ``methods`` per route, so a
+    child surface can narrow a parent route's verbs but never widen them.
+
+    GraphQL caveat — **REST-only discipline for attenuated surfaces.**
+    Method scoping confines REST read/write because the verb encodes the
+    semantics.  A GraphQL endpoint serves both queries (reads) and
+    mutations (writes) over a single ``POST`` path, so method scoping
+    *cannot* separate read from write there, and the broker does not
+    inspect request bodies.  An operator who needs to confine writes on a
+    GraphQL surface must place reads and writes behind distinct
+    ``base_url`` servers (each with its own credential/route allowlist) or
+    accept that granting ``POST`` grants both.
+
         Attributes:
             path_pattern (str):
             description (None | str | Unset):
             enabled (bool | Unset):  Default: True.
             permission_policy (HttpPermissionPolicy | None | Unset):
+            methods (list[HttpRouteSpecMethodsType0Item] | None | Unset):
     """
 
     path_pattern: str
     description: None | str | Unset = UNSET
     enabled: bool | Unset = True
     permission_policy: HttpPermissionPolicy | None | Unset = UNSET
+    methods: list[HttpRouteSpecMethodsType0Item] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.http_permission_policy import HttpPermissionPolicy
@@ -59,6 +84,18 @@ class HttpRouteSpec:
         else:
             permission_policy = self.permission_policy
 
+        methods: list[str] | None | Unset
+        if isinstance(self.methods, Unset):
+            methods = UNSET
+        elif isinstance(self.methods, list):
+            methods = []
+            for methods_type_0_item_data in self.methods:
+                methods_type_0_item = methods_type_0_item_data.value
+                methods.append(methods_type_0_item)
+
+        else:
+            methods = self.methods
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -72,6 +109,8 @@ class HttpRouteSpec:
             field_dict["enabled"] = enabled
         if permission_policy is not UNSET:
             field_dict["permission_policy"] = permission_policy
+        if methods is not UNSET:
+            field_dict["methods"] = methods
 
         return field_dict
 
@@ -112,11 +151,38 @@ class HttpRouteSpec:
 
         permission_policy = _parse_permission_policy(d.pop("permission_policy", UNSET))
 
+        def _parse_methods(
+            data: object,
+        ) -> list[HttpRouteSpecMethodsType0Item] | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                methods_type_0 = []
+                _methods_type_0 = data
+                for methods_type_0_item_data in _methods_type_0:
+                    methods_type_0_item = HttpRouteSpecMethodsType0Item(
+                        methods_type_0_item_data
+                    )
+
+                    methods_type_0.append(methods_type_0_item)
+
+                return methods_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(list[HttpRouteSpecMethodsType0Item] | None | Unset, data)
+
+        methods = _parse_methods(d.pop("methods", UNSET))
+
         http_route_spec = cls(
             path_pattern=path_pattern,
             description=description,
             enabled=enabled,
             permission_policy=permission_policy,
+            methods=methods,
         )
 
         return http_route_spec

--- a/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec_methods_type_0_item.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec_methods_type_0_item.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class HttpRouteSpecMethodsType0Item(str, Enum):
+    DELETE = "DELETE"
+    GET = "GET"
+    PATCH = "PATCH"
+    POST = "POST"
+    PUT = "PUT"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -270,10 +270,13 @@ def _build_instructions_block(
 def _build_http_servers_block(http_servers: list[HttpServerSpec]) -> str:
     """Render the agent's ``http_servers`` allowlist for the system prompt.
 
-    Includes server description plus each enabled route's pattern and
-    description, so the model knows what ``http_request`` calls it can
-    make. Iteration order is ``agent.http_servers`` declaration order
-    (prefix-cache-stable across steps).
+    Includes server description plus each enabled route's allowed HTTP
+    methods, pattern, and description, so the model knows what
+    ``http_request`` calls it can make. The method prefix renders the
+    route's scoped verbs (``ANY`` when unrestricted) so the model does not
+    attempt a verb the route gate would refuse (#828). Iteration order is
+    ``agent.http_servers`` declaration order (prefix-cache-stable across
+    steps).
     """
     if not http_servers:
         return ""
@@ -288,8 +291,9 @@ def _build_http_servers_block(http_servers: list[HttpServerSpec]) -> str:
             lines.append("")
             lines.append("Routes:")
             for r in enabled_routes:
+                verbs = "ANY" if r.methods is None else ",".join(sorted(set(r.methods)))
                 suffix = f" — {r.description}" if r.description else ""
-                lines.append(f"- {r.path_pattern}{suffix}")
+                lines.append(f"- {verbs} {r.path_pattern}{suffix}")
         sections.append("\n".join(lines))
     return "\n\n".join(sections)
 

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -67,6 +67,10 @@ PermissionPolicy = Literal["always_allow", "always_ask"]
 # ``McpToolsetConfig`` / ``McpToolConfig`` can override per-tool.
 ToolTransport = Literal["cli", "agent_tool", "both"]
 
+# HTTP methods an ``http_request`` route may be scoped to. Mirrors the broker's
+# ``_ALLOWED_METHODS`` tuple in ``tools/http_request.py``.
+HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
+
 _BUILTIN_NAMES: frozenset[str] = frozenset(get_args(BuiltinToolType))
 
 # Header names the MCP streamable-http transport authors on every request
@@ -219,6 +223,28 @@ class HttpRouteSpec(BaseModel):
     gates *invocation*: ``always_ask`` leaves the call unresolved in the
     event log until the client confirms via
     ``POST /sessions/:id/tool-confirmations``.
+
+    ``methods`` scopes the route to a set of HTTP verbs so a surface can
+    express read/write attenuation structurally — e.g. ``GET`` everywhere
+    but ``POST`` only on a sandbox path (#828).  ``None`` (the default)
+    means *all* methods are allowed (the method-dimension lattice top;
+    backward-compatible with routes authored before method scoping).  A
+    non-empty list restricts the route to exactly those verbs.  An empty
+    list (``[]``) is *deny-all* — the method-dimension lattice bottom, and
+    the natural result of intersecting two disjoint method sets during
+    attenuation; it matches nothing.  The capability meet
+    (:mod:`aios.models.attenuation`) intersects ``methods`` per route, so a
+    child surface can narrow a parent route's verbs but never widen them.
+
+    GraphQL caveat — **REST-only discipline for attenuated surfaces.**
+    Method scoping confines REST read/write because the verb encodes the
+    semantics.  A GraphQL endpoint serves both queries (reads) and
+    mutations (writes) over a single ``POST`` path, so method scoping
+    *cannot* separate read from write there, and the broker does not
+    inspect request bodies.  An operator who needs to confine writes on a
+    GraphQL surface must place reads and writes behind distinct
+    ``base_url`` servers (each with its own credential/route allowlist) or
+    accept that granting ``POST`` grants both.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -227,6 +253,7 @@ class HttpRouteSpec(BaseModel):
     description: str | None = None
     enabled: bool = True
     permission_policy: HttpPermissionPolicy | None = None
+    methods: list[HttpMethod] | None = None
 
 
 class HttpServerSpec(BaseModel):

--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 from typing import NamedTuple, Protocol
 
 from aios.models.agents import (
+    HttpMethod,
+    HttpRouteSpec,
     HttpServerSpec,
     McpPermissionPolicy,
     McpServerSpec,
@@ -312,6 +314,63 @@ def _meet_builtin(declared: ToolSpec, launcher: ToolSpec) -> ToolSpec | None:
     )
 
 
+# ── HTTP route method normal form (#828) ──────────────────────────────────────
+
+
+def _norm_methods(methods: list[HttpMethod] | None) -> list[HttpMethod] | None:
+    """Normal form for a route's ``methods``: ``None`` (all verbs — the method
+    lattice top) stays ``None``; a list is sorted and de-duplicated so the
+    normal-form contract holds byte-for-byte (``[]`` = deny-all stays ``[]``)."""
+    if methods is None:
+        return None
+    return sorted(set(methods))
+
+
+def _meet_methods(
+    declared: list[HttpMethod] | None, launcher: list[HttpMethod] | None
+) -> list[HttpMethod] | None:
+    """Set-intersection meet of two method sets. ``None`` is the top (all verbs),
+    so ``meet(None, X) == X``, ``meet(X, None) == X``, ``meet(None, None) == None``.
+    Two concrete sets meet to their (sorted) intersection — possibly ``[]`` (deny-all,
+    the bottom), which is kept verbatim rather than treated as a drop signal."""
+    if declared is None:
+        return _norm_methods(launcher)
+    if launcher is None:
+        return _norm_methods(declared)
+    return sorted(set(declared) & set(launcher))
+
+
+def _canon_http_server(s: HttpServerSpec) -> HttpServerSpec:
+    """Resolve an http server to its normal form: identity/headers/route order kept
+    verbatim, each route's ``methods`` normalized (sorted/deduped, ``None`` preserved)."""
+    routes = [r.model_copy(update={"methods": _norm_methods(r.methods)}) for r in s.routes]
+    return s.model_copy(update={"routes": routes})
+
+
+def _meet_http_server(declared: HttpServerSpec, launcher: HttpServerSpec) -> HttpServerSpec:
+    """Meet two http servers sharing a ``base_url`` key.
+
+    Path patterns, ordering, ``description``, ``enabled`` and ``permission_policy`` are
+    **launcher-verbatim** (parent-wins-frozen: a child cannot re-order, re-gate, or add
+    routes — preserving first-match-wins permission gates). The single dimension a child
+    may narrow is ``methods``: for each launcher route, if the child declares a route with
+    the same ``path_pattern``, the output route's methods are ``meet(launcher, child)``
+    (set intersection; ``None`` = all). A child that does not declare a matching path leaves
+    that launcher route's methods unchanged. The result is emitted in launcher route order.
+    """
+    declared_by_pattern: dict[str, HttpRouteSpec] = {}
+    for r in declared.routes:
+        declared_by_pattern.setdefault(r.path_pattern, r)  # first child declaration wins
+    out_routes: list[HttpRouteSpec] = []
+    for lr in launcher.routes:
+        child = declared_by_pattern.get(lr.path_pattern)
+        methods = (
+            _norm_methods(lr.methods) if child is None else _meet_methods(child.methods, lr.methods)
+        )
+        out_routes.append(lr.model_copy(update={"methods": methods}))
+    return launcher.model_copy(update={"routes": out_routes})
+
+
 # ── the operator ──────────────────────────────────────────────────────────────
 
 
@@ -324,10 +383,12 @@ def canonicalize(
     """Resolve a surface to its normal form (the identity element of the meet).
 
     Prunes disabled tools and dangling toolsets, resolves every ``None`` sentinel to
-    its concrete default, and emits toolsets in minimal-config normal form. Servers
+    its concrete default, and emits toolsets in minimal-config normal form. MCP servers
     are kept verbatim (they are compared and copied wholesale; normalizing e.g.
-    ``headers None→{}`` would create needless drift). ``canonicalize(x) ==
-    attenuate(x, x)``.
+    ``headers None→{}`` would create needless drift). HTTP servers keep their identity,
+    headers, and route order verbatim, but each route's ``methods`` is normalized
+    (sorted/deduped, ``None`` preserved) so the method-dimension meet has a byte-stable
+    normal form (#828). ``canonicalize(x) == attenuate(x, x)``.
 
     ``default_mcp_permission`` and ``builtin_transports`` are passed in (read from
     settings / the tool registry by the caller) to keep the operator pure.
@@ -347,7 +408,7 @@ def canonicalize(
             tools.append(
                 _canon_builtin(t, transport_default=builtin_transports.get(t.type, "both"))
             )
-    return Surface(tools, list(s.mcp_servers), list(s.http_servers))
+    return Surface(tools, list(s.mcp_servers), [_canon_http_server(srv) for srv in s.http_servers])
 
 
 def attenuate(
@@ -360,14 +421,15 @@ def attenuate(
     """The lattice meet: ``declared`` clamped to never exceed ``launcher``.
 
     Per identity key in ``declared``: absent from ``launcher`` → drop; present → the
-    per-dimension meet, dropping if it bottoms out. Servers survive only on a key match
+    per-dimension meet, dropping if it bottoms out. MCP servers survive only on a key match
     and are emitted **launcher-verbatim** (parent-wins-frozen: routes and headers come
-    from the launcher; the child narrows only by dropping whole servers). http servers
-    survive on a ``base_url`` key and are emitted launcher-verbatim — the child's declared
-    routes are inert here, consistent with the authoring gate, which now admits http
-    servers by identity (``(name, base_url)``) and inherits the launcher's frozen routes.
-    MCP servers key on the joint ``(name, url)`` — a re-pointed name is a different key
-    and drops. Output is canonical (``attenuate(d, l)`` is a fixpoint of ``canonicalize``).
+    from the launcher; the child narrows only by dropping whole servers); they key on the
+    joint ``(name, url)`` — a re-pointed name is a different key and drops. http servers
+    survive on a ``base_url`` key; their path patterns / ordering / ``description`` /
+    ``enabled`` / ``permission_policy`` are launcher-verbatim, but the child may narrow each
+    route's ``methods`` (set intersection; ``None`` = all verbs) — the one read/write
+    attenuation dimension (#828). Output is canonical (``attenuate(d, l)`` is a fixpoint of
+    ``canonicalize``).
     """
     d = canonicalize(
         declared,
@@ -380,9 +442,14 @@ def attenuate(
         builtin_transports=builtin_transports,
     )
 
-    # http_servers — key base_url, launcher-verbatim survival.
+    # http_servers — key base_url; launcher-verbatim path/order/permission, per-route
+    # ``methods`` narrowed by the child's matching declaration (#828).
     l_http = {srv.base_url: srv for srv in lau.http_servers}
-    out_http = [l_http[srv.base_url] for srv in d.http_servers if srv.base_url in l_http]
+    out_http = [
+        _meet_http_server(srv, l_http[srv.base_url])
+        for srv in d.http_servers
+        if srv.base_url in l_http
+    ]
 
     # mcp_servers — joint (name, url) key, launcher-verbatim survival.
     l_mcp = {(srv.name, srv.url): srv for srv in lau.mcp_servers}

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -101,10 +101,18 @@ def _find_server(servers: list[HttpServerSpec], server_ref: str) -> HttpServerSp
     return None
 
 
-def _match_route(server: HttpServerSpec, path: str) -> HttpRouteSpec | None:
+def _match_route(server: HttpServerSpec, path: str, method: str) -> HttpRouteSpec | None:
+    """First enabled route whose pattern matches ``path`` AND whose ``methods``
+    admit ``method``. ``methods is None`` means all verbs are allowed (the
+    method-dimension lattice top); a list scopes the route to exactly those
+    verbs (``[]`` = deny-all). First-match-wins on launcher route order, so a
+    method-disjoint earlier route does not shadow a later matching one."""
     for r in server.routes:
-        if r.enabled and match_glob(r.path_pattern, path):
-            return r
+        if not (r.enabled and match_glob(r.path_pattern, path)):
+            continue
+        if r.methods is not None and method not in r.methods:
+            continue
+        return r
     return None
 
 
@@ -155,20 +163,21 @@ def _classify_permission(
     leave the call unresolved (pending confirmation via
     ``POST /sessions/:id/tool-confirmations``) if the operator marked it
     ``always_ask``. Returns ``None`` for missing server / no route match
-    / bad args / query-or-fragment-bearing / dot-segment-bearing path —
-    the handler then runs and emits a typed error the model can
-    self-correct from.
+    (including method-disallowed) / bad args / query-or-fragment-bearing /
+    dot-segment-bearing path — the handler then runs and emits a typed
+    error the model can self-correct from.
     """
     server_ref = args.get("server_ref")
     path = args.get("path")
-    if not isinstance(server_ref, str) or not isinstance(path, str):
+    method = args.get("method")
+    if not isinstance(server_ref, str) or not isinstance(path, str) or not isinstance(method, str):
         return None
     if _path_rejected_reason(path) is not None:
         return None
     server = _find_server(agent.http_servers, server_ref)
     if server is None:
         return None
-    route = _match_route(server, path)
+    route = _match_route(server, path, method)
     if route is None or route.permission_policy is None:
         return None
     return route.permission_policy.type
@@ -227,10 +236,12 @@ async def _do_http_request(
     server = _find_server(servers, server_ref)
     if server is None:
         return {"error": (f"unknown server_ref {server_ref!r}; not declared on http_servers")}
-    if _match_route(server, path) is None:
+    if _match_route(server, path, method) is None:
         return {
             "error": (
-                f"path {path!r} does not match any enabled route on http_server {server_ref!r}"
+                f"{method} {path!r} does not match any enabled route on "
+                f"http_server {server_ref!r} — the path may be unlisted, or the "
+                f"route's allowed methods may not include this verb"
             )
         }
 

--- a/src/aios/workflows/run_tools.py
+++ b/src/aios/workflows/run_tools.py
@@ -157,7 +157,11 @@ async def invoke_run_tool(
         # which a run has no channel for. Deny rather than execute unconfirmed, so a run is
         # never *more* privileged than a session on the identical declared surface.
         server = _find_server(run.http_servers, str(args.get("server_ref", "")))
-        route = _match_route(server, str(args.get("path", ""))) if server is not None else None
+        route = (
+            _match_route(server, str(args.get("path", "")), str(args.get("method", "")))
+            if server is not None
+            else None
+        )
         if (
             route is not None
             and route.permission_policy is not None

--- a/tests/unit/test_agents_models.py
+++ b/tests/unit/test_agents_models.py
@@ -5,11 +5,31 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from aios.models.agents import AgentCreate, AgentUpdate
+from aios.models.agents import AgentCreate, AgentUpdate, HttpRouteSpec
 
 
 def _http_server(name: str, base_url: str) -> dict[str, str]:
     return {"name": name, "base_url": base_url}
+
+
+class TestHttpRouteSpecMethods:
+    def test_methods_default_none_means_all(self) -> None:
+        route = HttpRouteSpec(path_pattern="/x")
+        assert route.methods is None
+
+    def test_methods_accepts_explicit_list(self) -> None:
+        route = HttpRouteSpec(path_pattern="/x", methods=["GET", "POST"])
+        assert route.methods == ["GET", "POST"]
+
+    def test_methods_empty_list_is_deny_all(self) -> None:
+        # [] = lattice bottom (deny-all); a legitimate, if pointless, author choice
+        # and the natural empty-intersection result of the method meet.
+        route = HttpRouteSpec(path_pattern="/x", methods=[])
+        assert route.methods == []
+
+    def test_methods_rejects_unknown_verb(self) -> None:
+        with pytest.raises(ValidationError):
+            HttpRouteSpec.model_validate({"path_pattern": "/x", "methods": ["FETCH"]})
 
 
 class TestAgentCreateHttpServers:

--- a/tests/unit/test_attenuation.py
+++ b/tests/unit/test_attenuation.py
@@ -149,9 +149,11 @@ class TestServerSurvival:
         assert out.mcp_servers[0].headers == {"X-Toolsets": "issues"}  # launcher wins
         assert out != canon(Surface([], [d_srv], []))  # child must declare it identically
 
-    def test_http_routes_parent_wins_frozen(self) -> None:
-        # First-match-wins ordering: a child re-declaring the broad route must NOT be
-        # able to escape the launcher's earlier always_ask gate on /reports/admin.
+    def test_http_routes_path_permission_ordering_parent_wins_frozen(self) -> None:
+        # First-match-wins ordering / permission gates stay launcher-verbatim: a child
+        # re-declaring the broad route must NOT escape the launcher's earlier always_ask
+        # gate on /reports/admin, nor re-order, re-gate, or add routes. The ONLY thing a
+        # child can narrow is the per-route ``methods`` dimension (#828).
         l_routes = [
             HttpRouteSpec(
                 path_pattern="/reports/admin",
@@ -174,8 +176,117 @@ class TestServerSurvival:
             ],
         )
         out = att(Surface([], [], [d_srv]), Surface([], [], [l_srv]))
-        assert out.http_servers[0].routes == l_routes  # launcher-verbatim, both routes
-        assert out != canon(Surface([], [], [d_srv]))  # narrowing is rejected (R1: verbatim only)
+        # Both routes survive in launcher order with launcher permission/path/ordering;
+        # the child declared no ``methods`` so nothing is narrowed → launcher-verbatim.
+        assert out.http_servers[0].routes == l_routes
+
+    def test_http_route_method_meet_intersection(self) -> None:
+        # #828: the child narrows a launcher route's methods → sorted set intersection.
+        l_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/repos/**", methods=["GET", "POST", "DELETE"])],
+        )
+        d_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/repos/**", methods=["POST", "DELETE", "PUT"])],
+        )
+        out = att(Surface([], [], [d_srv]), Surface([], [], [l_srv]))
+        # PUT is dropped (launcher lacks it); result sorted.
+        assert out.http_servers[0].routes[0].methods == ["DELETE", "POST"]
+
+    def test_http_route_method_meet_none_is_top(self) -> None:
+        # meet(None, X) == X ; meet(X, None) == X ; meet(None, None) == None
+        l_open = HttpServerSpec(
+            name="api", base_url="https://api", routes=[HttpRouteSpec(path_pattern="/r/**")]
+        )
+        d_get = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/r/**", methods=["GET"])],
+        )
+        out = att(Surface([], [], [d_get]), Surface([], [], [l_open]))
+        assert out.http_servers[0].routes[0].methods == ["GET"]  # meet(None, [GET]) == [GET]
+
+        l_get = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/r/**", methods=["GET"])],
+        )
+        d_open = HttpServerSpec(
+            name="api", base_url="https://api", routes=[HttpRouteSpec(path_pattern="/r/**")]
+        )
+        out2 = att(Surface([], [], [d_open]), Surface([], [], [l_get]))
+        assert out2.http_servers[0].routes[0].methods == ["GET"]  # meet([GET], None) == [GET]
+
+        out3 = att(Surface([], [], [d_open]), Surface([], [], [l_open]))
+        assert out3.http_servers[0].routes[0].methods is None  # meet(None, None) == None
+
+    def test_http_route_method_meet_empty_is_deny_all_not_dropped(self) -> None:
+        # Disjoint methods → empty intersection → methods=[] (deny-all), route KEPT
+        # so launcher ordering / permission gates are not shifted.
+        l_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/r/**", methods=["GET"])],
+        )
+        d_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/r/**", methods=["POST"])],
+        )
+        out = att(Surface([], [], [d_srv]), Surface([], [], [l_srv]))
+        assert out.http_servers[0].routes[0].methods == []
+
+    def test_http_route_child_undeclared_path_keeps_launcher_methods(self) -> None:
+        # Child declares only /a; launcher has /a and /b. /b is emitted unchanged
+        # (child's silence does not narrow — parent-wins-frozen).
+        l_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[
+                HttpRouteSpec(path_pattern="/a", methods=["GET", "POST"]),
+                HttpRouteSpec(path_pattern="/b", methods=["GET"]),
+            ],
+        )
+        d_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/a", methods=["GET"])],
+        )
+        out = att(Surface([], [], [d_srv]), Surface([], [], [l_srv]))
+        routes = out.http_servers[0].routes
+        assert [r.path_pattern for r in routes] == ["/a", "/b"]  # launcher order, both kept
+        assert routes[0].methods == ["GET"]  # /a narrowed
+        assert routes[1].methods == ["GET"]  # /b launcher-verbatim
+
+    def test_http_route_methods_normalized_in_canon(self) -> None:
+        srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/r/**", methods=["POST", "GET", "GET"])],
+        )
+        out = canon(Surface([], [], [srv]))
+        assert out.http_servers[0].routes[0].methods == ["GET", "POST"]  # sorted, deduped
+
+    def test_http_route_meet_is_canon_fixpoint(self) -> None:
+        # attenuate(x, x) == canonicalize(x) and attenuate(attenuate(d,l),l) == attenuate(d,l)
+        l_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/r/**", methods=["GET", "POST"])],
+        )
+        d_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/r/**", methods=["POST"])],
+        )
+        lau = Surface([], [], [l_srv])
+        dec = Surface([], [], [d_srv])
+        assert att(lau, lau) == canon(lau)
+        once = att(dec, lau)
+        assert att(once, lau) == once
 
     def test_http_server_absent_is_dropped(self) -> None:
         d_srv = HttpServerSpec(name="api", base_url="https://api")

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -55,6 +55,7 @@ def _route(
     enabled: bool = True,
     policy: str | None = None,
     description: str | None = None,
+    methods: list[str] | None = None,
 ) -> HttpRouteSpec:
     permission = HttpPermissionPolicy(type=policy) if policy else None
     return HttpRouteSpec(
@@ -62,6 +63,7 @@ def _route(
         enabled=enabled,
         permission_policy=permission,
         description=description,
+        methods=cast(Any, methods),
     )
 
 
@@ -87,20 +89,25 @@ class TestClassifyPermission:
             ]
         )
         assert (
-            _classify_permission({"server_ref": "hue", "path": "/lights/1/state"}, agent)
+            _classify_permission(
+                {"server_ref": "hue", "path": "/lights/1/state", "method": "GET"}, agent
+            )
             == "always_ask"
         )
 
     def test_matched_route_with_always_allow(self) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*", policy="always_allow")])])
         assert (
-            _classify_permission({"server_ref": "hue", "path": "/lights/1"}, agent)
+            _classify_permission({"server_ref": "hue", "path": "/lights/1", "method": "GET"}, agent)
             == "always_allow"
         )
 
     def test_matched_route_with_no_policy_returns_none(self) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
-        assert _classify_permission({"server_ref": "hue", "path": "/lights/1"}, agent) is None
+        assert (
+            _classify_permission({"server_ref": "hue", "path": "/lights/1", "method": "GET"}, agent)
+            is None
+        )
 
     def test_disabled_route_does_not_match(self) -> None:
         agent = _agent(
@@ -110,12 +117,38 @@ class TestClassifyPermission:
                 )
             ]
         )
-        assert _classify_permission({"server_ref": "hue", "path": "/lights/1"}, agent) is None
+        assert (
+            _classify_permission({"server_ref": "hue", "path": "/lights/1", "method": "GET"}, agent)
+            is None
+        )
 
     def test_bad_args_returns_none(self) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
         assert _classify_permission({"server_ref": "hue"}, agent) is None
         assert _classify_permission({"server_ref": 123, "path": "/lights/1"}, agent) is None
+
+    def test_method_scoped_route_classifies_only_matching_method(self) -> None:
+        # A route scoped to POST with always_ask classifies a POST but not a GET
+        # (GET doesn't match the route at all → None → handler emits a typed error).
+        agent = _agent(
+            http_servers=[
+                _server(routes=[_route("/lights/*", policy="always_ask", methods=["POST"])])
+            ]
+        )
+        assert (
+            _classify_permission(
+                {"server_ref": "hue", "path": "/lights/1", "method": "POST"}, agent
+            )
+            == "always_ask"
+        )
+        assert (
+            _classify_permission({"server_ref": "hue", "path": "/lights/1", "method": "GET"}, agent)
+            is None
+        )
+
+    def test_missing_method_returns_none(self) -> None:
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*", policy="always_ask")])])
+        assert _classify_permission({"server_ref": "hue", "path": "/lights/1"}, agent) is None
 
 
 # ── _classify_tool_call (loop.py) over http_request ──────────────────────────
@@ -280,6 +313,44 @@ class TestHttpRequestHandler:
             )
         assert "error" in result
         assert "does not match any enabled route" in result["error"]
+
+    async def test_method_not_allowed_returns_error(self, _stub_runtime: Any) -> None:
+        # A route scoped to GET refuses a POST at the gate (no upstream dispatch).
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*", methods=["GET"])])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "POST"},
+            )
+        assert "error" in result
+        assert "POST" in result["error"]
+        assert "does not match any enabled route" in result["error"]
+        assert "url" not in captured  # not dispatched upstream
+
+    async def test_method_scoped_route_allows_matching_method(self, _stub_runtime: Any) -> None:
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*", methods=["GET"])])])
+        response = httpx.Response(
+            200, headers={"content-type": "application/json"}, content=b'{"on": true}'
+        )
+        stub = _make_stub_client(response=response)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth({"Authorization": "Bearer xyz"}),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        assert result["status"] == 200
 
     async def test_path_with_query_string_rejected(self, _stub_runtime: Any) -> None:
         """A ``path`` carrying a query string must be rejected even when the

--- a/tests/unit/test_step_context_http_block.py
+++ b/tests/unit/test_step_context_http_block.py
@@ -1,0 +1,54 @@
+"""Tests for the ``http_servers`` system-prompt allowlist block (#828).
+
+The block renders each enabled route's allowed HTTP methods so the model
+knows which verbs it may use. ``methods=None`` renders as ``ANY`` (all
+methods); a scoped list renders the verbs comma-joined and sorted.
+"""
+
+from __future__ import annotations
+
+from aios.harness.step_context import _build_http_servers_block
+from aios.models.agents import HttpRouteSpec, HttpServerSpec
+
+
+def test_method_scoped_route_renders_verb_prefix() -> None:
+    block = _build_http_servers_block(
+        [
+            HttpServerSpec(
+                name="api",
+                base_url="https://api",
+                routes=[
+                    HttpRouteSpec(path_pattern="/repos/**", methods=["GET", "POST"]),
+                ],
+            )
+        ]
+    )
+    assert "GET,POST /repos/**" in block
+
+
+def test_unscoped_route_renders_any() -> None:
+    block = _build_http_servers_block(
+        [
+            HttpServerSpec(
+                name="api",
+                base_url="https://api",
+                routes=[HttpRouteSpec(path_pattern="/x")],
+            )
+        ]
+    )
+    assert "ANY /x" in block
+
+
+def test_route_description_preserved_after_verb() -> None:
+    block = _build_http_servers_block(
+        [
+            HttpServerSpec(
+                name="api",
+                base_url="https://api",
+                routes=[
+                    HttpRouteSpec(path_pattern="/y", methods=["GET"], description="read a thing")
+                ],
+            )
+        ]
+    )
+    assert "GET /y — read a thing" in block


### PR DESCRIPTION
## What & why

`HttpRouteSpec` was `{path_pattern, description, enabled, permission_policy}` only — a surface couldn't express "GET real repos, POST only the sandbox repo", forcing the CEO-on-aios v0 PoC to split into two workflows to confine writes structurally.

This adds HTTP-method scoping to routes and threads it through the capability-attenuation lattice as a real **meet = intersection**.

### Changes

- **`HttpRouteSpec.methods: list[HttpMethod] | None`** (`models/agents.py`). `None` = all verbs (the method-dimension lattice **top**; backward-compatible with routes authored before this change). A list scopes the route to exactly those verbs. `[]` = **deny-all** (the lattice **bottom**, the natural empty-intersection result of the meet). No validator forbids `[]` so the normal-form contract stays clean.

- **Attenuation meet** (`models/attenuation.py`). http servers still survive on the `base_url` key with **launcher-verbatim path/order/description/enabled/permission_policy** (parent-wins-frozen preserves first-match-wins permission gates — a child cannot re-order, re-gate, or add routes), but a child may now narrow each route's `methods` by declaring a matching `path_pattern`. `_meet_methods` is set-intersection with `None` as top. `canonicalize` normalizes methods (sorted/deduped) so `attenuate(x,x) == canonicalize(x)` byte-for-byte and the operator stays a fixpoint.

- **Route gate** (`tools/http_request.py`). `_match_route` now takes the method and refuses a verb the route doesn't admit, before dispatch, with a typed error. `_classify_permission` (and the workflow-run dispatcher in `workflows/run_tools.py`) pass the method through.

- **System prompt** (`harness/step_context.py`). Each route renders its allowed verbs (`GET,POST /repos/**`, or `ANY /x` when unscoped) so the model doesn't attempt a verb the gate would refuse.

### GraphQL decision: REST-only discipline for attenuated surfaces

A GraphQL endpoint serves queries (reads) and mutations (writes) over a single `POST` path, so method scoping cannot separate read from write there, and the broker does not inspect request bodies. An operator who needs to confine writes on a GraphQL surface must place reads and writes behind distinct `base_url` servers, or accept that granting `POST` grants both. This is documented on `HttpRouteSpec`; no semantic body inspection was added (kept simple per repo conventions).

### Tests (TDD)

New/updated cases in `test_agents_models.py` (model field + verb validation), `test_attenuation.py` (intersection, `None`-is-top, empty-is-deny-all-not-dropped, child-undeclared-path-keeps-launcher-methods, canon normalization, fixpoint), `test_http_request.py` (method gate allow/refuse + classify), and a new `test_step_context_http_block.py` (verb rendering). Codegen artifacts (`openapi.json`, SDK `_generated/`) regenerated and committed. Mutation check confirmed the intersection test fails when the meet is flipped to union.

Closes #828