### PR TITLE
fix(dev-pipeline): dead-letter terminal drops autodev:in-progress (item-3 zombie)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -503,9 +503,9 @@ async def main(input):
         retry_count = 0
     if retry_count >= MAX_RUN_RETRIES:
         log("retry budget exhausted (retry_count=%d) -> dead-letter" % retry_count)
-        await _label(repo, issue_number, LABEL_FAILED)
-        return {"state": "dead_letter", "retry_count": retry_count,
-                "reason": "exceeded MAX_RUN_RETRIES (%d) auto-recovery attempts" % MAX_RUN_RETRIES}
+        return await _fail(repo, issue_number,
+                           {"state": "dead_letter", "retry_count": retry_count,
+                            "reason": "exceeded MAX_RUN_RETRIES (%d) auto-recovery attempts" % MAX_RUN_RETRIES})
     escalations = []
 
     # S1 — ingest the issue: body AND the comment thread (item 1). A design pass / resolved-

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -669,6 +669,11 @@ async def test_retry_count_at_budget_dead_letters() -> None:
     assert phases == []  # dead-lettered before even the ingest phase
     assert scn.tasks == []  # no spend
     assert "autodev:failed" in scn.labels_added
+    # item 3 (never a silent zombie): a prior attempt left autodev:in-progress; the
+    # dead-letter terminal must DROP it (replace with autodev:failed), exactly like _fail
+    # does on every other terminal failure — otherwise the issue is stuck both in-progress
+    # AND failed, perpetually claimed and never re-dispatchable.
+    assert "autodev:in-progress" in scn.labels_removed
 
 
 # ─── trigger envelope ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The dev-pipeline workflow's retry-budget **dead-letter** terminal (`main()`, the `retry_count >= MAX_RUN_RETRIES` early-return) added `autodev:failed` with a bare `_label()` but **never removed `autodev:in-progress`** — reimplementing only half of the `_fail()` helper.

A prior attempt claims the issue with `autodev:in-progress` (the ingest comment documents the contract: *"so an in-flight run is never a silent zombie (item 3); it is removed on success / replaced by autodev:failed"*). When the 3rd launch (`retry_count=2`) dead-letters, it added `failed` but left `in-progress` stuck — so the issue carries **both** labels: perpetually claimed (un-redispatchable) yet failed. Exactly the silent zombie item 3 exists to prevent.

## Fix

Route the dead-letter terminal through `_fail()`, the same chokepoint every **other** terminal failure already uses (spec-gate, ingest-read, review/CI exhaustion, merge-guard). `_fail` drops `in-progress`, raises `failed`, and returns its `result` arg unchanged — so the `{state: dead_letter, retry_count, reason}` envelope is byte-identical. `_unlabel` is 404-tolerant, so removing an absent label is harmless.

After this change, the dead-letter path was the **last** terminal-failure path bypassing `_fail`; all 7 failure returns now go through it (escalations/holds correctly park without failing; the success path removes `in-progress` at completion).

## Why it hid

`test_retry_count_at_budget_dead_letters` asserted `autodev:failed in labels_added` but never checked that `in-progress` was removed. This PR adds `assert "autodev:in-progress" in scn.labels_removed` — **RED** on the old code (`labels_removed == []`), **GREEN** after routing through `_fail`.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 2824 passed
- [x] `test_wf_dev_pipeline_fixture.py` — 36 passed (incl. the extended dead-letter test); new assertion confirmed RED→GREEN
- [ ] CI runs full integration/e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)