### PR TITLE
fix(pagination): route forged-cursor keyset coercion through a 422, not a 500

### DIFF
--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, status
 from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.agents import Agent, AgentCreate, AgentUpdate, AgentVersion
 from aios.models.common import ListResponse
-from aios.models.pagination import PageLimit, page_cursor, resolve_page_limit
+from aios.models.pagination import PageLimit, cursor_as_int, page_cursor, resolve_page_limit
 from aios.services import agents as service
 
 router = APIRouter(prefix="/v1/agents", tags=["agents"])
@@ -127,7 +127,7 @@ async def list_versions(
     version is a complete snapshot of the agent's config at creation time.
     """
     st = page_cursor(cursor, {"limit": limit})
-    after = int(st.cursor) if st is not None else None
+    after = cursor_as_int(st.cursor) if st is not None else None
     page_limit = resolve_page_limit(st, limit)
     items = await service.list_agent_versions(
         pool, agent_id, limit=page_limit + 1, after=after, account_id=account_id

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -49,6 +49,7 @@ from aios.models.pagination import (
     Direction,
     EventPageLimit,
     PageLimit,
+    cursor_as_int,
     page_cursor,
     resolve_page_limit,
 )
@@ -675,7 +676,7 @@ async def list_events(
         direction = st.direction
         kind = st.filters.get("kind")
         error_only = bool(st.filters.get("error_only"))
-        seq = int(st.cursor)
+        seq = cursor_as_int(st.cursor)
         after_seq, before = (seq, None) if direction == "forward" else (0, seq)
     else:
         error_only = bool(error_only)

--- a/src/aios/api/routers/skills.py
+++ b/src/aios/api/routers/skills.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, status
 
 from aios.api.deps import AccountIdDep, PoolDep
 from aios.models.common import ListResponse
-from aios.models.pagination import PageLimit, page_cursor, resolve_page_limit
+from aios.models.pagination import PageLimit, cursor_as_int, page_cursor, resolve_page_limit
 from aios.models.skills import Skill, SkillCreate, SkillVersion, SkillVersionCreate
 from aios.services import skills as service
 
@@ -105,7 +105,7 @@ async def list_versions(
     version is a complete file-bundle snapshot at the time it was created.
     """
     st = page_cursor(cursor, {"limit": limit})
-    after = int(st.cursor) if st is not None else None
+    after = cursor_as_int(st.cursor) if st is not None else None
     page_limit = resolve_page_limit(st, limit)
     items = await service.list_skill_versions(
         pool, skill_id, limit=page_limit + 1, after=after, account_id=account_id

--- a/src/aios/api/routers/workflows.py
+++ b/src/aios/api/routers/workflows.py
@@ -23,6 +23,7 @@ from aios.models.pagination import (
     MAX_EVENT_PAGE_LIMIT,
     EventPageLimit,
     PageLimit,
+    cursor_as_int,
     page_cursor,
     resolve_page_limit,
 )
@@ -260,7 +261,7 @@ async def list_run_events(
     await service.get_run(pool, run_id, account_id=account_id)
     st = page_cursor(cursor, {"limit": limit})
     page_limit = resolve_page_limit(st, limit, default=200, maximum=MAX_EVENT_PAGE_LIMIT)
-    after_seq = int(st.cursor) if st is not None else 0
+    after_seq = cursor_as_int(st.cursor) if st is not None else 0
     items = await service.list_run_events(
         pool, run_id, account_id=account_id, after_seq=after_seq, limit=page_limit + 1
     )

--- a/src/aios/models/pagination.py
+++ b/src/aios/models/pagination.py
@@ -98,6 +98,18 @@ def encode_cursor(state: CursorState) -> str:
     return base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
 
 
+def _malformed_cursor() -> ValidationError:
+    """The 422 for any unusable cursor, single-sourced so the message and hint stay
+    identical wherever a cursor is rejected — :func:`decode_cursor` for the envelope,
+    :func:`cursor_as_int` for the keyset. A tampered cursor must be indistinguishable
+    from a garbage one, and the wording must not drift between the two rejection sites.
+    """
+    return ValidationError(
+        "Malformed pagination cursor.",
+        detail={"hint": "Re-issue the original first-page query; cursors are not hand-editable."},
+    )
+
+
 def decode_cursor(token: str) -> CursorState:
     """Decode an opaque token back into a :class:`CursorState`.
 
@@ -118,12 +130,24 @@ def decode_cursor(token: str) -> CursorState:
             filters=raw_filters if isinstance(raw_filters, dict) else {},
         )
     except Exception as exc:
-        raise ValidationError(
-            "Malformed pagination cursor.",
-            detail={
-                "hint": "Re-issue the original first-page query; cursors are not hand-editable."
-            },
-        ) from exc
+        raise _malformed_cursor() from exc
+
+
+def cursor_as_int(cursor: str | int) -> int:
+    """A keyset cursor's value as an ``int``, or a malformed-cursor 422.
+
+    Seq/version-keyed list endpoints page on an integer keyset and coerce
+    ``st.cursor`` with ``int(...)``. The cursor is unsigned and forgeable (see the
+    module docstring) and :func:`decode_cursor` stores ``c`` verbatim, so a
+    tampered token can carry a non-numeric keyset. Routing the coercion through
+    here surfaces that as a 422 — the same malformed-cursor outcome
+    :func:`decode_cursor` raises for a garbage token — instead of letting the raw
+    ``ValueError`` escape as an unhandled 500.
+    """
+    try:
+        return int(cursor)
+    except (TypeError, ValueError) as exc:
+        raise _malformed_cursor() from exc
 
 
 def reject_params_with_cursor(provided: dict[str, Any]) -> None:

--- a/tests/e2e/test_events_pagination.py
+++ b/tests/e2e/test_events_pagination.py
@@ -9,6 +9,8 @@ the past.
 
 from __future__ import annotations
 
+import base64
+import json
 import secrets
 from collections.abc import AsyncIterator
 from typing import Any
@@ -285,6 +287,26 @@ class TestCursorValidation:
     ) -> None:
         r = await http_client.get(
             _EVENTS.format(sid=session_with_events), params={"cursor": "not-a-real-token!!!"}
+        )
+        assert r.status_code == 422, r.text
+
+    async def test_forged_non_int_keyset_is_422_not_500(
+        self, http_client: httpx.AsyncClient, session_with_events: str
+    ) -> None:
+        # A well-formed-but-tampered token: it decodes cleanly (the cursor is
+        # unsigned base64url(JSON)), but carries a non-int keyset ``c``. This
+        # endpoint coerces the keyset to int (``seq = int(st.cursor)``); a forged
+        # non-int must surface as a malformed-cursor 422, not crash the coercion
+        # into an unhandled 500.
+        forged = (
+            base64.urlsafe_b64encode(
+                json.dumps({"v": 1, "c": "not-an-int", "d": "f", "f": {}, "l": 50}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        r = await http_client.get(
+            _EVENTS.format(sid=session_with_events), params={"cursor": forged}
         )
         assert r.status_code == 422, r.text
 

--- a/tests/unit/test_cursor_codec.py
+++ b/tests/unit/test_cursor_codec.py
@@ -12,6 +12,7 @@ from aios.models.pagination import (
     MAX_EVENT_PAGE_LIMIT,
     MAX_PAGE_LIMIT,
     CursorState,
+    cursor_as_int,
     decode_cursor,
     encode_cursor,
     reject_params_with_cursor,
@@ -152,3 +153,37 @@ class TestResolvePageLimitBounds:
         # No cursor: the (already Pydantic-bounded) ?limit= or the default flows through.
         assert resolve_page_limit(None, 25) == 25
         assert resolve_page_limit(None, None) >= 1
+
+
+class TestCursorAsInt:
+    """Seq/version-keyed endpoints coerce the cursor's keyset with ``cursor_as_int``.
+    The cursor is forgeable and ``decode_cursor`` stores ``c`` verbatim, so a tampered
+    non-int keyset must surface as a malformed-cursor 422, not a raw ``ValueError``
+    that escapes the router as an unhandled 500."""
+
+    def test_int_passes_through(self) -> None:
+        assert cursor_as_int(5) == 5
+
+    def test_numeric_string_coerces(self) -> None:
+        # A legit id-keyed cursor never reaches here, but a numeric string is a valid
+        # keyset position and must coerce without error.
+        assert cursor_as_int("42") == 42
+
+    def test_forged_non_int_raises_422(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            cursor_as_int("not-an-int")
+        assert exc.value.status_code == 422
+
+    def test_decoded_forged_keyset_raises_422(self) -> None:
+        # The full path: a tampered token decodes cleanly (c stored verbatim), then the
+        # int coercion the routers perform must 422 rather than 500.
+        forged = (
+            base64.urlsafe_b64encode(
+                json.dumps({"v": 1, "c": "abc", "d": "f", "f": {}, "l": 50}).encode()
+            )
+            .decode()
+            .rstrip("=")
+        )
+        st = decode_cursor(forged)
+        with pytest.raises(ValidationError):
+            cursor_as_int(st.cursor)


### PR DESCRIPTION
## Summary

The opaque pagination cursor is unsigned `base64url(JSON)` — **forgeable by any authenticated client** — and `decode_cursor` stores its keyset value `"c"` **verbatim** (its type is endpoint-specific: a ULID `str` for id-keyed endpoints, an `int` for seq/version-keyed ones).

The seq/version-keyed list endpoints coerce it with `int(st.cursor)`. A tampered token carrying a non-int `"c"` (e.g. `{"c": "not-an-int"}`) decodes cleanly, then **`int("not-an-int")` raises an unhandled `ValueError` → 500** — instead of the malformed-cursor **422** every other tamper case (`decode_cursor`) returns. Only `AiosError`/`StarletteHTTPException`/`RequestValidationError` handlers are installed, so the raw `ValueError` falls through.

This is the sibling of #1162 (which clamped the forgeable `"l"` limit); this PR closes the forgeable `"c"` keyset — the same "validation enforced on one cursor field but not its sibling" shape.

## Fix

Add `cursor_as_int(cursor) -> int` to `models/pagination.py`: it coerces to int and raises the malformed-cursor 422 on failure (`ValueError` for a bad string, `TypeError` for a forged `dict`/`list`). Route all **four** int-keyed cursor sites through it:

- `GET /v1/sessions/{id}/events` · `GET /v1/runs/{id}/events`
- `GET /v1/agents/{id}/versions` · `GET /v1/skills/{id}/versions`

A `_malformed_cursor()` factory single-sources the 422 payload so `decode_cursor` and `cursor_as_int` can't drift (a tampered cursor stays indistinguishable from a garbage one). The 10 `str(st.cursor)` id-keyed sites are unaffected — `str()` of any scalar is crash-safe.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 2858 passed (incl. 4 new `TestCursorAsInt` cases)
- [x] e2e `test_forged_non_int_keyset_is_422_not_500` — confirmed **RED** on old code (`int("not-an-int")` → 500), **GREEN** (422) after, via local Docker
- [ ] CI runs full integration/e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)