### PR TITLE
refactor: collapse 5 copy-pasted open_listen_for_* listeners (#1079)

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -37,10 +37,10 @@ from aios.api.deps import (
     RuntimeAuthDep,
 )
 from aios.api.sse import (
-    SSE_PREFLIGHT_EXCEPTIONS,
     connection_discovery_stream,
     make_sse_response,
     management_calls_stream,
+    preflight_subscription,
     runtime_connector_calls_stream,
 )
 from aios.db import queries
@@ -55,7 +55,6 @@ from aios.errors import (
     ForbiddenError,
     NotFoundError,
     PayloadTooLargeError,
-    SSEPreflightFailedError,
     ValidationError,
 )
 from aios.logging import get_logger
@@ -347,19 +346,13 @@ async def get_connection_discovery(
     loop just doesn't see them.
     """
     _, connector, account_id, auth_connection_ids = auth
-    try:
-        subscription = await open_listen_for_connection_discovery(db_url, connector)
-    except SSE_PREFLIGHT_EXCEPTIONS as exc:
-        log.warning(
-            "sse.connection_discovery.preflight_failed",
-            connector=connector,
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
-        raise SSEPreflightFailedError(
-            "could not establish LISTEN connection for connection-discovery stream",
-            detail={"stream": "connection_discovery"},
-        ) from exc
+    subscription = await preflight_subscription(
+        open_listen_for_connection_discovery(db_url, connector),
+        stream_name="connection_discovery",
+        log_key="sse.connection_discovery.preflight_failed",
+        log_fields={"connector": connector},
+        log=log,
+    )
     return make_sse_response(
         subscription,
         connection_discovery_stream(
@@ -622,19 +615,13 @@ async def get_runtime_calls(
     filter to that set — out-of-scope calls are silently omitted.
     """
     _, connector, account_id, auth_connection_ids = auth
-    try:
-        subscription = await open_listen_for_connector_calls_by_type(db_url, connector)
-    except SSE_PREFLIGHT_EXCEPTIONS as exc:
-        log.warning(
-            "sse.runtime_calls.preflight_failed",
-            connector=connector,
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
-        raise SSEPreflightFailedError(
-            "could not establish LISTEN connection for runtime-calls stream",
-            detail={"stream": "runtime_calls"},
-        ) from exc
+    subscription = await preflight_subscription(
+        open_listen_for_connector_calls_by_type(db_url, connector),
+        stream_name="runtime_calls",
+        log_key="sse.runtime_calls.preflight_failed",
+        log_fields={"connector": connector},
+        log=log,
+    )
     return make_sse_response(
         subscription,
         runtime_connector_calls_stream(
@@ -664,19 +651,13 @@ async def get_runtime_management_calls(
     calls are connector-type-wide, not per-connection.
     """
     _, connector, account_id, _scope = auth
-    try:
-        subscription = await open_listen_for_management_calls(db_url, connector)
-    except SSE_PREFLIGHT_EXCEPTIONS as exc:
-        log.warning(
-            "sse.management_calls.preflight_failed",
-            connector=connector,
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
-        raise SSEPreflightFailedError(
-            "could not establish LISTEN connection for management-calls stream",
-            detail={"stream": "management_calls"},
-        ) from exc
+    subscription = await preflight_subscription(
+        open_listen_for_management_calls(db_url, connector),
+        stream_name="management_calls",
+        log_key="sse.management_calls.preflight_failed",
+        log_fields={"connector": connector},
+        log=log,
+    )
     return make_sse_response(
         subscription,
         management_calls_stream(subscription, pool, connector, account_id=account_id),

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -24,7 +24,7 @@ from aios.api.deps import (
     PoolDep,
     ProcrastinateDep,
 )
-from aios.api.sse import SSE_PREFLIGHT_EXCEPTIONS, make_sse_response, sse_event_stream
+from aios.api.sse import make_sse_response, preflight_subscription, sse_event_stream
 from aios.db import queries
 from aios.db.listen import (
     EVENTS_ARCHIVED_NOTIFY,
@@ -32,7 +32,7 @@ from aios.db.listen import (
     listen_for_events,
     open_listen_for_events,
 )
-from aios.errors import SSEPreflightFailedError, ValidationError
+from aios.errors import ValidationError
 from aios.ids import GITHUB_REPOSITORY, split_id
 from aios.logging import get_logger
 from aios.models.common import ListResponse
@@ -757,19 +757,13 @@ async def stream_events(
     after 200 OK has gone out.
     """
     await service.get_session_basic(pool, session_id, account_id=account_id)
-    try:
-        subscription = await open_listen_for_events(db_url, session_id)
-    except SSE_PREFLIGHT_EXCEPTIONS as exc:
-        log.warning(
-            "sse.session_events.preflight_failed",
-            session_id=session_id,
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
-        raise SSEPreflightFailedError(
-            "could not establish LISTEN connection for session events stream",
-            detail={"stream": "session_events"},
-        ) from exc
+    subscription = await preflight_subscription(
+        open_listen_for_events(db_url, session_id),
+        stream_name="session_events",
+        log_key="sse.session_events.preflight_failed",
+        log_fields={"session_id": session_id},
+        log=log,
+    )
     return make_sse_response(
         subscription,
         sse_event_stream(subscription, pool, session_id, after_seq=after_seq),

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -15,9 +15,8 @@ from fastapi import APIRouter, Query, status
 from sse_starlette import EventSourceResponse
 
 from aios.api.deps import AccountIdDep, DbUrlDep, PoolDep
-from aios.api.sse import SSE_PREFLIGHT_EXCEPTIONS, make_sse_response, wf_run_event_stream
+from aios.api.sse import make_sse_response, preflight_subscription, wf_run_event_stream
 from aios.db.listen import open_listen_for_run_events
-from aios.errors import SSEPreflightFailedError
 from aios.logging import get_logger
 from aios.models.common import ListResponse
 from aios.models.pagination import page_cursor
@@ -295,19 +294,13 @@ async def stream_run_events(
     transient connect failure is a clean 503 rather than a half-open stream.
     """
     await service.get_run(pool, run_id, account_id=account_id)  # 404s cross-tenant
-    try:
-        subscription = await open_listen_for_run_events(db_url, run_id)
-    except SSE_PREFLIGHT_EXCEPTIONS as exc:
-        log.warning(
-            "sse.wf_run_events.preflight_failed",
-            run_id=run_id,
-            error=str(exc),
-            error_type=type(exc).__name__,
-        )
-        raise SSEPreflightFailedError(
-            "could not establish LISTEN connection for run events stream",
-            detail={"stream": "wf_run_events"},
-        ) from exc
+    subscription = await preflight_subscription(
+        open_listen_for_run_events(db_url, run_id),
+        stream_name="wf_run_events",
+        log_key="sse.wf_run_events.preflight_failed",
+        log_fields={"run_id": run_id},
+        log=log,
+    )
     return make_sse_response(
         subscription, wf_run_event_stream(subscription, pool, run_id, after_seq=after_seq)
     )

--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -36,11 +36,14 @@ from sse_starlette import EventSourceResponse, ServerSentEvent
 
 from aios.db import queries
 from aios.db.listen import EVENTS_ARCHIVED_NOTIFY
+from aios.errors import SSEPreflightFailedError
 from aios.logging import get_logger
 from aios.models.workflows import TERMINAL_RUN_STATUSES
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Awaitable
+
+    import structlog
 
     from aios.db.listen import ListenSubscription
 
@@ -62,6 +65,43 @@ SSE_PREFLIGHT_EXCEPTIONS = (asyncpg.PostgresError, OSError)
 # discovery stream is zombied is otherwise invisible until the container
 # restarts (aios#962).
 SSE_PING_SECONDS = 15
+
+
+async def preflight_subscription(
+    open_coro: Awaitable[ListenSubscription],
+    *,
+    stream_name: str,
+    log_key: str,
+    log_fields: dict[str, str],
+    log: structlog.stdlib.BoundLogger,
+) -> ListenSubscription:
+    """Await ``open_coro`` (an ``open_listen_for_*`` call), translating the
+    realistic transient setup failures into a clean 503 (issue #376).
+
+    Single-sources the ``try: sub = await open_*() except
+    SSE_PREFLIGHT_EXCEPTIONS: log.warning(...); raise SSEPreflightFailedError``
+    block that the five SSE route handlers used to repeat verbatim. Each route
+    still names its own ``open_*`` coroutine, ``stream_name``, ``log_key`` and
+    resource ``log_fields`` — only the open-or-503 wiring is shared.
+
+    On success returns the :class:`ListenSubscription`; on
+    :data:`SSE_PREFLIGHT_EXCEPTIONS` logs ``log_key`` with ``log_fields`` and
+    raises :class:`aios.errors.SSEPreflightFailedError` with
+    ``detail={"stream": stream_name}``.
+    """
+    try:
+        return await open_coro
+    except SSE_PREFLIGHT_EXCEPTIONS as exc:
+        log.warning(
+            log_key,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            **log_fields,
+        )
+        raise SSEPreflightFailedError(
+            f"could not establish LISTEN connection for {stream_name} stream",
+            detail={"stream": stream_name},
+        ) from exc
 
 
 def make_sse_response(

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -89,6 +89,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -104,7 +105,8 @@ from aios.db.sse_lock import acquire_subscriber_lock
 from aios.logging import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Awaitable, Callable
+    from contextlib import AbstractAsyncContextManager
 
 log = get_logger("aios.db.listen")
 
@@ -158,29 +160,37 @@ class ListenSubscription:
         self._conn.terminate()
 
 
-async def open_listen_for_events(
+async def _open_drop_oldest_listener(
     db_url: str,
-    session_id: str,
+    channel: str,
     *,
-    queue_max: int = 1000,
-    acquire_lock: bool = True,
+    queue_max: int,
+    log_key: str,
+    log_fields: dict[str, str],
+    on_connected: Callable[[asyncpg.Connection[object]], Awaitable[None]] | None = None,
 ) -> ListenSubscription:
-    """Open a dedicated asyncpg connection, LISTEN events_<session_id>,
-    acquire the SSE subscriber lock, and return a :class:`ListenSubscription`.
+    """Open a dedicated asyncpg connection LISTENing ``channel`` with a
+    bounded **drop-oldest** delivery queue, and return a
+    :class:`ListenSubscription`.
 
-    Two-phase counterpart to :func:`listen_for_events` for callers (SSE
-    route handlers) that need to preflight setup BEFORE constructing the
-    streaming response.
+    This is the single source of the LISTEN-subscription open lifecycle that
+    #502 ("close conn on add_listener failure") and #609 ("reap PG backends on
+    disconnect via ``conn.terminate()``") previously had to shotgun-patch across
+    five byte-identical copies. Every ``open_listen_for_*`` below is a thin
+    call-through that supplies its channel template + log key/fields; a future
+    backpressure/terminate-class fix lands here once.
 
-    ``acquire_lock`` (default ``True``) controls whether the subscriber
-    advisory lock is taken (issue #81): with it held, the worker's
-    :func:`aios.db.sse_lock.has_subscriber` check returns True and the model
-    call takes the streaming path (deltas → ``pg_notify`` → SSE clients).
-    A caller that consumes ONLY the terminal completion state — never the
-    deltas — should pass ``acquire_lock=False`` so it doesn't force the
-    awaited session's worker into the slower streaming path for a consumer
-    that ignores deltas. The ``await``-primitive poller does exactly this,
-    mirroring how :func:`open_listen_for_run_events` omits the lock entirely.
+    On queue overflow the callback drops the OLDEST queued payload to make room
+    for the new one and logs ``log_key`` with ``log_fields`` (+ ``queue_max``).
+    SSE consumers recover from drops by reconnecting with ``?after_seq=``.
+
+    ``on_connected`` is an optional post-``add_listener`` hook run on the
+    dedicated connection. It exists for exactly one caller —
+    :func:`open_listen_for_events`, which passes ``acquire_subscriber_lock`` to
+    take the #81 subscriber advisory lock — and is deliberately a documented,
+    greppable hook rather than a bare ``lock: bool`` flag, so that a session's
+    streaming-vs-non-streaming inference economics can't be silently flipped by
+    toggling a boolean (see :func:`open_listen_for_events`).
 
     Any failure after the initial ``asyncpg.connect`` succeeds will
     ``conn.terminate()`` and re-raise.
@@ -188,7 +198,6 @@ async def open_listen_for_events(
     conn = await _connect_listener(db_url)
     try:
         queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"events_{session_id}"
 
         def _callback(
             _conn: asyncpg.Connection[object],
@@ -201,11 +210,7 @@ async def open_listen_for_events(
             try:
                 queue.put_nowait(payload)
             except asyncio.QueueFull:
-                log.warning(
-                    "listen.queue_full_drop",
-                    session_id=session_id,
-                    queue_max=queue_max,
-                )
+                log.warning(log_key, queue_max=queue_max, **log_fields)
                 # Drop oldest to make room. The SSE consumer can recover by
                 # reconnecting with `?after_seq=`.
                 try:
@@ -215,15 +220,76 @@ async def open_listen_for_events(
                     pass
 
         await conn.add_listener(channel, _callback)
-        if acquire_lock:
-            # Hold a shared advisory lock on this dedicated connection so the
-            # worker can detect that an SSE subscriber exists (issue #81).
-            # pg_locks releases automatically on connection close — no cleanup.
-            await acquire_subscriber_lock(conn, session_id)
+        if on_connected is not None:
+            await on_connected(conn)
     except BaseException:
         conn.terminate()
         raise
     return ListenSubscription(queue=queue, _conn=conn)
+
+
+# Sentinel distinguishing "caller did not pass on_connected, use the default
+# subscriber-lock hook" from "caller explicitly passed None to OMIT the lock".
+# The await-poller passes ``on_connected=None`` to deliberately skip the #81
+# lock (see below + services/sessions.py); a default of ``None`` would make
+# that omission indistinguishable from the unspecified case.
+_ACQUIRE_SUBSCRIBER_LOCK_DEFAULT = object()
+
+
+async def open_listen_for_events(
+    db_url: str,
+    session_id: str,
+    *,
+    queue_max: int = 1000,
+    on_connected: Callable[[asyncpg.Connection[object]], Awaitable[None]]
+    | None
+    | object = _ACQUIRE_SUBSCRIBER_LOCK_DEFAULT,
+) -> ListenSubscription:
+    """Open a dedicated asyncpg connection, LISTEN events_<session_id>,
+    acquire the SSE subscriber lock, and return a :class:`ListenSubscription`.
+
+    Two-phase counterpart to :func:`listen_for_events` for callers (SSE
+    route handlers) that need to preflight setup BEFORE constructing the
+    streaming response.
+
+    By default this acquires the #81 subscriber advisory lock via the explicit
+    ``on_connected=acquire_subscriber_lock`` hook: with the lock held, the
+    worker's :func:`aios.db.sse_lock.has_subscriber` check returns True and the
+    model call takes the streaming path (deltas → ``pg_notify`` → SSE clients).
+
+    A caller that consumes ONLY the terminal completion state — never the
+    deltas — should pass ``on_connected=None`` to OMIT the lock, so it doesn't
+    force the awaited session's worker into the slower streaming path for a
+    consumer that ignores deltas. The ``await``-primitive poller does exactly
+    this, mirroring how :func:`open_listen_for_run_events` omits the lock
+    entirely.
+
+    The lock is a documented, greppable ``on_connected`` call-site — NOT a bare
+    ``lock: bool`` flag — by design (issue #81): a future caller flipping a
+    boolean would silently change a session's streaming-vs-non-streaming
+    inference economics, whereas naming the hook keeps that coupling explicit
+    and at exactly one site.
+
+    Any failure after the initial ``asyncpg.connect`` succeeds will
+    ``conn.terminate()`` and re-raise.
+    """
+    if on_connected is _ACQUIRE_SUBSCRIBER_LOCK_DEFAULT:
+        # Hold a shared advisory lock on this dedicated connection so the
+        # worker can detect that an SSE subscriber exists (issue #81).
+        # pg_locks releases automatically on connection close — no cleanup.
+        hook: Callable[[asyncpg.Connection[object]], Awaitable[None]] | None = functools.partial(
+            acquire_subscriber_lock, session_id=session_id
+        )
+    else:
+        hook = on_connected  # type: ignore[assignment]
+    return await _open_drop_oldest_listener(
+        db_url,
+        f"events_{session_id}",
+        queue_max=queue_max,
+        log_key="listen.queue_full_drop",
+        log_fields={"session_id": session_id},
+        on_connected=hook,
+    )
 
 
 async def open_listen_for_run_events(
@@ -240,36 +306,13 @@ async def open_listen_for_run_events(
     signal (issue #81) with no workflow equivalent (a lost run wake self-heals via
     the needs-step sweep clauses, not via subscriber gating).
     """
-    conn = await _connect_listener(db_url)
-    try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"wf_run_events_{run_id}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            # Sync-only (asyncpg read loop). Same drop-oldest backpressure; the SSE
-            # consumer recovers by reconnecting with `?after_seq=`.
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.wf_run_events_queue_full_drop", run_id=run_id, queue_max=queue_max
-                )
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-    except BaseException:
-        conn.terminate()
-        raise
-    return ListenSubscription(queue=queue, _conn=conn)
+    return await _open_drop_oldest_listener(
+        db_url,
+        f"wf_run_events_{run_id}",
+        queue_max=queue_max,
+        log_key="listen.wf_run_events_queue_full_drop",
+        log_fields={"run_id": run_id},
+    )
 
 
 async def open_listen_for_connector_calls_by_type(
@@ -282,36 +325,13 @@ async def open_listen_for_connector_calls_by_type(
 
     Two-phase counterpart to :func:`listen_for_connector_calls_by_type`.
     """
-    conn = await _connect_listener(db_url)
-    try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"connector_calls_{connector}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.connector_calls_type_queue_full_drop",
-                    connector=connector,
-                    queue_max=queue_max,
-                )
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-    except BaseException:
-        conn.terminate()
-        raise
-    return ListenSubscription(queue=queue, _conn=conn)
+    return await _open_drop_oldest_listener(
+        db_url,
+        f"connector_calls_{connector}",
+        queue_max=queue_max,
+        log_key="listen.connector_calls_type_queue_full_drop",
+        log_fields={"connector": connector},
+    )
 
 
 async def open_listen_for_management_calls(
@@ -321,36 +341,13 @@ async def open_listen_for_management_calls(
     queue_max: int = 1000,
 ) -> ListenSubscription:
     """Open a dedicated asyncpg conn LISTENing ``connector_management_calls_<connector>``."""
-    conn = await _connect_listener(db_url)
-    try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"connector_management_calls_{connector}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.connector_management_calls_queue_full_drop",
-                    connector=connector,
-                    queue_max=queue_max,
-                )
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-    except BaseException:
-        conn.terminate()
-        raise
-    return ListenSubscription(queue=queue, _conn=conn)
+    return await _open_drop_oldest_listener(
+        db_url,
+        f"connector_management_calls_{connector}",
+        queue_max=queue_max,
+        log_key="listen.connector_management_calls_queue_full_drop",
+        log_fields={"connector": connector},
+    )
 
 
 async def open_listen_for_connection_discovery(
@@ -360,36 +357,13 @@ async def open_listen_for_connection_discovery(
     queue_max: int = 1000,
 ) -> ListenSubscription:
     """Open a dedicated asyncpg conn LISTENing ``connections_<connector>``."""
-    conn = await _connect_listener(db_url)
-    try:
-        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=queue_max)
-        channel = f"connections_{connector}"
-
-        def _callback(
-            _conn: asyncpg.Connection[object],
-            _pid: int,
-            _channel: str,
-            payload: str,
-        ) -> None:
-            try:
-                queue.put_nowait(payload)
-            except asyncio.QueueFull:
-                log.warning(
-                    "listen.connection_discovery_queue_full_drop",
-                    connector=connector,
-                    queue_max=queue_max,
-                )
-                try:
-                    queue.get_nowait()
-                    queue.put_nowait(payload)
-                except (asyncio.QueueEmpty, asyncio.QueueFull):
-                    pass
-
-        await conn.add_listener(channel, _callback)
-    except BaseException:
-        conn.terminate()
-        raise
-    return ListenSubscription(queue=queue, _conn=conn)
+    return await _open_drop_oldest_listener(
+        db_url,
+        f"connections_{connector}",
+        queue_max=queue_max,
+        log_key="listen.connection_discovery_queue_full_drop",
+        log_fields={"connector": connector},
+    )
 
 
 @asynccontextmanager
@@ -434,12 +408,28 @@ async def listen_for_connector_result(
 
 
 @asynccontextmanager
-async def listen_for_events(
+async def _listen_subscription(
+    open_coro: Awaitable[ListenSubscription],
+) -> AsyncIterator[asyncio.Queue[str]]:
+    """Generic context-manager wrapper over any ``open_listen_for_*`` coroutine.
+
+    Single-sources the ``sub = await open_*()`` / ``yield sub.queue`` /
+    ``finally: sub.terminate()`` skeleton shared by the named ``listen_for_*``
+    wrappers below, so the terminate-on-exit guarantee lives in one place.
+    """
+    subscription = await open_coro
+    try:
+        yield subscription.queue
+    finally:
+        subscription.terminate()
+
+
+def listen_for_events(
     db_url: str,
     session_id: str,
     *,
     queue_max: int = 1000,
-) -> AsyncIterator[asyncio.Queue[str]]:
+) -> AbstractAsyncContextManager[asyncio.Queue[str]]:
     """Open a dedicated asyncpg connection, LISTEN events_<session_id>,
     yield an asyncio.Queue that receives event ids as they arrive.
 
@@ -462,20 +452,15 @@ async def listen_for_events(
         Bound on the in-memory queue. Defaults to 1000 — generous enough
         that a slow consumer can fall behind by ~1000 events before drops.
     """
-    subscription = await open_listen_for_events(db_url, session_id, queue_max=queue_max)
-    try:
-        yield subscription.queue
-    finally:
-        subscription.terminate()
+    return _listen_subscription(open_listen_for_events(db_url, session_id, queue_max=queue_max))
 
 
-@asynccontextmanager
-async def listen_for_connector_calls_by_type(
+def listen_for_connector_calls_by_type(
     db_url: str,
     connector: str,
     *,
     queue_max: int = 1000,
-) -> AsyncIterator[asyncio.Queue[str]]:
+) -> AbstractAsyncContextManager[asyncio.Queue[str]]:
     """LISTEN ``connector_calls_<connector>``; yield a queue of ``"<session_id>|<connection_id>"`` payloads.
 
     Used by the runtime SSE introduced in #328 PR 5: one runtime
@@ -485,40 +470,32 @@ async def listen_for_connector_calls_by_type(
 
     Thin wrapper over :func:`open_listen_for_connector_calls_by_type`.
     """
-    subscription = await open_listen_for_connector_calls_by_type(
-        db_url, connector, queue_max=queue_max
+    return _listen_subscription(
+        open_listen_for_connector_calls_by_type(db_url, connector, queue_max=queue_max)
     )
-    try:
-        yield subscription.queue
-    finally:
-        subscription.terminate()
 
 
-@asynccontextmanager
-async def listen_for_management_calls(
+def listen_for_management_calls(
     db_url: str,
     connector: str,
     *,
     queue_max: int = 1000,
-) -> AsyncIterator[asyncio.Queue[str]]:
+) -> AbstractAsyncContextManager[asyncio.Queue[str]]:
     """LISTEN ``connector_management_calls_<connector>``; yield a queue of ``call_id`` payloads.
 
     Thin wrapper over :func:`open_listen_for_management_calls`.
     """
-    subscription = await open_listen_for_management_calls(db_url, connector, queue_max=queue_max)
-    try:
-        yield subscription.queue
-    finally:
-        subscription.terminate()
+    return _listen_subscription(
+        open_listen_for_management_calls(db_url, connector, queue_max=queue_max)
+    )
 
 
-@asynccontextmanager
-async def listen_for_connection_discovery(
+def listen_for_connection_discovery(
     db_url: str,
     connector: str,
     *,
     queue_max: int = 1000,
-) -> AsyncIterator[asyncio.Queue[str]]:
+) -> AbstractAsyncContextManager[asyncio.Queue[str]]:
     """LISTEN ``connections_<connector>``; yield a queue of ``"<event>|<connection_id>|<account>"``.
 
     Backs the connection-discovery SSE (#328 PR 5). The emit side lives
@@ -527,13 +504,9 @@ async def listen_for_connection_discovery(
 
     Thin wrapper over :func:`open_listen_for_connection_discovery`.
     """
-    subscription = await open_listen_for_connection_discovery(
-        db_url, connector, queue_max=queue_max
+    return _listen_subscription(
+        open_listen_for_connection_discovery(db_url, connector, queue_max=queue_max)
     )
-    try:
-        yield subscription.queue
-    finally:
-        subscription.terminate()
 
 
 SESSION_INTERRUPT_CHANNEL = "aios_session_interrupt"

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -624,7 +624,7 @@ async def await_session(
     # session's worker into the streaming model path for the entire await
     # window — wasted work for a consumer that ignores deltas. Mirrors how
     # open_listen_for_run_events omits the lock (issue #81).
-    subscription = await open_listen_for_events(db_url, session_id, acquire_lock=False)
+    subscription = await open_listen_for_events(db_url, session_id, on_connected=None)
     try:
         state = await await_completion(
             subscription.queue,

--- a/tests/integration/test_archive_session_notify.py
+++ b/tests/integration/test_archive_session_notify.py
@@ -65,7 +65,7 @@ async def test_archive_fires_notify_on_events_channel(
     after the archive commits."""
     pool, account_id, session_id = pool_and_session
 
-    subscription = await open_listen_for_events(migrated_db_url, session_id, acquire_lock=False)
+    subscription = await open_listen_for_events(migrated_db_url, session_id, on_connected=None)
     try:
         await service.archive_session(pool, session_id, account_id=account_id)
         payload = await asyncio.wait_for(subscription.queue.get(), timeout=5)
@@ -119,7 +119,7 @@ async def test_archive_already_archived_does_not_fire_second_poke(
     pool, account_id, session_id = pool_and_session
     await service.archive_session(pool, session_id, account_id=account_id)
 
-    subscription = await open_listen_for_events(migrated_db_url, session_id, acquire_lock=False)
+    subscription = await open_listen_for_events(migrated_db_url, session_id, on_connected=None)
     try:
         with pytest.raises(NotFoundError):
             await service.archive_session(pool, session_id, account_id=account_id)

--- a/tests/integration/test_await_session.py
+++ b/tests/integration/test_await_session.py
@@ -300,7 +300,7 @@ async def test_await_listen_does_not_acquire_subscriber_lock(
     pool, _account_id, session_id = pool_and_session
 
     # await-poller open: lock skipped → no subscriber observed.
-    sub = await open_listen_for_events(migrated_db_url, session_id, acquire_lock=False)
+    sub = await open_listen_for_events(migrated_db_url, session_id, on_connected=None)
     try:
         assert await has_subscriber(pool, session_id) is False
     finally:

--- a/tests/unit/test_listen_helper.py
+++ b/tests/unit/test_listen_helper.py
@@ -1,0 +1,137 @@
+"""Unit coverage for the single-sourced LISTEN-open lifecycle (issue #1079).
+
+The five ``open_listen_for_*`` drop-oldest listeners and their four thin
+``listen_for_*`` context-manager wrappers were collapsed onto one private
+helper (:func:`aios.db.listen._open_drop_oldest_listener`) plus one generic
+context manager (:func:`aios.db.listen._listen_subscription`). These tests pin
+the single-sourced behavior: the channel template each public open uses, the
+drop-oldest backpressure, and the #81 subscriber-lock ``on_connected`` hook.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.db import listen
+
+
+def _mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.add_listener = AsyncMock()
+    return conn
+
+
+def _captured_callback(conn: MagicMock) -> Any:
+    """Return the ``_callback`` passed to ``conn.add_listener(channel, cb)``."""
+    assert conn.add_listener.await_count == 1
+    return conn.add_listener.await_args.args[1]
+
+
+@pytest.mark.parametrize(
+    ("opener", "args", "expected_channel"),
+    [
+        (listen.open_listen_for_events, ("sess_X",), "events_sess_X"),
+        (listen.open_listen_for_run_events, ("run_X",), "wf_run_events_run_X"),
+        (
+            listen.open_listen_for_connector_calls_by_type,
+            ("telegram",),
+            "connector_calls_telegram",
+        ),
+        (
+            listen.open_listen_for_management_calls,
+            ("telegram",),
+            "connector_management_calls_telegram",
+        ),
+        (
+            listen.open_listen_for_connection_discovery,
+            ("telegram",),
+            "connections_telegram",
+        ),
+    ],
+)
+async def test_open_listeners_listen_on_expected_channel(
+    opener: Any, args: tuple[str, ...], expected_channel: str
+) -> None:
+    """Each public ``open_listen_for_*`` LISTENs on its own channel template."""
+    conn = _mock_conn()
+    with (
+        patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
+        patch("aios.db.listen.acquire_subscriber_lock", AsyncMock()),
+    ):
+        sub = await opener("postgresql://stub/aios", *args)
+    assert conn.add_listener.await_args.args[0] == expected_channel
+    sub.terminate()
+
+
+async def test_drop_oldest_callback_evicts_oldest_on_overflow() -> None:
+    """On QueueFull the callback drops the OLDEST payload and enqueues the new."""
+    conn = _mock_conn()
+    with patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)):
+        sub = await listen.open_listen_for_run_events(
+            "postgresql://stub/aios", "run_X", queue_max=2
+        )
+    cb = _captured_callback(conn)
+
+    cb(conn, 1, "wf_run_events_run_X", "a")
+    cb(conn, 1, "wf_run_events_run_X", "b")
+    # Queue is now full (maxsize=2): the next put drops the oldest ("a").
+    cb(conn, 1, "wf_run_events_run_X", "c")
+
+    drained = [sub.queue.get_nowait() for _ in range(sub.queue.qsize())]
+    assert drained == ["b", "c"]
+
+
+async def test_open_listen_for_events_acquires_subscriber_lock_by_default() -> None:
+    """Default open path takes the #81 subscriber advisory lock on the conn."""
+    conn = _mock_conn()
+    acquire = AsyncMock()
+    with (
+        patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
+        patch("aios.db.listen.acquire_subscriber_lock", acquire),
+    ):
+        sub = await listen.open_listen_for_events("postgresql://stub/aios", "sess_X")
+    acquire.assert_awaited_once_with(conn, session_id="sess_X")
+    sub.terminate()
+
+
+async def test_open_listen_for_events_on_connected_none_omits_lock() -> None:
+    """``on_connected=None`` (the await-poller's choice) skips the lock."""
+    conn = _mock_conn()
+    acquire = AsyncMock()
+    with (
+        patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
+        patch("aios.db.listen.acquire_subscriber_lock", acquire),
+    ):
+        sub = await listen.open_listen_for_events(
+            "postgresql://stub/aios", "sess_X", on_connected=None
+        )
+    acquire.assert_not_awaited()
+    sub.terminate()
+
+
+async def test_open_listen_for_run_events_does_not_acquire_lock() -> None:
+    """Non-events openers never touch the subscriber lock."""
+    conn = _mock_conn()
+    acquire = AsyncMock()
+    with (
+        patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)),
+        patch("aios.db.listen.acquire_subscriber_lock", acquire),
+    ):
+        sub = await listen.open_listen_for_run_events("postgresql://stub/aios", "run_X")
+    acquire.assert_not_awaited()
+    sub.terminate()
+
+
+async def test_listen_subscription_wrapper_terminates_on_exit() -> None:
+    """The generic ``listen_for_*`` wrapper terminates the conn on exit."""
+    conn = _mock_conn()
+    with patch("aios.db.listen.asyncpg.connect", AsyncMock(return_value=conn)):
+        async with listen.listen_for_connection_discovery(
+            "postgresql://stub/aios", "telegram"
+        ) as queue:
+            assert isinstance(queue, asyncio.Queue)
+    conn.terminate.assert_called_once()

--- a/tests/unit/test_preflight_subscription.py
+++ b/tests/unit/test_preflight_subscription.py
@@ -1,0 +1,77 @@
+"""Unit coverage for the single-sourced SSE preflight-or-503 helper (#1079).
+
+The five SSE route handlers shared a verbatim ``try: sub = await open_*()
+except SSE_PREFLIGHT_EXCEPTIONS: log.warning(...); raise
+SSEPreflightFailedError`` block. It was extracted to
+:func:`aios.api.sse.preflight_subscription`; these tests pin both the
+success pass-through and the 503-with-diagnostic failure path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import asyncpg
+import pytest
+
+from aios.api.sse import preflight_subscription
+from aios.errors import SSEPreflightFailedError
+
+
+async def test_preflight_returns_subscription_on_success() -> None:
+    sentinel = MagicMock(name="subscription")
+
+    async def _open() -> MagicMock:
+        return sentinel
+
+    log = MagicMock()
+    sub = await preflight_subscription(
+        _open(),
+        stream_name="runtime_calls",
+        log_key="sse.runtime_calls.preflight_failed",
+        log_fields={"connector": "telegram"},
+        log=log,
+    )
+    assert sub is sentinel
+    log.warning.assert_not_called()
+
+
+async def test_preflight_raises_503_and_logs_on_transient_failure() -> None:
+    async def _open() -> MagicMock:
+        raise asyncpg.CannotConnectNowError("startup blip")
+
+    log = MagicMock()
+    with pytest.raises(SSEPreflightFailedError) as excinfo:
+        await preflight_subscription(
+            _open(),
+            stream_name="runtime_calls",
+            log_key="sse.runtime_calls.preflight_failed",
+            log_fields={"connector": "telegram"},
+            log=log,
+        )
+
+    assert excinfo.value.detail == {"stream": "runtime_calls"}
+    log.warning.assert_called_once()
+    call = log.warning.call_args
+    assert call.args == ("sse.runtime_calls.preflight_failed",)
+    assert call.kwargs["connector"] == "telegram"
+    assert call.kwargs["error"] == "startup blip"
+    assert call.kwargs["error_type"] == "CannotConnectNowError"
+
+
+async def test_preflight_does_not_swallow_unexpected_errors() -> None:
+    """Non-preflight exceptions bubble as-is (not converted to 503)."""
+
+    async def _open() -> MagicMock:
+        raise ValueError("programmer error")
+
+    log = MagicMock()
+    with pytest.raises(ValueError, match="programmer error"):
+        await preflight_subscription(
+            _open(),
+            stream_name="runtime_calls",
+            log_key="sse.runtime_calls.preflight_failed",
+            log_fields={"connector": "telegram"},
+            log=log,
+        )
+    log.warning.assert_not_called()


### PR DESCRIPTION
## What

Collapses the five byte-identical `open_listen_for_*` drop-oldest listeners in `db/listen.py` onto one private helper, single-sourcing the LISTEN-subscription open lifecycle that #502 ("close conn on add_listener failure") and #609 ("reap PG backends via `conn.terminate()`") had to shotgun-patch across all five copies.

## Changes

- **`_open_drop_oldest_listener`** owns the connect → bounded-queue → drop-oldest callback → `add_listener` → terminate-on-failure skeleton. The five public `open_listen_for_*` functions become thin call-throughs that supply only their channel template + log key/fields.
- **`_listen_subscription`** is a single generic `@asynccontextmanager`; the four thin `listen_for_*` wrappers collapse onto it (their names stay public/greppable).
- **The #81 subscriber advisory lock is preserved as an explicit, greppable `on_connected=acquire_subscriber_lock` hook** on `open_listen_for_events` — *not* reduced to a bare `lock: bool` flag, so a future caller can't silently flip a session's streaming-vs-non-streaming inference economics. The await-poller's deliberate lock-omission becomes the named choice `on_connected=None` (replacing the old `acquire_lock=False`).
- **`preflight_subscription`** in `api/sse.py` extracts the verbatim `try: await open_*() except SSE_PREFLIGHT_EXCEPTIONS: log.warning(...); raise SSEPreflightFailedError` block; the 5 SSE route handlers (sessions, workflows, 3× connectors) repoint to it, each still naming its own open coroutine / stream name / log fields.

## Out of scope (per the issue's fence pass)

The `sse.py` generators, `listen_for_connector_result` (drop-newest), the `listen_for_session_interrupts`/`listen_for_mcp_evict_vault` pair (only 2 copies), and `listen_for_triggers_due` are deliberately untouched.

## Safety

Pure internal restructure — no schema, wire, NOTIFY-channel, or API-surface change (openapi.json regenerated clean, no drift). Existing `test_listen.py` / `test_sse_preflight.py` plus new `test_listen_helper.py` and `test_preflight_subscription.py` pin the behavior. Mypy + ruff + full unit suite (2671 passed) green; a mutation check confirmed the new drop-oldest test fails when the eviction is broken.

Closes #1079