### PR TITLE
fix: trusted system-owned wake-depth/source carrier (#1083)

### DIFF
--- a/src/aios/tools/wake_session.py
+++ b/src/aios/tools/wake_session.py
@@ -107,31 +107,43 @@ WAKE_SESSION_PARAMETERS_SCHEMA: dict[str, Any] = {
 }
 
 
-async def _read_source_wake_depth(pool: Any, session_id: str, *, account_id: str) -> int:
-    """Return the wake_depth stamped on the most recent user-role message.
+# The system-owned event that carries trusted wake lineage.  It is a
+# ``kind='span'`` event — a kind NO caller-facing path can append (the
+# operator POST and connector inbound paths only ever write ``kind='message'``
+# user events).  This is what makes the wake-depth / wake-source cap
+# non-forgeable: the cap reads provenance from this span, never from the
+# user message's ``metadata`` (which the operator-POST / connector paths
+# pass through unstripped — see issue #1083).
+WAKE_LINEAGE_SPAN_EVENT = "wake_lineage"
 
-    Reads the source's own log to inherit the depth of the message that
-    triggered this step.  Returns 0 when no user message has ``wake_depth``
-    stamped (root call — a human-originated message or first wake of a
-    chain).
+
+async def _read_source_wake_depth(pool: Any, session_id: str, *, account_id: str) -> int:
+    """Return the trusted wake_depth for the most recent wake of this session.
+
+    Reads the source's own log, but ONLY from the system-owned
+    ``wake_lineage`` span event — never from user-message metadata, which
+    the operator-POST / connector ingestion paths can forge (issue #1083).
+    Returns 0 when no wake-lineage span is present (root call — a
+    human-originated message or first wake of a chain).
     """
     async with pool.acquire() as conn:
         row = await conn.fetchrow(
             """
             SELECT COALESCE(
-                (data->'metadata'->>'wake_depth')::int,
+                (data->>'wake_depth')::int,
                 0
             ) AS depth
             FROM events
             WHERE session_id = $1
               AND account_id = $2
-              AND kind = 'message'
-              AND data->>'role' = 'user'
+              AND kind = 'span'
+              AND data->>'event' = $3
             ORDER BY seq DESC
             LIMIT 1
             """,
             session_id,
             account_id,
+            WAKE_LINEAGE_SPAN_EVENT,
         )
     if row is None:
         return 0
@@ -145,8 +157,12 @@ async def _count_recent_wakes_from(
     target_session_id: str,
     account_id: str,
 ) -> int:
-    """Count target-side user messages stamped with ``wake_source_session_id``
-    equal to ``source_session_id`` in the last hour.
+    """Count target-side ``wake_lineage`` spans stamped with
+    ``wake_source_session_id`` equal to ``source_session_id`` in the last hour.
+
+    Counts the system-owned ``wake_lineage`` span — NOT user-message
+    metadata, which the operator-POST / connector ingestion paths can forge
+    (issue #1083) to either evade or inflate the count.
 
     The rate-limit window is per (source, target) pair so an honest
     broadcast to many distinct targets isn't throttled; a single source
@@ -159,14 +175,15 @@ async def _count_recent_wakes_from(
             FROM events
             WHERE session_id = $1
               AND account_id = $2
-              AND kind = 'message'
-              AND data->>'role' = 'user'
-              AND data->'metadata'->>'wake_source_session_id' = $3
+              AND kind = 'span'
+              AND data->>'event' = $4
+              AND data->>'wake_source_session_id' = $3
               AND created_at > now() - interval '1 hour'
             """,
             target_session_id,
             account_id,
             source_session_id,
+            WAKE_LINEAGE_SPAN_EVENT,
         )
     return int(count or 0)
 
@@ -269,7 +286,22 @@ async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> di
     # ``append_user_message``) so we can stamp wake-tracking metadata
     # without involving the API-side size check / channel lift logic
     # — those are not relevant for an in-process wake.
+    #
+    # The ``metadata`` on the user message is DISPLAY-ONLY: it drives the
+    # model-visible wake header (``_wake_header`` in harness/context.py).
+    # It is NOT trusted by the depth / rate-limit cap, because the
+    # operator-POST and connector ingestion paths pass caller-supplied
+    # ``metadata`` through unstripped and could forge these keys (#1083).
     metadata: dict[str, Any] = {
+        "wake_source_session_id": session_id,
+        "wake_depth": new_depth,
+    }
+    # The TRUSTED carrier: a system-owned ``kind='span'`` event.  No
+    # caller-facing route appends span events, so the cap's reads
+    # (_read_source_wake_depth / _count_recent_wakes_from) can rely on it
+    # as non-forgeable provenance.
+    lineage_span: dict[str, Any] = {
+        "event": WAKE_LINEAGE_SPAN_EVENT,
         "wake_source_session_id": session_id,
         "wake_depth": new_depth,
     }
@@ -280,6 +312,13 @@ async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> di
             session_id=target_session_id,
             kind="message",
             data={"role": "user", "content": prompt, "metadata": metadata},
+        )
+        await queries.append_event(
+            conn,
+            account_id=target_account_id,
+            session_id=target_session_id,
+            kind="span",
+            data=lineage_span,
         )
     await defer_wake(
         pool,

--- a/tests/integration/test_wake_session.py
+++ b/tests/integration/test_wake_session.py
@@ -99,6 +99,28 @@ async def _count_user_messages(pool: asyncpg.Pool[Any], session_id: str) -> int:
         )
 
 
