### PR TITLE
feat(slack): inbound normalization + connector-side gates (self/bot/message_changed, mention-gate)

### DIFF
--- a/connectors/slack/src/aios_slack/connector.py
+++ b/connectors/slack/src/aios_slack/connector.py
@@ -1,12 +1,15 @@
 """Slack connector built on the aios-connector-http SDK.
 
-MVP slice 1/4 — the connection layer (design §3.1-§3.3).  This slice
-stands up the package, the Socket-Mode transport, and the
-:meth:`SlackConnector.serve_connection` lifecycle.  It does **not** yet
-parse, gate, or emit inbound events: the socket listener acks the
-envelope and pushes the *raw* Slack event onto a per-connection queue,
-and the drain task only logs.  Parsing / mention-gating / ``emit_inbound``
-land in slice B; the outbound ``@tool`` vocabulary in a later slice.
+MVP slices 1+2/4 — the connection layer (design §3.1-§3.3) plus the
+inbound decision layer (§3.4, §3.6).  Slice 1 stood up the package, the
+Socket-Mode transport, and the :meth:`SlackConnector.serve_connection`
+lifecycle.  Slice 2 adds inbound normalization and the four
+connector-side gates: the drain task now parses each raw Slack event,
+runs the self/bot-loop, cross-app/team, subtype, and mention gates (all
+pure functions in :mod:`aios_slack.parse`), and on a ``FORWARD`` outcome
+emits a normalized inbound via :meth:`emit_inbound`.  ``message_changed``
+is routed to a non-emitting system path; mention-gated drops are
+fail-quiet.  The outbound ``@tool`` vocabulary lands in a later slice.
 
 Multi-connection runtime container: one container can serve N
 connections of type ``"slack"``, each bound to one Slack workspace
@@ -31,7 +34,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
@@ -41,6 +44,8 @@ from slack_sdk.socket_mode.aiohttp import SocketModeClient as AsyncSocketModeCli
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web.async_client import AsyncWebClient
+
+from .parse import GateOutcome, InboundMessage, gate
 
 log = structlog.get_logger(__name__)
 
@@ -66,9 +71,20 @@ class _SlackConnectionState:
     socket_client: AsyncSocketModeClient
     bot_user_id: str
     team_id: str
-    # Slice A only enqueues the raw Slack event dict; parsing into a typed
-    # ``InboundMessage`` is slice B.
+    # The transport enqueues the raw Slack envelope dict
+    # ``{type, envelope_id, payload}``; the drain task parses + gates it.
     inbound_queue: asyncio.Queue[dict[str, Any]]
+    # ``api_app_id`` is not returned by ``auth.test``; it rides on every
+    # Socket-Mode event payload.  Cached lazily from the first event so the
+    # cross-app gate (§3.6 gate 2) has an expectation to enforce; until then
+    # it is ``None`` and the gate fails open on the app dimension (the
+    # ``team_id`` dimension still enforces).
+    api_app_id: str | None = None
+    # The per-thread sent-``ts`` set powering the ``bot_thread_participant``
+    # implicit-mention bypass (§3.6 gate 4).  Slice C populates this from the
+    # ``ts`` of every ``slack_send`` the bot makes into a thread; here it
+    # starts empty and is consulted read-only by the gate.
+    bot_thread_ts: set[str] = field(default_factory=set)
 
 
 class SlackConnector(HttpConnector):
@@ -220,29 +236,22 @@ class SlackConnector(HttpConnector):
         await asyncio.Event().wait()
 
     async def _drain_queue(self, connection_id: str, state: _SlackConnectionState) -> None:
-        """Drain the per-connection inbound queue.
+        """Drain the per-connection inbound queue: parse, gate, emit.
 
-        Slice A only logs the raw event off the ack path; parsing, gating,
-        and ``emit_inbound`` land in slice B.  Running this in its own task
-        (not the listener) keeps the ack path unblocked.
+        Runs off the ack path (its own task, not the listener) so gating +
+        ``emit_inbound`` never eat into the 3s Socket-Mode ack window.
 
-        Each iteration's handling is wrapped in a guard so that a transient
-        failure (today only a logging error; in slice B a parse/emit error)
-        is logged and the next event is processed, rather than escaping into
-        the :class:`asyncio.TaskGroup` and tearing down the whole connection
-        — and with it the socket task — over one bad envelope.
+        Each iteration's handling is wrapped in a guard so a transient
+        failure (a malformed envelope, a parse/emit error) is logged and
+        the next event is processed, rather than escaping into the
+        :class:`asyncio.TaskGroup` and tearing down the whole connection —
+        and with it the socket task — over one bad envelope.
         ``CancelledError`` is re-raised so shutdown still unwinds promptly.
         """
         while True:
-            event = await state.inbound_queue.get()
+            envelope = await state.inbound_queue.get()
             try:
-                log.info(
-                    "slack.inbound.raw",
-                    connection_id=connection_id,
-                    team_id=state.team_id,
-                    event_type=event.get("type"),
-                    envelope_id=event.get("envelope_id"),
-                )
+                await self._handle_envelope(connection_id, state, envelope)
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -250,8 +259,95 @@ class SlackConnector(HttpConnector):
                     "slack.inbound.drain_error",
                     connection_id=connection_id,
                     team_id=state.team_id,
-                    envelope_id=event.get("envelope_id"),
+                    envelope_id=envelope.get("envelope_id"),
                 )
