### PR TITLE
fix: push errored-session exclusion into GHOST_ASST_SQL (#897)

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -88,12 +88,25 @@ class _Candidate:
 # (#840).  Sessions with open calls still return ALL their
 # assistant-with-tool_calls events, so the per-tcid candidate loop downstream is
 # behaviorally unchanged.
+#
+# Also bounded by the errored-session predicate ``NOT (s.last_error_seq > 0 AND
+# s.last_error_seq > s.last_user_seq)`` (#897): an errored session is parked
+# until a user message recovers it, so its open tool_calls are part of the
+# terminal landing pad and must NOT be reaped.  ``find_and_repair_ghosts``
+# already drops these via the Python ``_errored_session_ids`` post-filter;
+# pushing the same predicate here stops the wasted event-log fetch on every 30s
+# sweep for the small set of errored sessions that still carry open calls.  The
+# predicate is byte-for-byte identical (modulo table alias) to
+# ``ERRORED_SESSIONS_SQL``'s ``WHERE`` — both consume the same maintained scalar
+# columns (migration 0066), so the SQL pre-filter's errored set EQUALS the
+# Python post-filter's; the post-filter is retained as defense in depth.
 GHOST_ASST_SQL = """
     SELECT e.session_id, e.data, e.created_at
       FROM events e
       JOIN sessions s ON s.id = e.session_id
      WHERE s.archived_at IS NULL
        AND s.open_tool_call_count > 0
+       AND NOT (s.last_error_seq > 0 AND s.last_error_seq > s.last_user_seq)
        AND e.kind = 'message'
        AND e.role = 'assistant'
        AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
@@ -284,6 +297,9 @@ async def find_and_repair_ghosts(
         # Skip errored sessions: their dispatched-but-unresolved tool calls are
         # part of the terminal landing pad and stay unreaped until a user
         # message recovers the session (mirrors the pre-derivation status skip).
+        # ``GHOST_ASST_SQL`` already pushes the identical errored predicate, so
+        # ``asst_rows`` carries no errored session here; this post-filter is
+        # retained as defense in depth (#897).
         errored = await _errored_session_ids(conn, session_id=session_id)
         if errored:
             asst_rows = [r for r in asst_rows if r["session_id"] not in errored]

--- a/tests/integration/test_tool_actions_on_errored.py
+++ b/tests/integration/test_tool_actions_on_errored.py
@@ -14,7 +14,7 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import ConflictError
-from aios.harness.sweep import find_and_repair_ghosts
+from aios.harness.sweep import GHOST_ASST_SQL, find_and_repair_ghosts
 from aios.harness.task_registry import TaskRegistry
 from aios.services import sessions as sessions_service
 from tests.integration.conftest import seed_agent_env_session
@@ -161,4 +161,104 @@ async def test_ghost_repair_skips_errored_session(
         f"ghost-repair attempted on an errored session (got {repaired}); "
         f"find_and_repair_ghosts is missing the derived-errored exclusion "
         f"(_errored_session_ids)."
+    )
+
+
+async def test_ghost_asst_sql_excludes_errored_session(
+    errored_session_with_tool_call: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """``GHOST_ASST_SQL`` itself must drop the errored session's
+    assistant-with-tool_calls rows — the errored exclusion is pushed into
+    SQL (#897), not only applied by the Python ``_errored_session_ids``
+    post-filter. The errored session here has an open tool_call ``tc_x``
+    (``open_tool_call_count > 0``), so without the pushed-down
+    ``last_error_seq`` predicate the row would survive the scan and be
+    fetched from the event log on every 30s sweep only to be discarded."""
+    pool, _account_id, session_id = errored_session_with_tool_call
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            GHOST_ASST_SQL.format(scope_clause="AND e.session_id = $1"),
+            session_id,
+        )
+    assert rows == [], (
+        f"GHOST_ASST_SQL returned rows for an errored session (got {len(rows)}); "
+        f"the errored-session exclusion (#897) was not pushed into SQL."
+    )
+
+
+@pytest.fixture
+async def healthy_session_with_open_tool_call(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, session_id)`` for a NON-errored session
+    carrying an assistant ``tool_call`` (``tc_live``) for the registered
+    built-in ``bash`` tool with no matching result — a genuine ghost.
+
+    This is the positive counterpart to the errored fixture: it pins that
+    pushing the errored predicate into ``GHOST_ASST_SQL`` does NOT
+    over-exclude a healthy errored-adjacent session. The session has
+    ``open_tool_call_count > 0`` but ``last_error_seq`` is unset, so it must
+    survive the scan and the ghost must be repaired."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_live_tool', NULL, TRUE, 'healthy-open-call')
+                """
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool, account_id="acc_live_tool", prefix="live-tool"
+        )
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                session_id=session.id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "tc_live",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        }
+                    ],
+                },
+                account_id="acc_live_tool",
+            )
+        yield pool, "acc_live_tool", session.id
+    finally:
+        await pool.close()
+
+
+async def test_ghost_repair_handles_healthy_session_with_open_call(
+    healthy_session_with_open_tool_call: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """A non-errored session with an open dispatched tool_call still has its
+    ghost repaired (#897). Pushing the errored predicate into
+    ``GHOST_ASST_SQL`` must not drop a session that ``ERRORED_SESSIONS_SQL``
+    would NOT classify as errored — otherwise a genuine ghost would never be
+    repaired."""
+    pool, _account_id, session_id = healthy_session_with_open_tool_call
+
+    # The session's assistant-with-tool_calls row must survive the scan.
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            GHOST_ASST_SQL.format(scope_clause="AND e.session_id = $1"),
+            session_id,
+        )
+    assert len(rows) == 1, (
+        f"GHOST_ASST_SQL dropped a healthy (non-errored) session with an open "
+        f"tool_call (got {len(rows)} rows); the #897 predicate over-excludes."
+    )
+
+    repaired = await find_and_repair_ghosts(pool, TaskRegistry(), session_id=session_id)
+    assert (session_id, "tc_live") in repaired, (
+        f"ghost-repair missed the open dispatched tool_call on a healthy "
+        f"session (got {repaired}); the #897 errored exclusion must not "
+        f"over-exclude non-errored sessions."
     )


