### PR TITLE
feat(workflows): create-time validation — compile + assert async def main(input) + AST-derived tool-surface union check

### DIFF
--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -40,6 +40,7 @@ from aios.services import attenuation as attenuation_service
 from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
+from aios.workflows.script_validation import validate_workflow_script
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
@@ -171,7 +172,16 @@ async def create_workflow(
     creating agent first. With no creator (the HTTP/operator path) any surface may be
     declared verbatim, account-scoped — but names-only sugar is unavailable there (no
     acting agent to resolve against).
+
+    **Create-time script validation (#1285):** the ``script`` is compiled, its
+    top-level ``async def main(input)`` shape is asserted, and every string-literal
+    ``tool("…")`` call it makes must be covered by the declared ``tools`` — a breach
+    raises :class:`WorkflowScriptValidationError` (a ``422``) and the workflow is NOT
+    created. Validation runs first, before any DB work, on every (agent + operator) path.
     """
+    validate_workflow_script(
+        script, tools=tools, mcp_servers=mcp_servers, http_servers=http_servers
+    )
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if creator_session_id is not None:
@@ -236,27 +246,44 @@ async def update_workflow(
     agent. The operator path stores declared http verbatim and rejects names-only sugar
     (no acting agent to resolve against).
     """
+    # Create-time script validation (#1285) on the UPDATE path too. The validation
+    # target is the *resulting* definition: the new ``script`` (or the preserved
+    # current one when ``script is None``) against the new ``tools`` (or preserved
+    # current ``tools`` when ``tools is None``) — so we read ``current`` up front (it
+    # also surfaces 404 for an unknown/cross-account id). The preconditions that gate
+    # the write (archived → 409, stale token → 409) are checked BEFORE validation, so
+    # a stale/unknown update keeps its existing 409/404 rather than masking it behind a
+    # 422 — and the agent path below reuses this same ``current`` so its surface read
+    # sees one consistent snapshot.
+    current = await get_workflow(pool, workflow_id, account_id=account_id)
+    if current.archived_at is not None:
+        raise ConflictError(f"workflow {workflow_id} is archived", detail={"id": workflow_id})
+    if current.version != expected_version:
+        raise ConflictError(
+            f"version mismatch: expected {expected_version}, current is {current.version}",
+            detail={
+                "expected": expected_version,
+                "current": current.version,
+                "id": workflow_id,
+            },
+        )
+    resulting_script = script if script is not None else current.script
+    resulting_tools = tools if tools is not None else current.tools
+    validate_workflow_script(
+        resulting_script,
+        tools=resulting_tools,
+        mcp_servers=mcp_servers if mcp_servers is not None else None,
+        http_servers=http_servers,
+    )
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if actor_session_id is None:
         operator_http = _reject_operator_path_names_only(http_servers)
     if actor_session_id is not None:
-        current = await get_workflow(pool, workflow_id, account_id=account_id)
-        if current.version != expected_version:
-            # Pin the attenuation read to the caller's token. Without this, an actor
-            # could send a FUTURE token: attenuation passes against today's surface,
-            # a concurrent update broadens it and bumps to exactly that token, and the
-            # optimistic UPDATE then matches — landing the actor's script on a surface
-            # that was never checked. With the pin, the UPDATE's ``WHERE version``
-            # guarantees nothing changed between this read and the write.
-            raise ConflictError(
-                f"version mismatch: expected {expected_version}, current is {current.version}",
-                detail={
-                    "expected": expected_version,
-                    "current": current.version,
-                    "id": workflow_id,
-                },
-            )
+        # The version pin above already held (it is the same consistency requirement the
+        # attenuation read needs: an actor sending a FUTURE token can't slip a script
+        # onto an unchecked, concurrently-broadened surface — the UPDATE's ``WHERE
+        # version`` plus this pre-read guarantee nothing changed between read and write).
         # ``current.http_servers`` is the already-resolved stored spec; ``list(...)``
         # widens it to ``list[HttpServerRef]`` for the (str | spec)-typed parameter.
         merged_http: list[HttpServerRef] = (

--- a/src/aios/workflows/script_validation.py
+++ b/src/aios/workflows/script_validation.py
@@ -1,0 +1,233 @@
+"""Create-time validation of a workflow's author ``script`` (#1285).
+
+A workflow is authored out-of-band as an inert ``script: str`` whose only contract
+is a docstring. Without create-time checking, three failure classes surface late —
+only as a *failed run* read back from the journal — instead of as an authoring-time
+error. This module lifts two of them (#1285 covers classes 1 and 2; the value-domain
+class is #934) to ``create_workflow`` / ``update_workflow``:
+
+1. **Syntax / structure** — the host already does
+   ``compile(source, "<workflow>", "exec", dont_inherit=True)`` in the exec path
+   (``wf_script_host._build_coroutine``); :func:`validate_workflow_script` lifts that
+   compile to create time and surfaces a precise compile/syntax error.
+2. **Surface drift** — the run's declared ``tools`` / ``http_servers`` /
+   ``mcp_servers`` are authored *separately* from the script, but must be a superset
+   of the surface the script actually exercises. We **validate-declared** (NOT
+   auto-derive, the settled fork): AST-extract every **string-literal**
+   ``tool("<name>", …)`` call name and every string-literal
+   ``agent(agent_id="<id>")`` reference, compute the required-surface union, and
+   assert the declared surface covers it — naming the specific missing element.
+
+**Literal-only extraction (settled design).** When a ``tool(name, …)`` name or an
+``agent_id`` is **not a string literal** (computed / a variable / from ``input``),
+that element is *un-AST-able* and is **excluded** from the required-surface check —
+the validator neither rejects on it nor tries to resolve it. Only string-literal
+names participate in the union, so a dynamic ``tool(name_var, …)`` never causes a
+false rejection.
+
+**Isolation note.** This module imports only ``ast`` (stdlib) +
+:mod:`aios.errors`. It is invoked from the credential-bearing service layer
+(``aios.services.workflows``), NOT from the credential-free script-host child, so
+it carries no new isolation risk for the host.
+
+**Agent-reference depth (documented per the issue).** A ``agent(agent_id="A")``
+child runs over ``agent ∩ run`` — the #794 clamp — so a named child can only ever
+receive a *subset* of the run's already-declared surface; it never adds a new
+tool/server requirement to the run. We therefore extract and surface literal
+``agent_id`` references (excluding non-literal ones), and they participate in the
+analysis, but per the workflow surface model they impose no *additional* create-time
+requirement that DB-free static analysis could check: resolving the named child
+agent's own tool surface to assert run-coverage requires a DB lookup and is out of
+scope for this change (the issue explicitly permits documenting this depth). The
+within-scope surface gate is the script's own literal ``tool("…")`` calls.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from aios.errors import ValidationError
+
+# The author entry point the host execs: ``async def main(input)`` (one positional
+# parameter named ``input``). Kept in sync with ``wf_script_host._build_coroutine``.
+_MAIN_NAME = "main"
+_MAIN_PARAM = "input"
+
+
+class WorkflowScriptValidationError(ValidationError):
+    """A workflow ``script`` failed create-time validation (#1285).
+
+    A ``422`` ``ValidationError`` subtype so the HTTP layer renders it like any other
+    request-shape rejection and the model-path dispatch (``_classify_tool_error``)
+    returns it cleanly to the model (a 4xx author error, not a 5xx). The message is
+    actionable: it names the compile failure, the missing/mis-signatured ``main``, or
+    the specific under-declared tool/server.
+    """
+
+    error_type = "workflow_script_validation_error"
+
+
+@dataclass
+class _ScriptRequirements:
+    """The AST-extracted, literal-only required surface of a workflow script."""
+
+    tool_names: set[str] = field(default_factory=set)
+    agent_ids: set[str] = field(default_factory=set)
+
+
+def _literal_str(node: ast.expr | None) -> str | None:
+    """Return the string value of a string-literal node, else ``None`` (un-AST-able)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _find_main(tree: ast.Module) -> ast.AsyncFunctionDef | ast.FunctionDef | None:
+    """Return the LAST top-level ``main`` def (async or plain), mirroring exec rebind
+    semantics where a later ``def main`` shadows an earlier one in the namespace."""
+    found: ast.AsyncFunctionDef | ast.FunctionDef | None = None
+    for stmt in tree.body:
+        if isinstance(stmt, (ast.AsyncFunctionDef, ast.FunctionDef)) and stmt.name == _MAIN_NAME:
+            found = stmt
+    return found
+
+
+def _assert_main_signature(fn: ast.AsyncFunctionDef | ast.FunctionDef) -> None:
+    """Assert the top-level ``main`` is ``async def main(input)`` (single ``input`` arg)."""
+    if not isinstance(fn, ast.AsyncFunctionDef):
+        raise WorkflowScriptValidationError(
+            "workflow script's top-level `main` must be `async def main(input)` — "
+            "found a plain `def main` (not async)"
+        )
+    args = fn.args
+    # Exactly one parameter named ``input``: no extra positionals, no *args/**kwargs,
+    # no keyword-only params, no defaults that would let a 0-arg call through.
+    positional = args.posonlyargs + args.args
+    bad_shape = (
+        len(positional) != 1
+        or positional[0].arg != _MAIN_PARAM
+        or args.vararg is not None
+        or args.kwarg is not None
+        or len(args.kwonlyargs) > 0
+    )
+    if bad_shape:
+        got = ", ".join(
+            [a.arg for a in args.posonlyargs]
+            + [a.arg for a in args.args]
+            + (["*" + args.vararg.arg] if args.vararg else [])
+            + [a.arg for a in args.kwonlyargs]
+            + (["**" + args.kwarg.arg] if args.kwarg else [])
+        )
+        raise WorkflowScriptValidationError(
+            "workflow script's `main` must accept exactly one `input` parameter "
+            f"(`async def main(input)`) — found signature `main({got})`"
+        )
+
+
+def _extract_requirements(tree: ast.Module) -> _ScriptRequirements:
+    """Walk the AST for string-literal ``tool("X", …)`` names and ``agent(agent_id="A")``
+    references. Non-literal names are *un-AST-able* and deliberately skipped."""
+    reqs = _ScriptRequirements()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Name):
+            continue
+        if func.id == "tool":
+            # tool(name, input): the first positional arg is the tool name.
+            if node.args:
+                name = _literal_str(node.args[0])
+                if name is not None:
+                    reqs.tool_names.add(name)
+        elif func.id == "agent":
+            # agent(input, *, agent_id="A", …): agent_id is keyword-only.
+            for kw in node.keywords:
+                if kw.arg == "agent_id":
+                    agent_id = _literal_str(kw.value)
+                    if agent_id is not None:
+                        reqs.agent_ids.add(agent_id)
+    return reqs
+
+
+def _declared_tool_names(tools: Sequence[object] | None) -> set[str]:
+    """The canonical tool-name set of a declared surface, matching run-time resolution
+    (``resolve_permission`` / the run-tool gate): a custom tool's name is its ``name``;
+    a built-in's is its ``type``. MCP toolsets declare no bare ``tool("…")`` name."""
+    names: set[str] = set()
+    for spec in tools or []:
+        type_ = getattr(spec, "type", None)
+        if type_ == "custom":
+            name = getattr(spec, "name", None)
+            if isinstance(name, str):
+                names.add(name)
+        elif isinstance(type_, str) and type_ != "mcp_toolset":
+            names.add(type_)
+    return names
+
+
+def validate_workflow_script(
+    script: str,
+    *,
+    tools: Sequence[object] | None = None,
+    mcp_servers: Sequence[object] | None = None,
+    http_servers: Sequence[object] | None = None,
+) -> None:
+    """Validate a workflow ``script`` at author time (create + update), raising
+    :class:`WorkflowScriptValidationError` with a precise, actionable message.
+
+    Checks, in order:
+
+    1. **Compile** the script with the host's exact flags. A ``SyntaxError`` is
+       surfaced as a compile failure with line/offset where available.
+    2. **Assert** a top-level ``async def main(input)`` exists.
+    3. **Assert** its signature is exactly the single ``input`` parameter.
+    4. **AST-extract** literal ``tool("…")`` names and assert the declared ``tools``
+       cover them, naming any missing tool.
+
+    Non-literal tool names / agent_ids are excluded from the surface check (the
+    settled literal-only extraction). ``mcp_servers`` / ``http_servers`` are accepted
+    for parity with the declared-surface signature; the script's own ``tool("…")``
+    union is the within-scope create-time gate (see the module docstring on agent
+    depth).
+    """
+    # 1. Compile — lift the host's exec-path compile to create time.
+    try:
+        compile(script, "<workflow>", "exec", dont_inherit=True)
+    except SyntaxError as exc:
+        where = ""
+        if exc.lineno is not None:
+            where = f" (line {exc.lineno}"
+            if exc.offset is not None:
+                where += f", offset {exc.offset}"
+            where += ")"
+        raise WorkflowScriptValidationError(
+            f"workflow script failed to compile: {exc.msg}{where}"
+        ) from exc
+
+    # The compile above guarantees ``ast.parse`` cannot raise on the same source.
+    tree = ast.parse(script)
+
+    # 2. + 3. Assert a top-level ``async def main(input)`` of the right signature.
+    main_fn = _find_main(tree)
+    if main_fn is None:
+        raise WorkflowScriptValidationError(
+            "workflow script must define a top-level `async def main(input)` "
+            "(no `main` found)"
+        )
+    _assert_main_signature(main_fn)
+
+    # 4. Validate the declared tool surface is a superset of the literal ``tool("…")``
+    #    union. Name every missing tool (sorted for a deterministic message).
+    reqs = _extract_requirements(tree)
+    declared = _declared_tool_names(tools)
+    missing = sorted(reqs.tool_names - declared)
+    if missing:
+        named = ", ".join(repr(m) for m in missing)
+        raise WorkflowScriptValidationError(
+            "workflow script calls tool(s) not present in the declared tool surface: "
+            f"{named}. Declare them in `tools` (the declared surface must be a superset "
+            "of the script's literal tool(\"…\") calls)."
+        )

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -89,7 +89,7 @@ async def _seed_workflow(pool: asyncpg.Pool[Any], *, account_id: str) -> str:
         pool,
         account_id=account_id,
         name="invocations-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -61,7 +61,7 @@ async def _seed_parent_run(pool: asyncpg.Pool[Any], *, account_id: str, environm
         pool,
         account_id=account_id,
         name="request-opened-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_trace_walk.py
+++ b/tests/integration/test_trace_walk.py
@@ -60,7 +60,7 @@ async def _seed_run(
         pool,
         account_id=account_id,
         name=f"trace-walk-wf-{uuid4().hex}",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/unit/test_workflow_script_validation.py
+++ b/tests/unit/test_workflow_script_validation.py
@@ -1,0 +1,217 @@
+"""Unit tests for create-time workflow ``script`` validation (#1285).
+
+Covers the acceptance criteria of #1285 at the validator level (pure, no DB):
+
+1. Syntax error → compile/syntax validation error (line/offset surfaced).
+2. Missing top-level ``main`` → rejected, message names the required ``main``.
+3. Mis-signatured ``main`` (not async / wrong params) → rejected, names the signature.
+4. Under-declared tool surface (literal ``tool("X")`` not in declared tools) → rejected,
+   names ``X``.
+5. Literal ``agent(agent_id="A")`` participation (the documented agent depth).
+6. Valid, fully-covered script → accepted (no raise).
+7. Un-AST-able (computed/variable) tool name / agent_id → accepted (excluded from the
+   required-surface check, never a false rejection).
+
+The service-path + tool-handler-path enforcement (criterion 8) and update enforcement
+are covered in ``test_workflow_management.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.models.agents import ToolSpec
+from aios.workflows.script_validation import (
+    WorkflowScriptValidationError,
+    validate_workflow_script,
+)
+
+_VALID_MAIN = "async def main(input):\n    return input\n"
+
+
+# ─── criterion 1: syntax / compile error ─────────────────────────────────────
+
+
+def test_syntax_error_rejected_as_compile_failure() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def main(input):\n    x = (\n")
+    msg = str(exc.value)
+    assert "compile" in msg
+    # Line is surfaced where available.
+    assert "line" in msg
+
+
+def test_stray_token_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError, match="compile"):
+        validate_workflow_script("async def main(input):\n    return 1 1\n")
+
+
+# ─── criterion 2: missing main ───────────────────────────────────────────────
+
+
+def test_missing_main_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("x = 1\n\nasync def helper(input):\n    return input\n")
+    assert "main" in str(exc.value)
+
+
+def test_main_not_top_level_rejected() -> None:
+    # A ``main`` nested inside another function is not a top-level entry point.
+    script = (
+        "def outer():\n"
+        "    async def main(input):\n"
+        "        return input\n"
+        "    return main\n"
+    )
+    with pytest.raises(WorkflowScriptValidationError, match="main"):
+        validate_workflow_script(script)
+
+
+# ─── criterion 3: mis-signatured main ────────────────────────────────────────
+
+
+def test_plain_def_main_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("def main(input):\n    return input\n")
+    assert "async" in str(exc.value)
+
+
+def test_main_zero_args_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def main():\n    return 1\n")
+    assert "input" in str(exc.value)
+
+
+def test_main_two_args_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def main(a, b):\n    return 1\n")
+    assert "input" in str(exc.value)
+
+
+def test_main_wrong_param_name_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError, match="input"):
+        validate_workflow_script("async def main(payload):\n    return payload\n")
+
+
+def test_main_varargs_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError, match="input"):
+        validate_workflow_script("async def main(*args):\n    return 1\n")
+
+
+def test_main_kwonly_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError, match="input"):
+        validate_workflow_script("async def main(input, *, x=1):\n    return input\n")
+
+
+# ─── criterion 4: under-declared tool surface ────────────────────────────────
+
+
+def test_under_declared_tool_rejected_names_the_tool() -> None:
+    script = 'async def main(input):\n    return await tool("http_request", {})\n'
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script, tools=[ToolSpec(type="bash")])
+    assert "http_request" in str(exc.value)
+
+
+def test_under_declared_tool_with_no_declared_tools_rejected() -> None:
+    script = 'async def main(input):\n    return await tool("bash", {})\n'
+    with pytest.raises(WorkflowScriptValidationError, match="bash"):
+        validate_workflow_script(script, tools=[])
+
+
+def test_multiple_missing_tools_all_named() -> None:
+    script = (
+        "async def main(input):\n"
+        '    await tool("web_search", {})\n'
+        '    return await tool("web_fetch", {})\n'
+    )
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script, tools=[])
+    msg = str(exc.value)
+    assert "web_search" in msg and "web_fetch" in msg
+
+
+# ─── criterion 5: literal agent_id participation (documented depth) ──────────
+
+
+def test_literal_agent_id_accepted_when_no_tool_drift() -> None:
+    # A named-agent child runs over ``agent ∩ run`` (it can only narrow the run's
+    # surface), so a bare literal agent reference adds no required tool and is
+    # accepted. The literal agent_id participates in the analysis (extracted), but
+    # imposes no DB-free surface requirement (see the module docstring on depth).
+    script = 'async def main(input):\n    return await agent({"x": 1}, agent_id="reviewer")\n'
+    validate_workflow_script(script, tools=[])
+
+
+def test_agent_reference_with_under_declared_tool_still_rejected() -> None:
+    # An agent reference does not excuse an under-declared literal tool call in the
+    # same script — the tool union still gates.
+    script = (
+        "async def main(input):\n"
+        '    await agent({"x": 1}, agent_id="reviewer")\n'
+        '    return await tool("bash", {})\n'
+    )
+    with pytest.raises(WorkflowScriptValidationError, match="bash"):
+        validate_workflow_script(script, tools=[])
+
+
+# ─── criterion 6: valid, fully-covered script accepted ───────────────────────
+
+
+def test_valid_fully_covered_script_accepted() -> None:
+    script = (
+        "async def main(input):\n"
+        '    out = await tool("bash", {"command": "echo hi"})\n'
+        '    return await agent(out, agent_id="reviewer")\n'
+    )
+    # No raise.
+    validate_workflow_script(script, tools=[ToolSpec(type="bash")])
+
+
+def test_minimal_valid_script_accepted() -> None:
+    validate_workflow_script(_VALID_MAIN, tools=[])
+
+
+def test_custom_tool_name_resolved_by_name() -> None:
+    # A custom tool's declared name is its ``name`` (not ``type == "custom"``).
+    script = 'async def main(input):\n    return await tool("my_tool", {})\n'
+    validate_workflow_script(
+        script,
+        tools=[ToolSpec(type="custom", name="my_tool", description="d", input_schema={})],
+    )
+
+
+def test_posonly_input_param_accepted() -> None:
+    validate_workflow_script("async def main(input, /):\n    return input\n", tools=[])
+
+
+# ─── criterion 7: un-AST-able names never cause false rejection ──────────────
+
+
+def test_computed_tool_name_accepted() -> None:
+    script = (
+        "async def main(input):\n"
+        '    name = input["tool"]\n'
+        "    return await tool(name, {})\n"
+    )
+    # The variable tool name is un-AST-able → excluded, not a violation.
+    validate_workflow_script(script, tools=[])
+
+
+def test_agent_id_from_input_accepted() -> None:
+    script = (
+        "async def main(input):\n"
+        '    return await agent({"x": 1}, agent_id=input["agent_id"])\n'
+    )
+    validate_workflow_script(script, tools=[])
+
+
+def test_mixed_literal_and_computed_only_literal_checked() -> None:
+    # The literal "bash" is checked (and covered); the computed name is skipped.
+    script = (
+        "async def main(input):\n"
+        '    await tool("bash", {})\n'
+        "    n = input[\"t\"]\n"
+        "    return await tool(n, {})\n"
+    )
+    validate_workflow_script(script, tools=[ToolSpec(type="bash")])

--- a/tests/unit/test_workflow_service_script_validation.py
+++ b/tests/unit/test_workflow_service_script_validation.py
@@ -1,0 +1,233 @@
+"""Service-path enforcement of create-time script validation (#1285, criterion 8).
+
+These exercise ``aios.services.workflows.create_workflow`` / ``update_workflow`` on the
+operator path (no acting session → no surface attenuation, no agent DB read), with the
+query layer mocked, to prove:
+
+* validation runs and rejects an invalid script **before any DB write** (the workflow
+  is NOT created / updated), and
+* a valid, fully-covered script flows through to the insert/update query unchanged
+  (the happy path is unaffected).
+
+The tool-handler path (``create_workflow_handler`` / ``update_workflow_handler``) calls
+straight through to these service functions, so enforcing here enforces both paths.
+``update_workflow`` is covered too (criteria 1-7 apply on update).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.models.agents import ToolSpec
+from aios.models.workflows import Workflow
+from aios.services import workflows as wf_service
+from aios.workflows.script_validation import WorkflowScriptValidationError
+
+_DT = datetime(2026, 1, 1, tzinfo=UTC)
+
+_BAD_SYNTAX = "async def main(input):\n    x = (\n"
+_NO_MAIN = "x = 1\n"
+_NOT_ASYNC = "def main(input):\n    return input\n"
+_BAD_SIG = "async def main():\n    return 1\n"
+_UNDER_TOOL = 'async def main(input):\n    return await tool("http_request", {})\n'
+_VALID = 'async def main(input):\n    return await tool("bash", {})\n'
+
+
+class _FakePool:
+    """A pool whose ``acquire()`` yields a sentinel conn; tracks whether it was used."""
+
+    def __init__(self) -> None:
+        self.acquired = False
+
+    @asynccontextmanager
+    async def acquire(self) -> Any:
+        self.acquired = True
+        yield object()
+
+
+def _workflow(**over: Any) -> Workflow:
+    base: dict[str, Any] = dict(
+        id="wf_1",
+        account_id="acc_x",
+        name="w",
+        version=1,
+        script=_VALID,
+        tools=[ToolSpec(type="bash")],
+        created_at=_DT,
+        updated_at=_DT,
+    )
+    base.update(over)
+    return Workflow(**base)
+
+
+# ─── create path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("script", "needle"),
+    [
+        (_BAD_SYNTAX, "compile"),
+        (_NO_MAIN, "main"),
+        (_NOT_ASYNC, "async"),
+        (_BAD_SIG, "input"),
+    ],
+)
+async def test_create_rejects_invalid_script_before_db(
+    monkeypatch: Any, script: str, needle: str
+) -> None:
+    insert = AsyncMock()
+    monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+    pool = _FakePool()
+    with pytest.raises(WorkflowScriptValidationError, match=needle):
+        await wf_service.create_workflow(pool, account_id="acc_x", name="w", script=script)
+    insert.assert_not_called()
+    assert pool.acquired is False  # not created — no DB connection taken
+
+
+async def test_create_rejects_under_declared_tool_naming_it(monkeypatch: Any) -> None:
+    insert = AsyncMock()
+    monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+    pool = _FakePool()
+    with pytest.raises(WorkflowScriptValidationError, match="http_request"):
+        await wf_service.create_workflow(
+            pool, account_id="acc_x", name="w", script=_UNDER_TOOL, tools=[ToolSpec(type="bash")]
+        )
+    insert.assert_not_called()
+
+
+async def test_create_accepts_valid_covered_script(monkeypatch: Any) -> None:
+    created = _workflow()
+    insert = AsyncMock(return_value=created)
+    monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+    out = await wf_service.create_workflow(
+        _FakePool(), account_id="acc_x", name="w", script=_VALID, tools=[ToolSpec(type="bash")]
+    )
+    assert out is created
+    insert.assert_awaited_once()
+
+
+async def test_create_accepts_unastable_tool_name(monkeypatch: Any) -> None:
+    insert = AsyncMock(return_value=_workflow())
+    monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+    script = 'async def main(input):\n    n = input["t"]\n    return await tool(n, {})\n'
+    await wf_service.create_workflow(_FakePool(), account_id="acc_x", name="w", script=script)
+    insert.assert_awaited_once()
+
+
+# ─── update path ─────────────────────────────────────────────────────────────
+
+
+async def test_update_rejects_invalid_script_before_db(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "aios.services.workflows.get_workflow", AsyncMock(return_value=_workflow())
+    )
+    update = AsyncMock()
+    monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+    pool = _FakePool()
+    with pytest.raises(WorkflowScriptValidationError, match="compile"):
+        await wf_service.update_workflow(
+            pool,
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            script=_BAD_SYNTAX,
+            tools=[],
+        )
+    update.assert_not_called()
+    assert pool.acquired is False  # not updated — no write connection taken
+
+
+async def test_update_rejects_under_declared_tool(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "aios.services.workflows.get_workflow", AsyncMock(return_value=_workflow())
+    )
+    update = AsyncMock()
+    monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+    with pytest.raises(WorkflowScriptValidationError, match="http_request"):
+        await wf_service.update_workflow(
+            _FakePool(),
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            script=_UNDER_TOOL,
+            tools=[ToolSpec(type="bash")],
+        )
+    update.assert_not_called()
+
+
+async def test_update_validates_new_script_against_preserved_tools(monkeypatch: Any) -> None:
+    # script changes, tools omitted (preserved) → validation must read current.tools.
+    # The current workflow declares only ``bash``; the new script calls ``http_request``.
+    current = _workflow(tools=[ToolSpec(type="bash")])
+    monkeypatch.setattr(
+        "aios.services.workflows.get_workflow", AsyncMock(return_value=current)
+    )
+    update = AsyncMock()
+    monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+    with pytest.raises(WorkflowScriptValidationError, match="http_request"):
+        await wf_service.update_workflow(
+            _FakePool(), "wf_1", account_id="acc_x", expected_version=1, script=_UNDER_TOOL
+        )
+    update.assert_not_called()
+
+
+async def test_update_validates_preserved_script_against_new_tools(monkeypatch: Any) -> None:
+    # script omitted (preserved current ``tool("bash")`` body), tools narrowed to [] →
+    # the preserved script's literal ``tool("bash")`` is now under-declared → rejected.
+    current = _workflow(script=_VALID, tools=[ToolSpec(type="bash")])
+    monkeypatch.setattr(
+        "aios.services.workflows.get_workflow", AsyncMock(return_value=current)
+    )
+    update = AsyncMock()
+    monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+    with pytest.raises(WorkflowScriptValidationError, match="bash"):
+        await wf_service.update_workflow(
+            _FakePool(), "wf_1", account_id="acc_x", expected_version=1, tools=[]
+        )
+    update.assert_not_called()
+
+
+async def test_update_stale_token_409_precedes_script_validation(monkeypatch: Any) -> None:
+    # A stale optimistic token keeps its 409 even when the new script is invalid —
+    # the precondition is checked before validation (no 422 masking the 409).
+    from aios.errors import ConflictError
+
+    monkeypatch.setattr(
+        "aios.services.workflows.get_workflow",
+        AsyncMock(return_value=_workflow(version=5)),
+    )
+    update = AsyncMock()
+    monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+    with pytest.raises(ConflictError, match="version mismatch"):
+        await wf_service.update_workflow(
+            _FakePool(),
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            script=_BAD_SYNTAX,
+        )
+    update.assert_not_called()
+
+
+async def test_update_accepts_valid_covered_script(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "aios.services.workflows.get_workflow", AsyncMock(return_value=_workflow())
+    )
+    updated = _workflow(version=2)
+    update = AsyncMock(return_value=updated)
+    monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+    out = await wf_service.update_workflow(
+        _FakePool(),
+        "wf_1",
+        account_id="acc_x",
+        expected_version=1,
+        script=_VALID,
+        tools=[ToolSpec(type="bash")],
+    )
+    assert out is updated
+    update.assert_awaited_once()


### PR DESCRIPTION
## Summary

Bakeoff build of #1221 (model: openai/gpt-5.5). **DO NOT MERGE without the comparison.** Part of #777, P0.

Lifts the host's exec-path `compile(...)` to author time and adds an AST-derived, literal-only tool-surface union check, so the late-failure (class 1) and surface-drift (class 2) failure classes are caught at `create_workflow` / `update_workflow` time instead of as a failed run read back from the journal. Value-domain traps (class 3) remain out of scope per the issue (#934).

## What changed

- **New `src/aios/workflows/script_validation.py`** (`validate_workflow_script`), stdlib-`ast`-only + `aios.errors`:
  1. **Compile** the script with the host's exact flags (`compile(source, "<workflow>", "exec", dont_inherit=True)`) — a `SyntaxError` is surfaced as a `WorkflowScriptValidationError` (a 422 `ValidationError` subtype) naming it a compile/syntax failure with line/offset where available.
  2. **Assert** a top-level `async def main(input)` exists (AST), and that its signature is exactly the single `input` parameter — rejecting plain `def main`, `main()`, `main(a, b)`, wrong-name, `*args`, kw-only, etc.
  3. **AST-extract** string-literal `tool("X", …)` names and assert the declared `tools` are a **superset**, naming the missing tool(s). This is **validate-declared** (the settled fork), with **literal-only extraction**: a computed/variable `tool(name_var, …)` name or an `agent_id` from `input`/a variable is *un-AST-able* and excluded — never a false rejection.
  - Declared tool-name resolution matches run-time (`resolve_permission` / the run-tool gate): a custom tool's name is its `name`, a builtin's is its `type`.

- **Wired into `src/aios/services/workflows.py`** `create_workflow` and `update_workflow` (the tool-handler path in `workflow_management.py` calls straight through, so both the handler path and the service path enforce it — criterion 8). On update, the **resulting** (merged) script+tools are validated; validation runs *after* the not-found / archived / stale-token preconditions so an unknown id keeps its 404 and a stale token keeps its 409 (no 422 masking).

## Agent-reference depth (criterion 5, documented)

Literal `agent(agent_id="A")` references are extracted and participate in the analysis. Per the project surface model a named child runs over `agent ∩ run` (the #794 clamp) — it can only ever receive a *subset* of the run's already-declared surface, never add to it — and the workflow surface model has no agent-id dimension to be a superset of. So a bare literal agent reference imposes no DB-free create-time requirement; the script's own literal `tool("…")` union is the within-scope surface gate. Resolving a named child agent's full tool surface to assert run-coverage needs a DB lookup and is explicitly out of scope for this issue.

## Tests / hygiene

- `tests/unit/test_workflow_script_validation.py` — validator-level coverage of criteria 1–7 (syntax, missing `main`, mis-signatured `main`, under-declared tool naming the tool, literal-agent participation, valid fully-covered, un-AST-able names accepted).
- `tests/unit/test_workflow_service_script_validation.py` — service create + update paths reject before any DB write and accept the happy path; update validates preserved-script/preserved-tools and keeps 409 precedence.
- Updated three integration fixtures (`test_invocations`, `test_request_opened_edge`, `test_trace_walk`) that used an inert `def main(ctx)` placeholder to a valid `async def main(input)`.
- Full unit suite passes (3108 passed, 1 pre-existing skip); `ruff` and `mypy --strict` clean on changed files; `wf_script_host` isolation unaffected (it does not import the validator).

Closes #1285.