### PR TITLE
feat: dev pipeline as a durable aios workflow (autodev#19 / aios#987) [draft — needs review+approval]

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -42,6 +42,38 @@ the load-bearing properties — validate the LIVE ``refs/pull/N/merge`` commit, 
 runs the configured sentinel commands against it; per-sentinel path-prefix *selection* (an
 efficiency optimisation, not a safety property) is deferred, so v1 runs every configured
 sentinel (strictly safer: more checks, never fewer).
+
+RESILIENCE CONTRACT (the Phase-0 hardening, aios#987; design doc §10):
+1. **Read the full issue.** S1 ingests the body AND ``GET /issues/{n}/comments``; the spec
+   gate counts words over body+comments and threads the comment array into every agent node
+   (implement/review/fix) so a design pass in the thread reaches the coder. The marker trap
+   still scans the BODY (no regression), but a body marker is SUPPRESSED when a later comment
+   quotes the offending line AND carries a resolution signal (resolved/settled/answer:/
+   decided/closed) — see ``spec_ok``. Comment pagination is a V1 deferral: the path-only route
+   allowlist forbids ``?page=``, so the clean ``/comments`` path returns GitHub's first page
+   (≤30); the dominant resolve-in-thread case is recent comments.
+2. **Retry transient 5xx.** Every scripted GitHub call goes through ``gh_retry`` — a bounded
+   (≤3) loop that re-issues the request on a 5xx / transport error / ``{"error":...}`` and
+   returns the last result for the caller to branch. Each retry is a fresh ``tool()`` await,
+   so the CallKeyer assigns it a distinct per-content-hash ordinal (``#0``/``#1``/``#2``) and
+   replay stays stable (the retry decision is a pure function of the memoized result).
+3. **Surface failures, never zombie.** ``autodev:in-progress`` is labelled at ingest and
+   removed on success; every terminal NON-gate failure ``return`` first labels
+   ``autodev:failed``. A gate park is a durable suspension (auto-recover on resume), NOT a
+   failure, so it is deliberately not labelled failed.
+4. **Auto-recovery.** ``retry_count`` rides the input envelope; a re-launched run that arrives
+   with ``retry_count >= MAX_RUN_RETRIES`` terminates at ``dead_letter`` instead of looping.
+   The DEPLOY-TIME WIRING (Phase 2, not in this script): a ``run_completion`` trigger fires on
+   ``status=errored`` and re-launches the workflow with ``retry_count + 1`` and the same
+   ``{repo, issue_number}``. Re-launch is idempotent by construction — S4 lists open PRs and
+   ADOPTS the branch's PR instead of creating a duplicate ("open-pr"; a 422 on create re-lists
+   and adopts), and MERGE re-confirms ``GET /pulls/{n}.merged`` before declaring
+   ``merge_failed`` so an already-merged PR is never double-merged or lost.
+5. **AgentError guards.** Every agentic node (implement/review/fix/ci-watch/risk) runs under a
+   defensive guard: an ``agent_not_found`` / transient agent error escalates to the relevant
+   gate (design / verify) or, for the best-effort risk + post-merge nodes, degrades to the
+   conservative default — so a flaky judgment agent parks the run for a human instead of
+   crashing it (an uncaught ``AgentError`` at the root fails the whole run).
 """
 
 from __future__ import annotations
@@ -122,6 +154,30 @@ SPEC_BLOCKERS: tuple[str, ...] = (
     r"(?i)needs? (more |further )?(design|discussion|thought|spec|input|clarification)",
     r"(?i)TODO[:\s].*spec",
 )
+# A later comment SUPPRESSES a body marker only when it both (a) quotes the offending
+# line and (b) carries one of these resolution signals — so a passing mention of "open
+# question" can't unlock the gate, but an explicit "Resolved: <quoted line> — use a typed
+# enum" does. Word-boundaried and case-insensitive (the body marker-trap itself is
+# untouched: a marker the comments never resolve still bounces).
+RESOLUTION_SIGNALS: tuple[str, ...] = (
+    r"(?i)\bresolved\b",
+    r"(?i)\bsettled\b",
+    r"(?i)\banswer\s*:",
+    r"(?i)\bdecided\b",
+    r"(?i)\bclosed\b",
+)
+
+# Failure-surfacing labels (item 3): never a silent zombie. ``IN_PROGRESS`` is applied at
+# ingest and removed on success; ``FAILED`` is applied on every terminal NON-gate failure
+# (a gate park is a durable suspension, not a failure, so it is NOT labelled failed).
+LABEL_IN_PROGRESS = "autodev:in-progress"
+LABEL_FAILED = "autodev:failed"
+
+# Auto-recovery (item 4): a re-launched run carries ``retry_count`` in its input envelope;
+# the deploy-time ``run_completion`` trigger (Phase 2) re-launches an ``errored`` run with
+# ``retry_count + 1``. The script-level guard bounds that loop: a run that arrives with
+# ``retry_count >= MAX_RUN_RETRIES`` terminates at the dead-letter state instead of looping.
+MAX_RUN_RETRIES = 2
 
 
 def _py(name: str, value: Any) -> str:
@@ -164,6 +220,10 @@ def _render_constants(
         _py("MIN_SPEC_BODY_WORDS", MIN_SPEC_BODY_WORDS),
         _py("MIN_BUG_BODY_WORDS", MIN_BUG_BODY_WORDS),
         _py("SPEC_BLOCKERS", list(SPEC_BLOCKERS)),
+        _py("RESOLUTION_SIGNALS", list(RESOLUTION_SIGNALS)),
+        _py("LABEL_IN_PROGRESS", LABEL_IN_PROGRESS),
+        _py("LABEL_FAILED", LABEL_FAILED),
+        _py("MAX_RUN_RETRIES", MAX_RUN_RETRIES),
         _py("IMPLEMENT_SCHEMA", IMPLEMENT_SCHEMA),
         _py("REVIEW_SCHEMA", REVIEW_SCHEMA),
         _py("FIX_SCHEMA", FIX_SCHEMA),
@@ -212,33 +272,76 @@ def _strip_meta(body):
     return "\n".join(out)
 
 
-def _find_blocker(body):
+def _comment_texts(comments):
+    """The body strings of the issue's comment thread (skipping empties/non-dicts).
+    ``comments`` is the array from ``GET /issues/{n}/comments`` (or [] when unread)."""
+    out = []
+    if isinstance(comments, list):
+        for c in comments:
+            if isinstance(c, dict):
+                text = c.get("body")
+                if isinstance(text, str) and text.strip():
+                    out.append(text)
+    return out
+
+
+def _marker_resolved(line_text, comments):
+    """True if SOME comment both quotes the offending body line AND carries a resolution
+    signal — the explicit "this open question is settled" handshake. Quoting is a
+    substring match on the marker line's stripped text (after blockquote/`>` stripping,
+    so a GitHub `> quoted line` still matches); a bare resolution word with no quote, or
+    a quote with no resolution word, does NOT suppress."""
+    needle = (line_text or "").strip()
+    if not needle:
+        return False
+    for raw in _comment_texts(comments):
+        dequoted = "\n".join(
+            re.sub(r"^\s*>+\s?", "", ln) for ln in raw.split("\n")
+        )
+        if needle not in dequoted:
+            continue
+        for pat in RESOLUTION_SIGNALS:
+            if re.search(pat, dequoted):
+                return True
+    return False
+
+
+def _find_blocker(body, comments=None):
+    """First unresolved marker in the BODY (comments never ADD markers — no regression of
+    the trap). A body marker whose line a later comment quotes-and-resolves is skipped."""
     scan = _strip_meta(body)
     for i, line in enumerate(scan.split("\n"), start=1):
         for pat in SPEC_BLOCKERS:
             if re.search(pat, line):
+                if comments is not None and _marker_resolved(line.strip(), comments):
+                    continue  # quoted + resolved in a later comment -> suppressed
                 return (pat, i, line.strip())
     return None
 
 
-def spec_ok(issue, kind):
+def spec_ok(issue, kind, comments=None):
     """The scripted pre-flight gate (V1 subset of autodev validation): empty-body,
-    word-count, unresolved-marker. Returns (ok, reason)."""
+    word-count, unresolved-marker. Returns (ok, reason).
+
+    The word-count runs over body PLUS the comment thread (a design pass in comments can
+    satisfy a thin body); the marker trap scans the BODY (a comment never introduces a
+    marker) but suppresses a body marker that a later comment quotes-and-resolves."""
     body = (issue.get("body") or "").strip()
     if not body:
         return (False, "Issue body is empty -- no spec to implement.")
-    words = len(body.split())
+    spec_text = "\n\n".join([body] + _comment_texts(comments))
+    words = len(spec_text.split())
     minimum = MIN_BUG_BODY_WORDS if kind == "bug" else MIN_SPEC_BODY_WORDS
     if words < minimum:
         return (False, "Issue body is too short (%d words, minimum %d)." % (words, minimum))
-    hit = _find_blocker(body)
+    hit = _find_blocker(body, comments)
     if hit is not None:
         return (False, "Spec contains an unresolved marker on line %d: %r. "
                        "Resolve all open questions before implementation." % (hit[1], hit[2]))
     return (True, "")
 
 
-async def gh(method, path, body=None):
+async def _gh_once(method, path, body=None):
     """One GitHub REST/GraphQL call through the run's bound-vault-authed http_request. A
     non-2xx or transport error is a VALUE the caller branches on, never a raise. ``path``
     must NOT carry a query string (the route allowlist is path-only) — filter in-script."""
@@ -246,6 +349,35 @@ async def gh(method, path, body=None):
     if body is not None:
         args["body"] = json.dumps(body)
     return await tool("http_request", args)
+
+
+def _is_transient(resp):
+    """A retryable GitHub response: a 5xx status, OR a transport/tool error (the
+    http_request tool surfaces a connection failure as ``{"error": ...}`` with no/None
+    status). A 4xx is the caller's problem (auth, 404, 422-already-exists) — NOT retried,
+    so a deterministic client error fails fast rather than burning three attempts."""
+    if not isinstance(resp, dict):
+        return True  # a non-dict result is a malformed tool return -> treat as transient
+    if resp.get("error") is not None:
+        return True
+    st = resp.get("status")
+    return isinstance(st, int) and 500 <= st <= 599
+
+
+async def gh(method, path, body=None):
+    """A GitHub call with bounded transient-5xx retry. Re-issues the request up to 3 times
+    on a 5xx / transport error / ``{"error":...}`` and returns the LAST result for the
+    caller to branch on (a value, never a raise — a persistent failure surfaces as the
+    last non-2xx response). Each attempt is a fresh ``tool()`` await, so the CallKeyer
+    gives it a distinct per-content-hash ordinal and replay stays stable. (Named ``gh`` so
+    every existing call site retries for free; the single-shot is ``_gh_once``.)"""
+    resp = None
+    for _ in range(3):
+        resp = await _gh_once(method, path, body)
+        if not _is_transient(resp):
+            return resp
+        log("gh transient failure, retrying:", method, path, _status(resp))
+    return resp
 
 
 def _status(resp):
@@ -320,6 +452,25 @@ def _mark_ready_query():
             "{pullRequest{isDraft}}}")
 
 
