### PR TITLE
feat(workflows): create-time validation — compile + assert async def main(input) + AST-derived tool/surface union check

### DIFF
--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -19,7 +19,7 @@ import asyncpg
 
 from aios.db.listen import open_listen_for_run_events
 from aios.db.queries import workflows as wf_queries
-from aios.errors import ConflictError, ForbiddenError, NotFoundError
+from aios.errors import ConflictError, ForbiddenError, NotFoundError, ValidationError
 from aios.models.agents import (
     HttpServerRef,
     HttpServerSpec,
@@ -41,6 +41,11 @@ from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
 from aios.workflows.service import create_run, resume_gate
+from aios.workflows.validation import (
+    ExtractedSurface,
+    declared_tool_name,
+    validate_workflow_script,
+)
 
 __all__ = [
     "archive_workflow",
@@ -146,6 +151,62 @@ def _reject_operator_path_names_only(
     return [s for s in http_servers if isinstance(s, HttpServerSpec)]
 
 
+async def _check_agent_surface(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    extracted: ExtractedSurface,
+    declared_tools: list[ToolSpec] | None,
+) -> None:
+    """Validate-declared coverage of string-literal ``agent(agent_id="A")`` references.
+
+    Surface-model depth (documented in the PR): a named child wields ``agent ∩ run``
+    (the #794 clamp), so a tool the child needs but the run under-declares is
+    **silently stripped** at spawn. We therefore resolve each *string-literal*
+    ``agent_id`` and require the declared tool surface to cover that agent's own
+    declared tools (the union half contributed by the named child). The error names
+    the missing tool(s) and the agent that needs them.
+
+    Bounded, false-rejection-free depth choices:
+      * **Un-AST-able** ``agent_id`` (computed / from ``input`` / a variable) never
+        reaches here — it is excluded by the literal-only AST extraction.
+      * An ``agent_id`` that **does not resolve** (no such agent in the account *yet*)
+        is **not** a create-time rejection: the agent may be authored later, and a run
+        would surface ``agent_not_found`` as a recoverable value. Rejecting here would
+        be a false positive against a still-valid authoring order.
+      * Only the named agent's **own** tools participate (one hop); a child's transitive
+        ``agent()`` fan-out is out of scope (it is gated at its own spawn).
+    """
+    if not extracted.agent_ids:
+        return
+    declared_names = {declared_tool_name(t) for t in (declared_tools or [])}
+    missing_by_agent: dict[str, list[str]] = {}
+    for agent_id in sorted(extracted.agent_ids):
+        try:
+            agent = await agents_service.get_agent(pool, agent_id, account_id=account_id)
+        except NotFoundError:
+            # Authoring may precede the named agent's creation; do not false-reject.
+            continue
+        missing = sorted(
+            declared_tool_name(t)
+            for t in agent.tools
+            if t.enabled and declared_tool_name(t) not in declared_names
+        )
+        if missing:
+            missing_by_agent[agent_id] = missing
+    if missing_by_agent:
+        parts = "; ".join(
+            f"agent {aid!r} needs " + ", ".join(repr(m) for m in tools)
+            for aid, tools in sorted(missing_by_agent.items())
+        )
+        raise ValidationError(
+            "workflow script references agent(s) whose required tools are not present "
+            f"in the declared `tools` surface ({parts}); a named agent child wields "
+            "agent ∩ run, so the under-declared tools would be silently stripped",
+            detail={"reason": "undeclared_agent_surface", "missing_by_agent": missing_by_agent},
+        )
+
+
 async def create_workflow(
     pool: asyncpg.Pool[Any],
     *,
@@ -172,6 +233,13 @@ async def create_workflow(
     declared verbatim, account-scoped — but names-only sugar is unavailable there (no
     acting agent to resolve against).
     """
+    # Create-time validation (#1284): compile + assert `async def main(input)` +
+    # validate the declared surface is a superset of the AST-extracted required surface
+    # (literal-only). Raises a model-visible ValidationError before any row is written.
+    extracted = validate_workflow_script(script, tools=tools)
+    await _check_agent_surface(
+        pool, account_id=account_id, extracted=extracted, declared_tools=tools
+    )
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if creator_session_id is not None:
@@ -236,6 +304,23 @@ async def update_workflow(
     agent. The operator path stores declared http verbatim and rejects names-only sugar
     (no acting agent to resolve against).
     """
+    # Create-time validation applies on update too (#1284): validate the MERGED
+    # result — an omitted ``script``/``tools`` preserves the stored value, so the
+    # script that will run after this update is ``script if script is not None else
+    # current.script`` checked against ``tools if tools is not None else
+    # current.tools``. Fetch current once here when either is omitted (the actor path
+    # re-reads below for the version-pinned attenuation; this read is account-scoped
+    # and cheap). Runs before any write, so a rejected update mutates nothing.
+    current_wf: Workflow | None = None
+    if script is None or tools is None:
+        current_wf = await get_workflow(pool, workflow_id, account_id=account_id)
+    merged_script = script if script is not None else (current_wf.script if current_wf else "")
+    merged_tools = tools if tools is not None else (current_wf.tools if current_wf else None)
+    extracted = validate_workflow_script(merged_script, tools=merged_tools)
+    await _check_agent_surface(
+        pool, account_id=account_id, extracted=extracted, declared_tools=merged_tools
+    )
+
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if actor_session_id is None:

--- a/src/aios/workflows/validation.py
+++ b/src/aios/workflows/validation.py
@@ -1,0 +1,250 @@
+"""Create-time validation of a workflow author script (#1284, part of #777).
+
+A workflow is authored as an inert ``script: str`` whose only contract is a
+docstring, and its declared tool/server surface is authored *separately* from the
+script. Historically three failure classes surfaced late — only as a *failed run*
+read back from the journal — instead of at authoring time:
+
+1. **Syntax / structure errors** — a typo, or a missing top-level
+   ``async def main(input)``, was not caught until the host ``exec``'d the script
+   in a run.
+2. **Silent surface drift** — the run's declared ``tools`` / ``http_servers`` /
+   ``mcp_servers`` must be the **union** of the script's own ``tool("…")`` calls
+   and every named ``agent(agent_id="…")`` child's surface (child surface =
+   ``agent ∩ run``, the #794 clamp). Under-declaring let the clamp **silently
+   strip** the missing tools, and the script hit a runtime route-mismatch — not a
+   load error. ``dev_pipeline.py`` documents two production incidents from exactly
+   this (an omitted ``DELETE`` silently no-op'd every unlabel; an omitted ``PATCH``
+   left merged issues open).
+
+This module lifts the compile the host already does
+(:func:`aios.workflows.wf_script_host._build_coroutine`) to **create time**, plus
+an AST structure check and an AST-derived **validate-declared** surface check, and
+raises a precise :class:`aios.errors.ValidationError` (a clean 4xx, model-visible).
+
+**Design decision (SETTLED — validate-declared, NOT auto-derive).** The author
+writes the declared surface; the validator checks the declared surface is a
+**superset** of the AST-extracted *required* surface. When a ``tool(name, …)`` name
+or an ``agent_id`` is **not a string literal** (computed / a variable / from
+``input``), that element is **un-AST-able** and is **excluded** from the
+required-surface check — the validator neither rejects on it nor tries to resolve
+it. Only string-literal ``tool("…")`` names and string-literal
+``agent(agent_id="…")`` references participate in the union.
+
+Value-domain / determinism traps (failure class 3) are out of scope here (#934).
+"""
+
+from __future__ import annotations
+
+import ast
+
+from aios.errors import ValidationError
+from aios.models.agents import ToolSpec
+
+# The filename the host compiles under (``aios.workflows.wf_script_host``); kept
+# identical so a create-time compile error reports the same ``<workflow>`` frame
+# an author would see from a run traceback.
+_COMPILE_FILENAME = "<workflow>"
+
+
+def declared_tool_name(spec: ToolSpec) -> str:
+    """The name a ``tool("…")`` call uses to reference this declared tool.
+
+    Mirrors the run-time surface gate (:func:`aios.workflows.run_tools.gate_run_tool`,
+    which keys builtins by ``type``) and the attenuation tool identity: a custom tool
+    is referenced by its ``name``; an MCP toolset by its server name; every other
+    (builtin) tool by its ``type`` string (``"bash"``, ``"http_request"``, …).
+    """
+    if spec.type == "custom":
+        return spec.name or ""
+    if spec.type == "mcp_toolset":
+        return spec.mcp_server_name or ""
+    return str(spec.type)
+
+
+def _literal_str(node: ast.expr | None) -> str | None:
+    """Return the value of ``node`` iff it is a string literal, else ``None``.
+
+    A non-literal (a ``Name``, an attribute, a subscript of ``input``, an f-string,
+    a call result) is **un-AST-able** and excluded from the required-surface check.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+class _SurfaceVisitor(ast.NodeVisitor):
+    """Collect string-literal ``tool("…")`` names and ``agent(agent_id="…")`` ids.
+
+    Only the **first positional argument** of a ``tool(...)`` call (its ``name``) and
+    the **``agent_id`` keyword** of an ``agent(...)`` call participate — matching the
+    injected capability signatures ``tool(name, input)`` and
+    ``agent(input, *, agent_id=None, …)``. Bare-name (un-AST-able) calls are skipped.
+    """
+
+    def __init__(self) -> None:
+        self.tool_names: set[str] = set()
+        self.agent_ids: set[str] = set()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        # We match the *injected* builtins by their bare name only (``tool(...)`` /
+        # ``agent(...)``); an attribute access (``obj.tool(...)``) is something else.
+        if isinstance(func, ast.Name):
+            if func.id == "tool" and node.args:
+                name = _literal_str(node.args[0])
+                if name is not None:
+                    self.tool_names.add(name)
+            elif func.id == "agent":
+                for kw in node.keywords:
+                    if kw.arg == "agent_id":
+                        agent_id = _literal_str(kw.value)
+                        if agent_id is not None:
+                            self.agent_ids.add(agent_id)
+        self.generic_visit(node)
+
+
+class ExtractedSurface:
+    """The AST-extracted required surface (literal-only) of a workflow script."""
+
+    __slots__ = ("agent_ids", "tool_names")
+
+    def __init__(self, tool_names: set[str], agent_ids: set[str]) -> None:
+        self.tool_names = tool_names
+        self.agent_ids = agent_ids
+
+
+def _check_main_signature(tree: ast.Module) -> None:
+    """Assert a top-level ``async def main(input)`` exists with the right shape.
+
+    Rejected (create-time :class:`ValidationError`):
+      * no top-level ``main`` at all,
+      * a ``main`` that is not ``async`` (a plain ``def main``),
+      * an ``async def main`` whose signature does not accept the single ``input``
+        parameter (``async def main()``, ``async def main(a, b)``, a required
+        second parameter, ``*args``/``**kwargs`` only, …).
+
+    Exactly one positional parameter is required; its *name* is not enforced (the
+    contract names it ``input``, but the load-bearing check is arity — a single
+    ``input`` arg). A trailing default on that one parameter is fine
+    (``async def main(input=None)`` still binds ``main(input)``); any second
+    parameter, ``*args``, or keyword-only parameter is rejected.
+    """
+    async_main: ast.AsyncFunctionDef | None = None
+    plain_main: ast.FunctionDef | None = None
+    for stmt in tree.body:
+        if isinstance(stmt, ast.AsyncFunctionDef) and stmt.name == "main":
+            async_main = stmt
+        elif isinstance(stmt, ast.FunctionDef) and stmt.name == "main":
+            plain_main = stmt
+
+    if async_main is None:
+        if plain_main is not None:
+            raise ValidationError(
+                "workflow script defines `main` but it is not async; the entry point "
+                "must be `async def main(input)`",
+                detail={"reason": "main_not_async"},
+            )
+        raise ValidationError(
+            "workflow script must define a top-level `async def main(input)` entry point",
+            detail={"reason": "missing_main"},
+        )
+
+    args = async_main.args
+    # The single accepted parameter may arrive positional-or-keyword or
+    # positional-only; ``input`` is conventionally positional-or-keyword.
+    positional = list(args.posonlyargs) + list(args.args)
+    n_positional = len(positional)
+    # ``main(input)`` must bind exactly one positional argument: reject zero
+    # parameters, and reject a second *required* positional parameter. A second
+    # parameter that carries a default would still bind ``main(input)``, but the
+    # contract is a single ``input`` — keep it strict and reject extra params.
+    if n_positional != 1 or args.vararg is not None or args.kwonlyargs:
+        raise ValidationError(
+            "workflow `async def main` must accept exactly the single `input` "
+            f"parameter (`async def main(input)`); got signature with {n_positional} "
+            "positional parameter(s)"
+            + (" plus *args" if args.vararg is not None else "")
+            + (" plus keyword-only parameter(s)" if args.kwonlyargs else ""),
+            detail={"reason": "bad_main_signature"},
+        )
+
+
+def extract_required_surface(script: str) -> ExtractedSurface:
+    """Compile-check ``script``, assert ``async def main(input)``, and AST-extract
+    the literal-only required surface.
+
+    Raises :class:`aios.errors.ValidationError` (a create-time 422, model-visible)
+    for a compile/syntax failure, a missing ``main``, or a mis-signatured ``main``.
+    Returns the :class:`ExtractedSurface` (string-literal ``tool`` names + ``agent_id``
+    references) for the caller's surface-coverage check.
+    """
+    # 1. Compile — the host already does exactly this (``dont_inherit=True``) in the
+    #    exec path; lift it here and surface a precise, line/offset-bearing error.
+    try:
+        compile(script, _COMPILE_FILENAME, "exec", dont_inherit=True)
+    except SyntaxError as exc:
+        where = ""
+        if exc.lineno is not None:
+            where = f" (line {exc.lineno}"
+            if exc.offset is not None:
+                where += f", offset {exc.offset}"
+            where += ")"
+        raise ValidationError(
+            f"workflow script failed to compile: {exc.msg}{where}",
+            detail={
+                "reason": "compile_error",
+                "lineno": exc.lineno,
+                "offset": exc.offset,
+                "msg": exc.msg,
+            },
+        ) from exc
+
+    # ``ast.parse`` cannot raise here — ``compile`` above already accepted the source.
+    tree = ast.parse(script, filename=_COMPILE_FILENAME)
+
+    # 2. Assert the entry point shape.
+    _check_main_signature(tree)
+
+    # 3. AST-extract the literal-only required surface.
+    visitor = _SurfaceVisitor()
+    visitor.visit(tree)
+    return ExtractedSurface(visitor.tool_names, visitor.agent_ids)
+
+
+def check_tool_surface(
+    required_tool_names: set[str], declared_tools: list[ToolSpec] | None
+) -> None:
+    """Raise :class:`ValidationError` if a literal ``tool("X")`` name is not declared.
+
+    Validate-declared: the declared tool surface must be a **superset** of the
+    AST-extracted required tool names. A missing name is named in the error.
+    """
+    declared_names = {declared_tool_name(t) for t in (declared_tools or [])}
+    missing = sorted(name for name in required_tool_names if name not in declared_names)
+    if missing:
+        raise ValidationError(
+            "workflow script calls tool(s) not present in the declared `tools` surface: "
+            + ", ".join(repr(m) for m in missing)
+            + " — add them to the workflow's declared tools (the surface must be a "
+            "superset of the tools the script calls)",
+            detail={"reason": "undeclared_tools", "missing_tools": missing},
+        )
+
+
+def validate_workflow_script(
+    script: str,
+    *,
+    tools: list[ToolSpec] | None = None,
+) -> ExtractedSurface:
+    """The single create-/update-time validator entry point (structure + tool surface).
+
+    Compile + ``async def main(input)`` assertion + literal-only tool-surface
+    superset check. Returns the :class:`ExtractedSurface` so a caller with DB access
+    (the service path) can additionally resolve and check string-literal ``agent_id``
+    references against the declared surface (see
+    :func:`aios.services.workflows._check_agent_surface`).
+    """
+    extracted = extract_required_surface(script)
+    check_tool_surface(extracted.tool_names, tools)
+    return extracted

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -279,7 +279,9 @@ async def test_update_workflow_roundtrip_and_stale_409(http_client: httpx.AsyncC
     assert updated["name"] == name
 
     # Stale token → 409; unknown id → 404.
-    r = await http_client.put(f"/v1/workflows/{wf['id']}", json={"version": 1, "script": "x"})
+    # (`script` is a valid `async def main(input)` here so create-time validation
+    # passes and the stale-version / missing-id checks are what return 409 / 404.)
+    r = await http_client.put(f"/v1/workflows/{wf['id']}", json={"version": 1, "script": _SCRIPT})
     assert r.status_code == 409
-    r = await http_client.put("/v1/workflows/wf_nope", json={"version": 1, "script": "x"})
+    r = await http_client.put("/v1/workflows/wf_nope", json={"version": 1, "script": _SCRIPT})
     assert r.status_code == 404

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -89,7 +89,7 @@ async def _seed_workflow(pool: asyncpg.Pool[Any], *, account_id: str) -> str:
         pool,
         account_id=account_id,
         name="invocations-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -61,7 +61,7 @@ async def _seed_parent_run(pool: asyncpg.Pool[Any], *, account_id: str, environm
         pool,
         account_id=account_id,
         name="request-opened-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_trace_walk.py
+++ b/tests/integration/test_trace_walk.py
@@ -60,7 +60,7 @@ async def _seed_run(
         pool,
         account_id=account_id,
         name=f"trace-walk-wf-{uuid4().hex}",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/unit/test_workflow_validation.py
+++ b/tests/unit/test_workflow_validation.py
@@ -1,0 +1,213 @@
+"""Unit tests for create-time workflow-script validation (#1284, part of #777).
+
+Pure (no DB): exercises the validator core in ``aios.workflows.validation`` —
+compile-check, ``async def main(input)`` structure assertion, and the literal-only
+**validate-declared** tool-surface superset check. The service-path / agent-surface
+and update-time wiring is covered in ``test_workflow_validation_service.py``.
+
+Maps to the issue's acceptance criteria:
+  1. syntax error          → rejected (compile/syntax message, line/offset)
+  2. missing ``main``       → rejected (names the required ``async def main(input)``)
+  3. mis-signatured ``main``→ rejected (not async / wrong arity)
+  4. under-declared tool    → rejected (names the missing tool)
+  6. valid covered          → accepted
+  7. un-AST-able names      → accepted (excluded from the required-surface check)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.errors import ValidationError
+from aios.models.agents import ToolSpec
+from aios.workflows.validation import (
+    extract_required_surface,
+    validate_workflow_script,
+)
+
+_GOOD_MAIN = "async def main(input):\n    return input\n"
+
+
+def _err(fn) -> ValidationError:  # type: ignore[no-untyped-def]
+    with pytest.raises(ValidationError) as ei:
+        fn()
+    return ei.value
+
+
+# ── criterion 1: syntax / structure errors ───────────────────────────────────
+
+
+class TestSyntaxError:
+    def test_unbalanced_paren_rejected_as_compile_error(self) -> None:
+        err = _err(lambda: validate_workflow_script("async def main(input):\n    x = (\n"))
+        assert "compile" in str(err).lower()
+        assert err.detail["reason"] == "compile_error"
+        # The error identifies it as a compile/syntax failure and surfaces a line.
+        assert err.detail["lineno"] is not None
+
+    def test_stray_token_rejected(self) -> None:
+        err = _err(lambda: validate_workflow_script("async def main(input):\n    return @@\n"))
+        assert err.error_type == "validation_error"
+        assert err.detail["reason"] == "compile_error"
+
+
+# ── criterion 2: missing main ─────────────────────────────────────────────────
+
+
+class TestMissingMain:
+    def test_no_main_at_all(self) -> None:
+        err = _err(lambda: validate_workflow_script("x = 1\n"))
+        assert "main" in str(err)
+        assert err.detail["reason"] == "missing_main"
+
+    def test_compiles_but_only_helper(self) -> None:
+        err = _err(lambda: validate_workflow_script("async def helper(input):\n    return 1\n"))
+        assert err.detail["reason"] == "missing_main"
+
+    def test_main_must_be_top_level(self) -> None:
+        # A nested `async def main` does not count (not a top-level entry point).
+        src = "async def outer(input):\n    async def main(input):\n        return 1\n"
+        err = _err(lambda: validate_workflow_script(src))
+        assert err.detail["reason"] == "missing_main"
+
+
+# ── criterion 3: mis-signatured main ──────────────────────────────────────────
+
+
+class TestMisSignaturedMain:
+    def test_plain_def_not_async(self) -> None:
+        err = _err(lambda: validate_workflow_script("def main(input):\n    return 1\n"))
+        assert err.detail["reason"] == "main_not_async"
+        assert "async" in str(err)
+
+    def test_async_main_zero_params(self) -> None:
+        err = _err(lambda: validate_workflow_script("async def main():\n    return 1\n"))
+        assert err.detail["reason"] == "bad_main_signature"
+        assert "input" in str(err)
+
+    def test_async_main_two_params(self) -> None:
+        err = _err(lambda: validate_workflow_script("async def main(a, b):\n    return 1\n"))
+        assert err.detail["reason"] == "bad_main_signature"
+
+    def test_async_main_varargs_only(self) -> None:
+        err = _err(lambda: validate_workflow_script("async def main(*args):\n    return 1\n"))
+        assert err.detail["reason"] == "bad_main_signature"
+
+    def test_async_main_kwargs_only(self) -> None:
+        err = _err(lambda: validate_workflow_script("async def main(**kw):\n    return 1\n"))
+        assert err.detail["reason"] == "bad_main_signature"
+
+    def test_async_main_single_param_with_default_accepted(self) -> None:
+        # A trailing default on the single `input` parameter still binds main(input).
+        validate_workflow_script("async def main(input=None):\n    return input\n")
+
+    def test_single_input_param_accepted(self) -> None:
+        # The happy-path shape — accepted (no raise).
+        validate_workflow_script(_GOOD_MAIN)
+
+    def test_positional_only_input_accepted(self) -> None:
+        validate_workflow_script("async def main(input, /):\n    return input\n")
+
+
+# ── criterion 4: under-declared tool surface ──────────────────────────────────
+
+
+class TestUnderDeclaredTool:
+    def test_literal_tool_not_declared_rejected(self) -> None:
+        src = _GOOD_MAIN + "\nasync def _x(input):\n    await tool('http_request', {})\n"
+        # tool() must be inside main for realism, but extraction is module-wide:
+        src = "async def main(input):\n    return await tool('http_request', {})\n"
+        err = _err(lambda: validate_workflow_script(src, tools=[]))
+        assert err.detail["reason"] == "undeclared_tools"
+        assert "http_request" in err.detail["missing_tools"]
+        assert "http_request" in str(err)
+
+    def test_partial_declaration_names_only_missing(self) -> None:
+        src = (
+            "async def main(input):\n"
+            "    await tool('bash', {})\n"
+            "    return await tool('http_request', {})\n"
+        )
+        err = _err(lambda: validate_workflow_script(src, tools=[ToolSpec(type="bash")]))
+        assert err.detail["missing_tools"] == ["http_request"]
+
+    def test_custom_tool_referenced_by_name(self) -> None:
+        src = "async def main(input):\n    return await tool('my_custom', {})\n"
+        # Declared as a custom tool whose *name* is 'my_custom' → covered.
+        validate_workflow_script(
+            src, tools=[ToolSpec(type="custom", name="my_custom", description="d", input_schema={})]
+        )
+        # A custom tool with a different name does NOT cover it.
+        err = _err(
+            lambda: validate_workflow_script(
+                src, tools=[ToolSpec(type="custom", name="other", description="d", input_schema={})]
+            )
+        )
+        assert "my_custom" in err.detail["missing_tools"]
+
+
+# ── criterion 6: valid, fully-covered script accepted ─────────────────────────
+
+
+class TestValidCovered:
+    def test_fully_covered_script_accepted(self) -> None:
+        src = (
+            "async def main(input):\n"
+            "    a = await tool('bash', {'command': 'echo hi'})\n"
+            "    b = await tool('http_request', {})\n"
+            "    return [a, b]\n"
+        )
+        extracted = validate_workflow_script(
+            src,
+            tools=[ToolSpec(type="bash"), ToolSpec(type="http_request")],
+        )
+        assert extracted.tool_names == {"bash", "http_request"}
+        assert extracted.agent_ids == set()
+
+    def test_no_tool_calls_accepted(self) -> None:
+        validate_workflow_script(_GOOD_MAIN, tools=[])
+
+
+# ── criterion 7: un-AST-able names do not cause false rejection ────────────────
+
+
+class TestUnAstableExcluded:
+    def test_variable_tool_name_accepted(self) -> None:
+        src = "async def main(input):\n    name = input['tool']\n    return await tool(name, {})\n"
+        # Declared tools empty — still accepted, the computed name is excluded.
+        extracted = validate_workflow_script(src, tools=[])
+        assert extracted.tool_names == set()
+
+    def test_agent_id_from_input_accepted(self) -> None:
+        src = (
+            "async def main(input):\n    return await agent({'x': 1}, agent_id=input['agent_id'])\n"
+        )
+        extracted = validate_workflow_script(src, tools=[])
+        assert extracted.agent_ids == set()
+
+    def test_mixed_literal_and_computed(self) -> None:
+        src = (
+            "async def main(input):\n"
+            "    n = input['t']\n"
+            "    await tool(n, {})\n"
+            "    return await tool('bash', {})\n"
+        )
+        # Only the literal 'bash' participates; the computed name is excluded.
+        err = _err(lambda: validate_workflow_script(src, tools=[]))
+        assert err.detail["missing_tools"] == ["bash"]
+
+
+# ── extraction surface (agent_id literals participate) ────────────────────────
+
+
+class TestExtraction:
+    def test_literal_agent_id_extracted(self) -> None:
+        src = "async def main(input):\n    return await agent({'x': 1}, agent_id='researcher')\n"
+        extracted = extract_required_surface(src)
+        assert extracted.agent_ids == {"researcher"}
+
+    def test_attribute_call_not_treated_as_builtin_tool(self) -> None:
+        # `obj.tool('x', ...)` is an attribute access, not the injected builtin.
+        src = "async def main(input):\n    obj = input\n    return obj.tool('x', {})\n"
+        extracted = extract_required_surface(src)
+        assert extracted.tool_names == set()

--- a/tests/unit/test_workflow_validation_service.py
+++ b/tests/unit/test_workflow_validation_service.py
@@ -1,0 +1,296 @@
+"""Service-path tests for create-time workflow validation (#1284).
+
+Exercises ``aios.services.workflows.create_workflow`` / ``update_workflow`` (the
+service path required by acceptance criterion 8) with a stubbed pool + query layer
+— no live Postgres. Covers:
+
+  * the validator runs and the workflow is **not** created on a rejection
+    (``insert_workflow`` is never called),
+  * criterion 5 — a string-literal ``agent(agent_id="A")`` whose required surface is
+    not covered by the declared surface is rejected, naming the missing element,
+  * the agent-surface check does NOT false-reject when the named agent does not
+    resolve (authoring may precede the agent's creation),
+  * criteria 1-7 are enforced on **update** as well as create (merged script/tools).
+
+The tool-handler path (``create_workflow_handler``) calls straight through to this
+service, so enforcing it here enforces it there too (see ``test_workflow_management``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from aios.db.queries import workflows as wf_queries
+from aios.errors import NotFoundError, ValidationError
+from aios.models.agents import Agent, ToolSpec
+from aios.models.workflows import Workflow
+from aios.services import agents as agents_service
+from aios.services import workflows as service
+
+_DT = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+class _FakeConn:
+    pass
+
+
+class _FakePool:
+    """Minimal async-context ``acquire()`` shim — the service only needs the conn
+    handle to thread into the (stubbed) query functions."""
+
+    def acquire(self) -> Any:
+        conn = _FakeConn()
+
+        class _Ctx:
+            async def __aenter__(self_inner) -> _FakeConn:
+                return conn
+
+            async def __aexit__(self_inner, *exc: Any) -> bool:
+                return False
+
+        return _Ctx()
+
+
+def _workflow(**over: Any) -> Workflow:
+    base: dict[str, Any] = dict(
+        id="wf_1",
+        account_id="acc_x",
+        name="w",
+        version=1,
+        script="async def main(input):\n    return input\n",
+        tools=[],
+        mcp_servers=[],
+        http_servers=[],
+        created_at=_DT,
+        updated_at=_DT,
+    )
+    base.update(over)
+    return Workflow(**base)
+
+
+def _agent(tools: list[ToolSpec]) -> Agent:
+    return Agent(
+        id="ag_1",
+        version=1,
+        name="researcher",
+        model="m",
+        system="s",
+        tools=tools,
+        mcp_servers=[],
+        http_servers=[],
+        description=None,
+        metadata={},
+        window_min=1,
+        window_max=2,
+        created_at=_DT,
+        updated_at=_DT,
+    )
+
+
+@pytest.fixture
+def insert_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture ``insert_workflow`` calls; a rejected create must record none."""
+    calls: list[dict[str, Any]] = []
+
+    async def _insert(conn: Any, **kw: Any) -> Workflow:
+        calls.append(kw)
+        return _workflow(**{k: v for k, v in kw.items() if k in {"name", "script", "tools"}})
+
+    monkeypatch.setattr(wf_queries, "insert_workflow", _insert)
+    return calls
+
+
+@pytest.fixture
+def update_calls(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    async def _update(conn: Any, workflow_id: str, **kw: Any) -> Workflow:
+        calls.append({"workflow_id": workflow_id, **kw})
+        return _workflow(version=2)
+
+    monkeypatch.setattr(wf_queries, "update_workflow", _update)
+    return calls
+
+
+_GOOD = "async def main(input):\n    return input\n"
+
+
+class TestCreatePathValidation:
+    async def test_valid_operator_create_succeeds(self, insert_calls: list[Any]) -> None:
+        wf = await service.create_workflow(
+            _FakePool(),
+            account_id="acc_x",
+            name="w",
+            script="async def main(input):\n    return await tool('bash', {})\n",
+            tools=[ToolSpec(type="bash")],
+        )
+        assert wf.name == "w"
+        assert len(insert_calls) == 1
+
+    async def test_syntax_error_not_created(self, insert_calls: list[Any]) -> None:
+        with pytest.raises(ValidationError):
+            await service.create_workflow(
+                _FakePool(),
+                account_id="acc_x",
+                name="w",
+                script="async def main(input):\n    x = (\n",
+            )
+        assert insert_calls == []  # workflow not created
+
+    async def test_missing_main_not_created(self, insert_calls: list[Any]) -> None:
+        with pytest.raises(ValidationError, match="main"):
+            await service.create_workflow(
+                _FakePool(),
+                account_id="acc_x",
+                name="w",
+                script="x = 1\n",
+            )
+        assert insert_calls == []
+
+    async def test_under_declared_tool_not_created(self, insert_calls: list[Any]) -> None:
+        with pytest.raises(ValidationError, match="http_request"):
+            await service.create_workflow(
+                _FakePool(),
+                account_id="acc_x",
+                name="w",
+                script="async def main(input):\n    return await tool('http_request', {})\n",
+                tools=[],
+            )
+        assert insert_calls == []
+
+
+class TestAgentSurface:
+    """Criterion 5 — string-literal ``agent(agent_id="A")`` surface coverage."""
+
+    async def test_under_declared_agent_surface_rejected(
+        self, insert_calls: list[Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The named agent needs 'http_request' but the workflow declares no tools →
+        # the #794 clamp would silently strip it. Rejected, naming the missing element.
+        async def _get_agent(pool: Any, agent_id: str, *, account_id: str) -> Agent:
+            assert agent_id == "researcher"
+            return _agent([ToolSpec(type="http_request")])
+
+        monkeypatch.setattr(agents_service, "get_agent", _get_agent)
+        with pytest.raises(ValidationError, match="researcher") as ei:
+            await service.create_workflow(
+                _FakePool(),
+                account_id="acc_x",
+                name="w",
+                script="async def main(input):\n    return await agent({'x': 1}, agent_id='researcher')\n",
+                tools=[],
+            )
+        assert "http_request" in str(ei.value)
+        assert ei.value.detail["reason"] == "undeclared_agent_surface"
+        assert insert_calls == []
+
+    async def test_covered_agent_surface_accepted(
+        self, insert_calls: list[Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _get_agent(pool: Any, agent_id: str, *, account_id: str) -> Agent:
+            return _agent([ToolSpec(type="http_request")])
+
+        monkeypatch.setattr(agents_service, "get_agent", _get_agent)
+        wf = await service.create_workflow(
+            _FakePool(),
+            account_id="acc_x",
+            name="w",
+            script="async def main(input):\n    return await agent({'x': 1}, agent_id='researcher')\n",
+            tools=[ToolSpec(type="http_request")],
+        )
+        assert wf is not None
+        assert len(insert_calls) == 1
+
+    async def test_unresolved_agent_does_not_false_reject(
+        self, insert_calls: list[Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Agent not yet created → not a create-time rejection (authoring may precede it).
+        async def _get_agent(pool: Any, agent_id: str, *, account_id: str) -> Agent:
+            raise NotFoundError("no such agent")
+
+        monkeypatch.setattr(agents_service, "get_agent", _get_agent)
+        wf = await service.create_workflow(
+            _FakePool(),
+            account_id="acc_x",
+            name="w",
+            script="async def main(input):\n    return await agent({'x': 1}, agent_id='later')\n",
+            tools=[],
+        )
+        assert wf is not None
+        assert len(insert_calls) == 1
+
+
+class TestUpdatePathValidation:
+    """Criteria 1-7 apply on update as well as create (merged script/tools)."""
+
+    async def test_update_new_script_syntax_error_rejected(
+        self, update_calls: list[Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # tools omitted → the merged-validation fetches current; stub it.
+        async def _get_wf(pool: Any, wid: str, *, account_id: str) -> Workflow:
+            return _workflow(tools=[])
+
+        monkeypatch.setattr(service, "get_workflow", _get_wf)
+        with pytest.raises(ValidationError):
+            await service.update_workflow(
+                _FakePool(),
+                "wf_1",
+                account_id="acc_x",
+                expected_version=1,
+                script="async def main(input):\n    x = (\n",
+            )
+        assert update_calls == []
+
+    async def test_update_new_script_under_declared_against_existing_tools(
+        self, update_calls: list[Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # tools omitted → merged tools = current.tools (empty) → uncovered 'http_request'.
+        async def _get_wf(pool: Any, wid: str, *, account_id: str) -> Workflow:
+            return _workflow(tools=[])
+
+        monkeypatch.setattr(service, "get_workflow", _get_wf)
+        with pytest.raises(ValidationError, match="http_request"):
+            await service.update_workflow(
+                _FakePool(),
+                "wf_1",
+                account_id="acc_x",
+                expected_version=1,
+                script="async def main(input):\n    return await tool('http_request', {})\n",
+            )
+        assert update_calls == []
+
+    async def test_update_script_omitted_validates_stored_script(
+        self, update_calls: list[Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # script omitted → merged script = current.script (which is valid) → accepted,
+        # even though only the description changed.
+        async def _get_wf(pool: Any, wid: str, *, account_id: str) -> Workflow:
+            return _workflow(script=_GOOD, tools=[])
+
+        monkeypatch.setattr(service, "get_workflow", _get_wf)
+        wf = await service.update_workflow(
+            _FakePool(),
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            description="new desc",
+        )
+        assert wf.version == 2
+        assert len(update_calls) == 1
+
+    async def test_update_valid_new_script_and_tools_succeeds(
+        self, update_calls: list[Any]
+    ) -> None:
+        wf = await service.update_workflow(
+            _FakePool(),
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            script="async def main(input):\n    return await tool('bash', {})\n",
+            tools=[ToolSpec(type="bash")],
+        )
+        assert wf.version == 2
+        assert len(update_calls) == 1


### PR DESCRIPTION
## Summary

Adds a **create-/update-time validator** to `create_workflow` / `update_workflow` so three failure classes that previously surfaced late (only as a *failed run* read back from the journal) are caught at **authoring time** instead. Part of #777.

The validator lives in a new module `src/aios/workflows/validation.py` and is wired into the service path (`src/aios/services/workflows.py`), which both the tool-handler path (`create_workflow_handler`/`update_workflow_handler`) and the HTTP/operator path call through. It runs **before any row is written**, so a rejection never creates/updates the workflow.

What it does, per the SETTLED **validate-declared, literal-only** design:
1. **Compile** the script — lifting the `compile(source, "<workflow>", "exec", dont_inherit=True)` the host already does in its exec path (`wf_script_host._build_coroutine`) to create time, surfacing a precise line/offset-bearing error.
2. **Assert** a top-level `async def main(input)` exists with the right shape (async, exactly one `input` parameter) via an AST check.
3. **AST-extract** string-literal `tool("…")` names and `agent(agent_id="…")` references, compute the **required surface union**, and validate the declared surface is a **superset** of it — emitting a precise error naming the missing tool/server.

All rejections raise a model-visible `ValidationError` (HTTP 422). Un-AST-able elements (a computed/variable `tool(name, …)` name or an `agent_id` from `input`/a variable) are **excluded** from the required-surface check — never a false rejection. Enforced on **update** as well as create (validating the merged script/tools — an omitted field preserves the stored value).

Value-domain / determinism traps (failure class 3) are out of scope (#934), as the issue specifies.

## Agent-surface depth (documented choice)

The issue permits scoping the `agent(agent_id="A")` check. The chosen depth: a **string-literal** `agent_id` is resolved (account-scoped, in the service path which has pool+account) and the named agent's own enabled tools must be covered by the declared tool surface — because a named child wields `agent ∩ run` (the #794 clamp), so under-declared tools would be **silently stripped** at spawn. Two guards against false rejection: (a) only literal `agent_id`s participate; (b) an `agent_id` that does **not resolve** (no such agent yet) is NOT a create-time rejection — authoring may legitimately precede the agent's creation, and a run would surface `agent_not_found` as a recoverable value. One hop only (a child's transitive `agent()` fan-out is gated at its own spawn).

## Acceptance criteria → tests

New `tests/unit/test_workflow_validation.py` (pure validator core) and `tests/unit/test_workflow_validation_service.py` (service path + update-time) cover criteria 1–7:
1. syntax error → rejected (compile/syntax message w/ line/offset); not created.
2. missing `main` → rejected (names required `async def main(input)`); not created.
3. mis-signatured `main` (not async / wrong arity / `*args` / `**kwargs`) → rejected; a single param with a default is accepted.
4. under-declared `tool("X")` → rejected naming `X`; not created.
5. under-declared literal `agent(agent_id="A")` surface → rejected naming the agent + missing tool(s); unresolved agent does not false-reject.
6. valid fully-covered script → succeeds unchanged (happy path).
7. un-AST-able tool name / `agent_id` from input → accepted.

## Validation

- `ruff check` + `ruff format --check`, `mypy src tests` — all clean across the tree.
- Full unit suite green (3076 passed). New tests pass.
- Confirmed the validator **accepts** the real production `dev_pipeline` workflow (`build_dev_pipeline_workflow_create`) — its literal `tool("http_request")`/`tool("bash")` are covered by the declared surface — i.e. it does not false-reject the very fixture behind the two cited production incidents.
- Updated a handful of integration/e2e fixtures whose throwaway scripts (`def main(ctx)`, `"x"`) are now intentionally rejected, replacing them with valid `async def main(input)` scripts (they were not testing the validator). Tests that insert workflows directly via the query layer (`wf_queries.insert_workflow`) are unaffected, so run-time gating tests (e.g. the `wt-undeclared` run-tool case) still exercise undeclared-surface behavior at run time.

**Note:** this is a bakeoff build of #1221 (model openrouter/z-ai/glm-5.2) — DO NOT MERGE without the comparison.