### PR TITLE
fix(harness): only inline image formats the provider accepts

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -42,6 +42,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from aios.harness.vision import (
+    PROVIDER_INLINE_IMAGE_FORMATS,
     can_inline_image,
     correct_image_mime_b64,
     make_image_url_part,
@@ -524,31 +525,33 @@ def render_user_event(
     return {"role": "user", "content": marker}
 
 
-def _image_bytes_decode(data: bytes) -> bool:
-    """True iff Pillow can FULLY decode ``data`` as an image.
+def _inline_image_format(data: bytes) -> str | None:
+    """Return Pillow's format name ("JPEG"/"PNG"/"TIFF"/...) if ``data`` fully
+    decodes as an image, else ``None``.
 
-    The inline gate (:func:`~aios.harness.vision.can_inline_image`) checks
-    only the mime prefix and the byte cap, and :func:`make_image_url_part`
-    only magic-byte-sniffs a 24-byte header — neither proves the pixels
-    decode. Providers DO full-decode an inline image and reject (HTTP 400)
-    bytes they can't, so the render boundary must apply the same verdict, or
-    an undecodable attachment (truncated/corrupt body behind a valid magic
-    prefix, or a zero-byte file) bricks the turn on every wake. ``img.load()``
-    forces the full decode — ``verify()`` passes a truncated body.
+    The render boundary inlines an image only when the provider will accept it
+    — which needs two things neither the declared mime
+    (:func:`~aios.harness.vision.can_inline_image`) nor the 24-byte magic sniff
+    (:func:`make_image_url_part`) can establish: the bytes must FULLY decode
+    (``img.load()`` — ``verify()`` passes a truncated body), and the ACTUAL
+    format must be one the provider supports (the caller checks the returned
+    name against :data:`~aios.harness.vision.PROVIDER_INLINE_IMAGE_FORMATS`).
+    A TIFF/BMP decodes fine yet every provider 400s on it, and a declared mime
+    can lie either way (a JPEG sent as image/jpg, a TIFF sent as image/png), so
+    only the decoded format is trustworthy. Both failure modes — undecodable,
+    or decodable-but-unsupported — degrade to a text marker the model can
+    ``read``, instead of re-sending a rejected part on every replay wake.
 
-    This predicate is TOTAL: any decode failure means "don't inline." Pillow
-    raises a wide, format-plugin-dependent set on hostile bytes —
-    ``UnidentifiedImageError``/``OSError`` (garbage/zero-byte/truncated),
-    ``DecompressionBombError`` (a pixel bomb we must not hand to the provider),
-    and ``ValueError``/``SyntaxError``/``struct.error`` from individual format
-    decoders. Catching only a subset would let an exotic decoder error escape
-    to ``build_messages``' poison backstop, which quarantines the WHOLE event
-    (losing the message text and any sibling attachments) rather than degrading
-    just this one attachment to a marker — so catch ``Exception`` (never
-    ``BaseException``: control-flow signals still propagate).
+    Returns ``None`` on ANY decode failure (total): Pillow raises a wide,
+    format-plugin-dependent set on hostile bytes (UnidentifiedImageError/
+    OSError, DecompressionBombError, ValueError/SyntaxError/struct.error).
+    Catching only a subset would let an exotic decoder error escape to
+    ``build_messages``' poison backstop, quarantining the WHOLE event (losing
+    the message text and sibling attachments) rather than degrading just this
+    attachment — so catch ``Exception`` (never ``BaseException``).
     """
     if not data:
-        return False
+        return None
     from io import BytesIO
 
     from PIL import Image
@@ -556,9 +559,9 @@ def _image_bytes_decode(data: bytes) -> bool:
     try:
         with Image.open(BytesIO(data)) as img:
             img.load()
+            return img.format
     except Exception:
-        return False
-    return True
+        return None
 
 
 def _apply_attachments(
@@ -630,7 +633,8 @@ def _apply_attachments(
             )
             marker_lines.append(text_marker(record))
             continue
-        if not _image_bytes_decode(payload):
+        image_format = _inline_image_format(payload)
+        if image_format is None:
             # Bytes that pass the mime+size gate but don't actually decode (a
             # truncated/corrupt body behind a valid magic prefix, or a
             # zero-byte file). The provider full-decodes and 400s on these,
@@ -641,6 +645,20 @@ def _apply_attachments(
             # build_messages poison backstop.
             log.warning(
                 "context.attachment_undecodable",
+                path=str(host_path),
+                filename=record.get("filename"),
+            )
+            marker_lines.append(text_marker(record))
+            continue
+        if image_format not in PROVIDER_INLINE_IMAGE_FORMATS:
+            # Decodes, but no vision provider accepts this format (TIFF, BMP,
+            # …) — they take only jpeg/png/gif/webp and 400 on the rest, so
+            # inlining it bricks the turn on every replay wake just like
+            # undecodable bytes. Gate on the DECODED format, not the declared
+            # mime (which can mislabel either way), and degrade to a marker.
+            log.warning(
+                "context.attachment_unsupported_image_format",
+                image_format=image_format,
                 path=str(host_path),
                 filename=record.get("filename"),
             )

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -98,6 +98,17 @@ def supports_vision(model: str) -> bool:
     return bool(info.get("supports_vision"))
 
 
+# Image formats every vision-capable provider in aios's routing set accepts as
+# an inline ``image_url`` — the intersection of Anthropic (jpeg/png/gif/webp)
+# and OpenAI (png/jpeg/webp/gif). Values are Pillow ``Image.format`` names
+# (uppercase). Other formats (TIFF, BMP, ICO, HEIC, AVIF, SVG) decode in Pillow
+# but the providers 400 on them, so the renderer degrades them to a text marker
+# the model can still ``read``. The check runs on the DECODED format, not the
+# declared mime — a sender can mislabel either way (a JPEG sent as image/jpg, a
+# TIFF sent as image/png), so only the decoded format is trustworthy.
+PROVIDER_INLINE_IMAGE_FORMATS = frozenset({"JPEG", "PNG", "GIF", "WEBP"})
+
+
 def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
     """True when ``model`` can see image bytes inlined as ``image_url``.
 

--- a/tests/helpers/images.py
+++ b/tests/helpers/images.py
@@ -29,3 +29,10 @@ def valid_jpeg_bytes() -> bytes:
 def valid_png_bytes() -> bytes:
     """A genuinely-decodable 1x1 PNG. See :func:`_valid_image`."""
     return _valid_image("PNG")
+
+
+def valid_tiff_bytes() -> bytes:
+    """A genuinely-decodable 1x1 TIFF — a format Pillow decodes but no vision
+    provider accepts for inlining, used to exercise the render boundary's
+    provider-format gate. See :func:`_valid_image`."""
+    return _valid_image("TIFF")

--- a/tests/unit/test_context_attachments.py
+++ b/tests/unit/test_context_attachments.py
@@ -26,7 +26,7 @@ from aios.harness.context import (
 )
 from aios.models.events import Event
 from aios.sandbox.volumes import session_attachments_dir
-from tests.helpers.images import valid_jpeg_bytes
+from tests.helpers.images import valid_jpeg_bytes, valid_tiff_bytes
 
 # These tests exercise attachment/vision rendering, not the `received=` envelope
 # (their assertions are substring checks). Inject a fixed created_at so callers
@@ -164,6 +164,42 @@ class TestVisionAwareRendering:
         assert isinstance(msg["content"], str), "undecodable image must not be inlined"
         assert "[image: bad.jpg" in msg["content"]
         assert "/mnt/attachments/echo/evt-1-bad.jpg" in msg["content"]
+
+    def test_decodable_but_provider_unsupported_format_falls_back_to_marker(
+        self, temp_workspace_root: Path
+    ) -> None:
+        """A TIFF under the cap DECODES in Pillow (so the decode gate passes
+        it) but no vision provider accepts TIFF — they take only
+        jpeg/png/gif/webp and 400 on the rest, bricking the turn on every wake.
+        The render boundary gates on the ACTUAL decoded format (not the
+        declared mime, which can lie either way) and degrades an unsupported
+        one to a text marker the model can still ``read``.
+        """
+        payload = valid_tiff_bytes()
+        sandbox_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "evt-1-scan.tiff", payload
+        )
+        event = _user_event(
+            content="scan",
+            attachments=[
+                {
+                    "filename": "scan.tiff",
+                    "content_type": "image/tiff",
+                    "size": len(payload),
+                    "in_sandbox_path": sandbox_path,
+                }
+            ],
+        )
+        msg = render_user_event(
+            event,
+            "echo/acct/chat-1",
+            "echo/acct/chat-1",
+            model="model/vision",
+            session_id="sess-1",
+        )
+        # Unsupported format → marker-only render (content collapses to a str).
+        assert isinstance(msg["content"], str), "unsupported image format must not be inlined"
+        assert "[image: scan.tiff" in msg["content"]
 
     def test_non_dict_attachment_record_is_skipped(self, temp_workspace_root: Path) -> None:
         """A non-dict element in ``metadata.attachments`` must not crash the renderer.


### PR DESCRIPTION
## Summary

- **Bug:** `can_inline_image` gates on `content_type.startswith("image/")`, and the render-boundary gate (iter `679fe63b`) only checked *decodability* — so a **TIFF or BMP** attachment under the inline cap (both decode fine in Pillow) was inlined as an `image_url` and sent to the provider, which accepts only **jpeg/png/gif/webp** and **400s** on the rest. Same brick class as the undecodable bug (the rejected part re-sends on every replay wake, terminally erroring the turn the model can't see) but a different cause: a *decodable-but-unsupported format*.
- **Fix:** gate on the **actual decoded format**. The render boundary reads Pillow's `img.format` and inlines only `PROVIDER_INLINE_IMAGE_FORMATS` (`JPEG/PNG/GIF/WEBP`, the cross-provider accepted set); anything else degrades to a text marker the model can `read`.

## Why the decoded format, not a declared-mime allowlist

A declared-mime allowlist (the obvious fix) is wrong **two ways**, because the declared mime is untrustworthy (the reason `make_image_url_part` already sniff-corrects):
- a JPEG sent as `image/jpg` would be **wrongly marker'd** (a regression — it inlines fine today via sniff-correction), and
- a TIFF sent as `image/png` would be **wrongly inlined** (still 400).

Checking the decoded `img.format` handles both: the `image/jpg` JPEG inlines (format `JPEG`), the mislabeled TIFF markers (format `TIFF`). `_image_bytes_decode` is evolved to `_inline_image_format` (returns the format name or `None`); the undecodable path is unchanged (`None` → marker).

## Verification

- Failing test written first (a real 1×1 TIFF attachment), confirmed red (TIFF inlined as `image_url`). Green after the fix (→ marker).
- Empirically confirmed Pillow's `img.format` strings match the allowlist (`JPEG/PNG/GIF/WEBP`; `TIFF`/`BMP` excluded; animated GIF → `GIF`).
- mypy clean · ruff + format clean · 51 vision tests · full unit suite 2656 passed.

## Note

The `read` tool (`tools/read.py`) is a *separate* image-inline path that doesn't flow through `_apply_attachments`; whether it needs the same decode+format gate is a plausible follow-up lead (unconfirmed), not in scope here.

## Test plan

- [x] `test_decodable_but_provider_unsupported_format_falls_back_to_marker` (red→green)
- [x] mypy / ruff / full unit suite green
- [ ] CI runs e2e / integration shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)