+async def _label(repo, issue_number, name):
+    """Add one label (best-effort, retried by gh)."""
+    await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number), {"labels": [name]})
+
+
+async def _unlabel(repo, issue_number, name):
+    """Remove one label by name (URL-encoded). A 404 (label absent) is a value gh ignores."""
+    await gh("DELETE", _ipath(repo, "/issues/%d/labels/%s"
+                              % (issue_number, name.replace(":", "%3A"))))
+
+
+async def _fail(repo, issue_number, result):
+    """Surface a terminal NON-gate failure: drop in-progress, raise autodev:failed, then
+    return the result the run terminates with (item 3 — never a silent zombie)."""
+    await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
+    await _label(repo, issue_number, LABEL_FAILED)
+    return result
+
+
 # ─── the state machine ───────────────────────────────────────────────────────
 
 async def main(input):
@@ -328,33 +479,63 @@ async def main(input):
     issue_number = int(payload["issue_number"])
     kind = payload.get("kind", "issue")
     model = payload.get("model") or DEFAULT_MODEL
+    # Auto-recovery (item 4): the Phase-2 run_completion trigger re-launches an errored run
+    # with retry_count+1. Bound that loop here so a deterministically-failing run dead-letters
+    # instead of looping forever; a missing/garbage value floors to 0 (first attempt).
+    try:
+        retry_count = int(payload.get("retry_count") or 0)
+    except (TypeError, ValueError):
+        retry_count = 0
+    if retry_count >= MAX_RUN_RETRIES:
+        log("retry budget exhausted (retry_count=%d) -> dead-letter" % retry_count)
+        await _label(repo, issue_number, LABEL_FAILED)
+        return {"state": "dead_letter", "retry_count": retry_count,
+                "reason": "exceeded MAX_RUN_RETRIES (%d) auto-recovery attempts" % MAX_RUN_RETRIES}
     escalations = []
 
-    # S1 — ingest the issue
+    # S1 — ingest the issue: body AND the comment thread (item 1). A design pass / resolved-
+    # decision lives in comments; thread it into the gate (word-count + marker-resolution) and
+    # every downstream agent. Claim the issue with autodev:in-progress so an in-flight run is
+    # never a silent zombie (item 3); it is removed on success / replaced by autodev:failed.
     phase("ingest")
+    await _label(repo, issue_number, LABEL_IN_PROGRESS)
     resp = await gh("GET", _ipath(repo, "/issues/%d" % issue_number))
     issue = _json_body(resp)
     if _status(resp) != 200 or issue is None:
-        return {"state": "error", "reason": "could not read issue %d (status %r)"
-                % (issue_number, _status(resp))}
+        return await _fail(repo, issue_number,
+                           {"state": "error", "reason": "could not read issue %d (status %r)"
+                            % (issue_number, _status(resp))})
+    comments_resp = await gh("GET", _ipath(repo, "/issues/%d/comments" % issue_number))
+    comments = _json_body(comments_resp)
+    if not isinstance(comments, list):
+        comments = []  # a comments-endpoint failure degrades to body-only (autodev's pattern)
+    comment_bodies = _comment_texts(comments)
 
-    # S2 — scripted pre-flight spec gate (regex/word-count; fail-fast before any spend)
+    # S2 — scripted pre-flight spec gate (regex/word-count over body+comments; fail-fast).
     phase("spec-gate")
-    ok, reason = spec_ok(issue, kind)
+    ok, reason = spec_ok(issue, kind, comments)
     if not ok:
         log("spec gate failed:", reason)
         await gh("POST", _ipath(repo, "/issues/%d/comments" % issue_number),
                  {"body": "## Spec not ready for implementation\n\n" + reason})
         await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number),
                  {"labels": ["underspecified"]})
-        return {"state": "spec_failed", "reason": reason}
+        return await _fail(repo, issue_number, {"state": "spec_failed", "reason": reason})
 
-    # A3 — implement (the coding agent: clone, explore, plan, TDD, self-review, push)
+    # A3 — implement (the coding agent: clone, explore, plan, TDD, self-review, push). The
+    # comment thread rides along so a design pass reaches the coder. An agent error escalates
+    # to the design gate (item 5) instead of crashing the run.
     phase("implement")
