### PR TITLE
fix(sandbox): skip same-tick-evicted snapshots in GC pointer reconcile

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -1437,12 +1437,18 @@ class SandboxRegistry:
 
         # Pass 3b — per-account snapshot cap (quota tiers / plan limits, §5.7).
         # Skip artifacts the pool-budget pass already evicted this tick.
-        await self._gc_account_cap_pass(
+        cap_evicted = await self._gc_account_cap_pass(
             retained, image_states, instance_id, already_evicted=pool_evicted
         )
 
-        # Pass 4 — pointer reconciliation against local store truth.
-        await self._gc_reconcile_pointers(retained, image_states, instance_id)
+        # Pass 4 — pointer reconciliation against local store truth. Skip every
+        # snapshot evicted this tick (passes 3 + 3b): its image is gone, but the
+        # tick-start state still shows the pre-eviction pointer, so reconciling
+        # would resurrect a pointer to a now-removed image (a dangling pointer →
+        # unresumable session).
+        await self._gc_reconcile_pointers(
+            retained, image_states, instance_id, already_evicted=pool_evicted | cap_evicted
+        )
 
         log.info(
             "sandbox.gc_tick",
@@ -1622,7 +1628,7 @@ class SandboxRegistry:
         instance_id: str,
         *,
         already_evicted: set[str] | None = None,
-    ) -> None:
+    ) -> set[str]:
         """Enforce per-account snapshot caps (``config.sandbox_snapshot_bytes``, §5.7).
 
         Mirrors the per-host pool-budget pass, but partitioned by account: each
@@ -1630,6 +1636,10 @@ class SandboxRegistry:
         model-visible ``sandbox_fs_expired {account_cap}`` event) until the
         account is back under cap. An account with no configured cap (none up its
         parent chain) is never enforced; under-cap accounts are untouched.
+
+        Returns the session_ids it evicted, so the pointer-reconcile pass can
+        skip them — their image is gone this tick but the tick-start state still
+        shows the pre-eviction pointer.
         """
         from aios.harness import runtime
 
@@ -1650,12 +1660,13 @@ class SandboxRegistry:
             totals[st.account_id] = totals.get(st.account_id, 0) + ub
 
         pool = runtime.require_pool()
+        evicted: set[str] = set()
         for account_id, sized in by_account.items():
             async with pool.acquire() as conn:
                 cap = await queries.resolve_effective_sandbox_snapshot_bytes(conn, account_id)
             if cap is None or totals[account_id] <= cap:
                 continue