### PR DESCRIPTION
## What

Push the scalar errored-session predicate into `GHOST_ASST_SQL` (`src/aios/harness/sweep.py`), so errored sessions that still carry open tool calls are excluded at the SQL layer instead of only by the Python `_errored_session_ids` post-filter.

## Why

`find_and_repair_ghosts` ran `GHOST_ASST_SQL` (scoped to `open_tool_call_count > 0` since #840) and *then* subtracted the errored set in Python. An errored session that still had open tool calls therefore had its assistant-with-tool_calls rows fetched from the event log on **every 30s sweep**, only to be discarded after the fact (follow-up to #840 / PR #893).

## Change

Added `AND NOT (s.last_error_seq > 0 AND s.last_error_seq > s.last_user_seq)` to `GHOST_ASST_SQL` — the same predicate `CANDIDATE_ROWS_SQL` already pushes.

**Equivalence / subset argument:** the predicate is byte-for-byte identical (modulo table alias) to `ERRORED_SESSIONS_SQL`'s `WHERE`. Both consume the same maintained `sessions` scalar columns (migration 0066), so the SQL pre-filter's errored set **equals** the Python post-filter's — the over-exclusion risk the issue flagged (dropping a session `ERRORED_SESSIONS_SQL` would *not* classify as errored) cannot occur. The Python `_errored_session_ids` post-filter is **retained as defense in depth** per the spec.

**Plan-shape safety:** the predicate is pure scalar column arithmetic on `sessions`, so the `EXPLAIN` plan introduces no correlated subplan over `events` — verified directly; the #840/perf invariant (`tests/e2e/test_sweep_perf.py`) holds.

## Tests

Extended `tests/integration/test_tool_actions_on_errored.py`:
- `test_ghost_asst_sql_excludes_errored_session` — the query itself drops an errored session that still has open tool calls (was RED before the change).
- `test_ghost_repair_handles_healthy_session_with_open_call` — a non-errored session with an open dispatched tool_call still has its ghost repaired, proving the new predicate does not over-exclude.

Both were confirmed non-vacuous via a mutation check (inverting the predicate fails both). All 2685 unit tests pass (incl. openapi/SDK snapshot — no codegen drift); the touched integration suite passes against a local Postgres.

Closes #897