### PR TITLE
fix: document run/session observability contract (#1140)

### DIFF
--- a/docs/reference/run-observability.md
+++ b/docs/reference/run-observability.md
@@ -1,0 +1,106 @@
+# Run & session observability: polling contract and event schemas
+
+Reference for anyone watching a run or session from the outside — an operator
+tailing with `aios`, an SDK consumer, or an agent awaiting a sub-run as an MCP
+tool. It pins down three contracts surfaced by the #1068 dogfood (#1140).
+
+## (a) Terminal state is `status` / `done`, never `state`
+
+A run's lifecycle field is **`status`**. There is **no `state` field** anywhere
+on a run row (`WfRun`) or on the `/wait` response (`WfRunWaitResponse`).
+
+A watcher that keys on `.state` reads `None` forever — even after `output` is
+already populated — because the field simply does not exist in the JSON. This is
+exactly the #1068 symptom: `GET /v1/runs/{id}/wait` "returned `state:None` while
+`output` was already populated."
+
+What to poll:
+
+| Surface | Field to poll | Terminal when |
+| --- | --- | --- |
+| `GET /v1/runs/{id}` (`WfRun`) | `status` | `status ∈ {completed, errored, cancelled}` |
+| `GET /v1/runs/{id}/wait` (`WfRunWaitResponse`) | `done` (bool) — or `run_status` | `done == true` (i.e. `run_status` terminal) |
+
+`/wait` is the await-a-completion primitive: it blocks until the run is terminal
+or `timeout` seconds elapse. On timeout it returns `done=false` with the live
+`run_status`; call again to keep blocking. The completion payload is
+`{done, output}` (success) or `{is_error, error}` (failure). `run_status`
+deliberately mirrors the run row's `status`; the response carries no `state`.
+
+> Sessions, by contrast, expose `status` (`SessionStatus`) and are not
+> persisted the way runs are — but the same rule holds: poll `status`, there is
+> no `state`.
+
+## (b) An empty event page is not a "session/run reset"
+
+`GET /v1/sessions/{id}/events` and `GET /v1/runs/{id}/events` can return an
+empty `items` list **transiently** — notably on back-to-back polls under load,
+which then recover on the next read. An empty page only means *no events match
+this page right now*; it is **never** a signal that the log was cleared or the
+session/run was reset.
+
+Causes of a legitimately-empty page:
+
+- A forward read whose `after_seq` is already at (or past) the current tail —
+  i.e. "nothing new yet."
+- Back-to-back polls racing the writer: the second read can momentarily observe
+  no new rows before the next event commits and notifies.
+- A filtered read (`?kind=`, `?error_only=`) with no matching rows in this
+  window.
+
+Correct consumer behavior: **page by `seq`** (carry the last `seq` you saw and
+read forward from it), and treat an empty page as "poll again," not as a reset.
+Do not infer log truncation, session loss, or run cancellation from emptiness —
+those are reported by `status` (see (a)), never by an empty list. For push-based
+consumption prefer the SSE `/stream` endpoint, which is backed by Postgres
+`LISTEN`/`NOTIFY`.
+
+## (c) Two event schemas coexist — don't assume one shape
+
+Run events and session events are **different shapes**. A consumer that watches
+both surfaces must branch on which endpoint produced the event.
+
+### Run events — `{type, payload, seq}`
+
+`GET /v1/runs/{id}/events` returns `WfRunEvent` rows (the run's append-only
+journal):
+
+```json
+{ "type": "run_started | call_started | call_result | annotation | run_completed",
+  "payload": { "...": "..." },
+  "seq": 1 }
+```
+
+`type` is the run journal's frame type. An `annotation` payload is a journaled
+progress marker, `{"kind": "log" | "phase", "text": ...}` — note this inner
+`kind` is *not* the session-event `kind` below.
+
+### Session events — `{kind, data}`
+
+`GET /v1/sessions/{id}/events` returns `Event` rows (the session log). These are
+the **child-session** events produced when a run spawns agent sessions:
+
+```json
+{ "kind": "message | lifecycle | span | interrupt",
+  "data": { "...": "..." },
+  "seq": 1 }
+```
+
+- `kind == "span"` — observability markers around model/tool calls.
+- `kind == "lifecycle"` — session state transitions (turn started/ended, status
+  changes, stop_reason).
+- `kind == "message"` — a chat-completions message dict; `data.role` ∈
+  `user | assistant | tool`.
+
+### At a glance
+
+| | Run event | Session event |
+| --- | --- | --- |
+| Endpoint | `/v1/runs/{id}/events` | `/v1/sessions/{id}/events` |
+| Model | `WfRunEvent` | `Event` |
+| Discriminator | `type` | `kind` |
+| Payload field | `payload` | `data` |
+| Values | run_started / call_started / call_result / annotation / run_completed | message / lifecycle / span / interrupt |
+
+Source of truth: `aios.models.workflows.WfRunEvent` and
+`aios.models.events.Event`.

--- a/openapi.json
+++ b/openapi.json
@@ -3181,7 +3181,7 @@
           "sessions"
         ],
         "summary": "List Events",
