### PR TITLE
fix(sandbox): re-encode the Basic-auth secret swap as UTF-8, not latin-1

### DIFF
--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -207,7 +207,10 @@ def _swap_header_value(name: str, value: str, swaps: list[tuple[str, str]]) -> s
         decoded = _decode_basic_credential(value)
         if decoded is not None:
             swapped = _apply_swaps_str(decoded, swaps)
-            reencoded = base64.b64encode(swapped.encode("latin-1")).decode("ascii")
+            # UTF-8 per RFC 7617's default charset: a vault secret may hold any
+            # Unicode codepoint, and ``latin-1`` would ``UnicodeEncodeError`` on one
+            # outside U+00FF — crashing the request into a TLS reset.
+            reencoded = base64.b64encode(swapped.encode("utf-8")).decode("ascii")
             return f"Basic {reencoded}"
     return _apply_swaps_str(value, swaps)
 
@@ -225,7 +228,7 @@ def _decode_basic_credential(value: str) -> str | None:
         return None
     try:
         raw = base64.b64decode(parts[1].strip(), validate=True)
-        return raw.decode("latin-1")
+        return raw.decode("utf-8")  # RFC 7617 default; symmetric with the re-encode
     except (binascii.Error, ValueError):
         return None
 

--- a/tests/unit/sandbox/test_secret_egress_proxy.py
+++ b/tests/unit/sandbox/test_secret_egress_proxy.py
@@ -259,16 +259,20 @@ class TestSwapForwarding:
 
 
 def _basic(user: str, password: str) -> str:
-    """An ``Authorization: Basic <b64>`` header value for ``user:password``."""
-    token = base64.b64encode(f"{user}:{password}".encode("latin-1")).decode("ascii")
+    """An ``Authorization: Basic <b64>`` header value for ``user:password``.
+
+    UTF-8 per RFC 7617 (the proxy's charset), so a non-ASCII credential survives
+    the encode/decode round-trip.
+    """
+    token = base64.b64encode(f"{user}:{password}".encode()).decode("ascii")
     return f"Basic {token}"
 
 
 def _decode_basic(value: str) -> str:
-    """Decode an ``Authorization: Basic <b64>`` header to its ``user:pass``."""
+    """Decode an ``Authorization: Basic <b64>`` header to its ``user:pass`` (UTF-8)."""
     scheme, token = value.split(" ", 1)
     assert scheme == "Basic"
-    return base64.b64decode(token).decode("latin-1")
+    return base64.b64decode(token).decode()
 
 
 class TestBasicAuthSwap:
@@ -293,6 +297,20 @@ class TestBasicAuthSwap:
         assert _decode_basic(out) == "x-access-token:ghp_REALSECRET"
         # The real secret must never leave as a placeholder.
         assert PH_GH not in _decode_basic(out)
+
+    async def test_basic_auth_non_latin1_secret_round_trips(self, make_proxy: MakeProxy) -> None:
+        # A vault secret accepts any UTF-8 string, but the Basic-auth re-encode used
+        # latin-1 — which raises UnicodeEncodeError on any non-Latin-1 codepoint,
+        # crashing the request into a TLS reset. RFC 7617's default charset is UTF-8;
+        # the swap must round-trip a Unicode secret unharmed.
+        secret = "ghp_\U0001f511_secret"  # 🔑 — outside latin-1 (U+1F511)
+        proxy, captured = await make_proxy(
+            [_cred("GH_TOKEN", secret, ("api.allowed.test",), PH_GH)]
+        )
+        header = _basic("x-access-token", PH_GH)
+        r = await _request(proxy, "api.allowed.test", "/x", headers={"Authorization": header})
+        assert r.status_code == 200
+        assert _decode_basic(captured[0].headers["authorization"]) == f"x-access-token:{secret}"
 
     async def test_basic_auth_placeholder_in_username(
         self, gh_proxy: tuple[SecretEgressProxy, list[httpx.Request]]


### PR DESCRIPTION
## Summary

The secret egress proxy decodes an `Authorization: Basic` credential, swaps the injected placeholder for the real vault secret, and re-encodes it for the upstream. The re-encode used `swapped.encode("latin-1")` — but a vault `secret_value` accepts **any UTF-8 string** (no charset constraint at create time, `models/vaults.py`), so a secret containing any codepoint **outside U+00FF** raised `UnicodeEncodeError`.

That exception propagates out of `_forward_headers` (past the 502 `try/except`), closes the writer, and **resets the sandbox's TLS connection** — git-over-HTTPS / `curl -u` against the egress proxy. The credential silently never works, with a confusing connection-reset failure mode rather than a clean error.

## Fix

RFC 7617's default charset for HTTP Basic credentials is **UTF-8**, not latin-1. Both the re-encode and the symmetric decode now use UTF-8:

- `swapped.encode("utf-8")` — no longer crashes on a Unicode secret.
- `raw.decode("utf-8")` — symmetric; a genuinely non-UTF-8 incoming credential raises `UnicodeDecodeError` (a `ValueError`), caught by the existing `except` → `None` → falls open to the literal-substring swap (the documented "not decodable text" path). A non-UTF-8 credential can't contain our ASCII placeholder anyway.

The other `latin-1` sites in this module are *decodes* of incoming bytes (latin-1 never raises) and the body swap already uses `encode()` (UTF-8) — so line 210 was the only crash site.

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 2950 passed
- [x] New `test_basic_auth_non_latin1_secret_round_trips` (secret = `ghp_🔑_secret`) confirmed **RED** (`UnicodeEncodeError` → `RemoteProtocolError: Server disconnected`) before, **GREEN** after; the 5 existing `TestBasicAuthSwap` ASCII cases unchanged (UTF-8 ≡ latin-1 for ASCII)
- [ ] CI runs full integration/e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)