### PR TITLE
feat(triggers): wake_session action — explicit-target async wake (#1280)

### DIFF
--- a/migrations/versions/0107_triggers_wake_session_action.py
+++ b/migrations/versions/0107_triggers_wake_session_action.py
@@ -1,0 +1,143 @@
+"""Triggers: ``wake_session`` action kind (#1280) — explicit-target async wake.
+
+Additive CHECK swap, zero row rewrites — the growth rule's "a new behavior is a
+new action *kind*, never a flag" applied verbatim. Follows the 0086 idiom
+(slice-2 ``workflow`` action): the ``triggers_action_shape`` predicate gains one
+new ``WHEN 'wake_session'`` branch; every pre-existing branch stays
+BYTE-IDENTICAL (a unit test pins this — see
+tests/unit/test_migration_0086_predicates.py extended for 0107).
+
+- ``triggers_action_shape`` swap (DROP + plain ADD on the capped table): the
+  new branch asserts ``target_session_id`` and ``content`` are strings and the
+  row carries no ``command`` key. ``wake_session`` rows carry NO
+  ``environment_id`` (left-side false = right-side false), so the sibling
+  ``triggers_environment_id_iff_workflow`` constraint is UNCHANGED.
+- A validating SELECT (names offending rows; diagnostic — no backfill here,
+  every pre-existing row satisfies the byte-identical old branches).
+- ``downgrade()`` fails hard on any ``action ->> 'kind' = 'wake_session'`` row
+  (unrepresentable + not reconstructible under the prior predicate, the 0086
+  stance) and restores the prior ``ACTION_PREDICATE`` verbatim-embedded (no
+  cross-migration import — migrations load under synthetic module names and
+  cannot import each other).
+
+Revision ID: 0107
+Revises: 0106
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0107"
+down_revision: str = "0106"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# The new predicate: 0086's ACTION_PREDICATE with one ``WHEN 'wake_session'``
+# branch spliced in before ``ELSE false``. The four pre-existing branches are
+# byte-identical to 0086's (the byte-identity unit test enforces this).
+ACTION_PREDICATE = """COALESCE((
+    CASE action ->> 'kind'
+        WHEN 'sandbox_command' THEN
+            jsonb_typeof(action -> 'command') = 'string'
+            AND jsonb_typeof(action -> 'timeout_seconds') = 'number'
+            AND jsonb_typeof(action -> 'max_output_bytes') = 'number'
+            AND NOT (action ? 'content')
+        WHEN 'wake_owner' THEN
+            jsonb_typeof(action -> 'content') = 'string'
+            AND NOT (action ? 'command')
+        WHEN 'workflow' THEN
+            jsonb_typeof(action -> 'workflow_id') = 'string'
+            AND (action ? 'workflow_version')
+            AND jsonb_typeof(action -> 'workflow_version') IN ('number', 'null')
+            AND (action ? 'input_template')
+            AND jsonb_typeof(action -> 'vault_ids') = 'array'
+            AND NOT (action ? 'environment_id')
+            AND NOT (action ? 'command')
+            AND NOT (action ? 'content')
+        WHEN 'wake_session' THEN
+            jsonb_typeof(action -> 'target_session_id') = 'string'
+            AND jsonb_typeof(action -> 'content') = 'string'
+            AND NOT (action ? 'command')
+        ELSE false
+    END
+), false)"""
+
+# Verbatim 0086 ACTION_PREDICATE (the head this migration extends), embedded for
+# downgrade only — no cross-migration import.
+ACTION_PREDICATE_0086 = """COALESCE((
+    CASE action ->> 'kind'
+        WHEN 'sandbox_command' THEN
+            jsonb_typeof(action -> 'command') = 'string'
+            AND jsonb_typeof(action -> 'timeout_seconds') = 'number'
+            AND jsonb_typeof(action -> 'max_output_bytes') = 'number'
+            AND NOT (action ? 'content')
+        WHEN 'wake_owner' THEN
+            jsonb_typeof(action -> 'content') = 'string'
+            AND NOT (action ? 'command')
+        WHEN 'workflow' THEN
+            jsonb_typeof(action -> 'workflow_id') = 'string'
+            AND (action ? 'workflow_version')
+            AND jsonb_typeof(action -> 'workflow_version') IN ('number', 'null')
+            AND (action ? 'input_template')
+            AND jsonb_typeof(action -> 'vault_ids') = 'array'
+            AND NOT (action ? 'environment_id')
+            AND NOT (action ? 'command')
+            AND NOT (action ? 'content')
+        ELSE false
+    END
+), false)"""
+
+
+def upgrade() -> None:
+    # Validating SELECT (shares ACTION_PREDICATE with ADD CONSTRAINT) — names
+    # offending rows instead of aborting on the first. No backfill here, so this
+    # is expected empty: every pre-existing row satisfies the byte-identical old
+    # branches inside the new predicate.
+    bad = (
+        op.get_bind()
+        .execute(
+            sa.text(f"""
+                SELECT id, action
+                FROM triggers
+                WHERE NOT {ACTION_PREDICATE}
+                LIMIT 20
+            """)
+        )
+        .fetchall()
+    )
+    if bad:
+        raise RuntimeError(
+            f"existing trigger rows violate the wake_session action shape contract: {bad!r}"
+        )
+
+    # DROP + plain ADD (0086 precedent on the capped table). One read-only
+    # validation scan; alembic holds the lock to commit either way, so
+    # NOT VALID + VALIDATE buys nothing here.
+    op.execute("ALTER TABLE triggers DROP CONSTRAINT triggers_action_shape")
+    op.execute(
+        f"ALTER TABLE triggers ADD CONSTRAINT triggers_action_shape CHECK ({ACTION_PREDICATE})"
+    )
+
+
+def downgrade() -> None:
+    # Fail hard on any wake_session row — unrepresentable under the prior
+    # predicate and not reconstructible (the 0086 wake_owner/workflow stance).
+    n = (
+        op.get_bind()
+        .execute(
+            sa.text("SELECT count(*) FROM triggers WHERE action ->> 'kind' = 'wake_session'")
+        )
+        .scalar()
+    )
+    if n:
+        raise RuntimeError(f"cannot downgrade: {n} wake_session trigger rows")
+
+    op.execute("ALTER TABLE triggers DROP CONSTRAINT triggers_action_shape")
+    op.execute(
+        f"ALTER TABLE triggers ADD CONSTRAINT triggers_action_shape CHECK ({ACTION_PREDICATE_0086})"
+    )

--- a/openapi.json
+++ b/openapi.json
@@ -15610,6 +15610,9 @@
                 "$ref": "#/components/schemas/WakeOwnerAction"
               },
               {
+                "$ref": "#/components/schemas/WakeSessionAction"
+              },
+              {
                 "$ref": "#/components/schemas/WorkflowAction"
               }
             ],
@@ -15619,6 +15622,7 @@
               "mapping": {
                 "sandbox_command": "#/components/schemas/SandboxCommandAction",
                 "wake_owner": "#/components/schemas/WakeOwnerAction",
+                "wake_session": "#/components/schemas/WakeSessionAction",
                 "workflow": "#/components/schemas/WorkflowAction"
               }
             }
@@ -15685,6 +15689,9 @@
                 "$ref": "#/components/schemas/WakeOwnerAction"
               },
               {
+                "$ref": "#/components/schemas/WakeSessionAction"
+              },
+              {
                 "$ref": "#/components/schemas/WorkflowAction"
               }
             ],
@@ -15694,6 +15701,7 @@
               "mapping": {
                 "sandbox_command": "#/components/schemas/SandboxCommandAction",
                 "wake_owner": "#/components/schemas/WakeOwnerAction",
+                "wake_session": "#/components/schemas/WakeSessionAction",
                 "workflow": "#/components/schemas/WorkflowAction"
               }
             }
@@ -15921,6 +15929,9 @@
                     "$ref": "#/components/schemas/WakeOwnerAction"
                   },
                   {
+                    "$ref": "#/components/schemas/WakeSessionAction"
+                  },
+                  {
                     "$ref": "#/components/schemas/WorkflowActionReplace"
                   }
                 ],
@@ -15929,6 +15940,7 @@
                   "mapping": {
                     "sandbox_command": "#/components/schemas/SandboxCommandActionReplace",
                     "wake_owner": "#/components/schemas/WakeOwnerAction",
+                    "wake_session": "#/components/schemas/WakeSessionAction",
                     "workflow": "#/components/schemas/WorkflowActionReplace"
                   }
                 }
@@ -16835,6 +16847,35 @@
         ],
         "title": "WakeOwnerAction",
         "description": "Deliver ``content`` as a user-role message to the trigger's OWNING\nsession, waking the model \u2014 the self-wake primitive on a timer.\n\nNo ``session_id``: the target is implicitly ``owner_session_id`` (NOT\nNULL this slice). An explicit-target wake is a separate future kind,\nnot a field on this one (avoids the uncapped cross-session wake that an\nunconstrained ``session_id`` would be \u2014 see the ``wake_session`` tool's\ndepth/rate caps)."
+      },
+      "WakeSessionAction": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "wake_session",
+            "title": "Kind",
+            "default": "wake_session"
+          },
+          "target_session_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Target Session Id"
+          },
+          "content": {
+            "type": "string",
+            "maxLength": 16384,
+            "minLength": 1,
+            "title": "Content"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "target_session_id",
+          "content"
+        ],
+        "title": "WakeSessionAction",
+        "description": "Deliver ``content`` as a user-role message to an EXPLICITLY-NAMED\nsame-account session, waking it. The cross-session twin of wake_owner:\nruns through ``services.wake.deliver_cross_session_wake`` with the FIRING\nTRIGGER as the lineage root, so the wake_session depth/per-pair-rate caps\napply (a fire\u2192wake\u2192fire cascade terminates in bounded steps).\n\n``target_session_id`` is NOT resolved in the model \u2014 it is account-data,\nchecked at fire time (same as ``workflow_id``). A cross-account / archived\n/ cap-breaching target surfaces as a fire ``error`` (no silent drop), not a\nwrite-time rejection. Single named target only: no topics, no\ncompeting-consumers, no fan-out (issue #1280)."
       },
       "WfRun": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -253,6 +253,7 @@ from .wait_response import WaitResponse
 from .wait_response_session_status import WaitResponseSessionStatus
 from .wait_response_session_stop_reason_type_0 import WaitResponseSessionStopReasonType0
 from .wake_owner_action import WakeOwnerAction
+from .wake_session_action import WakeSessionAction
 from .wf_run import WfRun
 from .wf_run_caller_type_0 import WfRunCallerType0
 from .wf_run_create import WfRunCreate
@@ -526,6 +527,7 @@ __all__ = (
     "WaitResponseSessionStatus",
     "WaitResponseSessionStopReasonType0",
     "WakeOwnerAction",
+    "WakeSessionAction",
     "WfRun",
     "WfRunCallerType0",
     "WfRunCreate",

--- a/packages/aios-sdk/aios_sdk/_generated/models/trigger_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trigger_create.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from ..models.sandbox_command_action import SandboxCommandAction
     from ..models.trigger_create_metadata import TriggerCreateMetadata
     from ..models.wake_owner_action import WakeOwnerAction
+    from ..models.wake_session_action import WakeSessionAction
     from ..models.workflow_action import WorkflowAction
 
 
@@ -32,14 +33,14 @@ class TriggerCreate:
         Attributes:
             name (str): Stable user-chosen identifier; unique per session.
             source (CronSource | OneShotSource | RunCompletionSource):
-            action (SandboxCommandAction | WakeOwnerAction | WorkflowAction):
+            action (SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction):
             enabled (bool | Unset):  Default: True.
             metadata (TriggerCreateMetadata | Unset):
     """
 
     name: str
     source: CronSource | OneShotSource | RunCompletionSource
-    action: SandboxCommandAction | WakeOwnerAction | WorkflowAction
+    action: SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction
     enabled: bool | Unset = True
     metadata: TriggerCreateMetadata | Unset = UNSET
 
@@ -48,6 +49,7 @@ class TriggerCreate:
         from ..models.one_shot_source import OneShotSource
         from ..models.sandbox_command_action import SandboxCommandAction
         from ..models.wake_owner_action import WakeOwnerAction
+        from ..models.wake_session_action import WakeSessionAction
 
         name = self.name
 
@@ -63,6 +65,8 @@ class TriggerCreate:
         if isinstance(self.action, SandboxCommandAction):
             action = self.action.to_dict()
         elif isinstance(self.action, WakeOwnerAction):
+            action = self.action.to_dict()
+        elif isinstance(self.action, WakeSessionAction):
             action = self.action.to_dict()
         else:
             action = self.action.to_dict()
@@ -97,6 +101,7 @@ class TriggerCreate:
         from ..models.sandbox_command_action import SandboxCommandAction
         from ..models.trigger_create_metadata import TriggerCreateMetadata
         from ..models.wake_owner_action import WakeOwnerAction
+        from ..models.wake_session_action import WakeSessionAction
         from ..models.workflow_action import WorkflowAction
 
         d = dict(src_dict)
@@ -131,7 +136,9 @@ class TriggerCreate:
 
         def _parse_action(
             data: object,
-        ) -> SandboxCommandAction | WakeOwnerAction | WorkflowAction:
+        ) -> (
+            SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction
+        ):
             try:
                 if not isinstance(data, dict):
                     raise TypeError()
