### PR TITLE
feat(workflows): names-only http_servers declaration (Ask 3 from #939)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -17569,7 +17569,14 @@
           },
           "http_servers": {
             "items": {
-              "$ref": "#/components/schemas/HttpServerSpec"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/HttpServerSpec"
+                }
+              ]
             },
             "type": "array",
             "title": "Http Servers"
@@ -17682,7 +17689,14 @@
             "anyOf": [
               {
                 "items": {
-                  "$ref": "#/components/schemas/HttpServerSpec"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "$ref": "#/components/schemas/HttpServerSpec"
+                    }
+                  ]
                 },
                 "type": "array"
               },

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_create.py
@@ -86,7 +86,7 @@ class WorkflowCreate:
         description (None | str | Unset):
         tools (list[ToolSpec] | Unset):
         mcp_servers (list[McpServerSpec] | Unset):
-        http_servers (list[HttpServerSpec] | Unset):
+        http_servers (list[HttpServerSpec | str] | Unset):
     """
 
     name: str
@@ -96,9 +96,10 @@ class WorkflowCreate:
     description: None | str | Unset = UNSET
     tools: list[ToolSpec] | Unset = UNSET
     mcp_servers: list[McpServerSpec] | Unset = UNSET
-    http_servers: list[HttpServerSpec] | Unset = UNSET
+    http_servers: list[HttpServerSpec | str] | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.http_server_spec import HttpServerSpec
         from ..models.workflow_create_input_schema_type_0 import (
             WorkflowCreateInputSchemaType0,
         )
@@ -146,11 +147,15 @@ class WorkflowCreate:
                 mcp_servers_item = mcp_servers_item_data.to_dict()
                 mcp_servers.append(mcp_servers_item)
 
-        http_servers: list[dict[str, Any]] | Unset = UNSET
+        http_servers: list[dict[str, Any] | str] | Unset = UNSET
         if not isinstance(self.http_servers, Unset):
             http_servers = []
             for http_servers_item_data in self.http_servers:
-                http_servers_item = http_servers_item_data.to_dict()
+                http_servers_item: dict[str, Any] | str
+                if isinstance(http_servers_item_data, HttpServerSpec):
+                    http_servers_item = http_servers_item_data.to_dict()
+                else:
+                    http_servers_item = http_servers_item_data
                 http_servers.append(http_servers_item)
 
         field_dict: dict[str, Any] = {}
@@ -259,11 +264,23 @@ class WorkflowCreate:
                 mcp_servers.append(mcp_servers_item)
 
         _http_servers = d.pop("http_servers", UNSET)
-        http_servers: list[HttpServerSpec] | Unset = UNSET
+        http_servers: list[HttpServerSpec | str] | Unset = UNSET
         if _http_servers is not UNSET:
             http_servers = []
             for http_servers_item_data in _http_servers:
-                http_servers_item = HttpServerSpec.from_dict(http_servers_item_data)
+
+                def _parse_http_servers_item(data: object) -> HttpServerSpec | str:
+                    try:
+                        if not isinstance(data, dict):
+                            raise TypeError()
+                        http_servers_item_type_1 = HttpServerSpec.from_dict(data)
+
+                        return http_servers_item_type_1
+                    except (TypeError, ValueError, AttributeError, KeyError):
+                        pass
+                    return cast(HttpServerSpec | str, data)
+
+                http_servers_item = _parse_http_servers_item(http_servers_item_data)
 
                 http_servers.append(http_servers_item)
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/workflow_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/workflow_update.py
@@ -95,7 +95,7 @@ class WorkflowUpdate:
             description (None | str | Unset):
             tools (list[ToolSpec] | None | Unset):
             mcp_servers (list[McpServerSpec] | None | Unset):
-            http_servers (list[HttpServerSpec] | None | Unset):
+            http_servers (list[HttpServerSpec | str] | None | Unset):
     """
 
     version: int
@@ -106,9 +106,10 @@ class WorkflowUpdate:
     description: None | str | Unset = UNSET
     tools: list[ToolSpec] | None | Unset = UNSET
     mcp_servers: list[McpServerSpec] | None | Unset = UNSET
-    http_servers: list[HttpServerSpec] | None | Unset = UNSET
+    http_servers: list[HttpServerSpec | str] | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.http_server_spec import HttpServerSpec
         from ..models.workflow_update_input_schema_type_0 import (
             WorkflowUpdateInputSchemaType0,
         )
@@ -176,13 +177,17 @@ class WorkflowUpdate:
         else:
             mcp_servers = self.mcp_servers
 
-        http_servers: list[dict[str, Any]] | None | Unset
+        http_servers: list[dict[str, Any] | str] | None | Unset
         if isinstance(self.http_servers, Unset):
             http_servers = UNSET
         elif isinstance(self.http_servers, list):
             http_servers = []
             for http_servers_type_0_item_data in self.http_servers:
