### PR TITLE
fix: don't retry deterministic broker/route errors (#1139)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -351,15 +351,27 @@ async def _gh_once(method, path, body=None):
     return await tool("http_request", args)
 
 
+_TRANSIENT_ERROR_PREFIXES = ("Request timed out", "HTTP transport error")
+
+
 def _is_transient(resp):
-    """A retryable GitHub response: a 5xx status, OR a transport/tool error (the
-    http_request tool surfaces a connection failure as ``{"error": ...}`` with no/None
-    status). A 4xx is the caller's problem (auth, 404, 422-already-exists) — NOT retried,
-    so a deterministic client error fails fast rather than burning three attempts."""
+    """A retryable GitHub response: a 5xx status, OR a genuine transport transient (the
+    http_request tool surfaces a timeout / connection failure as ``{"error": ...}`` with
+    no status). A 4xx is the caller's problem (auth, 404, 422-already-exists) — NOT retried.
+
+    An ``{"error": ...}`` envelope is NOT automatically transient: the broker's own gate
+    rejections — route-allowlist mismatch / method-not-allowed ("does not match any
+    enabled route"), unknown server_ref, SSRF block, path rejection — are DETERMINISTIC
+    (a 405-equivalent) and re-issuing the identical request just reproduces them. Retrying
+    those burned three pointless attempts on every such call (#1139). Only the transport
+    transients (request timeout, connection reset) earn a retry; every other error string
+    is terminal."""
     if not isinstance(resp, dict):
         return True  # a non-dict result is a malformed tool return -> treat as transient
-    if resp.get("error") is not None:
-        return True
+    err = resp.get("error")
+    if err is not None:
+        # Only timeouts / transport faults are transient; broker gate rejections are not.
+        return isinstance(err, str) and err.startswith(_TRANSIENT_ERROR_PREFIXES)
     st = resp.get("status")
     return isinstance(st, int) and 500 <= st <= 599
 

