### PR TITLE
fix(sandbox): reap idle _session_repos + _runs host scratch dirs at worker startup (#1192)

### DIFF
--- a/.claude/skills/aios-live-monitor/scripts/chat_filter.py
+++ b/.claude/skills/aios-live-monitor/scripts/chat_filter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Filter aios sessions stream output to a one-line-per-message chat view."""
+
 from __future__ import annotations
 
 import json
@@ -53,9 +54,7 @@ for raw in sys.stdin:
         sender = md.get("sender_name") or md.get("sender") or "?"
         channel = md.get("channel", "?")
         if isinstance(content, list):
-            text = next(
-                (p.get("text", "") for p in content if p.get("type") == "text"), ""
-            )
+            text = next((p.get("text", "") for p in content if p.get("type") == "text"), "")
             kinds = ",".join(p.get("type", "?") for p in content)
             print(f"[{seq}] USER<{sender}@{channel}> [{kinds}] {text[:200]}", flush=True)
         else:
@@ -75,9 +74,7 @@ for raw in sys.stdin:
             args_str = f.get("arguments", "")
             try:
                 args = json.loads(args_str)
-                args_summary = ", ".join(
-                    f"{k}={str(v)[:80]!r}" for k, v in list(args.items())[:3]
-                )
+                args_summary = ", ".join(f"{k}={str(v)[:80]!r}" for k, v in list(args.items())[:3])
             except json.JSONDecodeError:
                 args_summary = args_str[:200]
             print(

--- a/migrations/versions/0001_initial_schema.py
+++ b/migrations/versions/0001_initial_schema.py
@@ -45,8 +45,7 @@ def upgrade() -> None:
         """
     )
     op.execute(
-        "CREATE UNIQUE INDEX credentials_name_uniq "
-        "ON credentials (name) WHERE archived_at IS NULL;"
+        "CREATE UNIQUE INDEX credentials_name_uniq ON credentials (name) WHERE archived_at IS NULL;"
     )
 
     op.execute(
@@ -86,10 +85,7 @@ def upgrade() -> None:
         );
         """
     )
-    op.execute(
-        "CREATE UNIQUE INDEX agents_name_uniq "
-        "ON agents (name) WHERE archived_at IS NULL;"
-    )
+    op.execute("CREATE UNIQUE INDEX agents_name_uniq ON agents (name) WHERE archived_at IS NULL;")
 
     op.execute(
         """
@@ -113,14 +109,8 @@ def upgrade() -> None:
         );
         """
     )
-    op.execute(
-        "CREATE INDEX sessions_agent_idx "
-        "ON sessions (agent_id, created_at DESC);"
-    )
-    op.execute(
-        "CREATE INDEX sessions_status_idx "
-        "ON sessions (status) WHERE archived_at IS NULL;"
-    )
+    op.execute("CREATE INDEX sessions_agent_idx ON sessions (agent_id, created_at DESC);")
+    op.execute("CREATE INDEX sessions_status_idx ON sessions (status) WHERE archived_at IS NULL;")
     op.execute(
         "CREATE INDEX sessions_lease_idx "
         "ON sessions (lease_expires_at) WHERE lease_worker_id IS NOT NULL;"

--- a/migrations/versions/0004_custom_tools_env_config.py
+++ b/migrations/versions/0004_custom_tools_env_config.py
@@ -41,9 +41,7 @@ def upgrade() -> None:
     )
 
     # 2. Add config column to environments.
-    op.execute(
-        "ALTER TABLE environments ADD COLUMN config jsonb NOT NULL DEFAULT '{}'::jsonb;"
-    )
+    op.execute("ALTER TABLE environments ADD COLUMN config jsonb NOT NULL DEFAULT '{}'::jsonb;")
 
 
 def downgrade() -> None:

--- a/migrations/versions/0006_session_usage.py
+++ b/migrations/versions/0006_session_usage.py
@@ -26,15 +26,9 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "ALTER TABLE sessions ADD COLUMN input_tokens bigint NOT NULL DEFAULT 0;"
-    )
-    op.execute(
-        "ALTER TABLE sessions ADD COLUMN output_tokens bigint NOT NULL DEFAULT 0;"
-    )
-    op.execute(
-        "ALTER TABLE sessions ADD COLUMN cache_read_input_tokens bigint NOT NULL DEFAULT 0;"
-    )
+    op.execute("ALTER TABLE sessions ADD COLUMN input_tokens bigint NOT NULL DEFAULT 0;")
+    op.execute("ALTER TABLE sessions ADD COLUMN output_tokens bigint NOT NULL DEFAULT 0;")
+    op.execute("ALTER TABLE sessions ADD COLUMN cache_read_input_tokens bigint NOT NULL DEFAULT 0;")
     op.execute(
         "ALTER TABLE sessions ADD COLUMN cache_creation_input_tokens bigint NOT NULL DEFAULT 0;"
     )

--- a/migrations/versions/0007_rescheduling_status.py
+++ b/migrations/versions/0007_rescheduling_status.py
@@ -22,9 +22,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;"
-    )
+    op.execute("ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;")
     op.execute(
         "ALTER TABLE sessions ADD CONSTRAINT sessions_status_check "
         "CHECK (status IN ('running', 'idle', 'rescheduling', 'terminated'));"
@@ -32,9 +30,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        "ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;"
-    )
+    op.execute("ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;")
     op.execute(
         "ALTER TABLE sessions ADD CONSTRAINT sessions_status_check "
         "CHECK (status IN ('running', 'idle', 'terminated'));"

--- a/migrations/versions/0008_mcp_servers.py
+++ b/migrations/versions/0008_mcp_servers.py
@@ -23,9 +23,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "ALTER TABLE agents ADD COLUMN mcp_servers jsonb NOT NULL DEFAULT '[]'::jsonb;"
-    )
+    op.execute("ALTER TABLE agents ADD COLUMN mcp_servers jsonb NOT NULL DEFAULT '[]'::jsonb;")
     op.execute(
         "ALTER TABLE agent_versions ADD COLUMN mcp_servers jsonb NOT NULL DEFAULT '[]'::jsonb;"
     )

--- a/migrations/versions/0009_skills.py
+++ b/migrations/versions/0009_skills.py
@@ -55,12 +55,8 @@ def upgrade() -> None:
     """)
 
     # ── skills JSONB on agents ──────────────────────────────────────────
-    op.execute(
-        "ALTER TABLE agents ADD COLUMN skills jsonb NOT NULL DEFAULT '[]'::jsonb"
-    )
-    op.execute(
-        "ALTER TABLE agent_versions ADD COLUMN skills jsonb NOT NULL DEFAULT '[]'::jsonb"
-    )
+    op.execute("ALTER TABLE agents ADD COLUMN skills jsonb NOT NULL DEFAULT '[]'::jsonb")
+    op.execute("ALTER TABLE agent_versions ADD COLUMN skills jsonb NOT NULL DEFAULT '[]'::jsonb")
 
 
 def downgrade() -> None:

--- a/migrations/versions/0020_pending_session_status.py
+++ b/migrations/versions/0020_pending_session_status.py
@@ -31,9 +31,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        "UPDATE sessions SET status = 'idle' WHERE status = 'pending';"
-    )
+    op.execute("UPDATE sessions SET status = 'idle' WHERE status = 'pending';")
     op.execute("ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_status_check;")
     op.execute(
         "ALTER TABLE sessions ADD CONSTRAINT sessions_status_check "

--- a/migrations/versions/0021_agent_litellm_extra.py
+++ b/migrations/versions/0021_agent_litellm_extra.py
@@ -25,13 +25,9 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    op.execute("ALTER TABLE agents ADD COLUMN litellm_extra jsonb NOT NULL DEFAULT '{}'::jsonb;")
     op.execute(
-        "ALTER TABLE agents "
-        "ADD COLUMN litellm_extra jsonb NOT NULL DEFAULT '{}'::jsonb;"
-    )
-    op.execute(
-        "ALTER TABLE agent_versions "
-        "ADD COLUMN litellm_extra jsonb NOT NULL DEFAULT '{}'::jsonb;"
+        "ALTER TABLE agent_versions ADD COLUMN litellm_extra jsonb NOT NULL DEFAULT '{}'::jsonb;"
     )
 
 

--- a/migrations/versions/0022_events_search_paradigm_columns.py
+++ b/migrations/versions/0022_events_search_paradigm_columns.py
@@ -93,10 +93,7 @@ def upgrade() -> None:
         "ON events (session_id, channel, seq) "
         "WHERE channel IS NOT NULL"
     )
-    op.execute(
-        "CREATE INDEX events_session_created_at_idx "
-        "ON events (session_id, created_at)"
-    )
+    op.execute("CREATE INDEX events_session_created_at_idx ON events (session_id, created_at)")
     op.execute(
         "CREATE INDEX events_session_tool_name_seq_idx "
         "ON events (session_id, tool_name, seq) "

--- a/migrations/versions/0024_model_request_end_calibration_index.py
+++ b/migrations/versions/0024_model_request_end_calibration_index.py
@@ -44,7 +44,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     with op.get_context().autocommit_block():
-        op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS "
-            "events_model_request_end_calibration_idx"
-        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_model_request_end_calibration_idx")

--- a/migrations/versions/0027_connector_redesign.py
+++ b/migrations/versions/0027_connector_redesign.py
@@ -105,8 +105,7 @@ def upgrade() -> None:
         )
     """)
     op.execute(
-        "CREATE INDEX connection_chat_sessions_session_idx "
-        "ON connection_chat_sessions (session_id)"
+        "CREATE INDEX connection_chat_sessions_session_idx ON connection_chat_sessions (session_id)"
     )
 
     # Origin pointer for per_chat-spawned sessions.  Doubles as the
@@ -114,8 +113,7 @@ def upgrade() -> None:
     # can validate against either a connection attached to the calling
     # session OR the connection that spawned the session.
     op.execute(
-        "ALTER TABLE sessions ADD COLUMN spawned_from_connection_id text "
-        "REFERENCES connections(id)"
+        "ALTER TABLE sessions ADD COLUMN spawned_from_connection_id text REFERENCES connections(id)"
     )
 
     # Inbound dedup ledger.  Written in the same txn as ``append_event`` —

--- a/migrations/versions/0033_subsystem_tables.py
+++ b/migrations/versions/0033_subsystem_tables.py
@@ -93,8 +93,7 @@ def upgrade() -> None:
         "ON bindings (connection_id) WHERE archived_at IS NULL"
     )
     op.execute(
-        "CREATE INDEX bindings_session_id_idx "
-        "ON bindings (session_id) WHERE archived_at IS NULL"
+        "CREATE INDEX bindings_session_id_idx ON bindings (session_id) WHERE archived_at IS NULL"
     )
     op.execute(
         "CREATE INDEX bindings_session_template_id_idx "
@@ -136,9 +135,7 @@ def upgrade() -> None:
         )
         """
     )
-    op.execute(
-        "CREATE INDEX chat_sessions_session_idx ON chat_sessions (session_id)"
-    )
+    op.execute("CREATE INDEX chat_sessions_session_idx ON chat_sessions (session_id)")
     op.execute(
         """
         INSERT INTO chat_sessions (connection_id, chat_id, session_id, created_at)
@@ -166,9 +163,7 @@ def upgrade() -> None:
         )
         """
     )
-    op.execute(
-        "CREATE INDEX routing_rules_binding_id_idx ON routing_rules (binding_id)"
-    )
+    op.execute("CREATE INDEX routing_rules_binding_id_idx ON routing_rules (binding_id)")
 
     # ---- runtimes: container liveness ------------------------------------
     op.execute(
@@ -182,9 +177,7 @@ def upgrade() -> None:
         )
         """
     )
-    op.execute(
-        "CREATE INDEX runtimes_connector_idx ON runtimes (connector)"
-    )
+    op.execute("CREATE INDEX runtimes_connector_idx ON runtimes (connector)")
 
     # ---- runtime_tokens: per-connector-type bearer auth ------------------
     # No ``connection_id`` FK: one bearer scopes N connections of one type,

--- a/migrations/versions/0045_per_tenant_name_uniqueness.py
+++ b/migrations/versions/0045_per_tenant_name_uniqueness.py
@@ -50,6 +50,5 @@ def downgrade() -> None:
     for table, index_name, column in _INDEXES:
         op.execute(f"DROP INDEX IF EXISTS {index_name}")
         op.execute(
-            f"CREATE UNIQUE INDEX {index_name} "
-            f"ON {table} ({column}) WHERE archived_at IS NULL"
+            f"CREATE UNIQUE INDEX {index_name} ON {table} ({column}) WHERE archived_at IS NULL"
         )

--- a/migrations/versions/0046_reencrypt_vault_credentials_with_subkey.py
+++ b/migrations/versions/0046_reencrypt_vault_credentials_with_subkey.py
@@ -39,14 +39,13 @@ import os
 from collections.abc import Callable, Sequence
 from typing import Any
 
+import sqlalchemy as sa
+from alembic import op
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from nacl.exceptions import CryptoError
 from nacl.secret import SecretBox
 from nacl.utils import random as nacl_random
-import sqlalchemy as sa
-from alembic import op
-
 
 KEY_BYTES = SecretBox.KEY_SIZE
 NONCE_BYTES = SecretBox.NONCE_SIZE
@@ -74,7 +73,7 @@ class CryptoBox:
             info=info.encode(),
         ).derive(self._key)
 
-    def derive_account_subkey(self, account_id: str) -> "CryptoBox":
+    def derive_account_subkey(self, account_id: str) -> CryptoBox:
         if not account_id:
             raise ValueError("account_id must be non-empty")
         return CryptoBox(self.derive_subkey_bytes(f"aios-account-{account_id}"))
@@ -102,6 +101,7 @@ class CryptoBox:
         if not isinstance(decoded, dict):
             raise ValueError("decrypted blob did not decode to a dict")
         return decoded
+
 
 revision: str = "0046"
 down_revision: str = "0045"

--- a/migrations/versions/0047_reencrypt_connections_and_github_with_subkey.py
+++ b/migrations/versions/0047_reencrypt_connections_and_github_with_subkey.py
@@ -29,14 +29,13 @@ import os
 from collections.abc import Callable, Sequence
 from typing import Any
 
+import sqlalchemy as sa
+from alembic import op
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from nacl.exceptions import CryptoError
 from nacl.secret import SecretBox
 from nacl.utils import random as nacl_random
-import sqlalchemy as sa
-from alembic import op
-
 
 KEY_BYTES = SecretBox.KEY_SIZE
 NONCE_BYTES = SecretBox.NONCE_SIZE
@@ -64,7 +63,7 @@ class CryptoBox:
             info=info.encode(),
         ).derive(self._key)
 
-    def derive_account_subkey(self, account_id: str) -> "CryptoBox":
+    def derive_account_subkey(self, account_id: str) -> CryptoBox:
         if not account_id:
             raise ValueError("account_id must be non-empty")
         return CryptoBox(self.derive_subkey_bytes(f"aios-account-{account_id}"))
@@ -92,6 +91,7 @@ class CryptoBox:
         if not isinstance(decoded, dict):
             raise ValueError("decrypted blob did not decode to a dict")
         return decoded
+
 
 revision: str = "0047"
 down_revision: str = "0046"

--- a/migrations/versions/0049_pending_management_calls_account_id.py
+++ b/migrations/versions/0049_pending_management_calls_account_id.py
@@ -57,9 +57,7 @@ def upgrade() -> None:
          WHERE account_id IS NULL
         """
     )
