### PR TITLE
fix(sessions): validate pinned agent_version at write time

### DIFF
--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -140,6 +140,36 @@ async def get_agent_version(
         return await queries.get_agent_version(conn, agent_id, version, account_id=account_id)
 
 
+async def validate_pinned_agent_version(
+    conn: asyncpg.Connection[Any],
+    *,
+    agent_id: str | None,
+    agent_version: int | None,
+    account_id: str,
+) -> None:
+    """Reject a pinned ``agent_version`` that has no matching ``agent_versions`` row.
+
+    ``agent_version=None`` means "latest" and needs no check. A non-null pin is
+    otherwise write-trusted but read-fatal: the bare ``agent_id`` FK doesn't
+    constrain the integer, so a bad pin (e.g. a version past the agent's current
+    one) is accepted at write time, then the first step's ``load_for_session``
+    calls ``get_agent_version``, raises ``NotFoundError``, and the session burns
+    its retry budget into the terminal ``errored`` state — unrecoverable, since
+    ``agent_versions`` is append-only and the number only ever increments past
+    the bad pin. Validating here turns that silent mid-run brick into a clean
+    404 at the write the operator initiated. Shared by the session and template
+    create/update writers (on a caller ``conn`` so it joins their txn and rolls
+    back with them) so every pin path enforces it.
+    """
+    if agent_version is None:
+        return
+    # A non-null version always pairs with a non-null agent_id: sessions enforce
+    # it via sessions_agent_version_pair_ck (migration 0095); session_templates
+    # via the NOT NULL agent_id column (migration 0027).
+    assert agent_id is not None
+    await queries.get_agent_version(conn, agent_id, agent_version, account_id=account_id)
+
+
 async def _load_for_session_conn(
     conn: asyncpg.Connection[Any], session: Any, *, account_id: str
 ) -> Agent | AgentVersion:

--- a/src/aios/services/session_templates.py
+++ b/src/aios/services/session_templates.py
@@ -14,6 +14,7 @@ import asyncpg
 
 from aios.db import queries
 from aios.models.session_templates import SessionTemplate
+from aios.services import agents as agents_service
 
 
 async def create_session_template(
@@ -44,6 +45,11 @@ async def create_session_template(
             await queries.get_vault(conn, vault_id, account_id=account_id)
         for store_id in memory_store_ids:
             await queries.get_memory_store(conn, store_id, account_id=account_id)
+        # Reject a pinned version that doesn't exist before binding it — the
+        # supplied agent_id is the resolved binding here (no merge on create).
+        await agents_service.validate_pinned_agent_version(
+            conn, agent_id=agent_id, agent_version=agent_version, account_id=account_id
+        )
         return await queries.insert_session_template(
             conn,
             name=name,
@@ -106,7 +112,7 @@ async def update_session_template(
         if memory_store_ids is not None:
             for store_id in memory_store_ids:
                 await queries.get_memory_store(conn, store_id, account_id=account_id)
-        return await queries.update_session_template(
+        template = await queries.update_session_template(
             conn,
             template_id,
             name=name,
@@ -119,6 +125,15 @@ async def update_session_template(
             archive_when_idle=archive_when_idle,
             account_id=account_id,
         )
+        # Validate the resolved pin: agent_version may be supplied without
+        # agent_id, so only the post-merge row knows the effective binding.
+        await agents_service.validate_pinned_agent_version(
+            conn,
+            agent_id=template.agent_id,
+            agent_version=template.agent_version,
+            account_id=account_id,
+        )
+        return template
 
 
 async def archive_session_template(

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -281,6 +281,11 @@ async def create_session(
         # agent id would silently bind another tenant's model/surface into the
         # session. Mirrors the environment guard above (issue #755 / #851).
         await queries.get_agent(conn, agent_id, account_id=account_id)
+        # Reject a pinned version that doesn't exist before binding it — the
+        # supplied agent_id is the resolved binding here (no merge on create).
+        await agents_service.validate_pinned_agent_version(
+            conn, agent_id=agent_id, agent_version=agent_version, account_id=account_id
+        )
         session = await queries.insert_session(
             conn,
             agent_id=agent_id,
@@ -1348,6 +1353,16 @@ async def update_session(
             agent_version=agent_version,
             title=title,
             metadata=metadata,
+            account_id=account_id,
+        )
+        # Validate the resolved pin: agent_version may be supplied without
+        # agent_id (re-pin on the current agent), and changing agent_id resets
+        # the version to null — only the post-merge row knows the effective
+        # (agent_id, agent_version) binding.
+        await agents_service.validate_pinned_agent_version(
+            conn,
+            agent_id=session.agent_id,
+            agent_version=session.agent_version,
             account_id=account_id,
         )
         changed = False

--- a/tests/integration/test_agent_pinned_version_validation.py
+++ b/tests/integration/test_agent_pinned_version_validation.py
@@ -1,0 +1,177 @@
+"""Integration tests: a pinned ``agent_version`` is validated at write time.
+
+Pre-fix, create/update of a session or session_template wrote a
+caller-supplied ``agent_version`` with no existence check — the bare
+``agent_id`` FK constrains the agent, not the version integer. A bad pin
+(e.g. a version greater than the agent's current one) was accepted at
+write time and returned 200/201, then the first ``wake_session`` step's
+``load_for_session`` called ``get_agent_version``, raised
+``NotFoundError``, and the session burned its retry budget into the
+terminal ``errored`` state. ``agent_versions`` is append-only, so the pin
+never materializes — a permanent, unrecoverable brick from a write that
+looked healthy.
+
+The fix validates the *resolved* pin in all four writers
+(``create_session``, ``update_session``, ``create_session_template``,
+``update_session_template``) via the shared
+``validate_pinned_agent_version``, turning a silent mid-run brick into a
+clean ``NotFoundError`` at the write the operator initiated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError
+from aios.services import session_templates as templates_service
+from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+# A version that cannot exist for a freshly-seeded agent (which is at version 1).
+_BAD_PIN = 999
+
+
+@pytest.fixture
+async def pool_and_account(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_test', NULL, TRUE, 'tenant-test')
+                """
+            )
+        yield pool, "acc_test"
+    finally:
+        await pool.close()
+
+
+class TestCreateSessionPinValidation:
+    async def test_nonexistent_pin_rejected(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        pool, account_id = pool_and_account
+        agent, env, _ = await seed_agent_env_session(pool, account_id=account_id, prefix="pin-cs")
+        with pytest.raises(NotFoundError):
+            await sessions_service.create_session(
+                pool,
+                account_id=account_id,
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=_BAD_PIN,
+                title=None,
+                metadata={},
+            )
+
+    async def test_valid_pin_accepted(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        """The happy path is untouched: pinning the agent's real version succeeds."""
+        pool, account_id = pool_and_account
+        agent, env, _ = await seed_agent_env_session(
+            pool, account_id=account_id, prefix="pin-cs-ok"
+        )
+        session = await sessions_service.create_session(
+            pool,
+            account_id=account_id,
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            title=None,
+            metadata={},
+        )
+        assert session.agent_version == agent.version
+
+    async def test_none_pin_accepted(self, pool_and_account: tuple[asyncpg.Pool[Any], str]) -> None:
+        """``agent_version=None`` ("latest") needs no version and must pass."""
+        pool, account_id = pool_and_account
+        agent, env, _ = await seed_agent_env_session(
+            pool, account_id=account_id, prefix="pin-cs-none"
+        )
+        session = await sessions_service.create_session(
+            pool,
+            account_id=account_id,
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=None,
+            title=None,
+            metadata={},
+        )
+        assert session.agent_version is None
+
+
+class TestUpdateSessionPinValidation:
+    async def test_repin_to_nonexistent_rejected(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        """A re-pin via update (agent_version supplied, agent_id omitted) is
+        validated against the resolved current agent — the path that could
+        brick an already-running, previously-healthy session."""
+        pool, account_id = pool_and_account
+        agent, env, _ = await seed_agent_env_session(pool, account_id=account_id, prefix="pin-us")
+        session = await sessions_service.create_session(
+            pool,
+            account_id=account_id,
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=None,
+            title=None,
+            metadata={},
+        )
+        with pytest.raises(NotFoundError):
+            await sessions_service.update_session(
+                pool, session.id, account_id=account_id, agent_version=_BAD_PIN
+            )
+
+
+class TestCreateTemplatePinValidation:
+    async def test_nonexistent_pin_rejected(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        pool, account_id = pool_and_account
+        agent, env, _ = await seed_agent_env_session(pool, account_id=account_id, prefix="pin-ct")
+        with pytest.raises(NotFoundError):
+            await templates_service.create_session_template(
+                pool,
+                account_id=account_id,
+                name="pinned-template",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=_BAD_PIN,
+                vault_ids=[],
+                memory_store_ids=[],
+                metadata={},
+            )
+
+
+class TestUpdateTemplatePinValidation:
+    async def test_repin_to_nonexistent_rejected(
+        self, pool_and_account: tuple[asyncpg.Pool[Any], str]
+    ) -> None:
+        pool, account_id = pool_and_account
+        agent, env, _ = await seed_agent_env_session(pool, account_id=account_id, prefix="pin-ut")
+        template = await templates_service.create_session_template(
+            pool,
+            account_id=account_id,
+            name="repin-template",
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=None,
+            vault_ids=[],
+            memory_store_ids=[],
+            metadata={},
+        )
+        with pytest.raises(NotFoundError):
+            await templates_service.update_session_template(
+                pool, template.id, account_id=account_id, agent_version=_BAD_PIN
+            )


### PR DESCRIPTION
## Summary

A pinned `agent_version` was written **unvalidated**, then bricked the session at first step.

- `create_session` / `update_session` / `create_session_template` / `update_session_template` wrote a caller-supplied `agent_version` with no existence check — the bare `agent_id` FK constrains the *agent*, not the version integer, and there's no `(agent_id, agent_version)` FK to `agent_versions` (only the 0095 null-pairing CHECK).
- A bad pin (e.g. a version past the agent's current one) returned **200/201**, then the first `wake_session` step's `load_for_session` → `get_agent_version` raised `NotFoundError`, was caught by the retry handler, and the session descended through its backoff into the **terminal `errored`** state. `agent_versions` is append-only, so the pin never materializes — unrecoverable. `update_session` could do this to an already-running, previously-healthy session.

## Fix

- Add `agents.validate_pinned_agent_version(conn, *, agent_id, agent_version, account_id)` — a `None`-guarded `get_agent_version` lookup on the caller's txn (so it rolls back with the write). It lives in `services/agents.py` next to `get_agent_version` (the read whose failure was the brick).
- Called by **all four** pin writers. **Creates** validate the supplied pin before insert (fail-fast, like the sibling `get_agent`/`get_environment` ownership guards). **Updates** validate the *resolved post-merge row* — the only altitude that catches a version-only re-pin and the "changing `agent_id` resets the version to null" case (mirrors the `test_agent_window_validation` resolved-value precedent).
- A bad pin is now a clean `NotFoundError` at the write the operator initiated.

**Bypass check:** the 4 service functions are the only callers of the underlying `insert_session`/`insert_session_template`/`update_session`/`update_session_template`; `create_child_session` (workflow children) is agentless and pins no version. No write path bypasses the guard.

## Test plan

- [x] Type-checker (mypy) — clean, 603 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit + connector suites — passed via pre-commit hook
- [x] No OpenAPI/SDK drift (internal validation only)
- [x] **New integration test** `tests/integration/test_agent_pinned_version_validation.py` — red→green (verified by stashing only the fix):
  - all 4 write paths reject a nonexistent pin (`NotFoundError`) — these 4 fail `DID NOT RAISE` without the fix
  - happy path preserved: a valid pin and `agent_version=None` ("latest") both succeed
- [ ] CI runs full e2e/integration (Docker)

## Follow-up (noted, not in scope)

`pool_and_account` is now duplicated between this test and `test_agent_window_validation.py` (both file-local) — a `/kaizen` candidate to lift into `tests/integration/conftest.py` (touches the sibling's imports, so deferred from this bug PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)