### PR TITLE
feat(dev_pipeline): add rebase/sync recovery stage (#1385)

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -196,6 +196,7 @@ LABEL_FAILED = "autodev:failed"
 MARKER_SPEC_NOT_READY = "## Spec not ready for implementation"
 MARKER_RISK_ASSESSMENT = "## Risk Assessment"
 MARKER_MERGE_GUARD = "## Merge guard refused"
+MARKER_REBASE_CONFLICT = "## Rebase conflict — branch could not be healed"
 
 # Dispatch-claim label (#1188): the cron-scanner / dev-conveyor stamps an issue ``dispatched``
 # when it launches a run for it. Like ``IN_PROGRESS`` it is an IN-FLIGHT claim that must be
@@ -228,6 +229,37 @@ FIX_CI_LINT_HINT = (
     "— you MUST run `ruff format` (write mode, not --check) over the affected paths and "
     "commit the result. Run both `ruff check --fix` and `ruff format` so a combined "
     "lint+format failure is fully resolved before re-pushing."
+)
+
+# Rebase/sync recovery (#1385): when master moves under an open PR it goes DIRTY/non-
+# mergeable, GitHub can't compute ``refs/pull/N/merge``, CI never re-runs and the run jams at
+# the CI watch. The sync stage HEALS the branch instead of parking: a mechanical
+# ``git rebase origin/master`` + force-push-with-lease in a bash node, and — only if that hits
+# REAL conflicts — a bounded (≤MAX_REBASE_ATTEMPTS) hand-off to the SAME fix agent ``fix_ci``
+# uses, with a resolve-conflicts task. Still unresolved after the budget parks at a NEW,
+# distinct ``rebase_conflict`` gate (never the orphaned-at-CI jam, never a silent zombie).
+MAX_REBASE_ATTEMPTS = 2
+
+# Distinct bash exit codes the mechanical rebase node uses so the orchestrator can branch on
+# the OUTCOME (a value, never a raise) — mirrors the merge-guard's fail-closed exit-code style:
+#   0  -> rebased (or already current: an idempotent no-op re-run leaves the branch as-is)
+#   75 -> the branch is ALREADY current with origin/master (no rebase was needed) — a no-op
+#   76 -> the mechanical rebase hit REAL conflicts (a hand-off to the fix agent is required)
+#   77 -> a structural/plumbing failure (clone/fetch/push) the rebase could not even attempt
+REBASE_EXIT_DONE = 0
+REBASE_EXIT_NOOP = 75
+REBASE_EXIT_CONFLICT = 76
+REBASE_EXIT_ERROR = 77
+
+# The resolve-conflicts hand-off rides this hint so the fix agent (the same one ``fix_ci``
+# invokes) knows the task is a rebase-conflict resolution, not a CI failure: rebase onto
+# origin/master, resolve the conflict markers, commit, and force-push-with-lease the branch.
+FIX_REBASE_HINT = (
+    "This is a REBASE-CONFLICT resolution, not a CI fix. Master moved under this PR and a "
+    "mechanical `git rebase origin/master` hit conflicts the machine could not auto-resolve. "
+    "Fetch `origin/master`, rebase the PR branch onto it, resolve every conflict by hand "
+    "(remove all conflict markers, keep both intents correct), run the tests, then "
+    "`git push --force-with-lease` the rebased branch. Return the new head_sha."
 )
 
 
@@ -278,9 +310,16 @@ def _render_constants(
         _py("MARKER_SPEC_NOT_READY", MARKER_SPEC_NOT_READY),
         _py("MARKER_RISK_ASSESSMENT", MARKER_RISK_ASSESSMENT),
         _py("MARKER_MERGE_GUARD", MARKER_MERGE_GUARD),
+        _py("MARKER_REBASE_CONFLICT", MARKER_REBASE_CONFLICT),
         _py("MAX_RUN_RETRIES", MAX_RUN_RETRIES),
         _py("MAX_MASTER_CI_ITERS", MAX_MASTER_CI_ITERS),
+        _py("MAX_REBASE_ATTEMPTS", MAX_REBASE_ATTEMPTS),
+        _py("REBASE_EXIT_DONE", REBASE_EXIT_DONE),
+        _py("REBASE_EXIT_NOOP", REBASE_EXIT_NOOP),
+        _py("REBASE_EXIT_CONFLICT", REBASE_EXIT_CONFLICT),
+        _py("REBASE_EXIT_ERROR", REBASE_EXIT_ERROR),
         _py("FIX_CI_LINT_HINT", FIX_CI_LINT_HINT),
+        _py("FIX_REBASE_HINT", FIX_REBASE_HINT),
         _py("IMPLEMENT_SCHEMA", IMPLEMENT_SCHEMA),
         _py("REVIEW_SCHEMA", REVIEW_SCHEMA),
         _py("FIX_SCHEMA", FIX_SCHEMA),
@@ -622,6 +661,86 @@ def _merge_guard_command(repo, pr_number):
     return "\n".join(lines)
 
 
+def _needs_rebase(pr):
+    """Decide whether the PR's branch needs a sync/rebase from its mergeability fields
+    (#1385). ``pr`` is the ``GET /pulls/{n}`` payload; GitHub reports two signals:
+
+      - ``mergeable``: ``True`` (clean), ``False`` (conflicting), or ``None`` (GitHub has
+        not finished computing the merge yet — a transient unknown, NOT a conflict).
+      - ``mergeable_state``: ``clean`` / ``has_hooks`` / ``unstable`` / ``blocked`` (all
+        mergeable-against-base), vs ``dirty`` / ``behind`` (the branch is out of date with
+        base — exactly the master-moved-under case this stage heals).
+
+    We treat ONLY the unambiguous out-of-date states as needing a rebase: ``mergeable is
+    False`` (a real conflict GitHub already computed) OR ``mergeable_state in {dirty,
+    behind}``. A ``None``/unknown mergeable with a benign state is NOT forced through a
+    rebase (idempotence: a branch already current with master is a no-op — we don't rebase a
+    clean PR just because GitHub hasn't recomputed yet). Returns a plain bool.
+
+    The string set is deliberately tight: ``clean``/``unstable``/``has_hooks``/``blocked``
+    are all mergeable-against-base (``unstable`` = failing checks, ``blocked`` = required
+    review — neither is a master-moved-under conflict), so none of them triggers a rebase."""
+    if not isinstance(pr, dict):
+        return False
+    state = pr.get("mergeable_state")
+    if state in ("dirty", "behind"):
+        return True
+    if pr.get("mergeable") is False:
+        return True
+    return False
+
+
+def _rebase_command(repo, branch):
+    """The mechanical rebase node (#1385): fetch ``origin/master``, ``git rebase
+    origin/master`` the PR branch, and ``git push --force-with-lease`` the result. Run in a
+    bash node against a fresh clone, returning a DISTINCT exit code the orchestrator branches
+    on (a value, never a raise — same fail-closed exit-code discipline as the merge guard):
+
+      - REBASE_EXIT_NOOP (75): the branch is ALREADY current with origin/master — no rebase
+        is needed, nothing is pushed. This is the idempotence guarantee: re-running the stage
+        on an already-healed branch is a clean no-op under the at-least-once crash contract.
+      - REBASE_EXIT_DONE (0): the rebase replayed cleanly onto origin/master and the result
+        was force-pushed-with-lease. CI must re-run on the updated branch (the caller
+        re-enters the CI watch).
+      - REBASE_EXIT_CONFLICT (76): the rebase hit REAL conflicts ``git rebase`` could not
+        auto-resolve — we ``git rebase --abort`` (leave the branch untouched) and signal the
+        caller to hand off to the fix agent.
+      - REBASE_EXIT_ERROR (77): a plumbing failure (clone/fetch/push) before a rebase verdict
+        — fail-closed so a flaky clone is never mistaken for a clean branch.
+
+    ``--force-with-lease`` (not ``--force``) so a concurrent push to the PR branch aborts the
+    push rather than clobbering it. ``rm -rf`` then clone makes the node re-run-tolerant under
+    the at-least-once bash contract. ``set -u -o pipefail`` (NOT ``-e``: we branch on the
+    rebase's own exit explicitly, so a non-zero rebase must not abort the script)."""
+    lines = [
+        "set -u -o pipefail",
+        "D=/workspace/rebase-%s" % branch.replace("/", "-"),
+        "rm -rf \"$D\"",
+        "git clone --quiet "
+        "https://x-access-token:$GITHUB_TOKEN@github.com/%s.git \"$D\" || exit %d"
+        % (repo, REBASE_EXIT_ERROR),
+        "cd \"$D\" || exit %d" % REBASE_EXIT_ERROR,
+        "git config user.email dev-pipeline@aios.local",
+        "git config user.name 'aios dev-pipeline'",
+        "git fetch --quiet origin %s || exit %d" % (BASE_BRANCH, REBASE_EXIT_ERROR),
+        "git checkout --quiet -B %s origin/%s || exit %d"
+        % (branch, branch, REBASE_EXIT_ERROR),
+        # Already current with origin/master? (the branch contains origin/master's tip) ->
+        # nothing to do. This is the idempotent no-op: a re-driven stage on a healed branch.
+        "if git merge-base --is-ancestor origin/%s HEAD; then" % BASE_BRANCH,
+        "  echo REBASE_NOOP; exit %d" % REBASE_EXIT_NOOP,
+        "fi",
+        "if git rebase origin/%s; then" % BASE_BRANCH,
+        "  git push --force-with-lease origin %s || exit %d" % (branch, REBASE_EXIT_ERROR),
+        "  echo REBASE_DONE; exit %d" % REBASE_EXIT_DONE,
+        "else",
+        "  git rebase --abort || true",
+        "  echo REBASE_CONFLICT; exit %d" % REBASE_EXIT_CONFLICT,
+        "fi",
+    ]
+    return "\n".join(lines)
+
+
 def _mark_ready_query():
     return ("mutation($id:ID!){markPullRequestReadyForReview(input:{pullRequestId:$id})"
             "{pullRequest{isDraft}}}")
@@ -794,6 +913,132 @@ async def _file_followup(repo, title, body):
     if isinstance(created, dict):
         return created.get("number")
     return None
+
+
+async def _watch_ci(repo, pr_number, head_sha, comment_bodies, model, label_prefix):
+    """The bounded CI watch->fix->re-watch loop (the agent OWNS the durable wait), factored
+    out so it can be RE-ENTERED after a sync/rebase heals the branch (#1385): a successful
+    rebase force-pushes a new tip, so CI must re-run on the updated branch before merge. The
+    ``label_prefix`` distinguishes the labels of the second entry (``reci-…``) from the first
+    (``ci-…``) so replay stays deterministic (a distinct call_key per agent invocation).
+
+    Returns ``(ci_ok, ci_agent_error, head_sha)``: ``ci_ok`` True on green/no_ci, else the
+    caller parks at the verify gate; ``ci_agent_error`` distinguishes a flaky-agent break from
+    plain CI exhaustion; ``head_sha`` is the (possibly fix-advanced) head for downstream nodes.
+    Bounded N watches / N-1 fixes — matches autodev's CI loop."""
+    ci_ok = False
+    ci_agent_error = False
+    for i in range(MAX_CI_ITERS):
+        # A ci-watch / ci-fix agent error breaks the loop and falls through to the verify
+        # gate (item 5) — it does NOT crash the run nor silently pass a red PR.
+        try:
+            ci = await agent(
+                {"task": "watch_ci", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
+                agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model,
+                label="%s-%d" % (label_prefix, i))
+        except AgentError as exc:
+            log("ci-watch agent error -> escalate:", exc)
+            ci_agent_error = True
+            break
+        if ci["status"] in ("green", "no_ci"):
+            ci_ok = True
+            break
+        if i == MAX_CI_ITERS - 1:
+            break
+        before = head_sha
+        try:
+            fix = await agent(
+                {"task": "fix_ci", "repo": repo, "pr_number": pr_number,
+                 "detail": ci.get("detail", ""), "comments": comment_bodies,
+                 "lint_hint": FIX_CI_LINT_HINT},
+                agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model,
+                label="%s-fix-%d" % (label_prefix, i))
+            head_sha = fix["head_sha"]
+        except AgentError as exc:
+            log("ci-fix agent error -> escalate:", exc)
+            ci_agent_error = True
+            break
+        if before and head_sha == before:
+            break
+    return ci_ok, ci_agent_error, head_sha
+
+
+async def _sync_branch(repo, pr_number, branch, comment_bodies, model):
+    """Rebase/sync recovery stage (#1385): HEAL a branch master moved under instead of
+    parking or orphaning it. Returns one of:
+
+      - ``{"outcome": "noop"}``      — branch already current with master (idempotent no-op);
+                                       the CI watch does NOT need re-entry.
+      - ``{"outcome": "rebased", "head_sha": <sha or "">}`` — the branch was rebased (mechanically
+                                       or agent-resolved); the caller MUST re-enter the CI watch
+                                       so CI re-runs on the updated branch before merge.
+      - ``{"outcome": "conflict", "detail": <str>}`` — still unresolved after the bounded fix-agent
+                                       attempts; the caller parks at the ``rebase_conflict`` gate.
+      - ``{"outcome": "error", "detail": <str>}`` — a plumbing failure attempting the rebase;
+                                       the caller parks at the ``rebase_conflict`` gate too (we
+                                       cannot prove the branch is healthy — fail closed).
+
+    Flow: (1) read mergeability via ``GET /pulls/{n}``; a clean/unknown-but-benign branch is a
+    no-op. (2) A DIRTY/behind/conflicting branch gets a MECHANICAL ``git rebase origin/master``
+    + force-push-with-lease (``_rebase_command``). A clean replay -> rebased; an already-current
+    branch -> no-op (idempotent). (3) A REAL conflict hands off to the SAME fix agent ``fix_ci``
+    uses, with a resolve-conflicts task, bounded to MAX_REBASE_ATTEMPTS; each attempt re-runs
+    the mechanical rebase to confirm the branch is now clean. (4) Still conflicted after the
+    budget -> conflict (the caller parks at the new ``rebase_conflict`` gate)."""
+    # (1) Mergeability probe — a clean branch is the common case and a clean no-op.
+    pr = _json_body(await gh("GET", _ipath(repo, "/pulls/%d" % pr_number)))
+    if not _needs_rebase(pr):
+        log("sync: PR #%d is mergeable (state=%r) -> no rebase needed"
+            % (pr_number, pr.get("mergeable_state") if isinstance(pr, dict) else None))
+        return {"outcome": "noop"}
+
+    # (2) Mechanical rebase first — the cheap, deterministic path that heals the common
+    # master-moved-under-with-no-textual-conflict case without spending an agent.
+    rb = await tool("bash", {"command": _rebase_command(repo, branch), "timeout_seconds": 600})
+    code = rb.get("exit_code") if isinstance(rb, dict) else None
+    if code == REBASE_EXIT_NOOP:
+        log("sync: branch %r already current with %s -> no-op" % (branch, BASE_BRANCH))
+        return {"outcome": "noop"}
+    if code == REBASE_EXIT_DONE:
+        log("sync: mechanical rebase of %r onto %s succeeded -> re-enter CI"
+            % (branch, BASE_BRANCH))
+        return {"outcome": "rebased", "head_sha": ""}
+    if code == REBASE_EXIT_ERROR:
+        detail = "%s\n%s\nexit=%r" % (
+            (rb.get("stdout", "") if isinstance(rb, dict) else "")[-800:],
+            (rb.get("stderr", "") if isinstance(rb, dict) else "")[-400:], code)
+        log("sync: mechanical rebase plumbing error -> fail closed to rebase_conflict gate")
+        return {"outcome": "error", "detail": detail}
+
+    # (3) REAL conflict (REBASE_EXIT_CONFLICT) -> hand off to the fix agent, bounded. Each
+    # attempt: dispatch the resolve-conflicts task, then RE-RUN the mechanical rebase to
+    # CONFIRM the agent actually healed the branch (a no-op/done exit proves it).
+    last_detail = "mechanical rebase hit conflicts git could not auto-resolve"
+    for attempt in range(MAX_REBASE_ATTEMPTS):
+        try:
+            fix = await agent(
+                {"task": "fix_ci", "repo": repo, "pr_number": pr_number,
+                 "detail": last_detail, "comments": comment_bodies,
+                 "rebase_hint": FIX_REBASE_HINT, "lint_hint": FIX_CI_LINT_HINT},
+                agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model,
+                label="rebase-fix-%d" % attempt)
+        except AgentError as exc:
+            last_detail = "rebase-fix agent error: %s" % exc
+            log("sync: rebase-fix agent error on attempt %d:" % attempt, exc)
+            continue
+        # Confirm the branch is now mergeable by re-running the mechanical rebase: a
+        # NOOP (the agent rebased + pushed) or a clean DONE proves it healed.
+        confirm = await tool("bash",
+                             {"command": _rebase_command(repo, branch), "timeout_seconds": 600})
+        ccode = confirm.get("exit_code") if isinstance(confirm, dict) else None
+        if ccode in (REBASE_EXIT_NOOP, REBASE_EXIT_DONE):
+            log("sync: rebase conflict resolved by fix agent on attempt %d" % attempt)
+            return {"outcome": "rebased", "head_sha": fix.get("head_sha", "")
+                    if isinstance(fix, dict) else ""}
+        last_detail = ("rebase still conflicting after fix attempt %d (confirm exit=%r)"
+                       % (attempt, ccode))
+        log("sync:", last_detail)
+    return {"outcome": "conflict", "detail": last_detail}
 
 
 # ─── the state machine ───────────────────────────────────────────────────────
@@ -989,40 +1234,10 @@ async def main(input):
                     "escalations": escalations}
 
     # A9 — CI watch (the agent OWNS the durable wait) -> fix -> re-watch, bounded
-    # (N watches, N-1 fixes — matches autodev's CI loop).
-    ci_ok = False
-    ci_agent_error = False
-    for i in range(MAX_CI_ITERS):
-        # A ci-watch / ci-fix agent error breaks the loop and falls through to the verify
-        # gate (item 5) — it does NOT crash the run nor silently pass a red PR.
-        try:
-            ci = await agent(
-                {"task": "watch_ci", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
-                agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model, label="ci-%d" % i)
-        except AgentError as exc:
-            log("ci-watch agent error -> escalate:", exc)
-            ci_agent_error = True
-            break
-        if ci["status"] in ("green", "no_ci"):
-            ci_ok = True
-            break
-        if i == MAX_CI_ITERS - 1:
-            break
-        before = head_sha
-        try:
-            fix = await agent(
-                {"task": "fix_ci", "repo": repo, "pr_number": pr_number,
-                 "detail": ci.get("detail", ""), "comments": comment_bodies,
-                 "lint_hint": FIX_CI_LINT_HINT},
-                agent_id=FIX_AGENT_ID, output_schema=FIX_SCHEMA, model=model,
-                label="ci-fix-%d" % i)
-            head_sha = fix["head_sha"]
-        except AgentError as exc:
-            log("ci-fix agent error -> escalate:", exc)
-            ci_agent_error = True
-            break
-        if before and head_sha == before:
-            break
+    # (N watches, N-1 fixes — matches autodev's CI loop). Factored into _watch_ci so the
+    # post-rebase re-entry below can drive the identical loop with a distinct label prefix.
+    ci_ok, ci_agent_error, head_sha = await _watch_ci(
+        repo, pr_number, head_sha, comment_bodies, model, "ci")
     if not ci_ok:
         _ci_reason = ("CI-watch agent error" if ci_agent_error
                       else "CI failing after %d checks" % MAX_CI_ITERS)
@@ -1032,6 +1247,43 @@ async def main(input):
             return {"state": "escalated",
                     "reason": "ci_agent_error" if ci_agent_error else "ci_exhausted",
                     "escalations": escalations}
+
+    # S-SYNC — rebase/sync recovery (#1385). Early in the merge path (BEFORE the merge guard)
+    # and on every run re-entry: check mergeability and HEAL a branch master moved under
+    # instead of parking or orphaning it. A clean/already-current branch is an idempotent
+    # no-op (safe under the at-least-once crash contract). A DIRTY/behind branch is
+    # mechanically rebased + force-pushed-with-lease; a real conflict is handed to the SAME
+    # fix agent (bounded ≤MAX_REBASE_ATTEMPTS). Still unresolved -> park at the NEW, distinct
+    # `rebase_conflict` gate. After a successful rebase RE-ENTER the CI watch (CI must re-run
+    # on the updated branch) before proceeding to merge.
+    phase("sync")
+    sync = await _sync_branch(repo, pr_number, branch, comment_bodies, model)
+    if sync["outcome"] in ("conflict", "error"):
+        detail = sync.get("detail", "")
+        await post_markered_comment(repo, pr_number, MARKER_REBASE_CONFLICT,
+                                    "%s\n\n```\n%s\n```" % (MARKER_REBASE_CONFLICT, detail))
+        escalations.append("rebase_conflict")
+        decision = await gate({"kind": "rebase_conflict", "pr": pr_number, "detail": detail})
+        if not (isinstance(decision, dict) and decision.get("resolved")):
+            return {"state": "escalated", "reason": "rebase_conflict",
+                    "pr_url": pr_url, "pr_number": pr_number, "escalations": escalations}
+    elif sync["outcome"] == "rebased":
+        # The branch was rebased onto master: a new tip was force-pushed, so CI MUST re-run on
+        # the updated branch before merge. Re-enter the CI watch (distinct `reci` label prefix
+        # keeps replay deterministic). A fix-advanced head_sha overrides the (now-stale) one.
+        if sync.get("head_sha"):
+            head_sha = sync["head_sha"]
+        ci_ok, ci_agent_error, head_sha = await _watch_ci(
+            repo, pr_number, head_sha, comment_bodies, model, "reci")
+        if not ci_ok:
+            _ci_reason = ("CI-watch agent error after rebase" if ci_agent_error
+                          else "CI failing after %d checks after rebase" % MAX_CI_ITERS)
+            escalations.append("verify")
+            decision = await gate({"kind": "verify", "pr": pr_number, "reason": _ci_reason})
+            if not (isinstance(decision, dict) and decision.get("resolved")):
+                return {"state": "escalated",
+                        "reason": "ci_agent_error" if ci_agent_error else "ci_exhausted",
+                        "escalations": escalations}
 
     # A10/S11 — risk tiering (best-effort; never blocks). Conservative tier-3 default. The
     # guard tolerates BOTH a child failure (AgentError) AND a malformed/short return

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -54,16 +54,23 @@ def _issue_json(body: str = LONG_BODY) -> str:
     )
 
 
-def _pr_json(*, sha: str = "sha_initial", merged: bool = False) -> str:
-    return json.dumps(
-        {
-            "number": 42,
-            "node_id": "PR_node42",
-            "html_url": "https://github.com/o/r/pull/42",
-            "head": {"sha": sha, "ref": BRANCH},
-            "merged": merged,
-        }
-    )
+def _pr_json(
+    *, sha: str = "sha_initial", merged: bool = False, mergeable_state: str | None = None
+) -> str:
+    payload: dict[str, Any] = {
+        "number": 42,
+        "node_id": "PR_node42",
+        "html_url": "https://github.com/o/r/pull/42",
+        "head": {"sha": sha, "ref": BRANCH},
+        "merged": merged,
+    }
+    if mergeable_state is not None:
+        # The sync stage (#1385) reads mergeable_state to decide whether to rebase. A clean PR
+        # is the default (omitted -> _needs_rebase False -> sync no-op); set "dirty"/"behind"
+        # to model master having moved under the branch.
+        payload["mergeable_state"] = mergeable_state
+        payload["mergeable"] = mergeable_state == "clean"
+    return json.dumps(payload)
 
 
 # ─── the capability responder (a deterministic function of the capability) ────
@@ -99,6 +106,8 @@ class Scenario:
         merge_returns_sha: bool = True,
         commit_sha: str | None = MERGE_SHA,
         transient_5xx: dict[tuple[str, str], int] | None = None,
+        mergeable_state: str | None = None,
+        rebase_exit: list[int] | None = None,
     ) -> None:
         self.body = body
         # The comment-thread the GET /issues/{n}/comments responder returns (list of body
@@ -142,6 +151,13 @@ class Scenario:
         # then the real response. Counts are mutated as attempts arrive (replay-stable because
         # each retry is a distinct call_key, so a replay re-asks each attempt exactly once).
         self.transient_5xx = dict(transient_5xx or {})
+        # The sync stage (#1385). mergeable_state seeds the PR's mergeable_state field so the
+        # sync probe decides whether to rebase; rebase_exit is the queue of exit codes the
+        # mechanical-rebase bash node returns per invocation (75 noop / 0 done / 76 conflict /
+        # 77 error). When rebase_exit is exhausted the last code is reused.
+        self.mergeable_state = mergeable_state
+        self.rebase_exit = list(rebase_exit or [])
+        self.rebase_commands: list[str] = []  # every rebase bash command dispatched
         self.tasks: list[str] = []
         self.agent_inputs: list[dict[str, Any]] = []
         self.gates: list[dict[str, Any]] = []
@@ -239,8 +255,10 @@ class Scenario:
             raw = args.get("body")
             self.followups.append(json.loads(raw) if isinstance(raw, str) else {})
             return {"status": 201, "body": json.dumps({"number": 99})}
-        if method == "GET" and path == "/repos/o/r/pulls/42":  # merge-confirm read
-            body = json.loads(_pr_json(merged=self.pr_merged_on_confirm))
+        if method == "GET" and path == "/repos/o/r/pulls/42":  # sync probe + merge-confirm read
+            body = json.loads(
+                _pr_json(merged=self.pr_merged_on_confirm, mergeable_state=self.mergeable_state)
+            )
             body["merge_commit_sha"] = self.commit_sha  # confirm-read fallback for master sha
             return {"status": 200, "body": json.dumps(body)}
         if method == "GET" and path == "/repos/o/r/commits/master":  # ref->SHA-1 canonicalise
@@ -272,7 +290,25 @@ class Scenario:
         if cid == "tool":
             if spec["tool_name"] == "http_request":
                 return {"ok": self._http(spec["input"])}
-            if spec["tool_name"] == "bash":  # merge-ref guard
+            if spec["tool_name"] == "bash":
+                command = spec["input"].get("command", "")
+                if "git rebase origin/master" in command:  # sync-stage mechanical rebase (#1385)
+                    self.rebase_commands.append(command)
+                    code = (
+                        self.rebase_exit.pop(0)
+                        if len(self.rebase_exit) > 1
+                        else (self.rebase_exit[0] if self.rebase_exit else 0)
+                    )
+                    return {
+                        "ok": {
+                            "exit_code": code,
+                            "stdout": "REBASE",
+                            "stderr": "",
+                            "timed_out": False,
+                            "truncated": False,
+                        }
+                    }
+                # merge-ref guard
                 return {
                     "ok": {
                         "exit_code": self.merge_guard_exit,
@@ -386,6 +422,7 @@ async def test_happy_path_merges_and_completes() -> None:
         "implement",
         "open-pr",
         "verify",
+        "sync",
         "risk",
         "merge-guard",
         "mark-ready",
@@ -652,6 +689,96 @@ async def test_merge_guard_refusal_proceed_merges() -> None:
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"
     assert value["merged"] is True
+
+
+# ─── sync / rebase recovery (#1385) ───────────────────────────────────────────
+
+
+async def test_clean_pr_skips_rebase_entirely() -> None:
+    # A mergeable PR (no master drift) must NOT run any rebase bash node — the sync stage is
+    # an idempotent no-op and the run merges as before.
+    scn = Scenario(mergeable_state="clean")
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert scn.rebase_commands == []  # never touched the rebase bash node
+
+
+async def test_dirty_pr_mechanically_rebases_then_reenters_ci_and_merges() -> None:
+    # master moved under the branch (dirty) but the rebase replays cleanly (exit 0 = DONE).
+    # The branch is healed mechanically (no fix agent), CI re-runs on the updated branch
+    # (a distinct `reci-0` watch), and the PR merges.
+    scn = Scenario(mergeable_state="dirty", rebase_exit=[0])
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert len(scn.rebase_commands) == 1  # exactly the one mechanical rebase
+    # CI was re-entered after the rebase (the post-rebase `reci` watch ran)
+    assert any(t.startswith("reci") for t in scn.tasks)
+
+
+async def test_dirty_pr_already_current_is_noop_and_does_not_reenter_ci() -> None:
+    # GitHub reports dirty but the mechanical rebase finds the branch already current (exit
+    # 75 = NOOP) — a re-driven sync on an already-healed branch. CI is NOT re-entered.
+    scn = Scenario(mergeable_state="dirty", rebase_exit=[75])
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert not any(t.startswith("reci") for t in scn.tasks)  # no CI re-entry on a no-op
+
+
+async def test_real_conflict_resolved_by_fix_agent_then_merges() -> None:
+    # The mechanical rebase CONFLICTs (76); the fix agent resolves it; the confirm rebase
+    # reports NOOP (75) -> healed; CI re-runs; the PR merges. exits: [76, 75].
+    scn = Scenario(mergeable_state="dirty", rebase_exit=[76, 75])
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    # the SAME fix agent fix_ci uses was dispatched with the rebase resolve task
+    assert any(i.get("task") == "fix_ci" and "rebase_hint" in i for i in scn.agent_inputs)
+    assert any(t.startswith("reci") for t in scn.tasks)  # CI re-entered after the resolve
+
+
+async def test_unresolvable_conflict_parks_at_rebase_conflict_gate() -> None:
+    # The conflict never heals (mechanical 76, then both confirm attempts stay 76). The run
+    # parks at the NEW, distinct `rebase_conflict` gate — NOT the verify or merge gate.
+    scn = Scenario(
+        mergeable_state="dirty",
+        rebase_exit=[76, 76, 76],
+        gate_results={"rebase_conflict": {}},  # chairman does not resolve -> escalate
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "rebase_conflict"
+    assert any(g["kind"] == "rebase_conflict" for g in scn.gates)
+    # a marker comment naming the conflict was posted to the PR
+    assert any("Rebase conflict" in c for c in scn.comments_posted)
+
+
+async def test_rebase_conflict_gate_resolved_continues_to_merge() -> None:
+    # The chairman resolves the rebase_conflict gate -> the run continues past sync to merge.
+    scn = Scenario(
+        mergeable_state="dirty",
+        rebase_exit=[76, 76, 76],
+        gate_results={"rebase_conflict": {"resolved": True}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert any(g["kind"] == "rebase_conflict" for g in scn.gates)
+
+
+async def test_rebase_plumbing_error_fails_closed_to_rebase_conflict_gate() -> None:
+    # A clone/fetch/push failure (exit 77) cannot prove the branch is healthy: fail closed to
+    # the rebase_conflict gate rather than waving a possibly-unmergeable branch through.
+    scn = Scenario(
+        mergeable_state="dirty",
+        rebase_exit=[77],
+        gate_results={"rebase_conflict": {}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "rebase_conflict"
 
 
 async def test_high_risk_parks_for_merge_approval() -> None:

--- a/tests/unit/test_dev_pipeline_rebase.py
+++ b/tests/unit/test_dev_pipeline_rebase.py
@@ -1,0 +1,298 @@
+"""Unit tests for the rebase/sync recovery stage (#1385).
+
+``dev_pipeline.py`` used to have NO rebase/resolve logic: when master moved under an open
+PR it went DIRTY/non-mergeable, GitHub could not compute ``refs/pull/N/merge``, CI never
+re-ran, and the run jammed at the CI watch ("no checks reported"). Resolving such PRs was a
+manual CEO-seat operation (hand ``git rebase`` + re-dispatch).
+
+The fix adds a sync stage to the workflow *script body* that HEALS the branch instead of
+parking or orphaning it:
+
+  - ``_needs_rebase(pr)``    — read GitHub's ``mergeable``/``mergeable_state`` and decide.
+  - ``_rebase_command(...)`` — a mechanical ``git rebase origin/master`` + force-push-with-
+    lease bash node returning a DISTINCT exit code (noop / done / conflict / error).
+  - ``_sync_branch(...)``    — the orchestrator: probe mergeability, try the mechanical
+    rebase, hand a REAL conflict to the SAME fix agent ``fix_ci`` uses (bounded to
+    ``MAX_REBASE_ATTEMPTS``), and report ``noop`` / ``rebased`` / ``conflict`` / ``error``
+    for the caller to drive (re-enter CI / park at the new ``rebase_conflict`` gate).
+
+These helpers live inside the workflow script source (``_BODY``), so they are not importable
+as module attributes. We build the production script and ``exec`` it in a fresh namespace,
+inject fake async ``gh`` / ``tool`` / ``agent`` capabilities, then drive the coroutines.
+No LLM, no real I/O, no time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from aios.workflows.dev_pipeline import build_dev_pipeline_script
+
+
+class AgentError(Exception):
+    """The runtime-provided AgentError name the body's ``except AgentError`` resolves."""
+
+
+def _ns(
+    *,
+    gh: Any = None,
+    tool: Any = None,
+    agent: Any = None,
+) -> dict[str, Any]:
+    """A fresh exec namespace for the script body with runtime names injected."""
+    src = build_dev_pipeline_script(
+        implement_agent_id="a",
+        review_agent_id="b",
+        fix_agent_id="c",
+        ci_agent_id="d",
+        risk_agent_id="e",
+    )
+    namespace: dict[str, Any] = {}
+    exec(compile(src, "dev_pipeline_script", "exec"), namespace)
+    logs: list[str] = []
+    namespace["log"] = lambda *a: logs.append(" ".join(str(x) for x in a))
+    namespace["_LOGS"] = logs
+    namespace["AgentError"] = AgentError
+    if gh is not None:
+        namespace["gh"] = gh
+    if tool is not None:
+        namespace["tool"] = tool
+    if agent is not None:
+        namespace["agent"] = agent
+    return namespace
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+REPO = "eumemic/aios"
+PR = 1214
+BRANCH = "issue-1214"
+
+
+# ─── _needs_rebase: read mergeability correctly ───────────────────────────────
+
+
+def test_needs_rebase_true_for_dirty_and_behind() -> None:
+    ns = _ns()
+    assert ns["_needs_rebase"]({"mergeable_state": "dirty"}) is True
+    assert ns["_needs_rebase"]({"mergeable_state": "behind"}) is True
+
+
+def test_needs_rebase_true_when_mergeable_is_false() -> None:
+    # GitHub already computed a real conflict.
+    ns = _ns()
+    assert ns["_needs_rebase"]({"mergeable": False, "mergeable_state": "unknown"}) is True
+
+
+def test_needs_rebase_false_for_clean_and_benign_states() -> None:
+    ns = _ns()
+    for state in ("clean", "unstable", "has_hooks", "blocked"):
+        assert ns["_needs_rebase"]({"mergeable": True, "mergeable_state": state}) is False
+
+
+def test_needs_rebase_false_when_mergeable_unknown_and_state_benign() -> None:
+    # mergeable=None means GitHub hasn't recomputed yet; a benign state must NOT force a
+    # rebase of a clean PR (idempotence — we don't churn a healthy branch).
+    ns = _ns()
+    assert ns["_needs_rebase"]({"mergeable": None, "mergeable_state": "clean"}) is False
+
+
+def test_needs_rebase_false_for_non_dict() -> None:
+    ns = _ns()
+    assert ns["_needs_rebase"](None) is False
+
+
+# ─── _rebase_command: the mechanical rebase bash node ─────────────────────────
+
+
+def test_rebase_command_force_pushes_with_lease_not_force() -> None:
+    ns = _ns()
+    cmd = ns["_rebase_command"](REPO, BRANCH)
+    assert "git rebase origin/master" in cmd
+    assert "--force-with-lease" in cmd
+    # never a bare --force (which would clobber a concurrent push)
+    assert "push --force " not in cmd and "push --force\n" not in cmd
+
+
+def test_rebase_command_emits_distinct_exit_codes() -> None:
+    ns = _ns()
+    cmd = ns["_rebase_command"](REPO, BRANCH)
+    # noop / done / conflict / error are each reachable via a distinct exit
+    assert "exit 75" in cmd  # REBASE_EXIT_NOOP
+    assert "exit 0" in cmd  # REBASE_EXIT_DONE
+    assert "exit 76" in cmd  # REBASE_EXIT_CONFLICT
+    assert "exit 77" in cmd  # REBASE_EXIT_ERROR
+    # the no-op short-circuit (already current with master) precedes the rebase attempt
+    assert "merge-base --is-ancestor origin/master HEAD" in cmd
+
+
+def test_rebase_command_aborts_on_conflict() -> None:
+    # A real conflict must `git rebase --abort` so the branch is left untouched.
+    ns = _ns()
+    cmd = ns["_rebase_command"](REPO, BRANCH)
+    assert "git rebase --abort" in cmd
+
+
+# ─── fakes for the _sync_branch orchestrator ──────────────────────────────────
+
+
+class _FakeGH:
+    def __init__(self, pr_payload: dict[str, Any]) -> None:
+        self.pr_payload = pr_payload
+        self.calls: list[tuple[str, str]] = []
+
+    async def __call__(self, method: str, path: str, body: Any = None) -> dict[str, Any]:
+        self.calls.append((method, path))
+        import json
+
+        return {"status": 200, "body": json.dumps(self.pr_payload)}
+
+
+class _FakeBash:
+    """A fake ``tool`` that returns a queued exit_code per bash invocation."""
+
+    def __init__(self, exit_codes: list[int]) -> None:
+        self.exit_codes = list(exit_codes)
+        self.commands: list[str] = []
+
+    async def __call__(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        assert name == "bash"
+        self.commands.append(args["command"])
+        code = self.exit_codes.pop(0) if self.exit_codes else 0
+        return {"exit_code": code, "stdout": "out", "stderr": "err", "timed_out": False}
+
+
+class _FakeAgent:
+    """A fake ``agent`` recording its inputs; returns a head_sha or raises per script."""
+
+    def __init__(self, *, error: bool = False, head_sha: str = "newsha") -> None:
+        self.error = error
+        self.head_sha = head_sha
+        self.inputs: list[dict[str, Any]] = []
+
+    async def __call__(self, input: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        self.inputs.append(input)
+        if self.error:
+            raise AgentError("agent down")
+        return {"head_sha": self.head_sha, "pushed": True}
+
+
+def _sync(ns: dict[str, Any]) -> Any:
+    return _run(ns["_sync_branch"](REPO, PR, BRANCH, ["a comment"], None))
+
+
+# ─── _sync_branch: a clean/current branch is an idempotent no-op ──────────────
+
+
+def test_sync_clean_pr_is_noop_without_touching_bash() -> None:
+    gh = _FakeGH({"mergeable": True, "mergeable_state": "clean"})
+    tool = _FakeBash([])
+    ns = _ns(gh=gh, tool=tool, agent=_FakeAgent())
+    result = _sync(ns)
+    assert result == {"outcome": "noop"}
+    # idempotence: a mergeable branch never runs the rebase bash node at all
+    assert tool.commands == []
+
+
+def test_sync_already_current_branch_is_noop() -> None:
+    # DIRTY per GitHub but the mechanical rebase reports NOOP (already current — a re-driven
+    # stage on an already-healed branch). The caller must NOT re-enter CI.
+    gh = _FakeGH({"mergeable_state": "dirty"})
+    tool = _FakeBash([75])  # REBASE_EXIT_NOOP
+    ns = _ns(gh=gh, tool=tool, agent=_FakeAgent())
+    result = _sync(ns)
+    assert result == {"outcome": "noop"}
+
+
+# ─── _sync_branch: a clean mechanical rebase heals the branch ─────────────────
+
+
+def test_sync_clean_mechanical_rebase_returns_rebased() -> None:
+    gh = _FakeGH({"mergeable_state": "behind"})
+    tool = _FakeBash([0])  # REBASE_EXIT_DONE
+    agent = _FakeAgent()
+    ns = _ns(gh=gh, tool=tool, agent=agent)
+    result = _sync(ns)
+    assert result["outcome"] == "rebased"
+    # a mechanical rebase needs no fix agent
+    assert agent.inputs == []
+    # exactly one bash invocation (the mechanical rebase)
+    assert len(tool.commands) == 1
+
+
+# ─── _sync_branch: a REAL conflict is resolved by the fix agent (bounded) ─────
+
+
+def test_sync_conflict_resolved_by_fix_agent() -> None:
+    # mechanical rebase CONFLICTs (76); the fix agent runs; the confirm rebase reports NOOP
+    # (76 then 75) -> resolved.
+    gh = _FakeGH({"mergeable_state": "dirty"})
+    tool = _FakeBash([76, 75])  # conflict, then confirm noop
+    agent = _FakeAgent(head_sha="resolvedsha")
+    ns = _ns(gh=gh, tool=tool, agent=agent)
+    result = _sync(ns)
+    assert result["outcome"] == "rebased"
+    assert result["head_sha"] == "resolvedsha"
+    # the fix agent was dispatched exactly once with the rebase resolve-conflicts hint
+    assert len(agent.inputs) == 1
+    assert "rebase_hint" in agent.inputs[0]
+    assert agent.inputs[0]["task"] == "fix_ci"
+
+
+def test_sync_fix_agent_is_the_same_fix_agent_id() -> None:
+    # The resolve-conflicts hand-off MUST use FIX_AGENT_ID (the same agent fix_ci invokes).
+    captured: list[Any] = []
+    gh = _FakeGH({"mergeable_state": "dirty"})
+    tool = _FakeBash([76, 75])
+
+    class _CapAgent:
+        async def __call__(self, input: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+            captured.append(kwargs.get("agent_id"))
+            return {"head_sha": "s", "pushed": True}
+
+    ns = _ns(gh=gh, tool=tool, agent=_CapAgent())
+    _sync(ns)
+    # "c" is the fix_agent_id passed to build in _ns
+    assert captured == ["c"]
+
+
+def test_sync_unresolvable_conflict_returns_conflict_after_budget() -> None:
+    # mechanical conflict, then BOTH fix attempts fail to heal (confirm stays conflicting):
+    # 76 (mechanical), 76 (confirm 1), 76 (confirm 2). Bounded at MAX_REBASE_ATTEMPTS=2.
+    gh = _FakeGH({"mergeable_state": "dirty"})
+    tool = _FakeBash([76, 76, 76])
+    agent = _FakeAgent()
+    ns = _ns(gh=gh, tool=tool, agent=agent)
+    result = _sync(ns)
+    assert result["outcome"] == "conflict"
+    # exactly MAX_REBASE_ATTEMPTS fix-agent dispatches (bounded)
+    assert len(agent.inputs) == 2
+
+
+def test_sync_fix_agent_error_is_bounded_then_conflict() -> None:
+    # The fix agent errors on every attempt; the loop is bounded and ends at conflict (the
+    # caller parks at the rebase_conflict gate) rather than crashing the run.
+    gh = _FakeGH({"mergeable_state": "dirty"})
+    tool = _FakeBash([76])  # mechanical conflict; no confirm runs (agent errors first)
+    agent = _FakeAgent(error=True)
+    ns = _ns(gh=gh, tool=tool, agent=agent)
+    result = _sync(ns)
+    assert result["outcome"] == "conflict"
+    assert len(agent.inputs) == 2  # both attempts tried
+
+
+# ─── _sync_branch: a plumbing failure fails closed ────────────────────────────
+
+
+def test_sync_plumbing_error_fails_closed_to_error() -> None:
+    # A clone/fetch/push failure (exit 77) cannot prove the branch is healthy -> fail closed
+    # to "error" so the caller parks at the rebase_conflict gate (never waved through).
+    gh = _FakeGH({"mergeable_state": "dirty"})
+    tool = _FakeBash([77])  # REBASE_EXIT_ERROR
+    ns = _ns(gh=gh, tool=tool, agent=_FakeAgent())
+    result = _sync(ns)
+    assert result["outcome"] == "error"
+    assert "detail" in result


### PR DESCRIPTION
Heals an open PR's branch when master moves under it, instead of jamming at the CI watch ("no checks reported") or requiring a manual rebase.

## New sync stage

Runs after the CI watch and before risk/merge-guard, so the healed branch is re-verified before any merge decision.

- `_needs_rebase(pr)` — reads GitHub's `mergeable`/`mergeable_state`; only `dirty`/`behind`/a GitHub-computed conflict trigger a rebase (a clean/unknown-but-benign branch is left untouched, so a healthy PR is never churned).
- `_rebase_command(...)` — a mechanical `git rebase origin/master` + `git push --force-with-lease` bash node returning a DISTINCT exit code (noop / done / conflict / error) the orchestrator branches on, in the same fail-closed exit-code style as the merge guard.
- `_sync_branch(...)` — orchestrates: probe mergeability, try the mechanical rebase, and only on a REAL conflict hand off to the SAME fix agent `fix_ci` uses (bounded to `MAX_REBASE_ATTEMPTS`) with a resolve-conflicts task; each attempt re-runs the mechanical rebase to confirm the branch actually healed.
- `_watch_ci(...)` — the CI watch->fix->re-watch loop factored out of `main` so it can RE-ENTER after a successful rebase (a force-push means CI must re-run on the updated branch before merge); a distinct `reci` label prefix keeps replay deterministic.

## Behaviour

- A clean PR is an idempotent no-op (no bash, no force-push) — safe under the at-least-once crash contract.
- A dirty/behind branch is rebased mechanically; a real conflict is resolved by the bounded fix-agent hand-off; CI re-runs on the rebased branch before merge.
- Still-unresolved conflicts — or a plumbing failure (clone/fetch/push), which fails CLOSED because we cannot prove the branch is healthy — park at a NEW, distinct `rebase_conflict` gate with a marker comment. Never the old orphaned-at-CI jam, never a silent zombie. A chairman-resolved gate continues to merge.

## Tests

- Unit coverage for `_needs_rebase` / `_rebase_command` / `_sync_branch` (exec-and-inject against the production script body, no LLM/IO).
- End-to-end fixture scenarios: clean no-op, clean mechanical rebase + CI re-entry, already-current no-op (no CI re-entry), agent-resolved conflict, unresolvable conflict -> gate park + resume, and plumbing error -> fail closed.
- Full dev_pipeline suite (132 tests) green; ruff check + format clean.