### PR TITLE
feat(workflows): surface per-run usage (cost/tokens/wall-clock) on get_run/list_runs (#1324)

### DIFF
--- a/docs/reference/run-observability.md
+++ b/docs/reference/run-observability.md
@@ -104,3 +104,29 @@ the **child-session** events produced when a run spawns agent sessions:
 
 Source of truth: `aios.models.workflows.WfRunEvent` and
 `aios.models.events.Event`.
+
+## (d) Per-run cost / token / wall-clock usage on the read path (#1324)
+
+`GET /v1/runs/{id}` (`WfRun`) and `GET /v1/runs` (`list_runs`) carry a `usage`
+object — the run's realized spend, the machine-observer's cost-substrate. It is
+summed over the run's direct child sessions via the same `run_children_usage`
+source the in-script `budget()` builtin consumes, so the run's `budget_usd`
+*ceiling* and its `usage.cost_microusd` *spend* are both legible from the read
+path (not buried in a builtin). On `list_runs` the whole page is enriched in one
+batched aggregate — no per-run fan-out.
+
+`usage` fields (`WfRunUsage`):
+
+| Field | Meaning |
+| --- | --- |
+| `cost_microusd` | Summed child-session cost (µUSD). A childless run sums to a real `0`. |
+| `input_tokens` / `output_tokens` | Summed child-session tokens. |
+| `cache_read_input_tokens` / `cache_creation_input_tokens` | Summed child-session cache tokens. |
+| `iteration_count` | The run's wake/step count. **Always `null` today** — the host keeps no per-run iteration counter on any substrate; reserved for when one lands. |
+| `wall_clock_ms` | `updated_at − created_at` (ms) for a **terminal** run; `null` while the run is still live (its `updated_at` is a moving "last touched" stamp, not an end). |
+
+**Fail-loud absence.** Every field is `int | null`, and a value that cannot be
+determined is returned as **explicit `null`**, never a silent `0` or an omitted
+key (cf. the `vault_ids:null` read-path disease). An observer reads `null` as
+*cannot-determine* and fails loud; it reads `0` as a real observed zero. Do not
+conflate the two.

--- a/openapi.json
+++ b/openapi.json
@@ -17515,6 +17515,16 @@
               }
             ],
             "title": "Archived At"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WfRunUsage"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -17650,6 +17660,90 @@
         ],
         "title": "WfRunEvent",
         "description": "One row of a run's append-only journal (the replay-with-memo source).\n\n``call_key`` is set for ``call_started``/``call_result`` (the memo key) and for\n``annotation`` (the branch-local dedup key that makes ``log()``/``phase()``\nemit-once across replays); it is ``None`` for the ``run_started``/``run_completed``\nbookends. An ``annotation`` is a journaled progress marker (``payload`` =\n``{\"kind\": \"log\" | \"phase\", \"text\": ...}``), not a capability call.\n\nSchema note (#1140): a *run* event is ``{type, payload, seq}``. This is a\nDIFFERENT shape from a child-*session* event (``{kind, data}`` \u2014 see\n``aios.models.events.Event``). Don't assume one schema across both\nendpoints; ``docs/reference/run-observability.md`` documents the split."
+      },
+      "WfRunUsage": {
+        "properties": {
+          "cost_microusd": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Microusd"
+          },
+          "input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Tokens"
+          },
+          "output_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Tokens"
+          },
+          "cache_read_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Read Input Tokens"
+          },
+          "cache_creation_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Creation Input Tokens"
+          },
+          "iteration_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iteration Count"
+          },
+          "wall_clock_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wall Clock Ms"
+          }
+        },
+        "type": "object",
+        "title": "WfRunUsage",
+        "description": "Per-run cost / token / iteration / wall-clock \u2014 the machine-observer's substrate.\n\nThe read-path projection of a run's actual spend (#1324). The numbers are summed\nover the run's direct child sessions via ``run_children_usage`` \u2014 the SAME source\n``step.py``'s ``budget()`` builtin consumes \u2014 so a run's ``budget_usd`` *ceiling*\n(on ``WfRun``) and its realized ``cost_microusd`` *spend* (here) are finally both\nlegible from the read path.\n\nEVERY field is ``int | None``, and absence is reported as **explicit null**, never\na silent ``0`` or an omitted key (cf. the ``vault_ids:null`` read-path disease this\nmust not inherit \u2014 see the substrate-different-verdict invariant). The observer\nreads null as *cannot-determine* and fails loud, NOT as \"zero spend\":\n\n* ``cost_microusd`` / ``*_tokens`` \u2014 summed over the run's child sessions. A run\n  with no children sums to ``0`` (a real, observed zero \u2014 distinct from null).\n* ``iteration_count`` \u2014 the run's wake/step count. The host keeps **no** per-run\n  iteration counter on any substrate today, so this is reported as ``None``\n  (cannot-determine) rather than fabricated from an unrelated proxy. Reserved for\n  when a real counter lands; surfaced now so the observer's contract is stable.\n* ``wall_clock_ms`` \u2014 wall-clock span ``updated_at - created_at`` in milliseconds,\n  reported ONLY for a TERMINAL run (``updated_at`` is its completion instant). A\n  still-running run's ``updated_at`` is a moving \"last touched\" stamp, not an end,\n  so it is reported as ``None`` rather than a misleading partial span."
       },
       "WfRunWaitResponse": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -283,6 +283,7 @@ from .wf_run_event_payload import WfRunEventPayload
 from .wf_run_event_type import WfRunEventType
 from .wf_run_request_output_schema_type_0 import WfRunRequestOutputSchemaType0
 from .wf_run_status import WfRunStatus
