### PR TITLE
feat: add POST /v1/invocations API caller request-writer (#1128)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -9549,6 +9549,66 @@
           "targets": []
         }
       }
+    },
+    "/v1/invocations": {
+      "post": {
+        "tags": [
+          "invocations"
+        ],
+        "summary": "Invoke",
+        "description": "Write a trusted request edge + resolve-or-create a servicer, returning a handle.\n\n``target_kind=agent`` creates a **session** servicer (env-bound) and injects a\nchannel-less request; ``target_kind=workflow`` creates a **run** servicer;\n``target_kind=session`` invokes an existing same-account session by id. The\nreturned ``request_id`` correlates the matching awaiter\n(``GET /v1/sessions/{id}/await?request_id=`` for sessions, ``GET /v1/runs/{id}/wait``\nfor runs). A cross-tenant ``target`` 404s before any edge is written; a supplied\n``environment_id`` is ownership-checked against the caller's account.",
+        "operationId": "invoke",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvocationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvocationHandle"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -11483,6 +11543,89 @@
         ],
         "title": "HttpServerSpec",
         "description": "One entry in an agent's ``http_servers`` list.\n\nDeclares an authenticated HTTP endpoint the agent can reach via the\n``http_request`` built-in tool.  ``base_url`` is the common URL\nprefix the agent's ``path`` argument is appended to; ``routes`` is\nthe allowlist of path patterns the broker permits.  Credentials are\nresolved at request time from the session's bound vaults, keyed on\n``base_url``.  Secret never enters the sandbox \u2014 the worker authors\nthe ``Authorization`` header from the vault credential."
+      },
+      "InvocationHandle": {
+        "properties": {
+          "servicer_kind": {
+            "type": "string",
+            "enum": [
+              "session",
+              "run"
+            ],
+            "title": "Servicer Kind"
+          },
+          "servicer_id": {
+            "type": "string",
+            "title": "Servicer Id"
+          },
+          "request_id": {
+            "type": "string",
+            "title": "Request Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "servicer_kind",
+          "servicer_id",
+          "request_id"
+        ],
+        "title": "InvocationHandle",
+        "description": "Structured handle returned by ``POST /v1/invocations``.\n\nPlain JSON fields, no opaque encoding: the handle is **not** an auth boundary\n(``await`` re-authorizes by ``account_id``). The caller picks the matching\nawaiter off ``servicer_kind`` \u2014 ``session`` \u2192 ``GET /sessions/{servicer_id}/await``\nwith ``request_id``, ``run`` \u2192 ``GET /runs/{servicer_id}/wait``."
+      },
+      "InvocationRequest": {
+        "properties": {
+          "target_kind": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "workflow",
+              "session"
+            ],
+            "title": "Target Kind"
+          },
+          "target": {
+            "type": "string",
+            "title": "Target",
+            "description": "An agent_id / workflow_id / session_id, discriminated by ``target_kind``."
+          },
+          "input": {
+            "title": "Input",
+            "description": "The request payload delivered to the servicer (arbitrary JSON or a string)."
+          },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Schema",
+            "description": "Optional JSON Schema the response ``value`` must satisfy. Rides the request edge, per-request \u2014 coexists with any definition-level schema."
+          },
+          "environment_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Environment Id",
+            "description": "Environment to bind a created servicer to (agent \u2192 session, workflow \u2192 run). Ownership-checked against the caller's account. Inapplicable for ``target_kind=session`` (the session already exists)."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "target_kind",
+          "target"
+        ],
+        "title": "InvocationRequest",
+        "description": "Request body for ``POST /v1/invocations`` \u2014 the API caller's request-writer.\n\n``target`` is an ``agent_id | workflow_id | session_id`` and ``target_kind``\ndiscriminates it:\n\n* ``agent``     \u2014 create a **session** servicer and inject a channel-less\n  request into it (the API analog of ``invoke_agent``).\n* ``workflow``  \u2014 create a **run** servicer of the workflow.\n* ``session``   \u2014 invoke an **existing** same-account session by id (the API\n  analog of #1127's ``invoke(session_id)``). No ``environment_id`` applies \u2014\n  the session already exists.\n\n``output_schema`` is the per-request JSON Schema the response ``value`` must\nsatisfy; it rides the edge (``metadata.request.output_schema``), coexisting\nwith any definition-level schema. ``environment_id`` is ownership-checked\nagainst the caller's account on the ``agent`` / ``workflow`` create-paths\n(the per-field containment clamp is #1130's deliverable)."
       },
       "LimitedNetworking": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/invocations/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/invocations/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/packages/aios-sdk/aios_sdk/_generated/api/invocations/invoke.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/invocations/invoke.py