-        "description": "List a session's events by sequence number.\n\nFirst page: ``?dir=forward|backward`` (default forward) + optional\n``?kind=`` / ``?error_only=`` + ``?limit=``. Subsequent pages:\n``?cursor=<next_cursor>`` \u2014 the token carries direction and filters, so no\nother params are accepted alongside it. ``forward`` walks oldest\u2192newest;\n``backward`` loads the newest-first tail and pages into the past.",
+        "description": "List a session's events by sequence number.\n\nFirst page: ``?dir=forward|backward`` (default forward) + optional\n``?kind=`` / ``?error_only=`` + ``?limit=``. Subsequent pages:\n``?cursor=<next_cursor>`` \u2014 the token carries direction and filters, so no\nother params are accepted alongside it. ``forward`` walks oldest\u2192newest;\n``backward`` loads the newest-first tail and pages into the past.\n\nTransient-empty (#1140): an empty ``items`` list is NOT a \"session reset\"\n\u2014 it only means no events match this page (e.g. a forward read past the\ncurrent tail, or back-to-back polls racing the writer under load). Page by\n``seq`` and treat an empty page as \"nothing new yet,\" not as a cleared log.\n\nSchema (#1140): each item is a session event ``{kind, data, seq}``\n(``kind`` \u2208 message/lifecycle/span/interrupt) \u2014 a DIFFERENT shape from a\n*run* event (``{type, payload, seq}`` on ``/v1/runs/{id}/events``). See\n``docs/reference/run-observability.md``.",
         "operationId": "list_session_events",
         "parameters": [
           {
@@ -9194,7 +9194,7 @@
           "runs"
         ],
         "summary": "Await Run",
-        "description": "Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.\n\nThe ``await``-a-completion primitive (runs backing): one JSON round-trip returning the\ncompletion record \u2014 ``done`` + ``output``, or ``is_error`` + ``error``. A run still running\nafter ``timeout`` seconds returns ``done=false`` with its current status; call again to keep\nblocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP\ntool \u2014 an agent can await a sub-run and join. A cross-tenant run 404s.",
+        "description": "Block until the run reaches a terminal status (completed/errored/cancelled), or timeout.\n\nThe ``await``-a-completion primitive (runs backing): one JSON round-trip returning the\ncompletion record \u2014 ``done`` + ``output``, or ``is_error`` + ``error``. A run still running\nafter ``timeout`` seconds returns ``done=false`` with its current status; call again to keep\nblocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP\ntool \u2014 an agent can await a sub-run and join. A cross-tenant run 404s.\n\nWatch the right field (#1140): poll ``done`` (bool) or ``run_status`` \u2014 the\nresponse has NO ``state`` field, so a watcher keying on ``.state`` reads\n``None`` forever even after ``output`` is populated.",
         "operationId": "await_run",
         "parameters": [
           {
@@ -9265,7 +9265,7 @@
           "runs"
         ],
         "summary": "List Run Events",
-        "description": "A run's journal by sequence (oldest first). First page: optional ``limit``;\nsubsequent pages: ``?cursor=<next_cursor>``.",
+        "description": "A run's journal by sequence (oldest first). First page: optional ``limit``;\nsubsequent pages: ``?cursor=<next_cursor>``.\n\nTransient-empty (#1140): an empty ``items`` list is NOT a \"run reset\" \u2014 it\nonly means no journal rows past this ``seq`` yet. Page by ``seq`` and treat\nan empty page as \"nothing new yet.\"\n\nSchema (#1140): each item is a *run* event ``{type, payload, seq}`` \u2014 a\nDIFFERENT shape from a child-*session* event (``{kind, data}`` on\n``/v1/sessions/{id}/events``). See ``docs/reference/run-observability.md``.",
         "operationId": "list_run_events",
         "parameters": [
           {
@@ -11121,7 +11121,7 @@
           "created_at"
         ],
         "title": "Event",
-        "description": "Read view of a single event from the session log."
+        "description": "Read view of a single event from the session log.\n\nSchema (#1140): a session event is ``{kind, data, seq}`` \u2014 a DIFFERENT\nshape from a *run* event (``{type, payload, seq}``, see\n``aios.models.workflows.WfRunEvent``). See module docstring and\n``docs/reference/run-observability.md`` for the split."
       },
       "FileUploadResponse": {
         "properties": {
@@ -16427,7 +16427,8 @@
               "errored",
               "cancelled"
             ],
-            "title": "Status"
+            "title": "Status",
+            "description": "The run's lifecycle status \u2014 the ONLY lifecycle field on a run (there is no `state` field; a watcher keying on `.state` waits forever). Terminal values: `completed`/`errored`/`cancelled`."
           },
           "input": {
             "title": "Input"
@@ -16499,7 +16500,7 @@
           "updated_at"
         ],
         "title": "WfRun",
-        "description": "A durable workflow execution instance.\n\n``script`` is the run's own immutable snapshot of the workflow source at\ncreation time (``script_sha`` is its hash); every wake execs exactly this.\n``tools``/``mcp_servers``/``http_servers`` are the matching snapshot of the\ndeclared tool surface \u2014 pinned at launch like ``script``, so a later\n``update_workflow`` never shifts an in-flight run's authority.\n``status`` is persisted (unlike sessions): the run loop writes\n``suspended``/``completed``/``errored``."
+        "description": "A durable workflow execution instance.\n\n``script`` is the run's own immutable snapshot of the workflow source at\ncreation time (``script_sha`` is its hash); every wake execs exactly this.\n``tools``/``mcp_servers``/``http_servers`` are the matching snapshot of the\ndeclared tool surface \u2014 pinned at launch like ``script``, so a later\n``update_workflow`` never shifts an in-flight run's authority.\n``status`` is persisted (unlike sessions): the run loop writes\n``suspended``/``completed``/``errored``.\n\nNB (#1140): the run's lifecycle field is ``status`` \u2014 there is no ``state``\nfield on a run. A watcher polling ``.state`` reads ``None`` forever even\nthough ``output`` is already populated; poll ``status`` (terminal values:\n``completed``/``errored``/``cancelled``)."
       },
       "WfRunCreate": {
         "properties": {
@@ -16615,7 +16616,7 @@
           "created_at"
         ],
         "title": "WfRunEvent",
-        "description": "One row of a run's append-only journal (the replay-with-memo source).\n\n``call_key`` is set for ``call_started``/``call_result`` (the memo key) and for\n``annotation`` (the branch-local dedup key that makes ``log()``/``phase()``\nemit-once across replays); it is ``None`` for the ``run_started``/``run_completed``\nbookends. An ``annotation`` is a journaled progress marker (``payload`` =\n``{\"kind\": \"log\" | \"phase\", \"text\": ...}``), not a capability call."
+        "description": "One row of a run's append-only journal (the replay-with-memo source).\n\n``call_key`` is set for ``call_started``/``call_result`` (the memo key) and for\n``annotation`` (the branch-local dedup key that makes ``log()``/``phase()``\nemit-once across replays); it is ``None`` for the ``run_started``/``run_completed``\nbookends. An ``annotation`` is a journaled progress marker (``payload`` =\n``{\"kind\": \"log\" | \"phase\", \"text\": ...}``), not a capability call.\n\nSchema note (#1140): a *run* event is ``{type, payload, seq}``. This is a\nDIFFERENT shape from a child-*session* event (``{kind, data}`` \u2014 see\n``aios.models.events.Event``). Don't assume one schema across both\nendpoints; ``docs/reference/run-observability.md`` documents the split."
       },
       "WfRunWaitResponse": {
         "properties": {
@@ -16629,18 +16630,22 @@
               "errored",
               "cancelled"
             ],
-            "title": "Run Status"
+            "title": "Run Status",
+            "description": "The run's terminal-or-current lifecycle status (the run row's `status` field). This is the field to poll \u2014 there is no `state` field. Terminal values: `completed`/`errored`/`cancelled`."
           },
           "done": {
             "type": "boolean",
-            "title": "Done"
+            "title": "Done",
+            "description": "True once `run_status` is terminal (completed/errored/cancelled). Poll `done` (or `run_status`); there is no `state` field on this response (#1140)."
           },
           "output": {
-            "title": "Output"
+            "title": "Output",
+            "description": "The run's return value, set when `done` and not `is_error`; None otherwise."
           },
           "is_error": {
             "type": "boolean",
             "title": "Is Error",
+            "description": "True when run_status == errored.",
             "default": false
           },
           "error": {
@@ -16653,7 +16658,8 @@
                 "type": "null"
               }
             ],
