### PR TITLE
feat: trusted recursion depth on the edge; retire run_ancestor_depth (#1124)

### DIFF
--- a/migrations/versions/0100_wf_run_invoke_depth.py
+++ b/migrations/versions/0100_wf_run_invoke_depth.py
@@ -1,0 +1,45 @@
+"""Add the DOWN-counting trusted invocation ``depth`` scalar to ``wf_runs`` (#1124).
+
+Issue #1124 retires the run-only ancestor walk (the ``run_ancestor_depth``
+``WITH RECURSIVE`` CTE over ``wf_runs.parent_run_id``) and replaces it with a
+single DOWN-counting depth scalar carried on the trusted invocation edge. A run
+is a servicer with exactly one launch, so until #1126 makes the run-inbound
+edge first-class, the run carries its own remaining depth on the row.
+
+``depth`` is the budget remaining for this run's OUTGOING trusted edges (run→run
+sub-launches, run→session ``agent()`` children). An edgeless root (the
+operator/HTTP ``POST /runs`` path, a trigger fire with no completing-run parent)
+seeds at the full budget (10). A nested launch stamps ``parent.depth - 1`` and
+refuses BEFORE writing the child when the parent has no budget left. Cycles are
+bounded BY CONSTRUCTION — the decrement IS the cycle bound.
+
+Purely additive — a single ``ADD COLUMN`` with a default, so existing rows
+backfill to the full budget. Safe in the post-deploy new-code/old-schema window:
+the new code reads/writes ``depth`` only on runs it creates under the new schema,
+and the column is invisible to the running container until the migration
+completes.
+
+Revision ID: 0100
+Revises: 0099
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0100"
+down_revision: str = "0099"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE wf_runs ADD COLUMN depth integer NOT NULL DEFAULT 10 CHECK (depth >= 0)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE wf_runs DROP COLUMN depth")

--- a/openapi.json
+++ b/openapi.json
@@ -16384,6 +16384,11 @@
             ],
             "title": "Launcher Session Id"
           },
+          "depth": {
+            "type": "integer",
+            "title": "Depth",
+            "default": 0
+          },
           "script": {
             "type": "string",
             "title": "Script"

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -52,6 +52,7 @@ class WfRun:
             updated_at (datetime.datetime):
             parent_run_id (None | str | Unset):
             launcher_session_id (None | str | Unset):
+            depth (int | Unset):  Default: 0.
             tools (list[ToolSpec] | Unset):
             mcp_servers (list[McpServerSpec] | Unset):
             http_servers (list[HttpServerSpec] | Unset):
@@ -75,6 +76,7 @@ class WfRun:
     updated_at: datetime.datetime
     parent_run_id: None | str | Unset = UNSET
     launcher_session_id: None | str | Unset = UNSET
+    depth: int | Unset = 0
     tools: list[ToolSpec] | Unset = UNSET
     mcp_servers: list[McpServerSpec] | Unset = UNSET
     http_servers: list[HttpServerSpec] | Unset = UNSET
@@ -119,6 +121,8 @@ class WfRun:
             launcher_session_id = UNSET
         else:
             launcher_session_id = self.launcher_session_id
+
+        depth = self.depth
 
         tools: list[dict[str, Any]] | Unset = UNSET
         if not isinstance(self.tools, Unset):
@@ -186,6 +190,8 @@ class WfRun:
             field_dict["parent_run_id"] = parent_run_id
         if launcher_session_id is not UNSET:
             field_dict["launcher_session_id"] = launcher_session_id
+        if depth is not UNSET:
+            field_dict["depth"] = depth
         if tools is not UNSET:
             field_dict["tools"] = tools
         if mcp_servers is not UNSET:
@@ -253,6 +259,8 @@ class WfRun:
         launcher_session_id = _parse_launcher_session_id(
             d.pop("launcher_session_id", UNSET)
         )
+
+        depth = d.pop("depth", UNSET)
 
         _tools = d.pop("tools", UNSET)
         tools: list[ToolSpec] | Unset = UNSET
@@ -336,6 +344,7 @@ class WfRun:
             updated_at=updated_at,
             parent_run_id=parent_run_id,
             launcher_session_id=launcher_session_id,
+            depth=depth,
             tools=tools,
             mcp_servers=mcp_servers,
             http_servers=http_servers,

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -68,6 +68,7 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         environment_id=row["environment_id"],
         parent_run_id=row["parent_run_id"],
         launcher_session_id=row["launcher_session_id"],
+        depth=row["depth"],
         script=row["script"],
         script_sha=row["script_sha"],
         host_semantics_epoch=row["host_semantics_epoch"],
@@ -358,6 +359,25 @@ async def get_wf_run(conn: asyncpg.Connection[Any], run_id: str, *, account_id: 
     )
 
 
+async def get_run_depth(conn: asyncpg.Connection[Any], run_id: str, *, account_id: str) -> int:
+    """Read a run's DOWN-counting trusted invocation depth (#1124), account-scoped.
+
+    The remaining trusted-edge budget on ``run_id`` — what a sub-launch off this run
+    may carry as ``depth - 1``. ACCOUNT-SCOPED: a foreign or missing parent raises
+    ``NotFoundError`` (the same-account trust the deleted ``run_ancestor_depth`` CTE
+    enforced per hop, now a single point read). The depth is immutable once written,
+    so the read is race-free without locking.
+    """
+    depth: int | None = await conn.fetchval(
+        "SELECT depth FROM wf_runs WHERE id = $1 AND account_id = $2",
+        run_id,
+        account_id,
+    )
+    if depth is None:
+        raise NotFoundError(f"workflow run {run_id} not found", detail={"id": run_id})
+    return depth
+
+
 async def list_wf_runs(
     conn: asyncpg.Connection[Any],
     *,
@@ -417,10 +437,17 @@ async def insert_wf_run(
     http_servers: list[HttpServerSpec] | None = None,
     budget_usd: float | None = None,
     default_child_model: str | None = None,
+    depth: int,
 ) -> WfRun:
     """Insert a fresh ``pending`` run that snapshots ``script`` (+ ``script_sha``) and the
     declared tool surface (``tools``/``mcp_servers``/``http_servers``) — pinned at launch.
-    ``launcher_session_id`` records the agent session that launched it (NULL = operator)."""
+    ``launcher_session_id`` records the agent session that launched it (NULL = operator).
+
+    ``depth`` is the DOWN-counting trusted invocation budget (#1124) carried on the run:
+    the remaining hops this run may spend on its OUTGOING trusted edges. The caller
+    (``create_run``) computes it — full budget for an edgeless root, ``parent.depth - 1``
+    for a nested launch — and refuses BEFORE calling here when the parent has none left,
+    so no over-budget run row is ever written."""
     new_id = make_id(WORKFLOW_RUN)
     try:
         row = await conn.fetchrow(
@@ -428,9 +455,10 @@ async def insert_wf_run(
             INSERT INTO wf_runs
                 (id, workflow_id, account_id, environment_id, parent_run_id,
                  launcher_session_id, script, script_sha, host_semantics_epoch, status, input,
-                 tools, mcp_servers, http_servers, budget_total_microusd, default_child_model)
+                 tools, mcp_servers, http_servers, budget_total_microusd, default_child_model,
+                 depth)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending', $10::jsonb,
-                    $11::jsonb, $12::jsonb, $13::jsonb, $14, $15)
+                    $11::jsonb, $12::jsonb, $13::jsonb, $14, $15, $16)
             RETURNING *
             """,
             new_id,
@@ -448,6 +476,7 @@ async def insert_wf_run(
             json.dumps([s.model_dump() for s in (http_servers or [])]),
             round(budget_usd * 1_000_000) if budget_usd is not None else None,
             default_child_model,
+            depth,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -501,33 +530,6 @@ async def run_children_usage(
         cache_creation_input_tokens=row["cache_creation_input_tokens"],
         cost_microusd=row["cost_microusd"],
     )
-
-
-async def run_ancestor_depth(conn: asyncpg.Connection[Any], run_id: str, *, account_id: str) -> int:
-    """Depth of ``run_id`` in the ``parent_run_id`` chain (a root run = 1).
-
-    Walks ``wf_runs.parent_run_id`` upward via a recursive CTE, account-scoped on
-    every hop. Returns 0 if ``run_id`` doesn't exist for the account (defensive; the
-    depth cap passes a live ancestor). The chain is immutable once written, so the
-    count is race-free without locking — concurrent sibling inserts can't change an
-    ancestor's depth.
-    """
-    depth: int | None = await conn.fetchval(
-        """
-        WITH RECURSIVE chain AS (
-            SELECT id, parent_run_id, 1 AS depth
-              FROM wf_runs WHERE id = $1 AND account_id = $2
-            UNION ALL
-            SELECT r.id, r.parent_run_id, c.depth + 1
-              FROM wf_runs r JOIN chain c ON r.id = c.parent_run_id
-             WHERE r.account_id = $2
-        )
-        SELECT max(depth) FROM chain
-        """,
-        run_id,
-        account_id,
-    )
-    return depth or 0
 
 
 async def count_active_runs(

--- a/src/aios/harness/trigger_runner.py
+++ b/src/aios/harness/trigger_runner.py
@@ -546,9 +546,11 @@ async def _run_workflow(
                 if completed_run.status == "errored":
                     completed_error = await wf_queries.resolve_run_error(conn, completed_run.id)
             # The completing run is the lineage parent: same-account by the
-            # matcher's account-equality conjunct, and the existing depth cap
-            # then bounds completion→fire→run→completion cycles at
-            # WORKFLOW_RUN_MAX_DEPTH by construction.
+            # matcher's account-equality conjunct. ``create_run`` reads that
+            # parent's DOWN-counting depth (#1124) and stamps ``parent.depth - 1``
+            # on the new run, so completion→fire→run→completion cycles bottom out
+            # at the shared budget (INVOKE_MAX_DEPTH) BY CONSTRUCTION — the
+            # decrement IS the cycle bound.
             parent_run_id = completed_run.id
         else:
             # Timer fires inherit the owner session's own (immutable) lineage

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -89,6 +89,12 @@ class WfRun(BaseModel):
     # The agent session that launched this run (None = operator/HTTP). Lineage, plus
     # the per-launcher fan-out cap's count key.
     launcher_session_id: str | None = None
+    # The DOWN-counting trusted invocation depth (#1124): the budget remaining for
+    # this run's OUTGOING trusted edges (run→run sub-launches, run→session ``agent()``
+    # children). An edgeless root seeds at the full budget; a nested launch carries
+    # ``parent.depth - 1``. The decrement IS the cycle bound — a run at depth 0 may
+    # open no further trusted edges.
+    depth: int = 0
     script: str
     script_sha: str
     host_semantics_epoch: int

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -22,15 +22,26 @@ from aios.services import attenuation as attenuation_service
 from aios.services.wake import defer_run_wake
 from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
-# Vertical recursion bound: how deep a chain of runs (a run whose agent() child
-# launches a sub-run, and so on) may nest. Mirrors WAKE_SESSION_MAX_DEPTH — bounds
-# the strange loop the agent-acting builtins enable. Only the agent path threads a
-# parent_run_id, so the operator/HTTP path (parent_run_id=None) is never capped.
-WORKFLOW_RUN_MAX_DEPTH = 10
+# The single shared trusted-invocation depth budget (#1124): how many trusted
+# hops a chain of invocations (run→run sub-launches, run→session ``agent()``
+# children, and — once #1127/#1128 land their call sites — session→session and
+# api→session) may take before refusal. The DOWN-counter that replaces the
+# run-only ``parent_run_id`` ancestor walk (the deleted ``run_ancestor_depth``
+# CTE): every trusted edge carries ``parent.depth - 1`` and an edgeless root
+# (operator/HTTP ``POST /runs``, foreground session) seeds at the full budget.
+# The decrement IS the cycle bound — cycles (incl. session→session A↔B) bottom
+# out at the budget BY CONSTRUCTION, no wait-for-graph. The wake-side
+# ``WAKE_SESSION_MAX_DEPTH`` (#1083) is a separate carrier, left untouched here.
+INVOKE_MAX_DEPTH = 10
 
 
 class WorkflowRunDepthExceededError(AiosError):
-    """A ``create_run`` would nest deeper than ``WORKFLOW_RUN_MAX_DEPTH``."""
+    """A trusted invocation would nest past the shared depth budget (#1124).
+
+    Raised before the over-budget child run/edge is written — the model-visible
+    ``409`` refusal at every trusted-invocation hop (the ``error_type`` is kept
+    stable for clients across the run-only → edge-carried generalization).
+    """
 
     error_type = "workflow_run_depth_exceeded"
     status_code = 409
@@ -67,10 +78,13 @@ async def create_run(
     vaults bind as-is, account-scoped. Insert + bind are one transaction, so a breach
     or a bad vault leaves no run row; the wake fires only after commit.
 
-    ``parent_run_id`` records run lineage (an agent inside a run launching a sub-run)
-    and feeds the **vertical depth cap**: nesting past ``WORKFLOW_RUN_MAX_DEPTH`` raises
-    :class:`WorkflowRunDepthExceededError`. The operator/HTTP path passes none, so it is
-    a root run (never capped).
+    ``parent_run_id`` records run lineage (an agent inside a run launching a sub-run).
+    It also drives the **DOWN-counting trusted depth budget** (#1124): the new run
+    carries ``parent.depth - 1`` and the launch is **refused before any row is written**
+    when the parent run has no budget left — :class:`WorkflowRunDepthExceededError`. The
+    operator/HTTP path passes no parent, so it is an **edgeless root** seeded at the full
+    budget (``INVOKE_MAX_DEPTH``) — a chain launched off it still bottoms out at the
+    budget by construction.
 
     ``expected_version`` is the trigger ``workflow`` action's drift-assertion pin:
     when set, the workflow's CURRENT version must equal it or the launch raises
@@ -128,7 +142,14 @@ async def create_run(
             if launcher_surface is not None
             else surface_of(workflow)
         )
-        if parent_run_id is not None:
+        # The DOWN-counting trusted depth budget (#1124). An edgeless root
+        # (operator/HTTP ``POST /runs``, a trigger fire with no completing-run
+        # parent) seeds at the full budget; a nested launch reads the parent
+        # run's remaining budget off its row and refuses BEFORE writing the
+        # child when none is left, then carries ``parent.depth - 1``.
+        if parent_run_id is None:
+            child_depth = INVOKE_MAX_DEPTH
+        else:
             # ``parent_run_id`` is trusted same-account. Two callers set it: the
             # ``create_run`` builtin, threading the launcher session's own
             # ``parent_run_id`` (set by the run-spawn machinery to a same-account
@@ -136,18 +157,23 @@ async def create_run(
             # completing run's id (same-account by the completion matcher's
             # account-equality conjunct) or the owner session's own
             # ``parent_run_id`` — the same provenance as the builtin. The
-            # account-scoped ancestor walk relies on that — a foreign parent
-            # would resolve to depth 0 and read as a root. If a future path ever
-            # lets ``parent_run_id`` be caller-supplied, it must be
-            # account-validated here (like ``environment_id`` above).
-            parent_depth = await wf_queries.run_ancestor_depth(
+            # account-scoped read relies on that — a foreign/missing parent
+            # raises NotFoundError. If a future path ever lets ``parent_run_id``
+            # be caller-supplied, this same-account read is the gate (like
+            # ``environment_id`` above).
+            parent_depth = await wf_queries.get_run_depth(
                 conn, parent_run_id, account_id=account_id
             )
-            if parent_depth + 1 > WORKFLOW_RUN_MAX_DEPTH:
+            # Refuse-before-write: a parent with one (or zero) hop left cannot open
+            # another trusted edge — the child would be born at depth 0 with no way
+            # to bottom the chain out at the budget. The decrement IS the cycle
+            # bound; this is the only refusal, no wait-for-graph.
+            if parent_depth <= 1:
                 raise WorkflowRunDepthExceededError(
-                    f"run nesting would exceed depth {WORKFLOW_RUN_MAX_DEPTH}",
-                    detail={"max_depth": WORKFLOW_RUN_MAX_DEPTH, "parent_run_id": parent_run_id},
+                    f"trusted invocation would exceed depth budget {INVOKE_MAX_DEPTH}",
+                    detail={"max_depth": INVOKE_MAX_DEPTH, "parent_run_id": parent_run_id},
                 )
+            child_depth = parent_depth - 1
         if launcher_session_id is not None:
             held = set(
                 await get_session_vault_ids(conn, launcher_session_id, account_id=account_id)
@@ -201,6 +227,7 @@ async def create_run(
             http_servers=effective.http_servers,
             budget_usd=budget_usd,
             default_child_model=run_default_child_model,
+            depth=child_depth,
         )
         if requested:
             await wf_queries.set_run_vaults(conn, run.id, requested, account_id=account_id)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -901,11 +901,21 @@ async def _open_agent_capability(
     # rejected caps; this child would be the (agent_spawns + 1)-th, so cap it on strict ``>``.
     if agent_spawns + 1 > max_agent_calls:
         return _SpawnResult(rejected=False, needs_rewake=False, quota_exceeded=True)
+    # #1124: the run→session ``agent()`` edge spends one unit of the run's
+    # DOWN-counting trusted depth budget. Refuse BEFORE the child is written when
+    # the run has none left — a journaled, author-catchable rejection (raising here
+    # would crash the deterministic step), so no over-budget child row/edge exists.
+    # The child's edge carries ``run.depth - 1``; the decrement IS the cycle bound.
+    if run.depth <= 0:
+        # Late import: ``aios.workflows.service`` transitively pulls in the tools
+        # package, a cycle when step.py is on the import path.
+        from aios.workflows.service import INVOKE_MAX_DEPTH
+
+        return await _reject(
+            "invocation_depth_exceeded",
+            f"agent() would exceed the trusted invocation depth budget ({INVOKE_MAX_DEPTH})",
+        )
     run_vaults = await wf_queries.get_run_vault_ids(conn, run.id, account_id=account_id)
-    # #1123: the run→child request edge carries the run's lineage depth (carried,
-    # not enforced here — enforcement is #1124, which inherits this value). Sourced
-    # from the same account-scoped ancestor walk the create_run depth cap uses.
-    run_depth = await wf_queries.run_ancestor_depth(conn, run.id, account_id=account_id)
 
     created = await create_child_session(
         pool,
@@ -921,7 +931,7 @@ async def _open_agent_capability(
         request_id=cap.call_key,  # the agent() call IS the request the child must answer
         input=spec.get("input"),
         output_schema=output_schema,
-        depth=run_depth,
+        depth=run.depth - 1,
     )
     # On replay the row already carries its first-spawn version — journal THAT, so
     # call_started.child_agent_version always matches the version the child runs under.

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -256,6 +256,7 @@ async def test_runs_parent_run_id_filter(http_client: httpx.AsyncClient, pool: A
             script_sha="sha",
             host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             parent_run_id=parent["id"],
+            depth=9,
         )
     # An unrelated (parentless) run that must be excluded.
     await http_client.post("/v1/runs", json={"workflow_id": wf["id"], "environment_id": env_id})

--- a/tests/integration/test_env_var_credential_resolution.py
+++ b/tests/integration/test_env_var_credential_resolution.py
@@ -134,6 +134,7 @@ async def _make_run(
             script=wf.script,
             host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             script_sha=hashlib.sha256(wf.script.encode("utf-8")).hexdigest(),
+            depth=10,
         )
         if vault_ids:
             await db_queries.workflows.set_run_vaults(

--- a/tests/integration/test_list_sessions_run_children.py
+++ b/tests/integration/test_list_sessions_run_children.py
@@ -40,6 +40,7 @@ async def _seed_run(conn: asyncpg.Connection[Any], account_id: str, environment_
         script=wf.script,
         host_semantics_epoch=HOST_SEMANTICS_EPOCH,
         script_sha="deadbeef",
+        depth=10,
     )
     return run.id
 

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -82,6 +82,7 @@ async def _seed_parent_run(pool: asyncpg.Pool[Any], *, account_id: str, environm
             http_servers=[],
             budget_usd=None,
             default_child_model="openrouter/test",
+            depth=10,
         )
     return run.id
 
@@ -304,3 +305,63 @@ async def test_create_child_session_rollback_leaves_no_edge(
         )
     assert sess == 0
     assert edges == 0
+
+
+# ─── #1124: the DOWN-counting trusted depth on the edge bounds cycles ─────────
+
+
+async def test_session_to_session_cycle_bounded_by_construction(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """A session→session A↔B ping-pong terminates at the shared budget BY
+    CONSTRUCTION (#1124) — no wait-for-graph, no cycle detection. Each trusted
+    edge carries ``parent_depth - 1``; once the budget is spent the next hop
+    would carry a negative depth, which the decrement rule refuses. This is the
+    coverage the run-only ``run_ancestor_depth`` CTE could never provide: the
+    cycle bound is the depth budget itself, applied uniformly to the edge.
+    """
+    pool, account_id, _agent_id, env_id = pool_env
+    from aios.workflows.service import INVOKE_MAX_DEPTH
+
+    _a_agent, _a_env, sess_a = await seed_agent_env_session(
+        pool, account_id=account_id, prefix="cycle-a"
+    )
+    _b_agent, _b_env, sess_b = await seed_agent_env_session(
+        pool, account_id=account_id, prefix="cycle-b"
+    )
+
+    # Replay the A↔B invocation cycle the decrement rule produces: an edgeless
+    # root seeds at the full budget, and each trusted hop stamps parent_depth - 1.
+    # The loop stops emitting the moment a hop has no budget left to spend.
+    targets = [sess_b.id, sess_a.id]  # A invokes B, B invokes A, A invokes B, ...
+    callers = [sess_a.id, sess_b.id]
+    depth = INVOKE_MAX_DEPTH
+    hops = 0
+    async with pool.acquire() as conn, conn.transaction():
+        while depth >= 1:  # refuse-before-write: a 0-budget caller opens no edge
+            child_depth = depth - 1
+            await queries.append_request_opened(
+                conn,
+                session_id=targets[hops % 2],
+                account_id=account_id,
+                request_id=f"req-cycle-{hops}",
+                caller={"kind": "session", "id": callers[hops % 2]},
+                depth=child_depth,
+                environment_id=env_id,
+                frozen_surface={"tools": [], "mcp_servers": [], "http_servers": []},
+                vault_ids=[],
+            )
+            hops += 1
+            depth = child_depth
+
+    # The cycle bottomed out after exactly INVOKE_MAX_DEPTH hops — purely from the
+    # decrement, regardless of the A↔B structure.
+    assert hops == INVOKE_MAX_DEPTH
+    async with pool.acquire() as conn:
+        total = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE account_id = $1 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_opened' "
+            "AND (data->>'request_id') LIKE 'req-cycle-%'",
+            account_id,
+        )
+    assert total == INVOKE_MAX_DEPTH

--- a/tests/integration/test_trigger_event_fires.py
+++ b/tests/integration/test_trigger_event_fires.py
@@ -7,7 +7,7 @@ directly, with every procrastinate defer patched out — the same surface
 - THE coalescing regression (§1.2): two completions of one watched workflow →
   exactly two carrier rows, two distinct-keyed dispatches, two launched runs.
 - parent_run_id threading on BOTH fire origins + the self-fire depth-cycle
-  termination at WORKFLOW_RUN_MAX_DEPTH.
+  termination at INVOKE_MAX_DEPTH.
 - consecutive_failures atomicity under concurrent event fires; auto-disable at
   exactly the threshold with ONE surfaced message.
 - the jsonb round-trip read-acceptance regression (numeric-expanded template
@@ -218,7 +218,7 @@ async def test_self_fire_cycle_terminates_at_depth_cap(
     trig_runtime: asyncpg.Pool[Any],
 ) -> None:
     """Obligation 1, the loop bound: a trigger watching the workflow its own
-    action launches terminates at WORKFLOW_RUN_MAX_DEPTH — the depth-11 fire
+    action launches terminates at INVOKE_MAX_DEPTH — the depth-11 fire
     errors BEFORE any run row exists, so no completion ever re-arms the chain."""
     pool = trig_runtime
     _, env, session = await seed_agent_env_session(pool, account_id=ACC, prefix="loop")
@@ -251,7 +251,7 @@ async def test_self_fire_cycle_terminates_at_depth_cap(
 
     async with pool.acquire() as conn:
         total_runs = await conn.fetchval("SELECT count(*) FROM wf_runs WHERE workflow_id = $1", w)
-    assert total_runs == service.WORKFLOW_RUN_MAX_DEPTH  # 10 — none past the cap
+    assert total_runs == service.INVOKE_MAX_DEPTH  # 10 — none past the budget
 
     rows = await _carrier_rows(pool, tid)
     assert len(rows) == 10  # one fire per completion

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -57,6 +57,7 @@ async def _seed_run(conn: asyncpg.Connection[Any]) -> str:
         script=wf.script,
         host_semantics_epoch=HOST_SEMANTICS_EPOCH,
         script_sha="deadbeef",
+        depth=10,
     )
     return run.id
 
@@ -94,6 +95,7 @@ async def test_insert_run_snapshots_script(wf_conn: asyncpg.Connection[Any]) -> 
         script=wf.script,
         host_semantics_epoch=HOST_SEMANTICS_EPOCH,
         script_sha="sha-v1",
+        depth=10,
     )
     assert run.id.startswith("wfr_")
     assert run.status == "pending"
@@ -458,6 +460,7 @@ async def test_list_wf_runs_filters_by_launcher_session(wf_conn: asyncpg.Connect
             script_sha="sha",
             host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             launcher_session_id=launcher,
+            depth=10,
         )
         return run.id
 

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -51,7 +51,7 @@ from aios.services.sessions import create_child_session
 from aios.tools import workflow_management as wm
 from aios.workflows import service as wf_service_module
 from aios.workflows.child_id import child_session_id
-from aios.workflows.service import WORKFLOW_RUN_MAX_DEPTH, WorkflowRunDepthExceededError
+from aios.workflows.service import INVOKE_MAX_DEPTH, WorkflowRunDepthExceededError
 
 pytestmark = pytest.mark.integration
 
@@ -700,25 +700,63 @@ async def test_create_run_builtin_threads_parent_run_id(vault_pool: asyncpg.Pool
 
 
 async def test_create_run_depth_cap(vault_pool: asyncpg.Pool[Any]) -> None:
-    """The vertical depth cap: a parent_run_id chain may nest WORKFLOW_RUN_MAX_DEPTH deep, no more."""
+    """The DOWN-counting depth budget (#1124): a parent_run_id chain may take
+    INVOKE_MAX_DEPTH hops, no more. The edgeless root seeds at the full budget,
+    each child carries ``parent.depth - 1``, and the INVOKE_MAX_DEPTH-th run
+    bottoms out at depth 1 — the next launch refuses before any row is written."""
     pool = vault_pool
     wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-depth", script=_SCRIPT)
 
-    # Build a chain of runs at depths 1..MAX (the root has parent_run_id=None, uncapped).
+    # Build a chain: root seeds at INVOKE_MAX_DEPTH, then INVOKE_MAX_DEPTH-1 children
+    # decrementing to depth 1. INVOKE_MAX_DEPTH runs total, identical to the old up-walk.
     parent: str | None = None
-    for _ in range(WORKFLOW_RUN_MAX_DEPTH):
+    expected_depth = INVOKE_MAX_DEPTH
+    for _ in range(INVOKE_MAX_DEPTH):
         run = await wf_service.create_run(
             pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, parent_run_id=parent
         )
+        assert run.depth == expected_depth  # the down-counter decrements each hop
         parent = run.id
+        expected_depth -= 1
 
-    # One more would be depth MAX+1 → refused, and no run row leaks.
+    # The leaf bottomed out at depth 1 → one more would be depth 0, refused before write.
     before = await _run_count(pool)
     with pytest.raises(WorkflowRunDepthExceededError):
         await wf_service.create_run(
             pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, parent_run_id=parent
         )
     assert await _run_count(pool) == before
+
+
+async def test_create_run_edgeless_root_seeds_full_budget(vault_pool: asyncpg.Pool[Any]) -> None:
+    """An edgeless root — the operator/HTTP ``POST /runs`` path with no parent — is
+    seeded at the full shared budget (#1124), so a chain launched off it still has
+    INVOKE_MAX_DEPTH hops before it bottoms out."""
+    pool = vault_pool
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-root", script=_SCRIPT)
+
+    root = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, parent_run_id=None
+    )
+    assert root.depth == INVOKE_MAX_DEPTH
+
+    # The persisted column agrees with the returned row — the read-side the next hop uses.
+    async with pool.acquire() as conn:
+        assert await wf_queries.get_run_depth(conn, root.id, account_id=ACC) == INVOKE_MAX_DEPTH
+
+
+async def test_get_run_depth_account_scoped(vault_pool: asyncpg.Pool[Any]) -> None:
+    """``get_run_depth`` is account-scoped (#1124): a foreign id raises NotFoundError,
+    preserving the same-account trust the deleted ``run_ancestor_depth`` CTE enforced
+    per hop — a foreign parent can never launder a fresh full budget."""
+    pool = vault_pool
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="wf-scope", script=_SCRIPT)
+    root = await wf_service.create_run(
+        pool, account_id=ACC, workflow_id=wf.id, environment_id=ENV, parent_run_id=None
+    )
+    async with pool.acquire() as conn:
+        with pytest.raises(NotFoundError):
+            await wf_queries.get_run_depth(conn, root.id, account_id="acc_other")
 
 
 async def test_create_run_rejects_foreign_environment(vault_pool: asyncpg.Pool[Any]) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -664,6 +664,7 @@ async def test_children_listable_by_parent_run_id(
             script_sha="sha",
             host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             parent_run_id=parent_id,
+            depth=9,
         )
         child_runs = await wf_queries.list_wf_runs(
             conn, account_id="acc_wf", parent_run_id=parent_id, limit=50
@@ -708,6 +709,74 @@ async def test_agent_spawn_creates_child_and_suspends(
         )
     assert user_msgs == 1
     child_wake.assert_awaited_once()  # prompt wake of the child
+
+
+async def test_agent_spawn_stamps_decremented_depth_on_edge(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """The run->session ``agent()`` edge carries ``run.depth - 1`` (#1124): a root
+    run seeds at the full budget, so its child's ``request_opened`` edge is stamped
+    one below. The trusted depth rides ONLY the edge, never message metadata."""
+    from aios.workflows.service import INVOKE_MAX_DEPTH
+
+    pool = wf_runtime
+    script = f"async def main(input):\n    return await agent({{'task': 'go'}}, agent_id={wf_agent_id!r})\n"
+    run_id = await _make_run(pool, script)  # edgeless root -> depth == INVOKE_MAX_DEPTH
+    with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()):
+        await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        assert run is not None and run.depth == INVOKE_MAX_DEPTH
+        events = await wf_queries.list_run_events(conn, run_id)
+        child_id = next(e.payload["child_session_id"] for e in events if e.type == "call_started")
+        edge_depth = await conn.fetchval(
+            "SELECT (data->>'depth')::int FROM events WHERE session_id = $1 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_opened'",
+            child_id,
+        )
+    assert edge_depth == INVOKE_MAX_DEPTH - 1  # decremented one hop down
+
+
+async def test_agent_spawn_refused_when_run_depth_exhausted(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """A run at depth 0 has no trusted budget left: ``_open_agent_capability``
+    refuses BEFORE writing the child (a journaled, catchable rejection), so no
+    over-budget child session/edge ever exists (#1124)."""
+    from aios.workflows.host_launcher import EmittedCapability
+    from aios.workflows.step import _open_agent_capability
+
+    pool = wf_runtime
+    script = f"async def main(input):\n    return await agent('go', agent_id={wf_agent_id!r})\n"
+    run_id = await _make_run(pool, script)
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE wf_runs SET depth = 0 WHERE id = $1", run_id)
+
+    spec = {"agent_id": wf_agent_id, "input": "go", "output_schema": None}
+    call_key = CallKeyer().next("agent", spec)
+    cap = EmittedCapability(capability_id="agent", call_key=call_key, spec=spec)
+    cid = child_session_id(run_id, call_key)
+
+    async with pool.acquire() as conn:
+        run = await wf_queries.get_run_for_step(conn, run_id)
+        assert run is not None and run.depth == 0
+        with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()) as w:
+            result = await _open_agent_capability(
+                conn, pool, run, cap, agent_spawns=0, max_agent_calls=1000
+            )
+        assert result.rejected  # catchable rejection journaled, not a crash
+        w.assert_not_awaited()  # no child -> no wake
+        # Refuse-BEFORE-write: neither the child row nor its edge was created.
+        assert await conn.fetchval("SELECT count(*) FROM sessions WHERE id = $1", cid) == 0
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM events WHERE session_id = $1 "
+                "AND kind = 'lifecycle' AND data->>'event' = 'request_opened'",
+                cid,
+            )
+            == 0
+        )
 
 
 async def test_generic_agent_spawn_creates_agentless_child_with_run_surface(

--- a/tests/integration/test_wf_sweep.py
+++ b/tests/integration/test_wf_sweep.py
@@ -72,6 +72,7 @@ async def _make_run(pool: asyncpg.Pool[Any], *, status: str = "suspended") -> st
             script="x",
             host_semantics_epoch=HOST_SEMANTICS_EPOCH,
             script_sha="x",
+            depth=10,
         )
         if status != "pending":
             await wf_queries.set_run_status(conn, run.id, status, account_id="acc_sw")

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0099``."""
+    """The migration ladder has exactly one head: ``0100``."""
     script = _script_directory()
-    assert script.get_heads() == ["0099"]
+    assert script.get_heads() == ["0100"]
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
Closes #1124. autodev implementation completed + pushed but failed to emit the AUTODEV_DONE seal (root-caused: phantom http_request tool + system-prompt contradiction lured the agent into trying to open the PR itself). Opening by hand from the cleaner of the two pushed branches; CI gates it.