### PR TITLE
fix(sandbox): break the secret_egress_proxy <-> sandbox.spec import cycle

### DIFF
--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -75,7 +75,13 @@ from aios.logging import get_logger
 from aios.models.vaults import parse_allowed_host_entry
 from aios.sandbox.egress_ca import EgressCA, get_egress_ca, mint_server_leaf
 from aios.services.vaults import ResolvedEnvVarCredential
-from aios.tools import url_safety
+
+# NOTE: ``aios.tools.url_safety`` is imported lazily inside ``_resolve_pinned_ip``
+# (the only user) — not here. A module-level ``from aios.tools import ...`` makes
+# the ``aios.tools`` package (whose ``__init__`` imports ``bash`` → ``sandbox.spec``,
+# which binds ``SecretEgressProxy`` back from this module) part of this module's
+# import graph, so a standalone ``import aios.sandbox.secret_egress_proxy`` cycles
+# and ImportErrors. Deferring to call time keeps the import graph acyclic.
 
 log = get_logger("aios.sandbox.secret_egress_proxy")
 
@@ -242,6 +248,8 @@ async def _resolve_pinned_ip(host: str, port: int) -> str | None:
     worker is IPv4-only; a first-returned global IPv6 with no route would
     502 a reachable host otherwise).
     """
+    from aios.tools import url_safety  # deferred — see the import-graph note at module top
+
     if url_safety.is_blocked_hostname(host):
         return None
     try:

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -80,12 +80,11 @@ if TYPE_CHECKING:
     # new dependency edge regardless.)
     from aios.db.queries import EnvVarCredentialEcho
 
-    # Imported for typing only at module level: a runtime top-level import
-    # would pull in ``aios.tools`` (via ``secret_egress_proxy`` →
-    # ``url_safety``) whose package ``__init__`` imports ``bash``, which
-    # imports back from this module — a cycle. The concrete class is bound
-    # at module bottom (after every def runs) so it's still a patchable
-    # ``aios.sandbox.spec.SecretEgressProxy`` attribute.
+    # Typing-only here; the concrete class is bound at module bottom (after every
+    # def runs) so it stays a patchable ``aios.sandbox.spec.SecretEgressProxy``
+    # attribute for unit tests, with a placement robust against import ordering.
+    # The spec↔tools cycle is broken upstream: ``secret_egress_proxy`` defers its
+    # own ``aios.tools`` import (see that module's import-graph note).
     from aios.sandbox.secret_egress_proxy import SecretEgressProxy
 
 log = get_logger("aios.sandbox.spec")
@@ -1030,7 +1029,8 @@ def _assemble_plan(
 
 
 # Runtime binding for ``SecretEgressProxy`` (see the TYPE_CHECKING note at the
-# top). Imported at module bottom — after every def has run — so it resolves
-# the spec↔tools cycle while still exposing a patchable
-# ``aios.sandbox.spec.SecretEgressProxy`` attribute for unit tests.
+# top). Bound at module bottom — after every def has run — for an
+# ordering-robust, patchable ``aios.sandbox.spec.SecretEgressProxy`` attribute
+# (unit tests patch it). The spec↔tools cycle itself is broken upstream:
+# ``secret_egress_proxy`` defers its ``aios.tools`` import.
 from aios.sandbox.secret_egress_proxy import SecretEgressProxy  # noqa: E402

--- a/tests/unit/sandbox/test_import_hygiene.py
+++ b/tests/unit/sandbox/test_import_hygiene.py
@@ -1,0 +1,32 @@
+"""Import-hygiene guard for the sandbox ↔ tools circular dependency.
+
+``aios.sandbox.secret_egress_proxy`` must import cleanly even when it is the
+*first* aios module loaded — i.e. standalone, before a full test run's collection
+order happens to pre-break the ``sandbox.spec`` ↔ ``tools`` cycle. Run in a fresh
+subprocess so the assertion is deterministic regardless of what this process has
+already imported. A regression makes the module uncollectable in isolation and
+risks an app-startup ImportError if import order ever shifts.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _imports_clean(module: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_secret_egress_proxy_imports_standalone() -> None:
+    result = _imports_clean("aios.sandbox.secret_egress_proxy")
+    assert result.returncode == 0, result.stderr
+
+
+def test_sandbox_spec_imports_standalone() -> None:
+    result = _imports_clean("aios.sandbox.spec")
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

`import aios.sandbox.secret_egress_proxy` failed **standalone** with an `ImportError`. The module's top-level `from aios.tools import url_safety` pulls in the `aios.tools` package, whose `__init__` imports `bash` → `aios.sandbox.spec`, which binds `SecretEgressProxy` back from this **still-initializing** module:

```
secret_egress_proxy → tools/__init__ → bash → sandbox.spec → (SecretEgressProxy not yet defined) → ImportError
```

The cycle was masked in full test runs (collection order pre-broke it) but:
- made `tests/unit/sandbox/test_secret_egress_proxy.py` **uncollectable in isolation** (and intermittently under the hook's `pytest --lf`),
- is a **latent app-startup fragility** — an import-order shift would surface it at boot.

## Fix

Defer the **sole** `url_safety` use to a call-time import inside `_resolve_pinned_ip`, so this module's import graph no longer reaches `aios.tools` at load. That breaks the cycle at its single source edge (the other module-level imports — vaults, egress_ca — don't reach `spec`/`tools`).

`spec.py` keeps its bottom-binding of `SecretEgressProxy` (it provides the patchable `aios.sandbox.spec.SecretEgressProxy` attribute that 8+ unit tests rely on, with an ordering-robust placement); its now-inaccurate "resolves the spec↔tools cycle" comments are corrected to point at the real fix.

Adds `test_import_hygiene.py` asserting both `secret_egress_proxy` and `spec` import cleanly in a fresh subprocess.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 2949 passed (incl. all 8 `spec.SecretEgressProxy` patch-site tests, unchanged)
- [x] New `test_secret_egress_proxy_imports_standalone` confirmed **RED** (ImportError) before, **GREEN** after; `test_secret_egress_proxy.py` now collects standalone (57 tests)
- [ ] CI runs full integration/e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)