### PR TITLE
fix(tools): apply the inline decode+format gate to the read tool

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -45,6 +45,7 @@ from aios.harness.vision import (
     PROVIDER_INLINE_IMAGE_FORMATS,
     can_inline_image,
     correct_image_mime_b64,
+    inline_image_format,
     make_image_url_part,
     text_marker,
 )
@@ -525,45 +526,6 @@ def render_user_event(
     return {"role": "user", "content": marker}
 
 
-def _inline_image_format(data: bytes) -> str | None:
-    """Return Pillow's format name ("JPEG"/"PNG"/"TIFF"/...) if ``data`` fully
-    decodes as an image, else ``None``.
-
-    The render boundary inlines an image only when the provider will accept it
-    — which needs two things neither the declared mime
-    (:func:`~aios.harness.vision.can_inline_image`) nor the 24-byte magic sniff
-    (:func:`make_image_url_part`) can establish: the bytes must FULLY decode
-    (``img.load()`` — ``verify()`` passes a truncated body), and the ACTUAL
-    format must be one the provider supports (the caller checks the returned
-    name against :data:`~aios.harness.vision.PROVIDER_INLINE_IMAGE_FORMATS`).
-    A TIFF/BMP decodes fine yet every provider 400s on it, and a declared mime
-    can lie either way (a JPEG sent as image/jpg, a TIFF sent as image/png), so
-    only the decoded format is trustworthy. Both failure modes — undecodable,
-    or decodable-but-unsupported — degrade to a text marker the model can
-    ``read``, instead of re-sending a rejected part on every replay wake.
-
-    Returns ``None`` on ANY decode failure (total): Pillow raises a wide,
-    format-plugin-dependent set on hostile bytes (UnidentifiedImageError/
-    OSError, DecompressionBombError, ValueError/SyntaxError/struct.error).
-    Catching only a subset would let an exotic decoder error escape to
-    ``build_messages``' poison backstop, quarantining the WHOLE event (losing
-    the message text and sibling attachments) rather than degrading just this
-    attachment — so catch ``Exception`` (never ``BaseException``).
-    """
-    if not data:
-        return None
-    from io import BytesIO
-
-    from PIL import Image
-
-    try:
-        with Image.open(BytesIO(data)) as img:
-            img.load()
-            return img.format
-    except Exception:
-        return None
-
-
 def _apply_attachments(
     msg: dict[str, Any],
     attachments: list[Any],
@@ -633,7 +595,7 @@ def _apply_attachments(
             )
             marker_lines.append(text_marker(record))
             continue
-        image_format = _inline_image_format(payload)
+        image_format = inline_image_format(payload)
         if image_format is None:
             # Bytes that pass the mime+size gate but don't actually decode (a
             # truncated/corrupt body behind a valid magic prefix, or a

--- a/src/aios/harness/vision.py
+++ b/src/aios/harness/vision.py
@@ -109,6 +109,45 @@ def supports_vision(model: str) -> bool:
 PROVIDER_INLINE_IMAGE_FORMATS = frozenset({"JPEG", "PNG", "GIF", "WEBP"})
 
 
+def inline_image_format(data: bytes) -> str | None:
+    """Return Pillow's format name ("JPEG"/"PNG"/"TIFF"/...) if ``data`` fully
+    decodes as an image, else ``None``.
+
+    Every inline path (the attachment render boundary in
+    ``context._apply_attachments`` and the ``read`` tool's ``_read_image``)
+    must apply the SAME verdict the provider will: it full-decodes the bytes
+    and 400s on anything it can't, so neither the declared mime
+    (:func:`can_inline_image`) nor the 24-byte magic sniff
+    (:func:`make_image_url_part`) is enough. ``img.load()`` forces the full
+    decode (``verify()`` passes a truncated body); the caller then checks the
+    returned name against :data:`PROVIDER_INLINE_IMAGE_FORMATS`. A TIFF/BMP
+    decodes fine yet no provider accepts it, and a declared mime can lie either
+    way (a JPEG sent as image/jpg, a TIFF sent as image/png), so only the
+    decoded format is trustworthy. Both failure modes — undecodable, or
+    decodable-but-unsupported — degrade to a text marker rather than re-sending
+    a rejected part on every replay wake (a permanent brick the model can't
+    see). This helper is shared so the two inline paths cannot drift apart —
+    which is exactly how the ``read`` path missed the gate the render path got.
+
+    Returns ``None`` on ANY decode failure (total): Pillow raises a wide,
+    format-plugin-dependent set on hostile bytes (UnidentifiedImageError/
+    OSError, DecompressionBombError, ValueError/SyntaxError/struct.error), so
+    catch ``Exception`` (never ``BaseException``).
+    """
+    if not data:
+        return None
+    from io import BytesIO
+
+    from PIL import Image
+
+    try:
+        with Image.open(BytesIO(data)) as img:
+            img.load()
+            return img.format
+    except Exception:
+        return None
+
+
 def can_inline_image(*, model: str, content_type: str, size_bytes: int) -> bool:
     """True when ``model`` can see image bytes inlined as ``image_url``.
 

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -22,8 +22,10 @@ from aios.errors import AiosError
 from aios.harness import runtime
 from aios.harness.vision import (
     INLINE_SIZE_CAP_BYTES,
+    PROVIDER_INLINE_IMAGE_FORMATS,
     can_inline_image,
     human_size,
+    inline_image_format,
     make_image_url_part,
     supports_vision,
 )
@@ -241,6 +243,29 @@ async def _read_image(
                 f"Image at {path} exists ({human_size(size)}, {mime}) but cannot "
                 f"be inlined. Mind vision support: {vision}. "
                 f"Inline cap: {cap_mib:.2f} MiB ({INLINE_SIZE_CAP_BYTES} bytes)."
+            ),
+            is_error=False,
+        )
+
+    image_format = inline_image_format(data)
+    if image_format is None or image_format not in PROVIDER_INLINE_IMAGE_FORMATS:
+        # Passes the mime+size+vision gate but the provider will reject it:
+        # undecodable (corrupt/truncated body behind a valid magic prefix) or a
+        # decodable-but-unsupported format (e.g. a TIFF/BMP saved as .png — the
+        # .png extension skips the magic re-sniff). Inlining persists the bad
+        # data URI into the tool_result event, which build_messages replays on
+        # every wake → a 400 that terminally errors the turn the model can't
+        # see. Same decode+format gate the attachment render path applies.
+        detail = (
+            "its bytes do not decode as an image"
+            if image_format is None
+            else f"its format ({image_format}) is not one a vision model accepts "
+            "(only JPEG/PNG/GIF/WEBP)"
+        )
+        return ToolResult(
+            content=(
+                f"Image at {path} ({human_size(size)}, {mime}) cannot be inlined: "
+                f"{detail}. The file is present; use other tools to process it if needed."
             ),
             is_error=False,
         )

--- a/tests/e2e/test_extensionless_image_read.py
+++ b/tests/e2e/test_extensionless_image_read.py
@@ -35,14 +35,18 @@ from aios.tools.read import read_handler
 from aios.tools.registry import ToolResult
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness
+from tests.helpers.images import valid_gif_bytes, valid_jpeg_bytes, valid_png_bytes
 
 pytestmark = pytest.mark.docker
 
-# (extension-less filename, leading magic bytes, expected mime).
+# (extension-less filename, full decodable image bytes, expected mime). Real
+# images, not magic-prefix fragments: the read tool now full-decodes before
+# inlining (the provider 400s on undecodable bytes), so this sniff-routing test
+# must stage bytes that both sniff AND decode.
 _CASES = [
-    ("unnamed_png", b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR", "image/png"),
-    ("unnamed_jpg", b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00", "image/jpeg"),
-    ("unnamed_gif", b"GIF89a\x01\x00\x01\x00\x80\x00\x00", "image/gif"),
+    ("unnamed_png", valid_png_bytes(), "image/png"),
+    ("unnamed_jpg", valid_jpeg_bytes(), "image/jpeg"),
+    ("unnamed_gif", valid_gif_bytes(), "image/gif"),
 ]
 
 
@@ -63,8 +67,7 @@ class TestExtensionlessImageRead:
         # bind mount, so it exercises the real ``set -o pipefail; head -c 16 |
         # base64`` exec probe + ``_stat_and_read_via_exec`` full read.
         for parent in ("/workspace", "/tmp"):
-            for name, magic, expected_mime in _CASES:
-                payload = magic + f"-{parent}-{name}-sentinel".encode()
+            for name, payload, expected_mime in _CASES:
                 b64 = base64.b64encode(payload).decode("ascii")
                 write_cmd = f"printf '%s' {b64} | base64 -d > {parent}/{name}"
                 write_result = await bash_handler(session.id, {"command": write_cmd})

--- a/tests/e2e/test_workspace_image_read.py
+++ b/tests/e2e/test_workspace_image_read.py
@@ -26,6 +26,7 @@ from aios.tools.read import read_handler
 from aios.tools.registry import ToolResult
 from tests.conftest import needs_docker
 from tests.e2e.harness import Harness
+from tests.helpers.images import valid_png_bytes
 
 pytestmark = pytest.mark.docker
 
@@ -52,7 +53,7 @@ class TestWorkspaceImageRead:
         # inside the container.  The container sees ``/workspace`` as the
         # bind mount; the host sees it at
         # ``<workspace_root>/<account_id>/<session_id>``.
-        sentinel = b"PNG-SENTINEL-660"
+        sentinel = valid_png_bytes()  # must decode: the read tool now full-decodes before inlining
         b64 = base64.b64encode(sentinel).decode("ascii")
         write_cmd = f"printf '%s' {b64} | base64 -d > /workspace/img.png"
         write_result = await bash_handler(session.id, {"command": write_cmd})

--- a/tests/helpers/images.py
+++ b/tests/helpers/images.py
@@ -31,6 +31,16 @@ def valid_png_bytes() -> bytes:
     return _valid_image("PNG")
 
 
+def valid_gif_bytes() -> bytes:
+    """A genuinely-decodable 1x1 GIF. See :func:`_valid_image`."""
+    return _valid_image("GIF")
+
+
+def valid_webp_bytes() -> bytes:
+    """A genuinely-decodable 1x1 WEBP. See :func:`_valid_image`."""
+    return _valid_image("WEBP")
+
+
 def valid_tiff_bytes() -> bytes:
     """A genuinely-decodable 1x1 TIFF — a format Pillow decodes but no vision
     provider accepts for inlining, used to exercise the render boundary's

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -19,6 +19,13 @@ from aios.sandbox.backends.base import CommandResult, SandboxHandle
 from aios.sandbox.volumes import session_attachments_dir, workspace_dir_for
 from aios.tools.read import read_handler
 from aios.tools.registry import ToolResult
+from tests.helpers.images import (
+    valid_gif_bytes,
+    valid_jpeg_bytes,
+    valid_png_bytes,
+    valid_tiff_bytes,
+    valid_webp_bytes,
+)
 
 
 class _StubRegistry:
@@ -131,7 +138,8 @@ class TestImageBranch:
         stub_get_session_model: Any,
     ) -> None:
         stub_get_session_model.value = "model/vision"
-        _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNGbytes")
+        payload = valid_png_bytes()
+        _stage_workspace_image("sess_01TEST", "screenshot.png", payload)
 
         result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
 
@@ -141,9 +149,35 @@ class TestImageBranch:
         assert "Image: screenshot.png" in result.content[0]["text"]
         assert result.content[1] == {
             "type": "image_url",
-            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(b'PNGbytes').decode()}"},
+            "image_url": {"url": f"data:image/png;base64,{base64.b64encode(payload).decode()}"},
         }
         assert result.is_error is False