-    impl = await agent(
-        {"task": "implement", "repo": repo, "issue_number": issue_number, "kind": kind,
-         "title": issue.get("title", ""), "body": issue.get("body", "")},
-        agent_id=IMPLEMENT_AGENT_ID, output_schema=IMPLEMENT_SCHEMA, model=model, label="implement")
+    try:
+        impl = await agent(
+            {"task": "implement", "repo": repo, "issue_number": issue_number, "kind": kind,
+             "title": issue.get("title", ""), "body": issue.get("body", ""),
+             "comments": comment_bodies},
+            agent_id=IMPLEMENT_AGENT_ID, output_schema=IMPLEMENT_SCHEMA, model=model,
+            label="implement")
+    except AgentError as exc:
+        impl = {"escalated": True,
+                "escalation_reason": "implement agent error: %s" % exc}
     if impl.get("escalated"):
         escalations.append("design")
         decision = await gate({"kind": "design", "issue": issue_number,
@@ -362,13 +543,23 @@ async def main(input):
         if not (isinstance(decision, dict) and decision.get("resolved")):
             return {"state": "escalated", "reason": "design", "escalations": escalations}
         # resumed with a settled direction -> re-implement with the chairman's answer
-        impl = await agent(
-            {"task": "implement", "repo": repo, "issue_number": issue_number, "kind": kind,
-             "title": issue.get("title", ""), "body": issue.get("body", ""),
-             "resolution": decision.get("resolution", "")},
-            agent_id=IMPLEMENT_AGENT_ID, output_schema=IMPLEMENT_SCHEMA, model=model,
-            label="implement-resumed")
-    branch = impl["branch"]
+        try:
+            impl = await agent(
+                {"task": "implement", "repo": repo, "issue_number": issue_number, "kind": kind,
+                 "title": issue.get("title", ""), "body": issue.get("body", ""),
+                 "comments": comment_bodies, "resolution": decision.get("resolution", "")},
+                agent_id=IMPLEMENT_AGENT_ID, output_schema=IMPLEMENT_SCHEMA, model=model,
+                label="implement-resumed")
+        except AgentError as exc:
+            return await _fail(repo, issue_number,
+                               {"state": "failed_implement", "escalations": escalations,
+                                "reason": "implement agent error after resume: %s" % exc})
+    try:
+        branch = impl["branch"]
+    except (KeyError, TypeError) as exc:
+        return await _fail(repo, issue_number,
+                           {"state": "failed_implement", "escalations": escalations,
+                            "reason": "implement returned no branch: %s" % exc})
 
     # S4 — open / reconcile the PR. List open PRs (clean path; filter in-script), adopt one
     # for this branch if present, else create. A create that 422s (PR already exists, e.g. a
@@ -385,9 +576,10 @@ async def main(input):
         elif _status(created) == 422:  # already exists (re-drive / race) -> adopt it
             pr = _find_open_pr(_json_body(await gh("GET", _ipath(repo, "/pulls"))), branch)
         if pr is None:
-            return {"state": "failed_no_pr",
-                    "reason": "could not open or adopt a PR for branch %r (status %r)"
-                    % (branch, _status(created))}
+            return await _fail(repo, issue_number,
+                               {"state": "failed_no_pr",
+                                "reason": "could not open or adopt a PR for branch %r (status %r)"
+                                % (branch, _status(created))})
     pr_number = int(pr["number"])
     pr_node_id = pr.get("node_id", "")
     pr_url = pr.get("html_url", "")
@@ -399,10 +591,23 @@ async def main(input):
     phase("verify")
     review_ok = False
     for i in range(MAX_REVIEW_ITERS + 1):
-        review = await agent(
-            {"task": "review", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
-            agent_id=REVIEW_AGENT_ID, output_schema=REVIEW_SCHEMA, model=model,
-            label="review-%d" % i)
+        # A review-agent error escalates to the verify gate (item 5) — a flaky reviewer
+        # parks for a human rather than crashing the run. Resume-resolved continues.
+        try:
+            review = await agent(
+                {"task": "review", "repo": repo, "pr_number": pr_number, "head_sha": head_sha,
+                 "comments": comment_bodies},
+                agent_id=REVIEW_AGENT_ID, output_schema=REVIEW_SCHEMA, model=model,
+                label="review-%d" % i)
+        except AgentError as exc:
+            escalations.append("verify")
+            decision = await gate({"kind": "verify", "pr": pr_number,
+                                   "reason": "review agent error: %s" % exc})
+            if not (isinstance(decision, dict) and decision.get("resolved")):
+                return {"state": "escalated", "reason": "verify_agent_error",
+                        "escalations": escalations}
+            review_ok = True
+            break
         if not review.get("artifact_posted"):
             escalations.append("verify")
             decision = await gate({"kind": "verify", "pr": pr_number,
@@ -418,10 +623,21 @@ async def main(input):
         if i == MAX_REVIEW_ITERS:  # final re-review still failing -> exhausted
             break
         before = head_sha
-        fix = await agent(
-            {"task": "fix", "repo": repo, "pr_number": pr_number, "issues": review["issues"]},
-            agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model, label="fix-%d" % i)
-        head_sha = fix["head_sha"]
+        try:
+            fix = await agent(
+                {"task": "fix", "repo": repo, "pr_number": pr_number, "issues": review["issues"],
+                 "comments": comment_bodies},
+                agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model, label="fix-%d" % i)
+            head_sha = fix["head_sha"]
+        except AgentError as exc:
+            escalations.append("verify")
+            decision = await gate({"kind": "verify", "pr": pr_number,
+                                   "reason": "fix agent error: %s" % exc})
+            if not (isinstance(decision, dict) and decision.get("resolved")):
+                return {"state": "escalated", "reason": "verify_agent_error",
+                        "escalations": escalations}
+            review_ok = True
+            break
         if before and head_sha == before:  # empirical no-commit guard (head unchanged)
             escalations.append("verify")
             decision = await gate({"kind": "verify", "pr": pr_number,
@@ -443,29 +659,46 @@ async def main(input):
     # A9 — CI watch (the agent OWNS the durable wait) -> fix -> re-watch, bounded
     # (N watches, N-1 fixes — matches autodev's CI loop).
     ci_ok = False
+    ci_agent_error = False
     for i in range(MAX_CI_ITERS):
-        ci = await agent(
-            {"task": "watch_ci", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
-            agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model, label="ci-%d" % i)
+        # A ci-watch / ci-fix agent error breaks the loop and falls through to the verify
+        # gate (item 5) — it does NOT crash the run nor silently pass a red PR.
+        try:
+            ci = await agent(
+                {"task": "watch_ci", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
+                agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model, label="ci-%d" % i)
+        except AgentError as exc:
+            log("ci-watch agent error -> escalate:", exc)
+            ci_agent_error = True
+            break
         if ci["status"] in ("green", "no_ci"):
             ci_ok = True
             break
         if i == MAX_CI_ITERS - 1:
             break
         before = head_sha
-        fix = await agent(
-            {"task": "fix_ci", "repo": repo, "pr_number": pr_number,
-             "detail": ci.get("detail", "")},
-            agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model, label="ci-fix-%d" % i)
-        head_sha = fix["head_sha"]
+        try:
+            fix = await agent(
+                {"task": "fix_ci", "repo": repo, "pr_number": pr_number,
+                 "detail": ci.get("detail", ""), "comments": comment_bodies},
+                agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model,
+                label="ci-fix-%d" % i)
+            head_sha = fix["head_sha"]
+        except AgentError as exc:
+            log("ci-fix agent error -> escalate:", exc)
+            ci_agent_error = True
+            break
         if before and head_sha == before:
             break
     if not ci_ok:
+        _ci_reason = ("CI-watch agent error" if ci_agent_error
+                      else "CI failing after %d checks" % MAX_CI_ITERS)
         escalations.append("verify")
-        decision = await gate({"kind": "verify", "pr": pr_number,
-                               "reason": "CI failing after %d checks" % MAX_CI_ITERS})
+        decision = await gate({"kind": "verify", "pr": pr_number, "reason": _ci_reason})
         if not (isinstance(decision, dict) and decision.get("resolved")):
-            return {"state": "escalated", "reason": "ci_exhausted", "escalations": escalations}
+            return {"state": "escalated",
+                    "reason": "ci_agent_error" if ci_agent_error else "ci_exhausted",
+                    "escalations": escalations}
 
     # A10/S11 — risk tiering (best-effort; never blocks). Conservative tier-3 default. The
     # guard tolerates BOTH a child failure (AgentError) AND a malformed/short return
@@ -528,9 +761,11 @@ async def main(input):
         if isinstance(confirm, dict) and confirm.get("merged"):
             merged = True
         else:
-            return {"state": "merge_failed", "pr_url": pr_url, "pr_number": pr_number,
-                    "risk_tier": tier, "reason": "merge call returned %r" % _status(merge_resp),
-                    "escalations": escalations}
+            return await _fail(repo, issue_number,
+                               {"state": "merge_failed", "pr_url": pr_url, "pr_number": pr_number,
+                                "risk_tier": tier,
+                                "reason": "merge call returned %r" % _status(merge_resp),
+                                "escalations": escalations})
 
     # A15 — post-merge master-CI watch (the D-2 missing state). Red OR an errored watch =>
     # HALT at a gate; the merge is a committed fact, so we never discard it by failing here.
@@ -548,6 +783,8 @@ async def main(input):
         escalations.append("master_red")
         await gate({"kind": "master_red", "repo": repo, "detail": master_detail})
 
+    # Success: the issue is done, so release the in-progress claim (item 3).
+    await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
     return {"state": "done", "pr_url": pr_url, "pr_number": pr_number, "merged": merged,
             "risk_tier": tier, "escalations": escalations}
 '''

--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -1,0 +1,620 @@
+"""Reference dev-pipeline workflow script (the autodev#19 / aios#987 strange-loop endpoint).
+
+This is autodev's development pipeline — ``spec-gate → implement → verify → risk →
+merge-guard → mark-ready → merge → post-merge`` — re-expressed as a single durable aios
+workflow. One run = one issue, end to end, mirroring one autodev "job". The full
+state-machine design (every node, the agentic/computation partition, the dissolution
+ledger, the credential model) lives in eumemic-company
+``architecture/dev-pipeline-state-machine.md``.
+
+The exported builders return workflow *source code* (the ``deep_research.py`` pattern):
+``build_dev_pipeline_script`` is the production workload authored into the runtime via
+``aios workflows create``; ``build_dev_pipeline_fixture_script`` is the CI variant with
+tight iteration caps, driven by ``tests/integration/test_wf_dev_pipeline_fixture.py``
+against the host with simulated agent/tool returns to prove the machine replays,
+suspends on gates, resumes, and completes.
+
+NODE PARTITION (see the design doc):
+- **agentic** (``agent()``): implement, review, fix, ci-watch, risk — the five judgment nodes.
+- **scripted** (``tool('http_request')`` / ``tool('bash')`` / in-script ``re``): the spec
+  gate, PR/label/comment/status API calls, the merge-ref guard, mark-ready, merge.
+- **gate** (``gate()``): every escalation — unsettled design, review/CI exhaustion, a
+  no-commit fix, a fail-closed merge-guard refusal, high-risk merge approval, red master.
+  Each parks the run durably instead of dead-ending in autodev's ``awaiting_triage``.
+
+CREDENTIALS: the run binds a vault providing ``GITHUB_TOKEN``. GitHub *API* calls go through
+``tool('http_request', {server_ref: <github_server>, ...})`` (auth resolved against the bound
+vault); the merge-guard git plumbing runs in ``tool('bash')`` (the token is an egress-proxy
+placeholder, so ``git clone https://x-access-token:$GITHUB_TOKEN@github.com/...`` works); the
+implement/fix/ci agents clone in their own child sandboxes. No ``gh`` CLI — REST + git only.
+Note: ``http_request`` rejects a query string in ``path`` (the route allowlist is path-only),
+so list endpoints are fetched with a clean path and filtered in-script.
+
+DETERMINISM: the script imports only ``re``/``json`` (curated allowlist), keeps all capability
+I/O in the value domain (``None``/``bool``/``int``/``float``/``str``/``list``/``dict``), and
+emits capabilities in a fixed, bounded order — so replay-with-memo is stable.
+
+V1 SCOPE (documented simplifications vs autodev, see the design doc §3/§9): the scripted spec
+gate ports the empty-body / word-count / unresolved-marker checks; the assignee, duplicate-
+closing-PR, and bug-report-signal classifiers are deferred (the cron-scanner's ``dispatched``
+claim label + S4 PR-adoption cover the dominant dup-dispatch case). The merge-guard preserves
+the load-bearing properties — validate the LIVE ``refs/pull/N/merge`` commit, fail-closed — and
+runs the configured sentinel commands against it; per-sentinel path-prefix *selection* (an
+efficiency optimisation, not a safety property) is deferred, so v1 runs every configured
+sentinel (strictly safer: more checks, never fewer).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ─── default judgment-node agent ids (override per deployment) ───────────────
+DEFAULT_IMPLEMENT_AGENT_ID = "dev-implement"
+DEFAULT_REVIEW_AGENT_ID = "dev-review"
+DEFAULT_FIX_AGENT_ID = "dev-fix"
+DEFAULT_CI_AGENT_ID = "dev-ci-watch"
+DEFAULT_RISK_AGENT_ID = "dev-risk"
+
+# ─── output schemas the agentic nodes are forced to return ───────────────────
+IMPLEMENT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["branch", "pr_title", "pr_body", "escalated"],
+    "properties": {
+        "branch": {"type": "string"},
+        "pr_title": {"type": "string"},
+        "pr_body": {"type": "string"},
+        "escalated": {"type": "boolean"},
+        "escalation_reason": {"type": "string"},
+        "impl_notes": {"type": "string"},
+    },
+}
+
+REVIEW_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["verdict", "issues", "artifact_posted"],
+    "properties": {
+        "verdict": {"type": "string", "enum": ["pass", "fail"]},
+        "issues": {"type": "array", "items": {"type": "string"}},
+        "artifact_posted": {"type": "boolean"},
+    },
+}
+
+FIX_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["head_sha", "pushed"],
+    "properties": {
+        "head_sha": {"type": "string"},
+        "pushed": {"type": "boolean"},
+        "notes": {"type": "string"},
+    },
+}
+
+CI_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["status"],
+    "properties": {
+        "status": {"type": "string", "enum": ["green", "red", "no_ci"]},
+        "detail": {"type": "string"},
+    },
+}
+
+RISK_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["tier", "summary"],
+    "properties": {
+        "tier": {"type": "integer", "minimum": 1, "maximum": 4},
+        "summary": {"type": "string"},
+    },
+}
+
+# Scripted spec-gate constants (the empty-body / word-count / unresolved-marker subset of
+# autodev validation.py; see V1 SCOPE).
+MIN_SPEC_BODY_WORDS = 50
+MIN_BUG_BODY_WORDS = 20
+SPEC_BLOCKERS: tuple[str, ...] = (
+    r"(?i)\b[A-Z][A-Za-z]+:\s*TBD\b",
+    r"(?i)\bopen question",
+    r"(?i)needs? (more |further )?(design|discussion|thought|spec|input|clarification)",
+    r"(?i)TODO[:\s].*spec",
+)
+
+
+def _py(name: str, value: Any) -> str:
+    """One ``NAME = <repr>`` constant line for the prepended header. ``repr`` over the
+    value domain (str/int/bool/tuple/dict/list-of-those) yields valid, deterministic Python —
+    avoiding the ``{{}}`` escaping a single f-string body would force."""
+    return f"{name} = {value!r}"
+
+
+def _render_constants(
+    *,
+    implement_agent_id: str,
+    review_agent_id: str,
+    fix_agent_id: str,
+    ci_agent_id: str,
+    risk_agent_id: str,
+    github_server: str,
+    base_branch: str,
+    merge_sentinels: list[str],
+    max_review_iters: int,
+    max_ci_iters: int,
+    auto_merge_max_tier: int,
+    merge_method: str,
+    default_model: str | None,
+) -> str:
+    lines = [
+        _py("IMPLEMENT_AGENT_ID", implement_agent_id),
+        _py("REVIEW_AGENT_ID", review_agent_id),
+        _py("FIX_AGENT_ID", fix_agent_id),
+        _py("CI_AGENT_ID", ci_agent_id),
+        _py("RISK_AGENT_ID", risk_agent_id),
+        _py("GITHUB_SERVER", github_server),
+        _py("BASE_BRANCH", base_branch),
+        _py("MERGE_SENTINELS", list(merge_sentinels)),
+        _py("MAX_REVIEW_ITERS", max_review_iters),
+        _py("MAX_CI_ITERS", max_ci_iters),
+        _py("AUTO_MERGE_MAX_TIER", auto_merge_max_tier),
+        _py("MERGE_METHOD", merge_method),
+        _py("DEFAULT_MODEL", default_model),
+        _py("MIN_SPEC_BODY_WORDS", MIN_SPEC_BODY_WORDS),
+        _py("MIN_BUG_BODY_WORDS", MIN_BUG_BODY_WORDS),
+        _py("SPEC_BLOCKERS", list(SPEC_BLOCKERS)),
+        _py("IMPLEMENT_SCHEMA", IMPLEMENT_SCHEMA),
+        _py("REVIEW_SCHEMA", REVIEW_SCHEMA),
+        _py("FIX_SCHEMA", FIX_SCHEMA),
+        _py("CI_SCHEMA", CI_SCHEMA),
+        _py("RISK_SCHEMA", RISK_SCHEMA),
+    ]
+    return "\n".join(lines)
+
+
+# The static script body — references the prepended constants. Pure stdlib (re/json),
+# value-domain I/O, bounded loops: replay-stable by construction.
+_BODY = r'''
+import json
+import re
+
+
+# ─── scripted helpers (deterministic; no LLM, no time, no random) ────────────
+
+def _unwrap(input):
+    """Accept both a bare ``{repo, issue_number, kind}`` and the trigger envelope
+    ``{"trigger": ..., "input": ...}`` a WorkflowAction fire delivers."""
+    if isinstance(input, dict) and "trigger" in input and "input" in input:
+        return input["input"] or {}
+    return input or {}
+
+
+def _owner(repo):
+    return repo.split("/", 1)[0]
+
+
+def _strip_meta(body):
+    """Blank fenced code blocks / blockquotes / inline code before the spec-blocker
+    scan, preserving line count (autodev validation._strip_meta_content)."""
+    out = []
+    in_fence = False
+    for line in (body or "").split("\n"):
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        if in_fence or stripped.startswith(">"):
+            out.append("")
+            continue
+        out.append(re.sub(r"`[^`]*`", " ", line))
+    return "\n".join(out)
+
+
+def _find_blocker(body):
+    scan = _strip_meta(body)
+    for i, line in enumerate(scan.split("\n"), start=1):
+        for pat in SPEC_BLOCKERS:
+            if re.search(pat, line):
+                return (pat, i, line.strip())
+    return None
+
+
+def spec_ok(issue, kind):
+    """The scripted pre-flight gate (V1 subset of autodev validation): empty-body,
+    word-count, unresolved-marker. Returns (ok, reason)."""
+    body = (issue.get("body") or "").strip()
+    if not body:
+        return (False, "Issue body is empty -- no spec to implement.")
+    words = len(body.split())
+    minimum = MIN_BUG_BODY_WORDS if kind == "bug" else MIN_SPEC_BODY_WORDS
+    if words < minimum:
+        return (False, "Issue body is too short (%d words, minimum %d)." % (words, minimum))
+    hit = _find_blocker(body)
+    if hit is not None:
+        return (False, "Spec contains an unresolved marker on line %d: %r. "
+                       "Resolve all open questions before implementation." % (hit[1], hit[2]))
+    return (True, "")
+
+
+async def gh(method, path, body=None):
+    """One GitHub REST/GraphQL call through the run's bound-vault-authed http_request. A
+    non-2xx or transport error is a VALUE the caller branches on, never a raise. ``path``
+    must NOT carry a query string (the route allowlist is path-only) — filter in-script."""
+    args = {"server_ref": GITHUB_SERVER, "path": path, "method": method}
+    if body is not None:
+        args["body"] = json.dumps(body)
+    return await tool("http_request", args)
+
+
+def _status(resp):
+    return resp.get("status") if isinstance(resp, dict) else None
+
+
+def _json_body(resp):
+    if not isinstance(resp, dict):
+        return None
+    raw = resp.get("body")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return None
+
+
+def _ipath(repo, suffix):
+    return "/repos/%s%s" % (repo, suffix)
+
+
+def _pr_head_sha(pr):
+    return (pr.get("head") or {}).get("sha", "") if isinstance(pr, dict) else ""
+
+
+def _find_open_pr(prs, branch):
+    """Client-side filter of an open-PRs list for the one whose head ref is ``branch``
+    (http_request forbids a ?head= query, so we list clean and match here)."""
+    if not isinstance(prs, list):
+        return None
+    for pr in prs:
+        head = pr.get("head") or {}
+        if head.get("ref") == branch:
+            return pr
+    return None
+
+
+def _merge_guard_command(repo, pr_number):
+    """The merge-ref guard (autodev merge_guard.py, issue #177), preserving the load-bearing
+    properties: validate the commit GitHub would ACTUALLY produce on merge — the live
+    refs/pull/N/merge ref — not the PR head; FAIL CLOSED on any inability to complete
+    validation; a missing merge ref means a conflicted PR (GitHub omits it) => refuse. Runs
+    every configured MERGE_SENTINELS command against a detached checkout of the merge ref,
+    refusing on the first nonzero (path-prefix sentinel *selection* is a deferred v1
+    optimisation — running all is strictly safer). `set -eu -o pipefail` makes fail-closed
+    structural, not dependent on guarding each line. Re-run-tolerant (rm -rf then clone) per
+    the at-least-once bash contract."""
+    lines = [
+        "set -eu -o pipefail",
+        "D=/workspace/mg-%d" % pr_number,
+        "rm -rf \"$D\"",
+        "git clone --quiet --depth 50 "
+        "https://x-access-token:$GITHUB_TOKEN@github.com/%s.git \"$D\"" % repo,
+        "cd \"$D\"",
+        "if ! git fetch --quiet origin refs/pull/%d/merge:mgref 2>/dev/null; then" % pr_number,
+        "  echo 'MERGE_REF_MISSING: PR is conflicted (no computable merge result)'; exit 71",
+        "fi",
+        # ^1..merge is exactly what lands (merge commit's first parent is the base tip);
+        # an unresolvable diff is fail-closed.
+        "git diff --name-only mgref^1 mgref > /tmp/mg-changed.txt || exit 74",
+        "git checkout --quiet --detach mgref",
+    ]
+    for cmd in MERGE_SENTINELS:
+        lines.append("( %s ) || exit 73" % cmd)
+    lines.append("echo MERGE_GUARD_OK")
+    return "\n".join(lines)
+
+
+def _mark_ready_query():
+    return ("mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id})"
+            "{pullRequest{isDraft}}}")
+
+
+# ─── the state machine ───────────────────────────────────────────────────────
+
+async def main(input):
+    payload = _unwrap(input)
+    repo = payload["repo"]
+    issue_number = int(payload["issue_number"])
+    kind = payload.get("kind", "issue")
+    model = payload.get("model") or DEFAULT_MODEL
+    escalations = []
+
+    # S1 — ingest the issue
+    phase("ingest")
+    resp = await gh("GET", _ipath(repo, "/issues/%d" % issue_number))
+    issue = _json_body(resp)
+    if _status(resp) != 200 or issue is None:
+        return {"state": "error", "reason": "could not read issue %d (status %r)"
+                % (issue_number, _status(resp))}
+
+    # S2 — scripted pre-flight spec gate (regex/word-count; fail-fast before any spend)
+    phase("spec-gate")
+    ok, reason = spec_ok(issue, kind)
+    if not ok:
+        log("spec gate failed:", reason)
+        await gh("POST", _ipath(repo, "/issues/%d/comments" % issue_number),
+                 {"body": "## Spec not ready for implementation\n\n" + reason})
+        await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number),
+                 {"labels": ["underspecified"]})
+        return {"state": "spec_failed", "reason": reason}
+
+    # A3 — implement (the coding agent: clone, explore, plan, TDD, self-review, push)
+    phase("implement")
+    impl = await agent(
+        {"task": "implement", "repo": repo, "issue_number": issue_number, "kind": kind,
+         "title": issue.get("title", ""), "body": issue.get("body", "")},
+        agent_id=IMPLEMENT_AGENT_ID, output_schema=IMPLEMENT_SCHEMA, model=model, label="implement")
+    if impl.get("escalated"):
+        escalations.append("design")
+        decision = await gate({"kind": "design", "issue": issue_number,
+                               "question": impl.get("escalation_reason", "")})
+        if not (isinstance(decision, dict) and decision.get("resolved")):
+            return {"state": "escalated", "reason": "design", "escalations": escalations}
+        # resumed with a settled direction -> re-implement with the chairman's answer
+        impl = await agent(
+            {"task": "implement", "repo": repo, "issue_number": issue_number, "kind": kind,
+             "title": issue.get("title", ""), "body": issue.get("body", ""),
+             "resolution": decision.get("resolution", "")},
+            agent_id=IMPLEMENT_AGENT_ID, output_schema=IMPLEMENT_SCHEMA, model=model,
+            label="implement-resumed")
+    branch = impl["branch"]
+
+    # S4 — open / reconcile the PR. List open PRs (clean path; filter in-script), adopt one
+    # for this branch if present, else create. A create that 422s (PR already exists, e.g. a
+    # crash re-drive) re-lists and adopts — so the call is at-least-once tolerant.
+    phase("open-pr")
+    open_list = await gh("GET", _ipath(repo, "/pulls"))
+    pr = _find_open_pr(_json_body(open_list), branch)
+    if pr is None:
+        created = await gh("POST", _ipath(repo, "/pulls"),
+                           {"title": impl["pr_title"], "body": impl["pr_body"],
+                            "head": branch, "base": BASE_BRANCH, "draft": True})
+        if _status(created) in (200, 201):
+            pr = _json_body(created)
+        elif _status(created) == 422:  # already exists (re-drive / race) -> adopt it
+            pr = _find_open_pr(_json_body(await gh("GET", _ipath(repo, "/pulls"))), branch)
+        if pr is None:
+            return {"state": "failed_no_pr",
+                    "reason": "could not open or adopt a PR for branch %r (status %r)"
+                    % (branch, _status(created))}
+    pr_number = int(pr["number"])
+    pr_node_id = pr.get("node_id", "")
+    pr_url = pr.get("html_url", "")
+    head_sha = _pr_head_sha(pr)
+
+    # A5/S6/A7/S8 — verify loop (review->fix), bounded; artifact + no-commit guards. The loop
+    # runs MAX_REVIEW_ITERS fixes each followed by a re-review (the trailing iteration is the
+    # final re-review of the last fix — autodev's for/else off-by-one fix).
+    phase("verify")
+    review_ok = False
+    for i in range(MAX_REVIEW_ITERS + 1):
+        review = await agent(
+            {"task": "review", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
+            agent_id=REVIEW_AGENT_ID, output_schema=REVIEW_SCHEMA, model=model,
+            label="review-%d" % i)
+        if not review.get("artifact_posted"):
+            escalations.append("verify")
+            decision = await gate({"kind": "verify", "pr": pr_number,
+                                   "reason": "code-review posted no `### Code review` artifact"})
+            if not (isinstance(decision, dict) and decision.get("resolved")):
+                return {"state": "escalated", "reason": "verify_no_artifact",
+                        "escalations": escalations}
+            review_ok = True
+            break
+        if review["verdict"] == "pass" or not review["issues"]:
+            review_ok = True
+            break
+        if i == MAX_REVIEW_ITERS:  # final re-review still failing -> exhausted
+            break
+        before = head_sha
+        fix = await agent(
+            {"task": "fix", "repo": repo, "pr_number": pr_number, "issues": review["issues"]},
+            agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model, label="fix-%d" % i)
+        head_sha = fix["head_sha"]
+        if before and head_sha == before:  # empirical no-commit guard (head unchanged)
+            escalations.append("verify")
+            decision = await gate({"kind": "verify", "pr": pr_number,
+                                   "reason": "fix agent produced no new commit"})
+            if not (isinstance(decision, dict) and decision.get("resolved")):
+                return {"state": "escalated", "reason": "verify_no_commit",
+                        "escalations": escalations}
+            review_ok = True
+            break
+    if not review_ok:
+        escalations.append("verify")
+        decision = await gate({"kind": "verify", "pr": pr_number,
+                               "reason": "review still failing after %d fix iterations"
+                               % MAX_REVIEW_ITERS})
+        if not (isinstance(decision, dict) and decision.get("resolved")):
+            return {"state": "escalated", "reason": "verify_exhausted",
+                    "escalations": escalations}
+
+    # A9 — CI watch (the agent OWNS the durable wait) -> fix -> re-watch, bounded
+    # (N watches, N-1 fixes — matches autodev's CI loop).
+    ci_ok = False
+    for i in range(MAX_CI_ITERS):
+        ci = await agent(
+            {"task": "watch_ci", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
+            agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model, label="ci-%d" % i)
+        if ci["status"] in ("green", "no_ci"):
+            ci_ok = True
+            break
+        if i == MAX_CI_ITERS - 1:
+            break
+        before = head_sha
+        fix = await agent(
+            {"task": "fix_ci", "repo": repo, "pr_number": pr_number,
+             "detail": ci.get("detail", "")},
+            agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model, label="ci-fix-%d" % i)
+        head_sha = fix["head_sha"]
+        if before and head_sha == before:
+            break
+    if not ci_ok:
+        escalations.append("verify")
+        decision = await gate({"kind": "verify", "pr": pr_number,
+                               "reason": "CI failing after %d checks" % MAX_CI_ITERS})
+        if not (isinstance(decision, dict) and decision.get("resolved")):
+            return {"state": "escalated", "reason": "ci_exhausted", "escalations": escalations}
+
+    # A10/S11 — risk tiering (best-effort; never blocks). Conservative tier-3 default. The
+    # guard tolerates BOTH a child failure (AgentError) AND a malformed/short return
+    # (KeyError/ValueError/TypeError) so a flaky risk node can't discard a verified PR.
+    phase("risk")
+    tier = 3
+    summary = "risk assessment unavailable"
+    try:
+        risk = await agent(
+            {"task": "risk", "repo": repo, "pr_number": pr_number},
+            agent_id=RISK_AGENT_ID, output_schema=RISK_SCHEMA, model=model, label="risk")
+        tier = int(risk["tier"])
+        summary = str(risk["summary"])
+    except (AgentError, KeyError, ValueError, TypeError) as exc:
+        log("risk assessment failed (non-blocking):", exc)
+    await gh("POST", _ipath(repo, "/issues/%d/labels" % pr_number),
+             {"labels": ["risk:tier-%d" % tier]})
+    await gh("POST", _ipath(repo, "/issues/%d/comments" % pr_number),
+             {"body": "## Risk Assessment\n\n**Tier %d**\n\n%s" % (tier, summary)})
+
+    # S12 — merge-ref guard (fail-closed; the one node that catches broken-on-merge)
+    phase("merge-guard")
+    guard = await tool("bash", {"command": _merge_guard_command(repo, pr_number),
+                                "timeout_seconds": 600})
+    guard_ok = isinstance(guard, dict) and guard.get("exit_code") == 0
+    if not guard_ok:
+        detail = "%s\n%s\nexit=%r" % (
+            (guard.get("stdout", "") if isinstance(guard, dict) else "")[-1200:],
+            (guard.get("stderr", "") if isinstance(guard, dict) else "")[-600:],
+            guard.get("exit_code") if isinstance(guard, dict) else None)
+        await gh("POST", _ipath(repo, "/issues/%d/comments" % pr_number),
+                 {"body": "## Merge guard refused\n\n```\n%s\n```" % detail})
+        escalations.append("merge_guard")
+        decision = await gate({"kind": "merge_guard", "pr": pr_number, "detail": detail})
+        if not (isinstance(decision, dict) and decision.get("proceed")):
+            return {"state": "escalated", "reason": "merge_guard_refused",
+                    "pr_url": pr_url, "pr_number": pr_number, "escalations": escalations}
+
+    # S13 — mark the PR ready for review (best-effort; the merge step confirms non-draft)
+    phase("mark-ready")
+    if pr_node_id:
+        await gh("POST", "/graphql",
+                 {"query": _mark_ready_query(), "variables": {"id": pr_node_id}})
+
+    # MERGE — executable delegated authority: tier<=N auto-merges; tier>N parks at a gate.
+    phase("merge")
+    if tier > AUTO_MERGE_MAX_TIER:
+        escalations.append("merge_approval")
+        decision = await gate({"kind": "merge_approval", "pr": pr_number, "tier": tier})
+        if not (isinstance(decision, dict) and decision.get("approve")):
+            return {"state": "held", "reason": "merge_approval", "pr_url": pr_url,
+                    "pr_number": pr_number, "risk_tier": tier, "escalations": escalations}
+    merge_resp = await gh("PUT", _ipath(repo, "/pulls/%d/merge" % pr_number),
+                          {"merge_method": MERGE_METHOD})
+    merged = _status(merge_resp) == 200
+    if not merged:
+        # At-least-once: a crash-re-driven PUT against an already-merged PR returns 405/409.
+        # Confirm against GitHub before declaring failure, so a real merge is never lost.
+        confirm = _json_body(await gh("GET", _ipath(repo, "/pulls/%d" % pr_number)))
+        if isinstance(confirm, dict) and confirm.get("merged"):
+            merged = True
+        else:
+            return {"state": "merge_failed", "pr_url": pr_url, "pr_number": pr_number,
+                    "risk_tier": tier, "reason": "merge call returned %r" % _status(merge_resp),
+                    "escalations": escalations}
+
+    # A15 — post-merge master-CI watch (the D-2 missing state). Red OR an errored watch =>
+    # HALT at a gate; the merge is a committed fact, so we never discard it by failing here.
+    phase("post-merge")
+    try:
+        master = await agent(
+            {"task": "watch_ci", "repo": repo, "ref": BASE_BRANCH},
+            agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model, label="master-ci")
+        master_red = master["status"] == "red"
+        master_detail = master.get("detail", "")
+    except (AgentError, KeyError, TypeError) as exc:
+        master_red = True
+        master_detail = "master-CI watch failed: %s" % exc
+    if master_red:
+        escalations.append("master_red")
+        await gate({"kind": "master_red", "repo": repo, "detail": master_detail})
+
+    return {"state": "done", "pr_url": pr_url, "pr_number": pr_number, "merged": merged,
+            "risk_tier": tier, "escalations": escalations}
+'''
+
+
+def build_dev_pipeline_script(
+    *,
+    implement_agent_id: str = DEFAULT_IMPLEMENT_AGENT_ID,
+    review_agent_id: str = DEFAULT_REVIEW_AGENT_ID,
+    fix_agent_id: str = DEFAULT_FIX_AGENT_ID,
+    ci_agent_id: str = DEFAULT_CI_AGENT_ID,
+    risk_agent_id: str = DEFAULT_RISK_AGENT_ID,
+    github_server: str = "github",
+    base_branch: str = "master",
+    merge_sentinels: list[str] | None = None,
+    max_review_iters: int = 3,
+    max_ci_iters: int = 3,
+    auto_merge_max_tier: int = 2,
+    merge_method: str = "squash",
+    default_model: str | None = None,
+) -> str:
+    """Return the production dev-pipeline workflow source.
+
+    Defaults match a standard deployment (named judgment agents, a ``github`` http server
+    bound to ``https://api.github.com``, autodev's 3/3 iteration caps, and the delegated
+    merge authority: tier ≤2 auto-merges, tier ≥3 parks at a gate). ``merge_sentinels`` is a
+    list of shell commands run against the merge ref in the fail-closed guard; ``base_branch``
+    is the repo's default branch.
+    """
+    header = _render_constants(
+        implement_agent_id=implement_agent_id,
+        review_agent_id=review_agent_id,
+        fix_agent_id=fix_agent_id,
+        ci_agent_id=ci_agent_id,
+        risk_agent_id=risk_agent_id,
+        github_server=github_server,
+        base_branch=base_branch,
+        merge_sentinels=merge_sentinels or [],
+        max_review_iters=max_review_iters,
+        max_ci_iters=max_ci_iters,
+        auto_merge_max_tier=auto_merge_max_tier,
+        merge_method=merge_method,
+        default_model=default_model,
+    )
+    return header + "\n" + _BODY
+
+
+def build_dev_pipeline_fixture_script(
+    *,
+    implement_agent_id: str,
+    review_agent_id: str,
+    fix_agent_id: str,
+    ci_agent_id: str,
+    risk_agent_id: str,
+    max_review_iters: int = 2,
+    max_ci_iters: int = 2,
+    auto_merge_max_tier: int = 2,
+) -> str:
+    """The CI fixture variant: tight iteration caps (2/2) so the happy-path drive is short,
+    real generated agent ids, otherwise the identical script shape."""
+    return build_dev_pipeline_script(
+        implement_agent_id=implement_agent_id,
+        review_agent_id=review_agent_id,
+        fix_agent_id=fix_agent_id,
+        ci_agent_id=ci_agent_id,
+        risk_agent_id=risk_agent_id,
+        max_review_iters=max_review_iters,
+        max_ci_iters=max_ci_iters,
+        auto_merge_max_tier=auto_merge_max_tier,
+    )

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -1,0 +1,455 @@
+"""Dev-pipeline reference workflow fixture (autodev#19 / aios#987).
+
+Drives the production ``build_dev_pipeline_script`` directly against the real script
+host (no DB) with simulated agent/tool/gate resolutions, walking the state machine
+clutch by clutch. Because the pipeline is sequential (one capability per wake) and the
+driver re-runs from the start each wake — replaying the whole growing memo — these
+tests also assert the load-bearing durable property: **replay is deterministic** (every
+call_key is stable across every replay).
+
+Mirrors the host-subprocess style of ``test_wf_host.py``; needs no Postgres or sandbox.
+
+NOTE (a known limit, by design): ``run_script_host`` feeds *memoized* capability results,
+so these tests exercise the state machine but NOT the live ``http_request`` route gate —
+e.g. a query string in ``path`` is rejected by the real tool, which is why the script
+lists PRs with a clean path and filters in-script. The deploy-time live smoke covers the
+real tool surface (the deep_research "live demo" analog).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from aios.workflows.dev_pipeline import build_dev_pipeline_script
+from aios.workflows.host_launcher import run_script_host
+
+pytestmark = pytest.mark.integration
+
+REPO = "o/r"
+ISSUE = 5
+BRANCH = "issue-5"
+# A concrete, >50-word spec body that clears the scripted spec gate.
+LONG_BODY = (
+    "Add a durable retry wrapper around the outbound webhook dispatcher so that transient "
+    "five hundred level responses are retried with exponential backoff up to five attempts "
+    "on a jittered schedule, with a dead letter table for exhausted deliveries. The "
+    "implementation must add a new module, wire it into the dispatcher call site, cover the "
+    "backoff math with deterministic unit tests, and document the dead letter replay "
+    "procedure for operators in the runbook so the on call engineer has a clear recovery path."
+)
+
+
+def _issue_json(body: str = LONG_BODY) -> str:
+    return json.dumps(
+        {"number": ISSUE, "title": "Add webhook retry", "body": body, "state": "open"}
+    )
+
+
+def _pr_json(*, sha: str = "sha_initial", merged: bool = False) -> str:
+    return json.dumps(
+        {
+            "number": 42,
+            "node_id": "PR_node42",
+            "html_url": "https://github.com/o/r/pull/42",
+            "head": {"sha": sha, "ref": BRANCH},
+            "merged": merged,
+        }
+    )
+
+
+# ─── the capability responder (a deterministic function of the capability) ────
+
+
+class Scenario:
+    """A deterministic responder + a record of what the script asked for. Keying every
+    decision on the capability spec (and, for the bounded loops, the per-iteration
+    ``label``) keeps the responder a pure function of the call_key — so replay is stable.
+    """
+
+    def __init__(
+        self,
+        *,
+        body: str = LONG_BODY,
+        existing_pr: bool = False,
+        implement_escalated: bool = False,
+        review_results: list[dict[str, Any]] | None = None,
+        ci_results: list[dict[str, Any]] | None = None,
+        risk_result: dict[str, Any] | None = None,
+        merge_guard_exit: int = 0,
+        merge_status: int = 200,
+        pr_merged_on_confirm: bool = False,
+        gate_results: dict[str, Any] | None = None,
+        master_ci: str = "green",
+        master_ci_error: bool = False,
+    ) -> None:
+        self.body = body
+        self.existing_pr = existing_pr
+        self.implement_escalated = implement_escalated
+        self.review_results = review_results or [
+            {"verdict": "pass", "issues": [], "artifact_posted": True}
+        ]
+        self.ci_results = ci_results or [{"status": "green", "detail": ""}]
+        self.risk_result = (
+            risk_result if risk_result is not None else {"tier": 1, "summary": "safe"}
+        )
+        self.merge_guard_exit = merge_guard_exit
+        self.merge_status = merge_status
+        self.pr_merged_on_confirm = pr_merged_on_confirm
+        self.gate_results = gate_results or {}
+        self.master_ci = master_ci
+        self.master_ci_error = master_ci_error
+        self.tasks: list[str] = []
+        self.gates: list[dict[str, Any]] = []
+        self.http: list[tuple[str, str]] = []
+
+    def _http(self, args: dict[str, Any]) -> dict[str, Any]:
+        path, method = args["path"], args["method"]
+        self.http.append((method, path))
+        assert "?" not in path, f"query string in path is rejected by http_request: {path!r}"
+        is_issue_get = (
+            method == "GET"
+            and "/issues/5" in path
+            and "/comments" not in path
+            and "/labels" not in path
+        )
+        if is_issue_get:
+            return {"status": 200, "body": _issue_json(self.body)}
+        if method == "GET" and path == "/repos/o/r/pulls":  # list open PRs (clean path)
+            return {"status": 200, "body": "[" + _pr_json() + "]" if self.existing_pr else "[]"}
+        if method == "POST" and path == "/repos/o/r/pulls":
+            return {"status": 201, "body": _pr_json()}
+        if method == "GET" and path == "/repos/o/r/pulls/42":  # merge-confirm read
+            return {"status": 200, "body": _pr_json(merged=self.pr_merged_on_confirm)}
+        if method == "PUT" and path.endswith("/merge"):
+            return {"status": self.merge_status, "body": "{}"}
+        return {"status": 200, "body": "{}"}  # comments / labels / graphql
+
+    def outcome(self, cap: Any) -> dict[str, Any]:
+        """Return the full memo outcome ({"ok": value} or {"error": {...}}) for a capability."""
+        cid, spec = cap.capability_id, cap.spec
+        if cid == "tool":
+            if spec["tool_name"] == "http_request":
+                return {"ok": self._http(spec["input"])}
+            if spec["tool_name"] == "bash":  # merge-ref guard
+                return {
+                    "ok": {
+                        "exit_code": self.merge_guard_exit,
+                        "stdout": "MERGE_GUARD_OK"
+                        if self.merge_guard_exit == 0
+                        else "sentinel failed",
+                        "stderr": "",
+                        "timed_out": False,
+                        "truncated": False,
+                    }
+                }
+        if cid == "agent":
+            task = spec["input"].get("task")
+            label = cap.annotations.get("label", "")
+            self.tasks.append(label or task)
+            if task == "implement":
+                return {
+                    "ok": {
+                        "branch": BRANCH,
+                        "pr_title": "Add webhook retry",
+                        "pr_body": "Closes #5",
+                        "escalated": self.implement_escalated and label == "implement",
+                        "escalation_reason": "interface shape unsettled",
+                    }
+                }
+            if task == "review":
+                idx = int(label.rsplit("-", 1)[1]) if "-" in label else 0
+                return {"ok": self.review_results[min(idx, len(self.review_results) - 1)]}
+            if task == "watch_ci":
+                if spec["input"].get("ref"):  # post-merge master watch
+                    if self.master_ci_error:
+                        return {"error": {"kind": "child_errored"}}
+                    return {"ok": {"status": self.master_ci, "detail": ""}}
+                idx = int(label.rsplit("-", 1)[1]) if label.startswith("ci-") else 0
+                return {"ok": self.ci_results[min(idx, len(self.ci_results) - 1)]}
+            if task == "risk":
+                return {"ok": self.risk_result}
+            if task in ("fix", "fix_ci"):
+                return {"ok": {"head_sha": f"sha_{label}", "pushed": True}}
+        if cid == "gate":
+            self.gates.append(spec)
+            result: dict[str, Any] = self.gate_results.get(spec.get("kind"), {})
+            return {"ok": result}
+        raise AssertionError(f"unhandled capability {cid} spec={spec!r}")
+
+
+async def _drive(
+    scenario: Scenario,
+    *,
+    input: dict[str, Any] | None = None,
+    max_steps: int = 60,
+    **build_kwargs: Any,
+) -> tuple[Any, list[str], list[str]]:
+    """Drive the production script to a terminal outcome, returning
+    (return_value, phases, ordered_call_keys). Asserts replay-determinism (unique keys)."""
+    src = build_dev_pipeline_script(**build_kwargs)
+    inp = input or {"repo": REPO, "issue_number": ISSUE, "kind": "issue"}
+    memo: dict[str, Any] = {}
+    keys: list[str] = []
+    phases: list[str] = []
+    for _ in range(max_steps):
+        out = await run_script_host(source=src, input=inp, memo=memo)
+        phases = [a.payload["text"] for a in out.annotations if a.payload["kind"] == "phase"]
+        if out.kind == "returned":
+            assert len(keys) == len(set(keys)), "replay produced a duplicate call_key"
+            return out.value, phases, keys
+        assert out.kind == "suspended", (out.kind, out.error_repr, out.error_traceback)
+        assert len(out.emitted) == 1, [(e.capability_id, e.spec) for e in out.emitted]
+        cap = out.emitted[0]
+        keys.append(cap.call_key)
+        memo[cap.call_key] = scenario.outcome(cap)
+    raise AssertionError(f"workflow did not terminate within {max_steps} steps")
+
+
+# ─── happy path ───────────────────────────────────────────────────────────────
+
+
+async def test_happy_path_merges_and_completes() -> None:
+    scn = Scenario(risk_result={"tier": 1, "summary": "additive"})
+    value, phases, _keys = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value == {
+        "state": "done",
+        "pr_url": "https://github.com/o/r/pull/42",
+        "pr_number": 42,
+        "merged": True,
+        "risk_tier": 1,
+        "escalations": [],
+    }
+    assert phases == [
+        "ingest",
+        "spec-gate",
+        "implement",
+        "open-pr",
+        "verify",
+        "risk",
+        "merge-guard",
+        "mark-ready",
+        "merge",
+        "post-merge",
+    ]
+    assert scn.gates == []  # tier-1 auto-merges; no gate opened
+    assert scn.tasks == ["implement", "review-0", "ci-0", "risk", "master-ci"]
+    # never used a query string (the production-path bug the review caught)
+    assert all("?" not in path for _, path in scn.http)
+
+
+async def test_adopts_existing_open_pr_instead_of_creating() -> None:
+    scn = Scenario(existing_pr=True)
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert ("POST", "/repos/o/r/pulls") not in scn.http  # adopted, did not create
+
+
+# ─── scripted spec gate short-circuits before any spend ───────────────────────
+
+
+async def test_spec_gate_short_circuits_without_spawning_agents() -> None:
+    scn = Scenario(body="too short")
+    value, phases, _ = await _drive(scn)
+    assert value["state"] == "spec_failed"
+    assert "too short" in value["reason"]
+    assert phases == ["ingest", "spec-gate"]
+    assert scn.tasks == []  # no implement agent — failed before any spend
+    assert ("POST", "/repos/o/r/issues/5/labels") in scn.http
+
+
+async def test_spec_gate_blocks_unresolved_marker() -> None:
+    body = LONG_BODY + "\n\nApproach: TBD — still an open question we must settle first."
+    scn = Scenario(body=body)
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "spec_failed"
+    assert "unresolved marker" in value["reason"]
+
+
+# ─── escalations park at a gate (the durable-workflow upgrade of awaiting_triage) ─
+
+
+async def test_design_escalation_parks_then_resumes_and_completes() -> None:
+    scn = Scenario(
+        implement_escalated=True,
+        gate_results={"design": {"resolved": True, "resolution": "use a typed enum"}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert "design" in value["escalations"]
+    assert any(g["kind"] == "design" for g in scn.gates)
+    assert "implement-resumed" in scn.tasks  # resumed -> re-implemented
+
+
+async def test_design_escalation_unresolved_stays_escalated() -> None:
+    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False}})
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "design"
+
+
+async def test_merge_guard_refusal_parks_at_gate() -> None:
+    scn = Scenario(merge_guard_exit=73, gate_results={"merge_guard": {"proceed": False}})
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "merge_guard_refused"
+    assert any(g["kind"] == "merge_guard" for g in scn.gates)
+
+
+async def test_merge_guard_refusal_proceed_merges() -> None:
+    scn = Scenario(merge_guard_exit=73, gate_results={"merge_guard": {"proceed": True}})
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+
+
+async def test_high_risk_parks_for_merge_approval() -> None:
+    scn = Scenario(
+        risk_result={"tier": 4, "summary": "touches the scheduler"},
+        gate_results={"merge_approval": {"approve": True}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2, auto_merge_max_tier=2)
+    assert value["state"] == "done"
+    assert value["risk_tier"] == 4
+    assert any(g["kind"] == "merge_approval" for g in scn.gates)
+
+
+async def test_high_risk_hold_does_not_merge() -> None:
+    scn = Scenario(
+        risk_result={"tier": 4, "summary": "risky"},
+        gate_results={"merge_approval": {"approve": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2, auto_merge_max_tier=2)
+    assert value["state"] == "held"
+    assert value["reason"] == "merge_approval"
+
+
+# ─── robustness the adversarial review surfaced ───────────────────────────────
+
+
+async def test_malformed_risk_return_defaults_to_tier3_and_does_not_crash() -> None:
+    # A risk agent that returns a value missing 'tier' must NOT discard a verified PR; it
+    # falls back to the conservative tier-3 (which then parks for merge approval).
+    scn = Scenario(
+        risk_result={"summary": "no tier field"},
+        gate_results={"merge_approval": {"approve": True}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["risk_tier"] == 3
+    assert any(g["kind"] == "merge_approval" for g in scn.gates)
+
+
+async def test_merge_405_but_already_merged_is_treated_as_done() -> None:
+    # A crash-re-driven merge PUT against an already-merged PR returns 405; the confirm GET
+    # shows merged=true, so the run completes instead of mis-reporting merge_failed.
+    scn = Scenario(merge_status=405, pr_merged_on_confirm=True)
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert ("GET", "/repos/o/r/pulls/42") in scn.http  # the confirm read happened
+
+
+async def test_merge_failure_not_confirmed_reports_merge_failed() -> None:
+    scn = Scenario(merge_status=405, pr_merged_on_confirm=False)
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "merge_failed"
+
+
+async def test_post_merge_master_ci_agent_error_parks_master_red_not_lost_merge() -> None:
+    # If the post-merge master-CI agent ERRORS, the merge (a committed fact) must not be
+    # discarded: the run parks at master_red and still reports merged on resume.
+    scn = Scenario(master_ci_error=True)
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert "master_red" in value["escalations"]
+    assert any(g["kind"] == "master_red" for g in scn.gates)
+
+
+async def test_red_master_ci_parks_at_gate() -> None:
+    scn = Scenario(master_ci="red")
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"  # merge happened; parked then resumed
+    assert "master_red" in value["escalations"]
+
+
+# ─── bounded self-repair loops ────────────────────────────────────────────────
+
+
+async def test_ci_red_then_fix_then_green_completes() -> None:
+    scn = Scenario(
+        ci_results=[{"status": "red", "detail": "test_x failed"}, {"status": "green", "detail": ""}]
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=3)
+    assert value["state"] == "done"
+    assert "ci-fix-0" in scn.tasks
+    assert "ci-1" in scn.tasks
+
+
+async def test_review_fail_then_fix_then_pass_completes() -> None:
+    scn = Scenario(
+        review_results=[
+            {"verdict": "fail", "issues": ["unguarded null"], "artifact_posted": True},
+            {"verdict": "pass", "issues": [], "artifact_posted": True},
+        ]
+    )
+    value, _, _ = await _drive(scn, max_review_iters=3, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert "fix-0" in scn.tasks
+    assert "review-1" in scn.tasks
+
+
+async def test_review_loop_does_final_re_review_of_last_fix() -> None:
+    # max_review_iters=2 => up to 2 fixes, then a FINAL re-review (review-2) of the last fix.
+    # Here review-0 fail, review-1 fail, fix, review-2 PASS -> done (autodev's for/else shape).
+    scn = Scenario(
+        review_results=[
+            {"verdict": "fail", "issues": ["a"], "artifact_posted": True},
+            {"verdict": "fail", "issues": ["b"], "artifact_posted": True},
+            {"verdict": "pass", "issues": [], "artifact_posted": True},
+        ]
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert "review-2" in scn.tasks  # the final re-review ran
+    assert "fix-1" in scn.tasks
+
+
+async def test_missing_review_artifact_parks_at_gate() -> None:
+    scn = Scenario(
+        review_results=[{"verdict": "pass", "issues": [], "artifact_posted": False}],
+        gate_results={"verify": {"resolved": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "verify_no_artifact"
+
+
+async def test_review_exhaustion_parks_at_gate() -> None:
+    scn = Scenario(
+        review_results=[{"verdict": "fail", "issues": ["x"], "artifact_posted": True}],
+        gate_results={"verify": {"resolved": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "verify_exhausted"
+
+
+# ─── trigger envelope ─────────────────────────────────────────────────────────
+
+
+async def test_accepts_trigger_envelope_input() -> None:
+    scn = Scenario()
+    value, _, _ = await _drive(
+        scn,
+        input={
+            "trigger": {"kind": "cron"},
+            "input": {"repo": REPO, "issue_number": ISSUE, "kind": "issue"},
+        },
+        max_review_iters=2,
+        max_ci_iters=2,
+    )
+    assert value["state"] == "done"

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -73,10 +73,14 @@ class Scenario:
         self,
         *,
         body: str = LONG_BODY,
+        comments: list[str] | None = None,
         existing_pr: bool = False,
         implement_escalated: bool = False,
+        implement_error: bool = False,
         review_results: list[dict[str, Any]] | None = None,
+        review_error_on: str | None = None,
         ci_results: list[dict[str, Any]] | None = None,
+        ci_error_on: str | None = None,
         risk_result: dict[str, Any] | None = None,
         merge_guard_exit: int = 0,
         merge_status: int = 200,
@@ -84,14 +88,21 @@ class Scenario:
         gate_results: dict[str, Any] | None = None,
         master_ci: str = "green",
         master_ci_error: bool = False,
+        transient_5xx: dict[tuple[str, str], int] | None = None,
     ) -> None:
         self.body = body
+        # The comment-thread the GET /issues/{n}/comments responder returns (list of body
+        # strings → GitHub comment objects). None => no comments (empty array).
+        self.comments = comments or []
         self.existing_pr = existing_pr
         self.implement_escalated = implement_escalated
+        self.implement_error = implement_error
         self.review_results = review_results or [
             {"verdict": "pass", "issues": [], "artifact_posted": True}
         ]
+        self.review_error_on = review_error_on  # an agent label that raises AgentError
         self.ci_results = ci_results or [{"status": "green", "detail": ""}]
+        self.ci_error_on = ci_error_on  # an agent label that raises AgentError
         self.risk_result = (
             risk_result if risk_result is not None else {"tier": 1, "summary": "safe"}
         )
@@ -101,14 +112,39 @@ class Scenario:
         self.gate_results = gate_results or {}
         self.master_ci = master_ci
         self.master_ci_error = master_ci_error
+        # {(method, path): N} — return a transient 5xx for the FIRST N attempts of that call,
+        # then the real response. Counts are mutated as attempts arrive (replay-stable because
+        # each retry is a distinct call_key, so a replay re-asks each attempt exactly once).
+        self.transient_5xx = dict(transient_5xx or {})
         self.tasks: list[str] = []
+        self.agent_inputs: list[dict[str, Any]] = []
         self.gates: list[dict[str, Any]] = []
         self.http: list[tuple[str, str]] = []
+        self.labels_added: list[str] = []  # every label name POSTed to /labels (item 3)
+        self.labels_removed: list[str] = []  # every label name DELETEd from /labels
+
+    def _comments_json(self) -> str:
+        return json.dumps([{"id": i, "body": c} for i, c in enumerate(self.comments)])
 
     def _http(self, args: dict[str, Any]) -> dict[str, Any]:
         path, method = args["path"], args["method"]
+        remaining = self.transient_5xx.get((method, path), 0)
+        if remaining > 0:
+            self.transient_5xx[(method, path)] = remaining - 1
+            self.http.append((method, path))
+            return {"status": 503, "body": ""}  # transient -> gh_retry re-issues
         self.http.append((method, path))
         assert "?" not in path, f"query string in path is rejected by http_request: {path!r}"
+        if method == "POST" and path.endswith("/labels"):  # add label(s) — capture names
+            raw = args.get("body")
+            if isinstance(raw, str):
+                self.labels_added.extend(json.loads(raw).get("labels", []))
+            return {"status": 200, "body": "[]"}
+        if method == "DELETE" and "/labels/" in path:  # remove one label — capture decoded name
+            self.labels_removed.append(path.rsplit("/labels/", 1)[1].replace("%3A", ":"))
+            return {"status": 200, "body": "[]"}
+        if method == "GET" and path == "/repos/o/r/issues/5/comments":  # the item-1 thread read
+            return {"status": 200, "body": self._comments_json()}
         is_issue_get = (
             method == "GET"
             and "/issues/5" in path
@@ -149,7 +185,10 @@ class Scenario:
             task = spec["input"].get("task")
             label = cap.annotations.get("label", "")
             self.tasks.append(label or task)
+            self.agent_inputs.append(spec["input"])
             if task == "implement":
+                if self.implement_error and label == "implement":
+                    return {"error": {"kind": "agent_not_found"}}
                 return {
                     "ok": {
                         "branch": BRANCH,
@@ -160,6 +199,8 @@ class Scenario:
                     }
                 }
             if task == "review":
+                if self.review_error_on == label:
+                    return {"error": {"kind": "child_errored"}}
                 idx = int(label.rsplit("-", 1)[1]) if "-" in label else 0
                 return {"ok": self.review_results[min(idx, len(self.review_results) - 1)]}
             if task == "watch_ci":
@@ -167,11 +208,15 @@ class Scenario:
                     if self.master_ci_error:
                         return {"error": {"kind": "child_errored"}}
                     return {"ok": {"status": self.master_ci, "detail": ""}}
+                if self.ci_error_on == label:
+                    return {"error": {"kind": "child_errored"}}
                 idx = int(label.rsplit("-", 1)[1]) if label.startswith("ci-") else 0
                 return {"ok": self.ci_results[min(idx, len(self.ci_results) - 1)]}
             if task == "risk":
                 return {"ok": self.risk_result}
             if task in ("fix", "fix_ci"):
+                if self.review_error_on == label or self.ci_error_on == label:
+                    return {"error": {"kind": "child_errored"}}
                 return {"ok": {"head_sha": f"sha_{label}", "pushed": True}}
         if cid == "gate":
             self.gates.append(spec)
@@ -238,6 +283,12 @@ async def test_happy_path_merges_and_completes() -> None:
     assert scn.tasks == ["implement", "review-0", "ci-0", "risk", "master-ci"]
     # never used a query string (the production-path bug the review caught)
     assert all("?" not in path for _, path in scn.http)
+    # item 1: the comment thread is read at ingest
+    assert ("GET", "/repos/o/r/issues/5/comments") in scn.http
+    # item 3: in-progress claimed at ingest, released on success, never marked failed
+    assert "autodev:in-progress" in scn.labels_added
+    assert "autodev:in-progress" in scn.labels_removed
+    assert "autodev:failed" not in scn.labels_added
 
 
 async def test_adopts_existing_open_pr_instead_of_creating() -> None:
@@ -258,6 +309,9 @@ async def test_spec_gate_short_circuits_without_spawning_agents() -> None:
     assert phases == ["ingest", "spec-gate"]
     assert scn.tasks == []  # no implement agent — failed before any spend
     assert ("POST", "/repos/o/r/issues/5/labels") in scn.http
+    # item 3: a spec failure is a terminal NON-gate failure -> labelled autodev:failed
+    assert "autodev:failed" in scn.labels_added
+    assert "autodev:in-progress" in scn.labels_removed
 
 
 async def test_spec_gate_blocks_unresolved_marker() -> None:
@@ -266,6 +320,69 @@ async def test_spec_gate_blocks_unresolved_marker() -> None:
     value, _, _ = await _drive(scn)
     assert value["state"] == "spec_failed"
     assert "unresolved marker" in value["reason"]
+
+
+async def test_spec_gate_marker_resolved_in_comment_does_not_bounce() -> None:
+    # The body carries a marker; a LATER comment quotes that exact line AND signals a
+    # resolution -> the gate must NOT bounce, and the run proceeds to implement.
+    marker_line = "Approach: TBD — still an open question we must settle first."
+    body = LONG_BODY + "\n\n" + marker_line
+    scn = Scenario(
+        body=body,
+        comments=["Resolved: " + marker_line + " We will use a typed enum with a fallback arm."],
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"  # marker suppressed -> full pipeline ran
+    assert "implement" in scn.tasks
+
+
+async def test_spec_gate_comment_without_resolution_signal_still_bounces() -> None:
+    # A comment that merely QUOTES the marker line but carries NO resolution signal must
+    # NOT suppress it (no regression of the marker-trap protection).
+    marker_line = "Approach: TBD — still an open question we must settle first."
+    body = LONG_BODY + "\n\n" + marker_line
+    scn = Scenario(body=body, comments=["I also wonder: " + marker_line])
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "spec_failed"
+    assert "unresolved marker" in value["reason"]
+
+
+async def test_spec_gate_comment_resolution_word_without_quote_still_bounces() -> None:
+    # A resolution word with NO quote of the offending line must not unlock the gate.
+    marker_line = "Approach: TBD — still an open question we must settle first."
+    body = LONG_BODY + "\n\n" + marker_line
+    scn = Scenario(body=body, comments=["This is all resolved now, trust me."])
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "spec_failed"
+    assert "unresolved marker" in value["reason"]
+
+
+async def test_thin_body_satisfied_by_comment_thread_proceeds() -> None:
+    # A body too short on its own clears the word-count once the comment thread (a design
+    # pass) is threaded in — autodev's "comments count toward the spec" behaviour.
+    scn = Scenario(body="Add a retry wrapper.", comments=[LONG_BODY])
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+
+
+async def test_comments_threaded_into_every_agent_node() -> None:
+    # The comment array reaches implement, review, and fix agents (item 1).
+    scn = Scenario(
+        comments=["design note: prefer a typed enum"],
+        review_results=[
+            {"verdict": "fail", "issues": ["x"], "artifact_posted": True},
+            {"verdict": "pass", "issues": [], "artifact_posted": True},
+        ],
+    )
+    value, _, _ = await _drive(scn, max_review_iters=3, max_ci_iters=2)
+    assert value["state"] == "done"
+    threaded = "design note: prefer a typed enum"
+    implement_in = [i for i in scn.agent_inputs if i.get("task") == "implement"]
+    review_in = [i for i in scn.agent_inputs if i.get("task") == "review"]
+    fix_in = [i for i in scn.agent_inputs if i.get("task") == "fix"]
+    assert implement_in and all(threaded in i.get("comments", []) for i in implement_in)
+    assert review_in and all(threaded in i.get("comments", []) for i in review_in)
+    assert fix_in and all(threaded in i.get("comments", []) for i in fix_in)
 
 
 # ─── escalations park at a gate (the durable-workflow upgrade of awaiting_triage) ─
@@ -436,6 +553,122 @@ async def test_review_exhaustion_parks_at_gate() -> None:
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "escalated"
     assert value["reason"] == "verify_exhausted"
+
+
+# ─── transient-5xx retry (item 2) ─────────────────────────────────────────────
+
+
+async def test_transient_5xx_then_success_completes() -> None:
+    # The first two attempts of the ingest GET and the merge PUT return 503; gh's bounded
+    # retry re-issues and the third attempt succeeds -> the run completes normally.
+    scn = Scenario(
+        transient_5xx={
+            ("GET", "/repos/o/r/issues/5"): 2,
+            ("PUT", "/repos/o/r/pulls/42/merge"): 2,
+        }
+    )
+    value, _, keys = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    # the ingest GET was attempted 3 times (2 transient + 1 success), and so was the merge
+    assert sum(1 for m, p in scn.http if (m, p) == ("GET", "/repos/o/r/issues/5")) == 3
+    assert sum(1 for m, p in scn.http if (m, p) == ("PUT", "/repos/o/r/pulls/42/merge")) == 3
+    # replay stayed stable across all the extra attempts (no duplicate call_key)
+    assert len(keys) == len(set(keys))
+
+
+async def test_persistent_5xx_surfaces_failure_not_zombie() -> None:
+    # All three ingest attempts 503 -> gh returns the last 503; the run reports the read
+    # failure AND labels autodev:failed (item 3) rather than hanging silently.
+    scn = Scenario(transient_5xx={("GET", "/repos/o/r/issues/5"): 99})
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "error"
+    assert "autodev:failed" in scn.labels_added
+    # exactly 3 attempts (the bounded retry cap), then it gives up
+    assert sum(1 for m, p in scn.http if (m, p) == ("GET", "/repos/o/r/issues/5")) == 3
+
+
+# ─── failure surfacing (item 3) ───────────────────────────────────────────────
+
+
+async def test_merge_failed_is_labelled_autodev_failed() -> None:
+    scn = Scenario(merge_status=405, pr_merged_on_confirm=False)
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "merge_failed"
+    assert "autodev:failed" in scn.labels_added
+    assert "autodev:in-progress" in scn.labels_removed
+
+
+async def test_gate_park_is_not_labelled_failed() -> None:
+    # An escalation parks at a gate; a deliberate "stay escalated" resume is NOT a silent
+    # failure, so the run must NOT raise autodev:failed (the contract: a gate park ≠ fail).
+    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False}})
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "escalated"
+    assert "autodev:failed" not in scn.labels_added
+
+
+# ─── AgentError guards on every judgment node (item 5) ─────────────────────────
+
+
+async def test_implement_agent_error_escalates_to_design_gate() -> None:
+    scn = Scenario(implement_error=True, gate_results={"design": {"resolved": False}})
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "design"
+    assert any(g["kind"] == "design" for g in scn.gates)  # parked, did not crash the run
+
+
+async def test_review_agent_error_escalates_to_verify_gate() -> None:
+    scn = Scenario(review_error_on="review-0", gate_results={"verify": {"resolved": False}})
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "verify_agent_error"
+    assert any(g["kind"] == "verify" for g in scn.gates)
+
+
+async def test_ci_watch_agent_error_escalates_to_verify_gate() -> None:
+    scn = Scenario(ci_error_on="ci-0", gate_results={"verify": {"resolved": False}})
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "ci_agent_error"
+    assert any(g["kind"] == "verify" for g in scn.gates)
+
+
+async def test_agent_error_resume_resolved_continues() -> None:
+    # A reviewer error that the human resumes as resolved lets the run proceed to done.
+    scn = Scenario(review_error_on="review-0", gate_results={"verify": {"resolved": True}})
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+
+
+# ─── auto-recovery retry budget (item 4) ──────────────────────────────────────
+
+
+async def test_retry_count_under_budget_runs_normally() -> None:
+    scn = Scenario()
+    value, _, _ = await _drive(
+        scn,
+        input={"repo": REPO, "issue_number": ISSUE, "kind": "issue", "retry_count": 1},
+        max_review_iters=2,
+        max_ci_iters=2,
+    )
+    assert value["state"] == "done"
+
+
+async def test_retry_count_at_budget_dead_letters() -> None:
+    # A re-launched run that has already burned MAX_RUN_RETRIES (2) terminates at the
+    # dead-letter state instead of looping, and is labelled autodev:failed.
+    scn = Scenario()
+    value, phases, _ = await _drive(
+        scn,
+        input={"repo": REPO, "issue_number": ISSUE, "kind": "issue", "retry_count": 2},
+    )
+    assert value["state"] == "dead_letter"
+    assert value["retry_count"] == 2
+    assert phases == []  # dead-lettered before even the ingest phase
+    assert scn.tasks == []  # no spend
+    assert "autodev:failed" in scn.labels_added
 
 
 # ─── trigger envelope ─────────────────────────────────────────────────────────


### PR DESCRIPTION
> **Recreate of #1063** (reverted by #1067) as a **draft** for proper review + approval before it ships.
> Headline open item: the **executable delegated merge authority** this encodes (tier ≤2 auto-merge / tier ≥3 gate-park) needs explicit chairman ratification, and the live-route deployment gate (`/graphql` http_server route, bound vault, bash_timeout) is unexercised by the fixture. Not for merge until reviewed + `approved`.

---

## What

The first real implementation of autodev's development pipeline as a **native aios durable workflow** — the dissolution-thesis endpoint ([aios#987](https://github.com/eumemic/aios/issues/987) umbrella, [autodev#19](https://github.com/eumemic/autodev/issues/19) strange-loop). One run = one issue, end to end:

`ingest → spec-gate → implement → open-PR → verify(review/fix + CI) → risk → merge-guard → mark-ready → merge → post-merge`

- **`src/aios/workflows/dev_pipeline.py`** — a builder module (the `deep_research.py` pattern) returning the production workflow source + a fixture variant. A 16-node state machine.
- **`tests/integration/test_wf_dev_pipeline_fixture.py`** — drives the production script through the real script host (no DB) with simulated capability returns. 21 cases.

Full design of record: `eumemic-company/architecture/dev-pipeline-state-machine.md`.

## The node partition (intelligence vs computation)

Only **5 nodes are agentic** (`agent()`): implement, review, fix, ci-watch, risk. Everything else is deterministic computation — the spec gate (`re` in-script), all GitHub API ops (`tool('http_request')` against the run's bound vault), and the merge-ref guard (`tool('bash')`). **Escalations are `gate()` parks** — the durable-workflow upgrade of autodev's `awaiting_triage` dead-end: the run suspends for days until a human/cockpit resumes it.

Two design notes worth a look:
- **The "CI-wait blocker" dissolves.** The 2026-06-11 analysis flagged the verify-loop's "durably wait for CI" as needing a new `sleep` primitive. It doesn't: waiting-for-CI is *completion-uncertainty* (pending? flake? real? no-CI?), which the script-vs-agent doctrine says belongs in an `agent()`, not a script. A9 is an agent that owns the wait inside its 1h deadline.
- **Executable delegated merge authority.** tier ≤2 + green auto-merges (the merge-ref guard already validated the exact merge commit); tier ≥3 parks at `G:merge_approval`. This goes beyond autodev (which stops at mark-ready) and encodes the board's delegated merge authority as policy. **Flagged for chairman review.**

## Adversarial review folded

A 3-agent adversarial pass found — and this PR fixes — a genuine production blocker the happy-path test masked: `http_request` rejects a query string in `path`, so the original `GET /pulls?head=…` was dead code → now lists clean + filters in-script. Also folded: review-loop final-re-review (autodev's for/else shape), broadened risk-node guard (a malformed risk return can't discard a verified PR), merge re-drive confirmation (a 405 on an already-merged PR is confirmed, not mis-reported), post-merge agent-error gate (a merge is never lost), create-422→adopt, fail-closed `set -eu` merge-guard with the `^1..merge` diff, and a `base_branch` parameter. Each has a regression test.

## Tests

21 cases: replay-determinism (every call_key stable across every wake's full replay), every gate/escalation branch, the bounded self-repair loops with the no-commit + artifact guards, and the robustness folds above. Pre-commit ran the full repo suite (mypy 1059 files, 2653 unit tests) green.

## Deployment requirements (asserted at rollout, not by the script)

- A `github` http_server (`https://api.github.com`) with routes for `/repos/**` (GET/POST/PUT) **and a separate `/graphql` POST route** (a `/repos/**`-only allowlist silently breaks mark-ready → draft PR → merge 405). No `always_ask` routes.
- A bound vault providing `GITHUB_TOKEN`.
- The environment must set `bash_timeout_seconds` ≥ the merge-guard budget (#725).

## Named residuals (v1, tracked in the design doc)

Per-sentinel path-prefix *selection* in the merge-guard (v1 runs all configured sentinels — safe, just less efficient); comment marker-dedup; the deferred spec-gate checks (assignee / dup-closing-PR / bug-signal); gate-wrapping the pre-merge agent nodes (today a genuinely-errored child surfaces as an `errored` run for the D-3 reconciler — visible, not silent). Live end-to-end smoke against a real `shovel-ready` issue is the deploy step (the fixture's memoized results deliberately don't exercise the live route gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