-                http_servers_type_0_item = http_servers_type_0_item_data.to_dict()
+                http_servers_type_0_item: dict[str, Any] | str
+                if isinstance(http_servers_type_0_item_data, HttpServerSpec):
+                    http_servers_type_0_item = http_servers_type_0_item_data.to_dict()
+                else:
+                    http_servers_type_0_item = http_servers_type_0_item_data
                 http_servers.append(http_servers_type_0_item)
 
         else:
@@ -340,7 +345,9 @@ class WorkflowUpdate:
 
         mcp_servers = _parse_mcp_servers(d.pop("mcp_servers", UNSET))
 
-        def _parse_http_servers(data: object) -> list[HttpServerSpec] | None | Unset:
+        def _parse_http_servers(
+            data: object,
+        ) -> list[HttpServerSpec | str] | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -351,7 +358,23 @@ class WorkflowUpdate:
                 http_servers_type_0 = []
                 _http_servers_type_0 = data
                 for http_servers_type_0_item_data in _http_servers_type_0:
-                    http_servers_type_0_item = HttpServerSpec.from_dict(
+
+                    def _parse_http_servers_type_0_item(
+                        data: object,
+                    ) -> HttpServerSpec | str:
+                        try:
+                            if not isinstance(data, dict):
+                                raise TypeError()
+                            http_servers_type_0_item_type_1 = HttpServerSpec.from_dict(
+                                data
+                            )
+
+                            return http_servers_type_0_item_type_1
+                        except (TypeError, ValueError, AttributeError, KeyError):
+                            pass
+                        return cast(HttpServerSpec | str, data)
+
+                    http_servers_type_0_item = _parse_http_servers_type_0_item(
                         http_servers_type_0_item_data
                     )
 
@@ -360,7 +383,7 @@ class WorkflowUpdate:
                 return http_servers_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(list[HttpServerSpec] | None | Unset, data)
+            return cast(list[HttpServerSpec | str] | None | Unset, data)
 
         http_servers = _parse_http_servers(d.pop("http_servers", UNSET))
 

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -307,6 +307,63 @@ def validate_http_servers(servers: list[HttpServerSpec]) -> None:
         seen.add(server.base_url)
 
 
+# ── names-only http_server declaration (Ask 3 from #939) ──────────────────────
+#
+# A workflow author may reference a grant the acting agent already holds by *name
+# alone* — ``http_servers: ["davenant"]`` — instead of reconstructing the full
+# ``HttpServerSpec(name=..., base_url=...)`` whose identity must match the agent's.
+# The bare name is resolved against the acting agent's servers at the authoring
+# edge (``aios.services.workflows``); the agent's ``base_url`` + frozen routes are
+# then inherited launcher-frozen into storage exactly as the #949 identity-match
+# path already does. This is **pure surface ergonomics**: a names-only entry can
+# only resolve to a server the agent already has, so it grants no new authority
+# and the run-time parent-wins-frozen resolution (keyed on the verbatim agent name)
+# is untouched.
+#
+# Resolution lives in the service (it needs the acting agent); aliasing — declaring
+# the agent's server under a *different* name with ``server_ref`` resolving against
+# the alias — is an open fork (#953) deliberately NOT shipped here: it would require
+# a run-time resolution change beyond the committed surface-only scope.
+
+HttpServerRef = str | HttpServerSpec
+"""An authoring-edge http_server entry: a bare name (names-only sugar, resolved
+against the acting agent) or a full ``HttpServerSpec`` (identity-match, #949)."""
+
+
+def resolve_http_server_refs(
+    refs: list[HttpServerRef], agent_servers: list[HttpServerSpec]
+) -> list[HttpServerSpec]:
+    """Resolve names-only entries against the acting agent's ``http_servers``.
+
+    Each ``str`` entry is replaced by ``HttpServerSpec(name=<name>, base_url=<the
+    agent's base_url for that name>, routes=[])`` — an empty-routes identity spec
+    the existing authoring gate then admits by identity and inherits frozen routes
+    into. A name with no matching agent server raises ``ValueError`` (the author
+    referenced a grant the agent does not hold). Full ``HttpServerSpec`` entries
+    pass through verbatim (the #949 identity-match path).
+
+    Resolution is by name; if the agent declares the same name at multiple
+    ``base_url``s the first is taken (agents validate ``base_url`` uniqueness, not
+    name uniqueness, so duplicate names are possible but the authoring gate then
+    flags any genuine mismatch downstream).
+    """
+    by_name: dict[str, HttpServerSpec] = {}
+    for s in agent_servers:
+        by_name.setdefault(s.name, s)
+    out: list[HttpServerSpec] = []
+    for ref in refs:
+        if isinstance(ref, str):
+            agent_server = by_name.get(ref)
+            if agent_server is None:
+                raise ValueError(
+                    f"http_servers references {ref!r}, which the acting agent does not grant"
+                )
+            out.append(HttpServerSpec(name=ref, base_url=agent_server.base_url, routes=[]))
+        else:
+            out.append(ref)
+    return out
+
+
 # ── Tool declaration ──────────────────────────────────────────────────────────
 
 

--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -486,6 +486,12 @@ def surface_diff(expected: Surface, actual: Surface) -> dict[str, list[str]]:
     are identity-keyed on ``(name, base_url)`` (membership only): a server is flagged iff
     its identity is absent from ``actual``, never for a route/field divergence — the
     authoring gate inherits the launcher's frozen routes, so identity is the whole test.
+
+    A legibility nicety (#953): ``actual`` survives a declared server on its ``base_url``
+    key but emits it under the launcher's verbatim name, so a declared server whose
+    ``base_url`` IS present under a *different* name is reported as ``"name mismatch at
+    <base_url>"`` rather than listed bare among absent servers — distinguishing "you named
+    it wrong" from "the agent has no such grant".
     """
     out: dict[str, list[str]] = {}
 
@@ -504,7 +510,18 @@ def surface_diff(expected: Surface, actual: Surface) -> dict[str, list[str]]:
         out["mcp_servers"] = bad_mcp
 
     actual_ids = {(s.name, s.base_url) for s in actual.http_servers}
-    bad_http = [s.name for s in expected.http_servers if (s.name, s.base_url) not in actual_ids]
+    actual_base_urls = {s.base_url for s in actual.http_servers}
+    bad_http: list[str] = []
+    for s in expected.http_servers:
+        if (s.name, s.base_url) in actual_ids:
+            continue
+        if s.base_url in actual_base_urls:
+            # The base_url survived (matched the launcher) but under a different name —
+            # the declared name diverges from the agent's. Say so, rather than listing
+            # the declared name among grants the agent wholly lacks.
+            bad_http.append(f"name mismatch at {s.base_url}")
+        else:
+            bad_http.append(s.name)
     if bad_http:
         out["http_servers"] = bad_http
 

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -19,7 +19,13 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, validate_http_servers
+from aios.models.agents import (
+    HttpServerRef,
+    HttpServerSpec,
+    McpServerSpec,
+    ToolSpec,
+    validate_http_servers,
+)
 
 WfRunStatus = Literal["pending", "running", "suspended", "completed", "errored", "cancelled"]
 WfRunEventType = Literal[
@@ -277,11 +283,17 @@ class WorkflowCreate(BaseModel):
     # path is unattenuated operator authority.
     tools: list[ToolSpec] = Field(default_factory=list)
     mcp_servers: list[McpServerSpec] = Field(default_factory=list)
-    http_servers: list[HttpServerSpec] = Field(default_factory=list)
+    # ``http_servers`` accepts either a full ``HttpServerSpec`` (identity-match, #949)
+    # or a bare name string (names-only sugar, #953) resolved against the acting
+    # agent at the authoring edge. The HTTP/operator path has no acting agent, so a
+    # bare name there is rejected by the service (nothing to resolve against).
+    http_servers: list[HttpServerRef] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _validate_http_servers(self) -> WorkflowCreate:
-        validate_http_servers(self.http_servers)
+        # Cross-item base_url uniqueness applies to full specs only; bare names
+        # carry no base_url until resolved against the agent (validated there).
+        validate_http_servers([s for s in self.http_servers if isinstance(s, HttpServerSpec)])
         return self
 
 
@@ -307,12 +319,14 @@ class WorkflowUpdate(BaseModel):
     description: str | None = None
     tools: list[ToolSpec] | None = None
     mcp_servers: list[McpServerSpec] | None = None
-    http_servers: list[HttpServerSpec] | None = None
+    # See ``WorkflowCreate.http_servers`` — bare names (names-only sugar, #953) or
+    # full ``HttpServerSpec`` (identity-match, #949); ``None`` preserves current.
+    http_servers: list[HttpServerRef] | None = None
 
     @model_validator(mode="after")
     def _validate_http_servers(self) -> WorkflowUpdate:
         if self.http_servers is not None:
-            validate_http_servers(self.http_servers)
+            validate_http_servers([s for s in self.http_servers if isinstance(s, HttpServerSpec)])
         return self
 
 

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -20,7 +20,13 @@ import asyncpg
 from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ConflictError, ForbiddenError, NotFoundError
-from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.agents import (
+    HttpServerRef,
+    HttpServerSpec,
+    McpServerSpec,
+    ToolSpec,
+    resolve_http_server_refs,
+)
 from aios.models.attenuation import Surface, surface_diff, surface_of
 from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
@@ -64,7 +70,7 @@ async def _enforce_surface_attenuation(
     actor_session_id: str,
     tools: list[ToolSpec],
     mcp_servers: list[McpServerSpec],
-    http_servers: list[HttpServerSpec],
+    http_servers: list[HttpServerRef],
 ) -> Surface:
     """Raise ``ForbiddenError`` unless the declared surface is admissible against the acting
     agent's; return the effective (clamped) surface for storage.
@@ -79,7 +85,9 @@ async def _enforce_surface_attenuation(
     * http_servers — identity survival: every declared ``(name, base_url)`` must appear in
       the clamp's http servers. The agent's routes/fields are inherited launcher-frozen
       into storage (the returned ``effective``), so a workflow need only name the server,
-      not reproduce its routes byte-perfect.
+      not reproduce its routes byte-perfect. A bare-name entry (names-only sugar, #953)
+      is resolved against the acting agent first — ``["davenant"]`` becomes the agent's
+      ``davenant`` server (empty routes), then admitted by identity like any other.
 
     http servers remain parent-wins-frozen at run-time (run-launch clamps to
     launcher-verbatim) — only the AUTHORING gate relaxes to identity, which grants no new
@@ -89,7 +97,17 @@ async def _enforce_surface_attenuation(
         pool, actor_session_id, account_id=account_id
     )
     agent = await agents_service.load_for_session(pool, session, account_id=account_id)
-    declared = Surface(tools, mcp_servers, http_servers)
+    # Resolve names-only entries against the acting agent (#953). An unknown name —
+    # a grant the agent does not hold — fails closed as a ForbiddenError, the same
+    # authority breach as declaring a server the agent lacks by full identity.
+    try:
+        resolved_http = resolve_http_server_refs(http_servers, agent.http_servers)
+    except ValueError as exc:
+        raise ForbiddenError(
+            "workflow surface exceeds the acting agent's permissions",
+            detail={"exceeds": {"http_servers": [r for r in http_servers if isinstance(r, str)]}},
+        ) from exc
+    declared = Surface(tools, mcp_servers, resolved_http)
     expected = attenuation_service.normalize(declared)
     effective = attenuation_service.clamp(declared, surface_of(agent))
     surviving_http = {(s.name, s.base_url) for s in effective.http_servers}
@@ -106,6 +124,28 @@ async def _enforce_surface_attenuation(
     return effective
 
 
+def _reject_operator_path_names_only(
+    http_servers: list[HttpServerRef] | None,
+) -> list[HttpServerSpec] | None:
+    """The HTTP/operator path has no acting agent to resolve a bare name against, so
+    names-only sugar (#953) is meaningless there — a bare string would otherwise leak
+    into storage as a non-``HttpServerSpec``. Reject it with a clear error; otherwise
+    return the input narrowed to ``list[HttpServerSpec]`` (no bare names remain).
+
+    Operators declaring an http_server must give a full ``HttpServerSpec`` (verbatim,
+    unattenuated). Names-only is an agent-authoring convenience, keyed on the actor.
+    """
+    if http_servers is None:
+        return None
+    bare = [s for s in http_servers if isinstance(s, str)]
+    if bare:
+        raise ForbiddenError(
+            "names-only http_servers require an acting agent to resolve against; "
+            f"the operator path must declare full HttpServerSpec objects (got bare names {bare!r})",
+        )
+    return [s for s in http_servers if isinstance(s, HttpServerSpec)]
+
+
 async def create_workflow(
     pool: asyncpg.Pool[Any],
     *,
@@ -117,7 +157,7 @@ async def create_workflow(
     description: str | None = None,
     tools: list[ToolSpec] | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
-    http_servers: list[HttpServerSpec] | None = None,
+    http_servers: list[HttpServerRef] | None = None,
     creator_session_id: str | None = None,
 ) -> Workflow:
     """Create a workflow definition.
@@ -127,10 +167,13 @@ async def create_workflow(
     be a subset of the creating agent's own — an agent cannot grant a workflow a tool or
     server it does not itself have; a breach raises :class:`ForbiddenError`. http servers
     are admitted by identity (name + base_url) and their routes inherited launcher-frozen
-    into storage. With no creator (the HTTP/operator path) any surface may be declared
-    verbatim, account-scoped.
+    into storage; a names-only entry (``["davenant"]``, #953) is resolved against the
+    creating agent first. With no creator (the HTTP/operator path) any surface may be
+    declared verbatim, account-scoped — but names-only sugar is unavailable there (no
+    acting agent to resolve against).
     """
     effective: Surface | None = None
+    operator_http: list[HttpServerSpec] | None = None
     if creator_session_id is not None:
         effective = await _enforce_surface_attenuation(
             pool,
@@ -140,9 +183,11 @@ async def create_workflow(
             mcp_servers=mcp_servers or [],
             http_servers=http_servers or [],
         )
+    else:
+        operator_http = _reject_operator_path_names_only(http_servers)
     # Agent-authored: store the agent's launcher-frozen http routes (inherited by identity).
-    # Operator path: store the declared http servers verbatim.
-    http_to_store = effective.http_servers if effective is not None else http_servers
+    # Operator path: store the declared http servers verbatim (bare names already rejected).
+    http_to_store = effective.http_servers if effective is not None else operator_http
     async with pool.acquire() as conn:
         return await wf_queries.insert_workflow(
             conn,
@@ -171,7 +216,7 @@ async def update_workflow(
     description: str | None = None,
     tools: list[ToolSpec] | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
-    http_servers: list[HttpServerSpec] | None = None,
+    http_servers: list[HttpServerRef] | None = None,
     actor_session_id: str | None = None,
 ) -> Workflow:
     """Update a workflow in place (optimistic concurrency on ``expected_version``).
@@ -187,9 +232,14 @@ async def update_workflow(
     launch; only runs created after the update see the new definition.
 
     http servers are admitted by identity and their routes inherited launcher-frozen into
-    storage (mirroring create); the operator path stores declared http verbatim.
+    storage (mirroring create); a names-only entry (#953) is resolved against the acting
+    agent. The operator path stores declared http verbatim and rejects names-only sugar
+    (no acting agent to resolve against).
     """
     effective: Surface | None = None
+    operator_http: list[HttpServerSpec] | None = None
+    if actor_session_id is None:
+        operator_http = _reject_operator_path_names_only(http_servers)
     if actor_session_id is not None:
         current = await get_workflow(pool, workflow_id, account_id=account_id)
         if current.version != expected_version:
@@ -207,21 +257,26 @@ async def update_workflow(
                     "id": workflow_id,
                 },
             )
+        # ``current.http_servers`` is the already-resolved stored spec; ``list(...)``
+        # widens it to ``list[HttpServerRef]`` for the (str | spec)-typed parameter.
+        merged_http: list[HttpServerRef] = (
+            http_servers if http_servers is not None else list(current.http_servers)
+        )
         effective = await _enforce_surface_attenuation(
             pool,
             account_id=account_id,
             actor_session_id=actor_session_id,
             tools=tools if tools is not None else current.tools,
             mcp_servers=mcp_servers if mcp_servers is not None else current.mcp_servers,
-            http_servers=http_servers if http_servers is not None else current.http_servers,
+            http_servers=merged_http,
         )
     # Agent-actor touching http: store the inherited launcher-frozen routes. Operator path,
     # or an edit that didn't touch http (``http_servers is None`` → query preserves current):
-    # pass the original argument through unchanged.
+    # pass the original argument through unchanged (operator bare names already rejected).
     http_to_store = (
         effective.http_servers
         if (effective is not None and http_servers is not None)
-        else http_servers
+        else operator_http
     )
     async with pool.acquire() as conn:
         return await wf_queries.update_workflow(

--- a/src/aios/tools/workflow_management.py
+++ b/src/aios/tools/workflow_management.py
@@ -382,8 +382,11 @@ async def resume_gate_handler(session_id: str, arguments: dict[str, Any]) -> dic
 CREATE_WORKFLOW_DESCRIPTION = (
     "Author a new workflow (a deterministic Python orchestrator) under your account. "
     "Its declared tool/server surface must be a subset of your own — you cannot grant a "
-    "workflow a tool, MCP server, or HTTP server you don't yourself have. Returns the "
-    "created workflow (id, name, version).\n\n"
+    "workflow a tool, MCP server, or HTTP server you don't yourself have. For HTTP "
+    'servers you may pass a bare name string (e.g. http_servers: ["github"]) to '
+    "reference one of your own grants by name — its base_url and routes are resolved "
+    "from you — or a full HttpServerSpec object. Returns the created workflow (id, name, "
+    "version).\n\n"
     f"{WORKFLOW_SCRIPT_CONTRACT}"
 )
 UPDATE_WORKFLOW_DESCRIPTION = (

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -500,6 +500,151 @@ async def test_update_time_http_missing_server_still_forbidden(
     assert fetched.version == 1
 
 
+# ─── #953: names-only http_servers declaration (Ask 3 follow-up) ─────────────
+#
+# A workflow author may reference the acting agent's http server by NAME ALONE —
+# ``http_servers=["api"]`` — instead of constructing a full HttpServerSpec whose
+# (name, base_url) must identity-match the agent's. The bare name resolves against
+# the acting agent (the agent's base_url + frozen routes inherited into storage),
+# exactly as the #949 identity-match path does. An unknown name fails closed; the
+# operator path (no acting agent) rejects bare names. Aliasing (a divergent local
+# name) is the open fork and is NOT shipped — run-time resolution is untouched.
+
+
+async def test_create_time_http_names_only_resolves_against_agent(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Create-time: a names-only entry resolves to the agent's server and stores the
+    agent's full launcher-frozen routes — identical to declaring the spec by identity."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(
+        name="api",
+        base_url="https://api",
+        routes=[
+            HttpRouteSpec(
+                path_pattern="/v1/**",
+                permission_policy=HttpPermissionPolicy(type="always_ask"),
+            )
+        ],
+    )
+    agent = await _make_agent(pool, "http-names-only", http_servers=[agent_http])
+    creator = await _make_session(pool, agent)
+
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-http-names-only",
+        script=_SCRIPT,
+        http_servers=["api"],  # names-only sugar
+        creator_session_id=creator,
+    )
+    fetched = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    assert fetched.http_servers == [agent_http]
+
+
+async def test_create_time_http_names_only_unknown_name_forbidden(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Create-time: a bare name the agent does not grant fails closed (no row leaks)."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(name="api", base_url="https://api")
+    agent = await _make_agent(pool, "http-names-only-2", http_servers=[agent_http])
+    creator = await _make_session(pool, agent)
+
+    before = await _workflow_count(pool)
+    with pytest.raises(ForbiddenError, match=r"exceeds the acting agent's permissions") as ei:
+        await wf_service.create_workflow(
+            pool,
+            account_id=ACC,
+            name="w-http-names-ghost",
+            script=_SCRIPT,
+            http_servers=["ghost"],
+            creator_session_id=creator,
+        )
+    assert ei.value.detail["exceeds"]["http_servers"] == ["ghost"]
+    assert await _workflow_count(pool) == before
+
+
+async def test_create_time_http_names_only_rejected_on_operator_path(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Operator path (no creator): names-only sugar has no agent to resolve against and is
+    rejected; the operator must declare a full HttpServerSpec."""
+    pool = vault_pool
+    before = await _workflow_count(pool)
+    with pytest.raises(ForbiddenError, match=r"names-only http_servers require an acting agent"):
+        await wf_service.create_workflow(
+            pool,
+            account_id=ACC,
+            name="w-http-op-names",
+            script=_SCRIPT,
+            http_servers=["api"],
+        )
+    assert await _workflow_count(pool) == before
+
+
+async def test_update_time_http_names_only_resolves_against_agent(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """Update-time: a names-only entry resolves against the acting agent and stores the
+    agent's full launcher-frozen routes."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(
+        name="api",
+        base_url="https://api",
+        routes=[
+            HttpRouteSpec(
+                path_pattern="/v1/**",
+                permission_policy=HttpPermissionPolicy(type="always_ask"),
+            )
+        ],
+    )
+    agent = await _make_agent(pool, "http-names-up", http_servers=[agent_http])
+    actor = await _make_session(pool, agent)
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="w-http-names-up",
+        script=_SCRIPT,
+        http_servers=[HttpServerSpec(name="api", base_url="https://api", routes=[])],
+    )
+
+    updated = await wf_service.update_workflow(
+        pool,
+        wf.id,
+        account_id=ACC,
+        expected_version=1,
+        http_servers=["api"],  # names-only sugar
+        actor_session_id=actor,
+    )
+    assert updated.version == 2
+    fetched = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    assert fetched.http_servers == [agent_http]
+
+
+async def test_create_time_http_name_mismatch_reports_base_url(
+    vault_pool: asyncpg.Pool[Any],
+) -> None:
+    """A full spec declaring the agent's base_url under a DIFFERENT name is rejected; the
+    exceeds detail reads as a name mismatch at the base_url, not a bare absent name (#953
+    legibility nicety). The authoring gate is unchanged — still rejected."""
+    pool = vault_pool
+    agent_http = HttpServerSpec(name="api", base_url="https://api")
+    agent = await _make_agent(pool, "http-mismatch", http_servers=[agent_http])
+    creator = await _make_session(pool, agent)
+
+    with pytest.raises(ForbiddenError, match=r"exceeds the acting agent's permissions") as ei:
+        await wf_service.create_workflow(
+            pool,
+            account_id=ACC,
+            name="w-http-mismatch",
+            script=_SCRIPT,
+            http_servers=[HttpServerSpec(name="aliased", base_url="https://api")],
+            creator_session_id=creator,
+        )
+    assert ei.value.detail["exceeds"]["http_servers"] == ["name mismatch at https://api"]
+
+
 async def test_run_cannot_bind_foreign_or_missing_vault(vault_pool: asyncpg.Pool[Any]) -> None:
     """A run binds only its own account's vaults; a foreign/unknown id rolls the insert back.
 

--- a/tests/unit/test_agents_models.py
+++ b/tests/unit/test_agents_models.py
@@ -102,3 +102,55 @@ class TestAgentUpdateHttpServers:
         update = AgentUpdate.model_validate({"version": 1})
 
         assert update.http_servers is None
+
+
+class TestResolveHttpServerRefs:
+    """#953: names-only ``http_servers`` resolution against an acting agent's servers.
+
+    A bare name resolves to an empty-routes identity spec at the agent's ``base_url``
+    (the existing #949 identity-match path then inherits the agent's frozen routes); an
+    unknown name raises; full ``HttpServerSpec`` entries pass through verbatim.
+    """
+
+    def test_bare_name_resolves_to_agent_base_url_empty_routes(self) -> None:
+        from aios.models.agents import HttpServerSpec, resolve_http_server_refs
+
+        agent = [
+            HttpServerSpec(
+                name="davenant",
+                base_url="https://davenant.example",
+                routes=[HttpRouteSpec(path_pattern="/v1/**")],
+            )
+        ]
+        out = resolve_http_server_refs(["davenant"], agent)
+        assert out == [
+            HttpServerSpec(name="davenant", base_url="https://davenant.example", routes=[])
+        ]
+
+    def test_unknown_name_raises(self) -> None:
+        from aios.models.agents import HttpServerSpec, resolve_http_server_refs
+
+        agent = [HttpServerSpec(name="davenant", base_url="https://davenant.example")]
+        with pytest.raises(ValueError, match=r"references 'ghost', which the acting agent"):
+            resolve_http_server_refs(["ghost"], agent)
+
+    def test_full_spec_passes_through_verbatim(self) -> None:
+        from aios.models.agents import HttpServerSpec, resolve_http_server_refs
+
+        spec = HttpServerSpec(name="api", base_url="https://api", routes=[])
+        out = resolve_http_server_refs([spec], [spec])
+        assert out == [spec]
+
+    def test_mixed_names_and_specs(self) -> None:
+        from aios.models.agents import HttpServerSpec, resolve_http_server_refs
+
+        agent = [
+            HttpServerSpec(name="davenant", base_url="https://davenant.example"),
+            HttpServerSpec(name="api", base_url="https://api"),
+        ]
+        spec = HttpServerSpec(name="api", base_url="https://api", routes=[])
+        out = resolve_http_server_refs(["davenant", spec], agent)
+        assert out == [
+            HttpServerSpec(name="davenant", base_url="https://davenant.example", routes=[]),
+            spec,
+        ]

--- a/tests/unit/test_attenuation.py
+++ b/tests/unit/test_attenuation.py
@@ -332,9 +332,12 @@ class TestSurfaceDiffHttpIdentity:
         assert surface_diff(expected, actual) == {"http_servers": ["api"]}
 
     def test_surface_diff_http_flags_renamed_server_same_base_url(self) -> None:
+        # #953 legibility nicety: a declared name that diverges from the agent's at the
+        # SAME base_url reads as "name mismatch at <base_url>", not bare among absent
+        # grants — distinguishing "named it wrong" from "the agent has no such grant".
         expected = canon(Surface([], [], [HttpServerSpec(name="api", base_url="https://api")]))
         actual = canon(Surface([], [], [HttpServerSpec(name="api2", base_url="https://api")]))
-        assert surface_diff(expected, actual) == {"http_servers": ["api"]}
+        assert surface_diff(expected, actual) == {"http_servers": ["name mismatch at https://api"]}
 
 
 # ── MCP toolset normal form ───────────────────────────────────────────────────

--- a/tests/unit/test_dev_pipeline_surface.py
+++ b/tests/unit/test_dev_pipeline_surface.py
@@ -22,6 +22,7 @@ needs it:
 
 from __future__ import annotations
 
+from aios.models.agents import HttpServerSpec
 from aios.models.workflows import WorkflowCreate
 from aios.workflows.dev_pipeline import (
     REQUIRED_HTTP_SERVERS,
@@ -140,6 +141,7 @@ def test_workflow_create_carries_required_http_servers() -> None:
     wc = build_dev_pipeline_workflow_create(name="dev-pipeline")
     assert len(wc.http_servers) == 1
     server = wc.http_servers[0]
+    assert isinstance(server, HttpServerSpec)
     assert server.name == "github"
     assert {r.path_pattern for r in server.routes} == {"/repos/**", "/graphql"}
 
@@ -154,5 +156,5 @@ def test_workflow_create_github_server_name_matches_script_server() -> None:
     # The http_server name on the payload must equal the script's GITHUB_SERVER constant,
     # or every tool('http_request', {server_ref: GITHUB_SERVER}) fails with unknown server.
     wc = build_dev_pipeline_workflow_create(name="dev-pipeline", github_server="gh")
-    assert any(s.name == "gh" for s in wc.http_servers)
+    assert any(isinstance(s, HttpServerSpec) and s.name == "gh" for s in wc.http_servers)
     assert "'gh'" in wc.script or '"gh"' in wc.script

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -91,6 +91,41 @@ class TestWorkflowCreate:
             "https://two.example.com",
         ]
 
+    def test_accepts_names_only_http_servers(self) -> None:
+        # #953 names-only sugar: a bare string references a grant the acting agent
+        # holds; it carries no base_url at the model layer (resolved in the service).
+        wf = WorkflowCreate.model_validate(
+            {
+                "name": "w",
+                "script": "async def main(i): return 1",
+                "http_servers": ["davenant"],
+            }
+        )
+        assert wf.http_servers == ["davenant"]
+
+    def test_accepts_mixed_names_and_specs(self) -> None:
+        wf = WorkflowCreate.model_validate(
+            {
+                "name": "w",
+                "script": "async def main(i): return 1",
+                "http_servers": ["davenant", _http_server("h", "https://api.example")],
+            }
+        )
+        assert wf.http_servers[0] == "davenant"
+        assert wf.http_servers[1].base_url == "https://api.example"
+
+    def test_bare_names_skip_base_url_uniqueness(self) -> None:
+        # The cross-item base_url uniqueness check applies to full specs only — two
+        # bare names (no base_url yet) never collide at the model layer.
+        wf = WorkflowCreate.model_validate(
+            {
+                "name": "w",
+                "script": "async def main(i): return 1",
+                "http_servers": ["davenant", "other"],
+            }
+        )
+        assert wf.http_servers == ["davenant", "other"]
+
 
 class TestWorkflowUpdate:
     def test_version_required_fields_optional(self) -> None:

--- a/tests/unit/test_workflows_models.py
+++ b/tests/unit/test_workflows_models.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from aios.models.agents import HttpServerSpec
 from aios.models.workflows import GateResume, WfRun, WfRunCreate, WorkflowCreate, WorkflowUpdate
 
 
@@ -50,6 +51,7 @@ class TestWorkflowCreate:
             }
         )
         assert wf.mcp_servers[0].url == "https://srv.example"
+        assert isinstance(wf.http_servers[0], HttpServerSpec)
         assert wf.http_servers[0].base_url == "https://api.example"
         assert wf.tools == []
 
@@ -86,7 +88,11 @@ class TestWorkflowCreate:
             }
         )
 
-        assert [server.base_url for server in workflow.http_servers] == [
+        assert [
+            server.base_url
+            for server in workflow.http_servers
+            if isinstance(server, HttpServerSpec)
+        ] == [
             "https://one.example.com",
             "https://two.example.com",
         ]
@@ -112,6 +118,7 @@ class TestWorkflowCreate:
             }
         )
         assert wf.http_servers[0] == "davenant"
+        assert isinstance(wf.http_servers[1], HttpServerSpec)
         assert wf.http_servers[1].base_url == "https://api.example"
 
     def test_bare_names_skip_base_url_uniqueness(self) -> None:
@@ -161,7 +168,9 @@ class TestWorkflowUpdate:
         )
 
         assert update.http_servers is not None
-        assert [server.base_url for server in update.http_servers] == [
+        assert [
+            server.base_url for server in update.http_servers if isinstance(server, HttpServerSpec)
+        ] == [
             "https://one.example.com",
             "https://two.example.com",
         ]


### PR DESCRIPTION
## What

Implements the **committed half** of eumemic/eumemic-ops#303 (the explicit follow-up to eumemic/eumemic-ops#301/#949): a workflow author may declare an HTTP-server grant by **name alone** —

```python
http_servers: ["davenant"]
```

— instead of constructing a full `HttpServerSpec(name=..., base_url=...)` whose `(name, base_url)` must identity-match the acting agent's. The bare name is resolved against the acting agent at the authoring edge: it becomes an empty-routes identity spec at the agent's `base_url`, which the existing eumemic/aios#949 identity-match path then admits by identity and **inherits the agent's frozen routes** into workflow storage.

## Scope discipline (the open fork is NOT shipped)

The issue title carries two halves with different status. Only the **committed** half (names-only declaration) is implemented here. **Aliasing** — declaring the agent's server under a *different* local name with run-time `server_ref` resolving against the alias — is the open chairman fork and is deliberately left out: it would require a run-time resolution change beyond the committed *surface-ergonomics-only* scope. This change makes **no change to run-time parent-wins-frozen authority**: a names-only entry can only resolve to a grant the agent already holds, so it grants no new authority, and run-time `_find_server` resolution (keyed on the verbatim agent name) is untouched.

## Changes

- **`models/agents.py`**: `HttpServerRef = str | HttpServerSpec` + `resolve_http_server_refs()` (bare name → agent's empty-routes identity spec; unknown name raises; full specs pass through).
- **`models/workflows.py`**: `WorkflowCreate`/`WorkflowUpdate.http_servers` accept the union; the base_url-uniqueness validator applies to full specs only (bare names carry no base_url until resolved).
- **`services/workflows.py`**: resolve names against the acting agent in the create/update authoring gate; an unknown name **fails closed** as `ForbiddenError` (the same authority breach as declaring a missing server); the HTTP/operator path (no acting agent) rejects bare names with a clear error.
- **`models/attenuation.py` `surface_diff`**: the legibility nicety from the issue — a declared name diverging from the agent's at the *same* `base_url` is reported as `"name mismatch at <base_url>"` rather than listed bare among grants the agent wholly lacks.
- **`tools/workflow_management.py`**: `create_workflow` tool description documents the names-only sugar.
- Regenerated `openapi.json` + typed SDK snapshots (`workflow_create.py`, `workflow_update.py`).

## Tests (test-first)

- **Unit** (`test_agents_models.py`): `resolve_http_server_refs` — bare-name resolution to empty-routes spec, unknown-name raises, full-spec passthrough, mixed list.
- **Unit** (`test_workflows_models.py`): the models accept bare names, mixed lists, and skip base_url-uniqueness for bare names.
- **Unit** (`test_attenuation.py`): updated the renamed-server diff test to the new `"name mismatch at <base_url>"` message.
- **Integration** (`test_wf_run_vaults.py`): create/update names-only resolves against the agent and stores frozen routes; unknown name forbidden (no row leaks); operator path rejects bare names; full-spec name divergence reports the base_url mismatch and the authoring gate still rejects it.

Full unit suite green (3020 passed); ruff + mypy clean. Integration/e2e tests require a Postgres testcontainer + Docker (unavailable in the implement sandbox) and run in CI.