+
+    async def _handle_envelope(
+        self,
+        connection_id: str,
+        state: _SlackConnectionState,
+        envelope: dict[str, Any],
+    ) -> None:
+        """Parse one Socket-Mode envelope, run the gates, and maybe emit.
+
+        Only ``events_api`` envelopes carrying a ``message`` event are
+        actionable for slice 2; everything else (``hello``, slash
+        commands, interactivity, non-message events) is logged and
+        ignored.  The four gates (``aios_slack.parse.gate``) decide the
+        disposition:
+
+        * ``FORWARD``  → build the normalized inbound and ``emit_inbound``.
+        * ``DROP``     → fail-quiet (mention-gated drops would be recorded
+          to per-channel pending-history in slice C; for now they are
+          observably logged and dropped).
+        * ``DIVERT_EDIT`` → ``message_changed`` system path; non-emitting.
+        """
+        payload = envelope.get("payload")
+        if envelope.get("type") != "events_api" or not isinstance(payload, dict):
+            log.debug(
+                "slack.inbound.skip_non_event",
+                connection_id=connection_id,
+                envelope_type=envelope.get("type"),
+            )
+            return
+
+        event = payload.get("event")
+        if not isinstance(event, dict) or event.get("type") != "message":
+            return
+
+        # Cache ``api_app_id`` off the first event so the cross-app gate has
+        # an expectation to enforce on subsequent events.
+        api_app_id = payload.get("api_app_id")
+        if isinstance(api_app_id, str) and state.api_app_id is None:
+            state.api_app_id = api_app_id
+
+        decision = gate(
+            event,
+            bot_user_id=state.bot_user_id,
+            team_id=state.team_id,
+            api_app_id=state.api_app_id,
+            bot_thread_ts=frozenset(state.bot_thread_ts),
+        )
+
+        if decision.outcome is GateOutcome.FORWARD and decision.message is not None:
+            await self._emit_message(connection_id, state, decision.message)
+            return
+
+        log.info(
+            "slack.inbound.gated",
+            connection_id=connection_id,
+            team_id=state.team_id,
+            outcome=decision.outcome.value,
+            reason=decision.reason,
+            record_pending=decision.record_pending,
+        )
+
+    async def _emit_message(
+        self,
+        connection_id: str,
+        state: _SlackConnectionState,
+        msg: InboundMessage,
+    ) -> None:
+        """Forward a gate-passing normalized inbound to aios.
+
+        ``chat_id`` is the bare Slack conversation id (threads share the
+        channel session, §3.4).  Slack-specific extras ride
+        ``connector_metadata`` under **non-reserved** keys only; ``sender``
+        carries the opaque id + the (already-sanitized) display name.
+        """
+        sender_payload: dict[str, Any] = {
+            "id": msg.sender_id,
+            "display_name": msg.sender_name,
+        }
+        metadata = build_metadata(msg, state)
+        await self.emit_inbound(
+            connection_id=connection_id,
+            event_id=msg.event_id,
+            chat_id=msg.chat_id,
+            sender=sender_payload,
+            content=msg.text,
+            metadata=metadata,
+        )
 
     @staticmethod
     async def _close_socket(socket_client: AsyncSocketModeClient) -> None:
@@ -260,3 +356,37 @@ class SlackConnector(HttpConnector):
             await socket_client.disconnect()
         with contextlib.suppress(Exception):
             await socket_client.close()
+
+
+def build_metadata(msg: InboundMessage, state: _SlackConnectionState) -> dict[str, Any]:
+    """Stamp Slack-specific extras onto a normalized inbound (§3.4, §3.6).
+
+    Everything Slack-specific rides ``connector_metadata`` under
+    **non-reserved** keys only.  The load-bearing entry is ``thread_ts``:
+    it is the model's ``slack_send(thread_ts=…)`` source read off the
+    inbound metadata header (the Telegram ``reply_to_message_id`` shape) —
+    threads share the channel session, so ``chat_id`` stays bare and
+    ``thread_ts`` is the lone thread authority.
+
+    ``self_mentioned`` is the derived convenience the harness renders;
+    ``chat_kind`` / ``team_id`` / ``app_id`` / ``message_ts`` are the
+    self-describing platform extras.
+    """
+    metadata: dict[str, Any] = {
+        "channel": msg.chat_id,
+        "chat_kind": msg.chat_kind,
+        "team_id": state.team_id,
+        "message_ts": msg.message_ts,
+        "self_mentioned": state.bot_user_id in msg.mentions,
+    }
+    if msg.thread_ts is not None:
+        metadata["thread_ts"] = msg.thread_ts
+    if state.api_app_id is not None:
+        metadata["app_id"] = state.api_app_id
+    if msg.mentions:
+        metadata["mentions"] = list(msg.mentions)
+    if msg.edited:
+        metadata["edited"] = True
+        if msg.edit_ts is not None:
+            metadata["edit_ts"] = msg.edit_ts
+    return metadata

