### PR TITLE
feat(sessions): outbound-suppression mode for safe test/cutover (#710)

### DIFF
--- a/migrations/versions/0105_session_outbound_suppression.py
+++ b/migrations/versions/0105_session_outbound_suppression.py
@@ -1,0 +1,49 @@
+"""Per-session outbound-suppression mode (#710).
+
+Adds the ``outbound_suppression`` column to ``sessions``: the last remaining
+substrate dependency for jarbot's v1→v2 shard migration. When a session runs
+with this set ``'on'``, the tool brokers (HTTP via ``http_request``, MCP via
+``mcp call``) intercept side-effecting outbound calls — http_server writes
+(POST/PUT/PATCH/DELETE by default, per-route overridable) and all mcp_server
+calls (default-deny; per-tool ``read_allow`` opts in known reads) — returning a
+synthesized success and appending a ``tool_call_suppressed`` audit span instead
+of letting the request leave the broker. Reads pass through against real
+credentials. This enables tier-3 safe testing (real vaults + memory, no real
+sends) and live-cutover parallel runs (v2 suppressed alongside v1, then flip).
+
+* ``outbound_suppression`` (text, NOT NULL, default ``'off'``) — the per-session
+  mode. A plain text column with a CHECK to the two-value domain {off, on} so a
+  later "fully sandboxed mode" can extend the domain without a type migration.
+  Default ``'off'`` makes every existing and new session normal; suppression is
+  strictly opt-in. Backfill is the column default — no in-flight session changes
+  behavior.
+
+``sessions`` is not the hot ``events`` table, so plain in-transaction DDL is fine.
+
+Revision ID: 0105
+Revises: 0104
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0105"
+down_revision: str = "0104"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE sessions "
+        "ADD COLUMN outbound_suppression text NOT NULL DEFAULT 'off' "
+        "CONSTRAINT sessions_outbound_suppression_chk "
+        "CHECK (outbound_suppression IN ('off', 'on'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE sessions DROP COLUMN IF EXISTS outbound_suppression")

--- a/migrations/versions/0106_session_outbound_suppression.py
+++ b/migrations/versions/0106_session_outbound_suppression.py
@@ -20,7 +20,7 @@ sends) and live-cutover parallel runs (v2 suppressed alongside v1, then flip).
 
 ``sessions`` is not the hot ``events`` table, so plain in-transaction DDL is fine.
 
-Revision ID: 0105
+Revision ID: 0106
 Revises: 0104
 """
 
@@ -30,7 +30,7 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0105"
+revision: str = "0106"
 down_revision: str = "0104"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/openapi.json
+++ b/openapi.json
@@ -11636,6 +11636,17 @@
             "type": "boolean",
             "title": "Allow Query",
             "default": false
+          },
+          "suppress": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suppress"
           }
         },
         "additionalProperties": false,
@@ -11676,6 +11687,13 @@
             },
             "type": "array",
             "title": "Routes"
+          },
+          "suppressed_response_status": {
+            "type": "integer",
+            "maximum": 599.0,
+            "minimum": 100.0,
+            "title": "Suppressed Response Status",
+            "default": 200
           }
         },
         "additionalProperties": false,
@@ -12663,6 +12681,11 @@
               }
             ],
             "title": "Transport"
+          },
+          "read_allow": {
+            "type": "boolean",
+            "title": "Read Allow",
+            "default": false
           }
         },
         "additionalProperties": false,
@@ -12671,7 +12694,7 @@
           "name"
         ],
         "title": "McpToolConfig",
-        "description": "Per-tool override within an ``mcp_toolset`` entry."
+        "description": "Per-tool override within an ``mcp_toolset`` entry.\n\n``read_allow`` opts a single discovered tool into the outbound-suppression\nread allowlist (#710): MCP has no HTTP-method convention, so when a session\nruns with ``outbound_suppression == \"on\"`` every MCP call is *default-deny*\n(suppressed with a synthesized success) UNLESS the operator marked the\nspecific tool ``read_allow=True`` at config time. A read-allowed tool runs\nfor real even under suppression. Default ``False`` \u2014 the safe choice for a\nprotocol that can't self-describe side effects."
       },
       "McpToolsetConfig": {
         "properties": {
@@ -14097,6 +14120,15 @@
             "title": "Archive When Idle",
             "default": false
           },
+          "outbound_suppression": {
+            "type": "string",
+            "enum": [
+              "off",
+              "on"
+            ],
+            "title": "Outbound Suppression",
+            "default": "off"
+          },
           "last_event_at": {
             "anyOf": [
               {
@@ -14242,6 +14274,16 @@
             "title": "Archive When Idle",
             "description": "When true, the session is soft-archived the first time it goes idle owing nothing \u2014 a self-reclaiming, one-shot session. Immutable after launch. Workflow agent() children launch with this set.",
             "default": false
+          },
+          "outbound_suppression": {
+            "type": "string",
+            "enum": [
+              "off",
+              "on"
+            ],
+            "title": "Outbound Suppression",
+            "description": "Outbound-suppression mode (#710). 'off' (default) \u2014 normal behavior. 'on' \u2014 bound http_server writes (POST/PUT/PATCH/DELETE by default, per-route overridable) and ALL bound mcp_server calls (default-deny; opt known-safe reads in via McpToolConfig.read_allow) are intercepted: they return a synthesized success and append a tool_call_suppressed audit event instead of leaving the broker. Used for safe rehydration testing and parallel-run cutover. Mutable via PUT /sessions/{id}.",
+            "default": "off"
           },
           "workspace_path": {
             "anyOf": [
@@ -14686,6 +14728,22 @@
               }
             ],
             "title": "Resources"
+          },
+          "outbound_suppression": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "off",
+                  "on"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outbound Suppression",
+            "description": "Flip outbound-suppression mode (#710). None (default) preserves the current mode; 'on'/'off' sets it. Changing it recycles the session's cached sandbox so the next step re-reads the flag. This is the atomic 'flip outbound from v1 to v2' lever in a parallel-run cutover."
           }
         },
         "additionalProperties": false,

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -167,9 +167,11 @@ from .session_clone_request import SessionCloneRequest
 from .session_create import SessionCreate
 from .session_create_env import SessionCreateEnv
 from .session_create_metadata import SessionCreateMetadata
+from .session_create_outbound_suppression import SessionCreateOutboundSuppression
 from .session_interrupt_request import SessionInterruptRequest
 from .session_metadata import SessionMetadata
 from .session_origin import SessionOrigin
+from .session_outbound_suppression import SessionOutboundSuppression
 from .session_status import SessionStatus
 from .session_stop_reason_type_0 import SessionStopReasonType0
 from .session_template import SessionTemplate
@@ -180,6 +182,9 @@ from .session_template_update import SessionTemplateUpdate
 from .session_template_update_metadata_type_0 import SessionTemplateUpdateMetadataType0
 from .session_update import SessionUpdate
 from .session_update_metadata_type_0 import SessionUpdateMetadataType0
+from .session_update_outbound_suppression_type_0 import (
+    SessionUpdateOutboundSuppressionType0,
+)
 from .session_usage import SessionUsage
 from .session_user_message import SessionUserMessage
 from .session_user_message_metadata import SessionUserMessageMetadata
