### PR TITLE
feat: export dev-pipeline deploy surface (tools + http_servers)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -80,6 +80,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
+from aios.models.workflows import WorkflowCreate
+
 # ─── default judgment-node agent ids (override per deployment) ───────────────
 DEFAULT_IMPLEMENT_AGENT_ID = "dev-implement"
 DEFAULT_REVIEW_AGENT_ID = "dev-review"
@@ -866,4 +869,91 @@ def build_dev_pipeline_fixture_script(
         max_review_iters=max_review_iters,
         max_ci_iters=max_ci_iters,
         auto_merge_max_tier=auto_merge_max_tier,
+    )
+
+
+# ─── deploy surface (the tool + http_server envelope a WorkflowCreate needs) ──
+#
+# ``build_dev_pipeline_script`` returns only the workflow *script string*. A deployed
+# workflow ALSO needs its tool + http_server surface declared on the ``WorkflowCreate``,
+# or the very first ``tool('bash')`` / ``tool('http_request')`` call errors at runtime
+# ("tool 'bash' is not in the workflow's declared tools"). Exporting the surface here
+# alongside the script keeps the two from drifting (#1135).
+#
+# ``REQUIRED_TOOLS`` is the UNION of the script's own tools (``bash``/``http_request``)
+# AND every named judgment agent's tools (``read``/``write``/``edit``/``glob``/``grep``).
+# The child-agent surface is ``agent ∩ run`` (attenuation), so declaring only the
+# script's two tools would strip the editing tools from the implement/fix agents and
+# cripple them — the workflow must declare the union, each agent declaring its subset.
+REQUIRED_TOOLS: list[ToolSpec] = [
+    ToolSpec(type="bash"),
+    ToolSpec(type="read"),
+    ToolSpec(type="write"),
+    ToolSpec(type="edit"),
+    ToolSpec(type="glob"),
+    ToolSpec(type="grep"),
+    ToolSpec(type="http_request"),
+]
+
+# The GitHub http_server the scripted nodes reach via ``tool('http_request', ...)``.
+# Two routes, because GraphQL and REST need distinct method scoping:
+#   - ``/repos/**`` REST: GET·POST·PUT·DELETE. DELETE is load-bearing — the success-path
+#     ``_unlabel(autodev:in-progress)`` issues ``DELETE /repos/.../labels/...``; omitting
+#     it silently fails every unlabel (route-mismatch, then 3 pointless retries).
+#   - ``/graphql`` POST: the mark-ready mutation (``_mark_ready_query``). GraphQL serves
+#     reads and writes over one POST path, so it lives on its own route.
+
+
+def _github_http_server(*, name: str, base_url: str) -> HttpServerSpec:
+    return HttpServerSpec(
+        name=name,
+        base_url=base_url,
+        description="GitHub REST + GraphQL API (auth resolved from the bound vault's GITHUB_TOKEN).",
+        routes=[
+            HttpRouteSpec(
+                path_pattern="/repos/**",
+                methods=["GET", "POST", "PUT", "DELETE"],
+                description="Issues, PRs, labels, statuses, refs (DELETE removes labels).",
+            ),
+            HttpRouteSpec(
+                path_pattern="/graphql",
+                methods=["POST"],
+                description="GraphQL mutations (mark-ready: markPullRequestReadyForReview).",
+            ),
+        ],
+    )
+
+
+REQUIRED_HTTP_SERVERS: list[HttpServerSpec] = [
+    _github_http_server(name="github", base_url="https://api.github.com")
+]
+
+
+def build_dev_pipeline_workflow_create(
+    *,
+    name: str,
+    description: str | None = None,
+    github_server: str = "github",
+    github_base_url: str = "https://api.github.com",
+    **script_kwargs: Any,
+) -> WorkflowCreate:
+    """Return the complete ``WorkflowCreate`` payload for the production dev-pipeline.
+
+    Bundles the script (``build_dev_pipeline_script``) with the tool + http_server surface
+    it requires (``REQUIRED_TOOLS`` and the two-route ``github`` http_server), so a deployer
+    can POST one object instead of hand-assembling the surface from source — and so the
+    declared surface can never drift from the script that needs it (#1135).
+
+    ``github_server`` names the http_server and is threaded into the script's
+    ``GITHUB_SERVER`` constant so ``tool('http_request', {server_ref: ...})`` resolves;
+    ``github_base_url`` is the http_server's ``base_url`` (the credential-resolution key).
+    Any remaining keyword args are forwarded verbatim to ``build_dev_pipeline_script``.
+    """
+    script = build_dev_pipeline_script(github_server=github_server, **script_kwargs)
+    return WorkflowCreate(
+        name=name,
+        description=description,
+        script=script,
+        tools=list(REQUIRED_TOOLS),
+        http_servers=[_github_http_server(name=github_server, base_url=github_base_url)],
     )