--- a/connectors/slack/src/aios_slack/parse.py
+++ b/connectors/slack/src/aios_slack/parse.py
@@ -1,0 +1,453 @@
+"""Slack event → normalized :class:`InboundMessage` + the four connector gates.
+
+MVP slice 2/4 — the decision layer (design §3.4, §3.6).  This module is
+the pure, no-network core that turns a raw Slack Socket-Mode event
+payload into a normalized inbound and decides whether it should be
+forwarded to the model.  The transport (slice A) acks the envelope and
+hands the raw ``event`` dict here; the connector (slice C) wires the
+outcome into ``emit_inbound`` / outbound tool calls.
+
+Everything here is a **pure function over the event dict + cached
+connection identity** (``bot_user_id`` / ``team_id`` / ``api_app_id`` /
+the per-thread sent-``ts`` set).  No I/O, no Slack Web API calls — the
+missing-``thread_ts`` backfill (§3.4) is a separate drain-task concern,
+not a parse concern.
+
+Two load-bearing shapes:
+
+* :class:`InboundMessage` — a frozen, slots dataclass; the normalized
+  inbound the connector emits.  ``chat_id`` is the **bare** Slack
+  conversation id (``C…``/``G…``/``D…``) for both top-level and thread
+  messages (threads share the channel session, §3.4); ``thread_ts``
+  rides separately so the model can thread its replies via
+  ``slack_send(thread_ts=…)``.
+* :func:`gate` — runs the four connector-side gates in order and
+  returns a :class:`GateDecision` describing the outcome (forward, drop,
+  or divert to a non-emitting system path).  ``InboundMessage`` is only
+  built for events that pass.
+
+Gate order (design §3.6), all *before* ``emit_inbound``:
+
+1. **self / bot-loop filter** — drop the bot's own messages and
+   bot-authored traffic.  For ``subtype == message_changed`` the author
+   identity is **nested** under ``event.message`` — a top-level read
+   fails open for every edit — so the gate reads ``event.message.user`` /
+   ``.bot_id`` / ``.edited.user``.  ``message_changed`` is routed to a
+   **non-emitting** system path (``DIVERT_EDIT``) rather than into
+   ``emit_inbound``.
+2. **cross-app / cross-team filter** — drop on ``api_app_id`` /
+   ``team_id`` mismatch against the connection's own identity.
+3. **subtype filter** — drop non-plain-message subtypes (besides the
+   ``message_changed`` diversion handled in gate 1).
+4. **mention-gate** — encoded as a ``chat_kind`` discriminant, not
+   booleans: ``im`` always responds; ``mpim`` / ``channel`` / ``group``
+   require an explicit ``<@bot_user_id>`` mention, **with the
+   ``bot_thread_participant`` implicit-mention bypass** (a thread reply
+   bypasses the requirement when the thread already has bot activity).
+   Gated-out messages are recorded to pending-history and dropped
+   (fail-quiet).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Literal
+
+ChatKind = Literal["im", "mpim", "channel", "group"]
+
+# Slack conversation-id → chat_kind discriminant.  The conversation id's
+# leading glyph is the durable kind signal, but Slack also sends
+# ``channel_type`` on most message events; we prefer the explicit
+# ``channel_type`` and fall back to the id prefix.
+_CHANNEL_TYPE_TO_KIND: dict[str, ChatKind] = {
+    "im": "im",
+    "mpim": "mpim",
+    "channel": "channel",
+    "group": "group",
+}
+
+# Length cap for the sanitized sender display name (§3.6 — strip
+# newlines, length-cap so injected multi-line content can't ride into the
+# rendered ``from=`` clause).  Generous enough for any real Slack display
+# name; the cap is a hygiene ceiling, not a product constraint.
+_DISPLAY_NAME_MAX = 256
+
+# ``<@U0123ABCD>`` or ``<@U0123ABCD|alice>`` — Slack encodes a user
+# mention as an angle-bracketed link token; the optional ``|label`` is the
+# cached display label.  We only ever match against the bot's own id.
+_MENTION_RE = re.compile(r"<@(?P<uid>[A-Z0-9]+)(?:\|[^>]*)?>")
+
+
+@dataclass(slots=True, frozen=True)
+class InboundMessage:
+    """A normalized Slack inbound, ready for ``emit_inbound``.
+
+    ``chat_id`` is the **bare** Slack conversation id (``C…``/``G…``/
+    ``D…``) for both top-level and thread messages — threads share the
+    channel session (§3.4), so a thread reply keys on the same
+    ``chat_id`` as a top-level message in that channel.  ``thread_ts``
+    rides alongside (and onto ``connector_metadata`` under a non-reserved
+    key) as the model's ``slack_send(thread_ts=…)`` source.
+    """
+
+    chat_kind: ChatKind
+    channel_id: str
+    sender_id: str
+    sender_name: str
+    message_ts: str
+    thread_ts: str | None
+    text: str
+    edited: bool
+    edit_ts: str | None
+    mentions: tuple[str, ...]
+
+    @property
+    def chat_id(self) -> str:
+        """The bare Slack conversation id — the session/address key.
+
+        Identical for top-level and thread messages: threads share the
+        channel session (§3.4).  ``thread_ts`` is the lone thread
+        authority and rides ``connector_metadata`` separately.
+        """
+        return self.channel_id
+
+    @property
+    def event_id(self) -> str:
+        """Deterministic, redelivery- and restart-stable inbound id (§3.4).
+
+        * messages: ``slack-{channel}-{ts}``
+        * edits:    ``slack-{channel}-{ts}-e{edit_ts}``
+
+        The edit suffix keeps an edit from dedup-colliding with the
+        original on the ``connector_inbound_acks`` PK.
+        """
+        base = f"slack-{self.channel_id}-{self.message_ts}"
+        if self.edit_ts is not None:
+            return f"{base}-e{self.edit_ts}"
+        return base
+
+
+class GateOutcome(StrEnum):
+    """The terminal disposition the gates assign to a raw Slack event."""
+
+    #: Passes every gate — build an ``InboundMessage`` and ``emit_inbound``.
+    FORWARD = "forward"
+    #: Dropped by a gate (self/bot, cross-app/team, subtype, or
+    #: mention-gate).  ``reason`` carries which.  Fail-quiet; the
+    #: connector may record mention-gated drops to pending-history.
+    DROP = "drop"
+    #: ``message_changed`` routed to the non-emitting system path.
+    #: The author-identity self-filter already ran on the nested
+    #: ``event.message`` before this is returned, so a bot-authored edit
+    #: is a ``DROP``, not a ``DIVERT_EDIT``.
+    DIVERT_EDIT = "divert_edit"
+
+
+@dataclass(slots=True, frozen=True)
+class GateDecision:
+    """The result of running the four gates over one raw Slack event.
+
+    ``message`` is populated only when ``outcome is FORWARD``.
+    ``reason`` is a short machine-readable tag for observability on the
+    non-forward paths (e.g. ``"self"``, ``"bot"``, ``"cross_team"``,
+    ``"subtype"``, ``"mention_required"``).
+    """
+
+    outcome: GateOutcome
+    reason: str | None = None
+    message: InboundMessage | None = None
+    # When a mention-gated message is dropped it is still recorded to
+    # per-channel pending-history for later context (§3.6); the connector
+    # reads this flag to decide whether to stash it.
+    record_pending: bool = False
+    mentions: tuple[str, ...] = field(default_factory=tuple)
+
+
+# ── normalization helpers ─────────────────────────────────────────────
+
+
+def sanitize_display_name(raw: str | None, fallback: str) -> str:
+    """Strip newlines and length-cap a sender display name (§3.6).
+
+    A Slack display name is attacker-controlled free text that lands in
+    the model-rendered ``from=`` clause.  Collapsing CR/LF/other control
+    whitespace to single spaces and capping the length keeps it from
+    smuggling multi-line injected content into that clause.  This is
+    cheap hygiene, not a trust boundary — authz keys on the opaque
+    ``U…`` id, never the display name.
+    """
+    if not raw:
+        return fallback
+    # Replace any run of control/separator whitespace (newlines, tabs,
+    # vertical tabs, form feeds, NEL, line/paragraph separators) with a
+    # single space, then collapse and trim.
+    flattened = re.sub(r"[\r\n\t\v\f\x1c-\x1f\x85\u2028\u2029]+", " ", raw)
+    flattened = re.sub(r"\s+", " ", flattened).strip()
+    if not flattened:
+        return fallback
+    if len(flattened) > _DISPLAY_NAME_MAX:
+        flattened = flattened[:_DISPLAY_NAME_MAX].rstrip()
+    return flattened
+
+
+def chat_kind_of(event: dict[str, Any]) -> ChatKind:
+    """Derive the typed ``chat_kind`` discriminant for an event.
+
+    Prefers the explicit ``channel_type`` Slack stamps on message events,
+    falling back to the conversation-id leading glyph (``D…`` → ``im``,
+    ``G…`` → ``group``/``mpim``, ``C…`` → ``channel``).  An ``mpim``
+    can't be distinguished from a private ``group`` by id prefix alone
+    (both ``G…``/``C…`` depending on workspace era), so ``channel_type``
+    is authoritative when present; both ``mpim`` and ``group`` map to the
+    channel mention rule anyway (§3.6), so a mis-bucket here is policy-neutral.
+    """
+    ctype = event.get("channel_type")
+    if isinstance(ctype, str) and ctype in _CHANNEL_TYPE_TO_KIND:
+        return _CHANNEL_TYPE_TO_KIND[ctype]
+    channel = _channel_id_of(event)
+    if channel.startswith("D"):
+        return "im"
+    if channel.startswith("G"):
+        return "group"
+    return "channel"
+
+
+def _channel_id_of(event: dict[str, Any]) -> str:
+    channel = event.get("channel")
+    return channel if isinstance(channel, str) else ""
+
+
+def extract_mentions(text: str) -> tuple[str, ...]:
+    """Return the ordered tuple of user ids ``<@U…>``-mentioned in ``text``."""
+    return tuple(m.group("uid") for m in _MENTION_RE.finditer(text))
+
+
+def _message_body(event: dict[str, Any]) -> dict[str, Any]:
+    """The author-bearing body of an event.
+
+    For ``message_changed`` the new text + author live nested under
+    ``event.message``; for a plain message they are top-level.  Reading
+    the wrong level for an edit fails open on the self-filter (§3.6), so
+    this is the single chokepoint every author/text read goes through.
+    """
+    if event.get("subtype") == "message_changed":
+        nested = event.get("message")
+        if isinstance(nested, dict):
+            return nested
+    return event
+
+
+# ── gate 1: self / bot-loop filter ────────────────────────────────────
+
+
+def _is_self_or_bot(event: dict[str, Any], *, bot_user_id: str) -> str | None:
+    """Return a drop reason if the (possibly nested) author is self/bot.
+
+    Reads through :func:`_message_body` so a ``message_changed`` edit is
+    judged on its nested ``event.message.user`` / ``.bot_id`` /
+    ``.edited.user`` — never the (absent) top-level fields.  Returns
+    ``"self"``, ``"bot"``, or ``None``.
+    """
+    body = _message_body(event)
+    if body.get("user") == bot_user_id:
+        return "self"
+    # An edit whose *editor* is the bot (``message.edited.user``) is just
+    # as much a self-loop as a bot-authored original.
+    edited = body.get("edited")
+    if isinstance(edited, dict) and edited.get("user") == bot_user_id:
+        return "self"
+    if body.get("bot_id"):
+        return "bot"
+    return None
+
+
+# ── gate 4: mention-gate ──────────────────────────────────────────────
+
+
+def _bot_thread_participant(
+    event: dict[str, Any],
+    *,
+    bot_user_id: str,
+    bot_thread_ts: frozenset[str],
+) -> bool:
+    """Does this thread already have bot activity? (the implicit-mention bypass)
+
+    True when the inbound's ``thread_ts`` matches a thread the bot has
+    posted in (the connector's per-thread sent-``ts`` set) OR the direct
+    reply-to-bot case (``parent_user_id == bot_user_id``).  Ties to the
+    channel-session model: per-thread *participation*, not a per-thread
+    session (§3.6).
+    """
+    thread_ts = event.get("thread_ts")
+    if isinstance(thread_ts, str) and thread_ts in bot_thread_ts:
+        return True
+    return event.get("parent_user_id") == bot_user_id
+
+
+def _passes_mention_gate(
+    event: dict[str, Any],
+    *,
+    chat_kind: ChatKind,
+    mentions: tuple[str, ...],
+    bot_user_id: str,
+    bot_thread_ts: frozenset[str],
+) -> bool:
+    """The mention policy as a pure decision over the ``chat_kind`` kind.
+
+    * ``im`` → always respond.
+    * ``mpim`` / ``channel`` / ``group`` → require an explicit
+      ``<@bot_user_id>`` mention, **unless** the ``bot_thread_participant``
+      implicit-mention bypass fires.
+    """
+    if chat_kind == "im":
+        return True
+    if bot_user_id in mentions:
+        return True
+    return _bot_thread_participant(event, bot_user_id=bot_user_id, bot_thread_ts=bot_thread_ts)
+
+
+# ── the gate pipeline ─────────────────────────────────────────────────
+
+
+def gate(
+    event: dict[str, Any],
+    *,
+    bot_user_id: str,
+    team_id: str,
+    api_app_id: str | None = None,
+    allow_bots: bool = False,
+    bot_thread_ts: frozenset[str] = frozenset(),
+) -> GateDecision:
+    """Run the four connector-side gates over one raw Slack ``event``.
+
+    Returns a :class:`GateDecision`.  Only a ``FORWARD`` outcome carries a
+    built :class:`InboundMessage`.  Pure: no I/O, no Slack calls.
+
+    Order (§3.6): self/bot-loop → cross-app/team → subtype →
+    mention-gate.  ``message_changed`` is diverted to the non-emitting
+    system path (``DIVERT_EDIT``) **after** the nested-identity self
+    filter, so a bot-authored edit is a ``DROP`` rather than reaching the
+    system path.
+    """
+    subtype = event.get("subtype")
+
+    # ── gate 1: self / bot-loop (reads nested body for message_changed) ──
+    self_bot = _is_self_or_bot(event, bot_user_id=bot_user_id)
+    if self_bot == "self":
+        return GateDecision(GateOutcome.DROP, reason="self")
+    if self_bot == "bot" and not allow_bots:
+        return GateDecision(GateOutcome.DROP, reason="bot")
+
+    # ── gate 2: cross-app / cross-team ──────────────────────────────────
+    event_team = event.get("team") or event.get("user_team")
+    if isinstance(event_team, str) and event_team != team_id:
+        return GateDecision(GateOutcome.DROP, reason="cross_team")
+    event_app = event.get("api_app_id")
+    if api_app_id is not None and isinstance(event_app, str) and event_app != api_app_id:
+        return GateDecision(GateOutcome.DROP, reason="cross_app")
+
+    # ── message_changed diversion (after the nested self-filter) ────────
+    # A bot-authored edit was already dropped above.  Any surviving
+    # message_changed is a human edit routed to the non-emitting system
+    # path — never into ``emit_inbound``.
+    if subtype == "message_changed":
+        return GateDecision(GateOutcome.DIVERT_EDIT, reason="message_changed")
+
+    # ── gate 3: subtype filter ──────────────────────────────────────────
+    # Plain user messages have no subtype.  Everything else (channel_join,
+    # message_deleted, bot_message, file_share-as-subtype, …) is dropped.
+    if subtype is not None:
+        return GateDecision(GateOutcome.DROP, reason="subtype")
+
+    # ── normalize text + mentions for the mention-gate and the inbound ──
+    body = _message_body(event)
+    text = body.get("text")
+    text = text if isinstance(text, str) else ""
+    mentions = extract_mentions(text)
+    chat_kind = chat_kind_of(event)
+
+    # ── gate 4: mention-gate ────────────────────────────────────────────
+    if not _passes_mention_gate(
+        event,
+        chat_kind=chat_kind,
+        mentions=mentions,
+        bot_user_id=bot_user_id,
+        bot_thread_ts=bot_thread_ts,
+    ):
+        # Fail-quiet: record to per-channel pending-history, then drop.
+        return GateDecision(
+            GateOutcome.DROP,
+            reason="mention_required",
+            record_pending=True,
+            mentions=mentions,
+        )
+
+    message = build_inbound(event, chat_kind=chat_kind, mentions=mentions)
+    return GateDecision(GateOutcome.FORWARD, message=message, mentions=mentions)
+
+
+def build_inbound(
+    event: dict[str, Any],
+    *,
+    chat_kind: ChatKind | None = None,
+    mentions: tuple[str, ...] | None = None,
+) -> InboundMessage:
+    """Normalize a (gate-passing) plain message event into an InboundMessage.
+
+    ``message_ts`` is the message's own ``ts``; for an edit the original
+    text/ts come from the nested ``event.message`` and ``edit_ts`` is the
+    nested ``edited.ts`` (load-bearing for the distinct edit ``event_id``,
+    §3.4).  ``thread_ts`` is the bare thread anchor or ``None`` for a
+    top-level message.  ``sender_name`` is sanitized in this module
+    before it ever reaches ``emit_inbound``.
+    """
+    body = _message_body(event)
+    channel_id = _channel_id_of(event)
+    sender_id = body.get("user")
+    sender_id = sender_id if isinstance(sender_id, str) else ""
+    message_ts = body.get("ts")
+    message_ts = message_ts if isinstance(message_ts, str) else ""
+
+    edited_block = body.get("edited")
+    edited = isinstance(edited_block, dict)
+    edit_ts = edited_block.get("ts") if isinstance(edited_block, dict) else None
+    edit_ts = edit_ts if isinstance(edit_ts, str) else None
+
+    thread_ts = event.get("thread_ts") or body.get("thread_ts")
+    thread_ts = thread_ts if isinstance(thread_ts, str) else None
+    # A message whose thread_ts equals its own ts is a thread *root*, not
+    # a reply — surface None so it reads as top-level (the model only
+    # threads when replying into an existing thread).
+    if thread_ts is not None and thread_ts == message_ts:
+        thread_ts = None
+
+    text = body.get("text")
+    text = text if isinstance(text, str) else ""
+
+    if chat_kind is None:
+        chat_kind = chat_kind_of(event)
+    if mentions is None:
+        mentions = extract_mentions(text)
+
+    # display_name lives on the user-profile lookup the connector performs;
+    # parse only carries the opaque id when no name is present.  Whatever
+    # the caller provides via ``event['_display_name']`` (an enrichment the
+    # connector stamps) is sanitized here.
+    raw_name = event.get("_display_name")
+    raw_name = raw_name if isinstance(raw_name, str) else None
+    sender_name = sanitize_display_name(raw_name, fallback=sender_id)
+
+    return InboundMessage(
+        chat_kind=chat_kind,
+        channel_id=channel_id,
+        sender_id=sender_id,
+        sender_name=sender_name,
+        message_ts=message_ts,
+        thread_ts=thread_ts,
+        text=text,
+        edited=edited,
+        edit_ts=edit_ts,
+        mentions=mentions,
+    )

--- a/connectors/slack/tests/test_parse.py
+++ b/connectors/slack/tests/test_parse.py
@@ -1,0 +1,374 @@
+"""Table-driven tests for the slice-2 Slack decision layer (no network).
+
+Covers design §3.4 (``chat_id`` / ``event_id`` derivation, threads share
+the channel session) and §3.6 (the four connector-side gates):
+
+* self / bot-loop filter, including the **nested** ``message_changed``
+  author read (a bot-authored edit is dropped);
+* cross-app / cross-team filter;
+* subtype filter;
+* the mention-gate as a ``chat_kind`` discriminant, with the
+  ``bot_thread_participant`` implicit-mention bypass; and
+* the deterministic ``event_id`` (edit distinct from original).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios_slack.parse import (
+    GateOutcome,
+    InboundMessage,
+    build_inbound,
+    chat_kind_of,
+    extract_mentions,
+    gate,
+    sanitize_display_name,
+)
+
+BOT = "UBOT00000"
+TEAM = "T0AAAAAAA"
+APP = "A0APPAAAA"
+HUMAN = "UHUMAN111"
+OTHER_BOT = "B0BOTXXXX"
+
+
+def _msg(
+    *,
+    channel: str = "C0CHAN111",
+    user: str = HUMAN,
+    text: str = "hello",
+    ts: str = "1700000000.000100",
+    channel_type: str = "channel",
+    subtype: str | None = None,
+    thread_ts: str | None = None,
+    bot_id: str | None = None,
+    team: str | None = TEAM,
+    api_app_id: str | None = APP,
+    parent_user_id: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a synthetic Slack ``message`` event payload."""
+    event: dict[str, Any] = {
+        "type": "message",
+        "channel": channel,
+        "channel_type": channel_type,
+        "user": user,
+        "text": text,
+        "ts": ts,
+    }
+    if subtype is not None:
+        event["subtype"] = subtype
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    if bot_id is not None:
+        event["bot_id"] = bot_id
+    if team is not None:
+        event["team"] = team
+    if api_app_id is not None:
+        event["api_app_id"] = api_app_id
+    if parent_user_id is not None:
+        event["parent_user_id"] = parent_user_id
+    if extra:
+        event.update(extra)
+    return event
+
+
+def _message_changed(
+    *,
+    channel: str = "C0CHAN111",
+    user: str = HUMAN,
+    text: str = "edited text",
+    ts: str = "1700000000.000100",
+    edit_ts: str = "1700000999.000000",
+    bot_id: str | None = None,
+    channel_type: str = "channel",
+    team: str | None = TEAM,
+    api_app_id: str | None = APP,
+) -> dict[str, Any]:
+    """Build a synthetic ``message_changed`` event with a NESTED author."""
+    nested: dict[str, Any] = {
+        "type": "message",
+        "user": user,
+        "text": text,
+        "ts": ts,
+        "edited": {"user": user, "ts": edit_ts},
+    }
+    if bot_id is not None:
+        nested["bot_id"] = bot_id
+    event: dict[str, Any] = {
+        "type": "message",
+        "subtype": "message_changed",
+        "channel": channel,
+        "channel_type": channel_type,
+        "message": nested,
+        "previous_message": {"user": user, "text": "old text", "ts": ts},
+    }
+    if team is not None:
+        event["team"] = team
+    if api_app_id is not None:
+        event["api_app_id"] = api_app_id
+    return event
+
+
+def _mention(uid: str) -> str:
+    return f"<@{uid}>"
+
+
+# ── the gate outcome table ────────────────────────────────────────────
+
+# Each row: (id, event, kwargs-overrides, expected_outcome, expected_reason)
+GATE_CASES: list[tuple[str, dict[str, Any], dict[str, Any], GateOutcome, str | None]] = [
+    # ── self / bot-loop (gate 1) ──
+    (
+        "self_message_dropped",
+        _msg(user=BOT, channel_type="im", channel="D0DMDMDM1"),
+        {},
+        GateOutcome.DROP,
+        "self",
+    ),
+    (
+        "bot_authored_message_dropped",
+        _msg(user="USOMEBOT", bot_id=OTHER_BOT),
+        {},
+        GateOutcome.DROP,
+        "bot",
+    ),
+    (
+        "bot_authored_message_changed_dropped",
+        _message_changed(user="USOMEBOT", bot_id=OTHER_BOT),
+        {},
+        GateOutcome.DROP,
+        "bot",
+    ),
+    (
+        "self_authored_message_changed_dropped",
+        _message_changed(user=BOT),
+        {},
+        GateOutcome.DROP,
+        "self",
+    ),
+    # ── cross-app / cross-team (gate 2) ──
+    (
+        "cross_team_dropped",
+        _msg(team="T0WRONGGG", channel_type="im", channel="D0DMDMDM1"),
+        {},
+        GateOutcome.DROP,
+        "cross_team",
+    ),
+    (
+        "cross_app_dropped",
+        _msg(api_app_id="A0WRONGGG", channel_type="im", channel="D0DMDMDM1"),
+        {},
+        GateOutcome.DROP,
+        "cross_app",
+    ),
+    # ── message_changed diversion (human edit → non-emitting path) ──
+    (
+        "human_message_changed_diverted",
+        _message_changed(user=HUMAN),
+        {},
+        GateOutcome.DIVERT_EDIT,
+        "message_changed",
+    ),
+    # ── subtype filter (gate 3) ──
+    (
+        "channel_join_subtype_dropped",
+        _msg(subtype="channel_join", channel_type="im", channel="D0DMDMDM1"),
+        {},
+        GateOutcome.DROP,
+        "subtype",
+    ),
+    # ── mention-gate (gate 4) ──
+    (
+        "dm_always_passes",
+        _msg(channel_type="im", channel="D0DMDMDM1", text="no mention needed"),
+        {},
+        GateOutcome.FORWARD,
+        None,
+    ),
+    (
+        "channel_non_mention_dropped",
+        _msg(text="just chatting"),
+        {},
+        GateOutcome.DROP,
+        "mention_required",
+    ),
+    (
+        "channel_mention_passes",
+        _msg(text=f"hey {_mention(BOT)} look"),
+        {},
+        GateOutcome.FORWARD,
+        None,
+    ),
+    (
+        "mpim_non_mention_dropped",
+        _msg(channel_type="mpim", channel="G0MPIM111", text="group chatter"),
+        {},
+        GateOutcome.DROP,
+        "mention_required",
+    ),
+    (
+        "mpim_mention_passes",
+        _msg(channel_type="mpim", channel="G0MPIM111", text=f"{_mention(BOT)} hi"),
+        {},
+        GateOutcome.FORWARD,
+        None,
+    ),
+    (
+        "thread_continuation_bypass_passes",
+        _msg(text="follow-up with no mention", thread_ts="1700000000.000001"),
+        {"bot_thread_ts": frozenset({"1700000000.000001"})},
+        GateOutcome.FORWARD,
+        None,
+    ),
+    (
+        "reply_to_bot_bypass_passes",
+        _msg(
+            text="answering the bot",
+            thread_ts="1700000000.000001",
+            parent_user_id=BOT,
+        ),
+        {},
+        GateOutcome.FORWARD,
+        None,
+    ),
+    (
+        "thread_reply_unrelated_thread_still_gated",
+        _msg(text="unrelated thread, no mention", thread_ts="1700000000.000222"),
+        {"bot_thread_ts": frozenset({"1700000000.000001"})},
+        GateOutcome.DROP,
+        "mention_required",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("event", "overrides", "expected_outcome", "expected_reason"),
+    [pytest.param(ev, ov, out, rs, id=cid) for cid, ev, ov, out, rs in GATE_CASES],
+)
+def test_gate_outcomes(
+    event: dict[str, Any],
+    overrides: dict[str, Any],
+    expected_outcome: GateOutcome,
+    expected_reason: str | None,
+) -> None:
+    kwargs: dict[str, Any] = {
+        "bot_user_id": BOT,
+        "team_id": TEAM,
+        "api_app_id": APP,
+        **overrides,
+    }
+    decision = gate(event, **kwargs)
+    assert decision.outcome is expected_outcome
+    assert decision.reason == expected_reason
+    if expected_outcome is GateOutcome.FORWARD:
+        assert decision.message is not None
+    else:
+        assert decision.message is None
+
+
+def test_forward_builds_normalized_inbound() -> None:
+    event = _msg(text=f"hey {_mention(BOT)} please look", thread_ts="1700000000.000001")
+    decision = gate(event, bot_user_id=BOT, team_id=TEAM, api_app_id=APP)
+    assert decision.outcome is GateOutcome.FORWARD
+    msg = decision.message
+    assert msg is not None
+    assert msg.chat_kind == "channel"
+    assert msg.channel_id == "C0CHAN111"
+    assert msg.chat_id == "C0CHAN111"  # bare channel id, not channel:thread
+    assert msg.thread_ts == "1700000000.000001"
+    assert msg.sender_id == HUMAN
+    assert msg.mentions == (BOT,)
+    assert msg.edited is False
+    assert msg.edit_ts is None
+
+
+def test_mention_gate_drop_records_pending() -> None:
+    decision = gate(_msg(text="no mention"), bot_user_id=BOT, team_id=TEAM, api_app_id=APP)
+    assert decision.outcome is GateOutcome.DROP
+    assert decision.reason == "mention_required"
+    assert decision.record_pending is True
+
+
+# ── chat_id / event_id derivation (§3.4) ──────────────────────────────
+
+
+def test_event_id_message_is_channel_and_ts() -> None:
+    msg = build_inbound(_msg(ts="1700000000.000100"))
+    assert msg.event_id == "slack-C0CHAN111-1700000000.000100"
+
+
+def test_event_id_edit_distinct_from_original() -> None:
+    original = build_inbound(_msg(ts="1700000000.000100"))
+    edit_event = _message_changed(ts="1700000000.000100", edit_ts="1700000999.000000")
+    edited = build_inbound(edit_event)
+    assert edited.edited is True
+    assert edited.edit_ts == "1700000999.000000"
+    assert edited.event_id == "slack-C0CHAN111-1700000000.000100-e1700000999.000000"
+    # The load-bearing property: an edit does NOT dedup-collide with the
+    # original on the connector_inbound_acks PK.
+    assert edited.event_id != original.event_id
+
+
+def test_thread_and_toplevel_share_chat_id() -> None:
+    top = build_inbound(_msg(channel="C0BUSY999", ts="1700000000.000100"))
+    reply = build_inbound(
+        _msg(channel="C0BUSY999", ts="1700000000.000200", thread_ts="1700000000.000100")
+    )
+    # Threads share the channel session: bare channel id for both.
+    assert top.chat_id == reply.chat_id == "C0BUSY999"
+    assert top.thread_ts is None
+    assert reply.thread_ts == "1700000000.000100"
+
+
+def test_thread_root_surfaces_as_toplevel() -> None:
+    # thread_ts == own ts is a thread root, not a reply.
+    msg = build_inbound(_msg(ts="1700000000.000100", thread_ts="1700000000.000100"))
+    assert msg.thread_ts is None
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def test_chat_kind_from_channel_type() -> None:
+    assert chat_kind_of(_msg(channel_type="im", channel="D0X")) == "im"
+    assert chat_kind_of(_msg(channel_type="mpim", channel="G0X")) == "mpim"
+    assert chat_kind_of(_msg(channel_type="channel", channel="C0X")) == "channel"
+    assert chat_kind_of(_msg(channel_type="group", channel="G0X")) == "group"
+
+
+def test_chat_kind_falls_back_to_id_prefix() -> None:
+    no_type = {"type": "message", "channel": "D0DIRECT1", "user": HUMAN, "text": "hi", "ts": "1"}
+    assert chat_kind_of(no_type) == "im"
+
+
+def test_extract_mentions_handles_labels_and_order() -> None:
+    text = f"{_mention(HUMAN)} and {_mention(BOT)}|botlabel removed"
+    assert extract_mentions(f"{_mention(HUMAN)} and <@{BOT}|botlabel> too") == (HUMAN, BOT)
+    assert extract_mentions(text)[0] == HUMAN
+
+
+@pytest.mark.parametrize(
+    ("raw", "fallback", "expected"),
+    [
+        ("Alice", "UID", "Alice"),
+        ("multi\nline\ninjected", "UID", "multi line injected"),
+        ("  spaced  out \t name ", "UID", "spaced out name"),
+        ("", "UID", "UID"),
+        (None, "UID", "UID"),
+        ("\n\n\n", "UID", "UID"),
+        ("x" * 500, "UID", "x" * 256),
+    ],
+)
+def test_sanitize_display_name(raw: str | None, fallback: str, expected: str) -> None:
+    assert sanitize_display_name(raw, fallback) == expected
+
+
+def test_inbound_message_is_frozen() -> None:
+    msg = build_inbound(_msg())
+    assert isinstance(msg, InboundMessage)
+    with pytest.raises((AttributeError, Exception)):
+        msg.text = "mutated"  # type: ignore[misc]


### PR DESCRIPTION
**MVP slice 2/4 — the decision layer.** Turns a raw Slack event into a normalized inbound and decides whether to forward it. Closes #1230 (part of #1228; builds on #1229).

## What this adds

### `parse.py` — the pure, no-network decision core
- **`InboundMessage(slots=True, frozen=True)`** with `{chat_kind(im|mpim|channel|group), channel_id, sender_id, sender_name, message_ts, thread_ts|None, text, edited, edit_ts|None, mentions}`.
- **`chat_id` = the bare Slack conversation id** (`C…`/`G…`/`D…`) for BOTH top-level and thread messages — threads share the channel session (§3.4). Exposed as the `chat_id` property; `thread_ts` is carried separately and rides `connector_metadata` under a non-reserved key as the model's `slack_send(thread_ts=…)` source.
- **Deterministic `event_id`** (survives redelivery + restart): messages `slack-{channel}-{ts}`; edits `slack-{channel}-{ts}-e{edit_ts}` so an edit never dedup-collides with the original on the `connector_inbound_acks` PK.
- **Four pure gates** in `gate(...)`, run BEFORE `emit_inbound`, returning a `GateDecision{outcome, reason, message, record_pending}`:
  1. **self/bot-loop filter** — drops `event.user == bot_user_id` and `bot_id`-bearing traffic. For `subtype == message_changed` it reads the **nested** `event.message.user` / `.bot_id` / `.edited.user` (a top-level read fails open for every edit). `message_changed` is then routed to a **non-emitting** system path (`DIVERT_EDIT`) — only AFTER the nested self-filter, so a bot-authored edit is a `DROP`.
  2. **cross-app / cross-team filter** — drops on `api_app_id` / `team_id` mismatch.
  3. **subtype filter** — drops non-plain-message subtypes (besides the `message_changed` diversion).
  4. **mention-gate** — encoded as a `chat_kind` discriminant, not booleans: `im` → always respond; `mpim`/`channel`/`group` → require an explicit `<@bot_user_id>` mention, **with the `bot_thread_participant` implicit-mention bypass** (a thread reply bypasses the requirement when the thread already has bot activity, via the connector's per-thread sent-`ts` set or `parent_user_id == bot_user_id`). mpim defaults to the channel rule. Gated-out messages set `record_pending=True` and are dropped fail-quiet.
- **Sender attribution:** `sanitize_display_name` strips newlines/control whitespace and length-caps in `parse.py` before emit; opaque `U…` id carried as `sender.id`.

### `connector.py` — wiring (off the ack path)
The drain task now parses each `events_api` `message` envelope, runs `gate(...)`, and on `FORWARD` calls `emit_inbound` with the bare `chat_id`, the deterministic `event_id`, the sanitized sender, and Slack extras (`thread_ts`, `chat_kind`, `team_id`, `app_id`, `message_ts`, `self_mentioned`, `mentions`, edit info) on `connector_metadata` under non-reserved keys. `api_app_id` is cached lazily off the first event (it is not returned by `auth.test`); `bot_thread_ts` is a per-connection set the gate reads (populated by outbound sends in slice C).

## Tests
Parametrized table test (`tests/test_parse.py`, 33 cases incl. helpers) over synthetic events asserting every gate outcome: bot-authored `message_changed` dropped, self-authored `message_changed` dropped, human `message_changed` diverted, cross-team/cross-app dropped, subtype dropped, DM always passes, channel non-mention dropped, channel/mpim mention passes, thread-continuation bypass passes, reply-to-bot bypass passes, unrelated-thread still gated, and edit `event_id` distinct from original. No network. Full suite (41 tests) green; `ruff check`, `ruff format --check`, and `mypy --strict` all pass.