### PR TITLE
fix(wake): key wake priority off the latest open request edge

### DIFF
--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -335,11 +335,19 @@ async def get_wake_priority_context(
     - ``caller.kind = 'api'`` → foreground.
     - no ``request_opened`` edge (an ordinary root / fg-user session) → foreground.
 
-    Returns the **oldest open** edge's background fact: v1 injects one request per
-    child, so this is the single edge. A ``None`` result is the deleted-session
-    race — :func:`defer_wake` maps it to the foreground default, then the wake
-    no-ops harmlessly. Unscoped (internal/trusted), mirroring
-    :func:`get_session_workflow_context`.
+    Derives the demotion from the **latest still-open** edge — the most-recent
+    ``request_opened`` not yet answered by a ``request_response`` (the same
+    ``asked MINUS answered`` open set as :func:`get_open_request_ids`). A session
+    that has served several requests wakes at the priority of the edge that
+    triggered *this* wake, not its oldest-ever edge — reachable since ``invoke``
+    with ``target_kind='session'`` (#1128) appends a second edge to a live session:
+    keying on the oldest would pin a re-invoked background child at background while
+    it serves a foreground api request (and a fg-first session at foreground while a
+    background descendant drives it). An answered-and-gone request contributes
+    nothing, so a quiescent session falls back to the foreground default. A ``None``
+    result is the deleted-session race — :func:`defer_wake` maps it to the
+    foreground default, then the wake no-ops harmlessly. Unscoped (internal/trusted),
+    mirroring :func:`get_session_workflow_context`.
     """
     row = await conn.fetchrow(
         "SELECT s.account_id, "
@@ -355,7 +363,13 @@ async def get_wake_priority_context(
         "    FROM events req "
         "    WHERE req.session_id = s.id AND req.account_id = s.account_id "
         "    AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
-        "    ORDER BY req.seq ASC LIMIT 1"
+        "    AND req.data->>'request_id' IS NOT NULL "
+        "    AND NOT EXISTS ("
+        "      SELECT 1 FROM events resp "
+        "      WHERE resp.session_id = s.id AND resp.account_id = s.account_id "
+        "      AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
+        "      AND resp.data->>'request_id' = req.data->>'request_id') "
+        "    ORDER BY req.seq DESC LIMIT 1"
         "  ), FALSE) AS is_background "
         "FROM sessions s WHERE s.id = $1",
         session_id,

--- a/tests/integration/test_wake_priority_context.py
+++ b/tests/integration/test_wake_priority_context.py
@@ -84,6 +84,21 @@ async def _insert_session(
     return session.id
 
 
+async def _close_edge(pool: asyncpg.Pool[Any], *, session_id: str, request_id: str) -> None:
+    """Answer a request (``request_response``), so its edge is no longer open."""
+    async with pool.acquire() as conn:
+        wrote = await queries.write_response_if_absent(
+            conn,
+            session_id,
+            account_id=_ACCOUNT,
+            request_id=request_id,
+            is_error=False,
+            result={"ok": True},
+            error=None,
+        )
+    assert wrote
+
+
 async def test_no_edge_is_foreground(pool_env: tuple[asyncpg.Pool[Any], str, str, str]) -> None:
     """An ordinary root / fg-user session (no ``request_opened`` edge) → foreground."""
     pool, _account, agent_id, env_id = pool_env
@@ -166,3 +181,68 @@ async def test_missing_session_is_none(
     async with pool.acquire() as conn:
         ctx = await queries.get_wake_priority_context(conn, "ses_does_not_exist")
     assert ctx is None
+
+
+# --- Multi-edge per-stimulus correctness (#1125 oldest-vs-latest-open) --------
+#
+# A session that has served more than one request carries several
+# ``request_opened`` edges. The priority must reflect the **most-recently-opened
+# still-open** edge (the current stimulus), not the oldest-ever one. These cases
+# are the reachable inversions once ``POST /v1/invocations target_kind=session``
+# (#1128) appends a second edge to a live session; the single-edge cases above
+# cannot distinguish oldest from latest.
+
+
+async def test_latest_open_edge_wins_over_older_open(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """A background-rooted child (run edge) later invoked at foreground (api edge)
+    wakes **foreground** — the latest open edge is the api stimulus, not the
+    oldest run edge. The starvation inversion #1125 exists to prevent."""
+    pool, _account, agent_id, env_id = pool_env
+    sid = await _insert_session(pool, agent_id=agent_id, environment_id=env_id, origin="background")
+    await _open_edge(
+        pool, session_id=sid, request_id="req_run_old", caller={"kind": "run", "id": "wfr_1"}
+    )
+    await _open_edge(
+        pool, session_id=sid, request_id="req_api_new", caller={"kind": "api", "id": "k_1"}
+    )
+    async with pool.acquire() as conn:
+        ctx = await queries.get_wake_priority_context(conn, sid)
+    assert ctx is not None and ctx[1] is False
+
+
+async def test_latest_open_edge_demotes_when_newer_is_background(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """The symmetric inversion: a foreground-first session (api edge) later driven
+    by a background run edge wakes **background** — the latest open edge is the run
+    stimulus, so background fan-out can't compete with user messages."""
+    pool, _account, agent_id, env_id = pool_env
+    sid = await _insert_session(pool, agent_id=agent_id, environment_id=env_id, origin="background")
+    await _open_edge(
+        pool, session_id=sid, request_id="req_api_old", caller={"kind": "api", "id": "k_1"}
+    )
+    await _open_edge(
+        pool, session_id=sid, request_id="req_run_new", caller={"kind": "run", "id": "wfr_1"}
+    )
+    async with pool.acquire() as conn:
+        ctx = await queries.get_wake_priority_context(conn, sid)
+    assert ctx is not None and ctx[1] is True
+
+
+async def test_answered_edge_is_excluded(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """An answered (``request_response``-closed) edge no longer counts: a session
+    whose only request has been answered falls back to the foreground default,
+    matching the docstring's **still-open** edge contract."""
+    pool, _account, agent_id, env_id = pool_env
+    sid = await _insert_session(pool, agent_id=agent_id, environment_id=env_id, origin="background")
+    await _open_edge(
+        pool, session_id=sid, request_id="req_run_done", caller={"kind": "run", "id": "wfr_1"}
+    )
+    await _close_edge(pool, session_id=sid, request_id="req_run_done")
+    async with pool.acquire() as conn:
+        ctx = await queries.get_wake_priority_context(conn, sid)
+    assert ctx is not None and ctx[1] is False

--- a/tests/unit/test_wake_priority.py
+++ b/tests/unit/test_wake_priority.py
@@ -84,11 +84,13 @@ async def test_delayed_background_wake_is_also_demoted(in_memory_app: App) -> No
 
 
 async def test_reused_servicer_priority_is_per_stimulus(in_memory_app: App) -> None:
-    """The multi-edge per-stimulus distinction the locked decision turns on: the
-    same servicer woken by a bg-edge stimulus wakes background, and woken by a
-    fg-user stimulus wakes foreground. ``defer_wake`` derives priority freshly per
-    wake, so the carrier reflects *this* stimulus's edge — not a materialized
-    servicer-row scalar."""
+    """``defer_wake`` derives the job priority freshly per wake from
+    ``get_wake_priority_context`` — not from a materialized servicer-row scalar — so a
+    reused servicer's priority tracks *this* stimulus's edge. This tier **mocks** the
+    query (two verdicts → two priorities), proving only the wiring; the SQL that
+    actually picks the latest *open* edge over the oldest-ever one (the multi-edge
+    distinction itself) is covered by
+    ``tests/integration/test_wake_priority_context.py`` (``test_latest_open_edge_*``)."""
     pool = MagicMock()
     with patch("aios.services.wake.sessions_service.append_event", AsyncMock()):
         with patch(


### PR DESCRIPTION
## Summary

`get_wake_priority_context` (the single source of truth for `defer_wake`'s foreground/background demotion) derived priority from the **oldest** `request_opened` edge (`ORDER BY req.seq ASC LIMIT 1`), under the now-falsified *"v1 injects one request per child"* assumption.

Since #1128's `POST /v1/invocations target_kind=session` appends a **second** edge to a *live* session, this is now reachable:

- A workflow child (run edge → background) later invoked at foreground (api edge) woke at **background** priority and was starved on the worker semaphore — the exact inversion #1125 exists to prevent.
- The symmetric case demotes a foreground-first session that a background descendant later drives.

The commit message says priority is *"derived per-stimulus from the triggering edge"* and the docstring said *"oldest **open** edge"* — but the SQL picked the oldest-ever edge with no open-ness filter. Both stated intents were violated.

## Fix

Derive the demotion from the **latest still-open** edge:
- Add the open-ness filter (`asked MINUS answered`, byte-identical to the sibling `get_open_request_ids`, index-backed by `events_request_response_idx`).
- `ORDER BY req.seq DESC LIMIT 1` (was `ASC`) → the most-recent triggering edge.

This honors both the docstring's "open" qualifier and #1125's per-stimulus intent. An answered-and-gone request now contributes nothing, so a quiescent session falls back to the foreground default.

## Why the bug hid behind green tests

The committed unit test `test_reused_servicer_priority_is_per_stimulus` **mocks** `get_wake_priority_context`, so it never exercised the SQL; the integration tests seeded a single edge per session, where oldest == latest. Neither layer could fail. This PR adds three DB-backed integration tests that drive the real query, and scopes the unit test's docstring to the propagation wiring it actually covers.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 2824 passed (incl. `tests/unit/test_wake_priority.py`)
- [x] `tests/integration/test_wake_priority_context.py` — 9 passed (6 existing single-edge + 3 new multi-edge); the 3 new tests confirmed RED on the old SQL for the predicted reason, GREEN after the fix
- [ ] CI runs full integration/e2e suite

## Notes

- **No behavior change for single-open-edge sessions** (oldest == latest); all 6 pre-existing tests pass unchanged.
- The concurrent **multiple** simultaneously-open mixed-priority edges case keys off the latest open edge as a per-stimulus proxy; threading an explicit `request_id` through `defer_wake` for exactness remains a deferred follow-up (the heuristic self-corrects on the next wake and only nudges priority by ±10, never correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)