### PR TITLE
feat(connector-subsystem): chat-targeted (routing-key) lifecycle append

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -7710,6 +7710,68 @@
         }
       }
     },
+    "/v1/connectors/runtime/chat-lifecycle": {
+      "post": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Post Runtime Chat Lifecycle",
+        "description": "Append a ``kind=lifecycle`` event onto the single session that\n``body.chat_id`` resolves to on ``body.connection_id`` (#1260),\noptionally waking it.\n\nThe routing-key sibling of ``/runtime/session-lifecycle``: where that\nneeds the resolved ``session_id``, this carries the connector's per-peer\nrouting key (``chat_id``) and resolves it through the connection's\nper-chat binding server-side \u2014 the SMS design's \u00a73.5 req 1 second option\n(\"route the per-peer failure through the resolver on the callback's\n``To``\").  Like the session-lifecycle route it targets exactly one\nsession, NOT the broadcast fan-out: a per-peer delivery failure must not\npollute unrelated ``per_chat`` sessions.\n\nAuthorization mirrors the session-lifecycle route: the bearer's\nconnector must match ``body.connection_id``'s connector and any\nbearer-side ``connection_ids`` allowlist must include it (#350).  The\nbinding lookup itself is the per-session authorization \u2014 a ``chat_id``\nthat has no per-chat session on this connection 404s (no spurious\ncross-peer append), and the resolution is scoped to the bearer's\n``account_id``.\n\nWhen ``body.wake`` is set, a ``defer_wake`` is enqueued after the append\n(the same pattern as the session-lifecycle and tool-result intakes) so\nthe failure wakes the originating session rather than merely being\nvisible on its next turn.",
+        "operationId": "post_connector_runtime_chat_lifecycle",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeChatLifecycleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Post Connector Runtime Chat Lifecycle"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/connectors/runtime/tool-results": {
       "post": {
         "tags": [
@@ -13691,6 +13753,59 @@
         ],
         "title": "RunCompletionSourceReplace",
         "description": "Update-side variant (\u00a72.2 Replace rule): ``statuses`` is REQUIRED, so a\npartial source on update 422s instead of silently resetting a narrowed\nfilter back to all-three. (The first SOURCE member with a defaulted field,\nhence the first ``TriggerSourceReplace`` union.)"
+      },
+      "RuntimeChatLifecycleRequest": {
+        "properties": {
+          "connection_id": {
+            "type": "string",
+            "title": "Connection Id"
+          },
+          "chat_id": {
+            "type": "string",
+            "title": "Chat Id"
+          },
+          "event": {
+            "type": "string",
+            "title": "Event"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "wake": {
+            "type": "boolean",
+            "title": "Wake",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "connection_id",
+          "chat_id",
+          "event"
+        ],
+        "title": "RuntimeChatLifecycleRequest",
+        "description": "Body for ``POST /v1/connectors/runtime/chat-lifecycle`` (#1260).\n\nThe routing-key variant of :class:`RuntimeSessionLifecycleRequest`.\nBoth target a *single* session (not the broadcast fan-out), but where\nthe session-lifecycle route needs the caller to already hold the\nresolved ``session_id``, this route carries a per-peer **routing key**\n(``chat_id``) and resolves it through the connection's per-chat binding\nto the originating session server-side.\n\nThis is the second option the SMS design (\u00a73.5 req 1) calls out: \"route\nthe per-peer failure through the resolver on the callback's ``To``\".  A\nTwilio status callback knows the peer number (\u2192 ``chat_id``) but not the\nAIOS ``session_id`` \u2014 without this route the connector would have to do\nan extra round-trip (or maintain its own ``chat_id \u2192 session_id`` map)\njust to reach the originating per_chat session.  The broadcast\n``/runtime/lifecycle`` route stays for genuine connection-wide events.\n\n``chat_id`` is the connector's per-peer routing key, the same value the\ninbound path stamps onto ``chat_sessions``.  It must resolve to an\nexisting per-chat binding on ``connection_id`` \u2014 a routing key with no\nbound session 404s rather than fanning a spurious cross-peer notice (the\ndesign's \"if a correlation row is genuinely missing \u2026 drop rather than\nfan a spurious cross-peer failure\", \u00a73.5).\n\n``wake`` mirrors the session-lifecycle route: ``True`` pairs the append\nwith a ``defer_wake`` so the failure wakes the originating session;\ndefaults ``False`` (visible-on-next-turn)."
       },
       "RuntimeLifecycleRequest": {
         "properties": {

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -640,6 +640,75 @@ class HttpConnector:
             return None
         return dict(response.json())
 
+    async def emit_chat_lifecycle(
+        self,
+        *,
+        connection_id: str,
+        chat_id: str,
+        event: str,
+        reason: str | None = None,
+        data: dict[str, Any] | None = None,
+        wake: bool = False,
+    ) -> dict[str, Any] | None:
+        """Append a ``kind=lifecycle`` event onto the single session that
+        ``chat_id`` resolves to on ``connection_id`` (#1260), optionally
+        waking it.
+
+        The routing-key sibling of :meth:`emit_session_lifecycle`: where that
+        needs the resolved ``session_id``, this carries the connector's
+        per-peer routing key (``chat_id``) and lets AIOS resolve it through
+        the connection's per-chat binding. Use when a fact concerns one peer
+        and the connector knows the routing key but not the session — e.g. a
+        Twilio status callback that has the peer number (→ ``chat_id``) but
+        not the AIOS ``session_id``.
+
+        Set ``wake=True`` to make the failure wake the originating session
+        (stimulus-bearing) instead of merely being visible on its next turn.
+        Returns the appended-session payload (including the resolved
+        ``session_id``), or ``None`` when the API returned a non-fatal 4xx —
+        notably a ``404`` when the ``chat_id`` has no bound session on the
+        connection (a correlation gap is dropped, not raised), matching
+        :meth:`emit_inbound`/:meth:`emit_lifecycle`'s drop-don't-raise stance.
+        """
+        client = self._require_client()
+        log.info(
+            "connector.chat_lifecycle",
+            connector=self.connector,
+            connection_id=connection_id,
+            chat_id=chat_id,
+            lifecycle_event=event,
+            reason=reason,
+            wake=wake,
+        )
+        body: dict[str, Any] = {
+            "connection_id": connection_id,
+            "chat_id": chat_id,
+            "event": event,
+            "wake": wake,
+        }
+        if reason is not None:
+            body["reason"] = reason
+        if data is not None:
+            body["data"] = data
+        response = await client.get_async_httpx_client().post(
+            "/v1/connectors/runtime/chat-lifecycle",
+            json=body,
+        )
+        if response.is_error:
+            sc = response.status_code
+            log.warning(
+                "connector.chat_lifecycle.failed",
+                status_code=sc,
+                connection_id=connection_id,
+                chat_id=chat_id,
+                lifecycle_event=event,
+                body=response.text[:2000],
+            )
+            if _is_fatal_inbound_status(sc):
+                response.raise_for_status()
+            return None
+        return dict(response.json())
+
     # ─── runner ──────────────────────────────────────────────────────
 
     async def run_until_stopped(self, *, install_signal_handlers: bool = True) -> None:

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -1378,3 +1378,87 @@ class TestEmitSessionLifecycle:
         assert len(failed) == 1
         assert failed[0]["status_code"] == 422
         assert failed[0]["session_id"] == "sess_1"
+
+
+class TestEmitChatLifecycle:
+    """``emit_chat_lifecycle`` (#1260) POSTs the routing-key (chat_id)
+    variant of the session-targeted lifecycle route: the connector passes a
+    per-peer routing key and AIOS resolves it to the originating session."""
+
+    async def test_posts_chat_lifecycle_route_with_wake_and_data(
+        self, probe: _ProbeConnector
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.json = MagicMock(
+            return_value={"appended_session_ids": ["sess_1"], "session_id": "sess_1"}
+        )
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        result = await probe.emit_chat_lifecycle(
+            connection_id="conn_1",
+            chat_id="+15550123",
+            event="connector_delivery_failed",
+            reason="30007",
+            data={"detail": "carrier blocked", "peer": "+15550123"},
+            wake=True,
+        )
+
+        assert result == {"appended_session_ids": ["sess_1"], "session_id": "sess_1"}
+        # Targets the routing-key route, not the session-id or broadcast one.
+        url = mock_post.call_args.args[0]
+        assert url == "/v1/connectors/runtime/chat-lifecycle"
+        body = mock_post.call_args.kwargs["json"]
+        assert body == {
+            "connection_id": "conn_1",
+            "chat_id": "+15550123",
+            "event": "connector_delivery_failed",
+            "wake": True,
+            "reason": "30007",
+            "data": {"detail": "carrier blocked", "peer": "+15550123"},
+        }
+
+    async def test_wake_defaults_false_and_optional_fields_omitted(
+        self, probe: _ProbeConnector
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.is_error = False
+        mock_response.json = MagicMock(return_value={"appended_session_ids": ["sess_1"]})
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        await probe.emit_chat_lifecycle(
+            connection_id="conn_1",
+            chat_id="+15550123",
+            event="connector_delivery_failed",
+        )
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["wake"] is False
+        assert "reason" not in body
+        assert "data" not in body
+
+    async def test_non_fatal_4xx_drops_returns_none(self, probe: _ProbeConnector) -> None:
+        """A non-fatal 4xx (notably a 404 when the chat_id has no bound
+        session) is logged and dropped (returns ``None``), matching
+        ``emit_inbound``/``emit_lifecycle``'s drop-don't-raise stance."""
+        mock_response = MagicMock()
+        mock_response.is_error = True
+        mock_response.status_code = 404
+        mock_response.text = '{"error":"no session bound to this chat_id on the connection"}'
+        mock_post = AsyncMock(return_value=mock_response)
+        probe._client.get_async_httpx_client.return_value = MagicMock(post=mock_post)  # type: ignore[union-attr]
+
+        with structlog.testing.capture_logs() as records:
+            result = await probe.emit_chat_lifecycle(
+                connection_id="conn_1",
+                chat_id="+19999999",
+                event="connector_delivery_failed",
+            )
+
+        assert result is None
+        failed = [r for r in records if r.get("event") == "connector.chat_lifecycle.failed"]
+        assert len(failed) == 1
+        assert failed[0]["status_code"] == 404
+        assert failed[0]["chat_id"] == "+19999999"

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_chat_lifecycle.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/post_connector_runtime_chat_lifecycle.py
@@ -1,0 +1,418 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle import (
+    PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle,
+)
+from ...models.runtime_chat_lifecycle_request import RuntimeChatLifecycleRequest
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: RuntimeChatLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/connectors/runtime/chat-lifecycle",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+    | None
+):
+    if response.status_code == 201:
+        response_201 = PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle.from_dict(
+            response.json()
+        )
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeChatLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+]:
+    r"""Post Runtime Chat Lifecycle
+
+     Append a ``kind=lifecycle`` event onto the single session that
+    ``body.chat_id`` resolves to on ``body.connection_id`` (#1260),
+    optionally waking it.
+
+    The routing-key sibling of ``/runtime/session-lifecycle``: where that
+    needs the resolved ``session_id``, this carries the connector's per-peer
+    routing key (``chat_id``) and resolves it through the connection's
+    per-chat binding server-side — the SMS design's §3.5 req 1 second option
+    (\"route the per-peer failure through the resolver on the callback's
+    ``To``\").  Like the session-lifecycle route it targets exactly one
+    session, NOT the broadcast fan-out: a per-peer delivery failure must not
+    pollute unrelated ``per_chat`` sessions.
+
+    Authorization mirrors the session-lifecycle route: the bearer's
+    connector must match ``body.connection_id``'s connector and any
+    bearer-side ``connection_ids`` allowlist must include it (#350).  The
+    binding lookup itself is the per-session authorization — a ``chat_id``
+    that has no per-chat session on this connection 404s (no spurious
+    cross-peer append), and the resolution is scoped to the bearer's
+    ``account_id``.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the same pattern as the session-lifecycle and tool-result intakes) so
+    the failure wakes the originating session rather than merely being
+    visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeChatLifecycleRequest): Body for ``POST /v1/connectors/runtime/chat-
+            lifecycle`` (#1260).
+
+            The routing-key variant of :class:`RuntimeSessionLifecycleRequest`.
+            Both target a *single* session (not the broadcast fan-out), but where
+            the session-lifecycle route needs the caller to already hold the
+            resolved ``session_id``, this route carries a per-peer **routing key**
+            (``chat_id``) and resolves it through the connection's per-chat binding
+            to the originating session server-side.
+
+            This is the second option the SMS design (§3.5 req 1) calls out: "route
+            the per-peer failure through the resolver on the callback's ``To``".  A
+            Twilio status callback knows the peer number (→ ``chat_id``) but not the
+            AIOS ``session_id`` — without this route the connector would have to do
+            an extra round-trip (or maintain its own ``chat_id → session_id`` map)
+            just to reach the originating per_chat session.  The broadcast
+            ``/runtime/lifecycle`` route stays for genuine connection-wide events.
+
+            ``chat_id`` is the connector's per-peer routing key, the same value the
+            inbound path stamps onto ``chat_sessions``.  It must resolve to an
+            existing per-chat binding on ``connection_id`` — a routing key with no
+            bound session 404s rather than fanning a spurious cross-peer notice (the
+            design's "if a correlation row is genuinely missing … drop rather than
+            fan a spurious cross-peer failure", §3.5).
+
+            ``wake`` mirrors the session-lifecycle route: ``True`` pairs the append
+            with a ``defer_wake`` so the failure wakes the originating session;
+            defaults ``False`` (visible-on-next-turn).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeChatLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+    | None
+):
+    r"""Post Runtime Chat Lifecycle
+
+     Append a ``kind=lifecycle`` event onto the single session that
+    ``body.chat_id`` resolves to on ``body.connection_id`` (#1260),
+    optionally waking it.
+
+    The routing-key sibling of ``/runtime/session-lifecycle``: where that
+    needs the resolved ``session_id``, this carries the connector's per-peer
+    routing key (``chat_id``) and resolves it through the connection's
+    per-chat binding server-side — the SMS design's §3.5 req 1 second option
+    (\"route the per-peer failure through the resolver on the callback's
+    ``To``\").  Like the session-lifecycle route it targets exactly one
+    session, NOT the broadcast fan-out: a per-peer delivery failure must not
+    pollute unrelated ``per_chat`` sessions.
+
+    Authorization mirrors the session-lifecycle route: the bearer's
+    connector must match ``body.connection_id``'s connector and any
+    bearer-side ``connection_ids`` allowlist must include it (#350).  The
+    binding lookup itself is the per-session authorization — a ``chat_id``
+    that has no per-chat session on this connection 404s (no spurious
+    cross-peer append), and the resolution is scoped to the bearer's
+    ``account_id``.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the same pattern as the session-lifecycle and tool-result intakes) so
+    the failure wakes the originating session rather than merely being
+    visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeChatLifecycleRequest): Body for ``POST /v1/connectors/runtime/chat-
+            lifecycle`` (#1260).
+
+            The routing-key variant of :class:`RuntimeSessionLifecycleRequest`.
+            Both target a *single* session (not the broadcast fan-out), but where
+            the session-lifecycle route needs the caller to already hold the
+            resolved ``session_id``, this route carries a per-peer **routing key**
+            (``chat_id``) and resolves it through the connection's per-chat binding
+            to the originating session server-side.
+
+            This is the second option the SMS design (§3.5 req 1) calls out: "route
+            the per-peer failure through the resolver on the callback's ``To``".  A
+            Twilio status callback knows the peer number (→ ``chat_id``) but not the
+            AIOS ``session_id`` — without this route the connector would have to do
+            an extra round-trip (or maintain its own ``chat_id → session_id`` map)
+            just to reach the originating per_chat session.  The broadcast
+            ``/runtime/lifecycle`` route stays for genuine connection-wide events.
+
+            ``chat_id`` is the connector's per-peer routing key, the same value the
+            inbound path stamps onto ``chat_sessions``.  It must resolve to an
+            existing per-chat binding on ``connection_id`` — a routing key with no
+            bound session 404s rather than fanning a spurious cross-peer notice (the
+            design's "if a correlation row is genuinely missing … drop rather than
+            fan a spurious cross-peer failure", §3.5).
+
+            ``wake`` mirrors the session-lifecycle route: ``True`` pairs the append
+            with a ``defer_wake`` so the failure wakes the originating session;
+            defaults ``False`` (visible-on-next-turn).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeChatLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> Response[
+    HTTPValidationError
+    | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+]:
+    r"""Post Runtime Chat Lifecycle
+
+     Append a ``kind=lifecycle`` event onto the single session that
+    ``body.chat_id`` resolves to on ``body.connection_id`` (#1260),
+    optionally waking it.
+
+    The routing-key sibling of ``/runtime/session-lifecycle``: where that
+    needs the resolved ``session_id``, this carries the connector's per-peer
+    routing key (``chat_id``) and resolves it through the connection's
+    per-chat binding server-side — the SMS design's §3.5 req 1 second option
+    (\"route the per-peer failure through the resolver on the callback's
+    ``To``\").  Like the session-lifecycle route it targets exactly one
+    session, NOT the broadcast fan-out: a per-peer delivery failure must not
+    pollute unrelated ``per_chat`` sessions.
+
+    Authorization mirrors the session-lifecycle route: the bearer's
+    connector must match ``body.connection_id``'s connector and any
+    bearer-side ``connection_ids`` allowlist must include it (#350).  The
+    binding lookup itself is the per-session authorization — a ``chat_id``
+    that has no per-chat session on this connection 404s (no spurious
+    cross-peer append), and the resolution is scoped to the bearer's
+    ``account_id``.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the same pattern as the session-lifecycle and tool-result intakes) so
+    the failure wakes the originating session rather than merely being
+    visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeChatLifecycleRequest): Body for ``POST /v1/connectors/runtime/chat-
+            lifecycle`` (#1260).
+
+            The routing-key variant of :class:`RuntimeSessionLifecycleRequest`.
+            Both target a *single* session (not the broadcast fan-out), but where
+            the session-lifecycle route needs the caller to already hold the
+            resolved ``session_id``, this route carries a per-peer **routing key**
+            (``chat_id``) and resolves it through the connection's per-chat binding
+            to the originating session server-side.
+
+            This is the second option the SMS design (§3.5 req 1) calls out: "route
+            the per-peer failure through the resolver on the callback's ``To``".  A
+            Twilio status callback knows the peer number (→ ``chat_id``) but not the
+            AIOS ``session_id`` — without this route the connector would have to do
+            an extra round-trip (or maintain its own ``chat_id → session_id`` map)
+            just to reach the originating per_chat session.  The broadcast
+            ``/runtime/lifecycle`` route stays for genuine connection-wide events.
+
+            ``chat_id`` is the connector's per-peer routing key, the same value the
+            inbound path stamps onto ``chat_sessions``.  It must resolve to an
+            existing per-chat binding on ``connection_id`` — a routing key with no
+            bound session 404s rather than fanning a spurious cross-peer notice (the
+            design's "if a correlation row is genuinely missing … drop rather than
+            fan a spurious cross-peer failure", §3.5).
+
+            ``wake`` mirrors the session-lifecycle route: ``True`` pairs the append
+            with a ``defer_wake`` so the failure wakes the originating session;
+            defaults ``False`` (visible-on-next-turn).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    body: RuntimeChatLifecycleRequest,
+    authorization: None | str | Unset = UNSET,
+) -> (
+    HTTPValidationError
+    | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+    | None
+):
+    r"""Post Runtime Chat Lifecycle
+
+     Append a ``kind=lifecycle`` event onto the single session that
+    ``body.chat_id`` resolves to on ``body.connection_id`` (#1260),
+    optionally waking it.
+
+    The routing-key sibling of ``/runtime/session-lifecycle``: where that
+    needs the resolved ``session_id``, this carries the connector's per-peer
+    routing key (``chat_id``) and resolves it through the connection's
+    per-chat binding server-side — the SMS design's §3.5 req 1 second option
+    (\"route the per-peer failure through the resolver on the callback's
+    ``To``\").  Like the session-lifecycle route it targets exactly one
+    session, NOT the broadcast fan-out: a per-peer delivery failure must not
+    pollute unrelated ``per_chat`` sessions.
+
+    Authorization mirrors the session-lifecycle route: the bearer's
+    connector must match ``body.connection_id``'s connector and any
+    bearer-side ``connection_ids`` allowlist must include it (#350).  The
+    binding lookup itself is the per-session authorization — a ``chat_id``
+    that has no per-chat session on this connection 404s (no spurious
+    cross-peer append), and the resolution is scoped to the bearer's
+    ``account_id``.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the same pattern as the session-lifecycle and tool-result intakes) so
+    the failure wakes the originating session rather than merely being
+    visible on its next turn.
+
+    Args:
+        authorization (None | str | Unset):
+        body (RuntimeChatLifecycleRequest): Body for ``POST /v1/connectors/runtime/chat-
+            lifecycle`` (#1260).
+
+            The routing-key variant of :class:`RuntimeSessionLifecycleRequest`.
+            Both target a *single* session (not the broadcast fan-out), but where
+            the session-lifecycle route needs the caller to already hold the
+            resolved ``session_id``, this route carries a per-peer **routing key**
+            (``chat_id``) and resolves it through the connection's per-chat binding
+            to the originating session server-side.
+
+            This is the second option the SMS design (§3.5 req 1) calls out: "route
+            the per-peer failure through the resolver on the callback's ``To``".  A
+            Twilio status callback knows the peer number (→ ``chat_id``) but not the
+            AIOS ``session_id`` — without this route the connector would have to do
+            an extra round-trip (or maintain its own ``chat_id → session_id`` map)
+            just to reach the originating per_chat session.  The broadcast
+            ``/runtime/lifecycle`` route stays for genuine connection-wide events.
+
+            ``chat_id`` is the connector's per-peer routing key, the same value the
+            inbound path stamps onto ``chat_sessions``.  It must resolve to an
+            existing per-chat binding on ``connection_id`` — a routing key with no
+            bound session 404s rather than fanning a spurious cross-peer notice (the
+            design's "if a correlation row is genuinely missing … drop rather than
+            fan a spurious cross-peer failure", §3.5).
+
+            ``wake`` mirrors the session-lifecycle route: ``True`` pairs the append
+            with a ``defer_wake`` so the failure wakes the originating session;
+            defaults ``False`` (visible-on-next-turn).
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -142,6 +142,9 @@ from .o_auth_start_request_token_endpoint_auth_method_type_0 import (
 )
 from .o_auth_start_response import OAuthStartResponse
 from .one_shot_source import OneShotSource
+from .post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle import (
+    PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle,
+)
 from .post_connector_runtime_lifecycle_response_post_connector_runtime_lifecycle import (
     PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle,
 )
@@ -155,6 +158,10 @@ from .run_completion_source_replace_statuses_item import (
     RunCompletionSourceReplaceStatusesItem,
 )
 from .run_completion_source_statuses_item import RunCompletionSourceStatusesItem
+from .runtime_chat_lifecycle_request import RuntimeChatLifecycleRequest
+from .runtime_chat_lifecycle_request_data_type_0 import (
+    RuntimeChatLifecycleRequestDataType0,
+)
 from .runtime_lifecycle_request import RuntimeLifecycleRequest
 from .runtime_lifecycle_request_data_type_0 import RuntimeLifecycleRequestDataType0
 from .runtime_management_call_result_request import RuntimeManagementCallResultRequest
@@ -436,6 +443,7 @@ __all__ = (
     "OAuthStartRequestTokenEndpointAuthMethodType0",
     "OAuthStartResponse",
     "OneShotSource",
+    "PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle",
     "PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle",
     "PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle",
     "RecentChat",
@@ -443,6 +451,8 @@ __all__ = (
     "RunCompletionSourceReplace",
     "RunCompletionSourceReplaceStatusesItem",
     "RunCompletionSourceStatusesItem",
+    "RuntimeChatLifecycleRequest",
+    "RuntimeChatLifecycleRequestDataType0",
     "RuntimeLifecycleRequest",
     "RuntimeLifecycleRequestDataType0",
     "RuntimeManagementCallResultRequest",

--- a/packages/aios-sdk/aios_sdk/_generated/models/post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar(
+    "T",
+    bound="PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle",
+)
+
+
+@_attrs_define
+class PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle = cls()
+
+        post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle.additional_properties = d
+        return post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_chat_lifecycle_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_chat_lifecycle_request.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.runtime_chat_lifecycle_request_data_type_0 import (
+        RuntimeChatLifecycleRequestDataType0,
+    )
+
+
+T = TypeVar("T", bound="RuntimeChatLifecycleRequest")
+
+
+@_attrs_define
+class RuntimeChatLifecycleRequest:
+    """Body for ``POST /v1/connectors/runtime/chat-lifecycle`` (#1260).
+
+    The routing-key variant of :class:`RuntimeSessionLifecycleRequest`.
+    Both target a *single* session (not the broadcast fan-out), but where
+    the session-lifecycle route needs the caller to already hold the
+    resolved ``session_id``, this route carries a per-peer **routing key**
+    (``chat_id``) and resolves it through the connection's per-chat binding
+    to the originating session server-side.
+
+    This is the second option the SMS design (§3.5 req 1) calls out: "route
+    the per-peer failure through the resolver on the callback's ``To``".  A
+    Twilio status callback knows the peer number (→ ``chat_id``) but not the
+    AIOS ``session_id`` — without this route the connector would have to do
+    an extra round-trip (or maintain its own ``chat_id → session_id`` map)
+    just to reach the originating per_chat session.  The broadcast
+    ``/runtime/lifecycle`` route stays for genuine connection-wide events.
+
+    ``chat_id`` is the connector's per-peer routing key, the same value the
+    inbound path stamps onto ``chat_sessions``.  It must resolve to an
+    existing per-chat binding on ``connection_id`` — a routing key with no
+    bound session 404s rather than fanning a spurious cross-peer notice (the
+    design's "if a correlation row is genuinely missing … drop rather than
+    fan a spurious cross-peer failure", §3.5).
+
+    ``wake`` mirrors the session-lifecycle route: ``True`` pairs the append
+    with a ``defer_wake`` so the failure wakes the originating session;
+    defaults ``False`` (visible-on-next-turn).
+
+        Attributes:
+            connection_id (str):
+            chat_id (str):
+            event (str):
+            reason (None | str | Unset):
+            data (None | RuntimeChatLifecycleRequestDataType0 | Unset):
+            wake (bool | Unset):  Default: False.
+    """
+
+    connection_id: str
+    chat_id: str
+    event: str
+    reason: None | str | Unset = UNSET
+    data: None | RuntimeChatLifecycleRequestDataType0 | Unset = UNSET
+    wake: bool | Unset = False
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.runtime_chat_lifecycle_request_data_type_0 import (
+            RuntimeChatLifecycleRequestDataType0,
+        )
+
+        connection_id = self.connection_id
+
+        chat_id = self.chat_id
+
+        event = self.event
+
+        reason: None | str | Unset
+        if isinstance(self.reason, Unset):
+            reason = UNSET
+        else:
+            reason = self.reason
+
+        data: dict[str, Any] | None | Unset
+        if isinstance(self.data, Unset):
+            data = UNSET
+        elif isinstance(self.data, RuntimeChatLifecycleRequestDataType0):
+            data = self.data.to_dict()
+        else:
+            data = self.data
+
+        wake = self.wake
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "connection_id": connection_id,
+                "chat_id": chat_id,
+                "event": event,
+            }
+        )
+        if reason is not UNSET:
+            field_dict["reason"] = reason
+        if data is not UNSET:
+            field_dict["data"] = data
+        if wake is not UNSET:
+            field_dict["wake"] = wake
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.runtime_chat_lifecycle_request_data_type_0 import (
+            RuntimeChatLifecycleRequestDataType0,
+        )
+
+        d = dict(src_dict)
+        connection_id = d.pop("connection_id")
+
+        chat_id = d.pop("chat_id")
+
+        event = d.pop("event")
+
+        def _parse_reason(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        reason = _parse_reason(d.pop("reason", UNSET))
+
+        def _parse_data(
+            data: object,
+        ) -> None | RuntimeChatLifecycleRequestDataType0 | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                data_type_0 = RuntimeChatLifecycleRequestDataType0.from_dict(data)
+
+                return data_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | RuntimeChatLifecycleRequestDataType0 | Unset, data)
+
+        data = _parse_data(d.pop("data", UNSET))
+
+        wake = d.pop("wake", UNSET)
+
+        runtime_chat_lifecycle_request = cls(
+            connection_id=connection_id,
+            chat_id=chat_id,
+            event=event,
+            reason=reason,
+            data=data,
+            wake=wake,
+        )
+
+        return runtime_chat_lifecycle_request

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_chat_lifecycle_request_data_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_chat_lifecycle_request_data_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="RuntimeChatLifecycleRequestDataType0")
+
+
+@_attrs_define
+class RuntimeChatLifecycleRequestDataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        runtime_chat_lifecycle_request_data_type_0 = cls()
+
+        runtime_chat_lifecycle_request_data_type_0.additional_properties = d
+        return runtime_chat_lifecycle_request_data_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -274,6 +274,46 @@ class RuntimeSessionLifecycleRequest(BaseModel):
     wake: bool = False
 
 
+class RuntimeChatLifecycleRequest(BaseModel):
+    """Body for ``POST /v1/connectors/runtime/chat-lifecycle`` (#1260).
+
+    The routing-key variant of :class:`RuntimeSessionLifecycleRequest`.
+    Both target a *single* session (not the broadcast fan-out), but where
+    the session-lifecycle route needs the caller to already hold the
+    resolved ``session_id``, this route carries a per-peer **routing key**
+    (``chat_id``) and resolves it through the connection's per-chat binding
+    to the originating session server-side.
+
+    This is the second option the SMS design (§3.5 req 1) calls out: "route
+    the per-peer failure through the resolver on the callback's ``To``".  A
+    Twilio status callback knows the peer number (→ ``chat_id``) but not the
+    AIOS ``session_id`` — without this route the connector would have to do
+    an extra round-trip (or maintain its own ``chat_id → session_id`` map)
+    just to reach the originating per_chat session.  The broadcast
+    ``/runtime/lifecycle`` route stays for genuine connection-wide events.
+
+    ``chat_id`` is the connector's per-peer routing key, the same value the
+    inbound path stamps onto ``chat_sessions``.  It must resolve to an
+    existing per-chat binding on ``connection_id`` — a routing key with no
+    bound session 404s rather than fanning a spurious cross-peer notice (the
+    design's "if a correlation row is genuinely missing … drop rather than
+    fan a spurious cross-peer failure", §3.5).
+
+    ``wake`` mirrors the session-lifecycle route: ``True`` pairs the append
+    with a ``defer_wake`` so the failure wakes the originating session;
+    defaults ``False`` (visible-on-next-turn).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    connection_id: str
+    chat_id: str
+    event: str
+    reason: str | None = None
+    data: dict[str, Any] | None = None
+    wake: bool = False
+
+
 def _check_runtime_scope(auth_connector: str, target_connector: str) -> None:
     """Raise 403 if a runtime bearer reaches outside its connector type."""
     if auth_connector != target_connector:
@@ -608,6 +648,98 @@ async def post_runtime_session_lifecycle(
     # log/correlate without a second read.
     return {
         "appended_session_ids": [body.session_id],
+        "event_id": event.id,
+        "woke": body.wake,
+    }
+
+
+@router.post(
+    "/runtime/chat-lifecycle",
+    operation_id="post_connector_runtime_chat_lifecycle",
+    status_code=status.HTTP_201_CREATED,
+)
+async def post_runtime_chat_lifecycle(
+    body: RuntimeChatLifecycleRequest,
+    pool: PoolDep,
+    auth: RuntimeAuthDep,
+) -> dict[str, Any]:
+    """Append a ``kind=lifecycle`` event onto the single session that
+    ``body.chat_id`` resolves to on ``body.connection_id`` (#1260),
+    optionally waking it.
+
+    The routing-key sibling of ``/runtime/session-lifecycle``: where that
+    needs the resolved ``session_id``, this carries the connector's per-peer
+    routing key (``chat_id``) and resolves it through the connection's
+    per-chat binding server-side — the SMS design's §3.5 req 1 second option
+    ("route the per-peer failure through the resolver on the callback's
+    ``To``").  Like the session-lifecycle route it targets exactly one
+    session, NOT the broadcast fan-out: a per-peer delivery failure must not
+    pollute unrelated ``per_chat`` sessions.
+
+    Authorization mirrors the session-lifecycle route: the bearer's
+    connector must match ``body.connection_id``'s connector and any
+    bearer-side ``connection_ids`` allowlist must include it (#350).  The
+    binding lookup itself is the per-session authorization — a ``chat_id``
+    that has no per-chat session on this connection 404s (no spurious
+    cross-peer append), and the resolution is scoped to the bearer's
+    ``account_id``.
+
+    When ``body.wake`` is set, a ``defer_wake`` is enqueued after the append
+    (the same pattern as the session-lifecycle and tool-result intakes) so
+    the failure wakes the originating session rather than merely being
+    visible on its next turn.
+    """
+    _, auth_connector, account_id, auth_connection_ids = auth
+    async with pool.acquire() as conn:
+        connection = await queries.get_connection(conn, body.connection_id, account_id=account_id)
+        _check_runtime_scope(auth_connector, connection.connector)
+        _check_runtime_connection_scope(auth_connection_ids, body.connection_id)
+        # Resolve the per-peer routing key to its bound session. A missing
+        # row means the chat was never bound on this connection (past
+        # retention, or a routing key that never spawned a session) — drop
+        # with a 404 rather than fanning a spurious cross-peer notice (§3.5).
+        row = await queries.get_chat_session_row(
+            conn,
+            body.connection_id,
+            body.chat_id,
+            account_id=account_id,
+        )
+    if row is None:
+        raise NotFoundError(
+            "no session bound to this chat_id on the connection",
+            detail={"connection_id": body.connection_id, "chat_id": body.chat_id},
+        )
+    _chat_id, session_id, _created_at = row
+    payload: dict[str, Any] = {
+        "event": body.event,
+        "connection_id": body.connection_id,
+        "connector": connection.connector,
+        "chat_id": body.chat_id,
+    }
+    if body.reason is not None:
+        payload["reason"] = body.reason
+    if body.data is not None:
+        payload["data"] = body.data
+    event = await sessions_service.append_event(
+        pool,
+        session_id,
+        "lifecycle",
+        payload,
+        account_id=account_id,
+    )
+    if body.wake:
+        await defer_wake(
+            pool,
+            session_id,
+            cause="connector_lifecycle",
+            account_id=account_id,
+        )
+    # Mirror the session-lifecycle route's shape (single-element list keeps
+    # callers handling ``appended_session_ids`` uniform), plus the resolved
+    # session_id, the appended event id, and whether a wake was enqueued.
+    return {
+        "appended_session_ids": [session_id],
+        "session_id": session_id,
         "event_id": event.id,
         "woke": body.wake,
     }

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -45,6 +45,9 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
     "post_connector_runtime_inbound": (
         "Called by connector containers via runtime token; not for operators."
     ),
+    "post_connector_runtime_chat_lifecycle": (
+        "Called by connector containers via runtime token; not for operators."
+    ),
     "post_connector_runtime_lifecycle": (
         "Called by connector containers via runtime token; not for operators."
     ),

--- a/tests/integration/test_runtime_chat_lifecycle.py
+++ b/tests/integration/test_runtime_chat_lifecycle.py
@@ -1,0 +1,245 @@
+"""Integration tests for ``POST /v1/connectors/runtime/chat-lifecycle`` (#1260).
+
+The routing-key (``chat_id``) variant of the session-targeted lifecycle
+append. Where ``/runtime/session-lifecycle`` (#1261) needs the caller to
+already hold the resolved ``session_id``, this route carries the connector's
+per-peer routing key and resolves it through the connection's per-chat
+binding server-side — the SMS design's §3.5 req 1 second option ("route the
+per-peer failure through the resolver on the callback's ``To``").
+
+Like the session-lifecycle suite, the route handler ``post_runtime_chat_lifecycle``
+is driven directly with a real pool and a resolved ``RuntimeAuthDep`` tuple;
+``defer_wake`` is patched at the router's import site so the wake assertion
+observes the call without a live procrastinate worker.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.api.routers.connectors import (
+    RuntimeChatLifecycleRequest,
+    post_runtime_chat_lifecycle,
+)
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ForbiddenError, NotFoundError
+from aios.services import agents as agents_service
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+_CONNECTOR = "sms"
+_CHAT_ID = "+15550123"
+
+
+@pytest.fixture
+async def pool_with_chat_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str, str, str]]:
+    """Yield ``(pool, account_id, connection_id, chat_id, session_id)`` for an
+    account whose per-chat session (``chat_sessions`` row keyed on ``chat_id``)
+    is bound to an ``sms`` connection."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_cl', NULL, TRUE, 'tenant-cl')
+                """
+            )
+        agent = await agents_service.create_agent(
+            pool,
+            account_id="acc_cl",
+            name="cl-agent",
+            model="openrouter/test",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+        )
+        env = await environments_service.create_environment(
+            pool, account_id="acc_cl", name="cl-env"
+        )
+        async with pool.acquire() as conn:
+            session = await queries.insert_session(
+                conn,
+                account_id="acc_cl",
+                agent_id=agent.id,
+                environment_id=env.id,
+                agent_version=agent.version,
+                title=None,
+                metadata={},
+            )
+            connection = await queries.insert_connection(
+                conn,
+                account_id="acc_cl",
+                connector=_CONNECTOR,
+                external_account_id="+15550001",
+                metadata={},
+            )
+            # Per-chat binding: the routing key (chat_id) → session the
+            # resolver will return. No single_session binding here — this is
+            # exactly the per_chat shape the SMS connector spawns per peer.
+            await queries.insert_chat_session(
+                conn,
+                account_id="acc_cl",
+                connection_id=connection.id,
+                chat_id=_CHAT_ID,
+                session_id=session.id,
+            )
+        yield pool, "acc_cl", connection.id, _CHAT_ID, session.id
+    finally:
+        await pool.close()
+
+
+@pytest.fixture
+def patched_defer_wake() -> Any:
+    """Patch the router's ``defer_wake`` import site so the wake enqueue is a
+    no-op the test can assert against (no live procrastinate worker needed)."""
+    with mock.patch("aios.api.routers.connectors.defer_wake", new_callable=AsyncMock) as m:
+        yield m
+
+
+def _auth(account_id: str, connector: str = _CONNECTOR) -> tuple[str, str, str, None]:
+    """Shape of a resolved unscoped ``RuntimeAuthDep`` tuple:
+    ``(token_id, connector, account_id, connection_ids)``."""
+    return ("rt_test", connector, account_id, None)
+
+
+async def _lifecycle_rows(pool: asyncpg.Pool[Any], session_id: str) -> list[dict[str, Any]]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events WHERE session_id = $1 AND kind = 'lifecycle' ORDER BY seq",
+            session_id,
+        )
+    import json
+
+    return [json.loads(r["data"]) if isinstance(r["data"], str) else r["data"] for r in rows]
+
+
+class TestRuntimeChatLifecycle:
+    async def test_resolves_chat_id_to_the_one_session(
+        self,
+        pool_with_chat_session: tuple[asyncpg.Pool[Any], str, str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """The event lands on the session the chat_id resolves to (not
+        broadcast), carrying the chat_id in the payload alongside the
+        broadcast-route fields."""
+        pool, account_id, connection_id, chat_id, session_id = pool_with_chat_session
+
+        result = await post_runtime_chat_lifecycle(
+            RuntimeChatLifecycleRequest(
+                connection_id=connection_id,
+                chat_id=chat_id,
+                event="connector_delivery_failed",
+                reason="30007",
+                data={"detail": "carrier blocked", "peer": chat_id},
+                wake=False,
+            ),
+            pool,
+            _auth(account_id),
+        )
+
+        assert result["appended_session_ids"] == [session_id]
+        assert result["session_id"] == session_id
+        assert result["woke"] is False
+        rows = await _lifecycle_rows(pool, session_id)
+        assert len(rows) == 1
+        payload = rows[0]
+        assert payload["event"] == "connector_delivery_failed"
+        assert payload["connection_id"] == connection_id
+        assert payload["connector"] == _CONNECTOR
+        assert payload["chat_id"] == chat_id
+        assert payload["reason"] == "30007"
+        assert payload["data"] == {"detail": "carrier blocked", "peer": chat_id}
+
+    async def test_wake_true_enqueues_wake_false_does_not(
+        self,
+        pool_with_chat_session: tuple[asyncpg.Pool[Any], str, str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        pool, account_id, connection_id, chat_id, session_id = pool_with_chat_session
+
+        await post_runtime_chat_lifecycle(
+            RuntimeChatLifecycleRequest(
+                connection_id=connection_id,
+                chat_id=chat_id,
+                event="connector_delivery_failed",
+                wake=False,
+            ),
+            pool,
+            _auth(account_id),
+        )
+        assert patched_defer_wake.await_count == 0
+
+        await post_runtime_chat_lifecycle(
+            RuntimeChatLifecycleRequest(
+                connection_id=connection_id,
+                chat_id=chat_id,
+                event="connector_delivery_failed",
+                wake=True,
+            ),
+            pool,
+            _auth(account_id),
+        )
+        assert patched_defer_wake.await_count == 1
+        assert patched_defer_wake.await_args is not None
+        args = patched_defer_wake.await_args.args
+        kwargs = patched_defer_wake.await_args.kwargs
+        assert args[1] == session_id
+        assert kwargs["account_id"] == account_id
+        assert kwargs["cause"] == "connector_lifecycle"
+
+    async def test_not_found_when_chat_id_unbound(
+        self,
+        pool_with_chat_session: tuple[asyncpg.Pool[Any], str, str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """An unknown routing key resolves to no session — 404 (drop rather
+        than fan a spurious cross-peer notice), with no append and no wake."""
+        pool, account_id, connection_id, _chat_id, _session_id = pool_with_chat_session
+
+        with pytest.raises(NotFoundError):
+            await post_runtime_chat_lifecycle(
+                RuntimeChatLifecycleRequest(
+                    connection_id=connection_id,
+                    chat_id="+19999999",
+                    event="connector_delivery_failed",
+                    wake=True,
+                ),
+                pool,
+                _auth(account_id),
+            )
+        assert patched_defer_wake.await_count == 0
+
+    async def test_forbidden_when_bearer_connector_mismatch(
+        self,
+        pool_with_chat_session: tuple[asyncpg.Pool[Any], str, str, str, str],
+        patched_defer_wake: AsyncMock,
+    ) -> None:
+        """A bearer scoped to a different connector type cannot reach this
+        connection (``_check_runtime_scope``) — even before resolution."""
+        pool, account_id, connection_id, chat_id, _session_id = pool_with_chat_session
+
+        with pytest.raises(ForbiddenError):
+            await post_runtime_chat_lifecycle(
+                RuntimeChatLifecycleRequest(
+                    connection_id=connection_id,
+                    chat_id=chat_id,
+                    event="connector_delivery_failed",
+                ),
+                pool,
+                _auth(account_id, connector="whatsapp"),
+            )
+        assert patched_defer_wake.await_count == 0


### PR DESCRIPTION
## What & why

Resolves #1260 (part of #1252). Adds `POST /v1/connectors/runtime/chat-lifecycle` — the **routing-key** variant of the session-targeted lifecycle append called out by the SMS design (§3.5 req 1, §6).

`/runtime/lifecycle` fans an event out to **every** session bound to a connection and carries no per-session targeting, so a per-peer (e.g. SMS) delivery failure would pollute unrelated `per_chat` sessions. #1261/#1308 already shipped `/runtime/session-lifecycle`, the first option in the issue's scope (carry a resolved `session_id`, append to exactly that session). This PR implements the issue's **second** option: "route a per-peer event through the resolver on a provided routing key" — the design's literal "route the per-peer failure through the resolver on the callback's `To`".

A Twilio status callback knows the peer number (→ `chat_id`) but not the AIOS `session_id`. This route lets the connector pass the per-peer routing key and have AIOS resolve it through the connection's per-chat binding server-side, appending to exactly that one session (never the broadcast fan-out). The existing `/runtime/lifecycle` route stays for genuine connection-wide transport-down notices.

## Behaviour

- `RuntimeChatLifecycleRequest { connection_id, chat_id, event, reason?, data?, wake? }`.
- Auth mirrors the session-lifecycle / tool-result routes: `_check_runtime_scope` + `_check_runtime_connection_scope` (#350), scoped to the bearer's `account_id`.
- Resolves `chat_id` → `session_id` via `get_chat_session_row`. A `chat_id` with no bound session **404s** — drop rather than fan a spurious cross-peer notice (§3.5), not a server error.
- Appends one `kind=lifecycle` event carrying `{event, connection_id, connector, chat_id, reason?, data?}`.
- `wake=True` enqueues a `defer_wake(cause="connector_lifecycle")` after the append (same pattern as session-lifecycle/tool-result); defaults `False` (visible-on-next-turn).
- Returns `{appended_session_ids:[session_id], session_id, event_id, woke}`.

## Changes

- `src/aios/api/routers/connectors.py`: `RuntimeChatLifecycleRequest` + `post_runtime_chat_lifecycle` handler.
- `packages/aios-connector-http/.../runner.py`: `SessionRunner.emit_chat_lifecycle(...)` SDK helper (drop-don't-raise on non-fatal 4xx incl. the 404 correlation-gap, matching `emit_inbound`/`emit_lifecycle`).
- `src/aios/cli/allowlist.py`: allowlist the new runtime-only operation_id.
- Regenerated `openapi.json` + typed SDK under `packages/aios-sdk/.../_generated/` (diff confined to the new route/models).
- Tests: `tests/integration/test_runtime_chat_lifecycle.py` (resolve-and-target one session, wake on/off, 404 on unbound chat_id, connector-scope 403) and `TestEmitChatLifecycle` SDK unit tests, mirroring the session-lifecycle suites.

## Testing

- New integration tests pass against a local Postgres (8/8 incl. the existing session-lifecycle suite as a harness sanity check).
- `test_runner.py` (connector SDK), `test_cli_coverage.py`, `test_openapi_snapshot.py` all pass; ruff + mypy clean on changed sources.

The SMS connector's status-callback handler (built under #1252) is the consumer: on a terminal carrier-block class it looks up the originating peer's routing key and calls `emit_chat_lifecycle(..., event="connector_delivery_failed", reason=twilio_code, data={...}, wake=True)`.