### PR TITLE
fix(ci): harden the IaC-sync re-register Action — least-privilege permissions + polish (follow-up to #1179)

### DIFF
--- a/.github/workflows/reregister-dev-pipeline.yml
+++ b/.github/workflows/reregister-dev-pipeline.yml
@@ -24,13 +24,23 @@ on:
     paths:
       - "src/aios/workflows/dev_pipeline.py"
 
-# Never run two re-registers concurrently: a stacked pair of builder merges would
-# race the optimistic-version PUT (the loser hits a 409 and fails loudly). Serialise
-# on master and let the tip win; do NOT cancel an in-flight deploy (a half-applied
-# re-register must finish, not be killed).
+# Never run two re-registers concurrently. With cancel-in-progress: false a
+# stacked pair of builder merges queues on this group: GitHub cancels the older
+# PENDING (queued) run when a newer one arrives, so the tip run wins and applies
+# last. We do NOT cancel an in-flight (already-running) deploy — a half-applied
+# re-register must finish, not be killed. The script's 409 version-mismatch guard
+# stays as defence-in-depth against a manual PUT racing the Action, not as the
+# serialisation mechanism here.
 concurrency:
   group: reregister-dev-pipeline
   cancel-in-progress: false
+
+# Least-privilege: this job only checks out the repo and calls an external API —
+# it makes NO GitHub writes. Keep the GITHUB_TOKEN read-only so it can't be abused
+# (e.g. by a compromised freshly-resolved third-party dep) for a free write token
+# sitting next to the prod-mutating AIOS_API_KEY.
+permissions:
+  contents: read
 
 env:
   AIOS_URL: https://api.aios.eumemic.ai

--- a/scripts/reregister_dev_pipeline.py
+++ b/scripts/reregister_dev_pipeline.py
@@ -145,6 +145,10 @@ def needs_update(new_script: str, live_script: str) -> bool:
 
 # ─── HTTP I/O (the thin, network-touching shell) ─────────────────────────────
 
+# Hard ceiling on any single HTTP call so a hung connection fails fast instead of
+# stalling until the GitHub job's own timeout.
+_REQUEST_TIMEOUT_S = 30
+
 
 def _request(
     method: str, url: str, api_key: str, body: dict[str, Any] | None = None
@@ -156,7 +160,9 @@ def _request(
     if data is not None:
         req.add_header("Content-Type", "application/json")
     try:
-        with urllib.request.urlopen(req) as resp:
+        # timeout: a hung connection must fail fast (≈30s) rather than wait out
+        # the GitHub job timeout.
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
             raw = resp.read().decode()
             return resp.status, (json.loads(raw) if raw else {})
     except urllib.error.HTTPError as exc:
@@ -166,6 +172,11 @@ def _request(
         except json.JSONDecodeError:
             payload = {"raw": raw}
         return exc.code, payload
+    except urllib.error.URLError as exc:
+        # DNS / connection refused / timeout: surface as the clean fatal path
+        # (ReregisterError → FATAL:, non-zero exit) instead of an uncaught
+        # traceback. (HTTPError is a URLError subclass but is handled above.)
+        raise ReregisterError(f"{method} {url} failed: {exc.reason}") from exc
 
 
 def get_workflow(base_url: str, workflow_id: str, api_key: str) -> dict[str, Any]:
@@ -195,28 +206,36 @@ def put_workflow(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--api-key", default=os.environ.get("AIOS_API_KEY"), help="AIOS API key")
-    parser.add_argument("--url", default=os.environ.get("AIOS_URL"), help="AIOS base URL")
+    # Config is read from the environment only. In particular AIOS_API_KEY is
+    # NEVER a CLI flag: an argv-borne secret is exposed via `ps` /
+    # /proc/<pid>/cmdline on a manual run. The Action passes it solely via `env:`.
     parser.add_argument(
-        "--workflow-id",
-        default=os.environ.get("DEV_PIPELINE_WORKFLOW_ID"),
-        help="dev-pipeline workflow id",
+        "--verbose",
+        action="store_true",
+        help=(
+            "log the extracted live workflow constants (agent ids, sentinels, "
+            "tiers, model). Off by default to avoid writing prod config to CI logs."
+        ),
     )
     args = parser.parse_args(argv)
 
-    if not args.api_key:
+    api_key = os.environ.get("AIOS_API_KEY")
+    url = os.environ.get("AIOS_URL")
+    workflow_id = os.environ.get("DEV_PIPELINE_WORKFLOW_ID")
+
+    if not api_key:
         print("FATAL: AIOS_API_KEY is not set", file=sys.stderr)
         return 2
-    if not args.url:
+    if not url:
         print("FATAL: AIOS_URL is not set", file=sys.stderr)
         return 2
-    if not args.workflow_id:
+    if not workflow_id:
         print("FATAL: DEV_PIPELINE_WORKFLOW_ID is not set", file=sys.stderr)
         return 2
 
     try:
         # 1. Read the live workflow → current version + script.
-        live = get_workflow(args.url, args.workflow_id, args.api_key)
+        live = get_workflow(url, workflow_id, api_key)
         live_script = live.get("script")
         live_version = live.get("version")
         if not isinstance(live_script, str) or live_version is None:
@@ -227,9 +246,16 @@ def main(argv: list[str] | None = None) -> int:
 
         # 2. Extract configurable constants from the LIVE header (drift-safe).
         constants = extract_constants(live_script)
-        print(
-            "Extracted live constants: " + json.dumps({k: constants[k] for k in sorted(constants)})
-        )
+        # The constants are prod workflow config (agent ids, sentinels, tiers,
+        # model). Not secret, but don't dump them to CI logs by default — only
+        # under --verbose for local debugging.
+        if args.verbose:
+            print(
+                "Extracted live constants: "
+                + json.dumps({k: constants[k] for k in sorted(constants)})
+            )
+        else:
+            print(f"Extracted {len(constants)} live constants from the workflow header.")
 
         # 3. Rebuild from the UPDATED builder.
         new_script = regenerate_script(constants)
@@ -248,9 +274,9 @@ def main(argv: list[str] | None = None) -> int:
         # 6. PUT (version bumps; omitted tools/http_servers preserved).
         print(f"Script changed — re-registering (PUT with version={live_version})…")
         updated = put_workflow(
-            args.url,
-            args.workflow_id,
-            args.api_key,
+            url,
+            workflow_id,
+            api_key,
             version=live_version,
             script=new_script,
         )

--- a/tests/unit/test_reregister_dev_pipeline.py
+++ b/tests/unit/test_reregister_dev_pipeline.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import urllib.error
 from pathlib import Path
 from types import ModuleType
+from unittest import mock
 
 import pytest
 
@@ -169,3 +171,91 @@ def test_no_hardcoded_api_key() -> None:
     for path in (_WORKFLOW_PATH, _SCRIPT_PATH):
         text = path.read_text()
         assert not re.search(r"AIOS_API_KEY\s*[:=]\s*['\"]?[A-Za-z0-9_\-]{16,}", text)
+
+
+# ─── #1183: least-privilege + hardening guards ───────────────────────────────
+
+
+def test_workflow_declares_least_privilege_permissions() -> None:
+    """The job performs NO GitHub writes, so the GITHUB_TOKEN must be read-only
+    (#1183 item 1): a compromised freshly-resolved dep must not get a write token
+    for free next to the prod-mutating AIOS_API_KEY."""
+    text = _WORKFLOW_PATH.read_text()
+    assert re.search(r"permissions:\s*\n\s*contents:\s*read", text), (
+        "workflow must declare least-privilege `permissions: contents: read`"
+    )
+
+
+def test_api_key_is_env_only_no_cli_flag() -> None:
+    """The API key must be read from os.environ only — no --api-key argv path
+    (#1183 item 2): an argv flag is a /proc/<pid>/cmdline exposure footgun."""
+    text = _SCRIPT_PATH.read_text()
+    assert "--api-key" not in text, "the --api-key CLI flag must be removed (env-only)"
+    assert 'os.environ.get("AIOS_API_KEY")' in text or 'os.environ["AIOS_API_KEY"]' in text
+
+
+def test_request_catches_urlerror_cleanly() -> None:
+    """A DNS/connection/timeout failure (URLError) must surface as the clean
+    ReregisterError path, not an uncaught traceback (#1183 item 4)."""
+    with (
+        mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("name resolution failed"),
+        ),
+        pytest.raises(rr.ReregisterError),
+    ):
+        rr._request("GET", "https://example.invalid/v1/workflows/wf_x", "k")
+
+
+def test_request_passes_timeout_to_urlopen() -> None:
+    """urlopen must be called with a timeout so a hung connection fails fast
+    rather than waiting out the GitHub job timeout (#1183 item 5)."""
+    captured: dict[str, object] = {}
+
+    class _Resp:
+        status = 200
+
+        def read(self) -> bytes:
+            return b"{}"
+
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_urlopen(req: object, *args: object, **kwargs: object) -> _Resp:
+        captured.update(kwargs)
+        if args:
+            captured["positional_timeout"] = args[0]
+        return _Resp()
+
+    with mock.patch("urllib.request.urlopen", _fake_urlopen):
+        rr._request("GET", "https://example.test/v1/workflows/wf_x", "k")
+
+    timeout = captured.get("timeout", captured.get("positional_timeout"))
+    assert isinstance(timeout, (int, float)) and timeout > 0, (
+        "urlopen must be called with a positive timeout"
+    )
+
+
+def test_constants_print_is_verbose_gated() -> None:
+    """The 'Extracted live constants' dump of prod workflow config must be
+    trimmed/gated so it does not unconditionally write agent ids / sentinels /
+    tiers / model to CI logs (#1183 item 3)."""
+    text = _SCRIPT_PATH.read_text()
+    if "Extracted live constants" in text:
+        # If the verbose dump remains, it must be gated behind a --verbose flag.
+        assert "--verbose" in text or "args.verbose" in text, (
+            "the 'Extracted live constants' dump must be --verbose-gated, not "
+            "unconditionally printed to CI logs"
+        )
+
+
+def test_concurrency_comment_is_accurate() -> None:
+    """The concurrency rationale must not claim stacked merges race the
+    optimistic-version PUT (the loser hits 409); the actual mechanism is GitHub
+    cancelling the older PENDING run so the tip wins (#1183 item 6)."""
+    text = _WORKFLOW_PATH.read_text()
+    assert "race the optimistic-version PUT" not in text
+    assert "loser hits a 409" not in text


### PR DESCRIPTION
## Summary
Hardening follow-up to eumemic/eumemic-ops#309/#1180 (issue eumemic/aios#1183). The IaC-sync v1 re-register Action is still DORMANT (no `AIOS_API_KEY` provisioned), so none of these are active vulnerabilities — they land BEFORE the secret is provisioned so the Action first runs least-privilege. All changes are confined to `.github/workflows/reregister-dev-pipeline.yml` and `scripts/reregister_dev_pipeline.py` (no `dev_pipeline.py` change).

## Changes
1. **[minor] Least-privilege `permissions:`.** Added `permissions:\n  contents: read` to the workflow. The job only checks out the repo and calls an external API — it makes no GitHub writes — so the `GITHUB_TOKEN` must not sit write-capable next to the prod-mutating `AIOS_API_KEY` and freshly-resolved third-party deps.
2. **[minor] API key env-only.** Removed the `--api-key` CLI flag (argv-exposure footgun via `ps` / `/proc/<pid>/cmdline`); `AIOS_API_KEY` is read from `os.environ` only. `--url` / `--workflow-id` also moved to env-only so there is one consistent config path (the Action already passes everything via `env:`). A new `--verbose` flag is the only remaining argument.
3. **[nit] Verbose-gated the constants dump.** The `Extracted live constants` line (which printed prod workflow config — agent ids, sentinels, tiers, model — to CI logs) now only fires under `--verbose`; the default path prints just a count.
4. **[nit] Catch `urllib.error.URLError` in `_request`.** A DNS / connection-refused / timeout failure now surfaces as the clean `FATAL:` / `ReregisterError` path (non-zero exit) instead of an uncaught traceback. (`HTTPError`, a `URLError` subclass, is still handled separately above.)
5. **[nit] Added a 30s `timeout` to `urllib.request.urlopen`** so a hung connection fails fast instead of waiting out the GitHub job timeout.
6. **[nit] Corrected the concurrency comment.** It no longer claims stacked merges race the optimistic-version PUT (loser hits 409); it now states the real mechanism — GitHub cancels the older PENDING run so the tip wins — and notes the 409 guard remains as defence-in-depth against a manual PUT racing the Action.

## Testing
Test-first: added six unit guards in `tests/unit/test_reregister_dev_pipeline.py` (least-privilege permissions, env-only / no `--api-key`, `URLError` → `ReregisterError`, `urlopen` timeout, verbose-gated constants dump, accurate concurrency comment). All 20 unit tests pass; the existing `test_no_hardcoded_api_key` and `test_constant_map_covers_every_builder_kwarg` guards are unchanged and still pass. The `tests/integration/test_wf_dev_pipeline_fixture.py` fixture-drive (39 tests) and `ruff check` / `ruff format --check` are green.

## Acceptance
- [x] The workflow declares `permissions: contents: read`.
- [x] The script reads `AIOS_API_KEY` from env only (no `--api-key` argv path).
- [x] A network failure (`URLError`) and a hung connection (timeout) both surface cleanly and exit non-zero.
- [x] The constants print is `--verbose`-gated; the concurrency comment is accurate.
- [x] Existing tests pass; the `test_no_hardcoded_api_key` and `test_constant_map_covers_every_builder_kwarg` guards remain.

Closes eumemic/aios#1183.