@@ -437,9 +442,11 @@ __all__ = (
     "SessionCreate",
     "SessionCreateEnv",
     "SessionCreateMetadata",
+    "SessionCreateOutboundSuppression",
     "SessionInterruptRequest",
     "SessionMetadata",
     "SessionOrigin",
+    "SessionOutboundSuppression",
     "SessionStatus",
     "SessionStopReasonType0",
     "SessionTemplate",
@@ -450,6 +457,7 @@ __all__ = (
     "SessionTemplateUpdateMetadataType0",
     "SessionUpdate",
     "SessionUpdateMetadataType0",
+    "SessionUpdateOutboundSuppressionType0",
     "SessionUsage",
     "SessionUserMessage",
     "SessionUserMessageMetadata",

--- a/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/http_route_spec.py
@@ -72,6 +72,7 @@ class HttpRouteSpec:
             permission_policy (HttpPermissionPolicy | None | Unset):
             methods (list[HttpRouteSpecMethodsType0Item] | None | Unset):
             allow_query (bool | Unset):  Default: False.
+            suppress (bool | None | Unset):
     """
 
     path_pattern: str
@@ -80,6 +81,7 @@ class HttpRouteSpec:
     permission_policy: HttpPermissionPolicy | None | Unset = UNSET
     methods: list[HttpRouteSpecMethodsType0Item] | None | Unset = UNSET
     allow_query: bool | Unset = False
+    suppress: bool | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.http_permission_policy import HttpPermissionPolicy
@@ -116,6 +118,12 @@ class HttpRouteSpec:
 
         allow_query = self.allow_query
 
+        suppress: bool | None | Unset
+        if isinstance(self.suppress, Unset):
+            suppress = UNSET
+        else:
+            suppress = self.suppress
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -133,6 +141,8 @@ class HttpRouteSpec:
             field_dict["methods"] = methods
         if allow_query is not UNSET:
             field_dict["allow_query"] = allow_query
+        if suppress is not UNSET:
+            field_dict["suppress"] = suppress
 
         return field_dict
 
@@ -201,6 +211,15 @@ class HttpRouteSpec:
 
         allow_query = d.pop("allow_query", UNSET)
 
+        def _parse_suppress(data: object) -> bool | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(bool | None | Unset, data)
+
+        suppress = _parse_suppress(d.pop("suppress", UNSET))
+
         http_route_spec = cls(
             path_pattern=path_pattern,
             description=description,
@@ -208,6 +227,7 @@ class HttpRouteSpec:
             permission_policy=permission_policy,
             methods=methods,
             allow_query=allow_query,
+            suppress=suppress,
         )
 
         return http_route_spec

--- a/packages/aios-sdk/aios_sdk/_generated/models/http_server_spec.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/http_server_spec.py
@@ -31,12 +31,14 @@ class HttpServerSpec:
             base_url (str):
             description (None | str | Unset):
             routes (list[HttpRouteSpec] | Unset):
+            suppressed_response_status (int | Unset):  Default: 200.
     """
 
     name: str
     base_url: str
     description: None | str | Unset = UNSET
     routes: list[HttpRouteSpec] | Unset = UNSET
+    suppressed_response_status: int | Unset = 200
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
@@ -56,6 +58,8 @@ class HttpServerSpec:
                 routes_item = routes_item_data.to_dict()
                 routes.append(routes_item)
 
+        suppressed_response_status = self.suppressed_response_status
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -68,6 +72,8 @@ class HttpServerSpec:
             field_dict["description"] = description
         if routes is not UNSET:
             field_dict["routes"] = routes
+        if suppressed_response_status is not UNSET:
+            field_dict["suppressed_response_status"] = suppressed_response_status
 
         return field_dict
 
@@ -98,11 +104,14 @@ class HttpServerSpec:
 
                 routes.append(routes_item)
 
+        suppressed_response_status = d.pop("suppressed_response_status", UNSET)
+
         http_server_spec = cls(
             name=name,
             base_url=base_url,
             description=description,
             routes=routes,
+            suppressed_response_status=suppressed_response_status,
         )
 
         return http_server_spec

--- a/packages/aios-sdk/aios_sdk/_generated/models/mcp_tool_config.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/mcp_tool_config.py
@@ -19,17 +19,27 @@ T = TypeVar("T", bound="McpToolConfig")
 class McpToolConfig:
     """Per-tool override within an ``mcp_toolset`` entry.
 
-    Attributes:
-        name (str):
-        enabled (bool | Unset):  Default: True.
-        permission_policy (McpPermissionPolicy | None | Unset):
-        transport (McpToolConfigTransportType0 | None | Unset):
+    ``read_allow`` opts a single discovered tool into the outbound-suppression
+    read allowlist (#710): MCP has no HTTP-method convention, so when a session
+    runs with ``outbound_suppression == "on"`` every MCP call is *default-deny*
+    (suppressed with a synthesized success) UNLESS the operator marked the
+    specific tool ``read_allow=True`` at config time. A read-allowed tool runs
+    for real even under suppression. Default ``False`` — the safe choice for a
+    protocol that can't self-describe side effects.
+
+        Attributes:
+            name (str):
+            enabled (bool | Unset):  Default: True.
+            permission_policy (McpPermissionPolicy | None | Unset):
+            transport (McpToolConfigTransportType0 | None | Unset):
+            read_allow (bool | Unset):  Default: False.
     """
 
     name: str
     enabled: bool | Unset = True
     permission_policy: McpPermissionPolicy | None | Unset = UNSET
     transport: McpToolConfigTransportType0 | None | Unset = UNSET
+    read_allow: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.mcp_permission_policy import McpPermissionPolicy
@@ -54,6 +64,8 @@ class McpToolConfig:
         else:
             transport = self.transport
 
+        read_allow = self.read_allow
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -67,6 +79,8 @@ class McpToolConfig:
             field_dict["permission_policy"] = permission_policy
         if transport is not UNSET:
             field_dict["transport"] = transport
+        if read_allow is not UNSET:
+            field_dict["read_allow"] = read_allow
 
         return field_dict
 
@@ -117,11 +131,14 @@ class McpToolConfig:
 
         transport = _parse_transport(d.pop("transport", UNSET))
 
+        read_allow = d.pop("read_allow", UNSET)
+
         mcp_tool_config = cls(
             name=name,
             enabled=enabled,
             permission_policy=permission_policy,
             transport=transport,
+            read_allow=read_allow,
         )
 
         return mcp_tool_config

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -9,6 +9,7 @@ from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
 from ..models.session_origin import SessionOrigin
+from ..models.session_outbound_suppression import SessionOutboundSuppression
 from ..models.session_status import SessionStatus
 from ..types import UNSET, Unset
 
@@ -60,6 +61,7 @@ class Session:
             origin (SessionOrigin | Unset):  Default: SessionOrigin.FOREGROUND.
             parent_run_id (None | str | Unset):
             archive_when_idle (bool | Unset):  Default: False.
+            outbound_suppression (SessionOutboundSuppression | Unset):  Default: SessionOutboundSuppression.OFF.
             last_event_at (datetime.datetime | None | Unset):
             total_events (int | Unset):  Default: 0.
     """
@@ -89,6 +91,9 @@ class Session:
     origin: SessionOrigin | Unset = SessionOrigin.FOREGROUND
     parent_run_id: None | str | Unset = UNSET
     archive_when_idle: bool | Unset = False
+    outbound_suppression: SessionOutboundSuppression | Unset = (
+        SessionOutboundSuppression.OFF
+    )
     last_event_at: datetime.datetime | None | Unset = UNSET
     total_events: int | Unset = 0
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -194,6 +199,10 @@ class Session:
 
         archive_when_idle = self.archive_when_idle
 
+        outbound_suppression: str | Unset = UNSET
+        if not isinstance(self.outbound_suppression, Unset):
+            outbound_suppression = self.outbound_suppression.value
+
         last_event_at: None | str | Unset
         if isinstance(self.last_event_at, Unset):
             last_event_at = UNSET
@@ -245,6 +254,8 @@ class Session:
             field_dict["parent_run_id"] = parent_run_id
         if archive_when_idle is not UNSET:
             field_dict["archive_when_idle"] = archive_when_idle
+        if outbound_suppression is not UNSET:
+            field_dict["outbound_suppression"] = outbound_suppression
         if last_event_at is not UNSET:
             field_dict["last_event_at"] = last_event_at
         if total_events is not UNSET:
@@ -426,6 +437,13 @@ class Session:
 
         archive_when_idle = d.pop("archive_when_idle", UNSET)
 
+        _outbound_suppression = d.pop("outbound_suppression", UNSET)
+        outbound_suppression: SessionOutboundSuppression | Unset
+        if isinstance(_outbound_suppression, Unset):
+            outbound_suppression = UNSET
+        else:
+            outbound_suppression = SessionOutboundSuppression(_outbound_suppression)
+
         def _parse_last_event_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -469,6 +487,7 @@ class Session:
             origin=origin,
             parent_run_id=parent_run_id,
             archive_when_idle=archive_when_idle,
+            outbound_suppression=outbound_suppression,
             last_event_at=last_event_at,
             total_events=total_events,
         )

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_create.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
+from ..models.session_create_outbound_suppression import (
+    SessionCreateOutboundSuppression,
+)
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -33,6 +36,12 @@ class SessionCreate:
         archive_when_idle (bool | Unset): When true, the session is soft-archived the first time it goes idle owing
             nothing — a self-reclaiming, one-shot session. Immutable after launch. Workflow agent() children launch with
             this set. Default: False.
+        outbound_suppression (SessionCreateOutboundSuppression | Unset): Outbound-suppression mode (#710). 'off'
+            (default) — normal behavior. 'on' — bound http_server writes (POST/PUT/PATCH/DELETE by default, per-route
+            overridable) and ALL bound mcp_server calls (default-deny; opt known-safe reads in via McpToolConfig.read_allow)
+            are intercepted: they return a synthesized success and append a tool_call_suppressed audit event instead of
+            leaving the broker. Used for safe rehydration testing and parallel-run cutover. Mutable via PUT /sessions/{id}.
+            Default: SessionCreateOutboundSuppression.OFF.
         workspace_path (None | str | Unset): Absolute host path to use as the session workspace. If omitted, defaults to
             workspace_root/<account_id>/<session_id>. Must resolve within the account's workspace subdirectory. The
             directory must exist; aios will not create it.
@@ -62,6 +71,9 @@ class SessionCreate:
     metadata: SessionCreateMetadata | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
     archive_when_idle: bool | Unset = False
+    outbound_suppression: SessionCreateOutboundSuppression | Unset = (
+        SessionCreateOutboundSuppression.OFF
+    )
     workspace_path: None | str | Unset = UNSET
     env: SessionCreateEnv | Unset = UNSET
     initial_message: None | str | Unset = UNSET
@@ -96,6 +108,10 @@ class SessionCreate:
             vault_ids = self.vault_ids
 
         archive_when_idle = self.archive_when_idle
+
+        outbound_suppression: str | Unset = UNSET
+        if not isinstance(self.outbound_suppression, Unset):
+            outbound_suppression = self.outbound_suppression.value
 
         workspace_path: None | str | Unset
         if isinstance(self.workspace_path, Unset):
@@ -150,6 +166,8 @@ class SessionCreate:
             field_dict["vault_ids"] = vault_ids
         if archive_when_idle is not UNSET:
             field_dict["archive_when_idle"] = archive_when_idle
+        if outbound_suppression is not UNSET:
+            field_dict["outbound_suppression"] = outbound_suppression
         if workspace_path is not UNSET:
             field_dict["workspace_path"] = workspace_path
         if env is not UNSET:
@@ -204,6 +222,15 @@ class SessionCreate:
         vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
 
         archive_when_idle = d.pop("archive_when_idle", UNSET)
+
+        _outbound_suppression = d.pop("outbound_suppression", UNSET)
+        outbound_suppression: SessionCreateOutboundSuppression | Unset
+        if isinstance(_outbound_suppression, Unset):
+            outbound_suppression = UNSET
+        else:
+            outbound_suppression = SessionCreateOutboundSuppression(
+                _outbound_suppression
+            )
 
         def _parse_workspace_path(data: object) -> None | str | Unset:
             if data is None:
@@ -274,6 +301,7 @@ class SessionCreate:
             metadata=metadata,
             vault_ids=vault_ids,
             archive_when_idle=archive_when_idle,
+            outbound_suppression=outbound_suppression,
             workspace_path=workspace_path,
             env=env,
             initial_message=initial_message,

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_create_outbound_suppression.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_create_outbound_suppression.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class SessionCreateOutboundSuppression(str, Enum):
+    OFF = "off"
+    ON = "on"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_outbound_suppression.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_outbound_suppression.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class SessionOutboundSuppression(str, Enum):
+    OFF = "off"
+    ON = "on"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_update.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
+from ..models.session_update_outbound_suppression_type_0 import (
+    SessionUpdateOutboundSuppressionType0,
+)
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -41,6 +44,10 @@ class SessionUpdate:
             metadata (None | SessionUpdateMetadataType0 | Unset):
             vault_ids (list[str] | None | Unset):
             resources (list[GithubRepositoryResource | MemoryStoreResource] | None | Unset):
+            outbound_suppression (None | SessionUpdateOutboundSuppressionType0 | Unset): Flip outbound-suppression mode
+                (#710). None (default) preserves the current mode; 'on'/'off' sets it. Changing it recycles the session's cached
+                sandbox so the next step re-reads the flag. This is the atomic 'flip outbound from v1 to v2' lever in a
+                parallel-run cutover.
     """
 
     agent_id: None | str | Unset = UNSET
@@ -51,6 +58,7 @@ class SessionUpdate:
     resources: list[GithubRepositoryResource | MemoryStoreResource] | None | Unset = (
         UNSET
     )
+    outbound_suppression: None | SessionUpdateOutboundSuppressionType0 | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.memory_store_resource import MemoryStoreResource
@@ -108,6 +116,16 @@ class SessionUpdate:
         else:
             resources = self.resources
 
+        outbound_suppression: None | str | Unset
+        if isinstance(self.outbound_suppression, Unset):
+            outbound_suppression = UNSET
+        elif isinstance(
+            self.outbound_suppression, SessionUpdateOutboundSuppressionType0
+        ):
+            outbound_suppression = self.outbound_suppression.value
+        else:
+            outbound_suppression = self.outbound_suppression
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update({})
@@ -123,6 +141,8 @@ class SessionUpdate:
             field_dict["vault_ids"] = vault_ids
         if resources is not UNSET:
             field_dict["resources"] = resources
+        if outbound_suppression is not UNSET:
+            field_dict["outbound_suppression"] = outbound_suppression
 
         return field_dict
 
@@ -246,6 +266,29 @@ class SessionUpdate:
 
         resources = _parse_resources(d.pop("resources", UNSET))
 
+        def _parse_outbound_suppression(
+            data: object,
+        ) -> None | SessionUpdateOutboundSuppressionType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                outbound_suppression_type_0 = SessionUpdateOutboundSuppressionType0(
+                    data
+                )
+
+                return outbound_suppression_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | SessionUpdateOutboundSuppressionType0 | Unset, data)
+
+        outbound_suppression = _parse_outbound_suppression(
+            d.pop("outbound_suppression", UNSET)
+        )
+
         session_update = cls(
             agent_id=agent_id,
             agent_version=agent_version,
@@ -253,6 +296,7 @@ class SessionUpdate:
             metadata=metadata,
             vault_ids=vault_ids,
             resources=resources,
+            outbound_suppression=outbound_suppression,
         )
 
         return session_update

--- a/packages/aios-sdk/aios_sdk/_generated/models/session_update_outbound_suppression_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session_update_outbound_suppression_type_0.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class SessionUpdateOutboundSuppressionType0(str, Enum):
+    OFF = "off"
+    ON = "on"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -110,6 +110,7 @@ async def create(
         workspace_path=body.workspace_path,
         env=body.env or None,
         archive_when_idle=body.archive_when_idle,
+        outbound_suppression=body.outbound_suppression,
         account_id=account_id,
     )
     if body.initial_message is not None:
@@ -204,6 +205,7 @@ async def update(
         metadata=body.metadata,
         vault_ids=body.vault_ids,
         resources=body.resources,
+        outbound_suppression=body.outbound_suppression,
         crypto_box=crypto_box,
         account_id=account_id,
     )

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -151,6 +151,10 @@ def _row_to_session(row: asyncpg.Record) -> Session:
         origin=row.get("origin") or "foreground",
         parent_run_id=row.get("parent_run_id"),
         archive_when_idle=bool(row.get("archive_when_idle")),
+        # Soft read: present in every ``SELECT *`` / ``RETURNING *`` feeder;
+        # the few explicit-column reads that don't select it fall back to the
+        # safe default "off" (#710).
+        outbound_suppression=row.get("outbound_suppression") or "off",
         # Present only when the query derives it (list_sessions); other callers
         # (single read, INSERT ... RETURNING) leave it None.
         last_event_at=row.get("last_event_at"),
@@ -183,6 +187,7 @@ async def insert_session(
     focal_channel: str | None = None,
     focal_locked: bool = False,
     archive_when_idle: bool = False,
+    outbound_suppression: str = "off",
 ) -> Session:
     """Insert a fresh session row.
 
@@ -207,9 +212,10 @@ async def insert_session(
             INSERT INTO sessions (
                 id, agent_id, environment_id, agent_version, title, metadata,
                 workspace_volume_path, env,
-                focal_channel, focal_locked, account_id, archive_when_idle
+                focal_channel, focal_locked, account_id, archive_when_idle,
+                outbound_suppression
             )
-            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9, $10, $11, $12)
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb, $9, $10, $11, $12, $13)
             RETURNING *
             """,
             new_id,
@@ -224,6 +230,7 @@ async def insert_session(
             focal_locked,
             account_id,
             archive_when_idle,
+            outbound_suppression,
         )
     except asyncpg.ForeignKeyViolationError as exc:
         raise NotFoundError(
@@ -1173,6 +1180,7 @@ async def update_session(
     agent_version: int | None | EllipsisType = ...,
     title: str | None | EllipsisType = ...,
     metadata: dict[str, Any] | None = None,
+    outbound_suppression: str | None = None,
 ) -> Session:
     # Refuse updates to archived sessions: read paths
     # (``list_sessions``, the worker, the resolver) all filter
@@ -1207,6 +1215,8 @@ async def update_session(
         fields.append(("title", title, None))
     if metadata is not None:
         fields.append(("metadata", metadata, "jsonb"))
+    if outbound_suppression is not None:
+        fields.append(("outbound_suppression", outbound_suppression, None))
     sets = _build_set_assignments(fields, args)
     if not sets:
         return current

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -534,6 +534,26 @@ def launch_mcp_tool_calls(
     )
 
 
+async def _mcp_call_suppressed(
+    pool: asyncpg.Pool[Any], session_id: str, account_id: str, qualified_name: str
+) -> bool:
+    """Whether this MCP call is intercepted by outbound suppression (#710).
+
+    Returns ``False`` when the session is not in suppression mode (the common
+    case). Otherwise resolves the per-tool ``read_allow`` opt-in against the
+    session's effective agent tools (default-deny). Loaded here so the model
+    dispatch path and the sandbox CLI broker make the identical decision.
+    """
+    from aios.models.agents import mcp_tool_suppressed
+    from aios.services import agents as agents_service
+
+    session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
+    if session.outbound_suppression != "on":
+        return False
+    agent = await agents_service.load_for_session(pool, session, account_id=account_id)
+    return mcp_tool_suppressed(qualified_name, agent.tools)
+
+
 def _parse_mcp_tool_name(name: str) -> tuple[str, str]:
     """Parse ``mcp__<server_name>__<tool_name>`` into ``(server_name, tool_name)``.
 
@@ -596,15 +616,33 @@ async def _execute_mcp_tool_async(
             raise ToolBail(f"MCP server {server_name!r} not found")
         url = spec.url
 
-        from aios.mcp.client import call_mcp_tool, resolve_auth_for_target_url
+        # Outbound suppression (#710): MCP is default-deny. When the session is
+        # in suppression mode, every MCP call is intercepted (synthesized
+        # success + audit event) unless the per-tool ``read_allow`` opt-in
+        # marks it a known-safe read. Same decision the sandbox CLI broker
+        # makes — both consult ``mcp_tool_suppressed``.
+        from aios.services import outbound_suppression as suppression_service
 
-        crypto_box = runtime.require_crypto_box()
-        vault_id, headers = await resolve_auth_for_target_url(
-            pool, crypto_box, session_id, url, account_id=account_id
-        )
-        result = await call_mcp_tool(
-            url, vault_id, headers, tool_name, arguments, meta=meta, spec_headers=spec.headers
-        )
+        if await _mcp_call_suppressed(pool, session_id, account_id, tc.name):
+            await suppression_service.record_mcp_suppression(
+                pool,
+                session_id,
+                account_id=account_id,
+                server_name=server_name,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+            result = suppression_service.mcp_synthesized_result()
+        else:
+            from aios.mcp.client import call_mcp_tool, resolve_auth_for_target_url
+
+            crypto_box = runtime.require_crypto_box()
+            vault_id, headers = await resolve_auth_for_target_url(
+                pool, crypto_box, session_id, url, account_id=account_id
+            )
+            result = await call_mcp_tool(
+                url, vault_id, headers, tool_name, arguments, meta=meta, spec_headers=spec.headers
+            )
 
         mcp_is_error = "error" in result
         event_data: dict[str, Any] = {

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -192,7 +192,16 @@ class McpToolsetConfig(BaseModel):
 
 
 class McpToolConfig(BaseModel):
-    """Per-tool override within an ``mcp_toolset`` entry."""
+    """Per-tool override within an ``mcp_toolset`` entry.
+
+    ``read_allow`` opts a single discovered tool into the outbound-suppression
+    read allowlist (#710): MCP has no HTTP-method convention, so when a session
+    runs with ``outbound_suppression == "on"`` every MCP call is *default-deny*
+    (suppressed with a synthesized success) UNLESS the operator marked the
+    specific tool ``read_allow=True`` at config time. A read-allowed tool runs
+    for real even under suppression. Default ``False`` — the safe choice for a
+    protocol that can't self-describe side effects.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -200,6 +209,7 @@ class McpToolConfig(BaseModel):
     enabled: bool = True
     permission_policy: McpPermissionPolicy | None = None
     transport: ToolTransport | None = None
+    read_allow: bool = False
 
 
 # ── HTTP server declaration ──────────────────────────────────────────────────
@@ -271,6 +281,17 @@ class HttpRouteSpec(BaseModel):
     permission_policy: HttpPermissionPolicy | None = None
     methods: list[HttpMethod] | None = None
     allow_query: bool = False
+    # Outbound-suppression override (#710). When a session runs with
+    # ``outbound_suppression == "on"`` the broker classifies each matched call
+    # as read (passes through) or write (suppressed with a synthesized success
+    # + audit event). The default classifier is the HTTP method: ``GET`` is a
+    # read, ``POST``/``PUT``/``PATCH``/``DELETE`` are writes. ``suppress`` is the
+    # per-route escape hatch for the cases the method doesn't predict: set it
+    # ``True`` to suppress a side-effecting ``GET``, ``False`` to let a
+    # read-only ``POST`` (a GraphQL/JSON-RPC query, a search endpoint) pass.
+    # ``None`` (default) defers to the method classifier. Off when suppression
+    # is off — this never gates a normal request.
+    suppress: bool | None = None
 
 
 class HttpServerSpec(BaseModel):
@@ -291,6 +312,12 @@ class HttpServerSpec(BaseModel):
     base_url: str = Field(min_length=1)
     description: str | None = None
     routes: list[HttpRouteSpec] = Field(default_factory=list)
+    # Status code returned on a suppressed call's synthesized success response
+    # (#710). The synthesized body is empty (``""``) so a JSON parse yields
+    # nothing surprising; the status defaults to ``200``. Configurable per
+    # http_server for surfaces whose success contract is e.g. ``201 Created`` —
+    # the agent must observe a plausible success so its behavior validates.
+    suppressed_response_status: int = Field(default=200, ge=100, le=599)
 
 
 def validate_http_servers(servers: list[HttpServerSpec]) -> None:
@@ -493,6 +520,54 @@ class AgentVersion(BaseModel):
 def is_mcp_tool_name(name: str) -> bool:
     """True if ``name`` is the namespaced form ``mcp__<server>__<tool>``."""
     return name.startswith("mcp__")
+
+
+# ── Outbound-suppression classification (#710) ───────────────────────────────
+
+# HTTP methods that pass through unchanged under outbound suppression by
+# default (reads). Everything else (POST/PUT/PATCH/DELETE) is a write and is
+# suppressed. A per-route ``suppress`` override flips either direction.
+_SUPPRESSION_READ_METHODS: frozenset[str] = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+def http_route_suppressed(route: HttpRouteSpec, method: str) -> bool:
+    """Decide whether a matched HTTP route is suppressed for ``method``.
+
+    The default classifier is the HTTP method — ``GET`` (and the other safe
+    verbs) read and pass through; ``POST``/``PUT``/``PATCH``/``DELETE`` write
+    and are suppressed. The route's optional ``suppress`` override wins when
+    set: ``True`` suppresses a side-effecting read, ``False`` lets a read-only
+    write through. This is *only* consulted when the session's
+    ``outbound_suppression`` is ``"on"`` — callers gate on that first.
+    """
+    if route.suppress is not None:
+        return route.suppress
+    return method.upper() not in _SUPPRESSION_READ_METHODS
+
+
+def mcp_tool_suppressed(name: str, agent_tools: list[ToolSpec]) -> bool:
+    """Decide whether an MCP tool call is suppressed under outbound suppression.
+
+    MCP has no method convention, so the policy is *default-deny*: every MCP
+    call is suppressed UNLESS its per-tool ``McpToolConfig.read_allow`` is set
+    (an operator opt-in for a known-safe read). Resolution mirrors
+    :func:`resolve_mcp_enabled`: a matching ``configs[]`` entry decides; absent
+    one, the tool is suppressed. An undeclared/unmatched tool is suppressed
+    (the safe default). Callers gate on ``outbound_suppression == "on"`` first.
+    """
+    parts = name.split("__", 2)
+    if len(parts) < 3:
+        return True
+    server_name = parts[1]
+    tool_name = parts[2]
+    for spec in agent_tools:
+        if spec.type == "mcp_toolset" and spec.mcp_server_name == server_name:
+            if spec.configs:
+                for cfg in spec.configs:
+                    if cfg.name == tool_name:
+                        return not cfg.read_allow
+            return True
+    return True
 
 
 def resolve_permission(name: str, agent_tools: list[ToolSpec]) -> PermissionPolicy | None:

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -99,6 +99,27 @@ connector. ``background`` — spawned by a workflow run's ``agent()`` (carries a
 ``parent_run_id``); the completion tools (``return``/``error``) are injected only
 into background children, and the totality backstop supervises them."""
 
+OutboundSuppression = Literal["off", "on"]
+"""Per-session outbound-suppression mode (#710).
+
+``off`` (default) — normal behavior; outbound side-effecting tool calls fire.
+``on`` — the broker classifies each bound ``http_server`` / ``mcp_server``
+call: reads pass through against real credentials, writes are intercepted and
+return a synthesized success (no external request leaves the broker) plus a
+``tool_call_suppressed`` audit span on the session log. The agent is NOT told
+it's suppressed — synthesized responses look like real successes, because
+behavior validation requires the agent to act as it would in production.
+
+Two migration uses (jarbot v1→v2 shard cutover): tier-3 safe testing (run with
+real vaults + memory but no real sends) and live-cutover parallel runs (v2 runs
+suppressed alongside v1, operators compare, then flip outbound atomically).
+
+Out of scope here: connector tools (``signal_send`` etc.) are NOT suppressed —
+a test session's account boundary (fresh ExternalIdentity) isolates them. And
+GET responses are real (no shadow-state); the read/write consistency window is
+acceptable for short test/cutover windows.
+"""
+
 MAX_USER_MESSAGE_CHARS = 1_000_000
 
 
@@ -175,6 +196,19 @@ class SessionCreate(BaseModel):
             "When true, the session is soft-archived the first time it goes idle "
             "owing nothing — a self-reclaiming, one-shot session. Immutable after "
             "launch. Workflow agent() children launch with this set."
+        ),
+    )
+    outbound_suppression: OutboundSuppression = Field(
+        default="off",
+        description=(
+            "Outbound-suppression mode (#710). 'off' (default) — normal "
+            "behavior. 'on' — bound http_server writes (POST/PUT/PATCH/DELETE "
+            "by default, per-route overridable) and ALL bound mcp_server calls "
+            "(default-deny; opt known-safe reads in via McpToolConfig.read_allow) "
+            "are intercepted: they return a synthesized success and append a "
+            "tool_call_suppressed audit event instead of leaving the broker. Used "
+            "for safe rehydration testing and parallel-run cutover. Mutable via "
+            "PUT /sessions/{id}."
         ),
     )
 
@@ -279,6 +313,15 @@ class SessionUpdate(BaseModel):
     metadata: dict[str, Any] | None = None
     vault_ids: list[str] | None = None
     resources: list[SessionResource] | None = None
+    outbound_suppression: OutboundSuppression | None = Field(
+        default=None,
+        description=(
+            "Flip outbound-suppression mode (#710). None (default) preserves the "
+            "current mode; 'on'/'off' sets it. Changing it recycles the session's "
+            "cached sandbox so the next step re-reads the flag. This is the "
+            "atomic 'flip outbound from v1 to v2' lever in a parallel-run cutover."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_resources(self) -> SessionUpdate:
@@ -321,6 +364,7 @@ class Session(BaseModel):
     origin: SessionOrigin = "foreground"
     parent_run_id: str | None = None  # set for a workflow-spawned (background) child
     archive_when_idle: bool = False  # self-archive on first idle (immutable launch property)
+    outbound_suppression: OutboundSuppression = "off"  # #710 — intercept side-effecting outbound
     last_event_at: datetime | None = None
     total_events: int = 0
 

--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -677,6 +677,28 @@ class ToolBroker:
         session_id, server, _toolset, tool_name = resolved
         assert tool_name is not None
 
+        # Outbound suppression (#710): MCP is default-deny under suppression.
+        # The sandbox CLI broker makes the identical decision the model
+        # dispatch path does — so a tool called from bash and the same tool
+        # called by the model are suppressed (or not) alike.
+        from aios.harness import runtime
+        from aios.services import outbound_suppression as outbound_suppression_service
+        from aios.services import sessions as sessions_service
+
+        pool = runtime.require_pool()
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
+        qualified = f"mcp__{server.name}__{tool_name}"
+        if await self._mcp_suppressed(pool, session_id, account_id, qualified):
+            await outbound_suppression_service.record_mcp_suppression(
+                pool,
+                session_id,
+                account_id=account_id,
+                server_name=server.name,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+            return JSONResponse(outbound_suppression_service.mcp_synthesized_result())
+
         vault_id, headers = await self._load_auth_for(session_id, server.url)
         log.info(
             "tool_broker.invoke_mcp",
@@ -688,6 +710,22 @@ class ToolBroker:
             server.url, vault_id, headers, tool_name, arguments, spec_headers=server.headers
         )
         return JSONResponse(envelope)
+
+    async def _mcp_suppressed(
+        self, pool: Any, session_id: str, account_id: str, qualified_name: str
+    ) -> bool:
+        """Whether an MCP call from the sandbox CLI is suppressed (#710)."""
+        from aios.models.agents import mcp_tool_suppressed
+        from aios.services import agents as agents_service
+        from aios.services import sessions as sessions_service
+
+        session = await sessions_service.get_session_basic(
+            pool, session_id, account_id=account_id
+        )
+        if session.outbound_suppression != "on":
+            return False
+        agent = await agents_service.load_for_session(pool, session, account_id=account_id)
+        return mcp_tool_suppressed(qualified_name, agent.tools)
 
 
 __all__ = ["ToolBroker"]

--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -719,9 +719,7 @@ class ToolBroker:
         from aios.services import agents as agents_service
         from aios.services import sessions as sessions_service
 
-        session = await sessions_service.get_session_basic(
-            pool, session_id, account_id=account_id
-        )
+        session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
         if session.outbound_suppression != "on":
             return False
         agent = await agents_service.load_for_session(pool, session, account_id=account_id)

--- a/src/aios/services/outbound_suppression.py
+++ b/src/aios/services/outbound_suppression.py
@@ -1,0 +1,164 @@
+"""Outbound-suppression primitive (#710).
+
+When a session runs with ``outbound_suppression == "on"``, side-effecting
+outbound tool calls are intercepted at the broker boundary: instead of leaving
+the broker, a *write* returns a synthesized success and the intent is recorded
+as a ``tool_call_suppressed`` audit event on the session log. Reads pass
+through against the session's real credentials.
+
+This module is the single source of the suppression policy and the audit-event
+shape, shared by:
+
+* the HTTP broker (:mod:`aios.tools.http_request`) — both the model-tool path
+  and, transitively, the sandbox ``tool http_request`` / bash path, since both
+  funnel through the same ``http_request_handler``; and
+* the MCP broker — both the model-tool path
+  (:mod:`aios.harness.tool_dispatch`) and the sandbox CLI broker
+  (:mod:`aios.sandbox.tool_broker`).
+
+Connector tools (``signal_send`` etc.) are deliberately NOT routed here — a
+test session's account boundary isolates them (see the migration cutover
+playbook). Bash is opaque to aios and is not suppressed directly; its external
+effects compose through these brokers.
+
+Classification policy:
+
+* HTTP — the HTTP method is the default classifier (``GET`` passes, the
+  side-effecting verbs are suppressed); a per-route ``suppress`` override
+  handles the GETs-with-side-effects / reads-over-POST cases. See
+  :func:`aios.models.agents.http_route_suppressed`.
+* MCP — default-deny (suppress everything); an operator opts known-safe reads
+  in via ``McpToolConfig.read_allow``. See
+  :func:`aios.models.agents.mcp_tool_suppressed`.
+
+The agent is NOT told a call was suppressed — synthesized responses look like
+real successes, because behavior validation requires the agent to act as it
+would in production.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.logging import get_logger
+from aios.services import sessions as sessions_service
+
+log = get_logger("aios.services.outbound_suppression")
+
+# The audit event lives on the session log as a ``span``-kind event with this
+# discriminator under ``data.event`` — searchable via ``search_events`` for
+# post-test / post-cutover review. Reusing the existing ``span`` kind (rather
+# than minting a new top-level ``EventKind``) keeps the event model stable; the
+# discriminator names the new logical kind the migration doc asked for.
+SUPPRESSED_EVENT: str = "tool_call_suppressed"
+
+
+def http_synthesized_response(status: int) -> dict[str, Any]:
+    """The synthesized success an HTTP write observes under suppression.
+
+    Mirrors the real ``http_request`` return shape (``status``/``headers``/
+    ``body``) so the agent can't tell it apart from a real success. The body is
+    empty (``""``) — enough for v1; a per-route synthetic-response template is
+    explicitly deferred until a real test hits the limitation (e.g. a write that
+    returns the created entity's id).
+    """
+    return {"status": status, "headers": {}, "body": ""}
+
+
+def mcp_synthesized_result() -> dict[str, Any]:
+    """The synthesized success an MCP write observes under suppression.
+
+    Mirrors the MCP-tool success envelope (``call_mcp_tool`` returns a dict;
+    a real success carries ``content``, an error carries ``error``). An empty
+    ``content`` reads as a clean, side-effect-free success.
+    """
+    return {"content": ""}
+
+
+async def record_http_suppression(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    server_ref: str,
+    base_url: str,
+    method: str,
+    path: str,
+    body: str | None,
+    synthesized_status: int,
+) -> None:
+    """Append the ``tool_call_suppressed`` audit span for a suppressed HTTP write.
+
+    Records the un-suppressed request (server_ref + base_url + method + path +
+    body) plus ``would_have_returned: null`` so a reviewer sees exactly what the
+    agent attempted and that nothing came back from upstream. No auth header is
+    recorded — the agent never supplies one (the worker injects the vault
+    secret only on a *real* dispatch, which never happens here), so the secret
+    cannot leak into the log.
+    """
+    await _append_suppressed_event(
+        pool,
+        session_id,
+        account_id=account_id,
+        data={
+            "tool": "http_request",
+            "server_ref": server_ref,
+            "base_url": base_url,
+            "method": method,
+            "path": path,
+            "body": body,
+            "would_have_returned": None,
+            "synthesized_status": synthesized_status,
+        },
+    )
+
+
+async def record_mcp_suppression(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    server_name: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> None:
+    """Append the ``tool_call_suppressed`` audit span for a suppressed MCP call.
+
+    Records the server + tool + arguments and ``would_have_returned: null``.
+    MCP arguments are the agent's own input (no vault secret is ever placed
+    there — credentials are resolved into transport headers, never the JSON-RPC
+    params), so they're safe to log verbatim, same as authenticated request
+    logging.
+    """
+    await _append_suppressed_event(
+        pool,
+        session_id,
+        account_id=account_id,
+        data={
+            "tool": f"mcp__{server_name}__{tool_name}",
+            "server_name": server_name,
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "would_have_returned": None,
+        },
+    )
+
+
+async def _append_suppressed_event(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    *,
+    account_id: str,
+    data: dict[str, Any],
+) -> None:
+    payload = {"event": SUPPRESSED_EVENT, **data}
+    await sessions_service.append_event(
+        pool, session_id, "span", payload, account_id=account_id
+    )
+    log.info(
+        "outbound_suppression.suppressed",
+        session_id=session_id,
+        tool=data.get("tool"),
+    )

--- a/src/aios/services/outbound_suppression.py
+++ b/src/aios/services/outbound_suppression.py
@@ -154,9 +154,7 @@ async def _append_suppressed_event(
     data: dict[str, Any],
 ) -> None:
     payload = {"event": SUPPRESSED_EVENT, **data}
-    await sessions_service.append_event(
-        pool, session_id, "span", payload, account_id=account_id
-    )
+    await sessions_service.append_event(pool, session_id, "span", payload, account_id=account_id)
     log.info(
         "outbound_suppression.suppressed",
         session_id=session_id,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -254,6 +254,7 @@ async def create_session(
     focal_channel: str | None = None,
     focal_locked: bool = False,
     archive_when_idle: bool = False,
+    outbound_suppression: str = "off",
 ) -> Session:
     """Create a session row and return it.
 
@@ -305,6 +306,7 @@ async def create_session(
             focal_channel=focal_channel,
             focal_locked=focal_locked,
             archive_when_idle=archive_when_idle,
+            outbound_suppression=outbound_suppression,
             account_id=account_id,
         )
         if vault_ids:
@@ -1636,6 +1638,7 @@ async def update_session(
     metadata: dict[str, Any] | None = None,
     vault_ids: list[str] | None = None,
     resources: list[SessionResource] | None = None,
+    outbound_suppression: str | None = None,
     crypto_box: CryptoBox | None = None,
 ) -> Session:
     # One transaction so a 4xx from resource attach (e.g. name collision)
@@ -1648,6 +1651,12 @@ async def update_session(
         # create_session guard (issue #851).
         if agent_id is not None:
             await queries.get_agent(conn, agent_id, account_id=account_id)
+        # Whether outbound_suppression actually flips — read the pre-update
+        # value so an idempotent re-PUT (same mode) doesn't recycle the sandbox.
+        suppression_changed = False
+        if outbound_suppression is not None:
+            pre = await queries.get_session_bare(conn, session_id, account_id=account_id)
+            suppression_changed = outbound_suppression != pre.outbound_suppression
         session = await queries.update_session(
             conn,
             session_id,
@@ -1655,6 +1664,7 @@ async def update_session(
             agent_version=agent_version,
             title=title,
             metadata=metadata,
+            outbound_suppression=outbound_suppression,
             account_id=account_id,
         )
         # Validate the resolved pin: agent_version may be supplied without
@@ -1703,7 +1713,7 @@ async def update_session(
     # on the next step; no-op in the API process (registry global is
     # worker-only). An idempotent re-PUT (same vaults, same resources) writes
     # nothing and must not recycle the sandbox.
-    if changed:
+    if changed or suppression_changed:
         _evict_sandbox_for_resource_change(session_id)
     return result
 

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -25,8 +25,10 @@ from aios.models.agents import (
     HttpRouteSpec,
     HttpServerSpec,
     PermissionPolicy,
+    http_route_suppressed,
 )
 from aios.services import agents as agents_service
+from aios.services import outbound_suppression as outbound_suppression_service
 from aios.services import sessions as sessions_service
 from aios.tools._glob_match import match_glob
 from aios.tools.registry import registry
@@ -226,12 +228,12 @@ def _classify_permission(
     return route.permission_policy.type
 
 
-async def _load_session_agent(session_id: str) -> tuple[Agent | AgentVersion, str]:
+async def _load_session_agent(session_id: str) -> tuple[Agent | AgentVersion, str, str]:
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)
     agent = await agents_service.load_for_session(pool, session, account_id=account_id)
-    return agent, account_id
+    return agent, account_id, session.outbound_suppression
 
 
 def _decode_body(response: httpx.Response) -> str:
@@ -256,11 +258,22 @@ async def _do_http_request(
     servers: list[HttpServerSpec],
     arguments: dict[str, Any],
     resolve_auth: Callable[[str], Awaitable[tuple[str | None, dict[str, str]]]],
+    on_suppress: (
+        Callable[[HttpServerSpec, HttpRouteSpec, dict[str, Any]], Awaitable[dict[str, Any] | None]]
+        | None
+    ) = None,
 ) -> dict[str, Any]:
     """The owner-agnostic core: match a path against ``servers``' route allowlist,
     author the ``Authorization`` header via the injected ``resolve_auth``, and make the
     request. Shared by the session handler (servers = agent's) and the workflow-run
     dispatcher (servers = run's snapshot); the core never learns which principal it serves.
+
+    ``on_suppress`` (outbound suppression, #710) is consulted AFTER the path /
+    method / query gates pass but BEFORE the upstream dispatch. The session
+    handler injects it when ``outbound_suppression == "on"``; it returns a
+    synthesized success (and records the audit event) for a write, or ``None``
+    to let the call proceed normally for a read. The workflow-run dispatcher
+    leaves it ``None`` — suppression is a per-session property.
     """
     server_ref = arguments["server_ref"]
     path = arguments["path"]
@@ -295,6 +308,15 @@ async def _do_http_request(
     reason = _query_rejected_reason(route, path, query)
     if reason is not None:
         return {"error": reason}
+
+    # Outbound suppression (#710): a session in suppression mode short-circuits a
+    # write here — synthesized success, no upstream dispatch — AFTER the gates so
+    # the agent sees the same accept/reject surface it would in production, and
+    # the suppressed call is recorded against a real, allowlisted route.
+    if on_suppress is not None:
+        synthesized = await on_suppress(server, route, arguments)
+        if synthesized is not None:
+            return synthesized
 
     full_url = server.base_url.rstrip("/") + "/" + path.lstrip("/")
     if not is_safe_url(full_url):
@@ -333,7 +355,7 @@ async def _do_http_request(
 
 async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
     """Session entry: resolve the agent's ``http_servers`` + a session-scoped vault resolver."""
-    agent, account_id = await _load_session_agent(session_id)
+    agent, account_id, outbound_suppression = await _load_session_agent(session_id)
     pool = runtime.require_pool()
     crypto_box = runtime.require_crypto_box()
 
@@ -342,8 +364,34 @@ async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> di
             pool, crypto_box, session_id, base_url, account_id=account_id
         )
 
+    on_suppress = None
+    if outbound_suppression == "on":
+
+        async def on_suppress(
+            server: HttpServerSpec, route: HttpRouteSpec, args: dict[str, Any]
+        ) -> dict[str, Any] | None:
+            method = str(args.get("method", ""))
+            if not http_route_suppressed(route, method):
+                return None  # a read — let it through against real credentials
+            status = server.suppressed_response_status
+            await outbound_suppression_service.record_http_suppression(
+                pool,
+                session_id,
+                account_id=account_id,
+                server_ref=server.name,
+                base_url=server.base_url,
+                method=method,
+                path=str(args.get("path", "")),
+                body=args.get("body"),
+                synthesized_status=status,
+            )
+            return outbound_suppression_service.http_synthesized_response(status)
+
     return await _do_http_request(
-        servers=agent.http_servers, arguments=arguments, resolve_auth=resolve_auth
+        servers=agent.http_servers,
+        arguments=arguments,
+        resolve_auth=resolve_auth,
+        on_suppress=on_suppress,
     )
 
 

--- a/tests/integration/test_session_outbound_suppression.py
+++ b/tests/integration/test_session_outbound_suppression.py
@@ -1,0 +1,141 @@
+"""Integration test: the ``outbound_suppression`` session field round-trips
+through the DB column added in migration 0105 (#710).
+
+Exercises the create-with-mode, the default, the PUT flip (and that the flip
+recycles the cached sandbox), and the idempotent re-PUT (same mode → no
+recycle). Needs the real Postgres testcontainer so the migration's column +
+CHECK constraint and the INSERT/UPDATE plumbing are actually run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+from aios.services import sessions as sessions_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def suppression_env(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_supp', NULL, TRUE, 'outbound-suppression-test')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_supp",
+            name="supp-test",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_supp", name="supp-env"
+        )
+        yield pool, "acc_supp", agent.id, env.id
+    finally:
+        await pool.close()
+
+
+async def test_default_is_off(
+    suppression_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    pool, account_id, agent_id, env_id = suppression_env
+    session = await sessions_service.create_session(
+        pool,
+        account_id=account_id,
+        agent_id=agent_id,
+        environment_id=env_id,
+        title=None,
+        metadata={},
+    )
+    assert session.outbound_suppression == "off"
+    # Round-trips on a fresh read, too.
+    fetched = await sessions_service.get_session_basic(
+        pool, session.id, account_id=account_id
+    )
+    assert fetched.outbound_suppression == "off"
+
+
+async def test_create_with_suppression_on(
+    suppression_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    pool, account_id, agent_id, env_id = suppression_env
+    session = await sessions_service.create_session(
+        pool,
+        account_id=account_id,
+        agent_id=agent_id,
+        environment_id=env_id,
+        title=None,
+        metadata={},
+        outbound_suppression="on",
+    )
+    assert session.outbound_suppression == "on"
+
+
+async def test_flip_via_update_recycles_sandbox(
+    suppression_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    pool, account_id, agent_id, env_id = suppression_env
+    session = await sessions_service.create_session(
+        pool,
+        account_id=account_id,
+        agent_id=agent_id,
+        environment_id=env_id,
+        title=None,
+        metadata={},
+    )
+    with patch.object(sessions_service, "_evict_sandbox_for_resource_change") as evict:
+        updated = await sessions_service.update_session(
+            pool, session.id, account_id=account_id, outbound_suppression="on"
+        )
+    assert updated.outbound_suppression == "on"
+    evict.assert_called_once_with(session.id)
+
+    # Idempotent re-PUT (same mode) must not recycle.
+    with patch.object(sessions_service, "_evict_sandbox_for_resource_change") as evict2:
+        again = await sessions_service.update_session(
+            pool, session.id, account_id=account_id, outbound_suppression="on"
+        )
+    assert again.outbound_suppression == "on"
+    evict2.assert_not_called()
+
+
+async def test_check_constraint_rejects_bad_value(
+    suppression_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    pool, account_id, agent_id, env_id = suppression_env
+    session = await sessions_service.create_session(
+        pool,
+        account_id=account_id,
+        agent_id=agent_id,
+        environment_id=env_id,
+        title=None,
+        metadata={},
+    )
+    with pytest.raises(asyncpg.PostgresError):
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE sessions SET outbound_suppression = 'bogus' WHERE id = $1",
+                session.id,
+            )

--- a/tests/integration/test_session_outbound_suppression.py
+++ b/tests/integration/test_session_outbound_suppression.py
@@ -1,5 +1,5 @@
 """Integration test: the ``outbound_suppression`` session field round-trips
-through the DB column added in migration 0105 (#710).
+through the DB column added in migration 0106 (#710).
 
 Exercises the create-with-mode, the default, the PUT flip (and that the flip
 recycles the cached sandbox), and the idempotent re-PUT (same mode → no
@@ -71,9 +71,7 @@ async def test_default_is_off(
     )
     assert session.outbound_suppression == "off"
     # Round-trips on a fresh read, too.
-    fetched = await sessions_service.get_session_basic(
-        pool, session.id, account_id=account_id
-    )
+    fetched = await sessions_service.get_session_basic(pool, session.id, account_id=account_id)
     assert fetched.outbound_suppression == "off"
 
 

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -838,6 +838,7 @@ class TestOutboundSuppressionHttp:
         assert "url" not in captured
         # Audit event recorded with the un-suppressed intent.
         record.assert_awaited_once()
+        assert record.await_args is not None
         kwargs = record.await_args.kwargs
         assert kwargs["method"] == "POST"
         assert kwargs["path"] == "/lights/1"
@@ -938,6 +939,7 @@ class TestOutboundSuppressionHttp:
                 {"server_ref": "hue", "path": "/things", "method": "POST"},
             )
         assert result["status"] == 201
+        assert record.await_args is not None
         assert record.await_args.kwargs["synthesized_status"] == 201
 
     async def test_suppression_off_does_not_gate(self, _stub_runtime: Any) -> None:

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -43,9 +43,14 @@ def _server(
     base_url: str = "https://api.example.com/v1",
     routes: list[HttpRouteSpec] | None = None,
     description: str | None = None,
+    suppressed_response_status: int = 200,
 ) -> HttpServerSpec:
     return HttpServerSpec(
-        name=name, base_url=base_url, routes=routes or [], description=description
+        name=name,
+        base_url=base_url,
+        routes=routes or [],
+        description=description,
+        suppressed_response_status=suppressed_response_status,
     )
 
 
@@ -57,6 +62,7 @@ def _route(
     description: str | None = None,
     methods: list[str] | None = None,
     allow_query: bool = False,
+    suppress: bool | None = None,
 ) -> HttpRouteSpec:
     permission = HttpPermissionPolicy(type=policy) if policy else None
     return HttpRouteSpec(
@@ -66,6 +72,7 @@ def _route(
         description=description,
         methods=cast(Any, methods),
         allow_query=allow_query,
+        suppress=suppress,
     )
 
 
@@ -240,10 +247,12 @@ def _stub_runtime() -> Iterator[SimpleNamespace]:
         yield SimpleNamespace(pool=pool, crypto_box=crypto_box)
 
 
-def _patch_load_agent(agent: Agent | AgentVersion) -> Any:
+def _patch_load_agent(
+    agent: Agent | AgentVersion, outbound_suppression: str = "off"
+) -> Any:
     return patch(
         "aios.tools.http_request._load_session_agent",
-        AsyncMock(return_value=(agent, "acc_test_stub")),
+        AsyncMock(return_value=(agent, "acc_test_stub", outbound_suppression)),
     )
 
 
@@ -792,3 +801,178 @@ class TestDoHttpRequest:
             resolve_auth=resolve_auth,
         )
         assert "error" in out and "unknown server_ref" in out["error"]
+
+
+# ── outbound suppression (#710) ─────────────────────────────────────────────
+
+
+class TestOutboundSuppressionHttp:
+    """When a session runs with ``outbound_suppression == 'on'`` the HTTP broker
+    intercepts writes (synthesized success + audit event, no upstream dispatch)
+    and lets reads through against real credentials."""
+
+    async def test_write_suppressed_no_dispatch_and_records_event(
+        self, _stub_runtime: Any
+    ) -> None:
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        record = AsyncMock()
+        with (
+            _patch_load_agent(agent, outbound_suppression="on"),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+            patch(
+                "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
+                record,
+            ),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {
+                    "server_ref": "hue",
+                    "path": "/lights/1",
+                    "method": "POST",
+                    "body": '{"on": true}',
+                },
+            )
+        # Synthesized success — looks like a real response, no upstream dispatch.
+        assert result == {"status": 200, "headers": {}, "body": ""}
+        assert "url" not in captured
+        # Audit event recorded with the un-suppressed intent.
+        record.assert_awaited_once()
+        kwargs = record.await_args.kwargs
+        assert kwargs["method"] == "POST"
+        assert kwargs["path"] == "/lights/1"
+        assert kwargs["body"] == '{"on": true}'
+        assert kwargs["server_ref"] == "hue"
+
+    async def test_read_passes_through_under_suppression(self, _stub_runtime: Any) -> None:
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        response = httpx.Response(
+            200, headers={"content-type": "application/json"}, content=b'{"on": true}'
+        )
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=response, capture=captured)
+        record = AsyncMock()
+        with (
+            _patch_load_agent(agent, outbound_suppression="on"),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+            patch(
+                "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
+                record,
+            ),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        # Real dispatch, real response; nothing recorded.
+        assert captured["method"] == "GET"
+        assert result["status"] == 200
+        record.assert_not_awaited()
+
+    async def test_per_route_suppress_override_suppresses_get(self, _stub_runtime: Any) -> None:
+        # A GET that the operator marked suppress=True (a side-effecting read).
+        agent = _agent(
+            http_servers=[_server(routes=[_route("/trigger/*", suppress=True)])]
+        )
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        record = AsyncMock()
+        with (
+            _patch_load_agent(agent, outbound_suppression="on"),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+            patch(
+                "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
+                record,
+            ),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/trigger/1", "method": "GET"},
+            )
+        assert result == {"status": 200, "headers": {}, "body": ""}
+        assert "url" not in captured
+        record.assert_awaited_once()
+
+    async def test_per_route_suppress_false_lets_post_through(self, _stub_runtime: Any) -> None:
+        # A read-only POST (a query endpoint) the operator marked suppress=False.
+        agent = _agent(
+            http_servers=[_server(routes=[_route("/graphql", suppress=False)])]
+        )
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(
+            response=httpx.Response(200, content=b"{}"), capture=captured
+        )
+        record = AsyncMock()
+        with (
+            _patch_load_agent(agent, outbound_suppression="on"),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+            patch(
+                "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
+                record,
+            ),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/graphql", "method": "POST"},
+            )
+        assert captured["method"] == "POST"
+        assert result["status"] == 200
+        record.assert_not_awaited()
+
+    async def test_suppressed_status_is_configurable(self, _stub_runtime: Any) -> None:
+        agent = _agent(
+            http_servers=[
+                _server(
+                    routes=[_route("/things")], suppressed_response_status=201
+                )
+            ]
+        )
+        record = AsyncMock()
+        with (
+            _patch_load_agent(agent, outbound_suppression="on"),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch(
+                "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
+                record,
+            ),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/things", "method": "POST"},
+            )
+        assert result["status"] == 201
+        assert record.await_args.kwargs["synthesized_status"] == 201
+
+    async def test_suppression_off_does_not_gate(self, _stub_runtime: Any) -> None:
+        # The default mode never consults suppression — a write dispatches.
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        record = AsyncMock()
+        with (
+            _patch_load_agent(agent, outbound_suppression="off"),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+            patch(
+                "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
+                record,
+            ),
+        ):
+            await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "POST"},
+            )
+        assert captured["method"] == "POST"
+        record.assert_not_awaited()

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -247,9 +247,7 @@ def _stub_runtime() -> Iterator[SimpleNamespace]:
         yield SimpleNamespace(pool=pool, crypto_box=crypto_box)
 
 
-def _patch_load_agent(
-    agent: Agent | AgentVersion, outbound_suppression: str = "off"
-) -> Any:
+def _patch_load_agent(agent: Agent | AgentVersion, outbound_suppression: str = "off") -> Any:
     return patch(
         "aios.tools.http_request._load_session_agent",
         AsyncMock(return_value=(agent, "acc_test_stub", outbound_suppression)),
@@ -811,9 +809,7 @@ class TestOutboundSuppressionHttp:
     intercepts writes (synthesized success + audit event, no upstream dispatch)
     and lets reads through against real credentials."""
 
-    async def test_write_suppressed_no_dispatch_and_records_event(
-        self, _stub_runtime: Any
-    ) -> None:
+    async def test_write_suppressed_no_dispatch_and_records_event(self, _stub_runtime: Any) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
         captured: dict[str, Any] = {}
         stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
@@ -877,9 +873,7 @@ class TestOutboundSuppressionHttp:
 
     async def test_per_route_suppress_override_suppresses_get(self, _stub_runtime: Any) -> None:
         # A GET that the operator marked suppress=True (a side-effecting read).
-        agent = _agent(
-            http_servers=[_server(routes=[_route("/trigger/*", suppress=True)])]
-        )
+        agent = _agent(http_servers=[_server(routes=[_route("/trigger/*", suppress=True)])])
         captured: dict[str, Any] = {}
         stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
         record = AsyncMock()
@@ -903,13 +897,9 @@ class TestOutboundSuppressionHttp:
 
     async def test_per_route_suppress_false_lets_post_through(self, _stub_runtime: Any) -> None:
         # A read-only POST (a query endpoint) the operator marked suppress=False.
-        agent = _agent(
-            http_servers=[_server(routes=[_route("/graphql", suppress=False)])]
-        )
+        agent = _agent(http_servers=[_server(routes=[_route("/graphql", suppress=False)])])
         captured: dict[str, Any] = {}
-        stub = _make_stub_client(
-            response=httpx.Response(200, content=b"{}"), capture=captured
-        )
+        stub = _make_stub_client(response=httpx.Response(200, content=b"{}"), capture=captured)
         record = AsyncMock()
         with (
             _patch_load_agent(agent, outbound_suppression="on"),
@@ -931,11 +921,7 @@ class TestOutboundSuppressionHttp:
 
     async def test_suppressed_status_is_configurable(self, _stub_runtime: Any) -> None:
         agent = _agent(
-            http_servers=[
-                _server(
-                    routes=[_route("/things")], suppressed_response_status=201
-                )
-            ]
+            http_servers=[_server(routes=[_route("/things")], suppressed_response_status=201)]
         )
         record = AsyncMock()
         with (

--- a/tests/unit/test_mcp_dispatch_spec_headers.py
+++ b/tests/unit/test_mcp_dispatch_spec_headers.py
@@ -43,6 +43,14 @@ class TestMcpDispatchSpecHeaders:
             patch("aios.harness.tool_dispatch._tool_lifecycle", _fake_lifecycle),
             patch("aios.harness.tool_dispatch._append_tool_result_event", new_callable=AsyncMock),
             patch("aios.harness.tool_dispatch.runtime.require_crypto_box", return_value=object()),
+            # Outbound suppression off (#710): the dispatch path consults this
+            # gate before deciding to make the real call; this test exercises
+            # the real-dispatch path, so it stays open.
+            patch(
+                "aios.harness.tool_dispatch._mcp_call_suppressed",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
             patch(
                 "aios.mcp.client.resolve_auth_for_target_url",
                 new_callable=AsyncMock,
@@ -97,3 +105,51 @@ class TestMcpDispatchSpecHeaders:
             )
 
         assert "missing" in captured.get("bail", "")
+
+
+class TestMcpDispatchSuppression:
+    """When the suppression gate (#710) fires, the model-path dispatcher
+    synthesizes a success, records the audit event, and never calls
+    ``call_mcp_tool``."""
+
+    async def test_suppressed_call_synthesizes_and_records(self) -> None:
+        spec = McpServerSpec(name="gh", url="https://mcp.github/")
+        mcp_server_map = {"gh": spec}
+
+        call_mock = AsyncMock(return_value={"content": "ok"})
+        record_mock = AsyncMock()
+        with (
+            patch("aios.harness.tool_dispatch._tool_lifecycle", _fake_lifecycle),
+            patch("aios.harness.tool_dispatch._append_tool_result_event", new_callable=AsyncMock),
+            patch(
+                "aios.harness.tool_dispatch._mcp_call_suppressed",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "aios.services.outbound_suppression.record_mcp_suppression",
+                record_mock,
+            ),
+            patch("aios.mcp.client.call_mcp_tool", call_mock),
+        ):
+            await _execute_mcp_tool_async(
+                MagicMock(),
+                "sess_x",
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "mcp__gh__create_issue",
+                        "arguments": "{}",
+                    },
+                },
+                mcp_server_map,
+                account_id="acc_test_stub",
+            )
+
+        call_mock.assert_not_awaited()  # no real MCP round-trip
+        record_mock.assert_awaited_once()
+        kwargs = record_mock.await_args.kwargs
+        assert kwargs["server_name"] == "gh"
+        assert kwargs["tool_name"] == "create_issue"
+        # arguments come from the lifecycle-yielded _ToolCall.raw_args ("{}").
+        assert kwargs["arguments"] == {}

--- a/tests/unit/test_mcp_dispatch_spec_headers.py
+++ b/tests/unit/test_mcp_dispatch_spec_headers.py
@@ -148,6 +148,7 @@ class TestMcpDispatchSuppression:
 
         call_mock.assert_not_awaited()  # no real MCP round-trip
         record_mock.assert_awaited_once()
+        assert record_mock.await_args is not None
         kwargs = record_mock.await_args.kwargs
         assert kwargs["server_name"] == "gh"
         assert kwargs["tool_name"] == "create_issue"

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0105``."""
+    """The migration ladder has exactly one head: ``0106``."""
     script = _script_directory()
-    assert script.get_heads() == ["0105"]
+    assert script.get_heads() == ["0106"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0104``."""
+    """The migration ladder has exactly one head: ``0105``."""
     script = _script_directory()
-    assert script.get_heads() == ["0104"]
+    assert script.get_heads() == ["0105"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_outbound_suppression.py
+++ b/tests/unit/test_outbound_suppression.py
@@ -1,0 +1,74 @@
+"""Unit tests for the outbound-suppression classification helpers (#710).
+
+The pure decision functions live in :mod:`aios.models.agents`:
+
+* ``http_route_suppressed`` — method-default with per-route override.
+* ``mcp_tool_suppressed`` — default-deny with per-tool ``read_allow`` opt-in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.models.agents import (
+    HttpRouteSpec,
+    McpToolConfig,
+    ToolSpec,
+    http_route_suppressed,
+    mcp_tool_suppressed,
+)
+
+
+def _route(pattern: str = "/x", *, suppress: bool | None = None) -> HttpRouteSpec:
+    return HttpRouteSpec(path_pattern=pattern, suppress=suppress)
+
+
+class TestHttpRouteSuppressed:
+    @pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS", "get"])
+    def test_reads_pass_by_default(self, method: str) -> None:
+        assert http_route_suppressed(_route(), method) is False
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE", "post"])
+    def test_writes_suppressed_by_default(self, method: str) -> None:
+        assert http_route_suppressed(_route(), method) is True
+
+    def test_override_true_suppresses_a_read(self) -> None:
+        assert http_route_suppressed(_route(suppress=True), "GET") is True
+
+    def test_override_false_passes_a_write(self) -> None:
+        assert http_route_suppressed(_route(suppress=False), "POST") is False
+
+
+def _mcp_toolset(server: str, configs: list[McpToolConfig] | None = None) -> ToolSpec:
+    return ToolSpec(
+        type="mcp_toolset",
+        mcp_server_name=server,
+        configs=configs or [],
+    )
+
+
+class TestMcpToolSuppressed:
+    def test_default_deny_unconfigured_tool(self) -> None:
+        # A discovered tool with no matching config entry is suppressed.
+        tools = [_mcp_toolset("gh")]
+        assert mcp_tool_suppressed("mcp__gh__create_issue", tools) is True
+
+    def test_read_allow_opts_in(self) -> None:
+        tools = [_mcp_toolset("gh", [McpToolConfig(name="search", read_allow=True)])]
+        assert mcp_tool_suppressed("mcp__gh__search", tools) is False
+
+    def test_configured_without_read_allow_is_suppressed(self) -> None:
+        tools = [_mcp_toolset("gh", [McpToolConfig(name="create_issue")])]
+        assert mcp_tool_suppressed("mcp__gh__create_issue", tools) is True
+
+    def test_unknown_server_is_suppressed(self) -> None:
+        tools = [_mcp_toolset("gh", [McpToolConfig(name="search", read_allow=True)])]
+        assert mcp_tool_suppressed("mcp__other__search", tools) is True
+
+    def test_malformed_name_is_suppressed(self) -> None:
+        assert mcp_tool_suppressed("mcp__gh", []) is True
+
+    def test_read_allow_only_applies_to_named_tool(self) -> None:
+        tools = [_mcp_toolset("gh", [McpToolConfig(name="search", read_allow=True)])]
+        # A sibling tool not named in configs is still default-deny.
+        assert mcp_tool_suppressed("mcp__gh__create_issue", tools) is True


### PR DESCRIPTION
## What

Adds a per-session `outbound_suppression` mode (`off` default / `on`). When a session runs with it `on`, the tool brokers intercept **side-effecting** outbound calls at the broker boundary: instead of leaving the broker, a write returns a *synthesized success* and the intent is recorded as a `tool_call_suppressed` audit event on the session log. Reads pass through against the session's real credentials. The agent is not told a call was suppressed — synthesized responses look like real successes, because behaviour validation requires the agent to act as it would in production.

This is the last substrate dependency for the jarbot v1→v2 shard migration: it enables tier-3 safe testing (real vaults + memory, no real sends) and live-cutover parallel runs (v2 suppressed alongside v1, then flip outbound atomically via `PUT`).

## Classification

- **HTTP** (`http_request` broker — model-tool path and, transitively, the sandbox `tool http_request` / bash path, since both funnel through the same handler): the HTTP method is the default classifier — `GET`/`HEAD`/`OPTIONS` read and pass through; `POST`/`PUT`/`PATCH`/`DELETE` write and are suppressed. A per-route `HttpRouteSpec.suppress: bool | None` override flips either direction (suppress a side-effecting GET; let a read-only POST query through). `HttpServerSpec.suppressed_response_status` (default 200) sets the synthesized status.
- **MCP** (model-tool dispatch + sandbox CLI broker): default-deny — every MCP call is suppressed unless an operator marked the specific tool `McpToolConfig.read_allow=True` (MCP can't self-describe side effects). Both dispatch paths consult the same `mcp_tool_suppressed` decision.

Classification gates run *after* the existing path/method/query allowlist gates, so the agent sees the identical accept/reject surface it would in production and suppressed calls are only ever recorded against real, allowlisted routes.

## How

- `Session`/`SessionCreate`/`SessionUpdate` gain the field; `PUT /sessions/{id}` flips it (and recycles the cached sandbox so the next step re-reads the flag — the atomic cutover lever). Idempotent re-PUT (same mode) does not recycle.
- New `aios.services.outbound_suppression` module is the single source of the synthesized-response shapes and the audit-event append (`span` kind, `event=tool_call_suppressed`, searchable via `search_events`). No auth header / secret is ever logged — secrets are injected only on a real dispatch, which never happens for a suppressed call.
- Migration `0105` adds `sessions.outbound_suppression` (text, NOT NULL default `'off'`, CHECK `{off,on}`). Backfill is the default — every existing session stays normal; suppression is strictly opt-in.

## Out of scope (per the issue)

Connector tools (`signal_send` etc.) are not suppressed — a test session's account boundary isolates them. GET responses are real (no shadow-state); the read/write consistency window is acceptable for short test/cutover windows. A per-route synthetic-response *body* template is deferred until a real test needs it (empty body for now).

## Tests

- `tests/unit/test_outbound_suppression.py` — the pure classification helpers (HTTP method-default + override; MCP default-deny + `read_allow`).
- `tests/unit/test_http_request.py` — HTTP broker: write suppressed (no dispatch + audit recorded), read passes through, per-route `suppress=True/False` overrides, configurable status, and that mode `off` never gates.
- `tests/unit/test_mcp_dispatch_spec_headers.py` — MCP model-path: suppressed call synthesizes + records and makes no real round-trip.
- `tests/integration/test_session_outbound_suppression.py` — DB round-trip: default off, create-with-on, PUT flip recycles sandbox (idempotent re-PUT does not), CHECK constraint rejects bad values.
- Regenerated `openapi.json` + SDK `_generated/`; updated the migration-head assertion to `0105`. Full unit suite green; ruff + mypy clean.