### PR TITLE
fix(triage+dev pipeline): close the comment-POST non-idempotency class (#1292)

### DIFF
--- a/src/aios/workflows/comment_idempotency.py
+++ b/src/aios/workflows/comment_idempotency.py
@@ -1,0 +1,92 @@
+"""Shared maker-marker comment-idempotency helper (aios#1292) — the CLASS fix.
+
+Comment-POST is **not idempotent**: GitHub does not honor an ``Idempotency-Key`` on
+issue-comment create, so two POSTs of the "same" comment produce two comments. Two
+distinct hazards drive that duplication, and BOTH the triage pipeline and the dev
+pipeline POST chairman-facing markered comments, so this is a constellation-wide
+recurrence-class (eumemic-company#24, fractal-retro recurrence discipline). The class is
+closed HERE, in one shared helper that both pipelines inject into their workflow source,
+rather than patched per-call-site in each pipeline (which would let the fix drift).
+
+The two hazards:
+
+1. **At-least-once replay.** The aios crash contract (``run_tools.py``) is at-least-once:
+   a worker can run the comment POST and then crash *before journaling the result*, so
+   replay re-drives the POST → a duplicate comment. The guard: before POSTing, scan the
+   already-fetched comment thread for the comment's stable ``## <marker>`` heading and
+   SKIP if present. This is the maker-marker pattern — a posted comment is its own
+   "already done" marker, observed on the next read.
+
+2. **Error-path ordering (triage's needs-decision specifically).** When a comment is
+   paired with an additive idempotent label, the LABEL must be applied first and the
+   comment posted only after the label returns 2xx — so the label guards the comment (a
+   labeled issue drops out of the untriaged working set, so a re-run never re-classifies
+   and re-comments). That ordering is the *caller's* concern; this helper only owns the
+   maker-marker skip, which closes the replay hazard for EVERY markered comment.
+
+WHY A SOURCE STRING, NOT AN IMPORTED FUNCTION: each workflow is rendered to a single
+self-contained *script source* that the script-host ``exec``s in a curated namespace
+(stdlib ``re``/``json`` only — no ``aios`` import at runtime). So a genuinely shared
+helper has to be shared at *authoring* time: this module exports the helper SOURCE TEXT,
+authored once here, and both ``build_*_script`` functions splice it into their ``_BODY``.
+The text references ``gh`` and ``_ipath`` — names both pipeline bodies already define with
+identical semantics — so it composes without per-pipeline edits.
+
+DETERMINISM: the helper does only pure list/dict/string work plus the same ``gh`` /
+``_ipath`` calls the surrounding body already makes; it imports nothing and reads no
+clock. A skip returns a synthetic ``{"status": 200, "skipped": True}`` value (never a
+real tool() await), so the skip path emits no capability and replay stays stable.
+"""
+
+from __future__ import annotations
+
+# The shared helper source, authored once. Spliced verbatim into each pipeline's _BODY.
+# References ``gh`` and ``_ipath`` from the surrounding body (both pipelines define them
+# with identical signatures: ``await gh(method, path, body=None)`` and
+# ``_ipath(repo, suffix)``).
+COMMENT_IDEMPOTENCY_HELPERS = r'''
+# ─── shared comment-idempotency helper (aios#1292 — close the comment-POST class) ──
+# Comment-POST is NOT idempotent (GitHub ignores Idempotency-Key on comment create) and
+# the aios crash contract is at-least-once, so a replay can re-drive a comment POST and
+# duplicate it. The maker-marker guard: a posted comment carries a stable ``## <marker>``
+# heading; before POSTing, scan the already-fetched thread for that heading and skip if
+# present. The posted comment is its own "already done" marker on the next read.
+
+def _comment_thread_has_marker(comments, marker):
+    """True if any already-fetched comment's body contains ``marker``. ``comments`` is the
+    array from ``GET /issues/{n}/comments`` (or None/[] when unread → no marker → POST
+    proceeds, the safe default that preserves the first-post). Match is a substring test on
+    the stable heading, mirroring the maker-marker pattern."""
+    needle = (marker or "").strip()
+    if not needle or not isinstance(comments, list):
+        return False
+    for c in comments:
+        if isinstance(c, dict):
+            text = c.get("body")
+            if isinstance(text, str) and needle in text:
+                return True
+    return False
+
+
+async def post_comment_once(repo, number, marker, body, existing_comments):
+    """POST one issue comment UNLESS the already-fetched thread already carries ``marker``
+    (the maker-marker dedup). Returns the gh() response, or a synthetic skipped sentinel
+    (``{"status": 200, "skipped": True}``) when the marker is already present — so the
+    caller can treat a skip as a benign success and never emits a duplicate-POST capability
+    on replay. ``body`` MUST contain ``marker`` (the heading IS the marker) so the posted
+    comment is self-identifying on the next read."""
+    if _comment_thread_has_marker(existing_comments, marker):
+        log("comment skip (marker already present): #%s %r" % (number, marker))
+        return {"status": 200, "skipped": True}
+    return await gh("POST", _ipath(repo, "/issues/%d/comments" % number), {"body": body})
+
+
+def _comment_posted_ok(resp):
+    """True if a post_comment_once() result is a success — a real 2xx POST OR a skip."""
+    if not isinstance(resp, dict):
+        return False
+    if resp.get("skipped"):
+        return True
+    st = resp.get("status")
+    return isinstance(st, int) and 200 <= st <= 299
+'''

--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -92,6 +92,7 @@ from typing import Any
 
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.workflows import WorkflowCreate
+from aios.workflows.comment_idempotency import COMMENT_IDEMPOTENCY_HELPERS
 
 # ─── default judgment-node agent ids (override per deployment) ───────────────
 DEFAULT_IMPLEMENT_AGENT_ID = "dev-implement"
@@ -186,6 +187,15 @@ RESOLUTION_SIGNALS: tuple[str, ...] = (
 LABEL_IN_PROGRESS = "autodev:in-progress"
 LABEL_FAILED = "autodev:failed"
 
+# Stable heading markers on the chairman-facing comments this pipeline posts. Each heading is
+# BOTH the comment's first line AND the maker-marker the replay guard scans for: a posted
+# comment is its own "already done" marker on the next read, so an at-least-once replay (the
+# POST ran, the worker crashed before journaling) never duplicates it (aios#1292 — the class
+# shared with triage_pipeline, closed via the same comment_idempotency helper).
+MARKER_SPEC_NOT_READY = "## Spec not ready for implementation"
+MARKER_RISK_ASSESSMENT = "## Risk Assessment"
+MARKER_MERGE_GUARD = "## Merge guard refused"
+
 # Dispatch-claim label (#1188): the cron-scanner / dev-conveyor stamps an issue ``dispatched``
 # when it launches a run for it. Like ``IN_PROGRESS`` it is an IN-FLIGHT claim that must be
 # stripped at the terminal post-merge cleanup — otherwise a merged-but-open issue reads as
@@ -264,6 +274,9 @@ def _render_constants(
         _py("LABEL_IN_PROGRESS", LABEL_IN_PROGRESS),
         _py("LABEL_FAILED", LABEL_FAILED),
         _py("LABEL_DISPATCHED", LABEL_DISPATCHED),
+        _py("MARKER_SPEC_NOT_READY", MARKER_SPEC_NOT_READY),
+        _py("MARKER_RISK_ASSESSMENT", MARKER_RISK_ASSESSMENT),
+        _py("MARKER_MERGE_GUARD", MARKER_MERGE_GUARD),
         _py("MAX_RUN_RETRIES", MAX_RUN_RETRIES),
         _py("MAX_MASTER_CI_ITERS", MAX_MASTER_CI_ITERS),
         _py("FIX_CI_LINT_HINT", FIX_CI_LINT_HINT),
@@ -518,6 +531,18 @@ def _json_body(resp):
 
 def _ipath(repo, suffix):
     return "/repos/%s%s" % (repo, suffix)
+
+
+async def post_markered_comment(repo, number, marker, body):
+    """Post one markered comment on issue/PR ``number`` UNLESS the (FRESHLY-fetched) thread
+    already carries ``marker`` — the maker-marker replay guard (aios#1292). Used for the PR
+    comments (risk / merge-guard) whose thread isn't already in scope; it fetches the thread
+    first so the guard sees any prior post (including one from a pre-crash attempt). A site that
+    already holds the thread calls ``post_comment_once`` directly with it. Returns the
+    post_comment_once result (a 2xx, the skip sentinel, or the failed POST response)."""
+    existing = await gh_paginated(_ipath(repo, "/issues/%d/comments" % number))
+    return await post_comment_once(repo, number, marker, body,
+                                   existing if isinstance(existing, list) else [])
 
 
 def _pr_head_sha(pr):
@@ -845,10 +870,14 @@ async def main(input):
     ok, reason = spec_ok(issue, kind, comments)
     if not ok:
         log("spec gate failed:", reason)
-        await gh("POST", _ipath(repo, "/issues/%d/comments" % issue_number),
-                 {"body": "## Spec not ready for implementation\n\n" + reason})
+        # Label-before-comment + maker-marker dedup (aios#1292): apply the `underspecified`
+        # label FIRST (idempotent/additive), then post the explanation comment ONLY if the
+        # already-fetched thread doesn't already carry the marker — so an at-least-once replay
+        # doesn't post a second "spec not ready" comment.
         await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number),
                  {"labels": ["underspecified"]})
+        await post_comment_once(repo, issue_number, MARKER_SPEC_NOT_READY,
+                                MARKER_SPEC_NOT_READY + "\n\n" + reason, comments)
         return await _fail(repo, issue_number, {"state": "spec_failed", "reason": reason})
 
     # A3 — implement (the coding agent: clone, explore, plan, TDD, self-review, push). The
@@ -1067,8 +1096,10 @@ async def main(input):
                    % (summary, tier, ", ".join(floored_files)))
     await gh("POST", _ipath(repo, "/issues/%d/labels" % pr_number),
              {"labels": ["risk:tier-%d" % tier]})
