### PR TITLE
fix(dev-pipeline): resolve ruff-format-only CI failures (sentinel + fix-agent parity)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -198,6 +198,20 @@ MAX_RUN_RETRIES = 2
 # before the watch is declared indeterminate (a signal distinct from a genuinely-red master).
 MAX_MASTER_CI_ITERS = 3
 
+# CI-fix lint guidance (#1182): the GitHub CI ``lint`` job runs BOTH ``ruff check`` AND
+# ``ruff format --check``. A format-only failure (``Would reformat: …``) is NOT fixed by
+# ``ruff check --fix`` — it needs ``ruff format``. PR #1173 parked at the verify gate because
+# the CI-fix loop ran only ``ruff check --fix`` and exhausted all 3 iterations on a trivially
+# fixable format-only failure. This hint rides the ``fix_ci`` task so the fix agent knows to
+# run ``ruff format`` (write mode) for a formatting failure, making it auto-fixable.
+FIX_CI_LINT_HINT = (
+    "The CI `lint` job runs BOTH `ruff check` AND `ruff format --check`. If the failure is "
+    "formatting-only (e.g. `Would reformat: <file>`), `ruff check --fix` will NOT resolve it "
+    "— you MUST run `ruff format` (write mode, not --check) over the affected paths and "
+    "commit the result. Run both `ruff check --fix` and `ruff format` so a combined "
+    "lint+format failure is fully resolved before re-pushing."
+)
+
 
 def _py(name: str, value: Any) -> str:
     """One ``NAME = <repr>`` constant line for the prepended header. ``repr`` over the
@@ -244,6 +258,7 @@ def _render_constants(
         _py("LABEL_FAILED", LABEL_FAILED),
         _py("MAX_RUN_RETRIES", MAX_RUN_RETRIES),
         _py("MAX_MASTER_CI_ITERS", MAX_MASTER_CI_ITERS),
+        _py("FIX_CI_LINT_HINT", FIX_CI_LINT_HINT),
         _py("IMPLEMENT_SCHEMA", IMPLEMENT_SCHEMA),
         _py("REVIEW_SCHEMA", REVIEW_SCHEMA),
         _py("FIX_SCHEMA", FIX_SCHEMA),
@@ -541,6 +556,37 @@ def _find_open_pr(prs, branch):
     return None
 
 
+def _ruff_format_parity_sentinels(sentinels):
+    """Derive a ``ruff format --check <targets>`` command for every ``ruff check <targets>``
+    sentinel, so the merge guard's lint matches the GitHub CI ``lint`` job EXACTLY (which
+    runs BOTH ``ruff check`` AND ``ruff format --check`` over the same targets) — one source
+    of lint truth (#1182).
+
+    Without this the guard's lint is WEAKER than CI's: a format-only-broken PR passes the
+    guard while CI's ``ruff format --check`` rejects it, so the guard's signal is
+    misleadingly clean. We derive the format check from the deployed ``MERGE_SENTINELS``
+    (rather than hardcoding the target list) so prod config stays the single source of
+    targets through the reregister round-trip. A sentinel that already carries
+    ``ruff format`` is left alone — no duplicate is added. Returns the derived commands in
+    sentinel order; the caller appends them after the originals so the existing
+    ``ruff check`` still runs first."""
+    derived = []
+    have_format = any("ruff format" in cmd for cmd in sentinels)
+    for cmd in sentinels:
+        stripped = cmd.strip()
+        prefix = "ruff check "
+        if not stripped.startswith(prefix):
+            continue
+        targets = stripped[len(prefix):].strip()
+        if not targets:
+            continue
+        format_cmd = "ruff format --check " + targets
+        if have_format or format_cmd in derived:
+            continue
+        derived.append(format_cmd)
+    return derived
+
+
 def _merge_guard_command(repo, pr_number):
     """The merge-ref guard (autodev merge_guard.py, issue #177), preserving the load-bearing
     properties: validate the commit GitHub would ACTUALLY produce on merge — the live
@@ -550,7 +596,11 @@ def _merge_guard_command(repo, pr_number):
     refusing on the first nonzero (path-prefix sentinel *selection* is a deferred v1
     optimisation — running all is strictly safer). `set -eu -o pipefail` makes fail-closed
     structural, not dependent on guarding each line. Re-run-tolerant (rm -rf then clone) per
-    the at-least-once bash contract."""
+    the at-least-once bash contract.
+
+    Lint parity (#1182): for every ``ruff check`` sentinel we ALSO run the matching
+    ``ruff format --check`` so the guard's lint matches CI's ``lint`` job exactly — a
+    format-only-broken merge ref is refused here, not waved through."""
     lines = [
         "set -eu -o pipefail",
         "D=/workspace/mg-%d" % pr_number,
@@ -566,7 +616,8 @@ def _merge_guard_command(repo, pr_number):
         "git diff --name-only mgref^1 mgref > /tmp/mg-changed.txt || exit 74",
         "git checkout --quiet --detach mgref",
     ]
-    for cmd in MERGE_SENTINELS:
+    sentinels = list(MERGE_SENTINELS) + _ruff_format_parity_sentinels(MERGE_SENTINELS)
+    for cmd in sentinels:
         lines.append("( %s ) || exit 73" % cmd)
     lines.append("echo MERGE_GUARD_OK")
     return "\n".join(lines)
@@ -871,7 +922,8 @@ async def main(input):
         try:
             fix = await agent(
                 {"task": "fix_ci", "repo": repo, "pr_number": pr_number,
-                 "detail": ci.get("detail", ""), "comments": comment_bodies},
+                 "detail": ci.get("detail", ""), "comments": comment_bodies,
+                 "lint_hint": FIX_CI_LINT_HINT},
                 agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model,
                 label="ci-fix-%d" % i)
             head_sha = fix["head_sha"]

--- a/tests/unit/test_dev_pipeline_ruff_format.py
+++ b/tests/unit/test_dev_pipeline_ruff_format.py
@@ -1,0 +1,132 @@
+"""Unit tests for the dev-pipeline ruff-format lint-parity fix (#1182).
+
+PR #1173 parked at the verify gate after the CI-fix loop exhausted all 3 iterations on a
+``ruff format --check`` failure: the GitHub CI ``lint`` job runs BOTH ``ruff check`` AND
+``ruff format --check``, but the CI-fix path only ran ``ruff check --fix`` (which does NOT
+fix formatting) and the merge sentinel only ran ``ruff check`` (so its lint was WEAKER than
+CI). A single ``ruff format`` would have resolved it, yet the pipeline could not self-heal.
+
+Two in-script fixes, both exercised here by ``exec``-ing the production script body and
+pulling the (otherwise un-importable) helpers / task payload out of a fresh namespace:
+
+1. ``_merge_guard_command`` derives a matching ``ruff format --check <same targets>`` for
+   every ``ruff check <targets>`` sentinel, so the merge-guard lint matches the CI lint job
+   exactly (one source of lint truth) regardless of the deployed ``MERGE_SENTINELS`` config.
+2. The ``fix_ci`` task payload carries an explicit instruction that the CI lint job runs
+   ``ruff format --check`` and a format-only failure MUST be fixed by running ``ruff
+   format`` (not only ``ruff check --fix``), so a format-only failure is auto-fixable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios.workflows.dev_pipeline import build_dev_pipeline_script
+
+
+def _ns(**kwargs: Any) -> dict[str, Any]:
+    src = build_dev_pipeline_script(
+        implement_agent_id="a",
+        review_agent_id="b",
+        fix_agent_id="c",
+        ci_agent_id="d",
+        risk_agent_id="e",
+        **kwargs,
+    )
+    namespace: dict[str, Any] = {}
+    exec(compile(src, "dev_pipeline_script", "exec"), namespace)
+    return namespace
+
+
+# ─── part 2: merge-sentinel lint parity ──────────────────────────────────────
+
+
+def test_merge_guard_derives_ruff_format_check_for_ruff_check_sentinel() -> None:
+    """A ``ruff check <targets>`` sentinel gets a matching ``ruff format --check
+    <targets>`` appended in the merge guard, so the guard's lint matches CI's lint job."""
+    ns = _ns(merge_sentinels=["pytest -q", "ruff check src tests"])
+    cmd = ns["_merge_guard_command"]("owner/repo", 42)
+
+    # The original check sentinel still runs ...
+    assert "ruff check src tests" in cmd
+    # ... and a derived format --check over the SAME targets runs too.
+    assert "ruff format --check src tests" in cmd
+
+
+def test_merge_guard_format_check_preserves_full_target_set() -> None:
+    """The derived format check carries the EXACT target list of the check sentinel —
+    matching CI's wide target set (src tests packages/... connectors/...)."""
+    targets = (
+        "src tests packages/aios-sdk/aios_sdk connectors/signal/src "
+        "connectors/telegram/src connectors/whatsapp/src "
+        "packages/aios-connector-http/aios_connector_http"
+    )
+    ns = _ns(merge_sentinels=[f"ruff check {targets}"])
+    cmd = ns["_merge_guard_command"]("owner/repo", 7)
+    assert f"ruff format --check {targets}" in cmd
+
+
+def test_merge_guard_no_double_format_check_when_already_present() -> None:
+    """An already format-aware sentinel set is not duplicated: a config that already
+    carries ``ruff format --check`` does not get a second derived copy."""
+    ns = _ns(merge_sentinels=["ruff check src tests", "ruff format --check src tests"])
+    cmd = ns["_merge_guard_command"]("owner/repo", 9)
+    assert cmd.count("ruff format --check src tests") == 1
+
+
+def test_merge_guard_ignores_non_ruff_check_sentinels() -> None:
+    """Non-ruff sentinels (pytest, mypy) get no derived format check."""
+    ns = _ns(merge_sentinels=["pytest -q", "mypy src"])
+    cmd = ns["_merge_guard_command"]("owner/repo", 3)
+    assert "ruff format --check" not in cmd
+
+
+def test_merge_guard_empty_sentinels_safe() -> None:
+    """No sentinels => no ruff-format lines, guard still well-formed."""
+    ns = _ns(merge_sentinels=[])
+    cmd = ns["_merge_guard_command"]("owner/repo", 1)
+    assert "ruff format --check" not in cmd
+    assert "MERGE_GUARD_OK" in cmd
+
+
+# ─── part 1: fix_ci runs ruff format ─────────────────────────────────────────
+
+
+def test_script_fix_ci_instructs_ruff_format() -> None:
+    """The production script's ``fix_ci`` dispatch tells the fix agent that the CI lint
+    job runs ``ruff format --check`` and a format-only failure must be fixed with
+    ``ruff format`` — so the CI-fix loop can self-resolve a format-only failure instead
+    of falsely parking at the verify gate."""
+    src = build_dev_pipeline_script(
+        implement_agent_id="a",
+        review_agent_id="b",
+        fix_agent_id="c",
+        ci_agent_id="d",
+        risk_agent_id="e",
+    )
+    assert '"task": "fix_ci"' in src
+    # The dispatch carries explicit ruff-format guidance (via the named hint constant).
+    assert "ruff format" in src
+    # And the hint is attached to the fix_ci CI-fix payload, not only review-fix.
+    fix_ci_idx = src.index('"task": "fix_ci"')
+    window = src[fix_ci_idx : fix_ci_idx + 400]
+    assert "FIX_CI_LINT_HINT" in window
+
+
+def test_fix_ci_lint_hint_constant_present() -> None:
+    """The lint-fix hint is a named constant so it is one source of truth and survives
+    the reregister round-trip's header extraction unchanged."""
+    src = build_dev_pipeline_script(
+        implement_agent_id="a",
+        review_agent_id="b",
+        fix_agent_id="c",
+        ci_agent_id="d",
+        risk_agent_id="e",
+    )
+    assert "FIX_CI_LINT_HINT" in src
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Problem

PR #1173 (issue #1156) parked at the **verify gate** after the CI-fix loop exhausted all 3 iterations on a `ruff format --check` failure (`Would reformat: ...`). The fix was a single `ruff format` command (manual commit `00c247ee`), yet the pipeline could not self-resolve it. Two compounding gaps:

1. **The CI-fix path didn't run `ruff format`.** The GitHub CI `lint` job runs BOTH `ruff check` AND `ruff format --check`. On a format-only failure the fix agent ran only `ruff check --fix` (which does NOT fix formatting), so the failure persisted across all 3 CI-fix iterations → a false verify-gate park on a trivially-fixable issue.
2. **The merge sentinel omitted `ruff format --check`.** `MERGE_SENTINELS` ran `ruff check ...` but not `ruff format --check`, so the merge-guard's lint was WEAKER than CI's lint job — a format-only-broken PR passed the guard with a misleadingly clean signal.

## Fix

- **CI-fix runs `ruff format`.** New module constant `FIX_CI_LINT_HINT` is emitted into the workflow script header and attached to every `fix_ci` task dispatch as `lint_hint`. It tells the fix agent that the CI `lint` job runs both `ruff check` and `ruff format --check`, and that a formatting-only failure (`Would reformat: <file>`) MUST be resolved by running `ruff format` (write mode) — not only `ruff check --fix` — so a format-only failure is auto-fixable instead of parking.
- **Merge sentinel lint matches CI.** New helper `_ruff_format_parity_sentinels` derives a matching `ruff format --check <same targets>` for every `ruff check <targets>` sentinel, and `_merge_guard_command` appends those after the originals. The merge-guard lint now matches the CI lint job exactly (one source of lint truth), fail-closed. Targets are derived from the deployed `MERGE_SENTINELS` rather than hardcoded, so prod config stays the single source of truth and the change is drift-safe across the reregister round-trip; an already-format-aware sentinel set is not duplicated.

## Acceptance

- A PR failing only `ruff format --check` is auto-fixable by the CI-fix loop (the fix agent is now instructed to run `ruff format`), so it never falsely parks at the verify gate.
- The merge sentinel's lint step matches the CI lint job (both `ruff check` and `ruff format --check`).

## Tests

Added `tests/unit/test_dev_pipeline_ruff_format.py` (test-first): merge-guard derives `ruff format --check` for `ruff check` sentinels over the exact target set, no duplicate when already present, ignores non-ruff sentinels, safe on empty sentinels; and the `fix_ci` dispatch carries the named `FIX_CI_LINT_HINT` (which mentions `ruff format`). All 64 dev-pipeline unit tests pass (including the reregister byte-identical round-trip); `ruff check`, `ruff format --check`, and `mypy` clean on changed files.

Evidence: run `wfr_01KV6TNEE0M076B2YW037XH7PG` (issue #1156) parked at verify gate seq 26; CI lint log `Would reformat: ...`; manual fix commit `00c247ee`.

Closes #1182.