-    op.execute(
-        "ALTER TABLE pending_management_calls ALTER COLUMN account_id SET NOT NULL"
-    )
+    op.execute("ALTER TABLE pending_management_calls ALTER COLUMN account_id SET NOT NULL")
     op.execute(
         """
         ALTER TABLE pending_management_calls
@@ -83,9 +81,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        "DROP INDEX IF EXISTS pending_management_calls_connector_account_pending_idx"
-    )
+    op.execute("DROP INDEX IF EXISTS pending_management_calls_connector_account_pending_idx")
     op.execute(
         """
         CREATE INDEX pending_management_calls_connector_pending_idx

--- a/migrations/versions/0050_connections_external_account_id.py
+++ b/migrations/versions/0050_connections_external_account_id.py
@@ -49,9 +49,7 @@ def upgrade() -> None:
     # event_id)`` becomes ``(connector, external_account_id, event_id)``
     # — the PK constraint name (``connector_inbound_acks_pkey``) is
     # column-list-bound, not column-name-bound, so no rename needed.
-    op.execute(
-        "ALTER TABLE connector_inbound_acks RENAME COLUMN account TO external_account_id"
-    )
+    op.execute("ALTER TABLE connector_inbound_acks RENAME COLUMN account TO external_account_id")
 
 
 def downgrade() -> None:
@@ -66,6 +64,4 @@ def downgrade() -> None:
         "CREATE UNIQUE INDEX connections_active_account_uniq "
         "ON connections (connector, account) WHERE archived_at IS NULL"
     )
-    op.execute(
-        "ALTER TABLE connector_inbound_acks RENAME COLUMN external_account_id TO account"
-    )
+    op.execute("ALTER TABLE connector_inbound_acks RENAME COLUMN external_account_id TO account")

--- a/migrations/versions/0051_generalize_vault_credentials.py
+++ b/migrations/versions/0051_generalize_vault_credentials.py
@@ -45,12 +45,10 @@ def upgrade() -> None:
     # Drop the old CHECK so the data-migration UPDATEs aren't rejected.
     op.execute("ALTER TABLE vault_credentials DROP CONSTRAINT vault_credentials_auth_type_check")
     op.execute(
-        "UPDATE vault_credentials SET auth_type = 'bearer_header' "
-        "WHERE auth_type = 'static_bearer'"
+        "UPDATE vault_credentials SET auth_type = 'bearer_header' WHERE auth_type = 'static_bearer'"
     )
     op.execute(
-        "UPDATE vault_credentials SET auth_type = 'oauth2_refresh' "
-        "WHERE auth_type = 'mcp_oauth'"
+        "UPDATE vault_credentials SET auth_type = 'oauth2_refresh' WHERE auth_type = 'mcp_oauth'"
     )
     op.execute(
         "ALTER TABLE vault_credentials "
@@ -66,12 +64,10 @@ def downgrade() -> None:
 
     op.execute("ALTER TABLE vault_credentials DROP CONSTRAINT vault_credentials_auth_type_check")
     op.execute(
-        "UPDATE vault_credentials SET auth_type = 'static_bearer' "
-        "WHERE auth_type = 'bearer_header'"
+        "UPDATE vault_credentials SET auth_type = 'static_bearer' WHERE auth_type = 'bearer_header'"
     )
     op.execute(
-        "UPDATE vault_credentials SET auth_type = 'mcp_oauth' "
-        "WHERE auth_type = 'oauth2_refresh'"
+        "UPDATE vault_credentials SET auth_type = 'mcp_oauth' WHERE auth_type = 'oauth2_refresh'"
     )
     # Narrowing CHECK fails loud if any ``basic`` row remains.
     op.execute(

--- a/migrations/versions/0052_agents_http_servers.py
+++ b/migrations/versions/0052_agents_http_servers.py
@@ -26,13 +26,9 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    op.execute("ALTER TABLE agents ADD COLUMN http_servers jsonb NOT NULL DEFAULT '[]'::jsonb;")
     op.execute(
-        "ALTER TABLE agents "
-        "ADD COLUMN http_servers jsonb NOT NULL DEFAULT '[]'::jsonb;"
-    )
-    op.execute(
-        "ALTER TABLE agent_versions "
-        "ADD COLUMN http_servers jsonb NOT NULL DEFAULT '[]'::jsonb;"
+        "ALTER TABLE agent_versions ADD COLUMN http_servers jsonb NOT NULL DEFAULT '[]'::jsonb;"
     )
 
 

--- a/migrations/versions/0070_archive_when_idle.py
+++ b/migrations/versions/0070_archive_when_idle.py
@@ -29,8 +29,7 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.execute("ALTER TABLE sessions ADD COLUMN archive_when_idle boolean NOT NULL DEFAULT false")
     op.execute(
-        "ALTER TABLE session_templates "
-        "ADD COLUMN archive_when_idle boolean NOT NULL DEFAULT false"
+        "ALTER TABLE session_templates ADD COLUMN archive_when_idle boolean NOT NULL DEFAULT false"
     )
 
 

--- a/migrations/versions/0077_sessions_spec_version.py
+++ b/migrations/versions/0077_sessions_spec_version.py
@@ -80,8 +80,7 @@ def downgrade() -> None:
         "ON session_github_repositories"
     )
     op.execute(
-        "DROP TRIGGER IF EXISTS session_memory_stores_bump_spec_version "
-        "ON session_memory_stores"
+        "DROP TRIGGER IF EXISTS session_memory_stores_bump_spec_version ON session_memory_stores"
     )
     op.execute("DROP FUNCTION IF EXISTS bump_session_spec_version()")
     op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS spec_version")

--- a/migrations/versions/0083_triggers_rename_and_action_union.py
+++ b/migrations/versions/0083_triggers_rename_and_action_union.py
@@ -296,7 +296,9 @@ def downgrade() -> None:
     # be a silent lie. Sandbox-only data is fully reconstructible.
     n = (
         op.get_bind()
-        .execute(sa.text("SELECT count(*) FROM triggers WHERE action->>'kind' <> 'sandbox_command'"))
+        .execute(
+            sa.text("SELECT count(*) FROM triggers WHERE action->>'kind' <> 'sandbox_command'")
+        )
         .scalar()
     )
     if n:
@@ -341,8 +343,7 @@ def downgrade() -> None:
     op.execute("ALTER TABLE triggers DROP CONSTRAINT triggers_source_spec_shape")
     op.execute("ALTER TABLE triggers DROP CONSTRAINT triggers_action_shape")
     op.execute(
-        "ALTER TABLE triggers "
-        "DROP COLUMN source, DROP COLUMN source_spec, DROP COLUMN action"
+        "ALTER TABLE triggers DROP COLUMN source, DROP COLUMN source_spec, DROP COLUMN action"
     )
 
     # Reverse the trigger + hygiene renames + table/column renames.

--- a/migrations/versions/0086_triggers_slice2_workflow_action.py
+++ b/migrations/versions/0086_triggers_slice2_workflow_action.py
@@ -291,6 +291,5 @@ def downgrade() -> None:
     )
     op.execute("ALTER TABLE triggers DROP CONSTRAINT triggers_action_shape")
     op.execute(
-        f"ALTER TABLE triggers ADD CONSTRAINT triggers_action_shape "
-        f"CHECK ({ACTION_PREDICATE_0083})"
+        f"ALTER TABLE triggers ADD CONSTRAINT triggers_action_shape CHECK ({ACTION_PREDICATE_0083})"
     )

