### PR TITLE
feat(workflows): create-time validation — compile + assert async def main(input) + AST-derived tool/agent surface union check

### DIFF
--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -40,6 +40,11 @@ from aios.services import attenuation as attenuation_service
 from aios.services import sessions as sessions_service
 from aios.services.await_completion import await_completion
 from aios.services.wake import defer_run_wake
+from aios.workflows.script_validation import (
+    _declared_tool_names,
+    extract_literal_agent_ids,
+    validate_workflow_script,
+)
 from aios.workflows.service import create_run, resume_gate
 
 __all__ = [
@@ -146,6 +151,48 @@ def _reject_operator_path_names_only(
     return [s for s in http_servers if isinstance(s, HttpServerSpec)]
 
 
+async def _validate_script_at_authoring(
+    pool: asyncpg.Pool[Any],
+    *,
+    account_id: str,
+    script: str,
+    tools: list[ToolSpec],
+) -> None:
+    """Create/update-time validation of a workflow ``script`` (#1286): compile, assert a
+    top-level ``async def main(input)``, and check the declared tool surface is a superset
+    of the AST-extracted ``tool("…")`` / ``agent(agent_id="…")`` required union. Raises
+    :class:`ValidationError` with a precise message; a no-op when the script is admissible.
+
+    **Chosen ``agent_id`` depth.** A literal ``agent(agent_id="A")`` resolves the named
+    agent's *declared tool surface* (by the same ``type``/``name`` identity keys used for
+    ``tool("…")``) and requires the workflow's declared ``tools`` to cover it — the #794
+    clamp ``child = agent ∩ run`` silently strips any tool the workflow under-declares, so
+    an under-declaration is exactly the surface-drift bug this closes. A literal id naming
+    an agent that does not resolve (cross-account / archived / absent) is excluded from the
+    union — un-resolvable, never a false rejection — mirroring an un-AST-able name.
+    """
+
+    async def resolve_one(agent_id: str) -> frozenset[str] | None:
+        try:
+            agent = await agents_service.get_agent(pool, agent_id, account_id=account_id)
+        except NotFoundError:
+            return None
+        return frozenset(_declared_tool_names(list(agent.tools)))
+
+    # ``validate_workflow_script`` takes a *sync* resolver; pre-resolve the (tiny) set of
+    # literal agent ids here so the validator core stays pure/sync and DB-free. An
+    # unparsable script yields no ids — the compile step inside the validator reports it.
+    resolved: dict[str, frozenset[str] | None] = {
+        aid: await resolve_one(aid) for aid in extract_literal_agent_ids(script)
+    }
+
+    validate_workflow_script(
+        script,
+        tools=tools,
+        resolve_agent_tools=lambda aid: resolved.get(aid),
+    )
+
+
 async def create_workflow(
     pool: asyncpg.Pool[Any],
     *,
@@ -171,7 +218,15 @@ async def create_workflow(
     creating agent first. With no creator (the HTTP/operator path) any surface may be
     declared verbatim, account-scoped — but names-only sugar is unavailable there (no
     acting agent to resolve against).
+
+    **Create-time script validation (#1286):** the ``script`` is compiled and structurally
+    checked (top-level ``async def main(input)`` + declared-surface ⊇ AST-required union)
+    before anything is written; a breach raises :class:`ValidationError` and nothing is
+    created. This runs on both the agent (creator) and the HTTP/operator path.
     """
+    await _validate_script_at_authoring(
+        pool, account_id=account_id, script=script, tools=tools or []
+    )
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
     if creator_session_id is not None:
@@ -238,6 +293,7 @@ async def update_workflow(
     """
     effective: Surface | None = None
     operator_http: list[HttpServerSpec] | None = None
+    current: Workflow | None = None
     if actor_session_id is None:
         operator_http = _reject_operator_path_names_only(http_servers)
     if actor_session_id is not None:
@@ -269,6 +325,20 @@ async def update_workflow(
             tools=tools if tools is not None else current.tools,
             mcp_servers=mcp_servers if mcp_servers is not None else current.mcp_servers,
             http_servers=merged_http,
+        )
+    # Update-time script validation (#1286): validate the EFFECTIVE script + tools — the
+    # update merges with the stored definition (an omitted ``script``/``tools`` preserves
+    # current), so a rewrite that touches only one side must still satisfy the other. Read
+    # current on the operator path too (the actor path already fetched it above; reuse it).
+    if script is not None or tools is not None:
+        current_for_validation = current or await get_workflow(
+            pool, workflow_id, account_id=account_id
+        )
+        await _validate_script_at_authoring(
+            pool,
+            account_id=account_id,
+            script=script if script is not None else current_for_validation.script,
+            tools=tools if tools is not None else list(current_for_validation.tools),
         )
     # Agent-actor touching http: store the inherited launcher-frozen routes. Operator path,
     # or an edit that didn't touch http (``http_servers is None`` → query preserves current):

--- a/src/aios/workflows/script_validation.py
+++ b/src/aios/workflows/script_validation.py
@@ -1,0 +1,268 @@
+"""Create-time validation of a workflow ``script`` (#1221 / #1286).
+
+A workflow is authored out-of-band as an inert ``script: str`` whose only contract
+is a docstring, and whose declared tool/server surface is authored *separately* from
+the script body. Historically three failure classes only surfaced as a *failed run*
+read back from the journal rather than as an authoring-time error:
+
+1. **Syntax / structure errors** — a typo, or a missing top-level ``async def
+   main(input)`` — not caught until the host ``exec``'d the script in a run.
+2. **Silent surface drift** — the declared ``tools`` / ``http_servers`` /
+   ``mcp_servers`` must be the **union** of the script's own ``tool("…")`` calls and
+   every named ``agent(agent_id="…")`` child's tools; an under-declaration is
+   silently stripped by the #794 clamp and detonates as a runtime route-mismatch.
+
+This module lifts the host's own ``compile(...)`` to create time and adds an AST
+check, closing classes 1 and 2 (value-domain traps — class 3 — are out of scope,
+tracked by #934).
+
+**Design (SETTLED, #1286): validate-declared, literal-only extraction.** The author
+writes the declared surface; the validator checks the declared surface is a
+**superset** of the AST-extracted *required* surface. Only string-literal
+``tool("…")`` names and string-literal ``agent(agent_id="…")`` references participate
+in the required-surface union. A ``tool(name_var, …)`` or an ``agent_id`` that is not
+a string literal (computed / variable / from ``input``) is **un-AST-able** and is
+**excluded** from the check — it never causes a rejection.
+
+The single public entry point is :func:`validate_workflow_script`. It is pure and
+synchronous over the AST; the *named-agent surface* (the ``agent_id`` participation)
+is resolved by an injected ``resolve_agent_tools`` callback so the AST core stays
+DB-free and unit-testable, while the service path wires in the real agent lookup.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from aios.errors import ValidationError
+from aios.models.agents import ToolSpec
+
+# An ``agent_id``-surface resolver: given a literal agent id, return the set of tool
+# names (``ToolSpec`` identity keys, see :func:`_declared_tool_names`) that the named
+# child agent would bring to the run. Returning ``None`` means "agent not found /
+# unresolvable" — its surface is then excluded from the union (un-resolvable, like an
+# un-AST-able name), never a false rejection. The service supplies a DB-backed
+# implementation; unit tests supply a stub.
+ResolveAgentTools = Callable[[str], "frozenset[str] | None"]
+
+
+@dataclass(frozen=True)
+class _RequiredSurface:
+    """The AST-extracted *required* surface: literal tool names + literal agent ids."""
+
+    tool_names: set[str] = field(default_factory=set)
+    agent_ids: set[str] = field(default_factory=set)
+
+
+def _string_literal(node: ast.expr | None) -> str | None:
+    """Return the ``str`` value if ``node`` is a string-literal constant, else ``None``
+    (the un-AST-able case: a Name, an attribute, a subscript of ``input``, a join, …)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _call_func_name(node: ast.Call) -> str | None:
+    """The bare callable name for a ``Call`` node (``tool(...)`` → ``"tool"``).
+
+    Only a direct ``Name`` callee counts — ``mod.tool(...)`` (an attribute call) is not
+    the injected builtin and is ignored. The author namespace injects ``tool`` / ``agent``
+    as bare names, so this is the exact match for the capability API.
+    """
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    return None
+
+
+def _extract_required_surface(tree: ast.Module) -> _RequiredSurface:
+    """Walk the whole module and collect literal ``tool("…")`` names and literal
+    ``agent(agent_id="…")`` ids. Non-literal arguments are silently excluded."""
+    required = _RequiredSurface()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fname = _call_func_name(node)
+        if fname == "tool":
+            # tool(name, input) — name is the first positional argument.
+            if node.args:
+                name = _string_literal(node.args[0])
+                if name is not None:
+                    required.tool_names.add(name)
+            else:
+                # Defensively also accept a keyword ``tool(name="…", …)``.
+                for kw in node.keywords:
+                    if kw.arg == "name":
+                        name = _string_literal(kw.value)
+                        if name is not None:
+                            required.tool_names.add(name)
+        elif fname == "agent":
+            # agent(input, *, agent_id="…", …) — agent_id is keyword-only.
+            for kw in node.keywords:
+                if kw.arg == "agent_id":
+                    aid = _string_literal(kw.value)
+                    if aid is not None:
+                        required.agent_ids.add(aid)
+    return required
+
+
+def extract_literal_agent_ids(script: str) -> set[str]:
+    """Return the set of string-literal ``agent(agent_id="…")`` ids in ``script``.
+
+    A convenience for callers (the service layer) that need to *pre-resolve* each named
+    agent's surface asynchronously before handing the pure validator a sync resolver. An
+    unparsable script yields the empty set (the compile step reports the syntax error).
+    """
+    try:
+        tree = ast.parse(script, "<workflow>")
+    except SyntaxError:
+        return set()
+    return _extract_required_surface(tree).agent_ids
+
+
+def _declared_tool_names(tools: list[ToolSpec]) -> set[str]:
+    """The names a declared tool surface satisfies for a script ``tool("X")`` call.
+
+    A run resolves ``tool("X")`` against ``{t.type for t in run.tools}`` (see
+    :func:`aios.workflows.run_tools.gate_run_tool`), so ``type`` is the load-bearing
+    key (``"bash"``, ``"http_request"``, …). ``name`` is also accepted so a custom
+    tool referenced by its author-facing name is not a false positive.
+    """
+    names: set[str] = set()
+    for t in tools:
+        names.add(t.type)
+        if t.name:
+            names.add(t.name)
+        if t.mcp_server_name:
+            names.add(t.mcp_server_name)
+    return names
+
+
+def _find_main(tree: ast.Module) -> ast.AsyncFunctionDef | ast.FunctionDef | None:
+    """Return the top-level (module-level) function named ``main``, async or not, or
+    ``None`` if there is no top-level ``main``."""
+    for node in tree.body:
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and node.name == "main":
+            return node
+    return None
+
+
+def _check_main_signature(fn: ast.AsyncFunctionDef | ast.FunctionDef) -> None:
+    """Raise :class:`ValidationError` unless ``fn`` can be called as ``async def
+    main(input)`` — i.e. it is ``async`` and accepts exactly one positional argument.
+
+    The host invokes ``main(input_value)`` *positionally* (see
+    ``aios.workflows.wf_script_host._build_coroutine``), so the parameter's NAME is not
+    load-bearing — ``async def main(i)`` is admissible. What matters is arity: it must
+    accept exactly the single positional ``input`` and nothing more. A zero-arg
+    ``main()``, a two-arg ``main(a, b)``, a keyword-only ``main(*, input)``, or a
+    ``*args``/``**kwargs`` shape (which would receive ``input`` in the wrong slot, or a
+    required extra arg the host never supplies) is rejected.
+    """
+    if not isinstance(fn, ast.AsyncFunctionDef):
+        raise ValidationError(
+            "workflow script `main` must be `async def main(input)`: the top-level "
+            "`main` is a plain `def`, not `async def`."
+        )
+    a = fn.args
+    positional = a.posonlyargs + a.args
+    # The host calls ``main(input_value)`` positionally, so: exactly one positional
+    # parameter, no *args/**kwargs, and no keyword-only params (the single positional
+    # ``input`` could not be supplied by name to a keyword-only-only signature).
+    has_extra = bool(a.vararg or a.kwarg or a.kwonlyargs)
+    if len(positional) != 1 or has_extra:
+        raise ValidationError(
+            "workflow script `main` must be `async def main(input)` accepting exactly "
+            "the single positional `input` parameter (the run's input is passed "
+            "positionally)."
+        )
+
+
+def validate_workflow_script(
+    script: str,
+    *,
+    tools: list[ToolSpec] | None = None,
+    resolve_agent_tools: ResolveAgentTools | None = None,
+) -> None:
+    """Create/update-time validation of a workflow ``script``. Raises
+    :class:`ValidationError` (a client-class 4xx) with a precise, actionable message on
+    the first failure; returns ``None`` when the script is admissible.
+
+    Checks, in order:
+
+    1. **Compile** — ``compile(script, "<workflow>", "exec", dont_inherit=True)`` (the
+       exact call the host makes at run time, lifted here). A ``SyntaxError`` surfaces
+       as a compile/syntax validation error naming the line/offset where available.
+    2. **`main` present** — a top-level function named ``main`` must exist.
+    3. **`main` signature** — it must be ``async def main(input)`` (async, accepting
+       exactly one positional parameter; the host calls it positionally, so the
+       parameter name is not load-bearing).
+    4. **Tool surface covered** — every string-literal ``tool("X")`` name must be in the
+       declared tool surface (by ``type``/``name``).
+    5. **Named-agent surface covered** — every string-literal ``agent(agent_id="A")``
+       child's tool surface (resolved via ``resolve_agent_tools``) must be covered by
+       the declared tool surface. When no resolver is supplied, or the agent does not
+       resolve, the agent's surface is excluded from the union (never a false rejection).
+
+    Un-AST-able names (a computed/variable ``tool`` name or ``agent_id``) are excluded
+    from steps 4-5 by construction (they are not literals, so never extracted).
+    """
+    # 1. Compile (the host's own call, lifted to author time).
+    try:
+        compile(script, "<workflow>", "exec", dont_inherit=True)
+    except SyntaxError as exc:
+        where = ""
+        if exc.lineno is not None:
+            where = f" (line {exc.lineno}"
+            if exc.offset is not None:
+                where += f", offset {exc.offset}"
+            where += ")"
+        detail = (exc.msg or "syntax error").strip()
+        raise ValidationError(f"workflow script failed to compile: {detail}{where}") from exc
+
+    # Re-parse to an AST for the structural checks. ``compile`` already proved it parses,
+    # so ``ast.parse`` cannot raise here.
+    tree = ast.parse(script, "<workflow>")
+
+    # 2/3. main present + correctly signatured.
+    fn = _find_main(tree)
+    if fn is None:
+        raise ValidationError(
+            "workflow script must define a top-level `async def main(input)` "
+            "(no top-level `main` was found)."
+        )
+    _check_main_signature(fn)
+
+    # 4/5. Surface coverage.
+    required = _extract_required_surface(tree)
+    declared = _declared_tool_names(tools or [])
+
+    missing_tools = sorted(required.tool_names - declared)
+    if missing_tools:
+        names = ", ".join(repr(t) for t in missing_tools)
+        raise ValidationError(
+            "workflow script declares a tool surface that under-covers its "
+            f"`tool(...)` calls: missing tool(s) {names}. Add them to the workflow's "
+            "declared `tools` (or pass a non-literal name to opt out of the check).",
+            detail={"missing_tools": missing_tools},
+        )
+
+    if resolve_agent_tools is not None:
+        missing_from_agents: set[str] = set()
+        for agent_id in sorted(required.agent_ids):
+            agent_tools = resolve_agent_tools(agent_id)
+            if agent_tools is None:
+                # Unresolvable named agent: excluded from the union (like an un-AST-able
+                # name), never a false rejection.
+                continue
+            missing_from_agents |= agent_tools - declared
+        if missing_from_agents:
+            names = ", ".join(repr(t) for t in sorted(missing_from_agents))
+            raise ValidationError(
+                "workflow script references a named agent whose tool surface is not "
+                f"covered by the declared `tools`: missing element(s) {names}. The "
+                "#794 clamp would silently strip these from the child. Add them to the "
+                "workflow's declared `tools`.",
+                detail={"missing_agent_surface": sorted(missing_from_agents)},
+            )

--- a/tests/e2e/test_workflows_api.py
+++ b/tests/e2e/test_workflows_api.py
@@ -260,6 +260,97 @@ async def test_requires_auth(http_client: httpx.AsyncClient) -> None:
     assert r.status_code == 401, r.text
 
 
+async def test_create_workflow_script_validation_rejections(
+    http_client: httpx.AsyncClient,
+) -> None:
+    """Create-time script validation (#1286) over the HTTP surface: a non-compiling
+    script, a missing/mis-signatured `main`, and an under-declared `tool(...)` surface
+    are all rejected 422 and NOT created; a valid script still creates 201."""
+    # 1. Syntax error → 422, names a compile failure.
+    r = await http_client.post(
+        "/v1/workflows",
+        json={"name": f"bad-syn-{_uniq()}", "script": "async def main(input):\n    return (1\n"},
+    )
+    assert r.status_code == 422, r.text
+    assert "compile" in r.json()["error"]["message"]
+
+    # 2. Missing top-level main → 422.
+    r = await http_client.post(
+        "/v1/workflows", json={"name": f"bad-nomain-{_uniq()}", "script": "x = 1\n"}
+    )
+    assert r.status_code == 422, r.text
+    assert "main" in r.json()["error"]["message"]
+
+    # 3. Non-async main → 422.
+    r = await http_client.post(
+        "/v1/workflows",
+        json={"name": f"bad-sync-{_uniq()}", "script": "def main(input):\n    return input\n"},
+    )
+    assert r.status_code == 422, r.text
+    assert "async" in r.json()["error"]["message"]
+
+    # 4. Under-declared tool surface → 422, names the missing tool.
+    r = await http_client.post(
+        "/v1/workflows",
+        json={
+            "name": f"bad-tool-{_uniq()}",
+            "script": "async def main(input):\n    return await tool('bash', {})\n",
+            "tools": [],
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert "bash" in r.json()["error"]["message"]
+
+    # 5. The same script WITH the tool declared → 201 (covered surface succeeds).
+    r = await http_client.post(
+        "/v1/workflows",
+        json={
+            "name": f"ok-tool-{_uniq()}",
+            "script": "async def main(input):\n    return await tool('bash', {})\n",
+            "tools": [{"type": "bash"}],
+        },
+    )
+    assert r.status_code == 201, r.text
+
+    # 6. A computed (un-AST-able) tool name does NOT cause a false rejection.
+    r = await http_client.post(
+        "/v1/workflows",
+        json={
+            "name": f"ok-dyn-{_uniq()}",
+            "script": (
+                "async def main(input):\n"
+                "    name = input['tool']\n"
+                "    return await tool(name, {})\n"
+            ),
+            "tools": [],
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+async def test_update_workflow_script_validation_rejected(
+    http_client: httpx.AsyncClient,
+) -> None:
+    """Validation is enforced on update too (criterion 8): a structurally-bad script
+    update is rejected 422 and the stored definition is unchanged."""
+    name = f"upd-val-{_uniq()}"
+    r = await http_client.post("/v1/workflows", json={"name": name, "script": _SCRIPT})
+    assert r.status_code == 201
+    wf = r.json()
+
+    r = await http_client.put(
+        f"/v1/workflows/{wf['id']}",
+        json={"version": 1, "script": "def main(input):\n    return input\n"},
+    )
+    assert r.status_code == 422, r.text
+    assert "async" in r.json()["error"]["message"]
+
+    # Unchanged: still v1 with the original script.
+    r = await http_client.get(f"/v1/workflows/{wf['id']}")
+    assert r.status_code == 200
+    assert r.json()["version"] == 1
+
+
 async def test_update_workflow_roundtrip_and_stale_409(http_client: httpx.AsyncClient) -> None:
     name = f"upd-{_uniq()}"
     r = await http_client.post("/v1/workflows", json={"name": name, "script": _SCRIPT})
@@ -278,8 +369,10 @@ async def test_update_workflow_roundtrip_and_stale_409(http_client: httpx.AsyncC
     assert "v2" in updated["script"]
     assert updated["name"] == name
 
-    # Stale token → 409; unknown id → 404.
-    r = await http_client.put(f"/v1/workflows/{wf['id']}", json={"version": 1, "script": "x"})
+    # Stale token → 409; unknown id → 404. (Use a valid script: create-time validation
+    # (#1286) runs before the optimistic-version write, so a structurally-bad script
+    # would 422 first and mask the 409/404 this case is asserting.)
+    r = await http_client.put(f"/v1/workflows/{wf['id']}", json={"version": 1, "script": _SCRIPT})
     assert r.status_code == 409
-    r = await http_client.put("/v1/workflows/wf_nope", json={"version": 1, "script": "x"})
+    r = await http_client.put("/v1/workflows/wf_nope", json={"version": 1, "script": _SCRIPT})
     assert r.status_code == 404

--- a/tests/integration/test_invocations.py
+++ b/tests/integration/test_invocations.py
@@ -89,7 +89,7 @@ async def _seed_workflow(pool: asyncpg.Pool[Any], *, account_id: str) -> str:
         pool,
         account_id=account_id,
         name="invocations-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -61,7 +61,7 @@ async def _seed_parent_run(pool: asyncpg.Pool[Any], *, account_id: str, environm
         pool,
         account_id=account_id,
         name="request-opened-wf",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/integration/test_trace_walk.py
+++ b/tests/integration/test_trace_walk.py
@@ -60,7 +60,7 @@ async def _seed_run(
         pool,
         account_id=account_id,
         name=f"trace-walk-wf-{uuid4().hex}",
-        script="def main(ctx):\n    return None\n",
+        script="async def main(input):\n    return None\n",
         description=None,
         tools=[],
     )

--- a/tests/unit/test_workflow_script_validation.py
+++ b/tests/unit/test_workflow_script_validation.py
@@ -1,0 +1,430 @@
+"""Unit tests for create-time workflow script validation (#1286).
+
+Two layers:
+
+* The **pure validator** (:func:`aios.workflows.script_validation.validate_workflow_script`)
+  — compile + ``async def main(input)`` assertion + AST-derived tool/agent surface union
+  check, with a stub agent-surface resolver. This is the literal-only, validate-declared
+  contract (acceptance criteria 1-7).
+* The **service path** (:func:`aios.services.workflows.create_workflow` /
+  ``update_workflow``) — proves the validator is wired into BOTH create and update with a
+  stubbed pool/queries (criterion 8), so an under-declared or mis-shaped script is rejected
+  *before* anything is written, and a valid one still creates exactly as before.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.errors import NotFoundError, ValidationError
+from aios.models.agents import ToolSpec
+from aios.models.workflows import Workflow
+from aios.services import workflows as wf_service
+from aios.workflows.script_validation import (
+    extract_literal_agent_ids,
+    validate_workflow_script,
+)
+
+_DT = datetime(2026, 1, 1, tzinfo=UTC)
+
+_VALID_MAIN = "async def main(input):\n    return input\n"
+
+
+def _resolver(mapping: dict[str, frozenset[str]]):
+    def resolve(agent_id: str) -> frozenset[str] | None:
+        return mapping.get(agent_id)
+
+    return resolve
+
+
+# ─── the pure validator ──────────────────────────────────────────────────────
+
+
+class TestCompileAndShape:
+    def test_valid_script_passes(self) -> None:
+        # Criterion 6 (happy path): a correct top-level async main is accepted.
+        validate_workflow_script(_VALID_MAIN, tools=[])
+
+    def test_syntax_error_rejected_with_location(self) -> None:
+        # Criterion 1: a non-compiling script is rejected with a compile/syntax message
+        # surfacing the line where available.
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script("async def main(input):\n    return (1\n", tools=[])
+        assert "compile" in ei.value.message
+        assert "line" in ei.value.message
+
+    def test_missing_main_rejected(self) -> None:
+        # Criterion 2: compiles but no top-level main.
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script("x = 1\n", tools=[])
+        assert "main" in ei.value.message
+
+    def test_main_nested_not_toplevel_rejected(self) -> None:
+        # A main defined inside another function is NOT a top-level main.
+        src = "def wrapper():\n    async def main(input):\n        return input\n"
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script(src, tools=[])
+        assert "main" in ei.value.message
+
+    def test_plain_def_main_rejected(self) -> None:
+        # Criterion 3: top-level main that is not async.
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script("def main(input):\n    return input\n", tools=[])
+        assert "async" in ei.value.message
+
+    @pytest.mark.parametrize(
+        "sig",
+        [
+            "async def main():\n    return 1\n",
+            "async def main(a, b):\n    return 1\n",
+            "async def main(*args):\n    return 1\n",
+            "async def main(**kw):\n    return 1\n",
+            "async def main(*, input):\n    return 1\n",
+        ],
+    )
+    def test_mis_signatured_main_rejected(self, sig: str) -> None:
+        # Criterion 3: async main whose arity is not exactly one positional parameter.
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script(sig, tools=[])
+        assert "input" in ei.value.message
+
+    def test_posonly_input_accepted(self) -> None:
+        # A positional-only ``input`` still accepts the host's ``main(input_value)`` call.
+        validate_workflow_script("async def main(input, /):\n    return input\n", tools=[])
+
+    def test_single_positional_param_any_name_accepted(self) -> None:
+        # The host calls main positionally, so the parameter NAME is not load-bearing —
+        # ``async def main(i)`` (a real existing-test shape) is admissible.
+        validate_workflow_script("async def main(i):\n    return i\n", tools=[])
+
+    def test_default_valued_single_param_accepted(self) -> None:
+        validate_workflow_script("async def main(input=None):\n    return input\n", tools=[])
+
+
+class TestToolSurface:
+    def test_under_declared_tool_rejected_naming_it(self) -> None:
+        # Criterion 4: a literal tool("X") not in the declared surface → rejected, X named.
+        src = _VALID_MAIN.rstrip() + '\n\nasync def helper():\n    await tool("bash", {})\n'
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script(src, tools=[])
+        assert "bash" in ei.value.message
+        assert ei.value.detail.get("missing_tools") == ["bash"]
+
+    def test_covered_tool_accepted(self) -> None:
+        src = 'async def main(input):\n    return await tool("bash", {})\n'
+        validate_workflow_script(src, tools=[ToolSpec(type="bash")])
+
+    def test_covered_by_custom_name_accepted(self) -> None:
+        src = 'async def main(input):\n    return await tool("mytool", {})\n'
+        validate_workflow_script(
+            src,
+            tools=[
+                ToolSpec(
+                    type="custom",
+                    name="mytool",
+                    description="d",
+                    input_schema={"type": "object"},
+                )
+            ],
+        )
+
+    def test_multiple_missing_tools_all_named(self) -> None:
+        src = (
+            'async def main(input):\n    await tool("bash", {})\n    await tool("web_search", {})\n'
+        )
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script(src, tools=[ToolSpec(type="bash")])
+        assert "web_search" in ei.value.message
+        assert ei.value.detail.get("missing_tools") == ["web_search"]
+
+    def test_un_ast_able_tool_name_excluded(self) -> None:
+        # Criterion 7: a computed/variable tool name is not extracted → not a violation.
+        src = 'async def main(input):\n    name = input["tool"]\n    return await tool(name, {})\n'
+        validate_workflow_script(src, tools=[])
+
+    def test_attribute_call_not_treated_as_builtin(self) -> None:
+        # ``something.tool("x")`` is not the injected builtin and must be ignored.
+        src = 'async def main(input):\n    return obj.tool("bash", {})\n'
+        validate_workflow_script(src, tools=[])
+
+
+class TestAgentSurface:
+    def test_under_declared_agent_surface_rejected(self) -> None:
+        # Criterion 5: agent(agent_id="A") whose surface is not covered → rejected, named.
+        src = 'async def main(input):\n    return await agent({}, agent_id="a1")\n'
+        with pytest.raises(ValidationError) as ei:
+            validate_workflow_script(
+                src, tools=[], resolve_agent_tools=_resolver({"a1": frozenset({"bash"})})
+            )
+        assert "bash" in ei.value.message
+        assert ei.value.detail.get("missing_agent_surface") == ["bash"]
+
+    def test_covered_agent_surface_accepted(self) -> None:
+        src = 'async def main(input):\n    return await agent({}, agent_id="a1")\n'
+        validate_workflow_script(
+            src,
+            tools=[ToolSpec(type="bash")],
+            resolve_agent_tools=_resolver({"a1": frozenset({"bash"})}),
+        )
+
+    def test_unresolvable_agent_excluded(self) -> None:
+        # A literal agent_id that does not resolve (absent/cross-account) is excluded
+        # from the union — never a false rejection.
+        src = 'async def main(input):\n    return await agent({}, agent_id="ghost")\n'
+        validate_workflow_script(src, tools=[], resolve_agent_tools=_resolver({}))
+
+    def test_un_ast_able_agent_id_excluded(self) -> None:
+        # Criterion 7: agent_id from input/a variable is not extracted → accepted.
+        src = 'async def main(input):\n    return await agent({}, agent_id=input["a"])\n'
+        called: list[str] = []
+
+        def resolve(agent_id: str) -> frozenset[str] | None:
+            called.append(agent_id)
+            return frozenset({"bash"})
+
+        validate_workflow_script(src, tools=[], resolve_agent_tools=resolve)
+        assert called == []  # nothing literal to resolve
+
+    def test_no_resolver_skips_agent_check(self) -> None:
+        # Without a resolver the agent dimension is simply not enforced (still accepts).
+        src = 'async def main(input):\n    return await agent({}, agent_id="a1")\n'
+        validate_workflow_script(src, tools=[])
+
+
+class TestExtractLiteralAgentIds:
+    def test_extracts_literals_only(self) -> None:
+        src = (
+            "async def main(input):\n"
+            '    await agent({}, agent_id="a1")\n'
+            '    await agent({}, agent_id=input["x"])\n'
+            '    await agent({}, agent_id="a2")\n'
+        )
+        assert extract_literal_agent_ids(src) == {"a1", "a2"}
+
+    def test_unparsable_yields_empty(self) -> None:
+        assert extract_literal_agent_ids("async def main(input):\n    return (1\n") == set()
+
+
+# ─── service path: validation wired into create + update ─────────────────────
+
+
+class _FakeAcquire:
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> Any:
+        return self._conn
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+
+class _FakePool:
+    def __init__(self, conn: Any) -> None:
+        self._conn = conn
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self._conn)
+
+
+def _workflow(**over: Any) -> Workflow:
+    base: dict[str, Any] = dict(
+        id="wf_1",
+        account_id="acc_x",
+        name="w",
+        version=1,
+        script=_VALID_MAIN,
+        created_at=_DT,
+        updated_at=_DT,
+    )
+    base.update(over)
+    return Workflow(**base)
+
+
+@pytest.fixture
+def fake_pool() -> _FakePool:
+    return _FakePool(conn=object())
+
+
+class TestCreateServicePath:
+    """Operator path (no creator_session_id) — skips attenuation, so the validator is
+    the only gate before the insert. Proves criteria 1-7 are enforced on create."""
+
+    async def test_valid_script_creates(self, monkeypatch: Any, fake_pool: _FakePool) -> None:
+        insert = AsyncMock(return_value=_workflow())
+        monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+        wf = await wf_service.create_workflow(
+            fake_pool, account_id="acc_x", name="w", script=_VALID_MAIN
+        )
+        assert wf.id == "wf_1"
+        assert insert.await_count == 1
+
+    @pytest.mark.parametrize(
+        "script",
+        [
+            "async def main(input):\n    return (1\n",  # syntax
+            "x = 1\n",  # missing main
+            "def main(input):\n    return input\n",  # not async
+            "async def main():\n    return 1\n",  # bad sig
+        ],
+    )
+    async def test_bad_script_rejected_and_not_inserted(
+        self, monkeypatch: Any, fake_pool: _FakePool, script: str
+    ) -> None:
+        insert = AsyncMock(return_value=_workflow())
+        monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+        with pytest.raises(ValidationError):
+            await wf_service.create_workflow(fake_pool, account_id="acc_x", name="w", script=script)
+        assert insert.await_count == 0  # not created
+
+    async def test_under_declared_tool_rejected_not_inserted(
+        self, monkeypatch: Any, fake_pool: _FakePool
+    ) -> None:
+        insert = AsyncMock(return_value=_workflow())
+        monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+        script = 'async def main(input):\n    return await tool("bash", {})\n'
+        with pytest.raises(ValidationError) as ei:
+            await wf_service.create_workflow(
+                fake_pool, account_id="acc_x", name="w", script=script, tools=[]
+            )
+        assert "bash" in ei.value.message
+        assert insert.await_count == 0
+
+    async def test_literal_agent_surface_resolved_and_enforced(
+        self, monkeypatch: Any, fake_pool: _FakePool
+    ) -> None:
+        insert = AsyncMock(return_value=_workflow())
+        monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+        # The named agent declares ``bash``; the workflow under-declares (no tools).
+        # The service reads only ``agent.tools``, so a lightweight stub suffices.
+        agent = SimpleNamespace(tools=[ToolSpec(type="bash")])
+        monkeypatch.setattr("aios.services.agents.get_agent", AsyncMock(return_value=agent))
+        script = 'async def main(input):\n    return await agent({}, agent_id="a1")\n'
+        with pytest.raises(ValidationError) as ei:
+            await wf_service.create_workflow(
+                fake_pool, account_id="acc_x", name="w", script=script, tools=[]
+            )
+        assert "bash" in ei.value.message
+        assert insert.await_count == 0
+
+    async def test_unresolvable_agent_does_not_block_create(
+        self, monkeypatch: Any, fake_pool: _FakePool
+    ) -> None:
+        insert = AsyncMock(return_value=_workflow())
+        monkeypatch.setattr("aios.db.queries.workflows.insert_workflow", insert)
+        monkeypatch.setattr(
+            "aios.services.agents.get_agent",
+            AsyncMock(side_effect=NotFoundError("no such agent")),
+        )
+        script = 'async def main(input):\n    return await agent({}, agent_id="ghost")\n'
+        wf = await wf_service.create_workflow(
+            fake_pool, account_id="acc_x", name="w", script=script, tools=[]
+        )
+        assert wf.id == "wf_1"
+        assert insert.await_count == 1
+
+
+class TestUpdateServicePath:
+    """Operator path update — criterion 8: the validator runs on update too, and over the
+    EFFECTIVE (merged) script + tools."""
+
+    async def test_valid_update_succeeds(self, monkeypatch: Any, fake_pool: _FakePool) -> None:
+        update = AsyncMock(return_value=_workflow(version=2))
+        monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+        monkeypatch.setattr(
+            "aios.services.workflows.get_workflow", AsyncMock(return_value=_workflow())
+        )
+        wf = await wf_service.update_workflow(
+            fake_pool,
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            script=_VALID_MAIN,
+        )
+        assert wf.version == 2
+        assert update.await_count == 1
+
+    async def test_bad_script_update_rejected_not_written(
+        self, monkeypatch: Any, fake_pool: _FakePool
+    ) -> None:
+        update = AsyncMock(return_value=_workflow(version=2))
+        monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+        monkeypatch.setattr(
+            "aios.services.workflows.get_workflow", AsyncMock(return_value=_workflow())
+        )
+        with pytest.raises(ValidationError):
+            await wf_service.update_workflow(
+                fake_pool,
+                "wf_1",
+                account_id="acc_x",
+                expected_version=1,
+                script="def main(input):\n    return input\n",
+            )
+        assert update.await_count == 0
+
+    async def test_update_tools_only_validates_against_current_script(
+        self, monkeypatch: Any, fake_pool: _FakePool
+    ) -> None:
+        # Updating ONLY tools must re-validate the EFFECTIVE pair: the stored script
+        # calls tool("bash"); narrowing tools to [] (dropping bash) must be rejected.
+        stored = _workflow(
+            script='async def main(input):\n    return await tool("bash", {})\n',
+            tools=[ToolSpec(type="bash")],
+        )
+        monkeypatch.setattr("aios.services.workflows.get_workflow", AsyncMock(return_value=stored))
+        update = AsyncMock(return_value=_workflow(version=2))
+        monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+        with pytest.raises(ValidationError) as ei:
+            await wf_service.update_workflow(
+                fake_pool,
+                "wf_1",
+                account_id="acc_x",
+                expected_version=1,
+                tools=[],  # drops bash → effective script no longer covered
+            )
+        assert "bash" in ei.value.message
+        assert update.await_count == 0
+
+    async def test_update_script_only_validates_against_current_tools(
+        self, monkeypatch: Any, fake_pool: _FakePool
+    ) -> None:
+        # Updating ONLY the script must validate it against the STORED tools.
+        stored = _workflow(tools=[ToolSpec(type="bash")])
+        monkeypatch.setattr("aios.services.workflows.get_workflow", AsyncMock(return_value=stored))
+        update = AsyncMock(return_value=_workflow(version=2))
+        monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+        new_script = 'async def main(input):\n    return await tool("bash", {})\n'
+        wf = await wf_service.update_workflow(
+            fake_pool,
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            script=new_script,
+        )
+        assert wf.version == 2
+        assert update.await_count == 1
+
+    async def test_update_touching_neither_script_nor_tools_skips_validation(
+        self, monkeypatch: Any, fake_pool: _FakePool
+    ) -> None:
+        # A description-only update never reads/validates the script (no fetch needed on
+        # the operator path) and still writes.
+        get_wf = AsyncMock()
+        monkeypatch.setattr("aios.services.workflows.get_workflow", get_wf)
+        update = AsyncMock(return_value=_workflow(version=2))
+        monkeypatch.setattr("aios.db.queries.workflows.update_workflow", update)
+        wf = await wf_service.update_workflow(
+            fake_pool,
+            "wf_1",
+            account_id="acc_x",
+            expected_version=1,
+            description="new desc",
+        )
+        assert wf.version == 2
+        assert get_wf.await_count == 0
+        assert update.await_count == 1


### PR DESCRIPTION
## What & why

Bakeoff build of #1221 (Part of #777, P0). A workflow is authored out-of-band as an inert `script: str` whose declared tool/server surface is authored *separately* from the body, so two failure classes only surfaced as a *failed run* read back from the journal, not as an authoring-time error:

1. **Syntax / structure errors** — a typo or a missing top-level `async def main(input)`, not caught until the host `exec`'d the script.
2. **Silent surface drift** — an under-declared tool surface is silently stripped by the #794 clamp and detonates as a runtime route-mismatch (the two `dev_pipeline.py` production incidents: an omitted `DELETE`, an omitted `PATCH`).

This lifts the host's own `compile(...)` to create time and adds AST structural checks, dissolving both classes at author time. Value-domain traps (class 3) are out of scope (#934).

## Design (SETTLED, #1286): validate-declared, literal-only extraction

The author writes the declared surface; the validator checks it is a **superset** of the AST-extracted *required* surface. Only **string-literal** `tool("X")` names and string-literal `agent(agent_id="A")` references participate. A computed/variable `tool` name or an `agent_id` from `input`/a variable is **un-AST-able** and is excluded from the check — never a false rejection.

New module `src/aios/workflows/script_validation.py` exposes a pure, synchronous `validate_workflow_script(...)`:
1. **compile** the script (`compile(source, "<workflow>", "exec", dont_inherit=True)` — the exact host call) → precise syntax error with line/offset;
2. **assert** a top-level `async def main(input)` — async, accepting exactly one positional parameter. The host calls `main(input_value)` *positionally*, so the parameter NAME is not load-bearing (`async def main(i)` is admissible, matching existing runtime behaviour); arity violations (`main()`, `main(a, b)`, `*args`/`**kwargs`, keyword-only `main(*, input)`) are rejected;
3. **AST-extract** literal `tool("…")` names + literal `agent(agent_id="…")` references, compute the required union, and validate the declared `tools` cover it — naming the missing element(s).

Rejections use `ValidationError` (422, client-class). The pure AST core takes an injected sync `resolve_agent_tools` callback; the service wires a DB-backed agent resolver, keeping the core DB-free and unit-testable.

### Chosen `agent_id` depth (per the criterion-5 latitude)

A literal `agent(agent_id="A")` resolves the named agent's **declared tool surface** (same `type`/`name` identity keys used for `tool("…")`) and requires the workflow's declared `tools` to cover it — the #794 clamp `child = agent ∩ run` silently strips any tool the workflow under-declares, which is exactly the surface-drift bug. A literal id naming an agent that does not resolve (cross-account / archived / absent) is excluded from the union (un-resolvable, like an un-AST-able name) and never causes a false rejection. This is fail-closed coverage of the named child's surface; documented here as the trade-off vs. permitting silent clamp-narrowing.

## Wiring (criterion 8)

The validator runs in `aios.services.workflows.create_workflow` and `update_workflow`, which is the single path behind **both** the tool handler (`create_workflow_handler`/`update_workflow_handler`) and the HTTP/operator router. On **update** it validates the **EFFECTIVE merged** script + tools (an omitted `script`/`tools` preserves current), so a rewrite touching only one side still satisfies the other. Validation runs after the optimistic-version (409) and surface-attenuation (403) checks on the actor path, so those take precedence; on every path nothing is written when validation fails.

## Tests

- `tests/unit/test_workflow_script_validation.py` — the pure validator (criteria 1–7: compile/syntax, missing/nested/non-async/mis-arity `main`, under-declared tool naming X, covered tool, custom-tool name, un-AST-able tool name, agent surface covered/under-declared/unresolvable/un-AST-able) **plus** service-path tests with a stubbed pool/queries proving create + update enforce validation before any write, including update-tools-only and update-script-only effective-pair checks.
- `tests/e2e/test_workflows_api.py` — HTTP-surface 422 rejections on create (syntax / missing main / non-async / under-declared tool) + 201 on the covered and un-AST-able cases, and an update-rejection-leaves-unchanged case.

## Existing-test updates

Four pre-existing tests passed throwaway scripts that the new contract correctly forbids (inert plumbing bodies): `tests/integration/test_invocations.py`, `test_trace_walk.py`, `test_request_opened_edge.py` used a non-async `def main(ctx)` → switched to `async def main(input)`; `tests/e2e/test_workflows_api.py`'s stale-409/404 case used `script: "x"` (now 422 first) → switched to a valid script so it asserts the 409/404 it intends. Scripts inserted via the query layer (`wf_queries.insert_workflow`) and host-direct tests are unaffected (the validator is service-layer only).

## Hygiene

`ruff check`, `ruff format --check`, and `mypy` pass on the changed files. The full unit suite passes except 6 pre-existing, unrelated snapshot/env failures (`test_mcp_mount`, `test_openapi_snapshot`, `test_run_observability_contract`, `test_sdk_snapshot`) that fail identically on the base branch.

**DO NOT MERGE without the bakeoff comparison.**