+
+    async def test_undecodable_or_unsupported_image_returns_marker_not_inline(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """A file routed to the image branch whose bytes don't fully decode as
+        a provider-accepted format must NOT be inlined: the provider
+        full-decodes the data URI and 400s, and the tool_result is replayed
+        verbatim on every wake — bricking the turn. Two reachable vectors:
+        (a) a TIFF saved as .png (the .png extension skips the magic re-sniff,
+        and correct_image_mime_b64 can't re-sniff TIFF), and (b) a corrupt body
+        behind a valid PNG signature. Both must degrade to an explanatory text
+        result, the same as the attachment render path's decode+format gate."""
+        stub_get_session_model.value = "model/vision"
+        corrupt_png = b"\x89PNG\r\n\x1a\n" + b"not-a-real-png" * 8  # valid magic, garbage body
+        for name, payload in (("scan.png", valid_tiff_bytes()), ("broken.png", corrupt_png)):
+            _stage_workspace_image("sess_01TEST", name, payload)
+            result = await read_handler("sess_01TEST", {"path": f"/workspace/{name}"})
+            assert isinstance(result, ToolResult)
+            assert isinstance(result.content, str), (
+                f"{name}: unsupported/undecodable image must not inline; got {result.content!r}"
+            )
+            assert "image_url" not in result.content
+            assert result.is_error is False
 
     async def test_attachment_image_inlines_for_vision_mind(
         self,
@@ -152,7 +186,7 @@ class TestImageBranch:
         stub_get_session_model: Any,
     ) -> None:
         stub_get_session_model.value = "model/vision"
-        _stage_attachment("sess_01TEST", "echo", "evt-1-photo.jpg", b"JPGbytes")
+        _stage_attachment("sess_01TEST", "echo", "evt-1-photo.jpg", valid_jpeg_bytes())
 
         result = await read_handler(
             "sess_01TEST", {"path": "/mnt/attachments/echo/evt-1-photo.jpg"}
@@ -218,7 +252,7 @@ class TestImageBranch:
         # the pre-#409 path ``workspace_dir_for`` would compute.
         nested = (temp_workspace_root / "acct-X" / "sess_01TEST").resolve()
         nested.mkdir(parents=True)
-        payload = b"PNG-NESTED"
+        payload = valid_png_bytes()
         (nested / "img.png").write_bytes(payload)
 
         handle = SandboxHandle(
@@ -427,16 +461,14 @@ class TestExtensionlessImageDetection:
     @pytest.mark.parametrize(
         ("name", "payload", "mime"),
         [
-            ("unnamed", b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDRrest-of-png-bytes", "image/png"),
-            (
-                "signal-abc-unnamed",
-                b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00rest",
-                "image/jpeg",
-            ),
-            ("img", b"GIF89a\x01\x00\x01\x00\x80\x00\x00rest-of-gif-bytes", "image/gif"),
-            # WebP is a RIFF container — ``RIFF<4-byte size>WEBP`` — so the
-            # discriminating tag sits at offset 8.  The 16-byte probe covers it.
-            ("photo", b"RIFF\x24\x58\x00\x00WEBPVP8 \x18\x00\x00\x00webp-body", "image/webp"),
+            # Real decodable images of each format: the magic-byte probe routes
+            # by signature AND the render gate now full-decodes, so the payloads
+            # must be genuine (not the minimal magic-prefix fragments that
+            # passed the old sniff-only path).
+            ("unnamed", valid_png_bytes(), "image/png"),
+            ("signal-abc-unnamed", valid_jpeg_bytes(), "image/jpeg"),
+            ("img", valid_gif_bytes(), "image/gif"),
+            ("photo", valid_webp_bytes(), "image/webp"),
         ],
     )
     async def test_extensionless_image_inlines_via_magic_byte_sniff(
@@ -470,7 +502,7 @@ class TestExtensionlessImageDetection:
     ) -> None:
         """Finding 1: a NON-image extension whose bytes are a real image is detected by the sniff and inlined."""
         stub_get_session_model.value = "model/vision"
-        payload = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00jpeg-mislabeled-as-dat"
+        payload = valid_jpeg_bytes()  # a real JPEG mislabeled with a .dat extension
         _stage_workspace_image("sess_01TEST", "scan.dat", payload)
         result = await read_handler("sess_01TEST", {"path": "/workspace/scan.dat"})
         assert isinstance(result, ToolResult)
@@ -526,7 +558,7 @@ class TestExtensionlessImageDetection:
     ) -> None:
         """An image extension resolves the mime from the extension alone — no probe read."""
         stub_get_session_model.value = "model/vision"
-        _stage_workspace_image("sess_01TEST", "screenshot.png", b"PNGbytes")
+        _stage_workspace_image("sess_01TEST", "screenshot.png", valid_png_bytes())
         result = await read_handler("sess_01TEST", {"path": "/workspace/screenshot.png"})
         assert isinstance(result, ToolResult)
         assert isinstance(result.content, list)
@@ -541,8 +573,8 @@ class TestExtensionlessImageDetection:
     ) -> None:
         """Outside any bind mount the probe falls back to one docker-exec (with set -o pipefail), then the full read is a second exec."""
         stub_get_session_model.value = "model/vision"
-        png_head = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
-        full = png_head + b"-more-png-bytes"
+        full = valid_png_bytes()
+        png_head = full[:16]  # the head -c 16 probe sniffs the PNG signature
         stub_runtime.exec = AsyncMock(
             side_effect=[
                 CommandResult(


### PR DESCRIPTION
## Summary

- **Bug:** the render boundary's decode + provider-format gate (`context._apply_attachments`, added across #1061/#1070) is what stops an undecodable or provider-unsupported image from being inlined and **400-ing the provider on every replay wake**. The `read` tool's `_read_image` is an **independent inline path that never got it** — it gated only on `can_inline_image` (mime-prefix + size + vision) and `make_image_url_part`'s 24-byte magic sniff. So `read` on a **TIFF/BMP saved as `.png`** (the `.png` extension skips the magic re-sniff; `correct_image_mime_b64` can't re-sniff TIFF/BMP) or a **corrupt body behind a valid PNG/JPEG signature** inlined `data:image/png;base64,<undecodable>`, persisted into the `tool_result` event and replayed every wake → a 400 that terminally errors the turn the model can't see. Same permanent-brick class as the attachment path, **different code path**.
- **Fix:** lift the gate to a shared **`vision.inline_image_format`** (moved from `context.py`), called from **both** `_apply_attachments` and `_read_image`; an undecodable/unsupported image degrades to an explanatory text result. Sharing one gate is the *structural* fix — the read path drifted from the render path precisely because the decode/format logic was implicitly duplicated rather than shared.

## Why it kept happening

This is the third PR in the inline-image-brick family (#1061 undecodable, #1070 unsupported-format, this one for the read path). The first two fixed only `_apply_attachments`; the audit flagged the read path as a lead in both. Consolidating the gate into one shared helper closes the family and removes the drift surface.

## Verification

- Failing test written first (TIFF-as-`.png` + corrupt-PNG via `read`), confirmed red (inlined as `image_url`). Green after the fix (→ explanatory text).
- The read path's mime-routing tests staged minimal fake magic-prefix bytes and asserted inlining (they relied on the old sniff-only behavior); updated to stage genuinely-decodable images of each format via `tests.helpers.images` (adds `valid_gif_bytes`/`valid_webp_bytes`, empirically confirmed to sniff + decode). Both the bind-mount and docker-exec read paths are covered.
- mypy clean · ruff + format clean · 66 read/attachment/vision tests · full unit suite 2657 passed.

## Test plan

- [x] `test_undecodable_or_unsupported_image_returns_marker_not_inline` (red→green; bind-mount path)
- [x] updated routing tests cover bind-mount + exec paths × jpeg/png/gif/webp
- [x] mypy / ruff / full unit suite green
- [ ] CI runs e2e / integration shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)