### PR TITLE
followup(sandbox): #988/PR#992 deferred cleanups — owner-kind discriminator, dead pool plumbing, GC run-aware note (#995)

### DIFF
--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -129,6 +129,20 @@ def make_id(prefix: str, *, body: bytes | None = None) -> str:
     return f"{prefix}_{ULID()}"
 
 
+def is_run_owner_id(owner_id: str) -> bool:
+    """Is ``owner_id`` a workflow-run sandbox owner (``wfr_…``)?
+
+    The intrinsic owner-kind discriminator the sandbox registry routes teardown
+    on (#995): its ``_handles`` map holds both session (``sess_…``) and
+    workflow-run (``wfr_…``) owners, whose teardowns differ (a session snapshots
+    its rootfs + stops proxies; a run is a bare ephemeral destroy). Centralizing
+    the prefix test here keeps the run-vs-session fork a single source of truth —
+    so a future owner prefix added to the map can't silently inherit the session
+    path by an inlined ``startswith`` going stale at one call site.
+    """
+    return owner_id.startswith(f"{WORKFLOW_RUN}_")
+
+
 def split_id(value: str) -> tuple[str, str]:
     """Split a prefixed id into ``(prefix, ulid)``.
 

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from aios.config import get_settings
 from aios.db import queries
-from aios.ids import WORKFLOW_RUN
+from aios.ids import is_run_owner_id
 from aios.logging import get_logger
 from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
@@ -487,9 +487,7 @@ class SandboxRegistry:
 
     # ── workflow-run sandboxes (#988) ────────────────────────────────────────
 
-    async def get_or_provision_run(
-        self, run_id: str, *, pool: asyncpg.Pool[Any] | None = None
-    ) -> SandboxHandle:
+    async def get_or_provision_run(self, run_id: str) -> SandboxHandle:
         """Return the cached run sandbox handle, or provision a fresh one.
 
         The run-side analog of :meth:`get_or_provision`, owner-keyed on ``run_id``
@@ -505,8 +503,9 @@ class SandboxRegistry:
           the env image every time (no salvage preamble, no snapshot resume) — the
           run sandbox carries no durable rootfs.
 
-        ``pool`` is accepted for signature parity with the session path but is
-        currently unused (the run path emits no provision span).
+        Unlike the session path it takes no ``pool``: the run path reads no
+        ``sessions.*`` row on either the warm probe or the cold provision and
+        emits no provision span, so there is nothing to hand a connection to.
         """
         handle = self._handles.get(run_id)
         if handle is not None and await self._backend.is_alive(handle):
@@ -1323,13 +1322,16 @@ class SandboxRegistry:
 
         The ``_handles`` map holds both session (``sess_…``) and workflow-run
         (``wfr_…``) sandboxes; their teardowns differ (a session snapshots its
-        rootfs + stops proxies, a run is a bare ephemeral destroy). The prefix is
-        the discriminator — the same id the owner was provisioned under. An
-        unrecognized prefix falls through to the session path (the historical
-        default; a malformed owner id is a bug worth surfacing via that path's
-        logging rather than silently skipping the teardown).
+        rootfs + stops proxies, a run is a bare ephemeral destroy). The owner-kind
+        discriminator is :func:`aios.ids.is_run_owner_id` — the single source of
+        truth for the run-vs-session fork (#995), keyed on the same id the owner
+        was provisioned under, so a future owner prefix can't silently inherit the
+        session path by an inlined prefix test going stale here. A non-run owner
+        falls through to the session path (the historical default; a malformed
+        owner id is a bug worth surfacing via that path's logging rather than
+        silently skipping the teardown).
         """
-        if owner_id.startswith(f"{WORKFLOW_RUN}_"):
+        if is_run_owner_id(owner_id):
             await self.release_run(owner_id)
         else:
             await self.release(owner_id)
