### PR TITLE
fix(tools): derive web_fetch title from markdown (no phantom /extract fields)

### DIFF
--- a/src/aios/tools/web_fetch.py
+++ b/src/aios/tools/web_fetch.py
@@ -4,11 +4,15 @@ Uses Tavily's /extract endpoint for HTML-to-markdown conversion.
 SSRF protection blocks private/internal URLs.
 
 Return shape: {"url": "...", "title": "...", "content": "markdown..."}
+The ``title`` is derived from the markdown's first heading: Tavily's /extract
+response carries only ``url`` + ``raw_content`` (no title field — that belongs
+to /search), so reading a ``title`` key returned ``""`` on every real call.
 On error: {"error": "..."}
 """
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import httpx
@@ -27,6 +31,17 @@ class WebFetchArgumentError(AiosError):
 
 
 _MAX_CONTENT_CHARS = 100_000
+
+# First markdown ATX heading (``# `` … ``###### ``) — Tavily's /extract gives no
+# title, so we derive one from the converted markdown's first heading.
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _title_from_markdown(content: str) -> str:
+    """Best-effort page title: the text of the markdown's first heading, or ``""``."""
+    match = _HEADING_RE.search(content)
+    return match.group(1) if match else ""
+
 
 WEB_FETCH_DESCRIPTION = (
     "Fetch a URL and return its content as markdown. Uses Tavily's "
@@ -56,9 +71,11 @@ async def web_fetch_handler(session_id: str, arguments: dict[str, Any]) -> dict[
     try:
         response = await tavily_request("extract", {"urls": [url]})
         result = response["results"][0]
-        content = result.get("raw_content", "") or result.get("content", "")
-        content = content[:_MAX_CONTENT_CHARS]
-        return {"url": url, "title": result.get("title", ""), "content": content}
+        # /extract returns only ``raw_content`` (markdown); there is no ``title``
+        # or ``content`` field to read (those are /search fields), so derive the
+        # title from the markdown's first heading.
+        content = (result.get("raw_content") or "")[:_MAX_CONTENT_CHARS]
+        return {"url": url, "title": _title_from_markdown(content), "content": content}
     except WebToolError:
         raise
     except httpx.HTTPStatusError as exc:

--- a/tests/unit/test_web_fetch_handler.py
+++ b/tests/unit/test_web_fetch_handler.py
@@ -27,24 +27,37 @@ def mock_safe_url() -> Any:
 
 
 class TestWebFetchHandler:
-    async def test_valid_url_returns_content(
+    async def test_valid_url_derives_title_from_first_heading(
         self, mock_tavily: AsyncMock, mock_safe_url: Any
     ) -> None:
+        """Tavily's /extract returns only url + raw_content (no title field —
+        that belongs to /search), so the title is derived from the markdown's
+        first heading. The mock uses the REAL /extract shape (no title key)."""
         mock_tavily.return_value = {
             "results": [
                 {
                     "url": "https://example.com",
-                    "title": "Example",
                     "raw_content": "# Hello World\n\nSome content.",
-                    "content": "fallback",
                 }
             ]
         }
         result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
         assert result["url"] == "https://example.com"
-        assert result["title"] == "Example"
+        assert result["title"] == "Hello World"
         assert result["content"] == "# Hello World\n\nSome content."
         mock_tavily.assert_awaited_once()
+
+    async def test_no_heading_yields_empty_title(
+        self, mock_tavily: AsyncMock, mock_safe_url: Any
+    ) -> None:
+        """Best-effort: content with no markdown heading yields an empty title
+        rather than crashing or fabricating one."""
+        mock_tavily.return_value = {
+            "results": [{"url": "https://example.com", "raw_content": "plain body, no heading"}]
+        }
+        result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
+        assert result["title"] == ""
+        assert result["content"] == "plain body, no heading"
 
     async def test_ssrf_blocked_url_returns_error(
         self, mock_tavily: AsyncMock, mock_safe_url: Any
@@ -84,18 +97,13 @@ class TestWebFetchHandler:
         result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
         assert len(result["content"]) == 100_000
 
-    async def test_falls_back_to_content_field(
+    async def test_empty_raw_content_yields_empty_content(
         self, mock_tavily: AsyncMock, mock_safe_url: Any
     ) -> None:
-        mock_tavily.return_value = {
-            "results": [
-                {
-                    "url": "https://example.com",
-                    "title": "Fallback",
-                    "raw_content": "",
-                    "content": "fallback content",
-                }
-            ]
-        }
+        """/extract carries only raw_content (no 'content' field — that's a
+        /search field). An empty/absent raw_content yields empty content and an
+        empty title, with no crash; there is no phantom 'content' to fall back to."""
+        mock_tavily.return_value = {"results": [{"url": "https://example.com", "raw_content": ""}]}
         result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
-        assert result["content"] == "fallback content"
+        assert result["content"] == ""
+        assert result["title"] == ""


### PR DESCRIPTION
## Summary

- `web_fetch` read fields Tavily's `/extract` endpoint **never returns**: `result.get("title", "")` always fell through to `""` (`title` is a `/search` field, not `/extract`), and the `or result.get("content", "")` fallback was **dead** (no `content` field either — `raw_content` is the only populated source). Every fetch returned an empty title, losing the model's page disambiguator.
- **Fix:** read only `raw_content`, and derive the title from the markdown's first ATX heading via a small `_title_from_markdown` helper.
- **Corrected the two masking tests** that fed a fictional `/extract` shape (injected `title`/`content` keys the real API never sends) — they were hiding the bug.

No real contract regression: the old `title` was always `""`, and the dropped `content` fallback never fired against the real API.

## Test plan

- [x] Type-checker (mypy) — clean, 608 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — passed via pre-commit hook
- [x] No migration, no Docker, no OpenAPI drift
- [ ] CI runs full suite

### TDD (red→green)

`test_valid_url_derives_title_from_first_heading` uses the **real** `/extract` shape (`raw_content` only, no `title` key) and asserts `title == "Hello World"` (derived from `# Hello World`). Red on current code (`'' == 'Hello World'` — phantom `title` field). Companion tests pin the no-heading (`title == ""`) and empty-`raw_content` (no crash, no phantom `content` fallback) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)