### PR TITLE
fix(mcp): re-read discard_on_release under the lock in pool release()

### DIFF
--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -224,6 +224,18 @@ class McpSessionPool:
         if not in_use:
             del self._in_use[key]
 
+    def _schedule_background_close(self, entry: _Entry, url: str) -> None:
+        """Fire-and-forget ``entry.close()`` tracked in ``_close_tasks``.
+
+        asyncio only weak-refs tasks, so the strong ref keeps the close from
+        being GC'd before it unwinds the owner task's contexts (the leak the
+        idle reaper exists to prevent). Shared by :meth:`discard` and the
+        discard path of :meth:`release`.
+        """
+        task = asyncio.create_task(entry.close(), name=f"mcp-pool-discard:{url}")
+        self._close_tasks.add(task)
+        task.add_done_callback(self._close_tasks.discard)
+
     async def _open_entry(self, url: str, headers: dict[str, str]) -> _Entry:
         """Open a fresh session inside a dedicated long-lived owner task.
 
@@ -328,22 +340,30 @@ class McpSessionPool:
         ``last_used`` (the reaper's staleness signal) and notifies one waiter
         that a slot is free.
 
-        Exception: if :meth:`evict_by_vault` flagged this entry mid-checkout
-        (an operator rotated the vault credential), the entry's live session
-        still carries the OLD bearer, so it is DISCARDED here instead of being
-        returned to idle — the next acquire then opens a fresh session on the
-        rotated secret (#1030).
+        Exception: if :meth:`evict_by_vault` flagged this entry (an operator
+        rotated the vault credential), the entry's live session still carries
+        the OLD bearer, so it is DISCARDED here instead of being returned to
+        idle — the next acquire then opens a fresh session on the rotated
+        secret (#1030). The flag is read UNDER the key Condition because
+        ``evict_by_vault`` sets it while holding that same lock; an unlocked
+        check could pass and then race a concurrent eviction into the gap
+        before the lock, returning the stale-token session to idle for reuse.
         """
-        if entry.discard_on_release:
-            await self.discard(url, vault_id, headers_key, entry)
-            return
         entry.last_used = time.monotonic()
         key: _PoolKey = (url, vault_id, headers_key)
         cond = self._condition_for(key)
         async with cond:
             self._drop_in_use(key, entry)
-            self._idle.setdefault(key, []).append(entry)
+            # Re-read under the lock: serialize evict_by_vault's flag-set with
+            # this idle-vs-discard decision so a flag flipped while release()
+            # waited on the lock is observed (closes the #1030 reuse race).
+            discard = entry.discard_on_release
+            if not discard:
+                self._idle.setdefault(key, []).append(entry)
             cond.notify()
+        if discard:
+            self._schedule_background_close(entry, url)
+            log.info("mcp_pool.discarded", url=url)
 
     async def discard(
         self, url: str, vault_id: str | None, headers_key: str, entry: _Entry
@@ -362,9 +382,7 @@ class McpSessionPool:
         async with cond:
             self._drop_in_use(key, entry)
             cond.notify()
-        task = asyncio.create_task(entry.close(), name=f"mcp-pool-discard:{url}")
-        self._close_tasks.add(task)
-        task.add_done_callback(self._close_tasks.discard)
+        self._schedule_background_close(entry, url)
         log.info("mcp_pool.discarded", url=url)
 
     async def evict_by_vault(self, vault_id: str) -> None:

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -227,6 +227,43 @@ class TestMcpSessionPool:
         assert e2 is e1
         session.initialize.assert_awaited_once()
 
+    async def test_release_rereads_discard_flag_set_while_it_waited_on_lock(self) -> None:
+        """evict_by_vault flips ``discard_on_release`` while holding the key
+        Condition. If release() reads that flag BEFORE acquiring the same lock,
+        a concurrent eviction lands in the gap and the stale-token session is
+        returned to idle for reuse — the #1030 rotated-credential gap reopened
+        under a race. release() must re-read the flag UNDER the lock.
+        """
+        session = _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            pool = McpSessionPool()
+            key = (URL, "vault_a", EMPTY_KEY)
+            e1 = await pool.acquire(URL, "vault_a", EMPTY_KEY, {"Authorization": "Bearer old"})
+
+            # Hold the key Condition so release() blocks at `async with cond`,
+            # then flag the entry (as evict_by_vault does under this same lock)
+            # before letting release() proceed — the exact TOCTOU window.
+            cond = pool._condition_for(key)
+            await cond.acquire()
+            rel = asyncio.create_task(pool.release(URL, "vault_a", EMPTY_KEY, e1))
+            await asyncio.sleep(0)  # release() runs up to `async with cond` and parks
+            e1.discard_on_release = True
+            cond.release()
+            await rel
+            # Let the fire-and-forget close task run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            assert e1._owner_task.done(), (
+                "a flag set while release() waited on the lock must still discard the entry"
+            )
+            assert key not in pool._idle, (
+                "the stale-token session must not be returned to idle for reuse"
+            )
+
     async def test_concurrent_acquires_open_distinct_sessions_up_to_cap(self) -> None:
         """N concurrent checkouts of a cold key open N distinct sessions (no
         shared state) — replaces the old shared-session 'single initialize'


### PR DESCRIPTION
## Summary

Closes a race that could keep serving a **revoked/rotated MCP credential**.

- `release()` read `entry.discard_on_release` **outside** the key `asyncio.Condition`, but `evict_by_vault` (the #1030 credential-rotation eviction signal) **sets** that flag while holding the same Condition.
- When a rotation runs concurrently with an in-flight call's `release()` — the window opened by a sibling `acquire()` holding the cond across `await self._open_entry` — the flag-set lands in the gap *after* `release()`'s unlocked check. `release()` then returns the OLD-bearer `ClientSession` to the idle pool, and the next `acquire()` reuses the revoked credential until the 900s idle TTL. The #1030 gap, reopened under a race.

## Fix

- `release()` now reads `discard_on_release` **under the cond** (after `_drop_in_use`), appending to idle only when not flagged and scheduling the background close *outside* the lock when flagged — serializing the flag-set and the idle-vs-discard decision on one lock.
- Factored the fire-and-forget close (`create_task` + `_close_tasks` tracking) into `_schedule_background_close`, shared by `release()` and `discard()`.

Verified: flag-set and flag-read are now serialized on the same Condition; the close is scheduled off the lock (no deadlock); `discard()` is behaviorally identical; `notify()` fires in both branches. The single under-lock path also removes the old fast-path's redundant double-acquire (it called `discard()`, which re-acquired the cond).

## Test plan

- [x] Type-checker (mypy) — clean, 608 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — passed via pre-commit hook (incl. new `test_release_rereads_discard_flag_set_while_it_waited_on_lock`)
- [x] No migration, no Docker, no OpenAPI drift
- [ ] CI runs full suite

### TDD (behavioral red→green)

The test holds the key Condition (modelling `evict_by_vault` owning the lock), starts `release()` (which parks at `async with cond`), sets `discard_on_release=True`, releases the cond, and asserts the entry is **closed** and **absent from `_idle`**. Red without the fix (`release()` read the flag before the lock → owner task still alive, entry in `_idle`); green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)