### PR TITLE
feat(connector-subsystem): model-visible connector delivery failures

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7648,6 +7648,68 @@
         }
       }
     },
+    "/v1/connectors/runtime/session-lifecycle": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Post Runtime Session Lifecycle",
+        "description": "Append a ``kind=lifecycle`` event onto **one** session bound to\n``body.connection_id`` (#1261), optionally waking it.\n\nThe per-session-targeted sibling of the broadcast ``/runtime/lifecycle``\nroute: where that fans a notice across every bound session, this targets\nthe single ``body.session_id`` \u2014 the SMS design's \u00a73.5 req 1 (a delivery\nfailure must reach the *originating* session, not be broadcast).\n\nAuthorization mirrors ``post_runtime_tool_result`` exactly: the bearer's\nconnector must match ``body.connection_id``'s connector, any bearer-side\n``connection_ids`` allowlist must include it (#350), and the session must\nbe genuinely bound to that connection \u2014 so a runtime bearer can only\ntarget a session within its own connections.\n\nWhen ``body.wake`` is set, a ``defer_wake`` is enqueued after the append\n(the exact pattern as the tool-result intake) so the failure wakes the\nsession rather than merely being visible on its next turn.",
+        "operationId": "post_connector_runtime_session_lifecycle",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeSessionLifecycleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Post Connector Runtime Session Lifecycle"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/connectors/runtime/tool-results": {
       "post": {
         "tags": [
@@ -13695,6 +13757,59 @@
         ],
         "title": "RuntimeManagementCallResultRequest",
         "description": "Idempotent on ``call_id`` \u2014 a replay POST against an already-resolved\nrow no-ops (no double-NOTIFY)."
+      },
+      "RuntimeSessionLifecycleRequest": {
+        "properties": {
+          "connection_id": {
+            "type": "string",
+            "title": "Connection Id"
+          },
+          "session_id": {
+            "type": "string",
+            "title": "Session Id"
+          },
+          "event": {
+            "type": "string",
+            "title": "Event"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "wake": {
+            "type": "boolean",
+            "title": "Wake",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "connection_id",
+          "session_id",
+          "event"
+        ],
+        "title": "RuntimeSessionLifecycleRequest",
+        "description": "Body for ``POST /v1/connectors/runtime/session-lifecycle`` (#1261).\n\nThe per-session-targeted sibling of :class:`RuntimeLifecycleRequest`.\nWhere the broadcast ``/runtime/lifecycle`` route fans a transport-down\nnotice across *every* session bound to the connection, this appends a\nsingle ``kind=lifecycle`` event onto **one** named session \u2014 the gap\ncalled out by the SMS design (\u00a73.5 req 1): a delivery failure must reach\nthe *originating* session, not be broadcast.\n\n``wake`` optionally pairs the append with a ``defer_wake`` so the failure\nisn't merely visible-on-next-turn but actually wakes the session (the\n\"give it stimulus\" half of the design's option (a)). Defaults ``False``\nso the primitive stays a plain visible-on-next-wake append unless the\ncaller opts into the wake."
       },
       "RuntimeToken": {
         "properties": {

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -574,6 +574,72 @@ class HttpConnector:
             return None
         return dict(response.json())
 
+    async def emit_session_lifecycle(
+        self,
+        *,
+        connection_id: str,
+        session_id: str,
+        event: str,
+        reason: str | None = None,
+        data: dict[str, Any] | None = None,
+        wake: bool = False,
+    ) -> dict[str, Any] | None:
+        """Append a ``kind=lifecycle`` event onto **one** session bound to
+        ``connection_id`` (#1261), optionally waking it.
+
+        The per-session-targeted sibling of :meth:`emit_lifecycle`: where that
+        broadcasts a transport-down notice across every bound session, this
+        targets a single ``session_id``. Used when a fact concerns one
+        conversation, not the whole connection — e.g. a carrier-block /
+        delivery failure that must reach the *originating* session
+        (``event="connector_delivery_failed"``, ``wake=True``) rather than be
+        broadcast.
+
+        Set ``wake=True`` to make the failure wake the session (stimulus-
+        bearing) instead of merely being visible on its next turn. Returns the
+        appended-session payload, or ``None`` when the API returned a non-fatal
+        4xx (matching :meth:`emit_inbound`/:meth:`emit_lifecycle`'s
+        drop-don't-raise stance).
+        """
+        client = self._require_client()
+        log.info(
+            "connector.session_lifecycle",
+            connector=self.connector,
+            connection_id=connection_id,
+            session_id=session_id,
+            lifecycle_event=event,
+            reason=reason,
+            wake=wake,
+        )
+        body: dict[str, Any] = {
+            "connection_id": connection_id,
+            "session_id": session_id,
+            "event": event,
+            "wake": wake,
+        }
+        if reason is not None:
+            body["reason"] = reason
+        if data is not None:
+            body["data"] = data
+        response = await client.get_async_httpx_client().post(
+            "/v1/connectors/runtime/session-lifecycle",
+            json=body,
+        )
+        if response.is_error:
+            sc = response.status_code
+            log.warning(
+                "connector.session_lifecycle.failed",
+                status_code=sc,
+                connection_id=connection_id,
+                session_id=session_id,
+                lifecycle_event=event,
+                body=response.text[:2000],
+            )
+            if _is_fatal_inbound_status(sc):
+                response.raise_for_status()
+            return None
+        return dict(response.json())
+
     # ─── runner ──────────────────────────────────────────────────────
 
     async def run_until_stopped(self, *, install_signal_handlers: bool = True) -> None:

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -1114,9 +1114,7 @@ class TestDeadWorkerRespawn:
         class _Crashing(HttpConnector):
             connector = "crashy"
 
-            async def serve_connection(
-                self, connection_id: str, secrets: dict[str, str]
-            ) -> None:
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
                 raise RuntimeError("revoked token")
 
         c = _Crashing(base_url="http://x", token="aios_runtime_x")
@@ -1142,9 +1140,7 @@ class TestDeadWorkerRespawn:
         class _Returns(HttpConnector):
             connector = "returns"
 
-            async def serve_connection(
-                self, connection_id: str, secrets: dict[str, str]
-            ) -> None:
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
                 return
 
         c = _Returns(base_url="http://x", token="aios_runtime_x")
@@ -1159,9 +1155,7 @@ class TestDeadWorkerRespawn:
         class _Blocks(HttpConnector):
             connector = "blocks"
 
-            async def serve_connection(
-                self, connection_id: str, secrets: dict[str, str]
-            ) -> None:
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
                 await asyncio.Event().wait()
 
         c = _Blocks(base_url="http://x", token="aios_runtime_x")
@@ -1191,9 +1185,7 @@ class TestDeadWorkerRespawn:
             # Collapse backoff so the test doesn't actually wait.
             RECONNECT_BACKOFF_INITIAL = 0.0
 
-            async def serve_connection(
-                self, connection_id: str, secrets: dict[str, str]
-            ) -> None:
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
                 spawns.append(dict(secrets))
                 if len(spawns) == 1:
                     raise RuntimeError("first spawn: revoked token")
@@ -1273,9 +1265,7 @@ class TestDeadWorkerRespawn:
             connector = "crashy"
             RECONNECT_BACKOFF_INITIAL = 1.0
 
-            async def serve_connection(
-                self, connection_id: str, secrets: dict[str, str]
-            ) -> None:
+            async def serve_connection(self, connection_id: str, secrets: dict[str, str]) -> None:
                 raise RuntimeError("still revoked")
 
         c = _Crashing(base_url="http://x", token="aios_runtime_x")
@@ -1307,3 +1297,84 @@ class TestDeadWorkerRespawn:
         assert "conn_1" in c._reconnect_backoff
         await c._on_connection_removed("conn_1")
         assert "conn_1" not in c._reconnect_backoff
+
+
+class TestEmitSessionLifecycle:
+    """``emit_session_lifecycle`` (#1261) POSTs the per-session-targeted
+    lifecycle route, passing through ``wake`` and the carrier ``data`` so a
+    connector doesn't hand-roll the request."""
+
+    async def test_posts_session_lifecycle_route_with_wake_and_data(
+        self, probe: _ProbeConnector
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.json = MagicMock(return_value={"appended_session_id": "sess_1"})
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        result = await probe.emit_session_lifecycle(
+            connection_id="conn_1",
+            session_id="sess_1",
+            event="connector_delivery_failed",
+            reason="30007",
+            data={"detail": "carrier blocked", "peer": "+15550123"},
+            wake=True,
+        )
+
+        assert result == {"appended_session_id": "sess_1"}
+        # Targets the new route, not the broadcast one.
+        url = mock_post.call_args.args[0]
+        assert url == "/v1/connectors/runtime/session-lifecycle"
+        body = mock_post.call_args.kwargs["json"]
+        assert body == {
+            "connection_id": "conn_1",
+            "session_id": "sess_1",
+            "event": "connector_delivery_failed",
+            "wake": True,
+            "reason": "30007",
+            "data": {"detail": "carrier blocked", "peer": "+15550123"},
+        }
+
+    async def test_wake_defaults_false_and_optional_fields_omitted(
+        self, probe: _ProbeConnector
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.json = MagicMock(return_value={"appended_session_id": "sess_1"})
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        await probe.emit_session_lifecycle(
+            connection_id="conn_1",
+            session_id="sess_1",
+            event="connector_delivery_failed",
+        )
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["wake"] is False
+        assert "reason" not in body
+        assert "data" not in body
+
+    async def test_non_fatal_4xx_drops_returns_none(self, probe: _ProbeConnector) -> None:
+        """A non-fatal 4xx is logged and dropped (returns ``None``), matching
+        ``emit_inbound``/``emit_lifecycle``'s drop-don't-raise stance."""
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = 422
+        mock_response.text = '{"error":"bad"}'
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        with structlog.testing.capture_logs() as records:
+            result = await probe.emit_session_lifecycle(
+                connection_id="conn_1",
+                session_id="sess_1",
+                event="connector_delivery_failed",
+            )
+
+        assert result is None
+        failed = [r for r in records if r.get("event") == "connector.session_lifecycle.failed"]
+        assert len(failed) == 1
+        assert failed[0]["status_code"] == 422
+        assert failed[0]["session_id"] == "sess_1"

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_session_lifecycle.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_session_lifecycle.py
@@ -1,0 +1,334 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.post_connector_runtime_session_lifecycle_response_post_connector_runtime_session_lifecycle import (
+    PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle,
+)
+from ...models.runtime_session_lifecycle_request import RuntimeSessionLifecycleRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: RuntimeSessionLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connectors/runtime/session-lifecycle",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+    | None
+):
+    if response.status_code == 201:
+        response_201 = PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle.from_dict(
+            response.json()
+        )
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeSessionLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+]:
+    """Post Runtime Session Lifecycle
+
+     Append a ``kind=lifecycle`` event onto **one** session bound to
+    ``body.connection_id`` (#1261), optionally waking it.
+
+    The per-session-targeted sibling of the broadcast ``/runtime/lifecycle``
+    route: where that fans a notice across every bound session, this targets
+    the single ``body.session_id`` — the SMS design's §3.5 req 1 (a delivery
+    failure must reach the *originating* session, not be broadcast).
+
+    Authorization mirrors ``post_runtime_tool_result`` exactly: the bearer's
+    connector must match ``body.connection_id``'s connector, any bearer-side
+    ``connection_ids`` allowlist must include it (#350), and the session must
+    be genuinely bound to that connection — so a runtime bearer can only
+    target a session within its own connections.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the exact pattern as the tool-result intake) so the failure wakes the
+    session rather than merely being visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeSessionLifecycleRequest): Body for ``POST /v1/connectors/runtime/session-
+            lifecycle`` (#1261).
+
+            The per-session-targeted sibling of :class:`RuntimeLifecycleRequest`.
+            Where the broadcast ``/runtime/lifecycle`` route fans a transport-down
+            notice across *every* session bound to the connection, this appends a
+            single ``kind=lifecycle`` event onto **one** named session — the gap
+            called out by the SMS design (§3.5 req 1): a delivery failure must reach
+            the *originating* session, not be broadcast.
+
+            ``wake`` optionally pairs the append with a ``defer_wake`` so the failure
+            isn't merely visible-on-next-turn but actually wakes the session (the
+            "give it stimulus" half of the design's option (a)). Defaults ``False``
+            so the primitive stays a plain visible-on-next-wake append unless the
+            caller opts into the wake.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeSessionLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+    | None
+):
+    """Post Runtime Session Lifecycle
+
+     Append a ``kind=lifecycle`` event onto **one** session bound to
+    ``body.connection_id`` (#1261), optionally waking it.
+
+    The per-session-targeted sibling of the broadcast ``/runtime/lifecycle``
+    route: where that fans a notice across every bound session, this targets
+    the single ``body.session_id`` — the SMS design's §3.5 req 1 (a delivery
+    failure must reach the *originating* session, not be broadcast).
+
+    Authorization mirrors ``post_runtime_tool_result`` exactly: the bearer's
+    connector must match ``body.connection_id``'s connector, any bearer-side
+    ``connection_ids`` allowlist must include it (#350), and the session must
+    be genuinely bound to that connection — so a runtime bearer can only
+    target a session within its own connections.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the exact pattern as the tool-result intake) so the failure wakes the
+    session rather than merely being visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeSessionLifecycleRequest): Body for ``POST /v1/connectors/runtime/session-
+            lifecycle`` (#1261).
+
+            The per-session-targeted sibling of :class:`RuntimeLifecycleRequest`.
+            Where the broadcast ``/runtime/lifecycle`` route fans a transport-down
+            notice across *every* session bound to the connection, this appends a
+            single ``kind=lifecycle`` event onto **one** named session — the gap
+            called out by the SMS design (§3.5 req 1): a delivery failure must reach
+            the *originating* session, not be broadcast.
+
+            ``wake`` optionally pairs the append with a ``defer_wake`` so the failure
+            isn't merely visible-on-next-turn but actually wakes the session (the
+            "give it stimulus" half of the design's option (a)). Defaults ``False``
+            so the primitive stays a plain visible-on-next-wake append unless the
+            caller opts into the wake.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeSessionLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+]:
+    """Post Runtime Session Lifecycle
+
+     Append a ``kind=lifecycle`` event onto **one** session bound to
+    ``body.connection_id`` (#1261), optionally waking it.
+
+    The per-session-targeted sibling of the broadcast ``/runtime/lifecycle``
+    route: where that fans a notice across every bound session, this targets
+    the single ``body.session_id`` — the SMS design's §3.5 req 1 (a delivery
+    failure must reach the *originating* session, not be broadcast).
+
+    Authorization mirrors ``post_runtime_tool_result`` exactly: the bearer's
+    connector must match ``body.connection_id``'s connector, any bearer-side
+    ``connection_ids`` allowlist must include it (#350), and the session must
+    be genuinely bound to that connection — so a runtime bearer can only
+    target a session within its own connections.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the exact pattern as the tool-result intake) so the failure wakes the
+    session rather than merely being visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeSessionLifecycleRequest): Body for ``POST /v1/connectors/runtime/session-
+            lifecycle`` (#1261).
+
+            The per-session-targeted sibling of :class:`RuntimeLifecycleRequest`.
+            Where the broadcast ``/runtime/lifecycle`` route fans a transport-down
+            notice across *every* session bound to the connection, this appends a
+            single ``kind=lifecycle`` event onto **one** named session — the gap
+            called out by the SMS design (§3.5 req 1): a delivery failure must reach
+            the *originating* session, not be broadcast.
+
+            ``wake`` optionally pairs the append with a ``defer_wake`` so the failure
+            isn't merely visible-on-next-turn but actually wakes the session (the
+            "give it stimulus" half of the design's option (a)). Defaults ``False``
+            so the primitive stays a plain visible-on-next-wake append unless the
+            caller opts into the wake.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeSessionLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+    | None
+):
+    """Post Runtime Session Lifecycle
+
+     Append a ``kind=lifecycle`` event onto **one** session bound to
+    ``body.connection_id`` (#1261), optionally waking it.
+
+    The per-session-targeted sibling of the broadcast ``/runtime/lifecycle``
+    route: where that fans a notice across every bound session, this targets
+    the single ``body.session_id`` — the SMS design's §3.5 req 1 (a delivery
+    failure must reach the *originating* session, not be broadcast).
+
+    Authorization mirrors ``post_runtime_tool_result`` exactly: the bearer's
+    connector must match ``body.connection_id``'s connector, any bearer-side
+    ``connection_ids`` allowlist must include it (#350), and the session must
+    be genuinely bound to that connection — so a runtime bearer can only
+    target a session within its own connections.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the exact pattern as the tool-result intake) so the failure wakes the
+    session rather than merely being visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeSessionLifecycleRequest): Body for ``POST /v1/connectors/runtime/session-
+            lifecycle`` (#1261).
+
+            The per-session-targeted sibling of :class:`RuntimeLifecycleRequest`.
+            Where the broadcast ``/runtime/lifecycle`` route fans a transport-down
+            notice across *every* session bound to the connection, this appends a
+            single ``kind=lifecycle`` event onto **one** named session — the gap
+            called out by the SMS design (§3.5 req 1): a delivery failure must reach
+            the *originating* session, not be broadcast.
+
+            ``wake`` optionally pairs the append with a ``defer_wake`` so the failure
+            isn't merely visible-on-next-turn but actually wakes the session (the
+            "give it stimulus" half of the design's option (a)). Defaults ``False``
+            so the primitive stays a plain visible-on-next-wake append unless the
+            caller opts into the wake.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -145,6 +145,9 @@ from .one_shot_source import OneShotSource
 from .post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle import (
     PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle,
 )
+from .post_connector_runtime_session_lifecycle_response_post_connector_runtime_session_lifecycle import (
+    PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle,
+)
 from .recent_chat import RecentChat
 from .run_completion_source import RunCompletionSource
 from .run_completion_source_replace import RunCompletionSourceReplace
@@ -155,6 +158,10 @@ from .run_completion_source_statuses_item import RunCompletionSourceStatusesItem
 from .runtime_lifecycle_request import RuntimeLifecycleRequest
 from .runtime_lifecycle_request_data_type_0 import RuntimeLifecycleRequestDataType0
 from .runtime_management_call_result_request import RuntimeManagementCallResultRequest
+from .runtime_session_lifecycle_request import RuntimeSessionLifecycleRequest
+from .runtime_session_lifecycle_request_data_type_0 import (
+    RuntimeSessionLifecycleRequestDataType0,
+)
 from .runtime_token import RuntimeToken
 from .runtime_token_issue import RuntimeTokenIssue
 from .runtime_token_issued import RuntimeTokenIssued
@@ -430,6 +437,7 @@ __all__ = (
     "OAuthStartResponse",
     "OneShotSource",
     "PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle",
+    "PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle",
     "RecentChat",
     "RunCompletionSource",
     "RunCompletionSourceReplace",
@@ -438,6 +446,8 @@ __all__ = (
     "RuntimeLifecycleRequest",
     "RuntimeLifecycleRequestDataType0",
     "RuntimeManagementCallResultRequest",
+    "RuntimeSessionLifecycleRequest",
+    "RuntimeSessionLifecycleRequestDataType0",
     "RuntimeToken",
     "RuntimeTokenIssue",
     "RuntimeTokenIssued",

--- a/packages/aios-sdk/aios_sdk/_generated/models/post_connector_runtime_session_lifecycle_response_post_connector_runtime_session_lifecycle.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/post_connector_runtime_session_lifecycle_response_post_connector_runtime_session_lifecycle.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T",
+    bound="PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle",
+)
+
+
+@_attrs_define
+class PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        post_connector_runtime_session_lifecycle_response_post_connector_runtime_session_lifecycle = cls()
+
+        post_connector_runtime_session_lifecycle_response_post_connector_runtime_session_lifecycle.additional_properties = d
+        return post_connector_runtime_session_lifecycle_response_post_connector_runtime_session_lifecycle
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_session_lifecycle_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_session_lifecycle_request.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.runtime_session_lifecycle_request_data_type_0 import (
+        RuntimeSessionLifecycleRequestDataType0,
+    )
+
+
+T = TypeVar("T", bound="RuntimeSessionLifecycleRequest")
+
+
+@_attrs_define
+class RuntimeSessionLifecycleRequest:
+    """Body for ``POST /v1/connectors/runtime/session-lifecycle`` (#1261).
+
+    The per-session-targeted sibling of :class:`RuntimeLifecycleRequest`.
+    Where the broadcast ``/runtime/lifecycle`` route fans a transport-down
+    notice across *every* session bound to the connection, this appends a
+    single ``kind=lifecycle`` event onto **one** named session — the gap
+    called out by the SMS design (§3.5 req 1): a delivery failure must reach
+    the *originating* session, not be broadcast.
+
+    ``wake`` optionally pairs the append with a ``defer_wake`` so the failure
+    isn't merely visible-on-next-turn but actually wakes the session (the
+    "give it stimulus" half of the design's option (a)). Defaults ``False``
+    so the primitive stays a plain visible-on-next-wake append unless the
+    caller opts into the wake.
+
+        Attributes:
+            connection_id (str):
+            session_id (str):
+            event (str):
+            reason (None | str | Unset):
+            data (None | RuntimeSessionLifecycleRequestDataType0 | Unset):
+            wake (bool | Unset):  Default: False.
+    """
+
+    connection_id: str
+    session_id: str
+    event: str
+    reason: None | str | Unset = UNSET
+    data: None | RuntimeSessionLifecycleRequestDataType0 | Unset = UNSET
+    wake: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.runtime_session_lifecycle_request_data_type_0 import (
+            RuntimeSessionLifecycleRequestDataType0,
+        )
+
+        connection_id = self.connection_id
+
+        session_id = self.session_id
+
+        event = self.event
+
+        reason: None | str | Unset
+        if isinstance(self.reason, Unset):
+            reason = UNSET
+        else:
+            reason = self.reason
+
+        data: dict[str, Any] | None | Unset
+        if isinstance(self.data, Unset):
+            data = UNSET
+        elif isinstance(self.data, RuntimeSessionLifecycleRequestDataType0):
+            data = self.data.to_dict()
+        else:
+            data = self.data
+
+        wake = self.wake
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "connection_id": connection_id,
+                "session_id": session_id,
+                "event": event,
+            }
+        )
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+        if data is not UNSET:
+            field_dict["data"] = data
+        if wake is not UNSET:
+            field_dict["wake"] = wake
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.runtime_session_lifecycle_request_data_type_0 import (
+            RuntimeSessionLifecycleRequestDataType0,
+        )
+
+        d = dict(src_dict)
+        connection_id = d.pop("connection_id")
+
+        session_id = d.pop("session_id")
+
+        event = d.pop("event")
+
+        def _parse_reason(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        reason = _parse_reason(d.pop("reason", UNSET))
+
+        def _parse_data(
+            data: object,
+        ) -> None | RuntimeSessionLifecycleRequestDataType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_0 = RuntimeSessionLifecycleRequestDataType0.from_dict(data)
+
+                return data_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | RuntimeSessionLifecycleRequestDataType0 | Unset, data)
+
+        data = _parse_data(d.pop("data", UNSET))
+
+        wake = d.pop("wake", UNSET)
+
+        runtime_session_lifecycle_request = cls(
+            connection_id=connection_id,
+            session_id=session_id,
+            event=event,
+            reason=reason,
+            data=data,
+            wake=wake,
+        )
+
+        return runtime_session_lifecycle_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_session_lifecycle_request_data_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_session_lifecycle_request_data_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="RuntimeSessionLifecycleRequestDataType0")
+
+
+@_attrs_define
+class RuntimeSessionLifecycleRequestDataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        runtime_session_lifecycle_request_data_type_0 = cls()
+
+        runtime_session_lifecycle_request_data_type_0.additional_properties = d
+        return runtime_session_lifecycle_request_data_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -247,6 +247,33 @@ class RuntimeLifecycleRequest(BaseModel):
     data: dict[str, Any] | None = None
 
 
+class RuntimeSessionLifecycleRequest(BaseModel):
+    """Body for ``POST /v1/connectors/runtime/session-lifecycle`` (#1261).
+
+    The per-session-targeted sibling of :class:`RuntimeLifecycleRequest`.
+    Where the broadcast ``/runtime/lifecycle`` route fans a transport-down
+    notice across *every* session bound to the connection, this appends a
+    single ``kind=lifecycle`` event onto **one** named session — the gap
+    called out by the SMS design (§3.5 req 1): a delivery failure must reach
+    the *originating* session, not be broadcast.
+
+    ``wake`` optionally pairs the append with a ``defer_wake`` so the failure
+    isn't merely visible-on-next-turn but actually wakes the session (the
+    "give it stimulus" half of the design's option (a)). Defaults ``False``
+    so the primitive stays a plain visible-on-next-wake append unless the
+    caller opts into the wake.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    connection_id: str
+    session_id: str
+    event: str
+    reason: str | None = None
+    data: dict[str, Any] | None = None
+    wake: bool = False
+
+
 def _check_runtime_scope(auth_connector: str, target_connector: str) -> None:
     """Raise 403 if a runtime bearer reaches outside its connector type."""
     if auth_connector != target_connector:
@@ -504,6 +531,86 @@ async def post_runtime_lifecycle(
     if failed:
         result["failed_session_ids"] = failed
     return result
+
+
+@router.post(
+    "/runtime/session-lifecycle",
+    operation_id="post_connector_runtime_session_lifecycle",
+    status_code=status.HTTP_201_CREATED,
+)
+async def post_runtime_session_lifecycle(
+    body: RuntimeSessionLifecycleRequest,
+    pool: PoolDep,
+    auth: RuntimeAuthDep,
+) -> dict[str, Any]:
+    """Append a ``kind=lifecycle`` event onto **one** session bound to
+    ``body.connection_id`` (#1261), optionally waking it.
+
+    The per-session-targeted sibling of the broadcast ``/runtime/lifecycle``
+    route: where that fans a notice across every bound session, this targets
+    the single ``body.session_id`` — the SMS design's §3.5 req 1 (a delivery
+    failure must reach the *originating* session, not be broadcast).
+
+    Authorization mirrors ``post_runtime_tool_result`` exactly: the bearer's
+    connector must match ``body.connection_id``'s connector, any bearer-side
+    ``connection_ids`` allowlist must include it (#350), and the session must
+    be genuinely bound to that connection — so a runtime bearer can only
+    target a session within its own connections.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the exact pattern as the tool-result intake) so the failure wakes the
+    session rather than merely being visible on its next turn.
+    """
+    _, auth_connector, account_id, auth_connection_ids = auth
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, body.connection_id, account_id=account_id)
+        _check_runtime_scope(auth_connector, connection.connector)
+        _check_runtime_connection_scope(auth_connection_ids, body.connection_id)
+        if not await queries.is_session_bound_to_connection(
+            conn,
+            connection_id=body.connection_id,
+            session_id=body.session_id,
+            account_id=account_id,
+        ):
+            raise ForbiddenError(
+                "session is not bound to this connection",
+                detail={
+                    "session_id": body.session_id,
+                    "connection_id": body.connection_id,
+                },
+            )
+    payload: dict[str, Any] = {
+        "event": body.event,
+        "connection_id": body.connection_id,
+        "connector": connection.connector,
+    }
+    if body.reason is not None:
+        payload["reason"] = body.reason
+    if body.data is not None:
+        payload["data"] = body.data
+    event = await sessions_service.append_event(
+        pool,
+        body.session_id,
+        "lifecycle",
+        payload,
+        account_id=account_id,
+    )
+    if body.wake:
+        await defer_wake(
+            pool,
+            body.session_id,
+            cause="connector_lifecycle",
+            account_id=account_id,
+        )
+    # Mirror the broadcast route's payload shape (a single-element list keeps
+    # callers that already handle ``appended_session_ids`` uniform), plus the
+    # appended event id and whether a wake was enqueued so the connector can
+    # log/correlate without a second read.
+    return {
+        "appended_session_ids": [body.session_id],
+        "event_id": event.id,
+        "woke": body.wake,
+    }
 
 
 @router.post(

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -51,6 +51,9 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
     "post_connector_runtime_management_call_result": (
         "Called by connector containers via runtime token; not for operators."
     ),
+    "post_connector_runtime_session_lifecycle": (
+        "Called by connector containers via runtime token; not for operators."
+    ),
     "post_connector_runtime_tool_result": (
         "Called by connector containers via runtime token; not for operators."
     ),

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -121,6 +121,36 @@ def _render_fs_lifecycle_notice(data: dict[str, Any]) -> str:
     return f"[The sandbox filesystem for this session was reset because {detail}. {_FS_FRESH_BASE}]"
 
 
+def _render_delivery_failure_notice(data: dict[str, Any]) -> str:
+    """Render a ``connector_delivery_failed`` lifecycle event (#1261) as a
+    bracketed user-role notice.
+
+    A connector appends this when an outbound the model consciously sent did
+    not arrive (carrier block / delivery failure). Like the FS renderer it is
+    total by contract — a pure function of ``data`` that never raises, since it
+    runs inside the per-wake replay where a raise would brick the session. The
+    connector-specific particulars ride in ``data`` (``connector`` names the
+    transport, ``detail`` carries the carrier reason, ``peer`` the recipient)
+    so core renders the fact without knowing about any specific transport.
+    """
+    connector = data.get("connector") or data.get("connection_id") or "a connector"
+    nested = data.get("data")
+    peer = data.get("peer")
+    detail = data.get("detail") or data.get("reason")
+    if isinstance(nested, dict):
+        # Producers (e.g. the SMS status-callback handler) carry carrier
+        # specifics under ``data`` per the broadcast-route payload shape.
+        peer = peer or nested.get("peer")
+        detail = detail or nested.get("detail")
+        connector = nested.get("connector") or connector
+    peer_clause = f" to {peer}" if peer else ""
+    detail_clause = f": {detail}" if detail else ""
+    return (
+        f"[A message you sent via {connector}{peer_clause} was not delivered"
+        f"{detail_clause}. The recipient did not receive it.]"
+    )
+
+
 # Notification markers truncate the source content to this many chars
 # (plus an ellipsis when truncated) so a busy non-focal channel
 # contributes O(tens-of-tokens) per inbound to the context — cheap
@@ -963,7 +993,15 @@ def build_messages(
         # so a GC/reset append never advances ``reacting_to`` or wakes the
         # session; the model reads the notice at its next genuine wake.
         if e.kind == "lifecycle" and e.data.get("event") in MODEL_VISIBLE_LIFECYCLE_EVENTS:
-            messages.append({"role": "user", "content": _render_fs_lifecycle_notice(e.data)})
+            # Dispatch on the lifecycle kind: FS-loss notices keep their
+            # renderer; ``connector_delivery_failed`` (#1261) routes to its own.
+            # Both are NON-stimulus-bearing here — the delivery-failure wake is
+            # produced by the session-targeted lifecycle route, not by render.
+            if e.data.get("event") == "connector_delivery_failed":
+                content = _render_delivery_failure_notice(e.data)
+            else:
+                content = _render_fs_lifecycle_notice(e.data)
+            messages.append({"role": "user", "content": content})
             continue
         if e.kind != "message":
             continue

--- a/src/aios/models/events.py
+++ b/src/aios/models/events.py
@@ -38,8 +38,20 @@ EventKind = Literal["message", "lifecycle", "span", "interrupt"]
 # so both the harness renderer (``harness/context.py``) and the db read
 # (``db/queries/events.py``: ``read_windowed_context_events``) can name the same
 # allowlist without the db layer importing the harness.
+# ``connector_delivery_failed`` (#1261): a connector-generic, NON-SMS-special
+# kind a connector appends (via the session-targeted lifecycle route) when an
+# outbound the model *consciously sent* did not arrive (carrier block / delivery
+# failure). Unlike the FS-loss notices it is paired at the producer with a wake
+# (the session-targeted lifecycle route's ``wake=True``), so the failure reaches
+# the originating session in a form the model acts on; the connector carries the
+# carrier-specific detail in ``data`` so core stays transport-agnostic.
 MODEL_VISIBLE_LIFECYCLE_EVENTS: frozenset[str] = frozenset(
-    {"sandbox_fs_reset", "sandbox_fs_expired", "sandbox_fs_over_limit"}
+    {
+        "sandbox_fs_reset",
+        "sandbox_fs_expired",
+        "sandbox_fs_over_limit",
+        "connector_delivery_failed",
+    }
 )
 
 

--- a/tests/integration/test_runtime_session_lifecycle.py
+++ b/tests/integration/test_runtime_session_lifecycle.py
@@ -1,0 +1,247 @@
+"""Integration tests for ``POST /v1/connectors/runtime/session-lifecycle`` (#1261).
+
+The per-session-targeted, optionally-waking lifecycle route. Unlike the
+broadcast ``/runtime/lifecycle`` route (which fans an event across every
+session bound to a connection), this appends a single ``kind=lifecycle``
+event onto **one** named session — the per-session gap the SMS design (§3.5
+req 1) calls out: a delivery failure must reach the *originating* session, not
+be broadcast.
+
+Driven by calling the router handler ``post_runtime_session_lifecycle``
+directly with a real pool and the resolved ``RuntimeAuthDep`` tuple (the
+runtime-auth dependency resolves to a plain ``(token_id, connector,
+account_id, connection_ids)`` tuple, so the handler is callable without an
+HTTP layer). ``defer_wake`` is patched at the router's import site so the
+wake assertion observes the call without a live procrastinate worker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.api.routers.connectors import (
+    RuntimeSessionLifecycleRequest,
+    post_runtime_session_lifecycle,
+)
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ForbiddenError
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+_CONNECTOR = "sms"
+
+
+@pytest.fixture
+async def pool_with_bound_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str]]:
+    """Yield ``(pool, account_id, connection_id, session_id)`` for an account
+    whose session is bound (single_session) to an ``sms`` connection, plus an
+    UNbound sibling session on the same account (for the 403 case)."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_sl', NULL, TRUE, 'tenant-sl')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_sl",
+            name="sl-agent",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_sl", name="sl-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_sl",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            connection = await queries.insert_connection(
+                conn,
+                account_id="acc_sl",
+                connector=_CONNECTOR,
+                external_account_id="+15550001",
+                metadata={},
+            )
+            await queries.insert_binding(
+                conn,
+                account_id="acc_sl",
+                connection_id=connection.id,
+                mode="single_session",
+                session_id=session.id,
+            )
+        yield pool, "acc_sl", connection.id, session.id
+    finally:
+        await pool.close()
+
+
+@pytest.fixture
+def patched_defer_wake() -> Any:
+    """Patch the router's ``defer_wake`` import site so the wake enqueue is a
+    no-op the test can assert against (no live procrastinate worker needed)."""
+    with mock.patch("aios.api.routers.connectors.defer_wake", new_callable=AsyncMock) as m:
+        yield m
+
+
+def _auth(account_id: str, connector: str = _CONNECTOR) -> tuple[str, str, str, None]:
+    """Shape of a resolved unscoped ``RuntimeAuthDep`` tuple:
+    ``(token_id, connector, account_id, connection_ids)``."""
+    return ("rt_test", connector, account_id, None)
+
+
+async def _lifecycle_rows(pool: asyncpg.Pool[Any], session_id: str) -> list[dict[str, Any]]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events WHERE session_id = $1 AND kind = 'lifecycle' ORDER BY seq",
+            session_id,
+        )
+    import json
+
+    return [json.loads(r["data"]) if isinstance(r["data"], str) else r["data"] for r in rows]
+
+
+class TestRuntimeSessionLifecycle:
+    async def test_targets_exactly_the_one_session(
+        self,
+        pool_with_bound_session: tuple[asyncpg.Pool[Any], str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """The event lands on the named session only (not broadcast), with the
+        broadcast-route payload shape."""
+        pool, account_id, connection_id, session_id = pool_with_bound_session
+
+        result = await post_runtime_session_lifecycle(
+            RuntimeSessionLifecycleRequest(
+                connection_id=connection_id,
+                session_id=session_id,
+                event="connector_delivery_failed",
+                reason="30007",
+                data={"detail": "carrier blocked", "peer": "+15550123"},
+                wake=False,
+            ),
+            pool,
+            _auth(account_id),
+        )
+
+        assert result["appended_session_ids"] == [session_id]
+        assert result["woke"] is False
+        rows = await _lifecycle_rows(pool, session_id)
+        assert len(rows) == 1
+        payload = rows[0]
+        assert payload["event"] == "connector_delivery_failed"
+        assert payload["connection_id"] == connection_id
+        assert payload["connector"] == _CONNECTOR
+        assert payload["reason"] == "30007"
+        assert payload["data"] == {"detail": "carrier blocked", "peer": "+15550123"}
+
+    async def test_wake_true_enqueues_wake_false_does_not(
+        self,
+        pool_with_bound_session: tuple[asyncpg.Pool[Any], str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        pool, account_id, connection_id, session_id = pool_with_bound_session
+
+        await post_runtime_session_lifecycle(
+            RuntimeSessionLifecycleRequest(
+                connection_id=connection_id,
+                session_id=session_id,
+                event="connector_delivery_failed",
+                wake=False,
+            ),
+            pool,
+            _auth(account_id),
+        )
+        assert patched_defer_wake.await_count == 0
+
+        await post_runtime_session_lifecycle(
+            RuntimeSessionLifecycleRequest(
+                connection_id=connection_id,
+                session_id=session_id,
+                event="connector_delivery_failed",
+                wake=True,
+            ),
+            pool,
+            _auth(account_id),
+        )
+        assert patched_defer_wake.await_count == 1
+        assert patched_defer_wake.await_args is not None
+        args = patched_defer_wake.await_args.args
+        kwargs = patched_defer_wake.await_args.kwargs
+        assert args[1] == session_id
+        assert kwargs["account_id"] == account_id
+        assert kwargs["cause"] == "connector_lifecycle"
+
+    async def test_forbidden_when_session_not_bound(
+        self,
+        pool_with_bound_session: tuple[asyncpg.Pool[Any], str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """An unbound (but same-account) session is rejected — a runtime bearer
+        can only target a session genuinely bound to one of its connections."""
+        pool, account_id, connection_id, _session_id = pool_with_bound_session
+        # A fresh session on the same account, NOT bound to the connection.
+        from tests.integration.conftest import seed_agent_env_session
+
+        _agent, _env, unbound = await seed_agent_env_session(
+            pool, account_id=account_id, prefix="sl-unbound"
+        )
+
+        with pytest.raises(ForbiddenError):
+            await post_runtime_session_lifecycle(
+                RuntimeSessionLifecycleRequest(
+                    connection_id=connection_id,
+                    session_id=unbound.id,
+                    event="connector_delivery_failed",
+                    wake=True,
+                ),
+                pool,
+                _auth(account_id),
+            )
+        assert patched_defer_wake.await_count == 0
+        assert await _lifecycle_rows(pool, unbound.id) == []
+
+    async def test_forbidden_when_bearer_connector_mismatch(
+        self,
+        pool_with_bound_session: tuple[asyncpg.Pool[Any], str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """A bearer scoped to a different connector type cannot reach this
+        connection (``_check_runtime_scope``)."""
+        pool, account_id, connection_id, session_id = pool_with_bound_session
+
+        with pytest.raises(ForbiddenError):
+            await post_runtime_session_lifecycle(
+                RuntimeSessionLifecycleRequest(
+                    connection_id=connection_id,
+                    session_id=session_id,
+                    event="connector_delivery_failed",
+                ),
+                pool,
+                _auth(account_id, connector="whatsapp"),
+            )
+        assert patched_defer_wake.await_count == 0

--- a/tests/unit/test_context_connector_delivery_failure.py
+++ b/tests/unit/test_context_connector_delivery_failure.py
@@ -1,0 +1,117 @@
+"""Coverage for the model-visible connector-delivery-failure notice (#1261).
+
+A connector appends a ``connector_delivery_failed`` lifecycle event when an
+outbound the model *consciously sent* did not arrive (carrier block / delivery
+failure). It is the model-visible-lifecycle channel — like the FS-loss notices
+(``test_context_fs_lifecycle.py``) it must:
+  * be a member of the ``MODEL_VISIBLE_LIFECYCLE_EVENTS`` allowlist (so it both
+    renders and survives windowing), and
+  * render as a bracketed user-role notice at its seq position via a renderer
+    distinct from the FS-loss renderer (carrier specifics ride in ``data``),
+  * NOT advance ``reacting_to`` in the pure replay — the wake is produced by the
+    session-targeted lifecycle *route* (``wake=True``), not by ``build_messages``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from aios.harness.context import build_messages
+from aios.models.events import MODEL_VISIBLE_LIFECYCLE_EVENTS, Event
+
+_AT = datetime(2026, 6, 10, tzinfo=UTC)
+
+
+def _msg(seq: int, role: str, content: str) -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="message",
+        data={"role": role, "content": content},
+        created_at=_AT,
+        orig_channel=None,
+        focal_channel_at_arrival=None,
+    )
+
+
+def _lifecycle(seq: int, data: dict[str, Any]) -> Event:
+    return Event(
+        id=f"evt_{seq}",
+        session_id="sess_01TEST",
+        seq=seq,
+        kind="lifecycle",
+        data=data,
+        created_at=_AT,
+        orig_channel=None,
+        focal_channel_at_arrival=None,
+    )
+
+
+def test_connector_delivery_failed_is_allowlisted() -> None:
+    """The new kind is in the model-visible allowlist, so the windowing read
+    carries it through and the renderer dispatches on it."""
+    assert "connector_delivery_failed" in MODEL_VISIBLE_LIFECYCLE_EVENTS
+
+
+def test_delivery_failure_renders_as_user_notice() -> None:
+    events = [
+        _msg(1, "user", "ping the customer"),
+        _lifecycle(
+            2,
+            {
+                "event": "connector_delivery_failed",
+                "connector": "sms",
+                "data": {"detail": "blocked by carrier", "peer": "+15550123"},
+            },
+        ),
+    ]
+    result = build_messages(events, system_prompt=None)
+    notices = [
+        m
+        for m in result.messages
+        if m["role"] == "user" and isinstance(m["content"], str) and "not delivered" in m["content"]
+    ]
+    assert len(notices) == 1
+    content = notices[0]["content"]
+    assert content.startswith("[") and content.endswith("]")
+    assert "sms" in content
+    assert "blocked by carrier" in content
+    assert "+15550123" in content
+    assert "did not receive" in content
+
+
+def test_delivery_failure_uses_its_own_renderer_not_the_fs_one() -> None:
+    """A delivery-failure notice must NOT borrow the FS-loss copy."""
+    content = build_messages(
+        [
+            _msg(1, "user", "x"),
+            _lifecycle(2, {"event": "connector_delivery_failed", "connector": "sms"}),
+        ],
+        system_prompt=None,
+    ).messages[-1]["content"]
+    assert "filesystem" not in content
+    assert "not delivered" in content
+
+
+def test_delivery_failure_does_not_advance_reacting_to() -> None:
+    """The notice is NOT stimulus-bearing in the pure replay: the wake comes
+    from the session-targeted route's ``wake=True``, not the renderer. The
+    watermark stays at the last real stimulus (the user message)."""
+    events = [
+        _msg(1, "user", "send it"),
+        _lifecycle(5, {"event": "connector_delivery_failed", "connector": "sms"}),
+    ]
+    result = build_messages(events, system_prompt=None)
+    assert result.reacting_to == 1
+
+
+def test_delivery_failure_renderer_is_total_on_sparse_data() -> None:
+    """Renderer never raises even with no connector/detail — it runs inside the
+    per-wake replay where a raise would brick the session."""
+    content = build_messages(
+        [_msg(1, "user", "x"), _lifecycle(2, {"event": "connector_delivery_failed"})],
+        system_prompt=None,
+    ).messages[-1]["content"]
+    assert "not delivered" in content


### PR DESCRIPTION
Resolves #1261. Surfaces connector delivery failures (carrier block / undelivered outbound the model *consciously sent*) to the originating session as a stimulus-bearing, model-visible event.

## Decision (resolves the design fork)
Adopt **option (a): a model-visible lifecycle kind + a wake**, NOT option (b) the `tool_result`-shaped follow-up. Re-using the original `sms_send` tool_call_id is blocked by the `(session_id, tool_call_id)` idempotency guard (the send already resolved successfully; the failure arrives async via a status callback), and inventing a synthetic id is a special-case. Lifecycle is the existing, composable channel for "an async transport fact the model must see." Per the design (§3.5, §6 item 1) the failure must *wake*, not merely be visible — so the delivery-failure path is paired with a wake.

## Changes
- **`src/aios/models/events.py`** — add `"connector_delivery_failed"` to `MODEL_VISIBLE_LIFECYCLE_EVENTS` (a connector-generic, non-SMS-special kind). Membership makes a lifecycle row both render and survive windowing with no other change.
- **`src/aios/harness/context.py`** — dispatch the allowlisted lifecycle render on `e.data["event"]`: FS-loss events keep `_render_fs_lifecycle_notice`; `connector_delivery_failed` routes to a new total `_render_delivery_failure_notice(data)` that reads connector/detail/peer from `data` so core stays transport-agnostic. The notice is NON-stimulus-bearing in the pure replay (does not advance `reacting_to`) — the wake is produced by the route, not `build_messages`.
- **`src/aios/api/routers/connectors.py`** — new `POST /v1/connectors/runtime/session-lifecycle` (`post_runtime_session_lifecycle`, body `RuntimeSessionLifecycleRequest`): a **session-targeted, optionally-waking** lifecycle append closing the per-session gap (SMS design §3.5 req 1; the broadcast `/runtime/lifecycle` route stays for connection-wide notices). Auth mirrors `post_runtime_tool_result` exactly (`_check_runtime_scope` + `_check_runtime_connection_scope` + `is_session_bound_to_connection`). `wake=True` enqueues `defer_wake(..., cause="connector_lifecycle")` after the append.
- **`packages/aios-connector-http/.../runner.py`** — `emit_session_lifecycle(...)` SDK helper mirroring `emit_lifecycle` but POSTing the new route and passing `wake`; same drop-don't-raise posture (non-fatal 4xx → `None`).
- **`openapi.json` + `packages/aios-sdk/aios_sdk/_generated/`** — regenerated for the new route.

The SMS connector's status-callback handler (owned by the #1252 epic) is the consumer: on a terminal `failed`/`undelivered` carrier-block class it looks up the originating `session_id` and calls `emit_session_lifecycle(..., event="connector_delivery_failed", reason=twilio_code, data={...}, wake=True)`. Not built here.

## Tests
- `tests/unit/test_context_connector_delivery_failure.py`: allowlist membership; renders as a user-visible notice via its own (non-FS) renderer; does not advance `reacting_to`; renderer is total on sparse data.
- `packages/aios-connector-http/tests/test_runner.py::TestEmitSessionLifecycle`: posts the new route with `wake`/`data` passthrough; `wake` defaults false + optional fields omitted; non-fatal 4xx drops to `None`.
- `tests/integration/test_runtime_session_lifecycle.py`: targets exactly the one session (not broadcast) with the broadcast-route payload shape; `wake=True` enqueues a wake (`cause="connector_lifecycle"`) / `wake=False` does not; 403 when the session is unbound; 403 on connector mismatch.

Unit + runner tests, OpenAPI/SDK snapshot tests, ruff, and mypy all pass locally. Integration tests require Postgres/Docker (run in CI).

Refs: `docs/design/sms-connector.md` §3.5, §6. Part of #1252.