### PR TITLE
fix(context): defer mid-inference user messages to the tail (no assistant prefill)

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -935,10 +935,25 @@ def build_messages(
         else:
             horizon_for[seq] = _INF
 
+    # Blind-spot window for USER messages — the symmetric twin of the tool-result
+    # injection below. A user message that arrived DURING the last assistant's
+    # inference (committed before it, but after its visibility horizon
+    # ``reacting_to``) is "stranded": in seq order it lands *before* that trailing
+    # assistant turn, so the assembled context would END on an assistant message.
+    # Current reasoning models reject a trailing assistant turn as an unsupported
+    # prefill ("the conversation must end with a user message"), and the inference
+    # gate fires for it anyway (it's genuinely unreacted). So defer a user message
+    # in the window ``last_asst_rt < seq < last_asst_seq`` to the tail (flushed
+    # after the walk). Only the LAST assistant can strand the tail — a user blind
+    # to an earlier assistant is followed by a later one that reacted, so it never
+    # ends the list.
+    last_asst_seq, last_asst_rt = asst_list[-1] if asst_list else (0, 0)
+
     # Walk events in seq order.
     emitted_tcids: set[str] = set()
     messages: list[dict[str, Any]] = []
     inject_after: dict[int, list[tuple[str, dict[str, Any]]]] = {}
+    deferred_user_tail: list[dict[str, Any]] = []
     max_stimulus_seq: int = 0
 
     for e in events:
@@ -976,8 +991,13 @@ def build_messages(
                     session_id=session_id,
                     workspace_path=workspace_path,
                 )
-                messages.append(msg)
                 max_stimulus_seq = max(max_stimulus_seq, e.seq)
+                if last_asst_rt < e.seq < last_asst_seq:
+                    # Blind to the last assistant — defer to the tail (below) so
+                    # the context can't end on that assistant turn.
+                    deferred_user_tail.append(msg)
+                else:
+                    messages.append(msg)
 
             elif role == "assistant":
                 messages.append(e.data)
@@ -1097,6 +1117,13 @@ def build_messages(
             )
             messages.append(_quarantine_placeholder(e.seq))
             max_stimulus_seq = max(max_stimulus_seq, e.seq)
+
+    # Flush deferred blind-spot USER messages at the tail (see the window above):
+    # they now follow the assistant turn that never saw them, so the context ends
+    # on a user turn — the faithful chronology, since that turn's context never
+    # contained them — and no accidental prefill is sent. (max_stimulus_seq was
+    # already advanced for each at collection time, since max is order-independent.)
+    messages.extend(deferred_user_tail)
 
     # Prune dangling messages at the start of the window.  DB-level
     # windowing can cut in the middle of an assistant+tool_result group,

--- a/tests/e2e/test_mid_inference_prefill.py
+++ b/tests/e2e/test_mid_inference_prefill.py
@@ -1,0 +1,102 @@
+"""E2E regression: a user message that arrives mid-inference must not strand a
+prefill.
+
+When a user message lands while the model is composing a reply, the resulting
+assistant turn's ``reacting_to`` is behind that message. In seq order the message
+is then stranded *before* a trailing assistant turn, so the recovery step's
+context would END on an assistant message. Current reasoning models reject a
+trailing assistant turn as an unsupported prefill ("the conversation must end
+with a user message"), which errors the session and freezes the conversation.
+
+The context builder must defer such a stranded message to the tail so the context
+ends on a user turn (the faithful chronology — that assistant turn never saw it).
+This drives the real step function, gate, and context builder through Postgres;
+the scripted model faithfully rejects a trailing-assistant prefill, so the bug
+errors the session pre-fix and the session recovers post-fix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+from tests.e2e.harness import Harness, assistant
+
+
+def _last_role(messages: list[dict[str, Any]]) -> str:
+    return messages[-1]["role"] if messages else ""
+
+
+async def test_mid_inference_user_message_does_not_strand_a_prefill(harness: Harness) -> None:
+    h = harness
+    h.script_model(
+        [
+            assistant("Octopuses have three hearts and blue blood."),
+            assistant("Some jellyfish are biologically immortal."),
+        ]
+    )
+    session = await h.start("Tell me a fun fact about octopuses.")
+    sid = session.id
+
+    # Tail role of every context the model is asked to continue.
+    seen_last_roles: list[str] = []
+
+    async def racing_model(**kwargs: Any) -> Any:
+        msgs = kwargs.get("messages") or []
+        seen_last_roles.append(_last_role(msgs))
+        # Faithfully reject a trailing-assistant prefill, exactly as current
+        # Anthropic reasoning models do — this is what errors the session.
+        if _last_role(msgs) == "assistant":
+            raise RuntimeError(
+                "simulated provider error: this model does not support assistant "
+                "message prefill; the conversation must end with a user message"
+            )
+        # On the FIRST step only, a second user message lands mid-inference:
+        # after build_messages computed reacting_to (it saw only the first
+        # message), but before this assistant turn commits. That strands it.
+        if len(seen_last_roles) == 1:
+            await h.inject_message(sid, "Actually, make it about jellyfish instead.")
+        if kwargs.get("stream"):
+            return h._pop_streaming_response(**kwargs)
+        return h._pop_response(**kwargs)
+
+    with mock.patch("aios.harness.completion.litellm.acompletion", racing_model):
+        # Step 1: the model answers about octopuses while the jellyfish message
+        # lands; the committed assistant turn never reacted to it.
+        await h.run_step(sid)
+
+        # Precondition sanity: the stranded condition actually exists —
+        # assistant.reacting_to < jellyfish.seq < assistant.seq.
+        msgs = await h.events(sid)
+        asst = [e for e in msgs if e.data.get("role") == "assistant"]
+        jelly = [
+            e
+            for e in msgs
+            if e.data.get("role") == "user" and "jellyfish" in (e.data.get("content") or "")
+        ]
+        assert asst and jelly, "expected an assistant turn and the injected user message"
+        a, u2 = asst[-1], jelly[-1]
+        assert a.data["reacting_to"] < u2.seq < a.seq, (
+            f"stranded precondition not met: reacting_to={a.data['reacting_to']} "
+            f"jellyfish.seq={u2.seq} assistant.seq={a.seq}"
+        )
+
+        # The gate correctly wants another step — the jellyfish message is unreacted.
+        assert sid in await h.sessions_needing_inference(sid)
+
+        # Step 2: recovery. Pre-fix this builds a context ending on the assistant
+        # turn (a prefill) → the model rejects it → the session errors.
+        await h.run_step(sid)
+
+    # The fix: BOTH model calls were handed a context ending on a USER turn.
+    # Pre-fix the recovery context ends on the assistant turn → ["user", "assistant"].
+    assert seen_last_roles == ["user", "user"], seen_last_roles
+
+    # The session recovered cleanly and actually answered the second message.
+    s = await h.session(sid)
+    assert s.status == "idle", s.status
+    assert s.stop_reason == {"type": "end_turn"}, s.stop_reason
+    answers = [
+        e.data.get("content") for e in await h.events(sid) if e.data.get("role") == "assistant"
+    ]
+    assert any("jellyfish" in (c or "") for c in answers), answers

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -259,6 +259,57 @@ class TestBuildMessages:
         user_msgs = [m for m in msgs if m["role"] == "user"]
         assert len(user_msgs) == 1  # only the original user message
 
+    def test_user_message_in_last_assistant_blind_spot_moves_to_tail(self) -> None:
+        """A user message that arrives mid-inference (so the resulting assistant
+        turn's ``reacting_to`` is behind it) must not be left stranded before that
+        trailing assistant turn: the context would then END on an assistant
+        message, which current reasoning models reject as an unsupported prefill
+        ("the conversation must end with a user message"). It is deferred to the
+        tail — symmetric with the blind-spot handling for late tool results."""
+        events = [
+            _evt(1, "user", content="summarize the news"),
+            _evt(2, "assistant", tool_calls=[_tc("a", "web_search")]),
+            _evt(3, "tool", tool_call_id="a", content="search results"),
+            # arrives while the model is still composing its reply to the tool result
+            _evt(4, "user", content="actually, clear everything"),
+            # the reply only reacted to the tool result (seq 3); it never saw seq 4
+            _evt(5, "assistant", content="Here is the news summary."),
+        ]
+        events[1].data["reacting_to"] = 1
+        events[4].data["reacting_to"] = 3  # blind to the user message at seq 4
+
+        ctx = build_messages(events, system_prompt=None)
+        msgs = ctx.messages
+
+        # The context must NOT end on an assistant turn (no accidental prefill).
+        assert msgs[-1]["role"] == "user"
+        assert "clear everything" in msgs[-1]["content"]
+        # The trailing user message sits AFTER the assistant turn that never saw it.
+        assert msgs[-2]["role"] == "assistant"
+        # Surfaced exactly once — moved to the tail, not duplicated.
+        clears = [
+            m
+            for m in msgs
+            if m.get("role") == "user" and "clear everything" in str(m.get("content"))
+        ]
+        assert len(clears) == 1
+        # reacting_to still advances to include the surfaced stimulus, so the
+        # inference gate sees it as reacted and won't re-fire for it next step.
+        assert ctx.reacting_to == 4
+
+    def test_user_message_after_last_assistant_stays_at_tail(self) -> None:
+        """The ordinary case — a user message that genuinely follows the last
+        assistant turn — is untouched (already at the tail, surfaced once)."""
+        events = [
+            _evt(1, "user", content="hello"),
+            _evt(2, "assistant", content="hi"),
+            _evt(3, "user", content="how are you"),
+        ]
+        events[1].data["reacting_to"] = 1
+        msgs = build_messages(events, system_prompt=None).messages
+        assert [m["role"] for m in msgs] == ["user", "assistant", "user"]
+        assert "how are you" in msgs[-1]["content"]
+
     def test_multiple_tool_batches(self) -> None:
         events = [
             _evt(1, "user", content="start"),


### PR DESCRIPTION
## Summary

A user message that arrives **mid-inference** is stranded *before* the trailing assistant turn, so `build_messages` returns a context ending on an assistant message. Current reasoning models reject that as an unsupported prefill (*"the conversation must end with a user message"*), which errors the session — freezing any long-lived session where the human keeps typing while the agent is mid-turn. This defers such a stranded user message to the tail, completing the blind-spot mechanism that already handles late tool results.

## Substrate state changes

None — code-only change.

- [ ] Required env-var contract changed
- [ ] File-mount content shape changed
- [ ] Container UID, working-dir, or volume-permission expectations changed
- [ ] Persistent-volume layout changed
- [ ] External-service contract changed
- [ ] First-boot / migration grandfather hook needed

## Test plan

- **unit** (`tests/unit/test_context.py`): `build_messages` defers the stranded user to the tail; a control case (user genuinely after the last assistant) is untouched.
- **e2e** (`tests/e2e/test_mid_inference_prefill.py`): drives the real step / inference gate / context builder through Postgres. A second user message is injected *during* inference to strand it, and the scripted model faithfully rejects a trailing-assistant prefill. Verified **red → green**: fails pre-fix with the exact provider error, passes post-fix (session reaches `idle`/`end_turn`, both messages answered, both model calls handed a context ending on a user turn).
- Pre-commit gate green: `ruff`, `mypy src tests` (1066 files), full `pytest tests/unit` (2685) + connectors.
- Reproduced and confirmed live against a real `claude-opus-4-8` session before writing the tests.

## Risk / rollback

Low. Additive in the context builder, scoped to the previously-unhandled stranded-user case, and preserves the monotonicity invariant — it appends the deferred message *after* the assistant that never saw it, which is pure append onto the cached prefix (the seq-order placement it replaces was actually a rewrite). Rollback = revert this commit.

### Root cause (for reviewers)

Observed live: an assistant turn committed with `reacting_to=108` while the user's message sat at seq `117`. `find_sessions_needing_inference` correctly re-fired (117 is unreacted), but the rebuilt context ended on that assistant turn → `400` prefill → `step.litellm_failed` → `rescheduling` backoff loop → `errored`. The tool-result blind-spot (`inject_after`) already re-anchors a late result to the tail; the symmetric **user-message** case was simply missing. This adds it.
