### PR TITLE
feat(ci): IaC-sync v1 — deploy-on-merge re-register of dev-pipeline workflow

### DIFF
--- a/.github/workflows/reregister-dev-pipeline.yml
+++ b/.github/workflows/reregister-dev-pipeline.yml
@@ -1,0 +1,63 @@
+# IaC-sync v1 (issue #1179): deploy-on-merge for the dev-pipeline workflow object.
+#
+# The live `dev-pipeline` workflow is a DB snapshot — a run snapshots
+# `workflows.script` at launch and there is NO startup re-sync, so a merged fix to
+# `build_dev_pipeline_script()` is INERT until someone manually re-registers the
+# workflow (proven live 2026-06-16: #1177 merged but every run kept executing the
+# OLD script until a hand re-register). This Action automates exactly the hand
+# recipe that activated #1177+#1159 (v2→v3): on a push to `master` that touches the
+# builder, it reads the live workflow, re-extracts its configurable constants from
+# the LIVE header (drift-safe — NOT hardcoded), rebuilds the script from the updated
+# builder, validates it, and PUTs it back, bumping the version.
+#
+# This is IaC-sync **v1**: a one-shot reconcile of one known object. The v2
+# evolution — a reconcile loop over manifests for all infra (agents/triggers/envs as
+# source of truth) — is sketched in eumemic-company
+# `architecture/dev-machine-reification.md` § infrastructure-as-code.
+name: Re-register dev-pipeline (IaC-sync v1)
+
+on:
+  push:
+    branches: [master]
+    # Trigger ONLY when the builder changes — a builder-less master push is inert
+    # for the workflow object, so re-registering would be a pointless no-op PUT.
+    paths:
+      - "src/aios/workflows/dev_pipeline.py"
+
+# Never run two re-registers concurrently: a stacked pair of builder merges would
+# race the optimistic-version PUT (the loser hits a 409 and fails loudly). Serialise
+# on master and let the tip win; do NOT cancel an in-flight deploy (a half-applied
+# re-register must finish, not be killed).
+concurrency:
+  group: reregister-dev-pipeline
+  cancel-in-progress: false
+
+env:
+  AIOS_URL: https://api.aios.eumemic.ai
+  DEV_PIPELINE_WORKFLOW_ID: wf_01KV4YGV4PSGP08TJBAY32J2VK
+
+jobs:
+  reregister:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Sync deps (the script imports aios)
+        run: uv sync --dev
+
+      # Harder validation than the script's inline `ast.parse`: exec the emitted
+      # program against the host with simulated returns. Abort the deploy if the
+      # regenerated machine can't even be driven through its state machine.
+      - name: Validate regenerated script (fixture drive)
+        run: uv run pytest tests/integration/test_wf_dev_pipeline_fixture.py -q
+
+      - name: Re-register live workflow from the updated builder
+        env:
+          # Provisioned out-of-band by the maintainer; NEVER inline a key.
+          AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
+        run: uv run python scripts/reregister_dev_pipeline.py

