### PR TITLE
fix(dev-pipeline): allow PATCH so a merged PR actually CLOSES its source issue; gate the dispatched-strip on a confirmed close (#1208)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -733,32 +733,54 @@ async def _fail(repo, issue_number, result):
 
 
 async def _close_source_issue(repo, issue_number):
-    """Terminal post-merge cleanup (#1188): a confirmed merge is the issue's resolution, so
-    close the source issue and strip its in-flight CLAIM labels so it leaves the open-issue
-    working set instead of reading as live to a dispatch-gate sweep / rank-6 staleness reaper.
+    """Terminal post-merge cleanup (#1188, #1208): a confirmed merge is the issue's
+    resolution, so close the source issue and strip its in-flight CLAIM labels so it leaves
+    the open-issue working set instead of reading as live to a dispatch-gate sweep / rank-6
+    staleness reaper.
 
-    Three idempotent, best-effort steps:
-      1. DELETE ``autodev:in-progress`` AND ``dispatched`` (each via ``_unlabel``, which logs
-         its gh() response per rank-6 — a strip GitHub rejected is visible, not silent). A
-         label already gone is a 404 no-op, exactly what a re-drive wants.
-      2. PATCH ``/issues/{n}`` to ``state:closed`` + ``state_reason:completed`` — closing the
+    **CLOSE-BEFORE-STRIP ordering (#1208 fail-safe).** ``dispatched`` is the claim that keeps
+    a merged issue OUT of the dispatch gate (``approved ∧ shovel-ready ∧ ¬dispatched``). If we
+    stripped it BEFORE the close and the close then failed, the issue would be left
+    OPEN ∧ ¬``dispatched`` — RE-ARMED for a duplicate build of already-merged work (strictly
+    worse than pre-#1188, where a merged issue stayed OPEN ∧ ``dispatched`` and was safe). So
+    the ``dispatched`` strip is GATED on a confirmed close: never strip it unless the issue is
+    actually closed, so a close-failure fails SAFE to OPEN ∧ ``dispatched``.
+
+    Idempotent, best-effort steps, in this order:
+      1. PATCH ``/issues/{n}`` to ``state:closed`` + ``state_reason:completed`` — closing the
          issue on its OWN merge (the pipeline's PR bodies carry no ``Closes #N`` linkage, so
          GitHub never auto-closes). Re-closing an already-closed issue is a GitHub no-op (200).
-      3. Log the close response: a non-2xx close is surfaced (visible), never swallowed.
+         (Before #1208 the route allowlist omitted PATCH, so this call was rejected by the
+         broker before it reached GitHub and the close silently never fired.)
+      2. Log the close response (rank-6): a non-2xx close is surfaced, never swallowed.
+      3. ONLY IF the close confirmed (200), DELETE ``dispatched`` — the dispatch-gate claim is
+         safe to drop precisely because the issue is now closed. A label already gone is a 404
+         no-op, exactly what a re-drive wants.
+      4. DELETE ``autodev:in-progress`` regardless — it is NOT a dispatch-gate predicate, so
+         dropping it on a failed close cannot re-arm a re-dispatch; stripping it best-effort
+         keeps the in-flight surface clean.
 
     Returns the close (PATCH) gh() response. Pure of LLM/time/random; only GitHub I/O."""
-    # Step 1 — strip BOTH in-flight claim labels (best-effort, idempotent, logged).
-    await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
-    await _unlabel(repo, issue_number, LABEL_DISPATCHED)
-    # Step 2 — close the issue (re-close of an already-closed issue is a 200 no-op).
+    # Step 1 — close the issue FIRST (re-close of an already-closed issue is a 200 no-op).
     close_resp = await gh("PATCH", _ipath(repo, "/issues/%d" % issue_number),
                           {"state": "closed", "state_reason": "completed"})
-    # Step 3 — surface the outcome (rank-6): a failed close is visible, not silently swallowed.
+    # Step 2 — surface the outcome (rank-6): a failed close is visible, not silently swallowed.
     st = _status(close_resp)
-    if st == 200:
+    closed = st == 200
+    if closed:
         log("closed source issue #%d (state=closed, reason=completed)" % issue_number)
     else:
         log("close source issue #%d FAILED -> %r %r" % (issue_number, st, close_resp))
+    # Step 3 — strip `dispatched` ONLY on a confirmed close (#1208 fail-safe). A close-failure
+    # leaves the issue OPEN ∧ `dispatched` (still claimed, never re-dispatched), NOT
+    # OPEN ∧ ¬`dispatched` (which re-arms the dispatch gate for already-merged work).
+    if closed:
+        await _unlabel(repo, issue_number, LABEL_DISPATCHED)
+    else:
+        log("keeping `dispatched` on #%d — close did not confirm, failing safe to "
+            "OPEN+dispatched (not the #1208 re-dispatch loop)" % issue_number)
+    # Step 4 — strip in-progress regardless (not a dispatch-gate predicate; best-effort).
+    await _unlabel(repo, issue_number, LABEL_IN_PROGRESS)
     return close_resp
 
 
@@ -1285,9 +1307,13 @@ REQUIRED_TOOLS: list[ToolSpec] = [
 
 # The GitHub http_server the scripted nodes reach via ``tool('http_request', ...)``.
 # Two routes, because GraphQL and REST need distinct method scoping:
-#   - ``/repos/**`` REST: GET·POST·PUT·DELETE. DELETE is load-bearing — the success-path
-#     ``_unlabel(autodev:in-progress)`` issues ``DELETE /repos/.../labels/...``; omitting
-#     it silently fails every unlabel (route-mismatch, then 3 pointless retries).
+#   - ``/repos/**`` REST: GET·POST·PUT·DELETE·PATCH. DELETE is load-bearing — the
+#     success-path ``_unlabel(autodev:in-progress)`` issues ``DELETE /repos/.../labels/...``;
+#     omitting it silently fails every unlabel (route-mismatch, then 3 pointless retries).
+#     PATCH is load-bearing too (#1208) — the post-merge ``_close_source_issue`` issues
+#     ``PATCH /repos/.../issues/{n}`` to close the source issue; omitting it made the broker
+#     reject the close (route-mismatch), so a merged issue stayed OPEN while its ``dispatched``
+#     strip succeeded → re-armed the dispatch gate (a re-dispatch of already-merged work).
 #   - ``/graphql`` POST: the mark-ready mutation (``_mark_ready_query``). GraphQL serves
 #     reads and writes over one POST path, so it lives on its own route.
 
@@ -1299,8 +1325,14 @@ def _github_http_server(*, name: str, base_url: str) -> HttpServerSpec:
         description="GitHub REST + GraphQL API (auth resolved from the bound vault's GITHUB_TOKEN).",
         routes=[
             HttpRouteSpec(
+                # PATCH is load-bearing (#1208): the post-merge cleanup closes the source
+                # issue with PATCH /repos/.../issues/{n}. Omitting it made the broker reject
+                # the close as a route-allowlist mismatch (a deterministic {"error": ...}) so
+                # the close NEVER fired — the merged issue stayed OPEN while its `dispatched`
+                # strip (a DELETE, which IS allowed) succeeded, re-arming the dispatch gate
+                # (approved ∧ shovel-ready ∧ ¬dispatched) → a re-dispatch of already-merged work.
                 path_pattern="/repos/**",
-                methods=["GET", "POST", "PUT", "DELETE"],
+                methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
                 # allow_query: GitHub list endpoints paginate via ?per_page/?page, and the
                 # comment-thread read must follow Link: rel="next" past the first 30 to not
                 # silently drop late design/spec comments (#1156). Safe here — the route

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -390,6 +390,12 @@ async def test_happy_path_merges_and_completes() -> None:
     # the completed issue leaves the open working set (no merged-but-open residue).
     assert "dispatched" in scn.labels_removed
     assert scn.issue_patches == [{"state": "closed", "state_reason": "completed"}]
+    # #1208: the close (PATCH /issues/5) is the GATE for the `dispatched` strip — it MUST come
+    # before the DELETE of the `dispatched` label, so a close-failure fails safe to
+    # OPEN ∧ dispatched (not the re-dispatch loop). Assert the ordering at the HTTP-trace level.
+    close_i = scn.http.index(("PATCH", "/repos/o/r/issues/5"))
+    strip_i = scn.http.index(("DELETE", "/repos/o/r/issues/5/labels/dispatched"))
+    assert close_i < strip_i, "the issue close must precede the `dispatched` strip (#1208)"
 
 
 async def test_adopts_existing_open_pr_instead_of_creating() -> None:

--- a/tests/unit/test_dev_pipeline_close_on_merge.py
+++ b/tests/unit/test_dev_pipeline_close_on_merge.py
@@ -166,3 +166,48 @@ def test_unlabel_returns_and_logs_response() -> None:
     resp = _run(ns["_unlabel"](REPO, ISSUE, "dispatched"))
     assert resp == {"status": 200, "body": ""}
     assert any("unlabel" in line for line in ns["_LOGS"])
+
+
+# ─── #1208: fail-safe ordering — strip `dispatched` ONLY after the close succeeds ──
+
+
+def test_dispatched_stripped_only_after_a_successful_close() -> None:
+    # On a real merge the close PATCH succeeds (200), so `dispatched` IS stripped — the
+    # issue ends up CLOSED ∧ ¬dispatched and leaves the dispatch gate. The close must come
+    # at-or-before the dispatched strip so the strip is gated on it.
+    gh = _FakeGH({("PATCH", ISSUE_PATH): {"status": 200, "body": '{"state": "closed"}'}})
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+
+    methods_paths = [(m, p) for (m, p, _b) in gh.calls]
+    assert ("PATCH", ISSUE_PATH) in methods_paths
+    assert ("DELETE", DISPATCHED_PATH) in methods_paths
+    # The close must not happen AFTER the dispatched strip (else a failed close leaves the
+    # issue OPEN ∧ ¬dispatched — the #1208 re-dispatch loop). Assert PATCH precedes the
+    # dispatched DELETE.
+    patch_i = methods_paths.index(("PATCH", ISSUE_PATH))
+    strip_i = methods_paths.index(("DELETE", DISPATCHED_PATH))
+    assert patch_i < strip_i, "dispatched must only be stripped after the close fires"
+
+
+def test_dispatched_not_stripped_when_close_fails() -> None:
+    # #1208 guard: if the close PATCH fails (non-2xx), `dispatched` must NOT be stripped, so
+    # the issue fails SAFE to OPEN ∧ dispatched (still claimed, never re-dispatched) rather
+    # than OPEN ∧ ¬dispatched (re-enters the dispatch gate → duplicate build of merged work).
+    gh = _FakeGH({("PATCH", ISSUE_PATH): {"status": 422, "body": "unprocessable"}})
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+
+    methods_paths = [(m, p) for (m, p, _b) in gh.calls]
+    assert ("DELETE", DISPATCHED_PATH) not in methods_paths, (
+        "dispatched was stripped despite a failed close — fails UNSAFE to the re-dispatch loop"
+    )
+
+
+def test_close_failure_is_surfaced_when_dispatched_kept() -> None:
+    # A failed close that (correctly) keeps `dispatched` must still be visible in the log.
+    gh = _FakeGH({("PATCH", ISSUE_PATH): {"status": 500, "body": "server error"}})
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+    logs = "\n".join(ns["_LOGS"])
+    assert "FAILED" in logs and "close source issue" in logs

--- a/tests/unit/test_dev_pipeline_surface.py
+++ b/tests/unit/test_dev_pipeline_surface.py
@@ -13,8 +13,9 @@ needs it:
   child-agent surface is ``agent ∩ run``, so declaring only ``[bash, http_request]``
   on the workflow would strip the editing tools from the implement/fix agents.
 - ``REQUIRED_HTTP_SERVERS`` — the two-route ``github`` spec: ``/repos/**`` with
-  ``GET,POST,PUT,DELETE`` (DELETE is load-bearing for the success-path unlabel) and a
-  separate ``/graphql`` POST route (mark-ready mutation).
+  ``GET,POST,PUT,DELETE,PATCH`` (DELETE is load-bearing for the success-path unlabel;
+  PATCH is load-bearing for the post-merge issue-close, #1208) and a separate
+  ``/graphql`` POST route (mark-ready mutation).
 - ``build_dev_pipeline_workflow_create(...)`` — the complete ``WorkflowCreate`` payload
   (script + tools + http_servers) so the surface can't drift from the script.
 """
@@ -75,7 +76,21 @@ def test_repos_route_allows_delete() -> None:
     assert methods is not None
     # DELETE is load-bearing: the success-path _unlabel(autodev:in-progress) issues
     # DELETE /repos/.../labels/...; omitting it silently failed every unlabel.
-    assert set(methods) == {"GET", "POST", "PUT", "DELETE"}
+    # PATCH is load-bearing too: _close_source_issue (#1188) closes the source issue on
+    # merge with PATCH /repos/.../issues/{n}. Omitting PATCH made the broker reject the
+    # close as a route-allowlist mismatch (a deterministic {"error": ...}), so the close
+    # never fired — the merged issue stayed OPEN with `dispatched` stripped → re-dispatch
+    # loop (#1208). The strip (DELETE) succeeded while the close (PATCH) was silently denied.
+    assert set(methods) == {"GET", "POST", "PUT", "DELETE", "PATCH"}
+
+
+def test_repos_route_allows_patch_for_issue_close() -> None:
+    # #1208: closing the source issue on merge is a PATCH /repos/.../issues/{n}. If the
+    # route omits PATCH the broker denies the call before it reaches GitHub, so the issue
+    # is never closed (regression from #1188 — strip fired, close did not).
+    server = REQUIRED_HTTP_SERVERS[0]
+    repos = [r for r in server.routes if r.path_pattern == "/repos/**"]
+    assert "PATCH" in (repos[0].methods or [])
 
 
 def test_repos_route_allows_query_for_pagination() -> None:


### PR DESCRIPTION
## Summary

Fixes the #1188/#1203 regression where a merged dev-pipeline PR stripped the `dispatched` label from its source issue but never **closed** the issue — leaving it OPEN ∧ ¬`dispatched` ∧ `approved` ∧ `shovel-ready`, which re-armed the dispatch gate (`approved ∧ shovel-ready ∧ ¬dispatched`) and would RE-DISPATCH already-merged work (a duplicate-build loop). This was strictly worse than pre-#1188, where a merged issue stayed OPEN+`dispatched` and was safe from re-dispatch.

## Root cause (routed, not assumed)

The `github` http_server's `/repos/**` route allowlisted only `GET,POST,PUT,DELETE`. The post-merge `_close_source_issue` closes the issue with `PATCH /repos/.../issues/{n}` — but PATCH was **not** an allowed method, so the broker rejected the close as a route-allowlist mismatch (a deterministic terminal `{"error": ...}`, treated as terminal per #1139) **before it ever reached GitHub**. The close therefore silently never fired. The label strip (a DELETE, which WAS allowed) succeeded — producing exactly the observed OPEN+stripped state. The pipeline's PR bodies carry no `Closes #N` linkage, so GitHub never auto-closes either.

## Fix

1. **Add `PATCH` to the `/repos/**` route** in `_github_http_server` (and the `REQUIRED_HTTP_SERVERS` export) so the close request reaches GitHub.
2. **Reorder `_close_source_issue` to close-before-strip and gate the strip on a confirmed close** (the issue's requested guard):
   - PATCH the issue to `state=closed, state_reason=completed` FIRST (re-closing an already-closed issue is a 200 no-op → idempotent, fires only on a real merge).
   - Strip `dispatched` **only if** the close returned 200. A close-failure now fails SAFE to OPEN ∧ `dispatched` (still claimed, never re-dispatched) instead of OPEN ∧ ¬`dispatched` (the #1208 re-dispatch loop).
   - Strip `autodev:in-progress` regardless — it is not a dispatch-gate predicate, so dropping it on a failed close cannot re-arm a re-dispatch.
   - The failed close is logged (rank-6), not swallowed.

## Tests (test-first)

- `tests/unit/test_dev_pipeline_surface.py`: pins `/repos/**` methods to `{GET,POST,PUT,DELETE,PATCH}` on both `REQUIRED_HTTP_SERVERS` and `build_dev_pipeline_workflow_create`, so the declared surface can't drift from the script that needs PATCH.
- `tests/unit/test_dev_pipeline_close_on_merge.py`: new cases asserting (a) the PATCH close fires first, (b) `dispatched` is stripped only after a 200 close, (c) on a failed close `dispatched` is KEPT while `in-progress` is still best-effort stripped, and (d) the close-failure is surfaced (logged), not swallowed.

## Tier / dispatch

dev_pipeline.py change → SERIAL dispatch; Tier-3+ (touches the pipeline's own merge path) → gated to the seat.