### PR TITLE
fix(http_request+pipelines): signal body truncation; fail loud, never degrade-to-empty (#1294)

### DIFF
--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -12,6 +12,7 @@ On error: ``{"error": "..."}``.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -34,7 +35,32 @@ from aios.tools._glob_match import match_glob
 from aios.tools.registry import registry
 from aios.tools.url_safety import is_safe_url
 
-_MAX_RESPONSE_CHARS = 100_000
+# The response-body character cap. Bodies longer than this are truncated — but
+# NEVER silently: the result dict carries ``"truncated": True`` so the caller can
+# fail loud instead of degrading to an empty/None parse (aios#1294). The default is
+# ~1 MB (was 100 KB, which truncated a single page of a GitHub issue list mid-JSON
+# and broke the triage scan). Operators can raise/lower it via
+# ``AIOS_HTTP_RESPONSE_MAX_CHARS``; a missing / non-positive / unparseable value
+# falls back to the default so a bad env never disables the cap.
+_DEFAULT_MAX_RESPONSE_CHARS = 1_000_000
+
+
+def _max_response_chars() -> int:
+    """The response-body char cap, from ``AIOS_HTTP_RESPONSE_MAX_CHARS`` or the
+    default. Resolved per call so an operator override takes effect without a
+    process restart; a non-positive / unparseable value falls back to the default
+    (we never want a bad env to mean ``[:0]`` or an unbounded read)."""
+    raw = os.environ.get("AIOS_HTTP_RESPONSE_MAX_CHARS")
+    if raw:
+        try:
+            n = int(raw)
+        except ValueError:
+            return _DEFAULT_MAX_RESPONSE_CHARS
+        if n > 0:
+            return n
+    return _DEFAULT_MAX_RESPONSE_CHARS
+
+
 _TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
 _ALLOWED_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH")
 
@@ -48,9 +74,12 @@ HTTP_REQUEST_DESCRIPTION = (
     "Make an authenticated HTTP request to one of the agent's declared "
     "http_servers. Specify server_ref (the spec's name), path, method, "
     "optional headers (Authorization is set by the worker — your value "
-    "is ignored), and optional body. Response body is truncated to 100k "
-    "characters. Only paths matching an enabled route on the server's "
-    "allowlist are permitted; the worker refuses non-matching paths."
+    "is ignored), and optional body. Response body is truncated to ~1M "
+    "characters (configurable via AIOS_HTTP_RESPONSE_MAX_CHARS); when a body "
+    'is cut the result carries "truncated": true so callers never mistake a '
+    "truncated body for a complete one. Only paths matching an enabled route "
+    "on the server's allowlist are permitted; the worker refuses "
+    "non-matching paths."
 )
 
 HTTP_REQUEST_PARAMETERS_SCHEMA: dict[str, Any] = {
@@ -236,7 +265,16 @@ async def _load_session_agent(session_id: str) -> tuple[Agent | AgentVersion, st
     return agent, account_id, session.outbound_suppression
 
 
-def _decode_body(response: httpx.Response) -> str:
+def _decode_body(response: httpx.Response) -> tuple[str, bool]:
+    """Decode the response body to text and report whether it was truncated.
+
+    Returns ``(body, truncated)``. ``truncated`` is ``True`` only when a textish
+    body exceeded the char cap and was cut — so the caller can surface a
+    ``"truncated": True`` flag and NEVER hand back a body that silently lost its
+    tail (aios#1294: a 100 KB cut mid-JSON broke the triage scan). A refused
+    binary body is never "truncated" in this sense — the marker IS the full,
+    honest value — so it reports ``False``.
+    """
     content_type = response.headers.get("content-type", "")
     is_textish = (
         content_type.startswith("text/")
@@ -246,11 +284,15 @@ def _decode_body(response: httpx.Response) -> str:
         or content_type == ""
     )
     if is_textish:
-        return response.text[:_MAX_RESPONSE_CHARS]
+        text = response.text
+        cap = _max_response_chars()
+        if len(text) > cap:
+            return text[:cap], True
+        return text, False
     return (
         f"<binary content of type {content_type or 'unknown'}, "
         f"{len(response.content)} bytes — refused>"
-    )
+    ), False
 
 
 async def _do_http_request(
@@ -346,11 +388,18 @@ async def _do_http_request(
     except httpx.HTTPError as exc:
         return {"error": f"HTTP transport error: {type(exc).__name__}: {exc}"}
 
-    return {
+    body_text, truncated = _decode_body(response)
+    result: dict[str, Any] = {
         "status": response.status_code,
         "headers": dict(response.headers),
-        "body": _decode_body(response),
+        "body": body_text,
     }
+    # Signal a cut body explicitly (aios#1294). The flag is present ONLY when the
+    # body was truncated, so a caller can branch on its mere presence; never cut a
+    # body without saying so.
+    if truncated:
+        result["truncated"] = True
+    return result
 
 
 async def http_request_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -93,6 +93,7 @@ from typing import Any
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.workflows import WorkflowCreate
 from aios.workflows.comment_idempotency import COMMENT_IDEMPOTENCY_HELPERS
+from aios.workflows.gh_body import GH_BODY_HELPERS
 
 # ─── default judgment-node agent ids (override per deployment) ───────────────
 DEFAULT_IMPLEMENT_AGENT_ID = "dev-implement"
@@ -485,48 +486,13 @@ def _with_query(path, **params):
     return path + ("?" if qs else "") + qs
 
 
-async def gh_paginated(path, per_page=100, max_pages=50):
-    """GET every page of a GitHub list endpoint, following ``Link: rel="next"``.
-
-    Requests ``?per_page`` (so each page holds up to 100 rather than the default 30)
-    and walks ``page=2,3,...`` until GitHub stops emitting a ``rel="next"`` link or the
-    bounded ``max_pages`` cap is hit. Concatenates the per-page JSON arrays into one
-    list. A non-2xx / non-list page degrades gracefully: returns whatever was gathered
-    so far (the caller already treats a comments-read failure as body-only). The page
-    number is rebuilt onto OUR path, so no host-bearing next URL crosses the route gate;
-    each request is a distinct ``tool()`` await (per-content-hash call_key), so replay
-    stays stable. Requires the route to allow a query string (``allow_query``)."""
-    items = []
-    page = 1
-    for _ in range(max_pages):
-        resp = await gh("GET", _with_query(path, per_page=per_page, page=page))
-        if _status(resp) != 200:
-            break
-        chunk = _json_body(resp)
-        if not isinstance(chunk, list):
-            break
-        items.extend(chunk)
-        nxt = _link_next_page(_headers(resp).get("link"))
-        if nxt is None:
-            break
-        page = nxt
-    return items
-
-
 def _status(resp):
     return resp.get("status") if isinstance(resp, dict) else None
 
 
-def _json_body(resp):
-    if not isinstance(resp, dict):
-        return None
-    raw = resp.get("body")
-    if not isinstance(raw, str) or not raw:
-        return None
-    try:
-        return json.loads(raw)
-    except ValueError:
-        return None
+# ``_json_body`` and ``gh_paginated`` are spliced in from the shared
+# ``GH_BODY_HELPERS`` source (aios#1294) so the fail-loud-on-truncated-or-
+# unparseable-2xx contract can never drift between the dev and triage pipelines.
 
 
 def _ipath(repo, suffix):
@@ -1287,10 +1253,13 @@ def build_dev_pipeline_script(
         merge_method=merge_method,
         default_model=default_model,
     )
-    # Splice the shared comment-idempotency helper (aios#1292) into the body — authored once
-    # in comment_idempotency.py and injected into BOTH pipelines so the class fix can't drift.
-    # It references gh/_ipath/log from the body; module-level defs resolve names at call time.
-    return header + "\n" + _BODY + COMMENT_IDEMPOTENCY_HELPERS
+    # Splice the shared GitHub-body helper (aios#1294: _json_body / gh_paginated that fail
+    # LOUD on a truncated or unparseable-2xx body instead of degrading to None/[]) and the
+    # comment-idempotency helper (aios#1292) into the body — each authored once and injected
+    # into BOTH pipelines so the class fix can't drift. They reference
+    # gh/_status/_headers/_link_next_page/_with_query/_ipath/log from the body; module-level
+    # defs resolve names at call time, so appending after the body is fine.
+    return header + "\n" + _BODY + GH_BODY_HELPERS + COMMENT_IDEMPOTENCY_HELPERS
 
 
 def build_dev_pipeline_fixture_script(

--- a/src/aios/workflows/gh_body.py
+++ b/src/aios/workflows/gh_body.py
@@ -1,0 +1,136 @@
+"""Shared GitHub-body parsing helper (aios#1294) — the CLASS fix for silent
+truncate-then-degrade-to-empty.
+
+``http_request`` caps a response body at a configurable char limit and now sets
+``"truncated": True`` whenever it cuts one (the tool no longer truncates
+silently). But the *caller* contract matters just as much: BOTH the triage
+pipeline and the dev pipeline shared an identical ``_json_body`` /
+``gh_paginated`` pair that, on a truncated body or a JSON-parse failure of a 2xx
+response, returned ``None`` / broke the page loop and degraded to ``[]`` — a
+**silent ``scanned:0`` no-op** that blocked the triage loop on aios-sized repos
+(a single ``per_page=100`` issue page is ~591 KB, far over the old 100 KB cap).
+
+This module closes that recurrence-class in ONE place: a loud-failing
+``_json_body`` and ``gh_paginated`` authored once here and spliced into each
+pipeline's workflow ``_BODY`` (the same source-string sharing pattern as
+``comment_idempotency.COMMENT_IDEMPOTENCY_HELPERS``). The rule, applied
+identically by both pipelines:
+
+  * A ``truncated`` 2xx body → RAISE (the body is structurally incomplete; a
+    JSON parse would either crash mid-stream or — worse — succeed on a coincidentally
+    balanced prefix and silently drop the tail).
+  * A 2xx body that fails to JSON-parse → RAISE (a 200 with unparseable JSON is a
+    real defect, not an empty result; never swallow it into ``None``/``[]``).
+  * A non-2xx response is still a VALUE the caller branches on (auth/404/422 are
+    the caller's concern, mirroring the existing ``gh`` contract) — only a 2xx
+    body that we cannot faithfully parse is fatal.
+
+WHY A SOURCE STRING, NOT AN IMPORTED FUNCTION: each workflow is rendered to a
+single self-contained *script source* the script-host ``exec``s in a curated
+namespace (stdlib ``re``/``json`` only — no ``aios`` import at runtime). A
+genuinely shared helper must therefore be shared at *authoring* time: this module
+exports the helper SOURCE TEXT, authored once, and both ``build_*_script``
+functions splice it into their ``_BODY``. The text references ``gh``, ``_status``,
+``_headers``, ``_link_next_page``, ``_with_query`` and ``log`` — names both
+pipeline bodies already define with identical semantics — so it composes without
+per-pipeline edits.
+
+DETERMINISM: the helper does only pure string/list/dict work plus the same ``gh``
+calls the surrounding body already makes; it imports nothing and reads no clock.
+The raise is a deterministic function of the (replayed) tool result, so replay
+stays stable — a run that failed loud once fails loud identically on replay.
+"""
+
+from __future__ import annotations
+
+# The shared helper source, authored once. Spliced verbatim into each pipeline's
+# _BODY. References ``gh`` / ``_status`` / ``_headers`` / ``_link_next_page`` /
+# ``_with_query`` / ``log`` from the surrounding body (both pipelines define them
+# with identical semantics).
+GH_BODY_HELPERS = r'''
+# ─── shared GitHub-body parsing (aios#1294 — fail loud, never degrade-to-empty) ──
+# http_request caps a response body and flags ``truncated: True`` when it cuts one.
+# A truncated 2xx body is structurally incomplete and a 2xx body that won't
+# JSON-parse is a real defect — NEITHER may degrade silently to None/[] (that was
+# the silent ``scanned:0`` no-op that blocked the triage loop). Both raise here so
+# the failure is loud; a non-2xx response stays a value the caller branches on.
+
+class GitHubBodyError(RuntimeError):
+    """A 2xx GitHub response whose body could not be faithfully parsed —
+    truncated by the response cap, or 2xx-but-unparseable JSON. Raised instead of
+    returning None/[] so a structurally-incomplete read never degrades to a silent
+    empty result (aios#1294)."""
+
+
+def _resp_truncated(resp):
+    """True when http_request signalled it cut this body (``truncated: True``).
+    The flag is present ONLY when the body was truncated, so its mere presence is
+    the signal."""
+    return isinstance(resp, dict) and bool(resp.get("truncated"))
+
+
+def _json_body(resp):
+    """Parse a GitHub response body to JSON, failing LOUD on a faithless read.
+
+    - Not a dict / no body string → None (an empty or error-envelope response the
+      caller already branches on; a non-2xx is the caller's concern).
+    - A ``truncated`` body → raise GitHubBodyError (the body lost its tail; a parse
+      would crash mid-stream or silently succeed on a balanced prefix).
+    - A 2xx body that fails to JSON-parse → raise GitHubBodyError (a 200 with
+      unparseable JSON is a defect, never an empty result).
+    - A non-2xx body that fails to parse → None (e.g. a 404/422 with a non-JSON or
+      partial body is the caller's branch, not a fatal read).
+    """
+    if not isinstance(resp, dict):
+        return None
+    if _resp_truncated(resp):
+        raise GitHubBodyError(
+            "GitHub response body was TRUNCATED by the response cap (status %s) — "
+            "refusing to parse a structurally-incomplete body. Raise "
+            "AIOS_HTTP_RESPONSE_MAX_CHARS or page the endpoint more finely; never "
+            "degrade a truncated read to empty." % (_status(resp),)
+        )
+    raw = resp.get("body")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except ValueError as exc:
+        st = _status(resp)
+        if isinstance(st, int) and 200 <= st <= 299:
+            raise GitHubBodyError(
+                "GitHub returned a 2xx (%s) whose body failed to JSON-parse: %s — "
+                "a 2xx with unparseable JSON is a defect, not an empty result; "
+                "refusing to degrade to None." % (st, exc)
+            ) from exc
+        return None
+
+
+async def gh_paginated(path, per_page=100, max_pages=50):
+    """GET every page of a GitHub list endpoint, following ``Link: rel="next"``.
+
+    Concatenates the per-page JSON arrays. A non-2xx page stops pagination and
+    returns what was gathered so far (auth/404 is the caller's branch). But a 2xx
+    page that is TRUNCATED or fails to JSON-parse RAISES (via ``_json_body``) — it
+    NEVER degrades to a partial/empty list, which is the aios#1294 silent
+    ``scanned:0`` no-op. A 2xx page that parses to a non-list is a genuine shape
+    change and stops pagination (returns what was gathered). The page number is
+    rebuilt onto OUR path, so no host-bearing next URL crosses the route gate; each
+    request is a distinct ``tool()`` await (per-content-hash call_key), so replay
+    stays stable. Requires the route to allow a query string (``allow_query``)."""
+    items = []
+    page = 1
+    for _ in range(max_pages):
+        resp = await gh("GET", _with_query(path, per_page=per_page, page=page))
+        if _status(resp) != 200:
+            break
+        chunk = _json_body(resp)  # raises loud on truncated / unparseable 2xx
+        if not isinstance(chunk, list):
+            break
+        items.extend(chunk)
+        nxt = _link_next_page(_headers(resp).get("link"))
+        if nxt is None:
+            break
+        page = nxt
+    return items
+'''

--- a/src/aios/workflows/triage_pipeline.py
+++ b/src/aios/workflows/triage_pipeline.py
@@ -69,6 +69,7 @@ from typing import Any
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.workflows import WorkflowCreate
 from aios.workflows.comment_idempotency import COMMENT_IDEMPOTENCY_HELPERS
+from aios.workflows.gh_body import GH_BODY_HELPERS
 
 # The stable heading on the single needs-decision comment. It is BOTH the comment's first
 # line AND the maker-marker the replay guard scans for: a posted comment is its own
@@ -218,18 +219,6 @@ def _status(resp):
     return resp.get("status") if isinstance(resp, dict) else None
 
 
-def _json_body(resp):
-    if not isinstance(resp, dict):
-        return None
-    raw = resp.get("body")
-    if not isinstance(raw, str) or not raw:
-        return None
-    try:
-        return json.loads(raw)
-    except ValueError:
-        return None
-
-
 def _headers(resp):
     """Lower-cased response header map (GitHub sends ``Link`` capitalised)."""
     if not isinstance(resp, dict):
@@ -266,26 +255,9 @@ def _ipath(repo, suffix):
     return "/repos/%s%s" % (repo, suffix)
 
 
-async def gh_paginated(path, per_page=100, max_pages=50):
-    """GET every page of a GitHub list endpoint, following Link: rel="next". Concatenates the
-    per-page JSON arrays. A non-2xx / non-list page degrades to whatever was gathered so far.
-    Requires the route to allow a query string (allow_query). Replay-stable (each page is a
-    distinct tool() await)."""
-    items = []
-    page = 1
-    for _ in range(max_pages):
-        resp = await gh("GET", _with_query(path, per_page=per_page, page=page))
-        if _status(resp) != 200:
-            break
-        chunk = _json_body(resp)
-        if not isinstance(chunk, list):
-            break
-        items.extend(chunk)
-        nxt = _link_next_page(_headers(resp).get("link"))
-        if nxt is None:
-            break
-        page = nxt
-    return items
+# ``_json_body`` and ``gh_paginated`` are spliced in from the shared
+# ``GH_BODY_HELPERS`` source (aios#1294) so the fail-loud-on-truncated-or-
+# unparseable-2xx contract can never drift between the triage and dev pipelines.
 
 
 # ─── the untriaged filter (the idempotency boundary) ──────────────────────────
@@ -527,7 +499,14 @@ def build_triage_pipeline_script(
     # in comment_idempotency.py and injected into BOTH pipelines so the class fix can't drift.
     # It references gh/_ipath/log from the body (all defined above); module-level defs resolve
     # names at call time, so appending after the body is fine.
-    return header + "\n" + _BODY + COMMENT_IDEMPOTENCY_HELPERS
+    # Splice the shared GitHub-body helper (aios#1294: _json_body / gh_paginated that
+    # fail LOUD on a truncated or unparseable-2xx body instead of degrading to None/[])
+    # ahead of the comment-idempotency helper. Authored once in gh_body.py and injected
+    # into BOTH pipelines so the fail-loud contract can't drift. It references
+    # gh/_status/_headers/_link_next_page/_with_query/log from the body (all defined
+    # above); module-level defs resolve names at call time, so appending after the body
+    # is fine.
+    return header + "\n" + _BODY + GH_BODY_HELPERS + COMMENT_IDEMPOTENCY_HELPERS
 
 
 def build_triage_pipeline_fixture_script(

--- a/tests/unit/test_gh_body_helper.py
+++ b/tests/unit/test_gh_body_helper.py
@@ -1,0 +1,174 @@
+"""Unit tests for the shared GitHub-body parsing helper (aios#1294).
+
+The helper closes the silent-truncate-then-degrade-to-empty CLASS shared by the triage and
+dev pipelines: ``http_request`` now flags ``truncated: True`` when it cuts a body, and the
+shared ``_json_body`` / ``gh_paginated`` must FAIL LOUD on a truncated or unparseable-2xx
+body instead of returning ``None`` / breaking the page loop and degrading to ``[]`` (the
+silent ``scanned:0`` no-op that blocked the triage loop).
+
+The helper source is authored once in ``gh_body.GH_BODY_HELPERS`` and spliced into BOTH
+pipeline scripts. We exec it in a namespace with the names it references from the
+surrounding body (``gh`` / ``_status`` / ``_headers`` / ``_link_next_page`` /
+``_with_query`` / ``log``) and exercise the pure logic directly — no LLM, no real tool, no
+time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import Any
+
+import pytest
+
+from aios.workflows.gh_body import GH_BODY_HELPERS
+
+
+def _namespace(pages: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Exec the helper source with the body-provided names it references. ``pages`` is a
+    queue of canned http_request responses returned by the recording ``gh`` stub, one per
+    GET (so ``gh_paginated`` can be driven page by page)."""
+    queue = list(pages or [])
+    calls: list[str] = []
+
+    async def gh(method: str, path: str, body: Any = None) -> dict[str, Any]:
+        calls.append(path)
+        if queue:
+            return queue.pop(0)
+        return {"status": 404, "body": ""}
+
+    def _status(resp: Any) -> Any:
+        return resp.get("status") if isinstance(resp, dict) else None
+
+    def _headers(resp: Any) -> dict[str, Any]:
+        if not isinstance(resp, dict):
+            return {}
+        h = resp.get("headers")
+        if not isinstance(h, dict):
+            return {}
+        return {str(k).lower(): v for k, v in h.items()}
+
+    def _link_next_page(link_header: Any) -> int | None:
+        if not isinstance(link_header, str) or not link_header:
+            return None
+        for part in link_header.split(","):
+            seg = part.strip()
+            if 'rel="next"' not in seg:
+                continue
+            m = re.search(r"[?&]page=(\d+)", seg)
+            if m:
+                return int(m.group(1))
+        return None
+
+    def _with_query(path: str, **params: Any) -> str:
+        qs = "&".join(f"{k}={params[k]}" for k in sorted(params))
+        return path + ("?" if qs else "") + qs
+
+    ns: dict[str, Any] = {
+        "json": json,
+        "gh": gh,
+        "_status": _status,
+        "_headers": _headers,
+        "_link_next_page": _link_next_page,
+        "_with_query": _with_query,
+        "log": lambda *a, **k: None,
+        "calls": calls,
+    }
+    exec(compile(GH_BODY_HELPERS, "gh_body", "exec"), ns)
+    return ns
+
+
+# ─── _json_body ──────────────────────────────────────────────────────────────
+
+
+def test_json_body_parses_a_clean_2xx() -> None:
+    ns = _namespace()
+    out = ns["_json_body"]({"status": 200, "body": '[{"number": 1}]'})
+    assert out == [{"number": 1}]
+
+
+def test_json_body_none_for_non_dict_or_empty_body() -> None:
+    ns = _namespace()
+    assert ns["_json_body"]("boom") is None
+    assert ns["_json_body"]({"status": 200}) is None
+    assert ns["_json_body"]({"status": 200, "body": ""}) is None
+
+
+def test_json_body_raises_on_truncated_2xx() -> None:
+    # A truncated body lost its tail — refuse to parse it; never degrade to empty.
+    ns = _namespace()
+    err = ns["GitHubBodyError"]
+    resp = {"status": 200, "body": "[0,0,0", "truncated": True}
+    with pytest.raises(err):
+        ns["_json_body"](resp)
+
+
+def test_json_body_raises_on_truncated_even_if_prefix_parses() -> None:
+    # The dangerous case: a truncated body whose prefix happens to be valid JSON. The
+    # ``truncated`` flag must win — parsing it would silently drop the tail.
+    ns = _namespace()
+    err = ns["GitHubBodyError"]
+    resp = {"status": 200, "body": "[1,2,3]", "truncated": True}
+    with pytest.raises(err):
+        ns["_json_body"](resp)
+
+
+def test_json_body_raises_on_unparseable_2xx() -> None:
+    # A 200 with unparseable JSON is a defect, not an empty result.
+    ns = _namespace()
+    err = ns["GitHubBodyError"]
+    with pytest.raises(err):
+        ns["_json_body"]({"status": 200, "body": "not json at all"})
+
+
+def test_json_body_non_2xx_unparseable_stays_a_value() -> None:
+    # A 404/422 with a non-JSON body is the caller's branch, not a fatal read.
+    ns = _namespace()
+    assert ns["_json_body"]({"status": 404, "body": "Not Found"}) is None
+    assert ns["_json_body"]({"status": 422, "body": "<<garbage>>"}) is None
+
+
+# ─── gh_paginated ────────────────────────────────────────────────────────────
+
+
+def test_gh_paginated_concatenates_pages() -> None:
+    pages = [
+        {"status": 200, "body": "[1,2]", "headers": {"Link": '<...?page=2>; rel="next"'}},
+        {"status": 200, "body": "[3,4]"},
+    ]
+    ns = _namespace(pages)
+    items = asyncio.run(ns["gh_paginated"]("/repos/o/r/issues"))
+    assert items == [1, 2, 3, 4]
+
+
+def test_gh_paginated_raises_on_truncated_page_never_returns_partial() -> None:
+    # The exact aios#1294 failure: a truncated 2xx list page must RAISE, not degrade to a
+    # partial / empty list and report ``scanned:0``.
+    pages = [
+        {"status": 200, "body": "[1,2]", "headers": {"Link": '<...?page=2>; rel="next"'}},
+        {"status": 200, "body": "[3,4", "truncated": True},
+    ]
+    ns = _namespace(pages)
+    err = ns["GitHubBodyError"]
+    with pytest.raises(err):
+        asyncio.run(ns["gh_paginated"]("/repos/o/r/issues"))
+
+
+def test_gh_paginated_raises_on_unparseable_2xx_page() -> None:
+    pages = [{"status": 200, "body": "definitely not json"}]
+    ns = _namespace(pages)
+    err = ns["GitHubBodyError"]
+    with pytest.raises(err):
+        asyncio.run(ns["gh_paginated"]("/repos/o/r/issues"))
+
+
+def test_gh_paginated_non_2xx_page_stops_and_returns_gathered() -> None:
+    # A non-2xx page (auth/404) is the caller's branch — stop and return what we have.
+    pages = [
+        {"status": 200, "body": "[1,2]", "headers": {"Link": '<...?page=2>; rel="next"'}},
+        {"status": 403, "body": "Forbidden"},
+    ]
+    ns = _namespace(pages)
+    items = asyncio.run(ns["gh_paginated"]("/repos/o/r/issues"))
+    assert items == [1, 2]

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -214,22 +214,52 @@ class TestDecodeBody:
 
     def test_text_passthrough(self) -> None:
         r = self._response("text/plain", b"hello")
-        assert _decode_body(r) == "hello"
+        assert _decode_body(r) == ("hello", False)
 
     def test_json_passthrough(self) -> None:
         r = self._response("application/json", b'{"k": "v"}')
-        assert _decode_body(r) == '{"k": "v"}'
+        assert _decode_body(r) == ('{"k": "v"}', False)
 
     def test_binary_refused(self) -> None:
         r = self._response("application/octet-stream", b"\x00\x01\x02\x03")
-        decoded = _decode_body(r)
+        decoded, truncated = _decode_body(r)
         assert decoded.startswith("<binary content of type application/octet-stream")
         assert "4 bytes" in decoded
+        # A refused-binary marker is the full honest value, not a truncated body.
+        assert truncated is False
 
-    def test_truncates_at_cap(self) -> None:
-        large = b"x" * 200_000
+    def test_under_cap_not_truncated(self) -> None:
+        # Just under the default ~1 MB cap: full body, no truncated flag.
+        body = b"x" * 999_999
+        r = self._response("text/plain", body)
+        decoded, truncated = _decode_body(r)
+        assert len(decoded) == 999_999
+        assert truncated is False
+
+    def test_truncates_at_cap_and_signals(self) -> None:
+        # Over the default cap: body is cut AND truncated is reported True so the
+        # caller can fail loud instead of silently parsing a half-body (aios#1294).
+        large = b"x" * 2_000_000
         r = self._response("text/plain", large)
-        assert len(_decode_body(r)) == 100_000
+        decoded, truncated = _decode_body(r)
+        assert len(decoded) == 1_000_000
+        assert truncated is True
+
+    def test_cap_is_env_configurable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AIOS_HTTP_RESPONSE_MAX_CHARS", "50")
+        r = self._response("text/plain", b"y" * 200)
+        decoded, truncated = _decode_body(r)
+        assert len(decoded) == 50
+        assert truncated is True
+
+    def test_bad_env_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An unparseable / non-positive override must NOT disable the cap.
+        for bad in ("not-a-number", "0", "-5"):
+            monkeypatch.setenv("AIOS_HTTP_RESPONSE_MAX_CHARS", bad)
+            r = self._response("text/plain", b"z" * 1_500_000)
+            decoded, truncated = _decode_body(r)
+            assert len(decoded) == 1_000_000
+            assert truncated is True
 
 
 # ── http_request_handler ────────────────────────────────────────────────────
@@ -510,6 +540,35 @@ class TestHttpRequestHandler:
             )
         assert result["status"] == 200
         assert result["body"] == '{"on": true}'
+        # A complete body never carries the truncated flag.
+        assert "truncated" not in result
+
+    async def test_over_cap_body_sets_truncated_flag(
+        self, _stub_runtime: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An over-cap 2xx body is cut AND the result carries ``truncated: True``
+        # so the caller can fail loud rather than parse a half-body (aios#1294).
+        monkeypatch.setenv("AIOS_HTTP_RESPONSE_MAX_CHARS", "100")
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        response = httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b"[" + b"0," * 500 + b"0]",
+        )
+        stub = _make_stub_client(response=response)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth({"Authorization": "Bearer xyz"}),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        assert result["status"] == 200
+        assert len(result["body"]) == 100
+        assert result["truncated"] is True
 
     async def test_upstream_4xx_returns_status(self, _stub_runtime: Any) -> None:
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])


### PR DESCRIPTION
## Summary

Closes #1294. `http_request` silently truncated every response body at 100 KB with no signal, and the triage/dev pipelines' shared `_json_body`/`gh_paginated` then silently degraded a truncated (or unparseable-2xx) body to `None`/`[]` — a silent `scanned:0` no-op that blocked the triage loop on aios-sized repos (a single `per_page=100` GitHub issue page is ~591 KB, far over the old cap, so it arrived truncated mid-JSON and `json.loads` failed → `None` → `issues=[]`). This is a `silence-is-not-health` defect twice over; this PR closes both halves.

## Changes

**`src/aios/tools/http_request.py`**
- Raise the default response-body cap from 100 KB to ~1 MB, configurable via `AIOS_HTTP_RESPONSE_MAX_CHARS` (a missing / non-positive / unparseable value falls back to the default — a bad env never disables the cap).
- `_decode_body` now returns `(body, truncated)`; the result dict carries `"truncated": true` **whenever** the body is cut (present only when truncated, so callers can branch on its mere presence). Never truncate without signalling. A refused-binary marker is the full honest value and is not flagged truncated.
- Updated the tool description to document the cap, the env var, and the `truncated` flag.

**`src/aios/workflows/gh_body.py` (new — the shared CLASS fix)**
- Authored once and spliced into BOTH pipeline scripts (the same source-string sharing pattern as `comment_idempotency.COMMENT_IDEMPOTENCY_HELPERS`), so the contract can't drift.
- `_json_body` and `gh_paginated` now **fail loud** (`raise GitHubBodyError`) on a `truncated` 2xx body OR a JSON-parse failure of a 2xx body — never degrade to `None`/`[]`. The truncated flag wins even when the cut prefix coincidentally parses (which would silently drop the tail). A non-2xx response stays a VALUE the caller branches on (auth/404/422 unchanged), and a 2xx non-list page still stops pagination.
- Removed the duplicated `_json_body`/`gh_paginated` from `triage_pipeline.py` and `dev_pipeline.py`; both now splice in the shared helper.

## Tests
- `tests/unit/test_http_request.py`: under/over-cap, env-override, bad-env fallback, `truncated` flag on `_decode_body`; over-cap 2xx through `_do_http_request` sets `truncated`; complete body never carries the flag.
- `tests/unit/test_gh_body_helper.py` (new): exec the shared helper source and assert truncated / unparseable-2xx pages RAISE (incl. the dangerous balanced-prefix case), non-2xx stays a value, clean pages concatenate.

All touched unit suites + the dev (48) and triage (18) integration fixture runs pass; ruff check + format clean.