### PR TITLE
chore(db): drop the orphaned legacy credentials table (0099)

### DIFF
--- a/migrations/versions/0099_drop_legacy_credentials_table.py
+++ b/migrations/versions/0099_drop_legacy_credentials_table.py
@@ -1,0 +1,52 @@
+"""Drop the orphaned legacy ``credentials`` table.
+
+``credentials`` (migration 0001) was the pre-multi-tenancy, pre-vaults
+credential store. Migration 0005 introduced ``vaults``/``vault_credentials``
+and dropped the ``credential_id`` foreign-key columns from ``agents`` and
+``agent_versions``, leaving ``credentials`` with no incoming references. No
+code reads or writes it — it has been dead schema since 0005. Drop it.
+
+This is window-safe despite being a destructive ``DROP TABLE``: the running
+code (old or new) never touches ``credentials``, so the new-code/old-schema
+window during a post-deploy migrate has nothing to break. (Operators should
+confirm no un-migrated rows remain in ``credentials`` before deploying —
+this migration discards the table and any rows.)
+
+Revision ID: 0099
+Revises: 0098
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0099"
+down_revision: str = "0098"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS credentials")
+
+
+def downgrade() -> None:
+    # Recreate the orphaned table shape from migration 0001 (data-lossy: the
+    # dropped rows are not reconstituted, matching the one-way posture of the
+    # other legacy-table drops in this ladder). Nothing references it.
+    op.execute(
+        """
+        CREATE TABLE credentials (
+            id           text PRIMARY KEY,
+            name         text NOT NULL,
+            provider     text NOT NULL,
+            ciphertext   bytea NOT NULL,
+            nonce        bytea NOT NULL,
+            created_at   timestamptz NOT NULL DEFAULT now(),
+            updated_at   timestamptz NOT NULL DEFAULT now(),
+            archived_at  timestamptz
+        )
+        """
+    )

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -75,7 +75,6 @@ def test_migration_creates_all_tables(postgres: object) -> None:
             )
             names = {row["tablename"] for row in tables}
             assert {
-                "credentials",
                 "environments",
                 "agents",
                 "sessions",
@@ -98,7 +97,6 @@ def test_migration_creates_all_tables(postgres: object) -> None:
             )
             index_names = {row["indexname"] for row in indexes}
             for required in (
-                "credentials_name_uniq",
                 "agents_name_uniq",
                 "events_session_message_seq_idx",
                 "events_model_request_end_calibration_idx",

--- a/tests/integration/test_rekey_column_coverage.py
+++ b/tests/integration/test_rekey_column_coverage.py
@@ -26,15 +26,11 @@ from aios.cli.commands.ops import _REKEY_COLUMNS
 from tests.conftest import _docker_available, needs_docker
 from tests.integration.test_migrations import _alembic_url, _run_alembic
 
-# ``credentials`` (migration 0001) is the pre-multi-tenancy, pre-vaults
-# credential store, superseded by ``vaults``/``vault_credentials`` (0005) and
-# read/written by NO current code. It has no ``account_id`` column, so the
-# per-account-subkey scheme ``rekey`` uses cannot apply to it — it can be
-# neither rekeyed in place nor blindly added to ``_REKEY_COLUMNS``. Removing it
-# (and the ``agents``/``agent_versions`` ``credential_id`` FKs) is a separate
-# destructive-migration decision tracked outside this guard, so the table is
-# excluded here rather than silently passing the coverage assertion.
-_LEGACY_UNREKEYABLE = {("credentials", "ciphertext")}
+# The legacy ``credentials`` table (migration 0001) was the one historically
+# un-rekeyable encrypted column — no ``account_id`` for the per-account subkey,
+# read/written by no current code. Migration 0099 dropped it, so the coverage
+# assertion below is now TOTAL: every ``ciphertext`` column in the live schema
+# must be covered by ``_REKEY_COLUMNS``, with no exceptions.
 
 
 @pytest.fixture(scope="module")
@@ -69,7 +65,7 @@ def test_rekey_covers_every_encrypted_column(postgres: object) -> None:
 
         schema_cols = {(r["table_name"], r["column_name"]) for r in rows}
         rekey_cols = {(c.table, c.ciphertext) for c in _REKEY_COLUMNS}
-        missing = schema_cols - rekey_cols - _LEGACY_UNREKEYABLE
+        missing = schema_cols - rekey_cols
         assert not missing, (
             "encrypted columns present in the schema but NOT re-encrypted by "
             "`aios rekey` — a vault-key rotation would orphan these rows under "

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0098``."""
+    """The migration ladder has exactly one head: ``0099``."""
     script = _script_directory()
-    assert script.get_heads() == ["0098"]
+    assert script.get_heads() == ["0099"]
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
> ⚠️ **REVIEW-REQUIRED — destructive DROP TABLE.** Before merging, confirm prod `credentials` holds no un-migrated rows (`SELECT count(*) FROM credentials`). This discards the table and any rows. Do not auto-merge.

## Summary

Removes dead schema: the pre-vaults `credentials` table.

- `credentials` (migration 0001) was the pre-multi-tenancy, pre-vaults credential store. Migration **0005** introduced `vaults`/`vault_credentials` and **already dropped** the `credential_id` FK columns from `agents`/`agent_versions` — leaving `credentials` with **no incoming references** and **no code that reads or writes it** (verified: only the two tests below referenced it). Dead schema since 0005.
- Migration **0099** drops it. **Window-safe** despite being a `DROP TABLE`: the running code (old or new) never touches the table, so the post-deploy migrate window has nothing to break (the destructive-migration caution applies to columns the code *uses*).

## Cascade test updates (the only references that existed)

- `test_migration_chain` — head → `0099`.
- `test_rekey_column_coverage` — drops the now-obsolete `("credentials","ciphertext")` `_LEGACY_UNREKEYABLE` exception; the encrypted-column coverage assertion is now **total** (every `ciphertext` column must be in `_REKEY_COLUMNS`, no exceptions — a strictly stronger invariant).
- `test_migrations` — drops `credentials` from the expected-tables set and `credentials_name_uniq` from the index spot-check.

## Test plan

- [x] Type-checker (mypy) — clean
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — passed via pre-commit hook (incl. `test_migration_chain` single-head → 0099)
- [x] `alembic heads` — single head `0099`
- [x] **Migration integration tests run locally (Docker), both green:** `test_migrations` (creates-all-tables + index spot-check) and `test_rekey_column_coverage` (total coverage) — the latter confirms the migration applies cleanly and the stronger rekey-coverage invariant holds.
- [ ] CI runs the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)