### PR TITLE
fix(vaults): clear stale expires_at on OAuth refresh when expires_in omitted

### DIFF
--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -314,6 +314,14 @@ async def refresh_credential(
             seconds = 0
         if seconds > 0:
             payload["expires_at"] = (datetime.now(UTC) + timedelta(seconds=seconds)).isoformat()
+        else:
+            # No expires_in in the response: drop any prior expires_at so the
+            # fresh token reads as never-expiring. The prior value is within-skew
+            # by construction (a refresh only fires when is_expiring was True), so
+            # inheriting it would keep is_expiring True and re-trigger a refresh on
+            # every subsequent call — churning a rotated refresh_token and tripping
+            # rate limits. Mirrors _store_oauth_credential's write-even-when-None.
+            payload.pop("expires_at", None)
 
         new_blob = subkey.encrypt_dict(payload)
         await conn.execute(

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -788,6 +788,48 @@ class TestRefreshCredential:
         assert is_expiring(new_payload) is False
 
     @pytest.mark.asyncio
+    async def test_omitted_expires_in_clears_stale_expiry(self, crypto_box: CryptoBox) -> None:
+        """A refresh whose response omits ``expires_in`` must CLEAR the prior
+        ``expires_at``, not inherit it. The prior value is within-skew by
+        construction (a refresh only fires when ``is_expiring`` was True), so
+        retaining it leaves ``is_expiring`` True and forces a fresh refresh on
+        every subsequent call — churning a rotated refresh_token and tripping
+        rate limits into a hard ``OAuthRefreshError``. Mirrors the sibling
+        ``_store_oauth_credential`` guard, which writes ``expires_at`` even when
+        absent for exactly this reason.
+        """
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        payload = _expiring_oauth_payload()  # expires_at = now + 5s, within REFRESH_SKEW
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
+        conn = _conn_with_transaction()
+        # Fresh access_token, NO expires_in (RFC 6749 §5.1 makes it optional).
+        client = _async_client_returning(_http_response(body={"access_token": "fresh"}))
+
+        with (
+            patch.object(
+                queries,
+                "lock_oauth_credential_for_refresh",
+                AsyncMock(return_value=("vc_1", blob)),
+            ),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
+        ):
+            await refresh_credential(
+                crypto_box,
+                conn,
+                vault_id="vlt_1",
+                target_url="https://mcp.example.com",
+                account_id=account_id,
+            )
+
+        args = conn.execute.await_args.args
+        new_blob = EncryptedBlob(ciphertext=args[1], nonce=args[2])
+        new_payload = json.loads(crypto_box.derive_account_subkey(account_id).decrypt(new_blob))
+        assert new_payload["access_token"] == "fresh"
+        # The stale within-skew expires_at must be gone, so the fresh token reads
+        # as never-expiring rather than re-triggering a refresh on the next call.
+        assert is_expiring(new_payload) is False
+
+    @pytest.mark.asyncio
     async def test_persists_new_access_token_and_expires_at(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         payload = _expiring_oauth_payload()


### PR DESCRIPTION
## Summary

An MCP OAuth credential could enter a **re-refresh-on-every-call** loop.

- `refresh_credential` decrypts the stored payload, POSTs the refresh grant, re-encrypts. It only wrote `payload["expires_at"]` when `expires_in` parsed to `seconds > 0` — **no else** to clear the prior value.
- `expires_in` is optional (RFC 6749 §5.1; real providers omit it), and a refresh only fires when `is_expiring(payload)` was already True. So the **retained `expires_at` is within-skew** → `is_expiring(new_payload)` stays True → the next MCP call refreshes again → **every call refreshes**. That churns a per-use-rotated `refresh_token` and degrades to a hard `OAuthRefreshError` under the refresh endpoint's rate limit.

## Fix

Add `else: payload.pop("expires_at", None)` so an omitted (or garbage/zero) `expires_in` clears the stale value, leaving the fresh token never-expiring (`is_expiring` treats a missing `expires_at` as never-expiring). This mirrors the sibling `_store_oauth_credential` (`vault_oauth.py`), which already writes `expires_at` even when `None` for exactly this reason — the two paths had drifted; `refresh_credential` was the only divergent writer.

## Test plan

- [x] Type-checker (mypy) — clean, 603 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — passed via pre-commit hook (incl. new `TestRefreshCredential::test_omitted_expires_in_clears_stale_expiry`, red→green)
- [x] No migration, no Docker, no OpenAPI drift
- [ ] CI runs full suite

### TDD

The new unit test mirrors the existing `test_string_expires_in_is_accepted` but with **no** `expires_in` in the response: it builds an expiring payload (within-skew `expires_at`), refreshes, decrypts the written blob, and asserts `is_expiring(new_payload) is False`. Red pre-fix (`assert True is False` — stale `expires_at` retained), green after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)