### PR TITLE
Restore ON DELETE CASCADE on bindings.session_id (#1095)

### DIFF
--- a/migrations/versions/0105_bindings_session_cascade.py
+++ b/migrations/versions/0105_bindings_session_cascade.py
@@ -1,0 +1,64 @@
+"""Restore ON DELETE CASCADE on ``bindings.session_id`` (#1095).
+
+Of the ~12 child tables referencing ``sessions(id)``, all but one declare
+``ON DELETE CASCADE``. The lone outlier is ``bindings.session_id``: the
+0033 connector redesign recreated ``bindings`` with a bare
+``session_id text REFERENCES sessions(id)`` (no ``ON DELETE``), regressing
+the cascade the *original* ``bindings`` table carried
+(``0015``: ``session_id ... REFERENCES sessions(id) ON DELETE CASCADE``).
+``delete_session`` has papered over the regression with a hand-``DELETE
+FROM bindings`` ever since — an invariant held by one remembered statement
++ its comment, which any new session-deletion path can silently violate.
+
+This migration makes the cascade uniform across all session children by
+swapping the bare ``bindings_session_id_fkey`` for the **composite tenant
+FK** form ``FOREIGN KEY (session_id, account_id)
+REFERENCES sessions(id, account_id) ON DELETE CASCADE`` — the direction
+established by ``0093`` for the other secret/session-bearing chains
+(``session_vaults`` etc). The composite form addresses the steelman's
+tenant-tightness concern structurally (a binding can only be cascaded by
+its own tenant's session) while restoring the cascade.
+
+``bindings.account_id`` is ``NOT NULL`` (0044) and ``sessions`` already
+carries the ``sessions_id_account_id_key`` UNIQUE (id, account_id) that the
+composite FK targets (added by 0093). ``session_id`` is nullable (per_chat
+bindings have ``session_id IS NULL``); MATCH SIMPLE (the default) leaves
+those rows unconstrained, exactly as the prior single-column FK did.
+
+The constraint is added ``NOT VALID`` then ``VALIDATE``d in a second step
+(the ``0093`` precedent) so the validating table scan takes only a
+``SHARE UPDATE EXCLUSIVE`` lock rather than holding ``ACCESS EXCLUSIVE``
+for the whole scan.
+
+Revision ID: 0105
+Revises: 0104
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0105"
+down_revision: str = "0104"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE bindings DROP CONSTRAINT bindings_session_id_fkey")
+    op.execute(
+        "ALTER TABLE bindings ADD CONSTRAINT bindings_session_account_id_fkey "
+        "FOREIGN KEY (session_id, account_id) "
+        "REFERENCES sessions(id, account_id) ON DELETE CASCADE NOT VALID"
+    )
+    op.execute("ALTER TABLE bindings VALIDATE CONSTRAINT bindings_session_account_id_fkey")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE bindings DROP CONSTRAINT bindings_session_account_id_fkey")
+    op.execute(
+        "ALTER TABLE bindings ADD CONSTRAINT bindings_session_id_fkey "
+        "FOREIGN KEY (session_id) REFERENCES sessions(id)"
+    )

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -1262,16 +1262,10 @@ async def delete_session(
             session_id,
             account_id,
         )
-        # bindings.session_id has no ON DELETE CASCADE — every other
-        # session-children FK does, but bindings (migration 0033) is
-        # the lone outlier. Without this explicit DELETE, any session
-        # that's ever been attached to a connection trips the FK on
-        # `DELETE FROM sessions` and the route surfaces a 500.
-        await conn.execute(
-            "DELETE FROM bindings WHERE session_id = $1 AND account_id = $2",
-            session_id,
-            account_id,
-        )
+        # bindings.session_id now carries ON DELETE CASCADE (migration 0105,
+        # composite tenant FK per the 0093 precedent), uniform with every
+        # other session-children FK — no compensating hand-DELETE needed.
+        # The session row's deletion cascades to its bindings in Postgres.
         await conn.execute(
             "DELETE FROM sessions WHERE id = $1 AND account_id = $2",
             session_id,

--- a/tests/integration/test_delete_session_with_binding.py
+++ b/tests/integration/test_delete_session_with_binding.py
@@ -1,23 +1,26 @@
 """Integration test: ``delete_session`` must succeed when the session
-was ever attached to a connection (or otherwise had a ``bindings`` row).
+was ever attached to a connection (or otherwise had a ``bindings`` row),
+and its ``bindings`` rows must be cleaned up — by the DB cascade, with no
+help from any application-side hand-DELETE.
 
-``bindings.session_id REFERENCES sessions(id)`` carries NO ``ON DELETE
-CASCADE`` (migration 0033). Every other session-children FK (in
-``session_vaults``, ``session_memory_stores``, ``session_github_repositories``,
-``files``, ``events``, ``chat_sessions``) has the cascade — ``bindings``
-is the lone outlier. ``delete_session`` pre-deletes from ``session_vaults``
-and ``events`` (redundant given the cascades, but explicit-as-intent
-style), then runs ``DELETE FROM sessions`` — which trips the FK
-constraint and raises ``asyncpg.ForeignKeyViolationError`` whenever a
-binding row references the session.
+``bindings.session_id`` now carries ``ON DELETE CASCADE`` (migration 0105,
+composite tenant FK ``(session_id, account_id) REFERENCES
+sessions(id, account_id)`` per the 0093 precedent), uniform with every
+other session-children FK (``session_vaults``, ``session_memory_stores``,
+``session_github_repositories``, ``files``, ``events``, ``chat_sessions``).
+The 0033 connector redesign had recreated ``bindings`` with a bare
+``REFERENCES sessions(id)`` and regressed the cascade the original 0015
+table carried; ``delete_session`` papered over it with an explicit
+``DELETE FROM bindings``.
 
-The operator-curated single_session attach flow leaves a row even
-after detach (archived bindings stay in the table), so any session
-that's been bound via the connector tools is undeletable. Surfaces as
-500 from ``DELETE /v1/sessions/{id}``.
-
-Fix: pre-delete from ``bindings`` in ``delete_session``, mirroring
-the explicit-deletes pattern for the other session children.
+Before the cascade was restored, ``DELETE FROM sessions`` tripped the FK
+and raised ``asyncpg.ForeignKeyViolationError`` whenever a binding row
+referenced the session (the operator-curated single_session attach flow
+leaves an archived row even after detach, so any session ever bound via
+the connector tools was undeletable — surfacing as a 500 from
+``DELETE /v1/sessions/{id}``). The cascade makes that correct-by-
+construction: this test guards that ``delete_session`` succeeds and the
+binding is gone, so it keeps passing without the removed hand-DELETE.
 """
 
 from __future__ import annotations
@@ -107,23 +110,58 @@ class TestDeleteSessionWithBinding:
         """``delete_session`` must succeed and clean up the binding row
         even when the session has been attached to a connection.
 
-        Pre-fix: ``asyncpg.ForeignKeyViolationError`` propagates from
-        ``DELETE FROM sessions`` because ``bindings.session_id`` has no
-        ``ON DELETE CASCADE`` and ``delete_session`` doesn't pre-delete
-        from ``bindings`` (it pre-deletes from ``session_vaults`` and
-        ``events``, but missed ``bindings``).
+        Before the cascade was restored, ``asyncpg.ForeignKeyViolationError``
+        propagated from ``DELETE FROM sessions`` because
+        ``bindings.session_id`` had no ``ON DELETE CASCADE`` and
+        ``delete_session`` no longer carries a compensating
+        ``DELETE FROM bindings``. The 0105 cascade makes the row deletion
+        cascade in Postgres, so this passes purely on the constraint.
         """
         pool, session_id = pool_session_with_binding
         async with pool.acquire() as conn:
-            # Today: raises asyncpg.ForeignKeyViolationError.
+            # Without the 0105 cascade this raises ForeignKeyViolationError,
+            # since delete_session no longer pre-deletes from bindings.
             await queries.delete_session(conn, session_id, account_id="acc_a")
-            # Bindings for this session must be gone.
+            # Bindings for this session must be gone — cascaded by Postgres.
             remaining = await conn.fetchval(
                 "SELECT COUNT(*) FROM bindings WHERE session_id = $1",
                 session_id,
             )
         assert remaining == 0, (
             f"delete_session left {remaining} binding row(s) referencing "
-            f"the deleted session — bindings.session_id has no ON DELETE "
-            f"CASCADE and delete_session must pre-delete from bindings."
+            f"the deleted session — bindings.session_id must carry ON DELETE "
+            f"CASCADE so the row deletion cascades."
+        )
+
+    async def test_raw_delete_from_sessions_cascades_bindings(
+        self,
+        pool_session_with_binding: tuple[asyncpg.Pool[Any], str],
+    ) -> None:
+        """A session-deletion path that knows *nothing* about bindings —
+        a raw ``DELETE FROM sessions`` — must still succeed and leave no
+        stranded binding row.
+
+        This is the foreclosure guarantee of #1095: the invariant is held
+        by the DB constraint, not by application-code vigilance, so any new
+        delete path (bulk-purge, admin DELETE, a ``delete_session`` variant)
+        cannot strand a binding or trip the FK. Before the 0105 cascade this
+        raw ``DELETE`` tripped ``bindings_session_id_fkey`` and raised
+        ``asyncpg.ForeignKeyViolationError``.
+        """
+        pool, session_id = pool_session_with_binding
+        async with pool.acquire() as conn:
+            # Without the cascade this raises ForeignKeyViolationError.
+            await conn.execute(
+                "DELETE FROM sessions WHERE id = $1 AND account_id = $2",
+                session_id,
+                "acc_a",
+            )
+            remaining = await conn.fetchval(
+                "SELECT COUNT(*) FROM bindings WHERE session_id = $1",
+                session_id,
+            )
+        assert remaining == 0, (
+            f"raw DELETE FROM sessions left {remaining} binding row(s) — "
+            f"bindings.session_id ON DELETE CASCADE must clear them at "
+            f"delete time regardless of application code."
         )

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0104``."""
+    """The migration ladder has exactly one head: ``0105``."""
     script = _script_directory()
-    assert script.get_heads() == ["0104"]
+    assert script.get_heads() == ["0105"]
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
## What

Restores `ON DELETE CASCADE` on the `bindings.session_id` FK — the lone session-child FK that was held by an application-side hand-`DELETE` instead of the constraint — and removes the compensating delete from `delete_session`.

## Why

Of the ~12 child tables referencing `sessions(id)`, all but one cascade. The 0033 connector redesign **recreated** `bindings` with a bare `session_id text REFERENCES sessions(id)` (no `ON DELETE`), **regressing** the cascade the original 0015 `bindings` table carried. `delete_session` papered over it with an explicit `DELETE FROM bindings` whose comment names it "the lone outlier" — an invariant held by one remembered statement that any new session-deletion path (bulk-purge, raw admin `DELETE`, a `delete_session` variant) can silently violate, tripping the FK → 500. The codebase already paid this tax once (the comment exists *because* a bound session tripped the FK in production).

## Change

- **`migrations/versions/0105_bindings_session_cascade.py`** — swaps the bare `bindings_session_id_fkey` for the **composite tenant FK** `FOREIGN KEY (session_id, account_id) REFERENCES sessions(id, account_id) ON DELETE CASCADE`, following the in-tree `0093` precedent (the composite form the issue points to). Added `NOT VALID` then `VALIDATE`d in a second step so validation takes only a `SHARE UPDATE EXCLUSIVE` lock rather than holding `ACCESS EXCLUSIVE` for the whole scan. `bindings.account_id` is `NOT NULL` (0044) and `sessions` already carries the `sessions_id_account_id_key` UNIQUE the FK targets (0093). `session_id` is nullable (per_chat bindings) and MATCH SIMPLE leaves those rows unconstrained, exactly as before. Composite form addresses the tenant-tightness steelman structurally (a binding can only cascade with its own tenant's session).
- **`src/aios/db/queries/sessions.py`** — removes the compensating `DELETE FROM bindings` block from `delete_session`; Postgres now cascades. (The `events`/`session_vaults` explicit deletes are left as-is — out of scope.)

## Tests (test-first)

- Reframed the existing `test_delete_session_removes_bindings` to guard the cascade rather than the removed hand-DELETE (it now passes purely on the constraint, since `delete_session` no longer pre-deletes bindings).
- Added `test_raw_delete_from_sessions_cascades_bindings` — a raw `DELETE FROM sessions` (a path that knows nothing about bindings) must still succeed and strand no binding. This is the foreclosure guarantee: the invariant is enforced by Postgres at delete time, not by application-code vigilance.
- Bumped the migration-chain single-head pin to `0105`.

## Verification

Applied the full ladder + 0105 against a real Postgres 15: confirmed `bindings_session_account_id_fkey` has `confdeltype = c` (CASCADE), seeded a session+connection+binding and confirmed `DELETE FROM sessions` cascades the binding away, and exercised the `downgrade`/`upgrade` round-trip (back to the bare `ON NO ACTION` FK and forward to cascade) cleanly.

## Risk

Low — the cascade direction is exactly what the application already did manually. No read-path change; purely additive per expand/contract.