### PR TITLE
fix(accounts): require caller privilege to grant can_mint_children

### DIFF
--- a/src/aios/api/routers/accounts.py
+++ b/src/aios/api/routers/accounts.py
@@ -165,11 +165,12 @@ async def update_account(
     Omitted fields are preserved. Both fields null is a valid no-op
     that returns the current row.
     """
-    account_id, key_id, _can_mint = auth
+    account_id, key_id, can_mint = auth
     updated = await service.update_account(
         pool,
         target_account_id=target_id,
         caller_account_id=account_id,
+        caller_can_mint_children=can_mint,
         display_name=body.display_name,
         can_mint_children=body.can_mint_children,
         config=body.config,

--- a/src/aios/services/accounts.py
+++ b/src/aios/services/accounts.py
@@ -220,6 +220,7 @@ async def update_account(
     *,
     target_account_id: str,
     caller_account_id: str,
+    caller_can_mint_children: bool,
     display_name: str | None,
     can_mint_children: bool | None,
     config: AccountConfig | None = None,
@@ -230,8 +231,20 @@ async def update_account(
     (set keys only). Raises :class:`NotFoundError` if the target is missing,
     archived, or out of scope — the API doesn't distinguish out-of-scope from
     missing.
+
+    Granting ``can_mint_children`` requires the caller to hold it: the privilege
+    only ever flows DOWN from a privileged parent (the same rule
+    :func:`mint_child` enforces). Without this a child minted with
+    ``can_mint_children=False`` could PATCH its own account to ``True`` and
+    self-escalate up the lattice. Revoking it (or any update by a privileged
+    caller, including the legitimate parent-grants-child path) is unaffected.
     """
     await get_account_in_scope(pool, target_account_id, caller_account_id=caller_account_id)
+    if can_mint_children and not caller_can_mint_children:
+        raise ForbiddenError(
+            "caller account is not authorized to grant can_mint_children",
+            detail={"account_id": caller_account_id, "target_account_id": target_account_id},
+        )
     async with pool.acquire() as conn:
         updated = await queries.update_account(
             conn,

--- a/tests/e2e/test_accounts_mgmt.py
+++ b/tests/e2e/test_accounts_mgmt.py
@@ -338,6 +338,44 @@ class TestUpdate:
         assert r.status_code == 200
         assert r.json()["can_mint_children"] is True
 
+    async def test_child_cannot_self_grant_mint(
+        self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
+    ) -> None:
+        """A can_mint_children=False child must not be able to PATCH its OWN
+        account to grant itself the privilege. can_mint_children flows down
+        from a privileged parent (as mint_child enforces); a node setting its
+        own flag is escalation up the lattice. Complement of
+        test_update_can_mint_children, where the *root* (privileged) caller
+        legitimately grants a child — that path must keep working."""
+        m = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={"display_name": "self-escalator", "can_mint_children": False},
+        )
+        assert m.status_code == 201, m.text
+        child_id = m.json()["account_id"]
+        child_key = m.json()["plaintext_key"]
+        assert (await http_client.get("/v1/accounts/me", headers=_bearer(child_key))).json()[
+            "can_mint_children"
+        ] is False
+
+        # The child grants itself the privilege on its own account.
+        escalate = await http_client.patch(
+            f"/v1/accounts/{child_id}",
+            headers=_bearer(child_key),
+            json={"can_mint_children": True},
+        )
+        assert escalate.status_code == 403, escalate.text
+
+        # Defense in depth: even end-to-end, the escalation took no effect —
+        # the child still cannot mint a sub-tenant.
+        grandchild = await http_client.post(
+            "/v1/accounts/children",
+            headers=_bearer(child_key),
+            json={"display_name": "grandchild", "can_mint_children": False},
+        )
+        assert grandchild.status_code == 403, grandchild.text
+
     async def test_update_cross_tenant_404(
         self, http_client: httpx.AsyncClient, aios_env: dict[str, str]
     ) -> None:


### PR DESCRIPTION
## Summary

Closes a **privilege-escalation** hole in the account hierarchy.

- `PATCH /v1/accounts/{target}` let an account with `can_mint_children=False` set its **own** `can_mint_children=True` (self-targeting is in-scope via `get_account_in_scope`) and then mint sub-tenants — silently reversing the parent's delegation decision.
- `update_account` had **no caller-privilege guard**, and the route destructured the caller's `can_mint` bit and discarded it (`_can_mint`). `mint_child` already gates minting on `caller_can_mint_children` (`raise ForbiddenError`); the update path did not — the two had drifted.
- **Fix:** thread `caller_can_mint_children` into `update_account` and refuse *granting* the privilege unless the caller holds it. `can_mint_children` flows **down** from a privileged parent, never self-conjured. Revoking, and the legitimate privileged-parent-grants-child path, are unaffected.

## Bypass analysis (reviewed)

The fix closes the **only** unprivileged grant path. Every other write to `can_mint_children` is already safe:
- `bootstrap_root_account` hardcodes `TRUE`, gated by `AIOS_BOOTSTRAP_TOKEN` + root-already-exists check (unreachable by a bearer caller).
- `insert_child_account` is only reached via `mint_child` (already guarded).
- `queries.update_account` is only reached via the now-guarded service.
- The CLI is a thin HTTP wrapper routing through the guarded PATCH.

`caller_can_mint_children` is read fresh per-request from the caller's own account row (`require_bearer_auth`), not cached or spoofable.

## Test plan

- [x] Type-checker (mypy) — clean, 602 files
- [x] Linter + format-check (ruff, `src tests`) — clean
- [x] Unit suite — passed via pre-commit hook
- [x] No OpenAPI/SDK drift (purely internal — route path + request/response models unchanged)
- [x] **New e2e test** `tests/e2e/test_accounts_mgmt.py::TestUpdate::test_child_cannot_self_grant_mint` — red→green locally:
  - child minted `can_mint_children=False` → self-PATCH `{can_mint_children: True}` asserts **403** (was 200 — escalation succeeded)
  - defense-in-depth: child then mints a grandchild → asserts **403** (escalation had no effect end-to-end)
  - sibling `test_update_can_mint_children` (root-grants-child) still passes — delegation preserved
- [ ] CI runs full e2e/integration (Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)