-    await gh("POST", _ipath(repo, "/issues/%d/comments" % pr_number),
-             {"body": "## Risk Assessment\n\n**Tier %d**\n\n%s" % (tier, summary)})
+    # Maker-marker dedup (aios#1292): skip the POST if the PR thread already carries the Risk
+    # Assessment marker (an at-least-once replay re-driving this node).
+    await post_markered_comment(repo, pr_number, MARKER_RISK_ASSESSMENT,
+                                "%s\n\n**Tier %d**\n\n%s" % (MARKER_RISK_ASSESSMENT, tier, summary))
 
     # S12 — merge-ref guard (fail-closed; the one node that catches broken-on-merge)
     phase("merge-guard")
@@ -1080,8 +1111,10 @@ async def main(input):
             (guard.get("stdout", "") if isinstance(guard, dict) else "")[-1200:],
             (guard.get("stderr", "") if isinstance(guard, dict) else "")[-600:],
             guard.get("exit_code") if isinstance(guard, dict) else None)
-        await gh("POST", _ipath(repo, "/issues/%d/comments" % pr_number),
-                 {"body": "## Merge guard refused\n\n```\n%s\n```" % detail})
+        # Maker-marker dedup (aios#1292): a replay re-driving the failed-guard node must not
+        # post a second "Merge guard refused" comment on the PR.
+        await post_markered_comment(repo, pr_number, MARKER_MERGE_GUARD,
+                                    "%s\n\n```\n%s\n```" % (MARKER_MERGE_GUARD, detail))
         escalations.append("merge_guard")
         decision = await gate({"kind": "merge_guard", "pr": pr_number, "detail": detail})
         if not (isinstance(decision, dict) and decision.get("proceed")):