+async def _stamp_lineage_span(
+    pool: asyncpg.Pool[Any], session_id: str, account_id: str, depth: int
+) -> None:
+    """Append a system-owned ``wake_lineage`` span — the trusted depth carrier
+    the cap reads. Mirrors what ``wake_session_handler`` writes on a real wake.
+    """
+    from aios.tools.wake_session import WAKE_LINEAGE_SPAN_EVENT
+
+    async with pool.acquire() as conn:
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="span",
+            data={
+                "event": WAKE_LINEAGE_SPAN_EVENT,
+                "wake_source_session_id": "sess_seed_source",
+                "wake_depth": depth,
+            },
+        )
+
+
 @pytest.fixture
 def patched_defer_wake() -> Any:
     """Patch out the procrastinate enqueue.  The handler's SQL surface
@@ -203,27 +225,16 @@ class TestWakeSessionIntegration:
         pool_with_runtime: asyncpg.Pool[Any],
         patched_defer_wake: AsyncMock,
     ) -> None:
-        """Stamp a near-cap depth on the source's most recent user message;
-        a wake should bump to cap, the next attempt should refuse."""
+        """Stamp a near-cap depth in the trusted wake_lineage span on the
+        source; a wake should bump to cap, the next attempt should refuse."""
         pool = pool_with_runtime
         await _seed_account(pool, "acc_wake_depth", "wake-test-depth")
         _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_depth", prefix="src")
         _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_depth", prefix="dst")
 
-        # Stamp depth = MAX_DEPTH - 1 on the source so the next wake lands
-        # exactly at the cap and the one after would breach it.
-        async with pool.acquire() as conn:
-            await queries.append_event(
-                conn,
-                account_id="acc_wake_depth",
-                session_id=source.id,
-                kind="message",
-                data={
-                    "role": "user",
-                    "content": "incoming-wake",
-                    "metadata": {"wake_depth": WAKE_SESSION_MAX_DEPTH - 1},
-                },
-            )
+        # Stamp depth = MAX_DEPTH - 1 in the TRUSTED span carrier on the source
+        # so the next wake lands exactly at the cap and the one after breaches.
+        await _stamp_lineage_span(pool, source.id, "acc_wake_depth", WAKE_SESSION_MAX_DEPTH - 1)
 
         # First call: depth bumps from MAX-1 to MAX. Allowed.
         result = await wake_session_handler(
@@ -232,24 +243,104 @@ class TestWakeSessionIntegration:
         )
         assert result["wake_depth"] == WAKE_SESSION_MAX_DEPTH
 
-        # Stamp depth = MAX on the source so the next wake would breach.
-        async with pool.acquire() as conn:
-            await queries.append_event(
-                conn,
-                account_id="acc_wake_depth",
-                session_id=source.id,
-                kind="message",
-                data={
-                    "role": "user",
-                    "content": "second-wake-incoming",
-                    "metadata": {"wake_depth": WAKE_SESSION_MAX_DEPTH},
-                },
-            )
+        # Stamp depth = MAX in the trusted span so the next wake would breach.
+        await _stamp_lineage_span(pool, source.id, "acc_wake_depth", WAKE_SESSION_MAX_DEPTH)
 
         with pytest.raises(WakeSessionDepthExceededError):
             await wake_session_handler(
                 source.id,
                 {"target_session_id": target.id, "prompt": "should refuse"},
+            )
+
+    async def test_forged_user_metadata_does_not_evade_depth_cap(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """Red test for #1083: a caller posts a user message with a FORGED
+        ``metadata.wake_depth = 0`` on top of a real near-cap lineage span.
+        The cap must compute the TRUE depth from the trusted span and refuse
+        — the forged user metadata must be ignored.
+        """
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_forge", "wake-test-forge")
+        _, _, source = await seed_agent_env_session(pool, account_id="acc_wake_forge", prefix="src")
+        _, _, target = await seed_agent_env_session(pool, account_id="acc_wake_forge", prefix="dst")
+
+        # The real, system-stamped lineage puts the source at the cap.
+        await _stamp_lineage_span(pool, source.id, "acc_wake_forge", WAKE_SESSION_MAX_DEPTH)
+
+        # Attacker injects a LATER user message claiming depth 0 — exactly
+        # what the operator-POST / connector paths pass through unstripped.
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id="acc_wake_forge",
+                session_id=source.id,
+                kind="message",
+                data={
+                    "role": "user",
+                    "content": "reset my depth pretty please",
+                    "metadata": {"wake_depth": 0, "wake_source_session_id": "sess_forged"},
+                },
+            )
+
+        # The forged metadata must NOT reset the chain: the cap still sees
+        # the trusted depth at MAX and refuses.
+        with pytest.raises(WakeSessionDepthExceededError):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": "evade the cap"},
+            )
+
+    async def test_forged_user_metadata_does_not_evade_rate_limit(
+        self,
+        pool_with_runtime: asyncpg.Pool[Any],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """Red test for #1083 (rate-limit side): the per-pair count must be
+        derived from the trusted lineage span, so forged user-message
+        metadata can neither inflate nor evade the count.
+
+        Here we cap the pair with REAL wakes, then inject a forged user
+        message claiming a DIFFERENT ``wake_source_session_id`` — which, if
+        trusted, would lower the count and let the cap be evaded.  The cap
+        must still refuse the next wake.
+        """
+        pool = pool_with_runtime
+        await _seed_account(pool, "acc_wake_rforge", "wake-test-rforge")
+        _, _, source = await seed_agent_env_session(
+            pool, account_id="acc_wake_rforge", prefix="src"
+        )
+        _, _, target = await seed_agent_env_session(
+            pool, account_id="acc_wake_rforge", prefix="dst"
+        )
+
+        for i in range(WAKE_SESSION_MAX_PER_HOUR):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": f"wake-{i}"},
+            )
+
+        # Forge a user message on the target whose metadata claims a
+        # different source — counted nowhere if user metadata is ignored.
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id="acc_wake_rforge",
+                session_id=target.id,
+                kind="message",
+                data={
+                    "role": "user",
+                    "content": "noise",
+                    "metadata": {"wake_source_session_id": "sess_other"},
+                },
+            )
+
+        with pytest.raises(WakeSessionRateLimitedError):
+            await wake_session_handler(
+                source.id,
+                {"target_session_id": target.id, "prompt": "over-cap"},
             )
 
     async def test_rate_limit_caps_per_pair(

--- a/tests/unit/test_wake_session_handler.py
+++ b/tests/unit/test_wake_session_handler.py
@@ -185,7 +185,8 @@ class TestWakeSessionHandlerPermission:
             {"target_session_id": "sess_01TARGET", "prompt": "wake up"},
         )
         assert result["woken"] is True
-        mock_append.assert_awaited_once()
+        # Two appends: the user message + the trusted wake_lineage span.
+        assert mock_append.await_count == 2
         mock_defer.assert_awaited_once()
 
 
@@ -258,10 +259,11 @@ class TestWakeSessionHandlerLimits:
             "target_session_id": "sess_01TARGET",
             "wake_depth": 3,
         }
-        # The append landed on the TARGET session under its account_id with
-        # wake_source_session_id + wake_depth metadata.
-        mock_append.assert_awaited_once()
-        kwargs = mock_append.call_args.kwargs
+        # The user-message append landed on the TARGET session under its
+        # account_id with wake_source_session_id + wake_depth (display) metadata.
+        assert mock_append.await_count == 2
+        msg_call = next(c for c in mock_append.call_args_list if c.kwargs["kind"] == "message")
+        kwargs = msg_call.kwargs
         assert kwargs["session_id"] == "sess_01TARGET"
         assert kwargs["account_id"] == "acc_test_stub"
         assert kwargs["kind"] == "message"
@@ -276,3 +278,142 @@ class TestWakeSessionHandlerLimits:
             cause="agent_wake",
             account_id="acc_test_stub",
         )
+
+
+class TestWakeSessionTrustedLineage:
+    """The wake-depth/source cap must read provenance from a system-owned
+    slot (a ``kind='span'`` lineage event), never from caller-suppliable
+    user-message metadata that the operator-POST / connector paths forge.
+
+    See issue #1083.
+    """
+
+    async def test_depth_query_filters_to_span_lineage(
+        self, monkeypatch: Any, install_pool: Any
+    ) -> None:
+        """The source-depth read must be scoped to ``kind='span'`` lineage
+        events. A user message (forgeable) must NOT be a source of truth."""
+        captured: dict[str, str] = {}
+
+        pool = MagicMock()
+        conn = MagicMock()
+
+        async def _fetchrow(sql: str, *args: Any) -> Any:
+            # First fetchrow = target row; second = source depth read.
+            if "account_id" in sql and "archived_at" in sql:
+                return {
+                    "account_id": "acc_test_stub",
+                    "status": "idle",
+                    "archived_at": None,
+                }
+            captured["depth_sql"] = sql
+            return {"depth": 4}
+
+        conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+        conn.fetchval = AsyncMock(return_value=0)
+        conn.execute = AsyncMock()
+
+        class _CM:
+            async def __aenter__(self) -> MagicMock:
+                return conn
+
+            async def __aexit__(self, *a: Any) -> None:
+                return None
+
+        pool.acquire = lambda: _CM()
+        install_pool(pool)
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+
+        result = await wake_session_handler(
+            "sess_01SOURCE",
+            {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+        )
+
+        # The depth read must be scoped to the trusted span carrier and must
+        # NOT trust user-message metadata.
+        assert "kind = 'span'" in captured["depth_sql"]
+        assert "'role' = 'user'" not in captured["depth_sql"]
+        # Trusted depth 4 (from the span) → new depth 5.
+        assert result["wake_depth"] == 5
+
+    async def test_rate_limit_query_filters_to_span_lineage(
+        self, monkeypatch: Any, install_pool: Any
+    ) -> None:
+        """The per-pair rate-limit count must be scoped to ``kind='span'``
+        lineage events, not forgeable user messages."""
+        captured: dict[str, str] = {}
+
+        pool = MagicMock()
+        conn = MagicMock()
+
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {"account_id": "acc_test_stub", "status": "idle", "archived_at": None},
+                {"depth": 0},
+            ]
+        )
+
+        async def _fetchval(sql: str, *args: Any) -> int:
+            captured["rate_sql"] = sql
+            return 0
+
+        conn.fetchval = AsyncMock(side_effect=_fetchval)
+        conn.execute = AsyncMock()
+
+        class _CM:
+            async def __aenter__(self) -> MagicMock:
+                return conn
+
+            async def __aexit__(self, *a: Any) -> None:
+                return None
+
+        pool.acquire = lambda: _CM()
+        install_pool(pool)
+        monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+
+        await wake_session_handler(
+            "sess_01SOURCE",
+            {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+        )
+
+        assert "kind = 'span'" in captured["rate_sql"]
+        assert "'role' = 'user'" not in captured["rate_sql"]
+
+    async def test_appends_trusted_span_lineage_event(
+        self, monkeypatch: Any, install_pool: Any
+    ) -> None:
+        """wake_session must append a system-owned ``kind='span'`` lineage
+        event carrying the trusted wake_depth / wake_source_session_id, in
+        addition to the user message."""
+        install_pool(
+            _make_pool(
+                target_row={
+                    "account_id": "acc_test_stub",
+                    "status": "idle",
+                    "archived_at": None,
+                },
+                depth=2,
+                recent_wakes=0,
+            )
+        )
+        mock_append = AsyncMock()
+        monkeypatch.setattr("aios.db.queries.append_event", mock_append)
+        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+
+        await wake_session_handler(
+            "sess_01SOURCE",
+            {"target_session_id": "sess_01TARGET", "prompt": "hi"},
+        )
+
+        # Two appends: the user message AND the trusted span lineage.
+        kinds = [c.kwargs["kind"] for c in mock_append.call_args_list]
+        assert "span" in kinds
+        span_call = next(c for c in mock_append.call_args_list if c.kwargs["kind"] == "span")
+        span_data = span_call.kwargs["data"]
+        assert span_call.kwargs["session_id"] == "sess_01TARGET"
+        assert span_call.kwargs["account_id"] == "acc_test_stub"
+        assert span_data["event"] == "wake_lineage"
+        assert span_data["wake_source_session_id"] == "sess_01SOURCE"
+        assert span_data["wake_depth"] == 3


### PR DESCRIPTION
## Problem

The wake-depth recursion cap and the per-pair rate limit trusted **caller-supplied** metadata. `_read_source_wake_depth` and `_count_recent_wakes_from` (`tools/wake_session.py`) read `wake_depth` / `wake_source_session_id` off the most-recent `role='user'` message with **no origin filter**. But:

- the **operator POST** path (`post_message` in `api/routers/sessions.py`) passes `body.metadata` through **unstripped** (only `channel` is validated), and
- the **connector** path's `_RESERVED_METADATA_KEYS` denylist is a per-site convention, not a structural guarantee.

So a caller who can post a user message with forged `metadata.wake_depth = 0` / `wake_source_session_id` could spoof or evade the wake-depth cap — the runaway/abuse bound on agent self-/cross-wake recursion.

## Fix (root-cause, per epic #1122 boundary)

Move the trusted wake lineage into a **system-owned `kind='span'` event** (`event="wake_lineage"`). No caller-facing route appends `span` events — the operator-POST and connector ingestion paths only ever write `kind='message'` user events — so the span is a **non-forgeable carrier**, satisfying the "system-owned trusted slot" requirement without the broad namespace re-architecture (which the issue notes failed the anti-guard test).

- `wake_session_handler` now stamps a `wake_lineage` span on the target alongside the user message.
- Both cap reads (`_read_source_wake_depth`, `_count_recent_wakes_from`) are scoped to `kind='span'` + `event='wake_lineage'`.
- The user message keeps its `metadata.wake_depth`/`wake_source_session_id` for **display only** (the model-visible wake header in `harness/context.py`); the cap no longer trusts it.

This keeps `wake_session` as peer notification (no request_id / response / totality), with its own trusted hop-count carrier — deliberately not folded into the invocation edge (#1123/#1124).

## Tests (TDD)

- Unit: SQL scoping (`kind='span'`, not `role='user'`) for both depth and rate-limit reads; the trusted span is appended on a wake.
- Integration (live DB): depth inherits-then-caps via the trusted span; **forgery repros** — a forged user-message `wake_depth = 0` does not reset the chain, and a forged `wake_source_session_id` does not evade the rate limit.

Mutation-checked: reverting the depth read to user-message metadata fails the scoping test. mypy, ruff, full unit suite (2772 passed), and the repo pre-commit hook all green. No OpenAPI/SDK drift (no API surface changed).

Closes #1083