+from .wf_run_usage import WfRunUsage
 from .wf_run_wait_response import WfRunWaitResponse
 from .wf_run_wait_response_error_type_0 import WfRunWaitResponseErrorType0
 from .wf_run_wait_response_run_status import WfRunWaitResponseRunStatus
@@ -568,6 +569,7 @@ __all__ = (
     "WfRunEventType",
     "WfRunRequestOutputSchemaType0",
     "WfRunStatus",
+    "WfRunUsage",
     "WfRunWaitResponse",
     "WfRunWaitResponseErrorType0",
     "WfRunWaitResponseRunStatus",

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from ..models.wf_run_request_output_schema_type_0 import (
         WfRunRequestOutputSchemaType0,
     )
+    from ..models.wf_run_usage import WfRunUsage
 
 
 T = TypeVar("T", bound="WfRun")
@@ -68,6 +69,7 @@ class WfRun:
             budget_usd (float | None | Unset):
             default_child_model (None | str | Unset):
             archived_at (datetime.datetime | None | Unset):
+            usage (None | Unset | WfRunUsage):
     """
 
     id: str
@@ -95,6 +97,7 @@ class WfRun:
     budget_usd: float | None | Unset = UNSET
     default_child_model: None | str | Unset = UNSET
     archived_at: datetime.datetime | None | Unset = UNSET
+    usage: None | Unset | WfRunUsage = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -102,6 +105,7 @@ class WfRun:
         from ..models.wf_run_request_output_schema_type_0 import (
             WfRunRequestOutputSchemaType0,
         )
+        from ..models.wf_run_usage import WfRunUsage
 
         id = self.id
 
@@ -206,6 +210,14 @@ class WfRun:
         else:
             archived_at = self.archived_at
 
+        usage: dict[str, Any] | None | Unset
+        if isinstance(self.usage, Unset):
+            usage = UNSET
+        elif isinstance(self.usage, WfRunUsage):
+            usage = self.usage.to_dict()
+        else:
+            usage = self.usage
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -251,6 +263,8 @@ class WfRun:
             field_dict["default_child_model"] = default_child_model
         if archived_at is not UNSET:
             field_dict["archived_at"] = archived_at
+        if usage is not UNSET:
+            field_dict["usage"] = usage
 
         return field_dict
 
@@ -263,6 +277,7 @@ class WfRun:
         from ..models.wf_run_request_output_schema_type_0 import (
             WfRunRequestOutputSchemaType0,
         )
+        from ..models.wf_run_usage import WfRunUsage
 
         d = dict(src_dict)
         id = d.pop("id")
@@ -426,6 +441,23 @@ class WfRun:
 
         archived_at = _parse_archived_at(d.pop("archived_at", UNSET))
 
+        def _parse_usage(data: object) -> None | Unset | WfRunUsage:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                usage_type_0 = WfRunUsage.from_dict(data)
+
+                return usage_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | WfRunUsage, data)
+
+        usage = _parse_usage(d.pop("usage", UNSET))
+
         wf_run = cls(
             id=id,
             workflow_id=workflow_id,
@@ -452,6 +484,7 @@ class WfRun:
             budget_usd=budget_usd,
             default_child_model=default_child_model,
             archived_at=archived_at,
+            usage=usage,
         )
 
         wf_run.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/wf_run_usage.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/wf_run_usage.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="WfRunUsage")
+
+
+@_attrs_define
+class WfRunUsage:
+    """Per-run cost / token / iteration / wall-clock — the machine-observer's substrate.
+
+    The read-path projection of a run's actual spend (#1324). The numbers are summed
+    over the run's direct child sessions via ``run_children_usage`` — the SAME source
+    ``step.py``'s ``budget()`` builtin consumes — so a run's ``budget_usd`` *ceiling*
+    (on ``WfRun``) and its realized ``cost_microusd`` *spend* (here) are finally both
+    legible from the read path.
+
+    EVERY field is ``int | None``, and absence is reported as **explicit null**, never
+    a silent ``0`` or an omitted key (cf. the ``vault_ids:null`` read-path disease this
+    must not inherit — see the substrate-different-verdict invariant). The observer
+    reads null as *cannot-determine* and fails loud, NOT as "zero spend":
+
+    * ``cost_microusd`` / ``*_tokens`` — summed over the run's child sessions. A run
+      with no children sums to ``0`` (a real, observed zero — distinct from null).
+    * ``iteration_count`` — the run's wake/step count. The host keeps **no** per-run
+      iteration counter on any substrate today, so this is reported as ``None``
+      (cannot-determine) rather than fabricated from an unrelated proxy. Reserved for
+      when a real counter lands; surfaced now so the observer's contract is stable.
+    * ``wall_clock_ms`` — wall-clock span ``updated_at - created_at`` in milliseconds,
+      reported ONLY for a TERMINAL run (``updated_at`` is its completion instant). A
+      still-running run's ``updated_at`` is a moving "last touched" stamp, not an end,
+      so it is reported as ``None`` rather than a misleading partial span.
+
+        Attributes:
+            cost_microusd (int | None | Unset):
+            input_tokens (int | None | Unset):
+            output_tokens (int | None | Unset):
+            cache_read_input_tokens (int | None | Unset):
+            cache_creation_input_tokens (int | None | Unset):
+            iteration_count (int | None | Unset):
+            wall_clock_ms (int | None | Unset):
+    """
+
+    cost_microusd: int | None | Unset = UNSET
+    input_tokens: int | None | Unset = UNSET
+    output_tokens: int | None | Unset = UNSET
+    cache_read_input_tokens: int | None | Unset = UNSET
+    cache_creation_input_tokens: int | None | Unset = UNSET
+    iteration_count: int | None | Unset = UNSET
+    wall_clock_ms: int | None | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        cost_microusd: int | None | Unset
+        if isinstance(self.cost_microusd, Unset):
+            cost_microusd = UNSET
+        else:
+            cost_microusd = self.cost_microusd
+
+        input_tokens: int | None | Unset
+        if isinstance(self.input_tokens, Unset):
+            input_tokens = UNSET
+        else:
+            input_tokens = self.input_tokens
+
+        output_tokens: int | None | Unset
+        if isinstance(self.output_tokens, Unset):
+            output_tokens = UNSET
+        else:
+            output_tokens = self.output_tokens
+
+        cache_read_input_tokens: int | None | Unset
+        if isinstance(self.cache_read_input_tokens, Unset):
+            cache_read_input_tokens = UNSET
+        else:
+            cache_read_input_tokens = self.cache_read_input_tokens
+
+        cache_creation_input_tokens: int | None | Unset
+        if isinstance(self.cache_creation_input_tokens, Unset):
+            cache_creation_input_tokens = UNSET
+        else:
+            cache_creation_input_tokens = self.cache_creation_input_tokens
+
+        iteration_count: int | None | Unset
+        if isinstance(self.iteration_count, Unset):
+            iteration_count = UNSET
+        else:
+            iteration_count = self.iteration_count
+
+        wall_clock_ms: int | None | Unset
+        if isinstance(self.wall_clock_ms, Unset):
+            wall_clock_ms = UNSET
+        else:
+            wall_clock_ms = self.wall_clock_ms
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if cost_microusd is not UNSET:
+            field_dict["cost_microusd"] = cost_microusd
+        if input_tokens is not UNSET:
+            field_dict["input_tokens"] = input_tokens
+        if output_tokens is not UNSET:
+            field_dict["output_tokens"] = output_tokens
+        if cache_read_input_tokens is not UNSET:
+            field_dict["cache_read_input_tokens"] = cache_read_input_tokens
+        if cache_creation_input_tokens is not UNSET:
+            field_dict["cache_creation_input_tokens"] = cache_creation_input_tokens
+        if iteration_count is not UNSET:
+            field_dict["iteration_count"] = iteration_count
+        if wall_clock_ms is not UNSET:
+            field_dict["wall_clock_ms"] = wall_clock_ms
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_cost_microusd(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        cost_microusd = _parse_cost_microusd(d.pop("cost_microusd", UNSET))
+
+        def _parse_input_tokens(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        input_tokens = _parse_input_tokens(d.pop("input_tokens", UNSET))
+
+        def _parse_output_tokens(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        output_tokens = _parse_output_tokens(d.pop("output_tokens", UNSET))
+
+        def _parse_cache_read_input_tokens(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        cache_read_input_tokens = _parse_cache_read_input_tokens(
+            d.pop("cache_read_input_tokens", UNSET)
+        )
+
+        def _parse_cache_creation_input_tokens(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        cache_creation_input_tokens = _parse_cache_creation_input_tokens(
+            d.pop("cache_creation_input_tokens", UNSET)
+        )
+
+        def _parse_iteration_count(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        iteration_count = _parse_iteration_count(d.pop("iteration_count", UNSET))
+
+        def _parse_wall_clock_ms(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        wall_clock_ms = _parse_wall_clock_ms(d.pop("wall_clock_ms", UNSET))
+
+        wf_run_usage = cls(
+            cost_microusd=cost_microusd,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
+            iteration_count=iteration_count,
+            wall_clock_ms=wall_clock_ms,
+        )
+
+        wf_run_usage.additional_properties = d
+        return wf_run_usage
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -557,6 +557,57 @@ async def run_children_usage(
     )
 
 
+async def runs_children_usage(
+    conn: asyncpg.Connection[Any], run_ids: list[str], *, account_id: str
+) -> dict[str, RunChildrenUsage]:
+    """Batched :func:`run_children_usage` for the read path (#1324).
+
+    Sums each run's direct child sessions' usage in ONE grouped query, so
+    ``list_runs`` enriches a whole page without an N+1 fan-out of point reads.
+    Account-scoped identically to :func:`run_children_usage` (a child session
+    of another tenant never contributes). Per-run semantics are verbatim the
+    single-run query: ``COALESCE(SUM(...), 0)`` — a run with no children
+    *appears in the result* with an all-zero record (a real, observed zero),
+    so the caller can distinguish "summed to zero spend" from "run absent".
+
+    Keep the column list and the ``parent_run_id``/``account_id`` filter in
+    lockstep with :func:`run_children_usage`; the same #1131 ``parent_run_id``
+    point-read note applies.
+    """
+    if not run_ids:
+        return {}
+    rows = await conn.fetch(
+        """
+        SELECT
+            parent_run_id AS run_id,
+            COALESCE(SUM(input_tokens), 0)::bigint AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)::bigint AS output_tokens,
+            COALESCE(SUM(cache_read_input_tokens), 0)::bigint AS cache_read_input_tokens,
+            COALESCE(SUM(cache_creation_input_tokens), 0)::bigint AS cache_creation_input_tokens,
+            COALESCE(SUM(cost_microusd), 0)::bigint AS cost_microusd
+          FROM sessions
+         WHERE parent_run_id = ANY($1::text[]) AND account_id = $2
+         GROUP BY parent_run_id
+        """,
+        run_ids,
+        account_id,
+    )
+    summed = {
+        row["run_id"]: RunChildrenUsage(
+            input_tokens=row["input_tokens"],
+            output_tokens=row["output_tokens"],
+            cache_read_input_tokens=row["cache_read_input_tokens"],
+            cache_creation_input_tokens=row["cache_creation_input_tokens"],
+            cost_microusd=row["cost_microusd"],
+        )
+        for row in rows
+    }
+    # A run with zero child sessions has no GROUP BY row; surface it as a real
+    # all-zero record so every requested id is present in the result.
+    zero = RunChildrenUsage(0, 0, 0, 0, 0)
+    return {run_id: summed.get(run_id, zero) for run_id in run_ids}
+
+
 async def unscoped_terminal_run_ids(conn: asyncpg.Connection[Any], run_ids: list[str]) -> set[str]:
     """Return the subset of ``run_ids`` whose ``status`` is TERMINAL (#1192).
 

--- a/src/aios/models/workflows.py
+++ b/src/aios/models/workflows.py
@@ -71,6 +71,41 @@ class Workflow(BaseModel):
     archived_at: datetime | None = None
 
 
+class WfRunUsage(BaseModel):
+    """Per-run cost / token / iteration / wall-clock — the machine-observer's substrate.
+
+    The read-path projection of a run's actual spend (#1324). The numbers are summed
+    over the run's direct child sessions via ``run_children_usage`` — the SAME source
+    ``step.py``'s ``budget()`` builtin consumes — so a run's ``budget_usd`` *ceiling*
+    (on ``WfRun``) and its realized ``cost_microusd`` *spend* (here) are finally both
+    legible from the read path.
+
+    EVERY field is ``int | None``, and absence is reported as **explicit null**, never
+    a silent ``0`` or an omitted key (cf. the ``vault_ids:null`` read-path disease this
+    must not inherit — see the substrate-different-verdict invariant). The observer
+    reads null as *cannot-determine* and fails loud, NOT as "zero spend":
+
+    * ``cost_microusd`` / ``*_tokens`` — summed over the run's child sessions. A run
+      with no children sums to ``0`` (a real, observed zero — distinct from null).
+    * ``iteration_count`` — the run's wake/step count. The host keeps **no** per-run
+      iteration counter on any substrate today, so this is reported as ``None``
+      (cannot-determine) rather than fabricated from an unrelated proxy. Reserved for
+      when a real counter lands; surfaced now so the observer's contract is stable.
+    * ``wall_clock_ms`` — wall-clock span ``updated_at - created_at`` in milliseconds,
+      reported ONLY for a TERMINAL run (``updated_at`` is its completion instant). A
+      still-running run's ``updated_at`` is a moving "last touched" stamp, not an end,
+      so it is reported as ``None`` rather than a misleading partial span.
+    """
+
+    cost_microusd: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
+    iteration_count: int | None = None
+    wall_clock_ms: int | None = None
+
+
 class WfRun(BaseModel):
     """A durable workflow execution instance.
 
@@ -137,6 +172,12 @@ class WfRun(BaseModel):
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None
+    # The realized per-run usage (#1324) — cost/tokens summed over child sessions,
+    # plus iteration/wall-clock. Populated ONLY on the public read path (get_run /
+    # list_runs); ``None`` on the internal step-loop read (``get_run_for_step``),
+    # which never needs it and must not pay the extra aggregate query. ``budget_usd``
+    # above is the ceiling; ``usage.cost_microusd`` is the spend against it.
+    usage: WfRunUsage | None = None
 
 
 class WfRunEvent(BaseModel):

--- a/src/aios/services/workflows.py
+++ b/src/aios/services/workflows.py
@@ -32,6 +32,7 @@ from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
     WfRun,
     WfRunEvent,
+    WfRunUsage,
     WfRunWaitResponse,
     Workflow,
 )
@@ -415,9 +416,42 @@ async def list_workflows(
 # ─── runs ────────────────────────────────────────────────────────────────────
 
 
+def _wall_clock_ms(run: WfRun) -> int | None:
+    """Wall-clock span (ms) for a TERMINAL run; ``None`` while it's still live (#1324).
+
+    A terminal run's ``updated_at`` is its completion instant, so ``updated_at -
+    created_at`` is its true wall-clock. A non-terminal run's ``updated_at`` is a
+    moving "last touched" stamp — surfacing a span off it would be a misleading
+    partial, so we report explicit ``None`` (cannot-determine) instead.
+    """
+    if run.status not in TERMINAL_RUN_STATUSES:
+        return None
+    return max(0, round((run.updated_at - run.created_at).total_seconds() * 1000))
+
+
+def _run_usage(run: WfRun, children: wf_queries.RunChildrenUsage) -> WfRunUsage:
+    """Project a run + its summed child usage into the read-path :class:`WfRunUsage`.
+
+    cost/tokens are the real summed children; ``iteration_count`` is explicit
+    ``None`` (no per-run iteration counter exists on any substrate yet — see the
+    model docstring); ``wall_clock_ms`` is terminal-only (:func:`_wall_clock_ms`).
+    """
+    return WfRunUsage(
+        cost_microusd=children.cost_microusd,
+        input_tokens=children.input_tokens,
+        output_tokens=children.output_tokens,
+        cache_read_input_tokens=children.cache_read_input_tokens,
+        cache_creation_input_tokens=children.cache_creation_input_tokens,
+        iteration_count=None,
+        wall_clock_ms=_wall_clock_ms(run),
+    )
+
+
 async def get_run(pool: asyncpg.Pool[Any], run_id: str, *, account_id: str) -> WfRun:
     async with pool.acquire() as conn:
-        return await wf_queries.get_wf_run(conn, run_id, account_id=account_id)
+        run = await wf_queries.get_wf_run(conn, run_id, account_id=account_id)
+        children = await wf_queries.run_children_usage(conn, run.id, account_id=account_id)
+        return run.model_copy(update={"usage": _run_usage(run, children)})
 
 
 async def list_runs(
@@ -432,7 +466,7 @@ async def list_runs(
     launcher_session_id: str | None = None,
 ) -> list[WfRun]:
     async with pool.acquire() as conn:
-        return await wf_queries.list_wf_runs(
+        runs = await wf_queries.list_wf_runs(
             conn,
             account_id=account_id,
             limit=limit,
@@ -442,6 +476,12 @@ async def list_runs(
             parent_run_id=parent_run_id,
             launcher_session_id=launcher_session_id,
         )
+        # Enrich the whole page in ONE batched aggregate (no N+1) so list_runs
+        # carries the same per-run usage substrate as get_run (#1324).
+        usage_by_run = await wf_queries.runs_children_usage(
+            conn, [r.id for r in runs], account_id=account_id
+        )
+        return [r.model_copy(update={"usage": _run_usage(r, usage_by_run[r.id])}) for r in runs]
 
 
 async def list_run_events(

--- a/tests/integration/test_wf_queries.py
+++ b/tests/integration/test_wf_queries.py
@@ -535,3 +535,65 @@ async def test_run_children_usage_zero_and_account_scoped(wf_conn: asyncpg.Conne
     run_id = await _seed_run(wf_conn)
     usage = await wf_queries.run_children_usage(wf_conn, run_id, account_id="acc_root")
     assert usage == wf_queries.RunChildrenUsage(0, 0, 0, 0, 0)
+
+
+async def test_runs_children_usage_batches_and_zero_fills(
+    wf_conn: asyncpg.Connection[Any],
+) -> None:
+    """runs_children_usage sums per-run in one query and zero-fills childless ids (#1324).
+
+    The batched read-path variant of run_children_usage: every requested id is
+    present in the result — a run with children carries its summed usage, a
+    childless run a REAL all-zero record (never absent, never null).
+    """
+    run_with = await _seed_run(wf_conn)
+    # A second run against the SAME workflow (``_seed_run`` would collide on the
+    # unique workflow name); insert_wf_run mints a fresh run id.
+    wf_id = await wf_conn.fetchval("SELECT workflow_id FROM wf_runs WHERE id = $1", run_with)
+    run_without = (
+        await wf_queries.insert_wf_run(
+            wf_conn,
+            account_id="acc_root",
+            workflow_id=wf_id,
+            environment_id="env_root",
+            script="async def main(input):\n    return 1\n",
+            host_semantics_epoch=HOST_SEMANTICS_EPOCH,
+            script_sha="deadbeef",
+            depth=10,
+        )
+    ).id
+    await wf_conn.execute(
+        "INSERT INTO agents (id, name, model, system, account_id) "
+        "VALUES ('agent_batch', 'batch-agent', 'm', 's', 'acc_root')"
+    )
+    await wf_conn.execute(
+        "INSERT INTO agent_versions (agent_id, version, model, system, account_id) "
+        "VALUES ('agent_batch', 1, 'm', 's', 'acc_root')"
+    )
+    await wf_conn.execute(
+        """
+        INSERT INTO sessions (
+            id, agent_id, environment_id, agent_version, title, metadata,
+            workspace_volume_path, account_id, parent_run_id, input_tokens, output_tokens,
+            cache_read_input_tokens, cache_creation_input_tokens, cost_microusd
+        ) VALUES
+            ('ses_bx_a', 'agent_batch', 'env_root', 1, NULL, '{}'::jsonb, '/tmp/bxa', 'acc_root', $1, 10, 20, 3, 4, 100),
+            ('ses_bx_b', 'agent_batch', 'env_root', 1, NULL, '{}'::jsonb, '/tmp/bxb', 'acc_root', $1, 1, 2, 5, 6, 200)
+        """,
+        run_with,
+    )
+    usage = await wf_queries.runs_children_usage(
+        wf_conn, [run_with, run_without], account_id="acc_root"
+    )
+    assert set(usage) == {run_with, run_without}
+    assert usage[run_with] == wf_queries.RunChildrenUsage(11, 22, 8, 10, 300)
+    assert usage[run_without] == wf_queries.RunChildrenUsage(0, 0, 0, 0, 0)
+    # Matches the single-run query exactly for the same run.
+    single = await wf_queries.run_children_usage(wf_conn, run_with, account_id="acc_root")
+    assert usage[run_with] == single
+
+
+async def test_runs_children_usage_empty_input_is_empty(
+    wf_conn: asyncpg.Connection[Any],
+) -> None:
+    assert await wf_queries.runs_children_usage(wf_conn, [], account_id="acc_root") == {}

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -4781,3 +4781,157 @@ async def test_over_budget_agent_refusal_is_catchable(
     cr = next(e for e in events if e.type == "call_result" and e.payload.get("is_error"))
     assert cr.payload["error"]["kind"] == "budget_exceeded"
     assert child_count == 0
+
+
+async def _seed_child_session(
+    pool: asyncpg.Pool[Any],
+    *,
+    sid: str,
+    run_id: str,
+    account_id: str = "acc_wf",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    cost_microusd: int = 0,
+) -> None:
+    """Insert a run-child session carrying known usage (#1324 read-path seed)."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO agents (id, name, model, system, account_id) "
+            "VALUES ($1, $1, 'm', 's', $2) ON CONFLICT (id) DO NOTHING",
+            f"agent_{sid}",
+            account_id,
+        )
+        await conn.execute(
+            "INSERT INTO agent_versions (agent_id, version, model, system, account_id) "
+            "VALUES ($1, 1, 'm', 's', $2) ON CONFLICT DO NOTHING",
+            f"agent_{sid}",
+            account_id,
+        )
+        await conn.execute(
+            "INSERT INTO sessions (id, agent_id, environment_id, agent_version, title, metadata, "
+            "workspace_volume_path, account_id, parent_run_id, input_tokens, output_tokens, "
+            "cache_read_input_tokens, cache_creation_input_tokens, cost_microusd) "
+            "VALUES ($1, $2, 'env_wf', 1, NULL, '{}'::jsonb, $3, $4, $5, $6, $7, $8, $9, $10)",
+            sid,
+            f"agent_{sid}",
+            f"/tmp/{sid}",
+            account_id,
+            run_id,
+            input_tokens,
+            output_tokens,
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+            cost_microusd,
+        )
+
+
+async def test_get_run_surfaces_summed_child_usage_on_read_path(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """get_run sums its child sessions' cost/tokens onto WfRun.usage (#1324).
+
+    The keystone of the machine-observer substrate: a run's realized spend is
+    legible from the public read path, summed from the SAME run_children_usage
+    source budget() consumes — not buried in a builtin.
+    """
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1\n")
+    await _seed_child_session(
+        pool,
+        sid="ses_a",
+        run_id=run_id,
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_input_tokens=3,
+        cache_creation_input_tokens=4,
+        cost_microusd=123456,
+    )
+    await _seed_child_session(
+        pool,
+        sid="ses_b",
+        run_id=run_id,
+        input_tokens=1,
+        output_tokens=2,
+        cache_read_input_tokens=5,
+        cache_creation_input_tokens=6,
+        cost_microusd=654321,
+    )
+
+    run = await wf_service.get_run(pool, run_id, account_id="acc_wf")
+    assert run.usage is not None
+    assert run.usage.input_tokens == 11
+    assert run.usage.output_tokens == 22
+    assert run.usage.cache_read_input_tokens == 8
+    assert run.usage.cache_creation_input_tokens == 10
+    assert run.usage.cost_microusd == 777777
+    # The run is still pending (no step driven): wall_clock is cannot-determine,
+    # iteration_count has no substrate — both EXPLICIT null, never silently 0/omitted.
+    assert run.usage.wall_clock_ms is None
+    assert run.usage.iteration_count is None
+    # ``budget_usd`` (ceiling) and ``usage.cost_microusd`` (spend) are both legible now.
+    assert "usage" in run.model_dump()
+
+
+async def test_get_run_usage_zero_is_observed_not_null(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A childless run sums to a REAL zero (distinct from null cannot-determine)."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1\n")
+    run = await wf_service.get_run(pool, run_id, account_id="acc_wf")
+    assert run.usage is not None
+    assert run.usage.cost_microusd == 0
+    assert run.usage.input_tokens == 0
+    assert run.usage.output_tokens == 0
+
+
+async def test_terminal_run_surfaces_wall_clock_ms(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A TERMINAL run surfaces a non-null wall_clock_ms (updated_at - created_at)."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1\n")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_runs SET status = 'completed', "
+            "updated_at = created_at + interval '1500 milliseconds' WHERE id = $1",
+            run_id,
+        )
+    run = await wf_service.get_run(pool, run_id, account_id="acc_wf")
+    assert run.usage is not None
+    assert run.usage.wall_clock_ms == 1500
+    assert run.usage.iteration_count is None  # still no substrate
+
+
+async def test_list_runs_enriches_each_run_with_usage(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """list_runs carries per-run usage too — batched, one aggregate for the page (#1324)."""
+    pool = wf_runtime
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(
+            conn,
+            account_id="acc_wf",
+            name="w_list",
+            script="async def main(input):\n    return 1\n",
+        )
+    run_a = (
+        await service.create_run(
+            pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf"
+        )
+    ).id
+    run_b = (
+        await service.create_run(
+            pool, account_id="acc_wf", workflow_id=wf.id, environment_id="env_wf"
+        )
+    ).id
+    await _seed_child_session(pool, sid="ses_la", run_id=run_a, cost_microusd=500, input_tokens=7)
+    # run_b has no children → real zero.
+
+    runs = await wf_service.list_runs(pool, account_id="acc_wf")
+    by_id = {r.id: r for r in runs}
+    assert by_id[run_a].usage is not None and by_id[run_a].usage.cost_microusd == 500
+    assert by_id[run_a].usage.input_tokens == 7
+    assert by_id[run_b].usage is not None and by_id[run_b].usage.cost_microusd == 0

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -4932,6 +4932,10 @@ async def test_list_runs_enriches_each_run_with_usage(
 
     runs = await wf_service.list_runs(pool, account_id="acc_wf")
     by_id = {r.id: r for r in runs}
-    assert by_id[run_a].usage is not None and by_id[run_a].usage.cost_microusd == 500
-    assert by_id[run_a].usage.input_tokens == 7
-    assert by_id[run_b].usage is not None and by_id[run_b].usage.cost_microusd == 0
+    usage_a = by_id[run_a].usage
+    assert usage_a is not None
+    assert usage_a.cost_microusd == 500
+    assert usage_a.input_tokens == 7
+    usage_b = by_id[run_b].usage
+    assert usage_b is not None
+    assert usage_b.cost_microusd == 0


### PR DESCRIPTION
## What

Surfaces **per-run cost / token / wall-clock usage** on the public run read path — the machine-observer's cost-substrate (Plane C). `get_run` and `list_runs` now return a `usage` object summed from `run_children_usage`, the **same source** `step.py`'s `budget()` builtin already consumes, so a run's `budget_usd` *ceiling* and its realized `cost_microusd` *spend* are finally both legible from the read path instead of being buried in a builtin.

Closes #1324.

## How

- **New `WfRunUsage` model** on `WfRun.usage` (`models/workflows.py`): `cost_microusd`, `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `iteration_count`, `wall_clock_ms`.
- **Fail-loud absence:** every field is `int | None`; a value that cannot be determined is returned as **explicit `null`** (cannot-determine), never a silent `0` or an omitted key — exactly the `vault_ids:null` read-path disease this must not inherit.
  - `cost_microusd` / `*_tokens` — real summed children. A childless run sums to a **real `0`** (an observed zero, distinct from null).
  - `iteration_count` — **always `null` today**: the host keeps no per-run iteration counter on any substrate; surfaced now so the observer's contract is stable, reserved for when a real counter lands.
  - `wall_clock_ms` — `updated_at − created_at` (ms) for a **terminal** run only; `null` while live (a running run's `updated_at` is a moving "last touched" stamp, not an end).
- **Enrichment at the service layer** (`services/workflows.py`): `get_run` adds one `run_children_usage` read; `list_runs` uses a **new batched `runs_children_usage` query** so a whole page is enriched in ONE grouped aggregate (no N+1). The internal `get_run_for_step` step-loop path is untouched and pays no extra query.
- Regenerated `openapi.json` + the typed SDK (`packages/aios-sdk/.../wf_run_usage.py`, `wf_run.py`); documented as section (d) in `docs/reference/run-observability.md`.

## Tests (test-first)

- `test_wf_queries.py`: batched `runs_children_usage` sums per-run in one query, zero-fills childless ids, and matches the single-run query; empty input → `{}`.
- `test_wf_step.py`: `get_run` surfaces summed child cost/tokens; observed-zero for a childless run; terminal run surfaces non-null `wall_clock_ms` (and still-null `iteration_count`); `list_runs` enriches each run on a page.

All workflow query/step/host/invoke + e2e API + openapi/SDK snapshot suites pass; `ruff check`, `ruff format`, and `mypy` are clean.

## Go-live sequencing

Per the issue, this read-path enrichment is live only after the worker re-registers (deploy-on-merge, #1175); the code is built now.