@@ -1254,7 +1287,10 @@ def build_dev_pipeline_script(
         merge_method=merge_method,
         default_model=default_model,
     )
-    return header + "\n" + _BODY
+    # Splice the shared comment-idempotency helper (aios#1292) into the body — authored once
+    # in comment_idempotency.py and injected into BOTH pipelines so the class fix can't drift.
+    # It references gh/_ipath/log from the body; module-level defs resolve names at call time.
+    return header + "\n" + _BODY + COMMENT_IDEMPOTENCY_HELPERS
 
 
 def build_dev_pipeline_fixture_script(

--- a/src/aios/workflows/triage_pipeline.py
+++ b/src/aios/workflows/triage_pipeline.py
@@ -68,6 +68,12 @@ from typing import Any
 
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.workflows import WorkflowCreate
+from aios.workflows.comment_idempotency import COMMENT_IDEMPOTENCY_HELPERS
+
+# The stable heading on the single needs-decision comment. It is BOTH the comment's first
+# line AND the maker-marker the replay guard scans for: a posted comment is its own
+# "already done" marker on the next read (aios#1292).
+NEEDS_DECISION_MARKER = "## Triage: needs a decision"
 
 # ─── default judgment-node agent id (override per deployment) ─────────────────
 DEFAULT_TRIAGE_AGENT_ID = "triage-classify"
@@ -142,6 +148,7 @@ def _render_constants(
         _py("DEFAULT_MODEL", default_model),
         _py("TRIAGE_STATE_LABELS", list(TRIAGE_STATE_LABELS)),
         _py("TRIAGE_CLASSES", list(TRIAGE_CLASSES)),
+        _py("NEEDS_DECISION_MARKER", NEEDS_DECISION_MARKER),
         _py("CLASSIFY_INSTRUCTIONS", CLASSIFY_INSTRUCTIONS),
         _py("TRIAGE_SCHEMA", TRIAGE_SCHEMA),
     ]
@@ -351,7 +358,7 @@ def _decision_comment(reason):
     needed (the settled-vs-forks split where relevant)."""
     why = (reason or "").strip() or "This issue requires chairman judgment before it can proceed."
     return (
-        "## Triage: needs a decision\n\n"
+        NEEDS_DECISION_MARKER + "\n\n"
         "Automated intake-triage routed this issue to **needs-decision** — it requires "
         "chairman judgment (strategy / capital / external commitment / genuinely ambiguous) "
         "rather than being shovel-ready or merely needing design.\n\n"
@@ -359,21 +366,36 @@ def _decision_comment(reason):
     )
 
 
-async def _apply_classification(repo, issue_number, classification, reason):
+async def _apply_classification(repo, issue_number, classification, reason, existing_comments):
     """Apply the label (and, for needs-decision, the one comment) for a classification. This is
     the clean SEAM the #1218 design-vet automation plugs into: the needs-design branch is just a
-    label today; later it dispatches a design-vet sub-workflow here. Returns the gh() label
-    response so a caller can branch on it.
+    label today; later it dispatches a design-vet sub-workflow here.
 
-    Triage NEVER applies ``approved`` — only the spec-readiness axis. ``classification`` is one
-    of TRIAGE_CLASSES (already normalised); an unknown value is rejected by the caller."""
+    LABEL-BEFORE-COMMENT (aios#1292, hazard 1): apply the idempotent additive label FIRST and
+    post the needs-decision comment ONLY after the label returns 2xx. The label then guards the
+    comment — a labeled issue drops out of ``is_untriaged`` so a re-run never re-classifies and
+    re-comments. If the label fails, we return immediately and post NO comment (a comment without
+    a label is exactly the duplicate-spam loop this fixes).
+
+    REPLAY DEDUP (aios#1292, hazard 2): the comment goes through ``post_comment_once``, which
+    scans the already-fetched thread for ``NEEDS_DECISION_MARKER`` and skips the POST if present
+    — so an at-least-once replay (POST ran, crash before journaling) never duplicates it.
+
+    Returns ``(label_resp, comment_resp)``: the label gh() response and the comment response
+    (a 2xx, a skip sentinel, or None when not needs-decision / label failed) so the caller can
+    branch and count side effects correctly. Triage NEVER applies ``approved`` — only the
+    spec-readiness axis. ``classification`` is one of TRIAGE_CLASSES (already normalised)."""
+    label_resp = await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number),
+                          {"labels": [classification]})
+    if _status(label_resp) not in (200, 201):
+        # Label did not stick → do NOT post the comment; the label must guard it.
+        return (label_resp, None)
+    comment_resp = None
     if classification == "needs-decision":
