### PR TITLE
feat(workflows): no-silent-degrade list-read invariant — assert fetched==total / Link rel=next exhaustion on every LIST read (#1323)

### DIFF
--- a/src/aios/workflows/gh_body.py
+++ b/src/aios/workflows/gh_body.py
@@ -1,5 +1,5 @@
-"""Shared GitHub-body parsing helper (aios#1294) — the CLASS fix for silent
-truncate-then-degrade-to-empty.
+"""Shared GitHub-body parsing helper (aios#1294, aios#1323) — the CLASS fix for
+silent truncate-then-degrade-to-empty AND silent list under-count.
 
 ``http_request`` caps a response body at a configurable char limit and now sets
 ``"truncated": True`` whenever it cuts one (the tool no longer truncates
@@ -35,6 +35,27 @@ functions splice it into their ``_BODY``. The text references ``gh``, ``_status`
 pipeline bodies already define with identical semantics — so it composes without
 per-pipeline edits.
 
+aios#1323 — NO-SILENT-DEGRADE LIST-READ INVARIANT (generalises #1294 from response
+BODIES to list PAGINATION): a LIST read is only honest if it can prove it saw the
+WHOLE list. The shipped ``gh_paginated`` followed ``Link: rel="next"`` but, when it
+hit its ``max_pages`` ceiling with a ``rel="next"`` still dangling, RETURNED THE
+PARTIAL LIST AS IF COMPLETE — the same look-green-while-doing-less shape #1294
+polices, one layer up. A reconciler that reads a paginated check-runs list, gets
+page 1, and concludes "all green" is silently under-counting the substrate it
+judges. The fix here:
+
+  * ``gh_paginated`` now RAISES ``GitHubListIncomplete`` if it exhausts ``max_pages``
+    while GitHub still advertises an unfetched ``rel="next"`` page — it NEVER returns
+    a partial set silently treated as complete. (A truncated/unparseable 2xx page
+    still raises ``GitHubBodyError`` as before.)
+  * ``graphql_list_complete`` asserts ``len(nodes) == totalCount`` for a GraphQL
+    connection and raises ``GitHubListIncomplete`` on a mismatch — the GraphQL twin
+    of the REST ``rel="next"`` walk.
+
+``GitHubListIncomplete`` is the first-class ``cannot-determine`` verdict: a LIST
+read that cannot prove completeness is fatal-loud, NEVER coerced to an empty / ok /
+green partial result.
+
 DETERMINISM: the helper does only pure string/list/dict work plus the same ``gh``
 calls the surrounding body already makes; it imports nothing and reads no clock.
 The raise is a deterministic function of the (replayed) tool result, so replay
@@ -60,6 +81,17 @@ class GitHubBodyError(RuntimeError):
     truncated by the response cap, or 2xx-but-unparseable JSON. Raised instead of
     returning None/[] so a structurally-incomplete read never degrades to a silent
     empty result (aios#1294)."""
+
+
+class GitHubListIncomplete(RuntimeError):
+    """A LIST read that could NOT prove it fetched the whole list — REST
+    pagination that still advertised an unfetched ``Link: rel="next"`` page when
+    the page ceiling was hit, or a GraphQL connection where ``len(nodes)`` did not
+    equal ``totalCount``. This is the first-class ``cannot-determine`` verdict of
+    aios#1323: a list read that cannot prove completeness is raised LOUD, NEVER
+    returned as a partial set silently treated as complete (the dominant
+    look-green-while-doing-less shape — a paginated check-runs read that sees page
+    1 and concludes "all green")."""
 
 
 def _resp_truncated(resp):
@@ -117,20 +149,77 @@ async def gh_paginated(path, per_page=100, max_pages=50):
     change and stops pagination (returns what was gathered). The page number is
     rebuilt onto OUR path, so no host-bearing next URL crosses the route gate; each
     request is a distinct ``tool()`` await (per-content-hash call_key), so replay
-    stays stable. Requires the route to allow a query string (``allow_query``)."""
+    stays stable. Requires the route to allow a query string (``allow_query``).
+
+    aios#1323 — the no-silent-degrade list-read invariant: if the page ceiling
+    (``max_pages``) is reached while GitHub STILL advertises an unfetched
+    ``rel="next"`` page, we RAISE ``GitHubListIncomplete`` rather than return the
+    partial list as if it were the whole list. Silently truncating a list read at
+    the ceiling is exactly the look-green-while-doing-less shape (a check-runs read
+    that returns page 1 and is treated as "all green"); the cap exists to bound work,
+    not to license a silent under-count. Raise the ceiling for genuinely huge lists.
+    """
     items = []
     page = 1
     for _ in range(max_pages):
         resp = await gh("GET", _with_query(path, per_page=per_page, page=page))
         if _status(resp) != 200:
-            break
+            return items  # non-2xx (auth/404) is the caller's branch
         chunk = _json_body(resp)  # raises loud on truncated / unparseable 2xx
         if not isinstance(chunk, list):
-            break
+            return items  # genuine shape change — stop, return what we have
         items.extend(chunk)
         nxt = _link_next_page(_headers(resp).get("link"))
         if nxt is None:
-            break
+            return items  # last page reached cleanly — the list is COMPLETE
         page = nxt
-    return items
+    # Loop fell through the ceiling with a rel="next" still dangling: we CANNOT
+    # prove we saw the whole list, so this read is cannot-determine, never a
+    # silently-truncated "complete" list (aios#1323).
+    raise GitHubListIncomplete(
+        "GitHub list read for %r exhausted the %d-page ceiling while a "
+        "rel=\"next\" page was still unfetched — refusing to treat a partial "
+        "(%d-item) read as the complete list. Raise max_pages or paginate more "
+        "finely; never silently under-count a list read." % (path, max_pages, len(items))
+    )
+
+
+def graphql_list_complete(connection, *, where=""):
+    """Assert a GraphQL connection was fetched in FULL and return its ``nodes``.
+
+    ``connection`` is a parsed GraphQL connection object — a dict carrying both a
+    ``totalCount`` (the server's authoritative count) and a ``nodes`` list (what we
+    actually fetched). The GraphQL twin of the REST ``rel="next"`` walk: a single
+    GraphQL page returns at most ``first:N`` nodes, so a connection with more than
+    ``N`` items comes back with ``len(nodes) < totalCount`` and a ``pageInfo`` cursor
+    we did not follow. Returning those ``nodes`` as if complete is the same silent
+    under-count #1294 polices for bodies.
+
+    Returns ``nodes`` iff ``len(nodes) == totalCount``. On ANY mismatch — fewer
+    nodes than the count (unfetched pages) OR a malformed connection missing either
+    field — raise ``GitHubListIncomplete`` (cannot-determine), NEVER a partial list.
+    ``where`` is an optional label for the error message (e.g. ``"check runs for
+    <sha>"``). Pure: deterministic over its input, no I/O."""
+    label = (" for %s" % where) if where else ""
+    if not isinstance(connection, dict):
+        raise GitHubListIncomplete(
+            "GraphQL connection%s is not an object (%r) — cannot prove the list is "
+            "complete; refusing to degrade to empty (aios#1323)." % (label, type(connection).__name__)
+        )
+    total = connection.get("totalCount")
+    nodes = connection.get("nodes")
+    if not isinstance(total, int) or not isinstance(nodes, list):
+        raise GitHubListIncomplete(
+            "GraphQL connection%s is missing totalCount/nodes (totalCount=%r, "
+            "nodes=%r) — cannot prove the list is complete; refusing to degrade to "
+            "empty (aios#1323)." % (label, total, type(nodes).__name__)
+        )
+    if len(nodes) != total:
+        raise GitHubListIncomplete(
+            "GraphQL list%s under-counted: fetched %d node(s) but totalCount is %d "
+            "— there are unfetched pages, so this read is cannot-determine, NOT a "
+            "complete list. Paginate the connection (follow pageInfo.endCursor) "
+            "before treating it as whole (aios#1323)." % (label, len(nodes), total)
+        )
+    return nodes
 '''

--- a/tests/unit/test_gh_body_helper.py
+++ b/tests/unit/test_gh_body_helper.py
@@ -172,3 +172,106 @@ def test_gh_paginated_non_2xx_page_stops_and_returns_gathered() -> None:
     ns = _namespace(pages)
     items = asyncio.run(ns["gh_paginated"]("/repos/o/r/issues"))
     assert items == [1, 2]
+
+
+# ─── aios#1323: no-silent-degrade LIST-read invariant ────────────────────────
+
+
+def test_gh_paginated_raises_when_page_ceiling_hit_with_next_still_dangling() -> None:
+    # The aios#1323 core: every page we fetch STILL advertises rel="next" (an
+    # unbounded list relative to our ceiling). Hitting max_pages with a next page
+    # still dangling must RAISE cannot-determine, NEVER return the partial list as
+    # if it were complete.
+    page = {"status": 200, "body": "[1,2]", "headers": {"Link": '<...?page=99>; rel="next"'}}
+    ns = _namespace([dict(page) for _ in range(10)])
+    err = ns["GitHubListIncomplete"]
+    with pytest.raises(err):
+        asyncio.run(ns["gh_paginated"]("/repos/o/r/issues", max_pages=3))
+
+
+def test_gh_paginated_complete_walk_under_ceiling_returns_full_list() -> None:
+    # When the walk reaches a page with NO rel="next" before the ceiling, the list
+    # is provably complete and returns normally (no false cannot-determine).
+    pages = [
+        {"status": 200, "body": "[1,2]", "headers": {"Link": '<...?page=2>; rel="next"'}},
+        {"status": 200, "body": "[3,4]"},  # no Link -> last page, complete
+    ]
+    ns = _namespace(pages)
+    items = asyncio.run(ns["gh_paginated"]("/repos/o/r/issues", max_pages=3))
+    assert items == [1, 2, 3, 4]
+
+
+def test_paginated_check_runs_read_does_not_return_false_green() -> None:
+    # THE acceptance scenario: a reconciler reads a PAGINATED check-runs list to
+    # decide if a commit is "all green". Page 1 is all-success but a rel="next"
+    # dangles past the page ceiling — the red/pending check runs live on an
+    # unfetched page. A truncated read must NOT let the caller conclude "green".
+    #
+    # We model the caller's exact green-decision: it is green iff EVERY fetched
+    # check run concluded "success". The invariant guarantees it can only run that
+    # decision over a PROVABLY-COMPLETE list — a truncated read raises instead.
+    success_page = {
+        "status": 200,
+        "body": json.dumps([{"conclusion": "success"}, {"conclusion": "success"}]),
+        "headers": {"Link": '<...?page=99>; rel="next"'},  # more pages exist!
+    }
+    ns = _namespace([dict(success_page) for _ in range(10)])
+    err = ns["GitHubListIncomplete"]
+
+    def reconciler_says_green(repo_path: str) -> bool:
+        runs = asyncio.run(ns["gh_paginated"](repo_path, max_pages=3))
+        return all(r.get("conclusion") == "success" for r in runs)
+
+    # The truncated read does NOT silently return [all-success] -> "green"; it
+    # raises cannot-determine, so the caller can never emit a false green.
+    with pytest.raises(err):
+        reconciler_says_green("/repos/o/r/commits/abc/check-runs")
+
+
+# ─── aios#1323: graphql_list_complete (totalCount == len(nodes)) ─────────────
+
+
+def test_graphql_list_complete_returns_nodes_when_count_matches() -> None:
+    ns = _namespace()
+    conn = {"totalCount": 2, "nodes": [{"id": "a"}, {"id": "b"}]}
+    assert ns["graphql_list_complete"](conn) == [{"id": "a"}, {"id": "b"}]
+
+
+def test_graphql_list_complete_raises_on_undercount() -> None:
+    # len(nodes) < totalCount: there are unfetched pages -> cannot-determine.
+    ns = _namespace()
+    err = ns["GitHubListIncomplete"]
+    conn = {"totalCount": 5, "nodes": [{"id": "a"}, {"id": "b"}]}
+    with pytest.raises(err):
+        ns["graphql_list_complete"](conn, where="check runs for abc")
+
+
+def test_graphql_check_runs_undercount_does_not_return_false_green() -> None:
+    # GraphQL twin of the check-runs scenario: totalCount=4 but only the 2 fetched
+    # nodes are success; the unfetched 2 could be red. The caller can only run its
+    # green decision over a complete list, so the undercount raises instead of
+    # yielding a false green.
+    ns = _namespace()
+    err = ns["GitHubListIncomplete"]
+    conn = {
+        "totalCount": 4,
+        "nodes": [{"conclusion": "SUCCESS"}, {"conclusion": "SUCCESS"}],
+    }
+
+    def says_green() -> bool:
+        nodes = ns["graphql_list_complete"](conn, where="check runs")
+        return all(n.get("conclusion") == "SUCCESS" for n in nodes)
+
+    with pytest.raises(err):
+        says_green()
+
+
+def test_graphql_list_complete_raises_on_malformed_connection() -> None:
+    ns = _namespace()
+    err = ns["GitHubListIncomplete"]
+    with pytest.raises(err):
+        ns["graphql_list_complete"]({"nodes": []})  # no totalCount
+    with pytest.raises(err):
+        ns["graphql_list_complete"]({"totalCount": 0})  # no nodes
+    with pytest.raises(err):
+        ns["graphql_list_complete"]("not a dict")


### PR DESCRIPTION
## What

Generalizes the SHIPPED #1294 fail-loud-on-truncated-**body** contract from response **bodies** to list **pagination**. Implemented entirely as caller-side script logic in the shared `gh_body.GH_BODY_HELPERS` source — **no host-tool change** — so it is authored once and spliced into BOTH the dev and triage pipeline scripts and can't drift.

A LIST read is only honest if it can prove it saw the **whole** list. The shipped `gh_paginated` followed `Link: rel="next"` but, on hitting its `max_pages` ceiling with a `rel="next"` still dangling, returned the **partial** list as if complete — a silent list under-count and the dominant *look-green-while-doing-less* shape (a check-runs read that sees page 1 and concludes "all green"). This is the hard precondition for the substrate-different-verdict architecture: a re-derivation/reconciler is only uncorrelated if it cannot silently under-count.

## Changes

- **`gh_paginated`** now RAISES `GitHubListIncomplete` if it exhausts `max_pages` while GitHub still advertises an unfetched `Link: rel="next"` page — it never returns a partial set silently treated as complete. A clean walk that reaches a page with no `rel="next"` before the ceiling returns the provably-complete list as before; truncated/unparseable-2xx pages still raise `GitHubBodyError` (#1294).
- **`graphql_list_complete(connection)`** asserts `len(nodes) == totalCount` for a GraphQL connection — the GraphQL twin of the REST `rel="next"` walk — returning `nodes` on a match and raising `GitHubListIncomplete` on any under-count or malformed (missing `totalCount`/`nodes`) connection.
- **`GitHubListIncomplete`** is the first-class **cannot-determine** verdict: a list read that cannot prove completeness is raised loud, NEVER coerced to an empty / ok / green partial result.

## Tests (`tests/unit/test_gh_body_helper.py`)

- A **paginated check-runs read** whose page 1 is all-success but with a `rel="next"` past the ceiling does NOT return a false "green" — the reconciler's green decision can only run over a provably-complete list, so the truncated read raises cannot-determine.
- The **GraphQL** twin (`totalCount=4`, only 2 success nodes fetched) likewise raises instead of yielding a false green.
- `gh_paginated` raises on ceiling-exhaustion-with-dangling-next; returns the full list on a clean complete walk; `graphql_list_complete` returns nodes on a count match and raises on under-count / malformed connection.

All 17 tests in the file pass; `ruff check` and `ruff format --check` clean; both built pipeline scripts parse with the helper spliced in.

Closes #1323