### PR TITLE
fix: drop deprecated broker-POST archaeology from wake_self docs

### DIFF
--- a/src/aios/tools/trigger_create.py
+++ b/src/aios/tools/trigger_create.py
@@ -126,14 +126,9 @@ _SOURCE_SCHEMA: dict[str, Any] = {
 
 _SANDBOX_COMMAND_DESCRIPTION = (
     "Bash command run in the session's sandbox at each fire, WITHOUT waking "
-    "the model. To escalate (wake the model with a user-role message), the "
-    "canonical bash invocation is:\n"
-    "\n"
-    '  tool wake_self \'{"content":"<message to deliver to yourself>"}\'\n'
-    "\n"
-    "This keeps the broker secret out of the command string. Advanced or "
-    "scripted callers may still POST to "
-    "``$TOOL_BROKER_URL/v1/$TOOL_BROKER_SECRET/sessions/messages`` directly."
+    "the model. To escalate (wake the model with a user-role message), call "
+    '``tool wake_self \'{"content":"<message to deliver to yourself>"}\'`` '
+    "from inside the cron command."
 )
 
 _ACTION_SCHEMA: dict[str, Any] = {

--- a/src/aios/tools/wake_self.py
+++ b/src/aios/tools/wake_self.py
@@ -1,9 +1,8 @@
 """The ``wake_self`` tool — append a user-role message to *this* session.
 
-Canonical self-wake primitive for cron-fired bash commands (and any
-other sandbox-side caller). Replaces the older curl-the-broker idiom
-so the broker secret never has to be interpolated into the command
-string.
+Self-wake primitive for cron-fired bash commands (and any other
+sandbox-side caller): escalate a tool result, finding, or external
+event into a model wake.
 """
 
 from __future__ import annotations
@@ -24,13 +23,11 @@ class WakeSelfArgumentError(AiosError):
 
 WAKE_SELF_DESCRIPTION = (
     "Append content as a user-role message to your own session and "
-    "schedule the next step. This is the canonical self-wake primitive "
-    "from inside a trigger's sandbox_command (or any sandbox bash "
-    "command) — it replaces the older "
-    "``curl $TOOL_BROKER_URL/v1/$TOOL_BROKER_SECRET/sessions/messages`` "
-    "idiom and keeps the broker secret out of the command string. The "
-    "appended message is delivered to your next model call as a normal "
-    "user-role event. Available on both the model-tool surface and as "
+    "schedule the next step. Use from inside a trigger's sandbox_command "
+    "(or any sandbox bash command) to escalate a tool result, finding, or "
+    "external event into a model wake. The appended message is delivered "
+    "to your next model call as a normal user-role event. Available on "
+    "both the model-tool surface and as "
     '``tool wake_self \'{"content":"..."}\'`` from inside the sandbox.'
 )
 


### PR DESCRIPTION
## What & why

Follow-up to #703. The `wake_self` tool shipped, but its description (and `schedule_task_add`'s `sandbox_command` description) still carried archaeology about the deprecated pattern it replaced — noise for anyone reading the descriptions fresh.

Two clauses were dropped from the `wake_self` description:
- "it replaces the older `curl $TOOL_BROKER_URL/...` idiom" — only meaningful to someone who remembers the deprecated approach.
- "and keeps the broker secret out of the command string" — a justification framed against a problem that no longer exists in the documented API.

The matching sentences were dropped from `schedule_task_add`'s `sandbox_command` description ("This keeps the broker secret out of the command string. Advanced or scripted callers may still POST to `$TOOL_BROKER_URL/...` directly.") and replaced with a direct `tool wake_self '{"content":"..."}'` invocation.

## Changes
- `src/aios/tools/wake_self.py`: rewrote `WAKE_SELF_DESCRIPTION` per the issue's suggested rewrite (preserving the repo's accurate "trigger's sandbox_command" context). Also cleaned the same deprecated broker-POST reference out of the module docstring — same file, same flagged pattern (broken-windows).
- `src/aios/tools/trigger_create.py`: rewrote `_SANDBOX_COMMAND_DESCRIPTION` to drop the broker-secret/POST sentences.

Both descriptions now read as if `wake_self` had always been there.

## Validation
- `mypy`, `ruff check`, `ruff format --check`: clean.
- Full pre-commit suite green (2729 passed).
- No codegen drift: `regen-openapi.sh` produced no changes, and `test_openapi_snapshot` / `test_sdk_snapshot` pass — these tool descriptions are model-tool definitions, not FastAPI route schemas, so they don't reach `openapi.json` or the SDK.
- No tests assert on these description strings (pure copy edit; no logic surface).

Closes #706