### PR TITLE
fix(harness): degrade undecodable inline images to a text marker

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -534,6 +534,43 @@ def render_user_event(
     return {"role": "user", "content": marker}
 
 
+def _image_bytes_decode(data: bytes) -> bool:
+    """True iff Pillow can FULLY decode ``data`` as an image.
+
+    The inline gate (:func:`~aios.harness.vision.can_inline_image`) checks
+    only the mime prefix and the byte cap, and :func:`make_image_url_part`
+    only magic-byte-sniffs a 24-byte header — neither proves the pixels
+    decode. Providers DO full-decode an inline image and reject (HTTP 400)
+    bytes they can't, so the render boundary must apply the same verdict, or
+    an undecodable attachment (truncated/corrupt body behind a valid magic
+    prefix, or a zero-byte file) bricks the turn on every wake. ``img.load()``
+    forces the full decode — ``verify()`` passes a truncated body.
+
+    This predicate is TOTAL: any decode failure means "don't inline." Pillow
+    raises a wide, format-plugin-dependent set on hostile bytes —
+    ``UnidentifiedImageError``/``OSError`` (garbage/zero-byte/truncated),
+    ``DecompressionBombError`` (a pixel bomb we must not hand to the provider),
+    and ``ValueError``/``SyntaxError``/``struct.error`` from individual format
+    decoders. Catching only a subset would let an exotic decoder error escape
+    to ``build_messages``' poison backstop, which quarantines the WHOLE event
+    (losing the message text and any sibling attachments) rather than degrading
+    just this one attachment to a marker — so catch ``Exception`` (never
+    ``BaseException``: control-flow signals still propagate).
+    """
+    if not data:
+        return False
+    from io import BytesIO
+
+    from PIL import Image
+
+    try:
+        with Image.open(BytesIO(data)) as img:
+            img.load()
+    except Exception:
+        return False
+    return True
+
+
 def _apply_attachments(
     msg: dict[str, Any],
     attachments: list[Any],
@@ -600,6 +637,22 @@ def _apply_attachments(
                 "context.attachment_read_failed",
                 path=str(host_path),
                 error=str(err),
+            )
+            marker_lines.append(text_marker(record))
+            continue
+        if not _image_bytes_decode(payload):
+            # Bytes that pass the mime+size gate but don't actually decode (a
+            # truncated/corrupt body behind a valid magic prefix, or a
+            # zero-byte file). The provider full-decodes and 400s on these,
+            # and the bytes are immutable in the log, so inlining them re-sends
+            # the rejected part on every wake — terminally erroring the turn
+            # the model can't see. Degrade to a marker the model can ``read``,
+            # the same stance as the read-failure branch above and the
+            # build_messages poison backstop.
+            log.warning(
+                "context.attachment_undecodable",
+                path=str(host_path),
+                filename=record.get("filename"),
             )
             marker_lines.append(text_marker(record))
             continue

--- a/tests/e2e/test_context_endpoint.py
+++ b/tests/e2e/test_context_endpoint.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from tests.helpers.connections import authed_client, wired_app
+from tests.helpers.images import valid_png_bytes
 
 
 def _uniq() -> str:
@@ -292,7 +293,7 @@ class TestContextEndpoint:
 
         # Stage the image at the session's real ``workspace_volume_path``
         # (post-#409 ``<workspace_root>/<account_id>/<session_id>`` shape).
-        payload = b"PNGWORKSPACEBYTES"
+        payload = valid_png_bytes()  # must decode: the render boundary now gates inline images
         workspace_path = await sessions_svc.load_session_workspace_path(
             pool, session.id, account_id=account_id
         )

--- a/tests/helpers/images.py
+++ b/tests/helpers/images.py
@@ -1,0 +1,21 @@
+"""Shared image fixtures for vision / attachment rendering tests."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+
+def valid_jpeg_bytes() -> bytes:
+    """A genuinely-decodable 1x1 JPEG.
+
+    The render boundary decode-gates inline images (``context._apply_attachments``
+    degrades an undecodable attachment to a text marker rather than 400-ing the
+    provider on every wake), so any test asserting the *inline* path must stage
+    bytes Pillow can actually decode — not the ``b"...bytes"`` literals that
+    passed the old magic-sniff-only gate.
+    """
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), (10, 20, 30)).save(buf, format="JPEG")
+    return buf.getvalue()

--- a/tests/helpers/images.py
+++ b/tests/helpers/images.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from io import BytesIO
 
 
-def valid_jpeg_bytes() -> bytes:
-    """A genuinely-decodable 1x1 JPEG.
+def _valid_image(fmt: str) -> bytes:
+    """A genuinely-decodable 1x1 image in ``fmt`` (e.g. ``"JPEG"``, ``"PNG"``).
 
     The render boundary decode-gates inline images (``context._apply_attachments``
     degrades an undecodable attachment to a text marker rather than 400-ing the
@@ -17,5 +17,15 @@ def valid_jpeg_bytes() -> bytes:
     from PIL import Image
 
     buf = BytesIO()
-    Image.new("RGB", (1, 1), (10, 20, 30)).save(buf, format="JPEG")
+    Image.new("RGB", (1, 1), (10, 20, 30)).save(buf, format=fmt)
     return buf.getvalue()
+
+
+def valid_jpeg_bytes() -> bytes:
+    """A genuinely-decodable 1x1 JPEG. See :func:`_valid_image`."""
+    return _valid_image("JPEG")
+
+
+def valid_png_bytes() -> bytes:
+    """A genuinely-decodable 1x1 PNG. See :func:`_valid_image`."""
+    return _valid_image("PNG")

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -26,11 +26,15 @@ from aios.harness.context import (
 )
 from aios.models.events import Event
 from aios.sandbox.volumes import session_attachments_dir
+from tests.helpers.images import valid_jpeg_bytes
 
 # These tests exercise attachment/vision rendering, not the `received=` envelope
 # (their assertions are substring checks). Inject a fixed created_at so callers
 # needn't thread one through; the resulting `received` field is inert here.
 _CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+
+
+_VALID_JPEG = valid_jpeg_bytes()
 
 
 def render_user_event(
@@ -92,7 +96,7 @@ def _user_event(
 class TestVisionAwareRendering:
     def test_inlinable_image_emits_image_url_part(self, temp_workspace_root: Path) -> None:
         sandbox_path = _stage_image(
-            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"jpegbytes"
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", _VALID_JPEG
         )
         event = _user_event(
             content="hello",
@@ -100,7 +104,7 @@ class TestVisionAwareRendering:
                 {
                     "filename": "photo.jpg",
                     "content_type": "image/jpeg",
-                    "size": len(b"jpegbytes"),
+                    "size": len(_VALID_JPEG),
                     "in_sandbox_path": sandbox_path,
                 }
             ],
@@ -119,9 +123,47 @@ class TestVisionAwareRendering:
         assert content[1] == {
             "type": "image_url",
             "image_url": {
-                "url": f"data:image/jpeg;base64,{base64.b64encode(b'jpegbytes').decode()}"
+                "url": f"data:image/jpeg;base64,{base64.b64encode(_VALID_JPEG).decode()}"
             },
         }
+
+    def test_undecodable_under_cap_image_falls_back_to_marker(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """An image-typed attachment under the inline cap whose bytes Pillow
+        cannot decode (a corrupt body behind a valid JPEG magic prefix, or a
+        zero-byte file) must degrade to a text marker, NOT be inlined.
+
+        Providers full-decode an inline image and 400 on such bytes; the bytes
+        are immutable in the event log, so inlining them re-sends the rejected
+        part on every wake — bricking the turn into a terminal error the model
+        never sees (it's a provider-side 400, not something the model emitted).
+        The render boundary must apply the provider's own decodability verdict.
+        """
+        corrupt = b"\xff\xd8\xff" + b"garbage" * 4  # valid JPEG magic, undecodable body
+        sandbox_path = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-bad.jpg", corrupt)
+        event = _user_event(
+            content="look",
+            attachments=[
+                {
+                    "filename": "bad.jpg",
+                    "content_type": "image/jpeg",
+                    "size": len(corrupt),
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="model/vision",
+            session_id="sess-1",
+        )
+        # Marker-only render: content collapses to a string (no image_url part).
+        assert isinstance(msg["content"], str), "undecodable image must not be inlined"
+        assert "[image: bad.jpg" in msg["content"]
+        assert "/mnt/attachments/echo/evt-1-bad.jpg" in msg["content"]
 
     def test_non_dict_attachment_record_is_skipped(self, temp_workspace_root: Path) -> None:
         """A non-dict element in ``metadata.attachments`` must not crash the renderer.
@@ -156,14 +198,14 @@ class TestVisionAwareRendering:
         """A valid record next to malformed ones still renders correctly —
         the malformed entries are skipped, the valid one inlines as usual."""
         sandbox_path = _stage_image(
-            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"jpegbytes"
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", _VALID_JPEG
         )
         mixed: list[Any] = [
             "stray-string",
             {
                 "filename": "photo.jpg",
                 "content_type": "image/jpeg",
-                "size": len(b"jpegbytes"),
+                "size": len(_VALID_JPEG),
                 "in_sandbox_path": sandbox_path,
             },
             None,
@@ -221,7 +263,7 @@ class TestVisionAwareRendering:
         """
         oversize = vision.INLINE_SIZE_CAP_BYTES + 1
         _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-big.jpg", b"\0" * oversize)
-        inline_payload = b"resizedjpegbytes"
+        inline_payload = _VALID_JPEG
         inline_sandbox_path = _stage_image(
             temp_workspace_root,
             "sess-1",
@@ -365,7 +407,7 @@ class TestVisionAwareRendering:
         correct independent of what its caller happens to prepend.
         """
         sandbox_path = _stage_image(
-            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", b"PNG"
+            temp_workspace_root, "sess-1", "echo", "evt-1-photo.jpg", _VALID_JPEG
         )
         msg: dict[str, Any] = {"role": "user", "content": ""}  # empty leading text
         _apply_attachments(
@@ -374,7 +416,7 @@ class TestVisionAwareRendering:
                 {
                     "filename": "photo.jpg",
                     "content_type": "image/jpeg",
-                    "size": 3,
+                    "size": len(_VALID_JPEG),
                     "in_sandbox_path": sandbox_path,
                 }
             ],
@@ -404,7 +446,7 @@ class TestVisionAwareRendering:
         declarations from before the fix, so the renderer is the layer
         that unwedges them at replay time.
         """
-        jpeg_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+        jpeg_bytes = _VALID_JPEG
         sandbox_path = _stage_image(
             temp_workspace_root, "sess-1", "echo", "evt-1-lies.png", jpeg_bytes
         )
@@ -442,7 +484,7 @@ class TestVisionAwareRendering:
         pre-#409 ``workspace_root/session_id`` synthetic path."""
         nested = (temp_workspace_root / "acct-1" / "sess-1").resolve()
         nested.mkdir(parents=True)
-        payload = b"JPGNESTED"
+        payload = _VALID_JPEG
         (nested / "img.png").write_bytes(payload)
 
         event = _user_event(
@@ -511,7 +553,7 @@ class TestVisionAwareRendering:
         assert "[image: img.png" in msg["content"]
 
     def test_multiple_attachments_mixed(self, temp_workspace_root: Path) -> None:
-        a = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-a.jpg", b"AAA")
+        a = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-a.jpg", _VALID_JPEG)
         b = _stage_image(temp_workspace_root, "sess-1", "echo", "evt-1-b.pdf", b"PDF")
         event = _user_event(
             content="two",
@@ -519,7 +561,7 @@ class TestVisionAwareRendering:
                 {
                     "filename": "a.jpg",
                     "content_type": "image/jpeg",
-                    "size": 3,
+                    "size": len(_VALID_JPEG),
                     "in_sandbox_path": a,
                 },
                 {

--- a/tests/unit/test_switch_channel_recap_vision.py
+++ b/tests/unit/test_switch_channel_recap_vision.py
@@ -28,10 +28,12 @@ from aios.harness import vision
 from aios.models.events import Event
 from aios.sandbox.volumes import session_attachments_dir
 from aios.tools.switch_channel import render_reorient_block
+from tests.helpers.images import valid_jpeg_bytes
 
 CHAN_A = "signal/acct/chat-a"
 CHAN_B = "signal/acct/chat-b"
 SESSION_ID = "sess-test"
+_VALID_JPEG = valid_jpeg_bytes()
 
 
 @pytest.fixture
@@ -130,7 +132,7 @@ class TestRecapVision:
         return type widens from ``str`` to a content-parts list to
         carry the multimodal payload.
         """
-        payload = b"jpegbytes"
+        payload = _VALID_JPEG
         sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", payload)
         events = [
             _user_with_image(
@@ -161,14 +163,14 @@ class TestRecapVision:
         the model reads "this is historical content from the channel,
         and here's the picture they sent".
         """
-        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", b"PNGdata")
+        sandbox_path = _stage_image(temp_workspace_root, "signal", "evt-1-photo.jpg", _VALID_JPEG)
         events = [
             _user_with_image(
                 1,
                 channel=CHAN_A,
                 content="look at this banana",
                 sandbox_path=sandbox_path,
-                size=7,
+                size=len(_VALID_JPEG),
             )
         ]
         out = render_reorient_block(events, CHAN_A, model="model/vision", session_id=SESSION_ID)


### PR DESCRIPTION
## Summary

- **Bug:** `_apply_attachments` inlined any image-typed attachment that passed the mime+size gate as an `image_url` part **without checking the bytes actually decode**. An undecodable image under the inline cap — a truncated/corrupt body behind a valid magic prefix, or a zero-byte file — was base64-inlined and sent to the provider, which full-decodes and **400s**. The bytes are immutable in the event log and `build_messages` is pure replay, so the rejected part re-sends on **every wake**; `loop.py`'s generic `except` burns the retry budget and latches the turn into terminal `error` — a provider-side 400 the model never sees and can't self-correct.
- **Fix:** a render-boundary **decode gate** — after reading the staged bytes and before `make_image_url_part`, attempt a full Pillow decode (`img.load()`; `verify()` is insufficient — it passes a truncated body) and, on any decode failure, fall through to the existing `text_marker` path so the model gets an `[image: …]` line it can `read`.
- **Why the render boundary (not staging):** it covers **every** delivery path — connector-staging, direct/workspace/memory-store references, workflow-child — not just the staging path, which (a) doesn't see direct references and (b) has a header-only fast-path that never decodes a truncated-but-header-valid JPEG.
- **Total predicate:** catches `Exception` → `False`, so an exotic format-plugin error (`ValueError`/`struct.error` from a corrupt PSD/PPM, etc.) degrades **just this attachment** to a marker rather than escaping to the poison backstop, which would quarantine the whole event (losing the message text + sibling attachments).

## Test changes

Several existing tests asserted the inline path using fake `b"...bytes"` literals that only passed the old magic-sniff-only gate. With the decode gate they correctly no longer inline, so they're updated to stage genuinely-decodable bytes via a new shared `tests/helpers/images.valid_jpeg_bytes()`. Adds `test_undecodable_under_cap_image_falls_back_to_marker` (red→green).

## Discovery & verification

- Found via a hypothesis-driven audit (attachment/vision dimension); failing test written first, confirmed red (corrupt bytes inlined as `data:image/jpeg;base64,…` instead of a marker).
- Adversarial review attacked 5 vectors. It cleared valid-image handling (progressive/CMYK/animated/EXIF all decode), per-wake cost (bounded by the inline cap; same deferred-LRU-cache budget as the existing per-render base64), and the corrupt-`inline`-sibling path (degrades to the **original**'s marker). It drove one change — broadening the catch to `Exception` for correct per-attachment degradation granularity.

## Known residual (separate bug, filed for a follow-up iteration)

`can_inline_image` accepts any `image/*` including `image/tiff` / `image/bmp`, which Pillow **decodes** (so this gate passes them) but providers reject → still 400. That's a distinct *decodable-but-provider-unsupported-format* bug (fix = format allowlist), not introduced here; not in scope for this PR.

## Test plan

- [x] new regression test + updated inline-path tests across `test_context_attachments.py` and `test_switch_channel_recap_vision.py` (red→green)
- [x] mypy clean (595 files) · ruff check + format clean · full unit suite 2628 passed
- [ ] CI runs e2e / integration suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)