### PR TITLE
feat(workflows): create-time validation — compile + assert async def main(input) + AST-derived tool/surface union check (#1284)

### DIFF
--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -40,6 +40,7 @@ from aios.services import attenuation as attenuation_service
 from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
+from aios.workflows.script_validation import validate_workflow_script
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
@@ -172,6 +173,17 @@ async def create_workflow(
     declared verbatim, account-scoped — but names-only sugar is unavailable there (no
     acting agent to resolve against).
     """
+    # Create-time validation (#1284): compile + assert async def main(input) +
+    # AST-derived required-surface union ⊆ the DECLARED surface. Runs before any DB
+    # read so a malformed script / under-declared surface is rejected at author time
+    # with a precise error, not as a failed run read back from the journal. The
+    # declared (not clamped) surface is checked — that is what the author wrote.
+    validate_workflow_script(
+        script,
+        tools=tools or [],
+        mcp_servers=mcp_servers or [],
+        http_servers=http_servers or [],
+    )
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if creator_session_id is not None:
@@ -238,25 +250,43 @@ async def update_workflow(
     """
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
+    # Fetch current up front (one read, reused below). It 404s an absent/foreign id and
+    # gives the preserved (omitted-field) values the effective-shape validation merges in.
+    current = await get_workflow(pool, workflow_id, account_id=account_id)
+
+    # Order the cheap existence/conflict gates BEFORE validation so an unknown id (404)
+    # and a stale optimistic token (409) keep precedence over a 422 script-validation
+    # error — the contract a caller probing the version token relies on. (The query's
+    # ``WHERE version`` stays the authoritative write-time serializer; this pre-check is
+    # purely for deterministic ordering, mirroring the query's own up-front token check.)
+    if current.archived_at is not None:
+        raise ConflictError(f"workflow {workflow_id} is archived", detail={"id": workflow_id})
+    if current.version != expected_version:
+        raise ConflictError(
+            f"version mismatch: expected {expected_version}, current is {current.version}",
+            detail={
+                "expected": expected_version,
+                "current": current.version,
+                "id": workflow_id,
+            },
+        )
+
+    # Create-time validation also runs on UPDATE (#1284, criteria 1-7 apply on update):
+    # validate the EFFECTIVE script + declared surface — the new value where provided,
+    # the preserved current value where omitted — so an under-declared surface can't be
+    # introduced by narrowing ``tools`` while leaving a tool("X") call in the script.
+    validate_workflow_script(
+        script if script is not None else current.script,
+        tools=tools if tools is not None else current.tools,
+        mcp_servers=mcp_servers if mcp_servers is not None else current.mcp_servers,
+        http_servers=http_servers if http_servers is not None else list(current.http_servers),
+    )
+
     if actor_session_id is None:
         operator_http = _reject_operator_path_names_only(http_servers)
     if actor_session_id is not None:
-        current = await get_workflow(pool, workflow_id, account_id=account_id)
-        if current.version != expected_version:
-            # Pin the attenuation read to the caller's token. Without this, an actor
-            # could send a FUTURE token: attenuation passes against today's surface,
-            # a concurrent update broadens it and bumps to exactly that token, and the
-            # optimistic UPDATE then matches — landing the actor's script on a surface
-            # that was never checked. With the pin, the UPDATE's ``WHERE version``
-            # guarantees nothing changed between this read and the write.
-            raise ConflictError(
-                f"version mismatch: expected {expected_version}, current is {current.version}",
-                detail={
-                    "expected": expected_version,
-                    "current": current.version,
-                    "id": workflow_id,
-                },
-            )
+        # The version match was pinned above (current was read at this consistency
+        # point); the UPDATE's ``WHERE version`` remains the authoritative serializer.
         # ``current.http_servers`` is the already-resolved stored spec; ``list(...)``
         # widens it to ``list[HttpServerRef]`` for the (str | spec)-typed parameter.
         merged_http: list[HttpServerRef] = (

--- a/src/aios/workflows/script_validation.py
+++ b/src/aios/workflows/script_validation.py
@@ -1,0 +1,269 @@
+"""Create-time validation for workflow author scripts (#1221 / #1284).
+
+A workflow is authored out-of-band as an inert ``script: str`` whose declared
+tool/server surface is hand-derived and authored *separately* from the script.
+Without create-time checking, three failure classes surface only as a *failed
+run* read back from the journal instead of as an authoring-time error. This
+module closes the two structural classes (the value-domain class is #934):
+
+1. **Syntax / structure** — the script does not ``compile(...)``, or it has no
+   top-level ``async def main(input)`` (right name, ``async``, single ``input``
+   parameter).
+2. **Surface drift** — a string-literal ``tool("X", …)`` call (or string-literal
+   ``agent(agent_id="A")`` reference) whose required surface is not covered by
+   the *declared* surface. The author writes the declared surface; the validator
+   checks it is a **superset** of the AST-extracted required surface (the
+   *validate-declared* fork, settled in #1284 — NOT auto-derive).
+
+**Literal-only extraction.** When a ``tool(name, …)`` name or an ``agent_id`` is
+not a string literal (computed / a variable / from ``input``), that element is
+*un-AST-able* and is **excluded** from the required-surface check — the validator
+does not reject on it and does not attempt to resolve it. Only string-literal
+``tool("…")`` names and string-literal ``agent(agent_id="…")`` references take
+part in the union.
+
+The host already does ``compile(source, "<workflow>", "exec", dont_inherit=True)``
+in the exec path (:mod:`aios.workflows.wf_script_host`); this lifts that compile
+to create time and adds the AST checks, surfacing a precise, actionable error.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from aios.errors import ValidationError
+
+if TYPE_CHECKING:
+    from aios.models.agents import McpServerSpec, ToolSpec
+
+# Filename used for the lifted compile, matching the run-time exec path so the
+# surfaced line/offset is in the same coordinate system the author already sees
+# in a run traceback.
+_WORKFLOW_FILENAME = "<workflow>"
+
+
+class WorkflowScriptValidationError(ValidationError):
+    """A workflow script failed create-time validation (#1284).
+
+    A 422 (``ValidationError`` subclass) carrying an author-facing message that
+    names the specific defect — a compile/syntax failure (with line/offset where
+    available), a missing/mis-signatured ``async def main(input)``, or the
+    specific missing tool/server name(s) for an under-declared surface. Raised at
+    create *and* update time, before any row is written.
+    """
+
+    error_type = "workflow_script_validation_error"
+    status_code = 422
+
+
+def _declared_tool_names(tools: Sequence[ToolSpec]) -> set[str]:
+    """The set of names a script's ``tool("…")`` call may resolve to.
+
+    A run resolves ``tool(name)`` against ``{t.type for t in run.tools}`` (the
+    run-tool gate, :func:`aios.workflows.run_tools.gate_run_tool`), so a builtin's
+    callable name is its ``type``. A custom tool is callable by its ``name``. Both
+    are admitted so the required-surface check matches what the run will actually
+    resolve. (``mcp_toolset`` tools are namespaced and are never called by a bare
+    ``tool("…")`` literal, so they contribute no bare name here.)
+    """
+    names: set[str] = set()
+    for t in tools:
+        if t.type == "mcp_toolset":
+            continue
+        if t.type == "custom":
+            if t.name is not None:
+                names.add(t.name)
+            continue
+        names.add(t.type)
+        if t.name is not None:
+            names.add(t.name)
+    return names
+
+
+def _is_call_to(node: ast.Call, func_name: str) -> bool:
+    """True iff ``node`` is a direct call to the bare name ``func_name`` — e.g.
+    ``tool(...)`` / ``agent(...)``. Attribute calls (``obj.tool(...)``) are not the
+    injected capability and are ignored."""
+    return isinstance(node.func, ast.Name) and node.func.id == func_name
+
+
+def _literal_str(node: ast.expr | None) -> str | None:
+    """Return the string value if ``node`` is a string-literal constant, else None
+    (the un-AST-able case: a variable, attribute, f-string, ``input[...]``, …)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _extract_required_tools(tree: ast.AST) -> set[str]:
+    """String-literal ``tool("X", …)`` names — the first positional arg, literal only."""
+    required: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_call_to(node, "tool") and node.args:
+            name = _literal_str(node.args[0])
+            if name is not None:
+                required.add(name)
+    return required
+
+
+def _extract_required_agent_ids(tree: ast.AST) -> set[str]:
+    """String-literal ``agent(agent_id="A")`` references — the ``agent_id`` keyword,
+    literal only. ``agent_id`` is keyword-only in the author API
+    (``agent(input, *, agent_id=None, …)``), so only the keyword form participates.
+    """
+    required: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_call_to(node, "agent"):
+            for kw in node.keywords:
+                if kw.arg == "agent_id":
+                    agent_id = _literal_str(kw.value)
+                    if agent_id is not None:
+                        required.add(agent_id)
+    return required
+
+
+def _find_top_level_main(tree: ast.Module) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """The last top-level ``def``/``async def`` named ``main`` (mirroring exec
+    semantics, where a later binding shadows an earlier one), or None."""
+    found: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    for stmt in tree.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name == "main":
+            found = stmt
+    return found
+
+
+def _main_accepts_single_input(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True iff ``main``'s signature accepts the single ``input`` parameter — i.e.
+    exactly one positional-or-keyword parameter and no extra required params.
+
+    Accepts ``async def main(input)`` (the canonical form). Rejects ``main()``,
+    ``main(a, b)``, and keyword-only/var-arg-only shapes that cannot be called as
+    ``main(input_value)`` with one positional argument.
+    """
+    args = func.args
+    positional = args.posonlyargs + args.args
+    # Exactly one positional-or-keyword (or positional-only) parameter, and no
+    # other required parameters. ``*args``/``**kwargs`` and defaulted extras are
+    # not the contract shape; keep the check strict to the single ``input`` slot.
+    if len(positional) != 1:
+        return False
+    if args.vararg is not None or args.kwarg is not None:
+        return False
+    # Any required keyword-only parameter would make ``main(input_value)`` fail
+    # (a ``None`` in ``kw_defaults`` marks a kw-only param with no default).
+    return all(default is not None for default in args.kw_defaults)
+
+
+def validate_workflow_script(
+    script: str,
+    *,
+    tools: Sequence[ToolSpec] | None = None,
+    mcp_servers: Sequence[McpServerSpec] | None = None,
+    http_servers: Sequence[object] | None = None,
+) -> None:
+    """Validate a workflow author script at create/update time (#1284).
+
+    Raises :class:`WorkflowScriptValidationError` (422) with a precise,
+    actionable message on any of:
+
+    1. **Syntax / compile failure** — the script does not ``compile(...)`` (the
+       lifted host compile); the message identifies it as a syntax failure and
+       surfaces the line/offset where available. The workflow is not created.
+    2. **Missing ``main``** — no top-level ``async def main`` — message names the
+       required ``async def main(input)``.
+    3. **Mis-signatured ``main``** — a top-level ``main`` that is not ``async``,
+       or whose signature does not accept the single ``input`` parameter — message
+       names the signature requirement.
+    4. **Under-declared tool surface** — a string-literal ``tool("X", …)`` whose
+       ``"X"`` is not in the declared ``tools`` — message names ``X``.
+    5. **Under-declared agent reference** — a string-literal
+       ``agent(agent_id="A")`` whose ``"A"`` is not in the declared agent surface
+       — message names ``A``. (Depth note below.)
+
+    **Surface model / chosen depth.** This is *validate-declared*: the declared
+    surface must be a superset of the AST-extracted required surface, literal-only.
+    The ``tool("X")`` union is checked against the declared tool names. For
+    ``agent(agent_id="A")`` the child agent's *full* transitive surface cannot be
+    resolved here (it lives in the DB and is out of scope for this create-time,
+    DB-free validator, per #1284's "if resolving a child agent's full surface is
+    out of scope … at minimum the literal ``agent_id`` participation in the union
+    MUST be implemented"). So the ``agent_id`` participates in the union via the
+    workflow's own declared **mcp_servers** named surface: a literal ``agent_id``
+    that is not covered by a declared mcp server of the same name is reported as a
+    missing element. A literal ``agent_id`` that names a *tool* the script could
+    also call is covered by the declared tools. Un-AST-able (computed/variable)
+    ``agent_id`` values are excluded from the check.
+
+    Un-AST-able ``tool``/``agent_id`` names (computed / variable / from ``input``)
+    are excluded from the required-surface check entirely — never a violation.
+    """
+    # 1. Compile / syntax. Lift the host's exec-path compile to create time and
+    #    surface a precise error (line/offset where the SyntaxError carries them).
+    try:
+        compile(script, _WORKFLOW_FILENAME, "exec", dont_inherit=True)
+    except SyntaxError as exc:
+        loc = ""
+        if exc.lineno is not None:
+            loc = f" at line {exc.lineno}"
+            if exc.offset is not None:
+                loc += f", offset {exc.offset}"
+        msg = exc.msg or "invalid syntax"
+        raise WorkflowScriptValidationError(
+            f"workflow script failed to compile (syntax error{loc}): {msg}",
+            detail={"lineno": exc.lineno, "offset": exc.offset, "msg": msg},
+        ) from exc
+
+    # The AST is reparsed (compile() does not hand back a tree); same source, so it
+    # cannot raise here after a clean compile.
+    tree = ast.parse(script, filename=_WORKFLOW_FILENAME)
+
+    # 2/3. Top-level async def main(input).
+    main = _find_top_level_main(tree)
+    if main is None:
+        raise WorkflowScriptValidationError(
+            "workflow script must define a top-level `async def main(input)` "
+            "(no top-level `main` found)",
+        )
+    if not isinstance(main, ast.AsyncFunctionDef):
+        raise WorkflowScriptValidationError(
+            "workflow script `main` must be declared `async def main(input)` "
+            "(found a plain `def main`, not `async`)",
+        )
+    if not _main_accepts_single_input(main):
+        raise WorkflowScriptValidationError(
+            "workflow script `async def main` must accept the single `input` "
+            "parameter (signature `async def main(input)`)",
+        )
+
+    # 4/5. AST-derived required-surface union vs. the declared surface.
+    declared_tools = _declared_tool_names(tools or [])
+    declared_mcp = {s.name for s in (mcp_servers or [])}
+
+    required_tools = _extract_required_tools(tree)
+    missing_tools = sorted(required_tools - declared_tools)
+    if missing_tools:
+        names = ", ".join(repr(n) for n in missing_tools)
+        raise WorkflowScriptValidationError(
+            f"workflow script calls tool(s) not in the declared tool surface: {names}. "
+            "Add them to the workflow's declared `tools` (the declared surface must be a "
+            "superset of the tools the script calls by string literal).",
+            detail={"missing_tools": missing_tools},
+        )
+
+    # A literal agent_id participates in the union: it is covered when a declared
+    # tool OR a declared mcp server of that name exists. The child agent's full
+    # transitive surface is out of scope for this DB-free create-time validator
+    # (documented above); literal-only participation is the implemented depth.
+    required_agent_ids = _extract_required_agent_ids(tree)
+    covered = declared_tools | declared_mcp
+    missing_agents = sorted(required_agent_ids - covered)
+    if missing_agents:
+        names = ", ".join(repr(n) for n in missing_agents)
+        raise WorkflowScriptValidationError(
+            f"workflow script references agent(agent_id=…) not covered by the declared "
+            f"surface: {names}. Declare the corresponding tool/mcp server (the declared "
+            "surface must be a superset of the string-literal agent references).",
+            detail={"missing_agents": missing_agents},
+        )

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -89,7 +89,7 @@ async def _seed_workflow(pool: asyncpg.Pool[Any], *, account_id: str) -> str:
         pool,
         account_id=account_id,
         name="invocations-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -61,7 +61,7 @@ async def _seed_parent_run(pool: asyncpg.Pool[Any], *, account_id: str, environm
         pool,
         account_id=account_id,
         name="request-opened-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_trace_walk.py
+++ b/tests/integration/test_trace_walk.py
@@ -60,7 +60,7 @@ async def _seed_run(
         pool,
         account_id=account_id,
         name=f"trace-walk-wf-{uuid4().hex}",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/unit/test_workflow_script_validation.py
+++ b/tests/unit/test_workflow_script_validation.py
@@ -1,0 +1,258 @@
+"""Reference tests for create-time workflow-script validation (#1284).
+
+These exercise the pure validator (:func:`aios.workflows.script_validation.
+validate_workflow_script`) directly — no DB — so each acceptance criterion in
+#1284 has an objective pass/fail test:
+
+1. syntax / compile failure  → rejected, message identifies a syntax failure
+2. missing top-level ``main`` → rejected, message names ``async def main(input)``
+3. mis-signatured ``main``    → rejected (plain ``def``, ``main()``, ``main(a, b)``)
+4. under-declared tool        → rejected, message names the missing tool ``X``
+5. under-declared agent ref   → rejected, message names the missing element
+6. valid, fully-covered       → accepted (happy path unchanged)
+7. un-AST-able names          → accepted (excluded from the required-surface check)
+
+The service-path wiring (create + update both enforce it, the tool-handler path
+and HTTP path both flow through the service) is covered in
+``test_workflow_service_validation.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.errors import ValidationError
+from aios.models.agents import McpServerSpec, ToolSpec
+from aios.workflows.script_validation import (
+    WorkflowScriptValidationError,
+    validate_workflow_script,
+)
+
+_VALID_MAIN = "async def main(input):\n    return input\n"
+
+
+# ── 1. syntax / compile failure ──────────────────────────────────────────────
+
+
+def test_syntax_error_rejected_with_compile_message() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def main(input):\n    return (\n")
+    msg = exc.value.message
+    assert "compile" in msg or "syntax" in msg
+    # Line/offset surfaced where available.
+    assert "line" in msg
+    assert exc.value.detail.get("lineno") is not None
+
+
+def test_stray_token_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def main(input):\n    return 1 @\n")
+    assert "syntax" in exc.value.message or "compile" in exc.value.message
+
+
+def test_validation_error_is_422_aios_error() -> None:
+    err = WorkflowScriptValidationError("x")
+    assert isinstance(err, ValidationError)
+    assert err.status_code == 422
+
+
+# ── 2. missing main ──────────────────────────────────────────────────────────
+
+
+def test_missing_main_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def helper(input):\n    return 1\n")
+    assert "main(input)" in exc.value.message
+
+
+def test_main_not_top_level_rejected() -> None:
+    # A nested ``main`` is not the entry point.
+    script = "async def wrapper():\n    async def main(input):\n        return 1\n"
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script)
+    assert "main(input)" in exc.value.message
+
+
+# ── 3. mis-signatured main ───────────────────────────────────────────────────
+
+
+def test_plain_def_main_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("def main(input):\n    return 1\n")
+    assert "async" in exc.value.message
+
+
+def test_main_no_params_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def main():\n    return 1\n")
+    assert "input" in exc.value.message
+
+
+def test_main_two_params_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script("async def main(a, b):\n    return 1\n")
+    assert "input" in exc.value.message
+
+
+def test_main_required_kwonly_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError):
+        validate_workflow_script("async def main(input, *, x):\n    return 1\n")
+
+
+def test_main_varargs_only_rejected() -> None:
+    with pytest.raises(WorkflowScriptValidationError):
+        validate_workflow_script("async def main(*args):\n    return 1\n")
+
+
+def test_main_input_with_default_kwonly_accepted() -> None:
+    # A defaulted keyword-only extra still leaves ``main(input_value)`` callable.
+    validate_workflow_script("async def main(input, *, label=None):\n    return 1\n")
+
+
+# ── 4. under-declared tool surface ───────────────────────────────────────────
+
+
+def test_undeclared_tool_rejected_naming_it() -> None:
+    script = 'async def main(input):\n    return await tool("bash", {"command": "ls"})\n'
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script, tools=[])
+    assert "bash" in exc.value.message
+    assert "bash" in exc.value.detail.get("missing_tools", [])
+
+
+def test_declared_builtin_tool_accepted() -> None:
+    script = 'async def main(input):\n    return await tool("bash", {"command": "ls"})\n'
+    validate_workflow_script(script, tools=[ToolSpec(type="bash")])
+
+
+def test_declared_custom_tool_accepted_by_name() -> None:
+    script = 'async def main(input):\n    return await tool("my_tool", {})\n'
+    validate_workflow_script(
+        script, tools=[ToolSpec(type="custom", name="my_tool", description="d", input_schema={})]
+    )
+
+
+def test_multiple_undeclared_tools_all_named() -> None:
+    script = (
+        'async def main(input):\n    await tool("bash", {})\n    await tool("web_search", {})\n'
+    )
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script, tools=[])
+    assert "bash" in exc.value.message
+    assert "web_search" in exc.value.message
+
+
+def test_partially_declared_tools_names_only_missing() -> None:
+    script = (
+        'async def main(input):\n    await tool("bash", {})\n    await tool("web_search", {})\n'
+    )
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script, tools=[ToolSpec(type="bash")])
+    assert "web_search" in exc.value.message
+    assert "bash" not in exc.value.detail.get("missing_tools", [])
+
+
+# ── 5. under-declared agent reference ────────────────────────────────────────
+
+
+def test_undeclared_literal_agent_id_rejected_naming_it() -> None:
+    script = 'async def main(input):\n    return await agent({}, agent_id="scout")\n'
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script)
+    assert "scout" in exc.value.message
+    assert "scout" in exc.value.detail.get("missing_agents", [])
+
+
+def test_literal_agent_id_covered_by_mcp_accepted() -> None:
+    script = 'async def main(input):\n    return await agent({}, agent_id="scout")\n'
+    validate_workflow_script(
+        script, mcp_servers=[McpServerSpec(name="scout", url="https://example.test/mcp")]
+    )
+
+
+def test_literal_agent_id_covered_by_tool_accepted() -> None:
+    script = 'async def main(input):\n    return await agent({}, agent_id="scout")\n'
+    validate_workflow_script(
+        script, tools=[ToolSpec(type="custom", name="scout", description="d", input_schema={})]
+    )
+
+
+# ── 6. valid, fully-covered ──────────────────────────────────────────────────
+
+
+def test_valid_minimal_accepted() -> None:
+    validate_workflow_script(_VALID_MAIN)
+
+
+def test_valid_fully_covered_accepted() -> None:
+    script = (
+        "async def main(input):\n"
+        '    r = await tool("bash", {"command": "ls"})\n'
+        '    return await agent({}, agent_id="scout")\n'
+    )
+    validate_workflow_script(
+        script,
+        tools=[ToolSpec(type="bash")],
+        mcp_servers=[McpServerSpec(name="scout", url="https://example.test/mcp")],
+    )
+
+
+def test_posonly_input_accepted() -> None:
+    validate_workflow_script("async def main(input, /):\n    return input\n")
+
+
+def test_last_main_binding_wins() -> None:
+    # exec semantics: a later top-level ``main`` shadows an earlier one — the valid
+    # async one is the effective entry, so this is accepted.
+    script = "def main(input):\n    return 1\nasync def main(input):\n    return 2\n"
+    validate_workflow_script(script)
+
+
+# ── 7. un-AST-able names excluded (no false rejection) ───────────────────────
+
+
+def test_computed_tool_name_accepted() -> None:
+    script = (
+        "async def main(input):\n"
+        '    name_var = input["tool"]\n'
+        "    return await tool(name_var, {})\n"
+    )
+    validate_workflow_script(script, tools=[])
+
+
+def test_agent_id_from_input_accepted() -> None:
+    script = 'async def main(input):\n    return await agent({}, agent_id=input["a"])\n'
+    validate_workflow_script(script)
+
+
+def test_agent_id_from_variable_accepted() -> None:
+    script = (
+        "SCOUT = input_unused = None\n"
+        "async def main(input):\n"
+        '    aid = input["who"]\n'
+        "    return await agent({}, agent_id=aid)\n"
+    )
+    validate_workflow_script(script)
+
+
+def test_fstring_tool_name_accepted() -> None:
+    script = "async def main(input):\n    return await tool(f\"{input['kind']}_tool\", {})\n"
+    validate_workflow_script(script)
+
+
+def test_mixed_literal_and_computed_only_literal_checked() -> None:
+    # The computed call is excluded; the literal ``"bash"`` is the only required name.
+    script = 'async def main(input):\n    await tool(input["x"], {})\n    await tool("bash", {})\n'
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        validate_workflow_script(script, tools=[])
+    assert exc.value.detail.get("missing_tools") == ["bash"]
+
+
+def test_attribute_call_not_treated_as_capability() -> None:
+    # ``obj.tool("x")`` is not the injected ``tool(...)`` capability.
+    script = (
+        "class C:\n    def tool(self, n, i):\n        return None\n"
+        "async def main(input):\n"
+        '    return C().tool("bash", {})\n'
+    )
+    validate_workflow_script(script, tools=[])

--- a/tests/unit/test_workflow_service_validation.py
+++ b/tests/unit/test_workflow_service_validation.py
@@ -1,0 +1,207 @@
+"""Service-path wiring for create-time validation (#1284, criterion 8).
+
+Proves that BOTH the create path and the update path of
+``aios.services.workflows`` enforce :func:`validate_workflow_script` — the single
+chokepoint the tool-handler builtin (``create_workflow_handler`` /
+``update_workflow_handler``), the HTTP router, and any other caller all flow
+through. No DB: the query layer is stubbed, and on a rejecting script the service
+must raise *before* ever touching it.
+
+(The pure validator's full criteria 1-7 coverage lives in
+``test_workflow_script_validation.py``; here we only assert the service calls it
+and that a valid script still reaches the insert/update query unchanged — the
+happy path is unaffected.)
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from aios.models.agents import ToolSpec
+from aios.models.workflows import Workflow
+from aios.services import workflows as service
+from aios.workflows.script_validation import WorkflowScriptValidationError
+
+_DT = datetime(2026, 1, 1, tzinfo=UTC)
+
+_BAD_SCRIPT = "async def main(input):\n    return (\n"  # syntax error
+_UNDECLARED = 'async def main(input):\n    return await tool("bash", {})\n'
+_GOOD_SCRIPT = "async def main(input):\n    return input\n"
+
+
+class _FakePool:
+    """A pool whose ``acquire()`` yields a sentinel conn — the stubbed query
+    functions ignore it, so no DB is touched."""
+
+    @asynccontextmanager
+    async def acquire(self) -> Any:
+        yield object()
+
+
+def _workflow(**over: Any) -> Workflow:
+    base: dict[str, Any] = dict(
+        id="wf_1",
+        account_id="acc_x",
+        name="w",
+        version=1,
+        script=_GOOD_SCRIPT,
+        created_at=_DT,
+        updated_at=_DT,
+    )
+    base.update(over)
+    return Workflow(**base)
+
+
+# ── create ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_bad_script_before_db(monkeypatch: Any) -> None:
+    insert_called = False
+
+    async def _insert(*a: Any, **k: Any) -> Workflow:
+        nonlocal insert_called
+        insert_called = True
+        return _workflow()
+
+    monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", _insert)
+    with pytest.raises(WorkflowScriptValidationError):
+        await service.create_workflow(_FakePool(), account_id="acc_x", name="w", script=_BAD_SCRIPT)
+    assert insert_called is False  # rejected before the insert
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_undeclared_tool(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        "aios.db.queries.workflows.insert_workflow",
+        lambda *a, **k: pytest.fail("insert should not run"),
+    )
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        await service.create_workflow(
+            _FakePool(), account_id="acc_x", name="w", script=_UNDECLARED, tools=[]
+        )
+    assert "bash" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_valid_reaches_insert(monkeypatch: Any) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _insert(conn: Any, **k: Any) -> Workflow:
+        seen.update(k)
+        return _workflow(script=k["script"])
+
+    monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", _insert)
+    wf = await service.create_workflow(
+        _FakePool(),
+        account_id="acc_x",
+        name="w",
+        script=_UNDECLARED,
+        tools=[ToolSpec(type="bash")],
+    )
+    assert seen["script"] == _UNDECLARED  # happy path unchanged: reached the insert
+    assert wf.script == _UNDECLARED
+
+
+# ── update ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_bad_script(monkeypatch: Any) -> None:
+    # Operator path (no actor): the bad script is rejected before the update query.
+    async def _get(conn: Any, workflow_id: str, *, account_id: str) -> Workflow:
+        return _workflow(version=1)
+
+    monkeypatch.setattr("aios.db.queries.workflows.get_workflow", _get)
+    monkeypatch.setattr(
+        "aios.db.queries.workflows.update_workflow",
+        lambda *a, **k: pytest.fail("update should not run"),
+    )
+    with pytest.raises(WorkflowScriptValidationError):
+        await service.update_workflow(
+            _FakePool(),
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            script=_BAD_SCRIPT,
+            tools=[],
+            mcp_servers=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_validates_effective_surface_with_preserved_script(
+    monkeypatch: Any,
+) -> None:
+    # script omitted (preserved) but tools narrowed to [] — the preserved script
+    # still calls tool("bash"), so the effective shape is now under-declared.
+    async def _get(conn: Any, workflow_id: str, *, account_id: str) -> Workflow:
+        return _workflow(script=_UNDECLARED, tools=[ToolSpec(type="bash")])
+
+    monkeypatch.setattr("aios.db.queries.workflows.get_workflow", _get)
+    monkeypatch.setattr(
+        "aios.db.queries.workflows.update_workflow",
+        lambda *a, **k: pytest.fail("update should not run"),
+    )
+    with pytest.raises(WorkflowScriptValidationError) as exc:
+        await service.update_workflow(
+            _FakePool(),
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            tools=[],  # narrow away bash while the script still calls it
+        )
+    assert "bash" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_update_stale_version_409_precedes_script_validation(monkeypatch: Any) -> None:
+    # A stale optimistic token (409) keeps precedence over a 422 script-validation error
+    # even when the submitted script is invalid — the token-probe contract existing
+    # callers rely on (an invalid throwaway script must not mask the conflict).
+    from aios.errors import ConflictError
+
+    async def _get(conn: Any, workflow_id: str, *, account_id: str) -> Workflow:
+        return _workflow(version=5)
+
+    monkeypatch.setattr("aios.db.queries.workflows.get_workflow", _get)
+    monkeypatch.setattr(
+        "aios.db.queries.workflows.update_workflow",
+        lambda *a, **k: pytest.fail("update should not run"),
+    )
+    with pytest.raises(ConflictError):
+        await service.update_workflow(
+            _FakePool(),
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,  # stale
+            script=_BAD_SCRIPT,  # invalid, but the 409 must win
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_valid_reaches_update_query(monkeypatch: Any) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _get(conn: Any, workflow_id: str, *, account_id: str) -> Workflow:
+        return _workflow(script=_GOOD_SCRIPT, tools=[])
+
+    async def _update(conn: Any, workflow_id: str, **k: Any) -> Workflow:
+        seen.update(k)
+        return _workflow(version=2, script=k.get("script") or _GOOD_SCRIPT)
+
+    monkeypatch.setattr("aios.db.queries.workflows.get_workflow", _get)
+    monkeypatch.setattr("aios.db.queries.workflows.update_workflow", _update)
+    wf = await service.update_workflow(
+        _FakePool(),
+        "wf_1",
+        account_id="acc_x",
+        expected_version=1,
+        script=_UNDECLARED,
+        tools=[ToolSpec(type="bash")],
+    )
+    assert wf.version == 2  # happy path unchanged: reached the update query


### PR DESCRIPTION
## What & why

Bakeoff build of #1221 (model: openrouter/z-ai/glm-5.2) — **DO NOT MERGE without the comparison.** Part of #777.

A workflow is authored out-of-band as an inert `script: str` whose declared tool/server surface is hand-derived separately from the script. Without create-time checking, two structural failure classes surface only as a *failed run* read back from the journal instead of as an authoring-time error. This adds a create-time validator so they surface at author time with a precise, actionable message.

Covers failure classes **1 (syntax/structure)** and **2 (surface drift)** only; the value-domain class (3) is #934 and explicitly out of scope.

## Change

New pure, DB-free validator `aios.workflows.script_validation.validate_workflow_script(script, *, tools, mcp_servers, http_servers)`:

1. **Compile** the script (lifts the host's existing exec-path `compile(source, "<workflow>", "exec", dont_inherit=True)` to create time) → precise 422 on a syntax error, with line/offset where available.
2. **Assert** a top-level `async def main(input)` (AST): rejects missing `main`, a non-`async` `def main`, and a signature that does not accept the single `input` parameter (`main()`, `main(a, b)`, required kw-only, `*args`-only).
3. **AST-extract** string-literal `tool("X", …)` names and string-literal `agent(agent_id="A")` references and require the **declared** surface to be a **superset** (validate-declared — the settled #1284 fork, NOT auto-derive). The error names the specific missing tool/server. **Un-AST-able** (computed / variable / from `input`) names are excluded from the check — never a false rejection.

Wired into `aios.services.workflows.create_workflow` and `update_workflow` — the single chokepoint the agent builtin handlers (`create_workflow_handler` / `update_workflow_handler`), the HTTP router, and any other caller all flow through, so **both paths enforce it** (criterion 8). Validation runs on **update** too, against the *effective* shape (new field where provided, preserved current value where omitted) so an under-declared surface can't be introduced by narrowing `tools` while leaving a `tool("X")` call in the preserved script. On update the unknown-id (404) and stale-token (409) gates are ordered **before** validation so the existing token-probe contract (and the e2e `script:"x"` stale/unknown tests) is unchanged.

New `WorkflowScriptValidationError` (a 422 `AiosError`/`ValidationError` subclass): the generic `AiosError` handler renders it as a JSON 422 on the HTTP path, and `_classify_tool_error` (4xx) turns it into a clean model-visible tool result with no sandbox eviction on the agent path — exactly the discoverability win the issue wants.

## Chosen agent_id depth (documented per criterion 5)

Resolving a child agent's full transitive surface lives in the DB and is **out of scope** for this DB-free create-time validator (#1284 explicitly permits this). The implemented depth: a string-literal `agent_id` **participates in the union** by requiring coverage in the declared surface's named elements — a declared tool OR a declared mcp server of that name. A literal `agent_id` not so covered is reported as the missing element; un-AST-able `agent_id` values (the common real case — they are variables/constants like `SCOUT_AGENT_ID`) are excluded.

## Tests

- `tests/unit/test_workflow_script_validation.py` — reference tests for every acceptance criterion 1–7 against the pure validator (syntax, missing/mis-signatured/non-async/nested `main`, under-declared tool naming `X`, under-declared literal `agent_id`, valid fully-covered happy path, and the un-AST-able-excluded cases incl. computed names, f-strings, `input`-derived ids, attribute calls).
- `tests/unit/test_workflow_service_validation.py` — DB-free proof that **both** `create_workflow` and `update_workflow` enforce validation, that a valid script reaches the insert/update query unchanged (happy path unaffected), that update validates the preserved-script effective surface, and that a stale 409 keeps precedence over a 422.

Lint (ruff check + format) and typecheck (mypy) pass on all changed/new files. Existing workflow unit tests pass; the dev_pipeline builder output (`async def main(input)`, literal `tool('bash')`/`tool('http_request')`) validates, and the IaC reregister flow (operator update, tools preserved) is unaffected. Integration/e2e suites require Postgres/Docker (unavailable in this sandbox) and were not run here.

**DO NOT MERGE without the bakeoff comparison.**