### PR TITLE
feat: add pending_since to AwaitingToolCall (#816)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10329,16 +10329,22 @@
               "custom"
             ],
             "title": "Kind"
+          },
+          "pending_since": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Pending Since"
           }
         },
         "type": "object",
         "required": [
           "tool_call_id",
           "name",
-          "kind"
+          "kind",
+          "pending_since"
         ],
         "title": "AwaitingToolCall",
-        "description": "One pending tool call the harness will not dispatch itself.\n\nDerived view on session reads. Each entry is a tool_call in the\nlatest assistant message with no paired tool_result and no\nin-process executor:\n\n* ``kind == \"custom\"`` \u2014 client-executed; awaits POST to\n  ``/sessions/:id/tool-results`` (operator-facing) or\n  ``/connectors/runtime/tool-results`` (runtime-container-facing).\n* ``kind == \"builtin\" | \"mcp\"`` \u2014 ``always_ask``-gated and not yet\n  confirmed; awaits POST to ``/sessions/:id/tool-confirmations``.\n  Confirmed-but-not-yet-dispatched and ``always_allow`` calls don't\n  appear here \u2014 they're harness-internal."
+        "description": "One pending tool call the harness will not dispatch itself.\n\nDerived view on session reads. Each entry is a tool_call on any\nassistant turn (#741) with no paired tool_result and no in-process\nexecutor:\n\n* ``kind == \"custom\"`` \u2014 client-executed; awaits POST to\n  ``/sessions/:id/tool-results`` (operator-facing) or\n  ``/connectors/runtime/tool-results`` (runtime-container-facing).\n* ``kind == \"builtin\" | \"mcp\"`` \u2014 ``always_ask``-gated and not yet\n  confirmed; awaits POST to ``/sessions/:id/tool-confirmations``.\n  Confirmed-but-not-yet-dispatched and ``always_allow`` calls don't\n  appear here \u2014 they're harness-internal.\n\n``pending_since`` is the ``created_at`` of the assistant event that\ndeclared this tool_call (tz-aware UTC). For a ``kind == \"custom\"``\ncall an entry exists from the moment the assistant declares it until\na result is posted, so a healthy in-flight connector call (e.g.\n``signal_react``, ~2s) is otherwise indistinguishable from a stuck\none whose client died. Clients age-threshold custom calls against\n``pending_since`` (fresh = in-flight, present quietly; stale = stuck,\nalert); builtin/mcp are approval-gated and alert immediately.\n\nThis is the SAME clock the sweep's ``client_tool_call_max_age_seconds``\nabandonment bound (#752) keys off \u2014 the assistant turn's\n``created_at``. The two thresholds are intentionally different\ntimescales for different purposes (a cosmetic seconds-scale UI hint\nhere vs. an irreversible 24h \"client is gone\" abandonment there), not\nan inconsistency."
       },
       "BindChatRequest": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/awaiting_tool_call.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import datetime
 from collections.abc import Mapping
 from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from dateutil.parser import isoparse
 
 from ..models.awaiting_tool_call_kind import AwaitingToolCallKind
 
