### PR TITLE
fix(mcp): preserve a tool param named 'type' next to a union sibling

### DIFF
--- a/src/aios/mcp/schema.py
+++ b/src/aios/mcp/schema.py
@@ -8,13 +8,23 @@ from mcp.types import Tool
 
 
 def sanitize_mcp_schema(node: Any) -> Any:
-    """Drop ``type`` siblings of ``anyOf``/``oneOf`` (the union carries the real shape)."""
+    """Drop the ``type`` keyword next to ``anyOf``/``oneOf`` (the union carries the real shape).
+
+    Only the JSON Schema ``type`` **keyword** — whose value is a type name
+    (``"string"``) or a list of them (``["string", "null"]``) — is redundant beside
+    a union. A property literally **named** ``type`` (its value is a sub-schema
+    ``dict``) inside a ``properties`` map is a parameter, not a keyword, and must be
+    preserved even when a sibling property is named ``anyOf``/``oneOf``; aios
+    sanitizes untrusted third-party tool schemas, so dropping it would silently
+    corrupt a valid tool and make the model call it wrong.
+    """
     if isinstance(node, dict):
         has_union = "anyOf" in node or "oneOf" in node
+        drop_type = has_union and isinstance(node.get("type"), (str, list))
         return {
             key: sanitize_mcp_schema(value)
             for key, value in node.items()
-            if not (has_union and key == "type")
+            if not (drop_type and key == "type")
         }
     if isinstance(node, list):
         return [sanitize_mcp_schema(item) for item in node]

--- a/tests/unit/test_mcp_schema_sanitize.py
+++ b/tests/unit/test_mcp_schema_sanitize.py
@@ -84,6 +84,40 @@ class TestSanitizer:
         assert "type" not in inner
         assert "anyOf" in inner
 
+    def test_preserves_property_literally_named_type(self) -> None:
+        # `type`/`anyOf`/`oneOf` are JSON Schema KEYWORDS, but inside a `properties`
+        # map they are property NAMES. A tool param literally named `type` must not
+        # be stripped just because a sibling param is named `anyOf`/`oneOf`: the
+        # union-strip targets the `type` KEYWORD (a str/list value), not a named
+        # sub-schema (a dict). aios sanitizes untrusted third-party MCP schemas, so a
+        # tool with a param named `type` (common) alongside one named `anyOf` would
+        # otherwise have its `type` param silently dropped — the model then sees a
+        # parameter with no schema and calls the tool wrong.
+        node = {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string", "description": "the kind"},
+                "anyOf": {"type": "integer"},
+            },
+        }
+        cleaned = sanitize_mcp_schema(node)
+        assert "type" in cleaned["properties"]
+        assert cleaned["properties"]["type"] == {"type": "string", "description": "the kind"}
+        assert "anyOf" in cleaned["properties"]
+
+    def test_preserves_param_named_type_when_keyword_type_is_a_list(self) -> None:
+        # The `type` keyword may be a list (`["string","null"]`); that form is still a
+        # keyword and IS stripped next to a union, but a param NAMED type (dict value)
+        # at the same map is preserved.
+        node = {
+            "properties": {
+                "type": {"type": ["string", "null"]},
+                "oneOf": {"type": "boolean"},
+            },
+        }
+        cleaned = sanitize_mcp_schema(node)
+        assert "type" in cleaned["properties"]
+
     def test_returns_non_dict_unchanged(self) -> None:
         assert sanitize_mcp_schema("string") == "string"
         assert sanitize_mcp_schema(42) == 42


### PR DESCRIPTION
## Summary

`sanitize_mcp_schema` strips a `type` **key** from any dict node that also carries an `anyOf`/`oneOf` key — correct for the JSON Schema `type` **keyword** (the union carries the shape), but **context-blind**: inside a `properties` map the keys are property *names*, not keywords. So a tool parameter literally **named `type`** was silently dropped whenever a sibling parameter was named `anyOf`/`oneOf`.

aios runs this over **untrusted third-party MCP tool schemas** (it exists because real servers emit malformed `{"anyOf": [...], "type": "array"}` nodes — see `_MALFORMED_OPTIONAL_LIST_SCHEMA`). A param named `type` is common; when dropped, the model sees a parameter with no schema and calls the tool wrong — silent schema corruption.

## Fix

Drop `type` only when its value is the **keyword form** — a type-name `str` (`"string"`) or a list of them (`["string","null"]`) — never a named sub-schema (a `dict`):

```python
drop_type = has_union and isinstance(node.get("type"), (str, list))
```

The value's type is the signal that distinguishes the JSON Schema `type` *keyword* (str/list) from a property *named* `type` (a schema dict). Every existing strip case uses the str/list keyword form, so behavior there is unchanged.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 2854 passed (incl. all 10 existing sanitizer cases unchanged)
- [x] 2 new tests confirmed **RED** on old code (param `type` dropped → `{'oneOf': ...}`), **GREEN** after the fix; pure-unit (no DB)
- [ ] CI runs full integration/e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)