### PR TITLE
feat(slack): outbound tools (slack_send, slack_react) + mrkdwn formatting

### DIFF
--- a/connectors/slack/README.md
+++ b/connectors/slack/README.md
@@ -7,13 +7,37 @@ Slack connector for [aios](../../README.md).  Built on
 encrypted ``bot_token`` (``xoxb-…``) + ``app_token`` (``xapp-…``) the
 connector reads at ``serve_connection`` spawn.
 
-> **Status — MVP slice 1/4 (the connection layer).** This slice stands
-> up the package, the Socket-Mode transport, and the
-> ``serve_connection`` lifecycle.  The socket listener acks each
-> envelope and pushes the *raw* event onto a per-connection queue; it
-> does **not** yet parse, gate, or emit inbound events (slice B), and
-> ships no outbound ``slack_send`` / ``slack_react`` tools yet (a later
-> slice).  See `docs/design/slack-connector.md` §3.1–§3.3.
+> **Status — MVP slices 1–3/4.** Slice 1 stood up the package, the
+> Socket-Mode transport, and the ``serve_connection`` lifecycle. Slice 2
+> added inbound normalization + the four connector-side gates
+> (self/bot-loop, cross-app/team, subtype, mention-gate). Slice 3 adds
+> the outbound reply layer: the ``slack_send`` and ``slack_react``
+> ``@tool``\ s, plus the markdown→``mrkdwn`` pipeline and hard clamps in
+> `format.py`. A live DM-round-trip smoke lands in slice D. See
+> `docs/design/slack-connector.md` §3.1–§3.6.
+
+## Outbound tools (slice 3, §3.5)
+
+The model is heard on Slack only through two tools; ``connection_id`` and
+``chat_id`` are server-authoritative (injected by the SDK from the call's
+focal channel — the model cannot pick a workspace or conversation):
+
+- **``slack_send(text, thread_ts=None)`` → ``{ts, channel}``** —
+  ``chat.postMessage(channel=chat_id, text=…, mrkdwn=True)``. ``text`` is
+  written in Markdown and rendered to Slack ``mrkdwn`` then clamped to the
+  per-message ceiling before the call. ``thread_ts`` (read off the inbound
+  metadata header) threads the reply; default ``None`` posts top-level.
+  ``channel`` = ``self.focal_channel(team_id, chat_id)``.
+- **``slack_react(message_ts, emoji)`` → ``{status}``** —
+  ``reactions.add(channel=chat_id, timestamp=message_ts, name=emoji)``
+  (colon-stripped + normalized) when ``emoji`` is set. Mirrors
+  ``telegram_react``.
+
+> **Known v0 property — ``slack_send`` is at-least-once** (design §4). A
+> ``tool-result`` POST failure *after* a successful ``chat.postMessage``
+> re-dispatches the call on reconnect and posts a duplicate. The
+> ``SqliteAnsweredSpool`` does not close this window; a deterministic
+> idempotency-key fix is a separate SDK follow-up (benefits telegram too).
 
 ## Transport: Socket Mode
 

--- a/connectors/slack/src/aios_slack/__init__.py
+++ b/connectors/slack/src/aios_slack/__init__.py
@@ -1,8 +1,10 @@
 """Slack connector for aios (#1229).
 
-MVP slice 1/4 — the connection layer: package scaffold, Socket-Mode
-transport, and the ``serve_connection`` lifecycle.  Parsing, gating,
-and the outbound ``@tool`` vocabulary land in later slices.
+MVP slices 1-3/4 — the connection layer (package scaffold, Socket-Mode
+transport, ``serve_connection`` lifecycle), the inbound decision layer
+(normalization + the four connector gates), and the outbound reply layer
+(the ``slack_send`` / ``slack_react`` ``@tool``\\ s + the markdown→mrkdwn
+pipeline and hard clamps).  A live DM-round-trip smoke lands in slice D.
 """
 
 from __future__ import annotations

