### PR TITLE
refactor(sandbox): retire vestigial /sessions/messages self-wake route (#1164)

### DIFF
--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -871,10 +871,10 @@ def _assemble_plan(
         # them anyway (secret_name can't be a reserved key, models/vaults.py).
         "TOOL_BROKER_URL": tool_broker_url,
         "TOOL_BROKER_SECRET": tool_broker_secret,
-        # Scheduled-tasks escalation (#636): bash inside a cron sandbox
-        # POSTs to ``$TOOL_BROKER_URL/v1/$TOOL_BROKER_SECRET/sessions/messages``
-        # to wake the session. AIOS_SESSION_ID is also exposed so the
-        # bash can name its own session in logs / messages.
+        # A ``sandbox_command`` fire escalates back into its session via
+        # ``tool wake_self '{"content": "..."}'`` (timing lives in the
+        # trigger primitive, not inside the sandbox). AIOS_SESSION_ID is
+        # exposed so the bash can name its own session in logs / messages.
         "AIOS_SESSION_ID": session_id,
     }
 

--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -235,57 +235,8 @@ class ToolBroker:
                     self._mcp_invoke,
                     methods=["POST"],
                 ),
-                # Scheduled-tasks escalation (#636): bash inside a cron
-                # sandbox POSTs here to wake its session with a user-role
-                # message. Same per-session secret authn as the tool
-                # routes above.
-                Route(
-                    "/v1/{secret}/sessions/messages",
-                    self._post_session_message,
-                    methods=["POST"],
-                ),
             ]
         )
-
-    async def _post_session_message(self, request: Request) -> Response:
-        """Append a user-role message to the owning session and wake it.
-
-        Escalation primitive used by a trigger's ``sandbox_command``: a
-        bash script POSTs here to deliver a user-role event back into
-        its session, which causes the next step to run with the model
-        seeing the new message. The per-session secret in the URL path
-        binds the call to one specific session; the body is JSON
-        ``{"content": "..."}``.
-        """
-        from aios.harness import runtime
-        from aios.services import sessions as sessions_service
-        from aios.services.wake import defer_wake
-
-        resolved = await self._resolve_session(request)
-        if isinstance(resolved, Response):
-            return resolved
-        session_id = resolved
-
-        try:
-            body = await request.json()
-        except (json.JSONDecodeError, ValueError):
-            return _err(400, "invalid JSON body")
-        if not isinstance(body, dict):
-            return _err(400, 'body must be {"content": "..."}')
-        content = body.get("content")
-        if not isinstance(content, str) or not content:
-            return _err(400, "body.content must be a non-empty string")
-        metadata = body.get("metadata")
-        if metadata is not None and not isinstance(metadata, dict):
-            return _err(400, "body.metadata must be an object")
-
-        pool = runtime.require_pool()
-        account_id = await sessions_service.load_session_account_id(pool, session_id)
-        event = await sessions_service.append_user_message(
-            pool, session_id, content, metadata=metadata, account_id=account_id
-        )
-        await defer_wake(pool, session_id, cause="message", account_id=account_id)
-        return JSONResponse({"event_id": event.id, "session_id": session_id}, status_code=201)
 
     async def start(self) -> None:
         """Bind ``0.0.0.0:0`` and begin serving.

--- a/tests/unit/sandbox/test_tool_broker.py
+++ b/tests/unit/sandbox/test_tool_broker.py
@@ -519,3 +519,24 @@ class TestMcpGate:
                 )
         assert r.status_code == 403
         assert "always_ask" in r.json()["error"]
+
+
+# ── retired self-wake route (#1164) ──────────────────────────────────────────
+
+
+class TestRetiredSessionsMessages:
+    """The in-sandbox ``POST /sessions/messages`` self-wake route (#636)
+    is retired — timing belongs to triggers; an in-fire ``sandbox_command``
+    escalates via ``tool wake_self``. The broker must no longer route it.
+    """
+
+    async def test_sessions_messages_not_routed(self, broker: ToolBroker) -> None:
+        broker.register_session("sess_X", "s")
+        async with httpx.AsyncClient() as c:
+            r = await c.post(
+                _url(broker, "s", "sessions", "messages"),
+                json={"content": "wake up"},
+            )
+        # Starlette returns 404 for an unmatched path (405 only when the
+        # path matches but the method doesn't). The route is gone entirely.
+        assert r.status_code in (404, 405)


### PR DESCRIPTION
## Summary

Retires the tool-broker route `POST /v1/{secret}/sessions/messages` and its `_post_session_message` handler (`src/aios/sandbox/tool_broker.py`) — the `#636` "bash inside a cron sandbox wakes its session" escalation primitive. It is fully superseded by `tool wake_self` and had **zero in-tree callers**.

This locks the framing the issue settled on (**Fork A**): timing lives in the trigger primitive; the `sandbox_command` action is "run bash _at_ a scheduled time," never "schedule _from inside_ the sandbox." Scheduling is host/DB-side; the sandbox is a fire-time callee, never a self-scheduler.

## Changes

- **Delete** the `Route(".../sessions/messages", …)` registration and the `_post_session_message` handler in `src/aios/sandbox/tool_broker.py`. The unused optional `metadata` affordance is dropped with it (YAGNI — `wake_self` can grow `metadata` if a real need ever appears; `#818 §8.1` already recorded "no capability delta").
- **Update** the `src/aios/sandbox/spec.py` env comment: drop the `/sessions/messages` framing; note that a `sandbox_command` fire escalates via `tool wake_self '{"content": "..."}'`.
- **Add** a regression test (`TestRetiredSessionsMessages`) in `tests/unit/sandbox/test_tool_broker.py` asserting the broker no longer routes the path (404/405) for a registered session.

## Explicitly untouched (per issue scope)

- `TOOL_BROKER_URL` / `TOOL_BROKER_SECRET` injection (load-bearing for the entire `tool` CLI).
- `AIOS_SESSION_ID` injection (reserved env name; lets the agent name its own session in logs/messages).
- The `sandbox_command` trigger action (the non-superseded in-sandbox *execution* leg).

## Verification

- `grep -rnE "sessions/messages|_post_session_message" src/ bin/ connectors/ docs/` → empty; in `tests/` only the new regression test's prose.
- `tool wake_self` continues to route through `/builtins/wake_self` (unchanged).
- `ruff check`, `ruff format --check`, and `mypy` green on the touched files.
- `pytest tests/unit` green: **2950 passed, 1 skipped**; broker suite 24 passed (new test red before the deletion, green after).