### PR TITLE
fix(sandbox): decode HTTP Basic auth before egress secret-swap

### DIFF
--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -54,6 +54,8 @@ recycle-on-rotation are follow-ups (#877/#878).
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import contextlib
 import os
 import re
@@ -180,6 +182,46 @@ def _apply_swaps_bytes(data: bytes, swaps: list[tuple[str, str]]) -> bytes:
     for placeholder, secret in swaps:
         data = data.replace(placeholder.encode(), secret.encode())
     return data
+
+
+def _swap_header_value(name: str, value: str, swaps: list[tuple[str, str]]) -> str:
+    """Swap placeholders in a single forwarded header value.
+
+    ``Authorization: Basic <b64>`` is decoded first: HTTP Basic auth carries
+    the credential as ``base64("user:pass")``, and base64 shifts byte
+    boundaries so the injected ``AIOS_SECRET_PLACEHOLDER_…`` does not appear as
+    a literal substring of the encoded value — a raw ``.replace()`` over the
+    header is a no-op and the placeholder rides out to the remote (git over
+    HTTPS, ``curl -u``, …). So when a Basic credential is present we decode the
+    ``user:pass``, run the swap over the *decoded* text, and re-encode. Every
+    other header value (``Bearer …``, ``X-Api-Key: …``, custom schemes) keeps
+    the literal-substring swap.
+    """
+    if name.lower() == "authorization":
+        decoded = _decode_basic_credential(value)
+        if decoded is not None:
+            swapped = _apply_swaps_str(decoded, swaps)
+            reencoded = base64.b64encode(swapped.encode("latin-1")).decode("ascii")
+            return f"Basic {reencoded}"
+    return _apply_swaps_str(value, swaps)
+
+
+def _decode_basic_credential(value: str) -> str | None:
+    """Decode an ``Authorization: Basic <b64>`` value to its ``user:pass``.
+
+    Returns ``None`` (leaving the value to the literal-substring swap) when the
+    scheme is not ``Basic`` or the credential is not valid base64 / not
+    decodable text — fail open to the existing path rather than mangle a header
+    we don't understand.
+    """
+    parts = value.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "basic":
+        return None
+    try:
+        raw = base64.b64decode(parts[1].strip(), validate=True)
+        return raw.decode("latin-1")
+    except (binascii.Error, ValueError):
+        return None
 
 
 async def _resolve_addrinfos(host: str, port: int) -> list[tuple[Any, ...]]:
@@ -523,7 +565,7 @@ class SecretEgressProxy:
             name = raw_name.decode("latin-1")
             if name.lower() in _HOP_BY_HOP_REQUEST_HEADERS:
                 continue
-            fwd.append((name, _apply_swaps_str(raw_value.decode("latin-1"), swaps)))
+            fwd.append((name, _swap_header_value(name, raw_value.decode("latin-1"), swaps)))
         # Forward to (and name) the SNI host we terminated for.
         fwd.append(("host", host))
         return fwd

--- a/tests/unit/sandbox/test_secret_egress_proxy.py
+++ b/tests/unit/sandbox/test_secret_egress_proxy.py
@@ -13,6 +13,7 @@ No docker, no real upstream host, no real secret egress.
 from __future__ import annotations
 
 import asyncio
+import base64
 import socket
 import ssl
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
@@ -255,6 +256,84 @@ class TestSwapForwarding:
             assert proxy._client._transport._pool._max_keepalive_connections == 0  # type: ignore[attr-defined]
         finally:
             await proxy._client.aclose()
+
+
+def _basic(user: str, password: str) -> str:
+    """An ``Authorization: Basic <b64>`` header value for ``user:password``."""
+    token = base64.b64encode(f"{user}:{password}".encode("latin-1")).decode("ascii")
+    return f"Basic {token}"
+
+
+def _decode_basic(value: str) -> str:
+    """Decode an ``Authorization: Basic <b64>`` header to its ``user:pass``."""
+    scheme, token = value.split(" ", 1)
+    assert scheme == "Basic"
+    return base64.b64decode(token).decode("latin-1")
+
+
+class TestBasicAuthSwap:
+    """git-over-HTTPS / ``curl -u`` carry the credential as
+    ``Authorization: Basic base64("user:placeholder")`` — base64 hides the
+    placeholder from the literal-substring swap (#1134). The proxy must decode,
+    swap, and re-encode so the remote receives the real secret.
+    """
+
+    async def test_basic_auth_placeholder_swapped_after_decode(
+        self, gh_proxy: tuple[SecretEgressProxy, list[httpx.Request]]
+    ) -> None:
+        proxy, captured = gh_proxy
+        # x-access-token:$GITHUB_TOKEN is git's HTTPS-auth shape.
+        header = _basic("x-access-token", PH_GH)
+        # Sanity: the placeholder is NOT a literal substring of the b64 header,
+        # so a raw .replace() would be a no-op (this is the bug).
+        assert PH_GH not in header
+        r = await _request(proxy, "api.allowed.test", "/x", headers={"Authorization": header})
+        assert r.status_code == 200
+        out = captured[0].headers["authorization"]
+        assert _decode_basic(out) == "x-access-token:ghp_REALSECRET"
+        # The real secret must never leave as a placeholder.
+        assert PH_GH not in _decode_basic(out)
+
+    async def test_basic_auth_placeholder_in_username(
+        self, gh_proxy: tuple[SecretEgressProxy, list[httpx.Request]]
+    ) -> None:
+        proxy, captured = gh_proxy
+        header = _basic(PH_GH, "x-oauth-basic")
+        await _request(proxy, "api.allowed.test", "/x", headers={"Authorization": header})
+        out = captured[0].headers["authorization"]
+        assert _decode_basic(out) == "ghp_REALSECRET:x-oauth-basic"
+
+    async def test_bearer_auth_still_swapped_literally(
+        self, gh_proxy: tuple[SecretEgressProxy, list[httpx.Request]]
+    ) -> None:
+        # Non-Basic schemes keep the existing literal-substring swap.
+        proxy, captured = gh_proxy
+        await _request(
+            proxy, "api.allowed.test", "/x", headers={"Authorization": f"Bearer {PH_GH}"}
+        )
+        assert captured[0].headers["authorization"] == "Bearer ghp_REALSECRET"
+
+    async def test_malformed_basic_value_falls_through_to_literal_swap(
+        self, gh_proxy: tuple[SecretEgressProxy, list[httpx.Request]]
+    ) -> None:
+        # Not valid base64 → fall through to the literal swap rather than mangle.
+        proxy, captured = gh_proxy
+        await _request(
+            proxy, "api.allowed.test", "/x", headers={"Authorization": f"Basic not-b64-{PH_GH}"}
+        )
+        assert captured[0].headers["authorization"] == "Basic not-b64-ghp_REALSECRET"
+
+    async def test_basic_auth_outside_prefix_passes_placeholder_through(
+        self, make_proxy: MakeProxy
+    ) -> None:
+        proxy, captured = await make_proxy(
+            [_cred("GH_TOKEN", "ghp_REALSECRET", ("api.allowed.test/repos/ok",), PH_GH)]
+        )
+        header = _basic("x-access-token", PH_GH)
+        await _request(proxy, "api.allowed.test", "/repos/nope", headers={"Authorization": header})
+        out = captured[0].headers["authorization"]
+        # Outside the prefix → no swap → placeholder rides through verbatim.
+        assert _decode_basic(out) == f"x-access-token:{PH_GH}"
 
 
 class TestPathGating:


### PR DESCRIPTION
## Problem

The per-session secret-egress proxy swapped credential placeholders (`AIOS_SECRET_PLACEHOLDER_…`) for real vaulted secrets by **literal substring `.replace()`** over request headers and body. HTTP Basic auth — `git` over HTTPS (`x-access-token:$GITHUB_TOKEN`), `curl -u`, etc. — carries the credential as `Authorization: Basic base64("user:pass")`. base64 encoding shifts byte boundaries, so the injected placeholder does **not** appear as a literal substring of the encoded header value. The `.replace()` was a no-op, the raw placeholder rode out to the remote, and auth was rejected (`git clone` → `fatal: Authentication failed`, exit 128).

## Fix

Made the proxy **Basic-auth-aware** (the recommended option in the issue, chosen because it covers the whole class of Basic-auth carriers, not just git):

- `_decode_basic_credential()` parses `Authorization: Basic <b64>` and returns the decoded `user:pass`, or `None` for non-Basic / malformed values.
- `_swap_header_value()` runs the placeholder-swap over the **decoded** `user:pass`, then re-encodes to `Basic <b64>`. All other header values (`Bearer …`, `X-Api-Key: …`, custom schemes) keep the existing literal-substring swap, and a malformed Basic value falls through to that path rather than being mangled.
- `_forward_headers()` now routes each header value through `_swap_header_value()`.

The swap remains scoped by the existing per-request host + path-prefix gating: an out-of-scope request still rides the placeholder through unchanged (the decode/re-encode is a faithful round-trip when nothing swaps).

## Tests

New `TestBasicAuthSwap` reproduces probe-c against the real TLS-terminating proxy with a mocked upstream and asserts the **decoded** outbound `Authorization` header carries the real secret:
- placeholder in the password position (`x-access-token:$TOKEN`, git's shape) — with a sanity assert that the placeholder is not a literal substring of the encoded header (proving the bug)
- placeholder in the username position
- `Bearer` scheme still swaps literally (no regression)
- malformed (non-base64) Basic value falls through to the literal swap
- out-of-prefix request passes the placeholder through verbatim

Verified via mutation check: disabling the decode path makes the two key tests fail; restoring it makes them pass.

## Scope / notes

- No API routes, response models, or pydantic schemas changed → no FastAPI introspection impact, so `regen-openapi.sh` / `regen-client.sh` do not apply (not run).
- ⚠️ Security-sensitive: touches the secret-egress boundary — requires seat review before merge, do not auto-merge.
- `mypy src tests` and `ruff check`/`format` clean; full unit suite (2769 passed) green via the committed pre-commit hook.

Closes eumemic/eumemic-ops#307