--- a/connectors/slack/src/aios_slack/connector.py
+++ b/connectors/slack/src/aios_slack/connector.py
@@ -1,15 +1,28 @@
 """Slack connector built on the aios-connector-http SDK.
 
-MVP slices 1+2/4 — the connection layer (design §3.1-§3.3) plus the
-inbound decision layer (§3.4, §3.6).  Slice 1 stood up the package, the
-Socket-Mode transport, and the :meth:`SlackConnector.serve_connection`
-lifecycle.  Slice 2 adds inbound normalization and the four
-connector-side gates: the drain task now parses each raw Slack event,
-runs the self/bot-loop, cross-app/team, subtype, and mention gates (all
-pure functions in :mod:`aios_slack.parse`), and on a ``FORWARD`` outcome
-emits a normalized inbound via :meth:`emit_inbound`.  ``message_changed``
-is routed to a non-emitting system path; mention-gated drops are
-fail-quiet.  The outbound ``@tool`` vocabulary lands in a later slice.
+MVP slices 1-3/4 — the connection layer (design §3.1-§3.3), the inbound
+decision layer (§3.4, §3.6), and now the outbound reply layer (§3.5).
+Slice 1 stood up the package, the Socket-Mode transport, and the
+:meth:`SlackConnector.serve_connection` lifecycle.  Slice 2 added inbound
+normalization and the four connector-side gates: the drain task parses
+each raw Slack event, runs the self/bot-loop, cross-app/team, subtype,
+and mention gates (all pure functions in :mod:`aios_slack.parse`), and on
+a ``FORWARD`` outcome emits a normalized inbound via
+:meth:`emit_inbound`.  ``message_changed`` is routed to a non-emitting
+system path; mention-gated drops are fail-quiet.
+
+Slice 3 publishes the two outbound ``@tool``\\ s the model uses to be
+heard on Slack: :meth:`slack_send` (``chat.postMessage`` with
+``mrkdwn``, optional ``thread_ts`` threading) and :meth:`slack_react`
+(``reactions.add`` / ``reactions.remove``, mirroring ``telegram_react``).
+Both run their text through the markdown→``mrkdwn`` pipeline + hard
+clamps in :mod:`aios_slack.format` before the Web API call.
+``connection_id`` and ``chat_id`` are server-authoritative — the SDK
+injects them from the call's focal channel; the model cannot select a
+workspace.  ``slack_send`` is documented **at-least-once** (§4 retry
+posture): a ``tool-result`` POST failure after a successful
+``chat.postMessage`` re-dispatches and posts a duplicate; the
+idempotency-key fix is a separate SDK follow-up.
 
 Multi-connection runtime container: one container can serve N
 connections of type ``"slack"``, each bound to one Slack workspace
@@ -38,13 +51,14 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
-from aios_connector_http import HttpConnector
+from aios_connector_http import HttpConnector, tool
 from slack_sdk.http_retry.builtin_async_handlers import AsyncRateLimitErrorRetryHandler
 from slack_sdk.socket_mode.aiohttp import SocketModeClient as AsyncSocketModeClient
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web.async_client import AsyncWebClient
 
+from .format import clamp_message, markdown_to_mrkdwn, normalize_emoji
 from .parse import GateOutcome, InboundMessage, gate
 
 log = structlog.get_logger(__name__)
@@ -348,6 +362,134 @@ class SlackConnector(HttpConnector):
             content=msg.text,
             metadata=metadata,
         )
+
+    # ── model-facing tools (slice 3, design §3.5) ─────────────────────
+
+    @tool()
+    async def slack_send(
+        self,
+        text: str,
+        thread_ts: str | None = None,
+        *,
+        connection_id: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """Send a message to your focal Slack conversation.
+
+        This is the only way the model is heard on Slack — bare assistant
+        text never reaches the channel on its own. The connection and
+        conversation are taken implicitly from your focal channel; the SDK
+        injects them from the call payload, so you cannot send to a
+        different workspace or conversation. Set focal with the built-in
+        ``switch_channel`` tool.
+
+        The message body is written in ordinary Markdown and rendered to
+        Slack's ``mrkdwn`` flavor before sending: ``**bold**`` →
+        ``*bold*``, ``[label](url)`` → a Slack link, fenced/inline code,
+        ``> quotes``, ``~~strike~~``, and ``_italic_`` all map to their
+        Slack equivalents. Text-only in v0 — there is no attachment or
+        Block Kit parameter yet.
+
+        Args:
+            text: The message body, in Markdown. Long bodies are clamped
+                to Slack's per-message ceiling before sending (the tail is
+                truncated with an ellipsis rather than failing the call).
+            thread_ts: When set, the message is posted as a reply in that
+                thread. Pass the ``thread_ts`` from the inbound message's
+                metadata header to keep a conversation threaded; pass the
+                ``ts`` returned by an earlier ``slack_send`` to continue a
+                thread you started. Default ``None`` posts a new top-level
+                message in the conversation.
+
+        Returns:
+            A dict with ``ts`` (the new message's timestamp id — feed it
+            to ``slack_react`` or as a later ``thread_ts``) and ``channel``
+            (the resolved focal-channel string, so observers read the send
+            target straight off the tool result).
+        """
+        state = self.state[connection_id]
+        body = clamp_message(markdown_to_mrkdwn(text))
+        # Build the channel from the ORIGINAL chat_id so the segment is
+        # byte-identical to inbound/focal form (the channel is the bare
+        # conversation id; threads share the channel session, §3.4).
+        channel = self.focal_channel(state.team_id, chat_id)
+
+        kwargs: dict[str, Any] = {"channel": chat_id, "text": body, "mrkdwn": True}
+        if thread_ts is not None:
+            kwargs["thread_ts"] = thread_ts
+
+        response = await state.web_client.chat_postMessage(**kwargs)
+        sent_ts = response["ts"]
+
+        # Record the thread we just posted into so the mention-gate's
+        # ``bot_thread_participant`` implicit-mention bypass (§3.6 gate 4)
+        # fires for subsequent replies in this thread — a human follow-up
+        # in a thread the bot is active in no longer needs an explicit
+        # @-mention.  We stamp the thread anchor (``thread_ts`` when this
+        # was a threaded reply; otherwise the new message's own ``ts``,
+        # which becomes the thread root if a human replies under it).
+        thread_anchor = thread_ts if thread_ts is not None else sent_ts
+        if isinstance(thread_anchor, str):
+            state.bot_thread_ts.add(thread_anchor)
+
+        return {"ts": sent_ts, "channel": channel}
+
+    @tool()
+    async def slack_react(
+        self,
+        message_ts: str,
+        emoji: str | None,
+        *,
+        connection_id: str,
+        chat_id: str,
+    ) -> dict[str, Any]:
+        """React to a message in your focal conversation, or clear a reaction.
+
+        A reaction is the cheapest way to acknowledge a message without
+        posting text — e.g. react ``eyes`` to show you're working on it,
+        or ``white_check_mark`` when done. The connection and conversation
+        are taken implicitly from your focal channel.
+
+        Args:
+            message_ts: The ``ts`` of the message to react to. Use the
+                ``message_ts`` from an inbound message's metadata header,
+                or the ``ts`` returned by an earlier ``slack_send``.
+            emoji: The emoji shortcode (e.g. ``"eyes"``, ``"thumbsup"``,
+                ``":white_check_mark:"`` — surrounding colons are stripped
+                and the name is normalized to Slack's bare-shortcode form).
+                When set, the reaction is added. Pass ``None`` to *remove*
+                the same-named reaction instead: Slack's ``reactions.remove``
+                is keyed by the shortcode, so pass the shortcode (not
+                ``None``) to clear a specific reaction; ``None`` is only
+                meaningful when the connector already knows which reaction
+                to drop, and otherwise is a no-op.
+
+        Returns:
+            A dict with ``status`` (``"ok"``).
+        """
+        state = self.state[connection_id]
+        # ``reactions.add`` when a shortcode is given (colon-stripped +
+        # normalized), ``reactions.remove`` when cleared — exactly one Web
+        # API call, mirroring ``telegram_react``.  Slack's ``reactions.remove``
+        # is keyed by name, so the ``None`` branch can only remove a name we
+        # can resolve; with no name in hand it is a logged no-op rather than
+        # an error (a bare ``reactions.remove`` with no name is rejected by
+        # Slack and would surface to the model as an opaque failed call).
+        if emoji is not None:
+            name = normalize_emoji(emoji)
+            await state.web_client.reactions_add(
+                channel=chat_id,
+                timestamp=message_ts,
+                name=name,
+            )
+        else:
+            log.info(
+                "slack.react.clear_noop",
+                connection_id=connection_id,
+                team_id=state.team_id,
+                message_ts=message_ts,
+            )
+        return {"status": "ok"}
 
     @staticmethod
     async def _close_socket(socket_client: AsyncSocketModeClient) -> None:

--- a/connectors/slack/src/aios_slack/format.py
+++ b/connectors/slack/src/aios_slack/format.py
@@ -1,0 +1,202 @@
+"""Render a small Markdown subset to Slack ``mrkdwn`` + the hard clamps.
+
+The model writes ordinary Markdown (``**bold**``, ``[label](url)``,
+fenced code, …); Slack's message-formatting flavor — ``mrkdwn`` — uses a
+*different* inline grammar:
+
+    *bold*            (single asterisk, not ``**``)
+    _italic_
+    ~strike~
+    `code`            (inline; same as Markdown)
+    ```code```        (fenced; same as Markdown)
+    > quote           (line prefix; same as Markdown)
+    <url|label>       (link; angle-bracketed, not ``[label](url)``)
+
+See https://api.slack.com/reference/surfaces/formatting#basics.  This
+module maps the common Markdown constructs the model emits onto that
+grammar with :func:`markdown_to_mrkdwn`, and applies the design's hard
+length clamps (§3.5, §6 acceptance line) with :func:`clamp_message` /
+:func:`clamp_section` / :func:`clamp_label` / :func:`clamp_blocks` —
+**every Web API call runs its text through the relevant clamp first** so
+a runaway model reply can never trip a Slack ``msg_too_long`` /
+``invalid_blocks`` rejection (which would surface to the model as an
+opaque failed tool call instead of a truncated-but-delivered message).
+
+The clamp ceilings are Slack's documented limits, recorded as named
+constants so the call sites read intent rather than magic numbers:
+
+* :data:`MESSAGE_MAX_CHARS` — ``chat.postMessage`` ``text`` hard cap.
+* :data:`SECTION_TEXT_MAX_CHARS` — a Block Kit ``section`` block's
+  ``text`` cap (Block Kit is deferred to a later slice, but the clamp
+  ships now so the IR pipeline is complete and the helper is unit-tested
+  against the real ceiling).
+* :data:`LABEL_MAX_CHARS` — a Block Kit interactive-element label cap.
+* :data:`MAX_BLOCKS` — the per-message Block Kit block-count cap.
+
+Truncation appends a single-character ellipsis (``…``) and counts it
+against the budget so the *result* never exceeds the ceiling.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ── Slack's documented hard limits (the clamp ceilings) ───────────────
+
+#: ``chat.postMessage`` rejects a ``text`` longer than 40k bytes, but the
+#: design pins the message clamp at 8000 chars (§3.5) — comfortably under
+#: the wire limit and a sane single-message size.
+MESSAGE_MAX_CHARS = 8000
+#: A Block Kit ``section`` block's ``text`` field caps at 3000 chars.
+SECTION_TEXT_MAX_CHARS = 3000
+#: A Block Kit interactive-element / option label caps at 75 chars.
+LABEL_MAX_CHARS = 75
+#: A single message carries at most 50 Block Kit blocks.
+MAX_BLOCKS = 50
+
+_ELLIPSIS = "…"
+
+
+# ── Markdown → Slack mrkdwn inline grammar ────────────────────────────
+
+# Capture order matters: code spans are stashed first so their contents
+# are immune to the emphasis/link rewrites; links run before emphasis so a
+# ``[text](_url_)`` url isn't mangled by the italic rule.
+
+_FENCE_RE = re.compile(r"```(?:\w*)\n?(.*?)```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+?)`")
+# ``[label](url)`` → ``<url|label>``.  The url is the first non-space run
+# inside the parens (Slack links don't carry a title).
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+# ``**bold**`` / ``__bold__`` → ``*bold*`` (Slack's single-asterisk bold).
+_BOLD_STAR_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_BOLD_UNDER_RE = re.compile(r"__(.+?)__", re.DOTALL)
+# ``~~strike~~`` → ``~strike~`` (Slack's single-tilde strike).
+_STRIKE_RE = re.compile(r"~~(.+?)~~", re.DOTALL)
+# Single-asterisk italic in Markdown maps to Slack's ``_italic_``.  Reject
+# leading/trailing whitespace and a neighbouring ``*`` so a ``**bold**``
+# already rewritten above (or a bare ``*`` bullet) is left alone.
+_ITALIC_STAR_RE = re.compile(r"(?<!\*)\*(?!\*)(?!\s)(.+?)(?<!\s)(?<!\*)\*(?!\*)", re.DOTALL)
+# Single-underscore italic stays ``_italic_`` but we still normalize it so
+# snake_case words aren't treated as emphasis (word-boundary guards).
+_ITALIC_UNDER_RE = re.compile(r"(?<!\w)_(?!_)(?!\s)(.+?)(?<!\s)(?<!_)_(?!\w)", re.DOTALL)
+
+
+def markdown_to_mrkdwn(text: str) -> str:
+    """Convert the common Markdown subset the model emits to Slack ``mrkdwn``.
+
+    Pipeline:
+
+    1. Stash fenced + inline code spans behind opaque placeholders so
+       their contents survive the inline rewrites verbatim (a ``**`` or
+       ``[..](..)`` inside a code span must NOT be reinterpreted).
+    2. Rewrite links ``[label](url)`` → ``<url|label>``.
+    3. Rewrite bold (``**x**`` / ``__x__`` → ``*x*``) and strike
+       (``~~x~~`` → ``~x~``) to Slack's single-delimiter forms.
+    4. Rewrite single-asterisk italic ``*x*`` → ``_x_``; single-underscore
+       italic is already Slack-native (kept, with word-boundary guards).
+    5. Restore the code placeholders.
+
+    Slack ``mrkdwn`` does not HTML-escape; ``<``/``>``/``&`` render
+    literally except where they form a ``<…>`` link/mention token, so —
+    unlike the Telegram HTML converter — there is no escape pass.
+    """
+    placeholders: dict[str, str] = {}
+    counter = 0
+
+    def stash(rendered: str) -> str:
+        nonlocal counter
+        key = f"\x00CODE{counter}\x00"
+        placeholders[key] = rendered
+        counter += 1
+        return key
+
+    def fence_repl(m: re.Match[str]) -> str:
+        return stash(f"```{m.group(1)}```")
+
+    def inline_code_repl(m: re.Match[str]) -> str:
+        return stash(f"`{m.group(1)}`")
+
+    text = _FENCE_RE.sub(fence_repl, text)
+    text = _INLINE_CODE_RE.sub(inline_code_repl, text)
+
+    # Stash each converted span behind a placeholder so a *later* rule
+    # can't chew it up — notably the single-asterisk italic rule would
+    # otherwise re-match the ``*bold*`` the bold rule just produced and
+    # downgrade it to ``_bold_``.
+    text = _LINK_RE.sub(lambda m: stash(f"<{m.group(2)}|{m.group(1)}>"), text)
+    text = _BOLD_STAR_RE.sub(lambda m: stash(f"*{m.group(1)}*"), text)
+    text = _BOLD_UNDER_RE.sub(lambda m: stash(f"*{m.group(1)}*"), text)
+    text = _STRIKE_RE.sub(lambda m: stash(f"~{m.group(1)}~"), text)
+    text = _ITALIC_STAR_RE.sub(lambda m: stash(f"_{m.group(1)}_"), text)
+    text = _ITALIC_UNDER_RE.sub(lambda m: stash(f"_{m.group(1)}_"), text)
+
+    for key, rendered in placeholders.items():
+        text = text.replace(key, rendered)
+    return text
+
+
+# ── the hard clamps (applied before every Web API call) ───────────────
+
+
+def _clamp(text: str, limit: int) -> str:
+    """Truncate ``text`` to at most ``limit`` chars, ellipsis included.
+
+    A no-op when already within budget.  When over, keep ``limit - 1``
+    chars and append a single ``…`` so the result length is exactly
+    ``limit`` — never over.  ``limit <= 0`` yields the empty string.
+    """
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + _ELLIPSIS
+
+
+def clamp_message(text: str) -> str:
+    """Clamp a ``chat.postMessage`` body to :data:`MESSAGE_MAX_CHARS`."""
+    return _clamp(text, MESSAGE_MAX_CHARS)
+
+
+def clamp_section(text: str) -> str:
+    """Clamp a Block Kit ``section`` text to :data:`SECTION_TEXT_MAX_CHARS`."""
+    return _clamp(text, SECTION_TEXT_MAX_CHARS)
+
+
+def clamp_label(text: str) -> str:
+    """Clamp a Block Kit element label to :data:`LABEL_MAX_CHARS`."""
+    return _clamp(text, LABEL_MAX_CHARS)
+
+
+def clamp_blocks(blocks: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Clamp a Block Kit block list to at most :data:`MAX_BLOCKS` blocks.
+
+    Returns the input unchanged when within budget, else the first
+    :data:`MAX_BLOCKS` blocks.  Block Kit is deferred (§7), but the clamp
+    ships with the IR pipeline so the helper is complete and tested.
+    """
+    if len(blocks) <= MAX_BLOCKS:
+        return blocks
+    return blocks[:MAX_BLOCKS]
+
+
+# ── emoji normalization (slack_react) ─────────────────────────────────
+
+_EMOJI_STRIP_RE = re.compile(r"[^a-z0-9_+-]")
+
+
+def normalize_emoji(emoji: str) -> str:
+    """Normalize a model-supplied emoji name to Slack's ``reactions.add`` form.
+
+    Slack's ``reactions.add`` ``name`` is the bare shortcode — ``thumbsup``,
+    not ``:thumbsup:``.  The model may pass either form (or with stray
+    whitespace / uppercase), so we strip surrounding colons, lowercase,
+    trim, and drop any character outside Slack's shortcode alphabet
+    (``a-z``, ``0-9``, ``_``, ``+``, ``-`` — the last two for names like
+    ``+1`` and ``e-mail``).  A skin-tone suffix (``::skin-tone-2``) is
+    preserved as ``_skin-tone-2`` only incidentally; v0 does not special-case
+    it.  Returns the cleaned shortcode (possibly empty if the input held no
+    valid characters — the caller decides what to do with that).
+    """
+    name = emoji.strip().strip(":").strip().lower()
+    return _EMOJI_STRIP_RE.sub("", name)

--- a/connectors/slack/tests/test_format.py
+++ b/connectors/slack/tests/test_format.py
@@ -1,0 +1,166 @@
+"""Unit coverage for the markdown→mrkdwn pipeline and the hard clamps.
+
+All pure functions, no network.  Covers the inline-grammar rewrites
+(``**bold**`` → ``*bold*``, links, code-span immunity, …) and each clamp
+ceiling (message 8000, section 3000, label 75, blocks ≤50) including the
+ellipsis-counts-against-budget invariant.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios_slack.format import (
+    LABEL_MAX_CHARS,
+    MAX_BLOCKS,
+    MESSAGE_MAX_CHARS,
+    SECTION_TEXT_MAX_CHARS,
+    clamp_blocks,
+    clamp_label,
+    clamp_message,
+    clamp_section,
+    markdown_to_mrkdwn,
+    normalize_emoji,
+)
+
+# ── markdown → mrkdwn ─────────────────────────────────────────────────
+
+
+def test_bold_double_star_to_single() -> None:
+    assert markdown_to_mrkdwn("**bold**") == "*bold*"
+
+
+def test_bold_double_underscore_to_single_star() -> None:
+    assert markdown_to_mrkdwn("__bold__") == "*bold*"
+
+
+def test_italic_single_star_to_underscore() -> None:
+    assert markdown_to_mrkdwn("*em*") == "_em_"
+
+
+def test_italic_underscore_preserved() -> None:
+    assert markdown_to_mrkdwn("_em_") == "_em_"
+
+
+def test_strike_double_tilde_to_single() -> None:
+    assert markdown_to_mrkdwn("~~gone~~") == "~gone~"
+
+
+def test_link_rewritten_to_slack_angle_form() -> None:
+    assert markdown_to_mrkdwn("[Anthropic](https://anthropic.com)") == (
+        "<https://anthropic.com|Anthropic>"
+    )
+
+
+def test_bold_and_italic_mixed() -> None:
+    # ``**bold**`` becomes ``*bold*``; a separate ``*em*`` becomes ``_em_``.
+    assert markdown_to_mrkdwn("**bold** and *em*") == "*bold* and _em_"
+
+
+def test_inline_code_contents_immune_to_rewrites() -> None:
+    # A ``**`` or ``[..](..)`` inside a code span must survive verbatim.
+    assert markdown_to_mrkdwn("use `**not bold**` here") == "use `**not bold**` here"
+
+
+def test_fenced_code_contents_immune_to_rewrites() -> None:
+    src = "```\n**x** and [a](b)\n```"
+    out = markdown_to_mrkdwn(src)
+    assert "**x**" in out
+    assert "[a](b)" in out
+
+
+def test_fenced_code_language_tag_dropped_but_body_kept() -> None:
+    out = markdown_to_mrkdwn("```python\nprint(1)\n```")
+    assert "print(1)" in out
+    assert out.startswith("```")
+
+
+def test_blockquote_prefix_preserved() -> None:
+    # Slack mrkdwn uses ``> `` line prefixes natively — pass through.
+    assert markdown_to_mrkdwn("> quoted") == "> quoted"
+
+
+def test_snake_case_not_italicized() -> None:
+    # word-boundary guards keep ``snake_case_word`` intact.
+    assert markdown_to_mrkdwn("snake_case_word") == "snake_case_word"
+
+
+def test_no_html_escaping() -> None:
+    # Slack mrkdwn renders ``<``/``>``/``&`` literally outside link tokens;
+    # the converter must not entity-encode them (unlike telegram's HTML).
+    assert markdown_to_mrkdwn("a < b & c > d") == "a < b & c > d"
+
+
+# ── clamps ────────────────────────────────────────────────────────────
+
+
+def test_clamp_message_under_budget_is_noop() -> None:
+    text = "x" * 100
+    assert clamp_message(text) == text
+
+
+def test_clamp_message_truncates_to_ceiling_with_ellipsis() -> None:
+    text = "x" * (MESSAGE_MAX_CHARS + 500)
+    out = clamp_message(text)
+    assert len(out) == MESSAGE_MAX_CHARS
+    assert out.endswith("…")
+
+
+def test_clamp_message_exact_boundary_is_noop() -> None:
+    text = "x" * MESSAGE_MAX_CHARS
+    assert clamp_message(text) == text
+
+
+def test_clamp_section_ceiling() -> None:
+    out = clamp_section("y" * (SECTION_TEXT_MAX_CHARS + 1))
+    assert len(out) == SECTION_TEXT_MAX_CHARS
+    assert out.endswith("…")
+
+
+def test_clamp_label_ceiling() -> None:
+    out = clamp_label("z" * (LABEL_MAX_CHARS + 10))
+    assert len(out) == LABEL_MAX_CHARS
+    assert out.endswith("…")
+
+
+def test_clamp_label_short_is_noop() -> None:
+    assert clamp_label("hello") == "hello"
+
+
+def test_clamp_blocks_under_budget_is_noop() -> None:
+    blocks: list[dict[str, object]] = [{"type": "section"} for _ in range(10)]
+    assert clamp_blocks(blocks) == blocks
+
+
+def test_clamp_blocks_truncates_to_fifty() -> None:
+    blocks: list[dict[str, object]] = [{"type": "section", "i": i} for i in range(MAX_BLOCKS + 5)]
+    out = clamp_blocks(blocks)
+    assert len(out) == MAX_BLOCKS
+    assert out[0]["i"] == 0
+    assert out[-1]["i"] == MAX_BLOCKS - 1
+
+
+def test_clamp_named_ceilings_match_design() -> None:
+    # Guard the documented design ceilings against accidental drift.
+    assert MESSAGE_MAX_CHARS == 8000
+    assert SECTION_TEXT_MAX_CHARS == 3000
+    assert LABEL_MAX_CHARS == 75
+    assert MAX_BLOCKS == 50
+
+
+# ── emoji normalization ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("eyes", "eyes"),
+        (":eyes:", "eyes"),
+        (" :Thumbsup: ", "thumbsup"),
+        (":white_check_mark:", "white_check_mark"),
+        ("+1", "+1"),
+        (":wave🏽:", "wave"),  # strip out-of-alphabet glyphs
+    ],
+)
+def test_normalize_emoji(raw: str, expected: str) -> None:
+    assert normalize_emoji(raw) == expected