-            "title": "Error"
+            "title": "Error",
+            "description": "On is_error, the run_completed event's {kind,message,traceback}; None otherwise."
           }
         },
         "type": "object",

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/await_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/await_run.py
@@ -86,6 +86,10 @@ def sync_detailed(
     blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
     tool — an agent can await a sub-run and join. A cross-tenant run 404s.
 
+    Watch the right field (#1140): poll ``done`` (bool) or ``run_status`` — the
+    response has NO ``state`` field, so a watcher keying on ``.state`` reads
+    ``None`` forever even after ``output`` is populated.
+
     Args:
         run_id (str):
         timeout (int | Unset):  Default: 30.
@@ -129,6 +133,10 @@ def sync(
     blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
     tool — an agent can await a sub-run and join. A cross-tenant run 404s.
 
+    Watch the right field (#1140): poll ``done`` (bool) or ``run_status`` — the
+    response has NO ``state`` field, so a watcher keying on ``.state`` reads
+    ``None`` forever even after ``output`` is populated.
+
     Args:
         run_id (str):
         timeout (int | Unset):  Default: 30.
@@ -166,6 +174,10 @@ async def asyncio_detailed(
     after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
     blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
     tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+
+    Watch the right field (#1140): poll ``done`` (bool) or ``run_status`` — the
+    response has NO ``state`` field, so a watcher keying on ``.state`` reads
+    ``None`` forever even after ``output`` is populated.
 
     Args:
         run_id (str):
@@ -207,6 +219,10 @@ async def asyncio(
     after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
     blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
     tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+
+    Watch the right field (#1140): poll ``done`` (bool) or ``run_status`` — the
+    response has NO ``state`` field, so a watcher keying on ``.state`` reads
+    ``None`` forever even after ``output`` is populated.
 
     Args:
         run_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/list_run_events.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/list_run_events.py
@@ -90,10 +90,18 @@ def sync_detailed(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseWfRunEvent]:
-    """List Run Events
+    r"""List Run Events
 
      A run's journal by sequence (oldest first). First page: optional ``limit``;
     subsequent pages: ``?cursor=<next_cursor>``.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"run reset\" — it
+    only means no journal rows past this ``seq`` yet. Page by ``seq`` and treat
+    an empty page as \"nothing new yet.\"
+
+    Schema (#1140): each item is a *run* event ``{type, payload, seq}`` — a
+    DIFFERENT shape from a child-*session* event (``{kind, data}`` on
+    ``/v1/sessions/{id}/events``). See ``docs/reference/run-observability.md``.
 
     Args:
         run_id (str):
@@ -131,10 +139,18 @@ def sync(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseWfRunEvent | None:
-    """List Run Events
+    r"""List Run Events
 
      A run's journal by sequence (oldest first). First page: optional ``limit``;
     subsequent pages: ``?cursor=<next_cursor>``.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"run reset\" — it
+    only means no journal rows past this ``seq`` yet. Page by ``seq`` and treat
+    an empty page as \"nothing new yet.\"
+
+    Schema (#1140): each item is a *run* event ``{type, payload, seq}`` — a
+    DIFFERENT shape from a child-*session* event (``{kind, data}`` on
+    ``/v1/sessions/{id}/events``). See ``docs/reference/run-observability.md``.
 
     Args:
         run_id (str):
@@ -167,10 +183,18 @@ async def asyncio_detailed(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseWfRunEvent]:
-    """List Run Events
+    r"""List Run Events
 
      A run's journal by sequence (oldest first). First page: optional ``limit``;
     subsequent pages: ``?cursor=<next_cursor>``.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"run reset\" — it
+    only means no journal rows past this ``seq`` yet. Page by ``seq`` and treat
+    an empty page as \"nothing new yet.\"
+
+    Schema (#1140): each item is a *run* event ``{type, payload, seq}`` — a
+    DIFFERENT shape from a child-*session* event (``{kind, data}`` on
+    ``/v1/sessions/{id}/events``). See ``docs/reference/run-observability.md``.
 
     Args:
         run_id (str):
@@ -206,10 +230,18 @@ async def asyncio(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseWfRunEvent | None:
-    """List Run Events
+    r"""List Run Events
 
      A run's journal by sequence (oldest first). First page: optional ``limit``;
     subsequent pages: ``?cursor=<next_cursor>``.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"run reset\" — it
+    only means no journal rows past this ``seq`` yet. Page by ``seq`` and treat
+    an empty page as \"nothing new yet.\"
+
+    Schema (#1140): each item is a *run* event ``{type, payload, seq}`` — a
+    DIFFERENT shape from a child-*session* event (``{kind, data}`` on
+    ``/v1/sessions/{id}/events``). See ``docs/reference/run-observability.md``.
 
     Args:
         run_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_session_events.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/list_session_events.py
@@ -120,7 +120,7 @@ def sync_detailed(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseEvent]:
-    """List Events
+    r"""List Events
 
      List a session's events by sequence number.
 
@@ -129,6 +129,16 @@ def sync_detailed(
     ``?cursor=<next_cursor>`` — the token carries direction and filters, so no
     other params are accepted alongside it. ``forward`` walks oldest→newest;
     ``backward`` loads the newest-first tail and pages into the past.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"session reset\"
+    — it only means no events match this page (e.g. a forward read past the
+    current tail, or back-to-back polls racing the writer under load). Page by
+    ``seq`` and treat an empty page as \"nothing new yet,\" not as a cleared log.
+
+    Schema (#1140): each item is a session event ``{kind, data, seq}``
+    (``kind`` ∈ message/lifecycle/span/interrupt) — a DIFFERENT shape from a
+    *run* event (``{type, payload, seq}`` on ``/v1/runs/{id}/events``). See
+    ``docs/reference/run-observability.md``.
 
     Args:
         session_id (str):
@@ -175,7 +185,7 @@ def sync(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseEvent | None:
-    """List Events
+    r"""List Events
 
      List a session's events by sequence number.
 
@@ -184,6 +194,16 @@ def sync(
     ``?cursor=<next_cursor>`` — the token carries direction and filters, so no
     other params are accepted alongside it. ``forward`` walks oldest→newest;
     ``backward`` loads the newest-first tail and pages into the past.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"session reset\"
+    — it only means no events match this page (e.g. a forward read past the
+    current tail, or back-to-back polls racing the writer under load). Page by
+    ``seq`` and treat an empty page as \"nothing new yet,\" not as a cleared log.
+
+    Schema (#1140): each item is a session event ``{kind, data, seq}``
+    (``kind`` ∈ message/lifecycle/span/interrupt) — a DIFFERENT shape from a
+    *run* event (``{type, payload, seq}`` on ``/v1/runs/{id}/events``). See
+    ``docs/reference/run-observability.md``.
 
     Args:
         session_id (str):
@@ -225,7 +245,7 @@ async def asyncio_detailed(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | ListResponseEvent]:
-    """List Events
+    r"""List Events
 
      List a session's events by sequence number.
 
@@ -234,6 +254,16 @@ async def asyncio_detailed(
     ``?cursor=<next_cursor>`` — the token carries direction and filters, so no
     other params are accepted alongside it. ``forward`` walks oldest→newest;
     ``backward`` loads the newest-first tail and pages into the past.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"session reset\"
+    — it only means no events match this page (e.g. a forward read past the
+    current tail, or back-to-back polls racing the writer under load). Page by
+    ``seq`` and treat an empty page as \"nothing new yet,\" not as a cleared log.
+
+    Schema (#1140): each item is a session event ``{kind, data, seq}``
+    (``kind`` ∈ message/lifecycle/span/interrupt) — a DIFFERENT shape from a
+    *run* event (``{type, payload, seq}`` on ``/v1/runs/{id}/events``). See
+    ``docs/reference/run-observability.md``.
 
     Args:
         session_id (str):
@@ -278,7 +308,7 @@ async def asyncio(
     limit: int | None | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
 ) -> HTTPValidationError | ListResponseEvent | None:
-    """List Events
+    r"""List Events
 
      List a session's events by sequence number.
 
@@ -287,6 +317,16 @@ async def asyncio(
     ``?cursor=<next_cursor>`` — the token carries direction and filters, so no
     other params are accepted alongside it. ``forward`` walks oldest→newest;
     ``backward`` loads the newest-first tail and pages into the past.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a \"session reset\"
+    — it only means no events match this page (e.g. a forward read past the
+    current tail, or back-to-back polls racing the writer under load). Page by
+    ``seq`` and treat an empty page as \"nothing new yet,\" not as a cleared log.
+
+    Schema (#1140): each item is a session event ``{kind, data, seq}``
+    (``kind`` ∈ message/lifecycle/span/interrupt) — a DIFFERENT shape from a
+    *run* event (``{type, payload, seq}`` on ``/v1/runs/{id}/events``). See
+    ``docs/reference/run-observability.md``.
 
     Args:
         session_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/event.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/event.py
@@ -22,17 +22,22 @@ T = TypeVar("T", bound="Event")
 class Event:
     """Read view of a single event from the session log.
 
-    Attributes:
-        id (str):
-        session_id (str):
-        seq (int):
-        kind (EventKind):
-        data (EventData):
-        created_at (datetime.datetime):
-        cumulative_tokens (int | None | Unset):
-        orig_channel (None | str | Unset):
-        focal_channel_at_arrival (None | str | Unset):
-        channel (None | str | Unset):
+    Schema (#1140): a session event is ``{kind, data, seq}`` — a DIFFERENT
+    shape from a *run* event (``{type, payload, seq}``, see
+    ``aios.models.workflows.WfRunEvent``). See module docstring and
+    ``docs/reference/run-observability.md`` for the split.
+
+        Attributes:
+            id (str):
+            session_id (str):
+            seq (int):
+            kind (EventKind):
+            data (EventData):
+            created_at (datetime.datetime):
+            cumulative_tokens (int | None | Unset):
+            orig_channel (None | str | Unset):
+            focal_channel_at_arrival (None | str | Unset):
+            channel (None | str | Unset):
     """
 
     id: str

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -32,6 +32,11 @@ class WfRun:
     ``status`` is persisted (unlike sessions): the run loop writes
     ``suspended``/``completed``/``errored``.
 
+    NB (#1140): the run's lifecycle field is ``status`` — there is no ``state``
+    field on a run. A watcher polling ``.state`` reads ``None`` forever even
+    though ``output`` is already populated; poll ``status`` (terminal values:
+    ``completed``/``errored``/``cancelled``).
+
         Attributes:
             id (str):
             workflow_id (str):
@@ -40,7 +45,8 @@ class WfRun:
             script (str):
             script_sha (str):
             host_semantics_epoch (int):
-            status (WfRunStatus):
+            status (WfRunStatus): The run's lifecycle status — the ONLY lifecycle field on a run (there is no `state` field;
+                a watcher keying on `.state` waits forever). Terminal values: `completed`/`errored`/`cancelled`.
             last_event_seq (int):
             created_at (datetime.datetime):
             updated_at (datetime.datetime):

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_event.py
@@ -28,6 +28,11 @@ class WfRunEvent:
     bookends. An ``annotation`` is a journaled progress marker (``payload`` =
     ``{"kind": "log" | "phase", "text": ...}``), not a capability call.
 
+    Schema note (#1140): a *run* event is ``{type, payload, seq}``. This is a
+    DIFFERENT shape from a child-*session* event (``{kind, data}`` — see
+    ``aios.models.events.Event``). Don't assume one schema across both
+    endpoints; ``docs/reference/run-observability.md`` documents the split.
+
         Attributes:
             id (str):
             run_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_wait_response.py
@@ -28,11 +28,15 @@ class WfRunWaitResponse:
     keep blocking.
 
         Attributes:
-            run_status (WfRunWaitResponseRunStatus):
-            done (bool):
-            output (Any | Unset):
-            is_error (bool | Unset):  Default: False.
-            error (None | Unset | WfRunWaitResponseErrorType0):
+            run_status (WfRunWaitResponseRunStatus): The run's terminal-or-current lifecycle status (the run row's `status`
+                field). This is the field to poll — there is no `state` field. Terminal values:
+                `completed`/`errored`/`cancelled`.
+            done (bool): True once `run_status` is terminal (completed/errored/cancelled). Poll `done` (or `run_status`);
+                there is no `state` field on this response (#1140).
+            output (Any | Unset): The run's return value, set when `done` and not `is_error`; None otherwise.
+            is_error (bool | Unset): True when run_status == errored. Default: False.
+            error (None | Unset | WfRunWaitResponseErrorType0): On is_error, the run_completed event's
+                {kind,message,traceback}; None otherwise.
     """
 
     run_status: WfRunWaitResponseRunStatus

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -638,6 +638,16 @@ async def list_events(
     ``?cursor=<next_cursor>`` — the token carries direction and filters, so no
     other params are accepted alongside it. ``forward`` walks oldest→newest;
     ``backward`` loads the newest-first tail and pages into the past.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a "session reset"
+    — it only means no events match this page (e.g. a forward read past the
+    current tail, or back-to-back polls racing the writer under load). Page by
+    ``seq`` and treat an empty page as "nothing new yet," not as a cleared log.
+
+    Schema (#1140): each item is a session event ``{kind, data, seq}``
+    (``kind`` ∈ message/lifecycle/span/interrupt) — a DIFFERENT shape from a
+    *run* event (``{type, payload, seq}`` on ``/v1/runs/{id}/events``). See
+    ``docs/reference/run-observability.md``.
     """
     # Scope check: 404 cross-tenant probes before reading events. read_events
     # also filters by account_id, so the lookup yields a clean 404 rather than

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -221,6 +221,10 @@ async def await_run(
     after ``timeout`` seconds returns ``done=false`` with its current status; call again to keep
     blocking. Unlike the SSE ``/stream`` this is a plain request/response, so it works as an MCP
     tool — an agent can await a sub-run and join. A cross-tenant run 404s.
+
+    Watch the right field (#1140): poll ``done`` (bool) or ``run_status`` — the
+    response has NO ``state`` field, so a watcher keying on ``.state`` reads
+    ``None`` forever even after ``output`` is populated.
     """
     return await service.await_run(
         pool, db_url, run_id, account_id=account_id, timeout_seconds=timeout_seconds
@@ -236,7 +240,16 @@ async def list_run_events(
     limit: Annotated[int | None, Query(ge=1, le=500)] = None,
 ) -> ListResponse[WfRunEvent]:
     """A run's journal by sequence (oldest first). First page: optional ``limit``;
-    subsequent pages: ``?cursor=<next_cursor>``."""
+    subsequent pages: ``?cursor=<next_cursor>``.
+
+    Transient-empty (#1140): an empty ``items`` list is NOT a "run reset" — it
+    only means no journal rows past this ``seq`` yet. Page by ``seq`` and treat
+    an empty page as "nothing new yet."
+
+    Schema (#1140): each item is a *run* event ``{type, payload, seq}`` — a
+    DIFFERENT shape from a child-*session* event (``{kind, data}`` on
+    ``/v1/sessions/{id}/events``). See ``docs/reference/run-observability.md``.
+    """
     # Scope check: 404 a cross-tenant run id before reading its journal.
     await service.get_run(pool, run_id, account_id=account_id)
     st = page_cursor(cursor, {"limit": limit})

--- a/src/aios/models/events.py
+++ b/src/aios/models/events.py
@@ -14,6 +14,13 @@ over-validate at the boundary. Per-kind shapes are documented but not
 enforced via pydantic discriminated unions, because the message kind in
 particular has to round-trip arbitrary LiteLLM extensions without rejecting
 them.
+
+Schema note (#1140): a (child-)*session* event is ``{kind, data}`` (this
+model). A *run* event is the DIFFERENT shape ``{type, payload, seq}`` (see
+``aios.models.workflows.WfRunEvent``). Consumers watching both surfaces must
+not assume a single schema; ``docs/reference/run-observability.md`` documents
+the split (and, for ``kind == "message"``, the ``data.role`` ∈
+user/assistant/tool axis).
 """
 
 from __future__ import annotations
@@ -37,7 +44,13 @@ MODEL_VISIBLE_LIFECYCLE_EVENTS: frozenset[str] = frozenset(
 
 
 class Event(BaseModel):
-    """Read view of a single event from the session log."""
+    """Read view of a single event from the session log.
+
+    Schema (#1140): a session event is ``{kind, data, seq}`` — a DIFFERENT
+    shape from a *run* event (``{type, payload, seq}``, see
+    ``aios.models.workflows.WfRunEvent``). See module docstring and
+    ``docs/reference/run-observability.md`` for the split.
+    """
 
     id: str
     session_id: str

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -70,6 +70,11 @@ class WfRun(BaseModel):
     ``update_workflow`` never shifts an in-flight run's authority.
     ``status`` is persisted (unlike sessions): the run loop writes
     ``suspended``/``completed``/``errored``.
+
+    NB (#1140): the run's lifecycle field is ``status`` — there is no ``state``
+    field on a run. A watcher polling ``.state`` reads ``None`` forever even
+    though ``output`` is already populated; poll ``status`` (terminal values:
+    ``completed``/``errored``/``cancelled``).
     """
 
     id: str
@@ -90,7 +95,13 @@ class WfRun(BaseModel):
     tools: list[ToolSpec] = Field(default_factory=list)
     mcp_servers: list[McpServerSpec] = Field(default_factory=list)
     http_servers: list[HttpServerSpec] = Field(default_factory=list)
-    status: WfRunStatus
+    status: WfRunStatus = Field(
+        description=(
+            "The run's lifecycle status — the ONLY lifecycle field on a run "
+            "(there is no `state` field; a watcher keying on `.state` waits "
+            "forever). Terminal values: `completed`/`errored`/`cancelled`."
+        )
+    )
     input: Any = None  # arbitrary JSON: a workflow's input need not be an object
     output: Any = None  # arbitrary JSON: the script's return value
     budget_usd: float | None = None
@@ -109,6 +120,11 @@ class WfRunEvent(BaseModel):
     emit-once across replays); it is ``None`` for the ``run_started``/``run_completed``
     bookends. An ``annotation`` is a journaled progress marker (``payload`` =
     ``{"kind": "log" | "phase", "text": ...}``), not a capability call.
+
+    Schema note (#1140): a *run* event is ``{type, payload, seq}``. This is a
+    DIFFERENT shape from a child-*session* event (``{kind, data}`` — see
+    ``aios.models.events.Event``). Don't assume one schema across both
+    endpoints; ``docs/reference/run-observability.md`` documents the split.
     """
 
     id: str
@@ -145,11 +161,29 @@ class WfRunWaitResponse(BaseModel):
     keep blocking.
     """
 
-    run_status: WfRunStatus
-    done: bool  # run_status in TERMINAL_RUN_STATUSES (completed/errored/cancelled)
-    output: Any = None  # the run's return value (on completed; None otherwise)
-    is_error: bool = False  # run_status == errored
-    error: dict[str, Any] | None = None  # the run_completed event's {kind,message,traceback}
+    run_status: WfRunStatus = Field(
+        description=(
+            "The run's terminal-or-current lifecycle status (the run row's "
+            "`status` field). This is the field to poll — there is no `state` "
+            "field. Terminal values: `completed`/`errored`/`cancelled`."
+        )
+    )
+    done: bool = Field(
+        description=(
+            "True once `run_status` is terminal "
+            "(completed/errored/cancelled). Poll `done` (or `run_status`); "
+            "there is no `state` field on this response (#1140)."
+        )
+    )
+    output: Any = Field(
+        default=None,
+        description="The run's return value, set when `done` and not `is_error`; None otherwise.",
+    )
+    is_error: bool = Field(default=False, description="True when run_status == errored.")
+    error: dict[str, Any] | None = Field(
+        default=None,
+        description="On is_error, the run_completed event's {kind,message,traceback}; None otherwise.",
+    )
 
 
 # ─── request models (the public HTTP surface) ────────────────────────────────

--- a/tests/unit/test_run_observability_contract.py
+++ b/tests/unit/test_run_observability_contract.py
@@ -1,0 +1,102 @@
+"""Run-observability contract guards (issue #1140).
+
+These assert the documented contract for three #1068 dogfood papercuts:
+
+(a) The run ``/wait`` terminal state is carried by ``run_status``/``done`` —
+    there is NO ``state`` field, and the model/schema must say so explicitly so
+    a watcher does not key on a nonexistent ``.state`` and wait forever.
+(b) ``GET /v1/sessions/{id}/events`` (and the run-events twin) can return an
+    empty page transiently; the endpoint docs must tell consumers an empty list
+    is a paging artifact, not a "session reset."
+(c) The two coexisting event schemas (run ``{type,payload,seq}`` vs
+    child-session ``{kind,data}``) must be documented.
+
+Pure in-memory: no Postgres, no Docker. Schema assertions walk OpenAPI
+metadata, which is exactly what consumers (SDK/MCP) read.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _openapi() -> dict[str, Any]:
+    # Deferred import: app import runs get_settings() at import time; the
+    # conftest env fixture must fire first (see test_openapi_snapshot.py).
+    from aios.api.app import create_app
+
+    return create_app().openapi()
+
+
+class TestWaitTerminalStateField:
+    def test_wait_response_has_no_state_field(self) -> None:
+        from aios.models.workflows import WfRunWaitResponse
+
+        # The watcher in #1068 keyed on ``.state`` and waited forever. Guard
+        # that the field genuinely does not exist (so the fix is to document
+        # run_status/done, not to silently add a state alias).
+        assert "state" not in WfRunWaitResponse.model_fields
+        assert "run_status" in WfRunWaitResponse.model_fields
+        assert "done" in WfRunWaitResponse.model_fields
+
+    def test_wait_response_fields_describe_terminal_polling(self) -> None:
+        from aios.models.workflows import WfRunWaitResponse
+
+        run_status_desc = (WfRunWaitResponse.model_fields["run_status"].description or "").lower()
+        done_desc = (WfRunWaitResponse.model_fields["done"].description or "").lower()
+        # The terminal-state field must be self-describing in the schema.
+        assert "terminal" in run_status_desc or "status" in run_status_desc
+        assert "no" in done_desc and "state" in done_desc
+
+    def test_wfrun_status_field_is_documented(self) -> None:
+        from aios.models.workflows import WfRun
+
+        desc = (WfRun.model_fields["status"].description or "").lower()
+        assert "status" in desc
+        assert "state" in desc  # explicitly disambiguates status-vs-state
+
+    def test_openapi_wait_schema_documents_status_not_state(self) -> None:
+        schema = _openapi()["components"]["schemas"]["WfRunWaitResponse"]
+        props = schema["properties"]
+        assert "state" not in props
+        assert "run_status" in props and props["run_status"].get("description")
+
+
+class TestTransientEmptyEventsDocumented:
+    def test_session_events_op_warns_about_transient_empty(self) -> None:
+        op = _openapi()["paths"]["/v1/sessions/{session_id}/events"]["get"]
+        desc = (op.get("description", "") + op.get("summary", "")).lower()
+        assert "empty" in desc
+        assert "reset" in desc
+
+    def test_run_events_op_warns_about_transient_empty(self) -> None:
+        op = _openapi()["paths"]["/v1/runs/{run_id}/events"]["get"]
+        desc = (op.get("description", "") + op.get("summary", "")).lower()
+        assert "empty" in desc
+        assert "reset" in desc
+
+
+class TestDualEventSchemasDocumented:
+    def test_event_model_docstring_names_kind_data_shape(self) -> None:
+        from aios.models.events import Event
+
+        doc = (Event.__doc__ or "").lower()
+        assert "kind" in doc and "data" in doc
+
+    def test_wfrunevent_model_docstring_names_type_payload_shape(self) -> None:
+        from aios.models.workflows import WfRunEvent
+
+        doc = (WfRunEvent.__doc__ or "").lower()
+        assert "type" in doc and "payload" in doc
+
+    def test_reference_doc_exists(self) -> None:
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        doc = repo_root / "docs" / "reference" / "run-observability.md"
+        assert doc.exists(), "expected docs/reference/run-observability.md"
+        text = doc.read_text().lower()
+        # Must cover all three papercuts.
+        assert "run_status" in text and "state" in text
+        assert "empty" in text
+        assert "{type" in text or "type, payload" in text or "type,payload" in text


### PR DESCRIPTION
Three #1068 dogfood papercuts on run-observability. All are contract/documentation fixes — no runtime behavior changes — surfaced where consumers actually read them (pydantic `Field` descriptions → OpenAPI → SDK, endpoint docstrings, and a reference doc).

**(a) Terminal state is `status`/`done`, never `state`.**
`GET /v1/runs/{id}/wait` has no `state` field — a watcher keying on `.state` reads `None` forever even after `output` is populated. Made `WfRun.status` and every `WfRunWaitResponse` field (`run_status`, `done`, `output`, `is_error`, `error`) self-describing via `Field(description=...)`, and spelled out the field-to-poll in the `/wait` endpoint doc. There is deliberately no `state` alias added — the fix is to make the real field discoverable.

**(b) A transient-empty event page is not a "reset."**
`GET /v1/sessions/{id}/events` and `GET /v1/runs/{id}/events` can return an empty `items` list transiently (a forward read past the tail, or back-to-back polls racing the writer under load). Documented on both list endpoints that an empty page means "nothing new yet" — consumers must page by `seq`, never infer log truncation or session loss.

**(c) Two event schemas coexist.**
Run events are `{type, payload, seq}` (`WfRunEvent`); child-session events are `{kind, data}` (`Event`, `kind ∈ message/lifecycle/span/interrupt`, `message.data.role ∈ user/assistant/tool`). Documented the split on both models, both endpoints, and in a new `docs/reference/run-observability.md`.

**Tests:** added `tests/unit/test_run_observability_contract.py` (TDD; red→green; mutation-checked) asserting the schema has no `state` property, that the descriptions document terminal polling, that both event endpoints warn about transient-empty, and that the reference doc covers all three. Full unit suite (2787) + mypy + ruff green.

**Codegen:** regenerated `openapi.json` and `packages/aios-sdk` so the new descriptions ship to SDK/MCP consumers (staged in this commit).

Closes #1140