### PR TITLE
fix(dev-pipeline): sync stage re-enters CI watch on post-rebase head_sha, not stale pre-rebase one

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -963,6 +963,16 @@ async def _watch_ci(repo, pr_number, head_sha, comment_bodies, model, label_pref
     return ci_ok, ci_agent_error, head_sha
 
 
+async def _live_head_sha(repo, pr_number):
+    """Re-read the LIVE PR head SHA via ``GET /pulls/{n}`` after a rebase force-pushed a new
+    tip. The CI watch MUST key on the POST-rebase SHA, not the stale pre-rebase one: the old
+    commit carries the OLD (pre-rebase) green checks, and reporting it green would merge a tip
+    whose CI never re-ran (#1389). Returns ``""`` on a read failure — callers fall back to
+    whatever (possibly agent-reported) SHA they already hold and never silently trust junk."""
+    pr = _json_body(await gh("GET", _ipath(repo, "/pulls/%d" % pr_number)))
+    return _pr_head_sha(pr)
+
+
 async def _sync_branch(repo, pr_number, branch, comment_bodies, model):
     """Rebase/sync recovery stage (#1385): HEAL a branch master moved under instead of
     parking or orphaning it. Returns one of:
@@ -1002,7 +1012,7 @@ async def _sync_branch(repo, pr_number, branch, comment_bodies, model):
     if code == REBASE_EXIT_DONE:
         log("sync: mechanical rebase of %r onto %s succeeded -> re-enter CI"
             % (branch, BASE_BRANCH))
-        return {"outcome": "rebased", "head_sha": ""}
+        return {"outcome": "rebased", "head_sha": await _live_head_sha(repo, pr_number)}
     if code == REBASE_EXIT_ERROR:
         detail = "%s\n%s\nexit=%r" % (
             (rb.get("stdout", "") if isinstance(rb, dict) else "")[-800:],
@@ -1033,8 +1043,13 @@ async def _sync_branch(repo, pr_number, branch, comment_bodies, model):
         ccode = confirm.get("exit_code") if isinstance(confirm, dict) else None
         if ccode in (REBASE_EXIT_NOOP, REBASE_EXIT_DONE):
             log("sync: rebase conflict resolved by fix agent on attempt %d" % attempt)
-            return {"outcome": "rebased", "head_sha": fix.get("head_sha", "")
-                    if isinstance(fix, dict) else ""}
+            # Re-read the LIVE PR head rather than trusting the fix agent's reported
+            # head_sha: the confirm rebase above may itself have force-pushed a new tip,
+            # so the agent-reported SHA can already be stale. Fall back to the agent's
+            # value only if the live re-read comes back empty (plumbing hiccup).
+            live = await _live_head_sha(repo, pr_number)
+            agent_sha = fix.get("head_sha", "") if isinstance(fix, dict) else ""
+            return {"outcome": "rebased", "head_sha": live or agent_sha}
         last_detail = ("rebase still conflicting after fix attempt %d (confirm exit=%r)"
                        % (attempt, ccode))
         log("sync:", last_detail)

--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -967,10 +967,12 @@ async def _live_head_sha(repo, pr_number):
     """Re-read the LIVE PR head SHA via ``GET /pulls/{n}`` after a rebase force-pushed a new
     tip. The CI watch MUST key on the POST-rebase SHA, not the stale pre-rebase one: the old
     commit carries the OLD (pre-rebase) green checks, and reporting it green would merge a tip
-    whose CI never re-ran (#1389). Returns ``""`` on a read failure — callers fall back to
-    whatever (possibly agent-reported) SHA they already hold and never silently trust junk."""
+    whose CI never re-ran (#1389). Returns ``""`` on a read failure OR a non-SHA-1 value
+    (a 64-char SHA-256 GitHub's REST endpoints reject, #1178) — callers fall back to whatever
+    (possibly agent-reported) SHA they already hold and never silently trust junk."""
     pr = _json_body(await gh("GET", _ipath(repo, "/pulls/%d" % pr_number)))
-    return _pr_head_sha(pr)
+    sha = _pr_head_sha(pr)
+    return sha if _is_sha1(sha) else ""
 
 
 async def _sync_branch(repo, pr_number, branch, comment_bodies, model):

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -108,6 +108,8 @@ class Scenario:
         transient_5xx: dict[tuple[str, str], int] | None = None,
         mergeable_state: str | None = None,
         rebase_exit: list[int] | None = None,
+        post_rebase_head_sha: str | None = None,
+        ci_results_by_sha: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         self.body = body
         # The comment-thread the GET /issues/{n}/comments responder returns (list of body
@@ -157,6 +159,16 @@ class Scenario:
         # 77 error). When rebase_exit is exhausted the last code is reused.
         self.mergeable_state = mergeable_state
         self.rebase_exit = list(rebase_exit or [])
+        # #1389: after a successful mechanical rebase force-pushes a NEW tip, GET /pulls/42 must
+        # report the POST-rebase head SHA — the old `sha_initial` commit carries the OLD CI
+        # checks. When set, the PR's head.sha flips to this value once a rebase bash node has
+        # run (rebase_commands non-empty), modelling the live tip the CI re-entry MUST key on.
+        self.post_rebase_head_sha = post_rebase_head_sha
+        # #1389: a `watch_ci` responder that KEYS ON head_sha (the default ci_results queue is
+        # head_sha-independent, so it structurally cannot catch a stale-SHA read). Maps a head
+        # SHA -> the verdict the watch returns for it; a SHA absent from the map yields a failing
+        # (red) verdict, so a watch re-entered on the stale pre-rebase SHA does NOT report green.
+        self.ci_results_by_sha = ci_results_by_sha
         self.rebase_commands: list[str] = []  # every rebase bash command dispatched
         self.tasks: list[str] = []
         self.agent_inputs: list[dict[str, Any]] = []
@@ -256,8 +268,19 @@ class Scenario:
             self.followups.append(json.loads(raw) if isinstance(raw, str) else {})
             return {"status": 201, "body": json.dumps({"number": 99})}
         if method == "GET" and path == "/repos/o/r/pulls/42":  # sync probe + merge-confirm read
+            # #1389: once a rebase has force-pushed a new tip, the LIVE head SHA must reflect it
+            # so the CI re-entry keys on the post-rebase tip, not the stale pre-rebase one.
+            sha = (
+                self.post_rebase_head_sha
+                if (self.post_rebase_head_sha and self.rebase_commands)
+                else "sha_initial"
+            )
             body = json.loads(
-                _pr_json(merged=self.pr_merged_on_confirm, mergeable_state=self.mergeable_state)
+                _pr_json(
+                    sha=sha,
+                    merged=self.pr_merged_on_confirm,
+                    mergeable_state=self.mergeable_state,
+                )
             )
             body["merge_commit_sha"] = self.commit_sha  # confirm-read fallback for master sha
             return {"status": 200, "body": json.dumps(body)}
@@ -355,6 +378,17 @@ class Scenario:
                     return {"ok": {"status": self.master_ci, "detail": ""}}
                 if self.ci_error_on == label:
                     return {"error": {"kind": "child_errored"}}
+                # #1389: a SHA-keyed responder — the watch's verdict is a function of the
+                # head_sha it was dispatched with, so a re-entry on a STALE pre-rebase SHA
+                # reads a different (failing) verdict than the post-rebase tip. A SHA absent
+                # from the map is red, so a stale-SHA read can NEVER masquerade as green.
+                if self.ci_results_by_sha is not None:
+                    sha = spec["input"].get("head_sha", "")
+                    return {
+                        "ok": self.ci_results_by_sha.get(
+                            sha, {"status": "red", "detail": f"no CI for {sha}"}
+                        )
+                    }
                 idx = int(label.rsplit("-", 1)[1]) if label.startswith("ci-") else 0
                 return {"ok": self.ci_results[min(idx, len(self.ci_results) - 1)]}
             if task == "risk":
@@ -779,6 +813,71 @@ async def test_rebase_plumbing_error_fails_closed_to_rebase_conflict_gate() -> N
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "escalated"
     assert value["reason"] == "rebase_conflict"
+
+
+def _reentry_watch_shas(scn: Scenario) -> list[str]:
+    """The head_sha each branch (non-master, non-`ref`) CI watch was dispatched with, in
+    order. The FIRST is the pre-rebase `ci` watch (keyed on the original head); any LATER
+    one is the post-rebase `reci` re-entry — #1389 requires it to carry the rebased tip."""
+    return [
+        i["head_sha"]
+        for i in scn.agent_inputs
+        if i.get("task") == "watch_ci" and not i.get("ref")
+    ]
+
+
+async def test_mechanical_rebase_reenters_ci_on_post_rebase_sha_not_stale_head() -> None:
+    # #1389: a mechanical rebase (exit 0) force-pushes a NEW tip; the CI re-entry MUST key on
+    # the POST-rebase head SHA, not the stale pre-rebase `sha_initial`. The watch_ci responder
+    # here KEYS ON head_sha (the default queue is head_sha-independent and structurally cannot
+    # catch a stale read). Both heads are green so the run still merges; the load-bearing
+    # assertion is that the RE-ENTRY watch was dispatched with the rebased tip, not the stale
+    # one — before this fix it carried `sha_initial` (the empty-string head_sha was falsy, so
+    # `main` never overwrote the stale pre-rebase head before re-entering the watch).
+    scn = Scenario(
+        mergeable_state="dirty",
+        rebase_exit=[0],
+        post_rebase_head_sha="sha_rebased",
+        ci_results_by_sha={
+            "sha_initial": {"status": "green", "detail": ""},   # pre-rebase `ci` watch
+            "sha_rebased": {"status": "green", "detail": ""},   # post-rebase `reci` watch
+        },
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    shas = _reentry_watch_shas(scn)
+    # the pre-rebase watch keyed on the original head; the post-rebase re-entry on the tip
+    assert shas[0] == "sha_initial"
+    assert shas[-1] == "sha_rebased", (
+        "post-rebase CI re-entry must run against the rebased tip, not the stale head"
+    )
+    # the stale pre-rebase SHA is used by AT MOST the single pre-rebase watch
+    assert shas.count("sha_initial") == 1
+
+
+async def test_agent_resolved_conflict_reenters_ci_on_post_rebase_sha() -> None:
+    # #1389 (folded-in path): the mechanical rebase CONFLICTs (76), the fix agent resolves it,
+    # the confirm rebase reports NOOP (75). The CI re-entry MUST still key on the LIVE post-
+    # rebase head (read from GET /pulls/42), not the fix agent's (possibly stale) reported SHA
+    # nor the pre-rebase head. The SHA-keyed watch is green ONLY on the rebased tip.
+    scn = Scenario(
+        mergeable_state="dirty",
+        rebase_exit=[76, 75],
+        post_rebase_head_sha="sha_rebased",
+        ci_results_by_sha={
+            "sha_initial": {"status": "green", "detail": ""},
+            "sha_rebased": {"status": "green", "detail": ""},
+        },
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+    assert any(i.get("task") == "fix_ci" and "rebase_hint" in i for i in scn.agent_inputs)
+    shas = _reentry_watch_shas(scn)
+    assert shas[-1] == "sha_rebased", (
+        "post-rebase CI re-entry must run against the rebased tip, not the stale head"
+    )
 
 
 async def test_high_risk_parks_for_merge_approval() -> None:

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -37,6 +37,11 @@ BRANCH = "issue-5"
 # name (issue #1178) — a SHA-256 clone would re-resolve `master` to a 64-char id GitHub's
 # REST API rejects, hard-erroring the watch on a green master.
 MERGE_SHA = "f823360f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+# The SHA-1 the PR's head moves to after a sync-stage rebase force-pushes the rebased tip
+# (#1389). The CI re-entry MUST key on THIS, not the stale pre-rebase head_sha the run still
+# carries. A real 40-char SHA-1 (not a `sha_…` placeholder) so it survives _live_head_sha's
+# SHA-1 validation — a non-SHA-1 head is treated as unresolvable (#1178) and rejected.
+POST_REBASE_SHA = "ab12cd34ef560718293a4b5c6d7e8f9012345678"
 # A concrete, >50-word spec body that clears the scripted spec gate.
 LONG_BODY = (
     "Add a durable retry wrapper around the outbound webhook dispatcher so that transient "
@@ -820,9 +825,7 @@ def _reentry_watch_shas(scn: Scenario) -> list[str]:
     order. The FIRST is the pre-rebase `ci` watch (keyed on the original head); any LATER
     one is the post-rebase `reci` re-entry — #1389 requires it to carry the rebased tip."""
     return [
-        i["head_sha"]
-        for i in scn.agent_inputs
-        if i.get("task") == "watch_ci" and not i.get("ref")
+        i["head_sha"] for i in scn.agent_inputs if i.get("task") == "watch_ci" and not i.get("ref")
     ]
 
 
@@ -837,10 +840,10 @@ async def test_mechanical_rebase_reenters_ci_on_post_rebase_sha_not_stale_head()
     scn = Scenario(
         mergeable_state="dirty",
         rebase_exit=[0],
-        post_rebase_head_sha="sha_rebased",
+        post_rebase_head_sha=POST_REBASE_SHA,
         ci_results_by_sha={
-            "sha_initial": {"status": "green", "detail": ""},   # pre-rebase `ci` watch
-            "sha_rebased": {"status": "green", "detail": ""},   # post-rebase `reci` watch
+            "sha_initial": {"status": "green", "detail": ""},  # pre-rebase `ci` watch
+            POST_REBASE_SHA: {"status": "green", "detail": ""},  # post-rebase `reci` watch
         },
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
@@ -849,7 +852,7 @@ async def test_mechanical_rebase_reenters_ci_on_post_rebase_sha_not_stale_head()
     shas = _reentry_watch_shas(scn)
     # the pre-rebase watch keyed on the original head; the post-rebase re-entry on the tip
     assert shas[0] == "sha_initial"
-    assert shas[-1] == "sha_rebased", (
+    assert shas[-1] == POST_REBASE_SHA, (
         "post-rebase CI re-entry must run against the rebased tip, not the stale head"
     )
     # the stale pre-rebase SHA is used by AT MOST the single pre-rebase watch
@@ -864,10 +867,10 @@ async def test_agent_resolved_conflict_reenters_ci_on_post_rebase_sha() -> None:
     scn = Scenario(
         mergeable_state="dirty",
         rebase_exit=[76, 75],
-        post_rebase_head_sha="sha_rebased",
+        post_rebase_head_sha=POST_REBASE_SHA,
         ci_results_by_sha={
             "sha_initial": {"status": "green", "detail": ""},
-            "sha_rebased": {"status": "green", "detail": ""},
+            POST_REBASE_SHA: {"status": "green", "detail": ""},
         },
     )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
@@ -875,7 +878,7 @@ async def test_agent_resolved_conflict_reenters_ci_on_post_rebase_sha() -> None:
     assert value["merged"] is True
     assert any(i.get("task") == "fix_ci" and "rebase_hint" in i for i in scn.agent_inputs)
     shas = _reentry_watch_shas(scn)
-    assert shas[-1] == "sha_rebased", (
+    assert shas[-1] == POST_REBASE_SHA, (
         "post-rebase CI re-entry must run against the rebased tip, not the stale head"
     )
 

--- a/tests/unit/test_dev_pipeline_rebase.py
+++ b/tests/unit/test_dev_pipeline_rebase.py
@@ -223,6 +223,50 @@ def test_sync_clean_mechanical_rebase_returns_rebased() -> None:
     assert len(tool.commands) == 1
 
 
+# The post-rebase tip the live PR re-read reports (#1389): a 40-char SHA-1, distinct from any
+# stale pre-rebase head_sha the caller might otherwise carry into the CI re-entry.
+_LIVE_HEAD_SHA = "abcdef0123456789abcdef0123456789abcdef01"
+
+
+def test_sync_mechanical_rebase_threads_live_post_rebase_head_sha() -> None:
+    # #1389: after the mechanical rebase force-pushes the rebased tip, _sync_branch RE-READS
+    # the live PR head (GET /pulls/{n}) and returns THAT sha so the caller's CI re-entry keys
+    # on the rebased tip — not the stale pre-rebase head_sha.
+    gh = _FakeGH({"mergeable_state": "dirty", "head": {"sha": _LIVE_HEAD_SHA}})
+    tool = _FakeBash([0])  # REBASE_EXIT_DONE
+    ns = _ns(gh=gh, tool=tool, agent=_FakeAgent())
+    result = _sync(ns)
+    assert result["outcome"] == "rebased"
+    assert result["head_sha"] == _LIVE_HEAD_SHA
+    # the live re-read actually happened: a SECOND GET /pulls/{n} after the mergeability probe
+    assert gh.calls.count(("GET", f"/repos/{REPO}/pulls/{PR}")) == 2
+
+
+def test_sync_agent_resolved_conflict_prefers_live_head_over_agent_report() -> None:
+    # #1389 (agent path): the fix agent self-reports a head_sha, but the confirm rebase may
+    # have force-pushed a new tip on top of it. The live PR re-read is authoritative — its sha
+    # is threaded, NOT the agent's (possibly stale) self-report.
+    gh = _FakeGH({"mergeable_state": "dirty", "head": {"sha": _LIVE_HEAD_SHA}})
+    tool = _FakeBash([76, 0])  # mechanical conflict, then confirm DONE
+    agent = _FakeAgent(head_sha="agent-reported-sha")
+    ns = _ns(gh=gh, tool=tool, agent=agent)
+    result = _sync(ns)
+    assert result["outcome"] == "rebased"
+    assert result["head_sha"] == _LIVE_HEAD_SHA  # live tip wins over the agent's self-report
+
+
+def test_sync_agent_resolved_conflict_falls_back_to_agent_sha_when_live_read_blank() -> None:
+    # #1389 fallback: when the live PR re-read yields no usable SHA-1 (head absent), the agent's
+    # reported head_sha is used rather than returning an empty head_sha.
+    gh = _FakeGH({"mergeable_state": "dirty"})  # no head.sha in the payload
+    tool = _FakeBash([76, 75])  # conflict, then confirm NOOP
+    agent = _FakeAgent(head_sha="agentsha")
+    ns = _ns(gh=gh, tool=tool, agent=agent)
+    result = _sync(ns)
+    assert result["outcome"] == "rebased"
+    assert result["head_sha"] == "agentsha"
+
+
 # ─── _sync_branch: a REAL conflict is resolved by the fix agent (bounded) ─────
 
 


### PR DESCRIPTION
## Problem
The rebase/sync recovery stage (#1385 / PR #1388) re-entered the CI watch with a stale pre-rebase head_sha after a mechanical rebase. `_sync_branch` returned `{"outcome":"rebased","head_sha":""}`; in `main` the re-entry overwrites `head_sha` only `if sync.get("head_sha")` -- an empty string is falsy -- so `_watch_ci` ran against the stale pre-rebase head. A CI watch keyed on that SHA reads the OLD commit's green checks and reports green for a tip whose CI never re-ran. The agent-resolved-conflict confirm path had the same class of stale head_sha (it trusted the fix agent's reported SHA, which the confirm rebase can force-push past).

This becomes a hard misfire once #1316 (deterministic CI watch) lands, so it must land before #1316/#1318.

## Fix
Thread the rebased tip through to the CI re-entry on both paths via a new `_live_head_sha(repo, pr_number)` helper that re-reads the live PR head (`GET /pulls/{n}` -> `head.sha`) after the rebase force-pushes a new tip:
- Mechanical-rebase path (`REBASE_EXIT_DONE`): return the live post-rebase head instead of `""`.
- Agent-resolved confirm path: re-read the live head and prefer it over the fix agent's reported SHA (which the confirm rebase may have superseded), falling back to the agent value only if the live read comes back empty.

The existing `if sync.get("head_sha")` guard in `main` is preserved as a safety net: a failed live re-read returns `""` and the watch keeps the head it already held rather than trusting junk.

## Test
The prior `watch_ci` fixture responder served green from a head_sha-independent queue, so it structurally could not catch a stale-SHA read. Added: a `watch_ci` responder mode that keys on `head_sha` (`ci_results_by_sha`, red for any unmapped SHA); a `post_rebase_head_sha` flip so `GET /pulls/42` reports the post-rebase tip once a rebase bash node has run; and two tests asserting the re-entered watch is dispatched with the post-rebase SHA on both the mechanical-rebase and agent-resolved-conflict paths. Both fail on the pre-fix source and pass with the fix.

## Acceptance
After a mechanical rebase (and after an agent-resolved conflict), the CI watch runs against the rebased tip's SHA, not the pre-rebase SHA. New fixtures lock the property. Full dev-pipeline fixture suite (57 tests) green; ruff clean. Lands before #1316/#1318.