### PR TITLE
fix(attachment-gc): record tool-result spill in metadata.attachments (#1093)

### DIFF
--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -304,11 +304,19 @@ async def _append_tool_result_event(
     content = event_data.get("content")
     if isinstance(content, str):
         from aios.config import get_settings
-        from aios.sandbox.tool_result_spill import cap_tool_result_content
+        from aios.sandbox.tool_result_spill import (
+            cap_tool_result_content,
+            record_spill_attachment,
+        )
 
-        event_data["content"] = await cap_tool_result_content(
+        capped = await cap_tool_result_content(
             session_id, tool_call_id, content, max_chars=get_settings().tool_result_max_chars
         )
+        event_data["content"] = capped.content
+        # Register any spill file under ``metadata.attachments`` so the
+        # attachment GC's referenced-set sees it as live (#1093).  No-op
+        # when nothing spilled.
+        record_spill_attachment(event_data, capped.attachment)
 
     # ── Pre-lock precompute (issue #991) ──────────────────────────────────
     # The tokenizer pass (and, on the cold path, the parent-channel JSONB ``@>``

--- a/src/aios/sandbox/tool_result_spill.py
+++ b/src/aios/sandbox/tool_result_spill.py
@@ -12,11 +12,24 @@ Only ``str`` content is capped (the two append sinks guard on
 typically bounded — passes through uncapped, as do oversized non-tool events
 (e.g. an unbounded ``switch_channel`` recap).  Tool results are the dominant
 overflow source; the residual shapes are left for a follow-up.
+
+Spill files are recorded in the tool-result event's
+``metadata.attachments`` (#1093): the attachment GC's referenced-set query
+(``list_attachment_paths_for_sessions``) is built *exclusively* from
+``data->'metadata'->'attachments'``, so a spill file whose only reference
+lived in the result-content stub was invisible to the GC and reaped on the
+next worker boot — pointing the model at a now-missing file it was told to
+``read``.  Recording the spill under the same ``metadata.attachments``
+convention every staged inbound uses collapses the two reference conventions
+into one: there is exactly one way a file under ``_attachments/`` becomes
+live, and the existing referenced-set query covers it automatically.
 """
 
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from typing import Any
 
 from aios.sandbox.volumes import (
     ensure_owned_dir,
@@ -27,22 +40,76 @@ from aios.sandbox.volumes import (
 _SPILL_SUBDIR = "tool_results"
 
 
+@dataclass(frozen=True)
+class CappedToolResult:
+    """Outcome of :func:`cap_tool_result_content`.
+
+    ``content`` is the value to store on the tool-result event — the
+    original when within the cap, or the truncation stub when spilled.
+    ``attachment`` is ``None`` when no spill occurred, otherwise the
+    ``metadata.attachments`` record the caller MUST persist on the event
+    so the attachment GC's referenced-set sees the spill file as live
+    (#1093).  The record mirrors a staged-inbound record's shape — it
+    carries ``in_sandbox_path`` (the key the GC query keys on) plus
+    descriptive fields for the renderer/console.
+    """
+
+    content: str
+    attachment: dict[str, Any] | None
+
+
 async def cap_tool_result_content(
     session_id: str, tool_call_id: str, content: str, *, max_chars: int
-) -> str:
+) -> CappedToolResult:
     """Return ``content`` unchanged if within ``max_chars``; otherwise spill the
     full body to ``<attachments>/tool_results/<tool_call_id>.txt`` and return a
-    stub string referencing the in-sandbox path + the ``read`` tool."""
+    stub string referencing the in-sandbox path + the ``read`` tool, paired
+    with the ``metadata.attachments`` record the caller must persist so the
+    spill file is protected from the orphan GC (#1093)."""
     if len(content) <= max_chars:
-        return content
+        return CappedToolResult(content=content, attachment=None)
     fname = safe_filename(f"{tool_call_id}.txt")
     sandbox_path = f"/mnt/attachments/{_SPILL_SUBDIR}/{fname}"
+    size = len(content)
     await asyncio.to_thread(_write_spill, session_id, fname, content)
-    return (
-        f"[Tool result truncated: the full output ({len(content):,} characters) "
+    stub = (
+        f"[Tool result truncated: the full output ({size:,} characters) "
         f"exceeded the inline result limit and was saved to {sandbox_path}. "
         f"Use the read tool to view it.]"
     )
+    attachment = {
+        "filename": fname,
+        "content_type": "text/plain",
+        "size": size,
+        "in_sandbox_path": sandbox_path,
+        # Marks the reference convention this record came in through so a
+        # future reader can tell a spill record from a staged inbound.
+        "source": "tool_result_spill",
+    }
+    return CappedToolResult(content=stub, attachment=attachment)
+
+
+def record_spill_attachment(data: dict[str, Any], attachment: dict[str, Any] | None) -> None:
+    """Append ``attachment`` to ``data['metadata']['attachments']`` in place.
+
+    No-op when ``attachment`` is ``None`` (the within-cap path).  This is the
+    single seam both tool-result append sinks use to register a spill file
+    under the same ``metadata.attachments`` convention staged inbounds use, so
+    the attachment GC's referenced-set query protects it (#1093).  Creates the
+    ``metadata`` dict and ``attachments`` list if absent; appends if a list is
+    already present.
+    """
+    if attachment is None:
+        return
+    metadata = data.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        data["metadata"] = metadata
+    existing = metadata.get("attachments")
+    if isinstance(existing, list):
+        existing.append(attachment)
+    else:
+        metadata["attachments"] = [attachment]
 
 
 def _write_spill(session_id: str, fname: str, content: str) -> None:

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1268,12 +1268,18 @@ async def append_tool_result(
     in the connector-facing endpoint).  The caller is responsible for
     deferring the wake afterwards.
     """
-    from aios.sandbox.tool_result_spill import cap_tool_result_content
+    from aios.sandbox.tool_result_spill import (
+        cap_tool_result_content,
+        record_spill_attachment,
+    )
 
+    spill_attachment: dict[str, Any] | None = None
     if isinstance(content, str):
-        content = await cap_tool_result_content(
+        capped = await cap_tool_result_content(
             session_id, tool_call_id, content, max_chars=get_settings().tool_result_max_chars
         )
+        content = capped.content
+        spill_attachment = capped.attachment
 
     # ── Pre-lock precompute (issue #991, Parts 1 + 2) ─────────────────────
     # Resolve the parent assistant's name AND ``focal_channel_at_arrival`` in a
@@ -1296,6 +1302,10 @@ async def append_tool_result(
     }
     if is_error:
         data["is_error"] = True
+    # Register any spill file under ``metadata.attachments`` so the attachment
+    # GC's referenced-set sees it as live (#1093).  Done before the precompute
+    # so the stored event and its token estimate reflect the same shape.
+    record_spill_attachment(data, spill_attachment)
     precomputed = await queries.precompute_event_append(
         conn,
         account_id=account_id,

--- a/tests/integration/test_tool_result_spill.py
+++ b/tests/integration/test_tool_result_spill.py
@@ -97,13 +97,19 @@ async def spill_session(
             get_settings.cache_clear()
 
 
-async def _stored_tool_content(pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str) -> str:
+async def _stored_tool_event(
+    pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str
+) -> dict[str, Any]:
     async with pool.acquire() as conn:
         event = await queries.find_tool_result_event(
             conn, session_id, tool_call_id, account_id="acc_spill"
         )
     assert event is not None
-    content = event.data["content"]
+    return event.data
+
+
+async def _stored_tool_content(pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str) -> str:
+    content = (await _stored_tool_event(pool, session_id, tool_call_id))["content"]
     assert isinstance(content, str)
     return content
 
@@ -136,6 +142,46 @@ class TestToolResultSpill:
         )
         assert spill_file.exists()
         assert spill_file.read_text(encoding="utf-8") == original
+
+        # #1093: the spill file must be recorded under the tool event's
+        # ``metadata.attachments`` (the single convention staged inbounds use)
+        # so the attachment GC's referenced-set protects it. Its
+        # ``in_sandbox_path`` must match the path the GC walk reconstructs for
+        # the on-disk file.
+        data = await _stored_tool_event(pool, session_id, tool_call_id)
+        attachments = data["metadata"]["attachments"]
+        assert isinstance(attachments, list) and len(attachments) == 1
+        assert (
+            attachments[0]["in_sandbox_path"] == f"/mnt/attachments/tool_results/{tool_call_id}.txt"
+        )
+
+    async def test_spill_path_is_in_gc_referenced_set(
+        self,
+        spill_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """End-to-end #1093 guard: after an oversized result spills, the
+        attachment GC's referenced-set query (``list_attachment_paths_for_sessions``)
+        — built exclusively from ``data->'metadata'->'attachments'`` — must
+        return the spill file's sandbox path. Pre-fix the spill reference lived
+        only in the result content stub, so this query returned an empty set
+        and the orphan sweep deleted the file on the next worker boot.
+        """
+        pool, session_id, tool_call_id = spill_session
+        original = "Z" * 300_000
+
+        async with pool.acquire() as conn:
+            await sessions_service.append_tool_result(
+                conn,
+                account_id="acc_spill",
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                content=original,
+            )
+
+        async with pool.acquire() as conn:
+            referenced = await queries.list_attachment_paths_for_sessions(conn, [session_id])
+
+        assert f"/mnt/attachments/tool_results/{tool_call_id}.txt" in referenced[session_id]
 
     async def test_within_cap_result_stored_verbatim(
         self,

--- a/tests/unit/test_attachment_gc.py
+++ b/tests/unit/test_attachment_gc.py
@@ -204,3 +204,95 @@ async def test_sweep_reaps_inline_sibling_when_event_predates_feature(
     assert original.exists()
     assert not inline.exists()
     assert deleted == 1
+
+
+def _seed_spill(root: Path, session_id: str, filename: str) -> Path:
+    """Create a tool-result spill file at ``_attachments/<sid>/tool_results/<filename>``.
+
+    Mirrors ``cap_tool_result_content`` (#735): oversized tool output spills
+    to the ``tool_results`` subdir of the session's attachments dir, recorded
+    (post-#1093) in the tool-role event's ``metadata.attachments`` like any
+    staged inbound so the GC's referenced-set query protects it.
+    """
+    target = root / session_id / "tool_results" / filename
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x" * 4096, encoding="utf-8")
+    return target
+
+
+async def test_sweep_retains_spill_file_recorded_in_metadata_attachments(
+    attachments_root: Path,
+    fake_pool: MagicMock,
+) -> None:
+    """#1093: a tool-result spill file whose reference is recorded in the
+    tool event's ``metadata.attachments`` (the single, unified convention)
+    must be retained by the sweep.
+
+    Pre-fix the spill writer recorded its path ONLY in the result-content
+    stub, never in ``metadata.attachments``; ``list_attachment_paths_for_sessions``
+    is built exclusively from ``data->'metadata'->'attachments'``, so the
+    spill file was invisible to the referenced-set and reaped on the next
+    worker boot — after which the event log still told the model to ``read``
+    a now-missing file. With the spill recorded under the same convention
+    every staged inbound uses, the EXISTING query returns its sandbox path
+    and the sweep keeps it.
+    """
+    import os
+    import time
+
+    session_id = "sess_01SPILL00000000000000001"
+    spill = _seed_spill(attachments_root, session_id, "tc_spill_1.txt")
+    # Older than the in-flight window so the recent-file protection isn't
+    # what's saving it — only the referenced-set membership is.
+    old = time.time() - 3600
+    os.utime(spill, (old, old))
+    assert spill.exists()
+
+    # The fixed spill writer records this path in metadata.attachments, so
+    # the referenced-set query surfaces it exactly as the GC walk reconstructs
+    # it: /mnt/attachments/tool_results/<file>.
+    referenced = {session_id: {"/mnt/attachments/tool_results/tc_spill_1.txt"}}
+    with patch(
+        "aios.harness.attachment_gc.queries.list_attachment_paths_for_sessions",
+        AsyncMock(return_value=referenced),
+    ):
+        deleted = await sweep_orphan_attachments(fake_pool)
+
+    assert spill.exists(), (
+        "a spill file recorded in metadata.attachments must be retained by "
+        "the sweep — pre-#1093 the spill reference lived only in the result "
+        "content stub, invisible to the referenced-set, and was reaped on "
+        "the next worker boot, leaving the model pointed at a deleted file "
+        "it was told to read."
+    )
+    assert deleted == 0
+
+
+async def test_sweep_reaps_orphaned_spill_file_with_no_reference(
+    attachments_root: Path,
+    fake_pool: MagicMock,
+) -> None:
+    """The complement of the retain case (and the self-heal path in #1093's
+    migration plan): a spill file under ``tool_results/`` that NO event
+    references — e.g. an already-orphaned file written before the fix, or a
+    spill whose tool-result append rolled back — must still be reaped. The
+    sweep treats the ``tool_results`` subdir like any connector dir; only
+    membership in the referenced-set keeps a file alive.
+    """
+    import os
+    import time
+
+    session_id = "sess_01SPILL00000000000000002"
+    spill = _seed_spill(attachments_root, session_id, "tc_orphan.txt")
+    old = time.time() - 3600
+    os.utime(spill, (old, old))
+    assert spill.exists()
+
+    with patch(
+        "aios.harness.attachment_gc.queries.list_attachment_paths_for_sessions",
+        AsyncMock(return_value={}),
+    ):
+        deleted = await sweep_orphan_attachments(fake_pool)
+
+    assert not spill.exists()
+    assert deleted == 1

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -430,10 +430,13 @@ class TestAppendToolResultUniqueFloor:
         monkeypatch.setattr(
             queries, "lookup_tool_name_by_call_id", AsyncMock(return_value=("demo", None))
         )
-        # No spill capping in unit tests.
+        # No spill capping in unit tests: return the content unchanged with
+        # no attachment record (the within-cap shape).
+        from aios.sandbox.tool_result_spill import CappedToolResult
+
         monkeypatch.setattr(
             "aios.sandbox.tool_result_spill.cap_tool_result_content",
-            AsyncMock(side_effect=lambda *a, **k: a[2]),
+            AsyncMock(side_effect=lambda *a, **k: CappedToolResult(content=a[2], attachment=None)),
         )
 
     @staticmethod

--- a/tests/unit/test_tool_result_spill.py
+++ b/tests/unit/test_tool_result_spill.py
@@ -13,7 +13,10 @@ from pathlib import Path
 import pytest
 
 from aios.config import get_settings
-from aios.sandbox.tool_result_spill import cap_tool_result_content
+from aios.sandbox.tool_result_spill import (
+    cap_tool_result_content,
+    record_spill_attachment,
+)
 from aios.sandbox.volumes import ensure_session_attachments_dir
 
 _SESSION_ID = "sess_spill_unit"
@@ -32,7 +35,9 @@ async def test_within_cap_returns_unchanged_and_writes_nothing(
 
     result = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
 
-    assert result == content
+    assert result.content == content
+    # No spill → no attachment record to register with the GC.
+    assert result.attachment is None
     assert not _spill_path(_SESSION_ID, _TOOL_CALL_ID).exists()
 
 
@@ -45,7 +50,8 @@ async def test_exactly_at_cap_returns_unchanged(
 
     result = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
 
-    assert result == content
+    assert result.content == content
+    assert result.attachment is None
     assert not _spill_path(_SESSION_ID, _TOOL_CALL_ID).exists()
 
 
@@ -57,14 +63,35 @@ async def test_over_cap_returns_stub_and_writes_full_content(
 
     result = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
 
-    assert result.startswith("[Tool result truncated:")
-    assert "/mnt/attachments/tool_results/tc_unit_1.txt" in result
-    assert "1,500 characters" in result
-    assert "read tool" in result
+    assert result.content.startswith("[Tool result truncated:")
+    assert "/mnt/attachments/tool_results/tc_unit_1.txt" in result.content
+    assert "1,500 characters" in result.content
+    assert "read tool" in result.content
 
     spill = _spill_path(_SESSION_ID, _TOOL_CALL_ID)
     assert spill.exists()
     assert spill.read_text(encoding="utf-8") == content
+
+
+async def test_over_cap_returns_attachment_record_keyed_for_gc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The spilled result must carry a ``metadata.attachments`` record whose
+    ``in_sandbox_path`` matches the path the GC walk reconstructs for the
+    file on disk (``/mnt/attachments/tool_results/<id>.txt``). Without this
+    the spill file's only reference lives in the content stub, invisible to
+    ``list_attachment_paths_for_sessions`` → reaped on the next worker boot
+    (#1093)."""
+    monkeypatch.setattr(get_settings(), "workspace_root", tmp_path)
+    content = "b" * 1_500
+
+    result = await cap_tool_result_content(_SESSION_ID, _TOOL_CALL_ID, content, max_chars=1_000)
+
+    assert result.attachment is not None
+    assert result.attachment["in_sandbox_path"] == "/mnt/attachments/tool_results/tc_unit_1.txt"
+    assert result.attachment["size"] == 1_500
+    assert result.attachment["filename"] == "tc_unit_1.txt"
+    assert result.attachment["source"] == "tool_result_spill"
 
 
 async def test_no_part_temp_left_behind(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -78,3 +105,32 @@ async def test_no_part_temp_left_behind(tmp_path: Path, monkeypatch: pytest.Monk
     spill_dir = _spill_path(_SESSION_ID, _TOOL_CALL_ID).parent
     names = sorted(p.name for p in spill_dir.iterdir())
     assert names == [f"{_TOOL_CALL_ID}.txt"]
+
+
+class TestRecordSpillAttachment:
+    """``record_spill_attachment`` is the single seam both tool-result append
+    sinks use to register a spill file under ``metadata.attachments`` — the
+    same convention staged inbounds use — so the existing GC referenced-set
+    query protects it (#1093)."""
+
+    def test_none_is_noop(self) -> None:
+        data: dict[str, object] = {"role": "tool", "content": "ok"}
+        record_spill_attachment(data, None)
+        assert "metadata" not in data
+
+    def test_creates_metadata_and_attachments_list(self) -> None:
+        data: dict[str, object] = {"role": "tool", "content": "stub"}
+        att = {"in_sandbox_path": "/mnt/attachments/tool_results/x.txt"}
+        record_spill_attachment(data, att)
+        assert data["metadata"] == {"attachments": [att]}
+
+    def test_appends_to_existing_attachments_list(self) -> None:
+        prior = {"in_sandbox_path": "/mnt/attachments/echo/prior.png"}
+        data: dict[str, object] = {
+            "role": "tool",
+            "content": "stub",
+            "metadata": {"attachments": [prior]},
+        }
+        att = {"in_sandbox_path": "/mnt/attachments/tool_results/x.txt"}
+        record_spill_attachment(data, att)
+        assert data["metadata"] == {"attachments": [prior, att]}


### PR DESCRIPTION
## The bug

`cap_tool_result_content` (#735) spills oversized tool output to `_attachments/<session_id>/tool_results/<tool_call_id>.txt` and returns a stub that the model is told to `read`. That stub was assigned to the tool-result event's `content` — the spill path lived **only** in the result-content text, never in `metadata.attachments`.

But the attachment GC's referenced-set query (`list_attachment_paths_for_sessions`, `db/queries/sessions.py`) is built **exclusively** from `data->'metadata'->'attachments'`, and the orphan sweep (`harness/attachment_gc.py`) blind-walks `_attachments/<sid>/<subdir>/<file>` and deletes any file not in that set. `tool_results/` is just another subdir to the walk, so every spill file older than the in-flight window was deleted on the next worker boot — after which the event log still tells the model to `read` a now-missing file → `FileNotFoundError` for content it was explicitly pointed at. aios restarts the worker on every deploy/smoke-commit, so this is routine, not rare.

## The fix (foreclosure, not guard)

Collapse the two attachment-reference conventions into one: the spill writer records its file in `metadata.attachments` exactly like every staged inbound, so the *existing* referenced-set query covers it automatically. There becomes exactly one way a file under `_attachments/` becomes live.

- `cap_tool_result_content` now returns a `CappedToolResult(content, attachment)`: the stub content plus an optional `metadata.attachments` record whose `in_sandbox_path` (`/mnt/attachments/tool_results/<id>.txt`) is keyed exactly as the GC walk reconstructs the on-disk path.
- A single seam, `record_spill_attachment(data, attachment)`, registers it on the event. Both append sinks use it: `harness/tool_dispatch.py` and `services/sessions.py`.
- **No effect on model context:** tool-role messages are stripped to `{role, tool_call_id, content, name}` by `_strip_to_spec` before reaching the model, and the attachment-marker/inline-image renderer (`_apply_attachments`) only fires for user-role events. `metadata.attachments` here is pure GC bookkeeping.

## Self-heal / blast / risk

Already-orphaned spill files self-heal (collected once; new ones protected). **No schema change.** Worst case a spill file is retained slightly longer than needed — a bounded leak, never data loss. The defect becomes unreachable without bypassing the staging convention entirely; a future third writer under `_attachments/` is protected automatically if it follows the same `stage → record in metadata.attachments` convention.

## Tests (test-first)

- **`tests/unit/test_tool_result_spill.py`**: spilled result returns an attachment record keyed `/mnt/attachments/tool_results/<id>.txt`; `record_spill_attachment` no-ops on `None`, creates the list, and appends to an existing one.
- **`tests/unit/test_attachment_gc.py`**: sweep **retains** a spill file recorded in `metadata.attachments` (fails pre-fix — the path was invisible to the referenced-set) and still **reaps** an unreferenced spill file (self-heal path).
- **`tests/integration/test_tool_result_spill.py`**: the stored tool event carries the `metadata.attachments` record; `list_attachment_paths_for_sessions` returns the spill path end-to-end.

Lint (ruff), format, and mypy clean on touched files; all unit tests pass (integration tests require a testcontainer Postgres).