@@ -1,0 +1,289 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.invocation_handle import InvocationHandle
+from ...models.invocation_request import InvocationRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: InvocationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/invocations",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | InvocationHandle | None:
+    if response.status_code == 201:
+        response_201 = InvocationHandle.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | InvocationHandle]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: InvocationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | InvocationHandle]:
+    """Invoke
+
+     Write a trusted request edge + resolve-or-create a servicer, returning a handle.
+
+    ``target_kind=agent`` creates a **session** servicer (env-bound) and injects a
+    channel-less request; ``target_kind=workflow`` creates a **run** servicer;
+    ``target_kind=session`` invokes an existing same-account session by id. The
+    returned ``request_id`` correlates the matching awaiter
+    (``GET /v1/sessions/{id}/await?request_id=`` for sessions, ``GET /v1/runs/{id}/wait``
+    for runs). A cross-tenant ``target`` 404s before any edge is written; a supplied
+    ``environment_id`` is ownership-checked against the caller's account.
+
+    Args:
+        authorization (None | str | Unset):
+        body (InvocationRequest): Request body for ``POST /v1/invocations`` — the API caller's
+            request-writer.
+
+            ``target`` is an ``agent_id | workflow_id | session_id`` and ``target_kind``
+            discriminates it:
+
+            * ``agent``     — create a **session** servicer and inject a channel-less
+              request into it (the API analog of ``invoke_agent``).
+            * ``workflow``  — create a **run** servicer of the workflow.
+            * ``session``   — invoke an **existing** same-account session by id (the API
+              analog of #1127's ``invoke(session_id)``). No ``environment_id`` applies —
+              the session already exists.
+
+            ``output_schema`` is the per-request JSON Schema the response ``value`` must
+            satisfy; it rides the edge (``metadata.request.output_schema``), coexisting
+            with any definition-level schema. ``environment_id`` is ownership-checked
+            against the caller's account on the ``agent`` / ``workflow`` create-paths
+            (the per-field containment clamp is #1130's deliverable).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | InvocationHandle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: InvocationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | InvocationHandle | None:
+    """Invoke
+
+     Write a trusted request edge + resolve-or-create a servicer, returning a handle.
+
+    ``target_kind=agent`` creates a **session** servicer (env-bound) and injects a
+    channel-less request; ``target_kind=workflow`` creates a **run** servicer;
+    ``target_kind=session`` invokes an existing same-account session by id. The
+    returned ``request_id`` correlates the matching awaiter
+    (``GET /v1/sessions/{id}/await?request_id=`` for sessions, ``GET /v1/runs/{id}/wait``
+    for runs). A cross-tenant ``target`` 404s before any edge is written; a supplied
+    ``environment_id`` is ownership-checked against the caller's account.
+
+    Args:
+        authorization (None | str | Unset):
+        body (InvocationRequest): Request body for ``POST /v1/invocations`` — the API caller's
+            request-writer.
+
+            ``target`` is an ``agent_id | workflow_id | session_id`` and ``target_kind``
+            discriminates it:
+
+            * ``agent``     — create a **session** servicer and inject a channel-less
+              request into it (the API analog of ``invoke_agent``).
+            * ``workflow``  — create a **run** servicer of the workflow.
+            * ``session``   — invoke an **existing** same-account session by id (the API
+              analog of #1127's ``invoke(session_id)``). No ``environment_id`` applies —
+              the session already exists.
+
+            ``output_schema`` is the per-request JSON Schema the response ``value`` must
+            satisfy; it rides the edge (``metadata.request.output_schema``), coexisting
+            with any definition-level schema. ``environment_id`` is ownership-checked
+            against the caller's account on the ``agent`` / ``workflow`` create-paths
+            (the per-field containment clamp is #1130's deliverable).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | InvocationHandle
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: InvocationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | InvocationHandle]:
+    """Invoke
+
+     Write a trusted request edge + resolve-or-create a servicer, returning a handle.
+
+    ``target_kind=agent`` creates a **session** servicer (env-bound) and injects a
+    channel-less request; ``target_kind=workflow`` creates a **run** servicer;
+    ``target_kind=session`` invokes an existing same-account session by id. The
+    returned ``request_id`` correlates the matching awaiter
+    (``GET /v1/sessions/{id}/await?request_id=`` for sessions, ``GET /v1/runs/{id}/wait``
+    for runs). A cross-tenant ``target`` 404s before any edge is written; a supplied
+    ``environment_id`` is ownership-checked against the caller's account.
+
+    Args:
+        authorization (None | str | Unset):
+        body (InvocationRequest): Request body for ``POST /v1/invocations`` — the API caller's
+            request-writer.
+
+            ``target`` is an ``agent_id | workflow_id | session_id`` and ``target_kind``
+            discriminates it:
+
+            * ``agent``     — create a **session** servicer and inject a channel-less
+              request into it (the API analog of ``invoke_agent``).
+            * ``workflow``  — create a **run** servicer of the workflow.
+            * ``session``   — invoke an **existing** same-account session by id (the API
+              analog of #1127's ``invoke(session_id)``). No ``environment_id`` applies —
+              the session already exists.
+
+            ``output_schema`` is the per-request JSON Schema the response ``value`` must
+            satisfy; it rides the edge (``metadata.request.output_schema``), coexisting
+            with any definition-level schema. ``environment_id`` is ownership-checked
+            against the caller's account on the ``agent`` / ``workflow`` create-paths
+            (the per-field containment clamp is #1130's deliverable).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | InvocationHandle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: InvocationRequest,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | InvocationHandle | None:
+    """Invoke
+
+     Write a trusted request edge + resolve-or-create a servicer, returning a handle.
+
+    ``target_kind=agent`` creates a **session** servicer (env-bound) and injects a
+    channel-less request; ``target_kind=workflow`` creates a **run** servicer;
+    ``target_kind=session`` invokes an existing same-account session by id. The
+    returned ``request_id`` correlates the matching awaiter
+    (``GET /v1/sessions/{id}/await?request_id=`` for sessions, ``GET /v1/runs/{id}/wait``
+    for runs). A cross-tenant ``target`` 404s before any edge is written; a supplied
+    ``environment_id`` is ownership-checked against the caller's account.
+
+    Args:
+        authorization (None | str | Unset):
+        body (InvocationRequest): Request body for ``POST /v1/invocations`` — the API caller's
+            request-writer.
+
+            ``target`` is an ``agent_id | workflow_id | session_id`` and ``target_kind``
+            discriminates it:
+
+            * ``agent``     — create a **session** servicer and inject a channel-less
+              request into it (the API analog of ``invoke_agent``).
+            * ``workflow``  — create a **run** servicer of the workflow.
+            * ``session``   — invoke an **existing** same-account session by id (the API
+              analog of #1127's ``invoke(session_id)``). No ``environment_id`` applies —
+              the session already exists.
+
+            ``output_schema`` is the per-request JSON Schema the response ``value`` must
+            satisfy; it rides the edge (``metadata.request.output_schema``), coexisting
+            with any definition-level schema. ``environment_id`` is ownership-checked
+            against the caller's account on the ``agent`` / ``workflow`` create-paths
+            (the per-field containment clamp is #1130's deliverable).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | InvocationHandle
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -65,6 +65,11 @@ from .http_route_spec import HttpRouteSpec
 from .http_route_spec_methods_type_0_item import HttpRouteSpecMethodsType0Item
 from .http_server_spec import HttpServerSpec
 from .http_validation_error import HTTPValidationError
+from .invocation_handle import InvocationHandle
+from .invocation_handle_servicer_kind import InvocationHandleServicerKind
+from .invocation_request import InvocationRequest
+from .invocation_request_output_schema_type_0 import InvocationRequestOutputSchemaType0
+from .invocation_request_target_kind import InvocationRequestTargetKind
 from .limited_networking import LimitedNetworking
 from .list_connections_mode_type_0 import ListConnectionsModeType0
 from .list_response_agent import ListResponseAgent
@@ -334,6 +339,11 @@ __all__ = (
     "HttpRouteSpecMethodsType0Item",
     "HttpServerSpec",
     "HTTPValidationError",
+    "InvocationHandle",
+    "InvocationHandleServicerKind",
+    "InvocationRequest",
+    "InvocationRequestOutputSchemaType0",
+    "InvocationRequestTargetKind",
     "LimitedNetworking",
     "ListConnectionsModeType0",
     "ListResponseAgent",

--- a/packages/aios-sdk/aios_sdk/_generated/models/invocation_handle.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/invocation_handle.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.invocation_handle_servicer_kind import InvocationHandleServicerKind
+
+T = TypeVar("T", bound="InvocationHandle")
+
+
+@_attrs_define
+class InvocationHandle:
+    """Structured handle returned by ``POST /v1/invocations``.
+
+    Plain JSON fields, no opaque encoding: the handle is **not** an auth boundary
+    (``await`` re-authorizes by ``account_id``). The caller picks the matching
+    awaiter off ``servicer_kind`` — ``session`` → ``GET /sessions/{servicer_id}/await``
+    with ``request_id``, ``run`` → ``GET /runs/{servicer_id}/wait``.
+
+        Attributes:
+            servicer_kind (InvocationHandleServicerKind):
+            servicer_id (str):
+            request_id (str):
+    """
+
+    servicer_kind: InvocationHandleServicerKind
+    servicer_id: str
+    request_id: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        servicer_kind = self.servicer_kind.value
+
+        servicer_id = self.servicer_id
+
+        request_id = self.request_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "servicer_kind": servicer_kind,
+                "servicer_id": servicer_id,
+                "request_id": request_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        servicer_kind = InvocationHandleServicerKind(d.pop("servicer_kind"))
+
+        servicer_id = d.pop("servicer_id")
+
+        request_id = d.pop("request_id")
+
+        invocation_handle = cls(
+            servicer_kind=servicer_kind,
+            servicer_id=servicer_id,
+            request_id=request_id,
+        )
+
+        invocation_handle.additional_properties = d
+        return invocation_handle
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/invocation_handle_servicer_kind.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/invocation_handle_servicer_kind.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class InvocationHandleServicerKind(str, Enum):
+    RUN = "run"
+    SESSION = "session"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/invocation_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/invocation_request.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..models.invocation_request_target_kind import InvocationRequestTargetKind
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.invocation_request_output_schema_type_0 import (
+        InvocationRequestOutputSchemaType0,
+    )
+
+
+T = TypeVar("T", bound="InvocationRequest")
+
+
+@_attrs_define
+class InvocationRequest:
+    """Request body for ``POST /v1/invocations`` — the API caller's request-writer.
+
+    ``target`` is an ``agent_id | workflow_id | session_id`` and ``target_kind``
+    discriminates it:
+
+    * ``agent``     — create a **session** servicer and inject a channel-less
+      request into it (the API analog of ``invoke_agent``).
+    * ``workflow``  — create a **run** servicer of the workflow.
+    * ``session``   — invoke an **existing** same-account session by id (the API
+      analog of #1127's ``invoke(session_id)``). No ``environment_id`` applies —
+      the session already exists.
+
+    ``output_schema`` is the per-request JSON Schema the response ``value`` must
+    satisfy; it rides the edge (``metadata.request.output_schema``), coexisting
+    with any definition-level schema. ``environment_id`` is ownership-checked
+    against the caller's account on the ``agent`` / ``workflow`` create-paths
+    (the per-field containment clamp is #1130's deliverable).
+
+        Attributes:
+            target_kind (InvocationRequestTargetKind):
+            target (str): An agent_id / workflow_id / session_id, discriminated by ``target_kind``.
+            input_ (Any | Unset): The request payload delivered to the servicer (arbitrary JSON or a string).
+            output_schema (InvocationRequestOutputSchemaType0 | None | Unset): Optional JSON Schema the response ``value``
+                must satisfy. Rides the request edge, per-request — coexists with any definition-level schema.
+            environment_id (None | str | Unset): Environment to bind a created servicer to (agent → session, workflow →
+                run). Ownership-checked against the caller's account. Inapplicable for ``target_kind=session`` (the session
+                already exists).
+    """
+
+    target_kind: InvocationRequestTargetKind
+    target: str
+    input_: Any | Unset = UNSET
+    output_schema: InvocationRequestOutputSchemaType0 | None | Unset = UNSET
+    environment_id: None | str | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.invocation_request_output_schema_type_0 import (
+            InvocationRequestOutputSchemaType0,
+        )
+
+        target_kind = self.target_kind.value
+
+        target = self.target
+
+        input_ = self.input_
+
+        output_schema: dict[str, Any] | None | Unset
+        if isinstance(self.output_schema, Unset):
+            output_schema = UNSET
+        elif isinstance(self.output_schema, InvocationRequestOutputSchemaType0):
+            output_schema = self.output_schema.to_dict()
+        else:
+            output_schema = self.output_schema
+
+        environment_id: None | str | Unset
+        if isinstance(self.environment_id, Unset):
+            environment_id = UNSET
+        else:
+            environment_id = self.environment_id
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "target_kind": target_kind,
+                "target": target,
+            }
+        )
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+        if output_schema is not UNSET:
+            field_dict["output_schema"] = output_schema
+        if environment_id is not UNSET:
+            field_dict["environment_id"] = environment_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.invocation_request_output_schema_type_0 import (
+            InvocationRequestOutputSchemaType0,
+        )
+
+        d = dict(src_dict)
+        target_kind = InvocationRequestTargetKind(d.pop("target_kind"))
+
+        target = d.pop("target")
+
+        input_ = d.pop("input", UNSET)
+
+        def _parse_output_schema(
+            data: object,
+        ) -> InvocationRequestOutputSchemaType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                output_schema_type_0 = InvocationRequestOutputSchemaType0.from_dict(
+                    data
+                )
+
+                return output_schema_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(InvocationRequestOutputSchemaType0 | None | Unset, data)
+
+        output_schema = _parse_output_schema(d.pop("output_schema", UNSET))
+
+        def _parse_environment_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        environment_id = _parse_environment_id(d.pop("environment_id", UNSET))
+
+        invocation_request = cls(
+            target_kind=target_kind,
+            target=target,
+            input_=input_,
+            output_schema=output_schema,
+            environment_id=environment_id,
+        )
+
+        return invocation_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/invocation_request_output_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/invocation_request_output_schema_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="InvocationRequestOutputSchemaType0")
+
+
+@_attrs_define
+class InvocationRequestOutputSchemaType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        invocation_request_output_schema_type_0 = cls()
+
+        invocation_request_output_schema_type_0.additional_properties = d
+        return invocation_request_output_schema_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/invocation_request_target_kind.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/invocation_request_target_kind.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class InvocationRequestTargetKind(str, Enum):
+    AGENT = "agent"
+    SESSION = "session"
+    WORKFLOW = "workflow"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -25,6 +25,7 @@ from aios.api.routers import (
     connectors,
     environments,
     health,
+    invocations,
     memory_stores,
     runtime_tokens,
     session_templates,
@@ -133,6 +134,7 @@ def create_app() -> FastAPI:
     app.include_router(session_templates.router)
     app.include_router(workflows.router)
     app.include_router(workflows.runs_router)
+    app.include_router(invocations.router)
     _mount_mcp(app)
     return app
 

--- a/src/aios/api/routers/invocations.py
+++ b/src/aios/api/routers/invocations.py
@@ -1,0 +1,55 @@
+"""The API caller's request-*writer*: ``POST /v1/invocations`` (#1128).
+
+One kind-agnostic endpoint that, for an external/operator caller, **writes the
+trusted request edge** (#1123) and **resolves-or-creates a servicer** (a session
+or a run), returning a structured handle. The API caller is *ephemeral* —
+nothing to wake; the handle is its continuation, awaited via the already-shipped
+completion endpoints (``GET /v1/sessions/{id}/await`` with ``request_id``,
+``GET /v1/runs/{id}/wait``). The caller picks the matching awaiter off the
+handle's ``servicer_kind``.
+
+The handle is **not** an auth boundary (``await`` re-authorizes by
+``account_id``), so it ships as plain JSON fields — no opaque encoding.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+
+from aios.api.deps import AccountIdDep, CryptoBoxDep, PoolDep
+from aios.logging import get_logger
+from aios.models.invocations import InvocationHandle, InvocationRequest
+from aios.services import sessions as service
+
+log = get_logger("aios.api.routers.invocations")
+
+router = APIRouter(prefix="/v1/invocations", tags=["invocations"])
+
+
+@router.post("", operation_id="invoke", status_code=status.HTTP_201_CREATED)
+async def invoke(
+    body: InvocationRequest,
+    pool: PoolDep,
+    crypto_box: CryptoBoxDep,
+    account_id: AccountIdDep,
+) -> InvocationHandle:
+    """Write a trusted request edge + resolve-or-create a servicer, returning a handle.
+
+    ``target_kind=agent`` creates a **session** servicer (env-bound) and injects a
+    channel-less request; ``target_kind=workflow`` creates a **run** servicer;
+    ``target_kind=session`` invokes an existing same-account session by id. The
+    returned ``request_id`` correlates the matching awaiter
+    (``GET /v1/sessions/{id}/await?request_id=`` for sessions, ``GET /v1/runs/{id}/wait``
+    for runs). A cross-tenant ``target`` 404s before any edge is written; a supplied
+    ``environment_id`` is ownership-checked against the caller's account.
+    """
+    return await service.invoke(
+        pool,
+        account_id=account_id,
+        target_kind=body.target_kind,
+        target=body.target,
+        input=body.input,
+        output_schema=body.output_schema,
+        environment_id=body.environment_id,
+        crypto_box=crypto_box,
+    )

--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -99,6 +99,7 @@ from aios.cli.commands import chat as _chat  # noqa: E402
 from aios.cli.commands import connections as _connections  # noqa: E402
 from aios.cli.commands import dev as _dev  # noqa: E402
 from aios.cli.commands import envs as _envs  # noqa: E402
+from aios.cli.commands import invocations as _invocations  # noqa: E402
 from aios.cli.commands import ops as _ops  # noqa: E402
 from aios.cli.commands import session_templates as _session_templates  # noqa: E402
 from aios.cli.commands import sessions as _sessions  # noqa: E402
@@ -123,6 +124,7 @@ app.add_typer(_signal.app, name="signal")
 app.add_typer(_whatsapp.app, name="whatsapp")
 app.add_typer(_workflows.app, name="workflows")
 app.add_typer(_workflows.runs_app, name="runs")
+app.add_typer(_invocations.app, name="invocations")
 
 _ops.register(app)
 _status.register(app)

--- a/src/aios/cli/commands/invocations.py
+++ b/src/aios/cli/commands/invocations.py
@@ -1,0 +1,79 @@
+"""``aios invocations ...`` — the API caller's request-writer surface (#1128).
+
+One kind-agnostic command that writes a trusted request edge + resolves-or-creates
+a servicer (a session or a run) and prints the structured handle
+(``servicer_kind``, ``servicer_id``, ``request_id``). The handle is the
+ephemeral caller's continuation: await it with ``aios sessions await`` (for
+``servicer_kind=session``) or ``aios runs wait`` (for ``servicer_kind=run``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+import typer
+
+from aios.cli.commands._shared import call_single
+from aios.cli.coverage import covers
+from aios.cli.files import PayloadError
+from aios.cli.runtime import run_or_die
+from aios_sdk._generated.api.invocations import invoke
+from aios_sdk._generated.models.invocation_request import InvocationRequest
+
+app = typer.Typer(
+    name="invocations",
+    help="Write a request edge + resolve-or-create a servicer (the API caller surface).",
+    no_args_is_help=True,
+)
+
+
+def _json_arg(value: str | None) -> Any:
+    """Parse a JSON CLI argument (``--input`` / ``--output-schema``); ``None`` stays ``None``."""
+    if value is None:
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise PayloadError(f"invalid JSON: {exc}") from exc
+
+
+@app.command("create", help="Invoke a target and print the durable handle.")
+@covers("invoke")
+def create_(
+    ctx: typer.Context,
+    target_kind: Annotated[
+        str, typer.Option("--target-kind", help="One of: agent | workflow | session.")
+    ],
+    target: Annotated[
+        str, typer.Option("--target", help="An agent_id / workflow_id / session_id.")
+    ],
+    input_: Annotated[
+        str | None, typer.Option("--input", help="The request payload as JSON.")
+    ] = None,
+    output_schema: Annotated[
+        str | None,
+        typer.Option("--output-schema", help="JSON Schema the response value must satisfy."),
+    ] = None,
+    environment_id: Annotated[
+        str | None,
+        typer.Option(
+            "--environment-id",
+            help="Environment to bind a created servicer to (agent/workflow only).",
+        ),
+    ] = None,
+) -> None:
+    def _run() -> int | None:
+        body = InvocationRequest.from_dict(
+            {
+                "target_kind": target_kind,
+                "target": target,
+                "input": _json_arg(input_),
+                "output_schema": _json_arg(output_schema),
+                "environment_id": environment_id,
+            }
+        )
+        call_single(ctx, invoke.sync_detailed, body=body)
+        return None
+
+    run_or_die(_run)

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -67,6 +67,10 @@ OAUTH_FLOW: Final = "oaf"
 WORKFLOW: Final = "wf"
 WORKFLOW_RUN: Final = "wfr"
 WORKFLOW_EVENT: Final = "wfe"
+# Request edge (#1123/#1128): the id correlating a request to its response.
+# Run→child spawns reuse the workflow ``call_key`` as the request_id; the API
+# caller (#1128) has no call_key, so it mints a fresh ``req_`` id here.
+REQUEST: Final = "req"
 
 _PREFIXES: Final = frozenset(
     {
@@ -97,6 +101,7 @@ _PREFIXES: Final = frozenset(
         WORKFLOW,
         WORKFLOW_RUN,
         WORKFLOW_EVENT,
+        REQUEST,
     }
 )
 

--- a/src/aios/models/invocations.py
+++ b/src/aios/models/invocations.py
@@ -1,0 +1,84 @@
+"""The API caller's request-*writer* surface (#1128).
+
+``POST /v1/invocations`` is the one kind-agnostic request-writer for an
+external/operator caller: it materializes the trusted request edge (#1123) and
+constructs-or-resolves a servicer (a session or a run), returning a **structured
+handle** the ephemeral caller awaits via the already-shipped completion
+endpoints (``GET /sessions/{id}/await``, ``GET /runs/{id}/wait``).
+
+The handle is explicitly **not an auth boundary** — ``await`` re-authorizes by
+``account_id`` — so it ships as plain JSON fields, never an opaque/encoded
+string.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# The caller-kind written onto the request edge for the HTTP/operator path.
+# Generalizes the run-only ``{kind:"run", id:<run_id>}`` provenance to the
+# external client (#1123 / #1128).
+API_CALLER_KIND = "api"
+
+
+class InvocationRequest(BaseModel):
+    """Request body for ``POST /v1/invocations`` — the API caller's request-writer.
+
+    ``target`` is an ``agent_id | workflow_id | session_id`` and ``target_kind``
+    discriminates it:
+
+    * ``agent``     — create a **session** servicer and inject a channel-less
+      request into it (the API analog of ``invoke_agent``).
+    * ``workflow``  — create a **run** servicer of the workflow.
+    * ``session``   — invoke an **existing** same-account session by id (the API
+      analog of #1127's ``invoke(session_id)``). No ``environment_id`` applies —
+      the session already exists.
+
+    ``output_schema`` is the per-request JSON Schema the response ``value`` must
+    satisfy; it rides the edge (``metadata.request.output_schema``), coexisting
+    with any definition-level schema. ``environment_id`` is ownership-checked
+    against the caller's account on the ``agent`` / ``workflow`` create-paths
+    (the per-field containment clamp is #1130's deliverable).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_kind: Literal["agent", "workflow", "session"]
+    target: str = Field(
+        description="An agent_id / workflow_id / session_id, discriminated by ``target_kind``.",
+    )
+    input: Any = Field(
+        default=None,
+        description="The request payload delivered to the servicer (arbitrary JSON or a string).",
+    )
+    output_schema: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional JSON Schema the response ``value`` must satisfy. Rides the "
+            "request edge, per-request — coexists with any definition-level schema."
+        ),
+    )
+    environment_id: str | None = Field(
+        default=None,
+        description=(
+            "Environment to bind a created servicer to (agent → session, "
+            "workflow → run). Ownership-checked against the caller's account. "
+            "Inapplicable for ``target_kind=session`` (the session already exists)."
+        ),
+    )
+
+
+class InvocationHandle(BaseModel):
+    """Structured handle returned by ``POST /v1/invocations``.
+
+    Plain JSON fields, no opaque encoding: the handle is **not** an auth boundary
+    (``await`` re-authorizes by ``account_id``). The caller picks the matching
+    awaiter off ``servicer_kind`` — ``session`` → ``GET /sessions/{servicer_id}/await``
+    with ``request_id``, ``run`` → ``GET /runs/{servicer_id}/wait``.
+    """
+
+    servicer_kind: Literal["session", "run"]
+    servicer_id: str
+    request_id: str

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -29,15 +29,16 @@ from aios.errors import (
     ValidationError,
 )
 from aios.harness.window import WindowedEvents
-from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE, split_id
+from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE, REQUEST, make_id, split_id
 from aios.models.agents import (
     Agent,
     AgentVersion,
     is_mcp_tool_name,
     resolve_permission,
 )
-from aios.models.attenuation import Surface
+from aios.models.attenuation import Surface, surface_of
 from aios.models.events import Event, EventKind
+from aios.models.invocations import InvocationHandle
 from aios.models.memory_stores import MemoryStoreResource
 from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
@@ -484,6 +485,188 @@ async def create_child_session(
             vault_ids=vault_ids,
         )
         return True
+
+
+async def invoke(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    target_kind: str,
+    target: str,
+    input: Any,
+    output_schema: dict[str, Any] | None = None,
+    environment_id: str | None = None,
+    crypto_box: CryptoBox | None = None,
+) -> InvocationHandle:
+    """The API caller's request-*writer* (#1128).
+
+    Materializes the trusted request edge (#1123) and constructs-or-resolves a
+    servicer for an external/operator caller, returning a structured
+    :class:`InvocationHandle` the ephemeral caller awaits via the shipped
+    completion endpoints. Kind-agnostic — ``target_kind`` discriminates ``target``:
+
+    * ``agent``    — create a **session** servicer (env-bound) and inject a
+      channel-less request into it (the API analog of ``invoke_agent``).
+    * ``workflow`` — create a **run** servicer of the workflow.
+    * ``session``  — invoke an **existing** same-account session by id (no
+      ``environment_id`` — the session already exists).
+
+    The written edge **is** the authorization fact: ``caller={kind:"api", id:<account>}``
+    generalizes the run-only ``parent_run_id`` provenance gate to the HTTP caller.
+    A cross-tenant ``target`` 404s before any edge is written (the resolve-or-create
+    constructors all account-scope). ``environment_id`` is ownership-checked on the
+    ``agent`` / ``workflow`` create-paths (the per-field containment clamp is #1130).
+    """
+    caller = {"kind": "api", "id": account_id}
+
+    if target_kind == "agent":
+        if environment_id is None:
+            raise ValidationError(
+                "environment_id is required for target_kind=agent",
+                detail={"target_kind": target_kind},
+            )
+        # create_session account-scopes both agent_id and environment_id (404s a
+        # foreign id before any row is written) — the ownership half of #1130.
+        session = await create_session(
+            pool,
+            account_id=account_id,
+            agent_id=target,
+            environment_id=environment_id,
+            title=None,
+            metadata={},
+            crypto_box=crypto_box,
+            archive_when_idle=True,
+        )
+        request_id = await _inject_api_request(
+            pool,
+            session=session,
+            account_id=account_id,
+            caller=caller,
+            input=input,
+            output_schema=output_schema,
+        )
+        return InvocationHandle(
+            servicer_kind="session", servicer_id=session.id, request_id=request_id
+        )
+
+    if target_kind == "session":
+        # Resolve an existing same-account session (404s cross-tenant/missing
+        # before any edge is written). No environment_id applies.
+        if environment_id is not None:
+            raise ValidationError(
+                "environment_id is not applicable for target_kind=session",
+                detail={"target_kind": target_kind},
+            )
+        session = await get_session(pool, target, account_id=account_id)
+        request_id = await _inject_api_request(
+            pool,
+            session=session,
+            account_id=account_id,
+            caller=caller,
+            input=input,
+            output_schema=output_schema,
+        )
+        return InvocationHandle(
+            servicer_kind="session", servicer_id=session.id, request_id=request_id
+        )
+
+    if target_kind == "workflow":
+        if environment_id is None:
+            raise ValidationError(
+                "environment_id is required for target_kind=workflow",
+                detail={"target_kind": target_kind},
+            )
+        # create_run account-scopes both workflow_id and environment_id (404s a
+        # foreign id before the run row is written). The run→run request edge's
+        # ``request_opened`` is deferred to #1126 (a run has no session-scoped
+        # events log to key it on yet), so the run resolves via GET /runs/{id}/wait;
+        # the handle's request_id is the minted correlation id (table-free).
+        #
+        # Late import: ``services.workflows`` imports this module at load time,
+        # so a module-level import would be circular.
+        from aios.services import workflows as wf_service
+
+        run = await wf_service.create_run(
+            pool,
+            account_id=account_id,
+            workflow_id=target,
+            environment_id=environment_id,
+            input=input,
+        )
+        return InvocationHandle(
+            servicer_kind="run", servicer_id=run.id, request_id=make_id(REQUEST)
+        )
+
+    raise ValidationError(
+        f"unknown target_kind {target_kind!r}",
+        detail={"target_kind": target_kind},
+    )
+
+
+async def _inject_api_request(
+    pool: asyncpg.Pool[Any],
+    *,
+    session: Session,
+    account_id: str,
+    caller: dict[str, Any],
+    input: Any,
+    output_schema: dict[str, Any] | None,
+) -> str:
+    """Inject a channel-less request into ``session`` and open the request edge.
+
+    One transaction: append the request's ``user`` message (``metadata.request``
+    carries ``{request_id, caller}`` + optional ``output_schema`` so the target
+    correlates its response and the caller awaits it) and emit the trusted
+    ``request_opened`` lifecycle edge (#1123). Mirrors ``create_child_session``'s
+    dual-write, with ``caller={kind:"api", ...}`` and a **channel-less** message
+    (no ``orig_channel``) so the injected request never surfaces to a connector.
+
+    The request fires a wake so the target steps and answers it.
+    """
+    # Late import: ``services.wake`` imports this module at load time, so a
+    # module-level ``from aios.services.wake import defer_wake`` would be a
+    # circular import (mirrors the ``defer_run_wake`` pattern below).
+    from aios.services.wake import defer_wake
+
+    request_id = make_id(REQUEST)
+    content = input if isinstance(input, str) else json.dumps(input)
+    agent = await agents_service.load_for_session(pool, session, account_id=account_id)
+    frozen_surface = surface_of(agent)
+
+    request_meta: dict[str, Any] = {"request_id": request_id, "caller": caller}
+    if output_schema is not None:
+        request_meta["output_schema"] = output_schema
+
+    async with pool.acquire() as conn, conn.transaction():
+        vault_ids = await queries.get_session_vault_ids(conn, session.id, account_id=account_id)
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session.id,
+            kind="message",
+            data={
+                "role": "user",
+                "content": content,
+                "metadata": {"request": request_meta},
+            },
+        )
+        await queries.append_request_opened(
+            conn,
+            session_id=session.id,
+            account_id=account_id,
+            request_id=request_id,
+            caller=caller,
+            depth=0,
+            environment_id=session.environment_id,
+            frozen_surface={
+                "tools": [t.model_dump() for t in frozen_surface.tools],
+                "mcp_servers": [s.model_dump() for s in frozen_surface.mcp_servers],
+                "http_servers": [s.model_dump() for s in frozen_surface.http_servers],
+            },
+            vault_ids=vault_ids,
+        )
+    await defer_wake(pool, session.id, cause="api_invoke", account_id=account_id)
+    return request_id
 
 
 def _classify_awaiting(

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -1,0 +1,340 @@
+"""Integration tests for the API caller's request-writer — ``service.invoke`` (#1128).
+
+DB-backed (testcontainer Postgres). Exercises the kind-agnostic request-writer end
+to end against real rows:
+
+* ``target_kind=agent`` creates a **session** servicer, writes the request edge
+  (#1123) with ``caller={kind:"api", ...}``, and the returned ``request_id``
+  correlates a subsequent ``await_session`` to the agent's response.
+* ``target_kind=workflow`` creates a **run** servicer (``servicer_kind="run"``).
+* ``target_kind=session`` invokes an existing same-account session.
+* A cross-tenant ``target`` 404s before any edge is written.
+* An ``environment_id`` not owned by the caller's account is refused.
+* A ``target_kind``/``target`` mismatch is refused before any edge is written.
+
+The session-wake / run-wake defers are patched out — these tests cover the
+edge-write + servicer resolution, not the worker stepping.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import NotFoundError, ValidationError
+from aios.harness import runtime
+from aios.services import sessions as service
+from aios.services import workflows as wf_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT = "acc_invocations"
+_OTHER = "acc_invocations_other"
+
+
+@pytest.fixture
+async def pool_env(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str, str]]:
+    """Yield ``(pool, account_id, agent_id, environment_id, session_id)`` for a fresh tenant.
+
+    Patches out both the session-wake and run-wake defers so the request-write +
+    servicer-resolution paths run without a live procrastinate worker.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = pool
+    try:
+        async with pool.acquire() as conn:
+            for acc in (_ACCOUNT, _OTHER):
+                await conn.execute(
+                    "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                    "display_name) VALUES ($1, NULL, TRUE, 'invocations-test')",
+                    acc,
+                )
+        agent, env, session = await seed_agent_env_session(
+            pool, account_id=_ACCOUNT, prefix="invocations"
+        )
+        with (
+            mock.patch("aios.services.wake.defer_wake", new=AsyncMock()),
+            mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
+        ):
+            yield pool, _ACCOUNT, agent.id, env.id, session.id
+    finally:
+        runtime.pool = prev
+        await pool.close()
+
+
+async def _seed_workflow(pool: asyncpg.Pool[Any], *, account_id: str) -> str:
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=account_id,
+        name="invocations-wf",
+        script="def main(ctx):\n    return None\n",
+        description=None,
+        tools=[],
+    )
+    return wf.id
+
+
+# ─── target_kind=agent → session servicer ────────────────────────────────────
+
+
+async def test_agent_target_creates_session_and_writes_edge(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, agent_id, env_id, _session_id = pool_env
+
+    handle = await service.invoke(
+        pool,
+        account_id=account_id,
+        target_kind="agent",
+        target=agent_id,
+        input={"q": "hello"},
+        environment_id=env_id,
+    )
+
+    assert handle.servicer_kind == "session"
+    assert handle.servicer_id.startswith("sess_")
+    assert handle.request_id.startswith("req_")
+
+    # The session exists, is bound to the right agent/env, and owns the open request.
+    sess = await service.get_session(pool, handle.servicer_id, account_id=account_id)
+    assert sess.agent_id == agent_id
+    assert sess.environment_id == env_id
+    async with pool.acquire() as conn:
+        open_ids = await queries.get_open_request_ids(
+            conn, handle.servicer_id, account_id=account_id
+        )
+    assert open_ids == [handle.request_id]
+
+
+async def test_agent_request_correlates_await_to_response(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+    migrated_db_url: str,
+) -> None:
+    pool, account_id, agent_id, env_id, _session_id = pool_env
+
+    handle = await service.invoke(
+        pool,
+        account_id=account_id,
+        target_kind="agent",
+        target=agent_id,
+        input="solve it",
+        environment_id=env_id,
+    )
+
+    # Simulate the agent answering the request (what return() writes).
+    async with pool.acquire() as conn:
+        await queries.write_response_if_absent(
+            conn,
+            handle.servicer_id,
+            account_id=account_id,
+            request_id=handle.request_id,
+            is_error=False,
+            result={"answer": 42},
+            error=None,
+        )
+
+    resp = await service.await_session(
+        pool,
+        migrated_db_url,
+        handle.servicer_id,
+        account_id=account_id,
+        request_id=handle.request_id,
+        watermark=None,
+        timeout_seconds=5,
+    )
+    assert resp.done is True
+    assert resp.result == {"answer": 42}
+    assert resp.is_error is False
+
+
+async def test_agent_output_schema_rides_the_edge(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, agent_id, env_id, _session_id = pool_env
+    schema = {"type": "object", "properties": {"answer": {"type": "integer"}}}
+
+    handle = await service.invoke(
+        pool,
+        account_id=account_id,
+        target_kind="agent",
+        target=agent_id,
+        input="x",
+        output_schema=schema,
+        environment_id=env_id,
+    )
+
+    # The schema rides metadata.request.output_schema on the injected request message.
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events WHERE session_id = $1 AND kind = 'message' ORDER BY seq",
+            handle.servicer_id,
+        )
+    from aios.db.queries import parse_jsonb
+
+    metas = [parse_jsonb(r["data"]).get("metadata", {}).get("request") for r in rows]
+    matching = [m for m in metas if m and m.get("request_id") == handle.request_id]
+    assert matching and matching[0]["output_schema"] == schema
+    # Channel-less: the request never carries a connector channel.
+    assert "channel" not in (matching[0] or {})
+
+
+# ─── target_kind=session → existing session servicer ─────────────────────────
+
+
+async def test_session_target_invokes_existing_session(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, _agent_id, _env_id, session_id = pool_env
+
+    handle = await service.invoke(
+        pool,
+        account_id=account_id,
+        target_kind="session",
+        target=session_id,
+        input="ping",
+    )
+    assert handle.servicer_kind == "session"
+    assert handle.servicer_id == session_id
+    async with pool.acquire() as conn:
+        open_ids = await queries.get_open_request_ids(conn, session_id, account_id=account_id)
+    assert handle.request_id in open_ids
+
+
+async def test_session_target_rejects_environment_id(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, _agent_id, env_id, session_id = pool_env
+    with pytest.raises(ValidationError):
+        await service.invoke(
+            pool,
+            account_id=account_id,
+            target_kind="session",
+            target=session_id,
+            input="ping",
+            environment_id=env_id,
+        )
+
+
+# ─── target_kind=workflow → run servicer ─────────────────────────────────────
+
+
+async def test_workflow_target_creates_run(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, _agent_id, env_id, _session_id = pool_env
+    wf_id = await _seed_workflow(pool, account_id=account_id)
+
+    handle = await service.invoke(
+        pool,
+        account_id=account_id,
+        target_kind="workflow",
+        target=wf_id,
+        input={"n": 3},
+        environment_id=env_id,
+    )
+    assert handle.servicer_kind == "run"
+    assert handle.servicer_id.startswith("wfr_")
+    assert handle.request_id.startswith("req_")
+    # The run row exists and is account-scoped.
+    run = await wf_service.get_run(pool, handle.servicer_id, account_id=account_id)
+    assert run.workflow_id == wf_id
+
+
+# ─── auth + ownership + validation ───────────────────────────────────────────
+
+
+async def test_cross_tenant_agent_target_404s_before_edge(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, _account_id, agent_id, env_id, _session_id = pool_env
+    # The agent belongs to _ACCOUNT; the caller is _OTHER → 404 before any write.
+    with pytest.raises(NotFoundError):
+        await service.invoke(
+            pool,
+            account_id=_OTHER,
+            target_kind="agent",
+            target=agent_id,
+            input="x",
+            environment_id=env_id,
+        )
+    # No session was created for _OTHER.
+    sessions = await service.list_sessions(pool, account_id=_OTHER)
+    assert sessions == []
+
+
+async def test_cross_tenant_session_target_404s(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, _account_id, _agent_id, _env_id, session_id = pool_env
+    with pytest.raises(NotFoundError):
+        await service.invoke(
+            pool,
+            account_id=_OTHER,
+            target_kind="session",
+            target=session_id,
+            input="x",
+        )
+
+
+async def test_unowned_environment_refused(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, agent_id, _env_id, _session_id = pool_env
+    # Seed an env owned by the OTHER account.
+    from aios.services import environments as env_service
+
+    other_env = await env_service.create_environment(
+        pool, account_id=_OTHER, name="invocations-other-env"
+    )
+    with pytest.raises(NotFoundError):
+        await service.invoke(
+            pool,
+            account_id=account_id,
+            target_kind="agent",
+            target=agent_id,
+            input="x",
+            environment_id=other_env.id,
+        )
+
+
+async def test_target_kind_target_mismatch_refused(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, _agent_id, env_id, _session_id = pool_env
+    wf_id = await _seed_workflow(pool, account_id=account_id)
+    # A workflow_id under target_kind=agent must not resolve to an agent.
+    with pytest.raises(NotFoundError):
+        await service.invoke(
+            pool,
+            account_id=account_id,
+            target_kind="agent",
+            target=wf_id,
+            input="x",
+            environment_id=env_id,
+        )
+
+
+async def test_unknown_target_kind_refused(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str, str],
+) -> None:
+    pool, account_id, _agent_id, _env_id, _session_id = pool_env
+    with pytest.raises(ValidationError):
+        await service.invoke(
+            pool,
+            account_id=account_id,
+            target_kind="robot",
+            target="x",
+            input="y",
+        )

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -36,6 +36,7 @@ from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
+_ROOT = "acc_invocations_root"
 _ACCOUNT = "acc_invocations"
 _OTHER = "acc_invocations_other"
 
@@ -54,10 +55,19 @@ async def pool_env(
     runtime.pool = pool
     try:
         async with pool.acquire() as conn:
+            # A single active root is permitted (accounts_one_active_root); the two
+            # test tenants are sibling children of that root.
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
+                "display_name) VALUES ($1, NULL, TRUE, 'invocations-root')",
+                _ROOT,
+            )
             for acc in (_ACCOUNT, _OTHER):
                 await conn.execute(
                     "INSERT INTO accounts (id, parent_account_id, can_mint_children, "
-                    "display_name) VALUES ($1, NULL, TRUE, 'invocations-test')",
+                    "display_name) VALUES ($1, $2, FALSE, $3)",
+                    acc,
+                    _ROOT,
                     acc,
                 )
         agent, env, session = await seed_agent_env_session(

--- a/tests/unit/test_invocation_models.py
+++ b/tests/unit/test_invocation_models.py
@@ -1,0 +1,70 @@
+"""Unit tests for the invocation request/response models (#1128).
+
+The API caller's request-writer surface ships two plain ``BaseModel``s — no
+opaque encoding. These cover the wire-shape contract: discriminated
+``target_kind``, optional ``output_schema`` / ``environment_id``, and the
+structured (un-encoded) handle.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios.models.invocations import InvocationHandle, InvocationRequest
+
+
+class TestInvocationRequest:
+    def test_minimal_agent_request(self) -> None:
+        req = InvocationRequest(target_kind="agent", target="agent_x", environment_id="env_y")
+        assert req.target_kind == "agent"
+        assert req.target == "agent_x"
+        assert req.input is None
+        assert req.output_schema is None
+        assert req.environment_id == "env_y"
+
+    def test_session_target_needs_no_environment(self) -> None:
+        req = InvocationRequest(target_kind="session", target="sess_z", input={"q": 1})
+        assert req.environment_id is None
+        assert req.input == {"q": 1}
+
+    def test_output_schema_rides_the_request(self) -> None:
+        schema = {"type": "object", "properties": {"answer": {"type": "integer"}}}
+        req = InvocationRequest(
+            target_kind="workflow",
+            target="wf_a",
+            environment_id="env_b",
+            output_schema=schema,
+        )
+        assert req.output_schema == schema
+
+    def test_bad_target_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            InvocationRequest(target_kind="robot", target="x")
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            InvocationRequest(target_kind="agent", target="x", bogus="nope")  # type: ignore[call-arg]
+
+    def test_target_required(self) -> None:
+        with pytest.raises(ValidationError):
+            InvocationRequest(target_kind="agent")  # type: ignore[call-arg]
+
+
+class TestInvocationHandle:
+    def test_structured_fields_plain(self) -> None:
+        handle = InvocationHandle(servicer_kind="session", servicer_id="sess_1", request_id="req_1")
+        # No opaque encoding — the fields serialize verbatim.
+        assert handle.model_dump() == {
+            "servicer_kind": "session",
+            "servicer_id": "sess_1",
+            "request_id": "req_1",
+        }
+
+    def test_run_servicer_kind(self) -> None:
+        handle = InvocationHandle(servicer_kind="run", servicer_id="wfr_1", request_id="req_2")
+        assert handle.servicer_kind == "run"
+
+    def test_bad_servicer_kind_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            InvocationHandle(servicer_kind="agent", servicer_id="x", request_id="r")


### PR DESCRIPTION
## Summary

Adds the API caller's request-**writer**: a single kind-agnostic `POST /v1/invocations` that, for an external/operator caller, writes the trusted request edge (#1123) + resolves-or-creates a servicer (a session or a run) and returns a structured durable handle. The API caller is ephemeral — nothing to wake; the handle is its continuation, awaited via the already-shipped completion endpoints.

## What changed

- **`POST /v1/invocations`** (`src/aios/api/routers/invocations.py`, mounted at `app.py`): body `{target_kind, target, input, output_schema?, environment_id?}`, returns a plain `InvocationHandle {servicer_kind, servicer_id, request_id}` — **not** an opaque encoding (the handle is not an auth boundary; `await` re-authorizes by `account_id`).
- **`service.invoke`** (`src/aios/services/sessions.py`): the kind-agnostic request-writer.
  - `target_kind=agent` → creates a **session** servicer (env-bound), injects a **channel-less** request, and emits the `request_opened` edge with `caller={kind:"api", id:<account>}` — the API analog of `invoke_agent`. `output_schema` rides `metadata.request.output_schema`.
  - `target_kind=session` → invokes an **existing** same-account session by id (no `environment_id`; the API analog of #1127's `invoke(session_id)`).
  - `target_kind=workflow` → creates a **run** servicer via `create_run` (the run→run `request_opened` is deferred to #1126; the run resolves via `GET /runs/{id}/wait`).
- **Both awaiters retained unchanged.** The caller picks the matching one off `servicer_kind`.
- **Auth/ownership:** a cross-tenant `target` 404s before any edge is written (the resolve-or-create constructors all account-scope); a supplied `environment_id` is ownership-checked on the create-paths (the per-field containment clamp is #1130's deliverable).
- **`aios invocations create`** CLI command (satisfies the OpenAPI operation-coverage invariant) + the `req_` id prefix.
- Regenerated `openapi.json` and the typed SDK (`packages/aios-sdk/aios_sdk/_generated/`).

## Tests

- `tests/unit/test_invocation_models.py` — wire-shape contract for the request/handle models (mutation-checked).
- `tests/integration/test_invocations.py` — DB-backed: agent→session edge-write + `await_session` request_id correlation, `output_schema` rides the edge, channel-less injection, session-target invoke, workflow→run servicer, cross-tenant 404-before-write, unowned-env refusal, target_kind/target mismatch, unknown target_kind.

Unit suite green (2822 passed); lint + mypy clean; openapi snapshot drift check passes. Integration tests require Docker (testcontainer Postgres) and were verified by collection + the service/edge contract locally.

Closes #1128