### PR TITLE
test(invoke-edge): pin env ownership gate + sub-⊤ tripwire on the api→session edge (#1130)

### DIFF
--- a/tests/integration/test_invoke_env_containment_tripwire.py
+++ b/tests/integration/test_invoke_env_containment_tripwire.py
@@ -1,0 +1,166 @@
+"""Tripwire test pinning the deferral precondition for #1130.
+
+#1130 ships an **ownership-only** gate on the caller-supplied ``environment_id``
+at ``POST /v1/invocations`` (#1128): the supplied env must be owned by the
+authenticated account (``get_environment(conn, env_id, account_id=<caller>)``),
+exactly as ``create_session`` / ``create_run`` already enforce (#755). The
+*per-field containment clamp* (``networking`` / ``image`` / ``env``-keys subset-of a
+baseline env) is **deferred** — there is no attenuated / sub-TOP API principal to
+clamp against today, so ownership *is* the bound and there is nothing below top.
+
+This module is the tripwire that keeps the deferral sound. It asserts, from two
+independent angles, that **no sub-TOP / attenuated API principal exists today**:
+
+1. the account-key path (``account_keys`` schema) carries **no
+   surface / scope / attenuation column**; and
+2. the bearer-auth principal (``require_bearer_auth`` -> ``AccountAuthResult``)
+   resolves to a **full-account** ``account_id`` with no sub-TOP surface field.
+
+When either assertion fails — i.e. when an attenuated / delegated (sub-TOP) API
+principal *is* introduced — that is the signal to implement the deferred
+per-field env containment clamp (``networking`` / ``image`` / ``env``-keys subset-of
+baseline) on the api->session edge. See #1130. The failing test is the
+deferral's re-entry point.
+
+Sibling of #823 (the ``api_base`` second-authority axis) — same tripwire shape.
+"""
+
+from __future__ import annotations
+
+import typing
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.api import deps
+from aios.db.pool import create_pool
+
+pytestmark = pytest.mark.integration
+
+
+# The columns ``account_keys`` carries today (migration 0042). The tripwire
+# below asserts the live schema equals exactly this set — neither a missing
+# column (a precondition drift) nor a *new* column slipping in unnoticed. A new
+# column named for a surface / scope / attenuation axis is precisely the event
+# that re-opens the deferred clamp.
+_ACCOUNT_KEYS_COLUMNS_TODAY = frozenset(
+    {
+        "key_id",
+        "account_id",
+        "hash",
+        "label",
+        "created_at",
+        "last_used_at",
+        "revoked_at",
+    }
+)
+
+# Substrings that, if they appear in a *new* ``account_keys`` column name, would
+# signal an attenuation / sub-TOP surface being attached to the bearer principal.
+# Named explicitly so the failure message points the next implementer straight
+# at the deferred clamp.
+_ATTENUATION_COLUMN_HINTS = ("surface", "scope", "attenuat", "clamp", "baseline")
+
+# The env axes the deferred per-field containment clamp would eventually cover
+# (``EnvironmentConfig`` at ``models/environments.py``). Documented here as the
+# future clamp targets; NOT clamped now.
+_DEFERRED_CLAMP_AXES = ("networking", "image", "env")
+
+
+@pytest.fixture
+async def pool(migrated_db_url: str, _reset_db_state: None) -> AsyncIterator[asyncpg.Pool[Any]]:
+    p = await create_pool(migrated_db_url, min_size=1, max_size=2)
+    try:
+        yield p
+    finally:
+        await p.close()
+
+
+async def test_account_keys_has_no_attenuation_surface_column(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    """The ``account_keys`` path carries no surface / scope / attenuation column.
+
+    The bearer/account-key path (``require_bearer_auth`` ->
+    ``lookup_account_by_key_hash``) is the principal that authorizes
+    ``POST /v1/invocations``. Today every account key is full-account-TOP: the
+    ``account_keys`` row binds a key to an ``account_id`` and nothing finer.
+    There is no column describing an attenuated *subset* of that account's
+    surface, so the supplied ``environment_id`` has nothing below top to be
+    clamped against — ownership IS the bound.
+
+    When an attenuated / delegated (sub-TOP) API principal is introduced, this
+    assertion fails — that is the signal to implement the deferred per-field env
+    containment clamp (networking / image / env-keys subset-of baseline) on the
+    api->session edge. See #1130.
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name = 'account_keys'
+            """
+        )
+    live_columns = {r["column_name"] for r in rows}
+
+    # The connection_ids allowlist (#350) — the only attenuation surface in the
+    # codebase — lives on the *runtime-token* path, NOT here. account_keys must
+    # carry exactly its #1130-precondition column set: no more, no less.
+    assert live_columns == set(_ACCOUNT_KEYS_COLUMNS_TODAY), (
+        "account_keys schema drifted from the #1130 deferral precondition.\n"
+        f"  expected: {sorted(_ACCOUNT_KEYS_COLUMNS_TODAY)}\n"
+        f"  live:     {sorted(live_columns)}\n"
+        "If a column naming an attenuation / scope / surface axis was added, an "
+        "attenuated (sub-TOP) API principal now exists — implement the deferred "
+        "per-field env containment clamp "
+        f"({'/'.join(_DEFERRED_CLAMP_AXES)}-keys subset-of baseline) on the api->session "
+        "edge. See #1130."
+    )
+
+    # Belt-and-braces: no column name hints at an attenuation surface, even if
+    # the exact-set check above is ever relaxed.
+    offenders = [
+        c for c in live_columns if any(hint in c.lower() for hint in _ATTENUATION_COLUMN_HINTS)
+    ]
+    assert not offenders, (
+        f"account_keys grew an attenuation-shaped column {offenders!r}: a sub-TOP "
+        "API principal now exists. Implement the deferred per-field env "
+        "containment clamp on the api->session edge. See #1130."
+    )
+
+
+def test_bearer_auth_principal_is_full_account_no_subtop_surface() -> None:
+    """The bearer-auth tuple resolves to a full-account ``account_id``, no sub-TOP field.
+
+    ``require_bearer_auth`` returns ``AccountAuthResult`` — a
+    ``(account_id, key_id, can_mint_children)`` 3-tuple. None of those three is a
+    sub-TOP *surface*: ``account_id`` is the full tenant, ``key_id`` identifies the
+    key row, and ``can_mint_children`` is a tenancy-creation capability (a child
+    account is a *distinct* full-TOP ``account_id`` within its own tenant, not an
+    attenuated subset of the parent's surface). The invoke endpoint's ownership
+    gate uses ``account_id`` from this tuple — never a request-body-supplied
+    account.
+
+    When an attenuated / delegated (sub-TOP) API principal is introduced — e.g. a
+    fourth tuple element describing a surface subset, or ``account_id`` becoming
+    an attenuated handle — this assertion fails. That is the signal to implement
+    the deferred per-field env containment clamp (networking / image / env-keys
+    subset-of baseline) on the api->session edge. See #1130.
+    """
+    # AccountAuthResult is the resolved-auth contract. Pin its arity and members
+    # so a sub-TOP surface element can't be added without tripping this.
+    args = typing.get_args(deps.AccountAuthResult)
+    assert args == (str, str, bool), (
+        "AccountAuthResult changed shape from (account_id, key_id, "
+        f"can_mint_children); got {args!r}. If a sub-TOP surface element was "
+        "added to the bearer-auth principal, implement the deferred per-field "
+        "env containment clamp on the api->session edge. See #1130."
+    )
+
+    # The endpoint depends on AccountIdDep, which projects exactly the
+    # account_id out of the tuple — confirm that projection is still a pure
+    # full-account id with no attenuation wrapper.
+    assert deps.AccountIdDep is not None

--- a/tests/integration/test_session_cross_tenant_isolation.py
+++ b/tests/integration/test_session_cross_tenant_isolation.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
 
 import asyncpg
 import pytest
@@ -38,8 +40,11 @@ import pytest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import NotFoundError
+from aios.harness import runtime
 from aios.services import agents as agents_service
 from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
 
@@ -146,3 +151,116 @@ class TestSessionCrossTenantIsolation:
         async with pool.acquire() as conn:
             with pytest.raises(NotFoundError):
                 await queries.get_session_model(conn, session_id, account_id="acc_a")
+
+
+# ─── api->session invoke edge: caller-supplied environment_id ownership gate ───
+# (#1130, ships with #1128's POST /v1/invocations.)
+#
+# Unlike session-> / run-> callers (which inherit the launcher's env), the API
+# caller has no launcher to inherit from, so it supplies ``environment_id``
+# directly — re-opening the caller-chosen-env surface ``create_run`` forecloses.
+# #1130 gates that supply with the SAME ownership check ``create_session`` /
+# ``create_run`` already enforce (#755): the supplied env must be owned by the
+# *authenticated caller's* account (``get_environment(..., account_id=<caller>)``),
+# never a body-supplied account. These tests pin that gate on the invoke path.
+
+
+_API_ROOT = "acc_invoke_gate_root"
+_CALLER = "acc_invoke_gate_caller"
+_OTHER = "acc_invoke_gate_other"
+
+
+@pytest.fixture
+async def pool_invoke_gate(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, agent_id, caller_account_id)`` for the invoke ownership gate.
+
+    Two sibling tenants under one root: ``_CALLER`` (the authenticated caller,
+    owns an agent) and ``_OTHER`` (owns the env the gate must refuse). The
+    session-wake defer is patched out — the gate fires before any wake, and
+    these tests cover the ownership refusal, not the worker stepping.
+    """
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = pool
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ($1, NULL, TRUE,  'invoke-gate-root'),
+                       ($2, $1,   FALSE, 'invoke-gate-caller'),
+                       ($3, $1,   FALSE, 'invoke-gate-other')
+                """,
+                _API_ROOT,
+                _CALLER,
+                _OTHER,
+            )
+        agent, _env, _session = await seed_agent_env_session(
+            pool, account_id=_CALLER, prefix="invoke-gate"
+        )
+        with mock.patch("aios.services.wake.defer_wake", new=AsyncMock()):
+            yield pool, agent.id, _CALLER
+    finally:
+        runtime.pool = prev
+        await pool.close()
+
+
+class TestInvokeEnvironmentOwnershipGate:
+    async def test_invoke_refuses_cross_tenant_environment_id(
+        self,
+        pool_invoke_gate: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """``invoke`` (POST /v1/invocations) must refuse a foreign ``environment_id``.
+
+        The caller authenticates as ``_CALLER`` but supplies an env owned by
+        ``_OTHER``. The ownership gate (``get_environment(..., account_id=_CALLER)``
+        inside ``create_session``) raises :class:`NotFoundError` — the env
+        "doesn't exist" from the caller's vantage — and NO session is created.
+        Without the gate, a bare FK would accept the foreign id and leak its
+        image / env-vars / networking into the caller's servicer session.
+        """
+        pool, agent_id, caller = pool_invoke_gate
+        other_env = await environments_service.create_environment(
+            pool, account_id=_OTHER, name="invoke-gate-foreign-env"
+        )
+        before = {s.id for s in await sessions_service.list_sessions(pool, account_id=caller)}
+        with pytest.raises(NotFoundError):
+            await sessions_service.invoke(
+                pool,
+                account_id=caller,
+                target_kind="agent",
+                target=agent_id,
+                input="x",
+                environment_id=other_env.id,
+            )
+        # Fail-closed: the refused invoke spawned NO new servicer session (the
+        # gate raises inside create_session's transaction, before any insert).
+        after = {s.id for s in await sessions_service.list_sessions(pool, account_id=caller)}
+        assert after == before
+
+    async def test_invoke_accepts_self_owned_environment_id(
+        self,
+        pool_invoke_gate: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A self-owned ``environment_id`` passes the gate and binds the servicer.
+
+        The caller supplies an env it owns; the ownership gate accepts it and
+        the servicer session is created bound to that env.
+        """
+        pool, agent_id, caller = pool_invoke_gate
+        own_env = await environments_service.create_environment(
+            pool, account_id=caller, name="invoke-gate-own-env"
+        )
+        handle = await sessions_service.invoke(
+            pool,
+            account_id=caller,
+            target_kind="agent",
+            target=agent_id,
+            input="x",
+            environment_id=own_env.id,
+        )
+        assert handle.servicer_kind == "session"
+        session = await sessions_service.get_session(pool, handle.servicer_id, account_id=caller)
+        assert session.environment_id == own_env.id


### PR DESCRIPTION
## What & why

Part of #1122. Closes the env-containment slice of the api→session invoke edge (`POST /v1/invocations`, #1128).

Unlike `session→`/`run→` callers (which **inherit** the launcher's env), the API caller has no launcher to inherit from — so it supplies `environment_id` directly, re-opening the caller-chosen-env surface that `create_run` deliberately forecloses (`tools/workflow_management.py:97-98`). Per the **locked OWNERSHIP-ONLY decision** (Tom-locked), this issue puts a same-account **ownership gate** on that supply — exactly the check `create_session`/`create_run` already enforce (#755) — and pins a **tripwire** keeping the deferred per-field containment clamp sound.

## Deliverables

1. **Ownership gate (pinned, no source change).** The gate is `get_environment(conn, environment_id, account_id=<authenticated caller>)`, which `create_session` already calls on the invoke path (`services/sessions.py:285`, reached via `service.invoke` → `create_session`); the comment at `services/sessions.py:532-533` already attributes the ownership half to #1130. It ships *inside* #1128's `create_session` path, so this issue adds no source, **no alembic migration, and no API request/response model fields** (no openapi.json / aios-sdk regen attributable to it). The new tests pin the behavior in its named home.
   - `tests/integration/test_session_cross_tenant_isolation.py` (the #755 cross-tenant env-binding home): the invoke edge **refuses** a cross-tenant `environment_id` (`NotFoundError`, fail-closed — no servicer session created) and **accepts** a self-owned one (binds the servicer session to it). The gate uses the authenticated caller's `account_id`, never a body-supplied account.

2. **Tripwire test** — `tests/integration/test_invoke_env_containment_tripwire.py`: asserts no attenuated/sub-⊤ API principal exists today, from two angles:
   - `account_keys` (migration 0042) carries **no surface/scope/attenuation column** (schema introspection; the `connection_ids` allowlist #350 lives on the runtime-token path, not the bearer/account-key path);
   - the bearer-auth principal (`require_bearer_auth` → `AccountAuthResult`) resolves to a **full-account** `(account_id, key_id, can_mint_children)` tuple with no sub-⊤ surface field (child accounts are distinct full-⊤ tenants, not attenuated subsets).

   Each test's docstring states that when an attenuated/delegated (sub-⊤) API principal is introduced, the assertion fails — the signal to implement the **deferred** per-field env containment clamp (networking/image/env-keys ⊆ baseline) on the api→session edge (see #1130). The failing test is the deferral's re-entry point. Sibling of #823 (the `api_base` axis) — same tripwire shape.

## Not delivered (deferred behind the tripwire)

The per-field containment clamp. There is no sub-⊤ API principal to clamp against today, so ownership *is* the bound and there is nothing below top.

## Acceptance

- [x] `POST /invocations` with an `environment_id` not owned by the authenticated account is refused via the ownership gate; a self-owned `environment_id` is accepted and binds the servicer session.
- [x] The gate uses the authenticated caller's `account_id` from bearer auth, never a body-supplied account.
- [x] A tripwire test asserts no sub-⊤/attenuated API principal exists today; its docstring names the deferred per-field clamp as the action when the assertion ever fails.
- [x] No new alembic migration and no API request/response model fields added by this issue.
- [x] `uv run ruff check` + `ruff format --check`, `uv run mypy`, and the new + existing `test_session_cross_tenant_isolation.py` / `test_invocations.py` suites pass (verified against a local Postgres 16-equivalent; testcontainer suite unchanged).