### PR TITLE
fix(connector-subsystem): pop _connections on terminal serve failure so a backfill re-spawns a dead worker

### DIFF
--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -241,6 +241,26 @@ class HttpConnector:
         # the caller proceeds.  Reset to 0 on teardown so re-runs work.
         self._loops_backfilled: int = 0
         self._all_loops_live: asyncio.Event = asyncio.Event()
+        # Per-connection reconnect backoff, in seconds.  Keyed by
+        # connection_id.  ``_isolated_serve_connection`` pops
+        # ``_connections[connection_id]`` on a terminal (non-cancel)
+        # ``serve_connection`` failure so a later discovery ``added`` (or
+        # manual re-add) re-spawns the worker; this dict bounds how fast
+        # that re-spawn actually starts platform work, so a hard-failing
+        # connection (revoked token, unregistered phone) backs off
+        # exponentially instead of hot-looping on every backfill replay.
+        # An entry is cleared on a clean serve (one that ran past the
+        # backoff sleep without immediately failing) and on ``removed``.
+        self._reconnect_backoff: dict[str, float] = {}
+
+    # ── reconnect-backoff tunables (overridable on subclasses) ────────
+    #
+    # Bounds the re-spawn rate of a connection whose ``serve_connection``
+    # keeps failing terminally.  The first (re)spawn after a failure
+    # sleeps ``RECONNECT_BACKOFF_INITIAL``; each subsequent consecutive
+    # failure doubles it up to ``RECONNECT_BACKOFF_MAX``.
+    RECONNECT_BACKOFF_INITIAL: float = 1.0
+    RECONNECT_BACKOFF_MAX: float = 60.0
 
     # ─── helpers (subclasses use these) ──────────────────────────────
 
@@ -709,10 +729,50 @@ class HttpConnector:
         token) can't tear down sibling connections via the parent
         TaskGroup.  Always pops the user-state slot on exit so
         connections cycling in/out don't leak stale state.
