### PR TITLE
fix(dev-pipeline): post-merge master-CI watch is advisory, not a gate (#1176)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -19,8 +19,11 @@ NODE PARTITION (see the design doc):
 - **scripted** (``tool('http_request')`` / ``tool('bash')`` / in-script ``re``): the spec
   gate, PR/label/comment/status API calls, the merge-ref guard, mark-ready, merge.
 - **gate** (``gate()``): every escalation — unsettled design, review/CI exhaustion, a
-  no-commit fix, a fail-closed merge-guard refusal, high-risk merge approval, red master.
-  Each parks the run durably instead of dead-ending in autodev's ``awaiting_triage``.
+  no-commit fix, a fail-closed merge-guard refusal, high-risk merge approval. Each parks the
+  run durably instead of dead-ending in autodev's ``awaiting_triage``. NOTE (issue #1176): the
+  post-merge master-CI watch is NO LONGER a gate — the merge is a committed fact, so the run
+  returns done on merge and the watch runs ADVISORY (a red/indeterminate result files a
+  follow-up issue, never re-suspends the completed run).
 
 CREDENTIALS: the run binds a vault providing ``GITHUB_TOKEN``. GitHub *API* calls go through
 ``tool('http_request', {server_ref: <github_server>, ...})`` (auth resolved against the bound
@@ -71,9 +74,13 @@ RESILIENCE CONTRACT (the Phase-0 hardening, aios#987; design doc §10):
    ``merge_failed`` so an already-merged PR is never double-merged or lost.
 5. **AgentError guards.** Every agentic node (implement/review/fix/ci-watch/risk) runs under a
    defensive guard: an ``agent_not_found`` / transient agent error escalates to the relevant
-   gate (design / verify) or, for the best-effort risk + post-merge nodes, degrades to the
-   conservative default — so a flaky judgment agent parks the run for a human instead of
-   crashing it (an uncaught ``AgentError`` at the root fails the whole run).
+   gate (design / verify) or, for the best-effort risk node, degrades to the conservative
+   default — so a flaky judgment agent parks the run for a human instead of crashing it (an
+   uncaught ``AgentError`` at the root fails the whole run). The post-merge master-CI watch is
+   the one node that does NEITHER (issue #1176): the merge is already committed and the run has
+   already returned done, so a flaky watch is RETRIED (≤ ``MAX_MASTER_CI_ITERS``) and, if still
+   indeterminate, degrades to a distinct non-blocking advisory — never coerced to the
+   most-blocking outcome and never allowed to re-suspend a completed run at a false gate.
 """
 
 from __future__ import annotations
@@ -182,6 +189,12 @@ LABEL_FAILED = "autodev:failed"
 # ``retry_count >= MAX_RUN_RETRIES`` terminates at the dead-letter state instead of looping.
 MAX_RUN_RETRIES = 2
 
+# Post-merge master-CI watch is ADVISORY (issue #1176): the merge is a committed fact and the
+# run returns done the moment the merge confirms. A flaky watch agent must never re-suspend a
+# completed run, so an AgentError / malformed return is RETRIED a bounded number of times
+# before the watch is declared indeterminate (a signal distinct from a genuinely-red master).
+MAX_MASTER_CI_ITERS = 3
+
 
 def _py(name: str, value: Any) -> str:
     """One ``NAME = <repr>`` constant line for the prepended header. ``repr`` over the
@@ -227,6 +240,7 @@ def _render_constants(
         _py("LABEL_IN_PROGRESS", LABEL_IN_PROGRESS),
         _py("LABEL_FAILED", LABEL_FAILED),
         _py("MAX_RUN_RETRIES", MAX_RUN_RETRIES),
+        _py("MAX_MASTER_CI_ITERS", MAX_MASTER_CI_ITERS),
         _py("IMPLEMENT_SCHEMA", IMPLEMENT_SCHEMA),
         _py("REVIEW_SCHEMA", REVIEW_SCHEMA),
         _py("FIX_SCHEMA", FIX_SCHEMA),
@@ -484,6 +498,19 @@ async def _fail(repo, issue_number, result):
     await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
     await _label(repo, issue_number, LABEL_FAILED)
     return result
+
+
+async def _file_followup(repo, title, body):
+    """Open a best-effort follow-up issue for an ADVISORY post-merge signal (a red or
+    indeterminate master-CI watch). The merge is already a committed fact and the run has
+    already returned done, so this is a non-blocking alert: it must NEVER re-suspend the run,
+    and a create failure is swallowed (gh already retries transient 5xx). Returns the created
+    issue number when GitHub reports it, else None."""
+    resp = await gh("POST", _ipath(repo, "/issues"), {"title": title, "body": body})
+    created = _json_body(resp)
+    if isinstance(created, dict):
+        return created.get("number")
+    return None
 
 
 # ─── the state machine ───────────────────────────────────────────────────────
@@ -782,26 +809,68 @@ async def main(input):
                                 "reason": "merge call returned %r" % _status(merge_resp),
                                 "escalations": escalations})
 
-    # A15 — post-merge master-CI watch (the D-2 missing state). Red OR an errored watch =>
-    # HALT at a gate; the merge is a committed fact, so we never discard it by failing here.
-    phase("post-merge")
-    try:
-        master = await agent(
-            {"task": "watch_ci", "repo": repo, "ref": BASE_BRANCH},
-            agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model, label="master-ci")
-        master_red = master["status"] == "red"
-        master_detail = master.get("detail", "")
-    except (AgentError, KeyError, TypeError) as exc:
-        master_red = True
-        master_detail = "master-CI watch failed: %s" % exc
-    if master_red:
-        escalations.append("master_red")
-        await gate({"kind": "master_red", "repo": repo, "detail": master_detail})
-
-    # Success: the issue is done, so release the in-progress claim (item 3).
+    # A15 — DONE on merge (issue #1176). The merge PUT is a committed fact: the issue is
+    # resolved the moment it confirms, so release the in-progress claim and FIX the terminal
+    # outcome to done HERE — before the advisory master-CI watch runs. Nothing the watch does
+    # below can re-suspend or fail this completed run; a flaky watch agent can no longer
+    # manufacture a false human gate that parks a finished run indefinitely.
     await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
-    return {"state": "done", "pr_url": pr_url, "pr_number": pr_number, "merged": merged,
-            "risk_tier": tier, "escalations": escalations}
+    result = {"state": "done", "pr_url": pr_url, "pr_number": pr_number, "merged": merged,
+              "risk_tier": tier, "escalations": escalations}
+
+    # A15b — post-merge master-CI watch, ADVISORY. On a genuinely-RED master we raise a
+    # distinct "master_red" advisory; on an AgentError / malformed return we RETRY up to
+    # MAX_MASTER_CI_ITERS, and only if STILL indeterminate raise a DISTINCT
+    # "master_ci_indeterminate" advisory ("could not determine master state", NOT "master is
+    # red"). Both are NON-blocking: each files a best-effort follow-up issue and is recorded in
+    # result["advisories"] (telemetry that is provably distinct from a blocking gate-park in
+    # result["escalations"]) — agent flakiness is NEVER coerced to the most-blocking outcome.
+    phase("post-merge")
+    master_status = None
+    master_detail = ""
+    for i in range(MAX_MASTER_CI_ITERS):
+        try:
+            master = await agent(
+                {"task": "watch_ci", "repo": repo, "ref": BASE_BRANCH},
+                agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model,
+                label="master-ci-%d" % i)
+            master_status = master["status"]
+            master_detail = master.get("detail", "")
+            break  # a well-formed verdict (green/red/no_ci) — no retry needed
+        except (AgentError, KeyError, TypeError) as exc:
+            master_detail = "master-CI watch failed: %s" % exc
+            log("master-CI watch attempt %d indeterminate (non-blocking):" % i, exc)
+
+    advisories = []
+    if master_status == "red":
+        advisories.append("master_red")
+        result["advisories"] = advisories
+        result["master_ci"] = "red"
+        await _file_followup(
+            repo, "Post-merge: master CI is RED after merging #%d" % issue_number,
+            "Automated advisory from the dev-pipeline. The post-merge master-CI watch for "
+            "`%s` reported **red** after merging PR #%d (issue #%d).\n\nThe merge is a "
+            "committed fact and the run completed normally; this is a SEPARATE non-blocking "
+            "signal that master may need attention.\n\n```\n%s\n```"
+            % (BASE_BRANCH, pr_number, issue_number, master_detail))
+    elif master_status is None:
+        # Exhausted the bounded retries without a well-formed verdict: could not DETERMINE
+        # master state. This is a distinct reason from "master is red" — we degrade to a
+        # best-effort advisory and NEVER re-suspend the completed run.
+        advisories.append("master_ci_indeterminate")
+        result["advisories"] = advisories
+        result["master_ci"] = "indeterminate"
+        await _file_followup(
+            repo, "Post-merge: master CI state INDETERMINATE after merging #%d" % issue_number,
+            "Automated advisory from the dev-pipeline. The post-merge master-CI watch for "
+            "`%s` could not be DETERMINED after merging PR #%d (issue #%d) — the watch agent "
+            "errored or returned a malformed verdict on all %d attempts. This is NOT a red "
+            "master; master state is simply unknown and should be checked.\n\n```\n%s\n```"
+            % (BASE_BRANCH, pr_number, issue_number, MAX_MASTER_CI_ITERS, master_detail))
+    else:
+        result["master_ci"] = master_status  # "green" / "no_ci"
+
+    return result
 '''
 
 

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -218,9 +218,7 @@ class Scenario:
                 if spec["input"].get("ref"):  # post-merge master watch (advisory, retried)
                     if self.master_ci_results is not None:
                         idx = int(label.rsplit("-", 1)[1]) if "-" in label else 0
-                        item = self.master_ci_results[
-                            min(idx, len(self.master_ci_results) - 1)
-                        ]
+                        item = self.master_ci_results[min(idx, len(self.master_ci_results) - 1)]
                         if item == "error":
                             return {"error": {"kind": "child_errored"}}
                         return {"ok": item}

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -88,6 +88,7 @@ class Scenario:
         gate_results: dict[str, Any] | None = None,
         master_ci: str = "green",
         master_ci_error: bool = False,
+        master_ci_results: list[dict[str, Any] | str] | None = None,
         transient_5xx: dict[tuple[str, str], int] | None = None,
     ) -> None:
         self.body = body
@@ -112,6 +113,11 @@ class Scenario:
         self.gate_results = gate_results or {}
         self.master_ci = master_ci
         self.master_ci_error = master_ci_error
+        # Per-attempt post-merge master-CI verdicts, indexed by the watch's per-retry label
+        # ("master-ci-{i}"). Each item is either a verdict dict ({"status": ..., "detail": ...})
+        # or the string "error" (the watch agent raises AgentError that attempt). When set, this
+        # overrides master_ci/master_ci_error. The last item is reused for any later attempt.
+        self.master_ci_results = master_ci_results
         # {(method, path): N} — return a transient 5xx for the FIRST N attempts of that call,
         # then the real response. Counts are mutated as attempts arrive (replay-stable because
         # each retry is a distinct call_key, so a replay re-asks each attempt exactly once).
@@ -122,6 +128,7 @@ class Scenario:
         self.http: list[tuple[str, str]] = []
         self.labels_added: list[str] = []  # every label name POSTed to /labels (item 3)
         self.labels_removed: list[str] = []  # every label name DELETEd from /labels
+        self.followups: list[dict[str, Any]] = []  # advisory follow-up issues created (#1176)
 
     def _comments_json(self) -> str:
         return json.dumps([{"id": i, "body": c} for i, c in enumerate(self.comments)])
@@ -157,6 +164,10 @@ class Scenario:
             return {"status": 200, "body": "[" + _pr_json() + "]" if self.existing_pr else "[]"}
         if method == "POST" and path == "/repos/o/r/pulls":
             return {"status": 201, "body": _pr_json()}
+        if method == "POST" and path == "/repos/o/r/issues":  # advisory follow-up issue (#1176)
+            raw = args.get("body")
+            self.followups.append(json.loads(raw) if isinstance(raw, str) else {})
+            return {"status": 201, "body": json.dumps({"number": 99})}
         if method == "GET" and path == "/repos/o/r/pulls/42":  # merge-confirm read
             return {"status": 200, "body": _pr_json(merged=self.pr_merged_on_confirm)}
         if method == "PUT" and path.endswith("/merge"):
@@ -204,7 +215,15 @@ class Scenario:
                 idx = int(label.rsplit("-", 1)[1]) if "-" in label else 0
                 return {"ok": self.review_results[min(idx, len(self.review_results) - 1)]}
             if task == "watch_ci":
-                if spec["input"].get("ref"):  # post-merge master watch
+                if spec["input"].get("ref"):  # post-merge master watch (advisory, retried)
+                    if self.master_ci_results is not None:
+                        idx = int(label.rsplit("-", 1)[1]) if "-" in label else 0
+                        item = self.master_ci_results[
+                            min(idx, len(self.master_ci_results) - 1)
+                        ]
+                        if item == "error":
+                            return {"error": {"kind": "child_errored"}}
+                        return {"ok": item}
                     if self.master_ci_error:
                         return {"error": {"kind": "child_errored"}}
                     return {"ok": {"status": self.master_ci, "detail": ""}}
@@ -266,7 +285,11 @@ async def test_happy_path_merges_and_completes() -> None:
         "merged": True,
         "risk_tier": 1,
         "escalations": [],
+        "master_ci": "green",
     }
+    # a green master-CI watch raises no advisory and files no follow-up issue
+    assert "advisories" not in value
+    assert scn.followups == []
     assert phases == [
         "ingest",
         "spec-gate",
@@ -280,7 +303,7 @@ async def test_happy_path_merges_and_completes() -> None:
         "post-merge",
     ]
     assert scn.gates == []  # tier-1 auto-merges; no gate opened
-    assert scn.tasks == ["implement", "review-0", "ci-0", "risk", "master-ci"]
+    assert scn.tasks == ["implement", "review-0", "ci-0", "risk", "master-ci-0"]
     # never used a query string (the production-path bug the review caught)
     assert all("?" not in path for _, path in scn.http)
     # item 1: the comment thread is read at ingest
@@ -475,22 +498,81 @@ async def test_merge_failure_not_confirmed_reports_merge_failed() -> None:
     assert value["state"] == "merge_failed"
 
 
-async def test_post_merge_master_ci_agent_error_parks_master_red_not_lost_merge() -> None:
-    # If the post-merge master-CI agent ERRORS, the merge (a committed fact) must not be
-    # discarded: the run parks at master_red and still reports merged on resume.
+async def test_post_merge_master_ci_agent_error_returns_done_without_parking() -> None:
+    # #1176: a persistently-erroring post-merge master-CI watch must NOT park the completed
+    # run at a (false) human gate. The merge is a committed fact, so the run returns done; the
+    # erroring watch degrades to a DISTINCT, non-blocking "indeterminate" advisory (NOT
+    # master_red) recorded in result["advisories"], leaving the blocking escalations clean.
     scn = Scenario(master_ci_error=True)
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"
     assert value["merged"] is True
-    assert "master_red" in value["escalations"]
-    assert any(g["kind"] == "master_red" for g in scn.gates)
+    # agent flakiness is never coerced to the most-blocking outcome: no gate, no blocking escalation
+    assert scn.gates == []
+    assert value["escalations"] == []
+    assert "master_red" not in value["escalations"]
+    # the distinct "could not determine master state" signal, kept apart from "master is red"
+    assert value["master_ci"] == "indeterminate"
+    assert value["advisories"] == ["master_ci_indeterminate"]
+    # the watch was RETRIED a bounded number of times before being declared indeterminate
+    assert scn.tasks.count("master-ci-0") == 1
+    assert "master-ci-1" in scn.tasks
+    assert "master-ci-2" in scn.tasks
+    assert "master-ci-3" not in scn.tasks  # bounded at MAX_MASTER_CI_ITERS=3
+    # a best-effort follow-up issue is filed for the indeterminate state (non-blocking alert)
+    assert len(scn.followups) == 1
+    assert "INDETERMINATE" in scn.followups[0]["title"]
 
 
-async def test_red_master_ci_parks_at_gate() -> None:
+async def test_red_master_ci_files_advisory_and_returns_done_without_parking() -> None:
+    # #1176: a genuinely-RED master is a SEPARATE non-blocking signal, not a gate-park. The run
+    # returns done (the merge happened), files a follow-up issue, and records the distinct
+    # "master_red" advisory — never re-suspending the completed run.
     scn = Scenario(master_ci="red")
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
-    assert value["state"] == "done"  # merge happened; parked then resumed
-    assert "master_red" in value["escalations"]
+    assert value["state"] == "done"
+    assert scn.gates == []  # not a gate-park
+    assert value["escalations"] == []  # not coerced into the blocking escalations list
+    assert value["master_ci"] == "red"
+    assert value["advisories"] == ["master_red"]
+    assert len(scn.followups) == 1
+    assert "RED" in scn.followups[0]["title"]
+
+
+async def test_red_and_indeterminate_are_distinct_advisory_reasons() -> None:
+    # Acceptance: "master is red" and "could not determine master state" are DISTINCT reasons.
+    red = Scenario(master_ci="red")
+    red_value, _, _ = await _drive(red, max_review_iters=2, max_ci_iters=2)
+    indet = Scenario(master_ci_error=True)
+    indet_value, _, _ = await _drive(indet, max_review_iters=2, max_ci_iters=2)
+    assert red_value["advisories"] == ["master_red"]
+    assert indet_value["advisories"] == ["master_ci_indeterminate"]
+    assert red_value["advisories"] != indet_value["advisories"]
+    assert red_value["master_ci"] != indet_value["master_ci"]
+
+
+async def test_post_merge_watch_error_then_success_recovers_to_green() -> None:
+    # #1176: a TRANSIENTLY-flaky watch (errors once, then returns green) is retried within the
+    # bound and recovers — no advisory, no follow-up issue, run done.
+    scn = Scenario(master_ci_results=["error", {"status": "green", "detail": ""}])
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["master_ci"] == "green"
+    assert "advisories" not in value
+    assert scn.followups == []
+    assert "master-ci-0" in scn.tasks and "master-ci-1" in scn.tasks
+    assert "master-ci-2" not in scn.tasks  # stopped retrying once a verdict arrived
+
+
+async def test_post_merge_advisory_never_marks_failed_and_releases_in_progress() -> None:
+    # Telemetry must distinguish an advisory post-merge signal from genuinely-blocked work: an
+    # indeterminate/red watch must not label the issue failed, and the in-progress claim is
+    # released on merge (the issue is done).
+    scn = Scenario(master_ci="red")
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert "autodev:failed" not in scn.labels_added
+    assert "autodev:in-progress" in scn.labels_removed
 
 
 # ─── bounded self-repair loops ────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`dev_pipeline.py` post-merge block (the `A15` master-CI watch). The merge PUT is a committed fact by the time the watch runs, but an `AgentError` (agent_not_found / transient model error / timeout) or a malformed return set `master_red=True`, which UNCONDITIONALLY parked the **completed** run at the `master_red` gate. A flaky judgment agent — not an actually-red master — suspended a DONE run at a false human gate, and the only telemetry (`master-CI watch failed: <exc>`) was indistinguishable from a genuine CI failure. This inverted the resilience intent: it manufactured false gates and made a gate-park indistinguishable from genuinely-blocked work (confirmed live: task #63, run wfr_01KV6MN4).

## Fix

Implements all three remediation items from the issue:

1. **DONE on merge.** The success unlabel (`_unlabel(IN_PROGRESS)`) and the `state=done` terminal outcome are now FIXED the moment the merge PUT confirms — *before* the master-CI watch runs. Nothing the watch does can re-suspend or fail this completed run.
2. **Advisory watch.** On a genuinely-RED master, a DISTINCT non-blocking `master_red` advisory is raised; both red and indeterminate file a best-effort follow-up issue and are recorded in `result["advisories"]` (provably distinct from a blocking gate-park in `result["escalations"]`). The post-merge watch is no longer a `gate()` call.
3. **Bounded retry + distinct indeterminate reason.** On `AgentError`/malformed return the watch is retried up to `MAX_MASTER_CI_ITERS` (3); if still indeterminate it degrades to a DISTINCT `master_ci_indeterminate` advisory ("could not determine master state", NOT "master is red") — never coerced to the most-blocking outcome, never re-suspending the completed run.

New telemetry field `result["master_ci"]` ∈ {green, no_ci, red, indeterminate}.

## Acceptance

- ✅ A run whose merge succeeded returns `done` even if the master-CI watch errors (no gate, no blocking escalation).
- ✅ "master is red" (`master_red`) and "could not determine master state" (`master_ci_indeterminate`) are distinct advisory reasons.
- ✅ Run telemetry distinguishes an advisory post-merge signal (`advisories`) from genuinely-blocked work (`escalations`); an advisory never labels the issue `autodev:failed`.

## Tests (test-first)

Rewrote the two stale post-merge fixture tests to the advisory contract and added coverage: erroring watch returns done without parking (+ bounded-retry assertion), red files an advisory without parking, red-vs-indeterminate are distinct reasons, transient-error-then-green recovers with no advisory, and an advisory never marks failed. The fixture harness gained per-attempt master-CI verdicts (`master_ci_results`) and a follow-up-issue recorder. Verified the new tests FAIL against the pre-fix source and PASS after. `ruff` + `mypy` clean; full dev-pipeline test set (63 tests) green.

Pure `dev_pipeline.py` edit (+ fixture). Dedup of source-1 def#2 + source-3 def#6.