--- a/scripts/reregister_dev_pipeline.py
+++ b/scripts/reregister_dev_pipeline.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""IaC-sync v1: re-register the live dev-pipeline workflow from its builder.
+
+When ``src/aios/workflows/dev_pipeline.py`` changes on ``master``, the merged fix
+to ``build_dev_pipeline_script()`` is INERT — a run snapshots ``workflows.script``
+at launch and there is no startup re-sync, so the live workflow object keeps
+executing the OLD script until someone manually re-registers it (proven live
+2026-06-16: #1177 merged but every run ran the old script until a hand
+re-register).  This script automates the hand recipe that activated #1177+#1159
+(v2→v3): read the live workflow, re-extract its configurable constants, rebuild
+the script from the *updated* builder, validate it, and PUT it back — bumping the
+version — so merged builder fixes take effect automatically.
+
+This is **IaC-sync v1** for the workflow object: a one-shot reconcile of a single
+known object, driven by a deploy-on-merge GitHub Action.  The v2 evolution — a
+reconcile loop over manifests for all infra (agents/triggers/envs as source of
+truth) — is sketched in eumemic-company ``architecture/dev-machine-reification.md``
+§ infrastructure-as-code.  See ``.github/workflows/reregister-dev-pipeline.yml``.
+
+Design notes
+------------
+* Constants are read from the LIVE script header (the ``NAME = <repr>`` lines),
+  NOT hardcoded — that is what keeps the re-register drift-safe across prod config
+  changes (a new agent id / sentinel set / merge tier survives the round-trip).
+* The script is split into pure functions (extract / regenerate / validate /
+  decide) and a thin ``main`` that does the HTTP I/O, so the load-bearing logic is
+  unit-testable offline.
+* It is idempotent: when the regenerated script equals the live one, it no-ops and
+  exits 0 with no version bump.  It fails LOUDLY (non-zero exit) on a validation
+  failure, a 409 version-mismatch, or any non-2xx — drift must be visible, never
+  silently skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+# The configurable constants the builder accepts, in the order they appear in the
+# rendered header.  Each maps a header constant NAME (read from the LIVE script) to
+# the ``build_dev_pipeline_script`` keyword it feeds.  Reading these from the
+# deployed workflow (rather than hardcoding) is what preserves prod config across
+# the re-register.  Constants beyond these (MIN_SPEC_BODY_WORDS, the *_SCHEMA dicts,
+# …) are NOT builder kwargs — they are emitted by the builder from module-level
+# defaults, so re-deriving them from the rebuilt script would be circular; they are
+# intentionally excluded here.
+CONSTANT_TO_KWARG: dict[str, str] = {
+    "IMPLEMENT_AGENT_ID": "implement_agent_id",
+    "REVIEW_AGENT_ID": "review_agent_id",
+    "FIX_AGENT_ID": "fix_agent_id",
+    "CI_AGENT_ID": "ci_agent_id",
+    "RISK_AGENT_ID": "risk_agent_id",
+    "GITHUB_SERVER": "github_server",
+    "BASE_BRANCH": "base_branch",
+    "MERGE_SENTINELS": "merge_sentinels",
+    "MAX_REVIEW_ITERS": "max_review_iters",
+    "MAX_CI_ITERS": "max_ci_iters",
+    "AUTO_MERGE_MAX_TIER": "auto_merge_max_tier",
+    "MERGE_METHOD": "merge_method",
+    "DEFAULT_MODEL": "default_model",
+}
+
+
+class ReregisterError(RuntimeError):
+    """A loud, fatal failure — abort the PUT / fail the job."""
+
+
+def extract_constants(live_script: str) -> dict[str, Any]:
+    """Pull the builder-configurable constants out of the LIVE script header.
+
+    The header is a flat sequence of ``NAME = <repr>`` assignments emitted by
+    ``_render_constants``.  We parse the module with ``ast`` and read the literal
+    value of each top-level assignment whose target is one of the known builder
+    constants — so the extraction is robust to header reordering and to whatever
+    config the live deployment carries.  Raises if any expected constant is
+    missing (a header that no longer carries a constant means we'd silently
+    re-deploy with a builder default, which is exactly the drift we're guarding).
+    """
+    try:
+        module = ast.parse(live_script)
+    except SyntaxError as exc:  # pragma: no cover - defensive
+        raise ReregisterError(f"live script failed to parse: {exc}") from exc
+
+    found: dict[str, Any] = {}
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            name = target.id
+            if name not in CONSTANT_TO_KWARG:
+                continue
+            try:
+                value = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError) as exc:
+                raise ReregisterError(
+                    f"could not literal-eval header constant {name}: {exc}"
+                ) from exc
+            found[name] = value
+
+    missing = sorted(set(CONSTANT_TO_KWARG) - set(found))
+    if missing:
+        raise ReregisterError(
+            "live script header is missing expected constants: " + ", ".join(missing)
+        )
+
+    return {CONSTANT_TO_KWARG[name]: value for name, value in found.items()}
+
+
+def regenerate_script(constants: dict[str, Any]) -> str:
+    """Rebuild the production script from the UPDATED builder + live constants."""
+    # Imported here (not at module top) so the unit tests that exercise the pure
+    # extract/decide helpers do not require the full aios import surface, and so a
+    # missing dependency surfaces as a loud ImportError inside the run, not at
+    # collection time.
+    from aios.workflows.dev_pipeline import build_dev_pipeline_script
+
+    return build_dev_pipeline_script(**constants)
+
+
+def validate_script(new_script: str) -> None:
+    """Fail closed if the regenerated script is not even valid Python.
+
+    ``ast.parse`` is the minimum gate run inline here; the Action ALSO runs
+    ``tests/integration/test_wf_dev_pipeline_fixture.py`` (which execs the emitted
+    program) as a separate, harder gate before invoking this script's PUT path.
+    """
+    try:
+        ast.parse(new_script)
+    except SyntaxError as exc:
+        raise ReregisterError(f"regenerated script is not valid Python: {exc}") from exc
+
+
+def needs_update(new_script: str, live_script: str) -> bool:
+    """Idempotency check: only PUT when the regenerated script actually differs."""
+    return new_script != live_script
+
+
+# ─── HTTP I/O (the thin, network-touching shell) ─────────────────────────────
+
+
+def _request(
+    method: str, url: str, api_key: str, body: dict[str, Any] | None = None
+) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read().decode()
+            return resp.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode(errors="replace")
+        try:
+            payload = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            payload = {"raw": raw}
+        return exc.code, payload
+
+
+def get_workflow(base_url: str, workflow_id: str, api_key: str) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/v1/workflows/{workflow_id}"
+    status, payload = _request("GET", url, api_key)
+    if not (200 <= status < 300):
+        raise ReregisterError(f"GET workflow returned {status}: {json.dumps(payload)[:500]}")
+    return payload
+
+
+def put_workflow(
+    base_url: str, workflow_id: str, api_key: str, *, version: int, script: str
+) -> dict[str, Any]:
+    """PUT the new script. Omitted tools/http_servers are PRESERVED (operator path)."""
+    url = f"{base_url.rstrip('/')}/v1/workflows/{workflow_id}"
+    status, payload = _request("PUT", url, api_key, body={"version": version, "script": script})
+    if status == 409:
+        raise ReregisterError(
+            "PUT returned 409 version-mismatch — the live workflow was bumped "
+            "concurrently (version "
+            f"{version} is stale). Re-run the job. Body: {json.dumps(payload)[:500]}"
+        )
+    if not (200 <= status < 300):
+        raise ReregisterError(f"PUT workflow returned {status}: {json.dumps(payload)[:500]}")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-key", default=os.environ.get("AIOS_API_KEY"), help="AIOS API key")
+    parser.add_argument("--url", default=os.environ.get("AIOS_URL"), help="AIOS base URL")
+    parser.add_argument(
+        "--workflow-id",
+        default=os.environ.get("DEV_PIPELINE_WORKFLOW_ID"),
+        help="dev-pipeline workflow id",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.api_key:
+        print("FATAL: AIOS_API_KEY is not set", file=sys.stderr)
+        return 2
+    if not args.url:
+        print("FATAL: AIOS_URL is not set", file=sys.stderr)
+        return 2
+    if not args.workflow_id:
+        print("FATAL: DEV_PIPELINE_WORKFLOW_ID is not set", file=sys.stderr)
+        return 2
+
+    try:
+        # 1. Read the live workflow → current version + script.
+        live = get_workflow(args.url, args.workflow_id, args.api_key)
+        live_script = live.get("script")
+        live_version = live.get("version")
+        if not isinstance(live_script, str) or live_version is None:
+            raise ReregisterError(
+                f"live workflow response missing 'script'/'version': {json.dumps(live)[:500]}"
+            )
+        print(f"Live dev-pipeline workflow version={live_version}")
+
+        # 2. Extract configurable constants from the LIVE header (drift-safe).
+        constants = extract_constants(live_script)
+        print(
+            "Extracted live constants: " + json.dumps({k: constants[k] for k in sorted(constants)})
+        )
+
+        # 3. Rebuild from the UPDATED builder.
+        new_script = regenerate_script(constants)
+
+        # 4. Validate before any write (fail closed).
+        validate_script(new_script)
+
+        # 5. Idempotency: no-op when regenerated == live.
+        if not needs_update(new_script, live_script):
+            print(
+                "Regenerated script is identical to the live script — no-op "
+                "(no version bump). IaC is in sync."
+            )
+            return 0
+
+        # 6. PUT (version bumps; omitted tools/http_servers preserved).
+        print(f"Script changed — re-registering (PUT with version={live_version})…")
+        updated = put_workflow(
+            args.url,
+            args.workflow_id,
+            args.api_key,
+            version=live_version,
+            script=new_script,
+        )
+
+        # 7. Verify the version actually incremented.
+        new_version = updated.get("version")
+        if new_version is None or new_version <= live_version:
+            raise ReregisterError(
+                f"PUT succeeded but version did not increment "
+                f"(live={live_version}, response={new_version})"
+            )
+        print(f"Re-registered dev-pipeline workflow: version {live_version} → {new_version}.")
+        return 0
+
+    except ReregisterError as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_reregister_dev_pipeline.py
+++ b/tests/unit/test_reregister_dev_pipeline.py
@@ -1,0 +1,171 @@
+"""Unit tests for the IaC-sync v1 re-register script (issue #1179).
+
+The script's load-bearing logic is the pure pipeline: extract the configurable
+constants from the LIVE script header (drift-safe), rebuild from the updated
+builder, validate, and decide whether to PUT (idempotent). These tests exercise
+that logic offline — no network, no live workflow — plus the drift guard against
+the workflow YAML and the builder signature.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from aios.workflows.dev_pipeline import build_dev_pipeline_script
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "reregister_dev_pipeline.py"
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "reregister-dev-pipeline.yml"
+
+
+def _load_script_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("reregister_dev_pipeline", _SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rr = _load_script_module()
+
+
+# ─── extract_constants: drift-safe header parse ──────────────────────────────
+
+
+def test_extract_constants_roundtrips_default_builder() -> None:
+    """Constants extracted from a freshly-built script feed the builder back to
+    produce a byte-identical script — the round-trip the Action depends on."""
+    script = build_dev_pipeline_script()
+    constants = rr.extract_constants(script)
+    # Every builder kwarg is recovered.
+    assert set(constants) == set(rr.CONSTANT_TO_KWARG.values())
+    rebuilt = build_dev_pipeline_script(**constants)
+    assert rebuilt == script
+
+
+def test_extract_constants_preserves_non_default_prod_config() -> None:
+    """A live deployment with custom agent ids / sentinels / merge tier must
+    survive the extract → rebuild round-trip unchanged (drift-safe)."""
+    script = build_dev_pipeline_script(
+        implement_agent_id="ag_custom_impl",
+        review_agent_id="ag_custom_review",
+        merge_sentinels=["pytest -q", "ruff check src"],
+        auto_merge_max_tier=3,
+        merge_method="merge",
+        base_branch="main",
+    )
+    constants = rr.extract_constants(script)
+    assert constants["implement_agent_id"] == "ag_custom_impl"
+    assert constants["merge_sentinels"] == ["pytest -q", "ruff check src"]
+    assert constants["auto_merge_max_tier"] == 3
+    assert constants["merge_method"] == "merge"
+    assert constants["base_branch"] == "main"
+    assert build_dev_pipeline_script(**constants) == script
+
+
+def test_extract_constants_is_robust_to_header_reordering() -> None:
+    """Extraction keys on assignment NAME via ast, not line position, so a
+    reordered header still yields the right constants."""
+    script = build_dev_pipeline_script(base_branch="trunk")
+    lines = script.splitlines()
+    # Reverse the first 13 (constant) header lines; the body is unaffected.
+    reordered = "\n".join(lines[:13][::-1] + lines[13:])
+    constants = rr.extract_constants(reordered)
+    assert constants["base_branch"] == "trunk"
+
+
+def test_extract_constants_missing_constant_is_loud() -> None:
+    """A header that dropped a builder constant must fail loudly, not silently
+    re-deploy with a builder default."""
+    script = build_dev_pipeline_script()
+    stripped = "\n".join(ln for ln in script.splitlines() if not ln.startswith("MERGE_METHOD = "))
+    with pytest.raises(rr.ReregisterError):
+        rr.extract_constants(stripped)
+
+
+# ─── validate / needs_update ─────────────────────────────────────────────────
+
+
+def test_validate_script_accepts_real_builder_output() -> None:
+    rr.validate_script(build_dev_pipeline_script())
+
+
+def test_validate_script_rejects_syntax_error() -> None:
+    with pytest.raises(rr.ReregisterError):
+        rr.validate_script("def broken(:\n    pass\n")
+
+
+def test_needs_update_idempotent_on_identical() -> None:
+    script = build_dev_pipeline_script()
+    assert rr.needs_update(script, script) is False
+
+
+def test_needs_update_true_on_change() -> None:
+    a = build_dev_pipeline_script(base_branch="master")
+    b = build_dev_pipeline_script(base_branch="main")
+    assert rr.needs_update(b, a) is True
+
+
+def test_regenerate_from_constants_matches_direct_build() -> None:
+    constants = rr.extract_constants(build_dev_pipeline_script(merge_method="rebase"))
+    assert rr.regenerate_script(constants) == build_dev_pipeline_script(merge_method="rebase")
+
+
+# ─── builder-signature drift guard ───────────────────────────────────────────
+
+
+def test_constant_map_covers_every_builder_kwarg() -> None:
+    """If a new configurable kwarg is added to ``build_dev_pipeline_script`` it
+    MUST be added to CONSTANT_TO_KWARG (and echoed as a header constant), or the
+    re-register would drop it and silently re-deploy with a builder default.
+    Assert the map equals the builder's keyword-only parameters exactly."""
+    import inspect
+
+    sig = inspect.signature(build_dev_pipeline_script)
+    kwargs = {
+        name for name, p in sig.parameters.items() if p.kind == inspect.Parameter.KEYWORD_ONLY
+    }
+    assert set(rr.CONSTANT_TO_KWARG.values()) == kwargs, (
+        "CONSTANT_TO_KWARG is out of sync with build_dev_pipeline_script's "
+        "keyword-only parameters; update scripts/reregister_dev_pipeline.py "
+        "(and the header constants in dev_pipeline.py if a new constant was added)."
+    )
+
+
+# ─── GitHub Action drift guards ──────────────────────────────────────────────
+
+
+def test_workflow_triggers_only_on_builder_path() -> None:
+    text = _WORKFLOW_PATH.read_text()
+    assert "branches: [master]" in text
+    assert "src/aios/workflows/dev_pipeline.py" in text
+    # paths-filtered so unrelated master pushes don't fire.
+    assert re.search(r"paths:\s*\n\s*-\s*\"src/aios/workflows/dev_pipeline\.py\"", text)
+
+
+def test_workflow_references_secret_and_env_config() -> None:
+    text = _WORKFLOW_PATH.read_text()
+    # Key referenced via secrets, never inlined.
+    assert "${{ secrets.AIOS_API_KEY }}" in text
+    assert "AIOS_URL: https://api.aios.eumemic.ai" in text
+    assert "DEV_PIPELINE_WORKFLOW_ID: wf_01KV4YGV4PSGP08TJBAY32J2VK" in text
+
+
+def test_workflow_runs_fixture_validation_before_reregister() -> None:
+    """The fixture-drive validation step must precede the re-register PUT step."""
+    text = _WORKFLOW_PATH.read_text()
+    validate_at = text.find("test_wf_dev_pipeline_fixture.py")
+    reregister_at = text.find("reregister_dev_pipeline.py")
+    assert 0 < validate_at < reregister_at
+
+
+def test_no_hardcoded_api_key() -> None:
+    """Defence in depth: no inline key anywhere in the Action or script."""
+    for path in (_WORKFLOW_PATH, _SCRIPT_PATH):
+        text = path.read_text()
+        assert not re.search(r"AIOS_API_KEY\s*[:=]\s*['\"]?[A-Za-z0-9_\-]{16,}", text)


### PR DESCRIPTION
## What & why

Closes eumemic/eumemic-ops#309.

The live `dev-pipeline` workflow (`wf_01KV4YGV4PSGP08TJBAY32J2VK`) is a DB snapshot: a run snapshots `workflows.script` at launch and there is **no** startup re-sync, so a merged fix to `build_dev_pipeline_script()` in `src/aios/workflows/dev_pipeline.py` is **inert** until someone manually re-runs the builder and PUTs the workflow (proven live 2026-06-16 — eumemic/aios#1177 merged but every run kept executing the OLD script until a hand re-register). This blocks the self-improvement loop.

This PR adds **IaC-sync v1**: a deploy-on-merge GitHub Action that automates exactly the hand recipe that activated eumemic/aios#1177+#1159 (v2→v3).

## How it works (the proven recipe, automated)

1. **Trigger** — push to `master`, `paths`-filtered to `src/aios/workflows/dev_pipeline.py` only (a builder-less push is inert, so we don't fire).
2. Checkout + `uv sync --dev` (the script imports `aios`).
3. **Validate** — run `tests/integration/test_wf_dev_pipeline_fixture.py` (execs the emitted program) BEFORE any write; abort the deploy on failure.
4. `scripts/reregister_dev_pipeline.py`:
   - `GET /v1/workflows/<id>` → capture live `.version` + `.script`.
   - Extract the configurable constants from the **LIVE** header via `ast` (the 13 `NAME = value` builder constants), keyed on assignment name — **not hardcoded**, so prod config (agent ids / sentinels / merge tier / base branch / method / model) survives the round-trip drift-safe.
   - `build_dev_pipeline_script(**constants)` from the updated builder.
   - Inline `ast.parse` validation (fail closed).
   - **Idempotent**: if regenerated == live, no-op exit 0 (no version bump).
   - Otherwise `PUT {version, script}` (omitted `tools`/`http_servers` preserved — operator path). Verify the response `.version` incremented; **fail loudly** on 409 version-mismatch or any non-2xx.

## Config / secrets

- `AIOS_URL=https://api.aios.eumemic.ai` and `DEV_PIPELINE_WORKFLOW_ID=wf_01KV4YGV4PSGP08TJBAY32J2VK` as workflow `env`.
- `AIOS_API_KEY` referenced via `${{ secrets.AIOS_API_KEY }}` — never inlined (maintainer provisions the repo secret out-of-band, per the issue).

## Docs

The Action header and the script docstring document this is **IaC-sync v1** (a one-shot reconcile of one known object) and point at the reconcile-loop v2 evolution in eumemic-company `architecture/dev-machine-reification.md` § infrastructure-as-code. The full IaC umbrella and the container-redeploy half remain out of scope (separate issues).

## Tests

`tests/unit/test_reregister_dev_pipeline.py` (14 tests, offline — no network):
- extract→rebuild round-trips to a byte-identical script (default + non-default prod config);
- extraction is robust to header reordering and fails loudly on a missing constant;
- validate accepts real builder output / rejects a syntax error; `needs_update` idempotency;
- builder-signature drift guard (`CONSTANT_TO_KWARG` == the builder's keyword-only params);
- Action drift guards (path filter, secret/env config, validate-before-PUT ordering, no inlined key).

All new + the dev-pipeline fixture tests pass; `ruff check`, `ruff format --check`, and `mypy` are clean.