### PR TITLE
fix(loop): charge spend after the assistant persists, not before

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -607,25 +607,24 @@ async def _run_session_step_body(
         account_id=account_id,
     )
 
-    # Increment cumulative session-level token counters. A refusal still
-    # consumed tokens upstream, so this (and the model_request_end span above)
-    # runs unconditionally — only the *persist + dispatch* below is suppressed.
-    new_spent_microusd = await sessions_service.increment_usage(
-        pool,
-        session_id,
-        input_tokens=usage.get("input_tokens", 0),
-        output_tokens=usage.get("output_tokens", 0),
-        cache_read_input_tokens=usage.get("cache_read_input_tokens", 0),
-        cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
-        cost_microusd=cost_microusd,
-        account_id=account_id,
-    )
-    if _crossed_spend_warning_threshold(new_spent_microusd, cost_microusd, spend_limit_microusd):
-        log.warning(
-            "account.spend_limit_warning",
+    # Charge cumulative session-level usage AFTER the model response is durably
+    # recorded — the assistant message persisted below, or the refusal span in
+    # the branch. increment_usage commits in its own transaction, so charging
+    # BEFORE the persist double-bills whenever the persist raises (a DB error
+    # caught upstream → a retry that re-calls the model). Charging after fails
+    # safe: a crash in the gap loses the charge rather than duplicating it. A
+    # refusal still consumed tokens, so it charges too — after _handle_refusal
+    # records its span and latches errored.
+    async def _charge_usage() -> int:
+        return await sessions_service.increment_usage(
+            pool,
+            session_id,
+            input_tokens=usage.get("input_tokens", 0),
+            output_tokens=usage.get("output_tokens", 0),
+            cache_read_input_tokens=usage.get("cache_read_input_tokens", 0),
+            cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
+            cost_microusd=cost_microusd,
             account_id=account_id,
-            spent_usd=new_spent_microusd / 1_000_000,
-            spend_limit_usd=spend_limit_usd,
         )
 
     # A refusal bricks the turn: the assistant message is partial/empty and its
@@ -643,6 +642,7 @@ async def _run_session_step_body(
             finish_reason=finish_reason,
             account_id=account_id,
         )
+        await _charge_usage()
         log.warning(
             "step.model_refusal",
             session_id=session_id,
@@ -682,6 +682,15 @@ async def _run_session_step_body(
         account_id=account_id,
         parent_run_id=session.parent_run_id,
     )
+    # Charge now that the assistant message is durably persisted (see _charge_usage).
+    new_spent_microusd = await _charge_usage()
+    if _crossed_spend_warning_threshold(new_spent_microusd, cost_microusd, spend_limit_microusd):
+        log.warning(
+            "account.spend_limit_warning",
+            account_id=account_id,
+            spent_usd=new_spent_microusd / 1_000_000,
+            spend_limit_usd=spend_limit_usd,
+        )
     nudged = guard_result.nudged
     autoerror_caller_run_id = guard_result.autoerror_caller_run_id
     # The appended assistant event's locked focal stamp — threaded into the

--- a/tests/unit/test_loop_spend_gate.py
+++ b/tests/unit/test_loop_spend_gate.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
+import pytest
+
 from aios.harness.loop import (
     _crossed_spend_warning_threshold,
     _limit_to_microusd,
@@ -93,3 +95,93 @@ async def test_spend_gate_trips_before_context_build() -> None:
     assert stop_reason["type"] == "error"
     span_payloads = [c.args[3] for c in append_event.call_args_list if c.args[2] == "span"]
     assert any(p.get("event") == "spend_cap_exceeded" for p in span_payloads)
+
+
+async def test_usage_charged_only_after_assistant_persists() -> None:
+    """Spend must be charged AFTER the assistant message durably persists.
+
+    increment_usage previously committed BEFORE append_assistant_and_guard_quiescence;
+    if the persist raises (a DB error caught upstream → retry that re-calls the
+    model), the pre-persist charge double-bills the account for one response.
+    With the charge after the persist, a failed persist bills nothing and the
+    retry charges exactly once (fail-safe: under-, never over-charge)."""
+    pool = MagicMock()
+    task_registry = MagicMock()
+    task_registry.in_flight_tool_call_ids.return_value = set()
+    session = SimpleNamespace(
+        id="sess_x",
+        agent_id="agt_x",
+        agent_version=None,
+        focal_channel=None,
+        origin="foreground",
+        parent_run_id=None,
+    )
+    agent = SimpleNamespace(
+        model="openrouter/x",
+        tools=[],
+        mcp_servers=[],
+        http_servers=[],
+        skills=[],
+        system="sys",
+        litellm_extra={},
+        window_min=1000,
+        window_max=10000,
+    )
+    step_ctx = SimpleNamespace(
+        messages=[{"role": "user", "content": "hi"}], tools=[], skill_versions=[], reacting_to=0
+    )
+    increment = AsyncMock(return_value=5)
+    # The persist fails — models the soft path (DB error caught upstream → retry).
+    append_assistant = AsyncMock(side_effect=RuntimeError("persist failed"))
+    with (
+        patch(
+            "aios.harness.loop.find_sessions_needing_inference", AsyncMock(return_value={"sess_x"})
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.get_session_basic", AsyncMock(return_value=session)
+        ),
+        patch("aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)),
+        patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
+        patch("aios.harness.loop.refresh_session_mount_state", AsyncMock(return_value=[])),
+        patch("aios.harness.loop.compute_step_prelude", AsyncMock(return_value=SimpleNamespace())),
+        patch("aios.harness.loop.prelude_overhead_local", return_value=0),
+        patch(
+            "aios.harness.loop.sessions_service.read_windowed_events",
+            AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
+        ),
+        patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
+        patch(
+            "aios.harness.loop.accounts_service.get_account_spend_state",
+            AsyncMock(return_value=(0, 100.0)),  # well under the cap → gate passes
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.append_event",
+            AsyncMock(return_value=SimpleNamespace(id="ev")),
+        ),
+        patch("aios.harness.loop.compose_step_context", AsyncMock(return_value=step_ctx)),
+        patch("aios.harness.loop.has_subscriber", AsyncMock(return_value=False)),
+        patch(
+            "aios.harness.loop.call_litellm",
+            AsyncMock(
+                return_value=(
+                    {"role": "assistant", "content": "hi"},
+                    {"input_tokens": 10, "output_tokens": 5},
+                    0.001,
+                    "stop",
+                )
+            ),
+        ),
+        patch("aios.harness.loop.sessions_service.increment_usage", increment),
+        patch(
+            "aios.harness.loop.sessions_service.append_assistant_and_guard_quiescence",
+            append_assistant,
+        ),
+        pytest.raises(RuntimeError, match="persist failed"),
+    ):
+        await _run_session_step_body(
+            pool, task_registry, "sess_x", cause="message", account_id="acc_x"
+        )
+
+    append_assistant.assert_awaited_once()
+    # The charge comes AFTER the (failed) persist, so this attempt billed nothing.
+    increment.assert_not_awaited()


### PR DESCRIPTION
> ⚠️ **REVIEW-REQUIRED** — core step loop + billing. Please eyeball before merging (do not auto-merge).

## Summary

Fixes a **spend double-charge**.

- `_run_session_step_body` charged `increment_usage` in its **own committed transaction BEFORE** `append_assistant_and_guard_quiescence` persisted the assistant message, with no idempotency.
- If the persist raised (a DB error caught by `run_session_step`'s handler → a retry that re-calls the model, since the inference watermark only advances on a *persisted* assistant message), the account was billed **twice** for one response.
- **Fix (decided approach — charge-after-persist):** extract a local `_charge_usage()` closure and call it **after the durable record** in each terminal path — after `append_assistant` (normal turn), after `_handle_refusal` (refusal; it records the refusal span + latches errored). A crash in the gap now **loses** the charge (under-charge) rather than double-billing — the safe billing direction, and consistent with the model-error path which already charges after its error span.

## Review notes (all confirmed by code-review)

- **Exactly-once** on the happy path; **double-charge closed** (if persist raises, the charge that follows is never reached → retry charges once).
- **Spend gate timing unaffected:** the procrastinate `lock=session_id` holds for the whole step body, so the next step's gate can't start until this step's charge commits — no multi-step uncharged window.
- **Refusal** still charges (tokens were consumed); `_handle_refusal` completes (parks the session) before the charge, so a crash-then-retry can't re-charge.
- Spend-warning moved to the normal path only (a refusal already logs its own warning + parks).

## Test plan

- [x] Type-checker (mypy) — clean, 609 files
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — passed via pre-commit hook (incl. new `test_usage_charged_only_after_assistant_persists`)
- [x] No migration, no Docker, no OpenAPI drift
- [ ] CI runs full suite

### TDD (red→green)

The new test drives `_run_session_step_body` through a successful model response with `append_assistant_and_guard_quiescence` patched to **raise**, and asserts `increment_usage` is **not** awaited. Red on current code (`Awaited 1 times` — charge happened before the raising persist); green after the reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)