### PR TITLE
test(e2e): open procrastinate app in shared docker_harness fixture (#1169)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -256,6 +256,43 @@ async def real_wake_setup(aios_env: dict[str, str]) -> AsyncIterator[Any]:
 
 
 @pytest.fixture
+async def open_procrastinate_app(aios_env: dict[str, str]) -> AsyncIterator[None]:
+    """Open the procrastinate ``app`` against the testcontainer DB for the test.
+
+    Provision-bearing e2e tests reach ``defer_run_wake`` (and any other
+    ``app.configure_task(...).defer_async(...)`` enqueue) on the run-provision
+    path. That call requires the procrastinate app to be open — in production
+    the api/worker lifespan opens it (``api/app.py``, ``harness/worker.py``);
+    in tests nothing does, so the enqueue raises ``procrastinate.AppNotOpen``
+    at **setup**, before the test exercises the behavior under test (#1148,
+    #1163).
+
+    The module-level ``app`` singleton's connector was built at import time
+    from possibly-stale settings, so — mirroring ``test_wake_lock_release_latency``
+    and ``test_worker_concurrency`` — this fixture builds a fresh
+    ``PsycopgConnector`` pointed at this test instance's DB, opens it, and
+    swaps it in via ``replace_connector`` for the fixture's lifetime. The
+    swapped connector is closed on teardown.
+
+    Shared so every provision-bearing e2e inherits an open app
+    (``docker_harness`` depends on it) rather than each test opening one
+    itself.
+    """
+    from procrastinate import PsycopgConnector
+
+    from aios.harness.procrastinate_app import _sync_dsn
+    from aios.harness.procrastinate_app import app as procrastinate_app
+
+    connector = PsycopgConnector(conninfo=_sync_dsn(aios_env["AIOS_DB_URL"]))
+    await connector.open_async()
+    try:
+        with procrastinate_app.replace_connector(connector):
+            yield
+    finally:
+        await connector.close_async()
+
+
+@pytest.fixture
 def crypto_box(aios_env: dict[str, str]) -> Any:
     """The :class:`CryptoBox` keyed by the test instance's ``AIOS_VAULT_KEY``.
 
@@ -341,8 +378,17 @@ async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
 
 
 @pytest.fixture
-async def docker_harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
+async def docker_harness(
+    aios_env: dict[str, str], open_procrastinate_app: None
+) -> AsyncIterator[Harness]:
     """Like ``harness`` but with a real SandboxRegistry for Docker tests.
+
+    Depends on ``open_procrastinate_app`` so the procrastinate app is open
+    for the harness's lifetime: provision-bearing run tests reach
+    ``defer_run_wake`` on the run-provision path, which enqueues a
+    procrastinate task and otherwise crashes at setup with
+    ``procrastinate.AppNotOpen`` (#1148, #1163). Sharing it here means every
+    provision-bearing e2e inherits the open app for free.
 
     pytest-xdist note: ``SANDBOX_NETWORK_NAME`` is a hardcoded host-global
     name (``aios-sandbox``).  Under ``-n 2``, both xdist workers' sandbox

--- a/tests/e2e/test_run_provision_app_open.py
+++ b/tests/e2e/test_run_provision_app_open.py
@@ -1,0 +1,82 @@
+"""E2E: provision-bearing run tests get an OPEN procrastinate app (#1169).
+
+Two provision-bearing e2e tests (#1148, #1163) crashed at **setup** with
+``procrastinate.exceptions.AppNotOpen`` — before exercising the behavior under
+test — because the run-provision path enqueues a procrastinate task and the
+test context never opened the procrastinate app.
+
+The fix opens the app in the shared e2e fixture/conftest so every
+provision-bearing e2e inherits it (``docker_harness`` depends on the
+``open_procrastinate_app`` fixture). This test pins that contract directly:
+``workflows_service.create_run`` ends with a real ``defer_run_wake`` —
+``app.configure_task("harness.wake_workflow", ...).defer_async(...)`` — which
+raises ``AppNotOpen`` against a closed app. Driven through ``docker_harness``
+WITHOUT mocking ``defer_run_wake``, it must instead land a real
+``procrastinate_jobs`` row.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.queries import workflows as wf_queries
+from aios.models.agents import ToolSpec
+from aios.models.environments import EnvironmentConfig, LimitedNetworking
+from aios.services import environments as environments_service
+from aios.workflows import service as workflows_service
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness
+
+pytestmark = pytest.mark.docker
+
+_ACCOUNT_ID = "acc_test_stub"
+_ALLOWED_HOST = "api.github.com"
+_SCRIPT = """async def main(input):
+    return "ok"
+"""
+
+
+@needs_docker
+async def test_create_run_enqueues_wake_with_open_app(docker_harness: Harness) -> None:
+    """The shared fixture opens the procrastinate app, so the run-provision
+    path's real ``defer_run_wake`` enqueues instead of raising ``AppNotOpen``."""
+    pool: asyncpg.Pool[Any] = docker_harness._pool
+
+    env = await environments_service.create_environment(
+        pool,
+        account_id=_ACCOUNT_ID,
+        name="run-provision-app-open-e2e",
+        config=EnvironmentConfig(
+            networking=LimitedNetworking(type="limited", allowed_hosts=[_ALLOWED_HOST]),
+        ),
+    )
+    async with pool.acquire() as conn:
+        workflow = await wf_queries.insert_workflow(
+            conn,
+            account_id=_ACCOUNT_ID,
+            name="run-provision-app-open-e2e",
+            script=_SCRIPT,
+            tools=[ToolSpec(type="bash")],
+        )
+
+    # No ``defer_run_wake`` mock here: with a closed app this line raises
+    # ``procrastinate.AppNotOpen`` at the tail of ``create_run`` — the exact
+    # setup-time crash #1148/#1163 hit on the provision path.
+    run = await workflows_service.create_run(
+        pool,
+        account_id=_ACCOUNT_ID,
+        workflow_id=workflow.id,
+        environment_id=env.id,
+    )
+
+    async with pool.acquire() as conn:
+        enqueued = await conn.fetchval(
+            "SELECT count(*) FROM procrastinate_jobs "
+            "WHERE task_name = 'harness.wake_workflow' "
+            "AND args->>'run_id' = $1",
+            run.id,
+        )
+    assert int(enqueued or 0) >= 1


### PR DESCRIPTION
## Problem

Two provision-bearing e2e tests (#1148, #1163) crash at **setup** with `procrastinate.exceptions.AppNotOpen` — before they exercise the behavior under test. The run-provision path enqueues a procrastinate task (`defer_run_wake` → `app.configure_task("harness.wake_workflow", ...).defer_async(...)` in `aios/services/wake.py`), and that call requires the procrastinate app to be **open**. In production the api/worker lifespan opens it (`api/app.py`, `harness/worker.py`); in tests nothing did, so the enqueue raised `AppNotOpen` (CI `e2e (docker)` run 27576758171, `test_run_env_var_placeholder.py:203`).

## Fix

Open the procrastinate app in the **shared** e2e fixture so every provision-bearing e2e inherits it, rather than each test opening one itself.

- New `open_procrastinate_app` fixture in `tests/e2e/conftest.py`: builds a fresh `PsycopgConnector` pointed at this test instance's testcontainer DB, `open_async()`s it, and swaps it in via `procrastinate_app.replace_connector(...)` for the fixture's lifetime (the module-level `app` singleton's connector was built at import time from possibly-stale settings). This mirrors the established `test_wake_lock_release_latency` / `test_worker_concurrency` pattern. The connector is closed on teardown.
- `docker_harness` now depends on `open_procrastinate_app`, so every provision-bearing e2e (all of which use `docker_harness`) inherits the open app for free.

## Test

Adds `tests/e2e/test_run_provision_app_open.py`, which pins the contract directly: `workflows_service.create_run` ends with a real `defer_run_wake` (the same enqueue the provision path hits). Driven through `docker_harness` **without** mocking `defer_run_wake`, it must land a real `harness.wake_workflow` row in `procrastinate_jobs` instead of raising `AppNotOpen`. Against a closed app this test reproduces the crash; with the fixture it passes.

## Unblocks

- #1160 / #1163 → the #1158 functional swap-firing validation.
- #1148 → the invoke-edge env-ownership gate test.

Note: these are `pytest.mark.docker` e2e tests; they run in the `e2e (docker)` CI lane (no Docker in the implement sandbox, so the fix was validated by inspection, `py_compile`, and `ruff`).