### PR TITLE
fix(dev_pipeline): close the recovery asymmetry + two false-greens

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -67,23 +67,71 @@ RESILIENCE CONTRACT (the Phase-0 hardening, aios#987; design doc §10):
    removed on success; every terminal NON-gate failure ``return`` first labels
    ``autodev:failed``. A gate park is a durable suspension (auto-recover on resume), NOT a
    failure, so it is deliberately not labelled failed.
-4. **Auto-recovery.** ``retry_count`` rides the input envelope; a re-launched run that arrives
-   with ``retry_count >= MAX_RUN_RETRIES`` terminates at ``dead_letter`` instead of looping.
-   The DEPLOY-TIME WIRING (Phase 2, not in this script): a ``run_completion`` trigger fires on
-   ``status=errored`` and re-launches the workflow with ``retry_count + 1`` and the same
-   ``{repo, issue_number}``. Re-launch is idempotent by construction — S4 lists open PRs and
-   ADOPTS the branch's PR instead of creating a duplicate ("open-pr"; a 422 on create re-lists
-   and adopts), and MERGE re-confirms ``GET /pulls/{n}.merged`` before declaring
-   ``merge_failed`` so an already-merged PR is never double-merged or lost.
-5. **AgentError guards.** Every agentic node (implement/review/fix/ci-watch/risk) runs under a
-   defensive guard: an ``agent_not_found`` / transient agent error escalates to the relevant
-   gate (design / verify) or, for the best-effort risk node, degrades to the conservative
-   default — so a flaky judgment agent parks the run for a human instead of crashing it (an
-   uncaught ``AgentError`` at the root fails the whole run). The post-merge master-CI watch is
-   the one node that does NEITHER (issue #1176): the merge is already committed and the run has
+4. **Auto-recovery (closing the STRUCTURAL ASYMMETRY — the keystone).** The only armed
+   recovery is the DEPLOY-TIME ``run_completion`` trigger, which fires on a TERMINAL
+   ``status=errored`` and re-launches the workflow with the same ``{repo, issue_number}``. It
+   can NEVER see a durable ``suspended`` gate-park, so a recoverable failure buried in a verify
+   gate is structurally unreachable by recovery. A ci-watch / ci-fix CHILD that ERRORS mid-call
+   (the ~1hr ceiling / "errored before responding") is recoverable, NOT a real red verdict, so
+   it RAISES (→ ``errored`` → re-launch) rather than parking — see ``_recover_or_park``.
+   Re-launch is idempotent by construction (S4 ADOPTS the branch's existing PR; MERGE
+   re-confirms ``GET /pulls/{n}.merged``) and re-enters the sync stage, so it re-rebases too.
+   BOUNDED by a DURABLE counter: the re-launch re-runs the SAME static input template (the
+   trigger cannot mutate it to carry ``retry_count + 1`` — see
+   ``harness/trigger_runner.compose_workflow_run_input``), so the bound lives in GitHub state —
+   an ``autodev:recovery-N`` label stamped before each re-raise (``_recovery_attempts`` reads
+   it at ingest). After ``MAX_RECOVERY_ATTEMPTS`` the recoverable error PARKS at the verify
+   gate for a human instead of re-raising — never an unbounded re-spend loop. (The in-envelope
+   ``retry_count`` / ``MAX_RUN_RETRIES`` dead-letter guard at the top of ``main`` is retained as
+   a belt-and-suspenders for any future trigger that DOES set it, but the durable label is the
+   load-bearing bound.)
+5. **AgentError guards.** Every agentic node runs under a defensive guard. The implement/review
+   judgment nodes escalate an ``agent_not_found`` / transient error to the relevant gate
+   (design / verify) — a flaky judgment agent parks the run for a HUMAN rather than crashing it
+   (an uncaught ``AgentError`` at the root fails the whole run). The **CI-watch / CI-fix** nodes
+   are DIFFERENT (item 4): a child error WITH NO PRIOR RED in the loop is RECOVERABLE
+   (re-running re-attempts the same build), so it RAISES for bounded auto-recovery; but a child
+   error AFTER a genuine red verdict is NOT recoverable (the tree is really broken) and PARKS at
+   the verify gate, as does a GENUINELY red verdict that survives the bounded fixes. The
+   best-effort risk node degrades to the conservative default. The post-merge master-CI watch
+   does NEITHER park NOR raise (issue #1176): the merge is already committed and the run has
    already returned done, so a flaky watch is RETRIED (≤ ``MAX_MASTER_CI_ITERS``) and, if still
    indeterminate, degrades to a distinct non-blocking advisory — never coerced to the
    most-blocking outcome and never allowed to re-suspend a completed run at a false gate.
+6. **No false-greens (the CI verdict is script-VERIFIED, not agent-trusted).** A ``watch_ci``
+   agent's ``green`` / ``no_ci`` is re-classified in-script by ``_ci_verdict`` before it counts
+   as a pass — an uncorrelated guard against the two false-green holes: (a) a verdict whose
+   polled commit is NOT the live PR head (a wrong-parent / orphan re-trigger commit reading
+   ``total_count=0`` as ``no_ci``, #1314) is rejected; (b) a ``green`` declared before the FULL
+   required-check set concluded (#1364) is rejected as premature. ``_ci_verdict`` returns a
+   3-state label — ``pass`` (trusted), ``red`` (genuinely broken → fix), or ``retry`` (an
+   UNVERIFIED green/no_ci → RE-WATCH, never run a fixer against passing code). It fails CLOSED:
+   if NO head anchor is available (live read empty AND no dispatched SHA), the verdict is
+   ``retry``, never trusted. An unsettled loop falls through to the verify gate / the
+   uncorrelated merge-guard, so a false-green can never walk a genuinely-red PR toward a merge.
+
+OUT-OF-BAND DEPLOY STEPS (this script is necessary but not sufficient — both are needed for
+the recovery + false-green guards to actually function in prod):
+  * The ``run_completion[errored]`` trigger on this workflow MUST exist and re-launch with the
+    same ``{repo, issue_number}`` — items 4/5's RAISE only recovers if that trigger fires.
+    Without it a recoverable CI error terminates ``errored`` with ``autodev:in-progress`` left
+    on and no re-launch (a worse outcome than the prior gate-park) — register/verify it on
+    deploy.
+  * The ``dev-ci-watch`` agent (its prompt lives in the aios object graph, NOT this repo) MUST
+    be taught to emit ``polled_sha`` and, for green, ``required_complete`` (both new, both
+    OPTIONAL in ``CI_SCHEMA``). Until it does, ``_ci_verdict`` returns ``retry`` for every
+    green/no_ci and EVERY PR parks at the verify gate — fail-CLOSED (no false merges) but
+    auto-merge throughput is zero. Ship the agent-prompt change in lockstep with this script.
+
+KNOWN RESIDUALS (documented, not fixed here — narrow, backstopped):
+  * ``no_ci`` is exempt from ``required_complete`` (there are no required checks to wait on),
+    so a transient ``total_count=0`` on the GENUINE head (required checks configured but not
+    yet scheduled) reads ``no_ci`` -> ``pass`` before CI ran. Narrow window; the uncorrelated
+    merge-guard re-runs the sentinels on the merge ref as the backstop. Tightening this
+    without breaking legitimately-no-CI repos is a follow-up.
+  * ``autodev:recovery-N`` labels are not stripped on terminal success, so a CLOSED issue that
+    is later RE-OPENED and re-dispatched would read a stale budget. Rare (merged issues close);
+    cleanup is a cheap follow-up.
 """
 
 from __future__ import annotations
@@ -146,6 +194,18 @@ CI_SCHEMA: dict[str, Any] = {
     "properties": {
         "status": {"type": "string", "enum": ["green", "red", "no_ci"]},
         "detail": {"type": "string"},
+        # The commit the watch ACTUALLY polled check-runs for. The script verifies this
+        # equals the LIVE PR head before trusting a green/no_ci verdict (#1314): a watch that
+        # polled an orphan / wrong-parent commit (so `total_count=0` reads as `no_ci`) must
+        # never count as a pass on a PR whose real head is red. Omitted -> the verdict is
+        # SHA-unverifiable, so a green/no_ci is NOT trusted (fail-closed).
+        "polled_sha": {"type": "string"},
+        # True only when the FULL required-check set has CONCLUDED (not merely a subset +
+        # a clean commit-status). A green declared while lint/unit are still running is a
+        # premature-green (#1364); when False the script does not trust a green verdict and
+        # defers to the uncorrelated merge-guard. Omitted -> treated as not-complete
+        # (fail-closed: an old agent that can't report completeness can't manufacture a green).
+        "required_complete": {"type": "boolean"},
     },
 }
 
@@ -187,6 +247,19 @@ RESOLUTION_SIGNALS: tuple[str, ...] = (
 # (a gate park is a durable suspension, not a failure, so it is NOT labelled failed).
 LABEL_IN_PROGRESS = "autodev:in-progress"
 LABEL_FAILED = "autodev:failed"
+
+# Auto-recovery attempt counter (the keystone bound). The deploy-time
+# ``run_completion[errored]`` trigger re-launches a workflow with the SAME static input
+# template — it does NOT (and cannot) mutate the template to carry ``retry_count + 1`` (see
+# ``harness/trigger_runner.compose_workflow_run_input``: the author's template rides verbatim).
+# So an in-envelope ``retry_count`` never increments across re-launches, and a counter we keep
+# only in run state is reset every re-launch. The bound therefore lives in DURABLE,
+# re-launch-surviving GitHub state: a ``autodev:recovery-N`` label stamped on the issue before
+# each re-raise. ``_recovery_attempts`` reads the highest N already present at ingest; a
+# recoverable CI child-error re-raises only while ``N < MAX_RECOVERY_ATTEMPTS``, else it PARKS
+# at the verify gate for a human (never an unbounded re-spend loop).
+LABEL_RECOVERY_PREFIX = "autodev:recovery-"
+MAX_RECOVERY_ATTEMPTS = 2
 
 # Stable heading markers on the chairman-facing comments this pipeline posts. Each heading is
 # BOTH the comment's first line AND the maker-marker the replay guard scans for: a posted
@@ -307,6 +380,8 @@ def _render_constants(
         _py("LABEL_IN_PROGRESS", LABEL_IN_PROGRESS),
         _py("LABEL_FAILED", LABEL_FAILED),
         _py("LABEL_DISPATCHED", LABEL_DISPATCHED),
+        _py("LABEL_RECOVERY_PREFIX", LABEL_RECOVERY_PREFIX),
+        _py("MAX_RECOVERY_ATTEMPTS", MAX_RECOVERY_ATTEMPTS),
         _py("MARKER_SPEC_NOT_READY", MARKER_SPEC_NOT_READY),
         _py("MARKER_RISK_ASSESSMENT", MARKER_RISK_ASSESSMENT),
         _py("MARKER_MERGE_GUARD", MARKER_MERGE_GUARD),
@@ -562,6 +637,23 @@ def _is_sha1(value):
     REST commit/check-runs endpoints can resolve. A 64-char SHA-256 object id (issue #1178)
     returns False, so we never hand one to a GitHub REST endpoint."""
     return isinstance(value, str) and bool(_SHA1_RE.match(value))
+
+
+def _shas_equal(a, b):
+    """Whether two commit ids name the SAME commit, tolerant of case and abbreviation —
+    GitHub returns full 40-char lowercase SHAs but a watch agent may report an abbreviated
+    or upper-cased one. Equal iff (case-insensitively) one is a non-empty prefix of the other
+    AND both are at least 7 hex chars (git's minimum unambiguous abbreviation), so a stray
+    empty / 1-char value can never spuriously match. Used to verify a polled commit IS the
+    live PR head (#1314) — a conservative comparison: when in doubt it returns False (reject),
+    never a false match that would trust a wrong-parent green."""
+    if not (isinstance(a, str) and isinstance(b, str)):
+        return False
+    a, b = a.strip().lower(), b.strip().lower()
+    if len(a) < 7 or len(b) < 7:
+        return False
+    short, long = (a, b) if len(a) <= len(b) else (b, a)
+    return long.startswith(short)
 
 
 async def _resolve_sha1(repo, ref):
@@ -822,8 +914,10 @@ def _risk_floor(tier, files):
 
 
 async def _label(repo, issue_number, name):
-    """Add one label (best-effort, retried by gh)."""
-    await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number), {"labels": [name]})
+    """Add one label (best-effort, retried by gh). Returns the gh() response so a caller that
+    needs the label to have DURABLY persisted (the recovery counter) can confirm it."""
+    return await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number),
+                    {"labels": [name]})
 
 
 async def _unlabel(repo, issue_number, name):
