### PR TITLE
running==merged reconciler + build-SHA-in-image (aios#1327)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,28 @@ COPY migrations ./migrations
 # worker image; the worker resolves it via ``Path(__file__).parents[3]``.
 COPY bin ./bin
 COPY src ./src
+
+# Build-SHA-in-image (aios#1327, plane B2 of the substrate-different-verdict
+# invariant). Bake the git commit being built INTO the image so a genuinely
+# uncorrelated substrate (the live container) can report which commit it is
+# running — the deploy-ledger says only what the deploy actor INTENDED, never
+# what is running. The build-arg is injected by the eumemic-ops deploy step
+# (Coolify build-time env -> docker build --build-arg) immediately before each
+# deploy; an un-instrumented build leaves the `unknown` fallback so the
+# running==merged reconciler reads `cannot-determine` (never a false match).
+#
+#   * ENV   -> readable in-process by /health (Unit A2: os.environ["AIOS_BUILD_SHA"]).
+#   * LABEL -> readable by `docker inspect` over SSH without an HTTP call — the
+#     worker has no HTTP server, so the reconciler reads its running SHA off the
+#     running container's image label (Unit B step 2).
+#
+# Placed AFTER `COPY src ./src` so the SHA flips on the same layer the source
+# does (a source change is a new SHA); the cheap ARG/ENV/LABEL re-eval does not
+# bust the expensive `uv sync` layers above.
+ARG AIOS_BUILD_SHA=unknown
+ENV AIOS_BUILD_SHA=${AIOS_BUILD_SHA}
+LABEL org.eumemic.build_sha=${AIOS_BUILD_SHA}
+
 # Authored seccomp profile for sandbox containers (#807). The worker's docker
 # CLI reads this from its OWN filesystem and ships the JSON to the daemon (the
 # daemon never reads the worker's FS). Must match the default resolved by

--- a/migrations/versions/0107_triggers_wake_session_action.py
+++ b/migrations/versions/0107_triggers_wake_session_action.py
@@ -129,9 +129,7 @@ def downgrade() -> None:
     # predicate and not reconstructible (the 0086 wake_owner/workflow stance).
     n = (
         op.get_bind()
-        .execute(
-            sa.text("SELECT count(*) FROM triggers WHERE action ->> 'kind' = 'wake_session'")
-        )
+        .execute(sa.text("SELECT count(*) FROM triggers WHERE action ->> 'kind' = 'wake_session'"))
         .scalar()
     )
     if n:

--- a/openapi.json
+++ b/openapi.json
@@ -9,7 +9,7 @@
     "/health": {
       "get": {
         "summary": "Health",
-        "description": "Liveness probe. Unauthenticated; returns the running aios version.\n\nSuitable for load balancer health checks and monitoring probes. Always\nreturns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the\nprocess is up. Deliberately does NOT touch the DB pool \u2014 a post-startup\nPostgres outage must not flip liveness (that's ``/ready``'s job), or an\norchestrator would kill an otherwise-healthy process during a DB blip.",
+        "description": "Liveness probe. Unauthenticated; returns the running aios version + build SHA.\n\nSuitable for load balancer health checks and monitoring probes. Always\nreturns 200 with ``{\"status\": \"ok\", \"version\": <version>, \"build_sha\": <sha-or-None>}``\nif the process is up. Deliberately does NOT touch the DB pool \u2014 a post-startup\nPostgres outage must not flip liveness (that's ``/ready``'s job), or an\norchestrator would kill an otherwise-healthy process during a DB blip.\n\n``build_sha`` (aios#1327, Unit A2) is the git commit baked into THIS image at\nbuild time (``ENV AIOS_BUILD_SHA`` in the Dockerfile ``base`` stage). It is the\nin-process running-truth read: unlike ``version`` (a static package string that\nnever changes between builds), it tells you which commit is actually running.\n``None`` when ``AIOS_BUILD_SHA`` is unset \u2014 an un-instrumented build \u2014 which the\nrunning==merged reconciler reads as ``cannot-determine``, never a false match.\n``version`` stays the static package string, untouched.\n\nThe return type is ``dict[str, str | None]`` (not ``dict[str, str]``): ``build_sha``\nis genuinely nullable because ``os.environ.get`` returns ``str | None``.",
         "operationId": "get_health",
         "responses": {
           "200": {
@@ -18,7 +18,14 @@
               "application/json": {
                 "schema": {
                   "additionalProperties": {
-                    "type": "string"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "type": "object",
                   "title": "Response Get Health"

--- a/packages/aios-sdk/aios_sdk/_generated/api/default/get_health.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/default/get_health.py
@@ -50,13 +50,24 @@ def sync_detailed(
 ) -> Response[GetHealthResponseGetHealth]:
     r"""Health
 
-     Liveness probe. Unauthenticated; returns the running aios version.
+     Liveness probe. Unauthenticated; returns the running aios version + build SHA.
 
     Suitable for load balancer health checks and monitoring probes. Always
-    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>, \"build_sha\": <sha-or-None>}``
+    if the process is up. Deliberately does NOT touch the DB pool — a post-startup
     Postgres outage must not flip liveness (that's ``/ready``'s job), or an
     orchestrator would kill an otherwise-healthy process during a DB blip.
+
+    ``build_sha`` (aios#1327, Unit A2) is the git commit baked into THIS image at
+    build time (``ENV AIOS_BUILD_SHA`` in the Dockerfile ``base`` stage). It is the
+    in-process running-truth read: unlike ``version`` (a static package string that
+    never changes between builds), it tells you which commit is actually running.
+    ``None`` when ``AIOS_BUILD_SHA`` is unset — an un-instrumented build — which the
+    running==merged reconciler reads as ``cannot-determine``, never a false match.
+    ``version`` stays the static package string, untouched.
+
+    The return type is ``dict[str, str | None]`` (not ``dict[str, str]``): ``build_sha``
+    is genuinely nullable because ``os.environ.get`` returns ``str | None``.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -81,13 +92,24 @@ def sync(
 ) -> GetHealthResponseGetHealth | None:
     r"""Health
 
-     Liveness probe. Unauthenticated; returns the running aios version.
+     Liveness probe. Unauthenticated; returns the running aios version + build SHA.
 
     Suitable for load balancer health checks and monitoring probes. Always
-    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>, \"build_sha\": <sha-or-None>}``
+    if the process is up. Deliberately does NOT touch the DB pool — a post-startup
     Postgres outage must not flip liveness (that's ``/ready``'s job), or an
     orchestrator would kill an otherwise-healthy process during a DB blip.
+
+    ``build_sha`` (aios#1327, Unit A2) is the git commit baked into THIS image at
+    build time (``ENV AIOS_BUILD_SHA`` in the Dockerfile ``base`` stage). It is the
+    in-process running-truth read: unlike ``version`` (a static package string that
+    never changes between builds), it tells you which commit is actually running.
+    ``None`` when ``AIOS_BUILD_SHA`` is unset — an un-instrumented build — which the
+    running==merged reconciler reads as ``cannot-determine``, never a false match.
+    ``version`` stays the static package string, untouched.
+
+    The return type is ``dict[str, str | None]`` (not ``dict[str, str]``): ``build_sha``
+    is genuinely nullable because ``os.environ.get`` returns ``str | None``.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -108,13 +130,24 @@ async def asyncio_detailed(
 ) -> Response[GetHealthResponseGetHealth]:
     r"""Health
 
-     Liveness probe. Unauthenticated; returns the running aios version.
+     Liveness probe. Unauthenticated; returns the running aios version + build SHA.
 
     Suitable for load balancer health checks and monitoring probes. Always
-    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>, \"build_sha\": <sha-or-None>}``
+    if the process is up. Deliberately does NOT touch the DB pool — a post-startup
     Postgres outage must not flip liveness (that's ``/ready``'s job), or an
     orchestrator would kill an otherwise-healthy process during a DB blip.
+
+    ``build_sha`` (aios#1327, Unit A2) is the git commit baked into THIS image at
+    build time (``ENV AIOS_BUILD_SHA`` in the Dockerfile ``base`` stage). It is the
+    in-process running-truth read: unlike ``version`` (a static package string that
+    never changes between builds), it tells you which commit is actually running.
+    ``None`` when ``AIOS_BUILD_SHA`` is unset — an un-instrumented build — which the
+    running==merged reconciler reads as ``cannot-determine``, never a false match.
+    ``version`` stays the static package string, untouched.
+
+    The return type is ``dict[str, str | None]`` (not ``dict[str, str]``): ``build_sha``
+    is genuinely nullable because ``os.environ.get`` returns ``str | None``.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -137,13 +170,24 @@ async def asyncio(
 ) -> GetHealthResponseGetHealth | None:
     r"""Health
 
-     Liveness probe. Unauthenticated; returns the running aios version.
+     Liveness probe. Unauthenticated; returns the running aios version + build SHA.
 
     Suitable for load balancer health checks and monitoring probes. Always
-    returns 200 with ``{\"status\": \"ok\", \"version\": <version>}`` if the
-    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    returns 200 with ``{\"status\": \"ok\", \"version\": <version>, \"build_sha\": <sha-or-None>}``
+    if the process is up. Deliberately does NOT touch the DB pool — a post-startup
     Postgres outage must not flip liveness (that's ``/ready``'s job), or an
     orchestrator would kill an otherwise-healthy process during a DB blip.
+
+    ``build_sha`` (aios#1327, Unit A2) is the git commit baked into THIS image at
+    build time (``ENV AIOS_BUILD_SHA`` in the Dockerfile ``base`` stage). It is the
+    in-process running-truth read: unlike ``version`` (a static package string that
+    never changes between builds), it tells you which commit is actually running.
+    ``None`` when ``AIOS_BUILD_SHA`` is unset — an un-instrumented build — which the
+    running==merged reconciler reads as ``cannot-determine``, never a false match.
+    ``version`` stays the static package string, untouched.
+
+    The return type is ``dict[str, str | None]`` (not ``dict[str, str]``): ``build_sha``
+    is genuinely nullable because ``os.environ.get`` returns ``str | None``.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/packages/aios-sdk/aios_sdk/_generated/models/get_health_response_get_health.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/get_health_response_get_health.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -13,12 +13,15 @@ T = TypeVar("T", bound="GetHealthResponseGetHealth")
 class GetHealthResponseGetHealth:
     """ """
 
-    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, None | str] = _attrs_field(
+        init=False, factory=dict
+    )
 
     def to_dict(self) -> dict[str, Any]:
 
         field_dict: dict[str, Any] = {}
-        field_dict.update(self.additional_properties)
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop
 
         return field_dict
 
@@ -27,17 +30,29 @@ class GetHealthResponseGetHealth:
         d = dict(src_dict)
         get_health_response_get_health = cls()
 
-        get_health_response_get_health.additional_properties = d
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+
+            def _parse_additional_property(data: object) -> None | str:
+                if data is None:
+                    return data
+                return cast(None | str, data)
+
+            additional_property = _parse_additional_property(prop_dict)
+
+            additional_properties[prop_name] = additional_property
+
+        get_health_response_get_health.additional_properties = additional_properties
         return get_health_response_get_health
 
     @property
     def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
-    def __getitem__(self, key: str) -> str:
+    def __getitem__(self, key: str) -> None | str:
         return self.additional_properties[key]
 
-    def __setitem__(self, key: str, value: str) -> None:
+    def __setitem__(self, key: str, value: None | str) -> None:
         self.additional_properties[key] = value
 
     def __delitem__(self, key: str) -> None:

--- a/src/aios/api/routers/health.py
+++ b/src/aios/api/routers/health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
@@ -13,16 +14,31 @@ router = APIRouter()
 
 
 @router.get("/health", operation_id="get_health")
-async def health() -> dict[str, str]:
-    """Liveness probe. Unauthenticated; returns the running aios version.
+async def health() -> dict[str, str | None]:
+    """Liveness probe. Unauthenticated; returns the running aios version + build SHA.
 
     Suitable for load balancer health checks and monitoring probes. Always
-    returns 200 with ``{"status": "ok", "version": <version>}`` if the
-    process is up. Deliberately does NOT touch the DB pool — a post-startup
+    returns 200 with ``{"status": "ok", "version": <version>, "build_sha": <sha-or-None>}``
+    if the process is up. Deliberately does NOT touch the DB pool — a post-startup
     Postgres outage must not flip liveness (that's ``/ready``'s job), or an
     orchestrator would kill an otherwise-healthy process during a DB blip.
+
+    ``build_sha`` (aios#1327, Unit A2) is the git commit baked into THIS image at
+    build time (``ENV AIOS_BUILD_SHA`` in the Dockerfile ``base`` stage). It is the
+    in-process running-truth read: unlike ``version`` (a static package string that
+    never changes between builds), it tells you which commit is actually running.
+    ``None`` when ``AIOS_BUILD_SHA`` is unset — an un-instrumented build — which the
+    running==merged reconciler reads as ``cannot-determine``, never a false match.
+    ``version`` stays the static package string, untouched.
+
+    The return type is ``dict[str, str | None]`` (not ``dict[str, str]``): ``build_sha``
+    is genuinely nullable because ``os.environ.get`` returns ``str | None``.
     """
-    return {"status": "ok", "version": __version__}
+    return {
+        "status": "ok",
+        "version": __version__,
+        "build_sha": os.environ.get("AIOS_BUILD_SHA"),
+    }
 
 
 @router.get("/ready", operation_id="get_ready")

--- a/src/aios/workflows/running_merged_reconciler.py
+++ b/src/aios/workflows/running_merged_reconciler.py
@@ -1,0 +1,641 @@
+"""Running==merged reconciler workflow script (aios#1327, plane B2 of the
+substrate-different-verdict invariant; epic #1330, roadmap item 11).
+
+``build_running_merged_reconciler_script`` returns workflow *source code* (the
+``deep_research.py`` / ``dev_pipeline.py`` builder idiom) — a fully deterministic,
+**scriptable (no agent)** workflow launched by a ``CronSource → WorkflowAction``
+trigger. The SHA-diff predicate has a universally-correct policy, so it is
+admissible as a script per the script-vs-agent partition doctrine.
+
+WHAT IT RECONCILES — "the merged code is running". The deploy-actor's own ledger
+says only what it INTENDED to run; it is maker==checker on the comparison target
+(Coolify's app-config ``git_commit_sha`` literally returns ``'HEAD'``). The only
+genuinely-uncorrelated read of what is RUNNING is the eumemic-ops audit that SSHes
+to the host and ``docker inspect``s the LIVE container's image. This reconciler
+compares that live read against **git master HEAD** (immutable, not fleet-authored
+= the uncorrelated expected substrate), per app, and routes drift.
+
+THE TWO READS (every read in the value domain — None/str/int/bool/list/dict):
+
+1. **Expected SHA = git master HEAD.** ``tool('http_request', GET /repos/<repo>/commits/master)``
+   against GitHub (vault-bound ``GITHUB_TOKEN``); take ``.sha``. A failed / truncated
+   list read is ``cannot-determine`` (the no-silent-degrade list-read invariant,
+   roadmap item 1 — ``gh_paginated`` raises ``GitHubListIncomplete`` on an
+   unfetched ``rel="next"``; spliced from ``gh_body``).
+
+2. **Running SHA = ops-audit ``docker inspect LABEL org.eumemic.build_sha`` over SSH,
+   ONE read path for EVERY app** (the resolution of the previously-open fork — the
+   reconciler does NOT branch on app type). The worker has no HTTP server, so SSH +
+   ``docker inspect`` is the sole path for it; aios-api *could* be read via
+   ``GET /health.build_sha`` (which still ships from Unit A2 as the human/ad-hoc
+   liveness read) but is PINNED to the same SSH read to keep the reconciler a single
+   deterministic read path. Invoked via ``tool('bash')`` cloning eumemic-ops and
+   running the ``coolify-running-container-fresh.sh``-derived label read.
+   NOT the deploy-ledger; NOT Coolify ``git_commit_sha`` (returns ``'HEAD'``).
+
+PER-APP, NEVER AGGREGATE. The reconciler runs the read PER APP and decides PER APP.
+A read that returns ``null`` / ``unknown`` / ``__SSH_FAIL__`` / ``__MISSING__`` /
+unlabelled is ``cannot-determine`` for THAT app — NEVER coerced to ``ok``, and never
+collapsed into an aggregate ``ok`` that hides one app's unreadability behind
+another's match.
+
+VERDICTS (per app):
+  * ``ok``               — both reads succeeded and ``running_sha == master_head``
+                           (short/long normalised: compare on the running SHA's
+                           length prefix).
+  * ``drifted``          — both reads succeeded and differ.
+  * ``cannot-determine`` — that app's running SHA is unreadable, OR the master read
+                           failed / ``cannot-determine``. NEVER coerced to ``ok``.
+
+INTERIM MODE (A-interim — ships FIRST, before A1/A2/A3 land). Until the build-SHA is
+in the image, the running read bakes ``unknown`` → ``cannot-determine`` for the
+running axis. The interim mode still adds value: read master HEAD and the
+deploy-ledger's last track-G SHA (acknowledged maker==checker), diff them, and emit
+``needs-deploy`` when ledger-SHA ≠ master-HEAD (= "master moved past the last
+deploy" — the dominant drift shape), AND ``cannot-determine`` for the *running*-vs-
+ledger axis, explicitly self-flagged as not-yet-substrate-different so it is never
+mistaken for the real running-truth read. When A1/A2/A3 land the reconciler runs in
+full mode (``interim=False``) and the interim path is gone (one right way, no alias).
+
+ROUTING (buildable-today tier only). Any ``drifted`` / ``cannot-determine`` /
+``needs-deploy`` app → file/upsert ONE GitHub issue (idempotent by a stable title +
+maker-marker body, carrying the per-app verdicts). NO algedonic lane, NO
+cockpit-resume (deferred — ``role_bindings`` / priority-wake absent; out of scope).
+
+LATENCY-WINDOW (gap #3): cron can be up to its interval late, so a clean reconcile is
+"no drift seen at last poll", not "zero drift". ``external_event`` / #1281 can narrow
+it later; out of scope here.
+
+IDEMPOTENCY. The side-effecting node (file/upsert the drift issue) is idempotent by
+construction: it lists open issues, finds one by the stable title, and upserts a
+markered comment via ``post_comment_once`` (the maker-marker replay guard) rather than
+double-filing — so a crash re-drive / re-fire never double-files.
+
+DETERMINISM. Imports only ``re`` / ``json``; all capability I/O in the value domain;
+capabilities emitted in a FIXED, BOUNDED order (master read, then per-app reads in
+the configured ``APPS`` order, then the single routing read/write) — so replay-with-
+memo is stable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
+from aios.models.triggers import CronSource, TriggerCreate, WorkflowAction
+from aios.models.workflows import WorkflowCreate
+from aios.workflows.comment_idempotency import COMMENT_IDEMPOTENCY_HELPERS
+from aios.workflows.gh_body import GH_BODY_HELPERS
+
+# ─── defaults (override per deployment) ──────────────────────────────────────
+DEFAULT_REPO = "eumemic/aios"
+DEFAULT_OPS_REPO = "eumemic/eumemic-ops"
+# The Coolify apps reconciled, in a FIXED order (replay-stable capability ordering).
+# Each carries the Coolify app uuid the ops-audit reads the running container of.
+DEFAULT_APPS: tuple[dict[str, str], ...] = (
+    {"name": "aios-api", "uuid": "aios-api"},
+    {"name": "aios-worker", "uuid": "aios-worker"},
+)
+# Off-peak default cron (every 20 minutes). The latency-window known-miss class: a
+# clean reconcile is "no drift seen at last poll", bounded by this interval.
+DEFAULT_SCHEDULE = "*/20 * * * *"
+
+# The stable drift-issue title (idempotency-by-title key) and the maker-marker that
+# dedups the upserted comment across replays / re-fires.
+DRIFT_ISSUE_TITLE = "running==merged reconciler: drift / cannot-determine"
+MARKER_DRIFT = "## running-merged-reconciler"
+
+# Sentinels the ops-audit running-SHA read emits for an unreadable container. ANY of
+# these (or null/unknown/unlabelled/empty) is cannot-determine for that app.
+UNREADABLE_SENTINELS: tuple[str, ...] = ("unknown", "__SSH_FAIL__", "__MISSING__")
+
+
+def _py(name: str, value: Any) -> str:
+    """One ``NAME = <repr>`` constant line for the prepended header."""
+    return f"{name} = {value!r}"
+
+
+def _render_constants(
+    *,
+    repo: str,
+    ops_repo: str,
+    apps: tuple[dict[str, str], ...],
+    github_server: str,
+    base_branch: str,
+    interim: bool,
+) -> str:
+    lines = [
+        _py("REPO", repo),
+        _py("OPS_REPO", ops_repo),
+        _py("APPS", [dict(a) for a in apps]),
+        _py("GITHUB_SERVER", github_server),
+        _py("BASE_BRANCH", base_branch),
+        _py("INTERIM", interim),
+        _py("DRIFT_ISSUE_TITLE", DRIFT_ISSUE_TITLE),
+        _py("MARKER_DRIFT", MARKER_DRIFT),
+        _py("UNREADABLE_SENTINELS", list(UNREADABLE_SENTINELS)),
+    ]
+    return "\n".join(lines)
+
+
+# The static script body — references the prepended constants. Pure stdlib (re/json),
+# value-domain I/O, bounded loops in a fixed order: replay-stable by construction.
+_BODY = r'''
+import json
+import re
+
+
+# ─── scripted helpers (deterministic; no LLM, no time, no random) ────────────
+
+def _unwrap(input):
+    """Accept both a bare input dict and the trigger envelope
+    ``{"trigger": ..., "input": ...}`` a WorkflowAction fire delivers."""
+    if isinstance(input, dict) and "trigger" in input and "input" in input:
+        return input["input"] or {}
+    return input or {}
+
+
+def _ipath(repo, suffix):
+    return "/repos/%s%s" % (repo, suffix)
+
+
+async def _gh_once(method, path, body=None):
+    """One GitHub REST/GraphQL call through the run's bound-vault-authed http_request.
+    A non-2xx or transport error is a VALUE the caller branches on, never a raise.
+    ``path`` must NOT carry a query string unless the route opts into allow_query."""
+    args = {"server_ref": GITHUB_SERVER, "path": path, "method": method}
+    if body is not None:
+        args["body"] = json.dumps(body)
+    return await tool("http_request", args)
+
+
+_TRANSIENT_ERROR_PREFIXES = ("Request timed out", "HTTP transport error")
+
+
+def _is_transient(resp):
+    """A retryable GitHub response: a 5xx, OR a genuine transport transient. A 4xx is
+    the caller's problem (auth, 404, 422) — NOT retried. A broker gate rejection
+    (route-allowlist / SSRF / path) is DETERMINISTIC, not transient."""
+    if not isinstance(resp, dict):
+        return True
+    err = resp.get("error")
+    if err is not None:
+        return isinstance(err, str) and err.startswith(_TRANSIENT_ERROR_PREFIXES)
+    st = resp.get("status")
+    return isinstance(st, int) and 500 <= st <= 599
+
+
+async def gh(method, path, body=None):
+    """A GitHub call with bounded transient-5xx retry (≤3). Returns the LAST result
+    for the caller to branch on (a value, never a raise). Each attempt is a fresh
+    ``tool()`` await, so the CallKeyer gives it a distinct ordinal and replay is
+    stable (the retry decision is a pure function of the memoized result)."""
+    resp = None
+    for _ in range(3):
+        resp = await _gh_once(method, path, body)
+        if not _is_transient(resp):
+            return resp
+        log("gh transient failure, retrying:", method, path, _status(resp))
+    return resp
+
+
+def _headers(resp):
+    if not isinstance(resp, dict):
+        return {}
+    h = resp.get("headers")
+    if not isinstance(h, dict):
+        return {}
+    return {str(k).lower(): v for k, v in h.items()}
+
+
+def _link_next_page(link_header):
+    """The ``page`` number of the ``rel="next"`` URL in a GitHub Link header, or None.
+    We rebuild the next path against the path WE control, so a malformed/host-bearing
+    next URL never reaches the route gate."""
+    if not isinstance(link_header, str) or not link_header:
+        return None
+    for part in link_header.split(","):
+        seg = part.strip()
+        if 'rel="next"' not in seg:
+            continue
+        m = re.search(r"[?&]page=(\d+)", seg)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _with_query(path, **params):
+    """Append ``params`` as a query string (deterministic key order; ints/strs)."""
+    qs = "&".join("%s=%s" % (k, params[k]) for k in sorted(params))
+    return path + ("?" if qs else "") + qs
+
+
+def _status(resp):
+    return resp.get("status") if isinstance(resp, dict) else None
+
+
+# ``_json_body`` / ``gh_paginated`` / ``GitHubListIncomplete`` are spliced in from the
+# shared ``GH_BODY_HELPERS`` source (aios#1294/#1323): a truncated / unparseable 2xx
+# body or an under-counted paginated list raises (fail loud, never degrade to None/[]).
+# ``post_comment_once`` is spliced from ``COMMENT_IDEMPOTENCY_HELPERS`` (aios#1292).
+
+
+# ─── running-SHA read (the ops-audit docker-inspect LABEL over SSH) ──────────
+
+def _running_sha_command(uuid):
+    """The bash command that reads ONE app's LIVE running SHA — the genuinely-
+    uncorrelated substrate (the live container, a different actor than the deploy
+    ledger). Clones eumemic-ops and runs the audit's docker-inspect-LABEL reader,
+    which SSHes to the host and inspects the RUNNING container's image
+    ``LABEL org.eumemic.build_sha``. Prints exactly one line ``RUNNING_SHA=<value>``
+    where <value> is the SHA, or a sentinel (``__SSH_FAIL__`` / ``__MISSING__`` /
+    ``unknown`` for an unlabelled image) that the caller maps to cannot-determine.
+
+    Re-run tolerant (rm -rf then clone) per the at-least-once bash contract. The
+    token in the clone URL is an egress-proxy placeholder (as in dev_pipeline)."""
+    lines = [
+        "set -u",
+        "D=/workspace/ops-audit",
+        'rm -rf "$D"',
+        "git clone --quiet --depth 1 "
+        "https://x-access-token:$GITHUB_TOKEN@github.com/%s.git \"$D\" "
+        "|| { echo 'RUNNING_SHA=__SSH_FAIL__'; exit 0; }" % OPS_REPO,
+        'cd "$D"',
+        # The audit script emits ``image|status|startedAt`` (or __SSH_FAIL__/__MISSING__)
+        # and is driven by the LABEL read; we ask it for the build_sha LABEL of the
+        # running container of this app's uuid and normalise its output to one line.
+        'SHA="$(audit/checks/coolify-running-container-fresh.sh --app %s --emit-build-sha '
+        "2>/dev/null)\" || SHA=__SSH_FAIL__" % uuid,
+        '[ -z "$SHA" ] && SHA=__MISSING__',
+        'echo "RUNNING_SHA=$SHA"',
+    ]
+    return "\n".join(lines)
+
+
+def _parse_running_sha(bash_result):
+    """Pull the ``RUNNING_SHA=<value>`` line out of a tool('bash') result. Returns the
+    raw string value (possibly a sentinel), or None when the read itself failed to
+    produce the line (non-dict result, missing line, nonzero exit with no line) —
+    None is cannot-determine, never coerced to ok."""
+    if not isinstance(bash_result, dict):
+        return None
+    out = bash_result.get("stdout")
+    if not isinstance(out, str):
+        return None
+    val = None
+    for line in out.splitlines():
+        m = re.match(r"^RUNNING_SHA=(.*)$", line.strip())
+        if m:
+            val = m.group(1).strip()  # last wins (the command prints exactly one)
+    if val is None or val == "":
+        return None
+    return val
+
+
+def _is_unreadable_sha(value):
+    """True when a running-SHA read is cannot-determine: None, empty, a sentinel
+    (__SSH_FAIL__/__MISSING__/unknown), or not a hex-looking commit id."""
+    if not isinstance(value, str) or not value:
+        return True
+    if value in UNREADABLE_SENTINELS:
+        return True
+    return not re.match(r"^[0-9a-fA-F]{7,64}$", value)
+
+
+def _shas_match(running, master):
+    """Short/long normalised SHA equality: compare on the RUNNING sha's length prefix
+    (a short ``abc1234`` running id matches a full master id with that prefix). Both
+    lower-cased. Caller guarantees both are non-empty readable strings."""
+    r = running.lower()
+    m = master.lower()
+    n = min(len(r), len(m))
+    return r[:n] == m[:n]
+
+
+# ─── the deploy-ledger read (INTERIM mode only) ──────────────────────────────
+
+def _ledger_sha_command():
+    """INTERIM mode: read the deploy-ledger's last track-G SHA (acknowledged
+    maker==checker — the deploy actor's self-report, NOT a running-truth read).
+    Clones eumemic-ops and reads the ledger tail. Prints ``LEDGER_SHA=<value>`` (or
+    a sentinel). This axis is self-flagged not-yet-substrate-different in routing."""
+    lines = [
+        "set -u",
+        "D=/workspace/ops-audit",
+        'rm -rf "$D"',
+        "git clone --quiet --depth 1 "
+        "https://x-access-token:$GITHUB_TOKEN@github.com/%s.git \"$D\" "
+        "|| { echo 'LEDGER_SHA=__SSH_FAIL__'; exit 0; }" % OPS_REPO,
+        'cd "$D"',
+        'SHA="$(scripts/fleet ledger-last-track-g-sha 2>/dev/null)" || SHA=__SSH_FAIL__',
+        '[ -z "$SHA" ] && SHA=__MISSING__',
+        'echo "LEDGER_SHA=$SHA"',
+    ]
+    return "\n".join(lines)
+
+
+def _parse_ledger_sha(bash_result):
+    if not isinstance(bash_result, dict):
+        return None
+    out = bash_result.get("stdout")
+    if not isinstance(out, str):
+        return None
+    val = None
+    for line in out.splitlines():
+        m = re.match(r"^LEDGER_SHA=(.*)$", line.strip())
+        if m:
+            val = m.group(1).strip()
+    if val is None or val == "":
+        return None
+    return val
+
+
+# ─── routing (file/upsert ONE idempotent drift issue) ────────────────────────
+
+def _verdicts_need_routing(verdicts):
+    """True if ANY per-app verdict is not a clean ``ok`` — i.e. drifted /
+    cannot-determine / needs-deploy. A clean reconcile (every app ok) routes nothing."""
+    for v in verdicts:
+        if v.get("verdict") != "ok":
+            return True
+    return False
+
+
+def _drift_body(verdicts, master_head, interim):
+    """The stable, self-identifying drift-issue comment body (carries MARKER_DRIFT so
+    the maker-marker guard dedups it across replays). Renders the per-app verdicts and
+    both SHAs deterministically (sorted by app name)."""
+    lines = [MARKER_DRIFT, ""]
+    lines.append("mode: %s" % ("interim (running axis = cannot-determine)" if interim else "full"))
+    lines.append("master HEAD: %s" % (master_head if master_head else "cannot-determine"))
+    lines.append("")
+    for v in sorted(verdicts, key=lambda x: x.get("app", "")):
+        lines.append(
+            "- **%s** → `%s` (running=%r master=%r%s)"
+            % (
+                v.get("app", "?"),
+                v.get("verdict", "?"),
+                v.get("running"),
+                v.get("master"),
+                (" note=%s" % v["note"]) if v.get("note") else "",
+            )
+        )
+    return "\n".join(lines)
+
+
+async def _find_open_issue_by_title(repo, title):
+    """Find an OPEN issue whose title equals ``title`` (idempotency-by-title). Lists
+    open issues with the no-silent-degrade paginated read (raises on an under-counted
+    list — a partial list could miss the existing issue and double-file). Returns the
+    issue dict or None."""
+    # GET /repos/{repo}/issues defaults to state=open; gh_paginated adds per_page/page,
+    # so we pass a CLEAN path and filter in-script (PRs surface on the issues list and
+    # carry a "pull_request" key — exclude them so we never adopt a PR as the issue).
+    items = await gh_paginated(_ipath(repo, "/issues"))
+    if not isinstance(items, list):
+        return None
+    for it in items:
+        if isinstance(it, dict) and it.get("title") == title and "pull_request" not in it:
+            return it
+    return None
+
+
+async def _route_drift(repo, verdicts, master_head, interim):
+    """File / upsert ONE drift issue, idempotent by title + maker-marker. If an open
+    issue with DRIFT_ISSUE_TITLE exists, upsert a markered comment on it (skipped if
+    the freshly-read thread already carries the marker — the replay guard); else
+    create the issue carrying the marker in its body. Returns the issue number."""
+    body = _drift_body(verdicts, master_head, interim)
+    existing = await _find_open_issue_by_title(repo, DRIFT_ISSUE_TITLE)
+    if existing is not None:
+        number = int(existing["number"])
+        thread = await gh_paginated(_ipath(repo, "/issues/%d/comments" % number))
+        await post_comment_once(
+            repo, number, MARKER_DRIFT, body,
+            thread if isinstance(thread, list) else [],
+        )
+        return number
+    created = await gh(
+        "POST", _ipath(repo, "/issues"),
+        {"title": DRIFT_ISSUE_TITLE, "body": body, "labels": ["deploy-drift"]},
+    )
+    issue = _json_body(created)
+    return int(issue["number"]) if isinstance(issue, dict) and "number" in issue else None
+
+
+# ─── the reconciler state machine ────────────────────────────────────────────
+
+async def main(input):
+    payload = _unwrap(input)
+    repo = payload.get("repo") or REPO
+    interim = bool(payload.get("interim", INTERIM))
+
+    # ── STEP 1: expected SHA = git master HEAD (immutable, uncorrelated substrate) ──
+    # The no-silent-degrade contract: a failed / truncated read is cannot-determine
+    # for the master axis, which makes EVERY app cannot-determine — never coerced to ok.
+    phase("read-master")
+    master_head = None
+    master_readable = True
+    resp = await gh("GET", _ipath(repo, "/commits/%s" % BASE_BRANCH))
+    if _status(resp) == 200:
+        commit = _json_body(resp)  # raises loud on a truncated/unparseable 2xx body
+        if isinstance(commit, dict) and isinstance(commit.get("sha"), str) and commit["sha"]:
+            master_head = commit["sha"]
+        else:
+            master_readable = False
+    else:
+        master_readable = False
+    if not master_readable:
+        log("master read failed (status %r) -> cannot-determine for every app" % _status(resp))
+
+    # ── STEP 2+3: per-app running read + per-app diff (NEVER aggregate) ──
+    phase("read-running")
+    verdicts = []
+    if interim:
+        # A-interim: read the deploy-ledger's last track-G SHA (acknowledged
+        # maker==checker) and diff vs master. The running axis is explicitly
+        # cannot-determine and self-flagged not-yet-substrate-different.
+        ledger_raw = await tool("bash", {"command": _ledger_sha_command()})
+        ledger_sha = _parse_ledger_sha(ledger_raw)
+        for app in APPS:
+            name = app["name"]
+            # The needs-deploy axis (ledger vs master) — the dominant drift shape.
+            if not master_readable:
+                nd_verdict = "cannot-determine"
+            elif _is_unreadable_sha(ledger_sha):
+                nd_verdict = "cannot-determine"
+            elif _shas_match(ledger_sha, master_head):
+                nd_verdict = "ok"
+            else:
+                nd_verdict = "needs-deploy"
+            # The running-vs-ledger axis is ALWAYS cannot-determine in interim mode,
+            # self-flagged so it is never mistaken for the real running-truth read.
+            verdicts.append({
+                "app": name,
+                "verdict": nd_verdict,
+                "running": None,
+                "master": master_head,
+                "ledger": ledger_sha,
+                "note": "interim: running axis cannot-determine (not-yet-substrate-different)",
+            })
+    else:
+        # Full mode: ONE running-SHA read per app — the ops-audit docker inspect LABEL
+        # over SSH. Decide PER APP; never collapse into an aggregate ok.
+        for app in APPS:
+            name = app["name"]
+            uuid = app["uuid"]
+            running_raw = await tool("bash", {"command": _running_sha_command(uuid)})
+            running_sha = _parse_running_sha(running_raw)
+            if not master_readable:
+                verdict = "cannot-determine"
+                note = "master read failed"
+            elif _is_unreadable_sha(running_sha):
+                verdict = "cannot-determine"
+                note = "running SHA unreadable (%r)" % running_sha
+            elif _shas_match(running_sha, master_head):
+                verdict = "ok"
+                note = ""
+            else:
+                verdict = "drifted"
+                note = ""
+            verdicts.append({
+                "app": name,
+                "verdict": verdict,
+                "running": running_sha,
+                "master": master_head,
+                "note": note,
+            })
+
+    # ── STEP 5: routing (buildable-today tier: file/upsert ONE idempotent issue) ──
+    phase("route")
+    issue_number = None
+    if _verdicts_need_routing(verdicts):
+        issue_number = await _route_drift(repo, verdicts, master_head, interim)
+
+    clean = not _verdicts_need_routing(verdicts)
+    return {
+        "state": "reconciled",
+        "mode": "interim" if interim else "full",
+        "master_head": master_head,
+        "verdicts": verdicts,
+        "clean": clean,
+        "routed_issue": issue_number,
+    }
+'''
+
+
+def build_running_merged_reconciler_script(
+    *,
+    repo: str = DEFAULT_REPO,
+    ops_repo: str = DEFAULT_OPS_REPO,
+    apps: tuple[dict[str, str], ...] = DEFAULT_APPS,
+    github_server: str = "github",
+    base_branch: str = "master",
+    interim: bool = False,
+) -> str:
+    """Return the running==merged reconciler workflow source.
+
+    ``interim=True`` ships FIRST (A-interim): the running axis is cannot-determine and
+    the needs-deploy signal (ledger-SHA ≠ master-HEAD) is the value-add until the
+    build-SHA-in-image primitive (A1/A2/A3) lands. ``interim=False`` is the full
+    reconciler: one running-SHA read per app via the ops-audit docker-inspect LABEL.
+    """
+    header = _render_constants(
+        repo=repo,
+        ops_repo=ops_repo,
+        apps=apps,
+        github_server=github_server,
+        base_branch=base_branch,
+        interim=interim,
+    )
+    # Splice the shared GitHub-body helper (fail-loud on truncated/under-counted reads)
+    # and the comment-idempotency helper (maker-marker dedup) — each authored once and
+    # injected so the class fix can't drift (#1294/#1323/#1292).
+    return header + "\n" + _BODY + GH_BODY_HELPERS + COMMENT_IDEMPOTENCY_HELPERS
+
+
+# ─── deploy surface (the tool + http_server envelope a WorkflowCreate needs) ──
+
+REQUIRED_TOOLS: list[ToolSpec] = [
+    ToolSpec(type="bash"),
+    ToolSpec(type="http_request"),
+]
+
+
+def _github_http_server(*, name: str, base_url: str) -> HttpServerSpec:
+    return HttpServerSpec(
+        name=name,
+        base_url=base_url,
+        description="GitHub REST API (auth resolved from the bound vault's GITHUB_TOKEN).",
+        routes=[
+            HttpRouteSpec(
+                # GET: read master HEAD + list open issues + read a thread. POST: file
+                # the drift issue / upsert its comment. allow_query: the issues/comments
+                # list reads paginate via ?per_page/?page and the no-silent-degrade
+                # invariant must follow Link: rel="next" to prove completeness (#1323).
+                path_pattern="/repos/**",
+                methods=["GET", "POST"],
+                allow_query=True,
+                description="Read master HEAD; list/create issues + comments; "
+                "list endpoints paginate via ?per_page/?page.",
+            ),
+        ],
+    )
+
+
+REQUIRED_HTTP_SERVERS: list[HttpServerSpec] = [
+    _github_http_server(name="github", base_url="https://api.github.com")
+]
+
+
+def build_running_merged_reconciler_workflow_create(
+    *,
+    name: str,
+    description: str | None = None,
+    github_server: str = "github",
+    github_base_url: str = "https://api.github.com",
+    **script_kwargs: Any,
+) -> WorkflowCreate:
+    """Return the complete ``WorkflowCreate`` payload for the reconciler.
+
+    Bundles the script with the tool + http_server surface it requires, so the declared
+    surface can never drift from the script that needs it (#1135). Any remaining keyword
+    args are forwarded verbatim to ``build_running_merged_reconciler_script``.
+    """
+    script = build_running_merged_reconciler_script(github_server=github_server, **script_kwargs)
+    return WorkflowCreate(
+        name=name,
+        description=description,
+        script=script,
+        tools=list(REQUIRED_TOOLS),
+        http_servers=[_github_http_server(name=github_server, base_url=github_base_url)],
+    )
+
+
+def build_running_merged_reconciler_trigger(
+    *,
+    name: str,
+    workflow_id: str,
+    vault_id: str,
+    schedule: str = DEFAULT_SCHEDULE,
+    interim: bool = False,
+    workflow_version: int | None = None,
+) -> TriggerCreate:
+    """Return the ``CronSource → WorkflowAction`` trigger document (acceptance item 5).
+
+    Off-peak cron (default every 20 min) → launches ``workflow_id``. ``vault_id`` binds
+    the ``GITHUB_TOKEN`` the reconciler's ``http_request`` calls authenticate with. The
+    run input is the standard envelope ``{"trigger": ..., "input": <input_template>}``;
+    the template carries the ``interim`` flag so the trigger selects interim-vs-full
+    without rebuilding the workflow. ``CronSource`` + ``WorkflowAction`` are SHIPPED.
+    """
+    return TriggerCreate(
+        name=name,
+        source=CronSource(schedule=schedule),
+        action=WorkflowAction(
+            workflow_id=workflow_id,
+            workflow_version=workflow_version,
+            input_template={"interim": interim},
+            vault_ids=[vault_id],
+        ),
+    )

--- a/tests/integration/test_wf_running_merged_reconciler_fixture.py
+++ b/tests/integration/test_wf_running_merged_reconciler_fixture.py
@@ -181,7 +181,8 @@ async def _drive(
 def _verdict(value: dict[str, Any], app: str) -> str:
     for v in value["verdicts"]:
         if v["app"] == app:
-            return v["verdict"]
+            verdict: str = v["verdict"]
+            return verdict
     raise AssertionError(f"no verdict for {app}: {value['verdicts']!r}")
 
 

--- a/tests/integration/test_wf_running_merged_reconciler_fixture.py
+++ b/tests/integration/test_wf_running_merged_reconciler_fixture.py
@@ -1,0 +1,371 @@
+"""Running==merged reconciler fixture (aios#1327, plane B2).
+
+Drives the production ``build_running_merged_reconciler_script`` directly against the
+real script host (no DB, no sandbox, no model) with a deterministic capability
+responder simulating each ``http_request`` / ``bash`` return — the dev_pipeline fixture
+harness pattern. The reconciler is fully deterministic, so this verifies the full state
+machine AND the load-bearing durable property: replay is deterministic (every call_key
+is stable across every replay).
+
+The verdict matrix under test:
+  ok / drifted / cannot-determine (per app, NEVER aggregated), short/long SHA
+  normalisation, the per-app-not-aggregate must-fix, the no-silent-degrade master read,
+  idempotent routing, and the A-interim needs-deploy signal.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+
+from aios.workflows.host_launcher import run_script_host
+from aios.workflows.running_merged_reconciler import (
+    DRIFT_ISSUE_TITLE,
+    MARKER_DRIFT,
+    build_running_merged_reconciler_script,
+)
+
+pytestmark = pytest.mark.integration
+
+REPO = "eumemic/aios"
+MASTER_SHA = "abc1234deadbeefabc1234deadbeefabc1234dea"  # 40-char SHA-1
+
+
+class Scenario:
+    """A deterministic responder + a record of what the script asked for. Keys every
+    decision on the capability spec (and, for the per-app bash reads, the app uuid in
+    the command) so the responder is a pure function of the call_key — replay-stable.
+    """
+
+    def __init__(
+        self,
+        *,
+        master_sha: str | None = MASTER_SHA,
+        master_status: int = 200,
+        # {uuid: running_sha_or_sentinel} — what the ops-audit bash read returns per app.
+        running: dict[str, str] | None = None,
+        # Interim mode: the deploy-ledger last track-G SHA the bash read returns.
+        ledger_sha: str | None = MASTER_SHA,
+        # Whether an open drift issue with DRIFT_ISSUE_TITLE already exists (upsert path).
+        existing_drift_issue: bool = False,
+        # The comment thread of the existing drift issue (model an at-least-once replay
+        # where the markered comment was already posted).
+        drift_issue_comments: list[str] | None = None,
+    ) -> None:
+        self.master_sha = master_sha
+        self.master_status = master_status
+        self.running = running or {}
+        self.ledger_sha = ledger_sha
+        self.existing_drift_issue = existing_drift_issue
+        self.drift_issue_comments = drift_issue_comments or []
+        # Records for assertions.
+        self.http: list[tuple[str, str]] = []
+        self.issues_created: list[dict[str, Any]] = []
+        self.comments_posted: list[str] = []
+        self.bash_commands: list[str] = []
+
+    DRIFT_ISSUE_NUMBER = 777
+
+    def _http(self, args: dict[str, Any]) -> dict[str, Any]:
+        path, method = args["path"], args["method"]
+        self.http.append((method, path))
+        clean = path.partition("?")[0]
+
+        # master HEAD read
+        if method == "GET" and clean == f"/repos/{REPO}/commits/master":
+            if self.master_status != 200:
+                return {"status": self.master_status, "body": "{}"}
+            return {"status": 200, "body": json.dumps({"sha": self.master_sha})}
+
+        # list open issues (idempotency-by-title) — paginated, single page
+        if method == "GET" and clean == f"/repos/{REPO}/issues":
+            if self.existing_drift_issue:
+                body = json.dumps([{"number": self.DRIFT_ISSUE_NUMBER, "title": DRIFT_ISSUE_TITLE}])
+            else:
+                body = "[]"
+            return {"status": 200, "headers": {}, "body": body}
+
+        # the existing drift issue's comment thread (upsert dedup read)
+        cm = re.match(rf"^/repos/{re.escape(REPO)}/issues/(\d+)/comments$", clean)
+        if method == "GET" and cm:
+            return {
+                "status": 200,
+                "headers": {},
+                "body": json.dumps(
+                    [{"id": i, "body": b} for i, b in enumerate(self.drift_issue_comments)]
+                ),
+            }
+        if method == "POST" and cm:  # upsert comment on existing issue
+            raw = args.get("body")
+            if isinstance(raw, str):
+                self.comments_posted.append(json.loads(raw).get("body", ""))
+            return {"status": 201, "body": "{}"}
+
+        # create the drift issue
+        if method == "POST" and clean == f"/repos/{REPO}/issues":
+            raw = args.get("body")
+            if isinstance(raw, str):
+                self.issues_created.append(json.loads(raw))
+            return {"status": 201, "body": json.dumps({"number": self.DRIFT_ISSUE_NUMBER})}
+
+        return {"status": 200, "body": "{}"}
+
+    def _bash(self, command: str) -> dict[str, Any]:
+        self.bash_commands.append(command)
+        # The running-SHA read: identify the app uuid from the command.
+        m = re.search(r"--app (\S+) --emit-build-sha", command)
+        if m:
+            uuid = m.group(1)
+            sha = self.running.get(uuid, "__MISSING__")
+            return {
+                "exit_code": 0,
+                "stdout": f"RUNNING_SHA={sha}\n",
+                "stderr": "",
+                "timed_out": False,
+                "truncated": False,
+            }
+        # The interim ledger read.
+        if "ledger-last-track-g-sha" in command:
+            sha = self.ledger_sha if self.ledger_sha is not None else "__MISSING__"
+            return {
+                "exit_code": 0,
+                "stdout": f"LEDGER_SHA={sha}\n",
+                "stderr": "",
+                "timed_out": False,
+                "truncated": False,
+            }
+        return {"exit_code": 0, "stdout": "", "stderr": "", "timed_out": False, "truncated": False}
+
+    def outcome(self, cap: Any) -> dict[str, Any]:
+        cid, spec = cap.capability_id, cap.spec
+        if cid == "tool":
+            if spec["tool_name"] == "http_request":
+                return {"ok": self._http(spec["input"])}
+            if spec["tool_name"] == "bash":
+                return {"ok": self._bash(spec["input"]["command"])}
+        raise AssertionError(f"unhandled capability {cid} spec={spec!r}")
+
+
+async def _drive(
+    scenario: Scenario,
+    *,
+    input: dict[str, Any] | None = None,
+    max_steps: int = 40,
+    **build_kwargs: Any,
+) -> tuple[Any, list[str], list[str]]:
+    """Drive the reconciler to a terminal outcome, returning
+    (return_value, phases, ordered_call_keys). Asserts replay-determinism (unique keys).
+    """
+    src = build_running_merged_reconciler_script(**build_kwargs)
+    inp = input if input is not None else {"repo": REPO}
+    memo: dict[str, Any] = {}
+    keys: list[str] = []
+    phases: list[str] = []
+    for _ in range(max_steps):
+        out = await run_script_host(source=src, input=inp, memo=memo)
+        phases = [a.payload["text"] for a in out.annotations if a.payload["kind"] == "phase"]
+        if out.kind == "returned":
+            assert len(keys) == len(set(keys)), "replay produced a duplicate call_key"
+            return out.value, phases, keys
+        assert out.kind == "suspended", (out.kind, out.error_repr, out.error_traceback)
+        assert len(out.emitted) == 1, [(e.capability_id, e.spec) for e in out.emitted]
+        cap = out.emitted[0]
+        keys.append(cap.call_key)
+        memo[cap.call_key] = scenario.outcome(cap)
+    raise AssertionError(f"reconciler did not terminate within {max_steps} steps")
+
+
+def _verdict(value: dict[str, Any], app: str) -> str:
+    for v in value["verdicts"]:
+        if v["app"] == app:
+            return v["verdict"]
+    raise AssertionError(f"no verdict for {app}: {value['verdicts']!r}")
+
+
+# ─── full mode: ok ────────────────────────────────────────────────────────────
+
+
+async def test_ok_when_running_equals_master() -> None:
+    scn = Scenario(running={"aios-api": MASTER_SHA, "aios-worker": MASTER_SHA})
+    value, phases, _ = await _drive(scn)
+    assert value["state"] == "reconciled"
+    assert value["mode"] == "full"
+    assert _verdict(value, "aios-api") == "ok"
+    assert _verdict(value, "aios-worker") == "ok"
+    assert value["clean"] is True
+    # no issue filed, no comment posted, no owner-wake
+    assert scn.issues_created == []
+    assert scn.comments_posted == []
+    assert value["routed_issue"] is None
+    assert ("POST", f"/repos/{REPO}/issues") not in scn.http
+    assert phases == ["read-master", "read-running", "route"]
+
+
+# ─── full mode: drifted ─────────────────────────────────────────────────────
+
+
+async def test_drifted_when_running_lags_master() -> None:
+    other = "def5678" + "0" * 33  # a different 40-char SHA
+    scn = Scenario(running={"aios-api": other, "aios-worker": other})
+    value, _, _ = await _drive(scn)
+    assert _verdict(value, "aios-api") == "drifted"
+    assert _verdict(value, "aios-worker") == "drifted"
+    assert value["clean"] is False
+    # exactly one idempotent issue filed, carrying both SHAs
+    assert len(scn.issues_created) == 1
+    issue = scn.issues_created[0]
+    assert issue["title"] == DRIFT_ISSUE_TITLE
+    assert MASTER_SHA in issue["body"]
+    assert other in issue["body"]
+    assert MARKER_DRIFT in issue["body"]
+
+
+# ─── full mode: cannot-determine (running unreadable) ────────────────────────
+
+
+@pytest.mark.parametrize("sentinel", ["__SSH_FAIL__", "__MISSING__", "unknown", ""])
+async def test_cannot_determine_on_unreadable_running_sha(sentinel: str) -> None:
+    scn = Scenario(running={"aios-api": sentinel, "aios-worker": sentinel})
+    value, _, _ = await _drive(scn)
+    assert _verdict(value, "aios-api") == "cannot-determine"
+    assert _verdict(value, "aios-worker") == "cannot-determine"
+    # routed, not silently dropped
+    assert value["clean"] is False
+    assert len(scn.issues_created) == 1
+
+
+# ─── cannot-determine (master unreadable) — the no-silent-degrade invariant ──
+
+
+async def test_cannot_determine_on_unreadable_master() -> None:
+    # master GET fails -> EVERY app is cannot-determine (master axis failed), never ok.
+    scn = Scenario(
+        master_status=500,
+        running={"aios-api": MASTER_SHA, "aios-worker": MASTER_SHA},
+    )
+    value, _, _ = await _drive(scn)
+    assert value["master_head"] is None
+    assert _verdict(value, "aios-api") == "cannot-determine"
+    assert _verdict(value, "aios-worker") == "cannot-determine"
+    assert value["clean"] is False
+
+
+# ─── the per-app-not-aggregate must-fix ──────────────────────────────────────
+
+
+async def test_per_app_no_aggregate_ok() -> None:
+    # aios-api reads ok, aios-worker reads __SSH_FAIL__ -> the worker is
+    # cannot-determine and is NOT hidden behind the api's match.
+    scn = Scenario(running={"aios-api": MASTER_SHA, "aios-worker": "__SSH_FAIL__"})
+    value, _, _ = await _drive(scn)
+    assert _verdict(value, "aios-api") == "ok"
+    assert _verdict(value, "aios-worker") == "cannot-determine"
+    # NOT an aggregate ok: the run is not clean, and it routes the worker's unreadability.
+    assert value["clean"] is False
+    assert len(scn.issues_created) == 1
+    assert "aios-worker" in scn.issues_created[0]["body"]
+
+
+# ─── short/long SHA normalisation ────────────────────────────────────────────
+
+
+async def test_short_long_sha_normalization() -> None:
+    short = MASTER_SHA[:7]  # running reports a 7-char short SHA
+    scn = Scenario(running={"aios-api": short, "aios-worker": short})
+    value, _, _ = await _drive(scn)
+    assert _verdict(value, "aios-api") == "ok"  # prefix-normalised, no false drift
+    assert _verdict(value, "aios-worker") == "ok"
+    assert value["clean"] is True
+    assert scn.issues_created == []
+
+
+# ─── replay determinism ──────────────────────────────────────────────────────
+
+
+async def test_replay_deterministic() -> None:
+    other = "def5678" + "0" * 33
+    scn = Scenario(running={"aios-api": other, "aios-worker": MASTER_SHA})
+    _, _, keys = await _drive(scn)  # _drive already asserts unique keys
+    assert len(keys) == len(set(keys))
+
+
+# ─── idempotent routing (re-fire does not double-file) ───────────────────────
+
+
+async def test_idempotent_routing_existing_issue_upserts_comment() -> None:
+    other = "def5678" + "0" * 33
+    scn = Scenario(
+        running={"aios-api": other, "aios-worker": other},
+        existing_drift_issue=True,
+    )
+    value, _, _ = await _drive(scn)
+    # An open drift issue already exists -> upsert a markered comment, do NOT create a 2nd issue.
+    assert scn.issues_created == []
+    assert ("POST", f"/repos/{REPO}/issues") not in scn.http
+    assert len(scn.comments_posted) == 1
+    assert MARKER_DRIFT in scn.comments_posted[0]
+    assert value["routed_issue"] == Scenario.DRIFT_ISSUE_NUMBER
+
+
+async def test_idempotent_routing_skips_when_marker_already_present() -> None:
+    other = "def5678" + "0" * 33
+    scn = Scenario(
+        running={"aios-api": other, "aios-worker": other},
+        existing_drift_issue=True,
+        drift_issue_comments=[MARKER_DRIFT + "\n\nalready posted by a prior fire"],
+    )
+    _, _, _ = await _drive(scn)
+    # The maker-marker replay guard: the thread already carries the marker -> skip the POST.
+    assert scn.comments_posted == []
+    assert scn.issues_created == []
+
+
+# ─── A-interim needs-deploy signal (ships FIRST, before A1/A2/A3) ────────────
+
+
+async def test_interim_needs_deploy_signal() -> None:
+    # interim mode: ledger-SHA != master-HEAD -> needs-deploy; running axis is
+    # cannot-determine and self-flagged not-yet-substrate-different.
+    other = "def5678" + "0" * 33
+    scn = Scenario(ledger_sha=other)
+    value, _phases, _ = await _drive(scn, interim=True)
+    assert value["mode"] == "interim"
+    assert _verdict(value, "aios-api") == "needs-deploy"
+    assert _verdict(value, "aios-worker") == "needs-deploy"
+    for v in value["verdicts"]:
+        assert v["running"] is None  # running axis cannot-determine in interim
+        assert "not-yet-substrate-different" in v["note"]
+    assert value["clean"] is False
+    assert len(scn.issues_created) == 1
+    # the interim path never invokes the ops-audit per-app running read
+    assert all("--emit-build-sha" not in c for c in scn.bash_commands)
+
+
+async def test_interim_ok_when_ledger_equals_master() -> None:
+    scn = Scenario(ledger_sha=MASTER_SHA)
+    value, _, _ = await _drive(scn, interim=True)
+    assert _verdict(value, "aios-api") == "ok"
+    assert _verdict(value, "aios-worker") == "ok"
+    assert value["clean"] is True
+    assert scn.issues_created == []
+
+
+async def test_interim_cannot_determine_when_ledger_unreadable() -> None:
+    scn = Scenario(ledger_sha=None)  # bash read yields __MISSING__
+    value, _, _ = await _drive(scn, interim=True)
+    assert _verdict(value, "aios-api") == "cannot-determine"
+    assert _verdict(value, "aios-worker") == "cannot-determine"
+    assert value["clean"] is False
+
+
+# ─── trigger envelope unwrapping (WorkflowAction fire) ───────────────────────
+
+
+async def test_accepts_workflow_action_envelope() -> None:
+    scn = Scenario(running={"aios-api": MASTER_SHA, "aios-worker": MASTER_SHA})
+    value, _, _ = await _drive(scn, input={"trigger": {"kind": "cron"}, "input": {"repo": REPO}})
+    assert value["state"] == "reconciled"
+    assert value["clean"] is True

--- a/tests/unit/test_ready_route.py
+++ b/tests/unit/test_ready_route.py
@@ -124,3 +124,51 @@ def test_health_still_200_and_pool_untouched() -> None:
     body = resp.json()
     assert body["status"] == "ok"
     assert "version" in body
+
+
+# ─── /health build_sha (aios#1327, Unit A2) ──────────────────────────────────
+
+
+def test_health_shape_build_sha_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`/health` returns EXACTLY {"status","version","build_sha"}; ``build_sha`` is
+    ``None`` when ``AIOS_BUILD_SHA`` is unset (an un-instrumented build) — the
+    reconciler reads that as ``cannot-determine``, never a false match."""
+    monkeypatch.delenv("AIOS_BUILD_SHA", raising=False)
+    client = TestClient(_app_with_pool(_FakePool()))
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    # The must-fix shape assertion: exactly these three keys, no more, no less.
+    assert set(body.keys()) == {"status", "version", "build_sha"}
+    assert body["status"] == "ok"
+    assert body["build_sha"] is None
+
+
+def test_health_shape_build_sha_reports_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``AIOS_BUILD_SHA`` is set (Coolify build-arg baked into the image),
+    `/health` reports it verbatim. ``version`` stays the static package string,
+    UNCHANGED — ``build_sha`` is the new source of truth."""
+    from aios import __version__
+
+    monkeypatch.setenv("AIOS_BUILD_SHA", "abc1234deadbeef")
+    client = TestClient(_app_with_pool(_FakePool()))
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"status", "version", "build_sha"}
+    assert body["build_sha"] == "abc1234deadbeef"
+    assert body["version"] == __version__  # version field unchanged
+
+
+def test_health_build_sha_does_not_touch_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adding ``build_sha`` must not break the liveness contract: still no DB touch."""
+    monkeypatch.setenv("AIOS_BUILD_SHA", "feed")
+
+    class _ExplodingPool:
+        def acquire(self) -> Any:
+            raise AssertionError("/health must not touch the pool")
+
+    client = TestClient(_app_with_pool(_ExplodingPool()))
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["build_sha"] == "feed"

--- a/tests/unit/test_running_merged_reconciler_surface.py
+++ b/tests/unit/test_running_merged_reconciler_surface.py
@@ -1,0 +1,131 @@
+"""Unit tests for the running==merged reconciler deploy surface + trigger (aios#1327).
+
+Pins acceptance items 4 (the exported ``build_running_merged_reconciler_script`` builder:
+imports only re/json, value-domain I/O, fixed capability order) and 5 (a
+``CronSource → WorkflowAction`` trigger document targeting the reconciler, off-peak
+schedule, GITHUB_TOKEN vault bound), plus the deploy surface (tools + http_server) so it
+can't drift from the script that needs it (#1135) and validates at create time.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from aios.models.agents import HttpServerSpec
+from aios.models.triggers import CronSource, TriggerCreate, WorkflowAction
+from aios.models.workflows import WorkflowCreate
+from aios.workflows.running_merged_reconciler import (
+    DEFAULT_SCHEDULE,
+    REQUIRED_HTTP_SERVERS,
+    REQUIRED_TOOLS,
+    build_running_merged_reconciler_script,
+    build_running_merged_reconciler_trigger,
+    build_running_merged_reconciler_workflow_create,
+)
+from aios.workflows.script_validation import validate_workflow_script
+
+# ─── the script builder (acceptance item 4) ──────────────────────────────────
+
+
+def test_script_imports_only_re_and_json() -> None:
+    src = build_running_merged_reconciler_script()
+    tree = ast.parse(src)
+    imported = {n.names[0].name for n in ast.walk(tree) if isinstance(n, ast.Import)}
+    # Pure stdlib re/json only — value-domain I/O, replay-stable by construction.
+    assert imported == {"re", "json"}
+    assert not [n for n in ast.walk(tree) if isinstance(n, ast.ImportFrom)]
+
+
+def test_script_defines_async_main() -> None:
+    tree = ast.parse(build_running_merged_reconciler_script())
+    assert any(isinstance(n, ast.AsyncFunctionDef) and n.name == "main" for n in tree.body)
+
+
+def test_script_validates_against_declared_surface() -> None:
+    # create-time validation: the declared surface is a superset of the AST-required one.
+    src = build_running_merged_reconciler_script()
+    validate_workflow_script(src, list(REQUIRED_TOOLS))
+
+
+def test_interim_variant_validates_too() -> None:
+    src = build_running_merged_reconciler_script(interim=True)
+    validate_workflow_script(src, list(REQUIRED_TOOLS))
+    assert "INTERIM = True" in src
+
+
+# ─── REQUIRED_TOOLS / REQUIRED_HTTP_SERVERS (the deploy surface) ──────────────
+
+
+def test_required_tools_are_bash_and_http_request() -> None:
+    # The reconciler is scriptable (no agent): it only needs bash (ops-audit SSH read)
+    # and http_request (GitHub). No editing tools — there are no child agents.
+    assert {t.type for t in REQUIRED_TOOLS} == {"bash", "http_request"}
+
+
+def test_required_http_server_is_github_with_repos_route() -> None:
+    assert len(REQUIRED_HTTP_SERVERS) == 1
+    server = REQUIRED_HTTP_SERVERS[0]
+    assert server.name == "github"
+    assert server.base_url == "https://api.github.com"
+    repos = [r for r in server.routes if r.path_pattern == "/repos/**"]
+    assert len(repos) == 1
+    # GET (read master HEAD + list issues/comments) and POST (file issue / upsert comment).
+    assert set(repos[0].methods or []) == {"GET", "POST"}
+    # allow_query: the no-silent-degrade paginated reads add ?per_page/?page (#1323).
+    assert repos[0].allow_query is True
+
+
+# ─── build_*_workflow_create (the complete payload) ──────────────────────────
+
+
+def test_workflow_create_bundles_script_and_surface() -> None:
+    wc = build_running_merged_reconciler_workflow_create(name="running-merged-reconciler")
+    assert isinstance(wc, WorkflowCreate)
+    assert wc.name == "running-merged-reconciler"
+    assert wc.script == build_running_merged_reconciler_script()
+    assert {t.type for t in wc.tools} == {"bash", "http_request"}
+    assert len(wc.http_servers) == 1
+    assert isinstance(wc.http_servers[0], HttpServerSpec)
+    assert wc.http_servers[0].name == "github"
+
+
+def test_workflow_create_forwards_interim_kwarg() -> None:
+    wc = build_running_merged_reconciler_workflow_create(name="rmr-interim", interim=True)
+    assert wc.script == build_running_merged_reconciler_script(interim=True)
+
+
+# ─── the CronSource → WorkflowAction trigger document (acceptance item 5) ─────
+
+
+def test_trigger_is_cron_to_workflow_action() -> None:
+    tc = build_running_merged_reconciler_trigger(
+        name="rmr-cron", workflow_id="wf_abc", vault_id="vault_github"
+    )
+    assert isinstance(tc, TriggerCreate)
+    assert isinstance(tc.source, CronSource)
+    assert tc.source.schedule == DEFAULT_SCHEDULE  # off-peak default (every 20 min)
+    assert isinstance(tc.action, WorkflowAction)
+    assert tc.action.workflow_id == "wf_abc"
+    # GITHUB_TOKEN vault bound so the reconciler's http_request calls authenticate.
+    assert tc.action.vault_ids == ["vault_github"]
+    # the input envelope carries the interim flag (selects interim vs full at fire time)
+    assert tc.action.input_template == {"interim": False}
+
+
+def test_trigger_interim_flag_threads_into_template() -> None:
+    tc = build_running_merged_reconciler_trigger(
+        name="rmr-cron", workflow_id="wf_abc", vault_id="vault_github", interim=True
+    )
+    assert tc.action.input_template == {"interim": True}
+
+
+def test_trigger_custom_schedule_and_version_pin() -> None:
+    tc = build_running_merged_reconciler_trigger(
+        name="rmr-cron",
+        workflow_id="wf_abc",
+        vault_id="vault_github",
+        schedule="*/30 * * * *",
+        workflow_version=3,
+    )
+    assert tc.source.schedule == "*/30 * * * *"
+    assert tc.action.workflow_version == 3

--- a/tests/unit/test_running_merged_reconciler_surface.py
+++ b/tests/unit/test_running_merged_reconciler_surface.py
@@ -116,6 +116,7 @@ def test_trigger_interim_flag_threads_into_template() -> None:
     tc = build_running_merged_reconciler_trigger(
         name="rmr-cron", workflow_id="wf_abc", vault_id="vault_github", interim=True
     )
+    assert isinstance(tc.action, WorkflowAction)
     assert tc.action.input_template == {"interim": True}
 
 
@@ -127,5 +128,7 @@ def test_trigger_custom_schedule_and_version_pin() -> None:
         schedule="*/30 * * * *",
         workflow_version=3,
     )
+    assert isinstance(tc.source, CronSource)
     assert tc.source.schedule == "*/30 * * * *"
+    assert isinstance(tc.action, WorkflowAction)
     assert tc.action.workflow_version == 3


### PR DESCRIPTION
## aios#1327 — running==merged reconciler + build-SHA-in-image

Plane B2 of the substrate-different-verdict invariant (epic #1330, roadmap item 11). Reads the **LIVE running SHA** (the genuinely-uncorrelated ops-audit `docker inspect` substrate, not the deploy-ledger) vs **git master HEAD**, per app, and routes drift. `cannot-determine` is a first-class verdict, NEVER coerced to `ok`.

### What landed (the aios-side units)

**Unit A1 — bake the build-SHA into the image.** `Dockerfile` `base` stage (after `COPY src ./src`): `ARG AIOS_BUILD_SHA=unknown` + `ENV AIOS_BUILD_SHA` + `LABEL org.eumemic.build_sha`. Default `unknown` → an un-instrumented build reads as `cannot-determine`, never a false match. The `ENV` is the in-process read (`/health`); the `LABEL` is the `docker inspect`-over-SSH read (the worker has no HTTP server). Both `api`/`worker` stages inherit from `base`.

**Unit A2 — expose it at `/health`.** `GET /health` now returns `{"status","version","build_sha"}` where `build_sha = os.environ.get("AIOS_BUILD_SHA")` (None when unset). The handler return type is changed `dict[str, str]` → **`dict[str, str | None]`** (mypy green — `os.environ.get` is `str | None`). `version` stays the static package string, untouched; still unauthenticated; still no DB touch (the liveness contract `test_ready_route.py` pins).

**Unit B — `build_running_merged_reconciler_script`** (the `dev_pipeline.py` builder idiom; new module `src/aios/workflows/running_merged_reconciler.py`). A deterministic, scriptable (no-agent) workflow: imports only `re`/`json`, value-domain I/O, capabilities emitted in fixed bounded order (replay-stable).
- **Read master HEAD** via `tool('http_request', GET /repos/<repo>/commits/master)`; the no-silent-degrade list-read invariant (`gh_paginated` raises on an under-counted list) applies to the issue list read.
- **Read the running SHA — ONE path for EVERY app** (the resolution of the previously-open fork): the ops-audit `docker inspect LABEL org.eumemic.build_sha` over SSH, via `tool('bash')`. The reconciler does not branch on app type (aios-api's `/health.build_sha` still ships as the human/ad-hoc read).
- **Diff per app, NEVER aggregate:** `ok` / `drifted` / `cannot-determine` (short/long SHA prefix-normalised). One app's unreadability is never hidden behind another's match.
- **A-interim mode** (`interim=True`, ships first): emits `needs-deploy` when ledger-SHA ≠ master-HEAD (the dominant drift shape), with the running-vs-ledger axis self-flagged `not-yet-substrate-different`.
- **Routing:** any non-`ok` verdict → file/upsert ONE GitHub issue, idempotent by stable title + maker-marker comment dedup. No algedonic lane / cockpit-resume (deferred, out of scope).
- **Surface + trigger exported:** `REQUIRED_TOOLS` (`bash`, `http_request`), the `github` `/repos/**` http_server (`GET,POST`, `allow_query`), `build_running_merged_reconciler_workflow_create`, and `build_running_merged_reconciler_trigger` — a `CronSource(*/20) → WorkflowAction` document with `GITHUB_TOKEN` vault bound and the `interim` flag threaded into the input envelope.

### Tests (no DB / sandbox / model)
- `tests/unit/test_ready_route.py`: `/health` shape (exactly `{status,version,build_sha}`), `build_sha` None when unset / env value when set, version unchanged, no pool touch.
- `tests/integration/test_wf_running_merged_reconciler_fixture.py`: ok / drifted / cannot-determine (running + master), the per-app-not-aggregate must-fix, short/long normalisation, replay determinism, idempotent routing (create + upsert + skip-on-marker), the interim needs-deploy signal, trigger-envelope unwrapping.
- `tests/unit/test_running_merged_reconciler_surface.py`: re/json-only imports, async main, create-time validation, deploy surface, the CronSource→WorkflowAction trigger document.

Full set green; mypy + ruff (check + format) clean; dev/triage pipeline fixtures unregressed.

### Cross-repo boundary (named gap #2 — NOT in this PR)
The eumemic-ops half is a separate eumemic-ops PR: `scripts/deploy` + `deploy-app.yml` set the build-time `AIOS_BUILD_SHA` env on the Coolify app via `POST/DELETE /api/v1/applications/<uuid>/envs` before the deploy and GET-back-assert it (aborting on mismatch); the audit `coolify-running-container-fresh.sh` gains the `--app <uuid> --emit-build-sha` LABEL read; `scripts/fleet` gains `ledger-last-track-g-sha`. This aios PR builds to exactly those seams.