### PR TITLE
feat(connector-subsystem): outbound tool-call idempotency — persist result before result POST (#1234)

### DIFF
--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -37,9 +37,15 @@ connector type once, then races three jobs concurrently:
    in a :class:`asyncio.TaskGroup` for clean shutdown.
 
 The runner tracks answered ``tool_call_id``s in memory so SSE
-reconnects (which replay the backfill) don't double-execute.  For
-durability across container restart, override :meth:`load_answered` /
-:meth:`save_answered` (a small SQLite spool ships at ``spool.py``).
+reconnects (which replay the backfill) don't double-execute.  Each
+answered id maps to its serialized tool-result payload (or ``None``):
+the persist point sits *between* the side-effecting tool body and the
+tool-result POST, so a POST that fails after a successful platform send
+won't re-run the body on replay — the persisted result is simply
+re-POSTed (the AIOS append is idempotent on ``(session_id,
+tool_call_id)``).  For durability across container restart, override
+:meth:`load_answered` / :meth:`save_answered` (a small SQLite spool
+ships at ``spool.py``).
 """
 
 from __future__ import annotations
@@ -225,7 +231,11 @@ class HttpConnector:
         self._client: Client | None = None
         self._tools: dict[str, _ToolMeta] = self._collect_tools()
         self._management: dict[str, _ManagementHandlerMeta] = self._collect_management_handlers()
-        self._answered: set[str] = set()
+        # tool_call_id → serialized tool-result payload (or None when no
+        # result is persisted, e.g. management calls).  Persisted between
+        # the side-effecting tool body and the result POST so a failed POST
+        # replays the persisted result instead of re-running the body.
+        self._answered: dict[str, str | None] = {}
         self._connections: dict[str, _ConnectionState] = {}
         # Subclasses narrow the value type via a class-body annotation::
         #
@@ -361,12 +371,51 @@ class HttpConnector:
         if self._loops_backfilled >= 3:
             self._all_loops_live.set()
 
-    async def load_answered(self) -> set[str]:
-        """Override: persisted tool_call_ids from a previous lifetime."""
-        return set()
+    async def load_answered(self) -> dict[str, str | None]:
+        """Override: persisted tool_call_ids from a previous lifetime.
 
-    async def save_answered(self, tool_call_id: str) -> None:
-        """Override: persist a freshly-answered tool_call_id."""
+        Returns a map of ``tool_call_id`` → serialized tool-result payload
+        (or ``None`` when no result was persisted).  Default ``{}``.
+        """
+        return {}
+
+    async def save_answered(self, tool_call_id: str, result: str | None = None) -> None:
+        """Override: persist a freshly-answered tool_call_id.
+
+        ``result`` is the serialized platform-send result to persist
+        alongside the id (``None`` when there is nothing to replay, e.g.
+        management calls).  Default no-op.
+        """
+
+    async def _mark_answered(self, tool_call_id: str, result: str | None) -> None:
+        """Record ``tool_call_id`` as answered and persist its result.
+
+        Co-located with the side-effecting tool body so the persist lands
+        *before* the result POST: a POST that fails after a successful
+        platform send won't re-run the body on replay.
+        """
+        self._answered[tool_call_id] = result
+        await self.save_answered(tool_call_id, result)
+
+    async def _replay_tool_result(self, client: Client, call: dict[str, Any]) -> None:
+        """Re-POST the persisted result for an already-answered call.
+
+        Heals the send-succeeded/result-POST-failed window: the tool body
+        already ran (and its side effect happened), so we only re-deliver
+        the persisted result.  When no result was persisted (value is
+        ``None``) there is nothing to replay and we skip.
+        """
+        tool_call_id = call.get("tool_call_id", "")
+        result = self._answered.get(tool_call_id)
+        if result is None:
+            return
+        await self._post_tool_result(
+            client,
+            connection_id=call.get("connection_id", ""),
+            session_id=call.get("session_id", ""),
+            tool_call_id=tool_call_id,
+            content=result,
+        )
 
     # ─── connector → aios glue ───────────────────────────────────────
 
@@ -758,17 +807,28 @@ class HttpConnector:
                         continue
                     call = json.loads(msg.data)
                     tool_call_id = call.get("tool_call_id", "")
-                    if not tool_call_id or tool_call_id in self._answered:
+                    if not tool_call_id:
                         continue
+                    if tool_call_id in self._answered:
+                        # Already executed in a prior lifetime/connection.
+                        # The side effect already happened, so re-POST the
+                        # persisted result (healing a result-POST that failed
+                        # after a successful platform send) instead of
+                        # re-running the body.  No-op when nothing persisted.
+                        await self._replay_tool_result(client, call)
+                        continue
+                    # ``dispatch_call`` marks the call answered (via
+                    # ``_mark_answered``) *between* the side-effecting tool
+                    # body and the result POST, so a POST failure can't
+                    # re-run the body on replay.
                     await self.dispatch_call(call)
-                    self._answered.add(tool_call_id)
-                    await self.save_answered(tool_call_id)
             # Same retry posture as ``_discovery_loop`` — only catch transport
             # errors; let ``_post_tool_result`` RuntimeErrors and other
             # application bugs propagate. A persistent 4xx/5xx on tool-result
-            # POST would otherwise loop forever (the answered set is only
-            # updated after a successful dispatch, so backfill replays the
-            # same call_id on every reconnect).
+            # POST would otherwise loop forever; but because the call is
+            # marked answered *before* the POST, a reconnect replays via
+            # ``_replay_tool_result`` (re-POST only) rather than re-running
+            # the side-effecting body.
             except httpx.HTTPError as exc:
                 log.warning(
                     "connector.tool_loop.stream_error",
@@ -829,12 +889,14 @@ class HttpConnector:
                 session_id=session_id,
                 reason="unknown_tool",
             )
+            error_content = json.dumps({"error": f"unknown tool {name!r}"})
+            await self._mark_answered(tool_call_id, error_content)
             await self._post_tool_result(
                 client,
                 connection_id=connection_id,
                 session_id=session_id,
                 tool_call_id=tool_call_id,
-                content=json.dumps({"error": f"unknown tool {name!r}"}),
+                content=error_content,
                 is_error=True,
             )
             return
@@ -857,12 +919,14 @@ class HttpConnector:
                 reason="sandbox_path",
                 error=str(exc),
             )
+            error_content = json.dumps({"error": str(exc)})
+            await self._mark_answered(tool_call_id, error_content)
             await self._post_tool_result(
                 client,
                 connection_id=connection_id,
                 session_id=session_id,
                 tool_call_id=tool_call_id,
-                content=json.dumps({"error": str(exc)}),
+                content=error_content,
                 is_error=True,
             )
             return
@@ -902,17 +966,24 @@ class HttpConnector:
                 reason=reason,
                 error=str(exc),
             )
+            error_content = json.dumps(error_payload)
+            await self._mark_answered(tool_call_id, error_content)
             await self._post_tool_result(
                 client,
                 connection_id=connection_id,
                 session_id=session_id,
                 tool_call_id=tool_call_id,
-                content=json.dumps(error_payload),
+                content=error_content,
                 is_error=True,
             )
             return
         if not isinstance(result, str | list):
             result = json.dumps(result)
+        # Persist the (side-effecting) tool result BEFORE the result POST.
+        # A list result is serialized to JSON for persistence; it is still
+        # POSTed in its native list shape below.
+        serialized_result = result if isinstance(result, str) else json.dumps(result)
+        await self._mark_answered(tool_call_id, serialized_result)
         await self._post_tool_result(
             client,
             connection_id=connection_id,
@@ -971,8 +1042,9 @@ class HttpConnector:
                             "connector.management_call.dispatch_failed",
                             call_id=call_id,
                         )
-                    self._answered.add(call_id)
-                    await self.save_answered(call_id)
+                    # Management calls persist no replayable result; ``None``
+                    # keeps the existing skip-on-replay semantics.
+                    await self._mark_answered(call_id, None)
             except httpx.HTTPError as exc:
                 log.warning(
                     "connector.management_loop.stream_error",

--- a/packages/aios-connector-http/aios_connector_http/spool.py
+++ b/packages/aios-connector-http/aios_connector_http/spool.py
@@ -6,19 +6,25 @@ backfills every pending call again — including ones we already
 executed — and we'd double-execute (e.g. send a Telegram message
 twice).
 
-The spool persists the answered ids on disk.  Subclass
-:class:`HttpConnector` and wire it in::
+The spool persists the answered ids on disk, each mapped to the
+serialized tool-result payload that was sent for it (or ``None`` when
+no result is persisted, e.g. management calls).  On replay the
+connector re-POSTs the persisted result instead of re-running the
+side-effecting tool body.  Subclass :class:`HttpConnector` and wire it
+in::
 
     class MyConnector(HttpConnector):
         def __init__(self) -> None:
             super().__init__()
             self._spool = SqliteAnsweredSpool("/var/lib/myconn/answered.sqlite")
 
-        async def load_answered(self) -> set[str]:
+        async def load_answered(self) -> dict[str, str | None]:
             return self._spool.load()
 
-        async def save_answered(self, tool_call_id: str) -> None:
-            self._spool.add(tool_call_id)
+        async def save_answered(
+            self, tool_call_id: str, result: str | None = None
+        ) -> None:
+            self._spool.add(tool_call_id, result)
 """
 
 from __future__ import annotations
@@ -28,7 +34,7 @@ from pathlib import Path
 
 
 class SqliteAnsweredSpool:
-    """Tiny on-disk set of ``tool_call_id`` strings."""
+    """Tiny on-disk map of ``tool_call_id`` → serialized result."""
 
     def __init__(self, path: str | Path) -> None:
         self._path = Path(path)
@@ -37,18 +43,30 @@ class SqliteAnsweredSpool:
         self._conn.execute(
             "CREATE TABLE IF NOT EXISTS answered ("
             "  tool_call_id TEXT PRIMARY KEY,"
-            "  added_at REAL NOT NULL DEFAULT (unixepoch('subsec'))"
+            "  result TEXT,"
+            # ``unixepoch('subsec')`` (sub-second resolution) only exists on
+            # SQLite >= 3.42; on the bookworm runtime (3.40) it yields NULL,
+            # which would violate NOT NULL and make ``INSERT OR IGNORE``
+            # silently drop every row.  COALESCE to integer-second
+            # ``unixepoch()`` keeps NOT NULL satisfied everywhere.
+            "  added_at REAL NOT NULL "
+            "DEFAULT (COALESCE(unixepoch('subsec'), unixepoch()))"
             ")"
         )
         self._conn.commit()
 
-    def load(self) -> set[str]:
-        rows = self._conn.execute("SELECT tool_call_id FROM answered").fetchall()
-        return {row[0] for row in rows}
+    def load(self) -> dict[str, str | None]:
+        rows = self._conn.execute(
+            "SELECT tool_call_id, result FROM answered"
+        ).fetchall()
+        return {row[0]: row[1] for row in rows}
 
-    def add(self, tool_call_id: str) -> None:
+    def add(self, tool_call_id: str, result: str | None = None) -> None:
+        # INSERT OR IGNORE keeps the first persisted result for an id: a
+        # replay re-POST never overwrites the original send result.
         self._conn.execute(
-            "INSERT OR IGNORE INTO answered (tool_call_id) VALUES (?)", (tool_call_id,)
+            "INSERT OR IGNORE INTO answered (tool_call_id, result) VALUES (?, ?)",
+            (tool_call_id, result),
         )
         self._conn.commit()
 

--- a/packages/aios-connector-http/aios_connector_http/spool.py
+++ b/packages/aios-connector-http/aios_connector_http/spool.py
@@ -56,9 +56,7 @@ class SqliteAnsweredSpool:
         self._conn.commit()
 
     def load(self) -> dict[str, str | None]:
-        rows = self._conn.execute(
-            "SELECT tool_call_id, result FROM answered"
-        ).fetchall()
+        rows = self._conn.execute("SELECT tool_call_id, result FROM answered").fetchall()
         return {row[0]: row[1] for row in rows}
 
     def add(self, tool_call_id: str, result: str | None = None) -> None:

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -228,7 +228,7 @@ class TestAnsweredDedup:
     async def test_skips_already_answered(self, probe: _ProbeConnector) -> None:
         """The tool_loop guards against double-execution on SSE replay
         by checking ``_answered`` before dispatching.  Verify directly."""
-        probe._answered.add("call_1")
+        probe._answered["call_1"] = None
         call = {
             "connection_id": "conn_1",
             "tool_call_id": "call_1",
@@ -241,6 +241,147 @@ class TestAnsweredDedup:
         else:
             await probe.dispatch_call(call)
         assert probe.calls == []
+
+
+class _IdempotencyConnector(_ProbeConnector):
+    """Probe whose ``_post_tool_result`` can be made to fail.
+
+    Models the issue's failure window: a side-effecting tool body runs,
+    the platform send succeeds, then the tool-result POST fails.  On
+    replay the body must NOT run a second time (no double-send); the
+    persisted result is re-POSTed instead.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # When > 0, the next ``_post_tool_result`` raises and decrements.
+        self.fail_posts: int = 0
+        self.post_attempts: int = 0
+
+    async def _post_tool_result(  # type: ignore[override]
+        self,
+        client: Any,
+        *,
+        connection_id: str,
+        session_id: str,
+        tool_call_id: str,
+        content: str | list[dict[str, Any]],
+        is_error: bool = False,
+    ) -> None:
+        self.post_attempts += 1
+        if self.fail_posts > 0:
+            self.fail_posts -= 1
+            raise RuntimeError("tool-result POST failed")
+        await super()._post_tool_result(
+            client,
+            connection_id=connection_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            content=content,
+            is_error=is_error,
+        )
+
+
+class TestOutboundIdempotency:
+    """#1234: persist the tool result *before* the result POST so a POST
+    failure after a successful platform send doesn't re-run the body."""
+
+    @staticmethod
+    def _call(
+        tool_call_id: str, name: str = "shout", arguments: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        if arguments is None:
+            arguments = {"text": "hi"} if name == "shout" else {}
+        return {
+            "connection_id": "conn_1",
+            "tool_call_id": tool_call_id,
+            "session_id": "sess_1",
+            "name": name,
+            "arguments": json.dumps(arguments),
+        }
+
+    async def test_dispatch_marks_answered_before_result_post(self) -> None:
+        c = _IdempotencyConnector()
+        call = self._call("call_1")
+
+        # First dispatch: the body runs (side effect), then the result
+        # POST fails.  The id must already be marked answered.
+        c.fail_posts = 1
+        with pytest.raises(RuntimeError):
+            await c.dispatch_call(call)
+        assert c.calls == [("shout", {"text": "hi"})]
+        assert "call_1" in c._answered
+        assert c._answered["call_1"] == "HI"
+
+        # Reconnect replay: the loop sees the id is answered and re-POSTs
+        # the persisted result instead of re-running the body.
+        assert "call_1" in c._answered  # loop would take the replay branch
+        await c._replay_tool_result(c._client, call)
+
+        # Body ran exactly once — no second platform send.
+        assert c.calls == [("shout", {"text": "hi"})]
+        # The successful replay POST carried the persisted result.
+        assert len(c.results) == 1
+        assert c.results[0].kwargs["content"] == "HI"
+        assert c.results[0].kwargs["tool_call_id"] == "call_1"
+
+    async def test_already_answered_replays_persisted_result(self) -> None:
+        c = _IdempotencyConnector()
+        c._answered = {"call_x": "<result>"}
+        call = self._call("call_x")
+
+        # Simulate the _tool_loop replay branch for an already-answered id.
+        assert "call_x" in c._answered
+        await c._replay_tool_result(c._client, call)
+
+        # Tool body NOT invoked; persisted result re-POSTed.
+        assert c.calls == []
+        assert len(c.results) == 1
+        assert c.results[0].kwargs["content"] == "<result>"
+        assert c.results[0].kwargs["tool_call_id"] == "call_x"
+
+    async def test_replay_skips_when_no_persisted_result(self) -> None:
+        """A ``None`` persisted value (e.g. management call) has nothing to
+        replay, so ``_replay_tool_result`` is a no-op."""
+        c = _IdempotencyConnector()
+        c._answered = {"call_n": None}
+        await c._replay_tool_result(c._client, self._call("call_n"))
+        assert c.calls == []
+        assert c.results == []
+
+    async def test_error_result_marks_answered(self) -> None:
+        c = _IdempotencyConnector()
+        await c.dispatch_call(self._call("call_e", name="boom"))
+        # The raising tool ran once and produced an error result.
+        assert c.calls == [("boom", {})]
+        assert "call_e" in c._answered
+        body = json.loads(c._answered["call_e"])  # type: ignore[arg-type]
+        assert body["error"] == "kaboom"
+
+        # Replay does not re-invoke the tool body; it re-POSTs the error.
+        await c._replay_tool_result(c._client, self._call("call_e", name="boom"))
+        assert c.calls == [("boom", {})]
+        assert c.results[-1].kwargs["content"] == c._answered["call_e"]
+
+    async def test_unknown_tool_marks_answered(self) -> None:
+        c = _IdempotencyConnector()
+        await c.dispatch_call(self._call("call_u", name="no_such_tool"))
+        assert "call_u" in c._answered
+        body = json.loads(c._answered["call_u"])  # type: ignore[arg-type]
+        assert "unknown tool" in body["error"]
+
+    async def test_save_answered_receives_serialized_result(self) -> None:
+        """The persistence hook is handed the id and its serialized
+        result, exercising the widened ``save_answered`` contract."""
+        c = _IdempotencyConnector()
+        saved: list[tuple[str, str | None]] = []
+
+        async def _save(tool_call_id: str, result: str | None = None) -> None:
+            saved.append((tool_call_id, result))
+
+        c.save_answered = _save  # type: ignore[assignment,method-assign]
+        await c.dispatch_call(self._call("call_s"))
+        assert saved == [("call_s", "HI")]
 
 
 class _FocalConnector(_ProbeConnector):

--- a/packages/aios-connector-http/tests/test_spool.py
+++ b/packages/aios-connector-http/tests/test_spool.py
@@ -1,0 +1,56 @@
+"""Unit tests for :class:`SqliteAnsweredSpool` (#1234).
+
+The spool persists ``tool_call_id`` → serialized-result so a connector
+that restarts mid-window (platform send succeeded, result-POST failed)
+re-POSTs the persisted result on replay instead of re-running the
+side-effecting tool body.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aios_connector_http.spool import SqliteAnsweredSpool
+
+
+def test_add_and_load_round_trip(tmp_path: Path) -> None:
+    spool = SqliteAnsweredSpool(tmp_path / "answered.sqlite")
+    try:
+        spool.add("call_1", "RESULT_1")
+        spool.add("call_2", None)
+        assert spool.load() == {"call_1": "RESULT_1", "call_2": None}
+    finally:
+        spool.close()
+
+
+def test_add_defaults_result_to_none(tmp_path: Path) -> None:
+    spool = SqliteAnsweredSpool(tmp_path / "answered.sqlite")
+    try:
+        spool.add("call_1")
+        assert spool.load() == {"call_1": None}
+    finally:
+        spool.close()
+
+
+def test_insert_or_ignore_keeps_first_result(tmp_path: Path) -> None:
+    """A replay re-persist must not clobber the original send result."""
+    spool = SqliteAnsweredSpool(tmp_path / "answered.sqlite")
+    try:
+        spool.add("call_1", "FIRST")
+        spool.add("call_1", "SECOND")
+        assert spool.load() == {"call_1": "FIRST"}
+    finally:
+        spool.close()
+
+
+def test_persists_across_reopen(tmp_path: Path) -> None:
+    path = tmp_path / "answered.sqlite"
+    spool = SqliteAnsweredSpool(path)
+    spool.add("call_1", "RESULT_1")
+    spool.close()
+
+    reopened = SqliteAnsweredSpool(path)
+    try:
+        assert reopened.load() == {"call_1": "RESULT_1"}
+    finally:
+        reopened.close()


### PR DESCRIPTION
## What & why

Closes the **send-succeeded / result-POST-failed** double-send window described in #1234: today `_tool_loop` adds a `tool_call_id` to `self._answered` and calls `save_answered(...)` **only after** `dispatch_call()` returns — and `dispatch_call()` does the side-effecting platform send *inside* the `@tool` body and *then* POSTs the result. If `_post_tool_result` raises, the call is never marked answered, so the next SSE backfill re-runs the body → a second `chat.postMessage`.

This affects every connector with a side-effecting outbound tool, not just Slack.

## Design decision (resolves the fork)

Adopts **option 2 — persist the platform result before the tool-result POST, generalized into the SDK** — *not* a platform-specific `client_msg_id` (option 1). Option 1 is non-universal (Telegram has no native idempotency key and the slack design already routes it to option 2), so it would be a special-case still needing option 2 as a backstop. Option 2 is universal and adds no new hot-path cost: we already persist the answered id once per call; this just moves that persistence to *between* the side-effecting send and the result POST and lets it carry the send result. No AIOS server change — `append_tool_result` is already idempotent on `(session_id, tool_call_id)`.

## Changes

**`runner.py`**
- `self._answered`: `set[str]` → `dict[str, str | None]` (`tool_call_id` → serialized result, or `None`).
- Widened hooks: `load_answered() -> dict[str, str | None]` (default `{}`); `save_answered(tool_call_id, result=None)` (default no-op).
- New `_mark_answered(id, result)` (sets the dict entry **and** calls `save_answered`) and `_replay_tool_result(client, call)` (re-POSTs the persisted result; no-op when `None`).
- `dispatch_call` now calls `_mark_answered(...)` in **every** branch (happy path, unknown tool, sandbox error, tool exception) **before** the result POST, so a POST failure can't re-run the body on replay.
- `_tool_loop`: on an already-answered id it calls `_replay_tool_result` (re-POST only) instead of skipping silently; the post-dispatch `add`/`save_answered` lines are removed (responsibility moved into `dispatch_call`).
- `_management_call_loop`: persists `None` via `_mark_answered(call_id, None)`, keeping its existing skip-on-replay semantics.

**`spool.py`** (`SqliteAnsweredSpool`, the reference persistence impl)
- Adds a nullable `result TEXT` column (table created fresh; no migration — no users).
- `load()` returns `dict[str, str | None]`; `add(id, result=None)` uses `INSERT OR IGNORE` (first result wins, so a replay re-persist never clobbers the original).
- Fixed the `added_at` default: `unixepoch('subsec')` yields NULL on SQLite < 3.42 (the bookworm runtime ships 3.40), which violated `NOT NULL` and made `INSERT OR IGNORE` silently drop every row — now `COALESCE(unixepoch('subsec'), unixepoch())`.
- Updated module docstring wiring example to the dict shape.

## Tests (test-first)
- `tests/test_runner.py::TestOutboundIdempotency`: body runs **exactly once** when the first result-POST fails and the replay re-POSTs the persisted result; already-answered replay re-POSTs without invoking the body; `None` persisted value is a replay no-op; error/unknown-tool paths mark answered; `save_answered` receives the serialized result.
- New `tests/test_spool.py`: `add`/`load` round-trip, default-`None`, `INSERT OR IGNORE` keeps the first result, cross-reopen persistence.

All 109 connector-http tests pass; ruff + mypy clean.

Part of #1228.