@@ -840,6 +934,103 @@ async def _unlabel(repo, issue_number, name):
     else:
         log("unlabel %r on #%d FAILED -> %r %r" % (name, issue_number, st, resp))
     return resp
+
+
+def _recovery_attempts(issue):
+    """How many auto-recovery re-launches this issue has already had — read from the DURABLE
+    ``autodev:recovery-N`` labels on the issue (the only counter that survives a re-launch; an
+    in-envelope ``retry_count`` does not, since the trigger re-runs the static template). The
+    value is the highest N present, or 0 if none. Tolerant of a malformed label name."""
+    labels = issue.get("labels") if isinstance(issue, dict) else None
+    if not isinstance(labels, list):
+        return 0
+    best = 0
+    for lab in labels:
+        name = lab.get("name") if isinstance(lab, dict) else lab
+        if isinstance(name, str) and name.startswith(LABEL_RECOVERY_PREFIX):
+            tail = name[len(LABEL_RECOVERY_PREFIX):]
+            if tail.isdigit():
+                best = max(best, int(tail))
+    return best
+
+
+async def _recover_or_park(repo, issue_number, pr_number, attempts, reason, escalations):
+    """Dispose of a RECOVERABLE child-agent error (a ci-watch / ci-fix CHILD that ERRORED
+    mid-call — the ~1hr ceiling / "errored before responding" — NOT a real red verdict).
+
+    THE structural asymmetry (the keystone): the only armed auto-recovery is a
+    ``run_completion[errored]`` trigger, which fires on a TERMINAL ``errored`` and can NEVER
+    see a durable ``suspended`` gate-park. A recoverable error buried in a verify gate is thus
+    unreachable by recovery. So while we still have recovery budget we RAISE to terminate
+    ``errored`` — the trigger re-launches the build (S4 idempotently adopts the existing PR),
+    exactly what a gate-park denied these runs.
+
+    BOUNDED by a DURABLE counter (``autodev:recovery-N`` labels), because the re-launch carries
+    the SAME static input template — an in-envelope ``retry_count`` never increments (see
+    ``harness/trigger_runner``), so a run-state counter would reset every cycle and loop
+    forever. We stamp ``autodev:recovery-{attempts+1}`` BEFORE raising (durable, survives the
+    re-launch) and only raise while ``attempts < MAX_RECOVERY_ATTEMPTS``. Once the budget is
+    spent we PARK at the verify gate for a human instead — a recoverable error that keeps
+    recurring becomes a human escalation, never an unbounded re-spend loop.
+
+    Returns a terminal ``{"state": "escalated", ...}`` dict when it parked unresolved (the
+    caller returns it); RAISES ``RuntimeError`` (→ ``errored`` → re-launch) when budget remains;
+    returns ``None`` when a human resumed the verify gate (the caller proceeds)."""
+    if attempts < MAX_RECOVERY_ATTEMPTS:
+        # Stamp the durable attempt counter FIRST (so the re-launched run reads attempts+1),
+        # then raise to errored. The counter is the ONLY thing bounding the re-launch loop
+        # (the in-envelope retry_count never increments), so we MUST confirm the label
+        # persisted before raising: if the POST did not land, the re-launched run would read
+        # the SAME attempts value and loop forever with no advancing bound. So on a label-write
+        # failure we DON'T raise — we PARK at the verify gate (fail SAFE to a human, never an
+        # unbounded re-spend loop). autodev:in-progress is intentionally left on — the
+        # re-launch re-claims it idempotently. A genuinely-red tree (agent RETURNED red) is NOT
+        # routed here; it parks, because re-launching a real red PR just re-fails.
+        stamp = await _label(repo, issue_number, "%s%d" % (LABEL_RECOVERY_PREFIX, attempts + 1))
+        if _status(stamp) in (200, 201):
+            raise RuntimeError(
+                "dev_pipeline auto-recovery: %s (attempt %d/%d) — re-launching via "
+                "run_completion[errored]" % (reason, attempts + 1, MAX_RECOVERY_ATTEMPTS))
+        log("recovery counter label POST did NOT confirm (%r) -> NOT raising (would loop "
+            "unbounded); parking at verify gate instead: %s" % (_status(stamp), reason))
+    # Budget exhausted: a recurring recoverable error becomes a HUMAN escalation, not a loop.
+    log("auto-recovery budget exhausted (%d attempts) -> park at verify gate: %s"
+        % (attempts, reason))
+    escalations.append("verify")
+    decision = await gate({"kind": "verify", "pr": pr_number,
+                           "reason": "auto-recovery budget exhausted: %s" % reason})
+    if not (isinstance(decision, dict) and decision.get("resolved")):
+        return {"state": "escalated", "reason": "ci_recovery_exhausted",
+                "escalations": escalations}
+    return None
+
+
+async def _handle_ci_outcome(repo, issue_number, pr_number, ci_outcome, attempts,
+                             escalations, where):
+    """Dispose of a non-``pass`` ``_watch_ci`` outcome at a CI-watch call site. Returns ``None``
+    when the run may PROCEED (a human resumed a gate), a terminal ``{"state": "escalated", ...}``
+    dict the caller must return, or RAISES (→ errored → bounded auto-recovery re-launch) for a
+    recoverable child-agent error. ``where`` (e.g. "" / " after rebase") tags the gate reason.
+
+      * ``"agent_err"`` — recoverable child error, no prior real red -> _recover_or_park
+        (raise while budget remains, else park for a human).
+      * ``"red"`` / ``"unsettled"`` — genuinely red after fixes, OR CI never settled -> park at
+        the verify gate (re-launching would not help; a human decides)."""
+    if ci_outcome == "agent_err":
+        return await _recover_or_park(
+            repo, issue_number, pr_number, attempts,
+            "CI-watch/fix agent errored mid-call%s" % where, escalations)
+    reason = ("CI genuinely red after %d checks%s" % (MAX_CI_ITERS, where)
+              if ci_outcome == "red"
+              else "CI never settled (unverifiable head / incomplete checks) after %d checks%s"
+              % (MAX_CI_ITERS, where))
+    escalations.append("verify")
+    decision = await gate({"kind": "verify", "pr": pr_number, "reason": reason})
+    if not (isinstance(decision, dict) and decision.get("resolved")):
+        return {"state": "escalated",
+                "reason": "ci_exhausted" if ci_outcome == "red" else "ci_unsettled",
+                "escalations": escalations}
+    return None
 
 
 async def _fail(repo, issue_number, result):
