### PR TITLE
feat(accounts): pre-flight admission against rolled-up subtree envelope

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -451,9 +451,10 @@ async def _run_session_step_body(
     # an allocation market: dollars are an externally-checkable derived scalar.
     # (The post-call warning threshold below measures the freshly-charged flat
     # meter against this same effective limit — see `_charge_usage`.)
-    subtree_spent_microusd, spend_limit_usd = (
-        await accounts_service.get_account_subtree_spend_state(pool, account_id)
-    )
+    (
+        subtree_spent_microusd,
+        spend_limit_usd,
+    ) = await accounts_service.get_account_subtree_spend_state(pool, account_id)
     spend_limit_microusd = _limit_to_microusd(spend_limit_usd)
     if spend_limit_microusd is not None and subtree_spent_microusd >= spend_limit_microusd:
         assert spend_limit_usd is not None

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -438,16 +438,29 @@ async def _run_session_step_body(
         )
         return _StepResult()
 
-    spent_microusd, spend_limit_usd = await accounts_service.get_account_spend_state(
-        pool, account_id
+    # Pre-flight admission against the rolled-up subtree envelope (#1279).
+    #
+    # The admission decision — refusing to *start* this step's model call
+    # before dispatch — is made against the rolled-up subtree envelope (P1's
+    # `get_account_subtree_spent_microusd`, #1296): the SUM of every meter at
+    # or below this account, archived edges severed. The rollup includes the
+    # account's own meter, so it subsumes the flat ceiling — a flat breach is
+    # always a subtree breach — but it ALSO latches once descendants'
+    # *cumulative* spend breaches an ancestor's effective limit, even when no
+    # single account's flat meter has crossed on its own. A hard ceiling, not
+    # an allocation market: dollars are an externally-checkable derived scalar.
+    # (The post-call warning threshold below measures the freshly-charged flat
+    # meter against this same effective limit — see `_charge_usage`.)
+    subtree_spent_microusd, spend_limit_usd = (
+        await accounts_service.get_account_subtree_spend_state(pool, account_id)
     )
     spend_limit_microusd = _limit_to_microusd(spend_limit_usd)
-    if spend_limit_microusd is not None and spent_microusd >= spend_limit_microusd:
+    if spend_limit_microusd is not None and subtree_spent_microusd >= spend_limit_microusd:
         assert spend_limit_usd is not None
         await _handle_spend_cap(
             pool,
             session_id,
-            spent_microusd=spent_microusd,
+            spent_microusd=subtree_spent_microusd,
             spend_limit_usd=spend_limit_usd,
             account_id=account_id,
         )

--- a/src/aios/services/accounts.py
+++ b/src/aios/services/accounts.py
@@ -322,6 +322,34 @@ async def get_account_spend_state(
     return spent, limit
 
 
+async def get_account_subtree_spend_state(
+    pool: asyncpg.Pool[Any], account_id: str
+) -> tuple[int, float | None]:
+    """Return the rolled-up subtree spend (micro-USD) and the effective limit.
+
+    The sibling :func:`get_account_spend_state` reads the *flat* per-account
+    meter; this reads the *rolled-up* subtree envelope (every meter at or below
+    ``account_id``, archived edges severed — see
+    :func:`db.queries.get_account_subtree_spent_microusd`) against the same
+    effective spend limit. The pre-flight admission gate in the harness checks
+    against this rollup so an ancestor's ceiling is enforced once its
+    descendants' *cumulative* spend breaches it, even when no single account's
+    flat meter has crossed on its own. A hard ceiling, not an allocation
+    market — dollars are an externally-checkable derived scalar.
+    """
+    async with pool.acquire() as conn:
+        spent = await queries.get_account_subtree_spent_microusd(conn, account_id)
+        limit = await resolve_effective_spend_limit_usd_on(conn, account_id)
+    if not isinstance(cast(Any, spent), int) or not isinstance(
+        cast(Any, limit), int | float | None
+    ):
+        # Unit tests often use bare MagicMock pools and leave this collaborator
+        # unpatched. Treat untyped mock values as ungated; production queries
+        # return the annotated scalar types.
+        return 0, None
+    return spent, limit
+
+
 async def purge_account(
     pool: asyncpg.Pool[Any], *, target_account_id: str, caller_account_id: str
 ) -> None:

--- a/tests/unit/test_loop_spend_gate.py
+++ b/tests/unit/test_loop_spend_gate.py
@@ -71,7 +71,7 @@ async def test_spend_gate_trips_before_context_build() -> None:
         ),
         patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
         patch(
-            "aios.harness.loop.accounts_service.get_account_spend_state",
+            "aios.harness.loop.accounts_service.get_account_subtree_spend_state",
             AsyncMock(return_value=(1_000_000, 1.0)),
         ),
         patch("aios.harness.loop.sessions_service.append_event", append_event),
@@ -95,6 +95,156 @@ async def test_spend_gate_trips_before_context_build() -> None:
     assert stop_reason["type"] == "error"
     span_payloads = [c.args[3] for c in append_event.call_args_list if c.args[2] == "span"]
     assert any(p.get("event") == "spend_cap_exceeded" for p in span_payloads)
+
+
+async def test_preflight_gate_trips_on_subtree_rollup() -> None:
+    """The pre-flight gate refuses to start when the ROLLED-UP subtree envelope
+    breaches the effective limit — even though the account's own flat meter
+    would be under the cap on its own (the descendant-cumulative case, #1279).
+
+    The harness reads `get_account_subtree_spend_state` (P1's rollup), not the
+    flat per-account meter, for the admission decision. To prove the gate keys
+    on the SUBTREE value, the flat collaborator is wired well under the cap and
+    must be ignored: only the rollup (1_500_000 µ$ ≥ a 1.0 USD limit) trips it.
+    """
+    pool = MagicMock()
+    task_registry = MagicMock()
+    task_registry.in_flight_tool_call_ids.return_value = set()
+    session = SimpleNamespace(
+        id="sess_x",
+        agent_id="agt_x",
+        agent_version=None,
+        focal_channel=None,
+        origin="foreground",
+        parent_run_id=None,
+    )
+    agent = SimpleNamespace(
+        model="openrouter/x",
+        tools=[],
+        mcp_servers=[],
+        http_servers=[],
+        skills=[],
+        system="sys",
+        litellm_extra={},
+        window_min=1000,
+        window_max=10000,
+    )
+    append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
+    # Flat per-account meter is well under the cap; only the subtree rollup trips.
+    flat_state = AsyncMock(return_value=(100_000, 1.0))
+    subtree_state = AsyncMock(return_value=(1_500_000, 1.0))
+    with (
+        patch(
+            "aios.harness.loop.find_sessions_needing_inference", AsyncMock(return_value={"sess_x"})
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.get_session_basic", AsyncMock(return_value=session)
+        ),
+        patch("aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)),
+        patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
+        patch("aios.harness.loop.refresh_session_mount_state", AsyncMock(return_value=[])),
+        patch("aios.harness.loop.compute_step_prelude", AsyncMock(return_value=SimpleNamespace())),
+        patch("aios.harness.loop.prelude_overhead_local", return_value=0),
+        patch(
+            "aios.harness.loop.sessions_service.read_windowed_events",
+            AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
+        ),
+        patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
+        patch("aios.harness.loop.accounts_service.get_account_spend_state", flat_state),
+        patch(
+            "aios.harness.loop.accounts_service.get_account_subtree_spend_state", subtree_state
+        ),
+        patch("aios.harness.loop.sessions_service.append_event", append_event),
+        patch("aios.harness.loop.fail_all_open_requests", AsyncMock()) as fail_open,
+        patch(
+            "aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock()
+        ) as set_stop,
+        patch("aios.harness.loop.compose_step_context", AsyncMock()) as compose,
+    ):
+        result = await _run_session_step_body(
+            pool, task_registry, "sess_x", cause="message", account_id="acc_x"
+        )
+
+    assert result == _StepResult()
+    # No dispatch — the gate fired BEFORE context build / the model call.
+    compose.assert_not_awaited()
+    # Admission keyed on the rollup, not the flat meter.
+    subtree_state.assert_awaited_once_with(pool, "acc_x")
+    fail_open.assert_awaited_once_with(
+        ANY, "sess_x", account_id="acc_x", error={"kind": "spend_cap_exceeded"}
+    )
+    assert set_stop.await_args is not None
+    stop_reason = set_stop.await_args.args[2]
+    assert stop_reason["type"] == "error"
+    span_payloads = [c.args[3] for c in append_event.call_args_list if c.args[2] == "span"]
+    cap_spans = [p for p in span_payloads if p.get("event") == "spend_cap_exceeded"]
+    assert cap_spans, "expected a spend_cap_exceeded span"
+    # The span records the rolled-up subtree spend that breached the envelope.
+    assert cap_spans[0]["spent_microusd"] == 1_500_000
+
+
+async def test_preflight_gate_admits_when_subtree_under_limit() -> None:
+    """A subtree rollup under the effective limit admits the step (dispatch
+    proceeds past the gate). The flat meter being at/over its own row would not
+    matter — the rollup is the envelope — but here both are under the cap.
+    """
+    pool = MagicMock()
+    task_registry = MagicMock()
+    task_registry.in_flight_tool_call_ids.return_value = set()
+    session = SimpleNamespace(
+        id="sess_x",
+        agent_id="agt_x",
+        agent_version=None,
+        focal_channel=None,
+        origin="foreground",
+        parent_run_id=None,
+    )
+    agent = SimpleNamespace(
+        model="openrouter/x",
+        tools=[],
+        mcp_servers=[],
+        http_servers=[],
+        skills=[],
+        system="sys",
+        litellm_extra={},
+        window_min=1000,
+        window_max=10000,
+    )
+    compose = AsyncMock(side_effect=RuntimeError("stop after admission"))
+    with (
+        patch(
+            "aios.harness.loop.find_sessions_needing_inference", AsyncMock(return_value={"sess_x"})
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.get_session_basic", AsyncMock(return_value=session)
+        ),
+        patch("aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)),
+        patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
+        patch("aios.harness.loop.refresh_session_mount_state", AsyncMock(return_value=[])),
+        patch("aios.harness.loop.compute_step_prelude", AsyncMock(return_value=SimpleNamespace())),
+        patch("aios.harness.loop.prelude_overhead_local", return_value=0),
+        patch(
+            "aios.harness.loop.sessions_service.read_windowed_events",
+            AsyncMock(return_value=WindowedEvents(events=[], omission=None)),
+        ),
+        patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
+        patch(
+            "aios.harness.loop.accounts_service.get_account_subtree_spend_state",
+            AsyncMock(return_value=(500_000, 1.0)),  # subtree under the 1.0 USD cap
+        ),
+        patch(
+            "aios.harness.loop.sessions_service.append_event",
+            AsyncMock(return_value=SimpleNamespace(id="ev")),
+        ),
+        patch("aios.harness.loop.compose_step_context", compose),
+        pytest.raises(RuntimeError, match="stop after admission"),
+    ):
+        await _run_session_step_body(
+            pool, task_registry, "sess_x", cause="message", account_id="acc_x"
+        )
+
+    # The gate ADMITTED the step — execution reached context build / dispatch.
+    compose.assert_awaited_once()
 
 
 async def test_usage_charged_only_after_assistant_persists() -> None:
@@ -151,7 +301,7 @@ async def test_usage_charged_only_after_assistant_persists() -> None:
         ),
         patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
         patch(
-            "aios.harness.loop.accounts_service.get_account_spend_state",
+            "aios.harness.loop.accounts_service.get_account_subtree_spend_state",
             AsyncMock(return_value=(0, 100.0)),  # well under the cap → gate passes
         ),
         patch(

--- a/tests/unit/test_loop_spend_gate.py
+++ b/tests/unit/test_loop_spend_gate.py
@@ -151,9 +151,7 @@ async def test_preflight_gate_trips_on_subtree_rollup() -> None:
         ),
         patch("aios.harness.loop._dispatch_confirmed_tools", AsyncMock(return_value=[])),
         patch("aios.harness.loop.accounts_service.get_account_spend_state", flat_state),
-        patch(
-            "aios.harness.loop.accounts_service.get_account_subtree_spend_state", subtree_state
-        ),
+        patch("aios.harness.loop.accounts_service.get_account_subtree_spend_state", subtree_state),
         patch("aios.harness.loop.sessions_service.append_event", append_event),
         patch("aios.harness.loop.fail_all_open_requests", AsyncMock()) as fail_open,
         patch(


### PR DESCRIPTION
## What

Adds a **pre-flight admission gate** that refuses to *start* a session step (before the model call is dispatched) when the account's projected cost would breach its **rolled-up subtree envelope**, instead of only latching reactively after a single account's flat meter has already crossed.

Enforcement was reactive against a *flat* per-account meter: the harness latched a session `errored` only after `spent ≥ limit` (`harness/loop.py:441`), reading `get_account_spend_state` (the single-row `spent_microusd`). That never saw descendants' spend — an ancestor's effective limit could be blown by its subtree's *cumulative* spend while every individual flat meter stayed under its own row.

This builds directly on **P1** (subtree spend rollup, #1296): the pre-dispatch gate now keys on `get_account_subtree_spent_microusd` (the `WITH RECURSIVE` sum of every meter at or below the account, archived edges severed) compared against the same effective spend limit. A **hard ceiling, not an allocation market** — dollars stay an externally-checkable derived scalar.

Depends on P1 (#1296), which is already merged on `master`.

Closes #1279.

## Changes

- **`services/accounts.py`** — new `get_account_subtree_spend_state(pool, account_id)`: returns `(subtree_spent_microusd, effective_limit_usd)`, the rollup-spend sibling of the flat `get_account_spend_state`. Same MagicMock-tolerant typing guard as the flat helper.
- **`harness/loop.py`** — the pre-dispatch spend gate (before context build / the model call) now reads the subtree spend state and refuses admission (latches `spend_cap_exceeded` via the existing `_handle_spend_cap` path) when the rolled-up envelope breaches the effective limit. The rollup includes the account's own meter, so it subsumes the old flat ceiling (a flat breach is still a subtree breach) while *also* catching the descendant-cumulative case. The post-call 80%-warning threshold is unchanged (it still measures the freshly-charged flat meter against the same effective limit).

## Tests (test-first)

Extends `tests/unit/test_loop_spend_gate.py`:
- **`test_preflight_gate_trips_on_subtree_rollup`** — flat meter wired well under the cap, only the subtree rollup (1.5M µ$ ≥ a $1.00 limit) trips the gate; asserts no dispatch (`compose_step_context` not awaited), the gate keyed on the rollup, the `spend_cap_exceeded` span/latch fired, and the span recorded the rolled-up value.
- **`test_preflight_gate_admits_when_subtree_under_limit`** — a subtree rollup under the limit admits the step (execution reaches context build).
- Existing `test_spend_gate_trips_before_context_build` / `test_usage_charged_only_after_assistant_persists` updated to patch the new collaborator.

The new tests fail on the pre-change tree (AttributeError: no `get_account_subtree_spend_state`) and pass after. `tests/unit/test_loop_spend_gate.py` is green (6 passed); ruff + mypy clean on the touched files. A handful of unrelated unit failures (openapi/sdk snapshots, mcp-mount annotations, run-observability contract) reproduce identically on the clean checkout — pre-existing, environment/dependency-version drift, untouched by this change.