@@ -148,11 +155,19 @@ class TriggerCreate:
                 return action_type_1
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                action_type_2 = WakeSessionAction.from_dict(data)
+
+                return action_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
             if not isinstance(data, dict):
                 raise TypeError()
-            action_type_2 = WorkflowAction.from_dict(data)
+            action_type_3 = WorkflowAction.from_dict(data)
 
-            return action_type_2
+            return action_type_3
 
         action = _parse_action(d.pop("action"))
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/trigger_echo.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trigger_echo.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from ..models.sandbox_command_action import SandboxCommandAction
     from ..models.trigger_echo_metadata import TriggerEchoMetadata
     from ..models.wake_owner_action import WakeOwnerAction
+    from ..models.wake_session_action import WakeSessionAction
     from ..models.workflow_action import WorkflowAction
 
 
@@ -36,7 +37,7 @@ class TriggerEcho:
             id (str):
             name (str):
             source (CronSource | OneShotSource | RunCompletionSource):
-            action (SandboxCommandAction | WakeOwnerAction | WorkflowAction):
+            action (SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction):
             enabled (bool):
             next_fire (datetime.datetime | None):
             last_fire_at (datetime.datetime | None):
@@ -50,7 +51,7 @@ class TriggerEcho:
     id: str
     name: str
     source: CronSource | OneShotSource | RunCompletionSource
-    action: SandboxCommandAction | WakeOwnerAction | WorkflowAction
+    action: SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction
     enabled: bool
     next_fire: datetime.datetime | None
     last_fire_at: datetime.datetime | None
@@ -66,6 +67,7 @@ class TriggerEcho:
         from ..models.one_shot_source import OneShotSource
         from ..models.sandbox_command_action import SandboxCommandAction
         from ..models.wake_owner_action import WakeOwnerAction
+        from ..models.wake_session_action import WakeSessionAction
 
         id = self.id
 
@@ -83,6 +85,8 @@ class TriggerEcho:
         if isinstance(self.action, SandboxCommandAction):
             action = self.action.to_dict()
         elif isinstance(self.action, WakeOwnerAction):
+            action = self.action.to_dict()
+        elif isinstance(self.action, WakeSessionAction):
             action = self.action.to_dict()
         else:
             action = self.action.to_dict()
@@ -144,6 +148,7 @@ class TriggerEcho:
         from ..models.sandbox_command_action import SandboxCommandAction
         from ..models.trigger_echo_metadata import TriggerEchoMetadata
         from ..models.wake_owner_action import WakeOwnerAction
+        from ..models.wake_session_action import WakeSessionAction
         from ..models.workflow_action import WorkflowAction
 
         d = dict(src_dict)
@@ -180,7 +185,9 @@ class TriggerEcho:
 
         def _parse_action(
             data: object,
-        ) -> SandboxCommandAction | WakeOwnerAction | WorkflowAction:
+        ) -> (
+            SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction
+        ):
             try:
                 if not isinstance(data, dict):
                     raise TypeError()
@@ -197,11 +204,19 @@ class TriggerEcho:
                 return action_type_1
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                action_type_2 = WakeSessionAction.from_dict(data)
+
+                return action_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
             if not isinstance(data, dict):
                 raise TypeError()
-            action_type_2 = WorkflowAction.from_dict(data)
+            action_type_3 = WorkflowAction.from_dict(data)
 
-            return action_type_2
+            return action_type_3
 
         action = _parse_action(d.pop("action"))
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/trigger_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/trigger_update.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from ..models.sandbox_command_action_replace import SandboxCommandActionReplace
     from ..models.trigger_update_metadata_type_0 import TriggerUpdateMetadataType0
     from ..models.wake_owner_action import WakeOwnerAction
+    from ..models.wake_session_action import WakeSessionAction
     from ..models.workflow_action_replace import WorkflowActionReplace
 
 
@@ -32,7 +33,8 @@ class TriggerUpdate:
 
         Attributes:
             source (CronSource | None | OneShotSource | RunCompletionSourceReplace | Unset):