@@ -1552,6 +1554,15 @@ class SandboxRegistry:
         the next tick (the GC never raises). Each corpse is handled under the
         per-session lock with the cached-handle re-check.
         """
+        # NOTE (#995): this pass is NOT run-aware. ``ref.session_id`` carries the
+        # owner label, which for a workflow-run sandbox is a ``wfr_…`` id (#988) —
+        # never present in the ``sessions`` table, so its ``states`` lookup below is
+        # always ``None`` ⇒ ``keep_fs`` False ⇒ ``force_remove`` with NO snapshot.
+        # That is correct-by-coincidence today because a run sandbox is ephemeral
+        # scratch with no durable rootfs to salvage, but it is a latent footgun: if
+        # M2 ever gives run sandboxes a durable rootfs, a ``wfr_`` corpse would be
+        # dropped here without a commit. Make this owner-kind aware
+        # (:func:`aios.ids.is_run_owner_id`) before that lands.
         for ref in containers:
             sid = ref.session_id
             if sid is None:

--- a/src/aios/workflows/run_sandbox.py
+++ b/src/aios/workflows/run_sandbox.py
@@ -98,9 +98,9 @@ async def _run_sandbox_task(
         except Exception as exc:
             # Backstop — _execute maps gate/validation/provision/exec to their own
             # error values, but its pre-phase setup (require_sandbox_registry /
-            # require_pool / get_settings) raises BEFORE either guarded block. An
-            # uncaught escape would skip the signal write and, with the stale-call
-            # sweep horizon, park the run forever.
+            # get_settings) raises BEFORE either guarded block. An uncaught escape
+            # would skip the signal write and, with the stale-call sweep horizon,
+            # park the run forever.
             log.exception("run_sandbox.unexpected", run_id=run.id, call_key=call_key)
             result = {"error": f"sandbox task failed: {type(exc).__name__}: {exc}"}
         try:
@@ -174,10 +174,9 @@ async def _execute(run: WfRun, *, call_key: str, tool_name: str, tool_input: Any
 
     settings = get_settings()
     registry = runtime.require_sandbox_registry()
-    pool = runtime.require_pool()
 
     try:
-        handle = await registry.get_or_provision_run(run.id, pool=pool)
+        handle = await registry.get_or_provision_run(run.id)
     except Exception as exc:
         log.warning("run_sandbox.provision_failed", run_id=run.id, error=str(exc))
         return {"error": f"sandbox provisioning failed: {exc}"}

--- a/tests/unit/test_ids.py
+++ b/tests/unit/test_ids.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 import pytest
 
-from aios.ids import AGENT, CREDENTIAL, ENVIRONMENT, EVENT, SESSION, make_id, split_id
+from aios.ids import (
+    AGENT,
+    CREDENTIAL,
+    ENVIRONMENT,
+    EVENT,
+    SESSION,
+    WORKFLOW_RUN,
+    is_run_owner_id,
+    make_id,
+    split_id,
+)
 
 
 class TestMakeId:
@@ -53,6 +63,27 @@ class TestMakeIdDeterministic:
     def test_body_must_be_16_bytes(self) -> None:
         with pytest.raises(ValueError, match="must be exactly 16 bytes"):
             make_id(SESSION, body=b"too short")
+
+
+class TestIsRunOwnerId:
+    """The intrinsic owner-kind discriminator the sandbox registry routes teardown
+    on (issue #995): a single source of truth for "is this owner a workflow run?"
+    so a future owner prefix can't silently fall through the run-vs-session fork."""
+
+    def test_true_for_a_workflow_run_id(self) -> None:
+        assert is_run_owner_id(make_id(WORKFLOW_RUN)) is True
+
+    def test_false_for_a_session_id(self) -> None:
+        assert is_run_owner_id(make_id(SESSION)) is False
+
+    def test_false_for_other_prefixes(self) -> None:
+        # An unrelated owner-shaped id must NOT be misclassified as a run.
+        for prefix in (AGENT, ENVIRONMENT, EVENT):
+            assert is_run_owner_id(make_id(prefix)) is False
+
+    def test_requires_the_separator_not_just_the_prefix_chars(self) -> None:
+        # A literal ``wfr`` substring without the ``wfr_`` boundary is not a run id.
+        assert is_run_owner_id("wfrog_01HQR2K7VXBZ9MNPL3WYCT8F") is False
 
 
 class TestSplitId:

--- a/tests/unit/test_run_sandbox.py
+++ b/tests/unit/test_run_sandbox.py
@@ -67,7 +67,7 @@ class _FakeRegistry:
         self.exec_calls: list[dict[str, Any]] = []
         self.provision_count = 0
 
-    async def get_or_provision_run(self, run_id: str, *, pool: Any = None) -> SandboxHandle:
+    async def get_or_provision_run(self, run_id: str) -> SandboxHandle:
         self.provision_count += 1
         if self.provision_exc is not None:
             raise self.provision_exc
@@ -371,3 +371,45 @@ def test_launch_is_inflight_guarded() -> None:
             await task
 
     asyncio.run(_go())
+
+
+async def test_teardown_schedules_release_run_and_swallows_no_registry() -> None:
+    """``teardown_run_sandbox`` is best-effort fire-and-forget (#988):
+
+    - with a registry wired, it schedules ``registry.release_run(run_id)`` as a
+      detached task (held in the strong-ref set so it isn't GC'd mid-destroy);
+    - with NO registry on this worker (``require_sandbox_registry`` raises), it is
+      a silent no-op — a terminal-commit teardown must never raise.
+
+    Pins the dedicated assertion the run teardown path previously lacked (#995).
+    """
+    import asyncio
+
+    released: list[str] = []
+
+    class _Registry:
+        async def release_run(self, run_id: str) -> None:
+            released.append(run_id)
+
+    # No registry: silent no-op, nothing scheduled.
+    with patch(
+        "aios.workflows.run_sandbox.runtime.require_sandbox_registry",
+        side_effect=RuntimeError("no registry"),
+    ):
+        run_sandbox.teardown_run_sandbox("wfr_1")
+    assert not run_sandbox._TEARDOWN_TASKS
+
+    # Registry wired: a detached release task is scheduled and tracked.
+    with patch(
+        "aios.workflows.run_sandbox.runtime.require_sandbox_registry",
+        return_value=_Registry(),
+    ):
+        run_sandbox.teardown_run_sandbox("wfr_1")
+        assert len(run_sandbox._TEARDOWN_TASKS) == 1
+        task = next(iter(run_sandbox._TEARDOWN_TASKS))
+        await task
+        # The done-callback discards the task from the strong-ref set on completion.
+        await asyncio.sleep(0)
+
+    assert released == ["wfr_1"]
+    assert not run_sandbox._TEARDOWN_TASKS

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -1289,3 +1289,118 @@ class TestEnvVarCredentialDrift:
         else:
             assert destroys == [], f"{description!r} must not recycle the sandbox"
             assert registry.peek("sess_X") is not None
+
+
+class TestRunSandboxLifecycle:
+    """Dedicated unit assertions for the workflow-run (#988) sandbox lifecycle:
+    warm-hit container reuse, ``release_run``, and the ``_release_owner`` owner-kind
+    routing — paths exercised by integration tests but not previously pinned by
+    dedicated unit assertions (issue #995, "test coverage breadth").
+    """
+
+    @staticmethod
+    def _run_provision_patches(plan: ProvisioningPlan) -> ExitStack:
+        """Patch the run cold-path's external collaborators so ``_provision_run``
+        runs against the in-memory backend only. The Unrestricted, no-credential
+        plan makes ``_apply_egress_rules`` a no-op, so no lockdown sidecar fires."""
+        stack = ExitStack()
+        for cm in (
+            patch("aios.sandbox.registry.build_spec_from_run", AsyncMock(return_value=plan)),
+            patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+        ):
+            stack.enter_context(cm)
+        return stack
+
+    async def test_warm_hit_reuses_container_create_count_stays_one(self) -> None:
+        """Two ``get_or_provision_run`` calls in one run provision the container
+        ONCE: the second is a warm hit (liveness probe only, no re-create). This
+        pins the #988 e2e warm-hit-reuse strategy item — ``create_count == 1``
+        across two ``sandbox()`` calls in one run."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        plan = _provisioning_plan("wfr_X")  # Unrestricted, no creds → no egress wiring
+
+        with self._run_provision_patches(plan):
+            h1 = await registry.get_or_provision_run("wfr_X")
+            h2 = await registry.get_or_provision_run("wfr_X")
+
+        assert h1 is h2  # same cached handle
+        creates = [c for c in backend.calls if c[0] == "create"]
+        assert len(creates) == 1, "warm hit must NOT re-create the container"
+        # The warm call took the liveness-probe path, not a second provision.
+        assert any(c[0] == "is_alive" for c in backend.calls)
+
+    async def test_warm_hit_after_dead_container_reprovisions(self) -> None:
+        """If the cached container died between calls, the warm probe fails and the
+        run cold-reprovisions (a fresh ``create``) — the run sandbox is snapshot-free
+        so the dead handle is dropped without salvage."""
+        backend = FakeBackend(next_handle_id="run_sandbox_1")
+        registry = SandboxRegistry(backend=backend)
+        plan = _provisioning_plan("wfr_X")
+
+        with self._run_provision_patches(plan):
+            await registry.get_or_provision_run("wfr_X")
+            # Mark the cached container dead so the next warm probe fails.
+            backend.dead_sandbox_ids.add("run_sandbox_1")
+            backend.next_handle_id = "run_sandbox_2"
+            h2 = await registry.get_or_provision_run("wfr_X")
+
+        assert h2.sandbox_id == "run_sandbox_2"
+        creates = [c for c in backend.calls if c[0] == "create"]
+        assert len(creates) == 2  # cold start + reprovision after death
+        # The dead container was destroyed (no snapshot — run sandboxes are scratch).
+        assert any(c[0] == "destroy" for c in backend.calls)
+        assert not any(c[0] == "snapshot" for c in backend.calls)
+
+    async def test_release_run_destroys_cached_container_no_snapshot(self) -> None:
+        """``release_run`` is a bare destroy + cache eviction — no snapshot/pointer
+        machinery (a run sandbox has no durable rootfs)."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        plan = _provisioning_plan("wfr_X")
+
+        with self._run_provision_patches(plan):
+            handle = await registry.get_or_provision_run("wfr_X")
+
+        await registry.release_run("wfr_X")
+
+        destroys = [c for c in backend.calls if c[0] == "destroy"]
+        assert len(destroys) == 1
+        assert destroys[0][1]["sandbox_id"] == handle.sandbox_id
+        assert not any(c[0] == "snapshot" for c in backend.calls)
+        assert registry.peek("wfr_X") is None
+
+    async def test_release_run_is_noop_when_not_cached(self) -> None:
+        """``release_run`` for an unknown run never touches the backend."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+
+        await registry.release_run("wfr_unknown")
+
+        assert not any(c[0] == "destroy" for c in backend.calls)
+
+    async def test_release_owner_routes_run_id_to_release_run(self) -> None:
+        """A ``wfr_`` owner routes to ``release_run`` (the ephemeral-destroy path),
+        NOT the session ``release`` path."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        registry.release_run = AsyncMock()  # type: ignore[method-assign]
+        registry.release = AsyncMock()  # type: ignore[method-assign]
+
+        await registry._release_owner("wfr_01TEST")
+
+        registry.release_run.assert_awaited_once_with("wfr_01TEST")
+        registry.release.assert_not_awaited()
+
+    async def test_release_owner_routes_session_id_to_release(self) -> None:
+        """A ``sess_`` owner falls through to the session ``release`` path."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        registry.release_run = AsyncMock()  # type: ignore[method-assign]
+        registry.release = AsyncMock()  # type: ignore[method-assign]
+
+        await registry._release_owner("sess_01TEST")
+
+        registry.release.assert_awaited_once_with("sess_01TEST")
+        registry.release_run.assert_not_awaited()


### PR DESCRIPTION
## Summary

Addresses the tractable, self-contained subset of the #988 / PR #992 deferred cleanups captured in #995. All items are low-priority/non-blocking per the issue; this PR lands the ones that are concrete and verifiable today, with dedicated test coverage. The larger M2-adjacent refactors are left as explicit non-goals (see below).

### Implemented

- **Owner-kind discriminator** (issue item 4). Introduced `aios.ids.is_run_owner_id(owner_id)` as the single source of truth for the run-vs-session fork, and routed `SandboxRegistry._release_owner` through it instead of an inlined `owner_id.startswith(f"{WORKFLOW_RUN}_")`. A future owner prefix added to the `_handles` map can no longer silently inherit the session `release()` path via a stale inlined prefix test at one call site.

- **Dead plumbing removed** (issue item 5). Dropped `get_or_provision_run`'s unused `pool` param and the now-dead `runtime.require_pool()` call in `run_sandbox._execute`. The run path reads no `sessions.*` row and emits no provision span, so there was nothing to hand a connection to. Docstring/backstop comments updated to match; the fake registry in the unit test mirrors the new signature.

- **GC run-awareness clarifying comment** (issue item 2, "at minimum add a clarifying comment"). Added a `NOTE (#995)` to `_gc_corpse_pass` documenting that the corpse pass is NOT run-aware: a `wfr_…` owner label is never in the `sessions` table, so its state lookup is always `None` ⇒ `force_remove` without snapshot — correct-by-coincidence for snapshot-free ephemeral run scratch today, a latent footgun if M2 gives run sandboxes a durable rootfs. Points to `is_run_owner_id` as the seam to make it owner-kind aware before that lands.

### Test coverage (issue item 7, "test coverage breadth")

- `TestRunSandboxLifecycle` in `test_sandbox_registry.py`: pins warm-hit container reuse (`create_count == 1` across two `get_or_provision_run` calls in one run — the #988 e2e strategy item), dead-container reprovision (no snapshot), `release_run` (bare destroy, no snapshot machinery, no-op when uncached), and `_release_owner` routing both directions (`wfr_` → `release_run`, `sess_` → `release`).
- `test_teardown_run_sandbox` in `test_run_sandbox.py`: pins the best-effort fire-and-forget teardown — schedules+tracks a detached `release_run` task with a registry wired, silent no-op with none.
- `TestIsRunOwnerId` in `test_ids.py`: pins the new discriminator (true for `wfr_`, false for session/other prefixes, requires the `_` boundary).

Each behavioral test was verified to fail when its source change is reverted.

### Non-goals (left for M2 / follow-up, as the issue frames them)

- Provisioning under-extraction (broker-URL/secret block in `spec.py`) — larger refactor across two builders.
- Making the GC owner-kind aware (vs. the clarifying comment landed here) — gated on M2 giving run sandboxes a durable rootfs.
- Teardown-vs-inflight orphan race (cancelling the inflight task at teardown) — transient, reaper-reclaimed; consistent with the ephemeral-scratch contract.
- Harvest-skeleton shared helper in `step.py`.

## Testing

- `pytest tests/unit` — 2960 passed, 1 skipped.
- `ruff check` / `ruff format --check` — clean on all changed files.
- `mypy` — no issues on the changed source modules.

Refs #995, #988, #992.