### PR TITLE
feat(workflows): create-time script validation — compile + async def main(input) + AST-derived tool/surface union check (#1285)

### DIFF
--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -304,17 +304,20 @@ async def update_workflow(
     agent. The operator path stores declared http verbatim and rejects names-only sugar
     (no acting agent to resolve against).
     """
-    # Create-time validation (#1285) applies on UPDATE too. Only when this update
-    # actually replaces the script (``script is None`` preserves the stored — already
-    # validated — body). Validated against the MERGED tool surface (new ``tools`` if
-    # given, else the workflow's current tools). Fetch the current definition once here;
-    # the actor branch below re-reads under the version pin for its attenuation check.
-    if script is not None:
+    # Create-time validation (#1285) applies on UPDATE too. Runs whenever the update
+    # touches EITHER the script or the tool surface (``script is not None or tools is
+    # not None``): a tools-only update that narrows away a tool the STORED (unchanged)
+    # script still calls is itself surface drift, so re-validating only on a script
+    # change would leave that hole open. Validated against the EFFECTIVE merged surface
+    # — the new ``script`` if given else the stored body, against the new ``tools`` if
+    # given else the stored tools. Fetch the current definition once here; the actor
+    # branch below re-reads under the version pin for its attenuation check.
+    if script is not None or tools is not None:
         current_for_validation = await get_workflow(pool, workflow_id, account_id=account_id)
         await _validate_script_surface(
             pool,
             account_id=account_id,
-            script=script,
+            script=script if script is not None else current_for_validation.script,
             tools=tools if tools is not None else current_for_validation.tools,
         )
     effective: Surface | None = None

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -19,7 +19,7 @@ import asyncpg
 
 from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
-from aios.errors import ConflictError, ForbiddenError, NotFoundError
+from aios.errors import ConflictError, ForbiddenError, NotFoundError, ValidationError
 from aios.models.agents import (
     HttpServerRef,
     HttpServerSpec,
@@ -40,6 +40,11 @@ from aios.services import attenuation as attenuation_service
 from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
+from aios.workflows.script_validation import (
+    declared_tool_names,
+    extract_required_agent_ids,
+    validate_workflow_script,
+)
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
@@ -146,6 +151,65 @@ def _reject_operator_path_names_only(
     return [s for s in http_servers if isinstance(s, HttpServerSpec)]
 
 
+async def _validate_script_surface(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    script: str,
+    tools: list[ToolSpec],
+) -> None:
+    """Create-time validation of a workflow ``script`` (#1285).
+
+    Two halves of one check, run at author time so a structural or surface-drift
+    failure surfaces as a :class:`ValidationError` (a 4xx, turned into a clean
+    model-visible result by the tool dispatch layer) instead of a failed *run*:
+
+    * **Structural + script-local surface** — compile, top-level
+      ``async def main(input)``, and every string-literal ``tool("X")`` covered by
+      the declared ``tools``. Pure/AST (no pool); see
+      :func:`aios.workflows.script_validation.validate_workflow_script`.
+    * **Named-agent surface union** — for every string-literal
+      ``agent(agent_id="A")``, the run's declared surface must cover that child
+      agent's declared **tool** surface, or the #794 ``agent ∩ run`` clamp would
+      silently strip the child's tools at launch (the omitted-DELETE / omitted-PATCH
+      production incidents ``dev_pipeline.py`` records). Resolution needs the pool,
+      so it lives here, not in the pure validator.
+
+      **Chosen depth (documented in the PR):** resolve the child agent and require
+      the declared **tools** to be a superset of the child agent's declared tools. A
+      literal ``agent_id`` that does **not** resolve to a live same-account agent is
+      **skipped** (no false rejection) — such a call fails loud at run time as
+      ``agent_not_found``, which is a *different* failure class than surface drift and
+      out of scope for this create-time check. MCP / http-server union for child
+      agents is left to a follow-up; tool union covers the recorded incidents.
+    """
+    # Structural + script-local tool surface (raises ValidationError on failure).
+    validate_workflow_script(script, tools)
+
+    required_agent_ids = extract_required_agent_ids(script)
+    if not required_agent_ids:
+        return
+    declared = declared_tool_names(tools)
+    for agent_id in sorted(required_agent_ids):
+        try:
+            child = await agents_service.get_agent(pool, agent_id, account_id=account_id)
+        except NotFoundError:
+            # Un-resolvable (absent / archived / cross-account) — not a surface-drift
+            # failure; it fails loud at run time as ``agent_not_found``. Skip.
+            continue
+        child_tool_names = declared_tool_names([t for t in child.tools if t.enabled])
+        missing = sorted(child_tool_names - declared)
+        if missing:
+            joined = ", ".join(repr(m) for m in missing)
+            raise ValidationError(
+                f"workflow script invokes agent(agent_id={agent_id!r}) whose declared "
+                f"tool(s) {joined} are not in the workflow's declared tool surface; the "
+                "child surface is agent ∩ run (#794) — under-declaring silently strips "
+                "those tools from the child at launch. Add them to the workflow's `tools`",
+                detail={"agent_id": agent_id, "missing_tools": missing},
+            )
+
+
 async def create_workflow(
     pool: asyncpg.Pool[Any],
     *,
@@ -172,6 +236,10 @@ async def create_workflow(
     declared verbatim, account-scoped — but names-only sugar is unavailable there (no
     acting agent to resolve against).
     """
+    # Create-time validation (#1285): compile + `async def main(input)` + the declared
+    # surface must cover every literal tool("…")/agent(agent_id="…") the script uses.
+    # Runs on EVERY path (agent author + HTTP/operator), against the declared `tools`.
+    await _validate_script_surface(pool, account_id=account_id, script=script, tools=tools or [])
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if creator_session_id is not None:
@@ -236,6 +304,19 @@ async def update_workflow(
     agent. The operator path stores declared http verbatim and rejects names-only sugar
     (no acting agent to resolve against).
     """
+    # Create-time validation (#1285) applies on UPDATE too. Only when this update
+    # actually replaces the script (``script is None`` preserves the stored — already
+    # validated — body). Validated against the MERGED tool surface (new ``tools`` if
+    # given, else the workflow's current tools). Fetch the current definition once here;
+    # the actor branch below re-reads under the version pin for its attenuation check.
+    if script is not None:
+        current_for_validation = await get_workflow(pool, workflow_id, account_id=account_id)
+        await _validate_script_surface(
+            pool,
+            account_id=account_id,
+            script=script,
+            tools=tools if tools is not None else current_for_validation.tools,
+        )
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if actor_session_id is None:

--- a/src/aios/workflows/script_validation.py
+++ b/src/aios/workflows/script_validation.py
@@ -1,0 +1,222 @@
+"""Create-time validation of a workflow ``script`` (#1285, bakeoff of #1221).
+
+A workflow is authored out-of-band as an inert ``script: str``. Before this module
+the *only* contract checked at author time was the pydantic length/shape of the
+field — every structural and surface-drift failure surfaced **late**, only as a
+failed *run* read back off the journal:
+
+1. **Syntax / structure** — a typo, or a missing top-level ``async def main(input)``,
+   was not caught until the host ``exec``'d the script inside a run.
+2. **Silent surface drift** — the declared ``tools`` / ``http_servers`` /
+   ``mcp_servers`` are authored *separately* from the script but must cover the
+   union of the script's own ``tool("…")`` calls (and its named ``agent(agent_id=…)``
+   children — resolved in the service layer, see ``services.workflows``). An
+   under-declared surface is **silently clamped** at run launch (#794), so the
+   script hits a runtime route-mismatch, not a load error. ``dev_pipeline.py``
+   records two production incidents from exactly this (an omitted ``DELETE`` that
+   silently no-op'd every unlabel; an omitted ``PATCH`` that left merged issues open).
+
+This module lifts the host's own ``compile(...)`` to create time and adds two AST
+checks, so all of class (1) and the *script-local* half of class (2) are caught as
+an **authoring-time** :class:`ValidationError` (a 4xx — the tool dispatch layer turns
+it into a clean, model-visible result) instead of a failed run.
+
+**Design (SETTLED — #1285): validate-declared, literal-only.** The author writes the
+declared surface; the validator checks it is a **superset** of the AST-extracted
+*required* surface. A ``tool(name, …)`` whose name is **not a string literal**
+(computed / a variable / from ``input``) is **un-AST-able** and is **excluded** from
+the required-surface check — the validator neither rejects on it nor attempts to
+resolve it. Only string-literal names participate.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from aios.errors import ValidationError
+from aios.models.agents import ToolSpec
+
+__all__ = [
+    "declared_tool_names",
+    "extract_required_agent_ids",
+    "validate_workflow_script",
+]
+
+
+def declared_tool_names(tools: list[ToolSpec]) -> set[str]:
+    """The set of names a ``tool("…")`` call may legitimately reference.
+
+    The run-tool gate (:func:`aios.workflows.run_tools.gate_run_tool`) matches a
+    call against ``t.type`` (the builtin tool name, e.g. ``"bash"``,
+    ``"http_request"``). A ``custom`` tool is invoked by its ``t.name``. We accept
+    **either** so the literal-extraction check stays permissive (never a false
+    rejection) while still catching a flatly omitted tool. Disabled tools are
+    included: an author may intentionally ship a disabled tool the script names —
+    it resolves to a recoverable ``{"error": …}`` at run time, not a load failure,
+    so it is not the create-time concern this validator guards.
+    """
+    names: set[str] = set()
+    for spec in tools:
+        names.add(spec.type)
+        if spec.name is not None:
+            names.add(spec.name)
+    return names
+
+
+def _main_def(tree: ast.Module) -> ast.AsyncFunctionDef | ast.FunctionDef | None:
+    """The LAST top-level ``def``/``async def`` named ``main`` (last binding wins,
+    mirroring ``exec`` namespace semantics where a later definition shadows an
+    earlier one)."""
+    found: ast.AsyncFunctionDef | ast.FunctionDef | None = None
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and node.name == "main":
+            found = node
+    return found
+
+
+def _accepts_single_input(fn: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    """True iff ``fn`` can be called as ``main(input_value)`` — exactly one positional
+    argument.
+
+    The host invokes the entry point **positionally** (``entry(input_value)`` in
+    ``wf_script_host._build_coroutine``), so the check is on ARITY, not the parameter
+    *name*: ``async def main(input)`` and ``async def main(i)`` are equally valid (the
+    canonical name in the contract/docs is ``input``, but a differently-named single
+    parameter binds the same value — and many existing workflows use ``i``). Accepts
+    the single-positional shape (incl. ``def main(input, /)``) and a ``*args``
+    catch-all; rejects ``main()`` (too few — the run's ``input`` would have nowhere to
+    bind), ``main(a, b)`` (too many, no catch-all), and a sole parameter that is
+    *keyword-only* (``def main(*, input)`` — cannot be filled positionally).
+    """
+    args = fn.args
+    positional = args.posonlyargs + args.args
+    # Exactly one positional parameter (no catch-all needed), OR no declared
+    # positional params but a ``*args`` catch-all that still binds the one value.
+    return (len(positional) == 1 and args.vararg is None) or (
+        len(positional) == 0 and args.vararg is not None
+    )
+
+
+def validate_workflow_script(script: str, tools: list[ToolSpec]) -> None:
+    """Validate a workflow ``script`` at author time. Raises :class:`ValidationError`
+    (no return) on the first failure; returns ``None`` when the script passes the
+    structural + script-local-surface checks.
+
+    Checks, in order:
+
+    1. **Compile** — ``compile(script, "<workflow>", "exec", dont_inherit=True)``
+       (the exact host call, lifted from the run path). A failure raises naming it a
+       compile/syntax error, surfacing line/offset where the ``SyntaxError`` carries
+       them.
+    2. **``main`` exists** — a top-level ``async def main`` (AST).
+    3. **``main`` is well-signatured** — ``async`` (not a plain ``def``) and accepting
+       the single ``input`` parameter.
+    4. **Tool surface superset** — every string-literal ``tool("X", …)`` name is in
+       the declared ``tools``; a missing one raises naming ``X``.
+
+    The named-``agent(agent_id="A")`` half of the surface union is resolved against
+    the live agent in the service layer (it needs the pool); see
+    :func:`extract_required_agent_ids`.
+    """
+    # 1. Compile — mirror the host (wf_script_host._build_coroutine) exactly.
+    try:
+        compile(script, "<workflow>", "exec", dont_inherit=True)
+    except SyntaxError as exc:
+        where = ""
+        if exc.lineno is not None:
+            where = f" (line {exc.lineno}" + (
+                f", offset {exc.offset})" if exc.offset is not None else ")"
+            )
+        raise ValidationError(
+            f"workflow script failed to compile{where}: {exc.msg}",
+            detail={"lineno": exc.lineno, "offset": exc.offset, "msg": exc.msg},
+        ) from exc
+
+    tree = ast.parse(script)
+
+    # 2. + 3. A correctly-signatured top-level ``async def main(input)``.
+    main = _main_def(tree)
+    if main is None:
+        raise ValidationError(
+            "workflow script must define a top-level `async def main(input)` "
+            "(no such function found)"
+        )
+    if not isinstance(main, ast.AsyncFunctionDef):
+        raise ValidationError(
+            "workflow script `main` must be `async def main(input)` — "
+            "the top-level `main` is a plain `def`, not `async`"
+        )
+    if not _accepts_single_input(main):
+        raise ValidationError(
+            "workflow script `main` must accept the single `input` parameter "
+            "(`async def main(input)`)"
+        )
+
+    # 4. Tool surface superset (literal-only). A non-literal name is un-AST-able and
+    #    excluded — not a violation.
+    declared = declared_tool_names(tools)
+    missing = sorted(name for name in _extract_literal_tool_names(tree) if name not in declared)
+    if missing:
+        joined = ", ".join(repr(m) for m in missing)
+        raise ValidationError(
+            f"workflow script calls tool(s) {joined} not in the declared tool surface; "
+            "add them to the workflow's `tools` (the declared surface must cover every "
+            'literal tool("…") the script calls)',
+            detail={"missing_tools": missing},
+        )
+
+
+def _string_literal(node: ast.expr | None) -> str | None:
+    """The value of ``node`` if it is a plain string-literal constant, else ``None``
+    (so a computed / variable / f-string expression is treated as un-AST-able)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _extract_literal_tool_names(tree: ast.Module) -> set[str]:
+    """String-literal first-positional names of every ``tool("…", …)`` call.
+
+    Matches a bare ``tool(...)`` call (the injected builtin; the author namespace
+    binds ``tool`` directly — see ``wf_script_host.author_namespace``). A call whose
+    first argument is not a string literal is **excluded** (un-AST-able), per the
+    settled literal-only design.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (isinstance(node.func, ast.Name) and node.func.id == "tool"):
+            continue
+        first = node.args[0] if node.args else None
+        literal = _string_literal(first)
+        if literal is not None:
+            names.add(literal)
+    return names
+
+
+def extract_required_agent_ids(script: str) -> set[str]:
+    """String-literal ``agent_id`` values of every ``agent(..., agent_id="A")`` call.
+
+    The service layer resolves each to the live child agent and folds its declared
+    surface into the required-surface union (the #794 ``agent ∩ run`` clamp): the
+    run's declared surface must cover it, or the clamp would silently strip the
+    child's tools. A non-literal ``agent_id`` (from ``input`` / a variable / omitted
+    for the generic subagent) is un-AST-able and excluded.
+
+    Pure/AST-only and importable without a pool, so callers that only need the
+    structural checks (and tests) can use it standalone.
+    """
+    tree = ast.parse(script)
+    ids: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (isinstance(node.func, ast.Name) and node.func.id == "agent"):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "agent_id":
+                literal = _string_literal(kw.value)
+                if literal is not None:
+                    ids.add(literal)
+    return ids

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -278,8 +278,10 @@ async def test_update_workflow_roundtrip_and_stale_409(http_client: httpx.AsyncC
     assert "v2" in updated["script"]
     assert updated["name"] == name
 
-    # Stale token → 409; unknown id → 404.
-    r = await http_client.put(f"/v1/workflows/{wf['id']}", json={"version": 1, "script": "x"})
+    # Stale token → 409; unknown id → 404. Use a structurally valid script so the
+    # create-time script validation (#1285, which on UPDATE runs before the version /
+    # existence checks for an existing workflow) does not pre-empt the 409/404 under test.
+    r = await http_client.put(f"/v1/workflows/{wf['id']}", json={"version": 1, "script": _SCRIPT})
     assert r.status_code == 409
-    r = await http_client.put("/v1/workflows/wf_nope", json={"version": 1, "script": "x"})
+    r = await http_client.put("/v1/workflows/wf_nope", json={"version": 1, "script": _SCRIPT})
     assert r.status_code == 404

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -89,7 +89,7 @@ async def _seed_workflow(pool: asyncpg.Pool[Any], *, account_id: str) -> str:
         pool,
         account_id=account_id,
         name="invocations-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -61,7 +61,7 @@ async def _seed_parent_run(pool: asyncpg.Pool[Any], *, account_id: str, environm
         pool,
         account_id=account_id,
         name="request-opened-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_trace_walk.py
+++ b/tests/integration/test_trace_walk.py
@@ -60,7 +60,7 @@ async def _seed_run(
         pool,
         account_id=account_id,
         name=f"trace-walk-wf-{uuid4().hex}",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_wf_create_time_validation.py
+++ b/tests/integration/test_wf_create_time_validation.py
@@ -250,14 +250,40 @@ async def test_update_rejects_under_declared_tool_against_merged_surface(
     assert "http_request" in str(exc.value)
 
 
-async def test_update_without_script_change_is_not_revalidated(pool: asyncpg.Pool[Any]) -> None:
-    # An update that does not touch the script preserves the (already-validated) body and
-    # is not re-checked — a description-only edit succeeds.
+async def test_update_without_script_or_tools_change_is_not_revalidated(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    # An update that touches neither script nor tools preserves the (already-validated)
+    # body and surface and is not re-checked — a description-only edit succeeds.
     wf = await wf_service.create_workflow(pool, account_id=ACC, name="u3", script=_VALID)
     updated = await wf_service.update_workflow(
         pool, wf.id, account_id=ACC, expected_version=wf.version, description="touched"
     )
     assert updated.description == "touched" and updated.version == wf.version + 1
+
+
+async def test_update_tools_only_validates_against_current_script(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    # Updating ONLY tools must re-validate the EFFECTIVE pair: the stored script calls
+    # tool('bash'); narrowing tools to [] (dropping bash) must be rejected, because the
+    # unchanged stored script still calls it — a tools-only surface-drift hole.
+    script = "async def main(input):\n    return await tool('bash', {'command': 'ls'})\n"
+    wf = await wf_service.create_workflow(
+        pool, account_id=ACC, name="u5", script=script, tools=[ToolSpec(type="bash")]
+    )
+    with pytest.raises(ValidationError) as exc:
+        await wf_service.update_workflow(
+            pool,
+            wf.id,
+            account_id=ACC,
+            expected_version=wf.version,
+            tools=[],  # drops bash → stored script's tool('bash') no longer covered
+        )
+    assert "bash" in str(exc.value)
+    # The stored definition is unchanged (still at its original version, bash retained).
+    after = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    assert after.version == wf.version and {t.type for t in after.tools} == {"bash"}
 
 
 async def test_update_accepts_valid_new_script(pool: asyncpg.Pool[Any]) -> None:

--- a/tests/integration/test_wf_create_time_validation.py
+++ b/tests/integration/test_wf_create_time_validation.py
@@ -1,0 +1,274 @@
+"""Integration coverage for create-time workflow-script validation (#1285).
+
+Drives the **service path** (``aios.services.workflows.create_workflow`` /
+``update_workflow``) against a real Postgres, asserting the acceptance criteria hold
+at create AND update time, on both the operator path (no actor) and the agent-author
+path (criterion 5, the named-``agent(agent_id=…)`` surface union — which needs a live
+agent to resolve, so it cannot live in the pure unit tests).
+
+The tool-handler path (``create_workflow_handler`` in ``tools.workflow_management``)
+is a thin wrapper that calls this same service function, so enforcing here enforces
+there too (criterion 8); the pure structural criteria (1-4, 6, 7) are additionally
+covered without a DB in ``tests/unit/test_workflow_script_validation.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.db import queries as db_queries
+from aios.db.pool import create_pool
+from aios.errors import ValidationError
+from aios.harness import runtime
+from aios.models.agents import Agent, ToolSpec
+from aios.services import agents as agents_service
+from aios.services import workflows as wf_service
+
+pytestmark = pytest.mark.integration
+
+ACC = "acc_wfv"
+ENV = "env_wfv"
+
+_VALID = "async def main(input):\n    return input\n"
+
+
+@pytest.fixture
+async def pool(migrated_db_url: str, _reset_db_state: None) -> AsyncIterator[asyncpg.Pool[Any]]:
+    p = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = p
+    try:
+        async with p.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ('acc_wfv', NULL, TRUE, 'wfv-root')"
+            )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ('env_wfv', 'wfv-env', '{}'::jsonb, 'acc_wfv')"
+            )
+        with (
+            mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
+        ):
+            yield p
+    finally:
+        runtime.pool = prev
+        await p.close()
+
+
+async def _make_agent(
+    pool: asyncpg.Pool[Any], name: str, *, tools: list[ToolSpec] | None = None
+) -> Agent:
+    return await agents_service.create_agent(
+        pool,
+        account_id=ACC,
+        name=name,
+        model="test/dummy",
+        system="x",
+        tools=tools or [],
+        mcp_servers=None,
+        http_servers=None,
+        description=None,
+        metadata={},
+        window_min=1000,
+        window_max=100000,
+    )
+
+
+async def _make_session(pool: asyncpg.Pool[Any], agent: Agent) -> str:
+    async with pool.acquire() as conn:
+        session = await db_queries.insert_session(
+            conn,
+            account_id=ACC,
+            agent_id=agent.id,
+            environment_id=ENV,
+            agent_version=agent.version,
+            title=None,
+            metadata={},
+        )
+    return session.id
+
+
+# ─── create: criteria 1-4, 6, 7 on the operator path ─────────────────────────
+
+
+async def test_create_rejects_syntax_error(pool: asyncpg.Pool[Any]) -> None:
+    with pytest.raises(ValidationError) as exc:
+        await wf_service.create_workflow(
+            pool, account_id=ACC, name="bad", script="async def main(input):\n    return (\n"
+        )
+    assert "compile" in str(exc.value)
+    # Not created.
+    assert (await wf_service.list_workflows(pool, account_id=ACC)) == []
+
+
+async def test_create_rejects_missing_main(pool: asyncpg.Pool[Any]) -> None:
+    with pytest.raises(ValidationError) as exc:
+        await wf_service.create_workflow(pool, account_id=ACC, name="nm", script="x = 1\n")
+    assert "main" in str(exc.value)
+    assert (await wf_service.list_workflows(pool, account_id=ACC)) == []
+
+
+async def test_create_rejects_plain_def_main(pool: asyncpg.Pool[Any]) -> None:
+    with pytest.raises(ValidationError):
+        await wf_service.create_workflow(
+            pool, account_id=ACC, name="pd", script="def main(input):\n    return 1\n"
+        )
+    assert (await wf_service.list_workflows(pool, account_id=ACC)) == []
+
+
+async def test_create_rejects_bad_arity_main(pool: asyncpg.Pool[Any]) -> None:
+    with pytest.raises(ValidationError):
+        await wf_service.create_workflow(
+            pool, account_id=ACC, name="ar", script="async def main(a, b):\n    return 1\n"
+        )
+    assert (await wf_service.list_workflows(pool, account_id=ACC)) == []
+
+
+async def test_create_rejects_under_declared_tool(pool: asyncpg.Pool[Any]) -> None:
+    script = "async def main(input):\n    return await tool('bash', {'command': 'ls'})\n"
+    with pytest.raises(ValidationError) as exc:
+        await wf_service.create_workflow(pool, account_id=ACC, name="ud", script=script)
+    assert "bash" in str(exc.value)
+    assert (await wf_service.list_workflows(pool, account_id=ACC)) == []
+
+
+async def test_create_accepts_fully_covered(pool: asyncpg.Pool[Any]) -> None:
+    script = "async def main(input):\n    return await tool('bash', {'command': 'ls'})\n"
+    wf = await wf_service.create_workflow(
+        pool, account_id=ACC, name="ok", script=script, tools=[ToolSpec(type="bash")]
+    )
+    assert wf.id
+    assert wf.script == script
+    assert {t.type for t in wf.tools} == {"bash"}
+
+
+async def test_create_accepts_unastable_tool_name(pool: asyncpg.Pool[Any]) -> None:
+    # A computed tool name is excluded from the required-surface check — accepted even
+    # with an empty tool surface.
+    script = "async def main(input):\n    name = input['tool']\n    return await tool(name, {})\n"
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="dyn", script=script)
+    assert wf.id
+
+
+# ─── criterion 5: named-agent surface union (needs a live agent) ─────────────
+
+
+async def test_create_rejects_under_declared_agent_surface(pool: asyncpg.Pool[Any]) -> None:
+    # A child agent that declares `read`+`write`; the workflow declares only `read`.
+    # The #794 clamp (agent ∩ run) would silently strip `write` from the child -> reject.
+    child = await _make_agent(pool, "child", tools=[ToolSpec(type="read"), ToolSpec(type="write")])
+    agent_id = child.id
+    script = f"async def main(input):\n    return await agent({{'x': 1}}, agent_id={agent_id!r})\n"
+    with pytest.raises(ValidationError) as exc:
+        await wf_service.create_workflow(
+            pool, account_id=ACC, name="ag", script=script, tools=[ToolSpec(type="read")]
+        )
+    assert "write" in str(exc.value)
+    assert exc.value.detail is not None and "write" in exc.value.detail["missing_tools"]
+
+
+async def test_create_accepts_covered_agent_surface(pool: asyncpg.Pool[Any]) -> None:
+    child = await _make_agent(pool, "child2", tools=[ToolSpec(type="read"), ToolSpec(type="write")])
+    agent_id = child.id
+    script = f"async def main(input):\n    return await agent({{'x': 1}}, agent_id={agent_id!r})\n"
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=ACC,
+        name="ag-ok",
+        script=script,
+        tools=[ToolSpec(type="read"), ToolSpec(type="write")],
+    )
+    assert wf.id
+
+
+async def test_create_accepts_unknown_agent_id(pool: asyncpg.Pool[Any]) -> None:
+    # A literal agent_id that does not resolve to a live same-account agent is skipped
+    # (it fails loud at run time as agent_not_found — a different failure class).
+    script = "async def main(input):\n    return await agent({'x': 1}, agent_id='does-not-exist')\n"
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="ghost", script=script)
+    assert wf.id
+
+
+# ─── agent-author path enforces the same checks (criterion 8) ────────────────
+
+
+async def test_agent_author_path_enforces_validation(pool: asyncpg.Pool[Any]) -> None:
+    agent = await _make_agent(pool, "author", tools=[ToolSpec(type="bash")])
+    session_id = await _make_session(pool, agent)
+    bad = "async def main(input):\n    return (\n"
+    with pytest.raises(ValidationError):
+        await wf_service.create_workflow(
+            pool,
+            account_id=ACC,
+            name="auth",
+            script=bad,
+            tools=[ToolSpec(type="bash")],
+            creator_session_id=session_id,
+        )
+
+
+# ─── update enforces the same checks (criteria 1-7 on update) ────────────────
+
+
+async def test_update_rejects_syntax_error(pool: asyncpg.Pool[Any]) -> None:
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="u1", script=_VALID)
+    with pytest.raises(ValidationError) as exc:
+        await wf_service.update_workflow(
+            pool,
+            wf.id,
+            account_id=ACC,
+            expected_version=wf.version,
+            script="async def main(input):\n    return (\n",
+        )
+    assert "compile" in str(exc.value)
+    # The stored definition is unchanged (still at its original version).
+    after = await wf_service.get_workflow(pool, wf.id, account_id=ACC)
+    assert after.version == wf.version and after.script == _VALID
+
+
+async def test_update_rejects_under_declared_tool_against_merged_surface(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    # Created with bash declared; an update that introduces a tool('http_request') call
+    # without adding it to tools is rejected against the merged surface.
+    wf = await wf_service.create_workflow(
+        pool, account_id=ACC, name="u2", script=_VALID, tools=[ToolSpec(type="bash")]
+    )
+    new_script = "async def main(input):\n    return await tool('http_request', {})\n"
+    with pytest.raises(ValidationError) as exc:
+        await wf_service.update_workflow(
+            pool, wf.id, account_id=ACC, expected_version=wf.version, script=new_script
+        )
+    assert "http_request" in str(exc.value)
+
+
+async def test_update_without_script_change_is_not_revalidated(pool: asyncpg.Pool[Any]) -> None:
+    # An update that does not touch the script preserves the (already-validated) body and
+    # is not re-checked — a description-only edit succeeds.
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="u3", script=_VALID)
+    updated = await wf_service.update_workflow(
+        pool, wf.id, account_id=ACC, expected_version=wf.version, description="touched"
+    )
+    assert updated.description == "touched" and updated.version == wf.version + 1
+
+
+async def test_update_accepts_valid_new_script(pool: asyncpg.Pool[Any]) -> None:
+    wf = await wf_service.create_workflow(pool, account_id=ACC, name="u4", script=_VALID)
+    new_script = "async def main(input):\n    return await tool('bash', {'command': 'ls'})\n"
+    updated = await wf_service.update_workflow(
+        pool,
+        wf.id,
+        account_id=ACC,
+        expected_version=wf.version,
+        script=new_script,
+        tools=[ToolSpec(type="bash")],
+    )
+    assert updated.script == new_script and updated.version == wf.version + 1

--- a/tests/unit/test_workflow_script_validation.py
+++ b/tests/unit/test_workflow_script_validation.py
@@ -1,0 +1,227 @@
+"""Unit tests for create-time workflow-script validation (#1285).
+
+These exercise the **pure** validator (``aios.workflows.script_validation``) — no DB,
+no pool — covering the structural and script-local-surface acceptance criteria:
+
+* (1) syntax / compile failure
+* (2) missing top-level ``async def main``
+* (3) mis-signatured ``main`` (plain ``def``; wrong arity)
+* (4) under-declared tool surface (literal ``tool("X")`` not in ``tools``)
+* (6) a valid, fully-covered script passes
+* (7) un-AST-able (computed/variable) tool names + agent ids cause no false rejection
+
+The named-``agent(agent_id="…")`` surface union (criterion 5) is resolved against the
+live agent in the service layer and is covered by the integration tests
+(``test_wf_create_time_validation``); here we assert only the AST extraction it builds on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.errors import ValidationError
+from aios.models.agents import ToolSpec
+from aios.workflows.script_validation import (
+    declared_tool_names,
+    extract_required_agent_ids,
+    validate_workflow_script,
+)
+
+_VALID_MAIN = "async def main(input):\n    return input\n"
+
+
+# ─── (1) syntax / compile ────────────────────────────────────────────────────
+
+
+def test_syntax_error_is_rejected_with_compile_message() -> None:
+    script = "async def main(input):\n    return (\n"  # unbalanced paren
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    msg = str(exc.value)
+    assert "compile" in msg
+    # Line is surfaced where the SyntaxError carries it.
+    assert "line" in msg
+    assert exc.value.detail is not None and exc.value.detail.get("lineno") is not None
+
+
+def test_stray_token_is_a_compile_failure() -> None:
+    script = "async def main(input):\n    x = 1 2 3\n    return x\n"
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    assert "compile" in str(exc.value)
+
+
+# ─── (2) missing main ────────────────────────────────────────────────────────
+
+
+def test_missing_main_is_rejected() -> None:
+    script = "x = 1\nasync def helper(input):\n    return input\n"
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    assert "async def main(input)" in str(exc.value)
+
+
+def test_main_nested_inside_function_is_not_top_level() -> None:
+    script = "def outer():\n    async def main(input):\n        return input\n"
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    assert "async def main(input)" in str(exc.value)
+
+
+# ─── (3) mis-signatured main ─────────────────────────────────────────────────
+
+
+def test_plain_def_main_is_rejected() -> None:
+    script = "def main(input):\n    return input\n"
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    assert "async" in str(exc.value)
+
+
+def test_main_with_no_params_is_rejected() -> None:
+    script = "async def main():\n    return 1\n"
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    assert "input" in str(exc.value)
+
+
+def test_main_with_two_params_is_rejected() -> None:
+    script = "async def main(a, b):\n    return a\n"
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    assert "input" in str(exc.value)
+
+
+def test_main_with_differently_named_single_param_is_accepted() -> None:
+    # The host calls the entry point positionally, so arity — not the parameter name —
+    # is what matters. `main(i)` / `main(payload)` bind the run's input just like
+    # `main(input)`. Many existing workflows use `i`; rejecting on the name would break
+    # them.
+    validate_workflow_script("async def main(payload):\n    return payload\n", [])
+    validate_workflow_script("async def main(i):\n    return i\n", [])
+
+
+def test_main_keyword_only_input_is_rejected() -> None:
+    # `main(*, input)` cannot be called positionally as `main(value)`.
+    script = "async def main(*, input):\n    return input\n"
+    with pytest.raises(ValidationError):
+        validate_workflow_script(script, [])
+
+
+def test_main_posonly_input_is_accepted() -> None:
+    validate_workflow_script("async def main(input, /):\n    return input\n", [])
+
+
+def test_main_star_args_is_accepted() -> None:
+    # A `*args` catch-all still binds the single positional `input`.
+    validate_workflow_script("async def main(*args):\n    return args\n", [])
+
+
+def test_last_main_binding_wins() -> None:
+    # exec semantics: a later top-level `main` shadows an earlier one. The valid (async)
+    # one is last -> accepted.
+    script = "def main(input):\n    return 1\nasync def main(input):\n    return 2\n"
+    validate_workflow_script(script, [])
+    # ...and the reverse (valid first, broken last) is rejected on the last binding.
+    script2 = "async def main(input):\n    return 1\ndef main(input):\n    return 2\n"
+    with pytest.raises(ValidationError):
+        validate_workflow_script(script2, [])
+
+
+# ─── (4) under-declared tool surface ─────────────────────────────────────────
+
+
+def test_under_declared_tool_is_rejected_naming_the_tool() -> None:
+    script = "async def main(input):\n    r = await tool('bash', {'command': 'ls'})\n    return r\n"
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [])
+    assert "bash" in str(exc.value)
+    assert exc.value.detail is not None
+    assert "bash" in exc.value.detail["missing_tools"]
+
+
+def test_under_declared_lists_all_missing_tools() -> None:
+    script = (
+        "async def main(input):\n"
+        "    await tool('bash', {})\n"
+        "    await tool('http_request', {})\n"
+        "    return 1\n"
+    )
+    with pytest.raises(ValidationError) as exc:
+        validate_workflow_script(script, [ToolSpec(type="bash")])
+    # bash is declared; http_request is not -> only http_request is named.
+    assert exc.value.detail is not None
+    assert exc.value.detail["missing_tools"] == ["http_request"]
+
+
+def test_custom_tool_name_satisfies_the_declared_surface() -> None:
+    script = "async def main(input):\n    return await tool('my_tool', {})\n"
+    tools = [
+        ToolSpec(type="custom", name="my_tool", description="d", input_schema={"type": "object"})
+    ]
+    validate_workflow_script(script, tools)
+
+
+# ─── (6) valid, fully-covered ────────────────────────────────────────────────
+
+
+def test_valid_fully_covered_script_passes() -> None:
+    script = (
+        "async def main(input):\n"
+        "    out = await tool('bash', {'command': 'echo hi'})\n"
+        "    res = await agent({'task': 't'}, agent_id='impl')\n"
+        "    return {'out': out, 'res': res}\n"
+    )
+    validate_workflow_script(script, [ToolSpec(type="bash")])  # agent surface checked in service
+
+
+def test_no_tools_no_agents_minimal_script_passes() -> None:
+    validate_workflow_script(_VALID_MAIN, [])
+
+
+# ─── (7) un-AST-able names — no false rejection ──────────────────────────────
+
+
+def test_computed_tool_name_is_excluded_not_rejected() -> None:
+    script = "async def main(input):\n    name = input['tool']\n    return await tool(name, {})\n"
+    # Un-AST-able first arg -> excluded from the required-surface check. Accepted.
+    validate_workflow_script(script, [])
+
+
+def test_fstring_tool_name_is_excluded() -> None:
+    script = "async def main(input):\n    return await tool(f\"t_{input['x']}\", {})\n"
+    validate_workflow_script(script, [])
+
+
+def test_agent_id_from_input_is_excluded() -> None:
+    script = "async def main(input):\n    return await agent({'x': 1}, agent_id=input['a'])\n"
+    # No literal agent_id -> nothing required of the surface; accepted.
+    assert extract_required_agent_ids(script) == set()
+    validate_workflow_script(script, [])
+
+
+# ─── AST extraction helpers ──────────────────────────────────────────────────
+
+
+def test_extract_required_agent_ids_literal_only() -> None:
+    script = (
+        "async def main(input):\n"
+        "    await agent({}, agent_id='impl')\n"
+        "    await agent({}, agent_id='review')\n"
+        "    await agent({}, agent_id=input['x'])\n"  # excluded
+        "    await agent({})\n"  # generic subagent, no agent_id — excluded
+        "    return 1\n"
+    )
+    assert extract_required_agent_ids(script) == {"impl", "review"}
+
+
+def test_declared_tool_names_covers_type_and_custom_name() -> None:
+    names = declared_tool_names(
+        [
+            ToolSpec(type="bash"),
+            ToolSpec(type="custom", name="foo", description="d", input_schema={}),
+        ]
+    )
+    assert "bash" in names
+    assert "foo" in names
+    assert "custom" in names


### PR DESCRIPTION
## What

Closes #1221 (workflow create-time validation). Closes the late-failure + surface-drift discoverability gap for #1285 / #777.

Adds a **create-time validator** to the workflow service so the three structural failure classes that previously surfaced only as a *failed run* are now an **authoring-time** `ValidationError` (a 4xx — the tool dispatch layer turns it into a clean, model-visible result):

1. **Compile / syntax** — lifts the host's own `compile(source, "<workflow>", "exec", dont_inherit=True)` (from `wf_script_host`) to create time, surfacing line/offset.
2. **Missing / mis-signatured `main`** — AST-asserts a top-level `async def main(…)`.
3. **Under-declared tool/surface** — AST-extracts string-literal `tool("X")` names and string-literal `agent(agent_id="A")` references and checks the **declared surface is a superset** (validate-declared, literal-only — the settled fork).

## How

- **New pure module `src/aios/workflows/script_validation.py`** — `validate_workflow_script(script, tools)`: compile → top-level `async def main` → single-positional arity → literal `tool("X")` superset against declared `tools`. Plus `extract_required_agent_ids` / `declared_tool_names` helpers. No I/O, importable without a pool.
- **Service layer `src/aios/services/workflows.py`** — `create_workflow` and `update_workflow` call a new `_validate_script_surface`, which runs the pure validator AND resolves each literal `agent(agent_id="A")` child against the live agent, requiring the workflow's declared **tools** to cover the child agent's declared tools (the #794 `agent ∩ run` clamp; the omitted-DELETE/omitted-PATCH production incidents `dev_pipeline.py` records). Enforced on **create and update**; on update, validation runs whenever the script **or** the tool surface changes, against the **effective merged** pair (new `script` if given else the stored body, new `tools` if given else the stored tools) — so a tools-only update that narrows away a tool the stored script still calls is caught (criterion 8). The `create_workflow_handler` tool path calls the same service fn, so it is covered too.

## Design decisions (documented per the issue)

- **Validate-declared, literal-only.** A non-string-literal `tool(name, …)` / `agent_id` (computed / variable / from `input`) is **un-AST-able** and **excluded** from the required-surface check — never a false rejection (criterion 7).
- **`main` signature = ARITY, not parameter name.** The host invokes the entry point positionally (`entry(input_value)`), so `async def main(input)` and `async def main(i)` are equally valid; rejecting on the name would break many existing workflows/tests. We reject `main()` (too few), `main(a, b)` (too many, no catch-all), keyword-only `main(*, input)`, and a plain (non-async) `def main`. The canonical name in the contract stays `input`.
- **Named-agent depth.** The chosen depth is the child agent's **tool** union: resolve the agent and require the declared tools to be a superset. A literal `agent_id` that does not resolve to a live same-account agent is **skipped** (it fails loud at run time as `agent_not_found` — a different failure class, out of scope). MCP/http-server union for child agents is left to a follow-up; tool union covers the two recorded incidents.
- **Update re-validates on a tools-only change too.** The update gate fires on `script is not None or tools is not None` and validates the *effective* surface (incoming tools against the currently-stored script when the script isn't being replaced). A tools-only update that drops a tool the stored, unchanged script still calls is itself surface drift; gating only on a script change would leave that hole open (criterion 8).
- Value-domain / determinism traps (failure class 3) are explicitly **out of scope** (pairs with #934), as the issue states.

## Tests

- **`tests/unit/test_workflow_script_validation.py`** (no DB) — criteria 1–4, 6, 7: syntax/stray-token, missing/nested `main`, plain-`def`, bad arity, keyword-only, posonly/`*args` accepted, differently-named single param accepted, last-binding-wins, under-declared tool (names the tool), custom-tool-name coverage, computed/f-string tool names + `input`-derived agent ids excluded, AST-extraction helpers.
- **`tests/integration/test_wf_create_time_validation.py`** — the service path on create + update (operator and agent-author), incl. criterion 5 (named-agent surface union: under-declared rejected naming the missing tool, covered accepted, unknown agent_id skipped), and update-time enforcement (syntax, merged-surface tool check, **tools-only narrowing re-validated against the stored script**, update touching neither script nor tools not re-validated, valid new script accepted).
- Three existing integration tests that seeded workflows via the service with a placeholder `def main(ctx)` are updated to a valid `async def main(input)` (the script was never executed there).

Lint (ruff check + format), typecheck (mypy), and the unit + affected integration suites are green locally. Integration tests require Docker/Postgres and run in CI.
