### PR TITLE
fix(pagination): clamp forged-cursor page limit to the request ceiling

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -44,6 +44,7 @@ from aios.models.github_repositories import (
 )
 from aios.models.pagination import (
     DEFAULT_PAGE_LIMIT,
+    MAX_EVENT_PAGE_LIMIT,
     MAX_PAGE_LIMIT,
     Direction,
     EventPageLimit,
@@ -679,7 +680,7 @@ async def list_events(
     else:
         error_only = bool(error_only)
         after_seq, before = 0, None
-    page_limit = resolve_page_limit(st, limit, default=200)
+    page_limit = resolve_page_limit(st, limit, default=200, maximum=MAX_EVENT_PAGE_LIMIT)
     # Fetch one extra row to derive has_more without a separate COUNT query.
     rows = await service.read_events(
         pool,

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -19,7 +19,13 @@ from aios.api.sse import make_sse_response, preflight_subscription, wf_run_event
 from aios.db.listen import open_listen_for_run_events
 from aios.logging import get_logger
 from aios.models.common import ListResponse
-from aios.models.pagination import EventPageLimit, PageLimit, page_cursor, resolve_page_limit
+from aios.models.pagination import (
+    MAX_EVENT_PAGE_LIMIT,
+    EventPageLimit,
+    PageLimit,
+    page_cursor,
+    resolve_page_limit,
+)
 from aios.models.workflows import (
     GateResume,
     WfRun,
@@ -253,7 +259,7 @@ async def list_run_events(
     # Scope check: 404 a cross-tenant run id before reading its journal.
     await service.get_run(pool, run_id, account_id=account_id)
     st = page_cursor(cursor, {"limit": limit})
-    page_limit = resolve_page_limit(st, limit, default=200)
+    page_limit = resolve_page_limit(st, limit, default=200, maximum=MAX_EVENT_PAGE_LIMIT)
     after_seq = int(st.cursor) if st is not None else 0
     items = await service.list_run_events(
         pool, run_id, account_id=account_id, after_seq=after_seq, limit=page_limit + 1

--- a/src/aios/models/pagination.py
+++ b/src/aios/models/pagination.py
@@ -163,8 +163,9 @@ def resolve_page_limit(
     limit: int | None,
     *,
     default: int = DEFAULT_PAGE_LIMIT,
+    maximum: int = MAX_PAGE_LIMIT,
 ) -> int:
-    """Resolve the effective page size for a list request.
+    """Resolve the effective page size for a list request, bounded to ``[1, maximum]``.
 
     Collapses the repeated triple-nested ternary every router hand-wrote::
 
@@ -174,7 +175,16 @@ def resolve_page_limit(
     page it's the supplied ``?limit=`` or ``default``. Endpoints with a
     non-standard default (the events endpoints page 200 at a time) pass it as a
     named ``default=`` override rather than re-typing the literal.
+
+    The result is clamped to ``[1, maximum]``. This is the cursor-path half of
+    the request-boundary ceiling: the ``PageLimit``/``EventPageLimit`` Query
+    aliases enforce ``ge=1, le=ceiling`` only on the first-page ``?limit=`` query
+    param, but the cursor is unsigned and forgeable (see the module docstring),
+    so the size it carries reaches Postgres as ``LIMIT $n`` unvalidated unless
+    re-bounded here — a forged negative value raises an unhandled 500, a huge
+    one is an unbounded-fetch DoS. ``maximum`` defaults to :data:`MAX_PAGE_LIMIT`;
+    the events endpoints pass :data:`MAX_EVENT_PAGE_LIMIT` so a legitimate
+    full-size events cursor is honored rather than shrunk.
     """
-    if st is not None:
-        return st.limit
-    return limit if limit is not None else default
+    raw = st.limit if st is not None else (limit if limit is not None else default)
+    return max(1, min(raw, maximum))

--- a/tests/unit/test_cursor_codec.py
+++ b/tests/unit/test_cursor_codec.py
@@ -9,10 +9,13 @@ import pytest
 
 from aios.errors import ValidationError
 from aios.models.pagination import (
+    MAX_EVENT_PAGE_LIMIT,
+    MAX_PAGE_LIMIT,
     CursorState,
     decode_cursor,
     encode_cursor,
     reject_params_with_cursor,
+    resolve_page_limit,
 )
 
 
@@ -104,3 +107,48 @@ class TestRejectParamsWithCursor:
         with pytest.raises(ValidationError) as exc:
             reject_params_with_cursor({"limit": 10, "agent_id": "ag_1", "status": None})
         assert exc.value.detail["unexpected_params"] == ["agent_id", "limit"]
+
+
+class TestResolvePageLimitBounds:
+    """The cursor carries its own page size, but the cursor is unsigned and
+    forgeable (see the module docstring). The request-boundary ceiling the
+    ``PageLimit``/``EventPageLimit`` Query aliases enforce on ``?limit=`` must
+    therefore ALSO be enforced on the cursor-carried value, or a forged token
+    drives an out-of-range ``LIMIT`` straight into Postgres: a negative value
+    raises an unhandled 500, a huge value is an unbounded-fetch DoS, and zero
+    yields a malformed empty page that still reports ``has_more``."""
+
+    def test_normal_cursor_limit_passes_through(self) -> None:
+        st = CursorState(cursor="x", direction="forward", limit=50, filters={})
+        assert resolve_page_limit(st, None) == 50
+
+    def test_negative_cursor_limit_is_clamped_up(self) -> None:
+        st = CursorState(cursor="x", direction="forward", limit=-5, filters={})
+        assert resolve_page_limit(st, None) >= 1
+
+    def test_zero_cursor_limit_is_clamped_up(self) -> None:
+        st = CursorState(cursor="x", direction="forward", limit=0, filters={})
+        assert resolve_page_limit(st, None) >= 1
+
+    def test_huge_cursor_limit_is_clamped_to_ceiling(self) -> None:
+        st = CursorState(cursor="x", direction="forward", limit=100_000_000, filters={})
+        assert resolve_page_limit(st, None) <= MAX_PAGE_LIMIT
+
+    def test_events_ceiling_not_clamped_to_default_max(self) -> None:
+        # A legitimate events cursor carries up to MAX_EVENT_PAGE_LIMIT; the higher
+        # ceiling must be honored, not silently shrunk to MAX_PAGE_LIMIT.
+        st = CursorState(cursor="x", direction="forward", limit=MAX_EVENT_PAGE_LIMIT, filters={})
+        assert resolve_page_limit(st, None, maximum=MAX_EVENT_PAGE_LIMIT) == MAX_EVENT_PAGE_LIMIT
+
+    def test_forged_token_negative_limit_is_bounded_end_to_end(self) -> None:
+        # The full attack path: a hand-minted base64url(JSON) token with a negative
+        # limit decodes cleanly, then must resolve to a SQL-safe page size.
+        raw = json.dumps({"v": 1, "c": "01J9X", "d": "f", "f": {}, "l": -5}).encode()
+        forged = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+        st = decode_cursor(forged)
+        assert resolve_page_limit(st, None) >= 1
+
+    def test_first_page_limit_still_resolves(self) -> None:
+        # No cursor: the (already Pydantic-bounded) ?limit= or the default flows through.
+        assert resolve_page_limit(None, 25) == 25
+        assert resolve_page_limit(None, None) >= 1


### PR DESCRIPTION
## Summary

`resolve_page_limit` returned the **cursor-carried** page size verbatim. The `PageLimit`/`EventPageLimit` `Query` aliases enforce `ge=1, le=ceiling` only on the first-page `?limit=` query param — but the opaque cursor is unsigned `base64url(JSON)`, **forgeable by any authenticated client** (its module docstring states it is "not a security boundary," relying on `WHERE account_id=$1` for tenant isolation).

So a forged `?cursor=` carrying an out-of-range `"l"` reached Postgres as an unvalidated `LIMIT $n`:

- **`l = -5`** → `LIMIT -4` → `asyncpg.InvalidRowCountInLimitClauseError`, which has no installed handler → unhandled **500**.
- **`l = 100000000`** → unbounded row fetch (a **~1GB DoS** surface), on all 12 list endpoints.
- **`l = 0`** → malformed empty page that still reports `has_more`.

These are exactly the regressions #1155's `PageLimit`/`EventPageLimit` constraints were added to foreclose — but they were foreclosed only on the **query-param** boundary, never the sibling **cursor** path.

## Fix

Make `resolve_page_limit` enforce the request-boundary **ceiling** it was already declared the single source of truth for (#1155: "the two coupled facts every paginated list endpoint declares — the per-page default and the request-boundary ceiling"). It owned the *default*; now it owns the *ceiling* too:

```python
raw = st.limit if st is not None else (limit if limit is not None else default)
return max(1, min(raw, maximum))   # maximum defaults to MAX_PAGE_LIMIT
```

The two `EventPageLimit` endpoints (`GET /v1/sessions/{id}/events`, `GET /v1/runs/{id}/events`) pass `maximum=MAX_EVENT_PAGE_LIMIT` so a legitimate full-size (500-row) events cursor is honored, not shrunk to 200.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 2831 passed (incl. 7 new `TestResolvePageLimitBounds` cases)
- [x] New tests confirmed **RED** on old code (returned `-5` / `1e8` verbatim), **GREEN** after the clamp; pure-unit (no DB)
- [ ] CI runs full integration/e2e suite

## Verification (code-review)

A high-effort review traced all 14 `resolve_page_limit` call sites: every `EventPageLimit` (le=500) endpoint passes `maximum=500`, every `PageLimit` (le=200) endpoint uses the default — no endpoint clamps a legitimate request below its declared ceiling. Cursor minting is airtight (a legit cursor's limit is always ≤ its endpoint's ceiling), so no legitimate flow is altered.

## Noted residual (separate, pre-existing — not in scope)

The review surfaced a *sibling* gap in the same forgeable-cursor theme: the cursor's keyset field `"c"` is stored uncoerced, so a forged `{"c":"abc"}` on an int-keyed endpoint hits `int(st.cursor)` in the router → unhandled `ValueError` → **500**. This is a distinct bug (different field, mechanism, and fix location — `decode_cursor` type-validation vs this limit clamp) and is left for a separate change to preserve single-issue scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)