### PR TITLE
Make the pagination-limit contract route-derived: introspecting CI test + named limit constants

### DIFF
--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, status
 
 from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.agents import Agent, AgentCreate, AgentUpdate, AgentVersion
 from aios.models.common import ListResponse
-from aios.models.pagination import page_cursor
+from aios.models.pagination import PageLimit, page_cursor, resolve_page_limit
 from aios.services import agents as service
 
 router = APIRouter(prefix="/v1/agents", tags=["agents"])
@@ -46,7 +44,7 @@ async def list_(
     account_id: AccountIdDep,
     cursor: str | None = None,
     name: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[Agent]:
     """List agents (latest version of each), newest first, excluding archived.
 
@@ -56,7 +54,7 @@ async def list_(
     """
     st = page_cursor(cursor, {"name": name, "limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     if st is not None:
         name = st.filters.get("name")
     items = await service.list_agents(
@@ -121,7 +119,7 @@ async def list_versions(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[AgentVersion]:
     """List historical versions of an agent, newest first.
 
@@ -130,7 +128,7 @@ async def list_versions(
     """
     st = page_cursor(cursor, {"limit": limit})
     after = int(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     items = await service.list_agent_versions(
         pool, agent_id, limit=page_limit + 1, after=after, account_id=account_id
     )

--- a/src/aios/api/routers/connections.py
+++ b/src/aios/api/routers/connections.py
@@ -31,7 +31,13 @@ from aios.models.connections import (
     ConnectionSetSecrets,
     RecentChat,
 )
-from aios.models.pagination import page_cursor
+from aios.models.pagination import (
+    DEFAULT_PAGE_LIMIT,
+    MAX_PAGE_LIMIT,
+    PageLimit,
+    page_cursor,
+    resolve_page_limit,
+)
 from aios.services import connections as service
 
 router = APIRouter(prefix="/v1/connections", tags=["connections"])
@@ -104,7 +110,7 @@ async def list_(
     connector: str | None = None,
     session_id: str | None = None,
     mode: ConnectionMode | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[Connection]:
     """List connections, newest first, excluding archived.
 
@@ -118,7 +124,7 @@ async def list_(
         {"connector": connector, "session_id": session_id, "mode": mode, "limit": limit},
     )
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     if st is not None:
         connector = st.filters.get("connector")
         session_id = st.filters.get("session_id")
@@ -331,7 +337,7 @@ async def recent_chats(
     connection_id: str,
     pool: PoolDep,
     account_id: AccountIdDep,
-    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    limit: Annotated[int, Query(ge=1, le=MAX_PAGE_LIMIT)] = DEFAULT_PAGE_LIMIT,
 ) -> ListResponse[RecentChat]:
     """List chats that recently sent inbound on this connection, newest first.
 

--- a/src/aios/api/routers/environments.py
+++ b/src/aios/api/routers/environments.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, status
 
 from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
 from aios.models.environments import Environment, EnvironmentCreate, EnvironmentUpdate
-from aios.models.pagination import page_cursor
+from aios.models.pagination import PageLimit, page_cursor, resolve_page_limit
 from aios.services import environments as service
 
 router = APIRouter(prefix="/v1/environments", tags=["environments"])
@@ -34,7 +32,7 @@ async def list_(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[Environment]:
     """List environments, newest first, excluding archived.
 
@@ -43,7 +41,7 @@ async def list_(
     """
     st = page_cursor(cursor, {"limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     items = await service.list_environments(
         pool, limit=page_limit + 1, after=after, account_id=account_id
     )

--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -18,7 +18,12 @@ from aios.models.memory_stores import (
     MemoryUpdate,
     MemoryVersion,
 )
-from aios.models.pagination import page_cursor
+from aios.models.pagination import (
+    MAX_PAGE_LIMIT,
+    PageLimit,
+    page_cursor,
+    resolve_page_limit,
+)
 from aios.services import memory_stores as service
 
 router = APIRouter(prefix="/v1/memory-stores", tags=["memory-stores"])
@@ -52,7 +57,7 @@ async def list_stores(
     account_id: AccountIdDep,
     cursor: str | None = None,
     include_archived: bool | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[MemoryStore]:
     """List memory stores, newest first.
 
@@ -63,7 +68,7 @@ async def list_stores(
     """
     st = page_cursor(cursor, {"include_archived": include_archived, "limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 100)
+    page_limit = resolve_page_limit(st, limit, default=100)
     archived = (
         bool(st.filters.get("include_archived")) if st is not None else bool(include_archived)
     )
@@ -172,7 +177,7 @@ async def list_memories(
     path_prefix: str | None = None,
     order_by: str = "created_at",
     depth: int | None = None,
-    limit: Annotated[int, Query(ge=1, le=200)] = 100,
+    limit: Annotated[int, Query(ge=1, le=MAX_PAGE_LIMIT)] = 100,
 ) -> ListResponse[Memory | MemoryPrefix]:
     """List memories in a store, optionally filtered and grouped by path.
 
@@ -274,7 +279,7 @@ async def list_versions(
     pool: PoolDep,
     account_id: AccountIdDep,
     memory_id: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=200)] = 100,
+    limit: Annotated[int, Query(ge=1, le=MAX_PAGE_LIMIT)] = 100,
 ) -> ListResponse[MemoryVersion]:
     """List memory versions in a store, newest first.
 

--- a/src/aios/api/routers/session_templates.py
+++ b/src/aios/api/routers/session_templates.py
@@ -10,13 +10,11 @@ will fail at the inbound handler until the connection is reconfigured.
 
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, status
 
 from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
-from aios.models.pagination import page_cursor
+from aios.models.pagination import PageLimit, page_cursor, resolve_page_limit
 from aios.models.session_templates import (
     SessionTemplate,
     SessionTemplateCreate,
@@ -57,7 +55,7 @@ async def list_(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[SessionTemplate]:
     """List session templates, newest first, excluding archived.
 
@@ -65,7 +63,7 @@ async def list_(
     """
     st = page_cursor(cursor, {"limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     items = await service.list_session_templates(
         pool, limit=page_limit + 1, after=after, account_id=account_id
     )

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -42,7 +42,15 @@ from aios.models.github_repositories import (
     GithubRepositoryResourceEcho,
     GithubRepositoryUpdate,
 )
-from aios.models.pagination import Direction, page_cursor
+from aios.models.pagination import (
+    DEFAULT_PAGE_LIMIT,
+    MAX_PAGE_LIMIT,
+    Direction,
+    EventPageLimit,
+    PageLimit,
+    page_cursor,
+    resolve_page_limit,
+)
 from aios.models.sessions import (
     ContextResponse,
     Session,
@@ -120,7 +128,7 @@ async def list_(
         Query(alias="status"),
     ] = None,
     parent_run_id: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[Session]:
     """List sessions, newest first, keyset-paginated.
 
@@ -141,7 +149,7 @@ async def list_(
         },
     )
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     if st is not None:
         agent_id = st.filters.get("agent_id")
         status_filter = st.filters.get("status")
@@ -403,7 +411,7 @@ async def list_trigger_runs(
     name: str,
     pool: PoolDep,
     account_id: AccountIdDep,
-    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    limit: Annotated[int, Query(ge=1, le=MAX_PAGE_LIMIT)] = DEFAULT_PAGE_LIMIT,
 ) -> ListResponse[TriggerRunEcho]:
     """List a trigger's fires (the per-fire audit), newest first.
 
@@ -629,7 +637,7 @@ async def list_events(
     error_only: bool | None = None,
     # Higher cap than the standard 200: operators page full event logs via
     # ``aios sessions events``; 500 is the audit-recommended ceiling.
-    limit: Annotated[int | None, Query(ge=1, le=500)] = None,
+    limit: EventPageLimit = None,
 ) -> ListResponse[Event]:
     """List a session's events by sequence number.
 
@@ -666,13 +674,12 @@ async def list_events(
         direction = st.direction
         kind = st.filters.get("kind")
         error_only = bool(st.filters.get("error_only"))
-        page_limit = st.limit
         seq = int(st.cursor)
         after_seq, before = (seq, None) if direction == "forward" else (0, seq)
     else:
         error_only = bool(error_only)
-        page_limit = limit if limit is not None else 200
         after_seq, before = 0, None
+    page_limit = resolve_page_limit(st, limit, default=200)
     # Fetch one extra row to derive has_more without a separate COUNT query.
     rows = await service.read_events(
         pool,

--- a/src/aios/api/routers/skills.py
+++ b/src/aios/api/routers/skills.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, status
 
 from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
-from aios.models.pagination import page_cursor
+from aios.models.pagination import PageLimit, page_cursor, resolve_page_limit
 from aios.models.skills import Skill, SkillCreate, SkillVersion, SkillVersionCreate
 from aios.services import skills as service
 
@@ -38,7 +36,7 @@ async def list_(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[Skill]:
     """List skills (latest version of each), newest first, excluding archived.
 
@@ -46,7 +44,7 @@ async def list_(
     """
     st = page_cursor(cursor, {"limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     items = await service.list_skills(
         pool, limit=page_limit + 1, after=after, account_id=account_id
     )
@@ -99,7 +97,7 @@ async def list_versions(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[SkillVersion]:
     """List historical versions of a skill, newest first.
 
@@ -108,7 +106,7 @@ async def list_versions(
     """
     st = page_cursor(cursor, {"limit": limit})
     after = int(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     items = await service.list_skill_versions(
         pool, skill_id, limit=page_limit + 1, after=after, account_id=account_id
     )

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
-from fastapi import APIRouter, Query, status
+from fastapi import APIRouter, status
 
 from aios.api.deps import AccountIdDep, CryptoBoxDep, PoolDep
 from aios.models.common import ListResponse
-from aios.models.pagination import page_cursor
+from aios.models.pagination import PageLimit, page_cursor, resolve_page_limit
 from aios.models.vaults import (
     OAuthCompleteRequest,
     OAuthStartRequest,
@@ -45,7 +43,7 @@ async def list_(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[Vault]:
     """List vaults, newest first, excluding archived.
 
@@ -53,7 +51,7 @@ async def list_(
     """
     st = page_cursor(cursor, {"limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     items = await service.list_vaults(
         pool, limit=page_limit + 1, after=after, account_id=account_id
     )
@@ -202,7 +200,7 @@ async def list_credentials(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[VaultCredential]:
     """List credentials in a vault, newest first, excluding archived.
 
@@ -212,7 +210,7 @@ async def list_credentials(
     """
     st = page_cursor(cursor, {"limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     items = await service.list_vault_credentials(
         pool, vault_id, limit=page_limit + 1, after=after, account_id=account_id
     )

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -19,7 +19,7 @@ from aios.api.sse import make_sse_response, preflight_subscription, wf_run_event
 from aios.db.listen import open_listen_for_run_events
 from aios.logging import get_logger
 from aios.models.common import ListResponse
-from aios.models.pagination import page_cursor
+from aios.models.pagination import EventPageLimit, PageLimit, page_cursor, resolve_page_limit
 from aios.models.workflows import (
     GateResume,
     WfRun,
@@ -96,13 +96,13 @@ async def list_workflows(
     account_id: AccountIdDep,
     cursor: str | None = None,
     name: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[Workflow]:
     """List the account's workflows, newest first. First page: optional ``name`` +
     ``limit``; subsequent pages: ``?cursor=<next_cursor>``."""
     st = page_cursor(cursor, {"name": name, "limit": limit})
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     if st is not None:
         name = st.filters.get("name")
     items = await service.list_workflows(
@@ -163,7 +163,7 @@ async def list_runs(
     workflow_id: str | None = None,
     status: str | None = None,
     parent_run_id: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    limit: PageLimit = None,
 ) -> ListResponse[WfRun]:
     """List the account's runs, newest first. First page: optional ``workflow_id`` /
     ``status`` / ``parent_run_id`` filters + ``limit``; subsequent pages:
@@ -178,7 +178,7 @@ async def list_runs(
         },
     )
     after = str(st.cursor) if st is not None else None
-    page_limit = st.limit if st is not None else (limit if limit is not None else 50)
+    page_limit = resolve_page_limit(st, limit)
     if st is not None:
         workflow_id = st.filters.get("workflow_id")
         status = st.filters.get("status")
@@ -237,7 +237,7 @@ async def list_run_events(
     pool: PoolDep,
     account_id: AccountIdDep,
     cursor: str | None = None,
-    limit: Annotated[int | None, Query(ge=1, le=500)] = None,
+    limit: EventPageLimit = None,
 ) -> ListResponse[WfRunEvent]:
     """A run's journal by sequence (oldest first). First page: optional ``limit``;
     subsequent pages: ``?cursor=<next_cursor>``.
@@ -253,12 +253,8 @@ async def list_run_events(
     # Scope check: 404 a cross-tenant run id before reading its journal.
     await service.get_run(pool, run_id, account_id=account_id)
     st = page_cursor(cursor, {"limit": limit})
-    if st is not None:
-        page_limit = st.limit
-        after_seq = int(st.cursor)
-    else:
-        page_limit = limit if limit is not None else 200
-        after_seq = 0
+    page_limit = resolve_page_limit(st, limit, default=200)
+    after_seq = int(st.cursor) if st is not None else 0
     items = await service.list_run_events(
         pool, run_id, account_id=account_id, after_seq=after_seq, limit=page_limit + 1
     )

--- a/src/aios/cli/commands/_shared.py
+++ b/src/aios/cli/commands/_shared.py
@@ -13,6 +13,7 @@ from aios.cli.client import AiosApiError, AiosClient
 from aios.cli.output import OutputFormat, print_json, print_note, print_table
 from aios.cli.runtime import CliState, get_state
 from aios.models.common import ErrorResponse
+from aios.models.pagination import MAX_PAGE_LIMIT
 from aios_sdk._generated.types import Response, Unset
 
 
@@ -83,7 +84,7 @@ def fetch_all(
     path: str,
     *,
     params: dict[str, Any] | None = None,
-    page_size: int = 200,
+    page_size: int = MAX_PAGE_LIMIT,
 ) -> dict[str, Any]:
     """Walk every page of a list endpoint and return one envelope.
 
@@ -147,7 +148,7 @@ def render_paginated(
     all_: bool,
     limit: int = 50,
     max_widths: dict[str, int] | None = None,
-    page_size: int = 200,
+    page_size: int = MAX_PAGE_LIMIT,
     path_params: dict[str, Any] | None = None,
     **filters: Any,
 ) -> None:
@@ -198,7 +199,7 @@ def fetch_all_events(
     *,
     kind: str | None = None,
     direction: str = "forward",
-    page_size: int = 200,
+    page_size: int = MAX_PAGE_LIMIT,
 ) -> list[dict[str, Any]]:
     """Walk every page of ``/v1/sessions/:id/events`` and return the raw list.
 

--- a/src/aios/models/pagination.py
+++ b/src/aios/models/pagination.py
@@ -18,11 +18,45 @@ from __future__ import annotations
 import base64
 import json
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
+
+from fastapi import Query
 
 from aios.errors import ValidationError
 
 Direction = Literal["forward", "backward"]
+
+# --- The list-endpoint ``limit`` contract -----------------------------------
+#
+# Single source of truth for the two coupled facts every paginated list
+# endpoint declares: the per-page default and the request-boundary ceiling.
+# Previously these were 35 bare literals hand-typed across the routers (the
+# ``Query(le=N)`` ceiling and the ``… else N`` default), with no named
+# constant — so "default exceeds ceiling" was representable and a dropped
+# constraint looked identical to a typo.
+#
+# ``MAX_PAGE_LIMIT`` is also imported by the CLI (``cli/commands/_shared.py``)
+# so the cross-process invariant "CLI page_size ≤ server ceiling" is a
+# derivation rather than a coincidence two literals happen to satisfy.
+#
+# The events endpoints legitimately want a higher ceiling (operators page full
+# event logs); they pass it as a *named* override (:data:`MAX_EVENT_PAGE_LIMIT`)
+# so the deviation is a one-token, greppable, intentional act.
+DEFAULT_PAGE_LIMIT = 50
+MAX_PAGE_LIMIT = 200
+MAX_EVENT_PAGE_LIMIT = 500
+
+# ``PageLimit`` keeps the ``ge``/``le`` literals inline in the request
+# signature (FastAPI needs them statically for OpenAPI / SDK regen — a
+# computed runtime value would not appear in the schema), while collapsing
+# the repeated ``Annotated[int | None, Query(ge=1, le=MAX_PAGE_LIMIT)]`` to a
+# single alias. The ceiling still derives from the constant, so the emitted
+# ``le`` is byte-identical to the old hand-typed ``200`` and the openapi
+# snapshot test is unaffected.
+PageLimit = Annotated[int | None, Query(ge=1, le=MAX_PAGE_LIMIT)]
+
+# Events endpoints (session events, run events): same shape, higher ceiling.
+EventPageLimit = Annotated[int | None, Query(ge=1, le=MAX_EVENT_PAGE_LIMIT)]
 
 _CURSOR_VERSION = 1
 _DIR_TO_WIRE: dict[Direction, str] = {"forward": "f", "backward": "b"}
@@ -122,3 +156,25 @@ def page_cursor(cursor: str | None, first_page_params: dict[str, Any]) -> Cursor
         return None
     reject_params_with_cursor(first_page_params)
     return decode_cursor(cursor)
+
+
+def resolve_page_limit(
+    st: CursorState | None,
+    limit: int | None,
+    *,
+    default: int = DEFAULT_PAGE_LIMIT,
+) -> int:
+    """Resolve the effective page size for a list request.
+
+    Collapses the repeated triple-nested ternary every router hand-wrote::
+
+        page_limit = st.limit if st is not None else (limit if limit is not None else N)
+
+    On a ``?cursor=`` page the size is whatever the cursor carried; on a first
+    page it's the supplied ``?limit=`` or ``default``. Endpoints with a
+    non-standard default (the events endpoints page 200 at a time) pass it as a
+    named ``default=`` override rather than re-typing the literal.
+    """
+    if st is not None:
+        return st.limit
+    return limit if limit is not None else default

--- a/tests/e2e/test_pagination_limit_validation.py
+++ b/tests/e2e/test_pagination_limit_validation.py
@@ -12,16 +12,29 @@ Pydantic constraints. Three symptoms:
 * No upper bound — a single client request could pull unbounded rows
   (DoS surface; one request fetching ~1 GB of event data).
 
-Fix: every paginated route now declares
-``limit: Annotated[int, Query(ge=1, le=200)]`` (or ``le=500`` for the
-events endpoint). Pydantic / FastAPI rejects at the request boundary
-with 422; the routes never see invalid values.
+Fix: every paginated route now declares its ``limit`` via the shared
+``PageLimit`` / ``EventPageLimit`` aliases, whose ceiling derives from
+``MAX_PAGE_LIMIT`` / ``MAX_EVENT_PAGE_LIMIT``. Pydantic / FastAPI rejects
+at the request boundary with 422; the routes never see invalid values.
+
+Coverage is **route-derived, not hand-listed.** The earlier version of
+this file enumerated 8 paths by hand and had already drifted — it omitted
+``/v1/workflows`` (4 ``page_cursor`` sites) and every path-param'd list
+endpoint, so those routes had *zero* limit-validation coverage. Instead of
+re-curating that list, this test now walks ``app.routes`` for every handler
+returning ``ListResponse[...]`` that declares a ``limit`` query param and
+asserts each rejects ``limit=0``, ``limit=-1``, and ``limit=ceiling+1``.
+
+The consequence (the actual foreclosure): a new list endpoint that forgets
+the ``ge=1`` / ``le=…`` constraint is discovered here *by its return type*,
+not by an author remembering to append it to a list — so the omission fails
+CI whether or not the author knew the rule exists.
 """
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, NamedTuple
 
 import httpx
 import pytest
@@ -51,63 +64,179 @@ async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[http
         yield client
 
 
-# Path-free GET-list endpoints. Excludes endpoints that need an existing
-# session_id / store_id (events list, memories list, etc.) — those go
-# through the same Pydantic validation, the path-free set is enough to
-# pin the contract that the validation is uniformly applied.
-_LIST_PATHS = [
-    "/v1/agents",
-    "/v1/sessions",
-    "/v1/skills",
-    "/v1/environments",
-    "/v1/vaults",
-    "/v1/connections",
-    "/v1/memory-stores",
-    "/v1/session-templates",
-]
+class _ListRoute(NamedTuple):
+    """A discovered list endpoint and the data the test needs to probe it."""
+
+    path: str  # concrete request path (path params filled with placeholders)
+    ceiling: int  # the ``le=…`` cap declared on its ``limit`` query param
+
+    @property
+    def over_ceiling(self) -> int:
+        return self.ceiling + 1
+
+
+def _is_list_response(response_model: Any) -> bool:
+    """True iff ``response_model`` is ``ListResponse`` or a parametrization of it.
+
+    ``ListResponse[Foo]`` is a real pydantic generic subclass, so a plain
+    ``issubclass`` catches the parametrized forms; the bare class is checked
+    by identity. The fallback reads pydantic's generic metadata in case a
+    future pydantic stops making the parametrization a subclass.
+    """
+    from aios.models.common import ListResponse
+
+    if response_model is ListResponse:
+        return True
+    try:
+        if isinstance(response_model, type) and issubclass(response_model, ListResponse):
+            return True
+    except TypeError:
+        pass
+    meta = getattr(response_model, "__pydantic_generic_metadata__", {})
+    return meta.get("origin") is ListResponse
+
+
+def _limit_ceiling(field_info: Any) -> int | None:
+    """Extract the ``le=…`` ceiling from a FastAPI ``limit`` param, or None.
+
+    FastAPI keeps the numeric constraints in ``field_info.metadata`` as
+    annotated-types ``Le`` / ``Ge`` markers rather than plain attributes.
+    A ``limit`` param with no ``le`` is treated as *uncapped* (None) — which
+    the test flags, because an uncapped list endpoint is exactly the DoS
+    regression this contract forecloses.
+    """
+    for marker in getattr(field_info, "metadata", []) or []:
+        le = getattr(marker, "le", None)
+        if le is not None:
+            return int(le)
+    le = getattr(field_info, "le", None)
+    return int(le) if le is not None else None
+
+
+def _discover_list_routes() -> list[_ListRoute]:
+    """Walk the app's routes for every ``limit``-paginated list endpoint.
+
+    Gated on (a) returning ``ListResponse[...]`` and (b) declaring a ``limit``
+    query param — the gate avoids over-matching list endpoints that aren't
+    cursor/limit paginated (e.g. ``/v1/runtime-tokens``). Path params are
+    filled with a placeholder string: the request boundary validates the
+    query ``limit`` (422) *before* the handler runs its resource lookup, so a
+    non-existent id never shadows the validation we are asserting.
+    """
+    from fastapi.routing import APIRoute
+
+    from aios.api.app import create_app
+
+    routes: list[_ListRoute] = []
+    for route in create_app().routes:
+        if not isinstance(route, APIRoute):
+            continue
+        if "GET" not in route.methods:
+            continue
+        if not _is_list_response(route.response_model):
+            continue
+        limit_param = next((p for p in route.dependant.query_params if p.name == "limit"), None)
+        if limit_param is None:
+            continue
+        ceiling = _limit_ceiling(limit_param.field_info)
+        assert ceiling is not None, (
+            f"{route.path} declares a paginated `limit` query param with no `le=` "
+            f"ceiling — an unbounded list endpoint is a DoS surface. Declare it via "
+            f"`PageLimit` / `EventPageLimit` (see aios.models.pagination)."
+        )
+        # Fill path params (``{store_id}`` → ``placeholder``) so the path is
+        # requestable; the value never reaches a DB lookup before the 422.
+        concrete = route.path
+        for param in route.dependant.path_params:
+            concrete = concrete.replace("{" + param.name + "}", "id_placeholder")
+        routes.append(_ListRoute(path=concrete, ceiling=ceiling))
+    return routes
+
+
+# Discovered at import time so pytest can parametrize over it. If this is
+# empty the introspection broke (renamed ListResponse, etc.) — fail loudly
+# rather than silently testing nothing.
+_LIST_ROUTES = _discover_list_routes()
+assert _LIST_ROUTES, "route introspection found no `limit`-paginated list endpoints"
+
+
+def _route_id(route: _ListRoute) -> str:
+    return route.path
 
 
 class TestPaginationLimitValidation:
-    @pytest.mark.parametrize("path", _LIST_PATHS)
+    def test_introspection_covers_known_endpoints(self) -> None:
+        """The walk must find the canonical path-free endpoints + the
+        previously-drifted ones (``/v1/workflows`` and the path-param'd lists).
+
+        Pins the discovery itself so a regression that makes the introspection
+        match *nothing* (or drops the routes the old hand-list missed) is caught.
+        """
+        discovered = {r.path for r in _LIST_ROUTES}
+        # The 8 the old hand-list covered, plus the ones it had drifted past.
+        must_cover = {
+            "/v1/agents",
+            "/v1/sessions",
+            "/v1/skills",
+            "/v1/environments",
+            "/v1/vaults",
+            "/v1/connections",
+            "/v1/memory-stores",
+            "/v1/session-templates",
+            "/v1/workflows",  # drifted: missing from the old hand-list
+            "/v1/runs",
+            "/v1/sessions/id_placeholder/events",  # path-param'd: uncovered before
+            "/v1/runs/id_placeholder/events",
+        }
+        missing = must_cover - discovered
+        assert not missing, f"route introspection no longer discovers: {sorted(missing)}"
+
+    @pytest.mark.parametrize("route", _LIST_ROUTES, ids=_route_id)
     async def test_limit_zero_rejected_with_422(
-        self, http_client: httpx.AsyncClient, path: str
+        self, http_client: httpx.AsyncClient, route: _ListRoute
     ) -> None:
-        r = await http_client.get(path, params={"limit": 0})
+        r = await http_client.get(route.path, params={"limit": 0})
         assert r.status_code == 422, (
-            f"{path}?limit=0 should reject with 422 (Pydantic Field ge=1); "
+            f"{route.path}?limit=0 should reject with 422 (Pydantic Field ge=1); "
             f"got {r.status_code} body={r.text[:200]}"
         )
 
-    @pytest.mark.parametrize("path", _LIST_PATHS)
+    @pytest.mark.parametrize("route", _LIST_ROUTES, ids=_route_id)
     async def test_limit_negative_rejected_with_422(
-        self, http_client: httpx.AsyncClient, path: str
+        self, http_client: httpx.AsyncClient, route: _ListRoute
     ) -> None:
-        r = await http_client.get(path, params={"limit": -1})
+        r = await http_client.get(route.path, params={"limit": -1})
         assert r.status_code == 422, (
-            f"{path}?limit=-1 should reject with 422 (Pydantic Field ge=1); "
+            f"{route.path}?limit=-1 should reject with 422 (Pydantic Field ge=1); "
             f"got {r.status_code} body={r.text[:200]} — without the "
             f"constraint the value reaches Postgres as ``LIMIT -1`` and "
             f"raises asyncpg.InvalidRowCountInLimitClauseError → 500"
         )
 
-    @pytest.mark.parametrize("path", _LIST_PATHS)
+    @pytest.mark.parametrize("route", _LIST_ROUTES, ids=_route_id)
     async def test_limit_over_max_rejected_with_422(
-        self, http_client: httpx.AsyncClient, path: str
+        self, http_client: httpx.AsyncClient, route: _ListRoute
     ) -> None:
-        r = await http_client.get(path, params={"limit": 201})
+        r = await http_client.get(route.path, params={"limit": route.over_ceiling})
         assert r.status_code == 422, (
-            f"{path}?limit=201 should reject with 422 (Pydantic Field le=200); "
-            f"got {r.status_code} body={r.text[:200]} — without the cap "
-            f"a single request can pull unbounded rows (DoS surface)"
+            f"{route.path}?limit={route.over_ceiling} should reject with 422 "
+            f"(Pydantic Field le={route.ceiling}); got {r.status_code} "
+            f"body={r.text[:200]} — without the cap a single request can pull "
+            f"unbounded rows (DoS surface)"
         )
 
-    @pytest.mark.parametrize("path", _LIST_PATHS)
-    async def test_limit_at_default_works(self, http_client: httpx.AsyncClient, path: str) -> None:
-        """Regression guard: omitting limit (default) succeeds."""
-        r = await http_client.get(path)
-        assert r.status_code == 200, (
-            f"{path} default-limit request should succeed; got {r.status_code} body={r.text[:200]}"
+    @pytest.mark.parametrize("route", _LIST_ROUTES, ids=_route_id)
+    async def test_limit_at_ceiling_passes_validation(
+        self, http_client: httpx.AsyncClient, route: _ListRoute
+    ) -> None:
+        """The ceiling value itself is ``le``-valid, so it must NOT 422.
+
+        Confirms the cap is inclusive (``le``, not ``lt``) and that the only
+        thing rejected is *out-of-range* — the endpoint may still 404 on a
+        placeholder path id, but it must not fail request validation.
+        """
+        r = await http_client.get(route.path, params={"limit": route.ceiling})
+        assert r.status_code != 422, (
+            f"{route.path}?limit={route.ceiling} (== the ceiling) should pass "
+            f"validation; got 422 body={r.text[:200]}"
         )
-        body = r.json()
-        assert "data" in body
-        assert isinstance(body["data"], list)


### PR DESCRIPTION
## What & why

Closes #1094. The list-endpoint `limit` contract was 35 bare literals across 3 processes with no named constant, and its CI test (`tests/e2e/test_pagination_limit_validation.py`) hand-enumerated 8 of 15 routes — already drifted past `/v1/workflows` and every path-param'd list endpoint, leaving those routes with **zero** limit-validation coverage.

## Core — the foreclosure (route introspection)

Replaced the hand-listed `_LIST_PATHS` with a walk of `app.routes`: every `APIRoute` whose `response_model` is `ListResponse[...]` **and** that declares a `limit` query param is discovered, and each is asserted to reject `limit=0`, `limit=-1`, and `limit=ceiling+1` (the ceiling read from the route's own `le=` constraint). A `limit` param with **no** ceiling fails the test (`ceiling is not None`), so an unbounded list endpoint can't slip through.

Discovery now covers **19** endpoints (was 8), including the previously-uncovered `/v1/workflows`, `/v1/runs`, both events endpoints, and all path-param'd lists (`…/versions`, `…/credentials`, `…/events`, `…/memories`). The gate on a `limit` param avoids over-matching non-paginated lists (e.g. `/v1/runtime-tokens`).

Verified the foreclosure holds: a naive `limit: int = 50` (no constraint) list endpoint is flagged by return-type discovery and fails CI — not a "keep in sync" comment, not a per-site helper you can forget to call.

Path-param'd routes are probed with placeholder ids; FastAPI validates the query `limit` (422) at the request boundary **before** the handler's resource lookup runs, so a non-existent id never shadows the validation (confirmed in-process with a pool that raises if touched).

## Companion — consolidation

- `DEFAULT_PAGE_LIMIT` / `MAX_PAGE_LIMIT` / `MAX_EVENT_PAGE_LIMIT` in `aios.models.pagination` as the single source.
- `PageLimit` / `EventPageLimit` `Annotated` aliases (`Query(ge=1, le=MAX_PAGE_LIMIT)`) keep the `le` literals inline for OpenAPI/SDK regen while collapsing the repeated annotation. The events endpoints' higher ceiling is a named alias, making the deviation greppable.
- `resolve_page_limit(st, limit, default=…)` helper collapses the triple-nested `page_limit = st.limit if st is not None else (limit if limit is not None else N)` ternary; non-standard defaults (memory-stores 100, events 200) pass a named `default=` override.
- The CLI (`cli/commands/_shared.py`) imports `MAX_PAGE_LIMIT` for its three `page_size` defaults, so the cross-process "CLI page_size ≤ server ceiling" coupling is a derivation, not a coincidence.

## Regen-safety / risk

The `Annotated` aliases preserve the same `ge`/`le` values, so **OpenAPI output is byte-identical** and the SDK snapshot is unchanged — `test_openapi_snapshot.py` and `test_sdk_snapshot.py` both still pass. No DB/schema change. Risk: low.

## Validation

- `ruff check` + `ruff format --check` clean on `src tests`.
- `mypy --strict` clean across 632 source files (incl. the new test).
- `test_openapi_snapshot`, `test_sdk_snapshot`, `test_sdk_smoke`, `test_cli_coverage`, `test_mcp_mount`, `test_run_observability_contract` pass.
- New DB-free `test_introspection_covers_known_endpoints` pins discovery; the 4 parametrized HTTP assertions per route run against the Docker-backed e2e fixture (Postgres testcontainer) in CI.