### PR TITLE
fix(api): make validation error responses JSON-total (multipart UploadFile)

### DIFF
--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -267,16 +267,22 @@ async def http_exception_handler(request: Request, exc: Exception) -> JSONRespon
 async def validation_error_handler(request: Request, exc: Exception) -> JSONResponse:
     """Render pydantic/FastAPI request validation errors.
 
-    Pydantic's ``value_error`` entries include a ``ctx`` field that
-    carries a live ``ValueError`` instance — unserializable by
-    ``json.dumps``, so the handler itself would raise and Starlette
-    would fall back to a generic 500. We strip ``ctx`` from every
-    entry; it's internal pydantic bookkeeping, not load-bearing for
-    clients.
+    Each entry can carry values ``json.dumps`` chokes on: ``ctx`` holds a live
+    ``ValueError`` instance, and ``input`` echoes the offending value — which
+    on a multipart request is a non-serializable ``UploadFile``. If the handler
+    raised, Starlette would fall back to a generic 500 and the client would
+    lose the 422 and the error envelope. We drop ``ctx`` (internal pydantic
+    bookkeeping, not load-bearing for clients) and coerce every remaining value
+    to JSON-safe via a ``default=str`` round-trip, so the error list is total.
     """
     assert isinstance(exc, RequestValidationError)
     _log_handler_error("api.validation_error", request, 422, error_type="validation_error")
-    errors = [{k: v for k, v in err.items() if k != "ctx"} for err in exc.errors()]
+    errors = json.loads(
+        json.dumps(
+            [{k: v for k, v in err.items() if k != "ctx"} for err in exc.errors()],
+            default=str,
+        )
+    )
     return JSONResponse(
         status_code=422,
         content={

--- a/tests/unit/test_errors_handler.py
+++ b/tests/unit/test_errors_handler.py
@@ -8,11 +8,16 @@ to a generic 500.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+import io
+import json
+
+from fastapi import FastAPI, UploadFile
+from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, field_validator
+from starlette.requests import Request
 
-from aios.errors import install_exception_handlers
+from aios.errors import install_exception_handlers, validation_error_handler
 
 
 class _CustomModel(BaseModel):
@@ -64,3 +69,26 @@ def test_regular_type_error_still_422() -> None:
     response = client.post("/echo", json={"n": "not-an-int"})
     assert response.status_code == 422
     assert response.json()["error"]["type"] == "validation_error"
+
+
+async def test_non_serializable_input_does_not_crash_handler() -> None:
+    """A multipart validation error carries the offending ``UploadFile`` in its
+    ``input`` field, which ``json.dumps`` can't serialize. Before the fix the
+    handler's own ``JSONResponse`` raised ``TypeError`` and Starlette fell back
+    to a bare 500 — losing the 422 and the error envelope. The error list must
+    be coerced JSON-safe, not just have ``ctx`` stripped."""
+    upload = UploadFile(file=io.BytesIO(b"bytes"), filename="photo.png")
+    exc = RequestValidationError(
+        errors=[{"type": "model_attributes_type", "loc": ("body",), "msg": "bad", "input": upload}]
+    )
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/upload", "headers": [], "query_string": b""}
+    )
+
+    response = await validation_error_handler(request, exc)
+
+    assert response.status_code == 422
+    body = json.loads(bytes(response.body))
+    assert body["error"]["type"] == "validation_error"
+    # The non-serializable ``input`` is coerced to a string, not crashed on.
+    assert isinstance(body["error"]["detail"]["errors"][0]["input"], str)


### PR DESCRIPTION
## Summary

- **Bug:** `validation_error_handler` strips `ctx` (a live `ValueError`) from each pydantic validation error before serializing, but **not `input`** — which echoes the offending value and, on a **multipart request, is a non-serializable `UploadFile`**. The handler's own `JSONResponse` then raises `TypeError` serializing it, and Starlette falls back to a generic **500** — the client loses the intended 422 *and* the error envelope.
- **Fix:** after the `ctx` drop, coerce every remaining value JSON-safe via a `default=str` round-trip, so the error list is **total** — any non-serializable field (`input` today, anything future) is stringified rather than crashing the handler. The `ctx` drop stays (intentional declutter); the envelope shape is unchanged.

## Why total, not whack-a-mole

Dropping `input` like `ctx` would lose the useful "you sent X" echo for normal (serializable) errors. The `default=str` round-trip keeps serializable values as-is and only stringifies the unserializable ones — and it's future-proof against any other non-serializable field, rather than enumerating them one bug at a time.

## Verification

- Failing test written first (a `RequestValidationError` whose `input` is an `UploadFile`), confirmed red: `TypeError: Object of type UploadFile is not JSON serializable` from the handler's `JSONResponse`.
- The existing `ctx`-drop test still passes (behavior preserved). mypy clean · ruff + format clean · full unit suite 2658 passed. No openapi/SDK drift (envelope shape unchanged; snapshot tests pass).

## Test plan

- [x] `test_non_serializable_input_does_not_crash_handler` (red→green; direct handler call with an UploadFile input)
- [x] mypy / ruff / full unit suite green
- [ ] CI runs e2e / integration shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)