### PR TITLE
test: env-ownership gate + sub-top tripwire on invoke edge (#1130)

### DIFF
--- a/tests/e2e/test_invocations_env_ownership.py
+++ b/tests/e2e/test_invocations_env_ownership.py
@@ -1,0 +1,153 @@
+"""E2E: ``POST /v1/invocations`` env-ownership gate uses the *authenticated* account (#1130).
+
+Part of #1122. The invoke edge (#1128) lets an external/operator caller supply
+an ``environment_id`` for the servicer session it spawns. #1130 gates that
+supply with an **ownership-only** check: the env must be owned by the
+authenticated account (``get_environment(.., account_id=)`` — the same gate
+``create_session`` / ``create_run`` already enforce).
+
+These tests drive the HTTP endpoint end-to-end through bearer auth, so they pin
+the load-bearing invariant the service-level tests can't: the gate scopes on the
+account_id resolved from the **bearer token** (``AccountIdDep``), never a
+body-supplied account. A cross-tenant ``environment_id`` 404s; a self-owned one
+binds the servicer session.
+
+The wakes are mocked (``wired_app`` injects a MagicMock procrastinate handle and
+the auth fixture's app never runs a worker), so this exercises the edge-write +
+ownership gate, not the worker stepping.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from tests.helpers.connections import asgi_client
+
+pytestmark = pytest.mark.e2e
+
+# The bearer key seeded by ``aios_env`` binds to this account (tests/conftest.py).
+_CALLER = "acc_test_stub"
+_OTHER = "acc_invoke_other_tenant"
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    try:
+        yield p
+    finally:
+        await p.close()
+
+
+@pytest.fixture
+async def http_client(pool: Any) -> AsyncIterator[httpx.AsyncClient]:
+    async with asgi_client(pool) as client:
+        yield client
+
+
+@pytest.fixture
+async def caller_agent_id(pool: Any) -> str:
+    """An agent owned by the bearer-auth caller (``acc_test_stub``)."""
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=_CALLER,
+        name="invoke-owner-agent",
+        model="openrouter/test",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    return agent.id
+
+
+@pytest.fixture
+async def caller_env_id(pool: Any) -> str:
+    """An environment owned by the bearer-auth caller (``acc_test_stub``)."""
+    env = await environments_service.create_environment(
+        pool, account_id=_CALLER, name="invoke-owner-env"
+    )
+    return env.id
+
+
+@pytest.fixture
+async def other_tenant_env_id(pool: Any) -> str:
+    """An environment owned by a DIFFERENT account than the bearer caller."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            "VALUES ($1, NULL, FALSE, 'invoke-other-tenant')",
+            _OTHER,
+        )
+    env = await environments_service.create_environment(
+        pool, account_id=_OTHER, name="invoke-foreign-env"
+    )
+    return env.id
+
+
+class TestInvokeEnvOwnershipGate:
+    async def test_self_owned_environment_binds_servicer_session(
+        self,
+        http_client: httpx.AsyncClient,
+        aios_env: dict[str, str],
+        caller_agent_id: str,
+        caller_env_id: str,
+    ) -> None:
+        """An ``environment_id`` owned by the bearer caller is accepted and bound."""
+        r = await http_client.post(
+            "/v1/invocations",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={
+                "target_kind": "agent",
+                "target": caller_agent_id,
+                "input": {"q": "hello"},
+                "environment_id": caller_env_id,
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["servicer_kind"] == "session"
+        assert body["servicer_id"].startswith("sess_")
+        assert body["request_id"].startswith("req_")
+
+    async def test_cross_tenant_environment_refused(
+        self,
+        http_client: httpx.AsyncClient,
+        aios_env: dict[str, str],
+        caller_agent_id: str,
+        other_tenant_env_id: str,
+    ) -> None:
+        """An ``environment_id`` owned by a DIFFERENT account is refused (404).
+
+        The gate scopes ``get_environment`` by the account_id resolved from the
+        bearer token (``AccountIdDep``), so a foreign env id is not-found from
+        the caller's vantage — never accepted via a body-supplied account. This
+        is the #1130 ownership gate observed end-to-end through HTTP auth.
+        """
+        r = await http_client.post(
+            "/v1/invocations",
+            headers=_bearer(aios_env["AIOS_API_KEY"]),
+            json={
+                "target_kind": "agent",
+                "target": caller_agent_id,
+                "input": {"q": "hello"},
+                "environment_id": other_tenant_env_id,
+            },
+        )
+        assert r.status_code == 404, r.text

--- a/tests/integration/test_invoke_env_ownership_tripwire.py
+++ b/tests/integration/test_invoke_env_ownership_tripwire.py
@@ -1,0 +1,150 @@
+"""Tripwire: no attenuated / sub-top API principal exists today (#1130).
+
+Part of #1122. The ``POST /v1/invocations`` invoke edge (#1128) lets an
+external/operator caller supply an ``environment_id`` for the servicer session
+it spawns. Issue #1130 ships an **ownership-only** gate on that supply: the env
+must be owned by the authenticated account (``get_environment(.., account_id=)``,
+the same check ``create_session`` / ``create_run`` already enforce). It
+**defers** the per-field containment clamp (``networking`` / ``image`` /
+``env``-keys ⊆ a baseline env) because there is **no sub-top API principal** to
+clamp against — every account key is full-account-top, so ownership *is* the
+bound and there is nothing below top to clamp to.
+
+This test pins that deferral's precondition. It asserts, structurally, that the
+API bearer-auth principal carries **no attenuation / surface / scope field**:
+
+* the ``account_keys`` table (the bearer/account-key path) has **no**
+  surface / scope / attenuation column — only ``key_id, account_id, hash,
+  label, created_at, last_used_at, revoked_at`` (migration 0042);
+* ``require_bearer_auth`` resolves a token to a full-account
+  ``AccountAuthResult = (account_id, key_id, can_mint_children)`` — a plain
+  ``account_id`` with no sub-top surface descriptor.
+
+The ``connection_ids`` allowlist (#350) is a property of the **runtime-token**
+path (``require_runtime_auth``), NOT the bearer/account-key path, so it is not
+an attenuation of the API principal. Child accounts (``parent_account_id`` /
+``can_mint_children``) are full-top *within their own tenant* — a distinct
+``account_id``, not an attenuated subset of a parent's surface.
+
+WHEN AN ATTENUATED / DELEGATED (SUB-top) API PRINCIPAL IS INTRODUCED, THE
+ASSERTIONS BELOW FAIL — THAT IS THE SIGNAL TO IMPLEMENT THE DEFERRED PER-FIELD
+ENV CONTAINMENT CLAMP (networking / image / env-keys ⊆ baseline) ON THE
+api→session EDGE. The failing test is the deferral's re-entry point. The clamp
+targets are the ``EnvironmentConfig`` axes (``image``, ``networking``, ``env``;
+``models/environments.py``). See #1130. Sibling of #823 (the ``api_base``
+second-authority axis — same tripwire shape).
+"""
+
+from __future__ import annotations
+
+import typing
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.api import deps
+from aios.db.pool import create_pool
+
+pytestmark = pytest.mark.integration
+
+# The exact column set ``account_keys`` carries (migration 0042). Anything
+# beyond this on the bearer/account-key path is a candidate attenuation surface
+# that re-opens the deferred clamp.
+_EXPECTED_ACCOUNT_KEY_COLUMNS = frozenset(
+    {
+        "key_id",
+        "account_id",
+        "hash",
+        "label",
+        "created_at",
+        "last_used_at",
+        "revoked_at",
+    }
+)
+
+# Substrings that would name a sub-top attenuation surface on the principal — a
+# scope/surface/attenuation/grant restriction below full-account top.
+_ATTENUATION_MARKERS = ("scope", "surface", "attenuat", "grant", "permission", "capabilit")
+
+
+@pytest.fixture
+async def pool(migrated_db_url: str, _reset_db_state: None) -> AsyncIterator[asyncpg.Pool[Any]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=2)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+class TestNoSubTopApiPrincipal:
+    async def test_account_keys_has_no_attenuation_column(self, pool: asyncpg.Pool[Any]) -> None:
+        """The bearer/account-key path carries no scope/surface column.
+
+        If this fails, an attenuation surface was added to ``account_keys`` —
+        implement the deferred per-field env containment clamp on the
+        api→session edge (networking / image / env-keys ⊆ baseline). See #1130.
+        """
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'public' AND table_name = 'account_keys'"
+            )
+        columns = {r["column_name"] for r in rows}
+        # An exact-set match is the strongest pin: it fails both on a NEW column
+        # (e.g. a scope/surface/attenuation surface — see _ATTENUATION_MARKERS for
+        # the shapes that re-open the clamp) and on a dropped one. Any extra column
+        # is a candidate sub-top attenuation surface that re-opens the deferred clamp.
+        extra = columns - _EXPECTED_ACCOUNT_KEY_COLUMNS
+        attenuation_like = sorted(
+            c for c in extra if any(marker in c.lower() for marker in _ATTENUATION_MARKERS)
+        )
+        assert columns == _EXPECTED_ACCOUNT_KEY_COLUMNS, (
+            "account_keys columns drifted from the full-account-top shape "
+            f"{sorted(_EXPECTED_ACCOUNT_KEY_COLUMNS)} → {sorted(columns)} "
+            f"(attenuation-like new columns: {attenuation_like}). "
+            "If a scope/surface/attenuation column was added, a sub-top API "
+            "principal now exists: implement the deferred per-field env "
+            "containment clamp (networking/image/env-keys ⊆ baseline) on the "
+            "api→session edge. See #1130."
+        )
+
+    def test_bearer_auth_result_is_full_account_with_no_surface(self) -> None:
+        """``require_bearer_auth`` resolves to a full-account tuple, no sub-top surface.
+
+        The bearer-auth principal is ``AccountAuthResult =
+        (account_id, key_id, can_mint_children)`` — a plain ``account_id`` plus
+        the minting bit, neither of which is a sub-top surface descriptor. If a
+        surface/scope element is added to this tuple, a sub-top API principal now
+        exists: implement the deferred per-field env containment clamp
+        (networking/image/env-keys ⊆ baseline) on the api→session edge. See #1130.
+        """
+        # ``AccountAuthResult`` is a tuple alias; its element types pin the
+        # principal's shape. account_id (str) + key_id (str) + can_mint (bool):
+        # no surface/scope component.
+        args = typing.get_args(deps.AccountAuthResult)
+        assert args == (str, str, bool), (
+            "AccountAuthResult drifted from (account_id: str, key_id: str, "
+            f"can_mint_children: bool) → {args}. If a surface/scope element was "
+            "added, a sub-top API principal now exists: implement the deferred "
+            "per-field env containment clamp (networking/image/env-keys ⊆ "
+            "baseline) on the api→session edge. See #1130."
+        )
+
+    def test_get_account_id_returns_bare_account_id(self) -> None:
+        """``get_account_id`` (the dep the invoke endpoint uses) yields a bare account_id.
+
+        ``AccountIdDep`` (the dependency ``POST /v1/invocations`` consumes for
+        its ownership gate) destructures the auth tuple to a single
+        ``account_id: str`` — the gate scopes ``get_environment`` by that
+        full-account id, never a sub-top surface. Its return annotation is the
+        structural pin.
+        """
+        hints = typing.get_type_hints(deps.get_account_id)
+        assert hints.get("return") is str, (
+            "get_account_id no longer returns a bare account_id (str): "
+            f"{hints.get('return')}. The invoke ownership gate scopes on this "
+            "value; if it became a sub-top surface, implement the deferred "
+            "per-field env containment clamp. See #1130."
+        )


### PR DESCRIPTION
## What & why

Part of #1122. The api→session invoke edge (#1128) lets an external/operator caller supply an `environment_id` for the servicer session/run it spawns. Unlike `session→`/`run→` callers (which inherit the launcher's env), the API caller has no launcher, so it supplies the env directly — re-opening the caller-chosen-env surface that `create_run` forecloses.

Per the locked decision, #1130 ships **OWNERSHIP-ONLY**: the supplied env must be owned by the authenticated account, exactly as `create_session`/`create_run` already enforce via `get_environment(.., account_id=)` (#755). Every account key is full-account-top — there is **no sub-top API principal today**, so ownership *is* the bound and there is nothing below top to clamp. The per-field containment clamp (networking/image/env-keys ⊆ baseline) is **deferred behind a tripwire**.

The ownership gate is already present correct-by-construction: `service.invoke`'s `agent` path delegates to `create_session` and its `workflow` path to `create_run`, both of which call `get_environment(conn, environment_id, account_id=account_id)` before binding. Adding a redundant explicit gate would be defensive duplication, against the repo's extreme-simplicity rule. So this issue contributes **tests only** — no production code, no schema migration, no API-shape change (no openapi/sdk regen; the committed openapi snapshot test stays green).

## Deliverables

- **`tests/e2e/test_invocations_env_ownership.py`** — HTTP-level pin that `POST /v1/invocations` scopes the env-ownership gate on the `account_id` resolved from the **bearer token** (`AccountIdDep`), never a body-supplied account. A cross-tenant `environment_id` 404s; a self-owned one binds the servicer session (201).
- **`tests/integration/test_invoke_env_ownership_tripwire.py`** — tripwire asserting no attenuated/sub-top API principal exists today: `account_keys` carries no scope/surface/attenuation column (migration 0042 shape), and `require_bearer_auth` resolves to a full-account `AccountAuthResult = (account_id, key_id, can_mint_children)`. When a sub-top API principal is introduced these assertions fail — the documented signal to implement the deferred per-field env containment clamp on the api→session edge. Sibling of #823 (same tripwire shape).

## Validation

- `uv run ruff check src tests` + `ruff format --check src tests`: clean.
- `uv run mypy src tests`: clean (632 files).
- `uv run pytest tests/unit` (incl. `test_openapi_snapshot_matches_committed`): 2822 passed — confirms no openapi drift.
- Pre-commit hook (full lint/type/unit/connector suites) passed at commit.
- Mutation check: broke `AccountAuthResult` (added a 4th surface element); the tripwire failed as expected, then passed after restore. The two typing-based tripwire assertions and test collection of all 5 tests verified locally; the DB-backed tests could not be executed in-sandbox (no Docker) but follow the established `test_invocations.py` / `test_rekey_column_coverage.py` patterns.
Closes #1130