-        # Post the WHY comment first, then label — so a label-without-explanation window can't
-        # leave a needs-decision issue with no stated reason for the chairman.
-        await gh("POST", _ipath(repo, "/issues/%d/comments" % issue_number),
-                 {"body": _decision_comment(reason)})
-    return await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number),
-                    {"labels": [classification]})
+        comment_resp = await post_comment_once(
+            repo, issue_number, NEEDS_DECISION_MARKER,
+            _decision_comment(reason), existing_comments)
+    return (label_resp, comment_resp)
 
 
 # ─── the state machine ─────────────────────────────────────────────────────────
@@ -435,16 +457,31 @@ async def main(input):
                            % (result.get("classification") if isinstance(result, dict) else result)})
             continue
 
-        label_resp = await _apply_classification(repo, number, classification, reason)
+        # Label-before-comment + maker-marker dedup (aios#1292). The already-fetched
+        # ``comments`` thread is handed in so the replay guard can skip a duplicate POST.
+        label_resp, comment_resp = await _apply_classification(
+            repo, number, classification, reason,
+            comments if isinstance(comments, list) else [])
         if _status(label_resp) not in (200, 201):
             log("label %r on #%d FAILED -> %r" % (classification, number, _status(label_resp)))
             errors.append({"issue": number, "error": "label apply failed (status %r)"
                            % _status(label_resp)})
             continue
 
+        # The label stuck (the issue is now triaged and drops out of the next run's working
+        # set) → count it classified regardless of the comment outcome. A comment failure on
+        # an otherwise-labeled needs-decision issue is recorded as a NON-FATAL side-effect
+        # note, not a classify failure — the label already guards against re-classification,
+        # so this never undercounts the mutation (the MINOR fix in #1292).
         counts[classification] += 1
         if classification == "needs-decision":
             escalated.append({"issue": number, "reason": reason})
+            if not _comment_posted_ok(comment_resp):
+                log("needs-decision comment on #%d not posted -> %r" % (number, comment_resp))
+                errors.append({"issue": number,
+                               "error": "needs-decision comment not posted (status %r); "
+                               "label applied, will not re-classify"
+                               % _status(comment_resp)})
 
     # S3 — structured run summary: per-class counts + the explicit needs-decision list.
     phase("summary")
@@ -486,7 +523,11 @@ def build_triage_pipeline_script(
         max_issues_per_run=max_issues_per_run,
         default_model=default_model,
     )
