### PR TITLE
fix(dev-pipeline): thread the merge SHA-1 into the post-merge master-CI watch (#1178)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -501,6 +501,34 @@ def _pr_head_sha(pr):
     return (pr.get("head") or {}).get("sha", "") if isinstance(pr, dict) else ""
 
 
+_SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _is_sha1(value):
+    """True iff ``value`` is a 40-char (SHA-1) hex commit id — the only thing GitHub's
+    REST commit/check-runs endpoints can resolve. A 64-char SHA-256 object id (issue #1178)
+    returns False, so we never hand one to a GitHub REST endpoint."""
+    return isinstance(value, str) and bool(_SHA1_RE.match(value))
+
+
+async def _resolve_sha1(repo, ref):
+    """Resolve a git ref (branch name OR sha) to the GitHub-canonical SHA-1 commit id.
+
+    The post-merge master-CI watch is handed a BRANCH NAME (``BASE_BRANCH``); a watch agent
+    that re-resolves it via a local clone in SHA-256 object format yields a 64-char id the
+    GitHub REST API rejects (issue #1178). Ask GitHub itself — ``GET /repos/{repo}/commits/{ref}``
+    canonicalises any ref to the SHA-1 GitHub recognises. Returns the SHA-1 string, or ``None``
+    if it can't be resolved to a valid 40-char SHA-1 (caller decides what to do with that)."""
+    if _is_sha1(ref):
+        return ref
+    resp = await gh("GET", _ipath(repo, "/commits/%s" % ref))
+    if _status(resp) != 200:
+        return None
+    body = _json_body(resp)
+    sha = body.get("sha") if isinstance(body, dict) else None
+    return sha if _is_sha1(sha) else None
+
+
 def _find_open_pr(prs, branch):
     """Client-side filter of an open-PRs list for the one whose head ref is ``branch``
     (http_request forbids a ?head= query, so we list clean and match here)."""
@@ -935,12 +963,20 @@ async def main(input):
     merge_resp = await gh("PUT", _ipath(repo, "/pulls/%d/merge" % pr_number),
                           {"merge_method": MERGE_METHOD})
     merged = _status(merge_resp) == 200
+    # The merge PUT returns the merge commit's GitHub-canonical SHA-1 (issue #1178). Capture
+    # it here so the post-merge master-CI watch can be handed a known-good SHA-1 instead of a
+    # bare branch name (which a SHA-256 clone re-resolves to a 64-char id GitHub's REST API
+    # rejects). On a confirm-only re-drive the merge body is absent, so fall back to merge_sha.
+    _merge_body = _json_body(merge_resp)
+    merge_sha = _merge_body.get("sha") if isinstance(_merge_body, dict) else None
     if not merged:
         # At-least-once: a crash-re-driven PUT against an already-merged PR returns 405/409.
         # Confirm against GitHub before declaring failure, so a real merge is never lost.
         confirm = _json_body(await gh("GET", _ipath(repo, "/pulls/%d" % pr_number)))
         if isinstance(confirm, dict) and confirm.get("merged"):
             merged = True
+            if not merge_sha:
+                merge_sha = confirm.get("merge_commit_sha")
         else:
             return await _fail(repo, issue_number,
                                {"state": "merge_failed", "pr_url": pr_url, "pr_number": pr_number,
@@ -965,20 +1001,37 @@ async def main(input):
     # result["advisories"] (telemetry that is provably distinct from a blocking gate-park in
     # result["escalations"]) — agent flakiness is NEVER coerced to the most-blocking outcome.
     phase("post-merge")
+    # Resolve BASE_BRANCH to the GitHub-canonical SHA-1 ONCE, here in the workflow, and hand
+    # that sha to the watch — never the bare branch name (issue #1178). The merge PUT already
+    # returned the merge commit's SHA-1, so prefer it; otherwise ask GitHub to canonicalise
+    # the branch. A SHA-256 clone re-resolving `master` locally yields a 64-char id GitHub's
+    # REST check-runs endpoint rejects, hard-erroring the watch on a perfectly green master.
+    master_sha = merge_sha if _is_sha1(merge_sha) else None
+    if master_sha is None:
+        master_sha = await _resolve_sha1(repo, BASE_BRANCH)
     master_status = None
     master_detail = ""
-    for i in range(MAX_MASTER_CI_ITERS):
-        try:
-            master = await agent(
-                {"task": "watch_ci", "repo": repo, "ref": BASE_BRANCH},
-                agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model,
-                label="master-ci-%d" % i)
-            master_status = master["status"]
-            master_detail = master.get("detail", "")
-            break  # a well-formed verdict (green/red/no_ci) — no retry needed
-        except (AgentError, KeyError, TypeError) as exc:
-            master_detail = "master-CI watch failed: %s" % exc
-            log("master-CI watch attempt %d indeterminate (non-blocking):" % i, exc)
+    if not _is_sha1(master_sha):
+        # Regression guard: we could not obtain a SHA-1 for master, so we DO NOT dispatch the
+        # watch with a branch name (the path that produced the SHA-256 error). Treat as a
+        # non-blocking indeterminate — same advisory the retry-exhaustion path below files.
+        master_detail = ("master-CI watch skipped: could not resolve %r to a GitHub SHA-1 "
+                         "commit (merge_sha=%r)" % (BASE_BRANCH, merge_sha))
+        log("master-CI watch indeterminate (non-blocking):", master_detail)
+    else:
+        for i in range(MAX_MASTER_CI_ITERS):
+            try:
+                master = await agent(
+                    {"task": "watch_ci", "repo": repo, "ref": BASE_BRANCH,
+                     "head_sha": master_sha},
+                    agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model,
+                    label="master-ci-%d" % i)
+                master_status = master["status"]
+                master_detail = master.get("detail", "")
+                break  # a well-formed verdict (green/red/no_ci) — no retry needed
+            except (AgentError, KeyError, TypeError) as exc:
+                master_detail = "master-CI watch failed: %s" % exc
+                log("master-CI watch attempt %d indeterminate (non-blocking):" % i, exc)
 
     advisories = []
     if master_status == "red":

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -666,7 +666,7 @@ async def test_post_merge_watch_error_then_success_recovers_to_green() -> None:
     assert "master-ci-2" not in scn.tasks  # stopped retrying once a verdict arrived
 
 
-def _sha1_re():
+def _sha1_re() -> re.Pattern[str]:
     import re as _re
 
     return _re.compile(r"^[0-9a-f]{40}$")

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -32,6 +32,11 @@ pytestmark = pytest.mark.integration
 REPO = "o/r"
 ISSUE = 5
 BRANCH = "issue-5"
+# The merge PUT returns the merge commit's GitHub-canonical SHA-1 (40-char hex). The
+# post-merge master-CI watch threads THIS into the watch instead of re-resolving the branch
+# name (issue #1178) — a SHA-256 clone would re-resolve `master` to a 64-char id GitHub's
+# REST API rejects, hard-erroring the watch on a green master.
+MERGE_SHA = "f823360f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
 # A concrete, >50-word spec body that clears the scripted spec gate.
 LONG_BODY = (
     "Add a durable retry wrapper around the outbound webhook dispatcher so that transient "
@@ -90,6 +95,8 @@ class Scenario:
         master_ci: str = "green",
         master_ci_error: bool = False,
         master_ci_results: list[dict[str, Any] | str] | None = None,
+        merge_returns_sha: bool = True,
+        commit_sha: str | None = MERGE_SHA,
         transient_5xx: dict[tuple[str, str], int] | None = None,
     ) -> None:
         self.body = body
@@ -119,6 +126,12 @@ class Scenario:
         # or the string "error" (the watch agent raises AgentError that attempt). When set, this
         # overrides master_ci/master_ci_error. The last item is reused for any later attempt.
         self.master_ci_results = master_ci_results
+        # issue #1178: whether the merge PUT body carries the merge commit's SHA-1. When False,
+        # the workflow falls back to resolving BASE_BRANCH via GET /repos/{repo}/commits/master.
+        self.merge_returns_sha = merge_returns_sha
+        # The SHA-1 the GET /commits/master canonicalisation returns. Set to None to model a ref
+        # that can't be resolved to a SHA-1 (the watch must then NOT be dispatched at all).
+        self.commit_sha = commit_sha
         # {(method, path): N} — return a transient 5xx for the FIRST N attempts of that call,
         # then the real response. Counts are mutated as attempts arrive (replay-stable because
         # each retry is a distinct call_key, so a replay re-asks each attempt exactly once).
@@ -201,9 +214,22 @@ class Scenario:
             self.followups.append(json.loads(raw) if isinstance(raw, str) else {})
             return {"status": 201, "body": json.dumps({"number": 99})}
         if method == "GET" and path == "/repos/o/r/pulls/42":  # merge-confirm read
-            return {"status": 200, "body": _pr_json(merged=self.pr_merged_on_confirm)}
+            body = json.loads(_pr_json(merged=self.pr_merged_on_confirm))
+            body["merge_commit_sha"] = self.commit_sha  # confirm-read fallback for master sha
+            return {"status": 200, "body": json.dumps(body)}
+        if method == "GET" and path == "/repos/o/r/commits/master":  # ref->SHA-1 canonicalise
+            # GitHub canonicalises any ref to its SHA-1 commit id. The watch must use THIS,
+            # never a 64-char SHA-256 a local clone might produce (issue #1178).
+            if self.commit_sha is None:  # ref can't be resolved to a SHA-1
+                return {"status": 422, "body": "{}"}
+            return {"status": 200, "body": json.dumps({"sha": self.commit_sha})}
         if method == "PUT" and path.endswith("/merge"):
-            return {"status": self.merge_status, "body": "{}"}
+            # The merge PUT returns the merge commit's SHA-1 (issue #1178).
+            if self.merge_status == 200 and self.merge_returns_sha:
+                body = json.dumps({"sha": MERGE_SHA, "merged": True})
+            else:
+                body = "{}"
+            return {"status": self.merge_status, "body": body}
         return {"status": 200, "body": "{}"}  # comments / labels / graphql
 
     def outcome(self, cap: Any) -> dict[str, Any]:
@@ -638,6 +664,69 @@ async def test_post_merge_watch_error_then_success_recovers_to_green() -> None:
     assert scn.followups == []
     assert "master-ci-0" in scn.tasks and "master-ci-1" in scn.tasks
     assert "master-ci-2" not in scn.tasks  # stopped retrying once a verdict arrived
+
+
+def _sha1_re():
+    import re as _re
+    return _re.compile(r"^[0-9a-f]{40}$")
+
+
+async def test_post_merge_watch_is_handed_the_merge_sha1_not_the_branch_name() -> None:
+    # issue #1178: the post-merge master-CI watch must be handed the merge commit's
+    # GitHub-canonical SHA-1 (the merge PUT already returned it) — NOT a bare branch name a
+    # SHA-256 clone would re-resolve to a 64-char id GitHub's REST API rejects. On a green
+    # master this yields a real green verdict with no error and no advisory.
+    scn = Scenario()  # merge PUT returns MERGE_SHA, master_ci defaults to green
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["master_ci"] == "green"
+    assert "advisories" not in value  # green master raises no advisory
+    assert scn.followups == []
+    # the watch input carries a 40-char SHA-1 head_sha, not just a branch name
+    watch_in = [i for i in scn.agent_inputs
+                if i.get("task") == "watch_ci" and i.get("ref")]
+    assert watch_in, "post-merge master-CI watch was never dispatched"
+    for w in watch_in:
+        assert w["head_sha"] == MERGE_SHA
+        assert _sha1_re().match(w["head_sha"]), "watch head_sha must be a SHA-1"
+
+
+async def test_post_merge_watch_never_passes_a_sha256_to_a_github_endpoint() -> None:
+    # Regression guard (issue #1178): the watch must NEVER be handed a 64-char SHA-256 object
+    # id. Even when the merge PUT carries no sha (confirm-only re-drive), the workflow
+    # canonicalises the branch via GitHub and threads the resulting SHA-1 — and any head_sha
+    # it ever passes is provably 40-char SHA-1, never 64-char.
+    scn = Scenario(merge_returns_sha=False)  # force the GET /commits/master fallback
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["master_ci"] == "green"
+    watch_in = [i for i in scn.agent_inputs
+                if i.get("task") == "watch_ci" and i.get("ref")]
+    assert watch_in, "post-merge master-CI watch was never dispatched"
+    for w in watch_in:
+        sha = w["head_sha"]
+        assert len(sha) != 64, "a 64-char SHA-256 id must never reach the watch"
+        assert _sha1_re().match(sha), "watch head_sha must be a SHA-1"
+    # the fallback actually went to GitHub's canonicalising endpoint
+    assert ("GET", "/repos/o/r/commits/master") in scn.http
+
+
+async def test_post_merge_watch_unresolvable_sha_degrades_to_indeterminate() -> None:
+    # issue #1178 regression guard: if BASE_BRANCH cannot be resolved to a SHA-1 at all, the
+    # workflow must NOT fall back to dispatching the watch with a branch name (the very path
+    # that produced the SHA-256 error). It degrades to the non-blocking indeterminate advisory
+    # and the watch agent is never invoked.
+    scn = Scenario(merge_returns_sha=False, commit_sha=None)
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert value["escalations"] == []  # never coerced to a blocking outcome
+    assert value["master_ci"] == "indeterminate"
+    assert value["advisories"] == ["master_ci_indeterminate"]
+    # the watch agent was NOT dispatched with an unresolved ref
+    assert not any(t.startswith("master-ci-") for t in scn.tasks)
+    assert len(scn.followups) == 1
+    assert "INDETERMINATE" in scn.followups[0]["title"]
 
 
 async def test_post_merge_advisory_never_marks_failed_and_releases_in_progress() -> None:

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -668,6 +668,7 @@ async def test_post_merge_watch_error_then_success_recovers_to_green() -> None:
 
 def _sha1_re():
     import re as _re
+
     return _re.compile(r"^[0-9a-f]{40}$")
 
 
@@ -683,8 +684,7 @@ async def test_post_merge_watch_is_handed_the_merge_sha1_not_the_branch_name() -
     assert "advisories" not in value  # green master raises no advisory
     assert scn.followups == []
     # the watch input carries a 40-char SHA-1 head_sha, not just a branch name
-    watch_in = [i for i in scn.agent_inputs
-                if i.get("task") == "watch_ci" and i.get("ref")]
+    watch_in = [i for i in scn.agent_inputs if i.get("task") == "watch_ci" and i.get("ref")]
     assert watch_in, "post-merge master-CI watch was never dispatched"
     for w in watch_in:
         assert w["head_sha"] == MERGE_SHA
@@ -700,8 +700,7 @@ async def test_post_merge_watch_never_passes_a_sha256_to_a_github_endpoint() -> 
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"
     assert value["master_ci"] == "green"
-    watch_in = [i for i in scn.agent_inputs
-                if i.get("task") == "watch_ci" and i.get("ref")]
+    watch_in = [i for i in scn.agent_inputs if i.get("task") == "watch_ci" and i.get("ref")]
     assert watch_in, "post-merge master-CI watch was never dispatched"
     for w in watch_in:
         sha = w["head_sha"]


### PR DESCRIPTION
## Problem

The post-merge master-CI watch was dispatched with a bare branch name (`{"task":"watch_ci","repo":<repo>,"ref":BASE_BRANCH}`) and the watch agent re-resolved that ref to a commit id. In a clone using SHA-256 object format, that resolution yields a 64-char SHA-256 commit id, which GitHub's SHA-1 (40-char) REST check-runs endpoint cannot use — so the watch **hard-errored on a perfectly green master** (run `wfr_01KV7912SH0HV7K4AYRY01G0HH`, issue #1176), degrading to a false `master_red` (pre-#1177) or `master_ci_indeterminate` (post-#1177) advisory. The watch never actually checked master.

## Fix

Resolve `BASE_BRANCH` to the GitHub-canonical SHA-1 **once, in the workflow**, and hand that sha to the watch as `head_sha` — exactly as the working PR-CI watch already does — instead of letting the agent re-resolve the branch name:

- The merge `PUT` already returns the merge commit's SHA-1, so prefer it (`merge_resp.body.sha`).
- On a confirm-only crash re-drive (merge body absent) fall back to the confirm GET's `merge_commit_sha`.
- Otherwise canonicalise the branch via `GET /repos/{repo}/commits/{ref}`.
- **Regression guard:** if no valid 40-char SHA-1 can be obtained, we do NOT fall back to dispatching the watch with a branch name (the path that produced the SHA-256 error). We degrade to the existing non-blocking `master_ci_indeterminate` advisory — so a 64-char SHA-256 id can never reach a GitHub REST endpoint.

Adds two small helpers (`_is_sha1`, `_resolve_sha1`) inside the workflow script body.

## Tests (test-first)

Three new regression tests in `test_wf_dev_pipeline_fixture.py`, each of which fails on the pre-fix source and passes after:

1. `test_post_merge_watch_is_handed_the_merge_sha1_not_the_branch_name` — the watch input carries the 40-char SHA-1 merge sha; a green master returns `green` with no advisory.
2. `test_post_merge_watch_never_passes_a_sha256_to_a_github_endpoint` — with a merge PUT that returns no sha, the workflow falls back to the canonicalising `GET /commits/master`, and any `head_sha` it passes is provably 40-char SHA-1, never 64-char.
3. `test_post_merge_watch_unresolvable_sha_degrades_to_indeterminate` — an unresolvable ref degrades to the non-blocking indeterminate advisory without ever dispatching the watch with a branch name.

The fixture's GitHub mock was updated to model real GitHub behaviour (the merge PUT and the commits/confirm endpoints return a SHA-1). All 44 tests in the module pass.

## Acceptance

- ✅ The watch resolves `BASE_BRANCH` to the SHA-1 GitHub recognises and returns a real `green`/`red`/`no_ci` verdict.
- ✅ A run merged to a green master shows a green post-merge watch — no error, no `master_red`/`master_ci_indeterminate` advisory.
- ✅ Regression guard: the watch never hands a 64-char SHA-256 id to a GitHub REST endpoint.

Closes #1178.