--- a/migrations/versions/0093_composite_fk_backstop.py
+++ b/migrations/versions/0093_composite_fk_backstop.py
@@ -66,17 +66,13 @@ _COMPOSITE_FKS: Sequence[tuple[str, str, str]] = (
 
 def upgrade() -> None:
     for table, constraint in _PARENT_UNIQUES:
-        op.execute(
-            f"ALTER TABLE {table} ADD CONSTRAINT {constraint} UNIQUE (id, account_id)"
-        )
+        op.execute(f"ALTER TABLE {table} ADD CONSTRAINT {constraint} UNIQUE (id, account_id)")
 
     for table, constraint in _BARE_FKS:
         op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {constraint}")
 
     for table, constraint, definition in _COMPOSITE_FKS:
-        op.execute(
-            f"ALTER TABLE {table} ADD CONSTRAINT {constraint} {definition} NOT VALID"
-        )
+        op.execute(f"ALTER TABLE {table} ADD CONSTRAINT {constraint} {definition} NOT VALID")
 
     for table, constraint, _definition in _COMPOSITE_FKS:
         op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -328,6 +328,36 @@ class Settings(BaseSettings):
         "closed. An OAuth token refresh rotates the bearer, orphaning the "
         "old keyed entry; the idle reaper (checks every 60s) reclaims it.",
     )