--- a/tests/unit/test_dev_pipeline_surface.py
+++ b/tests/unit/test_dev_pipeline_surface.py
@@ -1,0 +1,133 @@
+"""Unit tests for the dev-pipeline deploy-surface export (#1135).
+
+``build_dev_pipeline_script`` returns only the workflow *script string*, but a deployed
+workflow ALSO needs its tool + http_server surface declared on the ``WorkflowCreate`` —
+otherwise the first ``tool('bash')`` call errors with "tool 'bash' is not in the
+workflow's declared tools" (run_tools.py).
+
+This module pins the exported deploy surface so it can't drift from the script that
+needs it:
+
+- ``REQUIRED_TOOLS`` — the UNION of the script's own tools (``bash``/``http_request``)
+  AND every named agent's tools (``read``/``write``/``edit``/``glob``/``grep``). The
+  child-agent surface is ``agent ∩ run``, so declaring only ``[bash, http_request]``
+  on the workflow would strip the editing tools from the implement/fix agents.
+- ``REQUIRED_HTTP_SERVERS`` — the two-route ``github`` spec: ``/repos/**`` with
+  ``GET,POST,PUT,DELETE`` (DELETE is load-bearing for the success-path unlabel) and a
+  separate ``/graphql`` POST route (mark-ready mutation).
+- ``build_dev_pipeline_workflow_create(...)`` — the complete ``WorkflowCreate`` payload
+  (script + tools + http_servers) so the surface can't drift from the script.
+"""
+
+from __future__ import annotations
+
+from aios.models.workflows import WorkflowCreate
+from aios.workflows.dev_pipeline import (
+    REQUIRED_HTTP_SERVERS,
+    REQUIRED_TOOLS,
+    build_dev_pipeline_script,
+    build_dev_pipeline_workflow_create,
+)
+
+# ─── REQUIRED_TOOLS: the union of script + agent tools ─────────────────────────
+
+
+def test_required_tools_is_the_full_union() -> None:
+    # The script uses bash + http_request; the implement/fix agents need the editing
+    # tools (read/write/edit/glob/grep). The export must emit the union so the child
+    # agents (agent ∩ run) keep their editing surface.
+    got = {t.type for t in REQUIRED_TOOLS}
+    assert got == {"bash", "read", "write", "edit", "glob", "grep", "http_request"}
+
+
+def test_required_tools_includes_scripts_own_tools() -> None:
+    types = {t.type for t in REQUIRED_TOOLS}
+    assert "bash" in types
+    assert "http_request" in types
+
+
+def test_required_tools_includes_agent_editing_tools() -> None:
+    types = {t.type for t in REQUIRED_TOOLS}
+    for editing in ("read", "write", "edit", "glob", "grep"):
+        assert editing in types, f"{editing} missing — implement/fix agents would be crippled"
+
+
+def test_required_tools_have_no_duplicates() -> None:
+    types = [t.type for t in REQUIRED_TOOLS]
+    assert len(types) == len(set(types))
+
+
+# ─── REQUIRED_HTTP_SERVERS: the two-route github spec ──────────────────────────
+
+
+def test_required_http_servers_has_single_github_server() -> None:
+    assert len(REQUIRED_HTTP_SERVERS) == 1
+    server = REQUIRED_HTTP_SERVERS[0]
+    assert server.name == "github"
+    assert server.base_url == "https://api.github.com"
+
+
+def test_repos_route_allows_delete() -> None:
+    server = REQUIRED_HTTP_SERVERS[0]
+    repos = [r for r in server.routes if r.path_pattern == "/repos/**"]
+    assert len(repos) == 1
+    methods = repos[0].methods
+    assert methods is not None
+    # DELETE is load-bearing: the success-path _unlabel(autodev:in-progress) issues
+    # DELETE /repos/.../labels/...; omitting it silently failed every unlabel.
+    assert set(methods) == {"GET", "POST", "PUT", "DELETE"}
+
+
+def test_graphql_route_is_separate_and_post_only() -> None:
+    server = REQUIRED_HTTP_SERVERS[0]
+    graphql = [r for r in server.routes if r.path_pattern == "/graphql"]
+    assert len(graphql) == 1
+    assert graphql[0].methods == ["POST"]
+
+
+def test_two_distinct_routes() -> None:
+    server = REQUIRED_HTTP_SERVERS[0]
+    patterns = {r.path_pattern for r in server.routes}
+    assert patterns == {"/repos/**", "/graphql"}
+
+
+# ─── build_dev_pipeline_workflow_create: the complete payload ──────────────────
+
+
+def test_workflow_create_is_a_valid_workflow_create() -> None:
+    wc = build_dev_pipeline_workflow_create(name="dev-pipeline")
+    assert isinstance(wc, WorkflowCreate)
+    assert wc.name == "dev-pipeline"
+
+
+def test_workflow_create_carries_the_script() -> None:
+    wc = build_dev_pipeline_workflow_create(name="dev-pipeline")
+    assert wc.script == build_dev_pipeline_script()
+    assert "tool(" in wc.script
+
+
+def test_workflow_create_carries_required_tools() -> None:
+    wc = build_dev_pipeline_workflow_create(name="dev-pipeline")
+    assert {t.type for t in wc.tools} == {t.type for t in REQUIRED_TOOLS}
+
+
+def test_workflow_create_carries_required_http_servers() -> None:
+    wc = build_dev_pipeline_workflow_create(name="dev-pipeline")
+    assert len(wc.http_servers) == 1
+    server = wc.http_servers[0]
+    assert server.name == "github"
+    assert {r.path_pattern for r in server.routes} == {"/repos/**", "/graphql"}
+
+
+def test_workflow_create_forwards_build_kwargs_to_script() -> None:
+    # Customising the script (e.g. iteration caps) must flow into the embedded script.
+    wc = build_dev_pipeline_workflow_create(name="dev-pipeline", max_review_iters=7)
+    assert wc.script == build_dev_pipeline_script(max_review_iters=7)
+
+
+def test_workflow_create_github_server_name_matches_script_server() -> None:
+    # The http_server name on the payload must equal the script's GITHUB_SERVER constant,
+    # or every tool('http_request', {server_ref: GITHUB_SERVER}) fails with unknown server.
+    wc = build_dev_pipeline_workflow_create(name="dev-pipeline", github_server="gh")
+    assert any(s.name == "gh" for s in wc.http_servers)
+    assert "'gh'" in wc.script or '"gh"' in wc.script


