### PR TITLE
test(dev-pipeline): pin deterministic issue-close keyed on issue_number, not PR-body free text (#1302)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -1146,6 +1146,13 @@ async def main(input):
     # dispatch-gate sweep / rank-6 staleness reaper. Make the terminal cleanup explicit and
     # idempotent: strip BOTH claim labels (logged) and close the issue (state_reason:completed).
     # A re-drive that finds it already closed / labels already gone is a no-op, not an error.
+    #
+    # #1302 — the close is keyed on the KNOWN `issue_number` here, NEVER on the PR body's
+    # `Closes #n` free text. #1298 merged but left #1292 OPEN because its body wrote "Closes
+    # the ... class" as prose with no `#n` link, so GitHub's auto-close-via-keyword never
+    # fired (the completion-marker-from-free-text antipattern). Closing on the structurally-
+    # known issue_number removes that free-text dependency entirely; the `Closes #n` in the
+    # body, when present, is a nicety we never rely on for the close.
     await _close_source_issue(repo, issue_number)
     result = {"state": "done", "pr_url": pr_url, "pr_number": pr_number, "merged": merged,
               "risk_tier": tier, "escalations": escalations}

--- a/tests/unit/test_dev_pipeline_close_on_merge.py
+++ b/tests/unit/test_dev_pipeline_close_on_merge.py
@@ -11,6 +11,13 @@ terminal post-merge cleanup that idempotently strips BOTH claim labels and close
 (``state:closed`` + ``state_reason:completed``), logging each gh() response (rank-6
 label-write visibility). ``_unlabel`` now also logs its DELETE outcome.
 
+#1302 sharpens the WHY: the pipeline must NOT delegate the close to GitHub's
+auto-close-via-PR-body-keyword. #1298 merged but left #1292 OPEN because the implement
+agent's body wrote ``Closes the ... **class**`` as prose (no ``Closes #<n>`` link) — the
+completion-marker-from-free-text antipattern. The deterministic close keys on the KNOWN
+``issue_number`` via the API, so a merged run whose PR body lacks ``Closes #n`` still ends
+with the issue CLOSED; the two ``test_close_*_pr_body*`` cases pin that property.
+
 These helpers live inside the workflow script source (``_BODY``), so they are not importable
 as module attributes. We build the production script and ``exec`` it in a fresh namespace,
 inject a fake async ``gh`` (recording every call) and a ``log`` sink, then drive the
@@ -211,3 +218,43 @@ def test_close_failure_is_surfaced_when_dispatched_kept() -> None:
     _run(ns["_close_source_issue"](REPO, ISSUE))
     logs = "\n".join(ns["_LOGS"])
     assert "FAILED" in logs and "close source issue" in logs
+
+
+# ─── #1302: the close is keyed on the KNOWN issue_number, NOT on PR-body free text ────
+
+
+def test_close_is_keyed_on_issue_number_not_pr_body_text() -> None:
+    # #1302: a merged dev_pipeline PR (#1298) left its source issue (#1292) OPEN because the
+    # pipeline delegated issue-close to GitHub's auto-close-via-PR-body-keyword, and the
+    # implement agent's body wrote ``Closes the ... **class**`` as *prose* — "Closes" with no
+    # ``#<n>`` link — so GitHub never closed it (the completion-marker-from-free-text
+    # antipattern). The deterministic fix closes on the KNOWN ``issue_number`` via the API.
+    #
+    # Pin that property structurally: ``_close_source_issue`` takes (repo, issue_number) and no
+    # PR body, and the PATCH path it targets is derived purely from ``issue_number`` — so the
+    # exact prose that broke #1298 (a "Closes ... class" body with no ``#n``) cannot affect the
+    # close. Whatever the body says, the merged issue ends CLOSED with state_reason=completed.
+    gh = _FakeGH()
+    ns = _ns(gh)
+    _run(ns["_close_source_issue"](REPO, ISSUE))
+
+    patches = [(p, b) for (m, p, b) in gh.calls if m == "PATCH"]
+    assert len(patches) == 1, "exactly one deterministic close PATCH, regardless of PR body"
+    path, body = patches[0]
+    # The close path is the KNOWN issue's path — derived from issue_number, never parsed prose.
+    assert path == ISSUE_PATH
+    assert str(ISSUE) in path
+    assert body == {"state": "closed", "state_reason": "completed"}
+
+
+def test_close_signature_takes_no_pr_body() -> None:
+    # #1302 regression guard against re-introducing the free-text dependency: the close helper
+    # must NOT grow a PR-body parameter — it closes on the structurally-known issue_number, so
+    # a body that omits or mangles ``Closes #n`` (the #1298 failure) is irrelevant to the close.
+    import inspect
+
+    ns = _ns(_FakeGH())
+    params = list(inspect.signature(ns["_close_source_issue"]).parameters)
+    assert params == ["repo", "issue_number"], (
+        "close must key on the known issue_number, never on PR-body text (#1302)"
+    )


### PR DESCRIPTION
## Summary

Fixes the invariant raised in #1302: a merged dev_pipeline PR must close its source issue **deterministically** via the API on the KNOWN `issue_number`, never via GitHub's auto-close-via-PR-body-keyword. #1298 merged but left #1292 OPEN because its body wrote `Closes the ... **class**` as prose with no `Closes #n` link — the completion-marker-from-free-text antipattern, which can leave a merged-but-open issue re-dispatchable.

## Finding

The deterministic post-merge close requested by #1302 — `PATCH /repos/{repo}/issues/{n}` `{"state":"closed","state_reason":"completed"}` keyed on the known `issue_number`, idempotent, in the A15 post-merge step — was **already implemented** by the #1188/#1208 work via `_close_source_issue(repo, issue_number)` (called at the A15 close site). Its signature takes `(repo, issue_number)` and no PR body, so it is structurally independent of any `Closes #n` prose.

The genuine gap was the test #1302 explicitly asks for — *"a merged run whose PR body lacks `Closes #n` still ends with the issue CLOSED"* — plus durable rationale linking the antipattern.

## Changes

- **tests/unit/test_dev_pipeline_close_on_merge.py**: two new #1302 regression tests:
  - `test_close_is_keyed_on_issue_number_not_pr_body_text` — asserts the close fires exactly one PATCH to the issue path derived from `issue_number` with `{state:closed, state_reason:completed}`, regardless of (and with no input from) any PR body.
  - `test_close_signature_takes_no_pr_body` — guards against re-introducing a free-text dependency: `_close_source_issue` must keep signature `(repo, issue_number)`.
  - Docstring updated to record the #1302 WHY.
- **src/aios/workflows/dev_pipeline.py**: comment at the A15 `_close_source_issue` call site documenting that the close is keyed on the known `issue_number`, never the PR body's `Closes #n` free text (the #1298/#1292 failure mode); the body keyword, when present, is a nicety never relied on.

## Test-first / verification

Wrote the tests against the existing helper and ran them in an isolated exec namespace (no LLM, no real I/O): 12/12 pass (10 existing + 2 new). `ruff check` and `ruff format --check` clean; both `dev_pipeline.py` and the generated workflow script parse.

No behavior change to the production close path was needed — the deterministic close already exists; this PR pins the #1302 invariant so it cannot regress.