### PR TITLE
fix(dev-pipeline): close source issue + strip dispatched/in-progress on merge (#1188)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -186,6 +186,13 @@ RESOLUTION_SIGNALS: tuple[str, ...] = (
 LABEL_IN_PROGRESS = "autodev:in-progress"
 LABEL_FAILED = "autodev:failed"
 
+# Dispatch-claim label (#1188): the cron-scanner / dev-conveyor stamps an issue ``dispatched``
+# when it launches a run for it. Like ``IN_PROGRESS`` it is an IN-FLIGHT claim that must be
+# stripped at the terminal post-merge cleanup — otherwise a merged-but-open issue reads as
+# live to a dispatch-gate sweep or a rank-6 staleness reaper. It is NOT applied by this
+# script (the conveyor owns the stamp); the post-merge node only REMOVES it, best-effort.
+LABEL_DISPATCHED = "dispatched"
+
 # Auto-recovery (item 4): a re-launched run carries ``retry_count`` in its input envelope;
 # the deploy-time ``run_completion`` trigger (Phase 2) re-launches an ``errored`` run with
 # ``retry_count + 1``. The script-level guard bounds that loop: a run that arrives with
@@ -256,6 +263,7 @@ def _render_constants(
         _py("RESOLUTION_SIGNALS", list(RESOLUTION_SIGNALS)),
         _py("LABEL_IN_PROGRESS", LABEL_IN_PROGRESS),
         _py("LABEL_FAILED", LABEL_FAILED),
+        _py("LABEL_DISPATCHED", LABEL_DISPATCHED),
         _py("MAX_RUN_RETRIES", MAX_RUN_RETRIES),
         _py("MAX_MASTER_CI_ITERS", MAX_MASTER_CI_ITERS),
         _py("FIX_CI_LINT_HINT", FIX_CI_LINT_HINT),
@@ -701,9 +709,19 @@ async def _label(repo, issue_number, name):
 
 
 async def _unlabel(repo, issue_number, name):
-    """Remove one label by name (URL-encoded). A 404 (label absent) is a value gh ignores."""
-    await gh("DELETE", _ipath(repo, "/issues/%d/labels/%s"
-                              % (issue_number, name.replace(":", "%3A"))))
+    """Remove one label by name (URL-encoded), best-effort. A 404/410 (label absent) is the
+    idempotent no-op a re-drive expects, NOT a failure. Per rank-6 (label-write visibility),
+    the gh() response is LOGGED so a strip that GitHub rejected is visible, not silently
+    swallowed: 200 (removed) / 404 (already absent) are benign; any other status is surfaced.
+    Returns the gh() response so a caller can branch on it."""
+    resp = await gh("DELETE", _ipath(repo, "/issues/%d/labels/%s"
+                                     % (issue_number, name.replace(":", "%3A"))))
+    st = _status(resp)
+    if st in (200, 204, 404, 410):
+        log("unlabel %r on #%d -> %r (ok)" % (name, issue_number, st))
+    else:
+        log("unlabel %r on #%d FAILED -> %r %r" % (name, issue_number, st, resp))
+    return resp
 
 
 async def _fail(repo, issue_number, result):
@@ -712,6 +730,36 @@ async def _fail(repo, issue_number, result):
     await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
     await _label(repo, issue_number, LABEL_FAILED)
     return result
+
+
+async def _close_source_issue(repo, issue_number):
+    """Terminal post-merge cleanup (#1188): a confirmed merge is the issue's resolution, so
+    close the source issue and strip its in-flight CLAIM labels so it leaves the open-issue
+    working set instead of reading as live to a dispatch-gate sweep / rank-6 staleness reaper.
+
+    Three idempotent, best-effort steps:
+      1. DELETE ``autodev:in-progress`` AND ``dispatched`` (each via ``_unlabel``, which logs
+         its gh() response per rank-6 — a strip GitHub rejected is visible, not silent). A
+         label already gone is a 404 no-op, exactly what a re-drive wants.
+      2. PATCH ``/issues/{n}`` to ``state:closed`` + ``state_reason:completed`` — closing the
+         issue on its OWN merge (the pipeline's PR bodies carry no ``Closes #N`` linkage, so
+         GitHub never auto-closes). Re-closing an already-closed issue is a GitHub no-op (200).
+      3. Log the close response: a non-2xx close is surfaced (visible), never swallowed.
+
+    Returns the close (PATCH) gh() response. Pure of LLM/time/random; only GitHub I/O."""
+    # Step 1 — strip BOTH in-flight claim labels (best-effort, idempotent, logged).
+    await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
+    await _unlabel(repo, issue_number, LABEL_DISPATCHED)
+    # Step 2 — close the issue (re-close of an already-closed issue is a 200 no-op).
+    close_resp = await gh("PATCH", _ipath(repo, "/issues/%d" % issue_number),
+                          {"state": "closed", "state_reason": "completed"})
+    # Step 3 — surface the outcome (rank-6): a failed close is visible, not silently swallowed.
+    st = _status(close_resp)
+    if st == 200:
+        log("closed source issue #%d (state=closed, reason=completed)" % issue_number)
+    else:
+        log("close source issue #%d FAILED -> %r %r" % (issue_number, st, close_resp))
+    return close_resp
 
 
 async def _file_followup(repo, title, body):
@@ -1061,7 +1109,14 @@ async def main(input):
     # outcome to done HERE — before the advisory master-CI watch runs. Nothing the watch does
     # below can re-suspend or fail this completed run; a flaky watch agent can no longer
     # manufacture a false human gate that parks a finished run indefinitely.
-    await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
+    #
+    # #1188 — the pipeline's PR bodies carry no `Closes #N` linkage, so GitHub never
+    # auto-closes the source issue on merge: it would otherwise sit OPEN with stale
+    # `autodev:in-progress` + `dispatched` claim labels, reading as in-flight to a
+    # dispatch-gate sweep / rank-6 staleness reaper. Make the terminal cleanup explicit and
+    # idempotent: strip BOTH claim labels (logged) and close the issue (state_reason:completed).
+    # A re-drive that finds it already closed / labels already gone is a no-op, not an error.
+    await _close_source_issue(repo, issue_number)
     result = {"state": "done", "pr_url": pr_url, "pr_number": pr_number, "merged": merged,
               "risk_tier": tier, "escalations": escalations}
 

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -142,6 +142,7 @@ class Scenario:
         self.http: list[tuple[str, str]] = []
         self.labels_added: list[str] = []  # every label name POSTed to /labels (item 3)
         self.labels_removed: list[str] = []  # every label name DELETEd from /labels
+        self.issue_patches: list[dict[str, Any]] = []  # every PATCH body to /issues/5 (#1188)
         self.followups: list[dict[str, Any]] = []  # advisory follow-up issues created (#1176)
 
     # GitHub's per-page cap for the comments endpoint in this fixture. The script asks for
@@ -197,6 +198,10 @@ class Scenario:
         if method == "DELETE" and "/labels/" in path:  # remove one label — capture decoded name
             self.labels_removed.append(path.rsplit("/labels/", 1)[1].replace("%3A", ":"))
             return {"status": 200, "body": "[]"}
+        if method == "PATCH" and path == "/repos/o/r/issues/5":  # close source issue (#1188)
+            raw = args.get("body")
+            self.issue_patches.append(json.loads(raw) if isinstance(raw, str) else {})
+            return {"status": 200, "body": _issue_json(self.body)}
         is_issue_get = (
             method == "GET"
             and "/issues/5" in path
@@ -381,6 +386,10 @@ async def test_happy_path_merges_and_completes() -> None:
     assert "autodev:in-progress" in scn.labels_added
     assert "autodev:in-progress" in scn.labels_removed
     assert "autodev:failed" not in scn.labels_added
+    # #1188: a merged PR closes the source issue and strips BOTH in-flight claim labels so
+    # the completed issue leaves the open working set (no merged-but-open residue).
+    assert "dispatched" in scn.labels_removed
+    assert scn.issue_patches == [{"state": "closed", "state_reason": "completed"}]
 
 
 async def test_adopts_existing_open_pr_instead_of_creating() -> None:

--- a/tests/unit/test_dev_pipeline_close_on_merge.py
+++ b/tests/unit/test_dev_pipeline_close_on_merge.py
@@ -1,0 +1,168 @@
+"""Unit tests for the post-merge source-issue cleanup (#1188).
+
+A merged dev-pipeline PR used to leave its source issue **OPEN** with stale
+``autodev:in-progress`` + ``dispatched`` claim labels: the pipeline's PR bodies carry no
+``Closes #N`` linkage, so GitHub never auto-closes the issue on merge, and the post-merge
+node only stripped ``autodev:in-progress``. To a dispatch-gate sweep / rank-6 staleness
+reaper the completed work then read as in-flight (#1156, #1176 both merged-but-open).
+
+The fix adds ``_close_source_issue(repo, issue_number)`` to the workflow *script body*: the
+terminal post-merge cleanup that idempotently strips BOTH claim labels and closes the issue
+(``state:closed`` + ``state_reason:completed``), logging each gh() response (rank-6
+label-write visibility). ``_unlabel`` now also logs its DELETE outcome.
+
+These helpers live inside the workflow script source (``_BODY``), so they are not importable
+as module attributes. We build the production script and ``exec`` it in a fresh namespace,
+inject a fake async ``gh`` (recording every call) and a ``log`` sink, then drive the
+coroutine to completion. No LLM, no real I/O, no time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from aios.workflows.dev_pipeline import build_dev_pipeline_script
+
+
+def _ns(gh: Any) -> dict[str, Any]:
+    """A fresh exec namespace for the script body with a fake ``gh`` and ``log`` injected.
+
+    ``gh``/``log`` are runtime-provided names in the deployed workflow (not defined in the
+    body); injecting them into the exec namespace lets the coroutine resolve them as globals.
+    """
+    src = build_dev_pipeline_script(
+        implement_agent_id="a",
+        review_agent_id="b",
+        fix_agent_id="c",
+        ci_agent_id="d",
+        risk_agent_id="e",
+    )
+    namespace: dict[str, Any] = {}
+    exec(compile(src, "dev_pipeline_script", "exec"), namespace)
+    logs: list[str] = []
+    namespace["gh"] = gh
+    namespace["log"] = lambda *a: logs.append(" ".join(str(x) for x in a))
+    namespace["_LOGS"] = logs
+    return namespace
+
+
+class _FakeGH:
+    """A recording fake for the workflow's ``gh(method, path, body=None)`` coroutine.
+
+    ``responses`` maps a ``(method, path)`` to the dict response to return; an unmapped call
+    returns a 200 with empty body (the GitHub default for a successful PATCH/DELETE here).
+    Every call is appended to ``calls`` so a test can assert exactly what was issued.
+    """
+
+    def __init__(self, responses: dict[tuple[str, str], dict[str, Any]] | None = None) -> None:
+        self.responses = responses or {}
+        self.calls: list[tuple[str, str, Any]] = []
+
+    async def __call__(self, method: str, path: str, body: Any = None) -> dict[str, Any]:
+        self.calls.append((method, path, body))
+        return self.responses.get((method, path), {"status": 200, "body": ""})
+
+
+REPO = "eumemic/aios"
+ISSUE = 1156
+IN_PROGRESS_PATH = "/repos/eumemic/aios/issues/1156/labels/autodev%3Ain-progress"
+DISPATCHED_PATH = "/repos/eumemic/aios/issues/1156/labels/dispatched"
+ISSUE_PATH = "/repos/eumemic/aios/issues/1156"
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+# ─── acceptance: a merged PR closes the issue and strips BOTH claim labels ─────
+
+
+def test_close_source_issue_strips_both_labels_and_closes() -> None:
+    gh = _FakeGH()
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+
+    methods_paths = [(m, p) for (m, p, _b) in gh.calls]
+    # Both in-flight claim labels are DELETEd...
+    assert ("DELETE", IN_PROGRESS_PATH) in methods_paths
+    assert ("DELETE", DISPATCHED_PATH) in methods_paths
+    # ...and the issue is PATCHed closed with the completed reason.
+    patch = [(m, p, b) for (m, p, b) in gh.calls if m == "PATCH"]
+    assert len(patch) == 1
+    assert patch[0][1] == ISSUE_PATH
+    assert patch[0][2] == {"state": "closed", "state_reason": "completed"}
+
+
+def test_close_source_issue_removes_dispatched_label() -> None:
+    # Regression: the old node stripped only autodev:in-progress, leaving `dispatched`.
+    gh = _FakeGH()
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+    assert ("DELETE", DISPATCHED_PATH) in [(m, p) for (m, p, _b) in gh.calls]
+
+
+# ─── idempotence: a re-drive over an already-cleaned issue is a no-op ──────────
+
+
+def test_idempotent_when_labels_absent_and_issue_already_closed() -> None:
+    # A re-launched run finds the labels already gone (404) and the issue already closed
+    # (PATCH returns 200 — re-closing is a GitHub no-op). It must NOT raise.
+    gh = _FakeGH(
+        {
+            ("DELETE", IN_PROGRESS_PATH): {"status": 404, "body": ""},
+            ("DELETE", DISPATCHED_PATH): {"status": 404, "body": ""},
+            ("PATCH", ISSUE_PATH): {"status": 200, "body": '{"state": "closed"}'},
+        }
+    )
+    ns = _ns(gh)
+    # No exception == idempotent no-op.
+    resp = _run(ns["_close_source_issue"](REPO, ISSUE))
+    assert resp == {"status": 200, "body": '{"state": "closed"}'}
+
+
+def test_label_already_absent_404_is_not_a_failure_log() -> None:
+    # A 404 unlabel (label absent) is the idempotent no-op a re-drive expects: logged as
+    # ok, NOT as a FAILED strip.
+    gh = _FakeGH(
+        {
+            ("DELETE", IN_PROGRESS_PATH): {"status": 404, "body": ""},
+            ("DELETE", DISPATCHED_PATH): {"status": 404, "body": ""},
+        }
+    )
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+    logs = "\n".join(ns["_LOGS"])
+    assert "FAILED" not in logs
+
+
+# ─── visibility: a failed strip / close is logged, not silently swallowed ──────
+
+
+def test_failed_label_strip_is_logged() -> None:
+    # A non-benign DELETE status (e.g. 403/500-after-retries) must be surfaced in the log.
+    gh = _FakeGH({("DELETE", DISPATCHED_PATH): {"status": 403, "body": "forbidden"}})
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+    logs = "\n".join(ns["_LOGS"])
+    assert "FAILED" in logs
+    assert "dispatched" in logs
+
+
+def test_failed_close_is_logged() -> None:
+    # A non-200 PATCH (close rejected) must be visible, never silently swallowed.
+    gh = _FakeGH({("PATCH", ISSUE_PATH): {"status": 422, "body": "unprocessable"}})
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+    logs = "\n".join(ns["_LOGS"])
+    assert "close source issue" in logs
+    assert "FAILED" in logs
+
+
+def test_unlabel_returns_and_logs_response() -> None:
+    # _unlabel now returns the gh() response and logs the outcome (rank-6 visibility).
+    gh = _FakeGH({("DELETE", DISPATCHED_PATH): {"status": 200, "body": ""}})
+    ns = _ns(gh)
+    resp = _run(ns["_unlabel"](REPO, ISSUE, "dispatched"))
+    assert resp == {"status": 200, "body": ""}
+    assert any("unlabel" in line for line in ns["_LOGS"])


### PR DESCRIPTION
## Problem

A merged dev-pipeline PR left its source issue **OPEN** with stale `autodev:in-progress` + `dispatched` claim labels. The pipeline's PR bodies are the spec contract and carry no `Closes #N`/`Fixes #N` linkage, so GitHub never auto-closes the issue on merge, and the post-merge node only stripped `autodev:in-progress` (never `dispatched`, never closing the issue). Completed work then read as in-flight to a dispatch-gate sweep / rank-6 staleness reaper (observed live: #1156 / PR #1173 and #1176 / PR #1177, both merged-but-open).

## Fix

Add `_close_source_issue(repo, issue_number)` — the terminal post-merge cleanup that runs after a confirmed merge (replacing the bare `_unlabel(autodev:in-progress)` call in the post-merge node), making the cleanup explicit and idempotent:

1. **Strip BOTH in-flight claim labels** — DELETE `autodev:in-progress` AND `dispatched`, each via `_unlabel` (best-effort; a label already gone is a 404 no-op).
2. **Close the issue** — `PATCH /issues/{n}` with `state:closed` + `state_reason:completed`, closing the issue on its own merge so it leaves the open-issue working set (the PR body carries no `Closes #N` linkage, so GitHub never auto-closes).
3. **Visibility (rank-6)** — `_unlabel` now logs its DELETE outcome and returns the response; `_close_source_issue` logs the PATCH outcome. A failed strip / close is surfaced in the log, not silently swallowed.

Added `LABEL_DISPATCHED = "dispatched"` as a rendered script constant (the conveyor owns the stamp; this script only removes it).

### Idempotence
A re-launched run that finds the labels already gone (404) and the issue already closed (re-close is a GitHub 200 no-op) completes without raising — a no-op, not an error.

## Acceptance (all covered by tests)
- A run whose PR merges leaves the source issue **closed** with `dispatched`/`autodev:in-progress` removed.
- Re-running the post-merge cleanup on an already-cleaned issue is a no-op.
- A failed label-strip / close is logged (visible), not silently swallowed.

## Tests (test-first)
- `tests/unit/test_dev_pipeline_close_on_merge.py` — execs the script body and drives `_close_source_issue` with a recording fake `gh`: strips both labels + PATCHes closed; idempotent on 404/already-closed; failed strip/close is logged. Confirmed failing against the pre-fix code, passing after.
- `tests/integration/test_wf_dev_pipeline_fixture.py` — the happy-path scenario now asserts a merged PR strips `dispatched` and PATCHes the issue `{state: closed, state_reason: completed}`.

`ruff check` + `ruff format --check` clean; full dev-pipeline unit + integration suites pass (74 unit, 51 integration).