-            action (None | SandboxCommandActionReplace | Unset | WakeOwnerAction | WorkflowActionReplace):
+            action (None | SandboxCommandActionReplace | Unset | WakeOwnerAction | WakeSessionAction |
+                WorkflowActionReplace):
             enabled (bool | None | Unset):
             metadata (None | TriggerUpdateMetadataType0 | Unset):
     """
@@ -45,6 +47,7 @@ class TriggerUpdate:
         | SandboxCommandActionReplace
         | Unset
         | WakeOwnerAction
+        | WakeSessionAction
         | WorkflowActionReplace
     ) = UNSET
     enabled: bool | None | Unset = UNSET
@@ -57,6 +60,7 @@ class TriggerUpdate:
         from ..models.sandbox_command_action_replace import SandboxCommandActionReplace
         from ..models.trigger_update_metadata_type_0 import TriggerUpdateMetadataType0
         from ..models.wake_owner_action import WakeOwnerAction
+        from ..models.wake_session_action import WakeSessionAction
         from ..models.workflow_action_replace import WorkflowActionReplace
 
         source: dict[str, Any] | None | Unset
@@ -77,6 +81,8 @@ class TriggerUpdate:
         elif isinstance(self.action, SandboxCommandActionReplace):
             action = self.action.to_dict()
         elif isinstance(self.action, WakeOwnerAction):
+            action = self.action.to_dict()
+        elif isinstance(self.action, WakeSessionAction):
             action = self.action.to_dict()
         elif isinstance(self.action, WorkflowActionReplace):
             action = self.action.to_dict()
@@ -119,6 +125,7 @@ class TriggerUpdate:
         from ..models.sandbox_command_action_replace import SandboxCommandActionReplace
         from ..models.trigger_update_metadata_type_0 import TriggerUpdateMetadataType0
         from ..models.wake_owner_action import WakeOwnerAction
+        from ..models.wake_session_action import WakeSessionAction
         from ..models.workflow_action_replace import WorkflowActionReplace
 
         d = dict(src_dict)
@@ -168,6 +175,7 @@ class TriggerUpdate:
             | SandboxCommandActionReplace
             | Unset
             | WakeOwnerAction
+            | WakeSessionAction
             | WorkflowActionReplace
         ):
             if data is None:
@@ -193,9 +201,17 @@ class TriggerUpdate:
             try:
                 if not isinstance(data, dict):
                     raise TypeError()
-                action_type_0_type_2 = WorkflowActionReplace.from_dict(data)
+                action_type_0_type_2 = WakeSessionAction.from_dict(data)
 
                 return action_type_0_type_2
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                action_type_0_type_3 = WorkflowActionReplace.from_dict(data)
+
+                return action_type_0_type_3
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
             return cast(
@@ -203,6 +219,7 @@ class TriggerUpdate:
                 | SandboxCommandActionReplace
                 | Unset
                 | WakeOwnerAction
+                | WakeSessionAction
                 | WorkflowActionReplace,
                 data,
             )

--- a/packages/aios-sdk/aios_sdk/_generated/models/wake_session_action.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wake_session_action.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import (
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+)
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="WakeSessionAction")
+
+
+@_attrs_define
+class WakeSessionAction:
+    """Deliver ``content`` as a user-role message to an EXPLICITLY-NAMED
+    same-account session, waking it. The cross-session twin of wake_owner:
+    runs through ``services.wake.deliver_cross_session_wake`` with the FIRING
+    TRIGGER as the lineage root, so the wake_session depth/per-pair-rate caps
+    apply (a fire→wake→fire cascade terminates in bounded steps).
+
+    ``target_session_id`` is NOT resolved in the model — it is account-data,
+    checked at fire time (same as ``workflow_id``). A cross-account / archived
+    / cap-breaching target surfaces as a fire ``error`` (no silent drop), not a
+    write-time rejection. Single named target only: no topics, no
+    competing-consumers, no fan-out (issue #1280).
+
+        Attributes:
+            target_session_id (str):
+            content (str):
+            kind (Literal['wake_session'] | Unset):  Default: 'wake_session'.
+    """
+
+    target_session_id: str
+    content: str
+    kind: Literal["wake_session"] | Unset = "wake_session"
+
+    def to_dict(self) -> dict[str, Any]:
+        target_session_id = self.target_session_id
+
+        content = self.content
+
+        kind = self.kind
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "target_session_id": target_session_id,
+                "content": content,
+            }
+        )
+        if kind is not UNSET:
+            field_dict["kind"] = kind
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        target_session_id = d.pop("target_session_id")
+
+        content = d.pop("content")
+
+        kind = cast(Literal["wake_session"] | Unset, d.pop("kind", UNSET))
+        if kind != "wake_session" and not isinstance(kind, Unset):
+            raise ValueError(f"kind must match const 'wake_session', got '{kind}'")
+
+        wake_session_action = cls(
+            target_session_id=target_session_id,
+            content=content,
+            kind=kind,
+        )
+
+        return wake_session_action

--- a/src/aios/harness/trigger_runner.py
+++ b/src/aios/harness/trigger_runner.py
@@ -58,11 +58,21 @@ from aios.models.triggers import (
     SandboxCommandAction,
     TriggerFireStatus,
     WakeOwnerAction,
+    WakeSessionAction,
     WorkflowAction,
 )
 from aios.models.workflows import WfRun
 from aios.services import sessions as sessions_service
-from aios.services.wake import defer_trigger_fire, defer_wake
+from aios.services.wake import (
+    CrossSessionWakeRoot,
+    WakeSessionDepthExceededError,
+    WakeSessionPermissionError,
+    WakeSessionRateLimitedError,
+    WakeSessionTargetUnavailableError,
+    defer_trigger_fire,
+    defer_wake,
+    deliver_cross_session_wake,
+)
 
 log = get_logger("aios.harness.trigger_runner")
 
@@ -204,6 +214,8 @@ async def run_trigger_step(trigger_id: str, trigger_run_id: str | None = None) -
         status, error_summary, result_id = await _run_sandbox_command(trigger, action)
     elif isinstance(action, WakeOwnerAction):
         status, error_summary, result_id = await _run_wake_owner(trigger, action)
+    elif isinstance(action, WakeSessionAction):
+        status, error_summary, result_id = await _run_wake_session(trigger, action)
     else:
         status, error_summary, result_id = await _run_workflow(
             trigger, action, event=event, started_at=started_at
@@ -226,6 +238,13 @@ async def run_trigger_step(trigger_id: str, trigger_run_id: str | None = None) -
                     trigger.account_id,
                     f"[Scheduled wake '{trigger.name}' failed to deliver: "
                     f"{error_summary or status}]",
+                )
+            elif isinstance(action, WakeSessionAction):
+                await _surface_failure(
+                    trigger.owner_session_id,
+                    trigger.account_id,
+                    f"[Trigger '{trigger.name}' failed to wake "
+                    f"{action.target_session_id}: {error_summary or status}]",
                 )
             elif isinstance(action, WorkflowAction):
                 await _surface_failure(
@@ -488,6 +507,56 @@ async def _run_wake_owner(
             session_id=trigger.owner_session_id,
             name=trigger.name,
         )
+        return "error", f"wake delivery failed: {type(e).__name__}: {e!s:.200}", None
+
+
+async def _run_wake_session(
+    trigger: queries.TriggerRow, action: WakeSessionAction
+) -> tuple[TriggerFireStatus, str | None, str | None]:
+    """Run a ``wake_session`` action — explicit-target cross-session wake.
+
+    The cross-session twin of ``wake_owner``: routes through
+    ``services.wake.deliver_cross_session_wake`` with the FIRING TRIGGER as the
+    lineage root (``source_id=f"trigger:{trigger.id}"``, ``source_depth=0`` — a
+    trigger has no session log to read a depth from), so the same
+    depth/per-pair-rate caps as the ``wake_session`` tool apply: a
+    fire→wake→fire cascade terminates in bounded steps.
+
+    Account-scope / archived / cap-breach checks live INSIDE
+    ``deliver_cross_session_wake`` (it raises the WakeSession* errors); the
+    runner just maps those to ``status="error"`` — feeding the
+    consecutive-failure counter + auto-disable, never a silent drop (the
+    connector-stuck lesson). Statuses: ok/error (timeout N/A); no resource
+    produced.
+    """
+    pool = runtime.require_pool()
+    try:
+        await deliver_cross_session_wake(
+            pool,
+            target_session_id=action.target_session_id,
+            content=action.content,
+            account_id=trigger.account_id,
+            root=CrossSessionWakeRoot(source_id=f"trigger:{trigger.id}", source_depth=0),
+            cause="trigger_wake",
+        )
+        log.info(
+            "trigger.fired",
+            trigger_id=trigger.id,
+            session_id=trigger.owner_session_id,
+            name=trigger.name,
+            kind="wake_session",
+            status="ok",
+        )
+        return "ok", None, None
+    except (
+        WakeSessionPermissionError,
+        WakeSessionTargetUnavailableError,
+        WakeSessionDepthExceededError,
+        WakeSessionRateLimitedError,
+    ) as e:
+        return "error", f"wake_session failed: {type(e).__name__}: {e!s:.200}", None
+    except Exception as e:
+        log.exception("trigger.wake_session_error", trigger_id=trigger.id)
         return "error", f"wake delivery failed: {type(e).__name__}: {e!s:.200}", None
 
 

--- a/src/aios/models/triggers.py
+++ b/src/aios/models/triggers.py
@@ -210,6 +210,26 @@ class WakeOwnerAction(BaseModel):
     content: str = Field(min_length=1, max_length=MAX_WAKE_CONTENT_CHARS)
 
 
+class WakeSessionAction(BaseModel):
+    """Deliver ``content`` as a user-role message to an EXPLICITLY-NAMED
+    same-account session, waking it. The cross-session twin of wake_owner:
+    runs through ``services.wake.deliver_cross_session_wake`` with the FIRING
+    TRIGGER as the lineage root, so the wake_session depth/per-pair-rate caps
+    apply (a fire→wake→fire cascade terminates in bounded steps).
+
+    ``target_session_id`` is NOT resolved in the model — it is account-data,
+    checked at fire time (same as ``workflow_id``). A cross-account / archived
+    / cap-breaching target surfaces as a fire ``error`` (no silent drop), not a
+    write-time rejection. Single named target only: no topics, no
+    competing-consumers, no fan-out (issue #1280).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["wake_session"] = "wake_session"
+    target_session_id: str = Field(min_length=1)
+    content: str = Field(min_length=1, max_length=MAX_WAKE_CONTENT_CHARS)
+
+
 class WorkflowAction(BaseModel):
     """Launch a run of ``workflow_id`` at fire time — deterministic, no model
     wake.
@@ -259,10 +279,11 @@ class WorkflowActionReplace(WorkflowAction):
 
 
 TriggerAction = Annotated[
-    SandboxCommandAction | WakeOwnerAction | WorkflowAction, Field(discriminator="kind")
+    SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction,
+    Field(discriminator="kind"),
 ]
 TriggerActionReplace = Annotated[
-    SandboxCommandActionReplace | WakeOwnerAction | WorkflowActionReplace,
+    SandboxCommandActionReplace | WakeOwnerAction | WakeSessionAction | WorkflowActionReplace,
     Field(discriminator="kind"),
 ]
 
@@ -273,9 +294,9 @@ TriggerActionReplace = Annotated[
 TRIGGER_SOURCE_ADAPTER: TypeAdapter[CronSource | OneShotSource | RunCompletionSource] = TypeAdapter(
     TriggerSource
 )
-TRIGGER_ACTION_ADAPTER: TypeAdapter[SandboxCommandAction | WakeOwnerAction | WorkflowAction] = (
-    TypeAdapter(TriggerAction)
-)
+TRIGGER_ACTION_ADAPTER: TypeAdapter[
+    SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction
+] = TypeAdapter(TriggerAction)
 
 
 def _validate_input_template_bound(action: Any) -> None:

--- a/src/aios/services/triggers.py
+++ b/src/aios/services/triggers.py
@@ -56,6 +56,7 @@ from aios.models.triggers import (
     TriggerRunEcho,
     TriggerUpdate,
     WakeOwnerAction,
+    WakeSessionAction,
     WorkflowAction,
     compute_initial_next_fire,
 )
@@ -64,7 +65,7 @@ from aios.models.triggers import (
 async def validate_trigger_spec(
     conn: asyncpg.Connection[Any],
     source: CronSource | OneShotSource | RunCompletionSource | None,
-    action: SandboxCommandAction | WakeOwnerAction | WorkflowAction | None,
+    action: SandboxCommandAction | WakeOwnerAction | WakeSessionAction | WorkflowAction | None,
     *,
     session_id: str,
     account_id: str,

--- a/src/aios/services/wake.py
+++ b/src/aios/services/wake.py
@@ -7,13 +7,14 @@ one place without creating a circular ``api → harness`` dependency.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from procrastinate import exceptions as procrastinate_exceptions
 from procrastinate.types import JSONValue
 
 from aios.config import get_settings
 from aios.db import queries
+from aios.errors import AiosError
 from aios.logging import get_logger
 from aios.services import sessions as sessions_service
 
@@ -21,6 +22,27 @@ if TYPE_CHECKING:
     import asyncpg
 
 log = get_logger("aios.services.wake")
+
+# ─── cross-session wake: caps + trusted lineage carrier ──────────────────────
+#
+# These were inlined in ``tools/wake_session.py`` (the agent tool) until the
+# trigger-action layer needed the SAME delivery primitive (issue #1280). They
+# now live here — the one shared home — and the tool imports them. Both callers
+# (the ``wake_session`` tool, and the ``wake_session`` TRIGGER ACTION) route
+# through :func:`deliver_cross_session_wake`, parameterized by the lineage
+# ROOT, so the depth/per-pair-rate caps apply uniformly.
+
+WAKE_SESSION_MAX_DEPTH = 10
+WAKE_SESSION_MAX_PER_HOUR = 10
+
+# The system-owned event that carries trusted wake lineage.  It is a
+# ``kind='span'`` event — a kind NO caller-facing path can append (the
+# operator POST and connector inbound paths only ever write ``kind='message'``
+# user events).  This is what makes the wake-depth / wake-source cap
+# non-forgeable: the cap reads provenance from this span, never from the
+# user message's ``metadata`` (which the operator-POST / connector paths
+# pass through unstripped — see issue #1083).
+WAKE_LINEAGE_SPAN_EVENT = "wake_lineage"
 
 # Foreground protection: procrastinate fetches todo jobs in (priority DESC, id ASC)
 # order, so a negative priority makes a job yield to higher-priority ones. Background
@@ -157,3 +179,263 @@ async def defer_trigger_fire(trigger_id: str, trigger_run_id: str) -> None:
         ).defer_async(trigger_id=trigger_id, trigger_run_id=trigger_run_id)
     except procrastinate_exceptions.AlreadyEnqueued:
         log.debug("trigger_fire.already_enqueued", trigger_run_id=trigger_run_id)
+
+
+# ─── cross-session wake error classes ────────────────────────────────────────
+#
+# Status-code-bearing AiosError subclasses (the tool's public contract). They
+# live HERE — the single home of the cross-session delivery primitive — so the
+# tool, the runner, and this module all import them from one place (no cycle:
+# services.wake does not import tools.wake_session). The tool re-imports them
+# so its long-standing public import path ``aios.tools.wake_session`` keeps
+# working for callers and tests.
+
+
+class WakeSessionArgumentError(AiosError):
+    error_type = "wake_session_argument_error"
+    status_code = 400
+
+
+class WakeSessionPermissionError(AiosError):
+    error_type = "wake_session_permission_error"
+    status_code = 403
+
+
+class WakeSessionTargetUnavailableError(AiosError):
+    error_type = "wake_session_target_unavailable"
+    status_code = 409
+
+
+class WakeSessionDepthExceededError(AiosError):
+    error_type = "wake_session_depth_exceeded"
+    status_code = 429
+
+
+class WakeSessionRateLimitedError(AiosError):
+    error_type = "wake_session_rate_limited"
+    status_code = 429
+
+
+class CrossSessionWakeRoot(NamedTuple):
+    """Lineage root for a cross-session wake — what the depth/rate caps
+    attribute the wake TO. Agent wakes root at the calling session
+    (source_id=session_id, source_depth=read from its log). Trigger wakes
+    root at the firing trigger (source_id=f"trigger:{trigger_id}",
+    source_depth=0 — a trigger has no session log to read a depth from)."""
+
+    source_id: str
+    source_depth: int
+
+
+async def read_source_wake_depth(pool: Any, session_id: str, *, account_id: str) -> int:
+    """Return the trusted wake_depth for the most recent wake of this session.
+
+    Reads the source's own log, but ONLY from the system-owned
+    ``wake_lineage`` span event — never from user-message metadata, which
+    the operator-POST / connector ingestion paths can forge (issue #1083).
+    Returns 0 when no wake-lineage span is present (root call — a
+    human-originated message or first wake of a chain).
+    """
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT COALESCE(
+                (data->>'wake_depth')::int,
+                0
+            ) AS depth
+            FROM events
+            WHERE session_id = $1
+              AND account_id = $2
+              AND kind = 'span'
+              AND data->>'event' = $3
+            ORDER BY seq DESC
+            LIMIT 1
+            """,
+            session_id,
+            account_id,
+            WAKE_LINEAGE_SPAN_EVENT,
+        )
+    if row is None:
+        return 0
+    return int(row["depth"])
+
+
+async def count_recent_wakes_from(
+    pool: Any,
+    *,
+    source_session_id: str,
+    target_session_id: str,
+    account_id: str,
+) -> int:
+    """Count target-side ``wake_lineage`` spans stamped with
+    ``wake_source_session_id`` equal to ``source_session_id`` in the last hour.
+
+    Counts the system-owned ``wake_lineage`` span — NOT user-message
+    metadata, which the operator-POST / connector ingestion paths can forge
+    (issue #1083) to either evade or inflate the count.
+
+    The rate-limit window is per (source, target) pair so an honest
+    broadcast to many distinct targets isn't throttled; a single source
+    only gets ``WAKE_SESSION_MAX_PER_HOUR`` wakes/hour at any one target.
+    The ``source_session_id`` is an OPAQUE string: a trigger root passes
+    ``f"trigger:{trigger_id}"``, getting its own per-(trigger,target) bucket.
+    """
+    async with pool.acquire() as conn:
+        count = await conn.fetchval(
+            """
+            SELECT count(*)
+            FROM events
+            WHERE session_id = $1
+              AND account_id = $2
+              AND kind = 'span'
+              AND data->>'event' = $4
+              AND data->>'wake_source_session_id' = $3
+              AND created_at > now() - interval '1 hour'
+            """,
+            target_session_id,
+            account_id,
+            source_session_id,
+            WAKE_LINEAGE_SPAN_EVENT,
+        )
+    return int(count or 0)
+
+
+async def deliver_cross_session_wake(
+    pool: asyncpg.Pool[Any],
+    *,
+    target_session_id: str,
+    content: str,
+    account_id: str,
+    root: CrossSessionWakeRoot,
+    cause: str,
+) -> int:
+    """Deliver ``content`` to ``target_session_id``, waking it — the shared
+    primitive behind the ``wake_session`` tool and the ``wake_session`` trigger
+    action.
+
+    Validate the target (same ``account_id``, not archived) → enforce
+    ``WAKE_SESSION_MAX_DEPTH`` (chain) and ``WAKE_SESSION_MAX_PER_HOUR``
+    (per ``(root.source_id, target)`` pair) BEFORE any side effect → append
+    ``content`` as a user-role message to the target (display-only wake
+    metadata) → stamp the non-forgeable ``wake_lineage`` span
+    (``wake_depth = root.source_depth + 1``,
+    ``wake_source_session_id = root.source_id``) → ``defer_wake(cause=cause)``.
+    Returns the new depth.
+
+    Raises :class:`WakeSessionPermissionError` (cross-account target — same
+    shape an attacker would see for an unknown id, no existence leak),
+    :class:`WakeSessionArgumentError` (target not found),
+    :class:`WakeSessionTargetUnavailableError` (archived target),
+    :class:`WakeSessionDepthExceededError`, :class:`WakeSessionRateLimitedError`.
+
+    Does NOT enforce a content-length cap — each CALLER validates its own
+    bound first (tool: 100_000; trigger: 16_384). The DB ``content`` CHECK
+    only asserts it is a string.
+    """
+    # Load the target row directly (unscoped) so we can produce a clear
+    # permission error when the target exists under a different account
+    # rather than a generic 404. This is the only place in the codebase
+    # that needs an unscoped-by-id read for a cross-session check, so it
+    # justifies bypassing the usual ``account_id``-scoped helper.
+    async with pool.acquire() as conn:
+        target_row = await conn.fetchrow(
+            "SELECT account_id, archived_at FROM sessions WHERE id = $1",
+            target_session_id,
+        )
+    if target_row is None:
+        raise WakeSessionArgumentError(
+            f"target session {target_session_id} not found",
+            detail={"target_session_id": target_session_id},
+        )
+
+    target_account_id: str = target_row["account_id"]
+    if target_account_id != account_id:
+        # Don't leak the existence of cross-account sessions: present the
+        # same shape an attacker would see for an unknown id.
+        raise WakeSessionPermissionError(
+            f"target session {target_session_id} not found",
+            detail={"target_session_id": target_session_id},
+        )
+
+    if target_row["archived_at"] is not None:
+        raise WakeSessionTargetUnavailableError(
+            f"target session {target_session_id} is archived",
+            detail={"target_session_id": target_session_id, "reason": "archived"},
+        )
+
+    # Wake-depth: inherit from the root; bail before any side effect if the
+    # new depth would breach the cap.
+    new_depth = root.source_depth + 1
+    if new_depth > WAKE_SESSION_MAX_DEPTH:
+        raise WakeSessionDepthExceededError(
+            f"wake-depth would exceed {WAKE_SESSION_MAX_DEPTH} "
+            f"(current={root.source_depth}); refusing to extend the chain",
+            detail={
+                "current_depth": root.source_depth,
+                "max_depth": WAKE_SESSION_MAX_DEPTH,
+            },
+        )
+
+    # Per (root.source_id, target) rate limit. Counted BEFORE the append so
+    # the window starts fresh for the next hour — a burst at the cap doesn't
+    # rebuild forward on every retry.
+    recent_wakes = await count_recent_wakes_from(
+        pool,
+        source_session_id=root.source_id,
+        target_session_id=target_session_id,
+        account_id=target_account_id,
+    )
+    if recent_wakes >= WAKE_SESSION_MAX_PER_HOUR:
+        raise WakeSessionRateLimitedError(
+            f"rate limit: {recent_wakes} wakes from {root.source_id} to "
+            f"{target_session_id} in the last hour (max "
+            f"{WAKE_SESSION_MAX_PER_HOUR})",
+            detail={
+                "recent_wakes": recent_wakes,
+                "max_per_hour": WAKE_SESSION_MAX_PER_HOUR,
+            },
+        )
+
+    # Append the user message to the TARGET, then defer a wake there.
+    #
+    # The ``metadata`` on the user message is DISPLAY-ONLY: it drives the
+    # model-visible wake header (``_wake_header`` in harness/context.py).
+    # It is NOT trusted by the depth / rate-limit cap, because the
+    # operator-POST and connector ingestion paths pass caller-supplied
+    # ``metadata`` through unstripped and could forge these keys (#1083).
+    metadata: dict[str, Any] = {
+        "wake_source_session_id": root.source_id,
+        "wake_depth": new_depth,
+    }
+    # The TRUSTED carrier: a system-owned ``kind='span'`` event. No
+    # caller-facing route appends span events, so the cap's reads
+    # (read_source_wake_depth / count_recent_wakes_from) can rely on it
+    # as non-forgeable provenance.
+    lineage_span: dict[str, Any] = {
+        "event": WAKE_LINEAGE_SPAN_EVENT,
+        "wake_source_session_id": root.source_id,
+        "wake_depth": new_depth,
+    }
+    async with pool.acquire() as conn:
+        await queries.append_event(
+            conn,
+            account_id=target_account_id,
+            session_id=target_session_id,
+            kind="message",
+            data={"role": "user", "content": content, "metadata": metadata},
+        )
+        await queries.append_event(
+            conn,
+            account_id=target_account_id,
+            session_id=target_session_id,
+            kind="span",
+            data=lineage_span,
+        )
+    await defer_wake(
+        pool,
+        target_session_id,
+        cause=cause,
+        account_id=target_account_id,
+    )
+
+    return new_depth

--- a/src/aios/tools/trigger_create.py
+++ b/src/aios/tools/trigger_create.py
@@ -49,7 +49,11 @@ TRIGGER_CREATE_DESCRIPTION = (
     "Actions: `{kind: 'sandbox_command', command}` runs bash in the "
     "session's sandbox WITHOUT waking the model; `{kind: 'wake_owner', "
     "content}` delivers `content` as a user-role message to THIS session, "
-    "waking the model; `{kind: 'workflow', workflow_id, input_template?, "
+    "waking the model; `{kind: 'wake_session', target_session_id, content}` "
+    "delivers `content` as a user-role message to ANOTHER same-account "
+    "session (named by id), waking it — subject to the same wake-depth / "
+    "per-pair-rate caps as the wake_session tool; `{kind: 'workflow', "
+    "workflow_id, input_template?, "
     "workflow_version?, vault_ids?}` launches a run of that workflow — "
     "deterministic, no model wake; the run launches into this session's own "
     "environment with your authority (its surface and vaults are checked "
@@ -179,6 +183,31 @@ _ACTION_SCHEMA: dict[str, Any] = {
                 },
             },
             "required": ["kind", "content"],
+            "additionalProperties": False,
+        },
+        {
+            "type": "object",
+            "properties": {
+                "kind": {"const": "wake_session"},
+                "target_session_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Session id (sess_...) of ANOTHER session in this account to "
+                        "wake at fire time."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": MAX_WAKE_CONTENT_CHARS,
+                    "description": (
+                        "Message delivered as a user-role event to the target session, "
+                        "waking it. Delivered verbatim."
+                    ),
+                },
+            },
+            "required": ["kind", "target_session_id", "content"],
             "additionalProperties": False,
         },
         {

--- a/src/aios/tools/trigger_update.py
+++ b/src/aios/tools/trigger_update.py
@@ -146,6 +146,31 @@ _ACTION_SCHEMA: dict[str, Any] = {
         {
             "type": "object",
             "properties": {
+                "kind": {"const": "wake_session"},
+                "target_session_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Session id (sess_...) of ANOTHER session in this account to "
+                        "wake at fire time."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": MAX_WAKE_CONTENT_CHARS,
+                    "description": (
+                        "Message delivered as a user-role event to the target session, "
+                        "waking it. Delivered verbatim."
+                    ),
+                },
+            },
+            "required": ["kind", "target_session_id", "content"],
+            "additionalProperties": False,
+        },
+        {
+            "type": "object",
+            "properties": {
                 "kind": {"const": "workflow"},
                 "workflow_id": {
                     "type": "string",

--- a/src/aios/tools/wake_session.py
+++ b/src/aios/tools/wake_session.py
@@ -34,40 +34,41 @@ from __future__ import annotations
 
 from typing import Any
 
-from aios.errors import AiosError
 from aios.harness import runtime
 from aios.services import sessions as sessions_service
-from aios.services.wake import defer_wake
+
+# The cross-session delivery primitive, the caps, the trusted-lineage span,
+# and the status-code-bearing error classes all live in ``services.wake`` (the
+# single home — issue #1280) so BOTH this tool and the ``wake_session`` trigger
+# action call one function. Re-imported here so the tool's long-standing public
+# import path keeps working for callers and tests.
+from aios.services.wake import (
+    WAKE_SESSION_MAX_DEPTH,
+    WAKE_SESSION_MAX_PER_HOUR,
+    CrossSessionWakeRoot,
+    WakeSessionArgumentError,
+    WakeSessionDepthExceededError,
+    WakeSessionPermissionError,
+    WakeSessionRateLimitedError,
+    WakeSessionTargetUnavailableError,
+    deliver_cross_session_wake,
+    read_source_wake_depth,
+)
 from aios.tools.registry import registry
 
-WAKE_SESSION_MAX_DEPTH = 10
-WAKE_SESSION_MAX_PER_HOUR = 10
+__all__ = [
+    "WAKE_SESSION_MAX_DEPTH",
+    "WAKE_SESSION_MAX_PER_HOUR",
+    "WAKE_SESSION_MAX_PROMPT_CHARS",
+    "WakeSessionArgumentError",
+    "WakeSessionDepthExceededError",
+    "WakeSessionPermissionError",
+    "WakeSessionRateLimitedError",
+    "WakeSessionTargetUnavailableError",
+    "wake_session_handler",
+]
+
 WAKE_SESSION_MAX_PROMPT_CHARS = 100_000
-
-
-class WakeSessionArgumentError(AiosError):
-    error_type = "wake_session_argument_error"
-    status_code = 400
-
-
-class WakeSessionPermissionError(AiosError):
-    error_type = "wake_session_permission_error"
-    status_code = 403
-
-
-class WakeSessionTargetUnavailableError(AiosError):
-    error_type = "wake_session_target_unavailable"
-    status_code = 409
-
-
-class WakeSessionDepthExceededError(AiosError):
-    error_type = "wake_session_depth_exceeded"
-    status_code = 429
-
-
-class WakeSessionRateLimitedError(AiosError):
-    error_type = "wake_session_rate_limited"
-    status_code = 429
 
 
 WAKE_SESSION_DESCRIPTION = (
@@ -107,90 +108,7 @@ WAKE_SESSION_PARAMETERS_SCHEMA: dict[str, Any] = {
 }
 
 
-# The system-owned event that carries trusted wake lineage.  It is a
-# ``kind='span'`` event — a kind NO caller-facing path can append (the
-# operator POST and connector inbound paths only ever write ``kind='message'``
-# user events).  This is what makes the wake-depth / wake-source cap
-# non-forgeable: the cap reads provenance from this span, never from the
-# user message's ``metadata`` (which the operator-POST / connector paths
-# pass through unstripped — see issue #1083).
-WAKE_LINEAGE_SPAN_EVENT = "wake_lineage"
-
-
-async def _read_source_wake_depth(pool: Any, session_id: str, *, account_id: str) -> int:
-    """Return the trusted wake_depth for the most recent wake of this session.
-
-    Reads the source's own log, but ONLY from the system-owned
-    ``wake_lineage`` span event — never from user-message metadata, which
-    the operator-POST / connector ingestion paths can forge (issue #1083).
-    Returns 0 when no wake-lineage span is present (root call — a
-    human-originated message or first wake of a chain).
-    """
-    async with pool.acquire() as conn:
-        row = await conn.fetchrow(
-            """
-            SELECT COALESCE(
-                (data->>'wake_depth')::int,
-                0
-            ) AS depth
-            FROM events
-            WHERE session_id = $1
-              AND account_id = $2
-              AND kind = 'span'
-              AND data->>'event' = $3
-            ORDER BY seq DESC
-            LIMIT 1
-            """,
-            session_id,
-            account_id,
-            WAKE_LINEAGE_SPAN_EVENT,
-        )
-    if row is None:
-        return 0
-    return int(row["depth"])
-
-
-async def _count_recent_wakes_from(
-    pool: Any,
-    *,
-    source_session_id: str,
-    target_session_id: str,
-    account_id: str,
-) -> int:
-    """Count target-side ``wake_lineage`` spans stamped with
-    ``wake_source_session_id`` equal to ``source_session_id`` in the last hour.
-
-    Counts the system-owned ``wake_lineage`` span — NOT user-message
-    metadata, which the operator-POST / connector ingestion paths can forge
-    (issue #1083) to either evade or inflate the count.
-
-    The rate-limit window is per (source, target) pair so an honest
-    broadcast to many distinct targets isn't throttled; a single source
-    only gets ``WAKE_SESSION_MAX_PER_HOUR`` wakes/hour at any one target.
-    """
-    async with pool.acquire() as conn:
-        count = await conn.fetchval(
-            """
-            SELECT count(*)
-            FROM events
-            WHERE session_id = $1
-              AND account_id = $2
-              AND kind = 'span'
-              AND data->>'event' = $4
-              AND data->>'wake_source_session_id' = $3
-              AND created_at > now() - interval '1 hour'
-            """,
-            target_session_id,
-            account_id,
-            source_session_id,
-            WAKE_LINEAGE_SPAN_EVENT,
-        )
-    return int(count or 0)
-
-
 async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
-    from aios.db import queries
-
     target_session_id = arguments.get("target_session_id")
     prompt = arguments.get("prompt")
     if not isinstance(target_session_id, str) or not target_session_id:
@@ -213,118 +131,21 @@ async def wake_session_handler(session_id: str, arguments: dict[str, Any]) -> di
 
     pool = runtime.require_pool()
 
-    # Caller's account_id: this is the authority the tool inherits.
+    # Caller's account_id: this is the authority the tool inherits. The
+    # tool's lineage ROOT is the calling session — depth read from its own
+    # log; the caps then attribute the wake to (this session, target).
     source_account_id = await sessions_service.load_session_account_id(pool, session_id)
-
-    # Load the target row directly (unscoped) so we can produce a clear
-    # permission error when the target exists under a different account
-    # rather than a generic 404.  This is the only place in the codebase
-    # that needs an unscoped-by-id read for a cross-session check, so it
-    # justifies bypassing the usual ``account_id``-scoped helper.
-    async with pool.acquire() as conn:
-        target_row = await conn.fetchrow(
-            "SELECT account_id, archived_at FROM sessions WHERE id = $1",
-            target_session_id,
-        )
-    if target_row is None:
-        raise WakeSessionArgumentError(
-            f"target session {target_session_id} not found",
-            detail={"target_session_id": target_session_id},
-        )
-
-    target_account_id: str = target_row["account_id"]
-    if target_account_id != source_account_id:
-        # Don't leak the existence of cross-account sessions: present
-        # the same shape an attacker would see for an unknown id.
-        raise WakeSessionPermissionError(
-            f"target session {target_session_id} not found",
-            detail={"target_session_id": target_session_id},
-        )
-
-    if target_row["archived_at"] is not None:
-        raise WakeSessionTargetUnavailableError(
-            f"target session {target_session_id} is archived",
-            detail={"target_session_id": target_session_id, "reason": "archived"},
-        )
-
-    # Wake-depth: inherit from the source's most recent user message;
-    # bail before any side effect if the new depth would breach the cap.
-    source_depth = await _read_source_wake_depth(pool, session_id, account_id=source_account_id)
-    new_depth = source_depth + 1
-    if new_depth > WAKE_SESSION_MAX_DEPTH:
-        raise WakeSessionDepthExceededError(
-            f"wake-depth would exceed {WAKE_SESSION_MAX_DEPTH} "
-            f"(current={source_depth}); refusing to extend the chain",
-            detail={
-                "current_depth": source_depth,
-                "max_depth": WAKE_SESSION_MAX_DEPTH,
-            },
-        )
-
-    # Per (source, target) rate limit.  Counted BEFORE the append so the
-    # window starts fresh for the next hour — a burst at the cap doesn't
-    # rebuild forward on every retry.
-    recent_wakes = await _count_recent_wakes_from(
-        pool,
-        source_session_id=session_id,
-        target_session_id=target_session_id,
-        account_id=source_account_id,
+    root = CrossSessionWakeRoot(
+        source_id=session_id,
+        source_depth=await read_source_wake_depth(pool, session_id, account_id=source_account_id),
     )
-    if recent_wakes >= WAKE_SESSION_MAX_PER_HOUR:
-        raise WakeSessionRateLimitedError(
-            f"rate limit: {recent_wakes} wakes from {session_id} to "
-            f"{target_session_id} in the last hour (max "
-            f"{WAKE_SESSION_MAX_PER_HOUR})",
-            detail={
-                "recent_wakes": recent_wakes,
-                "max_per_hour": WAKE_SESSION_MAX_PER_HOUR,
-            },
-        )
-
-    # Append the user message to the TARGET, then defer a wake there.
-    # Using ``queries.append_event`` directly (rather than
-    # ``append_user_message``) so we can stamp wake-tracking metadata
-    # without involving the API-side size check / channel lift logic
-    # — those are not relevant for an in-process wake.
-    #
-    # The ``metadata`` on the user message is DISPLAY-ONLY: it drives the
-    # model-visible wake header (``_wake_header`` in harness/context.py).
-    # It is NOT trusted by the depth / rate-limit cap, because the
-    # operator-POST and connector ingestion paths pass caller-supplied
-    # ``metadata`` through unstripped and could forge these keys (#1083).
-    metadata: dict[str, Any] = {
-        "wake_source_session_id": session_id,
-        "wake_depth": new_depth,
-    }
-    # The TRUSTED carrier: a system-owned ``kind='span'`` event.  No
-    # caller-facing route appends span events, so the cap's reads
-    # (_read_source_wake_depth / _count_recent_wakes_from) can rely on it
-    # as non-forgeable provenance.
-    lineage_span: dict[str, Any] = {
-        "event": WAKE_LINEAGE_SPAN_EVENT,
-        "wake_source_session_id": session_id,
-        "wake_depth": new_depth,
-    }
-    async with pool.acquire() as conn:
-        await queries.append_event(
-            conn,
-            account_id=target_account_id,
-            session_id=target_session_id,
-            kind="message",
-            data={"role": "user", "content": prompt, "metadata": metadata},
-        )
-        await queries.append_event(
-            conn,
-            account_id=target_account_id,
-            session_id=target_session_id,
-            kind="span",
-            data=lineage_span,
-        )
-    await defer_wake(
+    new_depth = await deliver_cross_session_wake(
         pool,
-        target_session_id,
+        target_session_id=target_session_id,
+        content=prompt,
+        account_id=source_account_id,
+        root=root,
         cause="agent_wake",
-        account_id=target_account_id,
     )
 
     return {

--- a/tests/integration/test_migrations_0107_triggers_wake_session.py
+++ b/tests/integration/test_migrations_0107_triggers_wake_session.py
@@ -125,20 +125,23 @@ def test_every_prior_kind_still_inserts_under_new_check(postgres: object) -> Non
 
     rows = {
         "sandbox": (
-            "'cron'", "'{\"schedule\": \"*/5 * * * *\"}'::jsonb",
-            "'{\"kind\": \"sandbox_command\", \"command\": \"echo hi\", "
-            "\"timeout_seconds\": 60, \"max_output_bytes\": 2048}'::jsonb",
+            "'cron'",
+            '\'{"schedule": "*/5 * * * *"}\'::jsonb',
+            '\'{"kind": "sandbox_command", "command": "echo hi", '
+            '"timeout_seconds": 60, "max_output_bytes": 2048}\'::jsonb',
             "NULL",
         ),
         "wake_owner": (
-            "'cron'", "'{\"schedule\": \"*/5 * * * *\"}'::jsonb",
-            "'{\"kind\": \"wake_owner\", \"content\": \"hi\"}'::jsonb",
+            "'cron'",
+            '\'{"schedule": "*/5 * * * *"}\'::jsonb',
+            '\'{"kind": "wake_owner", "content": "hi"}\'::jsonb',
             "NULL",
         ),
         "workflow": (
-            "'cron'", "'{\"schedule\": \"*/5 * * * *\"}'::jsonb",
-            "'{\"kind\": \"workflow\", \"workflow_id\": \"wf_x\", \"workflow_version\": null, "
-            "\"input_template\": null, \"vault_ids\": []}'::jsonb",
+            "'cron'",
+            '\'{"schedule": "*/5 * * * *"}\'::jsonb',
+            '\'{"kind": "workflow", "workflow_id": "wf_x", "workflow_version": null, '
+            '"input_template": null, "vault_ids": []}\'::jsonb',
             "'env_mig'",
         ),
     }

--- a/tests/integration/test_migrations_0107_triggers_wake_session.py
+++ b/tests/integration/test_migrations_0107_triggers_wake_session.py
@@ -1,0 +1,177 @@
+"""Integration tests for migration 0107 (triggers wake_session action, #1280).
+
+Owns the migration mechanics: a clean up/down round-trip, the fail-hard
+downgrade refusal once a ``wake_session`` row exists, that a ``wake_session``
+row INSERTs under the new CHECK and is REJECTED under the old, and that every
+pre-existing action kind still inserts under the new CHECK.
+
+Each test mutates ``alembic_version``, so the container is function-scoped.
+Modeled on tests/integration/test_migrations_0086_triggers_slice2.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+# FK chain for seeding a trigger row at head (NOT-NULL-without-default columns).
+_CHAIN_SQL = """
+INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+VALUES ('acc_mig', NULL, TRUE, 'mig-test') ON CONFLICT DO NOTHING;
+INSERT INTO environments (id, name, account_id)
+VALUES ('env_mig', 'mig-env', 'acc_mig') ON CONFLICT DO NOTHING;
+INSERT INTO agents (id, name, model, account_id)
+VALUES ('agn_mig', 'mig-agent', 'fake/test', 'acc_mig') ON CONFLICT DO NOTHING;
+INSERT INTO sessions (id, agent_id, environment_id, workspace_volume_path, account_id)
+VALUES ('ses_mig', 'agn_mig', 'env_mig', '/tmp/ws-mig', 'acc_mig') ON CONFLICT DO NOTHING;
+"""
+
+# A wake_session trigger row in its first-shipped shape: target_session_id +
+# content in the action, NULL next_fire (cron source carries one; we use a cron
+# source so it is schedulable, but a wake_session action — no environment_id, so
+# the iff constraint is satisfied with left-side false = right-side false).
+_WAKE_SESSION_ROW_SQL = """
+INSERT INTO triggers
+    (id, owner_session_id, account_id, name, source, source_spec, action, enabled, next_fire)
+VALUES
+    ('trig_ws', 'ses_mig', 'acc_mig', 'wake-row', 'cron',
+     '{"schedule": "*/5 * * * *"}'::jsonb,
+     '{"kind": "wake_session", "target_session_id": "sess_other", "content": "go look"}'::jsonb,
+     TRUE, now());
+"""
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    """Fresh function-scoped Postgres — each test mutates ``alembic_version``."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _execute(db_url: str, sql: str) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+async def _insert_raises(db_url: str, sql: str) -> bool:
+    """Return True iff the INSERT raises a CheckViolationError."""
+    conn = await asyncpg.connect(db_url)
+    try:
+        try:
+            await conn.execute(sql)
+        except asyncpg.CheckViolationError:
+            return True
+        return False
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+def test_upgrade_and_clean_downgrade_round_trip(postgres: object) -> None:
+    """With zero wake_session rows, 0107 upgrades and downgrades cleanly."""
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "0107"], db_url)
+    assert up.returncode == 0, f"upgrade to 0107 failed:\n{up.stderr}\n{up.stdout}"
+
+    down = _run_alembic(["downgrade", "0106"], db_url)
+    assert down.returncode == 0, f"downgrade to 0106 failed:\n{down.stderr}\n{down.stdout}"
+
+
+@needs_docker
+@pytest.mark.integration
+def test_wake_session_row_accepted_under_new_check_rejected_under_old(postgres: object) -> None:
+    """A wake_session row INSERTs at head (0107) and is rejected at the prior
+    revision (0106) — the CHECK swap is what makes the kind representable."""
+    db_url = _alembic_url(postgres)
+
+    # Under 0106 (prior head) the row is unrepresentable: ELSE false.
+    up106 = _run_alembic(["upgrade", "0106"], db_url)
+    assert up106.returncode == 0, f"upgrade to 0106 failed:\n{up106.stderr}\n{up106.stdout}"
+    asyncio.run(_execute(db_url, _CHAIN_SQL))
+    assert asyncio.run(_insert_raises(db_url, _WAKE_SESSION_ROW_SQL)), (
+        "wake_session row should violate the 0106 action CHECK"
+    )
+
+    # Under 0107 the same row inserts.
+    up107 = _run_alembic(["upgrade", "0107"], db_url)
+    assert up107.returncode == 0, f"upgrade to 0107 failed:\n{up107.stderr}\n{up107.stdout}"
+    asyncio.run(_execute(db_url, _WAKE_SESSION_ROW_SQL))
+
+
+@needs_docker
+@pytest.mark.integration
+def test_every_prior_kind_still_inserts_under_new_check(postgres: object) -> None:
+    """The four pre-existing branches stay byte-identical, so every prior
+    action kind still inserts under the 0107 CHECK."""
+    db_url = _alembic_url(postgres)
+    up = _run_alembic(["upgrade", "0107"], db_url)
+    assert up.returncode == 0, f"upgrade to 0107 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_execute(db_url, _CHAIN_SQL))
+
+    rows = {
+        "sandbox": (
+            "'cron'", "'{\"schedule\": \"*/5 * * * *\"}'::jsonb",
+            "'{\"kind\": \"sandbox_command\", \"command\": \"echo hi\", "
+            "\"timeout_seconds\": 60, \"max_output_bytes\": 2048}'::jsonb",
+            "NULL",
+        ),
+        "wake_owner": (
+            "'cron'", "'{\"schedule\": \"*/5 * * * *\"}'::jsonb",
+            "'{\"kind\": \"wake_owner\", \"content\": \"hi\"}'::jsonb",
+            "NULL",
+        ),
+        "workflow": (
+            "'cron'", "'{\"schedule\": \"*/5 * * * *\"}'::jsonb",
+            "'{\"kind\": \"workflow\", \"workflow_id\": \"wf_x\", \"workflow_version\": null, "
+            "\"input_template\": null, \"vault_ids\": []}'::jsonb",
+            "'env_mig'",
+        ),
+    }
+
+    async def _insert_all() -> None:
+        conn = await asyncpg.connect(db_url)
+        try:
+            for name, (src, spec, action, env) in rows.items():
+                # workflow rows carry environment_id (iff constraint).
+                await conn.execute(
+                    f"INSERT INTO triggers (id, owner_session_id, account_id, name, source, "
+                    f"source_spec, action, enabled, next_fire, environment_id) VALUES "
+                    f"('trig_{name}', 'ses_mig', 'acc_mig', '{name}', {src}, {spec}, {action}, "
+                    f"TRUE, now(), {env})"
+                )
+        finally:
+            await conn.close()
+
+    asyncio.run(_insert_all())
+
+
+@needs_docker
+@pytest.mark.integration
+def test_downgrade_refuses_wake_session_rows(postgres: object) -> None:
+    """A wake_session row is unrepresentable under the prior predicate, so the
+    downgrade fails hard and rolls back (the 0086 stance)."""
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "0107"], db_url)
+    assert up.returncode == 0, f"upgrade to 0107 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_execute(db_url, _CHAIN_SQL))
+    asyncio.run(_execute(db_url, _WAKE_SESSION_ROW_SQL))
+
+    down = _run_alembic(["downgrade", "0106"], db_url)
+    assert down.returncode != 0, f"downgrade should have failed loud:\n{down.stdout}"
+    assert "cannot downgrade" in down.stderr

--- a/tests/integration/test_trigger_event_fires.py
+++ b/tests/integration/test_trigger_event_fires.py
@@ -842,3 +842,155 @@ async def test_numeric_expanded_template_survives_read_and_claim(
     async with pool.acquire() as conn, conn.transaction():
         claimed = await queries.fetch_and_claim_due_triggers(conn, now_utc=datetime.now(UTC))
     assert [t.id for t in claimed] == [tid]
+
+
+# ─── wake_session action (#1280) — explicit-target async wake ────────────────
+
+
+async def _events_of(pool: asyncpg.Pool[Any], session_id: str) -> list[dict[str, Any]]:
+    """Return this session's events as ``{kind, data}`` dicts (role/content live
+    INSIDE ``data`` for message events; spans carry their payload there too)."""
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT kind, data FROM events WHERE session_id = $1 ORDER BY seq",
+            session_id,
+        )
+    return [{"kind": r["kind"], "data": queries.parse_jsonb(r["data"])} for r in rows]
+
+
+async def test_wake_session_fire_delivers_to_named_target(
+    trig_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A ``wake_session`` cron fire delivers ``content`` as a user-role event to
+    an EXPLICITLY-NAMED other same-account session, stamps the non-forgeable
+    ``wake_lineage`` span rooted at the firing trigger (depth 1), and records
+    the owner's carrier row ``ok``. The owner session is untouched — this is the
+    cross-session twin of wake_owner, not a self-wake."""
+    pool = trig_runtime
+    _, _, owner = await seed_agent_env_session(pool, account_id=ACC, prefix="wsowner")
+    _, _, target = await seed_agent_env_session(pool, account_id=ACC, prefix="wstarget")
+
+    tid = await _add_trigger(
+        pool,
+        owner.id,
+        {
+            "name": "poke-peer",
+            "source": {"kind": "cron", "schedule": "*/5 * * * *"},
+            "action": {
+                "kind": "wake_session",
+                "target_session_id": target.id,
+                "content": "go look at the run",
+            },
+        },
+    )
+
+    with mock.patch("aios.services.wake.defer_wake", new=AsyncMock()) as deferred:
+        await run_trigger_step(tid)  # tick-origin fire (no trigger_run_id)
+
+    rows = await _carrier_rows(pool, tid)
+    assert [r["status"] for r in rows] == ["ok"]
+
+    # Delivered to the TARGET: a user message + the trusted lineage span.
+    target_events = await _events_of(pool, target.id)
+    user_msgs = [e for e in target_events if e["data"].get("role") == "user"]
+    assert [e["data"]["content"] for e in user_msgs] == ["go look at the run"]
+    lineage = [
+        e["data"]
+        for e in target_events
+        if e["kind"] == "span" and e["data"].get("event") == "wake_lineage"
+    ]
+    assert len(lineage) == 1
+    assert lineage[0]["wake_depth"] == 1  # trigger root is depth 0
+    assert lineage[0]["wake_source_session_id"] == f"trigger:{tid}"
+
+    # The OWNER session got nothing — not a self-wake.
+    assert await _events_of(pool, owner.id) == []
+    # The wake was actually scheduled on the target.
+    deferred.assert_awaited_once()
+
+
+async def test_wake_session_fire_errors_on_cross_account_target(
+    trig_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A target under a DIFFERENT account surfaces as a fire ``error`` (feeding
+    the consecutive-failure counter), never a silent drop — and never an
+    existence leak (the target gets no event)."""
+    pool = trig_runtime
+    _, _, owner = await seed_agent_env_session(pool, account_id=ACC, prefix="wsxacc")
+
+    # A second account with its own session — the forbidden target.
+    other_acc = "acc_trig_other"
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            f"VALUES ('{other_acc}', NULL, TRUE, 'other')"
+        )
+    _, _, foreign = await seed_agent_env_session(pool, account_id=other_acc, prefix="wsforeign")
+
+    tid = await _add_trigger(
+        pool,
+        owner.id,
+        {
+            "name": "poke-foreign",
+            "source": {"kind": "cron", "schedule": "*/5 * * * *"},
+            "action": {
+                "kind": "wake_session",
+                "target_session_id": foreign.id,
+                "content": "should never arrive",
+            },
+        },
+    )
+
+    with mock.patch("aios.services.wake.defer_wake", new=AsyncMock()):
+        await run_trigger_step(tid)
+
+    rows = await _carrier_rows(pool, tid)
+    assert [r["status"] for r in rows] == ["error"]
+    assert "WakeSessionPermissionError" in rows[-1]["error_summary"]
+    assert await _consecutive_failures(pool, tid) == 1
+    # No event leaked into the foreign session.
+    assert await _events_of(pool, foreign.id) == []
+
+
+async def test_wake_session_fire_loop_terminates_at_rate_cap(
+    trig_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A runaway timer that re-fires the same wake_session is bounded: the
+    per-(trigger, target) rate limit caps it at WAKE_SESSION_MAX_PER_HOUR
+    deliveries, then every further fire errors. A trigger roots at depth 0, so
+    the depth cap can't bound it — the per-pair rate limit is the loop bound for
+    trigger wakes."""
+    from aios.services.wake import WAKE_SESSION_MAX_PER_HOUR
+
+    pool = trig_runtime
+    _, _, owner = await seed_agent_env_session(pool, account_id=ACC, prefix="wsloop")
+    _, _, target = await seed_agent_env_session(pool, account_id=ACC, prefix="wsloopt")
+
+    tid = await _add_trigger(
+        pool,
+        owner.id,
+        {
+            "name": "runaway",
+            "source": {"kind": "cron", "schedule": "* * * * *"},
+            "action": {
+                "kind": "wake_session",
+                "target_session_id": target.id,
+                "content": "tick",
+            },
+        },
+    )
+
+    n = WAKE_SESSION_MAX_PER_HOUR + 3
+    with mock.patch("aios.services.wake.defer_wake", new=AsyncMock()):
+        for _ in range(n):
+            await run_trigger_step(tid)
+
+    rows = await _carrier_rows(pool, tid)
+    statuses = [r["status"] for r in rows]
+    # First MAX deliveries land; the rest error — a bounded, self-limiting loop.
+    assert statuses == ["ok"] * WAKE_SESSION_MAX_PER_HOUR + ["error"] * 3
+    assert "WakeSessionRateLimitedError" in rows[-1]["error_summary"]
+
+    target_events = await _events_of(pool, target.id)
+    user_msgs = [e for e in target_events if e["data"].get("role") == "user"]
+    assert len(user_msgs) == WAKE_SESSION_MAX_PER_HOUR

--- a/tests/integration/test_trigger_event_fires.py
+++ b/tests/integration/test_trigger_event_fires.py
@@ -918,12 +918,17 @@ async def test_wake_session_fire_errors_on_cross_account_target(
     pool = trig_runtime
     _, _, owner = await seed_agent_env_session(pool, account_id=ACC, prefix="wsxacc")
 
-    # A second account with its own session — the forbidden target.
+    # A second account with its own session — the forbidden target. It is a
+    # CHILD of the seeded root (``ACC``): the ``accounts_one_active_root``
+    # partial unique index permits only one ``parent_account_id IS NULL`` row,
+    # so a second root would violate it. A child is a distinct ``account_id``,
+    # which is all the strict same-account wake check (``target_account_id !=
+    # account_id``) needs to reject the cross-account target.
     other_acc = "acc_trig_other"
     async with pool.acquire() as conn:
         await conn.execute(
             "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
-            f"VALUES ('{other_acc}', NULL, TRUE, 'other')"
+            f"VALUES ('{other_acc}', '{ACC}', FALSE, 'other')"
         )
     _, _, foreign = await seed_agent_env_session(pool, account_id=other_acc, prefix="wsforeign")
 

--- a/tests/integration/test_wake_session.py
+++ b/tests/integration/test_wake_session.py
@@ -105,7 +105,7 @@ async def _stamp_lineage_span(
     """Append a system-owned ``wake_lineage`` span — the trusted depth carrier
     the cap reads. Mirrors what ``wake_session_handler`` writes on a real wake.
     """
-    from aios.tools.wake_session import WAKE_LINEAGE_SPAN_EVENT
+    from aios.services.wake import WAKE_LINEAGE_SPAN_EVENT
 
     async with pool.acquire() as conn:
         await queries.append_event(
@@ -126,8 +126,12 @@ def patched_defer_wake() -> Any:
     """Patch out the procrastinate enqueue.  The handler's SQL surface
     (event append, permission check, depth/rate-limit reads) is what's
     under test; the job-queue enqueue is exercised by the existing
-    ``tests/unit/test_wake.py`` suite."""
-    with mock.patch("aios.tools.wake_session.defer_wake", new_callable=AsyncMock) as m:
+    ``tests/unit/test_wake.py`` suite.
+
+    ``defer_wake`` now lives in ``aios.services.wake`` (issue #1280 moved the
+    cross-session delivery primitive there); ``deliver_cross_session_wake``
+    calls it from that module, so the patch must target the definition site."""
+    with mock.patch("aios.services.wake.defer_wake", new_callable=AsyncMock) as m:
         yield m
 
 

--- a/tests/unit/test_migration_0086_predicates.py
+++ b/tests/unit/test_migration_0086_predicates.py
@@ -65,3 +65,22 @@ def test_embedded_downgrade_constants_match_live_0083() -> None:
     m83, m86 = _load("0083"), _load("0086")
     assert m86.SOURCE_SPEC_PREDICATE_0083 == m83.SOURCE_SPEC_PREDICATE
     assert m86.ACTION_PREDICATE_0083 == m83.ACTION_PREDICATE
+
+
+# ─── 0107: wake_session action kind (#1280) — same byte-identity discipline ──
+
+
+def test_0107_action_predicate_extends_0086_byte_identically() -> None:
+    """0107's ACTION_PREDICATE is 0086's with exactly one new ``wake_session``
+    branch spliced before the tail — every prior branch byte-identical, so the
+    constraint swap can never silently re-shape what slice-2 rows must satisfy.
+    """
+    m86, m107 = _load("0086"), _load("0107")
+    _assert_appended_branch_only(
+        m86.ACTION_PREDICATE, m107.ACTION_PREDICATE, added_branch="wake_session"
+    )
+
+
+def test_0107_embedded_downgrade_constant_matches_live_0086() -> None:
+    m86, m107 = _load("0086"), _load("0107")
+    assert m107.ACTION_PREDICATE_0086 == m86.ACTION_PREDICATE

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0106``."""
+    """The migration ladder has exactly one head: ``0107``."""
     script = _script_directory()
-    assert script.get_heads() == ["0106"]
+    assert script.get_heads() == ["0107"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_trigger_tool_schemas.py
+++ b/tests/unit/test_trigger_tool_schemas.py
@@ -55,6 +55,13 @@ class TestCreateSchemaBranches:
         # input_template is deliberately schemaless (any JSON type, incl. null).
         assert "type" not in branch["properties"]["input_template"]
 
+    def test_wake_session_branch(self) -> None:
+        branch = _branch(TRIGGER_CREATE_PARAMETERS_SCHEMA, "action", "wake_session")
+        assert branch["required"] == ["kind", "target_session_id", "content"]
+        assert branch["properties"]["target_session_id"]["type"] == "string"
+        assert branch["properties"]["content"]["type"] == "string"
+        assert branch["additionalProperties"] is False
+
     def test_existing_branches_untouched(self) -> None:
         assert [
             b["properties"]["kind"]["const"]
@@ -63,7 +70,7 @@ class TestCreateSchemaBranches:
         assert [
             b["properties"]["kind"]["const"]
             for b in TRIGGER_CREATE_PARAMETERS_SCHEMA["properties"]["action"]["oneOf"]
-        ] == ["sandbox_command", "wake_owner", "workflow"]
+        ] == ["sandbox_command", "wake_owner", "wake_session", "workflow"]
 
 
 class TestUpdateSchemaReplaceSemantics:
@@ -82,3 +89,16 @@ class TestUpdateSchemaReplaceSemantics:
             "vault_ids",
         ]
         assert "environment_id" not in branch["properties"]
+
+    def test_wake_session_branch(self) -> None:
+        # No Replace twin: both fields required at create, so the update branch
+        # is identical in required-fields shape.
+        branch = _branch(TRIGGER_UPDATE_PARAMETERS_SCHEMA, "action", "wake_session")
+        assert branch["required"] == ["kind", "target_session_id", "content"]
+        assert branch["additionalProperties"] is False
+
+    def test_existing_action_branches_untouched(self) -> None:
+        assert [
+            b["properties"]["kind"]["const"]
+            for b in TRIGGER_UPDATE_PARAMETERS_SCHEMA["properties"]["action"]["oneOf"]
+        ] == ["sandbox_command", "wake_owner", "wake_session", "workflow"]

--- a/tests/unit/test_triggers_models.py
+++ b/tests/unit/test_triggers_models.py
@@ -17,12 +17,14 @@ from aios.models.triggers import (
     MAX_SCHEDULE_CHARS,
     MAX_TRIGGERS_PER_SESSION,
     MAX_WAKE_CONTENT_CHARS,
+    TRIGGER_ACTION_ADAPTER,
     TRIGGER_SOURCE_ADAPTER,
     CronSource,
     OneShotSource,
     TriggerCreate,
     TriggerEcho,
     TriggerUpdate,
+    WakeSessionAction,
     compute_initial_next_fire,
     compute_next_fire,
     validate_triggers,
@@ -160,6 +162,77 @@ class TestWakeOwnerAction:
         # extra="forbid" — a wake_owner can't carry a sandbox_command key.
         with pytest.raises(ValidationError):
             _spec(action={"kind": "wake_owner", "content": "hi", "command": "echo"})
+
+
+class TestWakeSessionAction:
+    """The explicit-target cross-session wake action kind (#1280)."""
+
+    def test_accepts_and_round_trips(self) -> None:
+        spec = _spec(
+            action={
+                "kind": "wake_session",
+                "target_session_id": "sess_01TARGET",
+                "content": "go look at run X",
+            }
+        )
+        assert isinstance(spec.action, WakeSessionAction)
+        assert spec.action.model_dump() == {
+            "kind": "wake_session",
+            "target_session_id": "sess_01TARGET",
+            "content": "go look at run X",
+        }
+
+    def test_discriminator_routes_through_action_adapter(self) -> None:
+        action = TRIGGER_ACTION_ADAPTER.validate_python(
+            {"kind": "wake_session", "target_session_id": "sess_01T", "content": "hi"}
+        )
+        assert isinstance(action, WakeSessionAction)
+
+    def test_missing_target_session_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _spec(action={"kind": "wake_session", "content": "hi"})
+
+    def test_missing_content_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _spec(action={"kind": "wake_session", "target_session_id": "sess_01T"})
+
+    def test_empty_target_session_id_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _spec(action={"kind": "wake_session", "target_session_id": "", "content": "hi"})
+
+    def test_empty_content_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _spec(action={"kind": "wake_session", "target_session_id": "sess_01T", "content": ""})
+
+    def test_content_too_long_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _spec(
+                action={
+                    "kind": "wake_session",
+                    "target_session_id": "sess_01T",
+                    "content": "x" * (MAX_WAKE_CONTENT_CHARS + 1),
+                }
+            )
+
+    def test_extra_key_rejected(self) -> None:
+        # extra="forbid" — a wake_session can't carry a stray key.
+        with pytest.raises(ValidationError):
+            _spec(
+                action={
+                    "kind": "wake_session",
+                    "target_session_id": "sess_01T",
+                    "content": "hi",
+                    "command": "echo",
+                }
+            )
+
+    def test_accepted_on_update_no_replace_twin(self) -> None:
+        # No Replace twin: both fields are required-at-create, so the same
+        # member serves the update side.
+        u = TriggerUpdate.model_validate(
+            {"action": {"kind": "wake_session", "target_session_id": "sess_01T", "content": "hi"}}
+        )
+        assert isinstance(u.action, WakeSessionAction)
 
 
 class TestTriggerCreateOrthogonality:

--- a/tests/unit/test_wake_session_handler.py
+++ b/tests/unit/test_wake_session_handler.py
@@ -29,21 +29,22 @@ from aios.tools.wake_session import (
 def _make_pool(*, target_row: dict[str, Any] | None, depth: int, recent_wakes: int) -> MagicMock:
     """Build a mock pool whose ``pool.acquire()`` yields a single shared
     conn whose ``fetchrow``/``fetchval`` walk through the handler's call
-    sequence in order:
+    sequence in order (the tool now reads its lineage-root depth BEFORE
+    handing off to ``services.wake.deliver_cross_session_wake``, which then
+    validates the target — issue #1280):
 
-      1. fetchrow → target session row (SELECT account_id, status, archived_at)
-      2. fetchrow → wake_depth read on source (COALESCE … FROM events ...)
+      1. fetchrow → wake_depth read on source (COALESCE … FROM events ...)
+      2. fetchrow → target session row (SELECT account_id, archived_at)
       3. fetchval → recent-wake count (SELECT count(*) FROM events ...)
       4. append_event is patched separately via ``queries.append_event``.
 
     Each ``pool.acquire()`` invocation re-enters the same conn, so the
-    side_effect queue is shared across the three acquire blocks in the
-    handler.
+    side_effect queue is shared across the acquire blocks.
     """
     pool = MagicMock()
 
     conn = MagicMock()
-    conn.fetchrow = AsyncMock(side_effect=[target_row, {"depth": depth}])
+    conn.fetchrow = AsyncMock(side_effect=[{"depth": depth}, target_row])
     conn.fetchval = AsyncMock(side_effect=[recent_wakes])
     conn.execute = AsyncMock()
 
@@ -111,7 +112,7 @@ class TestWakeSessionHandlerPermission:
     async def test_unknown_target_rejects(self, monkeypatch: Any, install_pool: Any) -> None:
         install_pool(_make_pool(target_row=None, depth=0, recent_wakes=0))
         monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
         with pytest.raises(WakeSessionArgumentError, match="not found"):
             await wake_session_handler(
                 "sess_01SOURCE",
@@ -133,7 +134,7 @@ class TestWakeSessionHandlerPermission:
             )
         )
         monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
         with pytest.raises(WakeSessionPermissionError, match="not found") as exc_info:
             await wake_session_handler(
                 "sess_01SOURCE",
@@ -155,7 +156,7 @@ class TestWakeSessionHandlerPermission:
             )
         )
         monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
         with pytest.raises(WakeSessionTargetUnavailableError, match="archived"):
             await wake_session_handler(
                 "sess_01SOURCE",
@@ -178,7 +179,7 @@ class TestWakeSessionHandlerPermission:
         mock_append = AsyncMock()
         mock_defer = AsyncMock()
         monkeypatch.setattr("aios.db.queries.append_event", mock_append)
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", mock_defer)
+        monkeypatch.setattr("aios.services.wake.defer_wake", mock_defer)
 
         result = await wake_session_handler(
             "sess_01SOURCE",
@@ -204,7 +205,7 @@ class TestWakeSessionHandlerLimits:
             )
         )
         monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
         with pytest.raises(WakeSessionDepthExceededError, match="wake-depth"):
             await wake_session_handler(
                 "sess_01SOURCE",
@@ -224,7 +225,7 @@ class TestWakeSessionHandlerLimits:
             )
         )
         monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
         with pytest.raises(WakeSessionRateLimitedError, match="rate limit"):
             await wake_session_handler(
                 "sess_01SOURCE",
@@ -246,7 +247,7 @@ class TestWakeSessionHandlerLimits:
         mock_append = AsyncMock()
         mock_defer = AsyncMock()
         monkeypatch.setattr("aios.db.queries.append_event", mock_append)
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", mock_defer)
+        monkeypatch.setattr("aios.services.wake.defer_wake", mock_defer)
 
         result = await wake_session_handler(
             "sess_01SOURCE",
@@ -323,7 +324,7 @@ class TestWakeSessionTrustedLineage:
         pool.acquire = lambda: _CM()
         install_pool(pool)
         monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
 
         result = await wake_session_handler(
             "sess_01SOURCE",
@@ -347,10 +348,12 @@ class TestWakeSessionTrustedLineage:
         pool = MagicMock()
         conn = MagicMock()
 
+        # New order (issue #1280): the tool reads its lineage-root depth first,
+        # THEN deliver_cross_session_wake validates the target.
         conn.fetchrow = AsyncMock(
             side_effect=[
-                {"account_id": "acc_test_stub", "status": "idle", "archived_at": None},
                 {"depth": 0},
+                {"account_id": "acc_test_stub", "status": "idle", "archived_at": None},
             ]
         )
 
@@ -371,7 +374,7 @@ class TestWakeSessionTrustedLineage:
         pool.acquire = lambda: _CM()
         install_pool(pool)
         monkeypatch.setattr("aios.db.queries.append_event", AsyncMock())
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
 
         await wake_session_handler(
             "sess_01SOURCE",
@@ -400,7 +403,7 @@ class TestWakeSessionTrustedLineage:
         )
         mock_append = AsyncMock()
         monkeypatch.setattr("aios.db.queries.append_event", mock_append)
-        monkeypatch.setattr("aios.tools.wake_session.defer_wake", AsyncMock())
+        monkeypatch.setattr("aios.services.wake.defer_wake", AsyncMock())
 
         await wake_session_handler(
             "sess_01SOURCE",


### PR DESCRIPTION
## What & why

Resolves eumemic/aios#1280. Adds a fourth trigger action kind, `wake_session` — the cross-session twin of `wake_owner`. At fire time it delivers `content` as a user-role message to an **explicitly-named same-account session**, waking it. Single named target only: no topics, no competing-consumers, no fan-out (per the settled design in the issue thread).

## How

- **Shared primitive.** The runner routes through `services.wake.deliver_cross_session_wake` (the same primitive the `wake_session` tool was refactored onto earlier on this branch) with the **firing trigger** as the lineage root — `source_id="trigger:{id}"`, `source_depth=0`. So the wake-depth and per-`(source,target)` hourly rate caps apply identically to tool and trigger wakes.
- **Loop bound.** A trigger roots at depth 0, so the depth cap can't bound a runaway timer; the **per-pair hourly rate limit** is the loop bound — a runaway self-limits at `WAKE_SESSION_MAX_PER_HOUR` deliveries, then every further fire `error`s, feeding the consecutive-failure counter + auto-disable. Never a silent drop.
- **Fire-time resolution.** `target_session_id` is account-data, checked at fire time (like `workflow_id`): a cross-account / archived / cap-breaching target surfaces as a fire `error` and an owner-surfaced failure note — not a write-time rejection, and never an existence leak (cross-account targets get the same shape as unknown ids).
- **Migration 0107** extends the `triggers_action_shape` CHECK with one new, byte-identical `wake_session` branch (the 0086 idiom: every pre-existing branch stays byte-for-byte unchanged — pinned by a unit test). Downgrade fails hard on any `wake_session` row.
- Tool `trigger_create` / `trigger_update` schemas + prose, the action discriminator union (`TriggerAction` / `TriggerActionReplace` / adapter), `validate_trigger_spec` typing, OpenAPI snapshot, and the generated `aios-sdk` client all updated.

## Tests (test-first)

- **Unit:** model validation (required/empty/too-long/extra-key), discriminator routing, tool-schema drift on both create and update, migration-predicate byte-identity (0107 extends 0086), and single-head chain bump.
- **Integration (new `test_migrations_0107_*`):** up/down round-trip; the row is accepted under 0107 and rejected under 0106; every prior action kind still inserts; downgrade refuses once a `wake_session` row exists.
- **Integration (extends `test_trigger_event_fires`):** a cron fire delivers a user message + non-forgeable `wake_lineage` span (depth 1, rooted at `trigger:{id}`) to a named target while leaving the owner untouched; a cross-account target yields a surfaced `error` (no leak); and a runaway timer terminates at the per-pair rate cap.

The existing `wake_session` handler unit tests were retargeted to the extracted primitive (patch target + mocked fetch order), with the argument-validation contract preserved. Full unit suite green (3087 passed, 1 skipped); integration tests require Docker (not available in the implement sandbox) but collect and import cleanly.