### PR TITLE
fix: require explicit admin DSN for aios dev bootstrap/teardown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,16 @@ AIOS_LOG_LEVEL=INFO
 
 # ── Docker Compose / dev-bootstrap (issue #310) ───────────────────────
 
+# Required by `aios dev bootstrap` / `aios dev teardown` (issue #824).
+# The admin DSN those commands connect to in order to CREATE/DROP the
+# per-worktree `aios_dev_*` database. There is NO silent default: bootstrap/
+# teardown refuse to run unless this is set here or in the process env (env
+# wins), so they can never silently target a foreign postgres (e.g. a prod
+# server) that happens to own :5432 on a multi-DB host. Set it explicitly to
+# the dev postgres you actually run; :5433 matches the compose/README setup
+# that leaves :5432 free for an OS-installed postgres.
+# AIOS_POSTGRES_ADMIN_URL=postgresql://aios:aios@localhost:5433/postgres
+
 # Host directory bind-mounted into worker, api, and every connector at
 # the SAME path on each side.  The worker hands these path strings to
 # the host docker daemon when spawning sandbox containers, so they MUST

--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ The bootstrap script is idempotent — re-runs are a no-op once a connector's to
 Working on aios itself? `aios dev bootstrap` creates an isolated dev instance per git worktree — separate database, free port, scoped Docker labels — so multiple branches can run concurrently without stepping on each other:
 
 ```bash
+# Required: the admin DSN bootstrap/teardown use to CREATE/DROP the per-worktree
+# aios_dev_* database. There is NO silent default — set it explicitly (here, or
+# in ~/.aios/secrets.env) so these commands never silently target a foreign
+# postgres that owns :5432 on a multi-DB host. :5433 matches the compose setup.
+export AIOS_POSTGRES_ADMIN_URL=postgresql://aios:aios@localhost:5433/postgres
+
 uv run aios dev bootstrap   # provisions <worktree>.env + DB + port
 uv run aios dev status      # show this worktree's instance
 uv run aios dev teardown    # drop the DB and prune containers

--- a/src/aios/cli/commands/dev.py
+++ b/src/aios/cli/commands/dev.py
@@ -180,8 +180,6 @@ def load_instance_env(repo_root: Path) -> dict[str, str]:
 
 # ── URL + port helpers ─────────────────────────────────────────────────────
 
-DEFAULT_ADMIN_URL = "postgresql://aios:aios@localhost:5432/postgres"
-
 
 def derive_runtime_db_url(admin_url: str, instance_id: str) -> str:
     """Return an AIOS_DB_URL for this instance by swapping the DB name only.
@@ -339,12 +337,31 @@ async def _count_db_clients(db_url: str) -> int:
     return int(result or 0)
 
 
-def _resolve_admin_url(secrets: dict[str, str]) -> str:
-    """Pick the admin DSN from process env, then parsed secrets, then default."""
-    return (
-        os.environ.get("AIOS_POSTGRES_ADMIN_URL")
-        or secrets.get("AIOS_POSTGRES_ADMIN_URL")
-        or DEFAULT_ADMIN_URL
+def _resolve_admin_url(secrets: dict[str, str]) -> str | None:
+    """Pick the admin DSN from process env, then parsed secrets — no default.
+
+    Returns ``None`` when neither source supplies ``AIOS_POSTGRES_ADMIN_URL``.
+    There is deliberately NO silent fallback (issue #824): the old default
+    ``postgresql://aios:aios@localhost:5432/postgres`` could connect bootstrap/
+    teardown to whatever owns :5432 on a multi-postgres host (e.g. a foreign
+    production server), silently CREATE/DROP ``aios_dev_*`` databases there.
+    Requiring an explicit DSN forces the operator to name the target server.
+
+    Pure: process env takes precedence over the secrets.env value. Callers
+    are responsible for turning ``None`` into a user-facing error.
+    """
+    return os.environ.get("AIOS_POSTGRES_ADMIN_URL") or secrets.get("AIOS_POSTGRES_ADMIN_URL")
+
+
+def _print_missing_admin_url_error() -> None:
+    """Explain how to supply the now-required admin DSN (issue #824)."""
+    print_error("AIOS_POSTGRES_ADMIN_URL is not set.")
+    print_note("Supply it one of two ways:")
+    print_note("  export AIOS_POSTGRES_ADMIN_URL=postgresql://aios:aios@localhost:5433/postgres")
+    print_note("  or add AIOS_POSTGRES_ADMIN_URL=... to ~/.aios/secrets.env")
+    print_note(
+        "This is required deliberately: there is no silent localhost:5432 default, "
+        "so bootstrap/teardown never targets a foreign postgres on a multi-DB host."
     )
 
 
@@ -416,6 +433,9 @@ def bootstrap() -> None:
         raise typer.Exit(1)
 
     admin_url = _resolve_admin_url(secrets)
+    if admin_url is None:
+        _print_missing_admin_url_error()
+        raise typer.Exit(1)
 
     try:
         asyncio.run(_preflight_role_can_create_db(admin_url))
@@ -546,6 +566,9 @@ def teardown(
 
     secrets = parse_env_file(Path.home() / ".aios" / "secrets.env")
     admin_url = _resolve_admin_url(secrets)
+    if admin_url is None:
+        _print_missing_admin_url_error()
+        raise typer.Exit(1)
     try:
         asyncio.run(_drop_database(admin_url, db_name))
     except asyncpg.exceptions.PostgresError as exc:

--- a/tests/unit/cli/test_cli_dev.py
+++ b/tests/unit/cli/test_cli_dev.py
@@ -14,6 +14,7 @@ import pytest
 from aios.cli.commands.dev import (
     INSTANCE_ID_PATTERN,
     MAX_DB_NAME_BYTES,
+    _resolve_admin_url,
     derive_instance_id,
     derive_runtime_db_url,
     parse_env_file,
@@ -272,3 +273,32 @@ def test_settings_instance_id_rejects_unsafe_value(
 
     with pytest.raises(ValidationError):
         Settings(_env_file=(str(secrets),))
+
+
+# ── _resolve_admin_url (issue #824: no silent default) ─────────────────────
+
+
+def test_resolve_admin_url_returns_none_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No env var and empty secrets → None (no silent localhost:5432 default)."""
+    monkeypatch.delenv("AIOS_POSTGRES_ADMIN_URL", raising=False)
+    assert _resolve_admin_url({}) is None
+
+
+def test_resolve_admin_url_prefers_env_over_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Process env wins over the secrets.env value."""
+    monkeypatch.setenv("AIOS_POSTGRES_ADMIN_URL", "postgresql://env@localhost:5433/postgres")
+    secrets = {"AIOS_POSTGRES_ADMIN_URL": "postgresql://secrets@localhost:5433/postgres"}
+    assert _resolve_admin_url(secrets) == "postgresql://env@localhost:5433/postgres"
+
+
+def test_resolve_admin_url_uses_secrets_when_no_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no process env, the secrets.env value is returned unchanged."""
+    monkeypatch.delenv("AIOS_POSTGRES_ADMIN_URL", raising=False)
+    secrets = {"AIOS_POSTGRES_ADMIN_URL": "postgresql://secrets@localhost:5433/postgres"}
+    assert _resolve_admin_url(secrets) == "postgresql://secrets@localhost:5433/postgres"


### PR DESCRIPTION
## Problem

`aios dev bootstrap`/`teardown` fell back to a hard-coded admin DSN — `postgresql[REDACTED]localhost:5432/postgres` (`DEFAULT_ADMIN_URL`) — when `AIOS_POSTGRES_ADMIN_URL` was unset. On a multi-postgres host that silently connects to whatever owns `:5432`. On the primary dev laptop that's a foreign **production** postgres, so bootstrap would `CREATE DATABASE aios_dev_*` inside it (and teardown would `DROP` it there). Caught during the CEO-on-aios v0 PoC only because ports were audited first.

## Fix (scope: explicit-DSN-or-fail, the shovel-ready half of the design)

- **Delete `DEFAULT_ADMIN_URL`.** There is no longer any silent default.
- **`_resolve_admin_url(secrets) -> str | None`** now returns `None` when neither the process env nor `~/.aios/secrets.env` supplies `AIOS_POSTGRES_ADMIN_URL` (env still takes precedence over secrets). It stays **pure** — the file's documented pure/E2E boundary is preserved.
- **Both call sites** (`bootstrap`, `teardown`) turn `None` into an actionable `print_error` + `typer.Exit(1)` **before** any `asyncpg.connect` / `CREATE` / `DROP`. The shared `_print_missing_admin_url_error` helper names both ways to supply the DSN and explains *why* there's no default.
- **Docs:** the now-required `AIOS_POSTGRES_ADMIN_URL` is documented in the README per-worktree-dev section and `.env.example` (using `:5433` to match the compose/README convention that leaves `:5432` free for an OS-installed postgres).

Once the silent default is gone, an operator must *type* the DSN and can never **silently** target a foreign `:5432`. The server-identity safety model (sentinel marker DB / role / `system_identifier` allowlist) is the genuinely-undesigned hard part and is split into a separate needs-design follow-up.

## Tests

`tests/unit/cli/test_cli_dev.py` adds three pure tests for `_resolve_admin_url`: returns `None` when unset, prefers env over secrets, and uses secrets when no env. Verified red→green and mutation-checked (breaking the resolver makes the `None` test fail). The error-raising lives in the commands per the file's manual-E2E boundary. `grep DEFAULT_ADMIN_URL` returns zero hits across `src`, `tests`, `README.md`, and `.env.example`.

mypy + ruff (check & format) clean; full unit suite passes (ran via the repo's pre-commit hook). No codegen needed — `regen-openapi.sh` leaves `openapi.json` byte-identical (CLI-only change, no API surface touched).

Closes #824