### PR TITLE
fix(files): clean up staged upload when insert_file fails

### DIFF
--- a/src/aios/services/files.py
+++ b/src/aios/services/files.py
@@ -6,9 +6,13 @@ Two non-obvious choices worth recording here:
   read and discarded before raising ``PayloadTooLargeError``. Without
   the drain the parser bails out and the client sees a transport reset,
   which is much harder to diagnose than a clean 413.
-* **File-then-DB ordering.** Bytes hit disk and rename atomically into
-  place before the row insert. A half-written ``.part`` is a harmless
-  orphan; a DB row pointing at missing bytes is observable corruption.
+* **File-then-DB under one cleanup scope.** Bytes hit disk and rename
+  atomically into place, then the row inserts — all inside the ``try``
+  whose ``except`` unlinks partial state. A failure anywhere up to and
+  including the insert leaves no orphan (there is no upload reconciler,
+  so a stranded file would be permanent); only the success path, which
+  returns before the ``except`` fires, leaves durable bytes. The insert
+  being last is what keeps a DB row from ever pointing at missing bytes.
 """
 
 from __future__ import annotations
@@ -99,6 +103,23 @@ async def stage_upload(
                 detail={"max_size_bytes": settings.upload_max_size_bytes},
             )
         os.rename(temp_path, final_path)
+        # Insert inside the cleanup scope (see the module docstring): success
+        # returns before the except can fire, and any failure here — an FK
+        # violation if the session was hard-deleted since get_session_bare, or
+        # a pool/timeout error — unlinks the renamed file and re-raises.
+        async with pool.acquire() as conn:
+            return await queries.insert_file(
+                conn,
+                file_id=file_id,
+                session_id=session_id,
+                filename=filename,
+                host_path=str(final_path),
+                in_sandbox_path=in_sandbox_path,
+                size=size,
+                content_type=content_type,
+                sha256=hasher.hexdigest(),
+                account_id=account_id,
+            )
     except BaseException:
         # BaseException (not Exception) so partial state still gets cleaned up
         # under task cancellation — CancelledError doesn't inherit from
@@ -108,17 +129,3 @@ async def stage_upload(
         with contextlib.suppress(OSError):
             file_dir.rmdir()
         raise
-
-    async with pool.acquire() as conn:
-        return await queries.insert_file(
-            conn,
-            file_id=file_id,
-            session_id=session_id,
-            filename=filename,
-            host_path=str(final_path),
-            in_sandbox_path=in_sandbox_path,
-            size=size,
-            content_type=content_type,
-            sha256=hasher.hexdigest(),
-            account_id=account_id,
-        )

--- a/tests/unit/test_files_service.py
+++ b/tests/unit/test_files_service.py
@@ -200,6 +200,34 @@ class TestStageUploadOversize:
         assert list(uploads_dir.iterdir()) == []
 
 
+class TestStageUploadInsertFailure:
+    async def test_insert_failure_leaves_no_orphan_bytes(self, _workspace: Path) -> None:
+        """If the row insert fails after the bytes are renamed into place,
+        the staged file must not leak on disk.
+
+        ``stage_upload`` deliberately writes-then-inserts so a row never
+        points at missing bytes. But the renamed ``final_path`` lives
+        *outside* the ``except BaseException`` cleanup that guards the
+        write, so an ``insert_file`` failure (an FK violation when the
+        session is hard-deleted in the TOCTOU window after
+        ``get_session_bare``, or a pool/timeout error) used to strand the
+        fully-written file plus its ``<file_id>/`` dir forever — there is
+        no upload reconciler to sweep them. A failed upload must leave the
+        per-session dir as empty as a never-attempted one."""
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        upload = _FakeUpload(b"durable bytes", filename="ok.bin")
+        pool = cast("asyncpg.Pool[Any]", fake_pool_yielding_conn(MagicMock()))
+        insert_boom = patch(
+            "aios.services.files.queries.insert_file",
+            AsyncMock(side_effect=RuntimeError("insert failed")),
+        )
+        with _patch_session_get(), insert_boom, pytest.raises(RuntimeError):
+            await stage_upload(pool, session_id="sess_x", upload=upload, account_id=account_id)
+        uploads_dir = _workspace / "_uploads" / "sess_x"
+        assert uploads_dir.exists()
+        assert list(uploads_dir.iterdir()) == []
+
+
 class TestStageUploadSessionNotFound:
     async def test_nonexistent_session_propagates_404(self, _workspace: Path) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding


### PR DESCRIPTION
## Summary

- `stage_upload` writes the upload to a temp file, fsyncs, `os.rename`s it into place, then inserts the `files` row. The insert ran **outside** the `try/except BaseException` block that cleans up partial disk state, so an `insert_file` failure stranded the fully-written, renamed file plus its `<file_id>/` directory **forever** — there is no upload reconciler to sweep the leak.
- Reachable triggers: an FK violation if the session is hard-deleted in the window after `get_session_bare`, or a pool/timeout error from `pool.acquire()`/`insert_file`.
- **Fix:** move the insert inside the `try`, right after `os.rename`, so the existing cleanup unlinks the staged bytes and re-raises. The success path `return`s from inside the `try` before the `except` can fire, so durable bytes survive and a row still never points at missing bytes (the insert is last). The fix now also covers `pool.acquire()` itself raising — a strict superset of the original gap.
- Relocated the invariant rationale into the module docstring (the "File-then-DB" note now states the stronger post-fix invariant); the line-level comment is a slim pointer left as a regression guard.

## Test plan

- [x] Type-checker (mypy) — clean, 602 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — 2659 passed (incl. new `TestStageUploadInsertFailure::test_insert_failure_leaves_no_orphan_bytes`, red→green)
- [x] Connector suites — 187 + 99 + 157 + 99 passed
- [ ] CI runs e2e/integration (Docker)

### TDD

The new test patches `queries.insert_file` to raise after the bytes are renamed into place, then asserts the error propagates **and** that the per-session uploads dir holds no orphan `<file_id>/` subdirectory. It fails pre-fix on the orphan assertion (proving the leak) and passes post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)