### PR TITLE
feat(workflows): machine-observer anomaly-scan loop (telemetry_observer + observer_sweep) (#1326)

### DIFF
--- a/docs/ops/telemetry-observer-loop.md
+++ b/docs/ops/telemetry-observer-loop.md
@@ -1,0 +1,189 @@
+# Machine-observer anomaly-scan loop (aios#1326)
+
+The deterministic, substrate-different observer over the host's per-run telemetry journal.
+Plane C, roadmap item 8 of the substrate-different-verdict epic (aios#1330).
+
+Code: `src/aios/workflows/telemetry_observer.py`
+(`build_observer_script` / `build_observer_workflow_create` for the observer;
+`build_sweep_script` / `build_sweep_workflow_create` for the dead-man twin).
+Fixture proof: `tests/integration/test_wf_telemetry_observer_fixture.py`.
+
+---
+
+## What it is
+
+A scripted (NOT agent) workflow that, on every terminal run of a watched workflow, re-derives
+a waste verdict from the host-emitted `WfRunUsage` numbers (`get_run`'s `usage` object, #1324 /
+PR#1334). It is uncorrelated with the LLM nodes by **substrate** (host numbers, not the run's
+self-report `output`) and by **stage** (post-terminal, not in-pass). It never calls `agent()`
+or `gate()`: a numeric-threshold predicate has a universally-correct policy, so the verdict is
+a pure deterministic script — the moment a verdict needs judgment it would have to become an
+`agent()`, which would re-correlate it.
+
+### Honest scope (non-goals)
+
+The observer detects ONLY mechanically-legible pathologies. Semantically-wrong-but-cheap-and-
+on-budget output (a Ralph-Wiggum loop producing a plausible diff), design-misallocation, and
+coverage-selection blind spots trip NO numeric anomaly and stay chairman/seat-found (the
+irreducible residue, by the uncorrelated-immune theorem). **v1 ships with EXACTLY ONE live
+signal — the LEAD `cost-on-errored` signal.**
+
+---
+
+## Signals and substrate-availability
+
+The read-path `WfRunUsage` surfaces ONLY:
+`cost_microusd · input_tokens · output_tokens · cache_read_input_tokens ·
+cache_creation_input_tokens · iteration_count (ALWAYS null today) · wall_clock_ms`.
+
+| Signal | Field(s) | Status |
+|---|---|---|
+| **LEAD cost-on-errored** | `status` + `cost_microusd` | **LIVE** |
+| iteration-at-max | `iteration_count` (always null today) | DEFERRED — gated on a real host iteration counter |
+| byte-buffer | `input_tokens` + `net_diff_lines` | DEFERRED — gated on a host primitive emitting `net_diff_lines` |
+| cost-per-net-accepted-line | `cost_microusd` + `net_diff_lines` | DEFERRED — with byte-buffer |
+| cost-on-no-PR | PR-presence (lives only in the run `output`, forbidden) | DEFERRED — gated on a host primitive emitting PR-presence |
+
+The three DEFERRED signals are specified as frozen-band constants and fixture-locked against a
+**fabricated** `get_run` return to PIN their predicate contract, but they are **NOT wired into
+the live verdict path**. They cannot masquerade as live: the fail-loud rule makes any null/
+absent field used by a fired predicate yield `cannot-determine`, never a false `ok`/`anomaly`.
+
+**A NEW host primitive is required to lift byte-buffer / cost-on-no-PR / cost-per-net-accepted-
+line out of DEFERRED** (emit `net_diff_lines` and PR-presence onto the run read path, WITHOUT
+making the observer read the run's `output`). **A NEW per-run `iteration_count` counter** is
+required to lift the iteration signal out of DEFERRED. File both as follow-up dependencies.
+
+### The LEAD verdict (deterministic, vs frozen git-versioned bands)
+
+- `status == 'errored'` ∧ `cost_microusd > COST_WASTE_FLOOR` → `anomaly` (`cost-on-errored`).
+- `status == 'errored'` ∧ `cost_microusd` absent/null → `cannot-determine` (fail-loud).
+- `status == 'errored'` ∧ `cost_microusd <= COST_WASTE_FLOOR` → `ok` (cheap fast-fail).
+- any non-errored terminal status → `ok` (the lead predicate does not fire; no other live
+  signal in v1).
+
+The bands are PREPENDED constants in the committed script header (`COST_WASTE_FLOOR`,
+`ITER_MAX_BAND`, `BYTE_BUFFER_INPUT_BAND`, `DIFF_FLOOR`, `BANDS_VERSION`). The body imports
+neither `datetime` nor `time` and never infers a band at runtime — it gates on a frozen
+threshold, never on recency. Bumping any band MUST bump `BANDS_VERSION` (the residue table
+#1328 keys stored verdicts on it).
+
+### The verdict record (the observer's ONLY output)
+
+```
+{run_id, workflow_id, verdict ∈ {ok, anomaly, cannot-determine},
+ signals_fired:[...], telemetry_snapshot:{...}, bands_version}
+```
+
+Machine-readable telemetry, not a log scrape. The observer files NO GitHub issue / obliging
+action-item — this is enforced **structurally** (no `http_request` in its tool surface), so it
+cannot file into the Class-closed:NO graveyard before the fractal-retro closure machinery
+(eumemic-company#24) lands. Its output is the `finder=internal-armed-check` axis-1 rows for the
+residue table (#1328), and **a passing observer is FORBIDDEN as a safety signal for any
+autonomy increment** (the de-Goodharted gauge).
+
+---
+
+## The input-envelope unwrap (TRACED, not assumed)
+
+A `WorkflowAction` fire's run input is ALWAYS `{"trigger": <firing context>, "input":
+<template verbatim>}`. For a `run_completion` fire the completing run rides BY VALUE under
+`input["trigger"]["run"]` = `{id, workflow_id, status, output, error}`
+(traced to `harness/trigger_runner.py`'s `compose_workflow_run_input` + `_run_workflow`).
+
+**There is NO `input["trigger"]["event"]` for run_completion fires** — `event` is passed as
+`None` (it is non-None only for `external_event` fires). The earlier draft's citation of
+`input["trigger"]["event"]["run_id"]` was FALSE; the correct key path is
+`input["trigger"]["run"]["id"]`. The observer's `_run_id` reads that path AND accepts a bare
+`{"run_id": ...}` (the fixture / arm-time path). It reads `trigger.run` ONLY for the id — it
+NEVER reads `trigger.run.output` (the forbidden self-report substrate); the verdict is computed
+from `get_run`'s host numbers.
+
+---
+
+## Wiring blueprint (git-versioned watched-set)
+
+`RunCompletionSource.workflow_id` is a SINGLE id — there is no all-workflows wildcard — so the
+loop is **one trigger per watched workflow**, all pointing the same `WorkflowAction` at
+`telemetry_observer`. The observer is stateless w.r.t. which workflow fired it (it reads the
+run by id). **The watched-set is this git-versioned list; adding a workflow = adding a trigger,
+never a code change.**
+
+Watched workflows (v1):
+
+- `dev_pipeline`
+- `triage_pipeline`
+- (each conveyor/loop workflow as it lands)
+
+For each watched workflow `W`, create (via the `trigger_create` tool):
+
+```
+source = RunCompletionSource(workflow_id=<W>, statuses=["completed","errored","cancelled"])
+action = WorkflowAction(workflow_id=<telemetry_observer>, input_template=None)
+```
+
+`statuses` defaults to all-terminal (the no-silent-omission default). The observer reads the
+completing run's id from `input["trigger"]["run"]["id"]`.
+
+### The dead-man twin (`observer_sweep`) — REQUIRED
+
+A `RunCompletionSource` AUTO-DISABLES after `MAX_CONSECUTIVE_FAILURES` and CANNOT fire on its
+own non-firing — a dead observer is silent, and silence ≠ health. The cron twin is the dead-man
+over the alarm. It is a SEPARATE workflow (its crash mode must not entangle the observer),
+fired by:
+
+```
+source = CronSource(schedule="*/15 * * * *")   # sized to the watched-workflow completion rate
+action = WorkflowAction(workflow_id=<observer_sweep>,
+                        input_template={"watched_workflow_id": <W>,
+                                        "observer_workflow_id": <telemetry_observer>,
+                                        "after": <window cursor>})
+```
+
+It reads the terminal-run count (`list_runs` over `completed`/`errored`/`cancelled`) and the
+observer's own scan count, and rings (`alarm: True` / `cannot-determine`) when `N_runs >
+N_scans`. The `list_runs` read applies the **no-silent-degrade invariant (#1323)**: a FULL page
+(returned count == requested limit) means rows may exist unseen → the sweep cannot prove the
+count → `cannot-determine`, NEVER a silent under-count read as "all scanned".
+
+---
+
+## Arm-time known-anomalous proof (criterion 14)
+
+> A monitor is not armed until its alarm has rung once.
+
+After deploying `telemetry_observer` AND wiring its triggers, fire a synthetic run carrying
+KNOWN-anomalous telemetry through the LIVE observer and assert it returns `verdict:anomaly`:
+
+1. Cause (or replay) a run that **errored** with `cost_microusd` above `COST_WASTE_FLOOR`.
+2. Invoke the observer against that run id (bare `{"run_id": <id>}` is accepted).
+3. Assert the returned record is `verdict:anomaly`, `signals_fired:["cost-on-errored"]`.
+
+**This requires PR#1334 DEPLOYED on the worker — not merely merged.** A pre-#1334 worker
+returns a bare `WfRun` with no `usage` object, so the synthetic run reads `cost_microusd` as
+absent → `cannot-determine`, silently failing to actually arm. The CI fixture
+(`test_lead_cost_on_errored_above_floor_is_anomaly`) is the offline twin of this proof, and
+`test_errored_with_absent_usage_object_is_cannot_determine` demonstrates exactly the pre-#1334
+failure mode.
+
+---
+
+## Sequencing gates (criterion 15)
+
+- **Go-live is gated on PR#1334 DEPLOYED** (telemetry on the LIVE read path — "deployed", NOT
+  merely "merged" / "#1324 closed") **AND deploy-on-merge #1175** (a verification node the
+  worker isn't running is hollow). Both are merged in this repo; go-live waits on the live
+  worker re-registration.
+- Sequenced AFTER #1324 (telemetry surface, PR#1334) and #1323 (list-read invariant). FEEDS
+  item 9 (#1328 residue table).
+- **Observer output is axis-1 only and FORBIDDEN as a justification for any autonomy
+  increment.**
+
+## Named open risks (carried, out of scope here)
+
+- **Frozen-band drift.** The bands drift by construction under lily-pad cost arbitrage — they
+  need their own closure-sentinel re-tune cadence + TTL dead-man (a band nobody re-tunes is a
+  dead alarm). MUST be recorded as a known miss class.
+- **The DEFERRED-signal host primitives** (`net_diff_lines` / PR-presence on the read path; a
+  real per-run `iteration_count` counter) are the dependencies that lift signals 5/6/7 out of
+  DEFERRED. Filed as follow-up dependencies; this loop does NOT assume them.

--- a/src/aios/workflows/telemetry_observer.py
+++ b/src/aios/workflows/telemetry_observer.py
@@ -1,0 +1,569 @@
+"""Machine-observer anomaly-scan loop (aios#1326) — the deterministic substrate-different observer.
+
+Plane C, roadmap item 8 of the substrate-different-verdict epic (aios#1330).
+
+This module stands a DETERMINISTIC observer on the one substrate no agent can talk past:
+the host's per-run cost/token/iteration/wall-clock journal (``WfRunUsage``, #1324 / PR#1334).
+On every terminal run of a watched dev/conveyor/loop workflow a scripted (NOT agent) workflow
+re-derives a waste verdict from those host-emitted numbers — uncorrelated with the LLM nodes
+by **substrate** (host numbers, not the run's self-report) and by **stage** (post-terminal,
+not in-pass). It grades nobody's homework with an LLM: a numeric-threshold predicate has a
+universally-correct policy (the script-vs-agent partition doctrine), so the verdict can be a
+pure deterministic script. The moment a verdict needs judgment it would have to become an
+``agent()`` — which would re-correlate it — so this observer NEVER calls ``agent()``/``gate()``.
+
+HONEST SCOPE (stated up front, mirrors the issue's non-goals): the observer detects ONLY
+mechanically-legible pathologies. Semantically-wrong-but-cheap-and-on-budget output (a
+Ralph-Wiggum loop producing a plausible diff), design-misallocation, and coverage-selection
+blind spots trip NO numeric anomaly and stay chairman/seat-found (the irreducible residue, by
+the uncorrelated-immune theorem). v1 ships with EXACTLY ONE live signal — the LEAD
+``cost-on-errored`` signal — fully computable from host-emitted ``status`` + ``cost_microusd``.
+
+─── THE SUBSTRATE-AVAILABILITY MATRIX (governs which signals are buildable) ───────────────
+
+Verified against this repo: the read-path ``WfRunUsage`` (``models/workflows.py``) surfaces
+ONLY ``cost_microusd · input_tokens · output_tokens · cache_read_input_tokens ·
+cache_creation_input_tokens · iteration_count (ALWAYS null today) · wall_clock_ms``. Of the
+four candidate signals, only the LEAD ``cost-on-errored`` is fully computable:
+
+  * LEAD cost-on-errored  — ``status`` + ``cost_microusd``  → BOTH host-emitted → **LIVE**.
+  * byte-buffer           — needs ``net_diff_lines``, NOT on the host read path → DEFERRED.
+  * cost-on-no-PR         — needs PR-presence, lives only in the run's ``output`` → DEFERRED.
+  * iteration-at-max      — ``iteration_count`` is ALWAYS null today → DEFERRED.
+  * cost-per-net-line     — needs ``net_diff_lines`` (with byte-buffer) → DEFERRED.
+
+The three DEFERRED signals are specified as frozen-band constants and fixture-locked against a
+fabricated ``get_run`` return to PIN their predicate contract, but they are NOT wired into the
+live verdict path — an implement agent must not fabricate their substrate fields. They are
+gated behind a NEW host primitive (``net_diff_lines`` / PR-presence on the read path) and a
+NEW per-run iteration counter — filed as follow-up dependencies.
+
+Why DEFERRED can't masquerade as LIVE: the observer's fail-loud rule (criterion 9) makes ANY
+null/missing field used by a FIRED predicate yield ``cannot-determine`` — so a null
+``iteration_count`` / absent ``net_diff_lines`` consumed by its predicate can only ever read
+``cannot-determine``, never a false ``ok``/``anomaly``.
+
+─── THE INPUT ENVELOPE (TRACED, not assumed from a cited precedent) ───────────────────────
+
+The issue WARNS that an earlier draft falsely cited ``input["trigger"]["event"]["run_id"]`` as
+precedent. Tracing the actual construction site (``harness/trigger_runner.py`` —
+``compose_workflow_run_input`` + ``_run_workflow``) confirms:
+
+  * A ``WorkflowAction`` fire's run input is ALWAYS the envelope
+    ``{"trigger": <firing context>, "input": <input_template verbatim>}``.
+  * For a ``run_completion`` fire the completing run rides BY VALUE under
+    ``input["trigger"]["run"]`` = ``{id, workflow_id, status, output, error}``
+    (``trigger_runner.py``: ``trigger["run"] = {...}``).
+  * The ``event`` key is passed as ``None`` for ``run_completion`` fires
+    (``event=event if trigger_context == "external_event" else None``) — so there is
+    **NO** ``input["trigger"]["event"]`` for run-completion fires. The earlier citation was
+    indeed false; the correct key path is ``input["trigger"]["run"]["id"]``.
+
+The observer's ``_unwrap`` therefore reads ``input["trigger"]["run"]["id"]`` for the real
+trigger path, and ALSO accepts a bare ``{"run_id": ...}`` (the fixture / arm-time path).
+CRITICAL: the observer reads ``trigger.run`` ONLY for the run id — it NEVER reads
+``trigger.run.output`` (the run's self-report prose), which is the substrate it is forbidden
+to touch. The waste verdict is computed from ``get_run``'s host numbers, never from the
+envelope's ``output``.
+
+─── DESIGN (two scripted workflows + the builder idiom) ───────────────────────────────────
+
+Authored with the EXACT ``dev_pipeline.py`` / ``triage_pipeline.py`` builder idiom: an
+exported ``build_observer_script(...) -> str`` returning workflow SOURCE (a prepended
+frozen-band constants header + a static ``_OBSERVER_BODY`` of pure-stdlib ``re``/``json``,
+value-domain I/O, deterministic emit order → replay-stable), plus ``REQUIRED_TOOLS``, and
+``build_observer_workflow_create(...) -> WorkflowCreate`` bundling script+surface so the
+declared surface can't drift from the script (#1135). The dead-man twin (``observer_sweep``)
+is authored identically.
+
+Frozen bands are PREPENDED constants (committed in the loop blueprint, NEVER inferred at
+runtime — the body imports neither ``datetime`` nor ``time``); the verdict gates on a frozen
+threshold, never on recency.
+
+The observer's tool surface is ``REQUIRED_TOOLS = [get_run, list_runs]`` — no ``http_request``,
+no ``bash``, no ``edit``. The observer mutates nothing and touches no external artifact; its
+only output is the structured verdict record (a ledger row). This is structural enforcement of
+the issue-emission gating (criterion 11): with no ``http_request`` in surface, the observer
+CANNOT file a GitHub issue / obliging action-item — so it can't feed the
+Class-closed:NO graveyard before the fractal-retro closure machinery (eumemic-company#24) lands.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.models.agents import ToolSpec
+from aios.models.workflows import WorkflowCreate
+
+# ─── frozen bands (git-versioned blueprint constants; bumped together with bands_version) ──
+#
+# These live as constants in the prepended header and are committed in the loop blueprint.
+# The body NEVER infers a band at runtime (no datetime/time import) — it gates on a frozen
+# threshold. Bumping any band MUST bump BANDS_VERSION so a stored verdict row records which
+# band set produced it (the residue table #1328 keys on it). The DEFERRED-signal bands are
+# carried so their fixture contract is pinned; they are NOT consulted by the live verdict.
+
+# LEAD signal [LIVE]: spend (microusd) burned on a run that errored out. A run that errored
+# below this floor is benign (a cheap fast-fail). Tuned to the watched-workflow cost profile.
+DEFAULT_COST_WASTE_FLOOR = 500_000  # 0.50 USD in micro-USD
+
+# DEFERRED [gated on a real per-run iteration counter; iteration_count is ALWAYS null today].
+DEFAULT_ITER_MAX_BAND = 50
+
+# DEFERRED [gated on a host primitive emitting net_diff_lines onto the read path].
+DEFAULT_BYTE_BUFFER_INPUT_BAND = 1_000_000  # input_tokens ceiling for the byte-buffer signal
+DEFAULT_DIFF_FLOOR = 3  # net_diff_lines below this = "near-zero net diff"
+
+# Bump on ANY band change (the residue table keys verdicts on it).
+DEFAULT_BANDS_VERSION = "v1-lead-only-2026-06-17"
+
+# The verdict vocabulary — EXACTLY these three (criterion 3).
+VERDICTS: tuple[str, ...] = ("ok", "anomaly", "cannot-determine")
+
+# The one LIVE signal name (criterion 4). The DEFERRED names are carried for documentation /
+# the fixture contract only; they never appear in a live run's ``signals_fired``.
+LIVE_SIGNALS: tuple[str, ...] = ("cost-on-errored",)
+DEFERRED_SIGNALS: tuple[str, ...] = (
+    "iteration-at-max",
+    "byte-buffer",
+    "cost-per-net-accepted-line",
+    "cost-on-no-PR",
+)
+
+
+def _py(name: str, value: Any) -> str:
+    """One ``NAME = <repr>`` constant line for the prepended header (mirrors dev/triage)."""
+    return f"{name} = {value!r}"
+
+
+def _render_observer_constants(
+    *,
+    cost_waste_floor: int,
+    iter_max_band: int,
+    byte_buffer_input_band: int,
+    diff_floor: int,
+    bands_version: str,
+) -> str:
+    lines = [
+        _py("COST_WASTE_FLOOR", cost_waste_floor),
+        _py("ITER_MAX_BAND", iter_max_band),
+        _py("BYTE_BUFFER_INPUT_BAND", byte_buffer_input_band),
+        _py("DIFF_FLOOR", diff_floor),
+        _py("BANDS_VERSION", bands_version),
+        _py("LIVE_SIGNALS", list(LIVE_SIGNALS)),
+        _py("DEFERRED_SIGNALS", list(DEFERRED_SIGNALS)),
+    ]
+    return "\n".join(lines)
+
+
+# The static observer body — references the prepended constants. Pure stdlib (re/json),
+# value-domain I/O, bounded, NO datetime/time: replay-stable by construction.
+_OBSERVER_BODY = r'''
+import json
+
+
+# ─── input-envelope unwrap (TRACED, see module docstring) ─────────────────────
+
+def _run_id(input):
+    """Extract the completing run's id from EITHER the bare fixture/arm-time shape
+    ``{"run_id": ...}`` OR the real WorkflowAction trigger envelope.
+
+    The real run_completion envelope is
+    ``{"trigger": {"id","name","source","fired_at","run": {"id","workflow_id","status",
+    "output","error"}}, "input": <template>}`` — TRACED to
+    ``harness/trigger_runner.py``'s ``compose_workflow_run_input`` (the completing run
+    rides BY VALUE under ``trigger.run``; ``event`` is None for run_completion fires, so
+    there is NO ``trigger.event``). We read ONLY ``trigger.run.id`` — never
+    ``trigger.run.output`` (the run's self-report prose, the forbidden substrate).
+
+    Returns the run id, or None if no run id is reachably present (a finding, surfaced as
+    ``cannot-determine`` by the caller — never papered over).
+    """
+    if not isinstance(input, dict):
+        return None
+    # Bare fixture/arm-time path.
+    rid = input.get("run_id")
+    if isinstance(rid, str) and rid:
+        return rid
+    # Real trigger envelope.
+    trig = input.get("trigger")
+    if isinstance(trig, dict):
+        run = trig.get("run")
+        if isinstance(run, dict):
+            rid = run.get("id")
+            if isinstance(rid, str) and rid:
+                return rid
+    return None
+
+
+# ─── telemetry read (the host substrate; NEVER the run's output/prose) ────────
+
+async def _get_run(run_id):
+    """Read the completing run via the get_run builtin. The tool result is the full
+    WfRun dict (incl. the ``usage`` object once PR#1334 is deployed) OR an error value
+    ``{"error": ...}`` (a NotFound / scope failure resolves as a value, never a raise)."""
+    return await tool("get_run", {"run_id": run_id})
+
+
+def _usage_field(run, name):
+    """Pull one WfRunUsage field off a get_run return, distinguishing THREE states the
+    observer must never conflate (the load-bearing fail-loud distinction):
+
+    * ('absent',  None) — the ``usage`` object itself is missing/null (a pre-#1334 worker,
+      or a degraded read). The observer CANNOT determine spend → cannot-determine.
+    * ('null',    None) — ``usage`` is present but this field is explicit null (#1324
+      mandates explicit-null not silent-omit; e.g. ``iteration_count`` always-null today,
+      or the ``vault_ids:null`` disease shape on ``cost_microusd``). → cannot-determine.
+    * ('value',   v)    — a real observed number (note: a real observed ``0`` is a VALUE,
+      distinct from null — a childless run sums to a genuine zero).
+
+    Returns ``(state, value)``.
+    """
+    if not isinstance(run, dict):
+        return ("absent", None)
+    usage = run.get("usage")
+    if not isinstance(usage, dict):
+        return ("absent", None)
+    if name not in usage:
+        # An OMITTED key is the silent-omit disease — treat as cannot-determine, NOT as 0.
+        return ("null", None)
+    v = usage[name]
+    if v is None:
+        return ("null", None)
+    return ("value", v)
+
+
+# ─── the deterministic verdict (vs FROZEN bands; fixed signal order) ──────────
+
+def _record(run_id, workflow_id, verdict, signals_fired, snapshot):
+    """The structured per-run ledger row — the observer's ONLY output (criterion 3/11).
+    Machine-readable telemetry, not a log scrape. No GitHub issue, no obliging action-item
+    (structurally impossible: http_request is not in the observer's tool surface)."""
+    return {
+        "run_id": run_id,
+        "workflow_id": workflow_id,
+        "verdict": verdict,
+        "signals_fired": signals_fired,
+        "telemetry_snapshot": snapshot,
+        "bands_version": BANDS_VERSION,
+    }
+
+
+def _scan(run):
+    """Compute the verdict from host numbers, in fixed order, vs the frozen bands.
+
+    v1 evaluates EXACTLY ONE live signal — the LEAD cost-on-errored signal. The DEFERRED
+    signals are NOT evaluated here (they are specified + fixture-locked elsewhere, gated on
+    new host primitives). Returns ``(verdict, signals_fired, snapshot)``.
+
+    The verdict is determined by the LEAD predicate alone:
+      * status == 'errored' AND cost_microusd > COST_WASTE_FLOOR  → anomaly.
+      * status == 'errored' AND cost_microusd is absent/null      → cannot-determine
+        (fail-loud: a fired predicate read a missing field — NEVER silently ok).
+      * status == 'errored' AND cost_microusd <= COST_WASTE_FLOOR → ok (cheap fast-fail).
+      * any non-errored terminal status                          → ok (the lead predicate
+        does not fire; no other live signal exists in v1).
+
+    ``workflow_id`` comes off the host read row — NOT the trigger envelope — so the observer
+    is stateless w.r.t. which workflow fired it.
+    """
+    status = run.get("status") if isinstance(run, dict) else None
+    workflow_id = run.get("workflow_id") if isinstance(run, dict) else None
+    cost_state, cost = _usage_field(run, "cost_microusd")
+
+    # The telemetry snapshot is the host numbers the verdict was computed from (the residue
+    # table consumes it). We snapshot the LEAD-relevant fields plus the carried context.
+    snapshot = {
+        "status": status,
+        "cost_microusd": cost if cost_state == "value" else None,
+        "cost_microusd_state": cost_state,
+    }
+
+    # LEAD signal — cost-on-errored [LIVE]. The predicate FIRES only on an errored run; a
+    # field it reads being absent/null is fail-loud cannot-determine, never silent ok.
+    if status == "errored":
+        if cost_state != "value":
+            # A fired predicate consumed a missing/null field → cannot-determine.
+            return ("cannot-determine", [], snapshot)
+        if cost > COST_WASTE_FLOOR:
+            return ("anomaly", ["cost-on-errored"], snapshot)
+        return ("ok", [], snapshot)
+
+    # Non-errored terminal: the lead predicate does not fire, and v1 has no other live
+    # signal. (A within-bands MERGED run is the eventual ok case for the diff-based signals
+    # once they go live — but those are DEFERRED, so any non-errored run reads ok today.)
+    if status is None:
+        # status itself is missing — we couldn't even read the run row.
+        return ("cannot-determine", [], snapshot)
+    return ("ok", [], snapshot)
+
+
+# ─── entry ────────────────────────────────────────────────────────────────────
+
+async def main(input):
+    phase("unwrap")
+    run_id = _run_id(input)
+    if run_id is None:
+        # No reachable run id in the envelope — a finding, surfaced loud, not papered over.
+        log("observer: no run_id reachable in input envelope")
+        return _record(None, None, "cannot-determine", [], {"reason": "no run_id in input"})
+
+    phase("read")
+    run = await _get_run(run_id)
+    if isinstance(run, dict) and "error" in run and "status" not in run:
+        # get_run resolved an error value (NotFound / scope) — cannot read the substrate.
+        log("observer: get_run error for", run_id)
+        return _record(
+            run_id, None, "cannot-determine", [], {"reason": "get_run error"}
+        )
+
+    phase("scan")
+    verdict, signals_fired, snapshot = _scan(run)
+    workflow_id = run.get("workflow_id") if isinstance(run, dict) else None
+    log("observer verdict:", verdict, "signals:", signals_fired, "run:", run_id)
+    return _record(run_id, workflow_id, verdict, signals_fired, snapshot)
+'''
+
+
+def build_observer_script(
+    *,
+    cost_waste_floor: int = DEFAULT_COST_WASTE_FLOOR,
+    iter_max_band: int = DEFAULT_ITER_MAX_BAND,
+    byte_buffer_input_band: int = DEFAULT_BYTE_BUFFER_INPUT_BAND,
+    diff_floor: int = DEFAULT_DIFF_FLOOR,
+    bands_version: str = DEFAULT_BANDS_VERSION,
+) -> str:
+    """Return the production ``telemetry_observer`` workflow source.
+
+    Frozen bands are prepended as constants; the body imports neither ``datetime`` nor
+    ``time`` and never infers a band at runtime (it gates on the frozen threshold). v1 wires
+    EXACTLY ONE live signal — the LEAD cost-on-errored signal — fully computable from
+    host-emitted ``status`` + ``cost_microusd``. The other three are specified + fixture-locked
+    but DEFERRED behind named host primitives and NOT wired live.
+    """
+    header = _render_observer_constants(
+        cost_waste_floor=cost_waste_floor,
+        iter_max_band=iter_max_band,
+        byte_buffer_input_band=byte_buffer_input_band,
+        diff_floor=diff_floor,
+        bands_version=bands_version,
+    )
+    return header + "\n" + _OBSERVER_BODY
+
+
+def build_observer_fixture_script(
+    *,
+    cost_waste_floor: int = DEFAULT_COST_WASTE_FLOOR,
+    bands_version: str = DEFAULT_BANDS_VERSION,
+) -> str:
+    """The CI fixture variant: the identical script shape (the observer takes no scan cap —
+    it reads exactly one run by id). Driven by
+    ``tests/integration/test_wf_telemetry_observer_fixture.py``."""
+    return build_observer_script(cost_waste_floor=cost_waste_floor, bands_version=bands_version)
+
+
+# ─── the armed dead-man twin (observer_sweep) ─────────────────────────────────
+#
+# A SEPARATE scripted workflow (its crash mode must not entangle the observer), fired by a
+# CronSource -> WorkflowAction. It asserts, on a DIFFERENT substrate: N terminal runs in the
+# window => N observer-scans recorded. WHY required: a RunCompletionSource AUTO-DISABLES after
+# MAX_CONSECUTIVE_FAILURES and CANNOT fire on its own non-firing — a dead observer is silent,
+# and silence != health. The cron twin is the dead-man over the alarm.
+#
+# The list_runs read applies the no-silent-degrade invariant (#1323): a FULL page (returned
+# count == requested limit) means more rows may exist unseen → the sweep CANNOT prove it saw
+# all terminals → cannot-determine, NEVER a silent under-count read as "all scanned".
+
+_SWEEP_BODY = r'''
+import json
+
+
+def _unwrap(input):
+    """Accept a bare ``{watched_workflow_id, observer_workflow_id, after?}`` AND the cron
+    WorkflowAction trigger envelope ``{"trigger": ..., "input": ...}`` (a cron fire carries
+    no ``trigger.run``; the sweep takes its parameters from ``input``)."""
+    if isinstance(input, dict) and "trigger" in input and "input" in input:
+        return input.get("input") or {}
+    return input or {}
+
+
+async def _list_runs(args):
+    """One list_runs read (full WfRun rows, account-scoped to this run's session)."""
+    return await tool("list_runs", args)
+
+
+def _page_runs(resp):
+    """The runs list out of a list_runs tool return, or None if the read errored/degraded."""
+    if not isinstance(resp, dict):
+        return None
+    if "error" in resp and "runs" not in resp:
+        return None
+    runs = resp.get("runs")
+    if not isinstance(runs, list):
+        return None
+    return runs
+
+
+async def main(input):
+    phase("sweep")
+    args = _unwrap(input)
+    watched = args.get("watched_workflow_id")
+    observer = args.get("observer_workflow_id")
+    after = args.get("after")
+    # The list_runs page limit the sweep requests. A returned page of exactly LIMIT rows is
+    # the no-silent-degrade trip: more rows MAY exist unseen, so the count is unprovable.
+    limit = args.get("limit", 200)
+
+    if not isinstance(watched, str) or not isinstance(observer, str):
+        log("sweep: missing watched/observer workflow id")
+        return {
+            "alarm": True,
+            "verdict": "cannot-determine",
+            "reason": "missing watched_workflow_id / observer_workflow_id",
+            "bands_version": BANDS_VERSION,
+        }
+
+    # Count terminal runs of the watched workflow in the window. We read each terminal status
+    # explicitly (the no-silent-omission default mirrors RunCompletionSource's all-terminal).
+    n_runs = 0
+    for status in ("completed", "errored", "cancelled"):
+        req = {"workflow_id": watched, "status": status, "limit": limit, "account_wide": True}
+        if after is not None:
+            req["after"] = after
+        resp = await _list_runs(req)
+        runs = _page_runs(resp)
+        if runs is None:
+            log("sweep: list_runs read failed/degraded for", watched, status)
+            return {
+                "alarm": True,
+                "verdict": "cannot-determine",
+                "reason": "list_runs read failed for watched=%s status=%s" % (watched, status),
+                "bands_version": BANDS_VERSION,
+            }
+        # No-silent-degrade (#1323): a FULL page means rows may exist beyond it that we did
+        # NOT see — we cannot prove the terminal count, so we must NOT under-count silently.
+        if len(runs) >= limit:
+            log("sweep: truncated list_runs page (>= limit) for", watched, status)
+            return {
+                "alarm": True,
+                "verdict": "cannot-determine",
+                "reason": "truncated list_runs page for watched=%s status=%s (>= limit %d)"
+                % (watched, status, limit),
+                "bands_version": BANDS_VERSION,
+            }
+        n_runs += len(runs)
+
+    # Count the observer's own scan-runs in the same window (its recorded scans).
+    n_scans = 0
+    req = {"workflow_id": observer, "status": "completed", "limit": limit, "account_wide": True}
+    if after is not None:
+        req["after"] = after
+    resp = await _list_runs(req)
+    scans = _page_runs(resp)
+    if scans is None:
+        log("sweep: list_runs read failed/degraded for observer", observer)
+        return {
+            "alarm": True,
+            "verdict": "cannot-determine",
+            "reason": "list_runs read failed for observer=%s" % observer,
+            "bands_version": BANDS_VERSION,
+        }
+    if len(scans) >= limit:
+        log("sweep: truncated list_runs page (>= limit) for observer", observer)
+        return {
+            "alarm": True,
+            "verdict": "cannot-determine",
+            "reason": "truncated list_runs page for observer=%s (>= limit %d)" % (observer, limit),
+            "bands_version": BANDS_VERSION,
+        }
+    n_scans = len(scans)
+
+    # The assertion: every terminal run must have produced an observer scan. A shortfall is
+    # a dead/lagging observer — the dead-man rings.
+    if n_runs > n_scans:
+        log("sweep ALARM: n_runs", n_runs, ">", "n_scans", n_scans)
+        return {
+            "alarm": True,
+            "verdict": "cannot-determine",
+            "reason": "observer shortfall: %d terminal runs but only %d scans" % (n_runs, n_scans),
+            "n_runs": n_runs,
+            "n_scans": n_scans,
+            "bands_version": BANDS_VERSION,
+        }
+    log("sweep ok: n_runs", n_runs, "n_scans", n_scans)
+    return {
+        "alarm": False,
+        "verdict": "ok",
+        "n_runs": n_runs,
+        "n_scans": n_scans,
+        "bands_version": BANDS_VERSION,
+    }
+'''
+
+
+def build_sweep_script(*, bands_version: str = DEFAULT_BANDS_VERSION) -> str:
+    """Return the production ``observer_sweep`` (dead-man twin) workflow source.
+
+    A SEPARATE workflow from the observer (so the alarm's crash mode does not entangle the
+    observed). It reads the terminal-run count via ``list_runs`` and the observer-scan count,
+    and rings (``alarm: True`` / ``cannot-determine``) when terminal runs exceed scans OR when
+    a ``list_runs`` page is truncated (the #1323 no-silent-degrade trip — a truncated page is
+    NEVER read as "all scanned").
+    """
+    header = _py("BANDS_VERSION", bands_version)
+    return header + "\n" + _SWEEP_BODY
+
+
+def build_sweep_fixture_script(*, bands_version: str = DEFAULT_BANDS_VERSION) -> str:
+    """CI fixture variant of the dead-man twin (identical shape). Driven by
+    ``tests/integration/test_wf_telemetry_observer_fixture.py``."""
+    return build_sweep_script(bands_version=bands_version)
+
+
+# ─── deploy surface (the tool envelope a WorkflowCreate needs) ────────────────
+#
+# The observer reads host numbers via get_run; the sweep counts via list_runs. NEITHER
+# declares http_request / bash / edit — the observer mutates nothing and touches no external
+# artifact, and (structurally) CANNOT file a GitHub issue / obliging action-item (criterion
+# 11: the issue-emission gating is enforced by the absence of http_request, not by a runtime
+# check). Both workflows share this surface; the union is exactly {get_run, list_runs}.
+REQUIRED_TOOLS: list[ToolSpec] = [
+    ToolSpec(type="get_run"),
+    ToolSpec(type="list_runs"),
+]
+
+
+def build_observer_workflow_create(
+    *,
+    name: str = "telemetry_observer",
+    description: str | None = None,
+    **script_kwargs: Any,
+) -> WorkflowCreate:
+    """Return the complete ``WorkflowCreate`` for the production ``telemetry_observer``.
+
+    Bundles the script (``build_observer_script``) with its tool surface
+    (``REQUIRED_TOOLS = [get_run, list_runs]`` and NO http/bash/edit), so a deployer POSTs one
+    object and the declared surface can never drift from the script that needs it (#1135).
+    """
+    return WorkflowCreate(
+        name=name,
+        description=description,
+        script=build_observer_script(**script_kwargs),
+        tools=list(REQUIRED_TOOLS),
+    )
+
+
+def build_sweep_workflow_create(
+    *,
+    name: str = "observer_sweep",
+    description: str | None = None,
+    **script_kwargs: Any,
+) -> WorkflowCreate:
+    """Return the complete ``WorkflowCreate`` for the production ``observer_sweep`` dead-man
+    twin. Shares the observer's ``REQUIRED_TOOLS`` (it reads via ``list_runs``; no mutation)."""
+    return WorkflowCreate(
+        name=name,
+        description=description,
+        script=build_sweep_script(**script_kwargs),
+        tools=list(REQUIRED_TOOLS),
+    )

--- a/tests/integration/test_wf_telemetry_observer_fixture.py
+++ b/tests/integration/test_wf_telemetry_observer_fixture.py
@@ -1,0 +1,525 @@
+"""Machine-observer anomaly-scan fixture (aios#1326).
+
+Drives the production ``build_observer_script`` / ``build_sweep_script`` directly against the
+real script host (no DB, no live model) with simulated ``get_run`` / ``list_runs`` resolutions,
+walking the deterministic unwrap -> read -> scan -> verdict machine. Because the host re-runs
+from the start each wake (replaying the whole growing memo), these tests also assert the
+load-bearing durable property: **replay is deterministic** (every call_key is stable across
+every replay).
+
+It proves the #1326 acceptance:
+- the LEAD cost-on-errored signal [LIVE] -> anomaly (criterion 4),
+- a within-bands errored run + any non-errored run -> ok (criterion 8),
+- fail-loud: a null/absent telemetry field used by a FIRED predicate -> cannot-determine,
+  NEVER ok (criterion 9 — the load-bearing line),
+- the trigger-envelope unwrap reads ``input["trigger"]["run"]["id"]`` (the TRACED path, NOT
+  the falsely-cited ``trigger.event.run_id``) AND a bare ``{run_id}`` (criterion 2),
+- the structured record shape (criterion 3),
+- no GitHub issue / obliging action-item (structural: no http_request in surface — crit 11),
+- the DEFERRED signals' contract is fixture-locked against a FABRICATED return WITHOUT being
+  wired live (criteria 5/6/7): a fabricated non-null iteration_count / net_diff_lines does NOT
+  flip a real-run verdict, and a null one yields cannot-determine,
+- the dead-man twin (``observer_sweep``): N_runs > N_scans -> alarm; equal -> ok (crit 12);
+  a truncated list_runs page -> cannot-determine, never a silent under-count (crit 13).
+
+Mirrors the host-subprocess style of ``test_wf_triage_pipeline_fixture.py``; needs no Postgres.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios.workflows.host_launcher import run_script_host
+from aios.workflows.telemetry_observer import (
+    DEFAULT_COST_WASTE_FLOOR,
+    REQUIRED_TOOLS,
+    build_observer_fixture_script,
+    build_observer_workflow_create,
+    build_sweep_fixture_script,
+    build_sweep_workflow_create,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ─── a get_run return shaped exactly like the real WfRun read row (#1324) ─────
+
+
+def _wf_run(
+    run_id: str,
+    *,
+    workflow_id: str = "wf_dev_pipeline",
+    status: str = "completed",
+    usage: dict[str, Any] | None = None,
+    omit_usage: bool = False,
+) -> dict[str, Any]:
+    """A get_run tool return, real-shaped: the full WfRun dump with a ``usage`` object.
+
+    ``usage`` defaults to a complete, real-shaped WfRunUsage (cost/tokens/ wall-clock,
+    iteration_count explicit-null as the host emits it today). ``omit_usage`` models a
+    pre-#1334 worker that returns a bare WfRun with NO usage object (usage: None)."""
+    if usage is None and not omit_usage:
+        usage = {
+            "cost_microusd": 1000,
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "iteration_count": None,  # ALWAYS null today (no host counter)
+            "wall_clock_ms": 1234,
+        }
+    return {
+        "id": run_id,
+        "workflow_id": workflow_id,
+        "status": status,
+        "output": {"this": "is the run's self-report — the observer must NEVER read it"},
+        "usage": None if omit_usage else usage,
+    }
+
+
+class ObserverScenario:
+    """A deterministic responder for the observer: one get_run return, keyed by the call.
+    Keeping the response a pure function of the call_key keeps replay stable."""
+
+    def __init__(self, *, get_run_return: dict[str, Any]) -> None:
+        self.get_run_return = get_run_return
+        self.tool_calls: list[tuple[str, Any]] = []
+
+    def outcome(self, cap: Any) -> dict[str, Any]:
+        cid, spec = cap.capability_id, cap.spec
+        if cid == "tool":
+            name = spec["tool_name"]
+            self.tool_calls.append((name, spec["input"]))
+            if name == "get_run":
+                return {"ok": self.get_run_return}
+            raise AssertionError(f"observer must only call get_run, got {name}")
+        raise AssertionError(f"observer must not emit capability {cid} (no agent/gate); {spec!r}")
+
+
+async def _drive_observer(
+    scenario: ObserverScenario,
+    *,
+    input: dict[str, Any],
+    max_steps: int = 30,
+    **build_kwargs: Any,
+) -> tuple[Any, list[str]]:
+    """Drive the production observer to a terminal outcome; assert replay-determinism."""
+    src = build_observer_fixture_script(**build_kwargs)
+    memo: dict[str, Any] = {}
+    keys: list[str] = []
+    for _ in range(max_steps):
+        out = await run_script_host(source=src, input=input, memo=memo)
+        if out.kind == "returned":
+            assert len(keys) == len(set(keys)), "replay produced a duplicate call_key"
+            return out.value, keys
+        assert out.kind == "suspended", (out.kind, out.error_repr, out.error_traceback)
+        assert len(out.emitted) == 1, [(e.capability_id, e.spec) for e in out.emitted]
+        cap = out.emitted[0]
+        keys.append(cap.call_key)
+        memo[cap.call_key] = scenario.outcome(cap)
+    raise AssertionError(f"observer did not terminate within {max_steps} steps")
+
+
+# ─── criterion 4: LEAD cost-on-errored [LIVE] -> anomaly ──────────────────────
+
+
+async def test_lead_cost_on_errored_above_floor_is_anomaly() -> None:
+    usage = {
+        "cost_microusd": DEFAULT_COST_WASTE_FLOOR + 1,
+        "input_tokens": 999,
+        "output_tokens": 10,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "iteration_count": None,
+        "wall_clock_ms": 9999,
+    }
+    run = _wf_run("wfr_err", status="errored", usage=usage)
+    scn = ObserverScenario(get_run_return=run)
+    value, _keys = await _drive_observer(scn, input={"run_id": "wfr_err"})
+
+    assert value["verdict"] == "anomaly"
+    assert value["signals_fired"] == ["cost-on-errored"]
+    assert value["run_id"] == "wfr_err"
+    assert value["workflow_id"] == "wf_dev_pipeline"
+    assert value["telemetry_snapshot"]["cost_microusd"] == DEFAULT_COST_WASTE_FLOOR + 1
+    assert "bands_version" in value
+    # the observer read the run by id, never the run's output/prose
+    assert scn.tool_calls == [("get_run", {"run_id": "wfr_err"})]
+
+
+# ─── criterion 8: within-bands errored + non-errored -> ok ────────────────────
+
+
+async def test_errored_below_floor_is_ok() -> None:
+    usage = {
+        "cost_microusd": DEFAULT_COST_WASTE_FLOOR - 1,  # cheap fast-fail
+        "input_tokens": 10,
+        "output_tokens": 1,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "iteration_count": None,
+        "wall_clock_ms": 5,
+    }
+    run = _wf_run("wfr_cheap", status="errored", usage=usage)
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_cheap"})
+    assert value["verdict"] == "ok"
+    assert value["signals_fired"] == []
+
+
+async def test_completed_run_is_ok() -> None:
+    run = _wf_run("wfr_done", status="completed")
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_done"})
+    assert value["verdict"] == "ok"
+    assert value["signals_fired"] == []
+
+
+async def test_cancelled_run_is_ok() -> None:
+    run = _wf_run("wfr_cxl", status="cancelled")
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_cxl"})
+    assert value["verdict"] == "ok"
+    assert value["signals_fired"] == []
+
+
+# ─── criterion 9: fail-loud cannot-determine (the load-bearing criteria) ──────
+
+
+async def test_errored_with_null_cost_is_cannot_determine_not_ok() -> None:
+    """The vault_ids:null disease shape on cost_microusd: a FIRED predicate read a null
+    field -> cannot-determine, NEVER silently ok, NEVER anomaly."""
+    usage = {
+        "cost_microusd": None,  # explicit null (the disease shape)
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "iteration_count": None,
+        "wall_clock_ms": 10,
+    }
+    run = _wf_run("wfr_null", status="errored", usage=usage)
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_null"})
+    assert value["verdict"] == "cannot-determine"
+    assert value["verdict"] != "ok"
+    assert value["signals_fired"] == []
+
+
+async def test_errored_with_absent_usage_object_is_cannot_determine() -> None:
+    """A pre-#1334 worker returns a bare WfRun with usage:None. On an errored run the LEAD
+    predicate fires and reads an absent cost -> cannot-determine (this is exactly why the
+    arm-time proof needs PR#1334 DEPLOYED, not merely merged — criterion 14)."""
+    run = _wf_run("wfr_bare", status="errored", omit_usage=True)
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_bare"})
+    assert value["verdict"] == "cannot-determine"
+
+
+async def test_get_run_error_value_is_cannot_determine() -> None:
+    run = {"error": "NotFound: no such run"}
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_missing"})
+    assert value["verdict"] == "cannot-determine"
+
+
+# ─── criterion 2: the TRACED trigger-envelope unwrap ──────────────────────────
+
+
+async def test_unwraps_real_trigger_envelope_run_path() -> None:
+    """The real run_completion WorkflowAction envelope: run id at
+    ``input["trigger"]["run"]["id"]`` (TRACED to harness/trigger_runner.py — NOT the falsely
+    cited ``trigger.event.run_id``; there is NO trigger.event for run_completion fires)."""
+    usage = {
+        "cost_microusd": DEFAULT_COST_WASTE_FLOOR + 5,
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "iteration_count": None,
+        "wall_clock_ms": 1,
+    }
+    run = _wf_run("wfr_env", workflow_id="wf_triage", status="errored", usage=usage)
+    scn = ObserverScenario(get_run_return=run)
+    envelope = {
+        "trigger": {
+            "id": "trg_1",
+            "name": "observer-watch",
+            "source": "run_completion",
+            "fired_at": "2026-06-17T00:00:00+00:00",
+            "run": {
+                "id": "wfr_env",
+                "workflow_id": "wf_triage",
+                "status": "errored",
+                "output": {"self": "report — forbidden"},
+                "error": {"kind": "boom"},
+            },
+        },
+        "input": None,
+    }
+    value, _ = await _drive_observer(scn, input=envelope)
+    assert value["run_id"] == "wfr_env"
+    assert value["verdict"] == "anomaly"
+    # it asked get_run for the id pulled from trigger.run.id
+    assert scn.tool_calls == [("get_run", {"run_id": "wfr_env"})]
+
+
+async def test_envelope_without_reachable_run_id_is_cannot_determine() -> None:
+    """A trigger envelope carrying no reachable run id is a FINDING surfaced loud, not papered
+    over (the issue's explicit instruction)."""
+    envelope = {"trigger": {"id": "t", "source": "cron"}, "input": {}}
+    src = build_observer_fixture_script()
+    out = await run_script_host(source=src, input=envelope, memo={})
+    # No run id -> it returns immediately without any get_run call.
+    assert out.kind == "returned", (out.kind, out.error_repr)
+    assert out.value["verdict"] == "cannot-determine"
+    assert out.value["run_id"] is None
+
+
+# ─── criteria 5/6/7: DEFERRED signals fixture-locked WITHOUT being wired live ──
+
+
+async def test_fabricated_iteration_count_does_not_flip_a_real_verdict() -> None:
+    """iteration-at-max is DEFERRED. Even a FABRICATED non-null iteration_count above the
+    band must NOT produce an anomaly on a completed run — the signal is not wired live. (And
+    on a real run iteration_count is always null, which criterion 9 would make
+    cannot-determine if it were ever consumed.) This pins the contract: it ships DEFERRED."""
+    usage = {
+        "cost_microusd": 100,
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "iteration_count": 9999,  # FABRICATED non-null, way above any band
+        "wall_clock_ms": 10,
+    }
+    run = _wf_run("wfr_iter", status="completed", usage=usage)
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_iter"})
+    # NOT anomaly — the DEFERRED iteration signal is not wired live.
+    assert value["verdict"] == "ok"
+    assert "iteration-at-max" not in value["signals_fired"]
+
+
+async def test_fabricated_net_diff_lines_does_not_flip_a_real_verdict() -> None:
+    """byte-buffer / cost-per-net-line are DEFERRED (net_diff_lines is not on the host read
+    path). Even a FABRICATED high input_tokens + a fabricated net_diff_lines field must NOT
+    produce an anomaly — the signals are not wired live."""
+    usage = {
+        "cost_microusd": 100,
+        "input_tokens": 10_000_000,  # huge, above any byte-buffer band
+        "output_tokens": 5,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "iteration_count": None,
+        "wall_clock_ms": 10,
+    }
+    run = _wf_run("wfr_bb", status="completed", usage=usage)
+    run["usage"]["net_diff_lines"] = 0  # FABRICATED — not a real host field
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_bb"})
+    assert value["verdict"] == "ok"
+    assert value["signals_fired"] == []
+
+
+# ─── criterion 3/11: structured record + structural issue-emission gating ─────
+
+
+def test_observer_surface_has_no_mutation_or_http() -> None:
+    """The observer's only output is its structured return. With no http_request/bash/edit in
+    surface it CANNOT file a GitHub issue / obliging action-item — issue-emission gating is
+    structural (criterion 11)."""
+    types = {t.type for t in REQUIRED_TOOLS}
+    assert types == {"get_run", "list_runs"}
+    assert "http_request" not in types
+    assert "bash" not in types
+    assert "edit" not in types
+    wc = build_observer_workflow_create()
+    wc_types = {t.type for t in wc.tools}
+    assert wc_types == {"get_run", "list_runs"}
+    assert not wc.http_servers
+
+
+async def test_record_shape() -> None:
+    # a structural check of the verdict record keys (criterion 3)
+    run = _wf_run("wfr_shape", status="completed")
+    scn = ObserverScenario(get_run_return=run)
+    value, _ = await _drive_observer(scn, input={"run_id": "wfr_shape"})
+    assert set(value.keys()) == {
+        "run_id",
+        "workflow_id",
+        "verdict",
+        "signals_fired",
+        "telemetry_snapshot",
+        "bands_version",
+    }
+    assert value["verdict"] in ("ok", "anomaly", "cannot-determine")
+
+
+# ─── criteria 12/13: the dead-man twin (observer_sweep) ───────────────────────
+
+
+class SweepScenario:
+    """Deterministic responder for observer_sweep: a map of (workflow_id, status) -> list of
+    run rows, served once per list_runs call. Keying on the call's args keeps replay stable."""
+
+    def __init__(self, *, pages: dict[tuple[str, str], list[dict[str, Any]]]) -> None:
+        self.pages = pages
+        self.list_calls: list[dict[str, Any]] = []
+
+    def outcome(self, cap: Any) -> dict[str, Any]:
+        cid, spec = cap.capability_id, cap.spec
+        if cid == "tool" and spec["tool_name"] == "list_runs":
+            args = spec["input"]
+            self.list_calls.append(args)
+            key = (args["workflow_id"], args["status"])
+            runs = self.pages.get(key, [])
+            return {"ok": {"runs": runs}}
+        raise AssertionError(f"sweep must only call list_runs; got {cid} {spec!r}")
+
+
+async def _drive_sweep(
+    scenario: SweepScenario, *, input: dict[str, Any], max_steps: int = 30
+) -> Any:
+    src = build_sweep_fixture_script()
+    memo: dict[str, Any] = {}
+    keys: list[str] = []
+    for _ in range(max_steps):
+        out = await run_script_host(source=src, input=input, memo=memo)
+        if out.kind == "returned":
+            assert len(keys) == len(set(keys)), "replay produced a duplicate call_key"
+            return out.value
+        assert out.kind == "suspended", (out.kind, out.error_repr, out.error_traceback)
+        assert len(out.emitted) == 1
+        cap = out.emitted[0]
+        keys.append(cap.call_key)
+        memo[cap.call_key] = scenario.outcome(cap)
+    raise AssertionError("sweep did not terminate")
+
+
+def _run_row(i: int, status: str) -> dict[str, Any]:
+    return {"id": f"wfr_{status}_{i}", "workflow_id": "wf_watched", "status": status}
+
+
+async def test_sweep_alarms_on_run_scan_shortfall() -> None:
+    """3 terminal runs but only 2 recorded scans -> alarm (criterion 12)."""
+    pages = {
+        ("wf_watched", "completed"): [_run_row(0, "completed"), _run_row(1, "completed")],
+        ("wf_watched", "errored"): [_run_row(0, "errored")],
+        ("wf_watched", "cancelled"): [],
+        ("telemetry_observer", "completed"): [
+            {"id": "scan_0", "workflow_id": "telemetry_observer", "status": "completed"},
+            {"id": "scan_1", "workflow_id": "telemetry_observer", "status": "completed"},
+        ],
+    }
+    scn = SweepScenario(pages=pages)
+    value = await _drive_sweep(
+        scn,
+        input={
+            "watched_workflow_id": "wf_watched",
+            "observer_workflow_id": "telemetry_observer",
+        },
+    )
+    assert value["alarm"] is True
+    assert value["verdict"] == "cannot-determine"
+    assert value["n_runs"] == 3
+    assert value["n_scans"] == 2
+
+
+async def test_sweep_ok_when_runs_equal_scans() -> None:
+    """3 terminal runs and 3 recorded scans -> ok (criterion 12)."""
+    pages = {
+        ("wf_watched", "completed"): [_run_row(0, "completed"), _run_row(1, "completed")],
+        ("wf_watched", "errored"): [_run_row(0, "errored")],
+        ("wf_watched", "cancelled"): [],
+        ("telemetry_observer", "completed"): [
+            {"id": f"scan_{i}", "workflow_id": "telemetry_observer", "status": "completed"}
+            for i in range(3)
+        ],
+    }
+    scn = SweepScenario(pages=pages)
+    value = await _drive_sweep(
+        scn,
+        input={
+            "watched_workflow_id": "wf_watched",
+            "observer_workflow_id": "telemetry_observer",
+        },
+    )
+    assert value["alarm"] is False
+    assert value["verdict"] == "ok"
+    assert value["n_runs"] == 3
+    assert value["n_scans"] == 3
+
+
+async def test_sweep_truncated_page_is_cannot_determine_not_undercount() -> None:
+    """A FULL list_runs page (len == requested limit) means rows may exist beyond it -> the
+    sweep cannot prove the terminal count -> cannot-determine, NEVER a silent under-count read
+    as 'all scanned' (criterion 13, the #1323 no-silent-degrade invariant)."""
+    limit = 2
+    pages = {
+        # a full page of `limit` completed runs => possibly more unseen
+        ("wf_watched", "completed"): [_run_row(0, "completed"), _run_row(1, "completed")],
+        ("wf_watched", "errored"): [],
+        ("wf_watched", "cancelled"): [],
+        ("telemetry_observer", "completed"): [],
+    }
+    scn = SweepScenario(pages=pages)
+    value = await _drive_sweep(
+        scn,
+        input={
+            "watched_workflow_id": "wf_watched",
+            "observer_workflow_id": "telemetry_observer",
+            "limit": limit,
+        },
+    )
+    assert value["alarm"] is True
+    assert value["verdict"] == "cannot-determine"
+    assert "truncated" in value["reason"]
+
+
+async def test_sweep_list_read_error_is_cannot_determine() -> None:
+    """A list_runs read that errors -> cannot-determine, never a silent zero count."""
+
+    class ErroringSweep(SweepScenario):
+        def outcome(self, cap: Any) -> dict[str, Any]:
+            self.list_calls.append(cap.spec["input"])
+            return {"ok": {"error": "boom"}}
+
+    scn = ErroringSweep(pages={})
+    value = await _drive_sweep(
+        scn,
+        input={
+            "watched_workflow_id": "wf_watched",
+            "observer_workflow_id": "telemetry_observer",
+        },
+    )
+    assert value["alarm"] is True
+    assert value["verdict"] == "cannot-determine"
+
+
+def test_sweep_surface_is_list_runs_only() -> None:
+    wc = build_sweep_workflow_create()
+    assert {t.type for t in wc.tools} == {"get_run", "list_runs"}
+    assert not wc.http_servers
+
+
+# ─── create-time script validation: surface covers the script, main(input) exists ─
+
+
+def test_observer_and_sweep_scripts_validate_against_their_surface() -> None:
+    """The #1285 create-time validator: each script compiles, defines
+    ``async def main(input)``, and the declared ``REQUIRED_TOOLS`` is a superset of the
+    script's literal ``tool("…")`` names (so the surface can't drift from the script — #1135)."""
+    from aios.errors import ValidationError
+    from aios.models.agents import ToolSpec
+    from aios.workflows.script_validation import validate_workflow_script
+    from aios.workflows.telemetry_observer import build_observer_script, build_sweep_script
+
+    validate_workflow_script(script=build_observer_script(), tools=list(REQUIRED_TOOLS))
+    validate_workflow_script(script=build_sweep_script(), tools=list(REQUIRED_TOOLS))
+
+    # the sweep's list_runs call is not covered by a get_run-only surface -> rejected
+    with pytest.raises(ValidationError):
+        validate_workflow_script(script=build_sweep_script(), tools=[ToolSpec(type="get_run")])


### PR DESCRIPTION
## aios#1326 — the machine-observer anomaly-scan loop (Plane C, item 8 of #1330)

A **deterministic, substrate-different observer** over the host's per-run telemetry journal (`WfRunUsage`, #1324 / PR#1334). On every terminal run of a watched workflow, a scripted (NOT agent) workflow re-derives a waste verdict from host-emitted `status` + `cost_microusd` — uncorrelated with the LLM nodes by **substrate** (host numbers, not the run's self-report `output`) and by **stage** (post-terminal, not in-pass). It never calls `agent()`/`gate()`: a numeric-threshold predicate has a universally-correct policy, so the verdict is a pure deterministic script.

### What ships
- `src/aios/workflows/telemetry_observer.py` — `build_observer_script` / `build_sweep_script` (frozen-band header + pure-stdlib body, no `datetime`/`time`, replay-stable) + `REQUIRED_TOOLS=[get_run, list_runs]` + `build_observer_workflow_create` / `build_sweep_workflow_create` bundling script+surface so the declared surface can't drift from the script (#1135). Mirrors the `triage_pipeline`/`dev_pipeline` builder idiom.
- `tests/integration/test_wf_telemetry_observer_fixture.py` — proves the acceptance with NO live model (`run_script_host` + memo harness).
- `docs/ops/telemetry-observer-loop.md` — wiring blueprint (git-versioned watched-set), arm-time procedure, sequencing gates, named open risks.

### v1 = EXACTLY ONE live signal (honest floor)
- **LEAD `cost-on-errored` [LIVE]:** `status=='errored'` ∧ `cost_microusd > COST_WASTE_FLOOR` → `anomaly`. Both fields host-emitted; fully computable.
- **iteration-at-max / byte-buffer / cost-per-net-accepted-line / cost-on-no-PR [DEFERRED]:** specified + fixture-locked against *fabricated* returns to pin the contract, but **NOT wired live** — gated behind named NEW host primitives (a per-run `iteration_count` counter; `net_diff_lines` / PR-presence on the read path). An implement agent must not fabricate their substrate; this PR does not.

### Key correctness work
- **TRACED the input envelope** to `harness/trigger_runner.py` (`compose_workflow_run_input` + `_run_workflow`): for `run_completion` fires the completing run rides BY VALUE under `input["trigger"]["run"]` = `{id, workflow_id, status, output, error}`, and `event` is **None** — so there is NO `input["trigger"]["event"]`. The earlier draft's `trigger.event.run_id` citation was **false**; the correct path is `input["trigger"]["run"]["id"]`. `_run_id` reads that AND a bare `{run_id}`; it reads `trigger.run` only for the id, never `trigger.run.output` (the forbidden self-report substrate).
- **fail-loud `cannot-determine`:** any null/absent telemetry field used by a FIRED predicate → `cannot-determine`, never silent `ok` (the `vault_ids:null` disease shape). A pre-#1334 worker (no `usage` object) on an errored run reads `cannot-determine` — exactly why the arm-time proof needs **PR#1334 DEPLOYED, not merely merged**.
- **issue-emission gating is structural:** with no `http_request` in surface, the observer cannot file a GitHub issue / obliging action-item. Its only output is the structured record `{run_id, workflow_id, verdict∈{ok,anomaly,cannot-determine}, signals_fired, telemetry_snapshot, bands_version}`.
- **dead-man twin `observer_sweep`** (CronSource→WorkflowAction, a SEPARATE workflow): `N_runs > N_scans` → alarm; a FULL `list_runs` page → `cannot-determine`, never a silent under-count (the #1323 no-silent-degrade invariant). Required because a `RunCompletionSource` auto-disables and can't fire on its own non-firing.

### Tests (fixture, no live model)
LEAD anomaly; within-bands errored + non-errored → ok; fail-loud cannot-determine (null cost, absent usage, get_run error); the traced envelope unwrap + no-reachable-run-id finding; DEFERRED signals not flipping a real verdict; sweep alarm/ok/truncated-read/error-read; replay determinism (unique call_keys + stable re-run); and #1285 create-time script validation (compiles, `async def main(input)`, surface covers `tool()` calls). All pass; `ruff check` + `ruff format` clean.

### Sequencing (asserted, not buildable-around)
Go-live gated on **PR#1334 DEPLOYED** (telemetry on the LIVE read path — "deployed", not "merged") **AND #1175** (deploy-on-merge). Feeds the #1328 residue table as `finder=internal-armed-check` axis-1 rows; a passing observer is FORBIDDEN as a safety signal for any autonomy increment. Named open risks recorded: frozen-band drift (needs a re-tune cadence + TTL dead-man) and the DEFERRED-signal host primitives.

**Non-goals:** the observer detects NO semantic-correctness / design-misallocation / coverage-selection defect (a plausible-diff Ralph-Wiggum loop trips nothing) — those stay chairman/seat-found by theorem.