### PR TITLE
fix: guard against shared dev DB from a linked git worktree (#349)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,31 @@ uv run python -m aios api      # API server on :8090
 uv run python -m aios worker   # procrastinate worker
 ```
 
+### Worktree smoke / dev isolation
+
+Every git worktree gets its own isolated DB on the shared local Postgres via
+`aios dev bootstrap`. **The first step of any worktree smoke is to bootstrap,
+not to `source .env`.** Sourcing the main checkout's `.env` from a worktree
+silently points you at the shared dev DB (`localhost:5433/aios`) — real
+connection records and live traffic land in a shared/prod-shadow DB (#349).
+
+Sanctioned worktree-smoke sequence:
+
+```bash
+uv run aios dev bootstrap       # provisions aios_dev_<id> + writes worktree-local .env
+# open a FRESH shell (no stale AIOS_* exports)
+set -a && source .env && set +a # the WORKTREE-LOCAL .env, written by bootstrap
+uv run aios dev status          # sanity check: expect `mode: isolated`
+uv run python -m aios api       # / aios worker
+```
+
+`aios dev status` prints a `mode:` line — `isolated` (bootstrapped, on its own
+`aios_dev_*` DB), `shared` (linked worktree pointed at the shared dev DB — fix
+before proceeding), or `unbootstrapped` (run `aios dev bootstrap`). As a
+backstop, `aios api` / `aios worker` hard-fail when started from a linked
+worktree against the shared DB; override with `AIOS_ALLOW_SHARED_DB=1` only if
+you really mean it.
+
 ### Client CLI
 
 `aios` is a typer-based client CLI that talks to a running API. Config is read from env (`AIOS_URL`, `AIOS_API_KEY`) or `.env`; every command accepts `--url` / `--api-key` overrides and a global `--format {table,json}`.

--- a/src/aios/cli/commands/dev.py
+++ b/src/aios/cli/commands/dev.py
@@ -222,6 +222,126 @@ def get_git_repo_root() -> Path:
     return Path(out.strip())
 
 
+# ── shared-DB-from-worktree guard ──────────────────────────────────────────
+
+
+def is_linked_worktree() -> bool:
+    """Return True iff the cwd is inside a *linked* git worktree.
+
+    A linked worktree (created by ``git worktree add``) has its ``--git-dir``
+    point at ``<main>/.git/worktrees/<name>`` while ``--git-common-dir`` points
+    at the main checkout's ``.git``; they differ. In the main checkout both
+    resolve to the same path (``.git`` as-returned) so they are equal.
+
+    We compare both values *as returned* (NOT ``--absolute-git-dir``): in the
+    main checkout both are the relative string ``.git`` and compare equal,
+    which is exactly what we want.
+
+    Swallows ``CalledProcessError`` / ``FileNotFoundError`` → ``False`` so it
+    is prod-safe: the api image has no git binary, and the worker's ``/app``
+    has no ``.git`` because ``.dockerignore`` excludes it. Both cases must
+    never raise — they just mean "not a linked worktree."
+    """
+    try:
+        git_dir = subprocess.check_output(
+            ["git", "rev-parse", "--git-dir"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return git_dir != common_dir
+
+
+def db_name_is_shared(db_url: str) -> bool:
+    """Return True iff ``db_url``'s database name is NOT a bootstrapped one.
+
+    Every database created by ``aios dev bootstrap`` is named
+    ``aios_dev_<id>`` (see :func:`derive_runtime_db_url`). Anything else —
+    the shared local dev DB (``aios``), test DBs, etc. — is "shared" for the
+    purposes of the worktree guard.
+    """
+    db_name = urlparse(db_url).path.lstrip("/")
+    return not db_name.startswith(DB_PREFIX)
+
+
+def runtime_db_url(repo_root: Path) -> str | None:
+    """Resolve ``AIOS_DB_URL`` the way pydantic will at runtime.
+
+    Process env beats the worktree ``.env`` (``config.py`` env_file tuple),
+    so honour an exported value first, then fall back to the worktree
+    ``.env``. Returns ``None`` if neither sets it. Avoids constructing the
+    full :class:`Settings` so the guard never depends on a loadable config.
+    """
+    exported = os.environ.get("AIOS_DB_URL")
+    if exported:
+        return exported
+    env = parse_env_file(repo_root / ".env")
+    return env.get("AIOS_DB_URL")
+
+
+def assert_not_shared_in_worktree() -> None:
+    """Abort startup if a linked worktree is about to use the shared dev DB.
+
+    The footgun (#349): in a git worktree you source the main checkout's
+    ``.env`` (or never ran ``aios dev bootstrap``), so the runtime
+    ``AIOS_DB_URL`` points at the shared local dev DB while you believe you're
+    isolated — silently writing real records into a shared/prod-shadow DB.
+
+    Guard condition: running from a *linked worktree* AND the resolved runtime
+    ``AIOS_DB_URL`` db-name is not ``aios_dev_*``. ``AIOS_ALLOW_SHARED_DB=1``
+    is an explicit escape hatch.
+    """
+    if os.environ.get("AIOS_ALLOW_SHARED_DB") == "1":
+        return
+    if not is_linked_worktree():
+        return
+    db_url = runtime_db_url(get_git_repo_root())
+    if db_url is None or not db_name_is_shared(db_url):
+        return
+    print_error(
+        "refusing to start: this linked git worktree is pointing at the "
+        "shared dev DB (AIOS_DB_URL does not name an aios_dev_* database). "
+        "You probably sourced the main checkout's .env. Run `aios dev "
+        "bootstrap` and source the worktree-local .env in a fresh shell, or "
+        "set AIOS_ALLOW_SHARED_DB=1 to override."
+    )
+    raise typer.Exit(1)
+
+
+def classify_instance_mode(
+    env: dict[str, str],
+    resolved_db_url: str | None,
+    in_linked_worktree: bool,
+) -> str:
+    """Classify the worktree's dev mode for ``aios dev status``.
+
+    Returns one of ``"unbootstrapped"``, ``"shared"``, ``"isolated"``:
+
+    - ``unbootstrapped`` — the worktree ``.env`` lacks the four instance keys
+      (``aios dev bootstrap`` was never run here).
+    - ``shared`` — a linked worktree whose resolved runtime DB is shared.
+    - ``isolated`` — everything else (main checkout, or a bootstrapped
+      worktree pointing at its ``aios_dev_*`` DB).
+    """
+    required = (
+        "AIOS_INSTANCE_ID",
+        "AIOS_DB_URL",
+        "AIOS_API_PORT",
+        "AIOS_WORKSPACE_ROOT",
+    )
+    if any(k not in env for k in required):
+        return "unbootstrapped"
+    if in_linked_worktree and resolved_db_url is not None and db_name_is_shared(resolved_db_url):
+        return "shared"
+    return "isolated"
+
+
 # ── stale-export guard ─────────────────────────────────────────────────────
 
 _STALE_EXPORT_VARS = (
@@ -676,26 +796,50 @@ def _pkill_pattern(pattern: str) -> bool:
 @app.command("status", help="Show this worktree's aios dev instance status.")
 def status() -> None:
     repo_root = get_git_repo_root()
-    env = load_instance_env(repo_root)
-    instance_id = env["AIOS_INSTANCE_ID"]
-    validate_instance_id_for_db(instance_id)
-    db_name = DB_PREFIX + instance_id
-    port = int(env["AIOS_API_PORT"])
-    workspace_root = Path(env["AIOS_WORKSPACE_ROOT"])
+    # Read the worktree .env directly rather than via load_instance_env, which
+    # hard-exits on missing keys — we must report the unbootstrapped case, not
+    # die on it. Resolve the runtime DB the way pydantic will (exported value
+    # beats .env) so a stale exported AIOS_DB_URL is reflected — that divergence
+    # is the exact footgun #349 is about.
+    env = parse_env_file(repo_root / ".env")
+    resolved_db_url = runtime_db_url(repo_root)
+    in_worktree = is_linked_worktree()
+    mode = classify_instance_mode(env, resolved_db_url, in_worktree)
 
-    print(f"instance_id:     {instance_id}")
-    print(f"database:        {db_name}")
-    print(f"api_port:        {port}")
-    print(f"workspace_root:  {workspace_root}")
+    print(f"mode:            {mode}")
 
-    container_ids = _list_instance_containers(instance_id)
-    print(f"containers:      {len(container_ids)}")
+    instance_id = env.get("AIOS_INSTANCE_ID")
+    print(f"instance_id:     {instance_id or '-'}")
 
-    api_up = port_is_open(port)
-    print(f"api_port_open:   {api_up}")
+    if instance_id:
+        print(f"database:        {DB_PREFIX + instance_id}")
+    else:
+        print("database:        -")
 
-    try:
-        clients = asyncio.run(_count_db_clients(env["AIOS_DB_URL"]))
-        print(f"db_attached:     {clients}  (best-effort; any long-lived connection counts)")
-    except (asyncpg.exceptions.PostgresError, OSError) as exc:
-        print(f"db_attached:     unknown ({exc})")
+    port_str = env.get("AIOS_API_PORT")
+    print(f"api_port:        {port_str or '-'}")
+
+    workspace_root = env.get("AIOS_WORKSPACE_ROOT")
+    print(f"workspace_root:  {workspace_root or '-'}")
+
+    if instance_id:
+        container_ids = _list_instance_containers(instance_id)
+        print(f"containers:      {len(container_ids)}")
+    else:
+        print("containers:      -")
+
+    if port_str:
+        api_up = port_is_open(int(port_str))
+        print(f"api_port_open:   {api_up}")
+    else:
+        print("api_port_open:   -")
+
+    db_url = env.get("AIOS_DB_URL")
+    if db_url:
+        try:
+            clients = asyncio.run(_count_db_clients(db_url))
+            print(f"db_attached:     {clients}  (best-effort; any long-lived connection counts)")
+        except (asyncpg.exceptions.PostgresError, OSError) as exc:
+            print(f"db_attached:     unknown ({exc})")
+    else:
+        print("db_attached:     -")

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -21,7 +21,12 @@ from aios.errors import CryptoDecryptError
 def _run_api() -> int:
     import uvicorn
 
+    from aios.cli.commands.dev import assert_not_shared_in_worktree
     from aios.config import get_settings
+
+    # Abort before any DB connection if a linked worktree is about to use the
+    # shared dev DB (#349). No-op in the main checkout / when bootstrapped.
+    assert_not_shared_in_worktree()
 
     settings = get_settings()
     uvicorn.run(
@@ -36,8 +41,13 @@ def _run_api() -> int:
 
 
 def _run_worker() -> int:
+    from aios.cli.commands.dev import assert_not_shared_in_worktree
     from aios.harness.worker import worker_main
     from aios.logging import get_logger
+
+    # Abort before spawning any container / DB connection if a linked worktree
+    # is about to use the shared dev DB (#349). No-op in the main checkout.
+    assert_not_shared_in_worktree()
 
     try:
         asyncio.run(worker_main())

--- a/tests/unit/cli/test_cli_dev.py
+++ b/tests/unit/cli/test_cli_dev.py
@@ -10,14 +10,21 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import typer
 
+from aios.cli.commands import dev as dev_mod
 from aios.cli.commands.dev import (
     INSTANCE_ID_PATTERN,
     MAX_DB_NAME_BYTES,
     _resolve_admin_url,
+    assert_not_shared_in_worktree,
+    classify_instance_mode,
+    db_name_is_shared,
     derive_instance_id,
     derive_runtime_db_url,
+    is_linked_worktree,
     parse_env_file,
+    runtime_db_url,
     validate_instance_id_for_db,
     write_env_atomic,
 )
@@ -302,3 +309,174 @@ def test_resolve_admin_url_uses_secrets_when_no_env(
     monkeypatch.delenv("AIOS_POSTGRES_ADMIN_URL", raising=False)
     secrets = {"AIOS_POSTGRES_ADMIN_URL": "postgresql://secrets@localhost:5433/postgres"}
     assert _resolve_admin_url(secrets) == "postgresql://secrets@localhost:5433/postgres"
+
+
+# ── db_name_is_shared (criterion 1) ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "db_url,expected",
+    [
+        ("postgresql://h/aios", True),
+        ("postgresql://localhost/test", True),
+        ("postgresql://localhost:5433/aios", True),
+        ("postgresql://h/aios_dev_x", False),
+        ("postgresql://h/aios_dev_x?sslmode=require", False),
+        ("postgresql://user:pw@host:5432/aios_dev_proj_abcd1234", False),
+    ],
+)
+def test_db_name_is_shared(db_url: str, expected: bool) -> None:
+    assert db_name_is_shared(db_url) is expected
+
+
+# ── is_linked_worktree (criteria 4, 5) ─────────────────────────────────────
+
+
+def test_is_linked_worktree_true_when_dirs_differ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outputs = iter([".git/worktrees/foo\n", ".git\n"])
+    monkeypatch.setattr(
+        "aios.cli.commands.dev.subprocess.check_output", lambda *a, **k: next(outputs)
+    )
+    assert is_linked_worktree() is True
+
+
+def test_is_linked_worktree_false_when_dirs_equal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outputs = iter([".git\n", ".git\n"])
+    monkeypatch.setattr(
+        "aios.cli.commands.dev.subprocess.check_output", lambda *a, **k: next(outputs)
+    )
+    assert is_linked_worktree() is False
+
+
+def test_is_linked_worktree_false_on_called_process_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess
+
+    def _boom(*a, **k):
+        raise subprocess.CalledProcessError(128, "git")
+
+    monkeypatch.setattr("aios.cli.commands.dev.subprocess.check_output", _boom)
+    assert is_linked_worktree() is False
+
+
+def test_is_linked_worktree_false_on_file_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(*a, **k):
+        raise FileNotFoundError("git not installed")
+
+    monkeypatch.setattr("aios.cli.commands.dev.subprocess.check_output", _boom)
+    assert is_linked_worktree() is False
+
+
+# ── runtime_db_url ─────────────────────────────────────────────────────────
+
+
+def test_runtime_db_url_prefers_exported_over_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / ".env").write_text("AIOS_DB_URL=postgresql://h/aios_dev_x\n")
+    monkeypatch.setenv("AIOS_DB_URL", "postgresql://h/aios")
+    assert runtime_db_url(tmp_path) == "postgresql://h/aios"
+
+
+def test_runtime_db_url_falls_back_to_env_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / ".env").write_text("AIOS_DB_URL=postgresql://h/aios_dev_x\n")
+    monkeypatch.delenv("AIOS_DB_URL", raising=False)
+    assert runtime_db_url(tmp_path) == "postgresql://h/aios_dev_x"
+
+
+def test_runtime_db_url_none_when_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AIOS_DB_URL", raising=False)
+    assert runtime_db_url(tmp_path) is None
+
+
+# ── classify_instance_mode (criterion 7) ───────────────────────────────────
+
+_FULL_ENV = {
+    "AIOS_INSTANCE_ID": "proj_abcd1234",
+    "AIOS_DB_URL": "postgresql://h/aios_dev_proj_abcd1234",
+    "AIOS_API_PORT": "8090",
+    "AIOS_WORKSPACE_ROOT": "/tmp/ws",
+}
+
+
+def test_classify_unbootstrapped_when_keys_missing() -> None:
+    assert classify_instance_mode({}, None, True) == "unbootstrapped"
+    partial = dict(_FULL_ENV)
+    del partial["AIOS_DB_URL"]
+    assert classify_instance_mode(partial, None, True) == "unbootstrapped"
+
+
+def test_classify_shared_when_linked_worktree_and_shared_db() -> None:
+    assert classify_instance_mode(_FULL_ENV, "postgresql://h/aios", True) == "shared"
+
+
+def test_classify_isolated_when_linked_worktree_and_dev_db() -> None:
+    assert (
+        classify_instance_mode(_FULL_ENV, "postgresql://h/aios_dev_proj_abcd1234", True)
+        == "isolated"
+    )
+
+
+def test_classify_isolated_when_main_checkout_even_on_shared_db() -> None:
+    assert classify_instance_mode(_FULL_ENV, "postgresql://h/aios", False) == "isolated"
+
+
+# ── assert_not_shared_in_worktree (criteria 2, 3) ──────────────────────────
+
+
+def test_assert_raises_on_linked_shared_no_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AIOS_ALLOW_SHARED_DB", raising=False)
+    monkeypatch.setattr(dev_mod, "is_linked_worktree", lambda: True)
+    monkeypatch.setattr(dev_mod, "get_git_repo_root", lambda: Path("/repo"))
+    monkeypatch.setattr(dev_mod, "runtime_db_url", lambda _root: "postgresql://h/aios")
+
+    messages: list[str] = []
+    monkeypatch.setattr(dev_mod, "print_error", lambda msg: messages.append(msg))
+
+    with pytest.raises(typer.Exit) as excinfo:
+        assert_not_shared_in_worktree()
+    assert excinfo.value.exit_code == 1
+    joined = " ".join(messages)
+    assert "aios dev bootstrap" in joined
+    assert "AIOS_ALLOW_SHARED_DB=1" in joined
+
+
+def test_assert_noop_when_not_linked_worktree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AIOS_ALLOW_SHARED_DB", raising=False)
+    monkeypatch.setattr(dev_mod, "is_linked_worktree", lambda: False)
+    monkeypatch.setattr(dev_mod, "get_git_repo_root", lambda: Path("/repo"))
+    monkeypatch.setattr(dev_mod, "runtime_db_url", lambda _root: "postgresql://h/aios")
+    assert_not_shared_in_worktree()  # must not raise
+
+
+def test_assert_noop_when_db_is_dev_prefixed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AIOS_ALLOW_SHARED_DB", raising=False)
+    monkeypatch.setattr(dev_mod, "is_linked_worktree", lambda: True)
+    monkeypatch.setattr(dev_mod, "get_git_repo_root", lambda: Path("/repo"))
+    monkeypatch.setattr(dev_mod, "runtime_db_url", lambda _root: "postgresql://h/aios_dev_x")
+    assert_not_shared_in_worktree()  # must not raise
+
+
+def test_assert_noop_when_override_set_even_if_linked_shared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AIOS_ALLOW_SHARED_DB", "1")
+    monkeypatch.setattr(dev_mod, "is_linked_worktree", lambda: True)
+    monkeypatch.setattr(dev_mod, "get_git_repo_root", lambda: Path("/repo"))
+    monkeypatch.setattr(dev_mod, "runtime_db_url", lambda _root: "postgresql://h/aios")
+    assert_not_shared_in_worktree()  # must not raise

