### PR TITLE
fix(tools): reject custom tool names using the reserved mcp__ prefix

### DIFF
--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -341,6 +341,17 @@ class ToolSpec(BaseModel):
             ]
             if missing:
                 raise ValueError(f"custom tools require: {', '.join(missing)}")
+            # ``mcp__`` is the reserved MCP namespace (see is_mcp_tool_name): a
+            # custom tool with that prefix is classified as an MCP call by
+            # _classify_tool_call BEFORE the custom fallback, so it routes to
+            # the MCP dispatcher (erroring as an unknown server) and is never
+            # held for the client. Reject it here, at the operator-controlled
+            # definition layer, rather than letting it silently never work.
+            if self.name is not None and is_mcp_tool_name(self.name):
+                raise ValueError(
+                    f"custom tool name {self.name!r} must not start with the reserved "
+                    "'mcp__' prefix (it namespaces MCP-dispatched tools)"
+                )
         elif self.type == "mcp_toolset":
             if self.mcp_server_name is None:
                 raise ValueError("mcp_toolset requires mcp_server_name")

--- a/tests/unit/test_toolspec.py
+++ b/tests/unit/test_toolspec.py
@@ -25,6 +25,20 @@ class TestDefaults:
         assert spec.enabled is True
         assert spec.permission is None
 
+    def test_custom_mcp_prefix_name_rejected(self) -> None:
+        # ``mcp__`` namespaces MCP-dispatched tools (``is_mcp_tool_name``); a
+        # custom tool with that prefix is classified as MCP by
+        # ``_classify_tool_call`` BEFORE the custom fallback, so it is errored
+        # as an unknown server and never held for the client to execute.
+        # Reject it at definition — the layer the operator controls.
+        with pytest.raises(ValueError, match="mcp__"):
+            ToolSpec(
+                type="custom",
+                name="mcp__foo",
+                description="bar",
+                input_schema={"type": "object"},
+            )
+
 
 class TestPermissionField:
     def test_always_allow(self) -> None:


### PR DESCRIPTION
## Summary

- **Bug:** `_classify_tool_call` checks `is_mcp_tool_name` (`name.startswith("mcp__")`) **before** the custom-tool fallback. So a custom (client-executed) tool whose name starts with `mcp__` is classified as an MCP call, routed to the MCP dispatcher, and errored as an unknown/unregistered server (`unknown_mcp`) — **never held for the client to execute**. The custom tool silently never works, with no signal at definition time.
- **Fix:** `mcp__` is the reserved MCP namespace (`mcp__<server>__<tool>`); a custom tool must not squat it. Reject the prefix in `ToolSpec`'s custom-tool `model_validator`, **reusing `is_mcp_tool_name`** as the single source of truth for the namespace — failing at the operator-controlled definition layer with a clear error, rather than accepting a name that can never dispatch.

## Why validation-time rejection (not reordering the classifier)

Rejecting at definition is correct-by-construction and avoids a name-shadowing ambiguity (a custom tool named exactly like a real MCP tool would otherwise shadow it). It mirrors the validator's **existing** reject-on-construction stance for missing custom-tool fields. No existing custom tool or test uses an `mcp__` name (verified by grep), so nothing legitimate breaks.

## Verification

- Failing test written first, confirmed red (`DID NOT RAISE`: `ToolSpec(type="custom", name="mcp__foo", …)` was accepted).
- mypy clean · ruff check + format clean · unit suite 2655 passed. No openapi/SDK drift (a `model_validator` doesn't change the introspected schema; the snapshot tests pass).

## Test plan

- [x] `test_custom_mcp_prefix_name_rejected` (red→green)
- [x] mypy / ruff / full unit suite green
- [ ] CI runs e2e / integration shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)