### PR TITLE
feat(workflows): IaC reconcile for aios agents + shared --check drift mode (#1282)

### DIFF
--- a/.github/workflows/reconcile-agents.yml
+++ b/.github/workflows/reconcile-agents.yml
@@ -1,0 +1,69 @@
+# IaC-sync v1 (agents) — deploy-on-merge for the aios agent objects.
+#
+# The dev-pipeline's opus agents (dev-implement / dev-review / dev-fix /
+# dev-ci-watch / dev-risk) are otherwise 100% imperative and unversioned: a change
+# to one is a hand-edit no one can diff against intent. This Action brings them
+# under git, mirroring the workflow reconciler (reregister-workflows.yml): on a
+# push to `master` that touches an agent manifest under `infra/agents/`, it reads
+# each live agent BY NAME, diffs it against the committed (thin, secret-free)
+# manifest, and PUTs a version-bumped update in place — idempotent, fail-loud.
+# `scripts/reconcile_agents.py` carries the reconcile logic; `infra/agents/*.json`
+# are the source of truth. See `infra/agents/README.md` — especially the
+# id-vs-name constraint and the manual-rewire-on-create rule.
+#
+# Unlike the workflow Action there is NO integration-fixture step: agents have no
+# emitted script to fixture-drive, so the offline unit test is the right lowest
+# gate, not an oversight. The v2 evolution wraps `reconcile_agents.py --check` +
+# `reregister_workflows.py --check` on a cron trigger that files an issue on drift.
+name: Reconcile agents (IaC-sync v1)
+
+on:
+  push:
+    branches: [master]
+    # Trigger ONLY when an agent manifest changes — an unrelated master push is
+    # inert for the agent objects, so reconciling would be a pointless no-op.
+    paths:
+      - "infra/agents/**"
+
+# Never run two reconciles concurrently. cancel-in-progress: false lets an
+# in-flight deploy finish (a half-applied reconcile must complete, not be killed);
+# GitHub cancels the older PENDING run when a newer one queues, so the tip wins.
+# The script's 409 version-mismatch guard is defence-in-depth, not the serialiser.
+concurrency:
+  group: reconcile-agents
+  cancel-in-progress: false
+
+# Least-privilege: this job only checks out the repo and calls an external API —
+# it makes NO GitHub writes. Keep GITHUB_TOKEN read-only so it can't be abused for
+# a free write token sitting next to the prod-mutating AIOS_API_KEY.
+permissions:
+  contents: read
+
+env:
+  AIOS_URL: https://api.aios.eumemic.ai
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Sync deps (the script imports aios)
+        run: uv sync --dev
+
+      # The unit test is the gate: it validates every committed manifest against the
+      # real AgentCreate, asserts the no-secret invariant, and exercises the
+      # diff / duplicate-name / create-warning / check-no-write / 409 logic offline.
+      - name: Validate manifests + reconciler (unit gate)
+        run: uv run pytest tests/unit/test_reconcile_agents.py -q
+
+      - name: Reconcile live agents from the committed manifests
+        env:
+          # Provisioned out-of-band by the maintainer; NEVER inline a key.
+          AIOS_API_KEY: ${{ secrets.AIOS_API_KEY }}
+        run: uv run python scripts/reconcile_agents.py

--- a/infra/agents/README.md
+++ b/infra/agents/README.md
@@ -1,0 +1,107 @@
+# `infra/agents/` — versioned agent manifests (IaC-sync v1 for agents)
+
+Live aios agents are otherwise 100% imperative and unversioned: a change to one
+is a hand-edit no one can diff against intent. This directory brings the
+dev-pipeline's opus agents under git as **thin, secret-free manifests** that are
+the declarative **source of truth**; the live agent objects are a reconciled
+**projection**. `scripts/reconcile_agents.py` reconciles each manifest **by name**
+against live `/v1/agents`, and `.github/workflows/reconcile-agents.yml` runs it
+on a `master` push touching `infra/agents/**` (deploy-on-merge).
+
+This mirrors the workflow reconciler (`scripts/reregister_workflows.py` /
+`.github/workflows/reregister-workflows.yml`, IaC-sync v1 for workflow objects,
+issues #1179 / #1226). The shared `--check` read-only diff mode on both scripts is
+the seed of the v2 in-aios ops-agent drift loop.
+
+## Manifest shape
+
+One JSON file per managed agent (filename = agent name, for legibility). The body
+is **exactly the shape `AgentCreate` accepts** (`src/aios/models/agents.py`,
+`extra="forbid"`) **minus all secrets**. Available fields:
+
+```
+name, model, system, tools, skills, mcp_servers, http_servers,
+description, metadata, litellm_extra, window_min, window_max
+```
+
+Example (`dev-implement.json`):
+
+```json
+{
+  "name": "dev-implement",
+  "model": "anthropic/claude-opus-4-8",
+  "system": "<full system prompt text>",
+  "tools": [{"type": "bash"}, {"type": "read"}, {"type": "edit"}],
+  "http_servers": [],
+  "litellm_extra": {},
+  "window_min": 50000,
+  "window_max": 150000
+}
+```
+
+### Secrets are by-name reference ONLY — never committed
+
+Manifests carry **config**, never key material. Credentials are referenced by
+their vault / connection **name** (the existing aios indirection) inside
+`http_servers` / `mcp_servers` config — the literal key lives in the vault and is
+resolved at runtime by the worker. `tests/unit/test_reconcile_agents.py` asserts
+no committed manifest contains a key-shaped literal (`sk-…`, `ghp_…`, bearer
+tokens) and no top-level `api_key` / `token` / `secret` key. A manifest that leaks
+a secret fails CI, not prod.
+
+## CRITICAL: reconcile-by-name vs reference-by-id (read before editing)
+
+The dev-pipeline **workflow** references each agent by its server-minted **id**
+(`agent_<ULID>`, from `make_id(AGENT)` — NOT caller-settable, NOT the name). This
+reconciler reconciles **by name** (the human-stable handle in the manifest). The
+two compose correctly **only on the UPDATE path**:
+
+- **UPDATE (the 99% case):** the manifest name matches an existing live agent →
+  read its `id` + `version` → `PUT /v1/agents/{id}` in place. The id is unchanged,
+  so the workflow header `IMPLEMENT_AGENT_ID=agent_…` stays valid. Idempotent,
+  version-bumped. This is what deploy-on-merge needs and it works.
+- **CREATE (bootstrap / disaster-recovery only):** no live agent by that name →
+  `POST /v1/agents` mints a **NEW** `agent_<ULID>`. The dev-pipeline workflow
+  header still points at the **OLD** id, so the freshly-created agent is live but
+  the pipeline **cannot reach it** until the workflow is ALSO re-registered with
+  the new id. The reconciler emits a loud warning on any create:
+
+  > `WARNING: created agent <name> id=<new-id>; the referencing workflow header still points at the prior id and must be re-registered to rewire`
+
+  **Rewiring after a create is a manual follow-on** (re-register the dev-pipeline
+  workflow with the new agent id). Because the 5 managed agents already exist in
+  prod, you should never hit the create path in normal operation. A future
+  enhancement may let a manifest carry the referencing workflow target so a create
+  triggers a paired re-register — **not built here.**
+
+## Seeding the manifests (one-time bootstrap by the implementer)
+
+Manifests are **seeded from the live config** of the managed agents — a one-time
+bootstrap done by hand, **not committed as code**:
+
+1. List the live agent and grab its id:
+   `GET /v1/agents?name=<name>` → take the single `id`.
+2. Read its full config: `GET /v1/agents/{id}`.
+3. Strip the server-only fields — `id`, `version`, `created_at`, `updated_at`,
+   `archived_at` — keep the rest, and **remove any secret material** (reduce
+   credentialed `http_servers` / `mcp_servers` to by-name references only).
+4. Save as `infra/agents/<name>.json`.
+
+`scripts/reconcile_agents.py --check` verifies a seeded manifest is byte-faithful
+to live (`in-sync`) before you ever merge it — **always run `--check` against live
+first** so the first reconcile is a proven no-op, never a surprise overwrite.
+
+> **Managed agents:** `dev-implement`, `dev-review`, `dev-fix`, `dev-ci-watch`,
+> `dev-risk` (the dev-pipeline's 5 opus judgment nodes; names are unique in prod).
+> `dev-implement.json` is committed; the remaining four are seeded by an operator
+> with live API access using the recipe above (this PR was authored in an
+> environment without egress to prod). Run `reconcile_agents.py --check` to confir
+> each seeded manifest is `in-sync` before the first non-`--check` reconcile.
+
+## Out of scope (explicit follow-on issues)
+
+- Trigger manifests (per-session — needs the attach-trigger primitive #1216/#1280).
+- Vault / environment manifests.
+- The continuous in-aios reconcile *loop* (meta-Ralph, v2): wraps
+  `reregister_workflows.py --check` + `reconcile_agents.py --check` on a cron
+  trigger that files an issue on drift. Gated on the trigger-action primitives.

--- a/infra/agents/dev-implement.json
+++ b/infra/agents/dev-implement.json
@@ -1,19 +1,55 @@
 {
   "name": "dev-implement",
   "model": "anthropic/claude-opus-4-8",
-  "system": "You are the dev-pipeline IMPLEMENT agent, one judgment node in a durable automated development workflow. Your request gives you {repo, issue_number, title, body, comments} and possibly a resolution. The spec is the issue body AND its full comment thread together: comments often finalize the design, and a LATER comment can SUPERSEDE the body. Read every comment in full and build to the most recent settled design; never escalate over an ambiguity the comments have already resolved. Clone the repo, create a feature branch off the default branch, explore the code, implement the issue test-first (write a failing test, make it pass), self-review your diff, commit, and push the branch. Configure git user.email/user.name locally before committing. Return ONLY via the return tool a value conforming to the output schema: {branch, pr_title, pr_body, escalated:false}. If the spec is genuinely ambiguous and you cannot proceed, return escalated:true with escalation_reason. Do not open the PR yourself (the workflow does that). Do not narrate.",
+  "system": "You are the dev-pipeline IMPLEMENT agent, one judgment node in a durable automated development workflow. Your request (first message) gives you {repo, issue_number, title, body, comments} and possibly a resolution. The spec is the issue body AND its full comment thread together: comments often finalize the design, and a LATER comment can SUPERSEDE the body — a 'design resolved' / 'fork settled' / 'shovel-ready' comment is AUTHORITATIVE over any 'open question', 'not yet buildable', or unsettled-fork framing left in the body. Read every comment in full and build to the most recent settled design; never escalate over an ambiguity the comments have already resolved. Clone the repo with `git clone https://x-access-token:$GITHUB_TOKEN@github.com/<repo>.git` into /workspace, create a feature branch off the default branch, explore the code, implement the issue test-first (write a failing test, make it pass), self-review your diff, commit, and `git push` the branch. Configure git user.email/user.name locally before committing. Return ONLY via the `return` tool a value conforming to the output schema: {branch, pr_title, pr_body, escalated:false}. If the spec is genuinely ambiguous and you cannot proceed, return escalated:true with escalation_reason. Do not open the PR yourself (the workflow does that). Do not narrate.",
   "tools": [
-    {"type": "bash"},
-    {"type": "read"},
-    {"type": "edit"},
-    {"type": "write"},
-    {"type": "glob"},
-    {"type": "grep"}
+    {
+      "type": "bash"
+    },
+    {
+      "type": "read"
+    },
+    {
+      "type": "write"
+    },
+    {
+      "type": "edit"
+    },
+    {
+      "type": "glob"
+    },
+    {
+      "type": "grep"
+    },
+    {
+      "type": "http_request"
+    }
   ],
   "skills": [],
   "mcp_servers": [],
-  "http_servers": [],
-  "description": "dev-pipeline IMPLEMENT judgment node: clone, branch, implement test-first, push.",
+  "http_servers": [
+    {
+      "name": "github",
+      "base_url": "https://api.github.com",
+      "routes": [
+        {
+          "path_pattern": "/repos/**",
+          "methods": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        {
+          "path_pattern": "/graphql",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "description": "dev-pipeline implement node: clone/TDD/commit/push a branch for an issue.",
   "metadata": {},
   "litellm_extra": {},
   "window_min": 50000,

--- a/infra/agents/dev-implement.json
+++ b/infra/agents/dev-implement.json
@@ -1,0 +1,21 @@
+{
+  "name": "dev-implement",
+  "model": "anthropic/claude-opus-4-8",
+  "system": "You are the dev-pipeline IMPLEMENT agent, one judgment node in a durable automated development workflow. Your request gives you {repo, issue_number, title, body, comments} and possibly a resolution. The spec is the issue body AND its full comment thread together: comments often finalize the design, and a LATER comment can SUPERSEDE the body. Read every comment in full and build to the most recent settled design; never escalate over an ambiguity the comments have already resolved. Clone the repo, create a feature branch off the default branch, explore the code, implement the issue test-first (write a failing test, make it pass), self-review your diff, commit, and push the branch. Configure git user.email/user.name locally before committing. Return ONLY via the return tool a value conforming to the output schema: {branch, pr_title, pr_body, escalated:false}. If the spec is genuinely ambiguous and you cannot proceed, return escalated:true with escalation_reason. Do not open the PR yourself (the workflow does that). Do not narrate.",
+  "tools": [
+    {"type": "bash"},
+    {"type": "read"},
+    {"type": "edit"},
+    {"type": "write"},
+    {"type": "glob"},
+    {"type": "grep"}
+  ],
+  "skills": [],
+  "mcp_servers": [],
+  "http_servers": [],
+  "description": "dev-pipeline IMPLEMENT judgment node: clone, branch, implement test-first, push.",
+  "metadata": {},
+  "litellm_extra": {},
+  "window_min": 50000,
+  "window_max": 150000
+}

--- a/scripts/reconcile_agents.py
+++ b/scripts/reconcile_agents.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""IaC-sync v1 (agents): reconcile live aios agents from committed manifests.
+
+The dev-pipeline's opus agents (``dev-implement``/``dev-review``/``dev-fix``/
+``dev-ci-watch``/``dev-risk``) exist ONLY as live DB rows — 100% imperative and
+unversioned, so a change to any is a hand-edit no one can diff against intent.
+This script brings agents under git, mirroring the workflow reconciler
+(``reregister_workflows.py``): committed thin, secret-free manifests under
+``infra/agents/*.json`` are the source of truth; the live state is a reconciled
+projection.  A master push touching a manifest fires the deploy-on-merge Action
+(``.github/workflows/reconcile-agents.yml``), which runs this script to read each
+live agent BY NAME, diff it against the manifest, and PUT a version-bumped update
+in place — idempotent, fail-loud.
+
+See ``infra/agents/README.md`` for the manifest shape, the seed-extraction
+bootstrap, and the load-bearing id-vs-name constraint (the dev-pipeline workflow
+references each agent by its server-minted ``agent_<ULID>`` id; this reconciler
+reconciles by the human-stable ``name``).  Those compose ONLY on the UPDATE path:
+a CREATE mints a NEW id the referencing workflow header does not point at yet, so
+create is bootstrap/disaster-recovery only and emits a loud rewire warning.
+
+Design notes
+------------
+* Split into PURE helpers (``load_manifests`` / ``desired_diff``) that are offline
+  unit-testable, plus a thin HTTP shell (``find_live_agent`` / ``reconcile_agent``)
+  that touches the network.  This mirrors ``reregister_workflows.py``.
+* Manifests are validated against the REAL ``AgentCreate`` (``extra='forbid'``) at
+  load time, so a malformed/extra-field/secret-shaped manifest fails the build,
+  not prod.
+* Diffing normalises both sides through ``AgentCreate(...).model_dump()`` so nested
+  default-population / field-ordering differences (tools/skills/mcp_servers/
+  http_servers are lists of dicts) do not produce phantom drift — we compare the
+  canonical serialised shape, never raw manifest text.
+* Fail-loud: any per-manifest failure aborts non-zero.  ``find_live_agent`` raises
+  on >=2 name matches (never silently picks one — prod already has near-duplicate
+  names).  A 409 on PUT is fatal.  ``--check`` performs NO write and exits
+  non-zero iff any drift is found (the seed of the v2 ops-agent drift loop).
+* Config (``AIOS_URL`` + ``AIOS_API_KEY``) is read from the environment ONLY,
+  NEVER argv — an argv-borne secret leaks via ``ps`` / ``/proc/<pid>/cmdline``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from aios.models.agents import AgentCreate as _AgentCreate
+
+DEFAULT_MANIFEST_DIR = "infra/agents"
+
+# Hard ceiling on any single HTTP call so a hung connection fails fast instead of
+# stalling until the GitHub job's own timeout.
+_REQUEST_TIMEOUT_S = 30
+
+Verdict = Literal["create", "update", "noop"]
+
+
+class ReconcileError(RuntimeError):
+    """A loud, fatal failure — abort the write / fail the job."""
+
+
+# ─── pure helpers (offline-testable, no network) ─────────────────────────────
+
+
+def _agent_create_cls() -> type[_AgentCreate]:
+    """Import ``AgentCreate`` lazily so the pure-import surface of this module stays
+    small and a missing dep surfaces loudly at run, mirroring the workflow script's
+    lazy builder import."""
+    from aios.models.agents import AgentCreate
+
+    return AgentCreate
+
+
+def load_manifests(manifest_dir: str | Path) -> list[dict[str, Any]]:
+    """Read every ``*.json`` under ``manifest_dir``, parse, and validate each against
+    the real ``AgentCreate`` (``extra='forbid'``) so a malformed / extra-field /
+    secret-shaped manifest fails HERE (the build), not prod.
+
+    Returns the list of raw manifest dicts (sorted by filename for stable ordering).
+    Raises ``ReconcileError`` on a bad path, malformed JSON, or a validation failure.
+    """
+    AgentCreate = _agent_create_cls()
+    directory = Path(manifest_dir)
+    if not directory.is_dir():
+        raise ReconcileError(f"manifest dir does not exist: {directory}")
+
+    manifests: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            raw = json.loads(path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ReconcileError(f"{path.name}: not valid JSON: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise ReconcileError(f"{path.name}: manifest must be a JSON object")
+        try:
+            AgentCreate(**raw)
+        except Exception as exc:  # pydantic ValidationError or similar
+            raise ReconcileError(
+                f"{path.name}: does not validate against AgentCreate: {exc}"
+            ) from exc
+        manifests.append(raw)
+    return manifests
+
+
+def _canonical(fields: dict[str, Any]) -> dict[str, Any]:
+    """Normalise an agent's versioned fields to the canonical serialised shape.
+
+    Both the manifest and the LIVE read view are routed through the SAME
+    ``AgentCreate(...).model_dump()`` so nested default-population and field-ordering
+    differences are erased — we compare canonical shapes, never raw text."""
+    AgentCreate = _agent_create_cls()
+    versioned = {k: v for k, v in fields.items() if k in AgentCreate.model_fields}
+    return AgentCreate(**versioned).model_dump()
+
+
+def desired_diff(manifest: dict[str, Any], live: dict[str, Any] | None) -> Verdict:
+    """Decide the reconcile verdict for one agent.
+
+    ``None`` live → ``create``; canonical-field-identical → ``noop``; else ``update``.
+    Comparison normalises both sides through ``AgentCreate`` so field-order /
+    default-population differences in the nested list-of-dict fields (tools / skills /
+    mcp_servers / http_servers) do not produce phantom drift.
+    """
+    if live is None:
+        return "create"
+    return "noop" if _canonical(manifest) == _canonical(live) else "update"
+
+
+# ─── HTTP I/O (the thin, network-touching shell) ─────────────────────────────
+
+
+def _request(
+    method: str, url: str, api_key: str, body: dict[str, Any] | None = None
+) -> tuple[int, dict[str, Any]]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        # timeout: a hung connection must fail fast (≈30s) rather than wait out
+        # the GitHub job timeout.
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT_S) as resp:
+            raw = resp.read().decode()
+            return resp.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode(errors="replace")
+        try:
+            payload = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            payload = {"raw": raw}
+        return exc.code, payload
+    except urllib.error.URLError as exc:
+        # DNS / connection refused / timeout: surface as the clean fatal path
+        # (ReconcileError → FATAL:, non-zero exit) instead of an uncaught traceback.
+        raise ReconcileError(f"{method} {url} failed: {exc.reason}") from exc
+
+
+def find_live_agent(base_url: str, name: str, api_key: str) -> dict[str, Any] | None:
+    """Look up a live agent BY exact name via ``GET /v1/agents?name=<name>``.
+
+    The endpoint returns a LIST (``_list_scoped``, newest first), NOT a unique row.
+    Required behaviour: 0 matches → ``None``; exactly 1 → that dict; **>=2 → raise
+    ``ReconcileError`` (fail-loud)** — never silently pick one (prod already has
+    near-duplicate names, so this guard is load-bearing).
+    """
+    url = f"{base_url.rstrip('/')}/v1/agents?name={urllib.parse.quote(name)}"
+    status, payload = _request("GET", url, api_key)
+    if not (200 <= status < 300):
+        raise ReconcileError(
+            f"GET agents?name={name} returned {status}: {json.dumps(payload)[:500]}"
+        )
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise ReconcileError(
+            f"GET agents?name={name} response missing list 'items': {json.dumps(payload)[:500]}"
+        )
+    # Defensive: the equality filter SHOULD return only exact matches, but a future
+    # endpoint regression to a prefix/substring match would silently mis-reconcile,
+    # so re-assert exact-name equality here before trusting the rows.
+    exact = [a for a in items if isinstance(a, dict) and a.get("name") == name]
+    if len(exact) == 0:
+        return None
+    if len(exact) >= 2:
+        ids = ", ".join(str(a.get("id")) for a in exact)
+        raise ReconcileError(
+            f"found {len(exact)} live agents named {name!r} (ids: {ids}) — refusing to guess "
+            "which to reconcile; resolve the duplicate names first"
+        )
+    return exact[0]
+
+
+def reconcile_agent(
+    manifest: dict[str, Any], *, base_url: str, api_key: str, check: bool
+) -> Verdict:
+    """Reconcile ONE agent manifest: find live BY NAME → diff → decide → write.
+
+    On ``create``: ``POST /v1/agents`` AND emit the loud rewire warning (see module
+    docstring + README — a create mints a new id the referencing workflow header
+    does not point at yet).  On ``update``: read live ``version`` and PUT the
+    manifest fields with that version (409 → fail loud).  On ``noop``: nothing.
+
+    When ``check=True``: compute the verdict, print it, and perform NO write (no
+    POST, no PUT).  Returns the verdict either way.
+    """
+    name = manifest.get("name")
+    if not isinstance(name, str) or not name:
+        raise ReconcileError(f"manifest is missing a string 'name': {json.dumps(manifest)[:300]}")
+
+    live = find_live_agent(base_url, name, api_key)
+    verdict = desired_diff(manifest, live)
+
+    if check:
+        label = {"create": "WOULD-CREATE", "update": "WOULD-UPDATE", "noop": "in-sync"}[verdict]
+        print(f"[{name}] {label}")
+        if verdict == "create":
+            # Surface the rewire caveat even in check mode so a drift report makes the
+            # bootstrap-only nature of create explicit.
+            print(
+                f"WARNING: agent {name} does not exist live; a create would mint a NEW id that "
+                "the referencing workflow header does not point at — manual rewire required."
+            )
+        return verdict
+
+    if verdict == "noop":
+        print(f"[{name}] in-sync — no-op (no version bump).")
+        return verdict
+
+    if verdict == "create":
+        created = _post_agent(base_url, api_key, manifest)
+        new_id = created.get("id")
+        # The loud create-warning mandated by the CRITICAL DESIGN CONSTRAINT: a fresh
+        # agent is live but the dev-pipeline workflow header still points at the PRIOR
+        # id, so the pipeline cannot reach it until the workflow is re-registered.
+        print(
+            f"WARNING: created agent {name} id={new_id}; the referencing workflow header "
+            "still points at the prior id and must be re-registered to rewire."
+        )
+        return verdict
+
+    # update — verdict=="update" implies live was found (desired_diff returns
+    # "create" when live is None), so this narrowing always holds.
+    assert live is not None
+    live_version = live.get("version")
+    agent_id = live.get("id")
+    if live_version is None or not isinstance(agent_id, str):
+        raise ReconcileError(
+            f"[{name}] live agent response missing 'id'/'version': {json.dumps(live)[:500]}"
+        )
+    print(f"[{name}] drift detected — updating (PUT id={agent_id} with version={live_version})…")
+    updated = _put_agent(base_url, agent_id, api_key, version=live_version, manifest=manifest)
+    new_version = updated.get("version")
+    if new_version is None or new_version <= live_version:
+        raise ReconcileError(
+            f"[{name}] PUT succeeded but version did not increment "
+            f"(live={live_version}, response={new_version})"
+        )
+    print(f"[{name}] updated: version {live_version} → {new_version}.")
+    return verdict
+
+
+def _versioned_fields(manifest: dict[str, Any]) -> dict[str, Any]:
+    AgentCreate = _agent_create_cls()
+    return {k: v for k, v in manifest.items() if k in AgentCreate.model_fields}
+
+
+def _post_agent(base_url: str, api_key: str, manifest: dict[str, Any]) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/v1/agents"
+    status, payload = _request("POST", url, api_key, body=_versioned_fields(manifest))
+    if not (200 <= status < 300):
+        raise ReconcileError(f"POST agent returned {status}: {json.dumps(payload)[:500]}")
+    return payload
+
+
+def _put_agent(
+    base_url: str, agent_id: str, api_key: str, *, version: int, manifest: dict[str, Any]
+) -> dict[str, Any]:
+    url = f"{base_url.rstrip('/')}/v1/agents/{agent_id}"
+    body = {"version": version, **_versioned_fields(manifest)}
+    status, payload = _request("PUT", url, api_key, body=body)
+    if status == 409:
+        raise ReconcileError(
+            "PUT returned 409 version-mismatch — the live agent was bumped concurrently "
+            f"(version {version} is stale). Re-run the job. Body: {json.dumps(payload)[:500]}"
+        )
+    if not (200 <= status < 300):
+        raise ReconcileError(f"PUT agent returned {status}: {json.dumps(payload)[:500]}")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    # Config is read from the environment ONLY. In particular AIOS_API_KEY is NEVER a
+    # CLI flag: an argv-borne secret is exposed via `ps` / /proc/<pid>/cmdline. The
+    # Action passes it solely via `env:`.
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "read-only diff mode: print each agent's verdict (in-sync / WOULD-CREATE / "
+            "WOULD-UPDATE), perform NO write, and exit non-zero iff any drift is found. "
+            "This is the seed of the v2 ops-agent drift loop."
+        ),
+    )
+    parser.add_argument(
+        "--manifest-dir",
+        default=DEFAULT_MANIFEST_DIR,
+        metavar="DIR",
+        help=f"directory of *.json agent manifests (default: {DEFAULT_MANIFEST_DIR}).",
+    )
+    parser.add_argument(
+        "--only",
+        action="append",
+        default=None,
+        metavar="NAME",
+        help="reconcile only the named agent(s) (matched on manifest 'name'). Repeatable.",
+    )
+    args = parser.parse_args(argv)
+
+    api_key = os.environ.get("AIOS_API_KEY")
+    url = os.environ.get("AIOS_URL")
+    if not api_key:
+        print("FATAL: AIOS_API_KEY is not set", file=sys.stderr)
+        return 2
+    if not url:
+        print("FATAL: AIOS_URL is not set", file=sys.stderr)
+        return 2
+
+    try:
+        manifests = load_manifests(args.manifest_dir)
+    except ReconcileError as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        return 1
+
+    if args.only:
+        wanted = set(args.only)
+        unknown = wanted - {m.get("name") for m in manifests}
+        if unknown:
+            print(f"FATAL: unknown --only agent(s): {', '.join(sorted(unknown))}", file=sys.stderr)
+            return 2
+        manifests = [m for m in manifests if m.get("name") in wanted]
+
+    if not manifests:
+        print(f"FATAL: no agent manifests found under {args.manifest_dir}", file=sys.stderr)
+        return 2
+
+    counts = {"create": 0, "update": 0, "noop": 0}
+    for manifest in manifests:
+        try:
+            verdict = reconcile_agent(manifest, base_url=url, api_key=api_key, check=args.check)
+        except ReconcileError as exc:
+            print(f"FATAL: {exc}", file=sys.stderr)
+            return 1
+        counts[verdict] += 1
+
+    print(f"Done: {counts['create']} created, {counts['update']} updated, {counts['noop']} noop.")
+
+    if args.check and (counts["create"] or counts["update"]):
+        # Drift detected under --check: exit non-zero so the scheduled v2 check fails
+        # loudly (live ≠ declared), but write nothing.
+        print(
+            f"DRIFT: {counts['create']} would-create, {counts['update']} would-update "
+            "(no writes performed under --check).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_agents.py
+++ b/scripts/reconcile_agents.py
@@ -179,11 +179,19 @@ def find_live_agent(base_url: str, name: str, api_key: str) -> dict[str, Any] | 
         raise ReconcileError(
             f"GET agents?name={name} returned {status}: {json.dumps(payload)[:500]}"
         )
-    items = payload.get("items")
+    # GET /v1/agents returns the ListResponse[T] envelope (see
+    # src/aios/models/common.py): the rows live under 'data' (alongside
+    # 'has_more' / 'next_cursor') — there is NO 'items' key.
+    items = payload.get("data")
     if not isinstance(items, list):
         raise ReconcileError(
-            f"GET agents?name={name} response missing list 'items': {json.dumps(payload)[:500]}"
+            f"GET agents?name={name} response missing list 'data': {json.dumps(payload)[:500]}"
         )
+    # NOTE: we only inspect this first page of results. The name= equality filter
+    # returns newest-first, and the exact-name match we want is assumed to fit in a
+    # single page (the >=2-match guard below already refuses to reconcile when more
+    # than one exact match is present, so a name spilling onto a second page would
+    # have already tripped that guard). We deliberately do NOT follow next_cursor.
     # Defensive: the equality filter SHOULD return only exact matches, but a future
     # endpoint regression to a prefix/substring match would silently mis-reconcile,
     # so re-assert exact-name equality here before trusting the rows.

--- a/scripts/reregister_workflows.py
+++ b/scripts/reregister_workflows.py
@@ -278,10 +278,18 @@ def reconcile_target(
     workflow_id: str,
     api_key: str,
     verbose: bool,
+    check: bool = False,
 ) -> bool:
     """Reconcile ONE workflow target: read live → extract → rebuild → validate →
-    decide → PUT.  Returns True if a PUT (version bump) was applied, False on a
-    no-op (already in sync).  Raises ReregisterError on any fatal problem.
+    decide → PUT.  Returns True if the target CHANGED (a PUT was applied, or — under
+    ``check=True`` — a PUT WOULD be applied), False on a no-op (already in sync).
+    Raises ReregisterError on any fatal problem.
+
+    When ``check=True`` this runs steps 1-5 (read live → extract → rebuild →
+    validate → decide) but SKIPS the PUT (step 6): it prints the per-target verdict
+    (``in-sync`` / ``WOULD-RE-REGISTER``) and performs no write. ``main`` then exits
+    non-zero iff any target would change — the read-only drift detector that seeds
+    the v2 ops-agent Vaughan check.
 
     This is the shared per-target pipeline — adding a workflow is a TARGETS entry,
     not a fork of this logic."""
@@ -314,8 +322,16 @@ def reconcile_target(
 
     # 5. Idempotency: no-op when regenerated == live.
     if not needs_update(new_script, live_script):
-        print(f"[{target.key}] regenerated script is identical — no-op (no version bump).")
+        if check:
+            print(f"[{target.key}] in-sync")
+        else:
+            print(f"[{target.key}] regenerated script is identical — no-op (no version bump).")
         return False
+
+    # 5b. --check: drift exists, but perform NO write. Report and return changed=True.
+    if check:
+        print(f"[{target.key}] WOULD-RE-REGISTER")
+        return True
 
     # 6. PUT (version bumps; omitted tools/http_servers preserved).
     print(f"[{target.key}] script changed — re-registering (PUT with version={live_version})…")
@@ -355,6 +371,15 @@ def main(argv: list[str] | None = None) -> int:
             "Repeatable. Default: every target whose *_WORKFLOW_ID env var is set."
         ),
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "read-only diff mode: read live → extract → rebuild → validate → decide, "
+            "print each target's verdict (in-sync / WOULD-RE-REGISTER), perform NO PUT, "
+            "and exit non-zero iff any target would change. Seeds the v2 drift loop."
+        ),
+    )
     args = parser.parse_args(argv)
 
     api_key = os.environ.get("AIOS_API_KEY")
@@ -390,7 +415,12 @@ def main(argv: list[str] | None = None) -> int:
             continue
         try:
             if reconcile_target(
-                target, base_url=url, workflow_id=workflow_id, api_key=api_key, verbose=args.verbose
+                target,
+                base_url=url,
+                workflow_id=workflow_id,
+                api_key=api_key,
+                verbose=args.verbose,
+                check=args.check,
             ):
                 changed += 1
             reconciled += 1
@@ -399,9 +429,25 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     if reconciled == 0 and skipped > 0:
-        print("FATAL: no workflow targets were configured (every *_WORKFLOW_ID is unset)",
-              file=sys.stderr)
+        print(
+            "FATAL: no workflow targets were configured (every *_WORKFLOW_ID is unset)",
+            file=sys.stderr,
+        )
         return 2
+    if args.check:
+        print(
+            f"Done (check): {reconciled} target(s) checked, {changed} would re-register, "
+            f"{skipped} skipped."
+        )
+        if changed:
+            # Drift detected under --check: exit non-zero (live ≠ declared), no writes.
+            print(
+                f"DRIFT: {changed} target(s) would re-register (no writes performed under "
+                "--check).",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
     print(f"Done: {reconciled} target(s) reconciled, {changed} re-registered, {skipped} skipped.")
     return 0
 

--- a/tests/unit/test_reconcile_agents.py
+++ b/tests/unit/test_reconcile_agents.py
@@ -1,0 +1,472 @@
+"""Unit tests for the IaC-sync v1 agent reconciler (issue #1282).
+
+The script's load-bearing logic is the pure pipeline — load + validate manifests,
+diff against the live read view (normalised so nested default-population differences
+don't produce phantom drift), and decide create/update/noop — plus the fail-loud
+guards: the duplicate-name guard, the create rewire-warning, the `--check` no-write
+invariant, and the 409 version-mismatch. These tests exercise that logic OFFLINE
+(no network, no live agent), plus the committed-manifest validation + no-secret
+invariant, and the deploy-on-merge Action's drift guards.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from aios.models.agents import AgentCreate
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "reconcile_agents.py"
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "reconcile-agents.yml"
+_MANIFEST_DIR = _REPO_ROOT / "infra" / "agents"
+
+
+def _load_script_module() -> ModuleType:
+    # Mirror test_reregister_workflows.py's importlib harness: register before exec
+    # so dataclasses/annotations resolve via sys.modules[cls.__module__].
+    spec = importlib.util.spec_from_file_location("reconcile_agents", _SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ra = _load_script_module()
+
+
+def _manifest(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "dev-implement",
+        "model": "anthropic/claude-opus-4-8",
+        "system": "do the thing",
+        "tools": [{"type": "bash"}, {"type": "read"}],
+        "http_servers": [],
+        "litellm_extra": {},
+        "window_min": 50000,
+        "window_max": 150000,
+    }
+    base.update(over)
+    return base
+
+
+def _live_from(manifest: dict[str, Any], **over: Any) -> dict[str, Any]:
+    """Build a plausible LIVE read view from a manifest: normalise the manifest's
+    versioned fields through AgentCreate (default-populated, field-reordered) and
+    bolt on the server-only fields a real GET returns."""
+    canonical = AgentCreate(**manifest).model_dump()
+    live: dict[str, Any] = {
+        "id": "agent_01EXISTING",
+        "version": 4,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T00:00:00Z",
+        "archived_at": None,
+        **canonical,
+    }
+    live.update(over)
+    return live
+
+
+# ─── committed manifests: validate + no-secret invariant ─────────────────────
+
+
+def _committed_manifest_paths() -> list[Path]:
+    return sorted(_MANIFEST_DIR.glob("*.json"))
+
+
+def test_manifest_dir_has_at_least_one_manifest() -> None:
+    assert _committed_manifest_paths(), "expected at least one infra/agents/*.json manifest"
+
+
+def test_every_committed_manifest_validates_against_agentcreate() -> None:
+    """Extra-field / malformed manifests must fail HERE (AgentCreate is extra=forbid),
+    not in prod. load_manifests is the production path; assert it accepts the dir."""
+    manifests = ra.load_manifests(_MANIFEST_DIR)
+    assert len(manifests) == len(_committed_manifest_paths())
+    for m in manifests:
+        AgentCreate(**m)  # redundant belt-and-braces; raises on any drift
+
+
+def test_committed_manifests_carry_no_secret_shaped_literal() -> None:
+    """No-secret invariant: a manifest may reference a credential by NAME but must
+    never embed key material. Assert no key-shaped literal anywhere in the JSON, and
+    no top-level api_key/token/secret key."""
+    key_shaped = re.compile(
+        r"sk-[A-Za-z0-9]{16,}|ghp_[A-Za-z0-9]{16,}|Bearer\s+[A-Za-z0-9._\-]{16,}"
+    )
+    for path in _committed_manifest_paths():
+        text = path.read_text()
+        assert not key_shaped.search(text), f"{path.name} contains a key-shaped literal"
+        obj = json.loads(text)
+        forbidden = {"api_key", "token", "secret", "apikey"}
+        assert not (set(obj) & forbidden), f"{path.name} has a forbidden top-level secret key"
+
+
+# ─── load_manifests: fail-loud on bad input ──────────────────────────────────
+
+
+def test_load_manifests_rejects_extra_field(tmp_path: Path) -> None:
+    (tmp_path / "bad.json").write_text(json.dumps({**_manifest(), "nope": 1}))
+    with pytest.raises(ra.ReconcileError):
+        ra.load_manifests(tmp_path)
+
+
+def test_load_manifests_rejects_malformed_json(tmp_path: Path) -> None:
+    (tmp_path / "bad.json").write_text("{not json")
+    with pytest.raises(ra.ReconcileError):
+        ra.load_manifests(tmp_path)
+
+
+def test_load_manifests_missing_dir_is_loud() -> None:
+    with pytest.raises(ra.ReconcileError):
+        ra.load_manifests("/nonexistent/agents/dir")
+
+
+def test_load_manifests_reads_all_json(tmp_path: Path) -> None:
+    (tmp_path / "a.json").write_text(json.dumps(_manifest(name="a")))
+    (tmp_path / "b.json").write_text(json.dumps(_manifest(name="b")))
+    (tmp_path / "ignore.txt").write_text("not a manifest")
+    names = {m["name"] for m in ra.load_manifests(tmp_path)}
+    assert names == {"a", "b"}
+
+
+# ─── desired_diff: the truth table ───────────────────────────────────────────
+
+
+def test_desired_diff_none_live_is_create() -> None:
+    assert ra.desired_diff(_manifest(), None) == "create"
+
+
+def test_desired_diff_identical_is_noop() -> None:
+    m = _manifest()
+    assert ra.desired_diff(m, _live_from(m)) == "noop"
+
+
+def test_desired_diff_model_change_is_update() -> None:
+    m = _manifest()
+    live = _live_from(m)
+    assert ra.desired_diff(_manifest(model="anthropic/claude-opus-4-9"), live) == "update"
+
+
+def test_desired_diff_tool_added_is_update() -> None:
+    m = _manifest()
+    live = _live_from(m)
+    changed = _manifest(tools=[{"type": "bash"}, {"type": "read"}, {"type": "edit"}])
+    assert ra.desired_diff(changed, live) == "update"
+
+
+def test_desired_diff_system_text_change_is_update() -> None:
+    m = _manifest()
+    live = _live_from(m)
+    assert ra.desired_diff(_manifest(system="something else"), live) == "update"
+
+
+def test_desired_diff_nested_reorder_is_noop() -> None:
+    """Normalisation invariant: a manifest whose nested tool dict lists its keys in a
+    different order than the live read view (and omits default-populated keys) must be
+    `noop`, not phantom drift. Proves we compare canonical shapes, not raw text."""
+    m = _manifest(tools=[{"type": "bash", "enabled": True}])
+    # live read view: same tool but fully default-populated, keys in a different order
+    live = _live_from(_manifest(tools=[{"type": "bash"}]))
+    # sanity: the raw nested dicts differ in key set/order
+    assert m["tools"][0] != live["tools"][0]
+    assert ra.desired_diff(m, live) == "noop"
+
+
+# ─── find_live_agent: duplicate-name guard ───────────────────────────────────
+
+
+def _mock_request(status: int, payload: Any) -> Any:
+    return mock.patch.object(ra, "_request", return_value=(status, payload))
+
+
+def test_find_live_agent_zero_matches_is_none() -> None:
+    with _mock_request(200, {"items": []}):
+        assert ra.find_live_agent("https://x", "dev-implement", "k") is None
+
+
+def test_find_live_agent_one_match_returns_it() -> None:
+    row = {"id": "agent_1", "name": "dev-implement", "version": 4}
+    with _mock_request(200, {"items": [row]}):
+        assert ra.find_live_agent("https://x", "dev-implement", "k") == row
+
+
+def test_find_live_agent_two_matches_raises() -> None:
+    """>=2 exact-name matches → fail loud, NEVER silently pick one (prod has
+    near-duplicate names, so this guard is load-bearing)."""
+    rows = [
+        {"id": "agent_1", "name": "autodev-resilience-lieutenant", "version": 1},
+        {"id": "agent_2", "name": "autodev-resilience-lieutenant", "version": 1},
+    ]
+    with _mock_request(200, {"items": rows}), pytest.raises(ra.ReconcileError):
+        ra.find_live_agent("https://x", "autodev-resilience-lieutenant", "k")
+
+
+def test_find_live_agent_non_2xx_is_loud() -> None:
+    with _mock_request(500, {"detail": "boom"}), pytest.raises(ra.ReconcileError):
+        ra.find_live_agent("https://x", "dev-implement", "k")
+
+
+def test_find_live_agent_ignores_inexact_substring_match() -> None:
+    """Re-asserts exact equality on the rows the endpoint returns, so a future
+    prefix/substring regression can't mis-reconcile."""
+    rows = [{"id": "agent_x", "name": "dev-implement-v2", "version": 1}]
+    with _mock_request(200, {"items": rows}):
+        assert ra.find_live_agent("https://x", "dev-implement", "k") is None
+
+
+# ─── reconcile_agent: create-warning, check no-write, 409 ────────────────────
+
+
+def test_reconcile_agent_create_emits_rewire_warning(capsys: pytest.CaptureFixture[str]) -> None:
+    m = _manifest()
+    with (
+        mock.patch.object(ra, "find_live_agent", return_value=None),
+        mock.patch.object(
+            ra, "_post_agent", return_value={"id": "agent_NEW", "version": 1}
+        ) as post,
+    ):
+        verdict = ra.reconcile_agent(m, base_url="https://x", api_key="k", check=False)
+    assert verdict == "create"
+    post.assert_called_once()
+    out = capsys.readouterr().out
+    assert "WARNING: created agent dev-implement id=agent_NEW" in out
+    assert "re-registered to rewire" in out
+
+
+def test_reconcile_agent_check_performs_no_write_on_create() -> None:
+    m = _manifest()
+    with (
+        mock.patch.object(ra, "find_live_agent", return_value=None),
+        mock.patch.object(ra, "_post_agent") as post,
+        mock.patch.object(ra, "_put_agent") as put,
+    ):
+        verdict = ra.reconcile_agent(m, base_url="https://x", api_key="k", check=True)
+    assert verdict == "create"
+    post.assert_not_called()
+    put.assert_not_called()
+
+
+def test_reconcile_agent_check_performs_no_write_on_update() -> None:
+    m = _manifest()
+    live = _live_from(_manifest(model="anthropic/claude-opus-4-9"))
+    with (
+        mock.patch.object(ra, "find_live_agent", return_value=live),
+        mock.patch.object(ra, "_post_agent") as post,
+        mock.patch.object(ra, "_put_agent") as put,
+    ):
+        verdict = ra.reconcile_agent(m, base_url="https://x", api_key="k", check=True)
+    assert verdict == "update"
+    post.assert_not_called()
+    put.assert_not_called()
+
+
+def test_reconcile_agent_update_puts_with_live_version() -> None:
+    m = _manifest(model="anthropic/claude-opus-4-9")
+    live = _live_from(_manifest(), version=7, id="agent_LIVE")
+    with mock.patch.object(ra, "_request") as req:
+        # GET (find_live) then PUT
+        req.side_effect = [
+            (200, {"items": [live]}),
+            (200, {**live, "version": 8}),
+        ]
+        verdict = ra.reconcile_agent(m, base_url="https://x", api_key="k", check=False)
+    assert verdict == "update"
+    put_call = req.call_args_list[-1]
+    assert put_call.args[0] == "PUT"
+    assert "agent_LIVE" in put_call.args[1]
+    assert put_call.kwargs["body"]["version"] == 7
+    assert put_call.kwargs["body"]["model"] == "anthropic/claude-opus-4-9"
+
+
+def test_reconcile_agent_noop_writes_nothing() -> None:
+    m = _manifest()
+    live = _live_from(m)
+    with (
+        mock.patch.object(ra, "find_live_agent", return_value=live),
+        mock.patch.object(ra, "_post_agent") as post,
+        mock.patch.object(ra, "_put_agent") as put,
+    ):
+        verdict = ra.reconcile_agent(m, base_url="https://x", api_key="k", check=False)
+    assert verdict == "noop"
+    post.assert_not_called()
+    put.assert_not_called()
+
+
+def test_reconcile_agent_put_409_is_loud() -> None:
+    m = _manifest(model="anthropic/claude-opus-4-9")
+    live = _live_from(_manifest(), version=3, id="agent_LIVE")
+    with mock.patch.object(ra, "_request") as req:
+        req.side_effect = [
+            (200, {"items": [live]}),
+            (409, {"detail": "version mismatch"}),
+        ]
+        with pytest.raises(ra.ReconcileError):
+            ra.reconcile_agent(m, base_url="https://x", api_key="k", check=False)
+
+
+def test_reconcile_agent_put_version_must_increment() -> None:
+    m = _manifest(model="anthropic/claude-opus-4-9")
+    live = _live_from(_manifest(), version=5, id="agent_LIVE")
+    with mock.patch.object(ra, "_request") as req:
+        req.side_effect = [
+            (200, {"items": [live]}),
+            (200, {**live, "version": 5}),  # did NOT increment
+        ]
+        with pytest.raises(ra.ReconcileError):
+            ra.reconcile_agent(m, base_url="https://x", api_key="k", check=False)
+
+
+# ─── main(): exit codes + --check drift verdict ──────────────────────────────
+
+
+def _seed_dir(tmp_path: Path, *manifests: dict[str, Any]) -> Path:
+    for m in manifests:
+        (tmp_path / f"{m['name']}.json").write_text(json.dumps(m))
+    return tmp_path
+
+
+def test_main_missing_api_key_is_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AIOS_API_KEY", raising=False)
+    monkeypatch.setenv("AIOS_URL", "https://x")
+    assert ra.main([]) == 2
+
+
+def test_main_missing_url_is_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.delenv("AIOS_URL", raising=False)
+    assert ra.main([]) == 2
+
+
+def test_main_check_returns_zero_when_in_sync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    m = _manifest(name="a")
+    _seed_dir(tmp_path, m)
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://x")
+    with mock.patch.object(ra, "find_live_agent", return_value=_live_from(m)):
+        rc = ra.main(["--check", "--manifest-dir", str(tmp_path)])
+    assert rc == 0
+
+
+def test_main_check_returns_nonzero_on_drift_and_no_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    m = _manifest(name="a")
+    _seed_dir(tmp_path, m)
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://x")
+    live = _live_from(_manifest(name="a", model="anthropic/claude-opus-4-9"))
+    with (
+        mock.patch.object(ra, "find_live_agent", return_value=live),
+        mock.patch.object(ra, "_put_agent") as put,
+        mock.patch.object(ra, "_post_agent") as post,
+    ):
+        rc = ra.main(["--check", "--manifest-dir", str(tmp_path)])
+    assert rc == 1
+    put.assert_not_called()
+    post.assert_not_called()
+
+
+def test_main_only_filters_to_named_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_dir(tmp_path, _manifest(name="a"), _manifest(name="b"))
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://x")
+    seen: list[str] = []
+
+    def _stub(manifest: dict[str, Any], **_: Any) -> str:
+        seen.append(manifest["name"])
+        return "noop"
+
+    with mock.patch.object(ra, "reconcile_agent", _stub):
+        rc = ra.main(["--only", "b", "--manifest-dir", str(tmp_path)])
+    assert rc == 0
+    assert seen == ["b"]
+
+
+def test_main_unknown_only_is_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_dir(tmp_path, _manifest(name="a"))
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://x")
+    assert ra.main(["--only", "nope", "--manifest-dir", str(tmp_path)]) == 2
+
+
+def test_main_aborts_when_a_manifest_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_dir(tmp_path, _manifest(name="a"))
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://x")
+
+    def _boom(manifest: dict[str, Any], **_: Any) -> str:
+        raise ra.ReconcileError("kaboom")
+
+    with mock.patch.object(ra, "reconcile_agent", _boom):
+        assert ra.main(["--manifest-dir", str(tmp_path)]) == 1
+
+
+def test_main_real_committed_dir_is_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--manifest-dir defaults to infra/agents and the committed manifests load."""
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://x")
+    seen: list[str] = []
+
+    def _stub(manifest: dict[str, Any], **_: Any) -> str:
+        seen.append(manifest["name"])
+        return "noop"
+
+    # run from repo root so the default relative dir resolves
+    monkeypatch.chdir(_REPO_ROOT)
+    with mock.patch.object(ra, "reconcile_agent", _stub):
+        rc = ra.main([])
+    assert rc == 0
+    assert "dev-implement" in seen
+
+
+# ─── Action drift guards ─────────────────────────────────────────────────────
+
+
+def test_workflow_triggers_on_manifest_path() -> None:
+    text = _WORKFLOW_PATH.read_text()
+    assert "branches: [master]" in text
+    assert re.search(r"paths:\s*\n\s*-\s*\"infra/agents/\*\*\"", text)
+
+
+def test_workflow_least_privilege_and_secret() -> None:
+    text = _WORKFLOW_PATH.read_text()
+    assert re.search(r"permissions:\s*\n\s*contents:\s*read", text)
+    assert "${{ secrets.AIOS_API_KEY }}" in text
+    assert "AIOS_URL: https://api.aios.eumemic.ai" in text
+
+
+def test_workflow_concurrency_serialises() -> None:
+    text = _WORKFLOW_PATH.read_text()
+    assert "group: reconcile-agents" in text
+    assert "cancel-in-progress: false" in text
+
+
+def test_workflow_runs_unit_gate_before_reconcile() -> None:
+    text = _WORKFLOW_PATH.read_text()
+    gate_at = text.find("tests/unit/test_reconcile_agents.py")
+    reconcile_at = text.find("python scripts/reconcile_agents.py")
+    assert 0 < gate_at < reconcile_at
+
+
+def test_no_hardcoded_api_key_in_action_or_script() -> None:
+    for path in (_WORKFLOW_PATH, _SCRIPT_PATH):
+        text = path.read_text()
+        assert not re.search(r"AIOS_API_KEY\s*[:=]\s*['\"]?[A-Za-z0-9_\-]{16,}", text)
+
+
+def test_api_key_is_env_only_no_cli_flag() -> None:
+    text = _SCRIPT_PATH.read_text()
+    assert "--api-key" not in text
+    assert 'os.environ.get("AIOS_API_KEY")' in text

--- a/tests/unit/test_reconcile_agents.py
+++ b/tests/unit/test_reconcile_agents.py
@@ -190,14 +190,35 @@ def _mock_request(status: int, payload: Any) -> Any:
 
 
 def test_find_live_agent_zero_matches_is_none() -> None:
-    with _mock_request(200, {"items": []}):
+    with _mock_request(200, {"data": [], "has_more": False, "next_cursor": None}):
         assert ra.find_live_agent("https://x", "dev-implement", "k") is None
 
 
 def test_find_live_agent_one_match_returns_it() -> None:
     row = {"id": "agent_1", "name": "dev-implement", "version": 4}
-    with _mock_request(200, {"items": [row]}):
+    with _mock_request(200, {"data": [row], "has_more": False, "next_cursor": None}):
         assert ra.find_live_agent("https://x", "dev-implement", "k") == row
+
+
+def test_find_live_agent_reads_real_listresponse_data_envelope() -> None:
+    """Regression: GET /v1/agents returns the ``ListResponse[T]`` envelope from
+    src/aios/models/common.py — rows under 'data' (with 'has_more'/'next_cursor'),
+    NOT 'items'. Reading 'items' aborted every reconcile/--check run with a false
+    'response missing list' error. This pins the real envelope key."""
+    row = {"id": "agent_real", "name": "dev-implement", "version": 9}
+    envelope = {"data": [row], "has_more": False, "next_cursor": None}
+    with _mock_request(200, envelope):
+        assert ra.find_live_agent("https://x", "dev-implement", "k") == row
+
+
+def test_find_live_agent_legacy_items_envelope_is_loud() -> None:
+    """A response WITHOUT the 'data' key (e.g. the old/wrong 'items' shape) must
+    fail loud rather than be silently treated as zero matches."""
+    with (
+        _mock_request(200, {"items": [{"id": "a", "name": "dev-implement"}]}),
+        pytest.raises(ra.ReconcileError),
+    ):
+        ra.find_live_agent("https://x", "dev-implement", "k")
 
 
 def test_find_live_agent_two_matches_raises() -> None:
@@ -207,7 +228,10 @@ def test_find_live_agent_two_matches_raises() -> None:
         {"id": "agent_1", "name": "autodev-resilience-lieutenant", "version": 1},
         {"id": "agent_2", "name": "autodev-resilience-lieutenant", "version": 1},
     ]
-    with _mock_request(200, {"items": rows}), pytest.raises(ra.ReconcileError):
+    with (
+        _mock_request(200, {"data": rows, "has_more": False, "next_cursor": None}),
+        pytest.raises(ra.ReconcileError),
+    ):
         ra.find_live_agent("https://x", "autodev-resilience-lieutenant", "k")
 
 
@@ -220,7 +244,7 @@ def test_find_live_agent_ignores_inexact_substring_match() -> None:
     """Re-asserts exact equality on the rows the endpoint returns, so a future
     prefix/substring regression can't mis-reconcile."""
     rows = [{"id": "agent_x", "name": "dev-implement-v2", "version": 1}]
-    with _mock_request(200, {"items": rows}):
+    with _mock_request(200, {"data": rows, "has_more": False, "next_cursor": None}):
         assert ra.find_live_agent("https://x", "dev-implement", "k") is None
 
 
@@ -276,7 +300,7 @@ def test_reconcile_agent_update_puts_with_live_version() -> None:
     with mock.patch.object(ra, "_request") as req:
         # GET (find_live) then PUT
         req.side_effect = [
-            (200, {"items": [live]}),
+            (200, {"data": [live], "has_more": False, "next_cursor": None}),
             (200, {**live, "version": 8}),
         ]
         verdict = ra.reconcile_agent(m, base_url="https://x", api_key="k", check=False)
@@ -307,7 +331,7 @@ def test_reconcile_agent_put_409_is_loud() -> None:
     live = _live_from(_manifest(), version=3, id="agent_LIVE")
     with mock.patch.object(ra, "_request") as req:
         req.side_effect = [
-            (200, {"items": [live]}),
+            (200, {"data": [live], "has_more": False, "next_cursor": None}),
             (409, {"detail": "version mismatch"}),
         ]
         with pytest.raises(ra.ReconcileError):
@@ -319,7 +343,7 @@ def test_reconcile_agent_put_version_must_increment() -> None:
     live = _live_from(_manifest(), version=5, id="agent_LIVE")
     with mock.patch.object(ra, "_request") as req:
         req.side_effect = [
-            (200, {"items": [live]}),
+            (200, {"data": [live], "has_more": False, "next_cursor": None}),
             (200, {**live, "version": 5}),  # did NOT increment
         ]
         with pytest.raises(ra.ReconcileError):

--- a/tests/unit/test_reregister_workflows.py
+++ b/tests/unit/test_reregister_workflows.py
@@ -388,3 +388,61 @@ def test_main_missing_api_key_is_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AIOS_API_KEY", raising=False)
     monkeypatch.setenv("AIOS_URL", "https://example.test")
     assert rr.main([]) == 2
+
+
+# ─── #1282: --check (no-write diff) mode ─────────────────────────────────────
+
+
+def _mock_get_then_assert_no_put(live_script: str):
+    """Patch rr._request so GET returns a live workflow with `live_script`; fail the
+    test if a PUT is ever issued (proves --check writes nothing)."""
+
+    def _fake(method: str, url: str, api_key: str, body: Any = None):
+        if method == "GET":
+            return 200, {"version": 9, "script": live_script}
+        raise AssertionError(f"--check issued a {method} — it must perform NO write")
+
+    return mock.patch.object(rr, "_request", side_effect=_fake)
+
+
+def test_main_check_in_sync_returns_zero_no_put(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--check against an identical live script: zero exit, no PUT."""
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://example.test")
+    monkeypatch.setenv("DEV_PIPELINE_WORKFLOW_ID", "wf_dev")
+    monkeypatch.delenv("TRIAGE_PIPELINE_WORKFLOW_ID", raising=False)
+    live = build_dev_pipeline_script()  # identical to what the builder regenerates
+    with _mock_get_then_assert_no_put(live):
+        rc = rr.main(["--check"])
+    assert rc == 0
+
+
+def test_main_check_drift_returns_nonzero_no_put(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--check against a DIFFERING live script: non-zero exit, still no PUT."""
+    monkeypatch.setenv("AIOS_API_KEY", "k")
+    monkeypatch.setenv("AIOS_URL", "https://example.test")
+    monkeypatch.setenv("DEV_PIPELINE_WORKFLOW_ID", "wf_dev")
+    monkeypatch.delenv("TRIAGE_PIPELINE_WORKFLOW_ID", raising=False)
+    # live script body differs from what the builder regenerates (a stale deployed
+    # script the merged builder would rewrite) → drift the round-trip cannot absorb.
+    live = build_dev_pipeline_script() + "\n# stale hand-edit the builder drops\n"
+    with _mock_get_then_assert_no_put(live):
+        rc = rr.main(["--check"])
+    assert rc == 1
+
+
+def test_reconcile_target_check_skips_put(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The per-target pipeline under check=True returns changed=True on drift but
+    never PUTs."""
+    dev = _dev_target()
+    live = build_dev_pipeline_script() + "\n# stale hand-edit\n"
+    with _mock_get_then_assert_no_put(live):
+        changed = rr.reconcile_target(
+            dev,
+            base_url="https://x",
+            workflow_id="wf_dev",
+            api_key="k",
+            verbose=False,
+            check=True,
+        )
+    assert changed is True

--- a/tests/unit/test_reregister_workflows.py
+++ b/tests/unit/test_reregister_workflows.py
@@ -393,11 +393,11 @@ def test_main_missing_api_key_is_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
 # ─── #1282: --check (no-write diff) mode ─────────────────────────────────────
 
 
-def _mock_get_then_assert_no_put(live_script: str):
+def _mock_get_then_assert_no_put(live_script: str) -> mock._patch[mock.MagicMock]:
     """Patch rr._request so GET returns a live workflow with `live_script`; fail the
     test if a PUT is ever issued (proves --check writes nothing)."""
 
-    def _fake(method: str, url: str, api_key: str, body: Any = None):
+    def _fake(method: str, url: str, api_key: str, body: Any = None) -> tuple[int, dict[str, Any]]:
         if method == "GET":
             return 200, {"version": 9, "script": live_script}
         raise AssertionError(f"--check issued a {method} — it must perform NO write")


### PR DESCRIPTION
## What

Extends the IaC-sync reconcile discipline (workflow objects, eumemic/eumemic-ops#309/#1226 — **not rebuilt**) to the next 100%-imperative/unversioned object class: **agents**. The dev-pipeline's 5 opus agents (`dev-implement`/`dev-review`/`dev-fix`/`dev-ci-watch`/`dev-risk`) exist only as live DB rows; this brings them under git via thin, secret-free manifests + a by-name reconciler, and adds a read-only `--check` diff mode on **both** reconcilers (the v2 ops-agent drift-loop seed).

## Files ADDED

- **`infra/agents/dev-implement.json`** — thin per-agent manifest (versioned source of truth), the exact `AgentCreate` shape minus secrets. Filename = agent name.
- **`infra/agents/README.md`** — manifest shape, the no-secret (by-name reference only) rule, the one-time seed-extraction bootstrap recipe, and the load-bearing **id-vs-name** constraint + **manual-rewire-on-create** rule.
- **`scripts/reconcile_agents.py`** — pure helpers + thin HTTP shell mirroring `reregister_workflows.py`:
  - `load_manifests` validates every manifest against the real `AgentCreate` (`extra=forbid`) so malformed/extra-field/secret-shaped manifests fail the build, not prod.
  - `find_live_agent` reconciles **by name** via `GET /v1/agents?name=`, returns `None`/the row, and **raises `ReconcileError` on >=2 matches** (never silently picks one — prod has near-duplicate names).
  - `desired_diff` returns create/update/noop, normalising both sides through `AgentCreate(...).model_dump()` so nested default-population/field-order differences don't produce phantom drift.
  - `reconcile_agent` PUTs in place on update (409 → fail-loud), emits the **loud rewire WARNING** on create (bootstrap/DR only — a new id the workflow header doesn't point at yet), and writes nothing under `--check`.
  - `main` reads `AIOS_URL`/`AIOS_API_KEY` from env **only** (never argv), supports `--check`/`--manifest-dir`/`--only`, fails loud per-manifest, and exits non-zero iff drift under `--check`.
- **`.github/workflows/reconcile-agents.yml`** — deploy-on-merge: `on push master paths infra/agents/**`, `concurrency: reconcile-agents` (cancel-in-progress false), `permissions: contents: read`, env `AIOS_URL` + secret `AIOS_API_KEY` (env-only), unit gate (`test_reconcile_agents.py`) before the reconcile run. No integration-fixture step (agents emit no script — the unit test is the right lowest gate).
- **`tests/unit/test_reconcile_agents.py`** — offline gate: committed-manifest validation + no-secret invariant; `desired_diff` truth table incl. a nested-reorder `noop` (proves normalisation); duplicate-name guard; create rewire-warning; `--check` no-write; 409 fail-loud; main exit codes. Uses the importlib script-load harness.

## Files CHANGED

- **`scripts/reregister_workflows.py`** — additive `--check`: runs read→extract→rebuild→validate→decide, **skips the PUT**, prints `in-sync`/`WOULD-RE-REGISTER`, and `main` exits non-zero iff any target would change. **Default path unchanged** (no back-compat shim).
- **`tests/unit/test_reregister_workflows.py`** — added `--check` cases: identical live → zero/no PUT; differing live → non-zero/no PUT; per-target `check=True` skips the PUT.

## House-rule compliance

No back-compat shims (new files; `--check` is additive). Composable primitive (adding an agent = one manifest file; the per-object pipeline mirrors `reconcile_target`). Secrets by-name only, asserted by CI. **Migration: none** — pure tooling over existing `/v1/agents` versioning columns.

## Tests

`uv run pytest tests/unit/test_reconcile_agents.py tests/unit/test_reregister_workflows.py` → 73 passed. `ruff check`, `ruff format --check`, and `mypy scripts/reconcile_agents.py` all clean.

Refs eumemic/aios#1282.