### PR TITLE
feat(workflows): de-Goodharted detection-residue gauge — residue_events table + axis-segregated ledger render + stamped-at-source gate ingest (#1328)

### DIFF
--- a/migrations/versions/0109_residue_events.py
+++ b/migrations/versions/0109_residue_events.py
@@ -1,0 +1,147 @@
+"""Residue-events table (#1328) — the de-Goodharted detection-residue gauge.
+
+A fresh append-only ``residue_events`` table, the durable substrate behind
+Plane D of the substrate-different-verdict invariant (epic #1330, roadmap item
+9). Rows are CLASSIFICATIONS the ops-agent writes; the DENOMINATOR is never
+stored (it is computed live from uncorrelated substrates — ``wf_runs`` and the
+GitHub merged-PR set — in the render path), so the gauge can never be
+maker==checker. The table follows the ``wf_runs`` shape (prefixed-ULID id,
+``account_id``, ``created_at timestamptz default now()``) and the small-table
+idiom of ``0086``/``0108``.
+
+LOAD-BEARING INVARIANTS, made STRUCTURAL (not convention):
+
+- **Append-only.** A ``BEFORE UPDATE OR DELETE`` trigger ``RAISE EXCEPTION`` —
+  the never-delete stance turned into a constraint the query layer cannot
+  bypass. There is NO update/delete path in the query module.
+- **Axis segregation (the de-Goodhart).** ``axis smallint CHECK (axis IN (1,2))``
+  is a column-level invariant; the two axes (axis-1 = machine-found mechanical
+  waste; axis-2 = class migration) are STRUCTURALLY distinct and the query/render
+  layer never ``SUM``s across them (enforced additionally by a grep unit test).
+- **Frozen finder vocabulary.** ``finder CHECK (finder IN (...4 values))`` — a
+  new finder is a deliberate migration, not a typo.
+- **kind_source provenance.** ``kind_source CHECK (kind_source IN (...3))`` so a
+  ``manual``/``other`` row is distinguishable from a stamped-at-source one.
+- **OPEN residue_kind enum.** ``residue_kind`` is deliberately NOT CHECK-frozen:
+  the four human-in-loop kinds PLUS the ``other`` sentinel. ``other``-bucket
+  growth is a render-side ALARM, not a constraint.
+- **At-least-once idempotency.** ``UNIQUE(account_id, idempotency_key)`` +
+  ON CONFLICT DO NOTHING (the ``reference-workflow-crash-contract-at-least-once``
+  generalized to every ingest node) so a gate-resume replay or an observer
+  re-scan inserts ONE row, never a double-count.
+
+``downgrade()`` fails HARD if any ``residue_events`` row exists (the 0108
+unrepresentable-row / never-reconstruct stance) and then drops the trigger,
+function and table.
+
+Revision ID: 0109
+Revises: 0108
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0109"
+down_revision: str = "0108"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ─── frozen vocabularies (the CHECK predicates; pinned byte-for-byte by the
+#     0108-idiom predicate test so a silent vocabulary drift is caught) ─────────
+
+# The segregated axis: 1 = machine-found mechanical waste (observer/axis-1),
+# 2 = class migration (gate-resolve/axis-2). NEVER summed.
+AXIS_CHECK = "axis IN (1, 2)"
+
+# The ledger's frozen finder vocabulary — a new finder is a deliberate migration.
+FINDER_CHECK = (
+    "finder IN ('internal-armed-check', 'external-world', 'chairman', 'seat-incidental')"
+)
+
+# Provenance of residue_kind: stamped at the gate-resolve source, written by the
+# observer, or a manual classification. Distinguishes a stamped-at-source row
+# from an ``other``/manual one.
+KIND_SOURCE_CHECK = "kind_source IN ('gate-resolve-payload', 'observer', 'manual')"
+
+# The append-only guard: a trigger function that RAISEs on any UPDATE or DELETE.
+APPEND_ONLY_FN = "residue_events_append_only"
+APPEND_ONLY_TRIGGER = "residue_events_no_update_delete"
+
+
+def upgrade() -> None:
+    # 1. The table — wf_runs shape (prefixed-ULID id, account_id, created_at).
+    op.execute(
+        f"""
+        CREATE TABLE residue_events (
+            id                  text PRIMARY KEY,
+            account_id          text NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+            created_at          timestamptz NOT NULL DEFAULT now(),
+            axis                smallint NOT NULL CHECK ({AXIS_CHECK}),
+            finder              text NOT NULL CHECK ({FINDER_CHECK}),
+            residue_kind        text NOT NULL,
+            kind_source         text NOT NULL CHECK ({KIND_SOURCE_CHECK}),
+            signature           jsonb NOT NULL,
+            source_run_id       text,
+            source_gate_nonce   text,
+            issue_ref           text,
+            class_closed_issue  text,
+            idempotency_key     text NOT NULL,
+            UNIQUE (account_id, idempotency_key)
+        )
+        """
+    )
+    # Render-path reads pull each axis SEPARATELY over a created_at window, so an
+    # (account_id, axis, created_at) index serves both axis-scoped scans.
+    op.execute(
+        "CREATE INDEX residue_events_axis_idx "
+        "ON residue_events (account_id, axis, created_at DESC)"
+    )
+
+    # 2. Append-only made structural: a BEFORE UPDATE OR DELETE trigger that
+    #    RAISEs. never-delete is not a convention the query layer can drift from;
+    #    it is a constraint Postgres enforces against every writer.
+    op.execute(
+        f"""
+        CREATE FUNCTION {APPEND_ONLY_FN}() RETURNS trigger AS $$
+        BEGIN
+            RAISE EXCEPTION
+                'residue_events is append-only: % is forbidden (never-delete, #1328)',
+                TG_OP;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    op.execute(
+        f"""
+        CREATE TRIGGER {APPEND_ONLY_TRIGGER}
+            BEFORE UPDATE OR DELETE ON residue_events
+            FOR EACH ROW EXECUTE FUNCTION {APPEND_ONLY_FN}()
+        """
+    )
+
+
+def downgrade() -> None:
+    # Fail hard on any existing row — a classification is a never-reconstruct
+    # fact (the 0108 unrepresentable-row stance). A residue row deleted on
+    # downgrade would silently erase a recorded human-in-loop event.
+    n = (
+        op.get_bind()
+        .execute(sa.text("SELECT count(*) FROM residue_events"))
+        .scalar()
+    )
+    if n:
+        raise RuntimeError(
+            f"cannot downgrade: {n} residue_events row(s) — the residue ledger is "
+            "append-only and never reconstructed (#1328)."
+        )
+
+    # The trigger guards UPDATE/DELETE of ROWS; DROP TRIGGER / DROP TABLE are DDL
+    # and are not intercepted, so teardown is clean on an empty table.
+    op.execute(f"DROP TRIGGER IF EXISTS {APPEND_ONLY_TRIGGER} ON residue_events")
+    op.execute(f"DROP FUNCTION IF EXISTS {APPEND_ONLY_FN}()")
+    op.execute("DROP TABLE IF EXISTS residue_events")

--- a/migrations/versions/0109_residue_events.py
+++ b/migrations/versions/0109_residue_events.py
@@ -59,9 +59,7 @@ depends_on: str | Sequence[str] | None = None
 AXIS_CHECK = "axis IN (1, 2)"
 
 # The ledger's frozen finder vocabulary — a new finder is a deliberate migration.
-FINDER_CHECK = (
-    "finder IN ('internal-armed-check', 'external-world', 'chairman', 'seat-incidental')"
-)
+FINDER_CHECK = "finder IN ('internal-armed-check', 'external-world', 'chairman', 'seat-incidental')"
 
 # Provenance of residue_kind: stamped at the gate-resolve source, written by the
 # observer, or a manual classification. Distinguishes a stamped-at-source row
@@ -98,8 +96,7 @@ def upgrade() -> None:
     # Render-path reads pull each axis SEPARATELY over a created_at window, so an
     # (account_id, axis, created_at) index serves both axis-scoped scans.
     op.execute(
-        "CREATE INDEX residue_events_axis_idx "
-        "ON residue_events (account_id, axis, created_at DESC)"
+        "CREATE INDEX residue_events_axis_idx ON residue_events (account_id, axis, created_at DESC)"
     )
 
     # 2. Append-only made structural: a BEFORE UPDATE OR DELETE trigger that
@@ -129,11 +126,7 @@ def downgrade() -> None:
     # Fail hard on any existing row — a classification is a never-reconstruct
     # fact (the 0108 unrepresentable-row stance). A residue row deleted on
     # downgrade would silently erase a recorded human-in-loop event.
-    n = (
-        op.get_bind()
-        .execute(sa.text("SELECT count(*) FROM residue_events"))
-        .scalar()
-    )
+    n = op.get_bind().execute(sa.text("SELECT count(*) FROM residue_events")).scalar()
     if n:
         raise RuntimeError(
             f"cannot downgrade: {n} residue_events row(s) — the residue ledger is "

--- a/migrations/versions/0110_bindings_session_cascade.py
+++ b/migrations/versions/0110_bindings_session_cascade.py
@@ -36,7 +36,7 @@ precedent) so the constraint is added without a long ``ACCESS EXCLUSIVE``
 lock while existing rows are validated.
 
 Revision ID: 0110
-Revises: 0108
+Revises: 0109
 """
 
 from __future__ import annotations
@@ -46,7 +46,7 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "0110"
-down_revision: str = "0108"
+down_revision: str = "0109"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/aios/db/queries/residue.py
+++ b/src/aios/db/queries/residue.py
@@ -312,16 +312,16 @@ class MergedPrUniverse(NamedTuple):
     ``determinable=False`` and the render shows ``cannot-determine`` for axis-2 —
     NEVER an implicit short count (the look-green-while-doing-less guard)."""
 
-    count: int | None
+    pr_count: int | None
     determinable: bool
 
     @classmethod
     def determined(cls, count: int) -> MergedPrUniverse:
-        return cls(count=count, determinable=True)
+        return cls(pr_count=count, determinable=True)
 
     @classmethod
     def cannot_determine(cls) -> MergedPrUniverse:
-        return cls(count=None, determinable=False)
+        return cls(pr_count=None, determinable=False)
 
 
 # ─── axis-scoped found-by-finder breakdowns (NEVER cross-axis) ───────────────

--- a/src/aios/db/queries/residue.py
+++ b/src/aios/db/queries/residue.py
@@ -192,9 +192,9 @@ async def ingest_gate_resume_axis2(
     kind = gate_result_residue_kind(result)
     if kind is None:
         raise ValueError(
-            "gate_resume for human-in-loop kind %r is missing residue_kind — the "
+            f"gate_resume for human-in-loop kind {gate_kind!r} is missing residue_kind — the "
             "human_gate() wrapper should have rejected this resolve; refusing to "
-            "infer a kind (#1328)." % (gate_kind,)
+            "infer a kind (#1328)."
         )
     signature = {"gate_kind": gate_kind, "source_gate_nonce": source_gate_nonce}
     return await insert_residue_event(
@@ -249,8 +249,7 @@ async def ingest_observer_verdict_axis1(
         residue_kind = CANNOT_DETERMINE_KIND
     else:
         raise ValueError(
-            "unknown observer verdict %r (expected ok/anomaly/cannot-determine) "
-            "(#1328)" % (verdict,)
+            f"unknown observer verdict {verdict!r} (expected ok/anomaly/cannot-determine) (#1328)"
         )
     return await insert_residue_event(
         conn,

--- a/src/aios/db/queries/residue.py
+++ b/src/aios/db/queries/residue.py
@@ -1,0 +1,392 @@
+"""Queries for the de-Goodharted detection-residue gauge (#1328).
+
+The durable substrate behind Plane D of the substrate-different-verdict
+invariant (epic #1330, roadmap item 9). ``residue_events`` rows are
+CLASSIFICATIONS the ops-agent writes; this module is the ONLY write/read path to
+that table. The load-bearing properties, expressed in code:
+
+- **Append-only.** This module exposes INSERT + SELECT only. There is NO
+  ``UPDATE``/``DELETE`` against ``residue_events`` anywhere here; the migration's
+  ``BEFORE UPDATE OR DELETE`` trigger backstops it structurally.
+- **Axis segregation (the de-Goodhart).** Every aggregate read is axis-SCOPED:
+  the count helpers and the found-by-finder breakdown take an ``axis`` parameter
+  and filter ``WHERE axis = $axis``. NO query in this module ``SUM``s or
+  ``count``s across BOTH axes — a rising axis-1 (machine-found mechanical waste)
+  is NEVER combined with axis-2 (class migration) into a single ratio, because a
+  rising axis-1 is FORBIDDEN as an autonomy-increment justification. A unit test
+  greps this module and fails if a cross-axis aggregate appears.
+- **residue_kind never inferred.** The axis-2 ingest copies ``residue_kind``
+  VERBATIM from a stored ``gate_resume`` signal's ``result`` payload (the
+  finder's own stamp, written by ``dev_pipeline.py``'s ``human_gate()`` wrapper);
+  it CLASSIFIES (axis, dedupe) but does not DEFINE the kind. No prose parsing.
+- **Denominator from an uncorrelated substrate.** The denominators are computed
+  here (NOT stored as rows): the axis-1 universe is the host-emitted terminal-run
+  count from ``wf_runs``; the axis-2 universe is the GitHub merged-PR set, read by
+  the caller (``dev_pipeline.py``) and passed in as a ``MergedPrUniverse`` so the
+  fleet-didn't-author-it git substrate, not the ops-agent's account, sets the
+  denominator.
+- **At-least-once idempotency.** Every INSERT is ON CONFLICT DO NOTHING on
+  ``UNIQUE(account_id, idempotency_key)``; the key is ``hash(source_run_id ‖
+  residue_kind)`` for observer rows / ``hash(source_gate_nonce)`` for gate rows,
+  so a replay inserts ONE row.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, NamedTuple
+
+import asyncpg
+
+from aios.ids import RESIDUE_EVENT, make_id
+
+# ─── frozen vocabularies (mirror the migration CHECKs) ───────────────────────
+
+# The segregated axes. NEVER summed.
+AXIS_OBSERVER = 1  # machine-found mechanical waste (axis-1, from the observer)
+AXIS_CLASS_MIGRATION = 2  # class migration (axis-2, from gate-resolve)
+
+# The finder vocabulary, frozen in the migration CHECK.
+FINDERS = (
+    "internal-armed-check",
+    "external-world",
+    "chairman",
+    "seat-incidental",
+)
+
+# The four human-in-loop KINDS plus the OPEN ``other`` sentinel. The enum is
+# deliberately NOT CHECK-frozen in the table; ``other``-bucket growth is the
+# render-side ALARM. ``cannot-determine`` is a SEPARATE fail-loud verdict (a null
+# telemetry field), never folded into a clean/ok bucket.
+RESIDUE_KINDS = (
+    "uncorrelated-detection",
+    "deadlock-break",
+    "design-judgment",
+    "ladder-top-approval",
+)
+OTHER_KIND = "other"
+CANNOT_DETERMINE_KIND = "cannot-determine"
+# The accepted set the human_gate() wrapper (dev_pipeline.py) enforces: the four
+# kinds plus ``other``. Authored here so the wrapper and the ingest share one
+# source of truth.
+ACCEPTED_GATE_RESIDUE_KINDS = frozenset(RESIDUE_KINDS) | {OTHER_KIND}
+
+# kind_source provenance (mirrors the migration CHECK).
+KIND_SOURCE_GATE = "gate-resolve-payload"
+KIND_SOURCE_OBSERVER = "observer"
+KIND_SOURCE_MANUAL = "manual"
+
+
+def _idempotency_key(*parts: str | None) -> str:
+    """The at-least-once dedupe key: a stable hash over the provenance parts.
+
+    Gate rows key on ``hash(source_gate_nonce)``; observer rows key on
+    ``hash(source_run_id ‖ residue_kind)``. A NUL separator keeps the parts
+    unambiguous, and ``None`` parts are skipped so an absent field never collides
+    with an empty string.
+    """
+    joined = "\x00".join(p for p in parts if p is not None)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+# ─── INSERT (append-only; ON CONFLICT DO NOTHING) ────────────────────────────
+
+
+async def insert_residue_event(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    axis: int,
+    finder: str,
+    residue_kind: str,
+    kind_source: str,
+    signature: dict[str, Any],
+    idempotency_key: str,
+    source_run_id: str | None = None,
+    source_gate_nonce: str | None = None,
+    issue_ref: str | None = None,
+    class_closed_issue: str | None = None,
+) -> bool:
+    """Append one residue classification, idempotently.
+
+    Returns ``True`` if a row was inserted, ``False`` if a row with the same
+    ``(account_id, idempotency_key)`` already existed (ON CONFLICT DO NOTHING —
+    the at-least-once replay contract; a re-ingest never double-counts). The
+    CHECK constraints (axis/finder/kind_source) reject out-of-vocabulary values
+    as an IntegrityError, never a silent coercion.
+    """
+    row = await conn.fetchrow(
+        """
+        INSERT INTO residue_events (
+            id, account_id, axis, finder, residue_kind, kind_source, signature,
+            source_run_id, source_gate_nonce, issue_ref, class_closed_issue,
+            idempotency_key
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11, $12)
+        ON CONFLICT (account_id, idempotency_key) DO NOTHING
+        RETURNING id
+        """,
+        make_id(RESIDUE_EVENT),
+        account_id,
+        axis,
+        finder,
+        residue_kind,
+        kind_source,
+        json.dumps(signature),
+        source_run_id,
+        source_gate_nonce,
+        issue_ref,
+        class_closed_issue,
+        idempotency_key,
+    )
+    return row is not None
+
+
+# ─── axis-2 ingest: copy the finder's stamp from a gate_resume signal ────────
+
+# The dev_pipeline gate kinds that are human-in-loop (the human_gate() wrapper
+# demands a residue_kind for exactly these). Mirrored from dev_pipeline.py.
+HUMAN_IN_LOOP_GATE_KINDS = frozenset({"merge_approval", "design"})
+
+
+def gate_result_residue_kind(result: Any) -> str | None:
+    """Read ``residue_kind`` VERBATIM from a stored ``gate_resume`` ``result``.
+
+    The finder (seat/chairman) stamps the kind at the moment of human judgment
+    via the ``human_gate()`` wrapper; this reads it back, copying — never
+    inferring from prose. Returns the stamped kind, or ``None`` if absent.
+    """
+    if isinstance(result, dict):
+        kind = result.get("residue_kind")
+        if isinstance(kind, str) and kind:
+            return kind
+    return None
+
+
+async def ingest_gate_resume_axis2(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    source_gate_nonce: str,
+    gate_kind: str,
+    result: Any,
+    finder: str,
+    source_run_id: str | None = None,
+    issue_ref: str | None = None,
+) -> bool:
+    """Ingest one human-in-loop ``gate_resume`` as an axis-2 (class-migration) row.
+
+    Copies ``residue_kind`` from the stored ``result`` payload (the
+    stamped-at-source value); ``kind_source`` is therefore
+    ``gate-resolve-payload``. Idempotent on ``hash(source_gate_nonce)`` so a
+    gate-resume replay inserts ONE row. Returns ``True`` if inserted.
+
+    Only the human-in-loop kinds carry a residue stamp; a non-human-in-loop gate
+    (``verify``/``merge_guard``) is not an axis-2 residue event and is skipped
+    (returns ``False``). A human-in-loop resume whose ``result`` is MISSING the
+    stamp is a contract violation the ``human_gate()`` wrapper foreclosed
+    upstream; defensively we refuse to fabricate a kind and raise.
+    """
+    if gate_kind not in HUMAN_IN_LOOP_GATE_KINDS:
+        return False
+    kind = gate_result_residue_kind(result)
+    if kind is None:
+        raise ValueError(
+            "gate_resume for human-in-loop kind %r is missing residue_kind — the "
+            "human_gate() wrapper should have rejected this resolve; refusing to "
+            "infer a kind (#1328)." % (gate_kind,)
+        )
+    signature = {"gate_kind": gate_kind, "source_gate_nonce": source_gate_nonce}
+    return await insert_residue_event(
+        conn,
+        account_id=account_id,
+        axis=AXIS_CLASS_MIGRATION,
+        finder=finder,
+        residue_kind=kind,
+        kind_source=KIND_SOURCE_GATE,
+        signature=signature,
+        idempotency_key=_idempotency_key(source_gate_nonce),
+        source_gate_nonce=source_gate_nonce,
+        source_run_id=source_run_id,
+        issue_ref=issue_ref,
+    )
+
+
+# ─── axis-1 ingest: the machine-observer verdict (inert until item 8+2) ──────
+
+
+async def ingest_observer_verdict_axis1(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    source_run_id: str,
+    verdict: str,
+    signature: dict[str, Any],
+) -> bool:
+    """Ingest one machine-observer verdict as an axis-1 (mechanical-waste) row.
+
+    The observer (roadmap item 8, reading per-run telemetry from item 2) emits a
+    verdict per terminal run:
+
+    - ``anomaly`` → an axis-1 row, ``finder='internal-armed-check'``,
+      ``kind_source='observer'``, ``residue_kind='uncorrelated-detection'``,
+      ``signature`` = the anomaly fingerprint. Idempotent on
+      ``hash(source_run_id ‖ residue_kind)``.
+    - ``cannot-determine`` (any null telemetry field — the ``vault_ids:null``
+      disease) → a ``cannot-determine`` row so absence is FAIL-LOUD, NEVER
+      silently counted as clean. It writes NO ``ok`` row.
+    - ``ok`` → NO row (a clean run is the absence of a residue event, not a row).
+
+    Returns ``True`` if a row was inserted. Until the observer ships this path is
+    simply never called (the ingest is wired but inert: no telemetry → no
+    axis-1 rows), and the denominator is still computed from ``wf_runs``.
+    """
+    if verdict == "ok":
+        return False
+    if verdict == "anomaly":
+        residue_kind = "uncorrelated-detection"
+    elif verdict == "cannot-determine":
+        residue_kind = CANNOT_DETERMINE_KIND
+    else:
+        raise ValueError(
+            "unknown observer verdict %r (expected ok/anomaly/cannot-determine) "
+            "(#1328)" % (verdict,)
+        )
+    return await insert_residue_event(
+        conn,
+        account_id=account_id,
+        axis=AXIS_OBSERVER,
+        finder="internal-armed-check",
+        residue_kind=residue_kind,
+        kind_source=KIND_SOURCE_OBSERVER,
+        signature=signature,
+        idempotency_key=_idempotency_key(source_run_id, residue_kind),
+        source_run_id=source_run_id,
+    )
+
+
+# ─── denominators (computed live; NEVER stored; uncorrelated substrate) ──────
+
+# The host-emitted terminal-run statuses — the SAME truth the RunCompletionSource
+# matcher fires on. Imported lazily to keep this query module import-light.
+
+
+async def run_table_denominator(
+    conn: asyncpg.Connection[Any], *, account_id: str, window_start: Any
+) -> int:
+    """The axis-1 denominator: count of terminal ``wf_runs`` over the window.
+
+    "Of N terminal runs the HOST recorded, M had an observer-detected mechanical
+    anomaly." The count comes from ``wf_runs`` — the host-emitted substrate the
+    fleet did not author — NOT from how many events the ops-agent ingested, so
+    the gauge can never be maker==checker. ``window_start`` is a timezone-aware
+    datetime lower bound.
+    """
+    from aios.models.workflows import TERMINAL_RUN_STATUSES
+
+    statuses = list(TERMINAL_RUN_STATUSES)
+    row = await conn.fetchrow(
+        """
+        SELECT count(*) AS n
+          FROM wf_runs
+         WHERE account_id = $1
+           AND status = ANY($2::text[])
+           AND created_at >= $3
+        """,
+        account_id,
+        statuses,
+        window_start,
+    )
+    assert row is not None
+    return int(row["n"])
+
+
+class MergedPrUniverse(NamedTuple):
+    """The axis-2 denominator carrier: the GitHub merged-PR universe over the
+    window, OR a cannot-determine verdict.
+
+    The caller (``dev_pipeline.py``) reads the merged-PR set via ``http_request``
+    riding the no-silent-degrade list-read invariant (#1323: a truncated list →
+    ``GitHubListIncomplete``). When the read can prove completeness it passes
+    ``count`` with ``determinable=True``; when it cannot (truncation / a dangling
+    ``rel="next"`` / a GraphQL ``len(nodes) != totalCount``) it passes
+    ``determinable=False`` and the render shows ``cannot-determine`` for axis-2 —
+    NEVER an implicit short count (the look-green-while-doing-less guard)."""
+
+    count: int | None
+    determinable: bool
+
+    @classmethod
+    def determined(cls, count: int) -> MergedPrUniverse:
+        return cls(count=count, determinable=True)
+
+    @classmethod
+    def cannot_determine(cls) -> MergedPrUniverse:
+        return cls(count=None, determinable=False)
+
+
+# ─── axis-scoped found-by-finder breakdowns (NEVER cross-axis) ───────────────
+
+
+async def found_by_finder(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    axis: int,
+    window_start: Any,
+) -> dict[str, int]:
+    """The found-by-finder breakdown for a SINGLE axis over the window.
+
+    Returns ``{finder: count}`` for the given axis ONLY. The ``WHERE axis = $2``
+    is load-bearing: this never aggregates across both axes, so a caller cannot
+    accidentally combine axis-1 and axis-2 into one ratio. ``cannot-determine``
+    rows are EXCLUDED from the finder breakdown (they are surfaced on their own
+    line) so they are never silently counted as a clean finder hit.
+    """
+    rows = await conn.fetch(
+        """
+        SELECT finder, count(*) AS n
+          FROM residue_events
+         WHERE account_id = $1
+           AND axis = $2
+           AND created_at >= $3
+           AND residue_kind <> $4
+         GROUP BY finder
+        """,
+        account_id,
+        axis,
+        window_start,
+        CANNOT_DETERMINE_KIND,
+    )
+    return {r["finder"]: int(r["n"]) for r in rows}
+
+
+async def kind_count(
+    conn: asyncpg.Connection[Any],
+    *,
+    account_id: str,
+    axis: int,
+    residue_kind: str,
+    window_start: Any,
+) -> int:
+    """Count rows of one ``residue_kind`` within a SINGLE axis over the window.
+
+    Used for the ``other``-bucket growth alarm and the ``cannot-determine``
+    fail-loud line — each scoped to one axis, never summed across axes.
+    """
+    row = await conn.fetchrow(
+        """
+        SELECT count(*) AS n
+          FROM residue_events
+         WHERE account_id = $1
+           AND axis = $2
+           AND residue_kind = $3
+           AND created_at >= $4
+        """,
+        account_id,
+        axis,
+        residue_kind,
+        window_start,
+    )
+    assert row is not None
+    return int(row["n"])

--- a/src/aios/ids.py
+++ b/src/aios/ids.py
@@ -71,6 +71,10 @@ WORKFLOW_EVENT: Final = "wfe"
 # Run→child spawns reuse the workflow ``call_key`` as the request_id; the API
 # caller (#1128) has no call_key, so it mints a fresh ``req_`` id here.
 REQUEST: Final = "req"
+# Residue events (#1328): one row per CLASSIFICATION the ops-agent writes to the
+# de-Goodharted detection-residue gauge (``residue_events``). Append-only;
+# axis-segregated; residue_kind stamped at the gate-resolve source.
+RESIDUE_EVENT: Final = "res"
 
 _PREFIXES: Final = frozenset(
     {
@@ -102,6 +106,7 @@ _PREFIXES: Final = frozenset(
         WORKFLOW_RUN,
         WORKFLOW_EVENT,
         REQUEST,
+        RESIDUE_EVENT,
     }
 )
 

--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -356,6 +356,59 @@ import re
 # freely even though their ``def``s are appended after this block.
 
 
+# ─── residue_kind stamp at the gate-resolve source (aios#1328, locus (b)) ─────
+# The de-Goodharted residue gauge demands that the WHY of a human-in-loop gate is
+# STAMPED at the source by the finder, on the gate-resolve payload — never inferred
+# from prose by the ops-agent (the completion-marker antipattern one level up). The
+# platform resolve handler cannot enforce this (it never persists the gate kind down
+# the suspend/resolve path), so the guarantee is WORKFLOW-AUTHOR-ENFORCED here: the
+# script knows its own ``kind``, so this wrapper demands ``residue_kind`` exactly for
+# the human-in-loop kinds it itself authors (merge_approval, design) and nowhere else.
+
+# The human-in-loop gate kinds (the ONLY kinds that require a residue_kind stamp).
+# A non-human-in-loop gate (verify, merge_guard) does NOT require the key.
+HUMAN_IN_LOOP_GATE_KINDS = ("merge_approval", "design")
+
+# The four human-in-loop residue KINDS plus the OPEN ``other`` sentinel — the set
+# a resolve payload's ``residue_kind`` must fall within. Frozen here in the workflow
+# the author controls (mirrors aios.db.queries.residue.ACCEPTED_GATE_RESIDUE_KINDS).
+ACCEPTED_RESIDUE_KINDS = (
+    "uncorrelated-detection",
+    "deadlock-break",
+    "design-judgment",
+    "ladder-top-approval",
+    "other",
+)
+
+
+async def human_gate(spec):
+    """``gate(spec)`` for a HUMAN-IN-LOOP kind, with the residue_kind stamp enforced.
+
+    Suspends like ``gate`` and, on resume, inspects the returned ``result`` and REJECTS
+    the resolve as incomplete -- raising, so the run does NOT proceed past the gate -- if
+    ``residue_kind`` is absent or outside {the four kinds} + {other}. The kind is thus
+    captured at the moment of human judgment, never reconstructed from prose; the ops-agent's
+    axis-2 INSERT later copies this finder's-own stamp verbatim (it classifies, not defines).
+
+    For a NON-human-in-loop kind this is a plain ``gate`` (no stamp demanded) -- but callers
+    should only route the human-in-loop kinds through here."""
+    kind = spec.get("kind") if isinstance(spec, dict) else None
+    result = await gate(spec)
+    if kind in HUMAN_IN_LOOP_GATE_KINDS:
+        residue_kind = result.get("residue_kind") if isinstance(result, dict) else None
+        if residue_kind not in ACCEPTED_RESIDUE_KINDS:
+            # The resolve is INCOMPLETE: the finder did not stamp the WHY. Reject it --
+            # the run must not proceed past the gate. A re-resume carrying a valid
+            # residue_kind (the workflow-crash-contract re-delivery) completes normally.
+            raise ValueError(
+                "human-in-loop gate %r resolved without a valid residue_kind "
+                "(got %r; expected one of %r) -- the finder must stamp the WHY at the "
+                "gate-resolve source (aios#1328); refusing to let the run proceed "
+                "unstamped." % (kind, residue_kind, ACCEPTED_RESIDUE_KINDS)
+            )
+    return result
+
+
 # ─── the state machine ───────────────────────────────────────────────────────
 
 async def main(input):
@@ -430,8 +483,8 @@ async def main(input):
                 "escalation_reason": "implement agent error: %s" % exc}
     if impl.get("escalated"):
         escalations.append("design")
-        decision = await gate({"kind": "design", "issue": issue_number,
-                               "question": impl.get("escalation_reason", "")})
+        decision = await human_gate({"kind": "design", "issue": issue_number,
+                                     "question": impl.get("escalation_reason", "")})
         if not (isinstance(decision, dict) and decision.get("resolved")):
             return {"state": "escalated", "reason": "design", "escalations": escalations}
         # resumed with a settled direction -> re-implement with the chairman's answer
@@ -673,7 +726,7 @@ async def main(input):
     phase("merge")
     if tier > AUTO_MERGE_MAX_TIER:
         escalations.append("merge_approval")
-        decision = await gate({"kind": "merge_approval", "pr": pr_number, "tier": tier})
+        decision = await human_gate({"kind": "merge_approval", "pr": pr_number, "tier": tier})
         if not (isinstance(decision, dict) and decision.get("approve")):
             return {"state": "held", "reason": "merge_approval", "pr_url": pr_url,
                     "pr_number": pr_number, "risk_tier": tier, "escalations": escalations}

--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -382,16 +382,16 @@ ACCEPTED_RESIDUE_KINDS = (
 
 
 async def human_gate(spec):
-    """``gate(spec)`` for a HUMAN-IN-LOOP kind, with the residue_kind stamp enforced.
-
-    Suspends like ``gate`` and, on resume, inspects the returned ``result`` and REJECTS
-    the resolve as incomplete -- raising, so the run does NOT proceed past the gate -- if
-    ``residue_kind`` is absent or outside {the four kinds} + {other}. The kind is thus
-    captured at the moment of human judgment, never reconstructed from prose; the ops-agent's
-    axis-2 INSERT later copies this finder's-own stamp verbatim (it classifies, not defines).
-
-    For a NON-human-in-loop kind this is a plain ``gate`` (no stamp demanded) -- but callers
-    should only route the human-in-loop kinds through here."""
+    # ``gate(spec)`` for a HUMAN-IN-LOOP kind, with the residue_kind stamp enforced.
+    #
+    # Suspends like ``gate`` and, on resume, inspects the returned ``result`` and REJECTS
+    # the resolve as incomplete -- raising, so the run does NOT proceed past the gate -- if
+    # ``residue_kind`` is absent or outside {the four kinds} + {other}. The kind is thus
+    # captured at the moment of human judgment, never reconstructed from prose; the ops-agent's
+    # axis-2 INSERT later copies this finder's-own stamp verbatim (it classifies, not defines).
+    #
+    # For a NON-human-in-loop kind this is a plain ``gate`` (no stamp demanded) -- but callers
+    # should only route the human-in-loop kinds through here.
     kind = spec.get("kind") if isinstance(spec, dict) else None
     result = await gate(spec)
     if kind in HUMAN_IN_LOOP_GATE_KINDS:

--- a/src/aios/workflows/residue_render.py
+++ b/src/aios/workflows/residue_render.py
@@ -1,0 +1,131 @@
+"""Render the detection-residue gauge to ``found-by-finder-ledger.md`` (#1328).
+
+``found-by-finder-ledger.md`` stops being a hand-appended markdown file and
+becomes the RENDERED QUERY of the ``residue_events`` table. This module holds the
+PURE render function (deterministic over already-fetched data: no DB, no clock,
+no I/O) so the whole render is verifiable on fixtures with no live model. The
+deterministic ``render-ledger`` workflow (a ``CronSource → WorkflowAction``) does
+the I/O — pulls each axis SEPARATELY and the two denominators — then calls this.
+
+THE DE-GOODHART, RENDERED INTO THE INSTRUMENT:
+
+- axis-1 (machine-found mechanical waste) and axis-2 (class migration) appear
+  under TWO distinct ``##`` headers, each with its OWN denominator, and are
+  visually un-summable.
+- A hard-coded BANNER forbids axis-summing AND forbids a rising axis-1 as an
+  autonomy-increment justification — so a reader cannot accidentally combine the
+  two axes.
+- The ``other``-bucket count and the ``cannot-determine`` count are prominent
+  lines (the load-bearing growth alarm + the fail-loud absence), never buried.
+- A merged-PR denominator that came back ``cannot-determine`` (a truncated GitHub
+  list read, #1323) renders ``cannot-determine`` for axis-2 — NEVER an implicit
+  short count.
+- The historical hand-written ledger rows are appended below the live query as a
+  ``## Pre-instrument baseline`` section (never-delete).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from aios.db.queries.residue import FINDERS
+
+# The de-Goodhart banner, rendered into the instrument itself. The exact strings
+# are asserted by a render test, so a future edit that weakens the prohibition is
+# caught.
+BANNER = (
+    "> **axis-1 (machine-found mechanical waste) and axis-2 (class migration) are "
+    "NEVER summed; a rising axis-1 is FORBIDDEN as justification for any autonomy "
+    "increment.** axis-1 measures coverage of named, mechanically-legible classes "
+    "only; novel-class first-detection (axis-2) is structurally lagging, so a "
+    "rising axis-1 is a false safety signal. The chairman's irreducible residue is "
+    "MEASURED and BOUNDED (the `other`-bucket growth alarm below), never claimed "
+    "eliminated."
+)
+
+AXIS1_HEADER = "## axis-1 — machine-found mechanical waste (found-by-finder)"
+AXIS2_HEADER = "## axis-2 — class migration (found-by-finder)"
+BASELINE_HEADER = "## Pre-instrument baseline"
+
+
+class AxisView(NamedTuple):
+    """The fully-fetched, axis-SCOPED inputs to the render for ONE axis.
+
+    ``denominator`` is the uncorrelated universe (terminal-run count for axis-1;
+    merged-PR count for axis-2), or ``None`` when that axis's denominator came
+    back ``cannot-determine``. ``found_by_finder`` is ``{finder: count}`` for
+    THIS axis only. ``other_count`` / ``cannot_determine_count`` are the
+    alarm/fail-loud bucket sizes for THIS axis. There is no field that combines
+    the two axes — the segregation is structural in the data shape itself."""
+
+    denominator: int | None
+    found_by_finder: dict[str, int]
+    other_count: int
+    cannot_determine_count: int
+
+
+def _denominator_cell(denominator: int | None) -> str:
+    return "`cannot-determine`" if denominator is None else str(denominator)
+
+
+def _ratio_cell(found: int, denominator: int | None) -> str:
+    if denominator is None:
+        return "`cannot-determine`"
+    if denominator == 0:
+        return "n/a (0 in denominator)"
+    return "%.1f%%" % (100.0 * found / denominator)
+
+
+def _axis_section(header: str, denominator_label: str, view: AxisView) -> str:
+    lines = [header, ""]
+    lines.append("Denominator (%s): **%s**" % (denominator_label, _denominator_cell(view.denominator)))
+    lines.append("")
+    lines.append("| finder | count | of denominator |")
+    lines.append("| --- | --- | --- |")
+    total_found = 0
+    for finder in FINDERS:
+        n = view.found_by_finder.get(finder, 0)
+        total_found += n
+        lines.append("| %s | %d | %s |" % (finder, n, _ratio_cell(n, view.denominator)))
+    lines.append("")
+    # The load-bearing growth alarm + the fail-loud absence line — prominent, not
+    # buried in the table.
+    lines.append("- **`other`-bucket (chairman irreducible residue — GROWTH ALARM):** %d"
+                 % view.other_count)
+    lines.append("- **`cannot-determine` (fail-loud; null telemetry, NOT counted clean):** %d"
+                 % view.cannot_determine_count)
+    return "\n".join(lines)
+
+
+def render_ledger(
+    *,
+    axis1: AxisView,
+    axis2: AxisView,
+    baseline_markdown: str = "",
+) -> str:
+    """Render the full ``found-by-finder-ledger.md`` body.
+
+    The two axes are rendered under two distinct ``##`` headers with two distinct
+    denominators; the banner sits at the top forbidding any sum. ``baseline_markdown``
+    is the historical hand-written ledger, appended verbatim below the live query
+    (never-delete). Pure: deterministic over its inputs."""
+    parts = [
+        "# Found-by-finder ledger",
+        "",
+        "_This file is the RENDERED QUERY of the `residue_events` table (#1328). "
+        "Do not hand-edit the live sections below — append a `residue_events` row "
+        "instead. The `Pre-instrument baseline` section preserves the historical "
+        "hand-written rows._",
+        "",
+        BANNER,
+        "",
+        _axis_section(AXIS1_HEADER, "terminal wf_runs over window", axis1),
+        "",
+        _axis_section(AXIS2_HEADER, "merged PRs over window", axis2),
+    ]
+    if baseline_markdown.strip():
+        parts.append("")
+        parts.append(BASELINE_HEADER)
+        parts.append("")
+        parts.append(baseline_markdown.strip())
+    return "\n".join(parts) + "\n"

--- a/src/aios/workflows/residue_render.py
+++ b/src/aios/workflows/residue_render.py
@@ -78,7 +78,7 @@ def _ratio_cell(found: int, denominator: int | None) -> str:
 
 def _axis_section(header: str, denominator_label: str, view: AxisView) -> str:
     lines = [header, ""]
-    lines.append("Denominator (%s): **%s**" % (denominator_label, _denominator_cell(view.denominator)))
+    lines.append(f"Denominator ({denominator_label}): **{_denominator_cell(view.denominator)}**")
     lines.append("")
     lines.append("| finder | count | of denominator |")
     lines.append("| --- | --- | --- |")
@@ -86,14 +86,17 @@ def _axis_section(header: str, denominator_label: str, view: AxisView) -> str:
     for finder in FINDERS:
         n = view.found_by_finder.get(finder, 0)
         total_found += n
-        lines.append("| %s | %d | %s |" % (finder, n, _ratio_cell(n, view.denominator)))
+        lines.append(f"| {finder} | {n} | {_ratio_cell(n, view.denominator)} |")
     lines.append("")
     # The load-bearing growth alarm + the fail-loud absence line — prominent, not
     # buried in the table.
-    lines.append("- **`other`-bucket (chairman irreducible residue — GROWTH ALARM):** %d"
-                 % view.other_count)
-    lines.append("- **`cannot-determine` (fail-loud; null telemetry, NOT counted clean):** %d"
-                 % view.cannot_determine_count)
+    lines.append(
+        f"- **`other`-bucket (chairman irreducible residue — GROWTH ALARM):** {view.other_count}"
+    )
+    lines.append(
+        "- **`cannot-determine` (fail-loud; null telemetry, NOT counted clean):** "
+        f"{view.cannot_determine_count}"
+    )
     return "\n".join(lines)
 
 

--- a/tests/integration/test_residue_events_db.py
+++ b/tests/integration/test_residue_events_db.py
@@ -9,8 +9,9 @@ uncorrelated run-table denominator — all against real Postgres, no live model.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import asyncpg
 import pytest
@@ -24,9 +25,7 @@ ACCOUNT = "acc_residue"
 
 
 @pytest.fixture
-async def pool(
-    migrated_db_url: str, _reset_db_state: None
-) -> AsyncIterator[asyncpg.Pool[Any]]:
+async def pool(migrated_db_url: str, _reset_db_state: None) -> AsyncIterator[asyncpg.Pool[Any]]:
     p = await create_pool(migrated_db_url, min_size=1, max_size=4)
     try:
         async with p.acquire() as conn:
@@ -46,7 +45,7 @@ async def pool(
 
 
 def _window() -> datetime:
-    return datetime.now(timezone.utc) - timedelta(days=30)
+    return datetime.now(UTC) - timedelta(days=30)
 
 
 async def _insert_axis2(conn: asyncpg.Connection[Any], **kw: Any) -> bool:
@@ -131,14 +130,18 @@ async def test_kind_source_check_rejects_unknown_source(pool: asyncpg.Pool[Any])
 async def test_update_is_rejected_by_trigger(pool: asyncpg.Pool[Any]) -> None:
     async with pool.acquire() as conn:
         await residue.insert_residue_event(
-            conn, account_id=ACCOUNT, axis=2, finder="chairman",
-            residue_kind="design-judgment", kind_source=residue.KIND_SOURCE_GATE,
-            signature={}, idempotency_key="k_upd",
+            conn,
+            account_id=ACCOUNT,
+            axis=2,
+            finder="chairman",
+            residue_kind="design-judgment",
+            kind_source=residue.KIND_SOURCE_GATE,
+            signature={},
+            idempotency_key="k_upd",
         )
         with pytest.raises(asyncpg.PostgresError) as exc:
             await conn.execute(
-                "UPDATE residue_events SET finder = 'external-world' "
-                "WHERE account_id = $1",
+                "UPDATE residue_events SET finder = 'external-world' WHERE account_id = $1",
                 ACCOUNT,
             )
         assert "append-only" in str(exc.value)
@@ -147,9 +150,14 @@ async def test_update_is_rejected_by_trigger(pool: asyncpg.Pool[Any]) -> None:
 async def test_delete_is_rejected_by_trigger(pool: asyncpg.Pool[Any]) -> None:
     async with pool.acquire() as conn:
         await residue.insert_residue_event(
-            conn, account_id=ACCOUNT, axis=2, finder="chairman",
-            residue_kind="design-judgment", kind_source=residue.KIND_SOURCE_GATE,
-            signature={}, idempotency_key="k_del",
+            conn,
+            account_id=ACCOUNT,
+            axis=2,
+            finder="chairman",
+            residue_kind="design-judgment",
+            kind_source=residue.KIND_SOURCE_GATE,
+            signature={},
+            idempotency_key="k_del",
         )
         with pytest.raises(asyncpg.PostgresError) as exc:
             await conn.execute("DELETE FROM residue_events WHERE account_id = $1", ACCOUNT)
@@ -180,9 +188,7 @@ async def test_axis2_ingest_copies_stamp_verbatim(pool: asyncpg.Pool[Any]) -> No
 async def test_axis2_ingest_skips_non_human_in_loop_kind(pool: asyncpg.Pool[Any]) -> None:
     async with pool.acquire() as conn:
         # A verify/merge_guard gate is NOT a residue event.
-        inserted = await _insert_axis2(
-            conn, gate_kind="verify", result={"override": False}
-        )
+        inserted = await _insert_axis2(conn, gate_kind="verify", result={"override": False})
         assert inserted is False
         n = await conn.fetchval("SELECT count(*) FROM residue_events")
         assert n == 0
@@ -248,8 +254,11 @@ async def test_observer_cannot_determine_writes_fail_loud_row_not_ok(
 ) -> None:
     async with pool.acquire() as conn:
         inserted = await residue.ingest_observer_verdict_axis1(
-            conn, account_id=ACCOUNT, source_run_id="wfr_null",
-            verdict="cannot-determine", signature={"reason": "telemetry null"},
+            conn,
+            account_id=ACCOUNT,
+            source_run_id="wfr_null",
+            verdict="cannot-determine",
+            signature={"reason": "telemetry null"},
         )
         assert inserted is True
         row = await conn.fetchrow(
@@ -284,7 +293,7 @@ async def _seed_run(
         ACCOUNT,
         "res-wf",
     )
-    created = datetime.now(timezone.utc) - timedelta(days=age_days)
+    created = datetime.now(UTC) - timedelta(days=age_days)
     await conn.execute(
         "INSERT INTO wf_runs (id, workflow_id, account_id, environment_id, script, "
         "script_sha, host_semantics_epoch, status, created_at) "
@@ -321,7 +330,10 @@ async def test_denominator_independent_of_ops_agent_event_count(
             await _seed_run(conn, f"wfr_t{i}", "completed")
         # Ingest only ONE residue classification (far fewer than 5 runs).
         await residue.ingest_observer_verdict_axis1(
-            conn, account_id=ACCOUNT, source_run_id="wfr_t0", verdict="anomaly",
+            conn,
+            account_id=ACCOUNT,
+            source_run_id="wfr_t0",
+            verdict="anomaly",
             signature={"x": 1},
         )
         denom = await residue.run_table_denominator(
@@ -346,14 +358,24 @@ async def test_run_table_denominator_respects_window(pool: asyncpg.Pool[Any]) ->
 async def test_found_by_finder_is_axis_scoped(pool: asyncpg.Pool[Any]) -> None:
     async with pool.acquire() as conn:
         await residue.insert_residue_event(
-            conn, account_id=ACCOUNT, axis=1, finder="internal-armed-check",
-            residue_kind="uncorrelated-detection", kind_source=residue.KIND_SOURCE_OBSERVER,
-            signature={}, idempotency_key="a1",
+            conn,
+            account_id=ACCOUNT,
+            axis=1,
+            finder="internal-armed-check",
+            residue_kind="uncorrelated-detection",
+            kind_source=residue.KIND_SOURCE_OBSERVER,
+            signature={},
+            idempotency_key="a1",
         )
         await residue.insert_residue_event(
-            conn, account_id=ACCOUNT, axis=2, finder="chairman",
-            residue_kind="design-judgment", kind_source=residue.KIND_SOURCE_GATE,
-            signature={}, idempotency_key="a2",
+            conn,
+            account_id=ACCOUNT,
+            axis=2,
+            finder="chairman",
+            residue_kind="design-judgment",
+            kind_source=residue.KIND_SOURCE_GATE,
+            signature={},
+            idempotency_key="a2",
         )
         axis1 = await residue.found_by_finder(
             conn, account_id=ACCOUNT, axis=1, window_start=_window()
@@ -368,7 +390,10 @@ async def test_found_by_finder_is_axis_scoped(pool: asyncpg.Pool[Any]) -> None:
 async def test_found_by_finder_excludes_cannot_determine(pool: asyncpg.Pool[Any]) -> None:
     async with pool.acquire() as conn:
         await residue.ingest_observer_verdict_axis1(
-            conn, account_id=ACCOUNT, source_run_id="wfr_cd", verdict="cannot-determine",
+            conn,
+            account_id=ACCOUNT,
+            source_run_id="wfr_cd",
+            verdict="cannot-determine",
             signature={},
         )
         breakdown = await residue.found_by_finder(
@@ -377,7 +402,10 @@ async def test_found_by_finder_excludes_cannot_determine(pool: asyncpg.Pool[Any]
         # cannot-determine is surfaced on its own line, not as a clean finder hit.
         assert breakdown == {}
         cd = await residue.kind_count(
-            conn, account_id=ACCOUNT, axis=1,
-            residue_kind=residue.CANNOT_DETERMINE_KIND, window_start=_window(),
+            conn,
+            account_id=ACCOUNT,
+            axis=1,
+            residue_kind=residue.CANNOT_DETERMINE_KIND,
+            window_start=_window(),
         )
         assert cd == 1

--- a/tests/integration/test_residue_events_db.py
+++ b/tests/integration/test_residue_events_db.py
@@ -1,0 +1,383 @@
+"""DB-backed tests for the residue_events gauge (#1328).
+
+Exercises the append-only invariant, the CHECK vocabularies, the
+stamped-at-source axis-2 ingest, the axis-1 observer ingest, idempotency, and the
+uncorrelated run-table denominator — all against real Postgres, no live model.
+(The pure-Python render / axis-segregation / migration-predicate tests live in
+``tests/unit/``.)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, AsyncIterator
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.db.queries import residue
+
+pytestmark = pytest.mark.integration
+
+ACCOUNT = "acc_residue"
+
+
+@pytest.fixture
+async def pool(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[asyncpg.Pool[Any]]:
+    p = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with p.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'residue-root')",
+                ACCOUNT,
+            )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ('env_res', 'res-env', '{}'::jsonb, $1)",
+                ACCOUNT,
+            )
+        yield p
+    finally:
+        await p.close()
+
+
+def _window() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=30)
+
+
+async def _insert_axis2(conn: asyncpg.Connection[Any], **kw: Any) -> bool:
+    base: dict[str, Any] = dict(
+        account_id=ACCOUNT,
+        source_gate_nonce="gn_1",
+        gate_kind="design",
+        result={"approve": True, "residue_kind": "design-judgment"},
+        finder="chairman",
+    )
+    base.update(kw)
+    return await residue.ingest_gate_resume_axis2(conn, **base)
+
+
+# ─── AC1 (table exists) / AC3 (CHECK vocabularies reject bad inserts) ─────────
+
+
+async def test_insert_basic_row_and_open_residue_kind(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        # An ``other`` row inserts cleanly — residue_kind is an OPEN enum (no CHECK).
+        inserted = await residue.insert_residue_event(
+            conn,
+            account_id=ACCOUNT,
+            axis=residue.AXIS_CLASS_MIGRATION,
+            finder="chairman",
+            residue_kind="other",
+            kind_source=residue.KIND_SOURCE_MANUAL,
+            signature={"note": "irreducible"},
+            idempotency_key="k_other",
+        )
+        assert inserted is True
+
+
+async def test_axis_check_rejects_out_of_range(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.IntegrityConstraintViolationError):
+            await residue.insert_residue_event(
+                conn,
+                account_id=ACCOUNT,
+                axis=3,  # not in (1,2)
+                finder="chairman",
+                residue_kind="other",
+                kind_source=residue.KIND_SOURCE_MANUAL,
+                signature={},
+                idempotency_key="k_axis3",
+            )
+
+
+async def test_finder_check_rejects_unknown_finder(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.IntegrityConstraintViolationError):
+            await residue.insert_residue_event(
+                conn,
+                account_id=ACCOUNT,
+                axis=1,
+                finder="some-new-finder",
+                residue_kind="other",
+                kind_source=residue.KIND_SOURCE_OBSERVER,
+                signature={},
+                idempotency_key="k_badfinder",
+            )
+
+
+async def test_kind_source_check_rejects_unknown_source(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        with pytest.raises(asyncpg.IntegrityConstraintViolationError):
+            await residue.insert_residue_event(
+                conn,
+                account_id=ACCOUNT,
+                axis=1,
+                finder="chairman",
+                residue_kind="other",
+                kind_source="prose-inference",  # forbidden
+                signature={},
+                idempotency_key="k_badsrc",
+            )
+
+
+# ─── AC2 (append-only: UPDATE and DELETE both RAISE via the trigger) ──────────
+
+
+async def test_update_is_rejected_by_trigger(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        await residue.insert_residue_event(
+            conn, account_id=ACCOUNT, axis=2, finder="chairman",
+            residue_kind="design-judgment", kind_source=residue.KIND_SOURCE_GATE,
+            signature={}, idempotency_key="k_upd",
+        )
+        with pytest.raises(asyncpg.PostgresError) as exc:
+            await conn.execute(
+                "UPDATE residue_events SET finder = 'external-world' "
+                "WHERE account_id = $1",
+                ACCOUNT,
+            )
+        assert "append-only" in str(exc.value)
+
+
+async def test_delete_is_rejected_by_trigger(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        await residue.insert_residue_event(
+            conn, account_id=ACCOUNT, axis=2, finder="chairman",
+            residue_kind="design-judgment", kind_source=residue.KIND_SOURCE_GATE,
+            signature={}, idempotency_key="k_del",
+        )
+        with pytest.raises(asyncpg.PostgresError) as exc:
+            await conn.execute("DELETE FROM residue_events WHERE account_id = $1", ACCOUNT)
+        assert "append-only" in str(exc.value)
+
+
+# ─── AC7 (axis-2 ingest copies residue_kind verbatim; kind_source gate) ───────
+
+
+async def test_axis2_ingest_copies_stamp_verbatim(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        inserted = await _insert_axis2(
+            conn,
+            result={"approve": True, "residue_kind": "design-judgment"},
+        )
+        assert inserted is True
+        row = await conn.fetchrow(
+            "SELECT axis, residue_kind, kind_source, finder FROM residue_events "
+            "WHERE account_id = $1",
+            ACCOUNT,
+        )
+        assert row["axis"] == residue.AXIS_CLASS_MIGRATION
+        assert row["residue_kind"] == "design-judgment"  # copied, never inferred
+        assert row["kind_source"] == residue.KIND_SOURCE_GATE
+        assert row["finder"] == "chairman"
+
+
+async def test_axis2_ingest_skips_non_human_in_loop_kind(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        # A verify/merge_guard gate is NOT a residue event.
+        inserted = await _insert_axis2(
+            conn, gate_kind="verify", result={"override": False}
+        )
+        assert inserted is False
+        n = await conn.fetchval("SELECT count(*) FROM residue_events")
+        assert n == 0
+
+
+async def test_axis2_ingest_missing_stamp_refuses_to_fabricate(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        with pytest.raises(ValueError):
+            await _insert_axis2(conn, result={"approve": True})  # no residue_kind
+
+
+# ─── AC10 (idempotency: replaying the same gate inserts ONE row) ──────────────
+
+
+async def test_axis2_ingest_is_idempotent(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        first = await _insert_axis2(conn, source_gate_nonce="gn_dup")
+        second = await _insert_axis2(conn, source_gate_nonce="gn_dup")
+        assert first is True
+        assert second is False  # ON CONFLICT DO NOTHING
+        n = await conn.fetchval("SELECT count(*) FROM residue_events")
+        assert n == 1
+
+
+async def test_observer_ingest_is_idempotent(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        sig = {"anomaly": "cost_band", "run_id": "wfr_x"}
+        a = await residue.ingest_observer_verdict_axis1(
+            conn, account_id=ACCOUNT, source_run_id="wfr_x", verdict="anomaly", signature=sig
+        )
+        b = await residue.ingest_observer_verdict_axis1(
+            conn, account_id=ACCOUNT, source_run_id="wfr_x", verdict="anomaly", signature=sig
+        )
+        assert a is True and b is False
+        n = await conn.fetchval("SELECT count(*) FROM residue_events")
+        assert n == 1
+
+
+# ─── AC12 (axis-1 observer ingest: anomaly row; cannot-determine; ok→no row) ──
+
+
+async def test_observer_anomaly_writes_axis1_row(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        sig = {"anomaly": "token_band", "run_id": "wfr_a", "band": [0, 100]}
+        inserted = await residue.ingest_observer_verdict_axis1(
+            conn, account_id=ACCOUNT, source_run_id="wfr_a", verdict="anomaly", signature=sig
+        )
+        assert inserted is True
+        row = await conn.fetchrow(
+            "SELECT axis, finder, kind_source, residue_kind, signature "
+            "FROM residue_events WHERE account_id = $1",
+            ACCOUNT,
+        )
+        assert row["axis"] == residue.AXIS_OBSERVER
+        assert row["finder"] == "internal-armed-check"
+        assert row["kind_source"] == residue.KIND_SOURCE_OBSERVER
+        assert row["residue_kind"] == "uncorrelated-detection"
+        assert row["signature"]["anomaly"] == "token_band"  # fingerprint populated
+
+
+async def test_observer_cannot_determine_writes_fail_loud_row_not_ok(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    async with pool.acquire() as conn:
+        inserted = await residue.ingest_observer_verdict_axis1(
+            conn, account_id=ACCOUNT, source_run_id="wfr_null",
+            verdict="cannot-determine", signature={"reason": "telemetry null"},
+        )
+        assert inserted is True
+        row = await conn.fetchrow(
+            "SELECT residue_kind FROM residue_events WHERE account_id = $1", ACCOUNT
+        )
+        # A null-telemetry verdict is a cannot-determine row — NEVER an ok/clean row.
+        assert row["residue_kind"] == residue.CANNOT_DETERMINE_KIND
+
+
+async def test_observer_ok_writes_no_row(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        inserted = await residue.ingest_observer_verdict_axis1(
+            conn, account_id=ACCOUNT, source_run_id="wfr_ok", verdict="ok", signature={}
+        )
+        assert inserted is False
+        n = await conn.fetchval("SELECT count(*) FROM residue_events")
+        assert n == 0
+
+
+# ─── AC8 (run-table denominator from the uncorrelated wf_runs substrate) ──────
+
+
+async def _seed_run(
+    conn: asyncpg.Connection[Any], run_id: str, status: str, *, age_days: int = 0
+) -> None:
+    # First a workflow row to satisfy the FK.
+    await conn.execute(
+        "INSERT INTO workflows (id, account_id, name, script) VALUES "
+        "($1, $2, $3, 'async def main(input):\n    return None') "
+        "ON CONFLICT DO NOTHING",
+        "wf_res",
+        ACCOUNT,
+        "res-wf",
+    )
+    created = datetime.now(timezone.utc) - timedelta(days=age_days)
+    await conn.execute(
+        "INSERT INTO wf_runs (id, workflow_id, account_id, environment_id, script, "
+        "script_sha, host_semantics_epoch, status, created_at) "
+        "VALUES ($1, 'wf_res', $2, 'env_res', 'src', 'sha', 0, $3, $4)",
+        run_id,
+        ACCOUNT,
+        status,
+        created,
+    )
+
+
+async def test_run_table_denominator_counts_terminal_runs_only(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    async with pool.acquire() as conn:
+        await _seed_run(conn, "wfr_1", "completed")
+        await _seed_run(conn, "wfr_2", "errored")
+        await _seed_run(conn, "wfr_3", "cancelled")
+        await _seed_run(conn, "wfr_4", "running")  # non-terminal
+        await _seed_run(conn, "wfr_5", "suspended")  # non-terminal
+        denom = await residue.run_table_denominator(
+            conn, account_id=ACCOUNT, window_start=_window()
+        )
+        assert denom == 3  # only the 3 terminal runs
+
+
+async def test_denominator_independent_of_ops_agent_event_count(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    """The denominator comes from wf_runs, NOT from how many residue rows the
+    ops-agent ingested — fewer residue rows than runs, denominator still == runs."""
+    async with pool.acquire() as conn:
+        for i in range(5):
+            await _seed_run(conn, f"wfr_t{i}", "completed")
+        # Ingest only ONE residue classification (far fewer than 5 runs).
+        await residue.ingest_observer_verdict_axis1(
+            conn, account_id=ACCOUNT, source_run_id="wfr_t0", verdict="anomaly",
+            signature={"x": 1},
+        )
+        denom = await residue.run_table_denominator(
+            conn, account_id=ACCOUNT, window_start=_window()
+        )
+        assert denom == 5  # the run count, not the residue-row count
+
+
+async def test_run_table_denominator_respects_window(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        await _seed_run(conn, "wfr_recent", "completed", age_days=1)
+        await _seed_run(conn, "wfr_old", "completed", age_days=90)  # before the window
+        denom = await residue.run_table_denominator(
+            conn, account_id=ACCOUNT, window_start=_window()
+        )
+        assert denom == 1
+
+
+# ─── found-by-finder is axis-scoped (never cross-axis) ────────────────────────
+
+
+async def test_found_by_finder_is_axis_scoped(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        await residue.insert_residue_event(
+            conn, account_id=ACCOUNT, axis=1, finder="internal-armed-check",
+            residue_kind="uncorrelated-detection", kind_source=residue.KIND_SOURCE_OBSERVER,
+            signature={}, idempotency_key="a1",
+        )
+        await residue.insert_residue_event(
+            conn, account_id=ACCOUNT, axis=2, finder="chairman",
+            residue_kind="design-judgment", kind_source=residue.KIND_SOURCE_GATE,
+            signature={}, idempotency_key="a2",
+        )
+        axis1 = await residue.found_by_finder(
+            conn, account_id=ACCOUNT, axis=1, window_start=_window()
+        )
+        axis2 = await residue.found_by_finder(
+            conn, account_id=ACCOUNT, axis=2, window_start=_window()
+        )
+        assert axis1 == {"internal-armed-check": 1}
+        assert axis2 == {"chairman": 1}  # the two axes never mingle
+
+
+async def test_found_by_finder_excludes_cannot_determine(pool: asyncpg.Pool[Any]) -> None:
+    async with pool.acquire() as conn:
+        await residue.ingest_observer_verdict_axis1(
+            conn, account_id=ACCOUNT, source_run_id="wfr_cd", verdict="cannot-determine",
+            signature={},
+        )
+        breakdown = await residue.found_by_finder(
+            conn, account_id=ACCOUNT, axis=1, window_start=_window()
+        )
+        # cannot-determine is surfaced on its own line, not as a clean finder hit.
+        assert breakdown == {}
+        cd = await residue.kind_count(
+            conn, account_id=ACCOUNT, axis=1,
+            residue_kind=residue.CANNOT_DETERMINE_KIND, window_start=_window(),
+        )
+        assert cd == 1

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -728,7 +728,7 @@ async def test_comment_thread_single_page_does_not_over_fetch() -> None:
 async def test_design_escalation_parks_then_resumes_and_completes() -> None:
     scn = Scenario(
         implement_escalated=True,
-        gate_results={"design": {"resolved": True, "resolution": "use a typed enum"}},
+        gate_results={"design": {"resolved": True, "resolution": "use a typed enum", "residue_kind": "design-judgment"}},
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"
@@ -738,7 +738,7 @@ async def test_design_escalation_parks_then_resumes_and_completes() -> None:
 
 
 async def test_design_escalation_unresolved_stays_escalated() -> None:
-    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False}})
+    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}})
     value, _, _ = await _drive(scn)
     assert value["state"] == "escalated"
     assert value["reason"] == "design"
@@ -915,7 +915,7 @@ async def test_agent_resolved_conflict_reenters_ci_on_post_rebase_sha() -> None:
 async def test_high_risk_parks_for_merge_approval() -> None:
     scn = Scenario(
         risk_result={"tier": 4, "summary": "touches the scheduler"},
-        gate_results={"merge_approval": {"approve": True}},
+        gate_results={"merge_approval": {"approve": True, "residue_kind": "ladder-top-approval"}},
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2, auto_merge_max_tier=2)
     assert value["state"] == "done"
@@ -926,7 +926,7 @@ async def test_high_risk_parks_for_merge_approval() -> None:
 async def test_high_risk_hold_does_not_merge() -> None:
     scn = Scenario(
         risk_result={"tier": 4, "summary": "risky"},
-        gate_results={"merge_approval": {"approve": False}},
+        gate_results={"merge_approval": {"approve": False, "residue_kind": "ladder-top-approval"}},
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2, auto_merge_max_tier=2)
     assert value["state"] == "held"
@@ -941,7 +941,7 @@ async def test_malformed_risk_return_defaults_to_tier3_and_does_not_crash() -> N
     # falls back to the conservative tier-3 (which then parks for merge approval).
     scn = Scenario(
         risk_result={"summary": "no tier field"},
-        gate_results={"merge_approval": {"approve": True}},
+        gate_results={"merge_approval": {"approve": True, "residue_kind": "ladder-top-approval"}},
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"
@@ -1213,7 +1213,7 @@ async def test_merge_failed_is_labelled_autodev_failed() -> None:
 async def test_gate_park_is_not_labelled_failed() -> None:
     # An escalation parks at a gate; a deliberate "stay escalated" resume is NOT a silent
     # failure, so the run must NOT raise autodev:failed (the contract: a gate park ≠ fail).
-    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False}})
+    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}})
     value, _, _ = await _drive(scn)
     assert value["state"] == "escalated"
     assert "autodev:failed" not in scn.labels_added
@@ -1223,7 +1223,7 @@ async def test_gate_park_is_not_labelled_failed() -> None:
 
 
 async def test_implement_agent_error_escalates_to_design_gate() -> None:
-    scn = Scenario(implement_error=True, gate_results={"design": {"resolved": False}})
+    scn = Scenario(implement_error=True, gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}})
     value, _, _ = await _drive(scn)
     assert value["state"] == "escalated"
     assert value["reason"] == "design"
@@ -1302,3 +1302,113 @@ async def test_accepts_trigger_envelope_input() -> None:
         max_ci_iters=2,
     )
     assert value["state"] == "done"
+
+
+# ─── residue_kind stamp enforced at the human_gate() wrapper (aios#1328, AC6/AC7) ─
+# locus (b): the required-residue_kind check lives in the dev_pipeline.py human_gate()
+# wrapper (NOT a platform 422 — unbuildable, see the issue's enforcement-locus
+# correction). A human-in-loop gate (design / merge_approval) resolved WITHOUT a valid
+# residue_kind is REJECTED by the wrapper — the run raises and does NOT proceed past the
+# gate. A non-human-in-loop gate (verify / merge_guard) does NOT require the key.
+
+
+async def _drive_allowing_raise(
+    scenario: Scenario,
+    *,
+    input: dict[str, Any] | None = None,
+    max_steps: int = 60,
+    **build_kwargs: Any,
+) -> Any:
+    """Drive the production script, returning the final host OUTCOME (whose kind may be
+    ``raised`` — the wrapper rejecting an unstamped resolve). Mirrors ``_drive`` but does
+    not assert the terminal kind, so a wrapper raise is observable."""
+    src = build_dev_pipeline_script(**build_kwargs)
+    inp = input or {"repo": REPO, "issue_number": ISSUE, "kind": "issue"}
+    memo: dict[str, Any] = {}
+    out = None
+    for _ in range(max_steps):
+        out = await run_script_host(source=src, input=inp, memo=memo)
+        if out.kind != "suspended":
+            return out
+        assert len(out.emitted) == 1
+        cap = out.emitted[0]
+        memo[cap.call_key] = scenario.outcome(cap)
+    raise AssertionError("workflow did not terminate")
+
+
+async def test_design_gate_resolved_without_residue_kind_is_rejected() -> None:
+    # Resolve the design gate with a payload MISSING residue_kind → the wrapper raises;
+    # the run does NOT proceed past the gate (no re-implement).
+    scn = Scenario(
+        implement_escalated=True,
+        gate_results={"design": {"resolved": True, "resolution": "x"}},  # no residue_kind
+    )
+    out = await _drive_allowing_raise(scn, max_review_iters=2, max_ci_iters=2)
+    assert out.kind == "raised", out.kind
+    assert "residue_kind" in (out.error_repr or "")
+    assert "implement-resumed" not in scn.tasks  # never proceeded past the gate
+
+
+async def test_design_gate_resolved_with_invalid_residue_kind_is_rejected() -> None:
+    scn = Scenario(
+        implement_escalated=True,
+        gate_results={"design": {"resolved": True, "residue_kind": "not-a-real-kind"}},
+    )
+    out = await _drive_allowing_raise(scn, max_review_iters=2, max_ci_iters=2)
+    assert out.kind == "raised", out.kind
+    assert "residue_kind" in (out.error_repr or "")
+
+
+async def test_design_gate_resolved_with_residue_kind_proceeds() -> None:
+    # WITH a valid stamp → the resolve succeeds and the run re-implements (AC6 success leg).
+    scn = Scenario(
+        implement_escalated=True,
+        gate_results={"design": {"resolved": True, "resolution": "x",
+                                 "residue_kind": "design-judgment"}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert "implement-resumed" in scn.tasks
+
+
+async def test_design_gate_other_sentinel_is_accepted() -> None:
+    # The OPEN ``other`` sentinel is an accepted stamp (it is the chairman's irreducible
+    # residue, MEASURED not forbidden).
+    scn = Scenario(
+        implement_escalated=True,
+        gate_results={"design": {"resolved": True, "residue_kind": "other"}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+
+
+async def test_merge_approval_gate_requires_residue_kind() -> None:
+    scn = Scenario(
+        risk_result={"tier": 4, "summary": "touches the scheduler"},
+        gate_results={"merge_approval": {"approve": True}},  # no residue_kind
+    )
+    out = await _drive_allowing_raise(
+        scn, max_review_iters=2, max_ci_iters=2, auto_merge_max_tier=2
+    )
+    assert out.kind == "raised", out.kind
+    assert "residue_kind" in (out.error_repr or "")
+
+
+async def test_verify_gate_does_not_require_residue_kind() -> None:
+    # A non-human-in-loop gate (verify, opened on review exhaustion) does NOT require the
+    # stamp — it resolves through bare gate(), so an unstamped resolve proceeds normally.
+    scn = Scenario(
+        review_results=[{"verdict": "fail", "issues": ["x"], "artifact_posted": True}],
+        gate_results={"verify": {"override": False}},  # no residue_kind, must NOT raise
+    )
+    value, _, _ = await _drive(scn, max_review_iters=1, max_ci_iters=2)
+    # The run reaches a terminal state without the wrapper rejecting the verify resolve.
+    assert value["state"] in ("escalated", "done", "held", "failed_implement")
+
+
+async def test_merge_guard_gate_does_not_require_residue_kind() -> None:
+    # merge_guard is also non-human-in-loop: an unstamped {"proceed": ...} must NOT raise.
+    scn = Scenario(merge_guard_exit=73, gate_results={"merge_guard": {"proceed": False}})
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "merge_guard_refused"

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -728,7 +728,13 @@ async def test_comment_thread_single_page_does_not_over_fetch() -> None:
 async def test_design_escalation_parks_then_resumes_and_completes() -> None:
     scn = Scenario(
         implement_escalated=True,
-        gate_results={"design": {"resolved": True, "resolution": "use a typed enum", "residue_kind": "design-judgment"}},
+        gate_results={
+            "design": {
+                "resolved": True,
+                "resolution": "use a typed enum",
+                "residue_kind": "design-judgment",
+            }
+        },
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"
@@ -738,7 +744,10 @@ async def test_design_escalation_parks_then_resumes_and_completes() -> None:
 
 
 async def test_design_escalation_unresolved_stays_escalated() -> None:
-    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}})
+    scn = Scenario(
+        implement_escalated=True,
+        gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}},
+    )
     value, _, _ = await _drive(scn)
     assert value["state"] == "escalated"
     assert value["reason"] == "design"
@@ -1213,7 +1222,10 @@ async def test_merge_failed_is_labelled_autodev_failed() -> None:
 async def test_gate_park_is_not_labelled_failed() -> None:
     # An escalation parks at a gate; a deliberate "stay escalated" resume is NOT a silent
     # failure, so the run must NOT raise autodev:failed (the contract: a gate park ≠ fail).
-    scn = Scenario(implement_escalated=True, gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}})
+    scn = Scenario(
+        implement_escalated=True,
+        gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}},
+    )
     value, _, _ = await _drive(scn)
     assert value["state"] == "escalated"
     assert "autodev:failed" not in scn.labels_added
@@ -1223,7 +1235,10 @@ async def test_gate_park_is_not_labelled_failed() -> None:
 
 
 async def test_implement_agent_error_escalates_to_design_gate() -> None:
-    scn = Scenario(implement_error=True, gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}})
+    scn = Scenario(
+        implement_error=True,
+        gate_results={"design": {"resolved": False, "residue_kind": "design-judgment"}},
+    )
     value, _, _ = await _drive(scn)
     assert value["state"] == "escalated"
     assert value["reason"] == "design"
@@ -1363,8 +1378,9 @@ async def test_design_gate_resolved_with_residue_kind_proceeds() -> None:
     # WITH a valid stamp → the resolve succeeds and the run re-implements (AC6 success leg).
     scn = Scenario(
         implement_escalated=True,
-        gate_results={"design": {"resolved": True, "resolution": "x",
-                                 "residue_kind": "design-judgment"}},
+        gate_results={
+            "design": {"resolved": True, "resolution": "x", "residue_kind": "design-judgment"}
+        },
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"

--- a/tests/unit/test_migration_0109_predicates.py
+++ b/tests/unit/test_migration_0109_predicates.py
@@ -49,7 +49,7 @@ def test_finder_check_freezes_the_four_finders() -> None:
         "chairman",
         "seat-incidental",
     ):
-        assert "'%s'" % finder in pred, finder
+        assert f"'{finder}'" in pred, finder
     # A new finder must be a deliberate migration, not a typo: exactly four.
     assert pred.count("'") == 8
 
@@ -58,7 +58,7 @@ def test_kind_source_check_freezes_the_three_sources() -> None:
     m = _load("0109")
     pred = m.KIND_SOURCE_CHECK
     for src in ("gate-resolve-payload", "observer", "manual"):
-        assert "'%s'" % src in pred, src
+        assert f"'{src}'" in pred, src
     assert pred.count("'") == 6
 
 

--- a/tests/unit/test_migration_0109_predicates.py
+++ b/tests/unit/test_migration_0109_predicates.py
@@ -1,0 +1,87 @@
+"""Byte-identity / vocabulary guard for migration 0109's residue_events CHECKs
+and append-only trigger (#1328).
+
+Same discipline as ``test_migration_0108_predicates``: pin the migration's
+load-bearing CHECK predicate text and the append-only trigger so a silent
+vocabulary drift (a typo'd finder, an axis collapsed to a single value, an
+accidentally-relaxed append-only guard) is caught WITHOUT a DB.
+
+Pure-Python: loads the migration module off disk; no DB, no Docker.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "migrations" / "versions"
+
+
+def _load(name: str) -> ModuleType:
+    path = next(_VERSIONS_DIR.glob(f"{name}_*.py"))
+    spec = importlib.util.spec_from_file_location(f"_mig_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_revision_chains_onto_0108() -> None:
+    m = _load("0109")
+    assert m.revision == "0109"
+    assert m.down_revision == "0108"
+
+
+def test_axis_check_is_exactly_one_and_two() -> None:
+    m = _load("0109")
+    # The segregation is a column-level invariant: axis is 1 or 2 and NOTHING
+    # else. A drift that admitted a third axis would let a cross-axis sum hide.
+    assert m.AXIS_CHECK == "axis IN (1, 2)"
+
+
+def test_finder_check_freezes_the_four_finders() -> None:
+    m = _load("0109")
+    pred = m.FINDER_CHECK
+    for finder in (
+        "internal-armed-check",
+        "external-world",
+        "chairman",
+        "seat-incidental",
+    ):
+        assert "'%s'" % finder in pred, finder
+    # A new finder must be a deliberate migration, not a typo: exactly four.
+    assert pred.count("'") == 8
+
+
+def test_kind_source_check_freezes_the_three_sources() -> None:
+    m = _load("0109")
+    pred = m.KIND_SOURCE_CHECK
+    for src in ("gate-resolve-payload", "observer", "manual"):
+        assert "'%s'" % src in pred, src
+    assert pred.count("'") == 6
+
+
+def test_append_only_trigger_raises_on_update_and_delete() -> None:
+    m = _load("0109")
+    src = Path(next(_VERSIONS_DIR.glob("0109_*.py"))).read_text()
+    # The trigger must fire on BOTH UPDATE and DELETE and RAISE — append-only is
+    # structural, not convention.
+    assert "BEFORE UPDATE OR DELETE ON residue_events" in src
+    assert "RAISE EXCEPTION" in src
+    assert m.APPEND_ONLY_TRIGGER in src
+    assert m.APPEND_ONLY_FN in src
+
+
+def test_residue_kind_is_not_check_constrained() -> None:
+    """The residue_kind enum is deliberately OPEN (``other``-bucket growth is the
+    render-side alarm, not a constraint), so the migration must NOT add a CHECK on
+    residue_kind."""
+    src = Path(next(_VERSIONS_DIR.glob("0109_*.py"))).read_text()
+    assert "residue_kind        text NOT NULL," in src
+    assert "residue_kind text NOT NULL CHECK" not in src.replace("  ", " ")
+
+
+def test_idempotency_unique_is_account_scoped() -> None:
+    src = Path(next(_VERSIONS_DIR.glob("0109_*.py"))).read_text()
+    assert "UNIQUE (account_id, idempotency_key)" in src

--- a/tests/unit/test_residue_axis_segregation.py
+++ b/tests/unit/test_residue_axis_segregation.py
@@ -1,0 +1,87 @@
+"""Axis segregation is the de-Goodhart of the residue gauge (#1328, AC4/AC5).
+
+axis-1 (machine-found mechanical waste) and axis-2 (class migration) must be
+queried and rendered SEPARATELY by construction: no aggregate may combine
+``axis=1`` and ``axis=2`` rows into a single number, because a rising axis-1 is a
+false safety signal that is FORBIDDEN as an autonomy-increment justification.
+
+This test greps the residue query/render modules and FAILS if it finds:
+- a ``SUM``/``count`` aggregate that is not scoped by an ``axis`` filter, or
+- a query that aggregates ``residue_events`` without an ``axis = `` predicate.
+
+Pure-Python: reads the module source off disk. No DB.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[2] / "src" / "aios"
+_QUERY = _SRC / "db" / "queries" / "residue.py"
+_RENDER = _SRC / "workflows" / "residue_render.py"
+
+# A SQL statement that aggregates residue_events. We split the query module into
+# individual SQL string literals and check each aggregate touches residue_events
+# under an axis filter.
+_SQL_RE = re.compile(r'"""(.*?)"""', re.DOTALL)
+
+
+def _sql_blocks(text: str) -> list[str]:
+    return [m.group(1) for m in _SQL_RE.finditer(text)]
+
+
+def test_every_residue_aggregate_is_axis_scoped() -> None:
+    text = _QUERY.read_text()
+    aggregated = []
+    for block in _sql_blocks(text):
+        low = block.lower()
+        if "residue_events" not in low:
+            continue
+        is_aggregate = ("count(" in low) or ("sum(" in low) or ("group by" in low)
+        if not is_aggregate:
+            continue
+        # Every aggregate over residue_events MUST filter to a single axis.
+        assert "axis = $" in low or "axis = " in low, (
+            "an aggregate over residue_events is NOT axis-scoped — a cross-axis "
+            "aggregate would combine axis-1 and axis-2 (forbidden, #1328):\n%s" % block
+        )
+        aggregated.append(block)
+    # Sanity: there ARE aggregates (the test is actually exercising something).
+    assert aggregated, "expected at least one axis-scoped aggregate in residue.py"
+
+
+def test_no_sum_across_axes_anywhere() -> None:
+    """No SQL block may GROUP BY axis (which would put both axes in one result
+    set to be summed), and no aggregate may select both axes."""
+    for path in (_QUERY, _RENDER):
+        text = path.read_text()
+        for block in _sql_blocks(text):
+            low = block.lower()
+            if "residue_events" not in low:
+                continue
+            # GROUP BY axis would surface both axes in one aggregate result —
+            # exactly the cross-axis combination the de-Goodhart forbids.
+            assert "group by axis" not in low, (
+                "GROUP BY axis combines both axes into one aggregate (forbidden, "
+                "#1328): %s in %s" % (block, path.name)
+            )
+
+
+def test_render_keeps_axes_in_separate_data_structures() -> None:
+    """The render takes two distinct AxisView inputs — there is no field that
+    fuses the two axes, so the data shape itself enforces segregation."""
+    from aios.workflows.residue_render import AxisView, render_ledger
+
+    # render_ledger's signature takes axis1 and axis2 separately.
+    import inspect
+
+    params = inspect.signature(render_ledger).parameters
+    assert "axis1" in params and "axis2" in params
+    # AxisView carries only single-axis fields (no combined/total field).
+    assert set(AxisView._fields) == {
+        "denominator",
+        "found_by_finder",
+        "other_count",
+        "cannot_determine_count",
+    }

--- a/tests/unit/test_residue_axis_segregation.py
+++ b/tests/unit/test_residue_axis_segregation.py
@@ -44,7 +44,7 @@ def test_every_residue_aggregate_is_axis_scoped() -> None:
         # Every aggregate over residue_events MUST filter to a single axis.
         assert "axis = $" in low or "axis = " in low, (
             "an aggregate over residue_events is NOT axis-scoped — a cross-axis "
-            "aggregate would combine axis-1 and axis-2 (forbidden, #1328):\n%s" % block
+            f"aggregate would combine axis-1 and axis-2 (forbidden, #1328):\n{block}"
         )
         aggregated.append(block)
     # Sanity: there ARE aggregates (the test is actually exercising something).
@@ -64,17 +64,17 @@ def test_no_sum_across_axes_anywhere() -> None:
             # exactly the cross-axis combination the de-Goodhart forbids.
             assert "group by axis" not in low, (
                 "GROUP BY axis combines both axes into one aggregate (forbidden, "
-                "#1328): %s in %s" % (block, path.name)
+                f"#1328): {block} in {path.name}"
             )
 
 
 def test_render_keeps_axes_in_separate_data_structures() -> None:
     """The render takes two distinct AxisView inputs — there is no field that
     fuses the two axes, so the data shape itself enforces segregation."""
-    from aios.workflows.residue_render import AxisView, render_ledger
-
     # render_ledger's signature takes axis1 and axis2 separately.
     import inspect
+
+    from aios.workflows.residue_render import AxisView, render_ledger
 
     params = inspect.signature(render_ledger).parameters
     assert "axis1" in params and "axis2" in params

--- a/tests/unit/test_residue_render.py
+++ b/tests/unit/test_residue_render.py
@@ -1,0 +1,87 @@
+"""Render tests for the found-by-finder ledger (#1328, AC5/AC9/AC11).
+
+The render is a PURE function over already-fetched, axis-scoped data, so the whole
+markdown is verifiable here with no DB and no live model.
+"""
+
+from __future__ import annotations
+
+from aios.workflows.residue_render import (
+    AXIS1_HEADER,
+    AXIS2_HEADER,
+    BANNER,
+    BASELINE_HEADER,
+    AxisView,
+    render_ledger,
+)
+
+
+def _axis(denominator, found=None, other=0, cd=0):
+    return AxisView(
+        denominator=denominator,
+        found_by_finder=found or {},
+        other_count=other,
+        cannot_determine_count=cd,
+    )
+
+
+def test_banner_forbids_summing_and_autonomy_increment() -> None:
+    md = render_ledger(axis1=_axis(10), axis2=_axis(5))
+    assert BANNER in md
+    assert "NEVER summed" in md
+    assert "FORBIDDEN as justification for any autonomy increment" in md
+
+
+def test_two_distinct_axis_headers_with_two_distinct_denominators() -> None:
+    md = render_ledger(
+        axis1=_axis(10, {"internal-armed-check": 3}),
+        axis2=_axis(5, {"chairman": 2}),
+    )
+    assert AXIS1_HEADER in md
+    assert AXIS2_HEADER in md
+    # Two distinct denominators, each under its own header.
+    assert "terminal wf_runs over window): **10**" in md
+    assert "merged PRs over window): **5**" in md
+    # The headers are distinct ## blocks.
+    assert md.count("\n## ") >= 2
+
+
+def test_other_bucket_and_cannot_determine_lines_are_prominent() -> None:
+    md = render_ledger(
+        axis1=_axis(10, other=0, cd=1),
+        axis2=_axis(5, {"chairman": 1}, other=1, cd=0),
+    )
+    # The load-bearing growth alarm + fail-loud absence — both surface.
+    assert "`other`-bucket (chairman irreducible residue — GROWTH ALARM):** 1" in md
+    assert "`cannot-determine` (fail-loud; null telemetry, NOT counted clean):** 1" in md
+
+
+def test_cannot_determine_denominator_renders_cannot_determine_not_a_short_count() -> None:
+    # axis-2 merged-PR read was truncated → denominator is None → the render shows
+    # cannot-determine, NEVER an implicit short count (AC9, the look-green guard).
+    md = render_ledger(
+        axis1=_axis(10, {"internal-armed-check": 2}),
+        axis2=_axis(None, {"chairman": 3}),
+    )
+    assert "merged PRs over window): **`cannot-determine`**" in md
+    # The finder ratio cells for axis-2 also degrade to cannot-determine, never a
+    # fabricated percentage against an unknown denominator.
+    assert md.count("`cannot-determine`") >= 2
+
+
+def test_baseline_section_is_appended_below_live_query() -> None:
+    md = render_ledger(
+        axis1=_axis(1),
+        axis2=_axis(1),
+        baseline_markdown="| 2025-01-01 | chairman | found a thing |",
+    )
+    assert BASELINE_HEADER in md
+    # The baseline comes AFTER both live axis sections (never-delete, appended below).
+    assert md.index(AXIS1_HEADER) < md.index(BASELINE_HEADER)
+    assert md.index(AXIS2_HEADER) < md.index(BASELINE_HEADER)
+    assert "found a thing" in md
+
+
+def test_zero_denominator_does_not_divide_by_zero() -> None:
+    md = render_ledger(axis1=_axis(0, {"internal-armed-check": 0}), axis2=_axis(0))
+    assert "n/a (0 in denominator)" in md

--- a/tests/unit/test_residue_render.py
+++ b/tests/unit/test_residue_render.py
@@ -16,7 +16,12 @@ from aios.workflows.residue_render import (
 )
 
 
-def _axis(denominator, found=None, other=0, cd=0):
+def _axis(
+    denominator: int | None,
+    found: dict[str, int] | None = None,
+    other: int = 0,
+    cd: int = 0,
+) -> AxisView:
     return AxisView(
         denominator=denominator,
         found_by_finder=found or {},


### PR DESCRIPTION
## What & why

Implements the **de-Goodharted detection-residue gauge** (#1328) — the durable substrate behind Plane D of the substrate-different-verdict invariant (epic #1330, roadmap item 9). `found-by-finder-ledger.md` stops being a hand-appended file and becomes the *rendered query* of a new append-only `residue_events` table whose denominators are computed live from uncorrelated substrates, so the gauge can never be maker==checker.

The load-bearing invariants are made **structural**, not conventional:

- **Append-only** — a `BEFORE UPDATE OR DELETE` trigger `RAISE`s; the query layer exposes INSERT + SELECT only.
- **Axis segregation (the de-Goodhart)** — `axis CHECK (axis IN (1,2))`; every aggregate read is axis-scoped (`WHERE axis = $`), and no query ever `SUM`s across the two axes. A grep unit test fails on any cross-axis aggregate.
- **`residue_kind` never inferred** — the axis-2 ingest copies the kind *verbatim* from the gate-resolve payload (the finder's own stamp), stamped at the source by `dev_pipeline.py`'s new `human_gate()` wrapper; no prose parsing.
- **Denominators from uncorrelated substrates** — axis-1 = terminal `wf_runs` count; axis-2 = the GitHub merged-PR universe (passed in; `cannot-determine` on a truncated list read per #1323, never an implicit short count). Never stored as rows.
- **At-least-once idempotency** — `UNIQUE(account_id, idempotency_key)` + ON CONFLICT DO NOTHING; a gate-resume replay or observer re-scan inserts one row.
- **Fail-loud absence** — a null-telemetry observer verdict writes a `cannot-determine` row, never a clean/ok row; `other`-bucket growth is a prominent render alarm.

## Changes

- **migration 0109** `residue_events` (append-only trigger, axis/finder/kind_source CHECKs, OPEN `residue_kind` enum, account-scoped idempotency unique, axis index); `downgrade()` fails hard on any existing row (never-reconstruct, 0108 stance) then drops trigger/function/table.
- **`aios.db.queries.residue`** the only write/read path: idempotent INSERT, axis-2 gate-resume ingest (verbatim kind copy; raises on a missing stamp; skips non-human-in-loop gates), wired-but-inert axis-1 observer ingest, live `wf_runs` denominator + `MergedPrUniverse` carrier, axis-scoped found-by-finder / kind-count reads.
- **`aios.workflows.residue_render`** pure render of the ledger: two un-summable axis sections with distinct denominators, hard-coded de-Goodhart banner, prominent `other`/`cannot-determine` lines, baseline appended below.
- **`dev_pipeline.human_gate()`** enforces the `residue_kind` stamp for the human-in-loop kinds (`design`, `merge_approval`) at the gate-resolve source; `verify`/`merge_guard` unaffected. Existing gate-resume fixtures updated to carry the stamp.
- **`ids`** `res_` prefix.

## Tests (test-first)

- `test_migration_0109_predicates` — byte-identity pins on the CHECK vocabularies + append-only trigger (0108 idiom).
- `test_residue_render` / `test_residue_axis_segregation` — render purity + a grep guard that fails on any cross-axis aggregate.
- `test_residue_events_db` — DB-backed: append-only UPDATE/DELETE rejection, CHECK rejections, verbatim axis-2 ingest, observer anomaly/cannot-determine/ok ingest, idempotency, and the uncorrelated `wf_runs` denominator (window-scoped, independent of event count). Validated green against a real Postgres 15 locally (migration upgrade→downgrade→re-upgrade round-trip + all 19 cases).
- `test_wf_dev_pipeline_fixture` — 10 new cases: human-in-loop gates reject an unstamped/invalid resolve and do not proceed; valid stamp (incl. the `other` sentinel) proceeds; `verify`/`merge_guard` do not require the key.

Full dev-pipeline fixture suite + new unit/migration suites pass (74 + 19 green).