### PR TITLE
feat(deliver-kernel): factor the stimulate spine + add the Tell arm (Ask|Tell over one edge writer) (#1197)

### DIFF
--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -484,6 +484,14 @@ async def get_open_request_ids(
     injects one request per child, so this is ``[]`` or one id; the set shape is
     ready for multi-request `invoke_session`.
 
+    Only **awaited** edges (``awaited=true``, the ``Ask`` arm) count: a
+    ``Tell(NewSession)`` fire-and-forget spawn writes a real ``request_opened``
+    row with ``awaited=false`` (#1197) — it carries lineage/depth/surface but owes
+    **no** response, so the asked set filters it out. An absent ``awaited`` reads
+    as ``true`` (additive/legacy), so pre-#1197 rows keep their obligation. This
+    is one of the three awaited-triad readers (with the #1131 totality gate and
+    the #1132 cap) that must apply the same filter in lockstep.
+
     Reads the trusted ``request_opened`` frame rather than the forgeable
     ``metadata.request`` user-message blob (which #1123 still dual-writes for the
     legacy run path until #1131 retires it). Both halves are partial-indexed
@@ -495,6 +503,13 @@ async def get_open_request_ids(
         "WHERE req.session_id = $1 AND req.account_id = $2 "
         "AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
         "AND req.data->>'request_id' IS NOT NULL "
+        # #1197 awaited-triad filter: a ``Tell(NewSession)`` writes a real
+        # ``request_opened`` row with ``awaited=false`` (lineage/depth/surface
+        # carrier, no response obligation), so the open set must exclude it —
+        # else a fire-and-forget spawn would wrongly owe a response. An absent
+        # field reads as awaited=true (additive/legacy), so pre-#1197 rows keep
+        # their obligation.
+        "AND COALESCE((req.data->>'awaited')::boolean, TRUE) "
         "AND NOT EXISTS (SELECT 1 FROM events resp "
         "    WHERE resp.session_id = $1 AND resp.account_id = $2 "
         "    AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
@@ -746,6 +761,7 @@ async def append_request_opened(
     environment_id: str,
     frozen_surface: dict[str, Any],
     vault_ids: list[str],
+    awaited: bool = True,
 ) -> None:
     """Append the trusted ``request_opened`` lifecycle event — the *ask* half of
     the request edge (#1123).
@@ -767,6 +783,19 @@ async def append_request_opened(
     value. ``frozen_surface`` / ``vault_ids`` are the #794 clamp results computed
     at the launch site.
 
+    ``awaited`` (#1197) carries the ``Ask | Tell`` distinction on the edge: an
+    ``Ask`` opens an **awaited** edge (``awaited=true``) the target must answer
+    (``return``/``error``); a ``Tell(NewSession)`` fire-and-forget spawn opens an
+    **unawaited** edge (``awaited=false``) — a real ``request_opened`` row (so it
+    still carries lineage / depth / the #794-frozen surface), but with **no
+    response obligation**. It is a first-class, *explicitly-passed* field — never
+    inferred from ``request_id``-presence — so the discriminated-union discipline
+    holds at the call site. The triad of readers that derive "open request" from
+    this frame (this issue's quiescence guard nudge/``no_return`` loop, the #1131
+    totality gate, the #1132 cap) all filter ``awaited=true``; an absent field
+    reads as ``awaited=true`` (additive/legacy), so existing rows keep their
+    obligation.
+
     Idempotency is the **caller's** responsibility: the ``create_child_session``
     path gates this behind its first-spawn ``ON CONFLICT`` check, so a replayed
     wake opens the edge exactly once (see :func:`get_open_request_ids` for the
@@ -785,6 +814,7 @@ async def append_request_opened(
             "environment_id": environment_id,
             "frozen_surface": frozen_surface,
             "vault_ids": vault_ids,
+            "awaited": awaited,
         },
     )
 

--- a/src/aios/harness/trigger_runner.py
+++ b/src/aios/harness/trigger_runner.py
@@ -502,11 +502,18 @@ async def _run_wake_owner(
     """
     pool = runtime.require_pool()
     try:
-        await sessions_service.append_user_message(
-            pool, trigger.owner_session_id, action.content, account_id=trigger.account_id
-        )
-        await defer_wake(
-            pool, trigger.owner_session_id, cause="message", account_id=trigger.account_id
+        # #1197: `wake_owner` IS a `Tell(ExistingSession)` — a channel-less message
+        # + wake, no request edge. Route through the `stimulate` spine's
+        # existing-session Tell arm (the service-level mechanism the wake/notify
+        # policy surfaces share), preserving the channel-less invisibility property.
+        await sessions_service.stimulate(
+            pool,
+            sessions_service.TellExistingSession(
+                session_id=trigger.owner_session_id,
+                content=action.content,
+                cause="message",
+            ),
+            account_id=trigger.account_id,
         )
         log.info(
             "trigger.fired",

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -9,6 +9,7 @@ and inject environment variables at container provisioning time.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from types import EllipsisType
@@ -393,6 +394,304 @@ async def create_session(
         return session
 
 
+# ─── The `stimulate` spine: Ask | Tell over one edge writer (#1197) ──────────
+#
+# `stimulate` is the single, **service-internal** writer of the request edge /
+# surface / depth. It materializes-or-resolves a servicer, appends the stimulus
+# (the initial `user` message), threads lineage, and opens the `request_opened`
+# edge in one transaction, then wakes. The `Ask | Tell` distinction is carried as
+# an `awaited` bit ON THE EDGE — `Ask ⇒ awaited=true` (a response obligation the
+# target must answer via `return`/`error`); `Tell ⇒ awaited=false` (fire-and-
+# forget — a real edge that still carries lineage/depth/#794-frozen surface, but
+# owes no response).
+#
+# The union is a **type at the (service-internal) spine boundary**, NOT a public
+# bool: each arm is a distinct frozen dataclass, so the illegal combinations are
+# *unrepresentable* rather than runtime-guarded —
+#   * `Ask(ExistingSession)`            — there is no AskExistingSession class
+#                                         (deferred — #1131 + #1127);
+#   * `output_schema` on a `Tell`       — only Ask* arms carry `output_schema`;
+#   * `vault_ids` on a non-creating arm — only the NewSession arms carry vaults.
+#
+# The spine is NOT exposed (no public `deliver()`; the model reaches it only via
+# policy surfaces — the mechanism/policy split). `awaited` is the edge field, not
+# a public API bool.
+
+
+@dataclass(frozen=True)
+class AskNewSession:
+    """`Ask(NewSession)` — spawn a child session and inject an **awaited** request.
+
+    The `invoke_agent` arm: the child's first user message *is a request* it must
+    answer (`return`/`error`). Carries `output_schema` (the response contract) and
+    `vault_ids` (it creates a servicer). `awaited=true`.
+    """
+
+    session_id: str
+    agent_id: str | None
+    environment_id: str
+    agent_version: int | None
+    model: str | None
+    parent_run_id: str
+    surface: Surface
+    vault_ids: list[str]
+    request_id: str
+    input: Any
+    output_schema: dict[str, Any] | None = None
+    depth: int = 0
+    litellm_extra: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class TellNewSession:
+    """`Tell(NewSession)` — fire-and-forget spawn: create + deliver + wake, **no
+    response obligation**.
+
+    Identical materialization to `AskNewSession` (creates a servicer, so it still
+    decrements SPAWN depth and applies the #794 clamp + binds `vault_ids`), but the
+    edge is **unawaited** (`awaited=false`) and no `output_schema` is carried — the
+    target reaches idle owing nothing. The `request_id` still keys the (unawaited)
+    edge so lineage/depth/surface have a carrier.
+    """
+
+    session_id: str
+    agent_id: str | None
+    environment_id: str
+    agent_version: int | None
+    model: str | None
+    parent_run_id: str
+    surface: Surface
+    vault_ids: list[str]
+    request_id: str
+    input: Any
+    depth: int = 0
+    litellm_extra: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class AskExistingSession:
+    """`Ask(ExistingSession)` — inject an **awaited** request into an existing
+    same-account session (the API `invoke`/`invoke_session` arm).
+
+    Channel-less (no `orig_channel`) so the injected request never renders to a
+    connector. Carries `output_schema`; no `vault_ids` (a non-creating target binds
+    none). `awaited=true`.
+    """
+
+    session: Session
+    caller: dict[str, Any]
+    request_id: str
+    input: Any
+    output_schema: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class TellExistingSession:
+    """`Tell(ExistingSession)` — channel-less message + wake, **no request edge**.
+
+    The `_run_wake_owner` body generalized to any same-account target: an
+    `append_user_message` (channel-less, so a notify never renders to a human's
+    chat) + `defer_wake`. Opens no `request_opened` row — there is no response
+    obligation and no lineage edge to carry. The wake/notify policy surfaces
+    (`wake_session`/`wake_owner`/`schedule_wake`) recompose over this arm.
+    """
+
+    session_id: str
+    content: str
+    cause: str = "message"
+
+
+# The discriminated union at the spine boundary. Illegal arms are absent by
+# construction (no `AskExistingSession`+`vault_ids`, no `Tell`+`output_schema`).
+Stimulus = AskNewSession | TellNewSession | AskExistingSession | TellExistingSession
+
+
+async def stimulate(pool: asyncpg.Pool[Any], stim: Stimulus, *, account_id: str) -> bool:
+    """The private `stimulate` spine — the single writer of the request edge.
+
+    Dispatches the `Ask | Tell` union to the matching target arm. Each arm
+    materializes-or-resolves its servicer, appends the stimulus, threads lineage,
+    applies the #794 clamp + vault binding (creating arms only), opens the
+    `request_opened` edge with the correct `awaited` bit (`Ask ⇒ true`,
+    `Tell ⇒ false`; the existing-session `Tell` arm opens *no* edge), and wakes.
+
+    Service-internal: not exposed as a public or model-callable function — the
+    model reaches it only via policy surfaces (mechanism/policy split). Returns
+    `True` when the servicer was freshly stimulated, `False` on a spawn conflict
+    (replay — the new-session arms; the existing-session arms always return
+    `True`).
+    """
+    if isinstance(stim, AskNewSession | TellNewSession):
+        return await _stimulate_new_session(pool, stim, account_id=account_id)
+    if isinstance(stim, AskExistingSession):
+        return await _stimulate_existing_ask(pool, stim, account_id=account_id)
+    return await _stimulate_existing_tell(pool, stim, account_id=account_id)
+
+
+async def _stimulate_new_session(
+    pool: asyncpg.Pool[Any],
+    stim: AskNewSession | TellNewSession,
+    *,
+    account_id: str,
+) -> bool:
+    """The NewSession arm of the spine — idempotently spawn a child + deliver.
+
+    Shared by `Ask(NewSession)` (`awaited=true`, carries `output_schema`) and
+    `Tell(NewSession)` (`awaited=false`, no `output_schema`). Behavior-preserving
+    over the legacy `create_child_session`: same `ON CONFLICT (id) DO NOTHING`
+    first-spawn guard (a replayed wake never re-delivers), same one-transaction
+    insert → freeze surface → bind vaults → deliver → open edge.
+    """
+    awaited = isinstance(stim, AskNewSession)
+    output_schema = stim.output_schema if isinstance(stim, AskNewSession) else None
+    content = stim.input if isinstance(stim.input, str) else json.dumps(stim.input)
+    async with pool.acquire() as conn, conn.transaction():
+        child = await queries.insert_child_session(
+            conn,
+            session_id=stim.session_id,
+            account_id=account_id,
+            agent_id=stim.agent_id,
+            environment_id=stim.environment_id,
+            agent_version=stim.agent_version,
+            model=stim.model,
+            parent_run_id=stim.parent_run_id,
+            tools=stim.surface.tools,
+            mcp_servers=stim.surface.mcp_servers,
+            http_servers=stim.surface.http_servers,
+            litellm_extra=stim.litellm_extra or {},
+        )
+        if child is None:
+            return False  # replay: row exists — do NOT re-deliver the request
+        if stim.vault_ids:
+            await queries.set_session_vaults(
+                conn, stim.session_id, stim.vault_ids, account_id=account_id
+            )
+            # No advisory containment gate here: ``create_child_session`` is an
+            # internal workflow spawn (no console to surface a fast 422), and its
+            # caller in ``workflows/step.py`` only catches ``NotFoundError`` — a
+            # raised ``ValidationError`` would crash the procrastinate job. The
+            # authoritative gate in ``build_spec_from_session`` catches a
+            # mis-scoped child at provision. The advisory 422 stays on the
+            # operator-facing API attach paths (create_session/update_session).
+        request_meta: dict[str, Any] = {
+            "request_id": stim.request_id,
+            "caller": {"kind": "run", "id": stim.parent_run_id},
+        }
+        if output_schema is not None:
+            request_meta["output_schema"] = output_schema
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=stim.session_id,
+            kind="message",
+            data={
+                "role": "user",
+                "content": content,
+                "metadata": {"request": request_meta},
+            },
+        )
+        # #1123/#1197: emit the trusted ``request_opened`` lifecycle edge alongside
+        # the legacy ``metadata.request`` blob (dual-write until #1131 retires the
+        # blob). Gated by the ``child is None`` first-spawn check above, so a
+        # replayed wake (ON CONFLICT → ``child is None`` → early return) never
+        # re-opens the edge — exactly-once per request. ``awaited`` carries the
+        # Ask|Tell distinction: an Ask owes a response, a Tell does not.
+        await queries.append_request_opened(
+            conn,
+            session_id=stim.session_id,
+            account_id=account_id,
+            request_id=stim.request_id,
+            caller={"kind": "run", "id": stim.parent_run_id},
+            depth=stim.depth,
+            environment_id=stim.environment_id,
+            frozen_surface={
+                "tools": [t.model_dump() for t in stim.surface.tools],
+                "mcp_servers": [s.model_dump() for s in stim.surface.mcp_servers],
+                "http_servers": [s.model_dump() for s in stim.surface.http_servers],
+            },
+            vault_ids=stim.vault_ids,
+            awaited=awaited,
+        )
+        return True
+
+
+async def _stimulate_existing_ask(
+    pool: asyncpg.Pool[Any],
+    stim: AskExistingSession,
+    *,
+    account_id: str,
+) -> bool:
+    """The `Ask(ExistingSession)` arm — inject a channel-less awaited request.
+
+    One transaction: append the request's ``user`` message (``metadata.request``
+    carries ``{request_id, caller}`` + optional ``output_schema``) and open the
+    trusted ``request_opened`` edge (`awaited=true`). Channel-less (no
+    ``orig_channel``) so the injected request never surfaces to a connector. Then
+    a deferred wake so the target steps and answers it.
+    """
+    from aios.services.wake import defer_wake
+
+    session = stim.session
+    content = stim.input if isinstance(stim.input, str) else json.dumps(stim.input)
+    request_meta: dict[str, Any] = {"request_id": stim.request_id, "caller": stim.caller}
+    if stim.output_schema is not None:
+        request_meta["output_schema"] = stim.output_schema
+    agent = await agents_service.load_for_session(pool, session, account_id=account_id)
+    frozen_surface = surface_of(agent)
+    async with pool.acquire() as conn, conn.transaction():
+        vault_ids = await queries.get_session_vault_ids(conn, session.id, account_id=account_id)
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session.id,
+            kind="message",
+            data={
+                "role": "user",
+                "content": content,
+                "metadata": {"request": request_meta},
+            },
+        )
+        await queries.append_request_opened(
+            conn,
+            session_id=session.id,
+            account_id=account_id,
+            request_id=stim.request_id,
+            caller=stim.caller,
+            depth=0,
+            environment_id=session.environment_id,
+            frozen_surface={
+                "tools": [t.model_dump() for t in frozen_surface.tools],
+                "mcp_servers": [s.model_dump() for s in frozen_surface.mcp_servers],
+                "http_servers": [s.model_dump() for s in frozen_surface.http_servers],
+            },
+            vault_ids=vault_ids,
+            awaited=True,
+        )
+    await defer_wake(pool, session.id, cause="api_invoke", account_id=account_id)
+    return True
+
+
+async def _stimulate_existing_tell(
+    pool: asyncpg.Pool[Any],
+    stim: TellExistingSession,
+    *,
+    account_id: str,
+) -> bool:
+    """The `Tell(ExistingSession)` arm — channel-less message + wake, **no edge**.
+
+    The `_run_wake_owner` body generalized to any same-account target: an
+    `append_user_message` (channel-less — no ``orig_channel`` — so a notify never
+    renders to a human's chat) + `defer_wake`. Opens no `request_opened` row (no
+    response obligation, no lineage edge). The service-level mechanism the
+    wake/notify policy surfaces call.
+    """
+    from aios.services.wake import defer_wake
+
+    await append_user_message(pool, stim.session_id, stim.content, account_id=account_id)
+    await defer_wake(pool, stim.session_id, cause=stim.cause, account_id=account_id)
+    return True
+
+
 async def create_child_session(
     pool: asyncpg.Pool[Any],
     *,
@@ -405,109 +704,92 @@ async def create_child_session(
     parent_run_id: str,
     surface: Surface,
     vault_ids: list[str],
-    request_id: str,
     input: Any,
+    request_id: str | None = None,
     output_schema: dict[str, Any] | None = None,
     depth: int = 0,
     litellm_extra: dict[str, Any] | None = None,
+    awaited: bool = True,
 ) -> bool:
     """Idempotently spawn a workflow ``agent()`` child and inject the first request.
 
-    `invoke_agent` = create_session + invoke_session: the child's first user
-    message **is a request** — its content is ``input``, and ``metadata.request``
-    carries ``{request_id, caller}`` so the target can correlate its response and
-    the caller (the run) can be resumed. The child must answer this request via
-    ``return``/``error`` (exactly once); the ``request_id`` is surfaced to the model
-    as a render-time marker on the message (see ``render_user_event``) so it knows
-    which id to echo back.
+    A thin caller of the private :func:`stimulate` spine's NewSession arm: it
+    builds the matching ``Ask | Tell`` stimulus and delegates the
+    materialize → deliver → open-edge → (the caller wakes) middle. Both arms share
+    the same ``ON CONFLICT (id) DO NOTHING`` first-spawn guard, so a replayed wake
+    never re-delivers.
 
-    ``output_schema`` (optional) is the JSON Schema the request demands of the
-    response ``value``. It rides ``metadata.request.output_schema`` — per-request, so
-    a child owing several requests can carry a distinct schema for each — surfaced to
-    the model alongside the request and enforced when it calls ``return``.
+    **Ask (``awaited=true``, the default — `invoke_agent`):** the child's first
+    user message **is a request** — its content is ``input``, and
+    ``metadata.request`` carries ``{request_id, caller}`` so the target can
+    correlate its response and the caller (the run) can be resumed. The child must
+    answer this request via ``return``/``error`` (exactly once); the ``request_id``
+    is surfaced to the model as a render-time marker on the message (see
+    ``render_user_event``) so it knows which id to echo back. ``output_schema``
+    (optional) is the JSON Schema the request demands of the response ``value``.
+
+    **Tell (``awaited=false`` — fire-and-forget spawn, #1197):** create + deliver
+    + wake with an **unawaited** edge — still decrements SPAWN depth and applies the
+    #794 clamp (it creates a servicer), only the **response obligation** is dropped.
+    ``output_schema`` is not permitted (a Tell owes no response). When no
+    ``request_id`` is supplied (the natural Tell call shape) one is minted to key
+    the unawaited edge so lineage/depth/surface have a carrier.
 
     ``surface`` is the child's **frozen, run-attenuated** capability surface
     (``attenuate(agent, run)`` — #794); ``litellm_extra`` is the child's **frozen,
     clamped model identity** (``api_base`` foremost — #823), validated against the
     operator trusted-endpoint allowlist at the spawn edge before this call.
     ``vault_ids`` is the run's vault bindings, copied into the child's
-    ``session_vaults`` so it resolves credentials off its own (subset) table. All
-    three are written **only on a real insert**, inside the one transaction and pinned
-    under ``ON CONFLICT (id) DO NOTHING``, so a replay never re-freezes a shifted
-    surface, re-points a since-changed endpoint, or re-binds vaults.
+    ``session_vaults``. All three are written **only on a real insert**, inside the
+    one transaction and pinned under ``ON CONFLICT (id) DO NOTHING``, so a replay
+    never re-freezes a shifted surface, re-points a since-changed endpoint, or
+    re-binds vaults.
 
-    One transaction: insert the child row (``ON CONFLICT (id) DO NOTHING``) and,
-    **only on a real insert**, freeze the surface, bind the vaults, and deliver the
-    request — without a stimulus the child would be born-idle. Atomic, so a crash can
-    never leave a child row without its request. Returns ``True`` on first spawn,
-    ``False`` on conflict (replay → the caller harvests the response instead of
-    re-spawning).
+    Returns ``True`` on first spawn, ``False`` on conflict (replay → the caller
+    harvests the response instead of re-spawning).
     """
-    content = input if isinstance(input, str) else json.dumps(input)
-    async with pool.acquire() as conn, conn.transaction():
-        child = await queries.insert_child_session(
-            conn,
+    if awaited:
+        if request_id is None:
+            raise ValidationError(
+                "Ask(NewSession) requires a request_id (the response obligation key)",
+                detail={"awaited": True},
+            )
+        stim: AskNewSession | TellNewSession = AskNewSession(
             session_id=session_id,
-            account_id=account_id,
             agent_id=agent_id,
             environment_id=environment_id,
             agent_version=agent_version,
             model=model,
             parent_run_id=parent_run_id,
-            tools=surface.tools,
-            mcp_servers=surface.mcp_servers,
-            http_servers=surface.http_servers,
-            litellm_extra=litellm_extra or {},
-        )
-        if child is None:
-            return False  # replay: row exists — do NOT re-deliver the request
-        if vault_ids:
-            await queries.set_session_vaults(conn, session_id, vault_ids, account_id=account_id)
-            # No advisory containment gate here: ``create_child_session`` is an
-            # internal workflow spawn (no console to surface a fast 422), and its
-            # caller in ``workflows/step.py`` only catches ``NotFoundError`` — a
-            # raised ``ValidationError`` would crash the procrastinate job. The
-            # authoritative gate in ``build_spec_from_session`` catches a
-            # mis-scoped child at provision. The advisory 422 stays on the
-            # operator-facing API attach paths (create_session/update_session).
-        request_meta: dict[str, Any] = {
-            "request_id": request_id,
-            "caller": {"kind": "run", "id": parent_run_id},
-        }
-        if output_schema is not None:
-            request_meta["output_schema"] = output_schema
-        await queries.append_event(
-            conn,
-            account_id=account_id,
-            session_id=session_id,
-            kind="message",
-            data={
-                "role": "user",
-                "content": content,
-                "metadata": {"request": request_meta},
-            },
-        )
-        # #1123: emit the trusted ``request_opened`` lifecycle edge alongside the
-        # legacy ``metadata.request`` blob (dual-write until #1131 retires the
-        # blob). Gated by the ``child is None`` first-spawn check above, so a
-        # replayed wake (ON CONFLICT → ``child is None`` → early return) never
-        # re-opens the edge — exactly-once per request.
-        await queries.append_request_opened(
-            conn,
-            session_id=session_id,
-            account_id=account_id,
-            request_id=request_id,
-            caller={"kind": "run", "id": parent_run_id},
-            depth=depth,
-            environment_id=environment_id,
-            frozen_surface={
-                "tools": [t.model_dump() for t in surface.tools],
-                "mcp_servers": [s.model_dump() for s in surface.mcp_servers],
-                "http_servers": [s.model_dump() for s in surface.http_servers],
-            },
+            surface=surface,
             vault_ids=vault_ids,
+            request_id=request_id,
+            input=input,
+            output_schema=output_schema,
+            depth=depth,
+            litellm_extra=litellm_extra,
         )
-        return True
+    else:
+        if output_schema is not None:
+            raise ValidationError(
+                "Tell(NewSession) cannot carry an output_schema (it owes no response)",
+                detail={"awaited": False},
+            )
+        stim = TellNewSession(
+            session_id=session_id,
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=agent_version,
+            model=model,
+            parent_run_id=parent_run_id,
+            surface=surface,
+            vault_ids=vault_ids,
+            request_id=request_id if request_id is not None else make_id(REQUEST),
+            input=input,
+            depth=depth,
+            litellm_extra=litellm_extra,
+        )
+    return await _stimulate_new_session(pool, stim, account_id=account_id)
 
 
 async def invoke(
@@ -642,58 +924,24 @@ async def _inject_api_request(
 ) -> str:
     """Inject a channel-less request into ``session`` and open the request edge.
 
-    One transaction: append the request's ``user`` message (``metadata.request``
-    carries ``{request_id, caller}`` + optional ``output_schema`` so the target
-    correlates its response and the caller awaits it) and emit the trusted
-    ``request_opened`` lifecycle edge (#1123). Mirrors ``create_child_session``'s
-    dual-write, with ``caller={kind:"api", ...}`` and a **channel-less** message
-    (no ``orig_channel``) so the injected request never surfaces to a connector.
-
-    The request fires a wake so the target steps and answers it.
+    A thin caller of the private :func:`stimulate` spine's `Ask(ExistingSession)`
+    arm: mints the ``request_id``, builds the stimulus, and delegates the
+    append-message → open-edge (`awaited=true`) → wake middle. The injected
+    request is **channel-less** (no ``orig_channel``) so it never surfaces to a
+    connector, with ``caller={kind:"api", ...}``.
     """
-    # Late import: ``services.wake`` imports this module at load time, so a
-    # module-level ``from aios.services.wake import defer_wake`` would be a
-    # circular import (mirrors the ``defer_run_wake`` pattern below).
-    from aios.services.wake import defer_wake
-
     request_id = make_id(REQUEST)
-    content = input if isinstance(input, str) else json.dumps(input)
-    agent = await agents_service.load_for_session(pool, session, account_id=account_id)
-    frozen_surface = surface_of(agent)
-
-    request_meta: dict[str, Any] = {"request_id": request_id, "caller": caller}
-    if output_schema is not None:
-        request_meta["output_schema"] = output_schema
-
-    async with pool.acquire() as conn, conn.transaction():
-        vault_ids = await queries.get_session_vault_ids(conn, session.id, account_id=account_id)
-        await queries.append_event(
-            conn,
-            account_id=account_id,
-            session_id=session.id,
-            kind="message",
-            data={
-                "role": "user",
-                "content": content,
-                "metadata": {"request": request_meta},
-            },
-        )
-        await queries.append_request_opened(
-            conn,
-            session_id=session.id,
-            account_id=account_id,
-            request_id=request_id,
+    await _stimulate_existing_ask(
+        pool,
+        AskExistingSession(
+            session=session,
             caller=caller,
-            depth=0,
-            environment_id=session.environment_id,
-            frozen_surface={
-                "tools": [t.model_dump() for t in frozen_surface.tools],
-                "mcp_servers": [s.model_dump() for s in frozen_surface.mcp_servers],
-                "http_servers": [s.model_dump() for s in frozen_surface.http_servers],
-            },
-            vault_ids=vault_ids,
-        )
-    await defer_wake(pool, session.id, cause="api_invoke", account_id=account_id)
+            request_id=request_id,
+            input=input,
+            output_schema=output_schema,
+        ),
+        account_id=account_id,
+    )
     return request_id
 
 
@@ -1215,6 +1463,15 @@ async def append_assistant_and_guard_quiescence(
     can ever observe the session idle while a request is open — the invariant holds
     at write time, with no sweep backstop.
 
+    **The #1197 quiescence re-key:** "a session may not idle while it owes an
+    **awaited** open request." ``get_open_request_ids`` filters ``awaited=true``,
+    so a ``Tell(NewSession)`` fire-and-forget spawn (which writes an *unawaited*
+    ``request_opened`` edge) contributes nothing to ``open_ids`` — the
+    nudge/``no_return`` loop is skipped and the fire-and-forget agent reaches idle
+    with zero nudges. An ``Ask`` (awaited) request still triggers the loop. The
+    awaited filter lives in the reader (one of the load-bearing awaited triad), so
+    the re-key needs no special-casing here beyond an empty ``open_ids``.
+
     Returns an :class:`AssistantAppendResult` ``(nudged, autoerror_caller_run_id,
     assistant_focal_at_arrival)``; the caller (the harness loop) does the
     post-commit wakes — ``defer_wake(session)`` if nudged, ``defer_run_wake(run_id)``
@@ -1235,10 +1492,11 @@ async def append_assistant_and_guard_quiescence(
         # Gates, cheapest first (this runs on EVERY end-of-turn append):
         #   1. tool calls present → unresolved tool_call → active by construction
         #      (the tools haven't run yet), so it can't be idle — settle in memory.
-        #   2. nothing owed → no request edge at all (the ordinary session), or every
-        #      request already answered → one indexed anti-join. This — NOT parent_run_id
-        #      — is the totality gate (#1127): a session-caller invoke owes a request to
-        #      a non-run caller, so the guard can no longer short-circuit on child-ness.
+        #   2. nothing AWAITED owed → no request edge at all (the ordinary session),
+        #      every awaited request already answered, or only unawaited Tell edges
+        #      exist (#1197) → one indexed anti-join. This — NOT parent_run_id — is the
+        #      totality gate (#1127): a session-caller invoke owes a request to a
+        #      non-run caller, so the guard can no longer short-circuit on child-ness.
         #   3. only now pay the multi-EXISTS idleness derivation (the same
         #      _SESSION_STATUS_EXPR every external reader uses) — it could still be
         #      active via a user message that arrived during inference.

--- a/tests/e2e/test_triggers.py
+++ b/tests/e2e/test_triggers.py
@@ -784,9 +784,11 @@ class TestWakeOwnerAction:
         prev_registry = runtime.sandbox_registry
         runtime.pool = pool
         runtime.sandbox_registry = exploding
-        with mock.patch(
-            "aios.harness.trigger_runner.defer_wake", new_callable=mock.AsyncMock
-        ) as mock_defer:
+        # #1197: wake_owner now routes through the `stimulate` spine's
+        # Tell(ExistingSession) arm, which resolves `defer_wake` from its source
+        # module — so patch it there (the canonical call-site patch), not at the
+        # old `trigger_runner` import which the reroute no longer touches.
+        with mock.patch("aios.services.wake.defer_wake", new_callable=mock.AsyncMock) as mock_defer:
             try:
                 await trigger_runner.run_trigger_step(echo.id)
             finally:
@@ -843,7 +845,9 @@ class TestWakeOwnerAction:
 
         prev_pool = runtime.pool
         runtime.pool = pool
-        with mock.patch("aios.harness.trigger_runner.defer_wake", new_callable=mock.AsyncMock):
+        # #1197: wake_owner routes through the stimulate spine → patch defer_wake
+        # at its source module (the reroute bypasses the trigger_runner import).
+        with mock.patch("aios.services.wake.defer_wake", new_callable=mock.AsyncMock):
             try:
                 await trigger_runner.run_trigger_step(echo.id)
             finally:
@@ -1247,9 +1251,9 @@ class TestLiveAttachToLiveSession:
         # message lands and a wake is deferred (a `run_trigger` fired).
         prev_pool = runtime.pool
         runtime.pool = pool
-        with mock.patch(
-            "aios.harness.trigger_runner.defer_wake", new_callable=mock.AsyncMock
-        ) as mock_defer:
+        # #1197: wake_owner routes through the stimulate spine → patch defer_wake
+        # at its source module (the reroute bypasses the trigger_runner import).
+        with mock.patch("aios.services.wake.defer_wake", new_callable=mock.AsyncMock) as mock_defer:
             try:
                 await trigger_runner.run_trigger_step(echo_id)
             finally:

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -307,6 +307,191 @@ async def test_create_child_session_rollback_leaves_no_edge(
     assert edges == 0
 
 
+# ─── #1197: the `awaited` bit — Ask ⇒ true, Tell ⇒ false ─────────────────────
+
+
+async def test_ask_create_child_session_writes_awaited_true(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """The behavior-preserved ``Ask(NewSession)`` path writes ``awaited=true`` and
+    the child owes its response (it appears in the open set)."""
+    pool, account_id, agent_id, env_id = pool_env
+    parent_run_id = await _seed_parent_run(pool, account_id=account_id, environment_id=env_id)
+    child_id = "ses_ask_child"
+    surface = Surface(tools=[], mcp_servers=[], http_servers=[])
+
+    created = await service.create_child_session(
+        pool,
+        session_id=child_id,
+        account_id=account_id,
+        agent_id=agent_id,
+        environment_id=env_id,
+        agent_version=1,
+        model="openrouter/test",
+        parent_run_id=parent_run_id,
+        surface=surface,
+        vault_ids=[],
+        request_id="req-ask",
+        input="hello",
+        depth=1,
+    )
+    assert created is True
+    async with pool.acquire() as conn:
+        awaited = await conn.fetchval(
+            "SELECT data->>'awaited' FROM events WHERE session_id = $1 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_opened'",
+            child_id,
+        )
+        assert awaited == "true"
+        # An awaited edge IS in the open set — the child owes a response.
+        assert await queries.get_open_request_ids(conn, child_id, account_id=account_id) == [
+            "req-ask"
+        ]
+
+
+async def test_tell_new_session_writes_unawaited_edge_with_no_obligation(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """``Tell(NewSession)`` (``awaited=False``) writes a REAL ``request_opened``
+    row — lineage/depth/surface carrier — but it is EXCLUDED from the open set, so
+    the fire-and-forget child owes NO response (the awaited-triad filter)."""
+    pool, account_id, agent_id, env_id = pool_env
+    parent_run_id = await _seed_parent_run(pool, account_id=account_id, environment_id=env_id)
+    child_id = "ses_tell_child"
+    surface = Surface(tools=[], mcp_servers=[], http_servers=[])
+
+    created = await service.create_child_session(
+        pool,
+        session_id=child_id,
+        account_id=account_id,
+        agent_id=agent_id,
+        environment_id=env_id,
+        agent_version=1,
+        model="openrouter/test",
+        parent_run_id=parent_run_id,
+        surface=surface,
+        vault_ids=[],
+        input="fire-and-forget",
+        depth=1,
+        awaited=False,  # the Tell arm — no request_id needed
+    )
+    assert created is True
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT data FROM events WHERE session_id = $1 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_opened'",
+            child_id,
+        )
+        assert row is not None  # a real edge row exists (lineage/depth/surface carrier)
+        data = queries.parse_jsonb(row["data"])
+        assert data["awaited"] is False
+        assert data["depth"] == 1  # depth still carried
+        # ...but it is NOT in the open set — no response obligation.
+        assert await queries.get_open_request_ids(conn, child_id, account_id=account_id) == []
+
+
+async def test_tell_new_session_rejects_output_schema(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """A ``Tell`` cannot carry an ``output_schema`` (it owes no response)."""
+    from aios.errors import ValidationError
+
+    pool, account_id, agent_id, env_id = pool_env
+    parent_run_id = await _seed_parent_run(pool, account_id=account_id, environment_id=env_id)
+    surface = Surface(tools=[], mcp_servers=[], http_servers=[])
+    with pytest.raises(ValidationError):
+        await service.create_child_session(
+            pool,
+            session_id="ses_tell_bad",
+            account_id=account_id,
+            agent_id=agent_id,
+            environment_id=env_id,
+            agent_version=1,
+            model="openrouter/test",
+            parent_run_id=parent_run_id,
+            surface=surface,
+            vault_ids=[],
+            input="x",
+            depth=1,
+            awaited=False,
+            output_schema={"type": "object"},
+        )
+
+
+async def test_legacy_edge_without_awaited_field_reads_as_awaited(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """A pre-#1197 ``request_opened`` row with no ``awaited`` field reads as
+    awaited (additive/legacy) — it still owes a response."""
+    pool, account_id, _agent_id, env_id = pool_env
+    _agent, _env, session = await seed_agent_env_session(
+        pool, account_id=account_id, prefix="legacy-awaited"
+    )
+    # Hand-write a legacy frame WITHOUT the awaited key.
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO events (id, account_id, session_id, kind, data) "
+            "VALUES ('evt_legacy_awaited', $1, $2, 'lifecycle', $3::jsonb)",
+            account_id,
+            session.id,
+            '{"event":"request_opened","request_id":"req-legacy",'
+            '"caller":{"kind":"run","id":"run_x"},"depth":0,'
+            '"environment_id":"' + env_id + '","frozen_surface":'
+            '{"tools":[],"mcp_servers":[],"http_servers":[]},"vault_ids":[]}',
+        )
+    async with pool.acquire() as conn:
+        assert await queries.get_open_request_ids(conn, session.id, account_id=account_id) == [
+            "req-legacy"
+        ]
+
+
+async def test_tell_existing_session_appends_message_no_edge_channel_less(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``Tell(ExistingSession)`` appends a channel-less user message + wakes, opens
+    NO request edge, and never renders to a connector (no ``orig_channel``)."""
+    pool, account_id, _agent_id, _env_id = pool_env
+    _agent, _env, session = await seed_agent_env_session(
+        pool, account_id=account_id, prefix="tell-existing"
+    )
+
+    deferred: list[tuple[str, str]] = []
+
+    async def _fake_defer_wake(_pool: Any, sid: str, *, cause: str, account_id: str) -> None:
+        deferred.append((sid, cause))
+
+    import aios.services.wake as wake_module
+
+    monkeypatch.setattr(wake_module, "defer_wake", _fake_defer_wake)
+    ok = await service.stimulate(
+        pool,
+        service.TellExistingSession(session_id=session.id, content="go look", cause="message"),
+        account_id=account_id,
+    )
+    assert ok is True
+    assert deferred == [(session.id, "message")]
+
+    async with pool.acquire() as conn:
+        # A user message landed...
+        msg = await conn.fetchrow(
+            "SELECT data, orig_channel FROM events WHERE session_id = $1 "
+            "AND kind = 'message' AND role = 'user' ORDER BY seq DESC LIMIT 1",
+            session.id,
+        )
+        assert msg is not None
+        assert queries.parse_jsonb(msg["data"])["content"] == "go look"
+        # ...channel-less (never renders to a connector).
+        assert msg["orig_channel"] is None
+        # ...and NO request edge was opened.
+        edges = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 "
+            "AND kind = 'lifecycle' AND data->>'event' = 'request_opened'",
+            session.id,
+        )
+        assert edges == 0
+
+
 # ─── #1124: the DOWN-counting trusted depth on the edge bounds cycles ─────────
 
 

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -427,13 +427,23 @@ async def test_legacy_edge_without_awaited_field_reads_as_awaited(
     _agent, _env, session = await seed_agent_env_session(
         pool, account_id=account_id, prefix="legacy-awaited"
     )
-    # Hand-write a legacy frame WITHOUT the awaited key.
-    async with pool.acquire() as conn:
+    # Hand-write a legacy frame WITHOUT the awaited key. ``events.seq`` is
+    # ``bigint NOT NULL`` (gapless per session, allocated off the session's
+    # ``last_event_seq`` counter — see ``queries.events.append_event``), so the
+    # raw INSERT must allocate a seq the same way rather than omit the column.
+    async with pool.acquire() as conn, conn.transaction():
+        seq = await conn.fetchval(
+            "UPDATE sessions SET last_event_seq = last_event_seq + 1 "
+            "WHERE id = $1 AND account_id = $2 RETURNING last_event_seq",
+            session.id,
+            account_id,
+        )
         await conn.execute(
-            "INSERT INTO events (id, account_id, session_id, kind, data) "
-            "VALUES ('evt_legacy_awaited', $1, $2, 'lifecycle', $3::jsonb)",
+            "INSERT INTO events (id, account_id, session_id, seq, kind, data) "
+            "VALUES ('evt_legacy_awaited', $1, $2, $3, 'lifecycle', $4::jsonb)",
             account_id,
             session.id,
+            seq,
             '{"event":"request_opened","request_id":"req-legacy",'
             '"caller":{"kind":"run","id":"run_x"},"depth":0,'
             '"environment_id":"' + env_id + '","frozen_surface":'

--- a/tests/integration/test_trigger_event_fires.py
+++ b/tests/integration/test_trigger_event_fires.py
@@ -77,7 +77,12 @@ async def trig_runtime(
             mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()),
             mock.patch("aios.workflows.run_tools.defer_run_wake", new=AsyncMock()),
             mock.patch("aios.workflows.step.defer_trigger_fire", new=AsyncMock()),
+            # `_surface_failure` still calls the module-level import in
+            # trigger_runner; `wake_owner` now routes through the stimulate spine
+            # (#1197) and resolves defer_wake from its source module. Patch both
+            # call sites so neither path hits the (unopened) procrastinate app.
             mock.patch("aios.harness.trigger_runner.defer_wake", new=AsyncMock()),
+            mock.patch("aios.services.wake.defer_wake", new=AsyncMock()),
         ):
             yield pool
     finally:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1763,10 +1763,10 @@ async def test_tell_spawned_child_reaches_idle_with_zero_nudges(
     assert created is True
 
     assistant = await _idle_assistant_turn(pool, cid)
-    nudged, caller, _focal = await sessions_service.append_assistant_and_guard_quiescence(
+    result = await sessions_service.append_assistant_and_guard_quiescence(
         pool, cid, assistant, account_id="acc_wf", parent_run_id=run_id
     )
-    assert not nudged and caller is None  # no nudge, no auto-error
+    assert not result.nudged and result.autoerror_caller_run_id is None  # no nudge, no auto-error
 
     async with pool.acquire() as conn:
         # The unawaited edge is excluded from the open set — no obligation.

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1734,6 +1734,56 @@ async def test_idle_with_open_request_is_nudged(
     assert status == "active"  # the nudge user message keeps it alive, no idle window
 
 
+async def test_tell_spawned_child_reaches_idle_with_zero_nudges(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """#1197: a `Tell(NewSession)` fire-and-forget spawn writes an UNAWAITED edge,
+    so the child owes no response — the quiescence guard skips the nudge/no_return
+    loop entirely and it reaches idle with ZERO nudges (the acceptance criterion).
+
+    Contrast with `test_idle_with_open_request_is_nudged`: same idle assistant
+    turn, but the awaited bit is the only difference."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    cid = child_session_id(run_id, "sha:tell#0")
+    created = await sessions_service.create_child_session(
+        pool,
+        session_id=cid,
+        account_id="acc_wf",
+        agent_id=wf_agent_id,
+        environment_id="env_wf",
+        agent_version=1,
+        model=None,
+        parent_run_id=run_id,
+        surface=Surface([], [], []),
+        vault_ids=[],
+        input="fire-and-forget",
+        awaited=False,  # the Tell arm
+    )
+    assert created is True
+
+    assistant = await _idle_assistant_turn(pool, cid)
+    nudged, caller, _focal = await sessions_service.append_assistant_and_guard_quiescence(
+        pool, cid, assistant, account_id="acc_wf", parent_run_id=run_id
+    )
+    assert not nudged and caller is None  # no nudge, no auto-error
+
+    async with pool.acquire() as conn:
+        # The unawaited edge is excluded from the open set — no obligation.
+        open_ids = await db_queries.get_open_request_ids(conn, cid, account_id="acc_wf")
+        status = await db_queries.derive_session_status(conn, cid, account_id="acc_wf")
+        nudge_msgs = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND account_id = $2 "
+            "AND kind = 'message' AND role = 'user' "
+            "AND data->'metadata'->'nudged_request_ids' IS NOT NULL",
+            cid,
+            "acc_wf",
+        )
+    assert open_ids == []  # no awaited request open
+    assert status == "idle"  # free to rest — fire-and-forget owes nothing
+    assert nudge_msgs == 0  # ZERO nudges
+
+
 async def test_quiescence_guard_is_noop_for_non_child(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/unit/test_request_opened_edge.py
+++ b/tests/unit/test_request_opened_edge.py
@@ -94,13 +94,16 @@ def test_append_request_opened_emits_lifecycle_kind() -> None:
 
 
 def test_create_child_session_calls_append_request_opened_after_first_spawn_guard() -> None:
-    """``create_child_session`` opens the edge only on a real insert.
+    """The spine's NewSession arm opens the edge only on a real insert.
 
     The ``append_request_opened`` call must appear textually after the
     ``if child is None: return False`` first-spawn guard, so a replayed wake (which
-    early-returns at the guard) never re-opens the edge — exactly-once.
+    early-returns at the guard) never re-opens the edge — exactly-once. Since #1197
+    factored the three near-copy creation paths onto the private ``stimulate``
+    spine, the edge writer lives in ``_stimulate_new_session`` (the NewSession arm
+    ``create_child_session`` is now a thin caller of).
     """
-    func = _func_def(sessions_svc.create_child_session, "create_child_session")
+    func = _func_def(sessions_svc._stimulate_new_session, "_stimulate_new_session")
 
     # Find the line of `if child is None: return False`.
     guard_line: int | None = None
@@ -124,8 +127,11 @@ def test_create_child_session_calls_append_request_opened_after_first_spawn_guar
 
 
 def test_create_child_session_opens_edge_inside_transaction() -> None:
-    """The edge write shares the servicer-creation transaction (rollback → no edge)."""
-    func = _func_def(sessions_svc.create_child_session, "create_child_session")
+    """The edge write shares the servicer-creation transaction (rollback → no edge).
+
+    The edge writer lives in the spine's NewSession arm (#1197).
+    """
+    func = _func_def(sessions_svc._stimulate_new_session, "_stimulate_new_session")
     txn = next(node for node in ast.walk(func) if isinstance(node, ast.AsyncWith))
     end = max(
         (n.lineno for n in ast.walk(txn) if hasattr(n, "lineno")),
@@ -196,3 +202,56 @@ def test_get_open_request_ids_reads_request_opened_not_metadata_blob() -> None:
     assert "request_response" in sql
     # It must NOT read the asked set off the forgeable metadata blob anymore.
     assert "'metadata'->'request'" not in sql
+
+
+# ─── #1197: the `awaited` bit + the `Ask | Tell` discriminated union ──────────
+
+
+def test_open_request_ids_filters_awaited_true() -> None:
+    """The open-set reader is one of the awaited-triad readers: it must filter
+    ``awaited=true`` (absent → true), so a ``Tell(NewSession)``'s unawaited edge is
+    excluded and a fire-and-forget spawn never wrongly owes a response."""
+    sql = _sql_literals(sessions_q.get_open_request_ids)
+    assert "awaited" in sql, "open set must filter on the awaited bit (#1197)"
+    # Absent ⇒ awaited=true (additive/legacy): the filter must COALESCE to TRUE.
+    assert "COALESCE" in sql.upper()
+
+
+def test_append_request_opened_signature_has_awaited() -> None:
+    """``append_request_opened`` takes an explicit ``awaited`` field (default true)
+    — never inferred from request_id-presence, so the union discipline holds."""
+    import inspect
+
+    sig = inspect.signature(sessions_q.append_request_opened)
+    assert "awaited" in sig.parameters
+    assert sig.parameters["awaited"].default is True
+
+
+def test_stimulate_union_makes_illegal_combinations_unrepresentable() -> None:
+    """The ``Ask | Tell`` union is a TYPE at the spine boundary, not a runtime
+    guard: illegal combinations have no constructor.
+
+    * no ``AskExistingSession`` carries ``vault_ids`` (a non-creating target binds
+      none);
+    * no ``Tell*`` arm carries ``output_schema`` (a Tell owes no response).
+    """
+    import dataclasses
+
+    ask_existing_fields = {f.name for f in dataclasses.fields(sessions_svc.AskExistingSession)}
+    assert "vault_ids" not in ask_existing_fields
+
+    for tell_cls in (sessions_svc.TellNewSession, sessions_svc.TellExistingSession):
+        tell_fields = {f.name for f in dataclasses.fields(tell_cls)}
+        assert "output_schema" not in tell_fields, f"{tell_cls.__name__} must not own output_schema"
+
+
+def test_stimulate_is_not_model_callable() -> None:
+    """The spine is service-internal: it is NOT registered as a model-facing tool.
+
+    A weak structural proxy for the mechanism/policy split — ``stimulate`` is a
+    plain service function, not decorated/registered into the tool registry.
+    """
+    # The tool registry never imports `stimulate`; the public surface is the
+    # Ask|Tell type, not a `deliver()` bool. Assert no `deliver` public function
+    # leaked onto the service module.
+    assert not hasattr(sessions_svc, "deliver"), "no public deliver(); spine is private"


### PR DESCRIPTION
Closes #1197. Part of #1122.

Factors the two session-targeted near-copy creation paths onto **one private `stimulate` spine** and adds the missing **`Tell` arm** (fire-and-forget, no response obligation), with the `Ask`/`Tell` distinction carried as a first-class `awaited` bit on the `request_opened` edge. Implements Option A (locked): one lineage edge, `Tell` = unawaited edge; the kernel is service-only (no public `deliver()`), `awaited` is the internal edge field, and `Ask | Tell` is a discriminated **type** at the spine boundary.

## What changed

**The spine (`services/sessions.py`)**
- New private `stimulate(pool, stim, *, account_id)` dispatching an `Ask | Tell` discriminated union: `AskNewSession | TellNewSession | AskExistingSession | TellExistingSession`. Illegal combinations are unrepresentable by construction (no `AskExistingSession`+`vault_ids`; no `Tell`+`output_schema`; no `Ask(ExistingSession)` class).
- Three arms: `_stimulate_new_session` (Ask+Tell share the `ON CONFLICT DO NOTHING` first-spawn guard, surface freeze, vault bind, edge open), `_stimulate_existing_ask` (channel-less awaited request + edge + wake), `_stimulate_existing_tell` (channel-less message + wake, **no** edge — the `_run_wake_owner` body generalized).
- `create_child_session` is now a thin caller of the spine's NewSession arm; gains `awaited: bool = True`. `awaited=True` requires a `request_id`; `awaited=False` forbids `output_schema` and mints a `request_id` to key the unawaited (lineage/depth/surface) edge.
- `_inject_api_request` is now a thin caller of the spine's `AskExistingSession` arm (preserving `defer_wake(cause="api_invoke")` + channel-less invisibility).

**The edge (`db/queries/sessions.py`)**
- `append_request_opened` gains an explicit `awaited: bool = True` field on the `request_opened` payload (never inferred from `request_id`-presence).
- `get_open_request_ids` — the single reader the totality gate, quiescence guard, and the `return`/`error` path all funnel through — filters `COALESCE((awaited)::boolean, TRUE)`, so an unawaited `Tell` edge is excluded from the open set (absent reads as `true`, additive/legacy).

**The Tell(ExistingSession) recompose (`harness/trigger_runner.py`)**
- `_run_wake_owner` now routes through `stimulate(TellExistingSession(...))`, preserving its channel-less message + wake (no request edge) behavior.

## Behavior preservation
- `create_child_session`: `ON CONFLICT` idempotency preserved (the edge writer is gated behind the first-spawn check — exactly-once across replays); NewSession arm still does not wake (the workflow-step caller wakes), matching master.
- `_inject_api_request`: `defer_wake` + channel-less preserved.
- `create_run` / `Tell(NewRun)` unchanged — runs carry the ask/answer via the journal frame + `derive_run_response` (no session edge), so `create_run(request_id=None)` already is the degenerate `Tell(NewRun)`; not forced into the session-targeted union.

## Tests (test-first)
- unit: `awaited` default-true + signature; open-set `awaited` filter; union illegal-combo unrepresentability; spine-not-public; spine arms inspected for edge-after-guard + in-transaction invariants (re-pointed onto `_stimulate_new_session`).
- integration: `Ask(NewSession)` writes `awaited=true` + owes response; `Tell(NewSession)` writes a real unawaited edge but owes nothing (excluded from open set); `Tell` rejects `output_schema`; legacy edge (no `awaited`) reads as awaited; `Tell(ExistingSession)` appends channel-less message + wakes + opens no edge; **a `Tell`-spawned child reaches idle with zero nudges / no_return** (the acceptance criterion).

## Gates
`uv run mypy src tests`, `uv run ruff check src tests`, `uv run pytest tests/unit -q` (3216 passed) all green. Integration tests added but not run here (no Docker in the build sandbox).

## Not in scope (per issue)
The public/policy surfaces that call the spine (model spawn/invoke tools, `wake_session` policy refactor, #1165 trigger reframe); `Ask(ExistingSession)`; the #1132 cap; the #1130 env-containment clamp.