+
+        On a terminal (non-cancel) failure this ALSO pops
+        ``self._connections[connection_id]`` and clears the
+        ``_connection_served`` event, so the connection is no longer
+        treated as "already running": a subsequent discovery-backfill
+        ``added`` (or a manual re-add) re-spawns the worker with freshly
+        re-fetched secrets, rather than the connection becoming a
+        permanent zombie that ignores every ``added`` while process-level
+        health shows green (issue #1233).  A bounded exponential backoff
+        (:meth:`_arm_reconnect_backoff`) gates how fast that re-spawn
+        starts platform work, so a hard-failing connection backs off
+        instead of hot-looping on every backfill replay.
+
+        Cancellation (a ``removed`` event, or container shutdown) is NOT
+        a failure: it re-raises so the TaskGroup sees a clean cancel,
+        leaves ``_connections`` untouched here (``_on_connection_removed``
+        already owns that pop), and does not arm the backoff.
         """
+        # Re-spawn backoff: if this connection failed terminally on a
+        # previous spawn, sleep before doing platform work so a
+        # hard-failing connection doesn't hot-loop on every backfill
+        # ``added``.  Sleeping inside the worker task (not the discovery
+        # loop) keeps sibling connections' bring-up unblocked.  A
+        # CancelledError mid-sleep (connection ``removed`` while backing
+        # off) aborts the sleep and skips serve_connection cleanly.
+        delay = self._reconnect_backoff.get(connection_id, 0.0)
+        if delay:
+            log.info(
+                "connector.connection.reconnect_backoff",
+                connector=self.connector,
+                connection_id=connection_id,
+                delay=delay,
+            )
+            await asyncio.sleep(delay)
+        terminal_failure = False
         try:
             await self.serve_connection(connection_id, secrets)
+        except asyncio.CancelledError:
+            # Cooperative cancellation (removed / shutdown): re-raise for
+            # a clean TaskGroup cancel and do NOT arm backoff or pop
+            # ``_connections`` — that's _on_connection_removed's job.
+            raise
         except Exception as exc:
+            terminal_failure = True
             log.exception(
                 "connector.connection.serve_failed",
                 connector=self.connector,
@@ -721,12 +781,50 @@ class HttpConnector:
             )
         finally:
             self.state.pop(connection_id, None)
+            if terminal_failure:
+                self._arm_reconnect_backoff(connection_id)
+                # Drop the live-connection slot so a later ``added``
+                # re-spawns the worker instead of short-circuiting on
+                # "already running".
+                self._connections.pop(connection_id, None)
+                if event := self._connection_served.get(connection_id):
+                    event.clear()
+                log.warning(
+                    "connector.connection.worker_terminated",
+                    connector=self.connector,
+                    connection_id=connection_id,
+                    reconnect_backoff=self._reconnect_backoff.get(connection_id),
+                )
+            else:
+                # Clean exit (serve_connection returned, or was cancelled):
+                # reset the failure backoff so the next bring-up is prompt.
+                self._reconnect_backoff.pop(connection_id, None)
+
+    def _arm_reconnect_backoff(self, connection_id: str) -> None:
+        """Bump the per-connection re-spawn backoff after a terminal failure.
+
+        Starts at :attr:`RECONNECT_BACKOFF_INITIAL` and doubles on each
+        consecutive terminal failure up to :attr:`RECONNECT_BACKOFF_MAX`.
+        Reset to absent by a clean serve / ``removed`` so an intermittent
+        connection doesn't accumulate stale backoff.
+        """
+        current = self._reconnect_backoff.get(connection_id)
+        if current is None:
+            self._reconnect_backoff[connection_id] = self.RECONNECT_BACKOFF_INITIAL
+        else:
+            self._reconnect_backoff[connection_id] = min(
+                current * 2, self.RECONNECT_BACKOFF_MAX
+            )
 
     async def _on_connection_removed(self, connection_id: str) -> None:
         """Cancel the worker task for a vanished connection."""
         state = self._connections.pop(connection_id, None)
         if event := self._connection_served.get(connection_id):
             event.clear()
+        # A genuine ``removed`` (operator deleted the connection) clears
+        # any armed re-spawn backoff so a later re-add of the same id
+        # starts fresh rather than inheriting a stale failure backoff.
+        self._reconnect_backoff.pop(connection_id, None)
         if state is None or state.worker is None:
             return
         state.worker.cancel()

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -812,9 +812,7 @@ class HttpConnector:
         if current is None:
             self._reconnect_backoff[connection_id] = self.RECONNECT_BACKOFF_INITIAL
         else:
-            self._reconnect_backoff[connection_id] = min(
-                current * 2, self.RECONNECT_BACKOFF_MAX
-            )
+            self._reconnect_backoff[connection_id] = min(current * 2, self.RECONNECT_BACKOFF_MAX)
 
     async def _on_connection_removed(self, connection_id: str) -> None:
         """Cancel the worker task for a vanished connection."""

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 import structlog
 from aios_connector_http import HttpConnector, tool
+from aios_connector_http.runner import _ConnectionState
 
 
 class _RecordedResult:
@@ -954,3 +955,214 @@ class TestDiscoveryLoopReconnectsOnStaleStream:
         # It backed off between the failed attempt and the reconnect
         # (rather than busy-looping).
         assert sleeps and sleeps[0] >= 1.0
+
+
+class TestDeadWorkerRespawn:
+    """Regression for #1233: ``_isolated_serve_connection``'s ``finally``
+    must pop ``self._connections[connection_id]`` (not just ``self.state``)
+    on a terminal ``serve_connection`` failure, so a later discovery
+    ``added`` re-spawns the worker instead of being short-circuited as
+    "already running."  Paired with a bounded re-spawn backoff so a
+    hard-failing connection doesn't hot-loop.
+    """
+
+    async def test_terminal_failure_pops_connections_slot(self) -> None:
+        """A non-cancel ``serve_connection`` crash must clear the
+        ``_connections`` slot so the id is no longer "already running"."""
+
+        class _Crashing(HttpConnector):
+            connector = "crashy"
+
+            async def serve_connection(
+                self, connection_id: str, secrets: dict[str, str]
+            ) -> None:
+                raise RuntimeError("revoked token")
+
+        c = _Crashing(base_url="http://x", token="aios_runtime_x")
+        # Simulate the live-connection bookkeeping _on_connection_added sets.
+        c._connections["conn_1"] = _ConnectionState(
+            connection_id="conn_1", external_account_id="acct_1"
+        )
+        c._connection_served.setdefault("conn_1", asyncio.Event()).set()
+
+        # Should NOT raise (failure isolation preserved).
+        await c._isolated_serve_connection("conn_1", {"token": "bad"})
+
+        # The zombie is gone: the connection slot was popped so a later
+        # ``added`` re-spawns rather than short-circuiting.
+        assert "conn_1" not in c._connections
+        # The served event is cleared so wait_connection_served re-arms.
+        assert not c._connection_served["conn_1"].is_set()
+
+    async def test_clean_return_pops_connections_slot(self) -> None:
+        """A ``serve_connection`` that simply returns is also terminal —
+        no zombie and no armed backoff."""
+
+        class _Returns(HttpConnector):
+            connector = "returns"
+
+            async def serve_connection(
+                self, connection_id: str, secrets: dict[str, str]
+            ) -> None:
+                return
+
+        c = _Returns(base_url="http://x", token="aios_runtime_x")
+        await c._isolated_serve_connection("conn_1", {})
+        assert "conn_1" not in c._reconnect_backoff
+
+    async def test_cancellation_leaves_connections_to_removed_handler(self) -> None:
+        """A ``removed``-driven cancel must NOT pop ``_connections`` here
+        (that's ``_on_connection_removed``'s job) and must NOT arm backoff;
+        the CancelledError re-raises for a clean TaskGroup cancel."""
+
+        class _Blocks(HttpConnector):
+            connector = "blocks"
+
+            async def serve_connection(
+                self, connection_id: str, secrets: dict[str, str]
+            ) -> None:
+                await asyncio.Event().wait()
+
+        c = _Blocks(base_url="http://x", token="aios_runtime_x")
+        c._connections["conn_1"] = _ConnectionState(
+            connection_id="conn_1", external_account_id="acct_1"
+        )
+        task = asyncio.create_task(c._isolated_serve_connection("conn_1", {}))
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Not a failure: this handler leaves the slot for the removed path
+        # and arms no backoff.
+        assert "conn_1" in c._connections
+        assert "conn_1" not in c._reconnect_backoff
+
+    async def test_failed_connection_can_respawn_via_added(self) -> None:
+        """End-to-end of the fix: after a terminal failure the very next
+        discovery ``added`` must re-fetch secrets and re-spawn the
+        worker rather than short-circuiting on "already running"."""
+
+        spawns: list[dict[str, str]] = []
+        healthy = asyncio.Event()
+
+        class _FlakyThenOk(HttpConnector):
+            connector = "flaky"
+            # Collapse backoff so the test doesn't actually wait.
+            RECONNECT_BACKOFF_INITIAL = 0.0
+
+            async def serve_connection(
+                self, connection_id: str, secrets: dict[str, str]
+            ) -> None:
+                spawns.append(dict(secrets))
+                if len(spawns) == 1:
+                    raise RuntimeError("first spawn: revoked token")
+                # Second spawn (after secret correction): block forever.
+                healthy.set()
+                await asyncio.Event().wait()
+
+        c = _FlakyThenOk(base_url="http://x", token="aios_runtime_x")
+        c._client = MagicMock()
+
+        secrets_seq = [{"token": "bad"}, {"token": "good"}]
+
+        def _secrets_response(token_map: dict[str, str]) -> MagicMock:
+            body = MagicMock()
+            secrets_obj = MagicMock()
+            secrets_obj.additional_properties = token_map
+            body.secrets = secrets_obj
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.parsed = body
+            return resp
+
+        responses = [_secrets_response(s) for s in secrets_seq]
+
+        async def _fake_get_secrets(*, client: Any, connection_id: str) -> Any:
+            del client, connection_id
+            return responses.pop(0)
+
+        async with asyncio.TaskGroup() as tg:
+            with patch(
+                "aios_connector_http.runner._get_runtime_secrets",
+                new=_fake_get_secrets,
+            ):
+                # First ``added`` spawns a worker that fails terminally.
+                await c._on_connection_added(tg, "conn_1", "acct_1")
+                await c.wait_connection_served("conn_1", deadline=5.0)
+                # Let the failing worker run its finally and pop the slot.
+                for _ in range(50):
+                    await asyncio.sleep(0)
+                    if "conn_1" not in c._connections:
+                        break
+                assert "conn_1" not in c._connections, "zombie slot not cleared"
+
+                # The backfill replays ``added`` — must NOT short-circuit.
+                await c._on_connection_added(tg, "conn_1", "acct_1")
+                await asyncio.wait_for(healthy.wait(), timeout=5.0)
+
+            # Cancel the now-healthy blocking worker so the TG can exit.
+            await c._on_connection_removed("conn_1")
+
+        # Two spawns: the failed one, then the corrected re-spawn — and the
+        # second saw the corrected secret (re-fetched at re-spawn).
+        assert spawns == [{"token": "bad"}, {"token": "good"}]
+
+    def test_arm_reconnect_backoff_escalates_and_caps(self) -> None:
+        class _C(HttpConnector):
+            connector = "c"
+            RECONNECT_BACKOFF_INITIAL = 1.0
+            RECONNECT_BACKOFF_MAX = 4.0
+
+        c = _C(base_url="http://x", token="aios_runtime_x")
+        c._arm_reconnect_backoff("conn_1")
+        assert c._reconnect_backoff["conn_1"] == 1.0
+        c._arm_reconnect_backoff("conn_1")
+        assert c._reconnect_backoff["conn_1"] == 2.0
+        c._arm_reconnect_backoff("conn_1")
+        assert c._reconnect_backoff["conn_1"] == 4.0
+        c._arm_reconnect_backoff("conn_1")  # capped
+        assert c._reconnect_backoff["conn_1"] == 4.0
+
+    async def test_respawn_sleeps_backoff_before_serving(self) -> None:
+        """A re-spawn after a terminal failure sleeps the armed backoff
+        before doing platform work, so a hard-failing connection doesn't
+        hot-loop on every backfill replay."""
+
+        class _Crashing(HttpConnector):
+            connector = "crashy"
+            RECONNECT_BACKOFF_INITIAL = 1.0
+
+            async def serve_connection(
+                self, connection_id: str, secrets: dict[str, str]
+            ) -> None:
+                raise RuntimeError("still revoked")
+
+        c = _Crashing(base_url="http://x", token="aios_runtime_x")
+
+        sleeps: list[float] = []
+        _real_sleep = asyncio.sleep
+
+        async def _fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+            await _real_sleep(0)
+
+        with patch("aios_connector_http.runner.asyncio.sleep", new=_fake_sleep):
+            # First spawn: no backoff armed yet, no sleep.
+            await c._isolated_serve_connection("conn_1", {})
+            assert sleeps == []
+            assert c._reconnect_backoff["conn_1"] == 1.0
+            # Second spawn: armed backoff is slept before serving.
+            await c._isolated_serve_connection("conn_1", {})
+            assert sleeps == [1.0]
+            # Failure escalated the backoff for the next attempt.
+            assert c._reconnect_backoff["conn_1"] == 2.0
+
+    async def test_removed_clears_armed_backoff(self) -> None:
+        class _C(HttpConnector):
+            connector = "c"
+
+        c = _C(base_url="http://x", token="aios_runtime_x")
+        c._arm_reconnect_backoff("conn_1")
+        assert "conn_1" in c._reconnect_backoff
+        await c._on_connection_removed("conn_1")
+        assert "conn_1" not in c._reconnect_backoff


### PR DESCRIPTION
## Problem

`_isolated_serve_connection`'s `finally` popped `self.state[connection_id]` but **not** `self._connections[connection_id]`. Because `_on_connection_added` short-circuits when the id is already in `_connections`, a non-recoverable `serve_connection` failure (revoked bot token, unregistered phone, typo'd secret) left the connection a permanent **zombie**:

- every discovery-backfill `added` was ignored as "already running,"
- a later secret correction was never picked up (secrets are read only at spawn), and
- the workspace stayed silently dead while process-level health showed green.

This affects **every** connector on `aios-connector-http` (telegram/signal/whatsapp/slack), surfaced by the Slack design (§3.3, operability sev 76).

## Fix

In `_isolated_serve_connection`, on a terminal (non-`CancelledError`) failure:

- also pop `self._connections[connection_id]` and clear the `_connection_served` event, so a subsequent discovery `added` (or a manual re-add) **re-spawns the worker with freshly re-fetched secrets** instead of short-circuiting on "already running";
- arm a bounded per-connection exponential reconnect backoff (`RECONNECT_BACKOFF_INITIAL`=1s .. `RECONNECT_BACKOFF_MAX`=60s, overridable on subclasses). The backoff is slept **inside the worker task** before the next `serve_connection`, so a hard-failing connection backs off instead of hot-looping on every backfill replay, and sibling connections' bring-up stays unblocked.

Cancellation (`removed` / container shutdown) re-raises cleanly and is **not** treated as a failure: it leaves the `_connections` pop to `_on_connection_removed` and arms no backoff. A clean serve or a genuine `removed` resets the backoff so an intermittent connection doesn't accumulate stale state.

## Tests

New `TestDeadWorkerRespawn` (test-first; verified red against the pre-fix runner):
- terminal failure pops the `_connections` slot and clears the served event;
- clean return is terminal with no armed backoff;
- cancellation leaves the slot to `_on_connection_removed` and arms no backoff;
- end-to-end: after a terminal failure the next `added` re-fetches secrets and re-spawns (second spawn sees the corrected secret);
- backoff escalation/cap, backoff-slept-before-serving, and `removed` clears armed backoff.

Full `aios-connector-http` suite (106) plus the telegram (99), signal (187), and whatsapp (157) connector suites all pass; ruff + mypy clean.

## Relationship

The Slack connector ships its own block-and-retry workaround (issue D) and does not depend on this fix; once this lands that workaround becomes redundant for the auth-revoke case. Benefits telegram/signal/whatsapp equally.

Refs: `docs/design/slack-connector.md` §3.3, §6 (dead-worker row). Part of #1228. Closes #1233.