--- a/tests/unit/test_dev_pipeline_retry.py
+++ b/tests/unit/test_dev_pipeline_retry.py
@@ -1,0 +1,106 @@
+"""Unit tests for the dev-pipeline ``_is_transient`` retry classifier (#1139).
+
+``_is_transient`` lives inside the workflow *script source* (``_BODY``), so it is not
+importable as a module attribute. We build the production script and ``exec`` it in a
+fresh namespace — the body imports only ``json``/``re`` and references header constants,
+both satisfied by ``build_dev_pipeline_script`` — then pull the function out of the
+namespace and exercise it directly. The classifier is pure (no LLM, no tool, no time).
+
+The bug (#1139, dogfood 2026-06-14): the old classifier treated ANY ``{"error": ...}``
+tool result as transient, so a deterministic broker route-allowlist rejection
+("does not match any enabled route", a 405-equivalent) burned three pointless retries on
+every call. Only genuine transients — 5xx, request timeouts, and HTTP transport errors —
+must retry; every broker gate rejection (route mismatch / method-not-allowed / unknown
+server / SSRF block / path rejection) is terminal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from aios.workflows.dev_pipeline import build_dev_pipeline_script
+
+
+@pytest.fixture(scope="module")
+def is_transient() -> Callable[[Any], bool]:
+    src = build_dev_pipeline_script(
+        implement_agent_id="a",
+        review_agent_id="b",
+        fix_agent_id="c",
+        ci_agent_id="d",
+        risk_agent_id="e",
+    )
+    namespace: dict[str, Any] = {}
+    exec(compile(src, "dev_pipeline_script", "exec"), namespace)
+    fn: Callable[[Any], bool] = namespace["_is_transient"]
+    return fn
+
+
+# ─── genuine transients: retry ────────────────────────────────────────────────
+
+
+def test_5xx_status_is_transient(is_transient: Callable[[Any], bool]) -> None:
+    for status in (500, 502, 503, 599):
+        assert is_transient({"status": status}) is True
+
+
+def test_request_timeout_error_is_transient(is_transient: Callable[[Any], bool]) -> None:
+    # http_request surfaces a timeout as {"error": "Request timed out: ..."}.
+    assert is_transient({"error": "Request timed out: GET https://api.github.com/x"}) is True
+
+
+def test_transport_error_is_transient(is_transient: Callable[[Any], bool]) -> None:
+    # A connection reset / DNS failure surfaces as an HTTP transport error envelope.
+    assert is_transient({"error": "HTTP transport error: ConnectError: connection reset"}) is True
+
+
+def test_non_dict_result_is_transient(is_transient: Callable[[Any], bool]) -> None:
+    # A malformed (non-dict) tool return is treated as transient.
+    assert is_transient("boom") is True
+    assert is_transient(None) is True
+
+
+# ─── deterministic broker/route rejections: terminal (the #1139 fix) ──────────
+
+
+def test_route_mismatch_error_is_terminal(is_transient: Callable[[Any], bool]) -> None:
+    # The exact broker route-allowlist rejection from http_request.py — a 405-equivalent.
+    resp = {
+        "error": (
+            "DELETE '/repos/o/r/issues/1/labels/x' does not match any enabled route on "
+            "http_server 'github' — the path may be unlisted, or the route's allowed "
+            "methods may not include this verb"
+        )
+    }
+    assert is_transient(resp) is False
+
+
+def test_unknown_server_ref_error_is_terminal(is_transient: Callable[[Any], bool]) -> None:
+    resp = {"error": "unknown server_ref 'github'; not declared on http_servers"}
+    assert is_transient(resp) is False
+
+
+def test_ssrf_block_error_is_terminal(is_transient: Callable[[Any], bool]) -> None:
+    resp = {"error": "Blocked: URL targets a private/internal address: http://10.0.0.1/x"}
+    assert is_transient(resp) is False
+
+
+def test_path_rejection_error_is_terminal(is_transient: Callable[[Any], bool]) -> None:
+    resp = {"error": "path may not contain a query string"}
+    assert is_transient(resp) is False
+
+
+# ─── HTTP status results: 4xx/2xx are the caller's branch, never retried ───────
+
+
+def test_4xx_status_is_terminal(is_transient: Callable[[Any], bool]) -> None:
+    for status in (400, 401, 403, 404, 405, 422):
+        assert is_transient({"status": status}) is False
+
+
+def test_2xx_status_is_terminal(is_transient: Callable[[Any], bool]) -> None:
+    for status in (200, 201, 204):
+        assert is_transient({"status": status}) is False


### PR DESCRIPTION
## Problem

`dev_pipeline.py:_is_transient()` classified **any** `{"error": ...}` tool result as transient and retried it 3×. But the broker's own gate rejections are **deterministic** — re-issuing the identical request just reproduces them:

- route-allowlist mismatch / method-not-allowed (`"does not match any enabled route"`, a 405-equivalent)
- unknown `server_ref`
- SSRF block (`"Blocked: URL targets a private/internal address"`)
- path rejection (query string / dot-segments)

So every such call burned three pointless retries — observed on the success-path DELETE label-cleanup (whose route-allowlist gap is the companion fix in #1135). The same gap hit the `_fail` path, since its label cleanup routes through `gh()` → `_is_transient`.

## Fix

`_is_transient` now treats an `{"error": ...}` envelope as transient **only** when it's a genuine transport fault — a request timeout (`"Request timed out"`) or HTTP transport error (`"HTTP transport error"`, connection reset/DNS) — matched by message prefix. Every other error string is terminal (no retry). 5xx statuses still retry; 4xx/2xx remain the caller's branch as before. Non-dict (malformed) tool returns stay transient.

The fix is centralized in `_is_transient`, so both the success path (`gh()`) and the `_fail` path get it for free.

## Tests

Adds `tests/unit/test_dev_pipeline_retry.py`. Because the classifier lives inside the `_BODY` workflow script source (not an importable module symbol), the test builds the production script via `build_dev_pipeline_script` and `exec`s it in a fresh namespace to pull out `_is_transient`, then asserts the transient/terminal partition across timeouts, transport errors, route mismatches, unknown server, SSRF block, path rejection, and 5xx/4xx/2xx statuses. Verified red→green and mutation-checked (breaking the production line fails the new terminal-error tests).

No codegen drift: the change touches only the workflow script string — `regen-openapi.sh` and `regen-client.sh` produce no changes to `openapi.json` or the SDK.

Relates #1068. Provenance: dogfood 2026-06-14.

Closes #1139