@@ -15,9 +17,9 @@ T = TypeVar("T", bound="AwaitingToolCall")
 class AwaitingToolCall:
     """One pending tool call the harness will not dispatch itself.
 
-    Derived view on session reads. Each entry is a tool_call in the
-    latest assistant message with no paired tool_result and no
-    in-process executor:
+    Derived view on session reads. Each entry is a tool_call on any
+    assistant turn (#741) with no paired tool_result and no in-process
+    executor:
 
     * ``kind == "custom"`` — client-executed; awaits POST to
       ``/sessions/:id/tool-results`` (operator-facing) or
@@ -27,15 +29,33 @@ class AwaitingToolCall:
       Confirmed-but-not-yet-dispatched and ``always_allow`` calls don't
       appear here — they're harness-internal.
 
+    ``pending_since`` is the ``created_at`` of the assistant event that
+    declared this tool_call (tz-aware UTC). For a ``kind == "custom"``
+    call an entry exists from the moment the assistant declares it until
+    a result is posted, so a healthy in-flight connector call (e.g.
+    ``signal_react``, ~2s) is otherwise indistinguishable from a stuck
+    one whose client died. Clients age-threshold custom calls against
+    ``pending_since`` (fresh = in-flight, present quietly; stale = stuck,
+    alert); builtin/mcp are approval-gated and alert immediately.
+
+    This is the SAME clock the sweep's ``client_tool_call_max_age_seconds``
+    abandonment bound (#752) keys off — the assistant turn's
+    ``created_at``. The two thresholds are intentionally different
+    timescales for different purposes (a cosmetic seconds-scale UI hint
+    here vs. an irreversible 24h "client is gone" abandonment there), not
+    an inconsistency.
+
         Attributes:
             tool_call_id (str):
             name (str):
             kind (AwaitingToolCallKind):
+            pending_since (datetime.datetime):
     """
 
     tool_call_id: str
     name: str
     kind: AwaitingToolCallKind
+    pending_since: datetime.datetime
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -45,6 +65,8 @@ class AwaitingToolCall:
 
         kind = self.kind.value
 
+        pending_since = self.pending_since.isoformat()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -52,6 +74,7 @@ class AwaitingToolCall:
                 "tool_call_id": tool_call_id,
                 "name": name,
                 "kind": kind,
+                "pending_since": pending_since,
             }
         )
 
@@ -66,10 +89,13 @@ class AwaitingToolCall:
 
         kind = AwaitingToolCallKind(d.pop("kind"))
 
