### PR TITLE
feat(sandbox): fire the secret swap under Unrestricted egress, DNAT-only (#1153)

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -57,6 +57,7 @@ from aios.sandbox.git_proxy import GitProxy
 from aios.sandbox.network import WORKER_NETWORK_ALIAS
 from aios.sandbox.setup import (
     apply_network_lockdown,
+    apply_secret_egress_dnat,
     install_egress_ca,
     install_packages,
 )
@@ -464,7 +465,7 @@ class SandboxRegistry:
         try:
             await install_egress_ca(self._backend, handle)
             await install_packages(self._backend, handle, plan.env_config)
-            await self._maybe_apply_lockdown(handle, plan)
+            await self._apply_egress_rules(handle, plan)
         except BaseException:
             await self._destroy_quietly(handle, session_id)
             raise
@@ -560,7 +561,7 @@ class SandboxRegistry:
         try:
             await install_egress_ca(self._backend, handle)
             await install_packages(self._backend, handle, plan.env_config)
-            await self._maybe_apply_lockdown(handle, plan)
+            await self._apply_egress_rules(handle, plan)
         except BaseException:
             await self._destroy_run_quietly(run_id, handle)
             raise
@@ -616,48 +617,88 @@ class SandboxRegistry:
             return
         await self._destroy_run_quietly(run_id, handle)
 
-    async def _maybe_apply_lockdown(self, handle: SandboxHandle, plan: ProvisioningPlan) -> None:
-        """Apply network lockdown if the plan calls for it."""
-        from aios.harness import runtime
-        from aios.models.environments import LimitedNetworking
+    @staticmethod
+    def _secret_dnat(plan: ProvisioningPlan) -> tuple[list[str], tuple[str, int] | None]:
+        """Build the ``(dnat_hosts, dnat_target)`` pair for the secret-egress swap.
+
+        Shared by the Limited lockdown branch and the Unrestricted DNAT-only
+        branch (#1153) so the credential-host extraction lives in one place.
+        Returns ``([], None)`` when the plan carries no secret proxy (no env-var
+        credentials), so the caller can cleanly skip DNAT wiring.
+
+        Each credential's ``allowed_hosts`` holds canonical entries (a bare host
+        or a ``host/path-prefix``); the DNAT keys on the bare host only, de-dup'd.
+        """
         from aios.models.vaults import parse_allowed_host_entry
 
-        networking = plan.env_config.networking if plan.env_config else None
-        if not isinstance(networking, LimitedNetworking):
-            return
-        extra_host_ports: list[tuple[str, int]] = [
-            (WORKER_NETWORK_ALIAS, runtime.require_tool_broker().port),
-        ]
-        if plan.git_proxy is not None:
-            extra_host_ports.append((WORKER_NETWORK_ALIAS, plan.git_proxy.port))
+        if plan.secret_proxy is None:
+            return [], None
+        dnat_target = (WORKER_NETWORK_ALIAS, plan.secret_proxy.port)
         dnat_hosts: list[str] = []
-        dnat_target: tuple[str, int] | None = None
-        if plan.secret_proxy is not None:
-            # Open the filter OUTPUT for the rewritten (post-DNAT) flow to the
-            # proxy endpoint — mirrors the git_proxy precedent above. (#878)
-            extra_host_ports.append((WORKER_NETWORK_ALIAS, plan.secret_proxy.port))
-            dnat_target = (WORKER_NETWORK_ALIAS, plan.secret_proxy.port)
-            # Each credential's allowed_hosts holds canonical entries (host or
-            # host/path-prefix); DNAT keys on the bare host only.
-            seen: set[str] = set()
-            for cred in plan.env_var_credentials:
-                for entry in cred.allowed_hosts:
-                    host, _prefix = parse_allowed_host_entry(entry)
-                    if host not in seen:
-                        seen.add(host)
-                        dnat_hosts.append(host)
-        await apply_network_lockdown(
-            self._backend,
-            handle,
-            networking,
-            extra_host_ports=extra_host_ports,
-            dnat_hosts=dnat_hosts,
-            dnat_target=dnat_target,
-            # Pin the lockdown sidecar to the same container runtime as the
-            # sandbox it locks down (#1014) — sourced from the sandbox's own
-            # provisioning spec, never ambient config.
-            runtime=plan.spec.runtime,
-        )
+        seen: set[str] = set()
+        for cred in plan.env_var_credentials:
+            for entry in cred.allowed_hosts:
+                host, _prefix = parse_allowed_host_entry(entry)
+                if host not in seen:
+                    seen.add(host)
+                    dnat_hosts.append(host)
+        return dnat_hosts, dnat_target
+
+    async def _apply_egress_rules(self, handle: SandboxHandle, plan: ProvisioningPlan) -> None:
+        """Wire the sandbox's egress rules from the provisioning plan.
+
+        Three cases (#1153):
+
+        - **Limited** networking → full iptables lockdown (``-P OUTPUT DROP`` +
+          per-host ACCEPTs), plus the credential-host → proxy DNAT when the plan
+          carries env-var credentials. Today's path, unchanged.
+        - **Unrestricted / no-networking-config WITH env-var credentials** →
+          DNAT-only: install the credential-host → proxy swap chokepoint while
+          leaving general egress open (no DROP). The secret swap fires; the env
+          allowlist is not the containment boundary (the operator's CMA-faithful
+          choice).
+        - **Unrestricted / no config WITHOUT credentials** → nothing (today's
+          early return: no proxy, no DNAT).
+        """
+        from aios.harness import runtime
+        from aios.models.environments import LimitedNetworking
+
+        networking = plan.env_config.networking if plan.env_config else None
+        dnat_hosts, dnat_target = self._secret_dnat(plan)
+
+        if isinstance(networking, LimitedNetworking):
+            extra_host_ports: list[tuple[str, int]] = [
+                (WORKER_NETWORK_ALIAS, runtime.require_tool_broker().port),
+            ]
+            if plan.git_proxy is not None:
+                extra_host_ports.append((WORKER_NETWORK_ALIAS, plan.git_proxy.port))
+            if dnat_target is not None:
+                # Open the filter OUTPUT for the rewritten (post-DNAT) flow to
+                # the proxy endpoint — mirrors the git_proxy precedent. (#878)
+                extra_host_ports.append((WORKER_NETWORK_ALIAS, dnat_target[1]))
+            await apply_network_lockdown(
+                self._backend,
+                handle,
+                networking,
+                extra_host_ports=extra_host_ports,
+                dnat_hosts=dnat_hosts,
+                dnat_target=dnat_target,
+                # Pin the lockdown sidecar to the same container runtime as the
+                # sandbox it locks down (#1014) — sourced from the sandbox's own
+                # provisioning spec, never ambient config.
+                runtime=plan.spec.runtime,
+            )
+        elif dnat_target is not None:
+            # Unrestricted (or no networking config) WITH env-var credentials:
+            # install the DNAT-only swap chokepoint, leaving general egress open.
+            await apply_secret_egress_dnat(
+                self._backend,
+                handle,
+                dnat_hosts=dnat_hosts,
+                dnat_target=dnat_target,
+                runtime=plan.spec.runtime,
+            )
+        # else: Unrestricted, no credentials → nothing (today's early return).
 
     async def _stop_proxy_silently(
         self, proxy: GitProxy | SecretEgressProxy, session_id: str, *, kind: str

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -195,6 +195,58 @@ _IPTABLES_BACKEND_SELECT = (
 )
 
 
+def _nat_dnat_lines(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> list[str]:
+    """The nat-OUTPUT DNAT block: credential-host :443 → secret-egress proxy.
+
+    Shared by the Limited lockdown script (:func:`build_iptables_script`) and
+    the Unrestricted DNAT-only script (:func:`build_secret_egress_dnat_script`)
+    so the rule shape — and the ``$PROXY_IP``-miss fail-open-to-placeholder
+    guard — lives in exactly one place (#1153).
+
+    The proxy alias is resolved to ``$PROXY_IP`` exactly ONCE at sidecar
+    runtime (iptables ``--to-destination`` needs an IP, not a DNS name) and the
+    whole block is guarded by ``if [ -n "$PROXY_IP" ]`` so a proxy-alias DNS
+    miss emits no malformed rule. On such a miss the behavior is
+    fail-open-to-placeholder, NOT fail-closed: the placeholder reaches the real
+    upstream (an authentication failure, never a secret leak — the real secret
+    never enters the container). See :func:`build_iptables_script` for the full
+    rationale.
+
+    Callers only invoke this when ``dnat_hosts`` is non-empty and a
+    ``dnat_target`` is supplied.
+    """
+    proxy_alias, proxy_port = dnat_target
+    lines = [
+        "",
+        "# Route credential-host HTTPS through the secret-egress proxy (#878)",
+        # Resolve the proxy alias to an IP ONCE — iptables --to-destination
+        # needs an IP, not a DNS name. The block is guarded on a non-empty
+        # $PROXY_IP, so a proxy-alias DNS miss emits no malformed ":<port>"
+        # rule. NOTE the resulting behavior: under #879's `cred ⊆ env` gate
+        # (Limited) the credential host IS always in allowed_hosts and therefore
+        # filter-ACCEPTed on :443 — so on a proxy miss, traffic flows DIRECTLY
+        # to the real upstream carrying the opaque placeholder. That is
+        # fail-open-to-placeholder (auth failures), never a secret leak: the
+        # real secret never enters the container. (In practice the alias is the
+        # load-bearing WORKER_NETWORK_ALIAS, so a miss already means a
+        # non-functional sandbox.)
+        f"PROXY_IP=$(getent ahosts {proxy_alias} 2>/dev/null "
+        "| awk '{print $1}' | sort -u | head -n1)",
+        'if [ -n "$PROXY_IP" ]; then',
+    ]
+    for host in sorted(dnat_hosts):
+        lines.append(
+            f"  for ip in $(getent ahosts {host} 2>/dev/null | awk '{{print $1}}' | sort -u); do"
+        )
+        lines.append(
+            '    "$IPT" -t nat -A OUTPUT -d "$ip" -p tcp --dport 443 '
+            f'-j DNAT --to-destination "$PROXY_IP:{proxy_port}"'
+        )
+        lines.append("  done")
+    lines.append("fi")
+    return lines
+
+
 def build_iptables_script(
     allowed_hosts: set[str],
     extra_host_ports: Sequence[tuple[str, int]] = (),
@@ -273,42 +325,51 @@ def build_iptables_script(
         lines.append("done")
 
     if dnat_target is not None and dnat_hosts:
-        proxy_alias, proxy_port = dnat_target
-        lines.append("")
-        lines.append("# Route credential-host HTTPS through the secret-egress proxy (#878)")
-        # Resolve the proxy alias to an IP ONCE — iptables --to-destination
-        # needs an IP, not a DNS name. The block is guarded on a non-empty
-        # $PROXY_IP, so a proxy-alias DNS miss emits no malformed ":<port>"
-        # rule. NOTE the resulting behavior: under #879's `cred ⊆ env` gate
-        # the credential host IS always in allowed_hosts and therefore
-        # filter-ACCEPTed on :443 — so on a proxy miss, traffic flows
-        # DIRECTLY to the real upstream carrying the opaque placeholder.
-        # That is fail-open-to-placeholder (auth failures), never a secret
-        # leak: the real secret never enters the container. (In practice the
-        # alias is the load-bearing WORKER_NETWORK_ALIAS, so a miss already
-        # means a non-functional sandbox.)
-        lines.append(
-            f"PROXY_IP=$(getent ahosts {proxy_alias} 2>/dev/null "
-            "| awk '{print $1}' | sort -u | head -n1)"
-        )
-        lines.append('if [ -n "$PROXY_IP" ]; then')
-        for host in sorted(dnat_hosts):
-            lines.append(
-                f"  for ip in $(getent ahosts {host} 2>/dev/null "
-                "| awk '{print $1}' | sort -u); do"
-            )
-            lines.append(
-                '    "$IPT" -t nat -A OUTPUT -d "$ip" -p tcp --dport 443 '
-                f'-j DNAT --to-destination "$PROXY_IP:{proxy_port}"'
-            )
-            lines.append("  done")
-        lines.append("fi")
+        # The nat-OUTPUT DNAT block lives in one place (#1153) so the Limited
+        # lockdown script and the Unrestricted DNAT-only script emit a
+        # byte-identical rule shape.
+        lines.extend(_nat_dnat_lines(dnat_hosts, dnat_target))
 
     lines.append("")
     lines.append("# Drop everything else")
     lines.append('"$IPT" -P OUTPUT DROP')
 
     return "\n".join(lines)
+
+
+def build_secret_egress_dnat_script(dnat_hosts: Sequence[str], dnat_target: tuple[str, int]) -> str:
+    """Install ONLY the credential-host → proxy nat-OUTPUT DNAT (no lockdown).
+
+    For an **Unrestricted** environment that nonetheless carries env-var
+    credentials (#1153): the secret swap must fire, but general egress stays
+    open. So this emits the same nat-OUTPUT DNAT block as the Limited lockdown
+    (via the shared :func:`_nat_dnat_lines`) but leaves the filter OUTPUT policy
+    at its default ``ACCEPT`` — there is NO ``-P OUTPUT DROP`` and NO per-host
+    filter ``ACCEPT`` rules. The DNATed packet (now to ``$PROXY_IP:<port>``)
+    traverses the default-ACCEPT filter OUTPUT and is forwarded; no explicit
+    proxy ACCEPT is needed (and adding one would contradict the no-lockdown
+    intent).
+
+    Only the nat OUTPUT chain is flushed for idempotent re-apply — the filter
+    OUTPUT chain is deliberately left untouched.
+
+    Callers only invoke this with a non-empty ``dnat_hosts`` and a real
+    ``dnat_target`` (the registry routes here only when there are credentials),
+    so the nat block is always emitted.
+    """
+    return "\n".join(
+        [
+            "set -e",
+            "",
+            _IPTABLES_BACKEND_SELECT,
+            "",
+            "# Flush nat OUTPUT for idempotent re-apply (do NOT touch filter OUTPUT)",
+            '"$IPT" -t nat -F OUTPUT',
+            *_nat_dnat_lines(dnat_hosts, dnat_target),
+            # NO `-P OUTPUT DROP`, NO filter ACCEPTs — the filter policy stays
+            # ACCEPT so general egress remains open under Unrestricted.
+        ]
+    )
 
 
 # Docker's embedded DNS, served inside every user-defined-network netns (the
@@ -321,15 +382,30 @@ def build_iptables_script(
 _EMBEDDED_DNS_ADDRESS = "127.0.0.11"
 
 
+# Point the netns-joining sidecar at the embedded resolver before any
+# ``getent`` runs (Docker doesn't manage resolv.conf for a netns-joining
+# container). Prepended to BOTH the Limited lockdown apply script and the
+# Unrestricted DNAT-only apply script (#1153) so credential / allowed-host
+# resolution works the same way in either mode.
+_RESOLV_PREAMBLE = (
+    f"printf 'nameserver {_EMBEDDED_DNS_ADDRESS}\\n' > /etc/resolv.conf 2>/dev/null || true\n"
+)
+
+
 # Read-back assertion that the default OUTPUT policy is DROP — proves the
 # lockdown actually took effect in the shared netns, not just that the apply
 # script exited 0.
-def build_lockdown_verify_script(dnat_hosts: Sequence[str] = ()) -> str:
+def build_lockdown_verify_script(
+    dnat_hosts: Sequence[str] = (), *, assert_drop: bool = True
+) -> str:
     """Build the read-back verify script run by the lockdown sidecar.
 
-    Always asserts the filter-table default OUTPUT policy is ``DROP`` — proof
-    the lockdown actually landed in the shared netns, not merely that the apply
-    script exited 0.
+    When ``assert_drop`` (the default), asserts the filter-table default OUTPUT
+    policy is ``DROP`` — proof the lockdown actually landed in the shared netns,
+    not merely that the apply script exited 0. The DNAT-only Unrestricted path
+    (#1153) passes ``assert_drop=False``: that script deliberately leaves the
+    filter policy at ``ACCEPT``, so there is no DROP to assert (asserting it
+    would always fail).
 
     When ``dnat_hosts`` is non-empty it ALSO asserts the nat table carries at
     least one ``DNAT`` OUTPUT rule. Without this, a credential host whose
@@ -342,11 +418,15 @@ def build_lockdown_verify_script(dnat_hosts: Sequence[str] = ()) -> str:
     present fails the verify; the proxy-alias DNS-miss case — where the whole
     nat block is guarded out — is the documented fail-open-to-placeholder path
     in :func:`build_iptables_script` and is out of scope here.)
+
+    Under DNAT-only (``assert_drop=False``) the caller always passes a
+    non-empty ``dnat_hosts`` — it only runs when there are credentials — so the
+    verify always carries a positive nat-DNAT assertion and never degenerates
+    to a no-op.
     """
-    lines = [
-        _IPTABLES_BACKEND_SELECT,
-        "\"$IPT\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'",
-    ]
+    lines = [_IPTABLES_BACKEND_SELECT]
+    if assert_drop:
+        lines.append("\"$IPT\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'")
     if dnat_hosts:
         lines.append("\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'")
     return "\n".join(lines)
@@ -410,10 +490,7 @@ async def apply_network_lockdown(
         dnat_target=dnat_target,
     )
     # Point the sidecar at the netns's embedded resolver before getent runs.
-    apply_script = (
-        f"printf 'nameserver {_EMBEDDED_DNS_ADDRESS}\\n' > /etc/resolv.conf 2>/dev/null || true\n"
-        f"{iptables_script}"
-    )
+    apply_script = _RESOLV_PREAMBLE + iptables_script
     settings = get_settings()
 
     try:
@@ -474,5 +551,104 @@ async def apply_network_lockdown(
         owner_id=handle.owner_id,
         allowed_host_count=len(allowed),
         extra_host_port_count=len(extra_host_ports),
+        dnat_host_count=len(dnat_hosts),
+    )
+
+
+async def apply_secret_egress_dnat(
+    backend: SandboxBackend,
+    handle: SandboxHandle,
+    *,
+    dnat_hosts: Sequence[str],
+    dnat_target: tuple[str, int],
+    runtime: str | None = None,
+) -> None:
+    """Install the credential-host → proxy DNAT in an OPEN-egress sandbox (#1153).
+
+    The Unrestricted sibling of :func:`apply_network_lockdown`: for an
+    Unrestricted (or no-networking-config) environment that nonetheless carries
+    env-var credentials, the secret swap must fire — but general egress stays
+    open. So this runs the same operator-image netns sidecar with the same
+    fail-closed posture, but applies :func:`build_secret_egress_dnat_script`
+    (DNAT-only; the filter OUTPUT policy is left at ``ACCEPT``) and verifies
+    with ``assert_drop=False`` (assert the nat DNAT rule exists — fail-closed on
+    a zero-IP credential host per #984 — but NOT a DROP policy, of which there
+    is none).
+
+    Deliberately **NOT** factored into a shared sidecar helper with
+    :func:`apply_network_lockdown`: the two paths carry genuinely different
+    error semantics. A Limited apply/verify failure is a *policy violation*
+    ("refusing to run a Limited sandbox"); an Unrestricted DNAT apply/verify
+    failure is a *plumbing failure* (the secret-egress proxy / sidecar is
+    unavailable). The log events here are plumbing-specific
+    (``sandbox.secret_egress_dnat_*``) so an operator alert never mis-attributes
+    a proxy outage to a networking-policy violation.
+
+    **Fails closed**, identically to the Limited path: on a sidecar infra error,
+    a nonzero apply, or a failed read-back verify, :class:`SandboxBackendError`
+    propagates and the registry tears the sandbox down rather than handing back
+    a half-wired credentialed box whose swap silently doesn't fire.
+    """
+    apply_script = _RESOLV_PREAMBLE + build_secret_egress_dnat_script(dnat_hosts, dnat_target)
+    settings = get_settings()
+
+    try:
+        result = await backend.run_netns_sidecar(
+            handle.sandbox_id,
+            image=settings.docker_image,
+            script=apply_script,
+            timeout_seconds=30,
+            max_output_bytes=settings.bash_max_output_bytes,
+            runtime=runtime,
+        )
+    except SandboxBackendError:
+        # A credentialed sandbox whose swap chokepoint couldn't even be wired
+        # must fail the provision, not hand back a box where the secret swap
+        # silently never fires.
+        log.warning("sandbox.secret_egress_dnat_sidecar_error", owner_id=handle.owner_id)
+        raise
+
+    if result.exit_code != 0:
+        log.warning(
+            "sandbox.secret_egress_dnat_failed",
+            owner_id=handle.owner_id,
+            exit_code=result.exit_code,
+            stderr=result.stderr[:500],
+        )
+        raise SandboxBackendError(
+            f"secret-egress DNAT failed (exit {result.exit_code}) for session "
+            f"{handle.owner_id}; refusing to run an env-var-credentialed sandbox "
+            f"whose secret-swap DNAT didn't install"
+        )
+
+    # Read-back verify the nat DNAT rule actually landed — there is NO DROP
+    # policy to assert under DNAT-only (assert_drop=False).
+    try:
+        verify = await backend.run_netns_sidecar(
+            handle.sandbox_id,
+            image=settings.docker_image,
+            script=build_lockdown_verify_script(dnat_hosts, assert_drop=False),
+            timeout_seconds=15,
+            max_output_bytes=settings.bash_max_output_bytes,
+            runtime=runtime,
+        )
+    except SandboxBackendError:
+        log.warning("sandbox.secret_egress_dnat_verify_error", owner_id=handle.owner_id)
+        raise
+    if verify.exit_code != 0:
+        log.warning(
+            "sandbox.secret_egress_dnat_verify_failed",
+            owner_id=handle.owner_id,
+            exit_code=verify.exit_code,
+        )
+        raise SandboxBackendError(
+            f"secret-egress DNAT verification failed for session {handle.owner_id}: "
+            "nat OUTPUT carries no DNAT rule after apply; refusing to run an "
+            "env-var-credentialed sandbox whose secret-swap DNAT is unverified"
+        )
+
+    log.info(
+        "sandbox.secret_egress_dnat_applied",
+        owner_id=handle.owner_id,
         dnat_host_count=len(dnat_hosts),
     )

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -174,8 +174,9 @@ class ProvisioningPlan:
     # Per-session :class:`SecretEgressProxy` (#877), started here when the
     # session has env-var credentials. Like ``git_proxy``, the registry owns
     # its lifecycle: it records the proxy at provision time and stops it on
-    # release / recycle. ``None`` when the session has no env-var creds.
-    # INERT until #878 wires nat DNAT egress routing into it.
+    # release / recycle. ``None`` when the session has no env-var creds. The
+    # registry routes credential-host :443 egress through it via the nat-OUTPUT
+    # DNAT, under Limited (lockdown) and Unrestricted (DNAT-only) alike (#1153).
     secret_proxy: SecretEgressProxy | None = None
 
 
@@ -457,6 +458,47 @@ def _network_policy_from_config(env_config: EnvironmentConfig | None) -> Network
     return Unrestricted()
 
 
+def _warn_if_creds_under_open_egress(
+    owner_id: str,
+    env_config: EnvironmentConfig | None,
+    env_var_credentials: Sequence[ResolvedEnvVarCredential],
+) -> None:
+    """Log the operator-facing warning when env-var creds run under open egress.
+
+    Permit-with-warning (#1153): when a provision carries env-var credentials
+    AND the environment is not Limited, the secret swap still fires (the
+    DNAT-only chokepoint), but the environment allowlist is no longer the
+    exfil-containment boundary — the operator has elected that trade. This logs
+    a structured, operator-facing warning naming the trade precisely.
+
+    Operator-facing only (not model-visible): this is bowels-of-the-system
+    plumbing the operator owns, not something the model can act on.
+
+    No-op when there are no credentials, or when the environment is Limited (the
+    allowlist still contains exfiltration there).
+    """
+    if not env_var_credentials:
+        return
+    networking = env_config.networking if env_config else None
+    if isinstance(networking, LimitedNetworking):
+        return
+    cred_hosts = sorted({host for cred in env_var_credentials for host in cred.allowed_hosts})
+    log.warning(
+        "sandbox.envvar_creds_open_egress",
+        owner_id=owner_id,
+        credential_count=len(env_var_credentials),
+        cred_hosts=cred_hosts,
+        detail=(
+            "env-var credentials active under unrestricted egress. The egress proxy "
+            "is a bidirectional TLS-terminating MitM; upstream responses — including "
+            "3xx Location headers and error bodies that may echo request data — are "
+            "NOT scrubbed (#881), and with open egress there is no allowlist to "
+            "contain exfiltration of fetched/reflected data. Secret-string "
+            "confidentiality is still enforced by the egress proxy SNI host gate."
+        ),
+    )
+
+
 def _resolve_image(env_config: EnvironmentConfig | None, default_image: str) -> str:
     """Resolve the sandbox image from the environment config (#724) and enforce the
     cross-tenant snapshot gate (durable session sandboxes, §5.8).
@@ -525,22 +567,26 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     # allocated (#873): a corrupt blob fails hard here with nothing to
     # clean up, so this step stays OUTSIDE the cleanup envelope below.
     env_var_credentials = await _materialize_env_var_credentials(session_id, account_id=account_id)
-    # Two-layer env-var credential gate (#879): a session carrying
-    # environment_variable credentials requires a Limited environment whose
-    # allowed_hosts cover every credential host. The egress swap proxy only
-    # sees traffic via the Limited lockdown DNAT, so under Unrestricted the
-    # credential leaks/non-functions; the host-subset check prevents egress
-    # escalation. Provision is authoritative — both the env config and the
-    # credential set are independently mutable after attach, and only here do
-    # we see the current pair together. Skipped entirely when the session has
-    # no env-var credentials (zero behavior change for the common path).
-    # Raises before any host resource is allocated, so it too stays OUTSIDE
-    # the cleanup envelope.
+    # Env-var credential gate (#879, relaxed to permit-with-warning by #1153):
+    # under Limited, a session carrying environment_variable credentials still
+    # requires the env's allowed_hosts to cover every credential host (the
+    # egress-escalation guard — the DNAT sits ahead of the filter DROP). Under
+    # Unrestricted (or no env config) the credential is now ACCEPTED: the secret
+    # swap fires via the DNAT-only chokepoint and, with no DROP, there is no
+    # escalation hole to guard. Provision is authoritative — both the env config
+    # and the credential set are independently mutable after attach, and only
+    # here do we see the current pair together. Skipped entirely when the
+    # session has no env-var credentials. Raises before any host resource is
+    # allocated, so it too stays OUTSIDE the cleanup envelope.
     containment_error = env_var_credential_containment_error(
         env_config, [c.allowed_hosts for c in env_var_credentials]
     )
     if containment_error is not None:
         raise ValueError(containment_error)
+    # Permit-with-warning (#1153): a credentialed provision under non-Limited
+    # egress trades away exfil-containment (the operator's CMA-faithful choice);
+    # log the operator-facing warning. No-op for Limited or no-creds.
+    _warn_if_creds_under_open_egress(session_id, env_config, env_var_credentials)
 
     tool_broker = runtime.require_tool_broker()
     tool_socket_host_path = settings.tool_broker_socket_path
@@ -556,9 +602,10 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             session_id, account_id=account_id
         )
         # Start the per-session secret-egress proxy when the session has
-        # env-var credentials (#877). Inert until #878 routes egress through
-        # it; the registry owns its lifecycle from the returned plan,
-        # mirroring git_proxy.
+        # env-var credentials (#877). The registry routes credential-host egress
+        # through it via the nat-OUTPUT DNAT (#878 Limited / #1153 Unrestricted);
+        # the registry owns its lifecycle from the returned plan, mirroring
+        # git_proxy.
         #
         # Construct + start into a LOCAL, and only publish to the outer
         # ``secret_proxy`` once ``start()`` has returned cleanly. ``start()``
@@ -694,6 +741,9 @@ async def build_spec_from_run(run_id: str) -> ProvisioningPlan:
     )
     if containment_error is not None:
         raise ValueError(containment_error)
+    # Permit-with-warning (#1153): same operator-facing warning as the session
+    # path when a credentialed run provisions under non-Limited egress.
+    _warn_if_creds_under_open_egress(run_id, env_config, env_var_credentials)
 
     workspace_path = ensure_run_workspace_dir(run_id)
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -209,8 +209,12 @@ def _evict_sandbox_for_resource_change(session_id: str) -> None:
 async def _assert_env_var_creds_contained(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> None:
-    """Advisory #879 gate at attach: fast console 422 if the session's
-    env-var credentials aren't contained by its Limited environment.
+    """Advisory #879 gate at attach (relaxed by #1153): fast console 422 only
+    when, under a **Limited** environment, the session's env-var credential
+    hosts aren't covered by the env's allowed_hosts (the egress-escalation
+    guard). Under Unrestricted (or no env config) credentials are now accepted
+    (permit-with-warning), so this no longer 422s there — it shares the relaxed
+    ``env_var_credential_containment_error`` verdict.
 
     Best-effort UX only — ``build_spec_from_session`` is the authoritative
     gate (both sides are independently mutable after attach). Runs INSIDE

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -749,16 +749,29 @@ def env_var_credential_containment_error(
     these already-fetched — this function does no DB I/O so it stays pure
     and unit-testable.
 
-    Two checks (both authoritative at provision; advisory at attach):
+    Permit-with-warning posture (#1153), matching the CMA spec the #871
+    epic ports: env-var credentials are accepted under **any** networking
+    mode. The secret-swap chokepoint (the credential-host → proxy DNAT)
+    now installs under Unrestricted too (DNAT-only, no lockdown), so the
+    swap fires regardless of the environment networking; the operator
+    accepts the loss of exfil-containment as an informed, CMA-documented
+    choice (the warning is logged at provision in ``spec.py``).
 
-    1. Networking must be ``Limited`` — the swap proxy only sees traffic
-       via the Limited lockdown DNAT, so under Unrestricted (or no env /
-       no networking config) the credential silently leaks/non-functions.
-    2. Every credential host must appear in the env's ``allowed_hosts``
-       host set (egress-escalation prevention). Host parts are compared
-       via ``parse_allowed_host_entry`` on BOTH sides — the single grammar
-       authority — so a credential path-prefix only tightens below an
-       already-allowed host.
+    The one residual check applies **only under Limited**:
+
+    - **Limited** → every credential host must appear in the env's
+      ``allowed_hosts`` host set (egress-escalation prevention: the DNAT
+      sits in nat-OUTPUT *ahead of* the filter DROP, so a credential host
+      outside the allowlist would manufacture a forbidden egress channel).
+      Host parts are compared via ``parse_allowed_host_entry`` on BOTH
+      sides — the single grammar authority — so a credential path-prefix
+      only tightens below an already-allowed host.
+    - **Unrestricted / None** → ``None`` (accepted). There is no filter
+      DROP under Unrestricted, so every host is reachable anyway and the
+      subset check guards no real escalation hole — its rationale
+      evaporates. (``env_config=None`` and ``env_config.networking=None``
+      both resolve to ``Unrestricted()`` at runtime via
+      ``_network_policy_from_config``, so this is one runtime case.)
 
     The two sides parse asymmetrically. ``LimitedNetworking`` validates
     its ``allowed_hosts`` against ``HOSTNAME_RE``, which accepts IP
@@ -782,17 +795,13 @@ def env_var_credential_containment_error(
 
     networking = env_config.networking if env_config else None
     if not isinstance(networking, LimitedNetworking):
-        if env_config is None:
-            return (
-                "environment_variable credential requires a Limited environment, but the "
-                "session has no environment configured; the environment's allowed_hosts "
-                "is the containment boundary for the egress swap proxy"
-            )
-        return (
-            "environment_variable credential requires a Limited environment "
-            "(networking is not 'limited'); env allowed_hosts is the containment "
-            "boundary for the egress swap proxy"
-        )
+        # Permit-with-warning (#1153): under Unrestricted (or no env / no
+        # networking config) the secret swap still fires via the DNAT-only
+        # chokepoint, and with no filter DROP there is no egress-escalation
+        # hole for the host-subset check to guard. So the credential is
+        # accepted; the operator-facing exfil-containment warning is logged at
+        # provision (spec.py), not raised here.
+        return None
 
     # DNS hostnames are case-insensitive but ``HOSTNAME_RE`` (and thus
     # ``parse_allowed_host_entry``) preserves the stored casing, so case-fold

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -186,15 +186,55 @@ async def _build_with(*, env_config: object, creds: tuple[ResolvedEnvVarCredenti
         return await build_spec_from_session("sess_01TEST")
 
 
-async def test_env_var_cred_with_unrestricted_networking_rejected() -> None:
+async def test_env_var_cred_with_unrestricted_networking_provisions() -> None:
+    # Permit-with-warning (#1153): env-var creds under an Unrestricted env now
+    # provision (the secret swap fires via the DNAT-only chokepoint). The
+    # credential placeholder still lands in the env.
     env = EnvironmentConfig(networking=UnrestrictedNetworking())
-    with pytest.raises(ValueError, match="Limited"):
+    cred = _cred(["api.github.com"])
+    plan = await _build_with(env_config=env, creds=(cred,))
+    assert plan.spec.environment["GITHUB_TOKEN"] == cred.placeholder  # type: ignore[attr-defined]
+
+
+async def test_env_var_cred_with_no_env_config_provisions() -> None:
+    # No env config resolves to Unrestricted at runtime → permitted (#1153).
+    cred = _cred(["api.github.com"])
+    plan = await _build_with(env_config=None, creds=(cred,))
+    assert plan.spec.environment["GITHUB_TOKEN"] == cred.placeholder  # type: ignore[attr-defined]
+
+
+async def test_env_var_cred_under_unrestricted_logs_operator_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The permit-with-warning posture (#1153) logs a structured operator-facing
+    # warning naming the exfil-containment trade. Fires from build_spec_from_session.
+    env = EnvironmentConfig(networking=UnrestrictedNetworking())
+    with caplog.at_level(logging.WARNING, logger="aios.sandbox.spec"):
         await _build_with(env_config=env, creds=(_cred(["api.github.com"]),))
+    recs = [r for r in caplog.records if "sandbox.envvar_creds_open_egress" in r.getMessage()]
+    assert len(recs) == 1
 
 
-async def test_env_var_cred_with_no_env_config_rejected() -> None:
-    with pytest.raises(ValueError, match="Limited"):
-        await _build_with(env_config=None, creds=(_cred(["api.github.com"]),))
+async def test_env_var_cred_under_limited_no_open_egress_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A Limited env still contains exfiltration via the allowlist, so NO
+    # open-egress warning is logged (#1153).
+    with caplog.at_level(logging.WARNING, logger="aios.sandbox.spec"):
+        await _build_with(
+            env_config=limited_env("api.github.com"), creds=(_cred(["api.github.com"]),)
+        )
+    assert not [r for r in caplog.records if "sandbox.envvar_creds_open_egress" in r.getMessage()]
+
+
+async def test_no_creds_under_unrestricted_no_open_egress_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # No credentials ⇒ no warning even under Unrestricted (#1153).
+    env = EnvironmentConfig(networking=UnrestrictedNetworking())
+    with caplog.at_level(logging.WARNING, logger="aios.sandbox.spec"):
+        await _build_with(env_config=env, creds=())
+    assert not [r for r in caplog.records if "sandbox.envvar_creds_open_egress" in r.getMessage()]
 
 
 async def test_env_var_cred_uncovered_host_rejected_names_host() -> None:

--- a/tests/unit/sandbox/test_spec_run_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_run_env_var_credentials.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 from contextlib import AbstractContextManager
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -127,7 +128,13 @@ async def test_run_placeholder_lands_in_env_secret_never_does() -> None:
     assert set(plan.spec.environment) == {*runtime_reserved, "PW_DEV_GATE_PASSWORD"}
 
 
-async def test_run_env_var_cred_with_unrestricted_networking_rejected_before_broker() -> None:
+async def test_run_env_var_cred_with_unrestricted_networking_provisions_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Permit-with-warning (#1153): a credentialed run under an Unrestricted env
+    # now provisions (the secret swap fires via the DNAT-only chokepoint), and
+    # logs the operator-facing exfil-containment warning. The broker IS
+    # registered (the provision proceeds past the old gate).
     broker = MagicMock()
     broker.port = 54321
     broker.register_session = MagicMock()
@@ -138,9 +145,11 @@ async def test_run_env_var_cred_with_unrestricted_networking_rejected_before_bro
             broker=broker,
         ):
             stack.enter_context(ctx)
-        with pytest.raises(ValueError, match="Limited"):
-            await build_spec_from_run(_RUN_ID)
-    broker.register_session.assert_not_called()
+        with caplog.at_level(logging.WARNING, logger="aios.sandbox.spec"):
+            plan = await build_spec_from_run(_RUN_ID)
+    assert plan.env_var_credentials == (_CRED,)
+    broker.register_session.assert_called_once()
+    assert [r for r in caplog.records if "sandbox.envvar_creds_open_egress" in r.getMessage()]
 
 
 async def test_run_secret_proxy_constructed_started_and_cleaned_on_assembly_failure() -> None:

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -25,8 +25,10 @@ from aios.sandbox.backends.base import (
 from aios.sandbox.backends.docker import DockerBackend
 from aios.sandbox.setup import (
     apply_network_lockdown,
+    apply_secret_egress_dnat,
     build_iptables_script,
     build_lockdown_verify_script,
+    build_secret_egress_dnat_script,
 )
 from tests.helpers.sandbox import FakeBackend, make_handle
 
@@ -265,6 +267,83 @@ class TestBuildIptablesScript:
         assert "--dport 80 -j DNAT" not in script
 
 
+# ── DNAT-only Unrestricted swap chokepoint (no lockdown, #1153) ───────────────
+
+
+class TestBuildSecretEgressDnatScript:
+    """The Unrestricted DNAT-only script installs the credential-host → proxy
+    swap chokepoint while leaving general egress open (no ``-P OUTPUT DROP``)."""
+
+    def test_emits_nat_dnat_rule(self) -> None:
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com", "data.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        assert '"$IPT" -t nat -A OUTPUT' in script
+        assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in script
+        assert "getent ahosts api.secret.com" in script
+        assert "getent ahosts data.secret.com" in script
+        assert "PROXY_IP=$(getent ahosts aios-worker" in script
+
+    def test_no_drop_policy(self) -> None:
+        # The whole point: general egress stays open under Unrestricted.
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )
+        assert "-P OUTPUT DROP" not in script
+
+    def test_no_filter_accept_rules(self) -> None:
+        # No per-host filter ACCEPTs and no loopback/DNS/established ACCEPTs —
+        # the filter policy is left at its default ACCEPT (no lockdown).
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )
+        assert "-A OUTPUT -o lo -j ACCEPT" not in script
+        assert "--dport 53 -j ACCEPT" not in script
+        assert "ESTABLISHED,RELATED -j ACCEPT" not in script
+        assert "--dport 443 -j ACCEPT" not in script
+
+    def test_flushes_nat_output_only_not_filter(self) -> None:
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )
+        assert '"$IPT" -t nat -F OUTPUT' in script
+        # The filter OUTPUT chain is deliberately NOT flushed (would disturb a
+        # mode the operator left open).
+        assert '"$IPT" -F OUTPUT' not in script
+
+    def test_uses_selected_backend_no_bare_iptables(self) -> None:
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )
+        assert "command -v iptables-legacy" in script
+        for line in script.splitlines():
+            stripped = line.strip()
+            if "command -v iptables-legacy" in stripped:
+                continue
+            assert not stripped.startswith("iptables "), (
+                f"bare iptables invocation would use the nft default: {line!r}"
+            )
+
+    def test_dnat_rule_shape_matches_lockdown_script(self) -> None:
+        # The shared ``_nat_dnat_lines`` helper means the DNAT rule shape is
+        # byte-identical to the Limited lockdown's — proven here by extracting
+        # the DNAT line from each and comparing.
+        dnat_only = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )
+        lockdown = build_iptables_script(
+            allowed_hosts=set(),
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+
+        def _dnat_line(script: str) -> str:
+            return next(line for line in script.splitlines() if "-j DNAT --to-destination" in line)
+
+        assert _dnat_line(dnat_only) == _dnat_line(lockdown)
+
+
 # ── read-back verify script asserts DROP + DNAT coverage (#984) ───────────────
 
 
@@ -304,6 +383,19 @@ class TestBuildLockdownVerifyScript:
             assert not stripped.startswith("iptables "), (
                 f"verify uses a bare iptables (nft default): {line!r}"
             )
+
+    def test_assert_drop_false_omits_drop_assertion(self) -> None:
+        # The DNAT-only Unrestricted path (#1153) leaves the filter policy at
+        # ACCEPT, so the verify must NOT assert a DROP policy (it would always
+        # fail) — but still asserts nat DNAT coverage.
+        script = build_lockdown_verify_script(dnat_hosts=["api.secret.com"], assert_drop=False)
+        assert "OUTPUT DROP" not in script
+        assert "\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'" in script
+
+    def test_assert_drop_true_is_default(self) -> None:
+        # Backward-compat: the Limited callers pass no assert_drop and must keep
+        # getting the DROP assertion.
+        assert "OUTPUT DROP" in build_lockdown_verify_script(dnat_hosts=["api.secret.com"])
 
 
 # ── docker backend translates network policy to docker run argv ────────────────
@@ -707,3 +799,124 @@ class TestApplyNetworkLockdownFailsClosed:
         networking = LimitedNetworking(type="limited", allowed_hosts=["api.example.com"])
 
         await apply_network_lockdown(backend, handle, networking)  # must not raise
+
+
+# ── DNAT-only apply for Unrestricted credentialed sandboxes (#1153) ────────────
+
+
+class TestApplySecretEgressDnat:
+    """``apply_secret_egress_dnat`` installs the credential-host → proxy DNAT in
+    an OPEN-egress sandbox: same operator-image netns sidecar + fail-closed
+    posture as the Limited path, but DNAT-only (no filter DROP) and verified
+    with ``assert_drop=False``."""
+
+    @staticmethod
+    def _sidecar_scripts(backend: FakeBackend) -> list[str]:
+        return [c[1]["script"] for c in backend.calls if c[0] == "run_netns_sidecar"]
+
+    @pytest.mark.asyncio
+    async def test_applies_dnat_only_no_drop_then_verifies(self) -> None:
+        backend = FakeBackend()
+        handle = make_handle()
+
+        await apply_secret_egress_dnat(
+            backend,
+            handle,
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+
+        apply_script, verify_script = self._sidecar_scripts(backend)
+        # DNAT installed, but general egress stays open (no DROP, no per-host ACCEPT).
+        assert '--dport 443 -j DNAT --to-destination "$PROXY_IP:49152"' in apply_script
+        assert "getent ahosts api.secret.com" in apply_script
+        assert "-P OUTPUT DROP" not in apply_script
+        # The verify asserts nat DNAT coverage but NOT a DROP policy.
+        assert "\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'" in verify_script
+        assert "OUTPUT DROP" not in verify_script
+
+    @pytest.mark.asyncio
+    async def test_resolv_preamble_prepended_to_apply(self) -> None:
+        # The apply script points the netns-joining sidecar at the embedded
+        # resolver before any getent runs (same preamble as the Limited path).
+        backend = FakeBackend()
+        handle = make_handle()
+
+        await apply_secret_egress_dnat(
+            backend, handle, dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )
+
+        apply_script = self._sidecar_scripts(backend)[0]
+        assert "nameserver 127.0.0.11" in apply_script
+
+    @pytest.mark.asyncio
+    async def test_runtime_threaded_to_both_sidecar_calls(self) -> None:
+        backend = FakeBackend()
+        handle = make_handle()
+
+        await apply_secret_egress_dnat(
+            backend,
+            handle,
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+            runtime="runsc",
+        )
+
+        runtimes = [c[1]["runtime"] for c in backend.calls if c[0] == "run_netns_sidecar"]
+        assert runtimes == ["runsc", "runsc"]
+
+    @pytest.mark.asyncio
+    async def test_nonzero_apply_raises_sandbox_backend_error(self) -> None:
+        backend = FakeBackend()
+        backend.sidecar_results = [
+            CommandResult(
+                exit_code=3,
+                stdout="",
+                stderr="iptables: command not found",
+                timed_out=False,
+                truncated=False,
+            )
+        ]
+        handle = make_handle()
+
+        with pytest.raises(SandboxBackendError, match="secret-egress DNAT failed"):
+            await apply_secret_egress_dnat(
+                backend, handle, dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+            )
+
+    @pytest.mark.asyncio
+    async def test_failed_verify_raises(self) -> None:
+        # Apply succeeds but the read-back shows no DNAT rule landed (e.g. a
+        # zero-IP credential host, #984) → fail closed.
+        backend = FakeBackend()
+        ok = CommandResult(exit_code=0, stdout="", stderr="", timed_out=False, truncated=False)
+        bad = CommandResult(exit_code=1, stdout="", stderr="", timed_out=False, truncated=False)
+        backend.sidecar_results = [ok, bad]
+        handle = make_handle()
+
+        with pytest.raises(SandboxBackendError, match="secret-egress DNAT verification failed"):
+            await apply_secret_egress_dnat(
+                backend, handle, dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+            )
+
+    @pytest.mark.asyncio
+    async def test_sidecar_error_propagates(self) -> None:
+        backend = FakeBackend()
+        backend.run_netns_sidecar = AsyncMock(  # type: ignore[method-assign]
+            side_effect=SandboxBackendError("daemon hiccup")
+        )
+        handle = make_handle()
+
+        with pytest.raises(SandboxBackendError, match="daemon hiccup"):
+            await apply_secret_egress_dnat(
+                backend, handle, dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+            )
+
+    @pytest.mark.asyncio
+    async def test_zero_exit_does_not_raise(self) -> None:
+        backend = FakeBackend()  # default sidecar returns exit 0 for both calls
+        handle = make_handle()
+
+        await apply_secret_egress_dnat(
+            backend, handle, dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )  # must not raise

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -484,7 +484,7 @@ class TestSecretProxyDnatThreading:
     :443 egress through the proxy (#878).
 
     ``apply_network_lockdown`` is patched with an ``AsyncMock`` spy:
-    ``_maybe_apply_lockdown``'s extraction logic still runs in full, so the
+    ``_apply_egress_rules``'s extraction logic still runs in full, so the
     captured kwargs reflect the real wiring without booting a sidecar.
     """
 
@@ -630,6 +630,101 @@ class TestSecretProxyDnatThreading:
 
         proxy.stop.assert_awaited_once()
         assert "run_X" not in registry._secret_proxies
+
+
+class TestUnrestrictedSecretEgressDnat:
+    """Under an Unrestricted (or no-config) environment that carries env-var
+    credentials, the registry routes egress wiring to ``apply_secret_egress_dnat``
+    (DNAT-only, general egress open) instead of ``apply_network_lockdown`` (#1153).
+    Both are patched with spies so the branch selection + credential-host
+    extraction run in full without booting a sidecar.
+    """
+
+    @staticmethod
+    def _unrestricted_plan_with_creds(
+        session_id: str, *, proxy_port: int = 49152
+    ) -> ProvisioningPlan:
+        cred = ResolvedEnvVarCredential(
+            credential_id="cred_1",
+            secret_name="API_TOKEN",
+            secret_value="real-secret",
+            allowed_hosts=("api.secret.com", "data.secret.com/v1"),
+            updated_at=datetime(2025, 1, 1, tzinfo=UTC),
+            placeholder="AIOS_SECRET_PLACEHOLDER_deadbeef",
+        )
+        base = _provisioning_plan(session_id)  # Unrestricted, env_config=None
+        return ProvisioningPlan(
+            spec=base.spec,
+            env_config=base.env_config,
+            memory_echoes=base.memory_echoes,
+            github_echoes=base.github_echoes,
+            git_proxy=base.git_proxy,
+            env_var_credentials=(cred,),
+            secret_proxy=cast(Any, FakeSecretProxy(port=proxy_port)),
+        )
+
+    @staticmethod
+    def _patches(plan: ProvisioningPlan, lockdown: AsyncMock, dnat_only: AsyncMock) -> ExitStack:
+        broker = MagicMock()
+        broker.port = 8765
+        stack = ExitStack()
+        for cm in (
+            patch("aios.harness.runtime.require_tool_broker", lambda: broker),
+            patch("aios.sandbox.registry.build_spec_from_session", AsyncMock(return_value=plan)),
+            patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", lockdown),
+            patch("aios.sandbox.registry.apply_secret_egress_dnat", dnat_only),
+        ):
+            stack.enter_context(cm)
+        return stack
+
+    async def test_dnat_only_called_not_lockdown_when_creds_under_unrestricted(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        plan = self._unrestricted_plan_with_creds("sess_X")
+        lockdown = AsyncMock()
+        dnat_only = AsyncMock()
+
+        with self._patches(plan, lockdown, dnat_only):
+            await registry.get_or_provision("sess_X")
+
+        # The Unrestricted path uses the DNAT-only helper, never the lockdown.
+        lockdown.assert_not_awaited()
+        dnat_only.assert_awaited_once()
+        kwargs = dnat_only.call_args.kwargs
+        assert kwargs["dnat_target"] == ("aios-worker", 49152)
+        # The ``/v1`` path prefix is stripped and bare hosts de-dup'd — same
+        # extraction the Limited path uses (shared ``_secret_dnat`` helper).
+        assert set(kwargs["dnat_hosts"]) == {"api.secret.com", "data.secret.com"}
+
+    async def test_runtime_threaded_to_dnat_only(self) -> None:
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        plan = self._unrestricted_plan_with_creds("sess_X")
+        # The plan's spec carries the sandbox runtime; assert it reaches the DNAT call.
+        lockdown = AsyncMock()
+        dnat_only = AsyncMock()
+
+        with self._patches(plan, lockdown, dnat_only):
+            await registry.get_or_provision("sess_X")
+
+        assert "runtime" in dnat_only.call_args.kwargs
+
+    async def test_no_egress_wiring_when_unrestricted_without_creds(self) -> None:
+        # Unrestricted, no secret proxy / no creds → neither helper fires (the
+        # historical early-return path, preserved).
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        plan = _provisioning_plan("sess_X")  # Unrestricted, no creds, no proxy
+        lockdown = AsyncMock()
+        dnat_only = AsyncMock()
+
+        with self._patches(plan, lockdown, dnat_only):
+            await registry.get_or_provision("sess_X")
+
+        lockdown.assert_not_awaited()
+        dnat_only.assert_not_awaited()
 
 
 class TestStaleHandleDetection:

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -1247,28 +1247,26 @@ class TestEnvVarCredentialContainment:
         env = EnvironmentConfig(networking=UnrestrictedNetworking())
         assert env_var_credential_containment_error(env, []) is None
 
-    def test_unrestricted_env_with_creds_rejected(self) -> None:
+    def test_unrestricted_env_with_creds_permitted(self) -> None:
+        # Permit-with-warning (#1153): env-var creds under an Unrestricted env
+        # are now ACCEPTED — the secret swap fires via the DNAT-only chokepoint,
+        # and with no filter DROP there is no egress-escalation hole to guard.
+        # The exfil-containment warning is logged at provision (spec.py), not
+        # raised here.
         env = EnvironmentConfig(networking=UnrestrictedNetworking())
-        verdict = env_var_credential_containment_error(env, [("api.github.com",)])
-        assert verdict is not None
-        assert "Limited" in verdict
-        # An env IS bound (just not Limited) — the message must say so, distinct
-        # from the no-environment-configured branch below.
-        assert "networking is not" in verdict
+        assert env_var_credential_containment_error(env, [("api.github.com",)]) is None
 
-    def test_no_env_config_with_creds_rejected(self) -> None:
-        verdict = env_var_credential_containment_error(None, [("api.github.com",)])
-        assert verdict is not None
-        # No environment bound at all — the message must NOT point the operator
-        # at a networking setting that doesn't exist.
-        assert "no environment configured" in verdict
+    def test_no_env_config_with_creds_permitted(self) -> None:
+        # No environment bound at all resolves to Unrestricted() at runtime, so
+        # the same permit-with-warning posture applies (#1153).
+        assert env_var_credential_containment_error(None, [("api.github.com",)]) is None
 
-    def test_no_networking_config_with_creds_rejected(self) -> None:
-        # EnvironmentConfig() leaves networking unset (None) — not Limited.
-        verdict = env_var_credential_containment_error(EnvironmentConfig(), [("api.github.com",)])
-        assert verdict is not None
-        # An env IS bound; networking is just unset — the "not 'limited'" branch.
-        assert "networking is not" in verdict
+    def test_no_networking_config_with_creds_permitted(self) -> None:
+        # EnvironmentConfig() leaves networking unset (None) → Unrestricted() at
+        # runtime → permitted (#1153).
+        assert (
+            env_var_credential_containment_error(EnvironmentConfig(), [("api.github.com",)]) is None
+        )
 
     def test_covered_host_passes(self) -> None:
         env = limited_env("api.github.com")
@@ -1318,13 +1316,13 @@ class TestEnvVarCredentialContainment:
         assert verdict is not None
         assert "'pypi.org'" in verdict
 
-    def test_cred_with_empty_allowed_hosts_still_requireslimited_env(self) -> None:
-        # An empty allowed_hosts tuple still counts as "has a credential":
-        # the OUTER list is non-empty, so the Limited check still fires.
+    def test_cred_with_empty_allowed_hosts_permitted_under_unrestricted(self) -> None:
+        # An empty allowed_hosts tuple still counts as "has a credential" (the
+        # OUTER list is non-empty), but under Unrestricted the credential is now
+        # permitted (#1153) — the host-subset check is the only remaining gate
+        # and it applies only under Limited.
         env = EnvironmentConfig(networking=UnrestrictedNetworking())
-        verdict = env_var_credential_containment_error(env, [()])
-        assert verdict is not None
-        assert "Limited" in verdict
+        assert env_var_credential_containment_error(env, [()]) is None
 
     def test_ip_literal_env_host_is_skipped_not_crash(self) -> None:
         # LimitedNetworking.allowed_hosts accepts IP literals (HOSTNAME_RE), but
@@ -1349,9 +1347,9 @@ class TestEnvVarCredentialContainment:
         # returns None: the inner host loop never executes, so ∅ ⊆ env is
         # vacuously true. Such a credential is inert — there is no host for the
         # egress swap proxy to DNAT — and is prevented at create by
-        # VaultCredentialCreate._validate_shape. Note Check 1 (requires Limited)
-        # STILL fires for empty-hosts creds under Unrestricted, which
-        # test_cred_with_empty_allowed_hosts_still_requireslimited_env covers.
+        # VaultCredentialCreate._validate_shape. Under Unrestricted such a
+        # credential is now permitted (#1153), covered by
+        # test_cred_with_empty_allowed_hosts_permitted_under_unrestricted.
         assert env_var_credential_containment_error(limited_env("api.github.com"), [()]) is None
 
 
@@ -1373,7 +1371,10 @@ class TestEnvVarCredentialAttachGate:
     (credential list + env config), mirroring the call-site test style above."""
 
     @pytest.mark.asyncio
-    async def test_attach_unrestricted_env_with_creds_raises_422(self) -> None:
+    async def test_attach_unrestricted_env_with_creds_no_longer_raises(self) -> None:
+        # Permit-with-warning (#1153): the attach advisory shares the relaxed
+        # containment verdict, so env-var creds under an Unrestricted env no
+        # longer 422 at attach — they provision (with an operator warning).
         conn = MagicMock()
         env = EnvironmentConfig(networking=UnrestrictedNetworking())
         with (
@@ -1387,12 +1388,11 @@ class TestEnvVarCredentialAttachGate:
                 "get_environment_config_for_session",
                 AsyncMock(return_value=env),
             ),
-            pytest.raises(ValidationError, match="Limited") as exc,
         ):
+            # Must not raise.
             await sessions_service._assert_env_var_creds_contained(
                 conn, "sess_01TEST", account_id="acct_x"
             )
-        assert exc.value.status_code == 422
 
     @pytest.mark.asyncio
     async def test_attach_uncovered_host_raises_422_names_host(self) -> None:


### PR DESCRIPTION
## What & why

Resolves #1153. Decouples the env-var-credential **secret swap** from **Limited** networking.

Previously a session/run carrying `environment_variable` credentials *required* a Limited environment — `build_spec_from_session`/`build_spec_from_run` hard-rejected it otherwise, and the attach advisory 422'd. The rationale was that the swap proxy only saw traffic via the Limited lockdown DNAT. But that conflated two separable mechanisms:

- the credential-host → proxy **DNAT** (the swap chokepoint that makes the placeholder→real-secret swap fire), and
- the filter-OUTPUT **DROP** (general-egress exfil containment).

This PR installs the **DNAT alone** under Unrestricted (or no networking config) whenever a provision carries env-var credentials, leaving general egress open — so the swap fires in *every* networking mode. The loss of allowlist-based exfil containment becomes an informed operator choice, surfaced as a structured operator-facing warning at provision (`sandbox.envvar_creds_open_egress`), instead of a hard rejection. This matches the CMA permit-with-warning posture the #871 epic ports.

## Changes

- **`setup.py`** — extract the shared nat-OUTPUT DNAT block into `_nat_dnat_lines` (rule shape stays byte-identical across both paths); add `build_secret_egress_dnat_script` (DNAT-only: no `-P OUTPUT DROP`, no filter ACCEPTs, flushes only nat OUTPUT) and `apply_secret_egress_dnat` (same fail-closed sidecar apply+verify posture as `apply_network_lockdown`, with plumbing-specific `sandbox.secret_egress_dnat_*` log events so a proxy outage never mis-alerts as a networking-policy violation). `build_lockdown_verify_script` gains `assert_drop=False` for the no-DROP path while still asserting nat DNAT coverage (#984 fail-closed on a zero-IP credential host).
- **`registry.py`** — rename `_maybe_apply_lockdown` → `_apply_egress_rules`, branching: Limited → lockdown (+DNAT when creds); Unrestricted-with-creds → DNAT-only; Unrestricted-without-creds → nothing (preserved early return). Factor credential-host extraction into the shared `_secret_dnat` helper.
- **`vaults.py`** — `env_var_credential_containment_error` returns `None` under non-Limited (permit-with-warning); the host-subset egress-escalation guard still applies under Limited. The attach advisory inherits the relaxed verdict.
- **`spec.py`** — log the operator-facing open-egress warning (`_warn_if_creds_under_open_egress`) from both build sites; retire the stale `INERT until #878` / `requires a Limited environment` comments.
- **`sessions.py`** — docstring update on the attach advisory.

## Tests (test-first)

- `test_networking.py`: `build_secret_egress_dnat_script` shape (DNAT present, no DROP/ACCEPTs, flushes nat-only, backend-selected, rule shape identical to lockdown); verify-script `assert_drop=False`; full `apply_secret_egress_dnat` lifecycle incl. fail-closed on nonzero apply / failed verify / sidecar error, and runtime threading.
- `test_sandbox_registry.py`: new `TestUnrestrictedSecretEgressDnat` — DNAT-only helper called (not lockdown) when creds run under Unrestricted, runtime threaded, and neither helper fires without creds.
- `test_vault.py`, `test_spec_env_var_credentials.py`, `test_spec_run_env_var_credentials.py`: old hard-rejection expectations flipped to permit-with-warning (placeholder still lands; `sandbox.envvar_creds_open_egress` logged; Limited still enforces the host-subset guard).

The Limited-path lockdown golden assertions are unchanged (the refactor is byte-identical). Full affected unit suite, ruff, ruff format, and mypy all green.