@@ -915,6 +1106,67 @@ async def _file_followup(repo, title, body):
     return None
 
 
+async def _ci_verdict(repo, pr_number, ci, polled_head):
+    """Classify a ``watch_ci`` verdict — a SCRIPT-side (uncorrelated) re-check of the
+    correlated agent's claim, closing the two false-green holes the forensics found. Returns
+    one of three labels (NOT a bool), so the caller can distinguish a genuinely-broken tree
+    (FIX it) from an unverified-pass (just RE-WATCH — never run a fixer against passing code):
+
+      * ``"pass"``  — a TRUSTED green/no_ci: safe to proceed to merge.
+      * ``"red"``   — the agent RETURNED a red verdict: the tree is genuinely broken -> fix.
+      * ``"retry"`` — a green/no_ci we could NOT trust (unverifiable head, premature checks):
+                      re-watch on the next iteration; do NOT dispatch a fixer (the code is not
+                      broken, CI just hasn't settled / we couldn't confirm the head).
+
+    A green / no_ci is trusted as ``"pass"`` ONLY when ALL hold:
+
+    1. **A verifiable head exists.** The watch reports ``polled_sha`` (the commit it inspected).
+       We need an EXPECTED head to compare it against: GitHub's LIVE ``GET /pulls/{n}`` head,
+       or — only if that read comes back empty — the SHA we dispatched the watch with. If
+       NEITHER is available (both empty) we CANNOT verify the head, so we fail CLOSED to
+       ``"retry"`` rather than trust an unverifiable pass (#1314). A missing ``polled_sha`` is
+       likewise unverifiable -> ``"retry"``.
+    2. **The polled commit IS that head (#1314).** An empty re-trigger commit pushed onto the
+       WRONG parent never becomes head, so its ``total_count=0`` ``no_ci`` must not count.
+    3. **The full required-check set concluded (#1364).** A ``green`` declared while lint/unit
+       are still running is premature; require ``required_complete`` (``no_ci`` is exempt —
+       there are no required checks to wait on).
+
+    Never RAISES for a logic reason — only the underlying ``gh`` read can raise (a truncated
+    body), which the caller's loop is not expected to catch; that surfaces as a recoverable
+    errored run, the correct disposition for a persistent read fault."""
+    status = ci.get("status")
+    if status == "red":
+        return "red"
+    if status not in ("green", "no_ci"):
+        # An unexpected status (schema should prevent it) is treated as a non-pass we re-watch.
+        return "retry"
+    polled_sha = ci.get("polled_sha", "")
+    if not polled_sha:
+        log("ci verdict %r has no polled_sha -> cannot verify head, re-watching" % status)
+        return "retry"
+    # #1364 premature-green: green must see the FULL required-check set concluded. no_ci has
+    # no required checks, so the completeness flag does not apply to it.
+    if status == "green" and not ci.get("required_complete", False):
+        log("ci verdict green but required_complete is false -> premature, re-watching")
+        return "retry"
+    # #1314 wrong-parent: the polled commit must be the LIVE PR head. Prefer GitHub's live
+    # head; fall back to the dispatched SHA ONLY if the live read is empty. If we have NO
+    # anchor at all, fail CLOSED to retry (never trust an unverifiable head — the fail-OPEN
+    # hole the review caught).
+    live_head = await _live_head_sha(repo, pr_number)
+    expected = live_head or polled_head
+    if not expected:
+        log("ci verdict %r but no verifiable head (live+dispatched both empty) -> re-watching"
+            % status)
+        return "retry"
+    if not _shas_equal(polled_sha, expected):
+        log("ci verdict %r polled %r but expected head %r -> wrong-parent, re-watching"
+            % (status, polled_sha, expected))
+        return "retry"
+    return "pass"
+
+
 async def _watch_ci(repo, pr_number, head_sha, comment_bodies, model, label_prefix):
     """The bounded CI watch->fix->re-watch loop (the agent OWNS the durable wait), factored
     out so it can be RE-ENTERED after a sync/rebase heals the branch (#1385): a successful
@@ -922,27 +1174,49 @@ async def _watch_ci(repo, pr_number, head_sha, comment_bodies, model, label_pref
     ``label_prefix`` distinguishes the labels of the second entry (``reci-…``) from the first
     (``ci-…``) so replay stays deterministic (a distinct call_key per agent invocation).
 
-    Returns ``(ci_ok, ci_agent_error, head_sha)``: ``ci_ok`` True on green/no_ci, else the
-    caller parks at the verify gate; ``ci_agent_error`` distinguishes a flaky-agent break from
-    plain CI exhaustion; ``head_sha`` is the (possibly fix-advanced) head for downstream nodes.
-    Bounded N watches / N-1 fixes — matches autodev's CI loop."""
+    Returns ``(ci_ok, ci_outcome, head_sha)`` where ``ci_outcome`` is one of:
+
+      * ``"pass"``      — a TRUSTED green/no_ci (``ci_ok`` True): proceed to merge.
+      * ``"red"``       — genuinely red after exhausting the bounded fixes: park at the verify
+                          gate for a human (a re-launch would just re-fail).
+      * ``"agent_err"`` — a ci-watch / ci-fix CHILD ERRORED mid-call WITHOUT a prior real-red
+                          verdict in this loop: RECOVERABLE -> the caller re-launches (errored)
+                          for auto-recovery (bounded). This is the keystone class.
+      * ``"unsettled"`` — the loop ran out of iterations on ``"retry"`` verdicts (head never
+                          verifiable / checks never concluded): park at the verify gate, but
+                          NOT a recoverable re-launch (re-running won't make CI settle).
+
+    CRITICAL split (the review's #2): a child error AFTER a genuine red verdict is NOT
+    recoverable (the tree is really broken), so it degrades to ``"red"`` (park), not
+    ``"agent_err"`` (re-launch). And a ``"retry"`` verdict NEVER dispatches the fixer — running
+    a fixer against passing-but-unsettled code would churn the branch (the review's #4); only a
+    genuine ``"red"`` triggers a fix. ``head_sha`` is the (possibly fix-advanced) head for
+    downstream nodes. Bounded N watches / N-1 fixes — matches autodev's CI loop."""
     ci_ok = False
-    ci_agent_error = False
+    saw_real_red = False
+    last_outcome = "unsettled"
     for i in range(MAX_CI_ITERS):
-        # A ci-watch / ci-fix agent error breaks the loop and falls through to the verify
-        # gate (item 5) — it does NOT crash the run nor silently pass a red PR.
         try:
             ci = await agent(
                 {"task": "watch_ci", "repo": repo, "pr_number": pr_number, "head_sha": head_sha},
                 agent_id=CI_AGENT_ID, output_schema=CI_SCHEMA, model=model,
                 label="%s-%d" % (label_prefix, i))
         except AgentError as exc:
-            log("ci-watch agent error -> escalate:", exc)
-            ci_agent_error = True
-            break
-        if ci["status"] in ("green", "no_ci"):
-            ci_ok = True
-            break
+            # A child error AFTER a real red is NOT recoverable (the tree is genuinely broken);
+            # only a child error with no prior red is the recoverable keystone class.
+            log("ci-watch agent error:", exc)
+            return ci_ok, ("red" if saw_real_red else "agent_err"), head_sha
+        verdict = await _ci_verdict(repo, pr_number, ci, head_sha)
+        if verdict == "pass":
+            return True, "pass", head_sha
+        if verdict == "retry":
+            # Green/no_ci we could not trust (unverifiable head / premature checks): RE-WATCH
+            # on the next iteration. Do NOT run the fixer (the code is not broken).
+            last_outcome = "unsettled"
+            continue
+        # verdict == "red": the tree is genuinely broken -> dispatch the bounded fixer.
+        saw_real_red = True
+        last_outcome = "red"
         if i == MAX_CI_ITERS - 1:
             break
         before = head_sha
@@ -955,12 +1229,13 @@ async def _watch_ci(repo, pr_number, head_sha, comment_bodies, model, label_pref
                 label="%s-fix-%d" % (label_prefix, i))
             head_sha = fix["head_sha"]
         except AgentError as exc:
-            log("ci-fix agent error -> escalate:", exc)
-            ci_agent_error = True
-            break
+            # A fix-agent error on a genuinely-red tree is NOT recoverable (re-running re-fails)
+            # -> "red" (park for a human), never "agent_err" (re-launch).
+            log("ci-fix agent error (on a real-red tree):", exc)
+            return ci_ok, "red", head_sha
         if before and head_sha == before:
             break
-    return ci_ok, ci_agent_error, head_sha
+    return ci_ok, last_outcome, head_sha
 
 
 async def _live_head_sha(repo, pr_number):
@@ -1092,6 +1367,12 @@ async def main(input):
         return await _fail(repo, issue_number,
                            {"state": "error", "reason": "could not read issue %d (status %r)"
                             % (issue_number, _status(resp))})
+    # Auto-recovery attempt count — read from the DURABLE autodev:recovery-N labels on the
+    # issue (the only counter that survives a re-launch; see _recover_or_park). Bounds the
+    # keystone re-raise so a recurring recoverable CI child-error escalates to a human rather
+    # than looping. Read BEFORE in-progress is stamped affects nothing (recovery labels are a
+    # disjoint namespace), and BEFORE any recoverable raise can occur downstream.
+    recovery_attempts = _recovery_attempts(issue)
     # Read the FULL thread, not just GitHub's first 30: gh_paginated follows
     # Link: rel="next" so a design/spec resolution posted as comment #31+ is ingested
     # (#1156). A comments-endpoint failure degrades to whatever pages were gathered
@@ -1253,17 +1534,13 @@ async def main(input):
     # A9 — CI watch (the agent OWNS the durable wait) -> fix -> re-watch, bounded
     # (N watches, N-1 fixes — matches autodev's CI loop). Factored into _watch_ci so the
     # post-rebase re-entry below can drive the identical loop with a distinct label prefix.
-    ci_ok, ci_agent_error, head_sha = await _watch_ci(
+    ci_ok, ci_outcome, head_sha = await _watch_ci(
         repo, pr_number, head_sha, comment_bodies, model, "ci")
     if not ci_ok:
-        _ci_reason = ("CI-watch agent error" if ci_agent_error
-                      else "CI failing after %d checks" % MAX_CI_ITERS)
-        escalations.append("verify")
-        decision = await gate({"kind": "verify", "pr": pr_number, "reason": _ci_reason})
-        if not (isinstance(decision, dict) and decision.get("resolved")):
-            return {"state": "escalated",
-                    "reason": "ci_agent_error" if ci_agent_error else "ci_exhausted",
-                    "escalations": escalations}
+        terminal = await _handle_ci_outcome(repo, issue_number, pr_number, ci_outcome,
+                                            recovery_attempts, escalations, "")
+        if terminal is not None:
+            return terminal
 
     # S-SYNC — rebase/sync recovery (#1385). Early in the merge path (BEFORE the merge guard)
     # and on every run re-entry: check mergeability and HEAL a branch master moved under
@@ -1290,17 +1567,13 @@ async def main(input):
         # keeps replay deterministic). A fix-advanced head_sha overrides the (now-stale) one.
         if sync.get("head_sha"):
             head_sha = sync["head_sha"]
-        ci_ok, ci_agent_error, head_sha = await _watch_ci(
+        ci_ok, ci_outcome, head_sha = await _watch_ci(
             repo, pr_number, head_sha, comment_bodies, model, "reci")
         if not ci_ok:
-            _ci_reason = ("CI-watch agent error after rebase" if ci_agent_error
-                          else "CI failing after %d checks after rebase" % MAX_CI_ITERS)
-            escalations.append("verify")
-            decision = await gate({"kind": "verify", "pr": pr_number, "reason": _ci_reason})
-            if not (isinstance(decision, dict) and decision.get("resolved")):
-                return {"state": "escalated",
-                        "reason": "ci_agent_error" if ci_agent_error else "ci_exhausted",
-                        "escalations": escalations}
+            terminal = await _handle_ci_outcome(repo, issue_number, pr_number, ci_outcome,
+                                                recovery_attempts, escalations, " after rebase")
+            if terminal is not None:
+                return terminal
 
     # A10/S11 — risk tiering (best-effort; never blocks). Conservative tier-3 default. The
     # guard tolerates BOTH a child failure (AgentError) AND a malformed/short return

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -53,9 +53,17 @@ LONG_BODY = (
 )
 
 
-def _issue_json(body: str = LONG_BODY) -> str:
+def _issue_json(body: str = LONG_BODY, labels: list[str] | None = None) -> str:
     return json.dumps(
-        {"number": ISSUE, "title": "Add webhook retry", "body": body, "state": "open"}
+        {
+            "number": ISSUE,
+            "title": "Add webhook retry",
+            "body": body,
+            "state": "open",
+            # GitHub returns labels as objects with a `name`; the recovery-attempt counter
+            # (_recovery_attempts) reads the highest `autodev:recovery-N` present at ingest.
+            "labels": [{"name": n} for n in (labels or [])],
+        }
     )
 
 
@@ -91,6 +99,8 @@ class Scenario:
         self,
         *,
         body: str = LONG_BODY,
+        labels: list[str] | None = None,
+        label_post_fails: set[str] | None = None,
         comments: list[str] | None = None,
         pr_comments: list[str] | None = None,
         existing_pr: bool = False,
@@ -117,6 +127,12 @@ class Scenario:
         ci_results_by_sha: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         self.body = body
+        # Labels the issue GET reports (objects with `name`). The recovery-attempt counter
+        # reads any `autodev:recovery-N` here at ingest to bound the auto-recovery re-raise.
+        self.labels = labels or []
+        # Label names whose POST persistently fails (422) — models a label-write failure so the
+        # recovery counter cannot advance its durable bound.
+        self.label_post_fails = label_post_fails or set()
         # The comment-thread the GET /issues/{n}/comments responder returns (list of body
         # strings → GitHub comment objects). None => no comments (empty array).
         self.comments = comments or []
@@ -246,8 +262,12 @@ class Scenario:
         assert "?" not in path, f"query string in path is rejected by http_request: {path!r}"
         if method == "POST" and path.endswith("/labels"):  # add label(s) — capture names
             raw = args.get("body")
-            if isinstance(raw, str):
-                self.labels_added.extend(json.loads(raw).get("labels", []))
+            names = json.loads(raw).get("labels", []) if isinstance(raw, str) else []
+            # Model a persistent label-write FAILURE for specific names (the recovery counter
+            # must NOT raise-and-loop when its bound-advancing label can't persist).
+            if any(n in self.label_post_fails for n in names):
+                return {"status": 422, "body": "{}"}
+            self.labels_added.extend(names)
             return {"status": 200, "body": "[]"}
         if method == "DELETE" and "/labels/" in path:  # remove one label — capture decoded name
             self.labels_removed.append(path.rsplit("/labels/", 1)[1].replace("%3A", ":"))
@@ -263,7 +283,7 @@ class Scenario:
             and "/labels" not in path
         )
         if is_issue_get:
-            return {"status": 200, "body": _issue_json(self.body)}
+            return {"status": 200, "body": _issue_json(self.body, self.labels)}
         if method == "GET" and path == "/repos/o/r/pulls":  # list open PRs (clean path)
             return {"status": 200, "body": "[" + _pr_json() + "]" if self.existing_pr else "[]"}
         if method == "POST" and path == "/repos/o/r/pulls":
@@ -311,6 +331,22 @@ class Scenario:
             # file → the floor does not fire and the run completes normally.
             return {"status": 200, "body": "[]"}
         return {"status": 200, "body": "{}"}  # comments / labels / graphql
+
+    def _ci_verdict(self, verdict: dict[str, Any] | str, dispatched_sha: str) -> Any:
+        """Model a CORRECT ci-watch agent's structured verdict (#1314/#1364): unless the test's
+        verdict dict says otherwise, a watch reports the commit it polled (``polled_sha`` = the
+        head_sha it was dispatched with — the live head in this fixture) and, for a green,
+        ``required_complete=True`` (the full required-check set concluded). A test models a
+        FALSE-green by overriding ``polled_sha`` (wrong-parent #1314) or ``required_complete``
+        (premature #1364) in its ``ci_results`` entry. A non-dict verdict (a test sentinel) is
+        passed through unchanged."""
+        if not isinstance(verdict, dict):
+            return verdict
+        out = dict(verdict)
+        out.setdefault("polled_sha", dispatched_sha)
+        if out.get("status") == "green":
+            out.setdefault("required_complete", True)
+        return out
 
     def outcome(self, cap: Any) -> dict[str, Any]:
         """Return the full memo outcome ({"ok": value} or {"error": {...}}) for a capability."""
@@ -371,16 +407,21 @@ class Scenario:
                 idx = int(label.rsplit("-", 1)[1]) if "-" in label else 0
                 return {"ok": self.review_results[min(idx, len(self.review_results) - 1)]}
             if task == "watch_ci":
+                dispatched_sha = spec["input"].get("head_sha", "")
                 if spec["input"].get("ref"):  # post-merge master watch (advisory, retried)
                     if self.master_ci_results is not None:
                         idx = int(label.rsplit("-", 1)[1]) if "-" in label else 0
                         item = self.master_ci_results[min(idx, len(self.master_ci_results) - 1)]
                         if item == "error":
                             return {"error": {"kind": "child_errored"}}
-                        return {"ok": item}
+                        return {"ok": self._ci_verdict(item, dispatched_sha)}
                     if self.master_ci_error:
                         return {"error": {"kind": "child_errored"}}
-                    return {"ok": {"status": self.master_ci, "detail": ""}}
+                    return {
+                        "ok": self._ci_verdict(
+                            {"status": self.master_ci, "detail": ""}, dispatched_sha
+                        )
+                    }
                 if self.ci_error_on == label:
                     return {"error": {"kind": "child_errored"}}
                 # #1389: a SHA-keyed responder — the watch's verdict is a function of the
@@ -388,14 +429,21 @@ class Scenario:
                 # reads a different (failing) verdict than the post-rebase tip. A SHA absent
                 # from the map is red, so a stale-SHA read can NEVER masquerade as green.
                 if self.ci_results_by_sha is not None:
-                    sha = spec["input"].get("head_sha", "")
                     return {
-                        "ok": self.ci_results_by_sha.get(
-                            sha, {"status": "red", "detail": f"no CI for {sha}"}
+                        "ok": self._ci_verdict(
+                            self.ci_results_by_sha.get(
+                                dispatched_sha,
+                                {"status": "red", "detail": f"no CI for {dispatched_sha}"},
+                            ),
+                            dispatched_sha,
                         )
                     }
                 idx = int(label.rsplit("-", 1)[1]) if label.startswith("ci-") else 0
-                return {"ok": self.ci_results[min(idx, len(self.ci_results) - 1)]}
+                return {
+                    "ok": self._ci_verdict(
+                        self.ci_results[min(idx, len(self.ci_results) - 1)], dispatched_sha
+                    )
+                }
             if task == "risk":
                 return {"ok": self.risk_result}
             if task in ("fix", "fix_ci"):
@@ -435,6 +483,35 @@ async def _drive(
         keys.append(cap.call_key)
         memo[cap.call_key] = scenario.outcome(cap)
     raise AssertionError(f"workflow did not terminate within {max_steps} steps")
+
+
+async def _drive_to_raise(
+    scenario: Scenario,
+    *,
+    input: dict[str, Any] | None = None,
+    max_steps: int = 60,
+    **build_kwargs: Any,
+) -> tuple[str, list[str]]:
+    """Drive the script expecting it to TERMINATE ERRORED (a raise) — the keystone recovery
+    path: a recoverable child-agent error re-raises so the run goes ``errored`` and the
+    deploy-time ``run_completion[errored]`` trigger re-launches it (the structural-asymmetry
+    fix). Returns (error_repr, phases). Asserts the run did NOT return or suspend."""
+    src = build_dev_pipeline_script(**build_kwargs)
+    inp = input or {"repo": REPO, "issue_number": ISSUE, "kind": "issue"}
+    memo: dict[str, Any] = {}
+    phases: list[str] = []
+    for _ in range(max_steps):
+        out = await run_script_host(source=src, input=inp, memo=memo)
+        phases = [a.payload["text"] for a in out.annotations if a.payload["kind"] == "phase"]
+        if out.kind == "raised":
+            return out.error_repr or "", phases
+        assert out.kind == "suspended", (
+            f"expected a recoverable raise, got {out.kind}",
+            out.error_repr,
+        )
+        cap = out.emitted[0]
+        memo[cap.call_key] = scenario.outcome(cap)
+    raise AssertionError(f"workflow did not raise within {max_steps} steps")
 
 
 # ─── happy path ───────────────────────────────────────────────────────────────
@@ -1209,12 +1286,103 @@ async def test_review_agent_error_escalates_to_verify_gate() -> None:
     assert any(g["kind"] == "verify" for g in scn.gates)
 
 
-async def test_ci_watch_agent_error_escalates_to_verify_gate() -> None:
-    scn = Scenario(ci_error_on="ci-0", gate_results={"verify": {"resolved": False}})
+async def test_ci_watch_agent_error_re_raises_for_auto_recovery_not_gate_park() -> None:
+    # KEYSTONE FIX (the structural asymmetry): a ci-WATCH child that ERRORS mid-call is a
+    # RECOVERABLE failure, NOT a real red verdict. It must terminate the run ERRORED (a raise)
+    # so the deploy-time run_completion[errored] trigger RE-LAUNCHES it — never park it at a
+    # verify gate as a durable `suspended` the errored-only trigger can structurally never see.
+    scn = Scenario(ci_error_on="ci-0")
+    err, _ = await _drive_to_raise(scn, max_review_iters=2, max_ci_iters=2)
+    assert "auto-recovery" in err
+    assert "agent errored mid-call" in err
+    # it did NOT open a verify gate — a recoverable error is not a human escalation
+    assert not any(g["kind"] == "verify" for g in scn.gates)
+    # the DURABLE recovery counter was stamped BEFORE the raise (so the re-launched run reads
+    # attempt 1 and the bound is real across re-launches — the in-envelope retry_count can't).
+    assert "autodev:recovery-1" in scn.labels_added
+
+
+async def test_ci_fix_agent_error_after_real_red_parks_not_re_raises() -> None:
+    # The review's #2 split: a ci-FIX child that errors AFTER a genuine red verdict is NOT
+    # recoverable (the tree is really broken — re-running just re-fails), so it PARKS at the
+    # verify gate for a human rather than entering the auto-recovery re-launch loop.
+    scn = Scenario(
+        ci_results=[{"status": "red", "detail": "tests failing"}],
+        ci_error_on="ci-fix-0",
+        gate_results={"verify": {"resolved": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=3)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "ci_exhausted"  # genuine-red disposition, not a re-launch
+    assert any(g["kind"] == "verify" for g in scn.gates)
+    assert "autodev:recovery-1" not in scn.labels_added  # never entered the recovery path
+
+
+async def test_ci_recovery_budget_exhausted_parks_at_verify_gate_via_durable_label() -> None:
+    # The keystone bound is DURABLE: a run that re-launches and finds the issue already carries
+    # `autodev:recovery-2` (== MAX_RECOVERY_ATTEMPTS) must NOT re-raise — it PARKS at the verify
+    # gate for a human. This is the bound that the non-incrementing in-envelope retry_count
+    # could never provide (the trigger re-runs the static template).
+    scn = Scenario(
+        labels=["autodev:recovery-2"],
+        ci_error_on="ci-0",
+        gate_results={"verify": {"resolved": False}},
+    )
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "escalated"
-    assert value["reason"] == "ci_agent_error"
+    assert value["reason"] == "ci_recovery_exhausted"
     assert any(g["kind"] == "verify" for g in scn.gates)
+    # it did NOT stamp a third recovery label or raise — the budget is spent
+    assert "autodev:recovery-3" not in scn.labels_added
+
+
+async def test_ci_recovery_label_write_failure_parks_does_not_loop() -> None:
+    # The bound is the DURABLE label, so if its POST cannot persist the run must NOT re-raise
+    # (a re-launch would read the same attempts and loop forever with no advancing bound). It
+    # fails SAFE: PARK at the verify gate for a human instead of raising. (The review's #1.)
+    scn = Scenario(
+        ci_error_on="ci-0",
+        label_post_fails={"autodev:recovery-1"},
+        gate_results={"verify": {"resolved": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "ci_recovery_exhausted"  # parked, did not raise/loop
+    assert any(g["kind"] == "verify" for g in scn.gates)
+    assert "autodev:recovery-1" not in scn.labels_added  # the failed POST is not recorded
+
+
+async def test_ci_agent_error_at_retry_budget_dead_letters_not_infinite_raise() -> None:
+    # The retained belt-and-suspenders bound: a run that arrives with retry_count >=
+    # MAX_RUN_RETRIES dead-letters at the top of main (before any spend). (The durable-label
+    # bound above is the load-bearing one; this guards a future trigger that DOES set
+    # retry_count.)
+    scn = Scenario(ci_error_on="ci-0")
+    value, _, _ = await _drive(
+        scn,
+        input={"repo": REPO, "issue_number": ISSUE, "kind": "issue", "retry_count": 2},
+        max_review_iters=2,
+        max_ci_iters=2,
+    )
+    assert value["state"] == "dead_letter"
+    assert scn.tasks == []  # dead-lettered before any agent spend
+    assert "autodev:failed" in scn.labels_added
+
+
+async def test_ci_genuinely_red_after_fixes_still_parks_at_verify_gate() -> None:
+    # The split's OTHER half: a GENUINELY red tree (the agent RETURNED red, never errored)
+    # after exhausting the bounded fixes still parks at the verify gate for a human — it is
+    # NOT re-launched, because re-running a real red PR would just re-fail. (Distinguishes a
+    # recoverable child-error from an unrecoverable red verdict.)
+    scn = Scenario(
+        ci_results=[{"status": "red", "detail": "unit tests fail"}],
+        gate_results={"verify": {"resolved": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "ci_exhausted"
+    assert any(g["kind"] == "verify" for g in scn.gates)
+    assert "autodev:recovery-1" not in scn.labels_added  # a real red is not a recovery
 
 
 async def test_agent_error_resume_resolved_continues() -> None:
@@ -1222,6 +1390,73 @@ async def test_agent_error_resume_resolved_continues() -> None:
     scn = Scenario(review_error_on="review-0", gate_results={"verify": {"resolved": True}})
     value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
     assert value["state"] == "done"
+
+
+# ─── false-green guards (Fix 2: a false-green must never walk a red PR to a merge gate) ──
+
+
+async def test_no_ci_on_wrong_parent_commit_is_not_trusted_as_green() -> None:
+    # Fix 2a (#1314): a ci-watch that polled an ORPHAN / wrong-parent commit reads total_count=0
+    # = `no_ci`, but that commit is NOT the live PR head, so it must NOT count as a pass. The
+    # live head here is `sha_initial` (GET /pulls/42); the watch reports it polled a DIFFERENT
+    # commit -> the verdict is rejected -> the loop re-watches and (still wrong) parks at the
+    # verify gate rather than walking past it to a merge gate believing it was green.
+    wrong_parent = "0000000000000000000000000000000000000abc"  # a valid SHA-1, but not the head
+    scn = Scenario(
+        ci_results=[{"status": "no_ci", "detail": "no checks", "polled_sha": wrong_parent}],
+        gate_results={"verify": {"resolved": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    # the false `no_ci` did NOT pass; the run parked at the verify gate, never merged. The
+    # disposition is `ci_unsettled` (an unverifiable verdict we RE-WATCH), not `ci_exhausted`
+    # (a genuine red) — and crucially it never ran a FIXER against the (not-broken) branch.
+    assert value["state"] == "escalated"
+    assert value["reason"] == "ci_unsettled"
+    assert any(g["kind"] == "verify" for g in scn.gates)
+    assert "PUT" not in {m for m, _ in scn.http if "/merge" in _}  # never reached merge
+    assert not any(t.startswith("ci-fix") for t in scn.tasks)  # no fixer on a not-red tree
+
+
+async def test_legit_no_ci_on_actual_head_still_passes() -> None:
+    # The legitimate case Fix 2a must NOT break: a PR with NO CI configured (total_count=0) on
+    # the ACTUAL head is a real pass. The default _ci_verdict stamps polled_sha = the head the
+    # watch was dispatched with (the live head), so this no_ci is trusted and the run merges.
+    scn = Scenario(ci_results=[{"status": "no_ci", "detail": "repo has no CI"}])
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "done"
+    assert value["merged"] is True
+
+
+async def test_premature_green_before_required_checks_complete_is_not_trusted() -> None:
+    # Fix 2b (#1364): a `green` declared while the required-check set has NOT fully concluded
+    # (required_complete=False) is premature and must NOT be trusted. The watch keeps polling;
+    # if it never settles green-with-complete, the run defers to the verify gate / merge-guard
+    # (the uncorrelated backstop) rather than walking a possibly-red tree to merge.
+    scn = Scenario(
+        ci_results=[{"status": "green", "detail": "subset done", "required_complete": False}],
+        gate_results={"verify": {"resolved": False}},
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=2)
+    assert value["state"] == "escalated"
+    assert value["reason"] == "ci_unsettled"  # an unverified green is re-watched, not "red"
+    assert any(g["kind"] == "verify" for g in scn.gates)
+    # the review's #4: a premature green must NOT trigger the fixer (the code is not broken).
+    assert not any(t.startswith("ci-fix") for t in scn.tasks)
+
+
+async def test_premature_green_then_complete_green_passes() -> None:
+    # The watch self-heals: a premature green (required_complete=False) on the first poll is
+    # rejected, but a later poll reporting a COMPLETE green (required_complete=True) is trusted
+    # and the run merges. (Models CI finishing between two polls.)
+    scn = Scenario(
+        ci_results=[
+            {"status": "green", "detail": "subset", "required_complete": False},
+            {"status": "green", "detail": "all done", "required_complete": True},
+        ],
+    )
+    value, _, _ = await _drive(scn, max_review_iters=2, max_ci_iters=3)
+    assert value["state"] == "done"
+    assert value["merged"] is True
 
 
 # ─── auto-recovery retry budget (item 4) ──────────────────────────────────────

--- a/tests/unit/test_dev_pipeline_rebase.py
+++ b/tests/unit/test_dev_pipeline_rebase.py
@@ -340,3 +340,146 @@ def test_sync_plumbing_error_fails_closed_to_error() -> None:
     result = _sync(ns)
     assert result["outcome"] == "error"
     assert "detail" in result
+
+
+# ─── _shas_equal: the conservative commit-identity comparison (Fix 2a) ────────
+
+# A real PR head and a wrong-parent orphan, both valid SHA-1s.
+_HEAD = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+_ORPHAN = "0000000000000000000000000000000000000abc"
+
+
+def test_shas_equal_exact_match() -> None:
+    ns = _ns()
+    assert ns["_shas_equal"](_HEAD, _HEAD) is True
+
+
+def test_shas_equal_case_insensitive() -> None:
+    ns = _ns()
+    assert ns["_shas_equal"](_HEAD.upper(), _HEAD.lower()) is True
+
+
+def test_shas_equal_abbreviation_prefix_matches() -> None:
+    # git's short SHA is a prefix of the full one — they name the same commit.
+    ns = _ns()
+    assert ns["_shas_equal"](_HEAD[:8], _HEAD) is True
+    assert ns["_shas_equal"](_HEAD, _HEAD[:12]) is True
+
+
+def test_shas_equal_different_commits_do_not_match() -> None:
+    ns = _ns()
+    assert ns["_shas_equal"](_HEAD, _ORPHAN) is False
+
+
+def test_shas_equal_rejects_too_short_or_empty() -> None:
+    # A stray empty / 1-char value must never spuriously prefix-match (git's min unambiguous
+    # abbreviation is 7) — otherwise "" would "match" everything and re-open the false-green.
+    ns = _ns()
+    assert ns["_shas_equal"]("", _HEAD) is False
+    assert ns["_shas_equal"](_HEAD, "") is False
+    assert ns["_shas_equal"]("a1b2c3", _HEAD) is False  # 6 chars < 7
+    assert ns["_shas_equal"](None, _HEAD) is False
+
+
+# ─── _ci_verdict: the 3-state script-side verdict classifier (Fix 2a + 2b) ────
+# Returns "pass" (trusted), "red" (genuinely broken -> fix), or "retry" (unverified
+# green/no_ci -> re-watch, never fix). A "retry" is the key #4 fix: an unverified green is
+# NOT routed to the fixer (the code is not broken — CI just hasn't settled / we can't confirm).
+
+
+def _verdict(ns: dict[str, Any], ci: dict[str, Any], polled_head: str) -> str:
+    return str(_run(ns["_ci_verdict"](REPO, PR, ci, polled_head)))
+
+
+def test_ci_verdict_red_is_red() -> None:
+    ns = _ns(gh=_FakeGH({"head": {"sha": _HEAD}}))
+    assert _verdict(ns, {"status": "red", "polled_sha": _HEAD}, _HEAD) == "red"
+
+
+def test_ci_verdict_green_on_live_head_with_complete_checks_passes() -> None:
+    ns = _ns(gh=_FakeGH({"head": {"sha": _HEAD}}))
+    ci = {"status": "green", "polled_sha": _HEAD, "required_complete": True}
+    assert _verdict(ns, ci, _HEAD) == "pass"
+
+
+def test_ci_verdict_green_without_required_complete_is_retry_not_red() -> None:
+    # Fix 2b premature-green: green but the required set has not concluded -> RETRY (re-watch),
+    # NOT "red" (which would dispatch a fixer against a passing-but-incomplete build, #4).
+    ns = _ns(gh=_FakeGH({"head": {"sha": _HEAD}}))
+    ci = {"status": "green", "polled_sha": _HEAD, "required_complete": False}
+    assert _verdict(ns, ci, _HEAD) == "retry"
+    # a missing flag is treated as not-complete (fail-closed)
+    assert _verdict(ns, {"status": "green", "polled_sha": _HEAD}, _HEAD) == "retry"
+
+
+def test_ci_verdict_no_ci_on_live_head_passes_and_is_exempt_from_completeness() -> None:
+    # no_ci has no required checks to wait on, so it is exempt from required_complete; but it
+    # must still be on the live head.
+    ns = _ns(gh=_FakeGH({"head": {"sha": _HEAD}}))
+    assert _verdict(ns, {"status": "no_ci", "polled_sha": _HEAD}, _HEAD) == "pass"
+
+
+def test_ci_verdict_no_ci_on_wrong_parent_is_retry() -> None:
+    # Fix 2a wrong-parent: a no_ci read on an orphan commit (NOT the live head) is rejected to
+    # RETRY — the empty re-trigger commit that caused #1314.
+    ns = _ns(gh=_FakeGH({"head": {"sha": _HEAD}}))
+    assert _verdict(ns, {"status": "no_ci", "polled_sha": _ORPHAN}, _HEAD) == "retry"
+
+
+def test_ci_verdict_missing_polled_sha_is_retry() -> None:
+    # An agent that doesn't report which commit it polled cannot be verified -> fail closed.
+    ns = _ns(gh=_FakeGH({"head": {"sha": _HEAD}}))
+    assert _verdict(ns, {"status": "green", "required_complete": True}, _HEAD) == "retry"
+
+
+def test_ci_verdict_falls_back_to_dispatched_head_when_live_read_blank() -> None:
+    # When the live PR re-read yields no usable SHA-1 (head absent / non-SHA-1), fall back to
+    # the SHA the watch was dispatched with — so a genuine pass is not falsely rejected on a
+    # plumbing hiccup, but the polled commit must still match THAT.
+    ns = _ns(gh=_FakeGH({}))  # no head in payload -> _live_head_sha returns ""
+    ok = {"status": "green", "polled_sha": _HEAD, "required_complete": True}
+    assert _verdict(ns, ok, _HEAD) == "pass"
+    bad = {"status": "green", "polled_sha": _ORPHAN, "required_complete": True}
+    assert _verdict(ns, bad, _HEAD) == "retry"
+
+
+def test_ci_verdict_fails_closed_when_no_head_anchor_at_all() -> None:
+    # The review's fail-OPEN fix: if BOTH the live read is empty AND the dispatched head is
+    # empty, there is no anchor to verify against. The verdict must fail CLOSED to "retry" —
+    # NEVER trust an unverifiable green (the prior `expected = live or polled` -> "" path
+    # silently skipped the check and trusted the agent's polled_sha).
+    ns = _ns(gh=_FakeGH({}))  # _live_head_sha returns ""
+    ci = {"status": "green", "polled_sha": _ORPHAN, "required_complete": True}
+    assert _verdict(ns, ci, "") == "retry"  # polled_head also empty -> no anchor -> retry
+    # and a no_ci with no anchor is likewise not trusted
+    assert _verdict(ns, {"status": "no_ci", "polled_sha": _ORPHAN}, "") == "retry"
+
+
+# ─── _recovery_attempts: the durable re-launch-surviving counter (Fix 1 bound) ─
+
+
+def test_recovery_attempts_zero_when_no_label() -> None:
+    ns = _ns()
+    assert ns["_recovery_attempts"]({"labels": [{"name": "autodev:in-progress"}]}) == 0
+    assert ns["_recovery_attempts"]({}) == 0
+    assert ns["_recovery_attempts"](None) == 0
+
+
+def test_recovery_attempts_reads_highest_n() -> None:
+    ns = _ns()
+    issue = {
+        "labels": [
+            {"name": "autodev:recovery-1"},
+            {"name": "autodev:recovery-3"},
+            {"name": "autodev:recovery-2"},
+            {"name": "bug"},
+        ]
+    }
+    assert ns["_recovery_attempts"](issue) == 3
+
+
+def test_recovery_attempts_tolerates_string_labels_and_malformed() -> None:
+    ns = _ns()
+    # GitHub labels are objects, but tolerate bare strings + a non-numeric tail.
+    issue = {"labels": ["autodev:recovery-2", {"name": "autodev:recovery-x"}, {"name": "x"}]}
+    assert ns["_recovery_attempts"](issue) == 2


### PR DESCRIPTION
## Forensic root-cause

Stuck PRs are runs durably **`suspended` at a gate**, but the only armed auto-recovery fires on `status=errored` — a gate-park is structurally unreachable, so nothing re-attaches. Two false-green holes additionally walk a genuinely-**red** PR toward a merge gate. (Forensics run `wgleigtdf`.)

## What each fix changes

### Fix 1 (keystone) — recoverable CI child-errors re-launch instead of parking, bounded by a DURABLE counter
A ci-watch/ci-fix **child** that errors mid-call (the ~1hr ceiling / "errored before responding") is **recoverable**, not a real red verdict. It used to be caught and buried in a verify gate as a durable `suspended` that `run_completion[errored]` can never see.
- New `_recover_or_park` re-**raises** (→ `errored` → the existing trigger re-launches the build; S4 idempotently adopts the existing PR), so recovery actually fires.
- **The bound is durable.** The trigger re-runs the *same static input template* — it cannot mutate it to carry `retry_count+1` (confirmed in `harness/trigger_runner.compose_workflow_run_input`), so an in-envelope counter never increments. The bound therefore lives in GitHub state: an `autodev:recovery-N` label stamped before each re-raise (`_recovery_attempts` reads the highest N at ingest). After `MAX_RECOVERY_ATTEMPTS` (2) the error **parks at the verify gate** for a human — never an unbounded re-spend loop.
- **Fail-safe on a label-write failure:** the re-raise is gated on the recovery label POST *confirming* (200/201); if it didn't persist we park instead of raising (a raise without an advancing bound would loop forever).
- A child error **after** a genuine red verdict is **not** recoverable (the tree is really broken) → parks, never re-launches.

(`dev_pipeline.py`: `_recover_or_park`, `_recovery_attempts`, `_handle_ci_outcome`; the two CI-watch call sites in `main`.)

### Fix 2 (safety) — the CI verdict is script-CLASSIFIED, not agent-trusted
New `_ci_verdict` returns a **3-state** label instead of trusting the agent:
- **`pass`** — trusted green/no_ci → proceed to merge.
- **`red`** — agent returned red → genuinely broken → dispatch the fixer.
- **`retry`** — an *unverified* green/no_ci → **re-watch**, never run a fixer against passing code.

A green/no_ci is `pass` only when the polled commit **is the live PR head** (kills the **#1314** wrong-parent/orphan `no_ci`-as-pass) **and**, for green, the **required-check set concluded** (kills the **#1364** premature-green). It **fails closed**: with no head anchor (live read empty *and* dispatched SHA empty) the verdict is `retry`, never trusted. The uncorrelated merge-guard remains the backstop.

`CI_SCHEMA` gains `polled_sha` + `required_complete` (both fail-closed when omitted). New helper `_shas_equal` (case/abbreviation-tolerant, ≥7-char floor).

## Tests
- **Integration** (`test_wf_dev_pipeline_fixture.py`): keystone raise + durable-label stamp; real-red-then-fix-error **parks** (not re-launch); durable-label budget exhaustion → park; **label-write failure → park (no loop)**; retained `retry_count` dead-letter; genuine-red parks; wrong-parent/premature → `retry` (re-watch, asserts **no fixer churn**); premature-then-complete self-heal; legit no-CI still merges.
- **Unit** (`test_dev_pipeline_rebase.py`): 3-state `_ci_verdict` incl. the **fail-closed no-anchor** case; `_recovery_attempts`; `_shas_equal`.

The pre-existing ci-watch-error test is rewritten to the keystone behavior. Full `mypy`/`ruff`/unit/connector suite green (pre-commit hook).

## Adversarial review folded in
Two review passes; the redesign addresses every confirmed finding: the non-incrementing `retry_count` (was an unbounded loop → now durable-label bounded + fail-safe), the real-red-then-fix-error mis-classification (now parks), the fail-open `expected=""` hole (now fails closed), and premature-green routed to the fixer (now re-watches).

## Out-of-band deploy steps (this script is necessary, not sufficient)
- The **`run_completion[errored]` trigger** on this workflow must exist and re-launch with the same `{repo, issue_number}` — the keystone raise only recovers if it fires.
- The **`dev-ci-watch` agent prompt** (lives in the aios object graph, not this repo) must emit `polled_sha`/`required_complete`. Until it does, every green parks at the verify gate — fail-closed (no false merges) but zero auto-merge throughput. Ship the prompt change in lockstep.

Both are documented in the module docstring.

## Deferred (follow-ups; documented in the docstring)
- **Re-driving the EXISTING parked backlog** — needs a suspended-run recovery **sweep** (`run_completion` can't see `suspended`; `resume_gate` is launcher-attenuated). Fix 1 prevents *new* runs entering the unrecoverable-suspended state (the dominant cause); clearing the current pile is a separate mechanism.
- **Post-park rebase re-fire for a RESUMED gate** — the sync result is memoized at first execution; only a re-**launch** re-probes (which Fix 1 now does for the CI-errored class).
- **Migration-renumber collision re-check** against open PRs — touches agent behavior.

## Known residuals (narrow, backstopped; documented)
- `no_ci` is exempt from `required_complete`, so a transient `total_count=0` on the genuine head can `pass` before CI ran (merge-guard backstops it).
- `autodev:recovery-N` labels aren't stripped on terminal success (a re-opened+re-dispatched issue would read a stale budget — rare).

> Do NOT auto-merge — the seat reviews adversarially, then merges + re-registers (and ships the agent-prompt change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)