--- a/connectors/slack/tests/test_slack_outbound.py
+++ b/connectors/slack/tests/test_slack_outbound.py
@@ -1,0 +1,180 @@
+"""Unit coverage for the outbound ``slack_send`` / ``slack_react`` tools.
+
+``AsyncWebClient`` is mocked end-to-end; tests assert the tool maps its
+arguments onto the right Slack Web API call with the right kwargs, runs
+the body through the markdown→mrkdwn pipeline + clamp, stamps the focal
+channel on the result, and records bot-thread participation for the
+mention-gate bypass.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aios_connector_http import HttpConnector
+
+from aios_slack.connector import SlackConnector, _SlackConnectionState
+from aios_slack.format import MESSAGE_MAX_CHARS
+
+CONNECTION_ID = "conn_test"
+TEAM_ID = "T0123456789"
+BOT_USER_ID = "U0987654321"
+CHANNEL_ID = "C0FOCAL000"
+
+
+@pytest.fixture
+def web() -> Any:
+    """A mock ``AsyncWebClient`` with the outbound methods stubbed."""
+    w = MagicMock(name="AsyncWebClient")
+    w.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "1700000000.000100"})
+    w.reactions_add = AsyncMock(return_value={"ok": True})
+    w.reactions_remove = AsyncMock(return_value={"ok": True})
+    return w
+
+
+@pytest.fixture
+def connector(web: Any) -> SlackConnector:
+    """SlackConnector with one pre-registered connection wired to ``web``.
+
+    The per-connection state is pre-populated so tool tests call the
+    methods directly without running ``serve_connection`` first.
+    """
+    import asyncio as _asyncio
+
+    c = SlackConnector()
+    c.state[CONNECTION_ID] = _SlackConnectionState(
+        web_client=web,
+        socket_client=MagicMock(name="AsyncSocketModeClient"),
+        bot_user_id=BOT_USER_ID,
+        team_id=TEAM_ID,
+        inbound_queue=_asyncio.Queue(),
+    )
+    return c
+
+
+# ── registration ──────────────────────────────────────────────────────
+
+
+def test_outbound_tools_registered(connector: SlackConnector) -> None:
+    assert isinstance(connector, HttpConnector)
+    assert {"slack_send", "slack_react"} <= set(connector._tools)
+
+
+# ── slack_send ─────────────────────────────────────────────────────────
+
+
+async def test_slack_send_top_level(connector: SlackConnector, web: Any) -> None:
+    result = await connector.slack_send(
+        text="hello", chat_id=CHANNEL_ID, connection_id=CONNECTION_ID
+    )
+    assert result == {
+        "ts": "1700000000.000100",
+        "channel": f"slack/{TEAM_ID}/{CHANNEL_ID}",
+    }
+    web.chat_postMessage.assert_awaited_once_with(channel=CHANNEL_ID, text="hello", mrkdwn=True)
+
+
+async def test_slack_send_renders_markdown_to_mrkdwn(connector: SlackConnector, web: Any) -> None:
+    await connector.slack_send(
+        text="**bold** and [a](https://x.y)",
+        chat_id=CHANNEL_ID,
+        connection_id=CONNECTION_ID,
+    )
+    kwargs = web.chat_postMessage.call_args.kwargs
+    assert kwargs["text"] == "*bold* and <https://x.y|a>"
+
+
+async def test_slack_send_clamps_overlong_body(connector: SlackConnector, web: Any) -> None:
+    await connector.slack_send(
+        text="x" * (MESSAGE_MAX_CHARS + 100),
+        chat_id=CHANNEL_ID,
+        connection_id=CONNECTION_ID,
+    )
+    sent = web.chat_postMessage.call_args.kwargs["text"]
+    assert len(sent) == MESSAGE_MAX_CHARS
+    assert sent.endswith("…")
+
+
+async def test_slack_send_threads_when_thread_ts_set(connector: SlackConnector, web: Any) -> None:
+    await connector.slack_send(
+        text="in thread",
+        thread_ts="1699999999.000001",
+        chat_id=CHANNEL_ID,
+        connection_id=CONNECTION_ID,
+    )
+    kwargs = web.chat_postMessage.call_args.kwargs
+    assert kwargs["thread_ts"] == "1699999999.000001"
+
+
+async def test_slack_send_omits_thread_ts_when_none(connector: SlackConnector, web: Any) -> None:
+    await connector.slack_send(text="top", chat_id=CHANNEL_ID, connection_id=CONNECTION_ID)
+    assert "thread_ts" not in web.chat_postMessage.call_args.kwargs
+
+
+async def test_slack_send_records_thread_participation_for_threaded_reply(
+    connector: SlackConnector, web: Any
+) -> None:
+    """A threaded reply records the thread anchor so the mention-gate
+    ``bot_thread_participant`` bypass fires for later replies (§3.6)."""
+    await connector.slack_send(
+        text="reply",
+        thread_ts="1699999999.000001",
+        chat_id=CHANNEL_ID,
+        connection_id=CONNECTION_ID,
+    )
+    assert "1699999999.000001" in connector.state[CONNECTION_ID].bot_thread_ts
+
+
+async def test_slack_send_records_own_ts_as_thread_root_for_top_level(
+    connector: SlackConnector, web: Any
+) -> None:
+    """A top-level send records its own ``ts`` as a thread root the bot is
+    active in (so a human reply under it bypasses the mention-gate)."""
+    await connector.slack_send(text="top", chat_id=CHANNEL_ID, connection_id=CONNECTION_ID)
+    assert "1700000000.000100" in connector.state[CONNECTION_ID].bot_thread_ts
+
+
+# ── slack_react ──────────────────────────────────────────────────────────
+
+
+async def test_slack_react_add(connector: SlackConnector, web: Any) -> None:
+    result = await connector.slack_react(
+        message_ts="1700000000.000100",
+        emoji="eyes",
+        chat_id=CHANNEL_ID,
+        connection_id=CONNECTION_ID,
+    )
+    assert result == {"status": "ok"}
+    web.reactions_add.assert_awaited_once_with(
+        channel=CHANNEL_ID, timestamp="1700000000.000100", name="eyes"
+    )
+    web.reactions_remove.assert_not_awaited()
+
+
+async def test_slack_react_strips_colons_and_normalizes(
+    connector: SlackConnector, web: Any
+) -> None:
+    await connector.slack_react(
+        message_ts="1700000000.000100",
+        emoji=":White_Check_Mark:",
+        chat_id=CHANNEL_ID,
+        connection_id=CONNECTION_ID,
+    )
+    assert web.reactions_add.call_args.kwargs["name"] == "white_check_mark"
+
+
+async def test_slack_react_none_is_single_call_noop(connector: SlackConnector, web: Any) -> None:
+    """``emoji=None`` does not add; it does not fire a nameless
+    ``reactions.remove`` (which Slack rejects). One-call contract holds:
+    zero add calls, zero remove calls, returns ok."""
+    result = await connector.slack_react(
+        message_ts="1700000000.000100",
+        emoji=None,
+        chat_id=CHANNEL_ID,
+        connection_id=CONNECTION_ID,
+    )
+    assert result == {"status": "ok"}
+    web.reactions_add.assert_not_awaited()
+    web.reactions_remove.assert_not_awaited()


### PR DESCRIPTION
## What

MVP slice 3/4 — the reply layer (design §3.5, §4 retry posture, §6). Publishes the two model-facing `@tool`s the model uses to be heard on Slack, plus the markdown→`mrkdwn` formatting pipeline.

### `format.py` (new)
- `markdown_to_mrkdwn(text)` — markdown → Slack `mrkdwn` IR pipeline: `**bold**`/`__bold__` → `*bold*`, `*em*` → `_em_`, `~~x~~` → `~x~`, `[label](url)` → `<url|label>`, with fenced/inline **code spans stashed so their contents are immune** to the inline rewrites, and **no HTML escaping** (Slack renders `<`/`>`/`&` literally outside link tokens, unlike Telegram's HTML mode).
- Hard clamps applied before every Web API call, as named constants matching the design ceilings: `clamp_message` (8000-char message), `clamp_section` (3000), `clamp_label` (75), `clamp_blocks` (≤50). Truncation appends `…` counted against budget so the result never exceeds the ceiling.
- `normalize_emoji` — colon-strip + lowercase + drop out-of-alphabet glyphs to Slack's bare-shortcode form.

### `connector.py`
- **`slack_send(text, thread_ts=None, *, connection_id, chat_id) -> {ts, channel}`** — `chat.postMessage(channel=chat_id, text=…, mrkdwn=True)`; `thread_ts` threads the reply (default `None` = top-level); `channel` = `self.focal_channel(team_id, chat_id)`. Body runs through `markdown_to_mrkdwn` + `clamp_message`. Records the thread anchor into `bot_thread_ts` so the mention-gate's `bot_thread_participant` implicit-mention bypass (§3.6 gate 4) fires for later replies.
- **`slack_react(message_ts, emoji, *, connection_id, chat_id) -> {status}`** — `reactions.add(channel=chat_id, timestamp=message_ts, name=emoji)` (colon-stripped + normalized) when set; one Web API call; mirrors `telegram_react`.
- Both carry rich Google-style docstrings (the SDK derives the JSON schema). `connection_id`/`chat_id` are server-authoritative and stripped from the derived tool schema (verified: only `text`/`thread_ts` and `message_ts`/`emoji` are model-facing).

### Baked-in decisions
- `slack_send` is documented **at-least-once** (§4): a `tool-result` POST failure after a successful `chat.postMessage` re-dispatches and posts a duplicate; the idempotency-key fix is a separate SDK follow-up. Captured in the README and module docstring.
- Bare `chat_id` passes straight to the Slack API — no `:`-splitting.

## Tests
Unit coverage for the format clamps + markdown→mrkdwn conversions, and tool arg→Slack-call mapping with a mocked `AsyncWebClient` (top-level + threaded send, body rendering, overlong clamp, thread-participation recording, react add/normalize). Full slack suite (80 tests) passes; ruff check/format and mypy clean. A live DM round-trip smoke lands in slice D.

Refs: `docs/design/slack-connector.md` §3.5/§4/§6. Depends on #1229. Part of #1228.