+
+    # ── host scratch-dir reaper (#1192) ────────────────────────────────────
+    host_dir_reaper_enabled: bool = Field(
+        default=True,
+        description="Kill-switch for the idle host scratch-dir reaper "
+        "(``_session_repos`` working-tree clones and ``_runs`` per-run "
+        "scratch). When False the reaper is never started and deletes "
+        "nothing — so the worker that just had a P1 disk-fill can disable "
+        "irreversible host deletion without a redeploy (set "
+        "``AIOS_HOST_DIR_REAPER_ENABLED=false``). Default-on: the missing GC "
+        "is itself the floodgates incident (#1192).",
+    )
+    host_dir_reaper_min_age_seconds: int = Field(
+        default=3600,
+        ge=0,
+        description="Minimum age (by directory mtime) before an idle "
+        "``_session_repos``/``_runs`` host dir is eligible for reaping. A "
+        "race floor: a dir freshly created by an in-flight provision whose "
+        "DB row has not yet committed (or a run whose terminal status is "
+        "about to flip back) is left alone until it ages past this floor. "
+        "The dominant safety check is DB liveness; this is the belt-and-"
+        "suspenders for the provision/commit gap.",
+    )
+    host_dir_reaper_interval_seconds: float = Field(
+        default=3600.0,
+        gt=0.0,
+        description="Interval for the periodic host scratch-dir reaper sweep "
+        "(an immediate first sweep runs at worker startup, then repeats at "
+        "this cadence — mirrors the snapshot GC reconciler).",
+    )
     tool_broker_socket_path: Path | None = Field(
         default=None,
         description="Host path for the tool broker's Unix-domain socket. "

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -409,6 +409,7 @@ from .sandboxes import (  # noqa: E402
     gc_snapshot_session_states,
     unscoped_clear_session_snapshot,
     unscoped_get_session_snapshot_bytes,
+    unscoped_live_session_ids,
     unscoped_set_session_snapshot,
 )
 from .session_templates import (  # noqa: E402
@@ -784,6 +785,7 @@ __all__ = [
     "unscoped_get_session_spec_version",
     "unscoped_get_trigger_row",
     "unscoped_live_session_account_id",
+    "unscoped_live_session_ids",
     "unscoped_set_session_snapshot",
     "update_account",
     "update_agent",

--- a/src/aios/db/queries/sandboxes.py
+++ b/src/aios/db/queries/sandboxes.py
@@ -82,6 +82,38 @@ async def unscoped_clear_session_snapshot(conn: asyncpg.Connection[Any], session
     )
 
 
+async def unscoped_live_session_ids(
+    conn: asyncpg.Connection[Any], session_ids: Sequence[str]
+) -> set[str]:
+    """Return the subset of ``session_ids`` that are DB-live (#1192).
+
+    DB-live = the session row exists and is NOT soft-archived
+    (``archived_at IS NULL``). This is the keep-set for the
+    ``_session_repos`` host scratch reaper: a session container released by
+    the idle reaper (container-absent) is still live in the DB, and its
+    per-session working-tree clones must be preserved.
+
+    The clones are *reconstructible* (github-clone rmtree+re-clones on the
+    next provision), so an archived/deleted session being absent here — and
+    hence its clones reaped — is at worst a re-clone on a (rare) unarchive,
+    never data loss. A session id absent from this set means "not live ⇒
+    eligible to reap".
+
+    Worker-side and unscoped (per the ``unscoped_`` convention): the reaper
+    holds only the session ids it scraped off disk, across all accounts.
+    """
+    if not session_ids:
+        return set()
+    rows = await conn.fetch(
+        """
+        SELECT id FROM sessions
+         WHERE id = ANY($1::text[]) AND archived_at IS NULL
+        """,
+        list(session_ids),
+    )
+    return {row["id"] for row in rows}
+
+
 async def gc_snapshot_session_states(
     conn: asyncpg.Connection[Any], session_ids: Sequence[str]
 ) -> list[asyncpg.Record]:

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -557,6 +557,37 @@ async def run_children_usage(
     )
 
 
+async def unscoped_terminal_run_ids(conn: asyncpg.Connection[Any], run_ids: list[str]) -> set[str]:
+    """Return the subset of ``run_ids`` whose ``status`` is TERMINAL (#1192).
+
+    TERMINAL = ``status IN ('completed','errored','cancelled')`` (the exact
+    members of ``models.workflows.TERMINAL_RUN_STATUSES``). This is the
+    reap-set for the ``_runs/<wfr>`` per-run scratch reaper.
+
+    ``_runs`` scratch is **NOT reconstructible** (unlike ``_session_repos``),
+    so the reaper deletes ONLY on a *positively observed* terminal status. A
+    run that is ``suspended`` (gate-paused, container idle-released) stays
+    live in the DB and is absent here — its dir survives. A run id absent
+    from the ``wf_runs`` table entirely is likewise absent here and is kept:
+    we never delete non-reconstructible scratch on the mere *absence* of
+    confirmation. Inverting that would be the data-loss bug PR #1193 shipped.
+
+    Worker-side / unscoped: the reaper holds only the run ids it scraped off
+    disk, across all accounts.
+    """
+    if not run_ids:
+        return set()
+    rows = await conn.fetch(
+        """
+        SELECT id FROM wf_runs
+         WHERE id = ANY($1::text[])
+           AND status IN ('completed','errored','cancelled')
+        """,
+        run_ids,
+    )
+    return {row["id"] for row in rows}
+
+
 async def count_active_runs(
     conn: asyncpg.Connection[Any], *, account_id: str, launcher_session_id: str | None = None
 ) -> int:

--- a/src/aios/harness/host_dir_reaper.py
+++ b/src/aios/harness/host_dir_reaper.py
@@ -1,0 +1,222 @@
+"""Idle host scratch-dir reaper (#1192).
+
+Two reserved host trees grow monotonically with session/run count and have
+no GC — manual ``rm`` was the only reclaim, which is what caused the
+2026-06-16 floodgates disk-fill (``_session_repos`` reached 62GB across 150
+dirs → ``/`` to 100% → postgres ``PANIC: No space left on device`` → whole
+aios runtime down):
+
+* ``<workspace_root>/_session_repos/<session_id>/`` — per-session git
+  working-tree clones of ``github_repository`` attachments.
+* ``<workspace_root>/_runs/<run_id>/`` — per-run dev_pipeline scratch
+  (``/workspace`` for a run sandbox).
+
+This reaper closes that missing-GC gap. It runs an immediate sweep at worker
+startup and then periodically (mirroring the snapshot GC reconciler).
+
+Safety model — DB liveness, NOT container presence
+--------------------------------------------------
+The keep-set is derived from **DB liveness**, never from running-container
+presence. A session whose container the idle reaper released
+(``container_idle_timeout_seconds``), or a run that is gate-``suspended``,
+loses its container while staying live in the DB. Keying the keep-set on
+``docker ps`` would reap a LIVE owner's dir — the data-loss bug PR #1193
+shipped (a seat review caught it deleting a suspended run's ``/workspace``).
+
+The two trees are treated **asymmetrically** by *reconstructibility*:
+
+* ``_session_repos`` is RECONSTRUCTIBLE — github-clone rmtree+re-clones the
+  working tree on the next provision unconditionally. So it reaps on the
+  positive keep-set: keep iff the session is DB-live (row exists, not
+  archived); reap otherwise. A wrongly-reaped clone is just re-cloned.
+
+* ``_runs`` is NOT reconstructible — the per-run ``/workspace`` scratch is
+  ephemeral with no re-derivation path. So it reaps ONLY on a *positively
+  observed* TERMINAL run status (``completed``/``errored``/``cancelled``). A
+  ``suspended`` (or ``pending``/``running``, or absent) run is KEPT. We never
+  delete non-reconstructible scratch on the mere absence of confirmation.
+
+Per-tree liveness is re-derived from a fresh DB read **at sweep time**, after
+the on-disk enumeration and after the age floor — not frozen once globally —
+so the docstrings here describe the property the code actually has.
+
+Confinement (kept from PR #1193, these were sound)
+--------------------------------------------------
+* Operate only on direct ``iterdir()`` children of each resolved reserved
+  root; never string-join an id onto a path.
+* Each candidate must resolve to a real child *of that resolved root* and
+  must not be a symlink — a symlink whose target escapes the root is skipped.
+* The roots themselves are never deleted; an empty root is left in place so
+  the bind-mount source survives for the next provision.
+
+Kill-switch / fail-closed
+-------------------------
+``host_dir_reaper_enabled`` (default-on) disables the whole reaper without a
+redeploy — irreversible host deletion on a worker that just had a P1
+disk-fill must be disableable. On ANY DB error deriving liveness, the sweep
+deletes nothing this pass (fail-closed): a DB hiccup must never be read as
+"everything is dead".
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+from aios.config import get_settings
+from aios.db import queries
+from aios.db.queries import workflows as wf_queries
+from aios.logging import get_logger
+from aios.sandbox.volumes import run_workspace_dir, session_repos_root
+
+log = get_logger("aios.harness.host_dir_reaper")
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    """An on-disk reserved-tree child the sweep is considering for reaping.
+
+    ``owner_id`` is the session id (``_session_repos``) or run id
+    (``_runs``) parsed off the directory name — used only to look the owner
+    up in the DB liveness set; it is never re-joined onto a path.
+    """
+
+    owner_id: str
+    path: Path
+
+
+def _scan_children(root: Path, *, min_age_seconds: float, now: float) -> list[_Candidate]:
+    """Enumerate reap-eligible direct children of ``root`` (confinement gate).
+
+    A child is a candidate iff it (a) resolves to a real directory that is a
+    direct child of the *resolved* ``root``, (b) is not a symlink, and (c) is
+    older than ``min_age_seconds`` by mtime (the provision/commit race floor).
+    The root itself is never returned. A missing root yields no candidates.
+    """
+    resolved_root = root.resolve()
+    if not resolved_root.exists():
+        return []
+    cutoff = now - min_age_seconds
+    candidates: list[_Candidate] = []
+    for child in resolved_root.iterdir():
+        # Never follow a symlink: its target may escape the reserved root.
+        if child.is_symlink():
+            continue
+        if not child.is_dir():
+            continue
+        # Confinement: the child must resolve to a real child of the resolved
+        # root (defence in depth on top of the symlink skip above).
+        resolved_child = child.resolve()
+        if resolved_child.parent != resolved_root:
+            continue
+        try:
+            mtime = child.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > cutoff:
+            continue  # too fresh — may be an in-flight provision
+        candidates.append(_Candidate(owner_id=child.name, path=child))
+    return candidates
+
+
+def _reap(candidates: list[_Candidate], reap_ids: set[str]) -> int:
+    """rmtree every candidate whose ``owner_id`` is in ``reap_ids``.
+
+    Returns the count actually removed. Per-tree errors are logged and
+    swallowed — one un-removable dir (perm drift, FS read-only) must not
+    abort the rest of the sweep, and the next sweep retries it.
+    """
+    removed = 0
+    for cand in candidates:
+        if cand.owner_id not in reap_ids:
+            continue
+        try:
+            shutil.rmtree(cand.path)
+            removed += 1
+        except OSError:
+            log.exception("host_dir_reaper.rmtree_failed", path=str(cand.path))
+    return removed
+
+
+async def _reap_session_repos(
+    pool: asyncpg.Pool[Any], *, min_age_seconds: float, now: float
+) -> int:
+    """Reap idle ``_session_repos/<session_id>`` clones.
+
+    Reconstructible ⇒ reap on the positive keep-set: a candidate is reaped
+    iff its session is NOT DB-live (deleted or archived). Liveness is read
+    fresh here (not a frozen global snapshot). Fail-closed: a DB error reaps
+    nothing this pass.
+    """
+    # session_repos_root takes a session id only to build the per-session
+    # path; .parent is the reserved ``_session_repos`` root we scan.
+    root = session_repos_root("_").parent
+    candidates = _scan_children(root, min_age_seconds=min_age_seconds, now=now)
+    if not candidates:
+        return 0
+    owner_ids = [c.owner_id for c in candidates]
+    try:
+        async with pool.acquire() as conn:
+            live = await queries.unscoped_live_session_ids(conn, owner_ids)
+    except (asyncpg.PostgresError, OSError):
+        log.exception("host_dir_reaper.session_repos_liveness_failed")
+        return 0  # fail-closed: never reap on a failed liveness read
+    reap_ids = {oid for oid in owner_ids if oid not in live}
+    removed = _reap(candidates, reap_ids)
+    log.info(
+        "host_dir_reaper.session_repos_swept",
+        candidates=len(candidates),
+        removed=removed,
+        kept=len(candidates) - removed,
+    )
+    return removed
+
+
+async def _reap_runs(pool: asyncpg.Pool[Any], *, min_age_seconds: float, now: float) -> int:
+    """Reap ``_runs/<run_id>`` scratch for TERMINAL runs ONLY.
+
+    NOT reconstructible ⇒ reap ONLY on a positively observed terminal status;
+    a suspended/running/pending/absent run is kept. Fail-closed on DB error.
+    """
+    root = run_workspace_dir("_").parent
+    candidates = _scan_children(root, min_age_seconds=min_age_seconds, now=now)
+    if not candidates:
+        return 0
+    owner_ids = [c.owner_id for c in candidates]
+    try:
+        async with pool.acquire() as conn:
+            terminal = await wf_queries.unscoped_terminal_run_ids(conn, owner_ids)
+    except (asyncpg.PostgresError, OSError):
+        log.exception("host_dir_reaper.runs_liveness_failed")
+        return 0  # fail-closed
+    removed = _reap(candidates, terminal)
+    log.info(
+        "host_dir_reaper.runs_swept",
+        candidates=len(candidates),
+        removed=removed,
+        kept=len(candidates) - removed,
+    )
+    return removed
+
+
+async def sweep_host_dirs(pool: asyncpg.Pool[Any]) -> int:
+    """One reaper sweep over ``_session_repos`` and ``_runs``.
+
+    Returns the total directories removed. Honors the kill-switch
+    (``host_dir_reaper_enabled``): when disabled, deletes nothing and returns
+    0. Each tree is independent — a failure deriving one tree's liveness
+    fail-closes only that tree.
+    """
+    settings = get_settings()
+    if not settings.host_dir_reaper_enabled:
+        return 0
+    min_age = float(settings.host_dir_reaper_min_age_seconds)
+    now = time.time()
+    repos = await _reap_session_repos(pool, min_age_seconds=min_age, now=now)
+    runs = await _reap_runs(pool, min_age_seconds=min_age, now=now)
+    return repos + runs

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -40,6 +40,7 @@ from aios.db.pool import LISTENER_TCP_KEEPALIVE_SETTINGS, create_pool, normalize
 from aios.harness import runtime
 from aios.harness.attachment_gc import sweep_orphan_attachments
 from aios.harness.exit_diagnostics import install_exit_diagnostics
+from aios.harness.host_dir_reaper import sweep_host_dirs
 from aios.harness.procrastinate_app import app as procrastinate_app
 from aios.harness.scheduler import _LISTEN_RECONNECT_BACKOFF_SECONDS, event_driven_scheduler
 from aios.harness.sweep import (
@@ -318,6 +319,17 @@ async def worker_main() -> None:
         )
         _supervise(mcp_reaper_task, latch=supervised_latch, fatal=supervised_failure)
 
+        # Start the idle host scratch-dir reaper (#1192): GC the
+        # ``_session_repos`` working-tree clones and ``_runs`` per-run scratch
+        # that otherwise grow monotonically with session/run count (the
+        # 2026-06-16 floodgates disk-fill). Immediate first sweep at boot, then
+        # periodic; honours the ``host_dir_reaper_enabled`` kill-switch.
+        host_dir_reaper_task = asyncio.create_task(
+            _host_dir_reaper_loop(pool),
+            name="host_dir_reaper",
+        )
+        _supervise(host_dir_reaper_task, latch=supervised_latch, fatal=supervised_failure)
+
         # Start periodic sweep (every 30s).
         sweep_task = asyncio.create_task(
             _periodic_sweep(pool, task_registry, interval=30),
@@ -553,6 +565,30 @@ async def _periodic_sweep(
             await sweep_trigger_fires(pool)
         except Exception:
             log.exception("periodic_sweep.failed")
+
+
+async def _host_dir_reaper_loop(pool: asyncpg.Pool[Any]) -> None:
+    """Background loop: immediate first sweep, then every configured interval.
+
+    Mirrors the snapshot GC reconciler (``SandboxRegistry._gc_loop``): the
+    try/except is INSIDE the loop so one DB/FS hiccup never silently disables
+    the reaper for the worker's lifetime, and the first sweep runs at boot to
+    reclaim the predecessor's idle scratch immediately. ``sweep_host_dirs``
+    itself honours the ``host_dir_reaper_enabled`` kill-switch.
+    """
+    log = get_logger("aios.worker.host_dir_reaper")
+    interval = get_settings().host_dir_reaper_interval_seconds
+    first = True
+    while True:
+        try:
+            if not first:
+                await asyncio.sleep(interval)
+            first = False
+            removed = await sweep_host_dirs(pool)
+            if removed:
+                log.info("host_dir_reaper.swept", removed=removed)
+        except Exception:
+            log.exception("host_dir_reaper.tick_failed")
 
 
 async def _run_interrupt_listener(

--- a/tests/unit/test_host_dir_reaper.py
+++ b/tests/unit/test_host_dir_reaper.py
@@ -30,12 +30,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from aios.db import queries
+from aios.db.queries import workflows as wf_queries
 from aios.harness import host_dir_reaper
 from aios.harness.host_dir_reaper import sweep_host_dirs
 
 
 @pytest.fixture
-def roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+def roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """Point both reserved roots at tmpdirs and drop the age floor to 0.
 
     ``session_repos_root(id)`` / ``run_workspace_dir(id)`` are patched to
@@ -86,7 +88,7 @@ def _fake_pool() -> MagicMock:
 
 
 async def test_suspended_run_dir_survives_terminal_is_reaped(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A non-terminal (``suspended``) run keeps its scratch; a terminal one loses it.
 
@@ -99,13 +101,13 @@ async def test_suspended_run_dir_survives_terminal_is_reaped(
 
     # Only the terminal run id comes back from the terminal-status query.
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(return_value={"wfr_done"}),
     )
     # No session repos present; the session liveness query is irrelevant here.
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(return_value=set()),
     )
@@ -118,7 +120,7 @@ async def test_suspended_run_dir_survives_terminal_is_reaped(
 
 
 async def test_runs_absent_from_db_is_kept(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """An ``_runs`` dir whose run row is absent (not positively terminal) is KEPT.
 
@@ -127,12 +129,12 @@ async def test_runs_absent_from_db_is_kept(
     """
     orphan = _mkdir_aged(roots["runs"], "wfr_unknown")
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(return_value=set()),
     )
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(return_value=set()),
     )
@@ -144,19 +146,19 @@ async def test_runs_absent_from_db_is_kept(
 
 
 async def test_session_repos_live_survives_dead_reaped(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Reconstructible ``_session_repos`` reaps on the positive DB-liveness keep-set."""
     live = _mkdir_aged(roots["repos"], "sess_live")
     dead = _mkdir_aged(roots["repos"], "sess_dead")
 
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(return_value={"sess_live"}),
     )
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(return_value=set()),
     )
@@ -169,7 +171,7 @@ async def test_session_repos_live_survives_dead_reaped(
 
 
 async def test_kill_switch_disables_all_deletion(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """``host_dir_reaper_enabled=False`` deletes nothing without a redeploy."""
     roots["settings"].host_dir_reaper_enabled = False
@@ -178,8 +180,8 @@ async def test_kill_switch_disables_all_deletion(
 
     term = AsyncMock(return_value={"wfr_done"})
     live = AsyncMock(return_value=set())
-    monkeypatch.setattr(host_dir_reaper.wf_queries, "unscoped_terminal_run_ids", term)
-    monkeypatch.setattr(host_dir_reaper.queries, "unscoped_live_session_ids", live)
+    monkeypatch.setattr(wf_queries, "unscoped_terminal_run_ids", term)
+    monkeypatch.setattr(queries, "unscoped_live_session_ids", live)
 
     removed = await sweep_host_dirs(_fake_pool())
 
@@ -192,7 +194,7 @@ async def test_kill_switch_disables_all_deletion(
 
 
 async def test_db_error_fails_closed(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A liveness-query failure reaps NOTHING for that tree (fail-closed)."""
     import asyncpg
@@ -201,12 +203,12 @@ async def test_db_error_fails_closed(
     dead_sess = _mkdir_aged(roots["repos"], "sess_dead")
 
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(side_effect=asyncpg.PostgresError("boom")),
     )
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(side_effect=asyncpg.PostgresError("boom")),
     )
@@ -219,7 +221,7 @@ async def test_db_error_fails_closed(
 
 
 async def test_fresh_dir_below_age_floor_is_kept(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A dir younger than the age floor is skipped (provision/commit race guard)."""
     roots["settings"].host_dir_reaper_min_age_seconds = 3600
@@ -227,12 +229,12 @@ async def test_fresh_dir_below_age_floor_is_kept(
     fresh.mkdir()  # mtime ~= now, well under the 1h floor
 
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(return_value={"wfr_done"}),
     )
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(return_value=set()),
     )
@@ -244,7 +246,7 @@ async def test_fresh_dir_below_age_floor_is_kept(
 
 
 async def test_symlink_child_is_never_followed(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A symlink entry in a reserved root is skipped — its target may escape."""
     outside = tmp_path / "outside_target"
@@ -254,12 +256,12 @@ async def test_symlink_child_is_never_followed(
     link.symlink_to(outside)
 
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(return_value={"wfr_done"}),
     )
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(return_value=set()),
     )
@@ -272,18 +274,18 @@ async def test_symlink_child_is_never_followed(
 
 
 async def test_root_itself_is_never_removed(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Even with everything reaped, the reserved roots survive for the next mount."""
     _mkdir_aged(roots["runs"], "wfr_done")
     _mkdir_aged(roots["repos"], "sess_dead")
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(return_value={"wfr_done"}),
     )
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(return_value=set()),
     )
@@ -295,7 +297,7 @@ async def test_root_itself_is_never_removed(
 
 
 async def test_missing_root_is_a_noop(
-    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    roots: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """No reserved root on disk ⇒ zero work, no crash."""
     import shutil
@@ -303,12 +305,12 @@ async def test_missing_root_is_a_noop(
     shutil.rmtree(roots["runs"])
     shutil.rmtree(roots["repos"])
     monkeypatch.setattr(
-        host_dir_reaper.wf_queries,
+        wf_queries,
         "unscoped_terminal_run_ids",
         AsyncMock(return_value=set()),
     )
     monkeypatch.setattr(
-        host_dir_reaper.queries,
+        queries,
         "unscoped_live_session_ids",
         AsyncMock(return_value=set()),
     )

--- a/tests/unit/test_host_dir_reaper.py
+++ b/tests/unit/test_host_dir_reaper.py
@@ -1,0 +1,318 @@
+"""Unit tests for ``aios.harness.host_dir_reaper`` (#1192).
+
+The reaper GCs two reserved host trees that otherwise grow monotonically
+with session/run count (the 2026-06-16 floodgates disk-fill):
+
+* ``_session_repos/<session_id>`` — RECONSTRUCTIBLE git working-tree clones.
+* ``_runs/<run_id>``             — NON-reconstructible per-run scratch.
+
+The load-bearing safety property (the bug PR #1193 shipped) is that the
+keep-set is **DB liveness, NOT container presence**: a ``suspended`` run
+loses its container (idle-released) while staying live in the DB, so a
+container-presence keep-set would ``rmtree`` a LIVE run's ``/workspace``.
+These tests assert the DB-liveness keep-set directly, never a container set:
+
+* a ``suspended`` (non-terminal) run's ``_runs`` dir SURVIVES;
+* a TERMINAL run's ``_runs`` dir is reaped;
+* a DB-live session's ``_session_repos`` dir SURVIVES, a dead one is reaped;
+* fail-closed: a DB error reaps nothing;
+* the kill-switch disables the whole reaper;
+* confinement: symlinks and too-fresh dirs are never touched, the root
+  itself is never removed.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.harness import host_dir_reaper
+from aios.harness.host_dir_reaper import sweep_host_dirs
+
+
+@pytest.fixture
+def roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Point both reserved roots at tmpdirs and drop the age floor to 0.
+
+    ``session_repos_root(id)`` / ``run_workspace_dir(id)`` are patched to
+    return ``<root>/<id>`` so the reaper's ``.parent`` derivation lands on
+    the tmp roots.
+    """
+    repos_root = tmp_path / "_session_repos"
+    runs_root = tmp_path / "_runs"
+    repos_root.mkdir()
+    runs_root.mkdir()
+
+    monkeypatch.setattr(host_dir_reaper, "session_repos_root", lambda sid: repos_root / sid)
+    monkeypatch.setattr(host_dir_reaper, "run_workspace_dir", lambda rid: runs_root / rid)
+
+    settings = MagicMock()
+    settings.host_dir_reaper_enabled = True
+    settings.host_dir_reaper_min_age_seconds = 0
+    monkeypatch.setattr(host_dir_reaper, "get_settings", lambda: settings)
+
+    return {"repos": repos_root, "runs": runs_root, "settings": settings}
+
+
+def _mkdir_aged(parent: Path, name: str, *, age_s: float = 10_000.0) -> Path:
+    """Create ``parent/name`` and back-date its mtime past any age floor."""
+    d = parent / name
+    d.mkdir()
+    (d / "marker").write_text("scratch")
+    old = time.time() - age_s
+    import os
+
+    os.utime(d, (old, old))
+    return d
+
+
+def _fake_pool() -> MagicMock:
+    """Pool whose ``acquire()`` yields a context-managed MagicMock conn."""
+    pool = MagicMock()
+
+    class _Cm:
+        async def __aenter__(self) -> Any:
+            return MagicMock()
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+    pool.acquire.return_value = _Cm()
+    return pool
+
+
+async def test_suspended_run_dir_survives_terminal_is_reaped(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-terminal (``suspended``) run keeps its scratch; a terminal one loses it.
+
+    This is the inverse of the PR #1193 data-loss bug: the suspended run is
+    container-ABSENT but DB-LIVE, and its NON-reconstructible ``_runs`` dir
+    MUST be preserved.
+    """
+    suspended = _mkdir_aged(roots["runs"], "wfr_suspended")
+    terminal = _mkdir_aged(roots["runs"], "wfr_done")
+
+    # Only the terminal run id comes back from the terminal-status query.
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value={"wfr_done"}),
+    )
+    # No session repos present; the session liveness query is irrelevant here.
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(return_value=set()),
+    )
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 1
+    assert suspended.exists(), "a suspended (DB-live) run's _runs dir must survive"
+    assert not terminal.exists(), "a terminal run's _runs dir must be reaped"
+
+
+async def test_runs_absent_from_db_is_kept(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ``_runs`` dir whose run row is absent (not positively terminal) is KEPT.
+
+    Non-reconstructible scratch is only deleted on a POSITIVELY observed
+    terminal status — never on the mere absence of confirmation.
+    """
+    orphan = _mkdir_aged(roots["runs"], "wfr_unknown")
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value=set()),
+    )
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(return_value=set()),
+    )
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    assert orphan.exists()
+
+
+async def test_session_repos_live_survives_dead_reaped(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reconstructible ``_session_repos`` reaps on the positive DB-liveness keep-set."""
+    live = _mkdir_aged(roots["repos"], "sess_live")
+    dead = _mkdir_aged(roots["repos"], "sess_dead")
+
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(return_value={"sess_live"}),
+    )
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value=set()),
+    )
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 1
+    assert live.exists(), "a DB-live session's clone dir must survive"
+    assert not dead.exists(), "a dead/archived session's clone dir must be reaped"
+
+
+async def test_kill_switch_disables_all_deletion(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``host_dir_reaper_enabled=False`` deletes nothing without a redeploy."""
+    roots["settings"].host_dir_reaper_enabled = False
+    dead_run = _mkdir_aged(roots["runs"], "wfr_done")
+    dead_sess = _mkdir_aged(roots["repos"], "sess_dead")
+
+    term = AsyncMock(return_value={"wfr_done"})
+    live = AsyncMock(return_value=set())
+    monkeypatch.setattr(host_dir_reaper.wf_queries, "unscoped_terminal_run_ids", term)
+    monkeypatch.setattr(host_dir_reaper.queries, "unscoped_live_session_ids", live)
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    assert dead_run.exists()
+    assert dead_sess.exists()
+    # Disabled means we never even query the DB.
+    term.assert_not_awaited()
+    live.assert_not_awaited()
+
+
+async def test_db_error_fails_closed(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A liveness-query failure reaps NOTHING for that tree (fail-closed)."""
+    import asyncpg
+
+    dead_run = _mkdir_aged(roots["runs"], "wfr_done")
+    dead_sess = _mkdir_aged(roots["repos"], "sess_dead")
+
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(side_effect=asyncpg.PostgresError("boom")),
+    )
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(side_effect=asyncpg.PostgresError("boom")),
+    )
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    assert dead_run.exists(), "fail-closed: never reap on a failed liveness read"
+    assert dead_sess.exists()
+
+
+async def test_fresh_dir_below_age_floor_is_kept(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dir younger than the age floor is skipped (provision/commit race guard)."""
+    roots["settings"].host_dir_reaper_min_age_seconds = 3600
+    fresh = roots["runs"] / "wfr_done"
+    fresh.mkdir()  # mtime ~= now, well under the 1h floor
+
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value={"wfr_done"}),
+    )
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(return_value=set()),
+    )
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    assert fresh.exists()
+
+
+async def test_symlink_child_is_never_followed(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A symlink entry in a reserved root is skipped — its target may escape."""
+    outside = tmp_path / "outside_target"
+    outside.mkdir()
+    (outside / "precious").write_text("do not touch")
+    link = roots["runs"] / "wfr_done"
+    link.symlink_to(outside)
+
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value={"wfr_done"}),
+    )
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(return_value=set()),
+    )
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0
+    assert outside.exists()
+    assert (outside / "precious").exists()
+
+
+async def test_root_itself_is_never_removed(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Even with everything reaped, the reserved roots survive for the next mount."""
+    _mkdir_aged(roots["runs"], "wfr_done")
+    _mkdir_aged(roots["repos"], "sess_dead")
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value={"wfr_done"}),
+    )
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(return_value=set()),
+    )
+
+    await sweep_host_dirs(_fake_pool())
+
+    assert roots["runs"].exists() and roots["runs"].is_dir()
+    assert roots["repos"].exists() and roots["repos"].is_dir()
+
+
+async def test_missing_root_is_a_noop(
+    roots: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No reserved root on disk ⇒ zero work, no crash."""
+    import shutil
+
+    shutil.rmtree(roots["runs"])
+    shutil.rmtree(roots["repos"])
+    monkeypatch.setattr(
+        host_dir_reaper.wf_queries,
+        "unscoped_terminal_run_ids",
+        AsyncMock(return_value=set()),
+    )
+    monkeypatch.setattr(
+        host_dir_reaper.queries,
+        "unscoped_live_session_ids",
+        AsyncMock(return_value=set()),
+    )
+
+    removed = await sweep_host_dirs(_fake_pool())
+
+    assert removed == 0


### PR DESCRIPTION
## What
Adds a DB-liveness-keyed reaper for the two reserved host scratch trees that had no GC and grew monotonically with session/run count — the missing-GC gap behind the 2026-06-16 floodgates disk-fill (`_session_repos` reached 62GB → postgres `PANIC: No space left on device` → whole aios runtime down).

- `<workspace_root>/_session_repos/<session_id>` — per-session git working-tree clones.
- `<workspace_root>/_runs/<run_id>` — per-run dev_pipeline scratch (`/workspace`).

New module `aios.harness.host_dir_reaper` runs an immediate sweep at worker startup and then periodically (mirroring the snapshot GC reconciler loop).

## Safety model — built to the REVISED requirements (the #1193 bug)
The keep-set is **DB liveness, NOT container presence**. A `suspended` run (gate-paused, container idle-released) or an idle-released session is container-absent but DB-live; keying on `docker ps` would `rmtree` a LIVE owner's dir — the exact INVERSE data-loss bug a seat review caught in PR #1193.

1. **Keep-set = DB liveness.** `_session_repos` is preserved iff the session row exists and is not archived (`unscoped_live_session_ids`). `_runs` is preserved unless the run's status is positively TERMINAL (`unscoped_terminal_run_ids`, `status IN ('completed','errored','cancelled')` — the members of `TERMINAL_RUN_STATUSES`).
2. **`_runs` is NOT reconstructible** → reaped ONLY on a *positively observed* terminal status. A `suspended`/`running`/`pending`/absent run is KEPT (never deleted on mere absence of confirmation). `_session_repos` is reconstructible (github-clone rmtree+re-clones on next provision) → reaped on the positive DB-liveness keep-set.
3. **No false safety claim.** Per-tree liveness is re-derived from a fresh DB read at sweep time (after enumeration + age floor), and the docstrings describe exactly that — no "re-derived per delete" lie.
4. **Kill-switch.** `host_dir_reaper_enabled` (default-on) disables all irreversible host deletion without a redeploy; when off, nothing is queried or deleted.
5. **Fail-closed.** Any DB error deriving liveness reaps nothing for that tree.

### Kept from #1193 (sound)
Path/scope confinement: resolved-root `iterdir()` children only, no id string-join, symlink-safe (symlink children skipped — target may escape), resolved-child parent check, an mtime age floor (`host_dir_reaper_min_age_seconds`, default 1h) for the provision/commit race, and the reserved roots themselves are never deleted (left in place for the next bind-mount).

## Config (new)
- `host_dir_reaper_enabled` (default `true`) — kill-switch.
- `host_dir_reaper_min_age_seconds` (default `3600`) — race floor.
- `host_dir_reaper_interval_seconds` (default `3600.0`) — periodic cadence (immediate first sweep at boot).

## Tests
`tests/unit/test_host_dir_reaper.py` (test-first): a `suspended` run's `_runs` dir SURVIVES; a TERMINAL run's `_runs` dir is reaped; an absent run is kept; the DB-liveness keep-set for `_session_repos` (live survives, dead reaped); kill-switch disables all deletion (and doesn't even query); DB error fails closed; fresh dirs below the age floor are kept; symlink children are never followed; the root is never removed; missing root is a no-op.

All new + adjacent unit tests pass; ruff (check + format) and mypy clean on touched files.

Closes #1192.