### PR TITLE
fix(ops): rekey the oauth_flows encrypted table on vault-key rotation

### DIFF
--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -73,6 +73,12 @@ _REKEY_COLUMNS = (
         "placeholder_salt_ciphertext IS NOT NULL",
         "id",
     ),
+    # In-flight Connect OAuth flow state (#818 vault-oauth): the blob carries the
+    # PKCE code_verifier + client_secret, encrypted with the same per-account
+    # subkey as vault_credentials. Rows are short-lived (deleted on complete,
+    # pruned at ~10min) and ciphertext is NOT NULL — so "TRUE" rekeys every
+    # live row. Omitting it left an active flow undecryptable across a rotation.
+    _EncryptedColumn("oauth_flows", "ciphertext", "nonce", "TRUE"),
 )
 
 

--- a/tests/integration/test_rekey_column_coverage.py
+++ b/tests/integration/test_rekey_column_coverage.py
@@ -1,0 +1,80 @@
+"""`aios rekey` must cover EVERY encrypted column in the schema.
+
+A vault-key rotation re-encrypts a hand-maintained list of ``(table,
+ciphertext)`` columns (``ops._REKEY_COLUMNS``). If an encrypted column is added
+to the schema but not to that list, rotation silently leaves it encrypted under
+the OLD key — and once ``AIOS_VAULT_KEY_PREVIOUS`` is dropped after the
+rotation, those rows are permanently undecryptable (data loss).
+
+This pins the invariant by deriving the truth from the migrated schema rather
+than a second hand-maintained list: every ``*ciphertext*`` column the
+migrations create must have a ``_REKEY_COLUMNS`` entry. It caught
+``oauth_flows`` (the Connect-flow state table, migration 0061) being omitted,
+and it fails loudly the next time an encrypted table is added without wiring
+rekey.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import asyncpg
+import pytest
+
+from aios.cli.commands.ops import _REKEY_COLUMNS
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+# ``credentials`` (migration 0001) is the pre-multi-tenancy, pre-vaults
+# credential store, superseded by ``vaults``/``vault_credentials`` (0005) and
+# read/written by NO current code. It has no ``account_id`` column, so the
+# per-account-subkey scheme ``rekey`` uses cannot apply to it — it can be
+# neither rekeyed in place nor blindly added to ``_REKEY_COLUMNS``. Removing it
+# (and the ``agents``/``agent_versions`` ``credential_id`` FKs) is a separate
+# destructive-migration decision tracked outside this guard, so the table is
+# excluded here rather than silently passing the coverage assertion.
+_LEGACY_UNREKEYABLE = {("credentials", "ciphertext")}
+
+
+@pytest.fixture(scope="module")
+def postgres() -> Iterator[object]:
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+@needs_docker
+@pytest.mark.integration
+def test_rekey_covers_every_encrypted_column(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+    result = _run_alembic(["upgrade", "head"], db_url)
+    assert result.returncode == 0, f"alembic upgrade failed:\n{result.stderr}\n{result.stdout}"
+
+    async def check() -> None:
+        conn = await asyncpg.connect(db_url)
+        try:
+            # The vault crypto stores every encrypted value as a
+            # ``<name>ciphertext`` + ``<name>nonce`` pair, so a ``ciphertext``
+            # column is the reliable schema-level marker of an encrypted column.
+            rows = await conn.fetch(
+                "SELECT table_name, column_name FROM information_schema.columns "
+                "WHERE table_schema = 'public' AND column_name LIKE '%ciphertext%'"
+            )
+        finally:
+            await conn.close()
+
+        schema_cols = {(r["table_name"], r["column_name"]) for r in rows}
+        rekey_cols = {(c.table, c.ciphertext) for c in _REKEY_COLUMNS}
+        missing = schema_cols - rekey_cols - _LEGACY_UNREKEYABLE
+        assert not missing, (
+            "encrypted columns present in the schema but NOT re-encrypted by "
+            "`aios rekey` — a vault-key rotation would orphan these rows under "
+            f"the old key (permanent data loss): {sorted(missing)}. "
+            "Add an `_EncryptedColumn` entry for each to ops._REKEY_COLUMNS."
+        )
+
+    asyncio.run(check())


### PR DESCRIPTION
## Summary

- **Bug:** `aios rekey` re-encrypts a hand-maintained list of `(table, ciphertext)` columns (`_REKEY_COLUMNS`) but **omitted `oauth_flows`** — the in-flight Connect OAuth flow state, whose blob (PKCE `code_verifier` + `client_secret`) is encrypted with the *same* per-account subkey as `vault_credentials`. A vault-key rotation left an active flow's row encrypted under the **old** key; once `AIOS_VAULT_KEY_PREVIOUS` is dropped post-rotation, that row is **permanently undecryptable** and the flow can't complete.
- **Fix:** add the `oauth_flows` entry (`account_id` / `ciphertext` / `nonce`, `WHERE TRUE` — columns are `NOT NULL` and rows are deleted-on-complete, never zeroed, so every live row is rekeyed). Verified `oauth_flows` uses `derive_account_subkey(account_id)` (same scheme rekey decrypts/re-encrypts with) and the decrypt→re-encrypt round-trip preserves the payload.
- **Durable guard:** an integration test derives **every** encrypted (`*ciphertext`) column from the migrated schema and asserts each has a `_REKEY_COLUMNS` entry — so a future encrypted table can't be silently missed. (Correct-by-construction: the truth comes from the schema, not a second hand-maintained list.)

## A second omission the guard caught

The coverage test also flagged the pre-multi-tenancy **legacy `credentials` table** (migration 0001), superseded by `vault_credentials` (0005) and read by **no current code**. It has **no `account_id` column**, so the per-account rekey scheme can't apply — it can be neither rekeyed in place nor blindly added to the list. It's **excluded from the guard with a documented rationale**; its removal (a destructive migration that also drops the `agents`/`agent_versions` `credential_id` FKs, and must account for any legacy prod rows) is tracked as a **separate** decision rather than done here under a scheme that doesn't fit it.

## Verification

- Failing test written first; confirmed red — the guard reported `[('credentials','ciphertext'), ('oauth_flows','ciphertext')]` missing. Green after adding `oauth_flows` + documenting the `credentials` exclusion.
- Verified locally against the testcontainer Postgres (the integration shard runs it in CI).
- Self-verified: `oauth_flows` scheme/columns/WHERE; the `%ciphertext%` detector is complete (every `nonce` column's partner is a `*ciphertext` column).

## Test plan

- [x] `tests/integration/test_rekey_column_coverage.py` (red→green; runs in the `integration` shard)
- [x] mypy clean (602 files) · ruff check + format clean · unit suite 2654 passed
- [ ] CI runs the integration + e2e shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)