### PR TITLE
fix: add iter_all_connections helper, kill truncation footgun (#814)

### DIFF
--- a/src/aios/api/sse.py
+++ b/src/aios/api/sse.py
@@ -39,6 +39,7 @@ from aios.db.listen import EVENTS_ARCHIVED_NOTIFY
 from aios.errors import SSEPreflightFailedError
 from aios.logging import get_logger
 from aios.models.workflows import TERMINAL_RUN_STATUSES
+from aios.services import connections as connections_service
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable
@@ -504,32 +505,26 @@ async def connection_discovery_stream(
     try:
         emitted_added: set[str] = set()
 
-        # Page through all active connections of this type; the default
-        # ``list_connections`` limit (50) would silently under-fanout for
-        # runtimes with more than 50 active connections.
-        cursor: str | None = None
-        while True:
-            async with pool.acquire() as conn:
-                page = await queries.list_connections(
-                    conn, connector=connector, limit=200, after=cursor, account_id=account_id
-                )
-            for connection in page:
-                if allowlist is not None and connection.id not in allowlist:
-                    continue
-                emitted_added.add(connection.id)
-                yield ServerSentEvent(
-                    data=json.dumps(
-                        {
-                            "event": "added",
-                            "connection_id": connection.id,
-                            "external_account_id": connection.external_account_id,
-                        }
-                    ),
-                    event="connection",
-                )
-            if len(page) < 200:
-                break
-            cursor = page[-1].id
+        # Backfill every active connection of this type. ``iter_all_connections``
+        # keyset-paginates internally (acquiring/releasing the pool per page),
+        # so this fan-out can't silently under-count for runtimes with more
+        # than the default page of connections — and we don't re-roll the loop.
+        async for connection in connections_service.iter_all_connections(
+            pool, connector=connector, account_id=account_id
+        ):
+            if allowlist is not None and connection.id not in allowlist:
+                continue
+            emitted_added.add(connection.id)
+            yield ServerSentEvent(
+                data=json.dumps(
+                    {
+                        "event": "added",
+                        "connection_id": connection.id,
+                        "external_account_id": connection.external_account_id,
+                    }
+                ),
+                event="connection",
+            )
 
         while True:
             payload = await queue.get()

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -15,6 +15,7 @@ pre-#328-PR-7 wire shape.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any
 
 import asyncpg
@@ -161,6 +162,54 @@ async def list_connections(
             after=after,
             account_id=account_id,
         )
+
+
+# Internal keyset page size for :func:`iter_all_connections`. Not a public
+# knob — callers that want "all connections" must not think about paging at
+# all. Module-level so unit tests can monkeypatch it small to prove the
+# page-boundary advance without inserting hundreds of rows.
+_CONNECTION_PAGE_SIZE = 200
+
+
+async def iter_all_connections(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    connector: str | None = None,
+) -> AsyncIterator[Connection]:
+    """Yield **every** connection on ``account_id`` (optionally filtered to
+    one ``connector`` type), keyset-paginating internally.
+
+    Correct-by-construction enumeration: this helper exposes **no** ``limit``
+    parameter, so a caller can never silently under-count the way a bare
+    ``list_connections(..., limit=50)`` does. It is the single sanctioned way
+    to fan out over an account's full connection set; both
+    ``api/sse.py::connection_discovery_stream`` and the
+    ``list_related_sessions`` tool consume it instead of re-rolling the loop.
+
+    **Per-page-release contract (load-bearing — do not "optimize" away):**
+    each page is fetched under its own ``pool.acquire()`` block, which closes
+    *before* the page's rows are yielded. The connection is therefore not held
+    across the (potentially slow) consumer body — `sse.py`'s discovery stream
+    yields SSE events between pages and must not pin a pool connection across
+    those yields under a slow client. Collapsing this into a single held
+    ``conn`` would regress that pool discipline.
+    """
+    cursor: str | None = None
+    while True:
+        async with pool.acquire() as conn:
+            page = await queries.list_connections(
+                conn,
+                connector=connector,
+                limit=_CONNECTION_PAGE_SIZE,
+                after=cursor,
+                account_id=account_id,
+            )
+        for connection in page:
+            yield connection
+        if len(page) < _CONNECTION_PAGE_SIZE:
+            break
+        cursor = page[-1].id
 
 
 async def attach_connection(

--- a/src/aios/tools/list_related_sessions.py
+++ b/src/aios/tools/list_related_sessions.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from aios.harness import runtime
+from aios.services import connections as connections_service
 from aios.services import sessions as sessions_service
 from aios.tools.registry import registry
 
@@ -51,28 +52,25 @@ async def list_related_sessions_handler(
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     connection_id = arguments.get("connection_id")
 
-    rows_out: list[dict[str, Any]] = []
-    async with pool.acquire() as conn:
-        if isinstance(connection_id, str) and connection_id:
+    if isinstance(connection_id, str) and connection_id:
+        async with pool.acquire() as conn:
             # Account-scoped guard: raises NotFoundError on a cross-account
             # (or unknown) connection id before any listing happens.
             await queries.get_connection(conn, connection_id, account_id=account_id)
-            conns = [connection_id]
-        else:
-            # Page through every active connection on the account. The default
-            # ``list_connections`` limit (50) would silently truncate accounts
-            # with more than 50 connections, contradicting this tool's "every
-            # chat-session binding on your account" contract.
-            conns = []
-            cursor: str | None = None
-            while True:
-                page = await queries.list_connections(
-                    conn, account_id=account_id, limit=200, after=cursor
-                )
-                conns.extend(c.id for c in page)
-                if len(page) < 200:
-                    break
-                cursor = page[-1].id
+        conns = [connection_id]
+    else:
+        # Enumerate every connection on the account. ``iter_all_connections``
+        # keyset-paginates internally (no held conn across pages), so this can't
+        # silently truncate accounts with many connections — which would
+        # contradict this tool's "every chat-session binding on your account"
+        # contract.
+        conns = [
+            c.id
+            async for c in connections_service.iter_all_connections(pool, account_id=account_id)
+        ]
+
+    rows_out: list[dict[str, Any]] = []
+    async with pool.acquire() as conn:
         for cid in conns:
             rows = await queries.list_chat_sessions_for_connection(conn, cid, account_id=account_id)
             for chat_id, sess_id, created_at in rows:

--- a/tests/e2e/test_list_related_sessions.py
+++ b/tests/e2e/test_list_related_sessions.py
@@ -134,6 +134,47 @@ class TestListRelatedSessions:
             assert r["created_at"]
             assert "chat_name" not in r
 
+    async def test_returns_sessions_across_multiple_connections(
+        self, harness: Harness, crypto_box: CryptoBox
+    ) -> None:
+        """The no-filter branch enumerates every connection on the account
+        (via ``iter_all_connections``) and returns sessions for all of them.
+
+        End-to-end wiring proof for the multi-connection fan-out; the
+        page-boundary regression is covered cheaply by the unit test in
+        ``tests/unit/test_connections_service.py``.
+        """
+        from aios.services import connections as connections_service
+
+        account_id = "acc_test_stub"
+        caller_session_id = await _make_caller_session(harness, account_id, suffix="multi")
+
+        expected: set[tuple[str, str]] = set()
+        for i in range(4):
+            connection = await connections_service.create_connection(
+                harness._pool,
+                connector="echo",
+                external_account_id=f"echo-multi-{i}",
+                metadata={},
+                crypto_box=crypto_box,
+                account_id=account_id,
+            )
+            target = await _make_bare_session(harness, account_id, suffix=f"multi-{i}")
+            chat_id = f"chat_multi_{i}"
+            async with harness._pool.acquire() as db_conn:
+                await db_queries.insert_chat_session(
+                    db_conn,
+                    connection_id=connection.id,
+                    chat_id=chat_id,
+                    session_id=target,
+                    account_id=account_id,
+                )
+            expected.add((chat_id, target))
+
+        result = await list_related_sessions_handler(caller_session_id, {})
+        rows = result["sessions"]
+        assert {(r["chat_id"], r["session_id"]) for r in rows} == expected
+
     async def test_cross_account_session_not_visible(
         self, harness: Harness, crypto_box: CryptoBox
     ) -> None:

--- a/tests/unit/test_connections_service.py
+++ b/tests/unit/test_connections_service.py
@@ -1,0 +1,165 @@
+"""Unit tests for the connections service layer (issue #814).
+
+Focus: :func:`aios.services.connections.iter_all_connections`, the
+correct-by-construction "enumerate every connection on an account"
+helper that internally keyset-paginates so callers never re-implement
+the loop (and never silently truncate at the bounded ``list_connections``
+default of 50).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.models.connections import Connection
+from aios.services import connections as connections_service
+
+
+def _mk_connection(cid: str, external: str = "ext") -> Connection:
+    """Build a minimal :class:`Connection` with just the fields the helper
+    reads (``id``, threaded through; ``external_account_id`` for parity)."""
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    return Connection(
+        id=cid,
+        connector="telegram",
+        external_account_id=external,
+        metadata={},
+        secrets_set=False,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _mk_pool() -> MagicMock:
+    """Mock pool whose ``async with pool.acquire()`` yields a fresh MagicMock conn.
+
+    Records every ``acquire()`` invocation so tests can assert one acquire
+    per page (per-page release contract).
+    """
+    conn = MagicMock()
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool
+
+
+def _patch_list_connections(
+    monkeypatch: pytest.MonkeyPatch, pages: list[list[Connection]]
+) -> AsyncMock:
+    """Patch ``aios.services.connections.queries.list_connections`` to return
+    ``pages`` in order. Returns the AsyncMock for call-arg assertions."""
+    mock = AsyncMock(side_effect=pages)
+    monkeypatch.setattr("aios.services.connections.queries.list_connections", mock)
+    return mock
+
+
+async def _collect(pool: MagicMock, **kwargs: Any) -> list[Connection]:
+    return [c async for c in connections_service.iter_all_connections(pool, **kwargs)]
+
+
+async def test_yields_across_page_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A full page followed by a partial page yields every row and advances
+    the cursor to ``page[-1].id`` between fetches."""
+    monkeypatch.setattr(connections_service, "_CONNECTION_PAGE_SIZE", 2)
+    page1 = [_mk_connection("c3"), _mk_connection("c2")]
+    page2 = [_mk_connection("c1")]
+    mock = _patch_list_connections(monkeypatch, [page1, page2])
+
+    pool = _mk_pool()
+    result = await _collect(pool, account_id="acct_X")
+
+    assert [c.id for c in result] == ["c3", "c2", "c1"]
+    assert mock.await_count == 2
+    # First fetch: no cursor. Second fetch: cursor == last id of page1.
+    first_kwargs = mock.await_args_list[0].kwargs
+    second_kwargs = mock.await_args_list[1].kwargs
+    assert first_kwargs["after"] is None
+    assert second_kwargs["after"] == "c2"
+    assert first_kwargs["limit"] == 2
+    assert first_kwargs["account_id"] == "acct_X"
+
+
+async def test_exact_boundary_issues_second_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the total equals the page size, a second (empty) fetch is issued
+    and the iteration stops on the empty page."""
+    monkeypatch.setattr(connections_service, "_CONNECTION_PAGE_SIZE", 2)
+    page1 = [_mk_connection("c2"), _mk_connection("c1")]
+    page2: list[Connection] = []
+    mock = _patch_list_connections(monkeypatch, [page1, page2])
+
+    pool = _mk_pool()
+    result = await _collect(pool, account_id="acct_X")
+
+    assert [c.id for c in result] == ["c2", "c1"]
+    assert mock.await_count == 2
+
+
+async def test_single_short_page_one_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A page shorter than the page size does exactly one fetch."""
+    monkeypatch.setattr(connections_service, "_CONNECTION_PAGE_SIZE", 5)
+    page1 = [_mk_connection("c2"), _mk_connection("c1")]
+    mock = _patch_list_connections(monkeypatch, [page1])
+
+    pool = _mk_pool()
+    result = await _collect(pool, account_id="acct_X")
+
+    assert [c.id for c in result] == ["c2", "c1"]
+    assert mock.await_count == 1
+
+
+async def test_empty_account_one_fetch_yields_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(connections_service, "_CONNECTION_PAGE_SIZE", 5)
+    mock = _patch_list_connections(monkeypatch, [[]])
+
+    pool = _mk_pool()
+    result = await _collect(pool, account_id="acct_X")
+
+    assert result == []
+    assert mock.await_count == 1
+
+
+async def test_connector_filter_threaded_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(connections_service, "_CONNECTION_PAGE_SIZE", 5)
+    mock = _patch_list_connections(monkeypatch, [[]])
+
+    pool = _mk_pool()
+    await _collect(pool, account_id="acct_X", connector="telegram")
+
+    assert mock.await_args_list[0].kwargs["connector"] == "telegram"
+
+
+async def test_one_acquire_per_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each page is fetched under its own ``pool.acquire()``, released before
+    the next — assert acquire is called once per page, not once total."""
+    monkeypatch.setattr(connections_service, "_CONNECTION_PAGE_SIZE", 2)
+    page1 = [_mk_connection("c4"), _mk_connection("c3")]
+    page2 = [_mk_connection("c2"), _mk_connection("c1")]
+    page3: list[Connection] = []
+    _patch_list_connections(monkeypatch, [page1, page2, page3])
+
+    pool = _mk_pool()
+    result = await _collect(pool, account_id="acct_X")
+
+    assert [c.id for c in result] == ["c4", "c3", "c2", "c1"]
+    # Three pages fetched → three acquires.
+    assert pool.acquire.call_count == 3
+
+
+async def test_no_limit_parameter_exposed() -> None:
+    """The helper exposes no ``limit`` parameter — correct-by-construction."""
+    import inspect
+
+    sig = inspect.signature(connections_service.iter_all_connections)
+    assert "limit" not in sig.parameters

--- a/tests/unit/test_sse_connection_discovery.py
+++ b/tests/unit/test_sse_connection_discovery.py
@@ -1,0 +1,150 @@
+"""Unit tests for ``connection_discovery_stream`` backfill (issue #814).
+
+After migrating the hand-rolled keyset loop onto
+``connections_service.iter_all_connections``, the backfill must still:
+
+* emit a byte-identical ``{event:'added', connection_id, external_account_id}``
+  ``ServerSentEvent`` payload per active connection (the downstream runtime
+  discovery loop parses ``external_account_id``);
+* honour the ``connection_ids`` allowlist (out-of-scope ids skipped);
+* dedup so the live tail doesn't re-emit an already-backfilled ``added``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sse_starlette import ServerSentEvent
+
+from aios.api.sse import connection_discovery_stream
+from aios.db.listen import ListenSubscription
+from aios.models.connections import Connection
+
+
+def _mk_subscription() -> tuple[ListenSubscription, asyncio.Queue[str]]:
+    conn = MagicMock()
+    queue: asyncio.Queue[str] = asyncio.Queue(maxsize=8)
+    return ListenSubscription(queue=queue, _conn=conn), queue
+
+
+def _mk_pool() -> MagicMock:
+    conn = MagicMock()
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool
+
+
+def _mk_connection(cid: str, external: str) -> Connection:
+    now = datetime(2024, 1, 1, tzinfo=UTC)
+    return Connection(
+        id=cid,
+        connector="telegram",
+        external_account_id=external,
+        metadata={},
+        secrets_set=False,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _payload(evt: ServerSentEvent) -> dict[str, str]:
+    """Parse a ``ServerSentEvent``'s JSON ``data`` (typed ``Any | None``)."""
+    assert isinstance(evt.data, str)
+    parsed: dict[str, str] = json.loads(evt.data)
+    return parsed
+
+
+async def _drain_backfill(
+    gen: AsyncIterator[ServerSentEvent], expected_count: int
+) -> list[ServerSentEvent]:
+    """Pull exactly ``expected_count`` backfill events, then stop (the live
+    tail would block on an empty queue)."""
+    events: list[ServerSentEvent] = []
+    for _ in range(expected_count):
+        events.append(await gen.__anext__())
+    await gen.aclose()  # type: ignore[attr-defined]
+    return events
+
+
+async def test_backfill_payload_is_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "aios.services.connections.queries.list_connections",
+        AsyncMock(return_value=[_mk_connection("con_1", "ext_1")]),
+    )
+    subscription, _ = _mk_subscription()
+    pool = _mk_pool()
+
+    gen = connection_discovery_stream(subscription, pool, "telegram", account_id="acct_X")
+    events = await _drain_backfill(gen, 1)
+
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.event == "connection"
+    assert _payload(evt) == {
+        "event": "added",
+        "connection_id": "con_1",
+        "external_account_id": "ext_1",
+    }
+
+
+async def test_backfill_honours_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "aios.services.connections.queries.list_connections",
+        AsyncMock(
+            return_value=[
+                _mk_connection("con_1", "ext_1"),
+                _mk_connection("con_2", "ext_2"),
+                _mk_connection("con_3", "ext_3"),
+            ]
+        ),
+    )
+    subscription, _ = _mk_subscription()
+    pool = _mk_pool()
+
+    gen = connection_discovery_stream(
+        subscription,
+        pool,
+        "telegram",
+        account_id="acct_X",
+        connection_ids=["con_1", "con_3"],
+    )
+    events = await _drain_backfill(gen, 2)
+
+    ids = [_payload(e)["connection_id"] for e in events]
+    assert ids == ["con_1", "con_3"]
+
+
+async def test_live_tail_dedups_already_backfilled_added(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "aios.services.connections.queries.list_connections",
+        AsyncMock(return_value=[_mk_connection("con_1", "ext_1")]),
+    )
+    subscription, queue = _mk_subscription()
+    pool = _mk_pool()
+
+    gen = connection_discovery_stream(subscription, pool, "telegram", account_id="acct_X")
+
+    # First event is the backfilled "added".
+    first = await gen.__anext__()
+    assert _payload(first)["connection_id"] == "con_1"
+
+    # A duplicate "added" arriving on the live tail must be suppressed; only the
+    # subsequent distinct event is emitted.
+    await queue.put("added|con_1|acct_X|ext_1")
+    await queue.put("added|con_2|acct_X|ext_2")
+    nxt = await gen.__anext__()
+    assert _payload(nxt)["connection_id"] == "con_2"
+
+    await gen.aclose()  # type: ignore[attr-defined]

--- a/tests/unit/test_sse_generator_cleanup.py
+++ b/tests/unit/test_sse_generator_cleanup.py
@@ -49,12 +49,36 @@ def _install_query_backfill(
     attr: str,
     pool: MagicMock,
     exc: Exception | None,
-) -> None:
-    """Stub a ``aios.api.sse.queries.<attr>`` backfill function."""
-    if exc is None:
-        monkeypatch.setattr(f"aios.api.sse.queries.{attr}", AsyncMock(return_value=[]))
-    else:
-        monkeypatch.setattr(f"aios.api.sse.queries.{attr}", AsyncMock(side_effect=exc))
+) -> AsyncMock:
+    """Stub a ``aios.api.sse.queries.<attr>`` backfill function.
+
+    Returns the installed mock so the caller can assert it was awaited —
+    a wrong-symbol patch (one the generator no longer calls) then fails
+    loudly instead of passing for the wrong reason.
+    """
+    mock = AsyncMock(return_value=[]) if exc is None else AsyncMock(side_effect=exc)
+    monkeypatch.setattr(f"aios.api.sse.queries.{attr}", mock)
+    return mock
+
+
+def _install_discovery_backfill(
+    monkeypatch: pytest.MonkeyPatch,
+    pool: MagicMock,
+    exc: Exception | None,
+) -> AsyncMock:
+    """Dedicated installer for ``connection_discovery_stream``.
+
+    After migration (#814) the discovery backfill no longer calls
+    ``aios.api.sse.queries.list_connections`` directly — it consumes
+    ``connections_service.iter_all_connections``, which calls
+    ``aios.services.connections.queries.list_connections``. Patch THAT
+    symbol (leaving ``_install_query_backfill`` untouched for the two
+    sse-local cases) and return the mock so the test can assert it was
+    actually awaited.
+    """
+    mock = AsyncMock(return_value=[]) if exc is None else AsyncMock(side_effect=exc)
+    monkeypatch.setattr("aios.services.connections.queries.list_connections", mock)
+    return mock
 
 
 def _install_session_event_backfill(
@@ -125,7 +149,7 @@ _CASES = [
     ),
     pytest.param(
         lambda sub, pool: connection_discovery_stream(sub, pool, "telegram", account_id="acct_X"),
-        lambda mp, pool, exc: _install_query_backfill(mp, "list_connections", pool, exc),
+        lambda mp, pool, exc: _install_discovery_backfill(mp, pool, exc),
         id="connection_discovery_stream",
     ),
     pytest.param(
@@ -145,7 +169,7 @@ async def test_generator_terminates_conn_on_cancel(
     """Cancelling the consumer task must trigger subscription.terminate()."""
     subscription = _mk_subscription()
     pool = _mk_pool()
-    install_backfill(monkeypatch, pool, None)
+    backfill_mock = install_backfill(monkeypatch, pool, None)
 
     gen = build_gen(subscription, pool)
 
@@ -161,6 +185,10 @@ async def test_generator_terminates_conn_on_cancel(
         await task
 
     subscription._conn.terminate.assert_called_once()
+    # Where the installer patches a query symbol, it must have actually been
+    # awaited — guards against a wrong-symbol patch passing for the wrong reason.
+    if backfill_mock is not None:
+        backfill_mock.assert_awaited()
 
 
 @pytest.mark.parametrize("build_gen, install_backfill", _CASES)
@@ -172,7 +200,7 @@ async def test_generator_terminates_conn_when_backfill_raises(
     """Backfill query failure must still terminate the subscription."""
     subscription = _mk_subscription()
     pool = _mk_pool()
-    install_backfill(monkeypatch, pool, RuntimeError("backfill kaboom"))
+    backfill_mock = install_backfill(monkeypatch, pool, RuntimeError("backfill kaboom"))
 
     gen = build_gen(subscription, pool)
 
@@ -184,3 +212,7 @@ async def test_generator_terminates_conn_when_backfill_raises(
         await _consume()
 
     subscription._conn.terminate.assert_called_once()
+    # The raising symbol must have actually been awaited — guards against a
+    # wrong-symbol patch making the cleanup test pass for the wrong reason.
+    if backfill_mock is not None:
+        backfill_mock.assert_awaited()


### PR DESCRIPTION
## Problem

`queries.list_connections` enforces a default `limit=50` in SQL. Any caller that wants *all* of an account's connections had to remember to keyset-paginate with the `after` cursor; forgetting silently under-counts for accounts with >50 connections. Two independent call sites had re-implemented the same pagination dance, and one (`list_related_sessions`, PR #811) shipped the bug before review caught it. That's a recurring footgun.

## Fix

Add **one** correct-by-construction enumerator in `src/aios/services/connections.py`:

```python
async def iter_all_connections(pool, *, account_id, connector=None) -> AsyncIterator[Connection]
```

A pool-taking async-generator that keyset-paginates internally and exposes **no `limit` parameter** — a caller can't silently under-count. Page size is a monkeypatchable module constant `_CONNECTION_PAGE_SIZE` (replacing the two magic `200`s).

**Per-page-release contract (load-bearing):** each page is fetched under its own `pool.acquire()` block that closes *before* the page's rows are yielded. This is a drop-in for `sse.py`'s discovery stream — which yields SSE events between pages and must not pin a pool connection across yields under a slow client — and works for `list_related_sessions` too. The docstring calls this out so a future reader doesn't "optimize" it into a single held conn.

## Migrations (both hand-rolled loops deleted)

- **`api/sse.py::connection_discovery_stream`** — backfill now consumes `iter_all_connections`, preserving the `allowlist` filter, `emitted_added` dedup, and the **byte-identical** `{event:'added', connection_id, external_account_id}` SSE payload.
- **`tools/list_related_sessions.py`** — enumerates ids via `iter_all_connections`; the single-`connection_id` `get_connection` NotFoundError guard and the chat-session fan-out each run under their own `pool.acquire()` *after* enumeration (no conn held during pagination).

The bounded `queries.list_connections(limit=50)`, the router/CLI single-page reads, and the service-layer `list_connections(pool, ...)` wrapper stay **unchanged** — those are deliberate single-page reads, not footguns. NO-BACKCOMPAT: no `limit=None` sentinel, no parallel deprecated path.

## Tests

- `tests/unit/test_connections_service.py` (new): page-boundary advance, exact-boundary second fetch, single short page, empty account, `connector` threading, one-acquire-per-page, no-`limit`-param. Page size monkeypatched small.
- `tests/unit/test_sse_connection_discovery.py` (new): SSE backfill payload parity, allowlist filtering, live-tail dedup of already-backfilled `added`.
- `tests/unit/test_sse_generator_cleanup.py` (modified): dedicated backfill installer for the discovery case patching `aios.services.connections.queries.list_connections` (the symbol actually called post-migration), with an awaited-assertion so a wrong-symbol patch fails loudly; the two sse-local cases keep `_install_query_backfill` untouched.
- `tests/e2e/test_list_related_sessions.py` (extended): added a small 4-connection wiring case; existing one-connection / cross-account / connection-filter cases unchanged.

Mutation check confirmed the page-boundary unit test is non-vacuous. `mypy src tests`, `ruff check`/`format`, and the full unit suite (2729 passed) are green; all pre-commit hooks pass. No openapi/SDK codegen drift (no API schema touched).

Closes #814