-            await self._evict_most_dormant(
+            evicted |= await self._evict_most_dormant(
                 sized,
                 states,
                 instance_id,
@@ -1663,6 +1674,7 @@ class SandboxRegistry:
                 budget=cap,
                 reason="account_cap",
             )
+        return evicted
 
     async def _evict_most_dormant(
         self,
@@ -1711,6 +1723,8 @@ class SandboxRegistry:
         retained: list[GcImageVerdict],
         states: dict[str, SessionSnapshotState],
         instance_id: str,
+        *,
+        already_evicted: set[str] | None = None,
     ) -> None:
         """Heal a NULL/stale pointer for a retained canonical tag (§5.5 pass 4).
 
@@ -1718,7 +1732,13 @@ class SandboxRegistry:
         sessions whose ``snapshot_host`` is this host (or NULL, for the crash
         heal). Multi-host compare-and-swap is deferred — the ``snapshot_host``
         column is the seam that makes it additive.
+
+        ``already_evicted`` names sessions whose canonical image passes 3/3b
+        removed this tick. They are still in ``retained`` (the eviction passes
+        don't mutate it) with a tick-start NULL/stale pointer, so without this
+        skip the heal would write a pointer to an image that no longer exists.
         """
+        skip = already_evicted or set()
         base_sizes: dict[str, int] = {}  # shared across the pass (sessions share a base)
         for v in retained:
             if not v.is_canonical:
@@ -1726,6 +1746,8 @@ class SandboxRegistry:
             sid = v.session_id
             if sid is None:
                 continue
+            if sid in skip:
+                continue  # evicted this tick — its image is gone; never resurrect the pointer
             st = states.get(sid)
             if st is None:
                 continue

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -353,3 +353,52 @@ async def test_account_cap_pass_skips_waking_session(
     # The waking session is skipped; the next-most-dormant is evicted instead.
     assert old.removal_ref not in removed
     assert removed == [new.removal_ref]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_snapshot_evicted_this_tick(
+    fake_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pass 4 must not re-point a session whose canonical image an earlier pass
+    removed this tick.
+
+    The eviction passes leave the verdict in ``retained`` and don't mutate the
+    tick-start ``states``, so an evicted session still presents its pre-eviction
+    pointer (here NULL — the first-commit-crash-heal window: a committed tag
+    whose pointer write was lost). Without the ``already_evicted`` skip, pass 4
+    heals that NULL pointer by writing a pointer to the image pass 3 just
+    removed — a dangling pointer that makes the session unresumable.
+    """
+    instance_id = get_settings().instance_id
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    _stub_event_and_pointer(registry)  # stub eviction's event + pointer-clear side effects
+    verdict = _canonical_verdict("sess_x", size_bytes=2_000_000)
+    states = {
+        "sess_x": SessionSnapshotState(
+            session_id="sess_x",
+            account_id="acct",
+            archived=False,
+            last_event_at=_NOW - timedelta(days=1),
+            snapshot_ref=None,  # live canonical image on disk, but NULL DB pointer
+            snapshot_host=instance_id,
+            snapshot_bytes=None,
+        )
+    }
+    set_pointer = AsyncMock()
+    monkeypatch.setattr("aios.sandbox.registry.queries.unscoped_set_session_snapshot", set_pointer)
+
+    # Baseline: with nothing evicted, pass 4 legitimately heals the NULL pointer.
+    # This proves the resurrection path is live, so the skip below is not vacuous.
+    await registry._gc_reconcile_pointers([verdict], states, instance_id, already_evicted=set())
+    set_pointer.assert_awaited_once()
+    set_pointer.reset_mock()
+
+    # Pass 3 evicts sess_x under disk pressure (2 MB snapshot vs 1 MB pool budget).
+    evicted = await registry._gc_pool_budget_pass([verdict], states, 1_000_000, instance_id)
+    assert evicted == {"sess_x"}
+    assert verdict.removal_ref in backend.removed_image_refs
+
+    # Pass 4, told what was evicted this tick, must NOT re-point the removed image.
+    await registry._gc_reconcile_pointers([verdict], states, instance_id, already_evicted=evicted)
+    set_pointer.assert_not_awaited()


### PR DESCRIPTION
## Summary

A GC tick could leave a session **unresumable** by writing a snapshot pointer to an image it had just deleted.

- `_gc_once` runs pass 3 (pool budget), 3b (account cap), 4 (pointer reconcile) over a shared `retained` list + a tick-start `states` snapshot.
- The eviction passes (3/3b, via `_evict_most_dormant`) `remove_image` + clear the DB pointer, but **don't mutate `states`/`retained`**. So pass 4 reconciles against the stale tick-start state: a session in the **first-commit-crash-heal window** (committed canonical tag, but a NULL `snapshot_ref` because the pointer write was lost to a transient DB error) gets *re-pointed* at the image passes 3/3b just removed → a **dangling pointer to a non-existent image** → the session can never resume.

## Fix

Mirror the existing pass-3→3b `already_evicted` plumbing:
- `_gc_account_cap_pass` now **returns its evicted `set[str]`** (accumulated across accounts).
- `_gc_once` threads `pool_evicted | cap_evicted` into `_gc_reconcile_pointers(already_evicted=...)`, which `continue`s past those sids.

The two sets are **disjoint by construction** (cap_pass already skips pool-evicted sids), and they are the *truthful record of what eviction actually removed* — eviction is a runtime outcome, so a waking session or a refused `remove_image` is correctly **absent** from the set, preserving its legitimate heal. (An explicit set is the right altitude here: mutating the shared `states` mid-pass would corrupt the eviction loop's own iteration and pass 3b's byte-summing.)

## Test plan

- [x] Type-checker (mypy) — clean, 603 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — passed via pre-commit hook (incl. new `test_reconcile_skips_snapshot_evicted_this_tick`)
- [x] No migration, no Docker, no OpenAPI drift
- [ ] CI runs full suite

### TDD (behavioral red→green)

The test establishes a **live heal baseline** (`already_evicted=set()` → `set_pointer` awaited once — proving the resurrection path is real and the skip is non-vacuous), then drives the **real** `_gc_pool_budget_pass` to evict `sess_x` (asserts the image was removed), then calls reconcile with the evicted set and asserts `set_pointer` **not** awaited. Verified behaviorally red: deleting just the `if sid in skip: continue` line makes the final assertion fail with "Awaited 1 times" (the dangling-pointer write), while the baseline still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)