### PR TITLE
feat(trace): one-call linear trace of a run/session tree (#1149)

### DIFF
--- a/migrations/versions/0103_trace_caller_reverse_index.py
+++ b/migrations/versions/0103_trace_caller_reverse_index.py
@@ -1,0 +1,67 @@
+"""Add the reverse "children-of by caller" indexes — the trace walk's down-link
+(#1149), shared with #1152's cancel-cascade.
+
+The request edge is indexed for the *up* direction (``events_request_opened_idx``
+/ mig 0099 keys ``(session_id, (data->>'request_id'))``; a trace instead walks
+*down* — "every edge whose ``caller.id`` is this node." That reverse direction is
+unindexed today (the ``wf_runs.caller`` JSONB column from mig 0101 is likewise
+unindexed). #1149 builds it once and #1152 (cancel-cascade) reuses the same
+children-of direction.
+
+**Implementation fork (decided at PR time, per the lock-direction-defer-DDL
+convention).** Two candidates were on the table: a JSONB **expression** index vs.
+a promoted/generated ``caller_id`` column indexed plainly. This migration picks
+the **expression index** — it is purely additive (no table rewrite, no
+``ALTER TABLE … ADD COLUMN``), it mirrors the existing
+``events_request_opened_idx`` expression-index pattern verbatim, and it keys the
+*exact* predicate the trace query filters on
+(``data->'caller'->>'kind'`` + ``data->'caller'->>'id'`` for events;
+``caller->>'kind'`` + ``caller->>'id'`` for runs), so the
+``EXPLAIN``-asserting integration test can pin index use to the query predicate.
+The promoted-column variant (attractive for #1131's ``run_children_usage``
+rewrite) is left as a follow-up that can swap the index out without changing the
+query shape.
+
+Both built via ``op.get_context().autocommit_block()`` so neither takes an ACCESS
+EXCLUSIVE lock on the live-written ``events`` / ``wf_runs`` tables (same pattern
+as 0069 / 0097 / 0099). Safe in the new-code/old-schema window: the trace read
+works against the old schema (the index only speeds it up), and the index is
+invisible to a running container until it completes.
+
+Revision ID: 0103
+Revises: 0102
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0103"
+down_revision: str = "0102"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # run/session → child session: the reverse lookup on a ``request_opened``
+        # edge keyed on (caller.kind, caller.id). NOT id-alone — ``api`` edges
+        # store ``caller.id = account_id``, so kind is part of the key.
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_request_opened_caller_idx "
+            "ON events (account_id, (data->'caller'->>'kind'), (data->'caller'->>'id')) "
+            "WHERE kind = 'lifecycle' AND data->>'event' = 'request_opened'"
+        )
+        # run → sub-run: the reverse lookup on ``wf_runs.caller`` (#1129).
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS wf_runs_caller_idx "
+            "ON wf_runs (account_id, (caller->>'kind'), (caller->>'id'))"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_request_opened_caller_idx")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS wf_runs_caller_idx")

--- a/openapi.json
+++ b/openapi.json
@@ -3320,6 +3320,75 @@
         }
       }
     },
+    "/v1/sessions/{session_id}/trace": {
+      "get": {
+        "tags": [
+          "sessions"
+        ],
+        "summary": "Get Session Trace",
+        "description": "One-call linear trace rooted at a session + all nested sub-runs/sessions (#1149).\n\nThe session-root counterpart of ``GET /v1/runs/{id}/trace``: walks the\nparent\u2192child invocation-edge tree from this session (its ``agent()`` peer\nsessions and any runs it launched via the still-live ``launcher_session_id``\nFK), normalizes each node to ``terminal_state`` + raw ``error_kind``, and\ninterleaves journals into a flat DFS-pre-order list. See the run-trace\nendpoint for the verbosity / ordering / scope caveats. A cross-tenant session\n404s.",
+        "operationId": "get_session_trace",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "verbose",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Verbose"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/sessions/{session_id}/events/{event_id}": {
       "get": {
         "tags": [
@@ -9352,6 +9421,75 @@
         }
       }
     },
+    "/v1/runs/{run_id}/trace": {
+      "get": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Get Run Trace",
+        "description": "One-call linear trace of a run + all nested sessions and sub-runs (#1149).\n\nA read-projection over the invocation-edge tree: walks the parent\u2192child edge\ntree from this run, normalizes each node's outcome to\n``terminal_state \u2208 {ok,errored,cancelled,suspended,running}`` (+ raw\n``error_kind``), and interleaves the nodes' journals into a flat\n**DFS-pre-order** list (a CLI renders ``depth`` as indentation). A\ndeliberately-failed nested session's death cause is visible at a glance \u2014 the\nnode carries ``terminal_state`` + ``error_kind`` (e.g. ``no_return``) and the\nabbreviated default co-locates the proximate ``is_error`` frame.\n\n``verbose=false`` (default) keeps only the load-bearing frames per node\n(request/response/turn lifecycle, gates, errors); ``verbose=true`` lifts the\nfilter to the full per-node firehose. The walk runs in one ``REPEATABLE\nREAD`` snapshot with a node-count ceiling; a tree past the ceiling returns a\ntyped ``truncated: {at_nodes}`` marker.\n\nOrdering caveat: cross-subtree time-ordering is best-effort to transaction\ngranularity; only the causal parent\u2192child edge is exact. ``wake_session``\npeer-pokes are out of scope (a peer stimulus, not a spawn). A cross-tenant\nrun 404s.",
+        "operationId": "get_run_trace",
+        "parameters": [
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "verbose",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Verbose"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/runs/{run_id}/resume": {
       "post": {
         "tags": [
@@ -15219,6 +15357,154 @@
         ],
         "title": "ToolsSchemaUpdate",
         "description": "Body for ``PUT /v1/connectors/{connector}/tools_schema``."
+      },
+      "TraceEntry": {
+        "properties": {
+          "timestamp": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timestamp"
+          },
+          "depth": {
+            "type": "integer",
+            "title": "Depth"
+          },
+          "parent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Id"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "run",
+              "session",
+              "request",
+              "response",
+              "tool_call",
+              "gate",
+              "annotation",
+              "error",
+              "message",
+              "agent_call"
+            ],
+            "title": "Kind"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "default": ""
+          },
+          "terminal_state": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "ok",
+                  "errored",
+                  "cancelled",
+                  "suspended",
+                  "running"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Terminal State"
+          },
+          "error_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Kind"
+          }
+        },
+        "type": "object",
+        "required": [
+          "depth",
+          "kind",
+          "id"
+        ],
+        "title": "TraceEntry",
+        "description": "One line of a flattened trace.\n\n``depth`` is the node's DFS depth (0 = root); a CLI renders it as\nindentation. ``parent_id`` is the enclosing node's id (``None`` for the\nroot). For **node** entries ``terminal_state`` / ``error_kind`` carry the\nnormalized outcome; for **frame** entries they are ``None`` and ``summary``\ncarries the per-kind digest. ``timestamp`` is the entry's ``created_at``\n(``transaction_timestamp()`` for journal frames) \u2014 exposed as a column for\nchronology, NOT the canonical order (see the module docstring)."
+      },
+      "TraceResponse": {
+        "properties": {
+          "root_kind": {
+            "type": "string",
+            "enum": [
+              "run",
+              "session"
+            ],
+            "title": "Root Kind"
+          },
+          "root_id": {
+            "type": "string",
+            "title": "Root Id"
+          },
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/TraceEntry"
+            },
+            "type": "array",
+            "title": "Entries"
+          },
+          "truncated": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TraceTruncated"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "root_kind",
+          "root_id"
+        ],
+        "title": "TraceResponse",
+        "description": "A one-call flat trace for a run-root or session-root.\n\n``root_kind`` / ``root_id`` name the tree's root. ``entries`` is the flat\nDFS-pre-order list (nodes interleaved with their journal frames).\n``truncated`` is non-``None`` iff the node-count ceiling cut the walk.\n\nOrdering caveat (documented per #1149): cross-subtree time-ordering is\nbest-effort to **transaction granularity** \u2014 ``created_at`` is\n``transaction_timestamp()`` (constant for a whole run-step's journal; it can\ntie or invert across concurrent transactions on separate pooled\nconnections), and the two journals share no global sequence. Only the causal\nparent\u2192child edge is exact, so DFS pre-order is canonical; chronological is a\nclient-side re-sort.\n\nScope caveat: ``wake_session`` peer-pokes are out of scope (a peer stimulus,\nnot a spawn \u2014 no ``request_opened`` edge); they do not appear as nodes."
+      },
+      "TraceTruncated": {
+        "properties": {
+          "at_nodes": {
+            "type": "integer",
+            "title": "At Nodes",
+            "description": "Number of nodes emitted before the ceiling cut the walk."
+          }
+        },
+        "type": "object",
+        "required": [
+          "at_nodes"
+        ],
+        "title": "TraceTruncated",
+        "description": "The typed marker that the walk hit its node-count ceiling.\n\n``#1124``'s depth counter bounds path length (\u226410 by construction), but it\ndoes NOT bound the node count: ``workflow_max_agent_calls`` defaults to 1000\nlifetime ``agent()`` children per run. So the walk carries an explicit\nconfig-tunable node-count ceiling; when it trips, ``at_nodes`` records how\nmany nodes were emitted before the frontier was cut. The response stays\nwell-formed (a partial-but-honest tree), never a silent truncation."
       },
       "TriggerCreate": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/runs/get_run_trace.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/runs/get_run_trace.py
@@ -1,0 +1,287 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.trace_response import TraceResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    run_id: str,
+    *,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["verbose"] = verbose
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/runs/{run_id}/trace".format(
+            run_id=quote(str(run_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | TraceResponse | None:
+    if response.status_code == 200:
+        response_200 = TraceResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | TraceResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TraceResponse]:
+    """Get Run Trace
+
+     One-call linear trace of a run + all nested sessions and sub-runs (#1149).
+
+    A read-projection over the invocation-edge tree: walks the parent→child edge
+    tree from this run, normalizes each node's outcome to
+    ``terminal_state ∈ {ok,errored,cancelled,suspended,running}`` (+ raw
+    ``error_kind``), and interleaves the nodes' journals into a flat
+    **DFS-pre-order** list (a CLI renders ``depth`` as indentation). A
+    deliberately-failed nested session's death cause is visible at a glance — the
+    node carries ``terminal_state`` + ``error_kind`` (e.g. ``no_return``) and the
+    abbreviated default co-locates the proximate ``is_error`` frame.
+
+    ``verbose=false`` (default) keeps only the load-bearing frames per node
+    (request/response/turn lifecycle, gates, errors); ``verbose=true`` lifts the
+    filter to the full per-node firehose. The walk runs in one ``REPEATABLE
+    READ`` snapshot with a node-count ceiling; a tree past the ceiling returns a
+    typed ``truncated: {at_nodes}`` marker.
+
+    Ordering caveat: cross-subtree time-ordering is best-effort to transaction
+    granularity; only the causal parent→child edge is exact. ``wake_session``
+    peer-pokes are out of scope (a peer stimulus, not a spawn). A cross-tenant
+    run 404s.
+
+    Args:
+        run_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TraceResponse]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        verbose=verbose,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TraceResponse | None:
+    """Get Run Trace
+
+     One-call linear trace of a run + all nested sessions and sub-runs (#1149).
+
+    A read-projection over the invocation-edge tree: walks the parent→child edge
+    tree from this run, normalizes each node's outcome to
+    ``terminal_state ∈ {ok,errored,cancelled,suspended,running}`` (+ raw
+    ``error_kind``), and interleaves the nodes' journals into a flat
+    **DFS-pre-order** list (a CLI renders ``depth`` as indentation). A
+    deliberately-failed nested session's death cause is visible at a glance — the
+    node carries ``terminal_state`` + ``error_kind`` (e.g. ``no_return``) and the
+    abbreviated default co-locates the proximate ``is_error`` frame.
+
+    ``verbose=false`` (default) keeps only the load-bearing frames per node
+    (request/response/turn lifecycle, gates, errors); ``verbose=true`` lifts the
+    filter to the full per-node firehose. The walk runs in one ``REPEATABLE
+    READ`` snapshot with a node-count ceiling; a tree past the ceiling returns a
+    typed ``truncated: {at_nodes}`` marker.
+
+    Ordering caveat: cross-subtree time-ordering is best-effort to transaction
+    granularity; only the causal parent→child edge is exact. ``wake_session``
+    peer-pokes are out of scope (a peer stimulus, not a spawn). A cross-tenant
+    run 404s.
+
+    Args:
+        run_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TraceResponse
+    """
+
+    return sync_detailed(
+        run_id=run_id,
+        client=client,
+        verbose=verbose,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TraceResponse]:
+    """Get Run Trace
+
+     One-call linear trace of a run + all nested sessions and sub-runs (#1149).
+
+    A read-projection over the invocation-edge tree: walks the parent→child edge
+    tree from this run, normalizes each node's outcome to
+    ``terminal_state ∈ {ok,errored,cancelled,suspended,running}`` (+ raw
+    ``error_kind``), and interleaves the nodes' journals into a flat
+    **DFS-pre-order** list (a CLI renders ``depth`` as indentation). A
+    deliberately-failed nested session's death cause is visible at a glance — the
+    node carries ``terminal_state`` + ``error_kind`` (e.g. ``no_return``) and the
+    abbreviated default co-locates the proximate ``is_error`` frame.
+
+    ``verbose=false`` (default) keeps only the load-bearing frames per node
+    (request/response/turn lifecycle, gates, errors); ``verbose=true`` lifts the
+    filter to the full per-node firehose. The walk runs in one ``REPEATABLE
+    READ`` snapshot with a node-count ceiling; a tree past the ceiling returns a
+    typed ``truncated: {at_nodes}`` marker.
+
+    Ordering caveat: cross-subtree time-ordering is best-effort to transaction
+    granularity; only the causal parent→child edge is exact. ``wake_session``
+    peer-pokes are out of scope (a peer stimulus, not a spawn). A cross-tenant
+    run 404s.
+
+    Args:
+        run_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TraceResponse]
+    """
+
+    kwargs = _get_kwargs(
+        run_id=run_id,
+        verbose=verbose,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    run_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TraceResponse | None:
+    """Get Run Trace
+
+     One-call linear trace of a run + all nested sessions and sub-runs (#1149).
+
+    A read-projection over the invocation-edge tree: walks the parent→child edge
+    tree from this run, normalizes each node's outcome to
+    ``terminal_state ∈ {ok,errored,cancelled,suspended,running}`` (+ raw
+    ``error_kind``), and interleaves the nodes' journals into a flat
+    **DFS-pre-order** list (a CLI renders ``depth`` as indentation). A
+    deliberately-failed nested session's death cause is visible at a glance — the
+    node carries ``terminal_state`` + ``error_kind`` (e.g. ``no_return``) and the
+    abbreviated default co-locates the proximate ``is_error`` frame.
+
+    ``verbose=false`` (default) keeps only the load-bearing frames per node
+    (request/response/turn lifecycle, gates, errors); ``verbose=true`` lifts the
+    filter to the full per-node firehose. The walk runs in one ``REPEATABLE
+    READ`` snapshot with a node-count ceiling; a tree past the ceiling returns a
+    typed ``truncated: {at_nodes}`` marker.
+
+    Ordering caveat: cross-subtree time-ordering is best-effort to transaction
+    granularity; only the causal parent→child edge is exact. ``wake_session``
+    peer-pokes are out of scope (a peer stimulus, not a spawn). A cross-tenant
+    run 404s.
+
+    Args:
+        run_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TraceResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            run_id=run_id,
+            client=client,
+            verbose=verbose,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/get_session_trace.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/get_session_trace.py
@@ -1,0 +1,239 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.trace_response import TraceResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    session_id: str,
+    *,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    params: dict[str, Any] = {}
+
+    params["verbose"] = verbose
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/v1/sessions/{session_id}/trace".format(
+            session_id=quote(str(session_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | TraceResponse | None:
+    if response.status_code == 200:
+        response_200 = TraceResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | TraceResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TraceResponse]:
+    """Get Session Trace
+
+     One-call linear trace rooted at a session + all nested sub-runs/sessions (#1149).
+
+    The session-root counterpart of ``GET /v1/runs/{id}/trace``: walks the
+    parent→child invocation-edge tree from this session (its ``agent()`` peer
+    sessions and any runs it launched via the still-live ``launcher_session_id``
+    FK), normalizes each node to ``terminal_state`` + raw ``error_kind``, and
+    interleaves journals into a flat DFS-pre-order list. See the run-trace
+    endpoint for the verbosity / ordering / scope caveats. A cross-tenant session
+    404s.
+
+    Args:
+        session_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TraceResponse]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        verbose=verbose,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TraceResponse | None:
+    """Get Session Trace
+
+     One-call linear trace rooted at a session + all nested sub-runs/sessions (#1149).
+
+    The session-root counterpart of ``GET /v1/runs/{id}/trace``: walks the
+    parent→child invocation-edge tree from this session (its ``agent()`` peer
+    sessions and any runs it launched via the still-live ``launcher_session_id``
+    FK), normalizes each node to ``terminal_state`` + raw ``error_kind``, and
+    interleaves journals into a flat DFS-pre-order list. See the run-trace
+    endpoint for the verbosity / ordering / scope caveats. A cross-tenant session
+    404s.
+
+    Args:
+        session_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TraceResponse
+    """
+
+    return sync_detailed(
+        session_id=session_id,
+        client=client,
+        verbose=verbose,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> Response[HTTPValidationError | TraceResponse]:
+    """Get Session Trace
+
+     One-call linear trace rooted at a session + all nested sub-runs/sessions (#1149).
+
+    The session-root counterpart of ``GET /v1/runs/{id}/trace``: walks the
+    parent→child invocation-edge tree from this session (its ``agent()`` peer
+    sessions and any runs it launched via the still-live ``launcher_session_id``
+    FK), normalizes each node to ``terminal_state`` + raw ``error_kind``, and
+    interleaves journals into a flat DFS-pre-order list. See the run-trace
+    endpoint for the verbosity / ordering / scope caveats. A cross-tenant session
+    404s.
+
+    Args:
+        session_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | TraceResponse]
+    """
+
+    kwargs = _get_kwargs(
+        session_id=session_id,
+        verbose=verbose,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    session_id: str,
+    *,
+    client: AuthenticatedClient | Client,
+    verbose: bool | Unset = False,
+    authorization: None | str | Unset = UNSET,
+) -> HTTPValidationError | TraceResponse | None:
+    """Get Session Trace
+
+     One-call linear trace rooted at a session + all nested sub-runs/sessions (#1149).
+
+    The session-root counterpart of ``GET /v1/runs/{id}/trace``: walks the
+    parent→child invocation-edge tree from this session (its ``agent()`` peer
+    sessions and any runs it launched via the still-live ``launcher_session_id``
+    FK), normalizes each node to ``terminal_state`` + raw ``error_kind``, and
+    interleaves journals into a flat DFS-pre-order list. See the run-trace
+    endpoint for the verbosity / ordering / scope caveats. A cross-tenant session
+    404s.
+
+    Args:
+        session_id (str):
+        verbose (bool | Unset):  Default: False.
+        authorization (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | TraceResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            session_id=session_id,
+            client=client,
+            verbose=verbose,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -211,6 +211,12 @@ from .tool_spec_type_type_0 import ToolSpecTypeType0
 from .tool_spec_type_type_1 import ToolSpecTypeType1
 from .tools_schema_update import ToolsSchemaUpdate
 from .tools_schema_update_tools_item import ToolsSchemaUpdateToolsItem
+from .trace_entry import TraceEntry
+from .trace_entry_kind import TraceEntryKind
+from .trace_entry_terminal_state_type_0 import TraceEntryTerminalStateType0
+from .trace_response import TraceResponse
+from .trace_response_root_kind import TraceResponseRootKind
+from .trace_truncated import TraceTruncated
 from .trigger_create import TriggerCreate
 from .trigger_create_metadata import TriggerCreateMetadata
 from .trigger_echo import TriggerEcho
@@ -475,6 +481,12 @@ __all__ = (
     "ToolSpecTypeType1",
     "ToolsSchemaUpdate",
     "ToolsSchemaUpdateToolsItem",
+    "TraceEntry",
+    "TraceEntryKind",
+    "TraceEntryTerminalStateType0",
+    "TraceResponse",
+    "TraceResponseRootKind",
+    "TraceTruncated",
     "TriggerCreate",
     "TriggerCreateMetadata",
     "TriggerEcho",

--- a/packages/aios-sdk/aios_sdk/_generated/models/trace_entry.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trace_entry.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..models.trace_entry_kind import TraceEntryKind
+from ..models.trace_entry_terminal_state_type_0 import TraceEntryTerminalStateType0
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TraceEntry")
+
+
+@_attrs_define
+class TraceEntry:
+    """One line of a flattened trace.
+
+    ``depth`` is the node's DFS depth (0 = root); a CLI renders it as
+    indentation. ``parent_id`` is the enclosing node's id (``None`` for the
+    root). For **node** entries ``terminal_state`` / ``error_kind`` carry the
+    normalized outcome; for **frame** entries they are ``None`` and ``summary``
+    carries the per-kind digest. ``timestamp`` is the entry's ``created_at``
+    (``transaction_timestamp()`` for journal frames) — exposed as a column for
+    chronology, NOT the canonical order (see the module docstring).
+
+        Attributes:
+            depth (int):
+            kind (TraceEntryKind):
+            id (str):
+            timestamp (datetime.datetime | None | Unset):
+            parent_id (None | str | Unset):
+            summary (str | Unset):  Default: ''.
+            terminal_state (None | TraceEntryTerminalStateType0 | Unset):
+            error_kind (None | str | Unset):
+    """
+
+    depth: int
+    kind: TraceEntryKind
+    id: str
+    timestamp: datetime.datetime | None | Unset = UNSET
+    parent_id: None | str | Unset = UNSET
+    summary: str | Unset = ""
+    terminal_state: None | TraceEntryTerminalStateType0 | Unset = UNSET
+    error_kind: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        depth = self.depth
+
+        kind = self.kind.value
+
+        id = self.id
+
+        timestamp: None | str | Unset
+        if isinstance(self.timestamp, Unset):
+            timestamp = UNSET
+        elif isinstance(self.timestamp, datetime.datetime):
+            timestamp = self.timestamp.isoformat()
+        else:
+            timestamp = self.timestamp
+
+        parent_id: None | str | Unset
+        if isinstance(self.parent_id, Unset):
+            parent_id = UNSET
+        else:
+            parent_id = self.parent_id
+
+        summary = self.summary
+
+        terminal_state: None | str | Unset
+        if isinstance(self.terminal_state, Unset):
+            terminal_state = UNSET
+        elif isinstance(self.terminal_state, TraceEntryTerminalStateType0):
+            terminal_state = self.terminal_state.value
+        else:
+            terminal_state = self.terminal_state
+
+        error_kind: None | str | Unset
+        if isinstance(self.error_kind, Unset):
+            error_kind = UNSET
+        else:
+            error_kind = self.error_kind
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "depth": depth,
+                "kind": kind,
+                "id": id,
+            }
+        )
+        if timestamp is not UNSET:
+            field_dict["timestamp"] = timestamp
+        if parent_id is not UNSET:
+            field_dict["parent_id"] = parent_id
+        if summary is not UNSET:
+            field_dict["summary"] = summary
+        if terminal_state is not UNSET:
+            field_dict["terminal_state"] = terminal_state
+        if error_kind is not UNSET:
+            field_dict["error_kind"] = error_kind
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        depth = d.pop("depth")
+
+        kind = TraceEntryKind(d.pop("kind"))
+
+        id = d.pop("id")
+
+        def _parse_timestamp(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                timestamp_type_0 = isoparse(data)
+
+                return timestamp_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        timestamp = _parse_timestamp(d.pop("timestamp", UNSET))
+
+        def _parse_parent_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        parent_id = _parse_parent_id(d.pop("parent_id", UNSET))
+
+        summary = d.pop("summary", UNSET)
+
+        def _parse_terminal_state(
+            data: object,
+        ) -> None | TraceEntryTerminalStateType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                terminal_state_type_0 = TraceEntryTerminalStateType0(data)
+
+                return terminal_state_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | TraceEntryTerminalStateType0 | Unset, data)
+
+        terminal_state = _parse_terminal_state(d.pop("terminal_state", UNSET))
+
+        def _parse_error_kind(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        error_kind = _parse_error_kind(d.pop("error_kind", UNSET))
+
+        trace_entry = cls(
+            depth=depth,
+            kind=kind,
+            id=id,
+            timestamp=timestamp,
+            parent_id=parent_id,
+            summary=summary,
+            terminal_state=terminal_state,
+            error_kind=error_kind,
+        )
+
+        trace_entry.additional_properties = d
+        return trace_entry
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/trace_entry_kind.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trace_entry_kind.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class TraceEntryKind(str, Enum):
+    AGENT_CALL = "agent_call"
+    ANNOTATION = "annotation"
+    ERROR = "error"
+    GATE = "gate"
+    MESSAGE = "message"
+    REQUEST = "request"
+    RESPONSE = "response"
+    RUN = "run"
+    SESSION = "session"
+    TOOL_CALL = "tool_call"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/trace_entry_terminal_state_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trace_entry_terminal_state_type_0.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class TraceEntryTerminalStateType0(str, Enum):
+    CANCELLED = "cancelled"
+    ERRORED = "errored"
+    OK = "ok"
+    RUNNING = "running"
+    SUSPENDED = "suspended"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/trace_response.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trace_response.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.trace_response_root_kind import TraceResponseRootKind
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.trace_entry import TraceEntry
+    from ..models.trace_truncated import TraceTruncated
+
+
+T = TypeVar("T", bound="TraceResponse")
+
+
+@_attrs_define
+class TraceResponse:
+    """A one-call flat trace for a run-root or session-root.
+
+    ``root_kind`` / ``root_id`` name the tree's root. ``entries`` is the flat
+    DFS-pre-order list (nodes interleaved with their journal frames).
+    ``truncated`` is non-``None`` iff the node-count ceiling cut the walk.
+
+    Ordering caveat (documented per #1149): cross-subtree time-ordering is
+    best-effort to **transaction granularity** — ``created_at`` is
+    ``transaction_timestamp()`` (constant for a whole run-step's journal; it can
+    tie or invert across concurrent transactions on separate pooled
+    connections), and the two journals share no global sequence. Only the causal
+    parent→child edge is exact, so DFS pre-order is canonical; chronological is a
+    client-side re-sort.
+
+    Scope caveat: ``wake_session`` peer-pokes are out of scope (a peer stimulus,
+    not a spawn — no ``request_opened`` edge); they do not appear as nodes.
+
+        Attributes:
+            root_kind (TraceResponseRootKind):
+            root_id (str):
+            entries (list[TraceEntry] | Unset):
+            truncated (None | TraceTruncated | Unset):
+    """
+
+    root_kind: TraceResponseRootKind
+    root_id: str
+    entries: list[TraceEntry] | Unset = UNSET
+    truncated: None | TraceTruncated | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.trace_truncated import TraceTruncated
+
+        root_kind = self.root_kind.value
+
+        root_id = self.root_id
+
+        entries: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.entries, Unset):
+            entries = []
+            for entries_item_data in self.entries:
+                entries_item = entries_item_data.to_dict()
+                entries.append(entries_item)
+
+        truncated: dict[str, Any] | None | Unset
+        if isinstance(self.truncated, Unset):
+            truncated = UNSET
+        elif isinstance(self.truncated, TraceTruncated):
+            truncated = self.truncated.to_dict()
+        else:
+            truncated = self.truncated
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "root_kind": root_kind,
+                "root_id": root_id,
+            }
+        )
+        if entries is not UNSET:
+            field_dict["entries"] = entries
+        if truncated is not UNSET:
+            field_dict["truncated"] = truncated
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.trace_entry import TraceEntry
+        from ..models.trace_truncated import TraceTruncated
+
+        d = dict(src_dict)
+        root_kind = TraceResponseRootKind(d.pop("root_kind"))
+
+        root_id = d.pop("root_id")
+
+        _entries = d.pop("entries", UNSET)
+        entries: list[TraceEntry] | Unset = UNSET
+        if _entries is not UNSET:
+            entries = []
+            for entries_item_data in _entries:
+                entries_item = TraceEntry.from_dict(entries_item_data)
+
+                entries.append(entries_item)
+
+        def _parse_truncated(data: object) -> None | TraceTruncated | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                truncated_type_0 = TraceTruncated.from_dict(data)
+
+                return truncated_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | TraceTruncated | Unset, data)
+
+        truncated = _parse_truncated(d.pop("truncated", UNSET))
+
+        trace_response = cls(
+            root_kind=root_kind,
+            root_id=root_id,
+            entries=entries,
+            truncated=truncated,
+        )
+
+        trace_response.additional_properties = d
+        return trace_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/trace_response_root_kind.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trace_response_root_kind.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class TraceResponseRootKind(str, Enum):
+    RUN = "run"
+    SESSION = "session"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/trace_truncated.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trace_truncated.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="TraceTruncated")
+
+
+@_attrs_define
+class TraceTruncated:
+    """The typed marker that the walk hit its node-count ceiling.
+
+    ``#1124``'s depth counter bounds path length (≤10 by construction), but it
+    does NOT bound the node count: ``workflow_max_agent_calls`` defaults to 1000
+    lifetime ``agent()`` children per run. So the walk carries an explicit
+    config-tunable node-count ceiling; when it trips, ``at_nodes`` records how
+    many nodes were emitted before the frontier was cut. The response stays
+    well-formed (a partial-but-honest tree), never a silent truncation.
+
+        Attributes:
+            at_nodes (int): Number of nodes emitted before the ceiling cut the walk.
+    """
+
+    at_nodes: int
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        at_nodes = self.at_nodes
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "at_nodes": at_nodes,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        at_nodes = d.pop("at_nodes")
+
+        trace_truncated = cls(
+            at_nodes=at_nodes,
+        )
+
+        trace_truncated.additional_properties = d
+        return trace_truncated
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -69,6 +69,7 @@ from aios.models.sessions import (
     ToolResultRequest,
     WaitResponse,
 )
+from aios.models.trace import TraceResponse
 from aios.models.triggers import (
     TriggerCreate,
     TriggerEcho,
@@ -78,6 +79,7 @@ from aios.models.triggers import (
 from aios.services import files as files_service
 from aios.services import github_repositories as github_repo_service
 from aios.services import sessions as service
+from aios.services import trace as trace_service
 from aios.services import triggers as triggers_service
 from aios.services.wake import defer_wake
 
@@ -700,6 +702,30 @@ async def list_events(
         cursor=lambda x: x.seq,
         direction=direction,
         filters={"kind": kind, "error_only": error_only},
+    )
+
+
+@router.get("/{session_id}/trace", operation_id="get_session_trace")
+async def get_session_trace(
+    session_id: str,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    verbose: bool = False,
+) -> TraceResponse:
+    """One-call linear trace rooted at a session + all nested sub-runs/sessions (#1149).
+
+    The session-root counterpart of ``GET /v1/runs/{id}/trace``: walks the
+    parent→child invocation-edge tree from this session (its ``agent()`` peer
+    sessions and any runs it launched via the still-live ``launcher_session_id``
+    FK), normalizes each node to ``terminal_state`` + raw ``error_kind``, and
+    interleaves journals into a flat DFS-pre-order list. See the run-trace
+    endpoint for the verbosity / ordering / scope caveats. A cross-tenant session
+    404s.
+    """
+    # Scope check: 404 a cross-tenant session id before walking its tree.
+    await service.get_session_basic(pool, session_id, account_id=account_id)
+    return await trace_service.get_trace(
+        pool, root_kind="session", root_id=session_id, account_id=account_id, verbose=verbose
     )
 
 

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -27,6 +27,7 @@ from aios.models.pagination import (
     page_cursor,
     resolve_page_limit,
 )
+from aios.models.trace import TraceResponse
 from aios.models.workflows import (
     GateResume,
     WfRun,
@@ -37,6 +38,7 @@ from aios.models.workflows import (
     WorkflowCreate,
     WorkflowUpdate,
 )
+from aios.services import trace as trace_service
 from aios.services import workflows as service
 
 log = get_logger("aios.api.routers.workflows")
@@ -269,6 +271,42 @@ async def list_run_events(
     # to "backward", which is right only for the id-DESC list endpoints).
     return ListResponse[WfRunEvent].paginate(
         items, page_limit, cursor=lambda x: x.seq, direction="forward"
+    )
+
+
+@runs_router.get("/{run_id}/trace", operation_id="get_run_trace")
+async def get_run_trace(
+    run_id: str,
+    pool: PoolDep,
+    account_id: AccountIdDep,
+    verbose: bool = False,
+) -> TraceResponse:
+    """One-call linear trace of a run + all nested sessions and sub-runs (#1149).
+
+    A read-projection over the invocation-edge tree: walks the parent→child edge
+    tree from this run, normalizes each node's outcome to
+    ``terminal_state ∈ {ok,errored,cancelled,suspended,running}`` (+ raw
+    ``error_kind``), and interleaves the nodes' journals into a flat
+    **DFS-pre-order** list (a CLI renders ``depth`` as indentation). A
+    deliberately-failed nested session's death cause is visible at a glance — the
+    node carries ``terminal_state`` + ``error_kind`` (e.g. ``no_return``) and the
+    abbreviated default co-locates the proximate ``is_error`` frame.
+
+    ``verbose=false`` (default) keeps only the load-bearing frames per node
+    (request/response/turn lifecycle, gates, errors); ``verbose=true`` lifts the
+    filter to the full per-node firehose. The walk runs in one ``REPEATABLE
+    READ`` snapshot with a node-count ceiling; a tree past the ceiling returns a
+    typed ``truncated: {at_nodes}`` marker.
+
+    Ordering caveat: cross-subtree time-ordering is best-effort to transaction
+    granularity; only the causal parent→child edge is exact. ``wake_session``
+    peer-pokes are out of scope (a peer stimulus, not a spawn). A cross-tenant
+    run 404s.
+    """
+    # Scope check: 404 a cross-tenant run id before walking its tree.
+    await service.get_run(pool, run_id, account_id=account_id)
+    return await trace_service.get_trace(
+        pool, root_kind="run", root_id=run_id, account_id=account_id, verbose=verbose
     )
 
 

--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -107,6 +107,7 @@ from aios.cli.commands import signal as _signal  # noqa: E402
 from aios.cli.commands import skills as _skills  # noqa: E402
 from aios.cli.commands import status as _status  # noqa: E402
 from aios.cli.commands import tail as _tail  # noqa: E402
+from aios.cli.commands import trace as _trace  # noqa: E402
 from aios.cli.commands import vaults as _vaults  # noqa: E402
 from aios.cli.commands import whatsapp as _whatsapp  # noqa: E402
 from aios.cli.commands import workflows as _workflows  # noqa: E402
@@ -130,3 +131,4 @@ _ops.register(app)
 _status.register(app)
 _chat.register(app)
 _tail.register(app)
+_trace.register(app)

--- a/src/aios/cli/commands/trace.py
+++ b/src/aios/cli/commands/trace.py
@@ -1,0 +1,105 @@
+"""``aios trace <id>`` — one-call linear trace of a run/session tree (#1149).
+
+A thin client over ``GET /v1/runs/{id}/trace`` / ``GET /v1/sessions/{id}/trace``:
+it dispatches by the id prefix (``wfr_…`` → run, ``sess_…`` → session), renders
+``depth`` as indentation in table mode (the canonical DFS-pre-order makes a
+child's subtree contiguous under its parent), and supports ``--chronological``
+(re-sort the same entries by ``timestamp``, dropping indentation and showing
+depth as a number), ``--verbose``, and the global ``--format {table,json}``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated, Any
+
+import typer
+
+from aios.cli.commands._shared import with_client
+from aios.cli.coverage import covers
+from aios.cli.output import dim, print_json
+from aios.cli.runtime import run_or_die
+from aios.ids import SESSION, WORKFLOW_RUN, split_id
+
+_STATE_GLYPH = {
+    "ok": "✓",
+    "errored": "✗",
+    "cancelled": "⊘",
+    "suspended": "⏸",
+    "running": "…",
+}
+
+
+def register(app: typer.Typer) -> None:
+    @app.command(
+        "trace",
+        help="Linear trace of a run/session tree: nodes + interleaved journals (#1149).",
+    )
+    @covers("get_run_trace")
+    @covers("get_session_trace")
+    def trace(
+        ctx: typer.Context,
+        resource_id: Annotated[str, typer.Argument(help="A run (wfr_…) or session (sess_…) id.")],
+        chronological: Annotated[
+            bool,
+            typer.Option(
+                "--chronological",
+                help="Re-sort entries by timestamp (transaction-granular, approximate) "
+                "instead of the canonical causal DFS pre-order.",
+            ),
+        ] = False,
+        verbose: Annotated[
+            bool,
+            typer.Option("--verbose", help="Lift the abbreviation filter to the full journal."),
+        ] = False,
+    ) -> None:
+        def _run() -> None:
+            state, client = with_client(ctx)
+            path = _trace_path(resource_id)
+            with client:
+                resp = client.request("GET", path, params={"verbose": verbose})
+            if state.output_format == "json":
+                print_json(resp)
+                return
+            _render_tree(resp, chronological=chronological)
+
+        run_or_die(_run)
+
+
+def _trace_path(resource_id: str) -> str:
+    prefix, _ = split_id(resource_id)
+    if prefix == WORKFLOW_RUN:
+        return f"/v1/runs/{resource_id}/trace"
+    if prefix == SESSION:
+        return f"/v1/sessions/{resource_id}/trace"
+    raise typer.BadParameter(
+        f"{resource_id!r} is neither a run ({WORKFLOW_RUN}_…) nor a session ({SESSION}_…) id"
+    )
+
+
+def _render_tree(resp: dict[str, Any], *, chronological: bool) -> None:
+    entries: list[dict[str, Any]] = list(resp.get("entries", []))
+    if chronological:
+        # Re-sort by timestamp; show depth as a number rather than indentation.
+        entries.sort(key=lambda e: (e.get("timestamp") or "", e.get("depth", 0)))
+    sys.stdout.write(f"{resp.get('root_kind')} {resp.get('root_id')}\n")
+    for e in entries:
+        sys.stdout.write(_format_entry(e, chronological=chronological) + "\n")
+    truncated = resp.get("truncated")
+    if truncated:
+        sys.stdout.write(
+            dim(f"… truncated at {truncated.get('at_nodes')} nodes (node-count ceiling)\n")
+        )
+
+
+def _format_entry(e: dict[str, Any], *, chronological: bool) -> str:
+    depth = int(e.get("depth", 0))
+    state = e.get("terminal_state")
+    glyph = _STATE_GLYPH.get(state, " ") if state else " "
+    error_kind = e.get("error_kind")
+    suffix = f" [{error_kind}]" if error_kind else ""
+    label = f"{e.get('kind')}: {e.get('summary', '')}".rstrip()
+    if chronological:
+        return f"d{depth} {glyph} {label}{suffix}"
+    indent = "  " * depth
+    return f"{indent}{glyph} {label}{suffix}"

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -450,6 +450,19 @@ class Settings(BaseSettings):
         "— a child doing real model+tool work can legitimately run for minutes; "
         "this is the never-resolves backstop, not a tight SLA.",
     )
+    trace_max_nodes: int = Field(
+        default=2000,
+        ge=1,
+        description="Node-count ceiling for a single ``/trace`` walk (#1149). "
+        "#1124's depth counter bounds path length (≤10 by construction) but NOT "
+        "the node count — ``workflow_max_agent_calls`` defaults to 1000 lifetime "
+        "``agent()`` children per run, and fan-out caps are concurrency, not "
+        "totals. So the trace walk carries this explicit ceiling: once this many "
+        "nodes have been emitted, the frontier is cut and the response carries a "
+        "typed ``truncated: {at_nodes}`` marker rather than silently dropping "
+        "tail subtrees or running unbounded. Tunable upward for deliberately "
+        "deep-audit traces.",
+    )
     workflow_runs_per_launcher_max: int = Field(
         default=20,
         ge=1,

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -467,6 +467,14 @@ from .skills import (  # noqa: E402
     list_skills,
     resolve_skill_refs,
 )
+from .trace import (  # noqa: E402
+    ChildNode,
+    children_of,
+    read_run_journal_batched,
+    read_run_meta_batched,
+    read_session_journal_batched,
+    read_session_meta_batched,
+)
 from .triggers import (  # noqa: E402
     TriggerFireRef,
     TriggerRow,
@@ -534,6 +542,7 @@ __all__ = [
     "_SESSION_ERRORED_EXPR",
     "_SESSION_STATUS_EXPR",
     "ActiveBinding",
+    "ChildNode",
     "EnvVarCredentialEcho",
     "EnvVarCredentialRow",
     "TriggerFireRef",
@@ -579,6 +588,7 @@ __all__ = [
     "batch_list_session_memory_store_echoes",
     "batch_list_session_triggers",
     "bootstrap_root_account",
+    "children_of",
     "claim_trigger_run",
     "clone_session",
     "count_account_resources",
@@ -737,6 +747,10 @@ __all__ = [
     "read_events",
     "read_message_events",
     "read_request_response",
+    "read_run_journal_batched",
+    "read_run_meta_batched",
+    "read_session_journal_batched",
+    "read_session_meta_batched",
     "read_session_watermarks",
     "read_windowed_context_events",
     "read_windowed_events",

--- a/src/aios/db/queries/trace.py
+++ b/src/aios/db/queries/trace.py
@@ -1,0 +1,302 @@
+"""Read queries backing the trace walk (#1149).
+
+Two responsibilities, both pure reads:
+
+* **the reverse "children-of by caller" lookup** — for a node ``(kind, id)``,
+  the set of child nodes it invoked. It is the **union of the trusted edge and
+  the still-live structural FK columns** (``parent_run_id`` /
+  ``launcher_session_id``), because on master today (#1131 unmerged, dual-write
+  era) neither alone is complete. When #1131 retires the FK columns the FK half
+  simply drops out and the edge covers everything.
+* **batched journal reads** — once the node-id set is resolved, the per-node
+  event streams are read with ``= ANY($1)`` set-membership (no N+1).
+
+Every lookup re-applies ``account_id = $root_account`` as a SQL predicate (a
+tenant invariant) — never derive the next account from edge JSONB. Sessions key
+on ``events.account_id`` directly; runs key via a join to ``wf_runs``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import asyncpg
+
+from aios.db.queries import parse_jsonb
+
+NodeKind = Literal["run", "session"]
+
+
+@dataclass(frozen=True)
+class ChildNode:
+    """A child node discovered by the reverse walk.
+
+    ``spawn_at`` orders siblings under their parent (the child's spawn
+    ``created_at``); ``label`` is the parent-half ``call_started.label`` for an
+    ``agent()`` / ``invoke_workflow`` spawn (``None`` for FK-only / api / session
+    callers). ``request_id`` is the edge's request id when the child was invoked
+    *in service of a request* (``None`` for a root-style FK child).
+    """
+
+    kind: NodeKind
+    id: str
+    spawn_at: Any | None = None
+    label: str | None = None
+    request_id: str | None = None
+
+
+async def children_of(
+    conn: asyncpg.Connection[Any],
+    *,
+    caller_kind: str,
+    caller_id: str,
+    account_id: str,
+) -> list[ChildNode]:
+    """The child nodes ``(caller_kind, caller_id)`` invoked — edge union live FK.
+
+    Keyed on ``(caller.kind, caller.id)`` — **never ``id`` alone** — because
+    ``api`` edges store ``caller.id = account_id`` (so an id-only key would fan
+    a whole tenant's sessions under one api node). Dedups by ``(kind, id)`` so a
+    node visible via *both* the edge and its FK column is returned once (the edge
+    half is preferred — it carries the ``label`` + ``request_id``).
+    """
+    children: dict[tuple[str, str], ChildNode] = {}
+
+    # ── trusted-edge half (preferred) ────────────────────────────────────────
+    # run/session → child session: a ``request_opened`` whose caller matches.
+    sess_rows = await conn.fetch(
+        "SELECT e.session_id AS id, e.created_at AS spawn_at, "
+        "       e.data->>'request_id' AS request_id "
+        "FROM events e "
+        "WHERE e.account_id = $1 AND e.kind = 'lifecycle' "
+        "AND e.data->>'event' = 'request_opened' "
+        "AND e.data->'caller'->>'kind' = $2 AND e.data->'caller'->>'id' = $3",
+        account_id,
+        caller_kind,
+        caller_id,
+    )
+    for r in sess_rows:
+        key = ("session", r["id"])
+        children.setdefault(
+            key,
+            ChildNode(
+                kind="session",
+                id=r["id"],
+                spawn_at=r["spawn_at"],
+                request_id=r["request_id"],
+            ),
+        )
+
+    # run → sub-run: a ``wf_runs.caller`` matching (#1129). The spawn order is
+    # the sub-run's own ``created_at``.
+    subrun_rows = await conn.fetch(
+        "SELECT r.id AS id, r.created_at AS spawn_at, r.request_id AS request_id "
+        "FROM wf_runs r "
+        "WHERE r.account_id = $1 "
+        "AND r.caller->>'kind' = $2 AND r.caller->>'id' = $3",
+        account_id,
+        caller_kind,
+        caller_id,
+    )
+    for r in subrun_rows:
+        key = ("run", r["id"])
+        children.setdefault(
+            key,
+            ChildNode(kind="run", id=r["id"], spawn_at=r["spawn_at"], request_id=r["request_id"]),
+        )
+
+    # ── live FK half (until #1131) ───────────────────────────────────────────
+    # These cover pre-#1123/#1129 subtrees and the session→run launch path
+    # (#1127 writes no caller edge yet). They only ADD nodes the edge missed —
+    # ``setdefault`` keeps the richer edge row when both are present.
+    if caller_kind == "run":
+        fk_sessions = await conn.fetch(
+            "SELECT s.id AS id, s.created_at AS spawn_at FROM sessions s "
+            "WHERE s.account_id = $1 AND s.parent_run_id = $2",
+            account_id,
+            caller_id,
+        )
+        for r in fk_sessions:
+            children.setdefault(
+                ("session", r["id"]),
+                ChildNode(kind="session", id=r["id"], spawn_at=r["spawn_at"]),
+            )
+        fk_subruns = await conn.fetch(
+            "SELECT r.id AS id, r.created_at AS spawn_at FROM wf_runs r "
+            "WHERE r.account_id = $1 AND r.parent_run_id = $2",
+            account_id,
+            caller_id,
+        )
+        for r in fk_subruns:
+            children.setdefault(
+                ("run", r["id"]),
+                ChildNode(kind="run", id=r["id"], spawn_at=r["spawn_at"]),
+            )
+    elif caller_kind == "session":
+        # session → run: no caller edge exists yet (#1127 / launch path writes
+        # none), so the launcher FK is the SOLE source today.
+        fk_launched = await conn.fetch(
+            "SELECT r.id AS id, r.created_at AS spawn_at FROM wf_runs r "
+            "WHERE r.account_id = $1 AND r.launcher_session_id = $2",
+            account_id,
+            caller_id,
+        )
+        for r in fk_launched:
+            children.setdefault(
+                ("run", r["id"]),
+                ChildNode(kind="run", id=r["id"], spawn_at=r["spawn_at"]),
+            )
+
+    # Deterministic sibling order: spawn time, then id (a stable tiebreak when
+    # two siblings share a transaction_timestamp). ``None`` spawn_at sorts last.
+    return sorted(
+        children.values(),
+        key=lambda c: (c.spawn_at is None, c.spawn_at, c.id),
+    )
+
+
+async def read_session_meta_batched(
+    conn: asyncpg.Connection[Any],
+    session_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, dict[str, Any]]:
+    """Per-session metadata the normalizer needs, keyed by id (no N+1).
+
+    ``{stop_reason, archived_at, title, agent_id, created_at}`` plus the derived
+    open-request set (``open_request_ids``) so a root session's ``end_turn`` /
+    archived branch can tell "owes a request" from "done." Account-scoped.
+    """
+    if not session_ids:
+        return {}
+    rows = await conn.fetch(
+        "SELECT s.id, s.stop_reason, s.archived_at, s.title, s.agent_id, s.created_at, "
+        "  (SELECT array_agg(req.data->>'request_id') FROM events req "
+        "   WHERE req.session_id = s.id AND req.account_id = $2 "
+        "   AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
+        "   AND req.data->>'request_id' IS NOT NULL "
+        "   AND NOT EXISTS (SELECT 1 FROM events resp "
+        "       WHERE resp.session_id = s.id AND resp.account_id = $2 "
+        "       AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
+        "       AND resp.data->>'request_id' = req.data->>'request_id')) AS open_request_ids "
+        "FROM sessions s WHERE s.id = ANY($1) AND s.account_id = $2",
+        session_ids,
+        account_id,
+    )
+    out: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        out[r["id"]] = {
+            "stop_reason": parse_jsonb(r["stop_reason"]) if r["stop_reason"] is not None else None,
+            "archived_at": r["archived_at"],
+            "title": r["title"],
+            "agent_id": r["agent_id"],
+            "created_at": r["created_at"],
+            "open_request_ids": list(r["open_request_ids"] or []),
+        }
+    return out
+
+
+async def read_run_meta_batched(
+    conn: asyncpg.Connection[Any],
+    run_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, dict[str, Any]]:
+    """Per-run metadata the normalizer needs, keyed by id (no N+1).
+
+    ``{status, workflow_id, caller, request_id, created_at}`` plus the
+    ``run_completed`` payload (``{is_error, error}``) so a root run's terminal
+    state and ``error_kind`` resolve from the journal without a per-node fetch.
+    Account-scoped.
+    """
+    if not run_ids:
+        return {}
+    rows = await conn.fetch(
+        "SELECT r.id, r.status, r.workflow_id, r.caller, r.request_id, r.created_at, "
+        "  (SELECT e.payload FROM wf_run_events e "
+        "   WHERE e.run_id = r.id AND e.type = 'run_completed' LIMIT 1) AS completed "
+        "FROM wf_runs r WHERE r.id = ANY($1) AND r.account_id = $2",
+        run_ids,
+        account_id,
+    )
+    out: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        completed = parse_jsonb(r["completed"]) if r["completed"] is not None else None
+        out[r["id"]] = {
+            "status": r["status"],
+            "workflow_id": r["workflow_id"],
+            "caller": parse_jsonb(r["caller"]) if r["caller"] is not None else None,
+            "request_id": r["request_id"],
+            "created_at": r["created_at"],
+            "run_completed": completed,
+        }
+    return out
+
+
+async def read_run_journal_batched(
+    conn: asyncpg.Connection[Any],
+    run_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """The journal frames for a SET of runs, keyed by ``run_id`` (no N+1).
+
+    One ``run_id = ANY($1)`` read (account-scoped via the ``wf_runs`` join),
+    grouped in Python. Each frame is ``{seq, type, payload, created_at}``.
+    """
+    if not run_ids:
+        return {}
+    rows = await conn.fetch(
+        "SELECT e.run_id, e.seq, e.type, e.payload, e.created_at "
+        "FROM wf_run_events e JOIN wf_runs r ON r.id = e.run_id "
+        "WHERE e.run_id = ANY($1) AND r.account_id = $2 "
+        "ORDER BY e.run_id, e.seq ASC",
+        run_ids,
+        account_id,
+    )
+    out: dict[str, list[dict[str, Any]]] = {rid: [] for rid in run_ids}
+    for r in rows:
+        out[r["run_id"]].append(
+            {
+                "seq": r["seq"],
+                "type": r["type"],
+                "payload": parse_jsonb(r["payload"]),
+                "created_at": r["created_at"],
+            }
+        )
+    return out
+
+
+async def read_session_journal_batched(
+    conn: asyncpg.Connection[Any],
+    session_ids: list[str],
+    *,
+    account_id: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """The journal frames for a SET of sessions, keyed by ``session_id`` (no N+1).
+
+    One ``session_id = ANY($1)`` read (account-scoped on ``events.account_id``),
+    grouped in Python. Each frame is ``{seq, kind, data, created_at}``.
+    """
+    if not session_ids:
+        return {}
+    rows = await conn.fetch(
+        "SELECT e.session_id, e.seq, e.kind, e.data, e.created_at "
+        "FROM events e "
+        "WHERE e.session_id = ANY($1) AND e.account_id = $2 "
+        "ORDER BY e.session_id, e.seq ASC",
+        session_ids,
+        account_id,
+    )
+    out: dict[str, list[dict[str, Any]]] = {sid: [] for sid in session_ids}
+    for r in rows:
+        out[r["session_id"]].append(
+            {
+                "seq": r["seq"],
+                "kind": r["kind"],
+                "data": parse_jsonb(r["data"]),
+                "created_at": r["created_at"],
+            }
+        )
+    return out

--- a/src/aios/db/queries/trace.py
+++ b/src/aios/db/queries/trace.py
@@ -167,6 +167,15 @@ async def read_session_meta_batched(
     ``{stop_reason, archived_at, title, agent_id, created_at}`` plus the derived
     open-request set (``open_request_ids``) so a root session's ``end_turn`` /
     archived branch can tell "owes a request" from "done." Account-scoped.
+
+    For an **archived** session that owes an open request we also resolve that
+    request's terminal outcome (``owed_request_response``) under the same snapshot,
+    following :func:`aios.db.queries.sessions.derive_response` semantics: a written
+    ``request_response`` wins, else — because an archived session can never answer —
+    the request resolves to ``child_gone``. The normalizer's archived branch needs
+    this to flag a green-washed failed root (an archived session owing an errored
+    request) as ``errored`` instead of silently ``ok``. ``None`` for a live session
+    or one that owes nothing.
     """
     if not session_ids:
         return {}
@@ -179,22 +188,73 @@ async def read_session_meta_batched(
         "   AND NOT EXISTS (SELECT 1 FROM events resp "
         "       WHERE resp.session_id = s.id AND resp.account_id = $2 "
         "       AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
-        "       AND resp.data->>'request_id' = req.data->>'request_id')) AS open_request_ids "
+        "       AND resp.data->>'request_id' = req.data->>'request_id')) AS open_request_ids, "
+        # The oldest open request's written response, if any (deterministic
+        # oldest-first, mirroring get_open_request_ids). For an archived session
+        # this is NULL (the request is open precisely because nothing answered it);
+        # the derive_response child_gone fallback is applied in Python below.
+        "  (SELECT resp.data FROM events req "
+        "   JOIN events resp ON resp.session_id = req.session_id "
+        "       AND resp.account_id = req.account_id "
+        "       AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
+        "       AND resp.data->>'request_id' = req.data->>'request_id' "
+        "   WHERE req.session_id = s.id AND req.account_id = $2 "
+        "   AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
+        "   AND req.data->>'request_id' IS NOT NULL "
+        "   ORDER BY req.seq ASC LIMIT 1) AS owed_request_response "
         "FROM sessions s WHERE s.id = ANY($1) AND s.account_id = $2",
         session_ids,
         account_id,
     )
     out: dict[str, dict[str, Any]] = {}
     for r in rows:
+        open_ids = list(r["open_request_ids"] or [])
+        archived = r["archived_at"] is not None
+        written = (
+            parse_jsonb(r["owed_request_response"])
+            if r["owed_request_response"] is not None
+            else None
+        )
         out[r["id"]] = {
             "stop_reason": parse_jsonb(r["stop_reason"]) if r["stop_reason"] is not None else None,
             "archived_at": r["archived_at"],
             "title": r["title"],
             "agent_id": r["agent_id"],
             "created_at": r["created_at"],
-            "open_request_ids": list(r["open_request_ids"] or []),
+            "open_request_ids": open_ids,
+            "owed_request_response": _resolve_owed_response(
+                written, open_ids=open_ids, archived=archived
+            ),
         }
     return out
+
+
+def _resolve_owed_response(
+    written: dict[str, Any] | None,
+    *,
+    open_ids: list[str],
+    archived: bool,
+) -> dict[str, Any] | None:
+    """Resolve an archived session's owed-request outcome — derive_response in Python.
+
+    Mirrors :func:`aios.db.queries.sessions.derive_response`'s terminal rule for the
+    owed request, restricted to what the trace's archived-root branch consumes:
+
+    * a **written** ``request_response`` → that outcome (normalized to
+      ``{result, is_error, error}``);
+    * else, if the session is **archived** and still owes an open request (so it can
+      never answer) → a Failed ``child_gone`` outcome;
+    * else → ``None`` (nothing owed, or a live session — handled elsewhere).
+    """
+    if written is not None:
+        return {
+            "result": written.get("result"),
+            "is_error": bool(written.get("is_error")),
+            "error": written.get("error"),
+        }
+    if archived and open_ids:
+        return {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
+    return None
 
 
 async def read_run_meta_batched(

--- a/src/aios/models/trace.py
+++ b/src/aios/models/trace.py
@@ -1,0 +1,150 @@
+"""Trace resource: a one-call linear projection of a workflow-run / session tree
+(#1149).
+
+A *trace* is **not** a new subsystem — it is a read-projection over the
+invocation-edge tree the invoke-edge epic (#1122) already records. Three moves:
+**walk** the parent→child edge tree from the root, **normalize** each node's
+outcome into a small terminal-state enum (+ a raw ``error_kind`` passthrough),
+and **interleave** the nodes' existing journals (``events`` for sessions,
+``wf_run_events`` for runs).
+
+The wire shape is a **flat list** (no recursion — it fits codegen, and no
+recursive response models exist in this codebase). Causal **DFS pre-order** over
+the edge tree is canonical: a child's subtree is contiguous under its parent, so
+CLI indentation by ``depth`` is trivially correct. ``timestamp`` is exposed as a
+per-entry column for chronology; a ``--chronological`` client re-sort by
+``timestamp`` is best-effort to transaction granularity (the two journals share
+no global sequence — only the causal parent→child edge is exact).
+
+Scope = the invocation-edge tree (``agent()`` / ``invoke_workflow`` /
+api-invoke). ``wake_session`` peer-pokes are **out of scope** (a peer stimulus
+carrying ``wake_depth``, not a spawn — it opens no ``request_opened`` edge).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+# The normalized terminal state of a node — the small enum every caller reads at
+# a glance (the centerpiece of #1149 / #1140's shared normalizer). ``suspended``
+# is load-bearing: a pipeline parked at a ``gate()`` awaiting the chairman is
+# ``suspended`` and that is its dominant *healthy* state — it must be
+# distinguishable from actively-``running`` and from wedged.
+TerminalState = Literal["ok", "errored", "cancelled", "suspended", "running"]
+
+# A node entry is a session or run; a frame entry is one journal line under a
+# node. The ``agent_call`` / ``invoke_workflow`` run-journal frames are MERGED
+# into their child node (never double-listed) — a standalone ``agent_call``
+# entry appears only for an orphan (a child that was never spawned / rejected
+# pre-spawn).
+TraceEntryKind = Literal[
+    # node kinds (carry terminal_state / error_kind)
+    "run",
+    "session",
+    # frame kinds (live under a node; parent_id = the node)
+    "request",
+    "response",
+    "tool_call",
+    "gate",
+    "annotation",
+    "error",
+    "message",
+    "agent_call",  # orphan only — a call_started with no spawned child
+]
+
+
+class TraceEntry(BaseModel):
+    """One line of a flattened trace.
+
+    ``depth`` is the node's DFS depth (0 = root); a CLI renders it as
+    indentation. ``parent_id`` is the enclosing node's id (``None`` for the
+    root). For **node** entries ``terminal_state`` / ``error_kind`` carry the
+    normalized outcome; for **frame** entries they are ``None`` and ``summary``
+    carries the per-kind digest. ``timestamp`` is the entry's ``created_at``
+    (``transaction_timestamp()`` for journal frames) — exposed as a column for
+    chronology, NOT the canonical order (see the module docstring).
+    """
+
+    timestamp: datetime | None = None
+    depth: int
+    parent_id: str | None = None
+    kind: TraceEntryKind
+    id: str
+    summary: str = ""
+    terminal_state: TerminalState | None = None
+    error_kind: str | None = None
+
+
+class TraceTruncated(BaseModel):
+    """The typed marker that the walk hit its node-count ceiling.
+
+    ``#1124``'s depth counter bounds path length (≤10 by construction), but it
+    does NOT bound the node count: ``workflow_max_agent_calls`` defaults to 1000
+    lifetime ``agent()`` children per run. So the walk carries an explicit
+    config-tunable node-count ceiling; when it trips, ``at_nodes`` records how
+    many nodes were emitted before the frontier was cut. The response stays
+    well-formed (a partial-but-honest tree), never a silent truncation.
+    """
+
+    at_nodes: int = Field(description="Number of nodes emitted before the ceiling cut the walk.")
+
+
+class TraceResponse(BaseModel):
+    """A one-call flat trace for a run-root or session-root.
+
+    ``root_kind`` / ``root_id`` name the tree's root. ``entries`` is the flat
+    DFS-pre-order list (nodes interleaved with their journal frames).
+    ``truncated`` is non-``None`` iff the node-count ceiling cut the walk.
+
+    Ordering caveat (documented per #1149): cross-subtree time-ordering is
+    best-effort to **transaction granularity** — ``created_at`` is
+    ``transaction_timestamp()`` (constant for a whole run-step's journal; it can
+    tie or invert across concurrent transactions on separate pooled
+    connections), and the two journals share no global sequence. Only the causal
+    parent→child edge is exact, so DFS pre-order is canonical; chronological is a
+    client-side re-sort.
+
+    Scope caveat: ``wake_session`` peer-pokes are out of scope (a peer stimulus,
+    not a spawn — no ``request_opened`` edge); they do not appear as nodes.
+    """
+
+    root_kind: Literal["run", "session"]
+    root_id: str
+    entries: list[TraceEntry] = Field(default_factory=list)
+    truncated: TraceTruncated | None = None
+
+
+def node_summary_for_session(
+    *,
+    label: str | None,
+    title: str | None,
+    agent_id: str | None,
+) -> str:
+    """The session node's ``summary`` — ``label ‖ title ‖ agent_id ‖ 'generic agent'``.
+
+    The useful label lives on the **parent** half of the ``agent()`` edge (the
+    run-journal ``call_started.payload.label``), so the same join that de-dups
+    the ``agent_call`` frame also supplies the summary. Falls back through the
+    session's own ``title``, then its ``agent_id``, then a generic placeholder.
+    """
+    return label or title or agent_id or "generic agent"
+
+
+def summarize_tool_call(payload: dict[str, Any]) -> str:
+    """``tool_name`` + a truncated first line of the call input.
+
+    Handles the spill-reference shape (a large input stored out-of-band as
+    ``{"$spill": ...}``) by naming the reference rather than dumping it.
+    """
+    name = payload.get("tool_name") or payload.get("name") or "tool"
+    raw_input = payload.get("input")
+    if isinstance(raw_input, dict) and "$spill" in raw_input:
+        return f"{name} (spilled input)"
+    text = "" if raw_input is None else str(raw_input)
+    first = text.splitlines()[0] if text else ""
+    if len(first) > 80:
+        first = first[:77] + "..."
+    return f"{name}: {first}" if first else name

--- a/src/aios/services/trace.py
+++ b/src/aios/services/trace.py
@@ -1,0 +1,450 @@
+"""The trace service (#1149): walk → normalize → interleave.
+
+A *trace* is a read-projection over the invocation-edge tree the invoke-edge
+epic already records — no new subsystem, no trace table, no spans. This module:
+
+1. **Walks** the parent→child edge tree from the root (``db.queries.trace`` does
+   the reverse "children-of by caller" lookup, union of the trusted edge and the
+   still-live FK columns).
+2. **Normalizes** each node's outcome (``services.trace_normalizer``, reusing
+   #1126's ``derive_response`` / ``derive_run_response``).
+3. **Interleaves** the nodes' existing journals into a flat DFS-pre-order list.
+
+The whole walk runs in **one ``REPEATABLE READ`` transaction on a single
+connection**, so every read sees one MVCC snapshot — a live tree that mutates
+mid-walk can't produce a torn trace. A **node-count ceiling** bounds ``|V|`` (the
+depth cap bounds only path length); when it trips the response carries a typed
+``truncated`` marker.
+
+The pure traversal/assembly (``build_entries``) is split from the I/O so the
+DB-mocked unit tier can pin its behavior (DFS order, the ceiling, the
+``agent_call``→child merge) without a live Postgres.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.config import get_settings
+from aios.db import queries
+from aios.db.queries import trace as trace_q
+from aios.db.queries import workflows as wf_queries
+from aios.models.trace import (
+    TraceEntry,
+    TraceResponse,
+    TraceTruncated,
+    node_summary_for_session,
+    summarize_tool_call,
+)
+from aios.services import trace_normalizer
+
+# Abbreviated (``verbose=false``) keeps only the load-bearing frames per node:
+# the request/response/turn lifecycle, gates, and any ``is_error`` frame (so the
+# proximate cause sits one line from the terminal outcome). The full firehose is
+# ``verbose=true`` (or the per-resource ``…/events`` endpoints).
+_ABBREVIATED_LIFECYCLE_EVENTS = frozenset({"request_opened", "request_response", "turn_ended"})
+# Run-journal frame types kept in the abbreviated view (the run journal is
+# already sparse; gates + the request/run bookends + errors carry the signal).
+_ABBREVIATED_RUN_TYPES = frozenset(
+    {"run_started", "run_completed", "request_response", "annotation"}
+)
+
+
+class _Node:
+    """A resolved node in the walk, with its merge-from-parent context."""
+
+    __slots__ = ("children", "depth", "id", "kind", "label", "parent_id", "request_id")
+
+    def __init__(
+        self,
+        *,
+        kind: str,
+        id: str,
+        parent_id: str | None,
+        depth: int,
+        label: str | None,
+        request_id: str | None,
+    ) -> None:
+        self.kind = kind
+        self.id = id
+        self.parent_id = parent_id
+        self.depth = depth
+        self.label = label
+        self.request_id = request_id
+        self.children: list[_Node] = []
+
+
+async def get_trace(
+    pool: asyncpg.Pool[Any],
+    *,
+    root_kind: str,
+    root_id: str,
+    account_id: str,
+    verbose: bool = False,
+    max_nodes: int | None = None,
+) -> TraceResponse:
+    """Build the flat trace for a run-root or session-root, in one snapshot.
+
+    The caller (router) has already account-scoped the root via ``get_run`` /
+    ``get_session`` (404 cross-tenant). Here we re-open the work under a single
+    ``REPEATABLE READ`` connection so the walk is coherent.
+    """
+    ceiling = max_nodes if max_nodes is not None else get_settings().trace_max_nodes
+    async with pool.acquire() as conn, conn.transaction(isolation="repeatable_read", readonly=True):
+        nodes, truncated = await _walk(
+            conn, root_kind=root_kind, root_id=root_id, account_id=account_id, ceiling=ceiling
+        )
+        # Batch the journal + metadata reads over the collected id set (no N+1).
+        session_ids = [n.id for n in nodes if n.kind == "session"]
+        run_ids = [n.id for n in nodes if n.kind == "run"]
+        session_meta = await trace_q.read_session_meta_batched(
+            conn, session_ids, account_id=account_id
+        )
+        run_meta = await trace_q.read_run_meta_batched(conn, run_ids, account_id=account_id)
+        session_journals = await trace_q.read_session_journal_batched(
+            conn, session_ids, account_id=account_id
+        )
+        run_journals = await trace_q.read_run_journal_batched(conn, run_ids, account_id=account_id)
+        # Resolve each servicer node's caller's-eye response under the SAME
+        # snapshot (reusing the #1126 resolvers).
+        responses: dict[str, dict[str, Any] | None] = {}
+        for n in nodes:
+            if n.request_id is None:
+                continue
+            if n.kind == "session":
+                responses[n.id] = await queries.derive_response(
+                    conn, n.id, account_id=account_id, request_id=n.request_id
+                )
+            else:
+                responses[n.id] = await wf_queries.derive_run_response(
+                    conn, n.id, account_id=account_id, request_id=n.request_id
+                )
+
+    entries = build_entries(
+        nodes,
+        session_meta=session_meta,
+        run_meta=run_meta,
+        session_journals=session_journals,
+        run_journals=run_journals,
+        responses=responses,
+        verbose=verbose,
+    )
+    return TraceResponse(
+        root_kind=root_kind,
+        root_id=root_id,
+        entries=entries,
+        truncated=TraceTruncated(at_nodes=len(nodes)) if truncated else None,
+    )
+
+
+async def _walk(
+    conn: asyncpg.Connection[Any],
+    *,
+    root_kind: str,
+    root_id: str,
+    account_id: str,
+    ceiling: int,
+) -> tuple[list[_Node], bool]:
+    """DFS the edge tree from the root, building the node list in pre-order.
+
+    Returns ``(nodes, truncated)``. ``truncated`` is ``True`` iff the node
+    ceiling cut the frontier (the typed ``truncated`` marker). A visited set
+    keyed on ``(kind, id)`` makes the walk robust to any accidental cycle (the
+    depth cap already makes the real tree acyclic).
+    """
+    root = _Node(kind=root_kind, id=root_id, parent_id=None, depth=0, label=None, request_id=None)
+    nodes: list[_Node] = []
+    visited: set[tuple[str, str]] = set()
+    truncated = False
+
+    # Explicit stack of nodes to expand, preserving DFS pre-order: we emit a node
+    # when popped, then push its children in REVERSE so the first child is
+    # expanded next.
+    stack: list[_Node] = [root]
+    while stack:
+        node = stack.pop()
+        key = (node.kind, node.id)
+        if key in visited:
+            continue
+        if len(nodes) >= ceiling:
+            truncated = True
+            break
+        visited.add(key)
+        nodes.append(node)
+
+        children = await trace_q.children_of(
+            conn, caller_kind=node.kind, caller_id=node.id, account_id=account_id
+        )
+        # The api-edge caller id is the account_id; a session→session / run→child
+        # edge stores the node id. ``children_of`` already keys on (kind,id), so
+        # the only extra concern is that a node may also be reachable as an
+        # ``api``-caller's child (root only). We expand children spawned by THIS
+        # node's (kind,id).
+        child_nodes: list[_Node] = [
+            _Node(
+                kind=c.kind,
+                id=c.id,
+                parent_id=node.id,
+                depth=node.depth + 1,
+                label=c.label,
+                request_id=c.request_id,
+            )
+            for c in children
+        ]
+        node.children = child_nodes
+        for child in reversed(child_nodes):
+            stack.append(child)
+
+    return nodes, truncated
+
+
+def build_entries(
+    nodes: list[_Node],
+    *,
+    session_meta: dict[str, dict[str, Any]],
+    run_meta: dict[str, dict[str, Any]],
+    session_journals: dict[str, list[dict[str, Any]]],
+    run_journals: dict[str, list[dict[str, Any]]],
+    responses: dict[str, dict[str, Any] | None],
+    verbose: bool,
+) -> list[TraceEntry]:
+    """Assemble the flat DFS-pre-order entry list — pure, no I/O.
+
+    For each node (already in DFS pre-order) emit its node entry (normalized
+    ``terminal_state`` / ``error_kind``) followed by its abbreviated-or-full
+    journal frames. The ``agent_call`` / ``invoke_workflow`` run-journal frames
+    are NOT emitted as frames — they are merged into their child node (the
+    child's ``label`` already came from that frame), so a spawned child is never
+    double-listed.
+    """
+    entries: list[TraceEntry] = []
+    # The set of child ids each run spawned via a journal frame — so the merge
+    # can drop the frame and detect orphans (a call_started whose child id is
+    # not in the walked node set).
+    walked_ids = {n.id for n in nodes}
+
+    for node in nodes:
+        if node.kind == "session":
+            entries.append(_session_node_entry(node, session_meta, responses))
+            entries.extend(
+                _session_frames(node, session_journals.get(node.id, []), verbose=verbose)
+            )
+        else:
+            entries.append(_run_node_entry(node, run_meta, responses))
+            entries.extend(
+                _run_frames(
+                    node,
+                    run_journals.get(node.id, []),
+                    walked_ids=walked_ids,
+                    verbose=verbose,
+                )
+            )
+    return entries
+
+
+def _session_node_entry(
+    node: _Node,
+    session_meta: dict[str, dict[str, Any]],
+    responses: dict[str, dict[str, Any] | None],
+) -> TraceEntry:
+    meta = session_meta.get(node.id, {})
+    if node.request_id is not None:
+        # A servicer session — caller's-eye outcome.
+        state, error_kind = trace_normalizer.normalize_response(responses.get(node.id))
+    else:
+        # A root session — derive from stop_reason.
+        open_ids = meta.get("open_request_ids") or []
+        state, error_kind = trace_normalizer.normalize_session_root(
+            meta.get("stop_reason"),
+            owes_open_request=bool(open_ids),
+            is_archived=meta.get("archived_at") is not None,
+        )
+    summary = node_summary_for_session(
+        label=node.label, title=meta.get("title"), agent_id=meta.get("agent_id")
+    )
+    return TraceEntry(
+        timestamp=meta.get("created_at"),
+        depth=node.depth,
+        parent_id=node.parent_id,
+        kind="session",
+        id=node.id,
+        summary=summary,
+        terminal_state=state,
+        error_kind=error_kind,
+    )
+
+
+def _run_node_entry(
+    node: _Node,
+    run_meta: dict[str, dict[str, Any]],
+    responses: dict[str, dict[str, Any] | None],
+) -> TraceEntry:
+    meta = run_meta.get(node.id, {})
+    if node.request_id is not None:
+        state, error_kind = trace_normalizer.normalize_response(responses.get(node.id))
+    else:
+        completed = meta.get("run_completed") or {}
+        state, error_kind = trace_normalizer.normalize_run_root(
+            status=meta.get("status", "running"),
+            run_completed_error=completed.get("error"),
+            run_completed_is_error=bool(completed.get("is_error")),
+        )
+    summary = meta.get("workflow_id") or "workflow run"
+    return TraceEntry(
+        timestamp=meta.get("created_at"),
+        depth=node.depth,
+        parent_id=node.parent_id,
+        kind="run",
+        id=node.id,
+        summary=node.label or summary,
+        terminal_state=state,
+        error_kind=error_kind,
+    )
+
+
+def _session_frames(
+    node: _Node, journal: list[dict[str, Any]], *, verbose: bool
+) -> list[TraceEntry]:
+    out: list[TraceEntry] = []
+    for ev in journal:
+        kind = ev["kind"]
+        data = ev["data"] or {}
+        is_error = bool(data.get("is_error")) or kind == "interrupt"
+        if not verbose and not _keep_session_frame(kind, data, is_error):
+            continue
+        entry_kind, summary = _classify_session_frame(kind, data)
+        out.append(
+            TraceEntry(
+                timestamp=ev["created_at"],
+                depth=node.depth + 1,
+                parent_id=node.id,
+                kind=entry_kind,
+                id=f"{node.id}#{ev['seq']}",
+                summary=summary,
+                error_kind=(data.get("error") or {}).get("kind") if is_error else None,
+            )
+        )
+    return out
+
+
+def _keep_session_frame(kind: str, data: dict[str, Any], is_error: bool) -> bool:
+    if is_error:
+        return True
+    return kind == "lifecycle" and data.get("event") in _ABBREVIATED_LIFECYCLE_EVENTS
+
+
+def _classify_session_frame(kind: str, data: dict[str, Any]) -> tuple[str, str]:
+    if kind == "lifecycle":
+        event = data.get("event")
+        if event == "request_opened":
+            return "request", f"request {data.get('request_id', '')}".strip()
+        if event == "request_response":
+            err = (data.get("error") or {}).get("kind")
+            verb = f"error: {err}" if data.get("is_error") else "ok"
+            return "response", f"response {verb}"
+        return "annotation", str(event or "lifecycle")
+    if kind == "interrupt":
+        return "error", "interrupt"
+    if kind == "span" and (data.get("error") or data.get("is_error")):
+        return "error", _frame_error_summary(data)
+    if kind == "message":
+        role = data.get("role", "message")
+        return "message", str(role)
+    if data.get("is_error"):
+        return "error", _frame_error_summary(data)
+    return "message", kind
+
+
+def _frame_error_summary(data: dict[str, Any]) -> str:
+    err = data.get("error") or {}
+    kind = err.get("kind") if isinstance(err, dict) else None
+    msg = err.get("message") if isinstance(err, dict) else None
+    parts = [p for p in (kind, msg) if p]
+    return " · ".join(str(p) for p in parts) or "error"
+
+
+def _run_frames(
+    node: _Node,
+    journal: list[dict[str, Any]],
+    *,
+    walked_ids: set[str],
+    verbose: bool,
+) -> list[TraceEntry]:
+    out: list[TraceEntry] = []
+    for ev in journal:
+        etype = ev["type"]
+        payload = ev["payload"] or {}
+        # Merge: an agent()/invoke_workflow call_started whose child IS in the
+        # walked node set is folded into that child node — drop the frame. A
+        # call_started whose child was never spawned (orphan) is kept.
+        if etype == "call_started":
+            cap = payload.get("capability")
+            child_id = payload.get("child_session_id") or payload.get("child_run_id")
+            if cap in ("agent", "invoke_workflow"):
+                if child_id in walked_ids:
+                    continue  # merged into the child node
+                # Orphan: child never spawned / rejected pre-spawn.
+                out.append(
+                    TraceEntry(
+                        timestamp=ev["created_at"],
+                        depth=node.depth + 1,
+                        parent_id=node.id,
+                        kind="agent_call",
+                        id=f"{node.id}#{ev['seq']}",
+                        summary=f"orphan {cap}: {payload.get('label', '')}".strip(),
+                    )
+                )
+                continue
+        is_error = etype == "run_completed" and bool(payload.get("is_error"))
+        if not verbose and not _keep_run_frame(etype, payload, is_error):
+            continue
+        entry_kind, summary = _classify_run_frame(etype, payload)
+        out.append(
+            TraceEntry(
+                timestamp=ev["created_at"],
+                depth=node.depth + 1,
+                parent_id=node.id,
+                kind=entry_kind,
+                id=f"{node.id}#{ev['seq']}",
+                summary=summary,
+                error_kind=(payload.get("error") or {}).get("kind") if is_error else None,
+            )
+        )
+    return out
+
+
+def _keep_run_frame(etype: str, payload: dict[str, Any], is_error: bool) -> bool:
+    if is_error:
+        return True
+    if etype in _ABBREVIATED_RUN_TYPES:
+        return True
+    # Gates are load-bearing for the suspended-on-gate story.
+    return etype in ("call_started", "call_result") and payload.get("capability") == "gate"
+
+
+def _classify_run_frame(etype: str, payload: dict[str, Any]) -> tuple[str, str]:
+    cap = payload.get("capability")
+    if etype == "call_started":
+        if cap == "gate":
+            return "gate", f"gate {payload.get('gate_nonce', '')}".strip()
+        if cap == "tool":
+            return "tool_call", summarize_tool_call(payload)
+        return "tool_call", str(cap or "call")
+    if etype == "call_result":
+        if cap == "gate":
+            return "gate", "gate resumed"
+        return "tool_call", f"{cap or 'call'} result"
+    if etype == "annotation":
+        return "annotation", str(payload.get("text") or payload.get("kind") or "annotation")
+    if etype == "run_completed":
+        if payload.get("is_error"):
+            err = (payload.get("error") or {}).get("kind")
+            return "error", f"run errored: {err}"
+        return "annotation", "run completed"
+    if etype == "run_started":
+        return "annotation", "run started"
+    if etype == "request_response":
+        return "response", "response"
+    return "annotation", etype

--- a/src/aios/services/trace.py
+++ b/src/aios/services/trace.py
@@ -130,6 +130,7 @@ async def get_trace(
         run_journals=run_journals,
         responses=responses,
         verbose=verbose,
+        truncated=truncated,
     )
     return TraceResponse(
         root_kind=root_kind,
@@ -209,6 +210,7 @@ def build_entries(
     run_journals: dict[str, list[dict[str, Any]]],
     responses: dict[str, dict[str, Any] | None],
     verbose: bool,
+    truncated: bool = False,
 ) -> list[TraceEntry]:
     """Assemble the flat DFS-pre-order entry list — pure, no I/O.
 
@@ -218,6 +220,12 @@ def build_entries(
     are NOT emitted as frames — they are merged into their child node (the
     child's ``label`` already came from that frame), so a spawned child is never
     double-listed.
+
+    ``truncated`` is the walk's ceiling flag. It MUST be threaded through:
+    ``walked_ids`` is derived post-truncation, so a child cut by the ceiling is
+    absent from it and would otherwise be mislabelled a never-spawned "orphan".
+    When the walk truncated we suppress that orphan emission — an "orphan" must
+    mean *provably never spawned*, not *merely cut from this view*.
     """
     entries: list[TraceEntry] = []
     # The set of child ids each run spawned via a journal frame — so the merge
@@ -238,6 +246,7 @@ def build_entries(
                     node,
                     run_journals.get(node.id, []),
                     walked_ids=walked_ids,
+                    truncated=truncated,
                     verbose=verbose,
                 )
             )
@@ -259,6 +268,7 @@ def _session_node_entry(
         state, error_kind = trace_normalizer.normalize_session_root(
             meta.get("stop_reason"),
             owes_open_request=bool(open_ids),
+            owed_request_response=meta.get("owed_request_response"),
             is_archived=meta.get("archived_at") is not None,
         )
     summary = node_summary_for_session(
@@ -370,6 +380,7 @@ def _run_frames(
     journal: list[dict[str, Any]],
     *,
     walked_ids: set[str],
+    truncated: bool = False,
     verbose: bool,
 ) -> list[TraceEntry]:
     out: list[TraceEntry] = []
@@ -385,6 +396,13 @@ def _run_frames(
             if cap in ("agent", "invoke_workflow"):
                 if child_id in walked_ids:
                     continue  # merged into the child node
+                # A child absent from ``walked_ids`` is an orphan ONLY when the
+                # walk was complete. If the ceiling truncated the walk, the child
+                # may simply have been cut from this view — emitting "orphan {cap}"
+                # would falsely assert it was never spawned. Suppress it; the
+                # response carries the ``truncated`` marker for the cut frontier.
+                if truncated:
+                    continue
                 # Orphan: child never spawned / rejected pre-spawn.
                 out.append(
                     TraceEntry(

--- a/src/aios/services/trace_normalizer.py
+++ b/src/aios/services/trace_normalizer.py
@@ -1,0 +1,140 @@
+"""The trace normalizer (#1149 / #1140) — pure functions, no I/O.
+
+``terminal_state ∈ {ok, errored, cancelled, suspended, running}`` plus
+``error_kind: str | None`` carrying the **raw** discriminant verbatim. The rule
+unifies both servicer kinds (session, run) by **reusing #1126's resolver**
+(``derive_response`` / ``derive_run_response``): the walk fetches the resolved
+response dict and hands it here, so terminal-ness is never re-derived
+independently.
+
+These functions are deliberately I/O-free so the (DB-mocked) unit tier can pin
+the full truth table without a live Postgres.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.models.trace import TerminalState
+
+# Run statuses are persisted on ``wf_runs.status``; sessions have no status
+# column (their lifecycle is derived from ``stop_reason``).
+_TERMINAL_RUN_STATUSES = {"completed", "errored", "cancelled"}
+
+
+def normalize_response(response: dict[str, Any] | None) -> tuple[TerminalState, str | None]:
+    """Normalize a **servicer** node's caller's-eye outcome from a resolved response.
+
+    ``response`` is the dict ``derive_response`` / ``derive_run_response``
+    returns (or ``None`` when still pending):
+
+    * ``None`` → still running (alive and unanswered). Note: an *absent* response
+      means running — it is **never** ``no_return``. ``no_return`` is a
+      *present* ``request_response`` with ``error.kind == 'no_return'`` (written
+      by the quiescence guard), so it lands in the ``is_error`` branch below.
+    * ``is_error`` → ``errored`` + the raw ``error.kind`` (``no_return``,
+      ``child_gone``, …) passed through verbatim.
+    * otherwise → ``ok``.
+    """
+    if response is None:
+        return "running", None
+    if response.get("is_error"):
+        error = response.get("error") or {}
+        kind = error.get("kind") if isinstance(error, dict) else None
+        return "errored", kind
+    return "ok", None
+
+
+def normalize_run_root(
+    *,
+    status: str,
+    run_completed_error: dict[str, Any] | None,
+    run_completed_is_error: bool,
+) -> tuple[TerminalState, str | None]:
+    """Normalize a **root run** (no inbound request) from its own status.
+
+    * ``completed`` → ``errored`` if the ``run_completed`` payload ``is_error``
+      (``error_kind`` from ``run_completed.payload.error.kind`` — surfaces
+      ``output_schema_violation``, ``author_exception``, ``script_host_timeout``,
+      ``budget_exceeded``, …), else ``ok``.
+    * ``errored`` → ``errored`` (+ raw ``error.kind`` when present).
+    * ``cancelled`` → ``cancelled``.
+    * ``suspended`` → ``suspended``.
+    * ``pending`` / ``running`` (or anything else) → ``running``.
+    """
+    if status == "completed":
+        if run_completed_is_error:
+            return "errored", _kind_of(run_completed_error)
+        return "ok", None
+    if status == "errored":
+        return "errored", _kind_of(run_completed_error)
+    if status == "cancelled":
+        return "cancelled", None
+    if status == "suspended":
+        return "suspended", None
+    return "running", None
+
+
+def normalize_session_root(
+    stop_reason: dict[str, Any] | None,
+    *,
+    owes_open_request: bool,
+    owed_request_response: dict[str, Any] | None = None,
+    is_archived: bool = False,
+) -> tuple[TerminalState, str | None]:
+    """Normalize a **root session** (no inbound request) from ``stop_reason.type``.
+
+    A session has no status column and no hard terminal flag, so the state is
+    derived from the most-recent step's ``stop_reason``:
+
+    * ``error`` → ``errored`` (``error_kind`` from the reason's
+      ``error.kind`` / ``finish_reason`` when present).
+    * ``interrupt`` → ``cancelled``.
+    * ``rescheduling`` → ``running`` (a model-error backoff is still live).
+    * ``end_turn`` → ``ok`` if it owes no open request, else ``running``.
+    * an archived session with no stop_reason resolves its owed request
+      (``child_gone`` → ``errored + child_gone``) else ``ok``.
+    """
+    reason_type = (stop_reason or {}).get("type")
+    if reason_type == "error":
+        return "errored", _session_error_kind(stop_reason)
+    if reason_type == "interrupt":
+        return "cancelled", None
+    if reason_type == "rescheduling":
+        return "running", None
+    if reason_type == "end_turn":
+        return ("running", None) if owes_open_request else ("ok", None)
+    # No (or unknown) stop_reason. An archived session can never run again, so
+    # resolve any owed request; a live one is simply still running.
+    if is_archived:
+        if owed_request_response is not None and owed_request_response.get("is_error"):
+            return "errored", _kind_of(owed_request_response.get("error"))
+        return "ok", None
+    return "running", None
+
+
+def _kind_of(error: dict[str, Any] | None) -> str | None:
+    if isinstance(error, dict):
+        kind = error.get("kind")
+        return kind if isinstance(kind, str) else None
+    return None
+
+
+def _session_error_kind(stop_reason: dict[str, Any] | None) -> str | None:
+    """Best-effort raw discriminant for an errored session's stop_reason.
+
+    The harness stores ``{type:'error', message?, finish_reason?}`` and, for a
+    child whose turn errored, fails its open requests with a structured
+    ``error.kind`` separately. Prefer an explicit ``error.kind`` if the reason
+    carries one, then ``finish_reason`` (e.g. ``content_filter``), so the raw
+    discriminant is preserved verbatim rather than flattened to ``errored``.
+    """
+    if not isinstance(stop_reason, dict):
+        return None
+    error = stop_reason.get("error")
+    if isinstance(error, dict):
+        kind = error.get("kind")
+        if isinstance(kind, str):
+            return kind
+    finish = stop_reason.get("finish_reason")
+    return finish if isinstance(finish, str) else None

--- a/tests/integration/test_trace_walk.py
+++ b/tests/integration/test_trace_walk.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
+from uuid import uuid4
 
 import asyncpg
 import pytest
@@ -58,7 +59,7 @@ async def _seed_run(
     wf = await wf_service.create_workflow(
         pool,
         account_id=account_id,
-        name="trace-walk-wf",
+        name=f"trace-walk-wf-{uuid4().hex}",
         script="def main(ctx):\n    return None\n",
         description=None,
         tools=[],

--- a/tests/integration/test_trace_walk.py
+++ b/tests/integration/test_trace_walk.py
@@ -1,0 +1,197 @@
+"""DB-backed trace walk + reverse-index tests (#1149).
+
+Exercises the children-of reverse lookup and the full ``get_trace`` walk against
+real ``events`` / ``wf_runs`` / ``wf_run_events`` rows (testcontainer Postgres),
+and pins that the new ``0103`` reverse indexes are actually used by the
+children-of predicate (the EXPLAIN-asserting test the lock-direction-defer-DDL
+plan called for).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.db.queries import trace as trace_q
+from aios.db.queries import workflows as wf_queries
+from aios.services import trace as trace_service
+from aios.services import workflows as wf_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT = "acc_trace_walk"
+
+
+@pytest.fixture
+async def pool_env(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'trace-walk-test')",
+                _ACCOUNT,
+            )
+        _agent, env, _session = await seed_agent_env_session(
+            pool, account_id=_ACCOUNT, prefix="trace-walk"
+        )
+        yield pool, _ACCOUNT, env.id
+    finally:
+        await pool.close()
+
+
+async def _seed_run(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    environment_id: str,
+    caller: dict[str, Any] | None = None,
+    request_id: str | None = None,
+) -> str:
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=account_id,
+        name="trace-walk-wf",
+        script="def main(ctx):\n    return None\n",
+        description=None,
+        tools=[],
+    )
+    async with pool.acquire() as conn:
+        run = await wf_queries.insert_wf_run(
+            conn,
+            account_id=account_id,
+            workflow_id=wf.id,
+            environment_id=environment_id,
+            parent_run_id=None,
+            launcher_session_id=None,
+            request_id=request_id,
+            caller=caller,
+            script=wf.script,
+            script_sha="x" * 64,
+            host_semantics_epoch=1,
+            input=None,
+            tools=[],
+            mcp_servers=[],
+            http_servers=[],
+            budget_usd=None,
+            default_child_model="openrouter/test",
+            depth=10,
+        )
+    return run.id
+
+
+async def test_children_of_unions_edge_and_fk(
+    pool_env: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, env_id = pool_env
+    root = await _seed_run(pool, account_id=account_id, environment_id=env_id)
+    # A sub-run whose caller edge names the root run.
+    sub = await _seed_run(
+        pool,
+        account_id=account_id,
+        environment_id=env_id,
+        caller={"kind": "run", "id": root},
+        request_id="req-sub",
+    )
+    async with pool.acquire() as conn:
+        kids = await trace_q.children_of(
+            conn, caller_kind="run", caller_id=root, account_id=account_id
+        )
+    ids = {(k.kind, k.id) for k in kids}
+    assert ("run", sub) in ids
+
+
+async def test_children_of_is_account_scoped(
+    pool_env: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, env_id = pool_env
+    root = await _seed_run(pool, account_id=account_id, environment_id=env_id)
+    await _seed_run(
+        pool,
+        account_id=account_id,
+        environment_id=env_id,
+        caller={"kind": "run", "id": root},
+    )
+    # A different tenant must see nothing for this caller id.
+    async with pool.acquire() as conn:
+        kids = await trace_q.children_of(
+            conn, caller_kind="run", caller_id=root, account_id="acc_other"
+        )
+    assert kids == []
+
+
+async def test_get_trace_dfs_root_first(
+    pool_env: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, env_id = pool_env
+    root = await _seed_run(pool, account_id=account_id, environment_id=env_id)
+    sub = await _seed_run(
+        pool,
+        account_id=account_id,
+        environment_id=env_id,
+        caller={"kind": "run", "id": root},
+        request_id="req-sub",
+    )
+    resp = await trace_service.get_trace(pool, root_kind="run", root_id=root, account_id=account_id)
+    node_ids = [(e.kind, e.id) for e in resp.entries if e.kind in ("run", "session")]
+    assert node_ids[0] == ("run", root)  # DFS pre-order: root first
+    assert ("run", sub) in node_ids
+
+
+async def test_get_trace_ceiling_truncates(
+    pool_env: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    pool, account_id, env_id = pool_env
+    root = await _seed_run(pool, account_id=account_id, environment_id=env_id)
+    for _ in range(3):
+        await _seed_run(
+            pool,
+            account_id=account_id,
+            environment_id=env_id,
+            caller={"kind": "run", "id": root},
+        )
+    resp = await trace_service.get_trace(
+        pool, root_kind="run", root_id=root, account_id=account_id, max_nodes=2
+    )
+    assert resp.truncated is not None
+    assert resp.truncated.at_nodes == 2
+
+
+async def test_reverse_index_used_by_children_of_predicate(
+    pool_env: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """EXPLAIN pins the 0103 reverse indexes to the exact children-of predicate."""
+    pool, account_id, env_id = pool_env
+    root = await _seed_run(pool, account_id=account_id, environment_id=env_id)
+    async with pool.acquire() as conn:
+        # The runtime planner only prefers the index on a non-trivial table; force
+        # index consideration so the plan shape is deterministic in a small test
+        # table (seqscan is otherwise cheaper).
+        await conn.execute("SET enable_seqscan = off")
+        wf_plan = await conn.fetch(
+            "EXPLAIN SELECT r.id FROM wf_runs r "
+            "WHERE r.account_id = $1 AND r.caller->>'kind' = $2 AND r.caller->>'id' = $3",
+            account_id,
+            "run",
+            root,
+        )
+        ev_plan = await conn.fetch(
+            "EXPLAIN SELECT e.session_id FROM events e "
+            "WHERE e.account_id = $1 AND e.kind = 'lifecycle' "
+            "AND e.data->>'event' = 'request_opened' "
+            "AND e.data->'caller'->>'kind' = $2 AND e.data->'caller'->>'id' = $3",
+            account_id,
+            "run",
+            root,
+        )
+    wf_text = "\n".join(r["QUERY PLAN"] for r in wf_plan)
+    ev_text = "\n".join(r["QUERY PLAN"] for r in ev_plan)
+    assert "wf_runs_caller_idx" in wf_text
+    assert "events_request_opened_caller_idx" in ev_text

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0102``."""
+    """The migration ladder has exactly one head: ``0103``."""
     script = _script_directory()
-    assert script.get_heads() == ["0102"]
+    assert script.get_heads() == ["0103"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_trace_normalizer.py
+++ b/tests/unit/test_trace_normalizer.py
@@ -1,0 +1,148 @@
+"""The trace normalizer's truth table (#1149) — pure, DB-free.
+
+Pins the locked decisions:
+* ``no_return`` is a *present* ``request_response`` (``error.kind='no_return'``),
+  not an absence; an absence is ``running``.
+* the small enum ``{ok, errored, cancelled, suspended, running}`` + raw
+  ``error_kind`` passthrough (raw discriminant preserved verbatim).
+* ``suspended`` is distinct from ``running``.
+* session ``errored`` derives from ``stop_reason.type``, not a status column.
+"""
+
+from __future__ import annotations
+
+from aios.services import trace_normalizer as norm
+
+# ─── servicer nodes (derive_response / derive_run_response output) ────────────
+
+
+def test_absent_response_is_running_not_no_return() -> None:
+    # Absence ⇒ still running. NEVER no_return (the locked correction).
+    assert norm.normalize_response(None) == ("running", None)
+
+
+def test_no_return_is_a_present_errored_response() -> None:
+    resp = {"result": None, "is_error": True, "error": {"kind": "no_return"}}
+    assert norm.normalize_response(resp) == ("errored", "no_return")
+
+
+def test_child_gone_passes_through_verbatim() -> None:
+    resp = {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
+    assert norm.normalize_response(resp) == ("errored", "child_gone")
+
+
+def test_ok_response() -> None:
+    assert norm.normalize_response({"result": 42, "is_error": False}) == ("ok", None)
+
+
+def test_errored_without_error_kind_is_none() -> None:
+    assert norm.normalize_response({"is_error": True, "error": None}) == ("errored", None)
+
+
+# ─── root runs (wf_runs.status + run_completed payload) ──────────────────────
+
+
+def test_run_root_completed_ok() -> None:
+    assert norm.normalize_run_root(
+        status="completed", run_completed_error=None, run_completed_is_error=False
+    ) == ("ok", None)
+
+
+def test_run_root_completed_but_errored_surfaces_kind() -> None:
+    assert norm.normalize_run_root(
+        status="completed",
+        run_completed_error={"kind": "output_schema_violation"},
+        run_completed_is_error=True,
+    ) == ("errored", "output_schema_violation")
+
+
+def test_run_root_errored_status() -> None:
+    assert norm.normalize_run_root(
+        status="errored",
+        run_completed_error={"kind": "author_exception"},
+        run_completed_is_error=True,
+    ) == ("errored", "author_exception")
+
+
+def test_run_root_cancelled() -> None:
+    assert norm.normalize_run_root(
+        status="cancelled", run_completed_error=None, run_completed_is_error=False
+    ) == ("cancelled", None)
+
+
+def test_run_root_suspended_is_distinct_from_running() -> None:
+    suspended = norm.normalize_run_root(
+        status="suspended", run_completed_error=None, run_completed_is_error=False
+    )
+    running = norm.normalize_run_root(
+        status="running", run_completed_error=None, run_completed_is_error=False
+    )
+    assert suspended == ("suspended", None)
+    assert running == ("running", None)
+    assert suspended != running
+
+
+def test_run_root_pending_is_running() -> None:
+    assert norm.normalize_run_root(
+        status="pending", run_completed_error=None, run_completed_is_error=False
+    ) == ("running", None)
+
+
+# ─── root sessions (stop_reason.type, NOT a status column) ───────────────────
+
+
+def test_session_root_error_stop_reason() -> None:
+    state, kind = norm.normalize_session_root(
+        {"type": "error", "error": {"kind": "context_overflow"}}, owes_open_request=False
+    )
+    assert state == "errored"
+    assert kind == "context_overflow"
+
+
+def test_session_root_error_falls_back_to_finish_reason() -> None:
+    state, kind = norm.normalize_session_root(
+        {"type": "error", "finish_reason": "content_filter"}, owes_open_request=False
+    )
+    assert (state, kind) == ("errored", "content_filter")
+
+
+def test_session_root_interrupt_is_cancelled() -> None:
+    assert norm.normalize_session_root({"type": "interrupt"}, owes_open_request=False) == (
+        "cancelled",
+        None,
+    )
+
+
+def test_session_root_rescheduling_is_running() -> None:
+    assert norm.normalize_session_root({"type": "rescheduling"}, owes_open_request=False) == (
+        "running",
+        None,
+    )
+
+
+def test_session_root_end_turn_ok_when_owes_nothing() -> None:
+    assert norm.normalize_session_root({"type": "end_turn"}, owes_open_request=False) == (
+        "ok",
+        None,
+    )
+
+
+def test_session_root_end_turn_running_when_owes_request() -> None:
+    assert norm.normalize_session_root({"type": "end_turn"}, owes_open_request=True) == (
+        "running",
+        None,
+    )
+
+
+def test_session_root_archived_resolves_owed_child_gone() -> None:
+    state, kind = norm.normalize_session_root(
+        None,
+        owes_open_request=True,
+        owed_request_response={"is_error": True, "error": {"kind": "child_gone"}},
+        is_archived=True,
+    )
+    assert (state, kind) == ("errored", "child_gone")
+
+
+def test_session_root_live_no_stop_reason_is_running() -> None:
+    assert norm.normalize_session_root(None, owes_open_request=False) == ("running", None)

--- a/tests/unit/test_trace_queries.py
+++ b/tests/unit/test_trace_queries.py
@@ -1,0 +1,48 @@
+"""Pure helpers in ``db.queries.trace`` (#1149), DB-free.
+
+Pins ``_resolve_owed_response`` — the Python half of resolving an archived root
+session's owed-request outcome (the SQL fetches a *written* response; this helper
+applies the ``derive_response`` ``child_gone`` fallback an archived session can
+never answer). This is the wiring that makes the normalizer's archived
+``child_gone`` branch live instead of green-washing a failed root to ``ok``.
+"""
+
+from __future__ import annotations
+
+from aios.db.queries.trace import _resolve_owed_response
+
+
+def test_written_errored_response_passes_through() -> None:
+    written = {"result": None, "is_error": True, "error": {"kind": "no_return"}}
+    assert _resolve_owed_response(written, open_ids=["r1"], archived=True) == {
+        "result": None,
+        "is_error": True,
+        "error": {"kind": "no_return"},
+    }
+
+
+def test_written_ok_response_passes_through() -> None:
+    written = {"result": 42, "is_error": False, "error": None}
+    assert _resolve_owed_response(written, open_ids=[], archived=False) == {
+        "result": 42,
+        "is_error": False,
+        "error": None,
+    }
+
+
+def test_archived_with_open_request_resolves_child_gone() -> None:
+    # No written response, session archived, owes a request → derive child_gone.
+    assert _resolve_owed_response(None, open_ids=["r1"], archived=True) == {
+        "result": None,
+        "is_error": True,
+        "error": {"kind": "child_gone"},
+    }
+
+
+def test_archived_owing_nothing_is_none() -> None:
+    assert _resolve_owed_response(None, open_ids=[], archived=True) is None
+
+
+def test_live_session_owing_request_is_none() -> None:
+    # A live session that owes a request is still pending — not child_gone.
+    assert _resolve_owed_response(None, open_ids=["r1"], archived=False) is None

--- a/tests/unit/test_trace_service.py
+++ b/tests/unit/test_trace_service.py
@@ -139,6 +139,38 @@ def test_orphan_agent_call_is_kept() -> None:
     assert "ghost" in orphans[0].summary
 
 
+def test_truncated_walk_does_not_mislabel_cut_child_as_orphan() -> None:
+    # The walk truncated, so a child cut by the ceiling is absent from the node
+    # set — but its parent's call_started frame remains. That child must NOT be
+    # emitted as a never-spawned "orphan" (it WAS spawned; it was merely cut).
+    nodes = [_node("run", "wfr_root", depth=0)]
+    run_journals = {
+        "wfr_root": [
+            {
+                "seq": 7,
+                "type": "call_started",
+                "created_at": None,
+                "payload": {
+                    "capability": "agent",
+                    "child_session_id": "sess_cut",  # spawned, but cut by ceiling
+                    "label": "cut-child",
+                },
+            }
+        ]
+    }
+    entries = svc.build_entries(
+        nodes,
+        session_meta={},
+        run_meta={"wfr_root": {"status": "running"}},
+        session_journals={},
+        run_journals=run_journals,
+        responses={},
+        verbose=False,
+        truncated=True,
+    )
+    assert not any(e.kind == "agent_call" for e in entries)
+
+
 # ─── abbreviated vs verbose filtering ────────────────────────────────────────
 
 

--- a/tests/unit/test_trace_service.py
+++ b/tests/unit/test_trace_service.py
@@ -220,7 +220,7 @@ def test_walk_ceiling_truncates(monkeypatch: Any) -> None:
         ]
     }
     conn = _FakeConn(adjacency)
-    monkeypatch.setattr(svc.trace_q, "children_of", _fake_children_of)
+    monkeypatch.setattr("aios.services.trace.trace_q.children_of", _fake_children_of)
 
     nodes, truncated = asyncio.run(
         svc._walk(conn, root_kind="run", root_id="wfr_root", account_id="acct", ceiling=3)
@@ -234,7 +234,7 @@ def test_walk_no_truncation_under_ceiling(monkeypatch: Any) -> None:
         ("run", "wfr_root"): [ChildNode(kind="session", id="sess_x", label=None, request_id="r")]
     }
     conn = _FakeConn(adjacency)
-    monkeypatch.setattr(svc.trace_q, "children_of", _fake_children_of)
+    monkeypatch.setattr("aios.services.trace.trace_q.children_of", _fake_children_of)
     nodes, truncated = asyncio.run(
         svc._walk(conn, root_kind="run", root_id="wfr_root", account_id="acct", ceiling=50)
     )
@@ -249,7 +249,7 @@ def test_walk_is_cycle_safe(monkeypatch: Any) -> None:
         ("run", "wfr_b"): [ChildNode(kind="run", id="wfr_a", label=None, request_id="r2")],
     }
     conn = _FakeConn(adjacency)
-    monkeypatch.setattr(svc.trace_q, "children_of", _fake_children_of)
+    monkeypatch.setattr("aios.services.trace.trace_q.children_of", _fake_children_of)
     nodes, truncated = asyncio.run(
         svc._walk(conn, root_kind="run", root_id="wfr_a", account_id="acct", ceiling=50)
     )

--- a/tests/unit/test_trace_service.py
+++ b/tests/unit/test_trace_service.py
@@ -1,0 +1,257 @@
+"""Pure traversal/assembly of the trace service (#1149), DB mocked.
+
+Pins the structural decisions independent of Postgres:
+* ``build_entries`` emits **DFS pre-order** — a child's subtree is contiguous
+  under its parent (so CLI indentation by ``depth`` is correct).
+* the ``agent()`` / ``invoke_workflow`` ``call_started`` frame is **merged**
+  into its spawned child node (never double-listed); an *orphan* call (child not
+  in the walked set) is kept as a standalone ``agent_call`` entry.
+* the abbreviated (``verbose=false``) filter drops chatter but keeps the
+  request/response/turn lifecycle, gates, and any error frame; ``verbose=true``
+  lifts the filter.
+* ``_walk``'s node-count **ceiling** cuts the frontier and reports ``truncated``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from aios.db.queries.trace import ChildNode
+from aios.services import trace as svc
+
+
+def _node(
+    kind: str,
+    id: str,
+    *,
+    parent: str | None = None,
+    depth: int = 0,
+    label: str | None = None,
+    request_id: str | None = None,
+) -> svc._Node:
+    return svc._Node(
+        kind=kind, id=id, parent_id=parent, depth=depth, label=label, request_id=request_id
+    )
+
+
+# ─── build_entries: DFS pre-order + the agent_call merge ─────────────────────
+
+
+def test_build_entries_dfs_preorder_and_depth() -> None:
+    # run(root) → session A → run B ; plus session C under root.
+    nodes = [
+        _node("run", "wfr_root", depth=0),
+        _node("session", "sess_a", parent="wfr_root", depth=1, request_id="req_a"),
+        _node("run", "wfr_b", parent="sess_a", depth=2, request_id="req_b"),
+        _node("session", "sess_c", parent="wfr_root", depth=1, request_id="req_c"),
+    ]
+    entries = svc.build_entries(
+        nodes,
+        session_meta={"sess_a": {}, "sess_c": {}},
+        run_meta={"wfr_root": {"status": "running"}, "wfr_b": {}},
+        session_journals={},
+        run_journals={},
+        responses={
+            "sess_a": {"is_error": False},
+            "wfr_b": {"is_error": False},
+            "sess_c": {"is_error": False},
+        },
+        verbose=False,
+    )
+    # Node order is exactly the DFS pre-order we passed.
+    node_ids = [(e.kind, e.id) for e in entries if e.kind in ("run", "session")]
+    assert node_ids == [
+        ("run", "wfr_root"),
+        ("session", "sess_a"),
+        ("run", "wfr_b"),
+        ("session", "sess_c"),
+    ]
+    depths = {e.id: e.depth for e in entries if e.kind in ("run", "session")}
+    assert depths == {"wfr_root": 0, "sess_a": 1, "wfr_b": 2, "sess_c": 1}
+
+
+def test_agent_call_frame_merged_into_child_not_double_listed() -> None:
+    nodes = [
+        _node("run", "wfr_root", depth=0),
+        _node(
+            "session", "sess_child", parent="wfr_root", depth=1, label="reviewer", request_id="req1"
+        ),
+    ]
+    run_journals = {
+        "wfr_root": [
+            {
+                "seq": 1,
+                "type": "call_started",
+                "created_at": None,
+                "payload": {
+                    "capability": "agent",
+                    "child_session_id": "sess_child",
+                    "label": "reviewer",
+                },
+            }
+        ]
+    }
+    entries = svc.build_entries(
+        nodes,
+        session_meta={"sess_child": {"title": "Reviewer"}},
+        run_meta={"wfr_root": {"status": "running"}},
+        session_journals={},
+        run_journals=run_journals,
+        responses={"sess_child": {"is_error": False}},
+        verbose=True,
+    )
+    # The call_started for the spawned child is NOT emitted as a frame.
+    assert not any(e.kind == "agent_call" for e in entries)
+    # The child node appears exactly once, with the parent's label as summary.
+    child = [e for e in entries if e.id == "sess_child"]
+    assert len(child) == 1
+    assert child[0].summary == "reviewer"
+
+
+def test_orphan_agent_call_is_kept() -> None:
+    nodes = [_node("run", "wfr_root", depth=0)]
+    run_journals = {
+        "wfr_root": [
+            {
+                "seq": 7,
+                "type": "call_started",
+                "created_at": None,
+                "payload": {
+                    "capability": "agent",
+                    "child_session_id": "sess_never",
+                    "label": "ghost",
+                },
+            }
+        ]
+    }
+    entries = svc.build_entries(
+        nodes,
+        session_meta={},
+        run_meta={"wfr_root": {"status": "running"}},
+        session_journals={},
+        run_journals=run_journals,
+        responses={},
+        verbose=False,
+    )
+    orphans = [e for e in entries if e.kind == "agent_call"]
+    assert len(orphans) == 1
+    assert "ghost" in orphans[0].summary
+
+
+# ─── abbreviated vs verbose filtering ────────────────────────────────────────
+
+
+def _session_journal() -> list[dict[str, Any]]:
+    return [
+        {
+            "seq": 1,
+            "kind": "lifecycle",
+            "created_at": None,
+            "data": {"event": "request_opened", "request_id": "req1"},
+        },
+        {"seq": 2, "kind": "message", "created_at": None, "data": {"role": "assistant"}},
+        {
+            "seq": 3,
+            "kind": "span",
+            "created_at": None,
+            "data": {"is_error": True, "error": {"kind": "tool_failed"}},
+        },
+    ]
+
+
+def test_abbreviated_drops_chatter_keeps_error_and_lifecycle() -> None:
+    nodes = [_node("session", "sess_a", depth=0)]
+    entries = svc.build_entries(
+        nodes,
+        session_meta={"sess_a": {}},
+        run_meta={},
+        session_journals={"sess_a": _session_journal()},
+        run_journals={},
+        responses={},
+        verbose=False,
+    )
+    frame_kinds = [e.kind for e in entries if e.kind not in ("session", "run")]
+    # The message chatter frame is dropped; the request + error frames survive.
+    assert "message" not in frame_kinds
+    assert "request" in frame_kinds
+    assert "error" in frame_kinds
+    err = next(e for e in entries if e.kind == "error")
+    assert err.error_kind == "tool_failed"
+
+
+def test_verbose_keeps_everything() -> None:
+    nodes = [_node("session", "sess_a", depth=0)]
+    entries = svc.build_entries(
+        nodes,
+        session_meta={"sess_a": {}},
+        run_meta={},
+        session_journals={"sess_a": _session_journal()},
+        run_journals={},
+        responses={},
+        verbose=True,
+    )
+    frame_kinds = [e.kind for e in entries if e.kind not in ("session", "run")]
+    assert "message" in frame_kinds  # chatter retained under verbose
+
+
+# ─── _walk: the node-count ceiling ───────────────────────────────────────────
+
+
+class _FakeConn:
+    """A conn whose ``children_of`` is driven by an in-memory adjacency map."""
+
+    def __init__(self, adjacency: dict[tuple[str, str], list[ChildNode]]) -> None:
+        self._adj = adjacency
+
+
+async def _fake_children_of(
+    conn: _FakeConn, *, caller_kind: str, caller_id: str, account_id: str
+) -> list[ChildNode]:
+    return conn._adj.get((caller_kind, caller_id), [])
+
+
+def test_walk_ceiling_truncates(monkeypatch: Any) -> None:
+    # A root run with 5 child sessions; ceiling=3 ⇒ emit root + 2, truncated.
+    adjacency = {
+        ("run", "wfr_root"): [
+            ChildNode(kind="session", id=f"sess_{i}", label=None, request_id=f"r{i}")
+            for i in range(5)
+        ]
+    }
+    conn = _FakeConn(adjacency)
+    monkeypatch.setattr(svc.trace_q, "children_of", _fake_children_of)
+
+    nodes, truncated = asyncio.run(
+        svc._walk(conn, root_kind="run", root_id="wfr_root", account_id="acct", ceiling=3)
+    )
+    assert truncated is True
+    assert len(nodes) == 3  # root + 2 children before the ceiling cut
+
+
+def test_walk_no_truncation_under_ceiling(monkeypatch: Any) -> None:
+    adjacency = {
+        ("run", "wfr_root"): [ChildNode(kind="session", id="sess_x", label=None, request_id="r")]
+    }
+    conn = _FakeConn(adjacency)
+    monkeypatch.setattr(svc.trace_q, "children_of", _fake_children_of)
+    nodes, truncated = asyncio.run(
+        svc._walk(conn, root_kind="run", root_id="wfr_root", account_id="acct", ceiling=50)
+    )
+    assert truncated is False
+    assert [(n.kind, n.id) for n in nodes] == [("run", "wfr_root"), ("session", "sess_x")]
+
+
+def test_walk_is_cycle_safe(monkeypatch: Any) -> None:
+    # An accidental A→B→A cycle must not loop forever (visited set).
+    adjacency = {
+        ("run", "wfr_a"): [ChildNode(kind="run", id="wfr_b", label=None, request_id="r1")],
+        ("run", "wfr_b"): [ChildNode(kind="run", id="wfr_a", label=None, request_id="r2")],
+    }
+    conn = _FakeConn(adjacency)
+    monkeypatch.setattr(svc.trace_q, "children_of", _fake_children_of)
+    nodes, truncated = asyncio.run(
+        svc._walk(conn, root_kind="run", root_id="wfr_a", account_id="acct", ceiling=50)
+    )
+    assert [(n.kind, n.id) for n in nodes] == [("run", "wfr_a"), ("run", "wfr_b")]
+    assert truncated is False


### PR DESCRIPTION
## What

Adds a **trace** read-projection over the invocation-edge tree (#1122) — no new subsystem, no trace table, no spans. Two endpoints:

- `GET /v1/runs/{run_id}/trace`
- `GET /v1/sessions/{session_id}/trace`

Each walks the parent→child edge tree from the root in **one `REPEATABLE READ` snapshot**, normalizes every node's outcome to `terminal_state ∈ {ok, errored, cancelled, suspended, running}` (+ a raw `error_kind` passthrough), and interleaves the nodes' existing journals (`events` for sessions, `wf_run_events` for runs) into a flat **DFS-pre-order** entry list. A CLI renders `depth` as indentation, so a child's subtree is contiguous under its parent.

## How it's built

- **`services/trace_normalizer.py`** — the pure shared truth table (the #1140 normalizer), reusing #1126's `derive_response` / `derive_run_response` so terminal-ness is never re-derived independently. Locked correction honored: `no_return` is a *present* errored `request_response`, **never** an absence — an absent response is `running`. `suspended` is distinct from `running` (a pipeline parked at a `gate()` is healthy-suspended).
- **`services/trace.py`** — the walk + interleave. The pure `build_entries` (DFS order, node-count ceiling, the `agent()`/`invoke_workflow` call-frame→child merge) is split from the I/O so the DB-mocked unit tier can pin it. The `call_started` frame for a spawned child is merged into that child node (never double-listed); an orphan call (child never spawned) is kept as a standalone `agent_call` entry.
- **`db/queries/trace.py`** — the reverse "children-of by caller" lookup as the **union of the trusted edge and the still-live FK columns** (dual-write era; the FK half drops out when #1131 lands), plus batched journal/meta reads (no N+1). Every lookup re-applies `account_id` as a SQL predicate.
- **migration `0103`** — reverse caller indexes (the expression-index fork of the deferred DDL decision: purely additive, mirrors `events_request_opened_idx`, keys the exact children-of predicate), built `CONCURRENTLY` via `autocommit_block()`. An EXPLAIN-asserting integration test pins index use to the predicate.
- **`aios trace <id>` CLI** — dispatches by id prefix (`wfr_…`/`sess_…`), renders depth as indentation, supports `--chronological` (best-effort timestamp re-sort) and `--verbose`.
- Regenerated `openapi.json` + the typed SDK.

## Bounding & truncation

#1124's depth counter bounds path length (≤10) but **not** node count (`workflow_max_agent_calls` defaults to 1000/run). The walk carries a config-tunable `trace_max_nodes` ceiling (default 2000); when it trips, the response carries a typed `truncated: {at_nodes}` marker rather than silently dropping tail subtrees.

## Abbreviated vs verbose

`verbose=false` (default) keeps only the load-bearing frames per node (request/response/turn lifecycle, gates, and any `is_error` frame — so the proximate cause sits one line from the terminal outcome); `verbose=true` lifts the filter to the full per-node firehose.

## Caveats (documented in the models/docstrings)

- Cross-subtree time-ordering is best-effort to **transaction granularity**; only the causal parent→child edge is exact, so DFS pre-order is canonical and `--chronological` is a client-side re-sort.
- `wake_session` peer-pokes are **out of scope** (a peer stimulus, not a spawn — no `request_opened` edge).
- A cross-tenant root id 404s (scope-checked before the walk).

## Tests

- **unit** `test_trace_normalizer.py` — the full terminal-state truth table (servicer nodes, root runs, root sessions), incl. the `no_return`-is-not-absence and `suspended≠running` invariants.
- **unit** `test_trace_service.py` — `build_entries` DFS pre-order + depth, the agent-call→child merge, orphan retention, abbreviated/verbose filtering, and `_walk`'s ceiling + cycle-safety (DB mocked).
- **integration** `test_trace_walk.py` — `children_of` edge∪FK union + account-scoping, the end-to-end `get_trace` DFS walk + ceiling, and an EXPLAIN assertion that the 0103 reverse indexes back the children-of predicate.

All unit + snapshot/coverage/migration-chain tests pass; ruff + mypy clean across the tree. (Integration tests require the testcontainer Postgres / Docker, run in CI.)