-    return header + "\n" + _BODY
+    # Splice the shared comment-idempotency helper (aios#1292) into the body — authored once
+    # in comment_idempotency.py and injected into BOTH pipelines so the class fix can't drift.
+    # It references gh/_ipath/log from the body (all defined above); module-level defs resolve
+    # names at call time, so appending after the body is fine.
+    return header + "\n" + _BODY + COMMENT_IDEMPOTENCY_HELPERS
 
 
 def build_triage_pipeline_fixture_script(

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -80,6 +80,7 @@ class Scenario:
         *,
         body: str = LONG_BODY,
         comments: list[str] | None = None,
+        pr_comments: list[str] | None = None,
         existing_pr: bool = False,
         implement_escalated: bool = False,
         implement_error: bool = False,
@@ -103,6 +104,11 @@ class Scenario:
         # The comment-thread the GET /issues/{n}/comments responder returns (list of body
         # strings → GitHub comment objects). None => no comments (empty array).
         self.comments = comments or []
+        # The PR (and any non-#5 issue) comment thread the maker-marker guard fetches before
+        # posting a risk / merge-guard / spec comment (aios#1292). Defaults to empty (no prior
+        # post → the first POST goes through); set it to a list carrying a `## <marker>` heading
+        # to model an at-least-once replay where the comment was already posted.
+        self.pr_comments = pr_comments or []
         self.existing_pr = existing_pr
         self.implement_escalated = implement_escalated
         self.implement_error = implement_error
@@ -140,6 +146,7 @@ class Scenario:
         self.agent_inputs: list[dict[str, Any]] = []
         self.gates: list[dict[str, Any]] = []
         self.http: list[tuple[str, str]] = []
+        self.comments_posted: list[str] = []  # every comment body POSTed (#1292 dedup checks)
         self.labels_added: list[str] = []  # every label name POSTed to /labels (item 3)
         self.labels_removed: list[str] = []  # every label name DELETEd from /labels
         self.issue_patches: list[dict[str, Any]] = []  # every PATCH body to /issues/5 (#1188)
@@ -183,12 +190,26 @@ class Scenario:
         # The comment-thread read is the one route that carries a query string (per_page/page);
         # the GitHub /repos/** route opts into allow_query (#1156). Split it off, serve the page.
         clean, _, query = path.partition("?")
-        if method == "GET" and clean == "/repos/o/r/issues/5/comments":  # the item-1 thread read
+        cm = re.match(r"^/repos/o/r/issues/(\d+)/comments$", clean)
+        if method == "GET" and cm:
             page = 1
             m = re.search(r"[?&]page=(\d+)", "?" + query)
             if m:
                 page = int(m.group(1))
-            return self._comments_page(page)
+            if int(cm.group(1)) == 5:  # the item-1 issue thread read (paginated)
+                return self._comments_page(page)
+            # Any OTHER comment-thread read (the PR threads the #1292 maker-marker guard
+            # fetches before posting risk/merge-guard comments). Serve the configured PR thread.
+            return {
+                "status": 200,
+                "headers": {},
+                "body": json.dumps([{"id": i, "body": b} for i, b in enumerate(self.pr_comments)]),
+            }
+        if method == "POST" and cm:  # capture a posted comment (maker-marker assertions)
+            raw = args.get("body")
+            if isinstance(raw, str):
+                self.comments_posted.append(json.loads(raw).get("body", ""))
+            return {"status": 201, "body": "{}"}
         assert "?" not in path, f"query string in path is rejected by http_request: {path!r}"
         if method == "POST" and path.endswith("/labels"):  # add label(s) — capture names
             raw = args.get("body")
@@ -373,12 +394,13 @@ async def test_happy_path_merges_and_completes() -> None:
     ]
     assert scn.gates == []  # tier-1 auto-merges; no gate opened
     assert scn.tasks == ["implement", "review-0", "ci-0", "risk", "master-ci-0"]
-    # never used a query string EXCEPT on the allow_query comments-pagination path
-    # (#1156); every other GitHub call stays clean-path (the production-path bug review caught)
+    # never used a query string EXCEPT on the allow_query comments-pagination paths
+    # (#1156: the issue thread read; #1292: the maker-marker guard's PR-thread read before
+    # posting risk/merge-guard comments); every other GitHub call stays clean-path.
     assert all(
         "?" not in path
         for _, path in scn.http
-        if not path.startswith("/repos/o/r/issues/5/comments")
+        if not re.match(r"^/repos/o/r/issues/\d+/comments", path)
     )
     # item 1: the comment thread is read at ingest (paginated -> ?per_page/?page carried)
     assert any(m == "GET" and p.startswith("/repos/o/r/issues/5/comments") for m, p in scn.http)
@@ -462,6 +484,69 @@ async def test_spec_gate_comment_resolution_word_without_quote_still_bounces() -
     value, _, _ = await _drive(scn)
     assert value["state"] == "spec_failed"
     assert "unresolved marker" in value["reason"]