--- a/tests/unit/cli/test_ops.py
+++ b/tests/unit/cli/test_ops.py
@@ -17,6 +17,11 @@ def test_api_command_passes_proxy_headers_to_uvicorn(monkeypatch):
     behind a reverse proxy."""
     monkeypatch.setenv("AIOS_API_KEY", "test")
     monkeypatch.setenv("AIOS_DB_URL", "postgresql://localhost/test")
+    # The shared-DB guard fires from a linked worktree (the mandated dev
+    # workflow) because db name "test" is not aios_dev_*. Disable it here so we
+    # exercise uvicorn wiring, not the guard. (CI runs from a main checkout
+    # where the guard is a no-op, so it would never catch this regression.)
+    monkeypatch.setattr("aios.cli.commands.dev.is_linked_worktree", lambda: False)
 
     with patch("uvicorn.run") as mock_run:
         runner.invoke(app, ["api"])
@@ -27,3 +32,31 @@ def test_api_command_passes_proxy_headers_to_uvicorn(monkeypatch):
     assert kwargs.get("forwarded_allow_ips") == "*", (
         'uvicorn.run must be called with forwarded_allow_ips="*"'
     )
+
+
+def test_api_command_aborts_before_uvicorn_on_shared_worktree(monkeypatch):
+    """`api` from a linked worktree on the shared DB aborts before uvicorn.run."""
+    monkeypatch.setenv("AIOS_API_KEY", "test")
+    monkeypatch.setenv("AIOS_DB_URL", "postgresql://localhost/aios")
+    monkeypatch.delenv("AIOS_ALLOW_SHARED_DB", raising=False)
+    monkeypatch.setattr("aios.cli.commands.dev.is_linked_worktree", lambda: True)
+
+    with patch("uvicorn.run") as mock_run:
+        result = runner.invoke(app, ["api"])
+
+    mock_run.assert_not_called()
+    assert result.exit_code == 1
+
+
+def test_worker_command_aborts_before_worker_main_on_shared_worktree(monkeypatch):
+    """`worker` from a linked worktree on the shared DB aborts before worker_main."""
+    monkeypatch.setenv("AIOS_API_KEY", "test")
+    monkeypatch.setenv("AIOS_DB_URL", "postgresql://localhost/aios")
+    monkeypatch.delenv("AIOS_ALLOW_SHARED_DB", raising=False)
+    monkeypatch.setattr("aios.cli.commands.dev.is_linked_worktree", lambda: True)
+
+    with patch("aios.harness.worker.worker_main") as mock_worker_main:
+        result = runner.invoke(app, ["worker"])
+
+    mock_worker_main.assert_not_called()
+    assert result.exit_code == 1


### PR DESCRIPTION
## What & why

`aios dev bootstrap` provisions a per-worktree isolated DB, but it must be run *before* any `.env` is sourced and the failure mode is silent: sourcing the main checkout's `.env` from a worktree points `AIOS_DB_URL` at the shared local dev DB, silently writing real records into a shared/prod-shadow DB. This is the exact footgun documented in #349 (a smoke run persisted real connection records and ~380 live Telegram events before teardown).

## Changes

**Hard-fail guard (`dev.py` → `ops.py`):**
- `is_linked_worktree()` — distinguishes a *linked* worktree from the main checkout via `git rev-parse --git-dir` ≠ `--git-common-dir` (both as-returned, not `--absolute-git-dir`). Swallows `CalledProcessError`/`FileNotFoundError` → `False` so it's prod-safe (api image has no git binary; `.dockerignore` excludes `.git` from the worker image).
- `db_name_is_shared()` / `runtime_db_url()` — resolve the runtime `AIOS_DB_URL` the way pydantic will at runtime (process env beats `.env`) and flag any db name that isn't `aios_dev_*`. This catches both the never-bootstrapped case **and** the bootstrapped-but-wrong-env-sourced case (the real incident class).
- `assert_not_shared_in_worktree()` — called at the top of `_run_api()`/`_run_worker()`, before any DB connection or container spawn. Aborts exit-1 when a linked worktree targets the shared DB; `AIOS_ALLOW_SHARED_DB=1` is the escape hatch. The error message names both `aios dev bootstrap` and the override.

**`aios dev status` classification:**
- Prints a `mode: isolated|shared|unbootstrapped` line first.
- No longer hard-exits on a non-bootstrapped worktree — reads `.env` directly and degrades missing fields to `-` (no `KeyError`).

**Docs:** `CLAUDE.md` gains a "Worktree smoke / dev isolation" section walking through `aios dev bootstrap` → fresh shell → source worktree `.env` → `aios dev status` (expect `mode: isolated`) → api/worker.

## Tests

Unit-only, extending the pure-function suites. All 10 acceptance criteria from the design are covered: `db_name_is_shared` table, `is_linked_worktree` (equal/differ/`CalledProcessError`/`FileNotFoundError`), `runtime_db_url` precedence, `classify_instance_mode` table, `assert_not_shared_in_worktree` (raise + each negative + message contents), and the two `ops.py` call-site abort tests. The existing `test_api_command_passes_proxy_headers_to_uvicorn` now patches `is_linked_worktree`→`False` so the guard doesn't trip it from a linked worktree (the CI-blind regression flagged in the design).

`mypy src tests`, `ruff check`/`format`, and the full unit suite (2752 passed, 1 skipped) are green. Mutation check confirmed the new tests are non-vacuous. No API/openapi/SDK surface touched, so no codegen needed.

Closes #349