### PR DESCRIPTION
## What

`build_dev_pipeline_script(...)` returned only the workflow *script string*. A deployed workflow ALSO needs its tool + http_server surface declared on the `WorkflowCreate`, or the very first `tool('bash')` / `tool('http_request')` call errors at runtime (`tool 'bash' is not in the workflow's declared tools`). This PR exports the full deploy surface alongside the script so the two can't drift.

## Changes (all in `src/aios/workflows/dev_pipeline.py`)

- **`REQUIRED_TOOLS`** — the UNION of the script's own tools (`bash`, `http_request`) and every named judgment agent's editing tools (`read`, `write`, `edit`, `glob`, `grep`). Because the child-agent surface is `agent ∩ run`, declaring only the script's two tools would strip the editing tools from the implement/fix agents and cripple them. Full set: `bash, read, write, edit, glob, grep, http_request`.
- **`REQUIRED_HTTP_SERVERS`** — the two-route `github` spec:
  - `/repos/**` with `GET·POST·PUT·DELETE`. **DELETE is load-bearing**: the success-path `_unlabel(autodev:in-progress)` issues `DELETE /repos/.../labels/...`; omitting it silently failed every unlabel.
  - a separate `/graphql` `POST` route for the mark-ready mutation (GraphQL serves reads+writes over one POST path, so it lives on its own route).
- **`build_dev_pipeline_workflow_create(...)`** — returns the complete `WorkflowCreate` payload (script + tools + http_servers). `github_server` names the http_server and is threaded into the script's `GITHUB_SERVER` constant so `server_ref` resolves; remaining kwargs forward verbatim to `build_dev_pipeline_script`.

## Tests

New `tests/unit/test_dev_pipeline_surface.py` (13 cases): the tools union, DELETE on `/repos/**`, the separate POST-only `/graphql` route, and that the `WorkflowCreate` carries the script + tools + http_servers with a consistent server name. TDD red→green confirmed; mutation check verified the DELETE assertion fails when DELETE is dropped from the route. No API surface changed, so no openapi/sdk codegen drift. Full pre-commit suite (mypy + ruff + unit) passed at commit time.

Closes #1135