### PR TITLE
perf(test): polish from the June 2026 CI-runtime profiling pass (#868)

### DIFF
--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -378,18 +378,28 @@ class ToolBroker:
             # Graceful drain only matters once the server actually
             # bound — ``should_exit`` is checked inside the uvicorn
             # main loop, which never runs on a failed-bind path, so
-            # without this gate the failed-bind cleanup pays a
-            # pointless 5s wait on every retry.
+            # without the ``started`` gate the failed-bind cleanup pays
+            # a pointless 5s wait on every retry.
+            #
+            # Flip ``should_exit`` on *both* servers before awaiting
+            # either drain: uvicorn pays a ~150-200 ms fixed shutdown
+            # floor once the flag is set, so serializing the two waits
+            # doubles it. Setting both flags first lets the two floors
+            # overlap; ``gather`` then waits out the slower of the two.
+            drains: list[asyncio.Task[None]] = []
             if self._server is not None and self._server.started:
                 self._server.should_exit = True
                 if self._serve_task is not None:
-                    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
-                        await asyncio.wait_for(self._serve_task, timeout=5.0)
+                    drains.append(self._serve_task)
             if self._uds_server is not None and self._uds_server.started:
                 self._uds_server.should_exit = True
                 if self._uds_serve_task is not None:
-                    with contextlib.suppress(TimeoutError, asyncio.CancelledError):
-                        await asyncio.wait_for(self._uds_serve_task, timeout=5.0)
+                    drains.append(self._uds_serve_task)
+            if drains:
+                with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                    await asyncio.wait_for(
+                        asyncio.gather(*drains, return_exceptions=True), timeout=5.0
+                    )
         finally:
             if self._serve_task is not None and not self._serve_task.done():
                 self._serve_task.cancel()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -35,6 +35,25 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
+async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
+    """A function-scoped asyncpg pool against the testcontainer DB.
+
+    Promoted here from ~20 byte-identical per-file copies. Tests that
+    need a pre-bootstrap (no seeded root account) DB define their own
+    ``pool`` over ``aios_env_minimal`` — that local fixture overrides
+    this one via standard pytest resolution (see
+    ``test_accounts_bootstrap.py``).
+    """
+    from aios.config import get_settings
+    from aios.db.pool import create_pool
+
+    settings = get_settings()
+    p = await create_pool(settings.db_url, min_size=1, max_size=4)
+    yield p
+    await p.close()
+
+
+@pytest.fixture
 async def daemon(tmp_path: Path) -> AsyncIterator[tuple[DockerBackend, str, str, Path]]:
     """A real :class:`DockerBackend` + a unique (instance, session, workspace)
     plus container/snapshot-image cleanup.

--- a/tests/e2e/test_account_auth.py
+++ b/tests/e2e/test_account_auth.py
@@ -13,17 +13,6 @@ from tests.helpers.connections import asgi_client
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     async with asgi_client(pool) as client:
         yield client

--- a/tests/e2e/test_accounts_mgmt.py
+++ b/tests/e2e/test_accounts_mgmt.py
@@ -17,17 +17,6 @@ from tests.helpers.connections import asgi_client
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     async with asgi_client(pool) as client:
         yield client

--- a/tests/e2e/test_agent_litellm_extra.py
+++ b/tests/e2e/test_agent_litellm_extra.py
@@ -17,17 +17,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(

--- a/tests/e2e/test_agents_api.py
+++ b/tests/e2e/test_agents_api.py
@@ -21,17 +21,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(

--- a/tests/e2e/test_connection_reparent.py
+++ b/tests/e2e/test_connection_reparent.py
@@ -34,17 +34,6 @@ from tests.helpers.connections import asgi_client, bearer
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     """In-process API client (``asgi_client``).
 

--- a/tests/e2e/test_context_endpoint.py
+++ b/tests/e2e/test_context_endpoint.py
@@ -19,17 +19,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox

--- a/tests/e2e/test_events_pagination.py
+++ b/tests/e2e/test_events_pagination.py
@@ -27,17 +27,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(

--- a/tests/e2e/test_github_repositories.py
+++ b/tests/e2e/test_github_repositories.py
@@ -55,17 +55,6 @@ def _pat() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 def crypto_box(aios_env: dict[str, str]) -> Any:
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -31,17 +31,6 @@ def _sha(content: str) -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(

--- a/tests/e2e/test_pagination_limit_validation.py
+++ b/tests/e2e/test_pagination_limit_validation.py
@@ -43,17 +43,6 @@ from tests.helpers.connections import authed_client, wired_app
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(

--- a/tests/e2e/test_ready.py
+++ b/tests/e2e/test_ready.py
@@ -18,17 +18,6 @@ from tests.helpers.connections import asgi_client
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     async with asgi_client(pool) as client:
         yield client

--- a/tests/e2e/test_reap_stalled_jobs.py
+++ b/tests/e2e/test_reap_stalled_jobs.py
@@ -25,16 +25,6 @@ pytestmark = pytest.mark.docker
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    p = await create_pool(get_settings().db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def job_manager(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[Any]:
     """A fresh ``JobManager`` pointed at the testcontainer DB.
 

--- a/tests/e2e/test_session_clone.py
+++ b/tests/e2e/test_session_clone.py
@@ -23,17 +23,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     with mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock):

--- a/tests/e2e/test_session_status_pending.py
+++ b/tests/e2e/test_session_status_pending.py
@@ -19,17 +19,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     with mock.patch("aios.api.routers.sessions.defer_wake", new_callable=mock.AsyncMock):

--- a/tests/e2e/test_skills.py
+++ b/tests/e2e/test_skills.py
@@ -11,18 +11,6 @@ import pytest
 
 from aios.models.skills import AgentSkillRef
 
-
-@pytest.fixture
-async def pool(aios_env: dict[str, str]) -> Any:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
 _SKILL_MD = (
     "---\nname: test-skill\ndescription: A test skill for e2e\n---\n# Instructions\nDo stuff."
 )

--- a/tests/e2e/test_sse_lock.py
+++ b/tests/e2e/test_sse_lock.py
@@ -2,24 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
 from typing import Any
 
 import asyncpg
-import pytest
 
 from tests.e2e.conftest import wait_for_predicate
-
-
-@pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
 
 
 class TestSubscriberLockRoundTrip:

--- a/tests/e2e/test_submit_tool_result_name.py
+++ b/tests/e2e/test_submit_tool_result_name.py
@@ -30,17 +30,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     # No real worker in these tests; avoid enqueueing a wake for the

--- a/tests/e2e/test_tenant_isolation.py
+++ b/tests/e2e/test_tenant_isolation.py
@@ -20,17 +20,6 @@ from tests.helpers.connections import asgi_client
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     async with asgi_client(pool) as client:
         yield client

--- a/tests/e2e/test_triggers.py
+++ b/tests/e2e/test_triggers.py
@@ -61,17 +61,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(

--- a/tests/e2e/test_vault_oauth.py
+++ b/tests/e2e/test_vault_oauth.py
@@ -38,17 +38,6 @@ REDIRECT_URI = "https://console.example.com/api/auth/mcp-oauth/callback"
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> Any:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 def crypto_box(aios_env: dict[str, str]) -> Any:
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox

--- a/tests/e2e/test_vaults.py
+++ b/tests/e2e/test_vaults.py
@@ -15,17 +15,6 @@ from aios.models.vaults import VaultCredentialCreate, VaultCredentialUpdate
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> Any:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 def crypto_box(aios_env: dict[str, str]) -> Any:
     from aios.config import get_settings
     from aios.crypto.vault import CryptoBox

--- a/tests/e2e/test_wait_endpoint.py
+++ b/tests/e2e/test_wait_endpoint.py
@@ -19,17 +19,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     async with authed_client(

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -26,17 +26,6 @@ def _uniq() -> str:
 
 
 @pytest.fixture
-async def pool(aios_env: dict[str, str]) -> AsyncIterator[Any]:
-    from aios.config import get_settings
-    from aios.db.pool import create_pool
-
-    settings = get_settings()
-    p = await create_pool(settings.db_url, min_size=1, max_size=4)
-    yield p
-    await p.close()
-
-
-@pytest.fixture
 async def http_client(pool: Any, aios_env: dict[str, str]) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=wired_app(pool))
     # create_run + resume defer a wake; the procrastinate app isn't open in this ASGI

--- a/tests/unit/sandbox/test_tool_broker_stop.py
+++ b/tests/unit/sandbox/test_tool_broker_stop.py
@@ -1,0 +1,118 @@
+"""Unit tests for :meth:`ToolBroker.stop` drain concurrency.
+
+The broker runs two uvicorn servers (TCP + UDS). Each pays uvicorn's
+~150-200 ms fixed shutdown floor once ``should_exit`` is set. Draining
+them sequentially (set TCP flag, await TCP, *then* set UDS flag, await
+UDS) doubles that floor on every worker shutdown and across the unit
+suite. ``stop`` must set both flags first, then await the two serve
+tasks concurrently — while still running the finally-block cleanup for
+both tasks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aios.sandbox.tool_broker import ToolBroker
+
+
+class _FakeServer:
+    """Minimal uvicorn.Server stand-in.
+
+    Records the wall-clock order in which ``should_exit`` is set on it
+    (relative to its sibling) so the test can assert both flags flip
+    before either drain wait resolves. The flag setter also fires an
+    :class:`asyncio.Event` the serve task waits on, so the drain doesn't
+    busy-poll.
+    """
+
+    def __init__(self, log: list[str], name: str) -> None:
+        self.started = True
+        self._should_exit = False
+        self._log = log
+        self._name = name
+        self.exit_requested = asyncio.Event()
+
+    @property
+    def should_exit(self) -> bool:
+        return self._should_exit
+
+    @should_exit.setter
+    def should_exit(self, value: bool) -> None:
+        self._should_exit = value
+        if value:
+            self._log.append(f"flag:{self._name}")
+            self.exit_requested.set()
+
+
+def _drain_task(server: _FakeServer, log: list[str], name: str, delay: float) -> asyncio.Task[None]:
+    """A serve task that only completes after ``should_exit`` is set.
+
+    Sleeps ``delay`` after the flag flips to model uvicorn's fixed
+    shutdown floor, then records its completion.
+    """
+
+    async def _serve() -> None:
+        await server.exit_requested.wait()
+        await asyncio.sleep(delay)
+        log.append(f"done:{name}")
+
+    return asyncio.create_task(_serve())
+
+
+class TestStopDrainsConcurrently:
+    async def test_both_flags_set_before_either_drain_completes(self) -> None:
+        log: list[str] = []
+        broker = ToolBroker()
+
+        tcp = _FakeServer(log, "tcp")
+        uds = _FakeServer(log, "uds")
+        broker._server = tcp  # type: ignore[assignment]
+        broker._uds_server = uds  # type: ignore[assignment]
+        broker._serve_task = _drain_task(tcp, log, "tcp", delay=0.05)
+        broker._uds_serve_task = _drain_task(uds, log, "uds", delay=0.05)
+
+        await broker.stop()
+
+        # Both should_exit flags must be flipped before either serve task
+        # is allowed to finish draining — i.e. the two shutdown floors
+        # overlap rather than serialize.
+        first_done = next(i for i, e in enumerate(log) if e.startswith("done:"))
+        flags_before = {e for e in log[:first_done] if e.startswith("flag:")}
+        assert flags_before == {"flag:tcp", "flag:uds"}, log
+
+    async def test_stop_completes_faster_than_sequential_floor(self) -> None:
+        """Concurrent drain wall-time ≈ one floor, not two."""
+        log: list[str] = []
+        broker = ToolBroker()
+
+        tcp = _FakeServer(log, "tcp")
+        uds = _FakeServer(log, "uds")
+        broker._server = tcp  # type: ignore[assignment]
+        broker._uds_server = uds  # type: ignore[assignment]
+        floor = 0.15
+        broker._serve_task = _drain_task(tcp, log, "tcp", delay=floor)
+        broker._uds_serve_task = _drain_task(uds, log, "uds", delay=floor)
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        await broker.stop()
+        elapsed = loop.time() - start
+
+        # Sequential would be ~2*floor; concurrent stays well under it.
+        assert elapsed < floor * 1.8, elapsed
+
+    async def test_both_tasks_finalized_when_uds_absent(self) -> None:
+        """TCP-only broker (no UDS) still drains cleanly."""
+        log: list[str] = []
+        broker = ToolBroker()
+
+        tcp = _FakeServer(log, "tcp")
+        broker._server = tcp  # type: ignore[assignment]
+        broker._serve_task = _drain_task(tcp, log, "tcp", delay=0.02)
+
+        await broker.stop()
+
+        assert "done:tcp" in log
+        assert broker._serve_task is not None
+        assert broker._serve_task.done()

--- a/tests/unit/test_attachment_staging.py
+++ b/tests/unit/test_attachment_staging.py
@@ -8,7 +8,9 @@ matches the :class:`aios.services.files.UploadStream` Protocol.
 
 from __future__ import annotations
 
+import functools
 import io
+import random
 from pathlib import Path
 
 import pytest
@@ -24,18 +26,23 @@ from aios.services.attachment_staging import (
 )
 
 
+@functools.cache
 def _real_jpeg_bytes(width: int, height: int, *, quality: int = 95) -> bytes:
     """Return real JPEG bytes Pillow can decode (the staging downsample
     path actually opens the file, so opaque ``b"\\0"`` payloads aren't
     enough to exercise it).
+
+    The pixel data is genuine seeded noise so the JPEG re-encode in the
+    staging path really shrinks the multi-megapixel cases below
+    ``INLINE_SIZE_CAP_BYTES`` (solid fills would compress to nothing and
+    defeat the test). ``Random(seed).randbytes`` + :meth:`Image.frombytes`
+    replaces the old per-pixel Python loop (12.25M writes for the
+    3500x3500 case, regenerated identically per test); ``functools.cache``
+    memoizes the immutable ``bytes`` result so repeated identical
+    requests are free.
     """
-    img = Image.new("RGB", (width, height))
-    pixels = img.load()
-    assert pixels is not None
-    for y in range(height):
-        for x in range(width):
-            v = (x * 2654435761 + y * 40503) & 0xFFFFFF
-            pixels[x, y] = (v & 0xFF, (v >> 8) & 0xFF, (v >> 16) & 0xFF)
+    data = random.Random(f"{width}x{height}q{quality}").randbytes(width * height * 3)
+    img = Image.frombytes("RGB", (width, height), data)
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=quality)
     return buf.getvalue()

--- a/tests/unit/test_image_resize.py
+++ b/tests/unit/test_image_resize.py
@@ -9,7 +9,9 @@ deterministically.
 
 from __future__ import annotations
 
+import functools
 import io
+import random
 
 import pytest
 from PIL import Image
@@ -32,23 +34,23 @@ def _encode(img: Image.Image, fmt: str, **save_kwargs: object) -> bytes:
     return buf.getvalue()
 
 
+@functools.cache
 def _noisy_rgb(width: int, height: int) -> Image.Image:
     """Return an RGB image whose pixel data resists JPEG compression.
 
     Solid colors compress to a few bytes regardless of quality, which
-    makes it impossible to test the quality ladder.  Random-ish pixels
-    keep the encoded size proportional to dimensions.
+    makes it impossible to test the quality ladder.  Seeded random
+    bytes keep the encoded size proportional to dimensions.
+
+    The old per-pixel Python loop wrote every channel by hand (12.25M
+    ``PixelAccess`` writes for the 3500x3500 case, regenerated per
+    test).  ``Random(seed).randbytes`` + :meth:`Image.frombytes` builds
+    the same noise in one buffer, and ``functools.cache`` memoizes the
+    result so identical (width, height) requests reuse it.  Callers
+    must treat the returned image as read-only — copy before mutating.
     """
-    # Deterministic pseudo-random via a hash — keeps tests reproducible
-    # without seeding the RNG and without adding a numpy dep.
-    img = Image.new("RGB", (width, height))
-    pixels = img.load()
-    assert pixels is not None
-    for y in range(height):
-        for x in range(width):
-            v = (x * 2654435761 + y * 40503) & 0xFFFFFF
-            pixels[x, y] = (v & 0xFF, (v >> 8) & 0xFF, (v >> 16) & 0xFF)
-    return img
+    data = random.Random(f"{width}x{height}").randbytes(width * height * 3)
+    return Image.frombytes("RGB", (width, height), data)
 
 
 class TestNoOp:


### PR DESCRIPTION
Implements the cleanly-bounded, behavior-preserving work packages from the profiling-remainder issue. These are per-job / local-dev-loop wins; none move the CI critical path.

## Package 3 — `ToolBroker.stop` drains its two uvicorn servers concurrently
`stop()` set `should_exit` on the TCP server and awaited its serve task, *then* did the same for the UDS server — each await paying uvicorn's ~150–200 ms fixed shutdown floor sequentially. Now both `should_exit` flags are flipped first, then the two serve tasks are awaited together via `asyncio.gather` (wrapped in the same 5 s `wait_for` budget). The finally-block per-task cancel/cleanup is unchanged. (~1 s across unit tests + faster production worker shutdown.)
- Test-first: new `tests/unit/sandbox/test_tool_broker_stop.py` asserts both flags flip before either drain completes and that wall-time stays under the sequential floor. Verified failing against the old sequential implementation, passing with the fix.

## Package 2 — Unit image-fixture generation
`tests/unit/test_attachment_staging.py` and `tests/unit/test_image_resize.py` built multi-megapixel "noisy" images via per-pixel Python loops (12.25M `PixelAccess` writes for the 3500x3500 case, regenerated identically per test). Switched both helpers to `random.Random(seed).randbytes` + `Image.frombytes`, memoized with `functools.cache`. Preserves the genuine `>INLINE_SIZE_CAP_BYTES` / JPEG-incompressible semantics (verified encoded sizes stay above/below the cap exactly as before); all 36 tests in those modules pass.

## Package 4 (partial) — e2e `pool` fixture dedup
Promoted the ~20 byte-identical `pool(aios_env)` fixtures to `tests/e2e/conftest.py` and removed the per-file copies (23 files), plus the now-unused imports ruff flagged. `test_accounts_bootstrap.py` keeps its `aios_env_minimal` variant, which overrides the shared fixture via standard pytest resolution. Full e2e collection still resolves (665 tests collected, no fixture errors).

### Deliberately scoped out
- **Package 1 (migration-test mechanics)**: larger, testcontainer-infra-heavy change (per-test `CREATE DATABASE`, in-process alembic + new `downgrade_to`, pinned upgrade tails) — better as its own focused PR.
- **The `http_client` half of package 4**: the e2e conftest already defines a differently-behaving `http_client` (mocks defer_wake + registers `tool_provider`); the ~8 plain per-file copies are *lighter* and intentionally don't mock defer_wake. Promoting one over the other would silently change behavior for those files, so left untouched.
- **Package 5 items** (detect-job inlining, in-process sdk-snapshot, `dateparser` language pin): explicit judgment/product calls flagged in the issue as needing sign-off.

Full unit suite (2952 passed, 1 skipped), ruff check/format, and mypy all green on the changed files.