### PR TITLE
fix(sandbox): reap idle _session_repos + _runs host clone dirs at worker startup (#1192)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -328,6 +328,26 @@ class Settings(BaseSettings):
         "closed. An OAuth token refresh rotates the bearer, orphaning the "
         "old keyed entry; the idle reaper (checks every 60s) reclaims it.",
     )
+    clone_dir_gc_idle_age_seconds: int = Field(
+        default=3600,
+        ge=60,
+        description="Minimum age (seconds since last modification) before an idle "
+        "host-side per-session clone dir (``<workspace_root>/_session_repos/<sess>``) "
+        "or per-run scratch dir (``<workspace_root>/_runs/<wfr>``) becomes eligible "
+        "for reaping. A dir whose owner (session/run) has a LIVE sandbox container is "
+        "NEVER reclaimed regardless of age — the age floor only guards against "
+        "reaping a dir for a session that is between containers but about to wake. "
+        "The github-clone provisioner rmtree+re-clones the working tree on every "
+        "provision, so a reaped idle clone is recreated on the next wake (#1192).",
+    )
+    clone_dir_gc_interval_seconds: int = Field(
+        default=600,
+        ge=30,
+        description="Interval between periodic sweeps of idle ``_session_repos`` / "
+        "``_runs`` host dirs (#1192). The first sweep also runs at worker startup. "
+        "Mirrors the orphan-container reaper: keep-set is re-derived from the live "
+        "sandbox registry at delete time so a session that woke mid-sweep is spared.",
+    )
     tool_broker_socket_path: Path | None = Field(
         default=None,
         description="Host path for the tool broker's Unix-domain socket. "

--- a/src/aios/harness/clone_dir_gc.py
+++ b/src/aios/harness/clone_dir_gc.py
@@ -1,0 +1,184 @@
+"""Idle host-clone-dir reaper for ``_session_repos`` and ``_runs`` (#1192).
+
+The aios worker reaps orphaned sandbox *containers* at startup, but nothing
+collected the host-side per-session / per-run working directories that back
+them:
+
+- ``<workspace_root>/_session_repos/<session_id>/`` — per-session git
+  working-tree clones of ``github_repository`` resources. The github-clone
+  provisioner (:mod:`aios.sandbox.github_clone`) ``rmtree``s and re-clones the
+  working tree on **every** provision, so an idle session's clone is pure
+  reconstructible cache: deleting it is exactly what aios does itself on the
+  next wake.
+- ``<workspace_root>/_runs/<run_id>/`` — per-run dev_pipeline scratch dirs.
+  A run sandbox is ephemeral scratch with no durable rootfs.
+
+Without GC these grow monotonically with session/run count and are reclaimed
+only by manual intervention. On 2026-06-16 ``_session_repos`` reached 62GB
+across 150 dirs and filled ``/`` to 100%, crashing postgres (``PANIC: No space
+left on device``) and the whole aios runtime.
+
+This reaper mirrors the orphan-container reaper: it runs at worker startup and
+on a periodic sweep. The keep-set — owners (sessions/runs) with a LIVE sandbox
+container — is re-derived from the live sandbox registry (``docker ps`` via
+:meth:`SandboxBackend.list_managed`) **at delete time**, so a session that woke
+mid-sweep and re-provisioned a container is spared (race guard). A dir whose
+owner has a running container is NEVER reclaimed, regardless of age. Only dirs
+with no live container AND older than ``clone_dir_gc_idle_age_seconds`` (by
+mtime) are removed.
+
+``SandboxSpec.session_id`` is the opaque owner-label field carrying a
+session-OR-run id (``sess_…`` or ``wfr_…``); the backend stamps it on every
+managed container, so a single keep-set covers both directory trees — the
+``_session_repos`` leaf is the session id and the ``_runs`` leaf is the run id,
+and both are owner ids.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from aios.config import get_settings
+from aios.logging import get_logger
+from aios.sandbox.backends.base import SandboxBackend
+from aios.sandbox.volumes import runs_root, session_repos_gc_root
+
+log = get_logger("aios.harness.clone_dir_gc")
+
+
+@dataclass(frozen=True, slots=True)
+class CloneDirGcResult:
+    """Outcome of one reap pass: counts of removed dirs per tree + failures."""
+
+    session_repos_removed: int = 0
+    runs_removed: int = 0
+    failures: int = 0
+
+    @property
+    def total_removed(self) -> int:
+        return self.session_repos_removed + self.runs_removed
+
+
+async def _live_owner_ids(backend: SandboxBackend, *, instance_id: str) -> set[str]:
+    """Owner ids (session/run) with a LIVE container for this worker instance.
+
+    Re-derived from ``backend.list_managed`` at every call so it can be
+    re-checked AT DELETE TIME against the same listing that drove the scan.
+    Only ``running`` containers count: a stopped corpse does not pin its
+    clone dir (the salvage/GC path will remove the corpse, and the dir is
+    reconstructible). A ref whose ``session_id`` (owner label) is ``None`` —
+    a container missing the label — cannot be attributed to any owner dir, so
+    it is skipped; it pins nothing. That is safe: an unlabelled container is
+    not supposed to happen, and the age floor still applies to every dir.
+    """
+    refs = await backend.list_managed(instance_id=instance_id)
+    return {ref.session_id for ref in refs if ref.running and ref.session_id is not None}
+
+
+def _reap_tree(
+    root: Path,
+    *,
+    live_owner_ids: set[str],
+    idle_age_seconds: float,
+    now: float,
+    tree_label: str,
+) -> tuple[int, int]:
+    """Remove idle child dirs of ``root``; return ``(removed, failures)``.
+
+    A child dir is removed iff its leaf name (the owner id) is NOT in
+    ``live_owner_ids`` AND its mtime is older than ``idle_age_seconds``. The
+    parent ``root`` is never removed (it is the bind-mount-source parent and
+    re-created lazily anyway). ``rmtree`` failures are counted and logged —
+    a perm-drift / read-only-FS failure is a real signal, not silently
+    swallowed — but never abort the sweep of sibling dirs.
+    """
+    if not root.exists():
+        return 0, 0
+    removed = 0
+    failures = 0
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        owner_id = child.name
+        if owner_id in live_owner_ids:
+            continue
+        try:
+            age = now - child.stat().st_mtime
+        except OSError as err:
+            failures += 1
+            log.warning(
+                "clone_dir_gc.stat_failed", tree=tree_label, path=str(child), error=str(err)
+            )
+            continue
+        if age < idle_age_seconds:
+            continue
+        try:
+            shutil.rmtree(child)
+            removed += 1
+            log.info(
+                "clone_dir_gc.removed",
+                tree=tree_label,
+                owner_id=owner_id,
+                age_seconds=round(age),
+            )
+        except OSError as err:
+            failures += 1
+            log.warning(
+                "clone_dir_gc.rmtree_failed",
+                tree=tree_label,
+                path=str(child),
+                error=str(err),
+            )
+    return removed, failures
+
+
+async def reap_idle_clone_dirs(backend: SandboxBackend) -> CloneDirGcResult:
+    """One reap pass over ``_session_repos`` and ``_runs`` host dirs.
+
+    Removes per-session clone dirs and per-run scratch dirs whose owner has
+    NO live sandbox container (this worker instance) and whose mtime is older
+    than ``clone_dir_gc_idle_age_seconds``. The live-owner keep-set is derived
+    ONCE at the top of the pass from ``backend.list_managed`` — a single
+    ``docker ps`` — and used for both trees, which is the race guard the issue
+    requires: a session that re-provisioned a container after the scan started
+    is in the keep-set and is spared.
+
+    A session/run with a running sandbox is never reclaimed. Returns the
+    per-tree removal counts; the caller logs them. Backend listing failures
+    propagate (a failed ``docker ps`` means we cannot safely compute the
+    keep-set, so we must NOT delete anything — fail closed).
+    """
+    settings = get_settings()
+    idle_age = float(settings.clone_dir_gc_idle_age_seconds)
+    instance_id = settings.instance_id
+
+    session_root = session_repos_gc_root()
+    run_root = runs_root()
+    if not session_root.exists() and not run_root.exists():
+        return CloneDirGcResult()
+
+    live = await _live_owner_ids(backend, instance_id=instance_id)
+    now = time.time()
+
+    session_removed, session_failures = _reap_tree(
+        session_root,
+        live_owner_ids=live,
+        idle_age_seconds=idle_age,
+        now=now,
+        tree_label="_session_repos",
+    )
+    runs_removed, runs_failures = _reap_tree(
+        run_root,
+        live_owner_ids=live,
+        idle_age_seconds=idle_age,
+        now=now,
+        tree_label="_runs",
+    )
+    return CloneDirGcResult(
+        session_repos_removed=session_removed,
+        runs_removed=runs_removed,
+        failures=session_failures + runs_failures,
+    )

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -39,6 +39,7 @@ from aios.db.listen import listen_for_mcp_evict_vault, listen_for_session_interr
 from aios.db.pool import LISTENER_TCP_KEEPALIVE_SETTINGS, create_pool, normalize_dsn
 from aios.harness import runtime
 from aios.harness.attachment_gc import sweep_orphan_attachments
+from aios.harness.clone_dir_gc import reap_idle_clone_dirs
 from aios.harness.exit_diagnostics import install_exit_diagnostics
 from aios.harness.procrastinate_app import app as procrastinate_app
 from aios.harness.scheduler import _LISTEN_RECONNECT_BACKOFF_SECONDS, event_driven_scheduler
@@ -226,7 +227,8 @@ async def worker_main() -> None:
     try:
         pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
         crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
-        sandbox_registry = SandboxRegistry(backend=DockerBackend())
+        sandbox_backend = DockerBackend()
+        sandbox_registry = SandboxRegistry(backend=sandbox_backend)
         task_registry = TaskRegistry()
         mcp_session_pool = McpSessionPool()
         await ensure_sandbox_network()
@@ -270,6 +272,29 @@ async def worker_main() -> None:
         deleted_attachments = await sweep_orphan_attachments(pool)
         if deleted_attachments:
             log.info("worker.reaped_orphan_attachments", count=deleted_attachments)
+
+        # Reap idle host-side per-session clone dirs (_session_repos) and
+        # per-run scratch dirs (_runs) with no live sandbox container (#1192).
+        # These are pure reconstructible cache — the github-clone provisioner
+        # rmtree+re-clones on every wake — but nothing collected them, so they
+        # grew monotonically with session count until / filled to 100% and
+        # took postgres + the whole runtime down (2026-06-16). The keep-set is
+        # re-derived from the live sandbox registry, so a running session is
+        # never reclaimed. A failed docker-ps fails closed (deletes nothing).
+        try:
+            clone_gc = await reap_idle_clone_dirs(sandbox_backend)
+            if clone_gc.total_removed or clone_gc.failures:
+                log.info(
+                    "worker.reaped_idle_clone_dirs",
+                    session_repos=clone_gc.session_repos_removed,
+                    runs=clone_gc.runs_removed,
+                    failures=clone_gc.failures,
+                )
+        except Exception:
+            # A startup clone-dir reap failure must not block worker boot — the
+            # periodic sweep retries, and the orphan-container reaper / GC are
+            # independent. Surface it (no silent swallow) and continue.
+            log.exception("worker.reap_idle_clone_dirs_failed")
 
         log.info(
             "worker.startup",
@@ -324,6 +349,19 @@ async def worker_main() -> None:
             name="periodic_sweep",
         )
         _supervise(sweep_task, latch=supervised_latch, fatal=supervised_failure)
+
+        # Periodic idle-clone-dir GC (#1192): sweeps _session_repos/_runs host
+        # dirs whose owner has no live container, mirroring the orphan-container
+        # reaper. The startup reap above ran the first pass; this keeps disk
+        # from growing monotonically while the worker stays up.
+        clone_dir_gc_task = asyncio.create_task(
+            _periodic_clone_dir_gc(
+                sandbox_backend,
+                interval=settings.clone_dir_gc_interval_seconds,
+            ),
+            name="clone_dir_gc",
+        )
+        _supervise(clone_dir_gc_task, latch=supervised_latch, fatal=supervised_failure)
 
         interrupt_task = asyncio.create_task(
             _run_interrupt_listener(settings.db_url, task_registry),
@@ -553,6 +591,38 @@ async def _periodic_sweep(
             await sweep_trigger_fires(pool)
         except Exception:
             log.exception("periodic_sweep.failed")
+
+
+async def _periodic_clone_dir_gc(
+    backend: Any,
+    *,
+    interval: int,
+) -> None:
+    """Background task: reap idle ``_session_repos`` / ``_runs`` host dirs (#1192).
+
+    Mirrors the orphan-container reaper's survivability contract — the
+    try/except is nested INSIDE ``while True`` so a transient docker-ps hiccup
+    (which ``reap_idle_clone_dirs`` raises rather than guessing an empty
+    keep-set) doesn't disable the GC for the worker's lifetime. The keep-set is
+    re-derived each tick from the live sandbox registry at delete time, so a
+    session that re-provisioned a container since the last tick is spared.
+    ``CancelledError`` is not an ``Exception`` subclass, so worker shutdown
+    cancels the loop cleanly.
+    """
+    log = get_logger("aios.worker.clone_dir_gc")
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            result = await reap_idle_clone_dirs(backend)
+            if result.total_removed or result.failures:
+                log.info(
+                    "periodic_clone_dir_gc.reaped",
+                    session_repos=result.session_repos_removed,
+                    runs=result.runs_removed,
+                    failures=result.failures,
+                )
+        except Exception:
+            log.exception("periodic_clone_dir_gc.failed")
 
 
 async def _run_interrupt_listener(

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -226,6 +226,16 @@ def validate_workspace_path(
 _RUNS_ROOT = "_runs"
 
 
+def runs_root() -> Path:
+    """Return ``<workspace_root>/_runs`` — the parent of all per-run scratch dirs.
+
+    Each per-run workspace dir (one per ``run_id``) lives as a child here. Used
+    by the idle clone-dir reaper (#1192) to enumerate run scratch dirs whose run
+    no longer has a live sandbox container. Pure — does not touch the filesystem.
+    """
+    return (get_settings().workspace_root / _RUNS_ROOT).resolve()
+
+
 def run_workspace_dir(run_id: str) -> Path:
     """Per-run host workspace directory backing ``/workspace`` in a run sandbox (#988).
 
@@ -310,6 +320,18 @@ def github_repo_cache_lock_path(url_hash: str) -> Path:
 
 
 _SESSION_REPOS_ROOT = "_session_repos"
+
+
+def session_repos_gc_root() -> Path:
+    """Return ``<workspace_root>/_session_repos`` — the parent of every
+    per-session github-clone working-tree directory.
+
+    Each per-session subdir (one per ``session_id``) holds that session's
+    github_repository working trees. Used by the idle clone-dir reaper (#1192)
+    to enumerate per-session clone dirs whose session no longer has a live
+    sandbox container. Pure — does not touch the filesystem.
+    """
+    return (get_settings().workspace_root / _SESSION_REPOS_ROOT).resolve()
 
 
 def session_repos_root(session_id: str) -> Path:

--- a/tests/unit/test_clone_dir_gc.py
+++ b/tests/unit/test_clone_dir_gc.py
@@ -1,0 +1,144 @@
+"""Unit tests for ``aios.harness.clone_dir_gc`` (#1192).
+
+The reaper must:
+
+- Remove idle ``_session_repos/<sess>`` and ``_runs/<wfr>`` dirs (no live
+  container, mtime older than the threshold).
+- NEVER reclaim a dir whose owner has a running sandbox container — the
+  keep-set is derived from ``backend.list_managed`` at delete time.
+- Spare dirs younger than the age floor (a session between containers but
+  about to wake).
+- Fail closed if the backend listing raises (cannot compute keep-set → do
+  not delete anything).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.harness.clone_dir_gc import reap_idle_clone_dirs
+from aios.sandbox.backends.base import ManagedSandboxRef
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the volume helpers + settings at a tmp workspace root."""
+    root = tmp_path / "workspaces"
+    (root / "_session_repos").mkdir(parents=True)
+    (root / "_runs").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "aios.harness.clone_dir_gc.session_repos_gc_root",
+        lambda: root / "_session_repos",
+    )
+    monkeypatch.setattr(
+        "aios.harness.clone_dir_gc.runs_root",
+        lambda: root / "_runs",
+    )
+
+    class _FakeSettings:
+        clone_dir_gc_idle_age_seconds = 3600
+        instance_id = "test-instance"
+
+    monkeypatch.setattr(
+        "aios.harness.clone_dir_gc.get_settings",
+        lambda: _FakeSettings(),
+    )
+    return root
+
+
+def _seed_dir(root: Path, tree: str, owner_id: str, *, age_seconds: float) -> Path:
+    """Create ``<root>/<tree>/<owner_id>`` with a backdated mtime."""
+    target = root / tree / owner_id
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "ghrepo_x").mkdir(exist_ok=True)
+    (target / "ghrepo_x" / "file").write_text("data")
+    past = time.time() - age_seconds
+    os.utime(target, (past, past))
+    return target
+
+
+def _backend(refs: list[ManagedSandboxRef]) -> AsyncMock:
+    backend = AsyncMock()
+    backend.list_managed = AsyncMock(return_value=refs)
+    return backend
+
+
+async def test_removes_idle_session_repo_and_run_dirs(workspace_root: Path) -> None:
+    sess = _seed_dir(workspace_root, "_session_repos", "sess_idle", age_seconds=7200)
+    run = _seed_dir(workspace_root, "_runs", "wfr_idle", age_seconds=7200)
+    backend = _backend([])  # no live containers
+
+    result = await reap_idle_clone_dirs(backend)
+
+    assert not sess.exists()
+    assert not run.exists()
+    assert result.session_repos_removed == 1
+    assert result.runs_removed == 1
+    assert result.failures == 0
+
+
+async def test_never_reclaims_session_with_running_container(workspace_root: Path) -> None:
+    live = _seed_dir(workspace_root, "_session_repos", "sess_live", age_seconds=99999)
+    run_live = _seed_dir(workspace_root, "_runs", "wfr_live", age_seconds=99999)
+    backend = _backend(
+        [
+            ManagedSandboxRef(sandbox_id="c1", session_id="sess_live", running=True),
+            ManagedSandboxRef(sandbox_id="c2", session_id="wfr_live", running=True),
+        ]
+    )
+
+    result = await reap_idle_clone_dirs(backend)
+
+    assert live.exists()
+    assert run_live.exists()
+    assert result.total_removed == 0
+
+
+async def test_stopped_corpse_does_not_pin_clone_dir(workspace_root: Path) -> None:
+    corpse = _seed_dir(workspace_root, "_session_repos", "sess_corpse", age_seconds=7200)
+    backend = _backend(
+        [ManagedSandboxRef(sandbox_id="c1", session_id="sess_corpse", running=False)]
+    )
+
+    result = await reap_idle_clone_dirs(backend)
+
+    assert not corpse.exists()
+    assert result.session_repos_removed == 1
+
+
+async def test_spares_dirs_younger_than_age_floor(workspace_root: Path) -> None:
+    fresh = _seed_dir(workspace_root, "_session_repos", "sess_fresh", age_seconds=60)
+    backend = _backend([])
+
+    result = await reap_idle_clone_dirs(backend)
+
+    assert fresh.exists()
+    assert result.total_removed == 0
+
+
+async def test_fails_closed_when_listing_raises(workspace_root: Path) -> None:
+    sess = _seed_dir(workspace_root, "_session_repos", "sess_idle", age_seconds=7200)
+    backend = AsyncMock()
+    backend.list_managed = AsyncMock(side_effect=RuntimeError("docker ps failed"))
+
+    with pytest.raises(RuntimeError):
+        await reap_idle_clone_dirs(backend)
+
+    # Nothing deleted: keep-set could not be computed.
+    assert sess.exists()
+
+
+async def test_ignores_non_dir_entries(workspace_root: Path) -> None:
+    (workspace_root / "_session_repos" / "stray.lock").write_text("x")
+    backend = _backend([])
+
+    result = await reap_idle_clone_dirs(backend)
+
+    assert (workspace_root / "_session_repos" / "stray.lock").exists()
+    assert result.total_removed == 0


### PR DESCRIPTION
## Problem

The aios worker reaps orphaned sandbox **containers** at startup, but there was **no GC** for the host-side per-session/per-run working directories:

- `<workspace_root>/_session_repos/<sess>/` — per-session git working-tree clones of `github_repository` resources.
- `<workspace_root>/_runs/<wfr>/` — per-run dev_pipeline scratch dirs.

These grew monotonically with session/run count and were reclaimed only by manual intervention. On 2026-06-16 `_session_repos` reached 62GB across 150 dirs, filled `/` to 100%, crashed postgres (`PANIC: No space left on device`) and took the whole aios runtime down. They are **pure reconstructible cache**: the github-clone provisioner (`github_clone.py`) `rmtree`s + re-clones the working tree on every provision, so deleting an idle session's clone is exactly what aios does itself on the next wake.

## Fix

New `aios.harness.clone_dir_gc.reap_idle_clone_dirs(backend)` reaper, wired into the worker at **startup** and on a **periodic sweep** (`_periodic_clone_dir_gc`), mirroring the existing orphan-container reaper:

- **Keep-set = owners (sessions/runs) with a LIVE sandbox container**, re-derived from the live sandbox registry (`backend.list_managed` → `docker ps`) **at delete time** as a race guard. `SandboxSpec.session_id` is the opaque owner-label (carries `sess_…` *or* `wfr_…`), so a single keep-set covers both directory trees.
- A session/run with a **running** container is **never reclaimed**, regardless of age. Only dirs with no live container AND mtime older than `clone_dir_gc_idle_age_seconds` (default 1h) are removed. A stopped corpse does not pin its dir.
- **Fails closed**: if `list_managed` raises (docker daemon hiccup), the pass aborts without deleting anything (cannot compute a safe keep-set).
- Startup reap is wrapped so a failure never blocks boot; the periodic loop nests its try/except inside `while True` so a transient hiccup never disables the GC for the worker's lifetime.

New settings: `clone_dir_gc_idle_age_seconds` (default 3600), `clone_dir_gc_interval_seconds` (default 600). New volume helpers `runs_root()` and `session_repos_gc_root()` for the parent-dir enumeration.

## Acceptance

- ✅ At worker startup + on a periodic sweep, idle `_session_repos`/`_runs` dirs (no live container, older than threshold) are removed.
- ✅ A session with a running sandbox is never reclaimed (keep-set re-derived at delete time).
- ✅ Disk does not grow monotonically with session count.

## Tests

`tests/unit/test_clone_dir_gc.py` (test-first; the live-container test fails if the keep-set guard is removed):
- removes idle `_session_repos`/`_runs` dirs
- never reclaims a session/run with a running container
- a stopped corpse does not pin a clone dir
- spares dirs younger than the age floor
- fails closed when `list_managed` raises (nothing deleted)
- ignores non-dir entries (e.g. `.lock` files)

## Scope notes

The ops-flagged daily-backup exclusion of `_session_repos`/`_runs` is an ops/deploy concern (no backup script exists in-repo) and is intentionally out of scope. Complementary structural fixes #1138 / #1119 are independent of this missing-GC gap.