+        pending_since = isoparse(d.pop("pending_since"))
+
         awaiting_tool_call = cls(
             tool_call_id=tool_call_id,
             name=name,
             kind=kind,
+            pending_since=pending_since,
         )
 
         awaiting_tool_call.additional_properties = d

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -1172,7 +1172,7 @@ async def _unresolved_tool_calls(
     # string-interpolated into the SQL.
     asst_rows = await conn.fetch(
         """
-        SELECT session_id, data
+        SELECT session_id, data, created_at
           FROM events
          WHERE session_id = ANY($1::text[])
            AND account_id = $2
@@ -1202,7 +1202,13 @@ async def _unresolved_tool_calls(
         completed: set[str] = results_by_sid.get(sid, set())
         for tc in data.get("tool_calls") or []:
             if tc.get("id") and tc["id"] not in completed:
-                out.setdefault(sid, []).append(tc)
+                # Shallow copy so the read-model carries the parent
+                # assistant turn's created_at without mutating the parsed
+                # source dict (parse_jsonb may return a shared reference if
+                # a JSONB codec is ever registered). Connector-SSE consumers
+                # build their own explicit output dicts, so this extra key
+                # never leaks into their payloads.
+                out.setdefault(sid, []).append({**tc, "_pending_since": row["created_at"]})
     return out
 
 
@@ -1246,7 +1252,8 @@ async def list_unresolved_tool_calls_batch(
     unresolved on an earlier turn still appears in ``Session.awaiting``
     (#741).  Used by :func:`services.sessions.compute_awaiting` to build the
     ``Session.awaiting`` derived view. Returned dicts have keys
-    ``tool_call_id``, ``name``, ``arguments``, ``has_allow_lifecycle``
+    ``tool_call_id``, ``name``, ``arguments``, ``has_allow_lifecycle``,
+    ``pending_since`` (the parent assistant event's ``created_at``)
     — the caller classifies kind / needs_confirm using ``agent`` (and
     the tool's ``classify_permission`` for arg-aware routes like
     ``http_request``).
@@ -1288,6 +1295,7 @@ async def list_unresolved_tool_calls_batch(
                     "name": name,
                     "arguments": fn.get("arguments", "{}"),
                     "has_allow_lifecycle": tc["id"] in allows,
+                    "pending_since": tc["_pending_since"],
                 }
             )
         if entries:

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -114,9 +114,9 @@ class SessionUsage(BaseModel):
 class AwaitingToolCall(BaseModel):
     """One pending tool call the harness will not dispatch itself.
 
-    Derived view on session reads. Each entry is a tool_call in the
-    latest assistant message with no paired tool_result and no
-    in-process executor:
+    Derived view on session reads. Each entry is a tool_call on any
+    assistant turn (#741) with no paired tool_result and no in-process
+    executor:
 
     * ``kind == "custom"`` — client-executed; awaits POST to
       ``/sessions/:id/tool-results`` (operator-facing) or
@@ -125,11 +125,28 @@ class AwaitingToolCall(BaseModel):
       confirmed; awaits POST to ``/sessions/:id/tool-confirmations``.
       Confirmed-but-not-yet-dispatched and ``always_allow`` calls don't
       appear here — they're harness-internal.
+
+    ``pending_since`` is the ``created_at`` of the assistant event that
+    declared this tool_call (tz-aware UTC). For a ``kind == "custom"``
+    call an entry exists from the moment the assistant declares it until
+    a result is posted, so a healthy in-flight connector call (e.g.
+    ``signal_react``, ~2s) is otherwise indistinguishable from a stuck
+    one whose client died. Clients age-threshold custom calls against
+    ``pending_since`` (fresh = in-flight, present quietly; stale = stuck,
+    alert); builtin/mcp are approval-gated and alert immediately.
+
+    This is the SAME clock the sweep's ``client_tool_call_max_age_seconds``
+    abandonment bound (#752) keys off — the assistant turn's
+    ``created_at``. The two thresholds are intentionally different
+    timescales for different purposes (a cosmetic seconds-scale UI hint
+    here vs. an irreversible 24h "client is gone" abandonment there), not
+    an inconsistency.
     """
 
     tool_call_id: str
     name: str
     kind: Literal["builtin", "mcp", "custom"]
+    pending_since: datetime
 
 
 class SessionCreate(BaseModel):

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -486,13 +486,16 @@ def _classify_awaiting(
     name = tc["name"]
     tool_call_id = tc["tool_call_id"]
     has_allow_lifecycle = tc["has_allow_lifecycle"]
+    pending_since = tc["pending_since"]
 
     if is_mcp_tool_name(name):
         if (
             agents_service.effective_mcp_permission(name, agent.tools) == "always_ask"
             and not has_allow_lifecycle
         ):
-            return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="mcp")
+            return AwaitingToolCall(
+                tool_call_id=tool_call_id, name=name, kind="mcp", pending_since=pending_since
+            )
         return None
     if tool_registry.has(name):
         perm_tool = resolve_permission(name, agent.tools)
@@ -503,10 +506,14 @@ def _classify_awaiting(
             if args is not None:
                 perm_route = tool_def.classify_permission(args, agent)
         if (perm_tool == "always_ask" or perm_route == "always_ask") and not has_allow_lifecycle:
-            return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="builtin")
+            return AwaitingToolCall(
+                tool_call_id=tool_call_id, name=name, kind="builtin", pending_since=pending_since
+            )
         return None
     # Unknown name: client-executed custom tool.
-    return AwaitingToolCall(tool_call_id=tool_call_id, name=name, kind="custom")
+    return AwaitingToolCall(
+        tool_call_id=tool_call_id, name=name, kind="custom", pending_since=pending_since
+    )
 
 
 async def compute_awaiting(

--- a/tests/integration/test_awaiting_spans_all_assistants.py
+++ b/tests/integration/test_awaiting_spans_all_assistants.py
@@ -165,18 +165,57 @@ class TestAwaitingSpansAllAssistants:
 
     async def test_compute_awaiting_populates_pending_since(
         self,
-        session_with_two_assistant_turns: tuple[asyncpg.Pool[Any], str, Session],
+        migrated_db_url: str,
+        _reset_db_state: None,
     ) -> None:
         """#816: the full service path ``compute_awaiting`` → ``AwaitingToolCall``
-        yields populated, tz-aware ``pending_since`` for each awaiting entry."""
-        pool, account_id, session = session_with_two_assistant_turns
-        awaiting_by_sid = await compute_awaiting(pool, [session], account_id=account_id)
-        entries = awaiting_by_sid.get(session.id, [])
-        by_id = {e.tool_call_id: e for e in entries}
-        assert set(by_id) == {"tc_X", "tc_Z"}
-        for call in entries:
+        yields populated, tz-aware ``pending_since`` for each awaiting entry.
+
+        Uses a CUSTOM (client-executed) tool_call — its result never lands
+        server-side, so it is unconditionally ``awaiting`` (unlike a built-in
+        ``always_allow`` ``bash`` call, which ``_classify_awaiting`` filters out
+        as harness-internal)."""
+        pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            account_id = "acc_awaiting_compute"
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                    "display_name) VALUES ($1, NULL, TRUE, $2)",
+                    account_id,
+                    "awaiting-compute-test",
+                )
+            _agent, _env, session = await seed_agent_env_session(
+                pool,
+                account_id=account_id,
+                prefix="awaiting-compute",
+                tools=[
+                    ToolSpec(
+                        type="custom",
+                        name="client_thing",
+                        description="a client-executed tool",
+                        input_schema={"type": "object"},
+                    )
+                ],
+            )
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn,
+                    account_id=account_id,
+                    session_id=session.id,
+                    kind="message",
+                    data=_assistant("tc_C", name="client_thing"),
+                )
+            awaiting_by_sid = await compute_awaiting(pool, [session], account_id=account_id)
+            entries = awaiting_by_sid.get(session.id, [])
+            by_id = {e.tool_call_id: e for e in entries}
+            assert set(by_id) == {"tc_C"}
+            call = by_id["tc_C"]
+            assert call.kind == "custom"
             assert isinstance(call.pending_since, datetime)
             assert call.pending_since.tzinfo is not None
+        finally:
+            await pool.close()
 
     async def test_two_tool_calls_in_one_event_share_pending_since(
         self,

--- a/tests/integration/test_awaiting_spans_all_assistants.py
+++ b/tests/integration/test_awaiting_spans_all_assistants.py
@@ -20,6 +20,7 @@ and omitted the still-pending X.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from datetime import datetime
 from typing import Any
 
 import asyncpg
@@ -28,6 +29,8 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.models.agents import ToolSpec
+from aios.models.sessions import Session
+from aios.services.sessions import compute_awaiting
 from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
@@ -50,8 +53,8 @@ def _assistant(tool_call_id: str, name: str = "bash") -> dict[str, Any]:
 @pytest.fixture
 async def session_with_two_assistant_turns(
     migrated_db_url: str, _reset_db_state: None
-) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
-    """Yield ``(pool, account_id, session_id)`` for a session whose log is:
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, Session]]:
+    """Yield ``(pool, account_id, session)`` for a session whose log is:
     A1(tool_call tc_X) → user → A2(tool_call tc_Z), with NO tool_result for
     either.  ``tc_X`` is the earlier, non-latest unresolved tool_call.
     """
@@ -93,7 +96,7 @@ async def session_with_two_assistant_turns(
                 kind="message",
                 data=_assistant("tc_Z"),
             )
-        yield pool, account_id, session.id
+        yield pool, account_id, session
     finally:
         await pool.close()
 
@@ -101,18 +104,117 @@ async def session_with_two_assistant_turns(
 class TestAwaitingSpansAllAssistants:
     async def test_unresolved_from_earlier_assistant_is_surfaced(
         self,
-        session_with_two_assistant_turns: tuple[asyncpg.Pool[Any], str, str],
+        session_with_two_assistant_turns: tuple[asyncpg.Pool[Any], str, Session],
     ) -> None:
         """#741: an unresolved tool_call on a non-latest assistant must appear
         in the unresolved batch, not be hidden by a later assistant turn."""
-        pool, account_id, session_id = session_with_two_assistant_turns
+        pool, account_id, session = session_with_two_assistant_turns
         async with pool.acquire() as conn:
             unresolved = await queries.list_unresolved_tool_calls_batch(
-                conn, [session_id], account_id=account_id
+                conn, [session.id], account_id=account_id
             )
-        tcids = {e["tool_call_id"] for e in unresolved.get(session_id, [])}
+        tcids = {e["tool_call_id"] for e in unresolved.get(session.id, [])}
         assert tcids == {"tc_X", "tc_Z"}, (
             "Session.awaiting missed tc_X (on the earlier assistant A1) because "
             "the unresolved-tool_calls query only inspected the latest assistant "
             "turn (#741, sibling of #737)"
         )
+
+    async def test_pending_since_reflects_per_turn_created_at(
+        self,
+        session_with_two_assistant_turns: tuple[asyncpg.Pool[Any], str, Session],
+    ) -> None:
+        """#816: each unresolved entry carries ``pending_since`` = the declaring
+        assistant event's ``created_at``.  Because A1 and A2 are appended in
+        distinct transactions, their per-row ``now()`` values are monotone, so
+        ``tc_X`` (earlier turn) must be strictly older than ``tc_Z``."""
+        pool, account_id, session = session_with_two_assistant_turns
+        async with pool.acquire() as conn:
+            unresolved = await queries.list_unresolved_tool_calls_batch(
+                conn, [session.id], account_id=account_id
+            )
+        by_id = {e["tool_call_id"]: e for e in unresolved.get(session.id, [])}
+        assert set(by_id) == {"tc_X", "tc_Z"}
+        for entry in by_id.values():
+            assert isinstance(entry["pending_since"], datetime)
+            assert entry["pending_since"].tzinfo is not None
+        assert by_id["tc_X"]["pending_since"] < by_id["tc_Z"]["pending_since"], (
+            "pending_since must reflect each tool_call's OWN declaring assistant "
+            "turn — tc_X (earlier A1) before tc_Z (later A2) — proving per-row "
+            "stamping, not the latest turn's timestamp (#816)"
+        )
+
+    async def test_compute_awaiting_populates_pending_since(
+        self,
+        session_with_two_assistant_turns: tuple[asyncpg.Pool[Any], str, Session],
+    ) -> None:
+        """#816: the full service path ``compute_awaiting`` → ``AwaitingToolCall``
+        yields populated, tz-aware ``pending_since`` for each awaiting entry."""
+        pool, account_id, session = session_with_two_assistant_turns
+        awaiting_by_sid = await compute_awaiting(pool, [session], account_id=account_id)
+        entries = awaiting_by_sid.get(session.id, [])
+        by_id = {e.tool_call_id: e for e in entries}
+        assert set(by_id) == {"tc_X", "tc_Z"}
+        for call in entries:
+            assert isinstance(call.pending_since, datetime)
+            assert call.pending_since.tzinfo is not None
+        assert by_id["tc_X"].pending_since < by_id["tc_Z"].pending_since
+
+    async def test_two_tool_calls_in_one_event_share_pending_since(
+        self,
+        migrated_db_url: str,
+        _reset_db_state: None,
+    ) -> None:
+        """#816: two tool_calls declared in the SAME assistant event share the
+        same ``pending_since`` (== that one turn's ``created_at``)."""
+        pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+        try:
+            account_id = "acc_awaiting_same_event"
+            async with pool.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                    "display_name) VALUES ($1, NULL, TRUE, $2)",
+                    account_id,
+                    "awaiting-same-event-test",
+                )
+            _agent, _env, session = await seed_agent_env_session(
+                pool,
+                account_id=account_id,
+                prefix="awaiting-same-event",
+                tools=[ToolSpec(type="bash")],
+            )
+            async with pool.acquire() as conn:
+                await queries.append_event(
+                    conn,
+                    account_id=account_id,
+                    session_id=session.id,
+                    kind="message",
+                    data={
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "tc_A",
+                                "type": "function",
+                                "function": {"name": "bash", "arguments": "{}"},
+                            },
+                            {
+                                "id": "tc_B",
+                                "type": "function",
+                                "function": {"name": "bash", "arguments": "{}"},
+                            },
+                        ],
+                    },
+                )
+            async with pool.acquire() as conn:
+                unresolved = await queries.list_unresolved_tool_calls_batch(
+                    conn, [session.id], account_id=account_id
+                )
+            by_id = {e["tool_call_id"]: e for e in unresolved.get(session.id, [])}
+            assert set(by_id) == {"tc_A", "tc_B"}
+            assert by_id["tc_A"]["pending_since"] == by_id["tc_B"]["pending_since"], (
+                "two tool_calls in one assistant event must share pending_since "
+                "(== that turn's created_at) (#816)"
+            )
+        finally:
+            await pool.close()

--- a/tests/integration/test_awaiting_spans_all_assistants.py
+++ b/tests/integration/test_awaiting_spans_all_assistants.py
@@ -20,7 +20,7 @@ and omitted the still-pending X.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import asyncpg
@@ -125,11 +125,29 @@ class TestAwaitingSpansAllAssistants:
         session_with_two_assistant_turns: tuple[asyncpg.Pool[Any], str, Session],
     ) -> None:
         """#816: each unresolved entry carries ``pending_since`` = the declaring
-        assistant event's ``created_at``.  Because A1 and A2 are appended in
-        distinct transactions, their per-row ``now()`` values are monotone, so
-        ``tc_X`` (earlier turn) must be strictly older than ``tc_Z``."""
+        assistant event's OWN ``created_at`` — tc_X (earlier A1) before tc_Z
+        (later A2), proving per-row stamping, not the latest turn's timestamp.
+
+        We pin the two assistant turns' ``created_at`` to explicit, distinct
+        values (A1 one hour before A2) so the ordering is deterministic rather
+        than reliant on sub-millisecond wall-clock separation between two quick
+        appends in the fixture."""
         pool, account_id, session = session_with_two_assistant_turns
+        a1_ts = datetime(2026, 6, 10, 12, 0, 0, tzinfo=UTC)
+        a2_ts = datetime(2026, 6, 10, 13, 0, 0, tzinfo=UTC)
         async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE events SET created_at = $1 "
+                'WHERE session_id = $2 AND data @> \'{"tool_calls":[{"id":"tc_X"}]}\'',
+                a1_ts,
+                session.id,
+            )
+            await conn.execute(
+                "UPDATE events SET created_at = $1 "
+                'WHERE session_id = $2 AND data @> \'{"tool_calls":[{"id":"tc_Z"}]}\'',
+                a2_ts,
+                session.id,
+            )
             unresolved = await queries.list_unresolved_tool_calls_batch(
                 conn, [session.id], account_id=account_id
             )
@@ -138,11 +156,12 @@ class TestAwaitingSpansAllAssistants:
         for entry in by_id.values():
             assert isinstance(entry["pending_since"], datetime)
             assert entry["pending_since"].tzinfo is not None
-        assert by_id["tc_X"]["pending_since"] < by_id["tc_Z"]["pending_since"], (
-            "pending_since must reflect each tool_call's OWN declaring assistant "
-            "turn — tc_X (earlier A1) before tc_Z (later A2) — proving per-row "
-            "stamping, not the latest turn's timestamp (#816)"
+        assert by_id["tc_X"]["pending_since"] == a1_ts, (
+            "pending_since must reflect tc_X's OWN declaring assistant turn (A1), "
+            "not the latest turn's timestamp (#816)"
         )
+        assert by_id["tc_Z"]["pending_since"] == a2_ts
+        assert by_id["tc_X"]["pending_since"] < by_id["tc_Z"]["pending_since"]
 
     async def test_compute_awaiting_populates_pending_since(
         self,
@@ -158,7 +177,6 @@ class TestAwaitingSpansAllAssistants:
         for call in entries:
             assert isinstance(call.pending_since, datetime)
             assert call.pending_since.tzinfo is not None
-        assert by_id["tc_X"].pending_since < by_id["tc_Z"].pending_since
 
     async def test_two_tool_calls_in_one_event_share_pending_since(
         self,

--- a/tests/integration/test_stale_connector_backfill.py
+++ b/tests/integration/test_stale_connector_backfill.py
@@ -292,6 +292,20 @@ class TestStaleConnectorBackfill:
         assert by_id["tc_fresh"]["name"] == SEND_TOOL
         assert by_id["tc_fresh"]["connection_id"]
         assert by_id["tc_fresh"]["arguments"] == '{"text": "hi"}'
+        # #816: the awaiting read-model now stamps each unresolved tool_call
+        # with a per-row ``pending_since`` (and an internal ``_pending_since``
+        # carrier from ``_unresolved_tool_calls``). The connector backfill
+        # builds its own explicit output dict, so neither key must leak into
+        # the transmit payload — its shape is exactly the documented set.
+        assert set(by_id["tc_fresh"]) == {
+            "session_id",
+            "tool_call_id",
+            "name",
+            "arguments",
+            "connection_id",
+            "focal_channel",
+            "workspace_path",
+        }
 
 
 class TestStaleConnectorTail:

--- a/tests/unit/test_classify_awaiting.py
+++ b/tests/unit/test_classify_awaiting.py
@@ -1,0 +1,92 @@
+"""Unit tests for ``services.sessions._classify_awaiting`` (#816).
+
+The read-model classifier turns an unresolved-tool_call entry dict (as
+produced by ``list_unresolved_tool_calls_batch``) into an
+``AwaitingToolCall`` for ``Session.awaiting``. #816 added a required
+``pending_since`` field — the declaring assistant event's ``created_at``
+— so clients can distinguish a healthy in-flight custom call from a stuck
+one. These tests assert ``pending_since`` propagates onto the classified
+entry for each of the custom / builtin / mcp branches.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from aios.models.agents import Agent, ToolSpec
+from aios.models.sessions import AwaitingToolCall
+from aios.services.sessions import _classify_awaiting
+
+PENDING_SINCE = datetime(2026, 6, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_agent(tools: list[ToolSpec]) -> Agent:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    return Agent(
+        id="agt_test",
+        version=1,
+        name="test-agent",
+        model="gpt-test",
+        system="be helpful",
+        tools=tools,
+        mcp_servers=[],
+        description=None,
+        metadata={},
+        window_min=1,
+        window_max=10,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _entry(name: str, *, has_allow_lifecycle: bool = False, **overrides: Any) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "tool_call_id": "tc_1",
+        "name": name,
+        "arguments": "{}",
+        "has_allow_lifecycle": has_allow_lifecycle,
+        "pending_since": PENDING_SINCE,
+    }
+    entry.update(overrides)
+    return entry
+
+
+class TestClassifyAwaitingPendingSince:
+    def test_custom_tool_carries_pending_since(self) -> None:
+        agent = _make_agent([])
+        result = _classify_awaiting(_entry("some_custom_connector_tool"), agent)
+        assert result is not None
+        assert result.kind == "custom"
+        assert result.pending_since == PENDING_SINCE
+
+    def test_builtin_always_ask_carries_pending_since(self) -> None:
+        agent = _make_agent([ToolSpec(type="bash", permission="always_ask")])
+        result = _classify_awaiting(_entry("bash"), agent)
+        assert result is not None
+        assert result.kind == "builtin"
+        assert result.pending_since == PENDING_SINCE
+
+    def test_mcp_always_ask_carries_pending_since(self) -> None:
+        # No matching mcp_toolset entry → effective permission defaults to
+        # always_ask, so the mcp call surfaces as awaiting.
+        agent = _make_agent([])
+        result = _classify_awaiting(_entry("mcp__server__tool"), agent)
+        assert result is not None
+        assert result.kind == "mcp"
+        assert result.pending_since == PENDING_SINCE
+
+
+class TestAwaitingToolCallModel:
+    def test_pending_since_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            AwaitingToolCall(tool_call_id="tc_1", name="x", kind="custom")  # type: ignore[call-arg]
+
+    def test_constructs_with_pending_since(self) -> None:
+        call = AwaitingToolCall(
+            tool_call_id="tc_1", name="x", kind="custom", pending_since=PENDING_SINCE
+        )
+        assert call.pending_since == PENDING_SINCE


### PR DESCRIPTION
## What

Adds a required, derived `pending_since: datetime` to `AwaitingToolCall` = the declaring assistant event's `created_at` (tz-aware UTC).

## Why

`Session.awaiting` entries carried only `{tool_call_id, name, kind}`. For `kind == "custom"`, an entry exists from the moment the assistant declares the call until the executor posts a result — so a healthy in-flight connector call (e.g. `signal_react`, ~2s) was indistinguishable from a stuck one whose client died. Consumers (the console tool-confirmation surface) need an age signal everywhere, including the sessions list where no transcript is loaded.

With `pending_since`, clients can do age-based presentation: fresh custom = in-flight (quiet), stale custom = stuck (alert); builtin/mcp remain approval-gated (alert immediately).

## How

Threaded through the read-model in four hops (zero new DB state — `events.created_at` already exists):

- `_unresolved_tool_calls` now `SELECT`s `created_at` and stamps each unresolved call via a **shallow copy** (`{**tc, "_pending_since": row["created_at"]}`), never mutating the parsed source dict.
- `list_unresolved_tool_calls_batch` surfaces `pending_since` per entry (docstring updated).
- `_classify_awaiting` propagates it onto all three `AwaitingToolCall` variants (custom/builtin/mcp).
- `AwaitingToolCall` gains the required field.

The two connector-SSE paths (`list_pending_calls_for_connector`, `list_pending_calls_for_session_and_connection`) build their own explicit output dicts, so the extra `_pending_since` key is inert there — guarded by a new key-set regression assertion.

The model docstring notes this is the **same clock** the sweep's `client_tool_call_max_age_seconds` abandonment bound (#752) keys off; the two thresholds are intentionally different timescales (seconds-scale UI hint vs. 24h irreversible abandonment), not an inconsistency. Also corrected the stale "latest assistant message" docstring → "any assistant turn (#741)".

Regenerated `openapi.json` + the generated SDK (`awaiting_tool_call.py`) via `scripts/regen-client.sh`.

## Tests

- **New** `tests/unit/test_classify_awaiting.py`: `pending_since` propagates onto each custom/builtin/mcp variant; field is required (constructing without it raises `ValidationError`). Mutation-checked.
- **Extended** `test_awaiting_spans_all_assistants.py`: per-turn `pending_since` (tc_X earlier turn < tc_Z later turn), full `compute_awaiting` service path, and two-calls-in-one-event share the same `pending_since`.
- **Extended** `test_stale_connector_backfill.py`: connector backfill output dict shape is exactly the documented set (no leak).
- All 2713 unit tests pass; mypy + ruff clean; openapi/sdk snapshot tests green. Integration tests collect cleanly (require Docker Postgres; run in CI).

Closes #816