### PR TITLE
fix(tools): default web_search result fields instead of KeyError-then-evict

### DIFF
--- a/src/aios/tools/web_search.py
+++ b/src/aios/tools/web_search.py
@@ -62,10 +62,14 @@ async def web_search_handler(session_id: str, arguments: dict[str, Any]) -> dict
             "search",
             {"query": query, "max_results": min(limit, _MAX_LIMIT), "include_images": False},
         )
+        # Tavily /search guarantees no per-entry fields, so default each one
+        # (like web_fetch). A bracket read would raise KeyError that escapes
+        # this except and — via _classify_tool_error — evicts the session's
+        # sandbox while the model sees a cryptic Python error, not a tool error.
         normalized = [
             {
-                "title": r["title"],
-                "url": r["url"],
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
                 "description": r.get("content", ""),
             }
             for r in response["results"]
@@ -77,6 +81,10 @@ async def web_search_handler(session_id: str, arguments: dict[str, Any]) -> dict
         return {"error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"}
     except httpx.TimeoutException:
         return {"error": "Search request timed out"}
+    except (KeyError, IndexError):
+        # A 200 response missing the 'results' key — surface a legible tool
+        # error instead of letting the KeyError escape and evict the sandbox.
+        return {"error": "No results returned for query"}
 
 
 def _register() -> None:

--- a/tests/unit/test_web_search_handler.py
+++ b/tests/unit/test_web_search_handler.py
@@ -65,3 +65,25 @@ class TestWebSearchHandler:
         mock_tavily.side_effect = WebToolError("TAVILY_API_KEY not set")
         with pytest.raises(WebToolError):
             await web_search_handler("sess_01TEST", {"query": "test"})
+
+    async def test_partial_result_missing_title_url_defaults(self, mock_tavily: AsyncMock) -> None:
+        """Tavily /search guarantees no per-entry fields. A result lacking
+        'title'/'url' must default to '' (like web_fetch's defensive .get), not
+        raise a KeyError that escapes the handler's except and — via
+        _classify_tool_error — needlessly evicts the session's sandbox while the
+        model sees a cryptic 'KeyError: title' instead of a legible result."""
+        mock_tavily.return_value = {"results": [{"content": "desc only, no title or url"}]}
+        result = await web_search_handler("sess_01TEST", {"query": "x"})
+        assert result["results"][0]["title"] == ""
+        assert result["results"][0]["url"] == ""
+        assert result["results"][0]["description"] == "desc only, no title or url"
+
+    async def test_malformed_response_without_results_returns_error(
+        self, mock_tavily: AsyncMock
+    ) -> None:
+        """A 200 response missing the 'results' key surfaces as a legible tool
+        error (mirroring web_fetch), not a KeyError that escapes and evicts the
+        sandbox."""
+        mock_tavily.return_value = {}
+        result = await web_search_handler("sess_01TEST", {"query": "x"})
+        assert "error" in result


### PR DESCRIPTION
## Summary

- `web_search` normalized Tavily `/search` results with bracket access `r["title"]`/`r["url"]` (only `description` used `.get`). Tavily guarantees no per-entry fields, so a partial result raised `KeyError`.
- That `KeyError` escaped the handler's `except` (which caught only `WebToolError`/httpx errors). A bare `KeyError` is neither `AiosError` nor `ToolBail`, so `_classify_tool_error` treats it as `evict=True`: the session's **sandbox is needlessly evicted** and the model sees a cryptic `KeyError: 'title'` instead of a tool error (violating the fail-hard-but-legible stance). Also hit the workflow `run_tools` path as a raw exception.
- **Fix (mirrors `web_fetch`):** default each field via `.get`, and add `except (KeyError, IndexError)` so a malformed response (missing the `results` key) surfaces as a legible tool error rather than escaping.

## Test plan

- [x] Type-checker (mypy) — clean, 608 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — passed via pre-commit hook
- [x] No migration, no Docker, no OpenAPI drift
- [ ] CI runs full suite

### TDD (red→green)

`test_partial_result_missing_title_url_defaults` feeds a result with only `content` (no `title`/`url`) and asserts both default to `""`. Red on current code (`KeyError: 'title'` raised before the assertion). `test_malformed_response_without_results_returns_error` feeds `{}` and asserts an `error` dict (was an escaping `KeyError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)