### PR TITLE
refactor: single-source the reaction watermark (delete sweep CTE)

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -178,22 +178,21 @@ CONFIRMED_ROWS_SQL = """
        {scope_clause}
 """
 
+# The reaction watermark — ``MAX(COALESCE(reacting_to, seq))`` over assistant
+# messages — lives in exactly ONE writable place: the ``last_reacted_seq``
+# UPDATE in ``append_event`` (db/queries/events.py), seeded once by migration
+# 0066's backfill. This gate consumes that maintained scalar directly via a
+# JOIN; it does NOT recompute the watermark. Re-deriving the formula here (the
+# pre-#1080 ``session_max_reacting`` CTE) re-introduces the #155-class drift
+# the deletion in #1080 foreclosed — keep this an equality JOIN, not a CTE.
 UNREACTED_ROWS_SQL = """
-    WITH session_max_reacting AS (
-        SELECT session_id,
-               MAX(COALESCE((data->>'reacting_to')::bigint, seq)) AS max_reacting
-          FROM events
-         WHERE kind = 'message' AND role = 'assistant'
-           AND session_id = ANY($1::text[])
-         GROUP BY session_id
-    )
     SELECT e.session_id, e.data
       FROM events e
-      LEFT JOIN session_max_reacting smr ON smr.session_id = e.session_id
+      JOIN sessions s ON s.id = e.session_id
      WHERE e.session_id = ANY($1::text[])
        AND e.kind = 'message'
        AND e.role <> 'assistant'
-       AND e.seq > COALESCE(smr.max_reacting, 0)
+       AND e.seq > s.last_reacted_seq
 """
 
 ALL_RESULT_ROWS_SQL = """

--- a/tests/unit/test_unreacted_rows_single_source.py
+++ b/tests/unit/test_unreacted_rows_single_source.py
@@ -1,0 +1,71 @@
+"""Foreclosure test for the single-sourced reaction watermark (#1080).
+
+The reaction watermark — ``MAX(COALESCE(reacting_to, seq))`` over assistant
+messages — must live in exactly **one** writable place: the ``last_reacted_seq``
+``UPDATE`` in ``append_event`` (seeded once by migration 0066's backfill).
+
+Before #1080, ``UNREACTED_ROWS_SQL`` **recomputed** that same watermark via a
+duplicate ``session_max_reacting`` CTE (the literal partial migration left by
+#750). Any change to reaction semantics had to land in three coordinated places
+with nothing forcing the sweep CTE to track — the #155-class drift hazard.
+
+These assertions fail the moment someone reconstitutes the split by authoring a
+fresh watermark formula at the sweep site instead of joining the maintained
+scalar. They run without Postgres: they inspect the query text directly.
+"""
+
+from __future__ import annotations
+
+import re
+
+from aios.harness.sweep import UNREACTED_ROWS_SQL
+
+
+def test_unreacted_rows_does_not_redefine_the_watermark() -> None:
+    """The duplicate ``session_max_reacting`` CTE — and the watermark formula it
+    re-derived — must not exist at the sweep site. Reconstituting the split
+    requires deliberately re-authoring this aggregate, which this catches."""
+    sql = UNREACTED_ROWS_SQL.lower()
+
+    assert "session_max_reacting" not in sql, (
+        "UNREACTED_ROWS_SQL re-introduced the session_max_reacting CTE. The "
+        "reaction watermark must be single-sourced from sessions.last_reacted_seq "
+        "(maintained in append_event), not recomputed here (#1080)."
+    )
+
+    # The watermark formula is MAX(COALESCE(... 'reacting_to' ..., seq)). Catch
+    # any re-derivation of it regardless of whitespace/alias choices.
+    redefines_watermark = re.search(r"max\s*\(\s*coalesce\s*\(.*reacting_to", sql, re.DOTALL)
+    assert redefines_watermark is None, (
+        "UNREACTED_ROWS_SQL recomputes the reaction watermark "
+        "(MAX(COALESCE(reacting_to, seq))). This formula must live in exactly one "
+        "writable place — append_event's last_reacted_seq UPDATE (#1080)."
+    )
+
+
+def test_unreacted_rows_joins_the_maintained_scalar() -> None:
+    """The unreacted-rows gate must consume the maintained scalar directly:
+    JOIN sessions and filter ``e.seq > s.last_reacted_seq``."""
+    sql = UNREACTED_ROWS_SQL.lower()
+
+    assert "join sessions" in sql, (
+        "UNREACTED_ROWS_SQL must JOIN sessions to read the maintained "
+        "last_reacted_seq watermark (#1080)."
+    )
+    assert "last_reacted_seq" in sql, (
+        "UNREACTED_ROWS_SQL must filter on the maintained last_reacted_seq scalar (#1080)."
+    )
+    # The filter compares the candidate event seq against the maintained scalar.
+    assert re.search(r"e\.seq\s*>\s*s\.last_reacted_seq", sql), (
+        "UNREACTED_ROWS_SQL must gate on e.seq > s.last_reacted_seq (#1080)."
+    )
+
+
+def test_unreacted_rows_still_excludes_assistant_messages() -> None:
+    """Behavior preservation: the gate still returns only non-assistant
+    ('user' + 'tool') message rows."""
+    sql = UNREACTED_ROWS_SQL.lower()
+    assert "role <> 'assistant'" in sql or "role != 'assistant'" in sql, (
+        "UNREACTED_ROWS_SQL must still exclude assistant messages."
+    )
+    assert "kind = 'message'" in sql


### PR DESCRIPTION
## What

Delete the duplicate `session_max_reacting` CTE from `UNREACTED_ROWS_SQL` in `harness/sweep.py` and replace it with a JOIN on the maintained `sessions.last_reacted_seq` scalar:

```sql
SELECT e.session_id, e.data FROM events e
JOIN sessions s ON s.id = e.session_id
WHERE e.session_id = ANY($1::text[])
  AND e.kind='message' AND e.role <> 'assistant'
  AND e.seq > s.last_reacted_seq
```

## Why

The reaction watermark — `MAX(COALESCE(reacting_to, seq))` over assistant messages — existed in **two** places that had to agree: `append_event` maintains the scalar `sessions.last_reacted_seq` (forward `GREATEST` accumulation), while `UNREACTED_ROWS_SQL` recomputed the byte-identical formula via the CTE. This was the literal partial migration left by #750 (it moved `CANDIDATE_ROWS_SQL` onto the maintained scalar but left the CTE in the sweep gate). Any change to reaction semantics had to land in three coordinated places with nothing forcing the sweep CTE to track — the #155-class wake-no-progress / skipped-inference drift hazard.

After this, the watermark formula no longer exists at the sweep site; it lives in exactly **one** writable place (`append_event`'s `UPDATE`), seeded once by migration 0066's backfill. Reconstituting the split now requires deliberately re-authoring the aggregate — not an unaware edit that merely compiles.

## Behavior preservation

- The 0066 backfill `react_s` CTE is byte-for-byte identical to `session_max_reacting`.
- The no-`reacting_to` fallback (`last_event_seq+1` = the assistant's own seq) equals the CTE's `COALESCE`-to-`seq`.
- `last_reacted_seq` defaults to `0`, preserving the old `COALESCE(max_reacting, 0)` semantics for sessions with no assistant messages.
- The e2e perf guard `test_unreacted_rows_is_not_n_plus_1` still holds — the rewrite removes a `GROUP BY` aggregate for an equality JOIN (strictly fewer event-log passes).

## Tests

Adds `tests/unit/test_unreacted_rows_single_source.py`, a Postgres-free foreclosure test that fails if the duplicate CTE or the watermark formula is reintroduced at the sweep site, and that asserts the JOIN-on-maintained-scalar shape. Verified red→green and via a mutation check. Full unit suite (2661) passes; mypy and ruff clean. No API surface change (OpenAPI snapshot unchanged, regen produced no diff).

Closes #1080