### PR TITLE
test(sessions): add github twin of cross-tenant add-one 404 guard (#270)

### DIFF
--- a/tests/integration/test_session_resource_incremental.py
+++ b/tests/integration/test_session_resource_incremental.py
@@ -450,6 +450,25 @@ async def test_add_cross_tenant_session_not_found(
     assert store_id  # silence unused (the in-tenant store exists for contrast)
 
 
+async def test_add_cross_tenant_github_session_not_found(
+    env: tuple[asyncpg.Pool[Any], str, CryptoBox],
+) -> None:
+    """Github twin of the memory cross-tenant guard: a github add-one onto
+    another tenant's session 404s. Unlike the memory path, github ``add_one``
+    fetches no caller-owned resource to incidentally trip on — only the
+    session-ownership guard in ``add_resource`` stops the INSERT from silently
+    mounting the attacker's repo on the victim's session."""
+    pool, session_id, crypto_box = env
+    with pytest.raises(NotFoundError):
+        await sessions_service.add_resource(
+            pool,
+            session_id,
+            _gh("https://x/cross.git", "/mnt/cross"),
+            crypto_box=crypto_box,
+            account_id=_OTHER_ACCOUNT_ID,
+        )
+
+
 async def test_remove_cross_tenant_not_found(
     env: tuple[asyncpg.Pool[Any], str, CryptoBox],
 ) -> None:


### PR DESCRIPTION
Follow-up test-only coverage for the cross-tenant attach guard that landed with #1106 (`add_resource`/`remove_resource` now call `get_session_bare(account_id=...)` so a cross-tenant session id 404s instead of silently attaching).

#1106 shipped a dedicated cross-tenant test for the **memory** branch but not the **github** branch. This adds `test_add_cross_tenant_github_session_not_found`. It matters because:

- memory's `add_one` fetches a caller-owned store (`get_memory_store(account_id=...)`), so it has an incidental ownership touchpoint;
- github's `add_one` fetches **no** caller-owned resource — the session-ownership guard in `add_resource` is the **only** thing stopping a foreign caller from mounting a repo on the victim's session.

Verified load-bearing: the test fails with `DID NOT RAISE NotFoundError` if the guard is removed; passes against current master.

Test-only, additive, no production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)