### PR TITLE
fix: DNAT lockdown nat-flush idempotency + verify coverage

### DIFF
--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -238,8 +238,9 @@ def build_iptables_script(
         "",
         _IPTABLES_BACKEND_SELECT,
         "",
-        "# Flush existing OUTPUT rules",
+        "# Flush existing OUTPUT rules (filter + nat) for idempotent re-apply",
         '"$IPT" -F OUTPUT',
+        '"$IPT" -t nat -F OUTPUT',
         "",
         "# Allow loopback",
         '"$IPT" -A OUTPUT -o lo -j ACCEPT',
@@ -319,12 +320,36 @@ def build_iptables_script(
 # fails CLOSED (the host gets no ACCEPT rule → blocked), never a bypass.
 _EMBEDDED_DNS_ADDRESS = "127.0.0.11"
 
+
 # Read-back assertion that the default OUTPUT policy is DROP — proves the
 # lockdown actually took effect in the shared netns, not just that the apply
 # script exited 0.
-_LOCKDOWN_VERIFY_SCRIPT = (
-    f"{_IPTABLES_BACKEND_SELECT}\n\"$IPT\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'"
-)
+def build_lockdown_verify_script(dnat_hosts: Sequence[str] = ()) -> str:
+    """Build the read-back verify script run by the lockdown sidecar.
+
+    Always asserts the filter-table default OUTPUT policy is ``DROP`` — proof
+    the lockdown actually landed in the shared netns, not merely that the apply
+    script exited 0.
+
+    When ``dnat_hosts`` is non-empty it ALSO asserts the nat table carries at
+    least one ``DNAT`` OUTPUT rule. Without this, a credential host whose
+    ``getent`` returns zero IPs emits no DNAT rule and no error: apply exits 0,
+    a filter-only verify passes, and the session runs WITHOUT DNAT for that host
+    — the placeholder goes direct to the real upstream and auth fails with no
+    operator signal (#984). Asserting nat coverage turns that silent omission
+    into a fail-closed provision error. (Coverage is asserted at the table
+    level, not per-host: any host resolving to zero IPs with NO other DNAT rule
+    present fails the verify; the proxy-alias DNS-miss case — where the whole
+    nat block is guarded out — is the documented fail-open-to-placeholder path
+    in :func:`build_iptables_script` and is out of scope here.)
+    """
+    lines = [
+        _IPTABLES_BACKEND_SELECT,
+        "\"$IPT\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'",
+    ]
+    if dnat_hosts:
+        lines.append("\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'")
+    return "\n".join(lines)
 
 
 async def apply_network_lockdown(
@@ -350,9 +375,11 @@ async def apply_network_lockdown(
 
     ``dnat_hosts`` + ``dnat_target`` are threaded into
     :func:`build_iptables_script` to DNAT credential-host :443 egress through
-    the secret-egress proxy (#878). The read-back verify reads the **filter**
-    table (``iptables -S OUTPUT``) only, so the added nat-table OUTPUT rules
-    don't affect it.
+    the secret-egress proxy (#878). The read-back verify always asserts the
+    filter-table DROP policy and, when ``dnat_hosts`` is non-empty, ALSO
+    asserts the nat table carries a ``DNAT`` OUTPUT rule
+    (:func:`build_lockdown_verify_script`) so a host resolving to zero IPs
+    fails closed instead of silently running without DNAT (#984).
 
     **Off the tenant-writable filesystem (§5.8).** Under durable persistence,
     running the lockdown *inside* the sandbox (its own ``iptables``/``getent``)
@@ -422,7 +449,7 @@ async def apply_network_lockdown(
         verify = await backend.run_netns_sidecar(
             handle.sandbox_id,
             image=settings.docker_image,
-            script=_LOCKDOWN_VERIFY_SCRIPT,
+            script=build_lockdown_verify_script(dnat_hosts),
             timeout_seconds=15,
             max_output_bytes=settings.bash_max_output_bytes,
             runtime=runtime,

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -24,9 +24,9 @@ from aios.sandbox.backends.base import (
 )
 from aios.sandbox.backends.docker import DockerBackend
 from aios.sandbox.setup import (
-    _LOCKDOWN_VERIFY_SCRIPT,
     apply_network_lockdown,
     build_iptables_script,
+    build_lockdown_verify_script,
 )
 from tests.helpers.sandbox import FakeBackend, make_handle
 
@@ -129,6 +129,25 @@ class TestBuildIptablesScript:
         assert "getent ahosts api.example.com" in script
         assert "getent ahosts cdn.example.com" in script
 
+    def test_flushes_filter_output_chain(self) -> None:
+        script = build_iptables_script(allowed_hosts={"api.example.com"})
+        assert '"$IPT" -F OUTPUT' in script
+
+    def test_flushes_nat_output_chain_for_idempotent_reapply(self) -> None:
+        """#984: a future re-apply path (e.g. credential rotation refreshing the
+        lockdown without a full netns recycle) would accumulate duplicate DNAT
+        entries unless the nat OUTPUT chain is flushed alongside the filter
+        chain. Flushing both makes re-apply idempotent."""
+        script = build_iptables_script(
+            allowed_hosts={"api.example.com"},
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        assert '"$IPT" -t nat -F OUTPUT' in script
+        # The nat flush precedes the DNAT rules, so re-running the script
+        # replaces (not appends to) the existing nat OUTPUT chain.
+        assert script.index('"$IPT" -t nat -F OUTPUT') < script.index("-j DNAT")
+
     def test_loopback_and_dns_always_allowed(self) -> None:
         script = build_iptables_script(allowed_hosts=set())
         assert '"$IPT" -A OUTPUT -o lo -j ACCEPT' in script
@@ -202,11 +221,13 @@ class TestBuildIptablesScript:
         assert "REDIRECT" not in script
 
     def test_no_nat_rules_without_dnat_target(self) -> None:
+        # The unconditional nat flush is always present (#984 idempotency); what
+        # must be absent without a dnat_target is the DNAT rule *addition*.
         script = build_iptables_script(
             allowed_hosts={"api.example.com"},
             dnat_hosts=["api.secret.com"],
         )
-        assert "-t nat" not in script
+        assert "-t nat -A OUTPUT" not in script
         assert "DNAT" not in script
 
     def test_no_nat_rules_without_dnat_hosts(self) -> None:
@@ -215,12 +236,13 @@ class TestBuildIptablesScript:
             dnat_hosts=[],
             dnat_target=("aios-worker", 49152),
         )
-        assert "-t nat" not in script
+        assert "-t nat -A OUTPUT" not in script
         assert "DNAT" not in script
 
     def test_existing_callers_unchanged(self) -> None:
         script = build_iptables_script(allowed_hosts={"api.example.com"})
-        assert "-t nat" not in script
+        assert "-t nat -A OUTPUT" not in script
+        assert "DNAT" not in script
         assert '"$IPT" -P OUTPUT DROP' in script
 
     def test_allowed_host_gets_accept_not_dnat(self) -> None:
@@ -241,6 +263,47 @@ class TestBuildIptablesScript:
             dnat_target=("aios-worker", 49152),
         )
         assert "--dport 80 -j DNAT" not in script
+
+
+# ── read-back verify script asserts DROP + DNAT coverage (#984) ───────────────
+
+
+class TestBuildLockdownVerifyScript:
+    def test_asserts_filter_drop_policy(self) -> None:
+        script = build_lockdown_verify_script()
+        assert "\"$IPT\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'" in script
+
+    def test_no_dnat_assertion_without_dnat_hosts(self) -> None:
+        """With no credential hosts, there's no nat coverage to assert — the
+        verify must not reference the nat table."""
+        script = build_lockdown_verify_script(dnat_hosts=[])
+        assert "-t nat" not in script
+        assert "DNAT" not in script
+
+    def test_asserts_nat_dnat_coverage_when_dnat_hosts_present(self) -> None:
+        """#984: a credential host whose getent returns zero IPs emits no DNAT
+        rule and no error — apply exits 0 and a filter-only verify passes,
+        silently running the session without DNAT. When dnat_hosts is non-empty
+        the verify must ALSO assert the nat table carries a DNAT OUTPUT rule, so
+        the zero-IP omission fails the verify (and thus the provision) instead of
+        passing silently."""
+        script = build_lockdown_verify_script(dnat_hosts=["api.secret.com"])
+        assert "\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'" in script
+        # The filter-table DROP assertion is still present.
+        assert "OUTPUT DROP" in script
+
+    def test_uses_selected_backend_no_bare_iptables(self) -> None:
+        """Both assertions go through the ``$IPT`` selector so the verify reads
+        the same netfilter backend the apply wrote to (#1022)."""
+        script = build_lockdown_verify_script(dnat_hosts=["api.secret.com"])
+        assert "command -v iptables-legacy" in script
+        for line in script.splitlines():
+            stripped = line.strip()
+            if "command -v iptables-legacy" in stripped:
+                continue
+            assert not stripped.startswith("iptables "), (
+                f"verify uses a bare iptables (nft default): {line!r}"
+            )
 
 
 # ── docker backend translates network policy to docker run argv ────────────────
@@ -496,10 +559,27 @@ class TestApplyNetworkLockdown:
             dnat_target=("aios-worker", 49152),
         )
 
-        script = self._sidecar_scripts(backend)[0]
-        assert '"$IPT" -t nat -A OUTPUT' in script
-        assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in script
-        assert "getent ahosts api.secret.com" in script
+        apply_script, verify_script = self._sidecar_scripts(backend)
+        assert '"$IPT" -t nat -A OUTPUT' in apply_script
+        assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in apply_script
+        assert "getent ahosts api.secret.com" in apply_script
+        # #984: with dnat_hosts present, the read-back verify also asserts the
+        # nat table carries a DNAT rule — a zero-IP host fails closed.
+        assert "\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'" in verify_script
+
+    @pytest.mark.asyncio
+    async def test_verify_omits_nat_assertion_without_dnat_hosts(self) -> None:
+        """Without credential DNAT, the read-back verify only asserts the filter
+        DROP policy — it must not reference the nat table (#984)."""
+        backend = FakeBackend()
+        handle = make_handle()
+        networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
+
+        await apply_network_lockdown(backend, handle, networking)
+
+        _apply, verify_script = self._sidecar_scripts(backend)
+        assert "-t nat" not in verify_script
+        assert "DNAT" not in verify_script
 
     @pytest.mark.asyncio
     async def test_apply_and_verify_agree_on_legacy_backend(self) -> None:
@@ -527,12 +607,13 @@ class TestApplyNetworkLockdown:
                 f"verify uses a bare iptables (nft default): {line!r}"
             )
 
-    def test_verify_script_constant_uses_selected_backend(self) -> None:
-        """The module-level verify constant itself selects the legacy backend so
-        any caller that runs it directly stays consistent with the apply path."""
-        assert "command -v iptables-legacy" in _LOCKDOWN_VERIFY_SCRIPT
-        assert '"$IPT" -S OUTPUT' in _LOCKDOWN_VERIFY_SCRIPT
-        assert "OUTPUT DROP" in _LOCKDOWN_VERIFY_SCRIPT
+    def test_verify_script_uses_selected_backend(self) -> None:
+        """The verify script itself selects the legacy backend so any caller
+        that runs it directly stays consistent with the apply path."""
+        script = build_lockdown_verify_script()
+        assert "command -v iptables-legacy" in script
+        assert '"$IPT" -S OUTPUT' in script
+        assert "OUTPUT DROP" in script
 
     @pytest.mark.asyncio
     async def test_runtime_threaded_to_both_sidecar_calls(self) -> None:


### PR DESCRIPTION
## What & why

Two deferred-safety findings from PR #977's security review, both in the sandbox network-lockdown chain-of-record (`src/aios/sandbox/setup.py`).

### 1. `iptables -F OUTPUT` didn't flush the nat table
`build_iptables_script` flushed only the filter OUTPUT chain. Lockdown runs once per fresh netns today, so no stale rules exist — but any future re-apply path (e.g. credential rotation refreshing the lockdown without a full netns recycle) would silently accumulate duplicate DNAT entries. The script now also emits `"$IPT" -t nat -F OUTPUT` directly before the DNAT rule additions, making re-apply idempotent (the flush replaces, rather than appends to, the nat OUTPUT chain).

### 2. Verify script covered only the filter table — silent DNAT omission undetected
The read-back verify was a static constant asserting only `-P OUTPUT DROP` on the filter table. If a credential host's `getent` returned zero IPs, the DNAT loop body emitted no rule and no error: apply exited 0, the filter-only verify passed, and the session ran **without DNAT** for that host — placeholder traffic went direct to the real upstream and auth failed with no operator signal.

The constant is now `build_lockdown_verify_script(dnat_hosts)`. It always asserts the filter DROP policy and, when `dnat_hosts` is non-empty, **additionally** asserts `"$IPT" -t nat -S OUTPUT | grep -q -- '-j DNAT'`. A zero-IP host now fails the verify (and thus fails the provision closed) instead of passing silently. `apply_network_lockdown` threads its `dnat_hosts` into the verify builder.

Coverage is asserted at the table level, not per-host — the proxy-alias DNS-miss case (where the whole nat block is guarded out) remains the documented fail-open-to-placeholder path and is out of scope here.

## Tests
- New unit tests for the nat flush (present + ordered before DNAT rules) in `TestBuildIptablesScript`.
- New `TestBuildLockdownVerifyScript` covering: filter DROP assertion always present; no nat reference without `dnat_hosts`; DNAT-coverage assertion present with `dnat_hosts`; backend selector used (no bare iptables).
- New `apply_network_lockdown` tests asserting the verify script gains/omits the nat assertion based on `dnat_hosts`.
- Three pre-existing `-t nat not in script` assertions tightened to `-t nat -A OUTPUT not in script`, since the unconditional flush now always appears (the rule *additions* are what must be absent).
- Mutation-checked: stubbing out the dnat-coverage branch makes the coverage test fail; restoring passes.

No API/route/schema changes → no openapi/SDK codegen (confirmed clean by the committed snapshot tests in the pre-commit suite). mypy, ruff, and the full unit suite pass.
Closes #984