+
+
+# ─── #1292: close the comment-POST non-idempotency class (shared with triage) ─
+
+
+async def test_spec_gate_applies_label_before_comment() -> None:
+    # Label-before-comment ordering: the `underspecified` label (idempotent/additive) is
+    # POSTed BEFORE the "spec not ready" comment, so the label guards the comment.
+    scn = Scenario(body="too short")
+    await _drive(scn)
+    ordered = [
+        p
+        for (m, p) in scn.http
+        if m == "POST"
+        and p in ("/repos/o/r/issues/5/labels", "/repos/o/r/issues/5/comments")
+    ]
+    # the "spec not ready" comment is POSTed, and a label POST precedes it (label guards it)
+    assert "/repos/o/r/issues/5/comments" in ordered
+    comment_at = ordered.index("/repos/o/r/issues/5/comments")
+    assert ordered[:comment_at].count("/repos/o/r/issues/5/labels") >= 1
+    assert any("Spec not ready for implementation" in c for c in scn.comments_posted)
+
+
+async def test_spec_gate_skips_comment_when_marker_already_present() -> None:
+    # Replay dedup: the issue thread already carries the "## Spec not ready" marker (a prior
+    # attempt posted it, then the worker crashed before journaling) → the comment is skipped.
+    scn = Scenario(
+        body="too short",
+        comments=["## Spec not ready for implementation\n\nIssue body is too short (2 words)."],
+    )
+    value, _, _ = await _drive(scn)
+    assert value["state"] == "spec_failed"
+    assert scn.comments_posted == []  # no duplicate "spec not ready" comment
+
+
+async def test_risk_and_merge_guard_comments_skip_on_marker_replay() -> None:
+    # Replay dedup for the PR comments: the PR thread already carries BOTH the Risk Assessment
+    # and Merge guard refused markers → neither comment is re-posted on a replay. We force the
+    # merge guard to refuse (exit!=0) and park at the gate so both nodes run.
+    scn = Scenario(
+        merge_guard_exit=1,
+        gate_results={"merge_guard": {"proceed": False}},
+        pr_comments=[
+            "## Risk Assessment\n\n**Tier 1**\n\nsafe",
+            "## Merge guard refused\n\n```\nsentinel failed\n```",
+        ],
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "merge_guard_refused"
+    # both markered PR comments were already present -> nothing re-posted
+    assert scn.comments_posted == []
+
+
+async def test_risk_and_merge_guard_comments_posted_when_absent() -> None:
+    # The complement: an empty PR thread → both markered comments ARE posted (first time).
+    scn = Scenario(
+        merge_guard_exit=1,
+        gate_results={"merge_guard": {"proceed": False}},
+    )
+    await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert any("Risk Assessment" in c for c in scn.comments_posted)
+    assert any("Merge guard refused" in c for c in scn.comments_posted)
 
 
 async def test_thin_body_satisfied_by_comment_thread_proceeds() -> None:

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -497,8 +497,7 @@ async def test_spec_gate_applies_label_before_comment() -> None:
     ordered = [
         p
         for (m, p) in scn.http
-        if m == "POST"
-        and p in ("/repos/o/r/issues/5/labels", "/repos/o/r/issues/5/comments")
+        if m == "POST" and p in ("/repos/o/r/issues/5/labels", "/repos/o/r/issues/5/comments")
     ]
     # the "spec not ready" comment is POSTed, and a label POST precedes it (label guards it)
     assert "/repos/o/r/issues/5/comments" in ordered

--- a/tests/integration/test_wf_triage_pipeline_fixture.py
+++ b/tests/integration/test_wf_triage_pipeline_fixture.py
@@ -412,6 +412,72 @@ async def test_label_post_failure_is_recorded_per_issue() -> None:
     assert "label apply failed" in value["errors"][0]["error"]
 
 
+# ─── #1292: close the comment-POST non-idempotency class ──────────────────────
+
+
+async def test_needs_decision_applies_label_before_comment() -> None:
+    # Hazard 1 (error-path ordering): the idempotent additive label must be applied FIRST,
+    # the comment posted only after the label returns 2xx — so the label guards the comment.
+    issues = [_issue(1224, labels=list(PARITY_LABELS))]
+    scn = Scenario(
+        issues=issues,
+        classifications={1224: {"classification": "needs-decision", "reason": "capital"}},
+    )
+    await _drive(scn)
+    # the two mutating POSTs for #1224, in order
+    muts = [
+        (m, p)
+        for (m, p) in scn.http
+        if m == "POST"
+        and p in ("/repos/o/r/issues/1224/labels", "/repos/o/r/issues/1224/comments")
+    ]
+    assert muts == [
+        ("POST", "/repos/o/r/issues/1224/labels"),
+        ("POST", "/repos/o/r/issues/1224/comments"),
+    ], "label must be POSTed before the needs-decision comment"
+
+
+async def test_needs_decision_label_fail_posts_no_comment() -> None:
+    # If the label POST fails, the comment must NOT be posted — the label guards the comment,
+    # and a comment-without-label would re-classify (and re-comment) on the next run.
+    issues = [_issue(1224, labels=list(PARITY_LABELS))]
+    scn = Scenario(
+        issues=issues,
+        classifications={1224: {"classification": "needs-decision", "reason": "capital"}},
+        label_post_status=422,
+    )
+    value, _, _ = await _drive(scn)
+    assert scn.comments_posted == {}  # no comment when the label failed
+    assert value["classified"] == 0
+    assert len(value["errors"]) == 1
+    assert value["errors"][0]["issue"] == 1224
+    assert "label apply failed" in value["errors"][0]["error"]
+
+
+async def test_needs_decision_skips_comment_when_marker_already_present() -> None:
+    # Hazard 2 (at-least-once replay): the maker-marker guard. If the already-fetched thread
+    # already carries the `## Triage: needs a decision` heading, the comment POST is skipped —
+    # no duplicate. (The label is still (idempotently) re-applied; that's additive and safe.)
+    issues = [_issue(1224, labels=list(PARITY_LABELS))]
+    scn = Scenario(
+        issues=issues,
+        classifications={1224: {"classification": "needs-decision", "reason": "capital"}},
+        comments={
+            1224: [
+                "## Triage: needs a decision\n\nAutomated intake-triage routed this issue "
+                "to **needs-decision**.\n\n**Why:** capital"
+            ]
+        },
+    )
+    value, _, _ = await _drive(scn)
+    assert scn.comments_posted == {}  # the prior comment is its own marker -> no duplicate
+    # the label is still applied and the issue still counts as classified (a skip is benign)
+    assert scn.labels_added[1224] == ["needs-decision"]
+    assert value["classified"] == 1
+    assert value["counts"]["needs-decision"] == 1
+    assert value["needs_decision"] == [{"issue": 1224, "reason": "capital"}]
+
+
 # ─── input handling ───────────────────────────────────────────────────────────
 
 

--- a/tests/integration/test_wf_triage_pipeline_fixture.py
+++ b/tests/integration/test_wf_triage_pipeline_fixture.py
@@ -428,8 +428,7 @@ async def test_needs_decision_applies_label_before_comment() -> None:
     muts = [
         (m, p)
         for (m, p) in scn.http
-        if m == "POST"
-        and p in ("/repos/o/r/issues/1224/labels", "/repos/o/r/issues/1224/comments")
+        if m == "POST" and p in ("/repos/o/r/issues/1224/labels", "/repos/o/r/issues/1224/comments")
     ]
     assert muts == [
         ("POST", "/repos/o/r/issues/1224/labels"),

--- a/tests/unit/test_comment_idempotency_helper.py
+++ b/tests/unit/test_comment_idempotency_helper.py
@@ -91,9 +91,7 @@ def test_replay_with_marker_present_skips_the_post() -> None:
     # The replay/duplicate hazard: the marker is already in the thread → skip, no POST.
     ns = _namespace()
     post = ns["post_comment_once"]
-    resp = asyncio.run(
-        post("o/r", 7, MARKER, BODY, existing_comments=[{"body": BODY}])
-    )
+    resp = asyncio.run(post("o/r", 7, MARKER, BODY, existing_comments=[{"body": BODY}]))
     assert resp.get("skipped") is True
     assert resp["status"] == 200
     assert ns["posts"] == []  # NO duplicate POST

--- a/tests/unit/test_comment_idempotency_helper.py
+++ b/tests/unit/test_comment_idempotency_helper.py
@@ -1,0 +1,110 @@
+"""Unit tests for the shared comment-idempotency helper (aios#1292).
+
+The helper closes the comment-POST non-idempotency CLASS shared by the triage and dev
+pipelines: GitHub ignores ``Idempotency-Key`` on comment create, and the aios crash
+contract is at-least-once, so a replay (or a label-fail re-classify loop) can re-drive a
+comment POST and duplicate it. The maker-marker guard scans the already-fetched thread for
+the comment's stable ``## <marker>`` heading and skips the POST if present.
+
+The helper source is authored once in ``comment_idempotency.COMMENT_IDEMPOTENCY_HELPERS``
+and spliced into BOTH pipeline scripts. We exec it in a namespace with a recording ``gh``
+stub (the helper references ``gh`` / ``_ipath`` from the surrounding body) and exercise the
+pure logic directly — no LLM, no real tool, no time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from aios.workflows.comment_idempotency import COMMENT_IDEMPOTENCY_HELPERS
+
+
+def _namespace() -> dict[str, Any]:
+    """Exec the helper source with the two names it references from a pipeline body:
+    a recording async ``gh`` and ``_ipath`` / ``log``."""
+    posts: list[dict[str, Any]] = []
+
+    async def gh(method: str, path: str, body: Any = None) -> dict[str, Any]:
+        posts.append({"method": method, "path": path, "body": body})
+        return {"status": 201, "body": "{}"}
+
+    def _ipath(repo: str, suffix: str) -> str:
+        return f"/repos/{repo}{suffix}"
+
+    ns: dict[str, Any] = {"gh": gh, "_ipath": _ipath, "log": lambda *a, **k: None, "posts": posts}
+    exec(compile(COMMENT_IDEMPOTENCY_HELPERS, "comment_idempotency", "exec"), ns)
+    return ns
+
+
+MARKER = "## Triage: needs a decision"
+BODY = MARKER + "\n\nWhy: needs capital sign-off"
+
+
+# ─── _comment_thread_has_marker ──────────────────────────────────────────────
+
+
+def test_marker_detected_in_thread() -> None:
+    ns = _namespace()
+    has = ns["_comment_thread_has_marker"]
+    comments = [{"body": "unrelated chatter"}, {"body": BODY}]
+    assert has(comments, MARKER) is True
+
+
+def test_marker_absent_from_thread() -> None:
+    ns = _namespace()
+    has = ns["_comment_thread_has_marker"]
+    comments = [{"body": "unrelated"}, {"body": "more chatter"}]
+    assert has(comments, MARKER) is False
+
+
+def test_unread_thread_reports_no_marker() -> None:
+    # None / [] / non-list → no marker → the first POST proceeds (safe default).
+    ns = _namespace()
+    has = ns["_comment_thread_has_marker"]
+    assert has(None, MARKER) is False
+    assert has([], MARKER) is False
+    assert has("boom", MARKER) is False
+
+
+def test_non_dict_and_empty_comments_are_ignored() -> None:
+    ns = _namespace()
+    has = ns["_comment_thread_has_marker"]
+    assert has(["a string", {"body": None}, {"nope": 1}], MARKER) is False
+
+
+# ─── post_comment_once: the maker-marker dedup ───────────────────────────────
+
+
+def test_first_post_goes_through() -> None:
+    ns = _namespace()
+    post = ns["post_comment_once"]
+    resp = asyncio.run(post("o/r", 7, MARKER, BODY, existing_comments=[]))
+    assert resp["status"] == 201
+    assert not resp.get("skipped")
+    assert ns["posts"] == [
+        {"method": "POST", "path": "/repos/o/r/issues/7/comments", "body": {"body": BODY}}
+    ]
+
+
+def test_replay_with_marker_present_skips_the_post() -> None:
+    # The replay/duplicate hazard: the marker is already in the thread → skip, no POST.
+    ns = _namespace()
+    post = ns["post_comment_once"]
+    resp = asyncio.run(
+        post("o/r", 7, MARKER, BODY, existing_comments=[{"body": BODY}])
+    )
+    assert resp.get("skipped") is True
+    assert resp["status"] == 200
+    assert ns["posts"] == []  # NO duplicate POST
+
+
+def test_skip_and_real_post_both_count_as_posted_ok() -> None:
+    ns = _namespace()
+    ok = ns["_comment_posted_ok"]
+    assert ok({"status": 200, "skipped": True}) is True
+    assert ok({"status": 201}) is True
+    assert ok({"status": 200}) is True
+    assert ok({"status": 403}) is False
+    assert ok({"error": "boom"}) is False
+    assert ok(None) is False


### PR DESCRIPTION
## What

Closes the comment-POST non-idempotency **class** shared by the triage and dev pipelines (found by the #1227 adversarial review). Comment-POST is not idempotent (GitHub ignores `Idempotency-Key` on comment create) and the aios crash contract (`run_tools.py`) is at-least-once, so a replay — or, in triage, a label-fail re-classify loop — can re-drive a comment POST and produce a duplicate chairman-facing comment.

Per the fractal-retro recurrence discipline (eumemic-company#24), the fix is shared in **one helper** rather than patched per-site, so it can't drift between the two pipelines.

## How

- **New `aios.workflows.comment_idempotency`** — a shared helper SOURCE string (`post_comment_once` + `_comment_thread_has_marker` + `_comment_posted_ok`), authored once and spliced into BOTH pipeline scripts (each workflow is rendered to a self-contained script `exec`d in a curated stdlib-only namespace, so the helper is shared at *authoring* time). The maker-marker guard scans the already-fetched thread for the comment's stable `## <marker>` heading and skips the POST if present; the skip returns a synthetic sentinel and emits no `tool()` await, so replay stays stable.
- **triage `_apply_classification`** — apply the idempotent additive label **first**; post the `needs-decision` comment only after the label returns 2xx **and** only if the marker is absent. If the label fails, post NO comment — closing the comment-without-label re-classify loop (the label then guards the comment, since a labeled issue drops out of `is_untriaged`).
- **triage summary (MINOR)** — a labeled issue is counted `classified` regardless of the comment outcome; a comment failure on an otherwise-labeled `needs-decision` issue is now a non-fatal side-effect note instead of being undercounted only under `errors`.
- **dev_pipeline** — label-before-comment on the spec gate, plus the maker-marker dedup on all three markered comments (spec-not-ready, risk assessment, merge guard refused); the two PR comments fetch the PR thread first so the guard sees a prior post.

## Tests (test-first)

- New unit test `test_comment_idempotency_helper.py` exercises the shared helper directly (marker detect/absent/unread, first-post-through, replay-skip, posted-ok).
- New triage fixture cases: label-before-comment ordering, label-fail posts no comment, maker-marker replay skip (label still applied + counted).
- New dev fixture cases: spec-gate label-before-comment + replay-skip, risk/merge-guard comments skip on marker replay and post when absent.

All 107 workflow unit + integration tests pass; ruff check + format clean. (The 9 unrelated unit failures in the repo — MCP-mount / openapi-snapshot / sdk-snapshot / run-observability — are pre-existing on the base commit and untouched here.)