### PR TITLE
feat(harness): archived-session workspace reaper — the 45G hole (#40)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -358,6 +358,52 @@ class Settings(BaseSettings):
         "(an immediate first sweep runs at worker startup, then repeats at "
         "this cadence — mirrors the snapshot GC reconciler).",
     )
+
+    # ── archived-session workspace reaper (#40, the 45G hole) ──────────────────
+    workspace_reaper_enabled: bool = Field(
+        default=False,
+        description="Kill-switch for the archived-session workspace reaper "
+        "(reclaims the per-session ``/workspace`` host dir of "
+        "``archived_at IS NOT NULL`` sessions — the 45G hole #1192 did not "
+        "cover). Ships DARK (default OFF) and is enabled after review (set "
+        "``AIOS_WORKSPACE_REAPER_ENABLED=true``): unlike the #1192 reaper, this "
+        "deletes a session's actual working files, not reconstructible clones, "
+        "so it does not ship enabled. When False the reaper is never started "
+        "and deletes nothing.",
+    )
+    workspace_reaper_dry_run: bool = Field(
+        default=False,
+        description="When True the archived-session workspace reaper logs what "
+        "it WOULD reap (paths + bytes reclaimable) and the structured per-sweep "
+        "count, but deletes nothing. Lets a deploy verify the keep-set/predicate "
+        "on real data before the destructive sweep is armed "
+        "(``AIOS_WORKSPACE_REAPER_DRY_RUN=true``).",
+    )
+    workspace_reaper_min_archived_age_seconds: int = Field(
+        default=86_400,
+        ge=0,
+        description="Minimum age, by ``sessions.archived_at`` (DB archive time, "
+        "NOT file mtime), before an archived session's ``/workspace`` dir is "
+        "eligible for reaping. Conservative default 24h: guards a just-archived "
+        "session whose workspace something might still be reading in the window "
+        "right after archive.",
+    )
+    workspace_reaper_min_mtime_age_seconds: int = Field(
+        default=3600,
+        ge=0,
+        description="Belt-and-suspenders floor on the workspace dir's own mtime "
+        "for the archived-session workspace reaper: a dir touched more recently "
+        "than this (e.g. a step that was mid-write at archive time) is left "
+        "alone regardless of archive age. The dominant gate is the DB "
+        "archived-and-aged check; this is the provision/write race floor.",
+    )
+    workspace_reaper_interval_seconds: float = Field(
+        default=3600.0,
+        gt=0.0,
+        description="Interval for the periodic archived-session workspace "
+        "reaper sweep (an immediate first sweep runs at worker startup, then "
+        "repeats at this cadence).",
+    )
     tool_broker_socket_path: Path | None = Field(
         default=None,
         description="Host path for the tool broker's Unix-domain socket. "

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -412,6 +412,7 @@ from .sandboxes import (  # noqa: E402
     unscoped_clear_session_snapshot,
     unscoped_get_session_snapshot_bytes,
     unscoped_live_session_ids,
+    unscoped_reapable_archived_workspaces,
     unscoped_set_session_snapshot,
 )
 from .session_templates import (  # noqa: E402
@@ -804,6 +805,7 @@ __all__ = [
     "unscoped_get_trigger_row",
     "unscoped_live_session_account_id",
     "unscoped_live_session_ids",
+    "unscoped_reapable_archived_workspaces",
     "unscoped_set_session_snapshot",
     "update_account",
     "update_agent",

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -412,6 +412,7 @@ from .sandboxes import (  # noqa: E402
     unscoped_clear_session_snapshot,
     unscoped_get_session_snapshot_bytes,
     unscoped_live_session_ids,
+    unscoped_live_workspace_volume_paths,
     unscoped_reapable_archived_workspaces,
     unscoped_set_session_snapshot,
 )
@@ -805,6 +806,7 @@ __all__ = [
     "unscoped_get_trigger_row",
     "unscoped_live_session_account_id",
     "unscoped_live_session_ids",
+    "unscoped_live_workspace_volume_paths",
     "unscoped_reapable_archived_workspaces",
     "unscoped_set_session_snapshot",
     "update_account",

--- a/src/aios/db/queries/sandboxes.py
+++ b/src/aios/db/queries/sandboxes.py
@@ -163,6 +163,36 @@ async def unscoped_reapable_archived_workspaces(
     return rows
 
 
+async def unscoped_live_workspace_volume_paths(
+    conn: asyncpg.Connection[Any],
+) -> list[str]:
+    """Return every NON-archived (live) session's stored ``workspace_volume_path``.
+
+    The keep-set for the archived-workspace reaper's live-clone cross-check
+    (aios#40, same never-delete class as the confinement gate). ``clone_session``
+    lets a live clone *share* the volume of another session — and a live clone
+    can legitimately point at an ARCHIVED parent's OWN canonical default path
+    (``<root>/<account>/<parent>``). Reaping that archived parent's row would
+    ``rmtree`` the very directory the live clone is using ⇒ cross-session live
+    data loss.
+
+    Returns the *stored* paths verbatim, across all accounts (``unscoped_``); the
+    caller realpath-normalizes them into a keep-set and skips any reap candidate
+    whose canonical realpath collides with a live path. NULL/empty stored values
+    are filtered out (they can never realpath-collide with a real canonical dir).
+    """
+    rows = await conn.fetch(
+        """
+        SELECT workspace_volume_path
+          FROM sessions
+         WHERE archived_at IS NULL
+           AND workspace_volume_path IS NOT NULL
+           AND workspace_volume_path <> ''
+        """,
+    )
+    return [row["workspace_volume_path"] for row in rows]
+
+
 async def gc_snapshot_session_states(
     conn: asyncpg.Connection[Any], session_ids: Sequence[str]
 ) -> list[asyncpg.Record]:

--- a/src/aios/db/queries/sandboxes.py
+++ b/src/aios/db/queries/sandboxes.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import asyncpg
 
+from aios.db.queries.sessions import session_active_predicate
+
 # ─── durable session sandboxes: snapshot pointer (§5.1) ───────────────────────
 #
 # Worker-side, unscoped (per the ``unscoped_`` convention): the snapshot
@@ -112,6 +114,53 @@ async def unscoped_live_session_ids(
         list(session_ids),
     )
     return {row["id"] for row in rows}
+
+
+async def unscoped_reapable_archived_workspaces(
+    conn: asyncpg.Connection[Any], *, min_archived_age_seconds: float
+) -> list[asyncpg.Record]:
+    """Return ``(id, account_id, workspace_volume_path)`` for sessions whose
+    ``/workspace`` host dir is reap-eligible — the archived-session workspace
+    reaper (aios#40, the "45G hole").
+
+    A session qualifies iff ALL hold:
+
+    * ``archived_at IS NOT NULL`` — archived-only. Session archival is terminal
+      and permanent: no code path ever clears ``sessions.archived_at`` (the
+      archive fence at ``append_event`` rejects every later write), so an
+      archived session never wakes, never re-provisions, never re-reads its
+      ``/workspace``. We reap only archived sessions; a live/idle/running
+      session is structurally excluded by this clause.
+
+    * ``archived_at < now() - min_archived_age_seconds`` — the min-age floor, on
+      *DB archive time* (not file mtime). Guards a just-archived session whose
+      workspace something might still be reading in the seconds after archive.
+
+    * ``NOT (active)`` — defense-in-depth. Archived dominates the read-path
+      status label, but the explicit ``archive_session`` path carries no
+      active-guard, so archived ∧ event-watermark-active is reachable for a
+      step that was in flight at archive time. We re-confirm not-active here
+      with the SAME predicate the wake sweep uses, read fresh at sweep time, so
+      a session with work still pending is never a candidate.
+
+    Returns the *stored* ``workspace_volume_path`` verbatim; the caller is
+    responsible for the canonical-path confinement check (it reaps ONLY the
+    derived ``workspace_root/<account_id>/<session_id>`` and only when the
+    stored value resolves equal to it — a user-overridden / clone-shared /
+    aliased path is therefore never reaped). Worker-side / unscoped: the reaper
+    holds these rows across all accounts.
+    """
+    rows: list[asyncpg.Record] = await conn.fetch(
+        f"""
+        SELECT id, account_id, workspace_volume_path
+          FROM sessions
+         WHERE archived_at IS NOT NULL
+           AND archived_at < now() - make_interval(secs => $1::double precision)
+           AND NOT {session_active_predicate("sessions")}
+        """,
+        float(min_archived_age_seconds),
+    )
+    return rows
 
 
 async def gc_snapshot_session_states(

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -49,6 +49,7 @@ from aios.harness.sweep import (
 )
 from aios.harness.task_registry import TaskRegistry
 from aios.harness.trigger_runner import sweep_trigger_fires
+from aios.harness.workspace_reaper import sweep_archived_workspaces
 from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool
 from aios.sandbox.backends.docker import DockerBackend
@@ -330,6 +331,17 @@ async def worker_main() -> None:
         )
         _supervise(host_dir_reaper_task, latch=supervised_latch, fatal=supervised_failure)
 
+        # Start the archived-session workspace reaper (#40 — the 45G hole): GC
+        # the per-session ``/workspace`` host dir of archived sessions, which
+        # the #1192 reaper does NOT cover. Ships DARK
+        # (``workspace_reaper_enabled`` defaults OFF) — it deletes real working
+        # files, not reconstructible clones, so it is enabled only after review.
+        workspace_reaper_task = asyncio.create_task(
+            _workspace_reaper_loop(pool),
+            name="workspace_reaper",
+        )
+        _supervise(workspace_reaper_task, latch=supervised_latch, fatal=supervised_failure)
+
         # Start periodic sweep (every 30s).
         sweep_task = asyncio.create_task(
             _periodic_sweep(pool, task_registry, interval=30),
@@ -589,6 +601,34 @@ async def _host_dir_reaper_loop(pool: asyncpg.Pool[Any]) -> None:
                 log.info("host_dir_reaper.swept", removed=removed)
         except Exception:
             log.exception("host_dir_reaper.tick_failed")
+
+
+async def _workspace_reaper_loop(pool: asyncpg.Pool[Any]) -> None:
+    """Background loop for the archived-session workspace reaper (#40).
+
+    Same shape as ``_host_dir_reaper_loop``: try/except INSIDE the loop so one
+    DB/FS hiccup never silently disables it, immediate first sweep at boot, then
+    every configured interval. ``sweep_archived_workspaces`` itself honours the
+    ``workspace_reaper_enabled`` kill-switch (default OFF — ships dark).
+    """
+    log = get_logger("aios.worker.workspace_reaper")
+    interval = get_settings().workspace_reaper_interval_seconds
+    first = True
+    while True:
+        try:
+            if not first:
+                await asyncio.sleep(interval)
+            first = False
+            result = await sweep_archived_workspaces(pool)
+            if result.reaped or result.bytes_freed:
+                log.info(
+                    "workspace_reaper.swept",
+                    reaped=result.reaped,
+                    bytes_freed=result.bytes_freed,
+                    dry_run=result.dry_run,
+                )
+        except Exception:
+            log.exception("workspace_reaper.tick_failed")
 
 
 async def _run_interrupt_listener(

--- a/src/aios/harness/workspace_reaper.py
+++ b/src/aios/harness/workspace_reaper.py
@@ -43,10 +43,20 @@ reaps **only** that, and **only** when the stored ``workspace_volume_path``
   never be ``workspace_root`` itself or a reserved sibling root (``_runs`` …).
 * A relative / empty / out-of-tree stored value never resolves-equal ⇒ skipped.
 
-A symlink AT the canonical leaf is additionally never followed (its target may
-be a live sibling session's dir, or escape the root). The symlink check runs on
-the UN-resolved leaf — the path handed to ``rmtree`` is never symlink-
-dereferenced — so a symlink swap can't redirect the delete onto a real victim.
+Confinement is proven on the FULLY-RESOLVED canonical path — no symlink anywhere
+in its chain (leaf, parent ACCOUNT component, OR root) and its realpath still
+exactly ``<resolved_root>/<account>/<session>``. A symlink at ANY component
+(e.g. a swapped ``<root>/<account>`` redirecting at another account's LIVE dir)
+breaks that and is skipped. The path handed to ``rmtree`` is the UN-resolved
+canonical — never symlink-dereferenced — so a swap can't redirect the delete
+onto a real victim. (The CHECK resolves; the TARGET does not — they are kept
+deliberately separate, since re-merging them is what caused the prior bugs.)
+
+A residual same-class guard: a LIVE clone can share an archived parent's OWN
+canonical default dir (``clone_session`` shares volumes). Before reaping, the
+candidate's canonical realpath is cross-checked against the keep-set of every
+non-archived session's workspace realpath; a collision skips the candidate so
+reaping the parent never deletes a live clone's volume.
 
 Six guardrails (irreversible deletion — never-delete care)
 ----------------------------------------------------------
@@ -161,6 +171,26 @@ def _canonical_workspace_path(account_id: str, session_id: str, workspace_root: 
     return workspace_root / account_id / session_id
 
 
+def _live_workspace_realpath_keepset(live_paths: list[str]) -> frozenset[str]:
+    """Realpath-normalize the live-clone keep-set (Fix 2), in a sync helper.
+
+    Kept off the async sweep path so the ``os.path.realpath`` calls don't trip
+    ASYNC240 (and mirror ``_resolve_reap_target``'s sync filesystem discipline).
+    A ``realpath`` that raises (vanished path / perm) drops that entry — but a
+    dropped live path can never *match* a candidate's canonical realpath, so
+    dropping is conservative: it never causes a wrong delete. (A candidate's own
+    canonical realpath is computed independently and must equal a KEPT live path
+    to be skipped.)
+    """
+    out: set[str] = set()
+    for p in live_paths:
+        try:
+            out.add(os.path.realpath(p))
+        except OSError:
+            continue
+    return frozenset(out)
+
+
 def _resolve_reap_target(
     *,
     account_id: str,
@@ -168,6 +198,7 @@ def _resolve_reap_target(
     stored_path: str | None,
     workspace_root: Path,
     mtime_cutoff: float,
+    live_workspace_realpaths: frozenset[str],
 ) -> tuple[Path | None, str]:
     """Decide whether (and where) to reap a single archived session's workspace.
 
@@ -177,6 +208,10 @@ def _resolve_reap_target(
     fail-closed: anything we cannot positively confirm safe returns ``None``.
 
     ``workspace_root`` MUST be already-resolved (the caller resolves it once).
+    ``live_workspace_realpaths`` is the realpath keep-set of every LIVE (non-
+    archived) session's stored workspace path (the caller builds it once); a
+    candidate whose canonical realpath collides with a live path is skipped (a
+    live clone can share an archived parent's own canonical dir).
     """
     # Id-shape gate: a well-formed id can't contain a separator/``..``, so an
     # interpolated id can never reshape the path. Reject anything off-shape.
@@ -185,9 +220,54 @@ def _resolve_reap_target(
 
     canonical = _canonical_workspace_path(account_id, session_id, workspace_root)
 
-    # Never follow a symlink at the canonical leaf — its target may be a live
-    # sibling session's dir or escape the root. Checked on the UN-resolved path
-    # (``lstat``/``islink``), before any dereference, or this guard is dead.
+    # ── Confinement CHECK vs. rmtree TARGET — two DIFFERENT resolutions ──────
+    # These two concerns MUST stay separate (re-merging them is what caused the
+    # two prior confinement bugs). The CHECK proves safety on the FULLY-RESOLVED
+    # path (symlinks collapsed at EVERY component — leaf, parent, AND root); the
+    # TARGET handed to ``rmtree`` is the UN-resolved ``canonical`` (a path with a
+    # symlink anywhere in its chain must never be dereferenced into a delete).
+    #
+    # Why the earlier guards were insufficient (the cross-account LIVE-data
+    # delete the review proved): a symlink at the ACCOUNT component
+    # ``<root>/<account_id>`` is invisible to a leaf-only ``is_symlink()`` check,
+    # and ``realpath(stored) == realpath(canonical)`` collapses that parent
+    # symlink IDENTICALLY on both sides (so it matches and waves the candidate
+    # through), and ``canonical.parent.parent == workspace_root`` is computed on
+    # the UN-resolved path (so it passes trivially). ``rmtree(canonical)`` then
+    # follows the parent symlink and deletes its real target — which can be
+    # ANOTHER account's LIVE session dir. ``volumes.py`` documents in-sandbox
+    # symlink swaps under ``workspace_root`` as a real, defended-against threat,
+    # so this is reachable, not theoretical.
+    #
+    # The fix: confirm the canonical path has NO symlink anywhere in its chain
+    # (``realpath(canonical) == canonical``) AND its realpath is still exactly
+    # ``realpath(workspace_root)/<account_id>/<session_id>`` (two levels under
+    # the RESOLVED root). A symlink at ANY component (leaf OR parent OR root)
+    # breaks one of these equalities ⇒ skipped, never reaped.
+    #
+    # IMPORTANT: never replace ``canonical`` (the rmtree target) with its
+    # ``.resolve()``/``realpath`` form — the target must stay the un-resolved
+    # path so a swap can't redirect the delete onto a real victim.
+    try:
+        canonical_real = os.path.realpath(canonical)
+    except OSError:
+        return None, "confinement"
+    if canonical_real != str(canonical):
+        # A symlink exists somewhere in the canonical chain (leaf, parent, or
+        # root). The un-resolved path differs from its realpath ⇒ fail closed.
+        return None, "confinement"
+    # And the resolved canonical must sit exactly two levels under the RESOLVED
+    # root: ``realpath(root)/<account_id>/<session_id>``. ``workspace_root`` is
+    # already resolved by the caller, but a parent/root symlink could still have
+    # left ``canonical_real`` outside it — recompute against the resolved root.
+    expected_real = os.path.join(os.path.realpath(workspace_root), account_id, session_id)
+    if canonical_real != expected_real:
+        return None, "confinement"
+
+    # Belt-and-suspenders: never follow a symlink at the canonical leaf either.
+    # Checked on the UN-resolved path (``lstat``/``islink``); redundant with the
+    # realpath-equality above but kept as a cheap, explicit leaf guard so a
+    # future refactor of the chain check can't silently reintroduce leaf-follow.
     if canonical.is_symlink():
         return None, "confinement"
 
@@ -198,9 +278,20 @@ def _resolve_reap_target(
     if not stored_path:
         return None, "confinement"
     try:
-        if os.path.realpath(stored_path) != os.path.realpath(canonical):
+        if os.path.realpath(stored_path) != canonical_real:
             return None, "confinement"
     except OSError:
+        return None, "confinement"
+
+    # Live-clone keep-set cross-check (same never-delete class): a LIVE clone can
+    # share an archived parent's OWN canonical default dir. Reaping the archived
+    # parent's row would ``rmtree`` the directory the live clone is still using ⇒
+    # cross-session live data loss. Skip if this candidate's canonical realpath
+    # collides with any live session's workspace realpath. (The keep-set is
+    # fail-closed-empty only when its query erred — and on that error the caller
+    # skips the WHOLE sweep, so an empty set here always means "no live collision
+    # among the sessions we could enumerate".)
+    if canonical_real in live_workspace_realpaths:
         return None, "confinement"
 
     # Structural belt: a real dir that is exactly two levels under the root.
@@ -244,10 +335,20 @@ async def sweep_archived_workspaces(pool: asyncpg.Pool[Any]) -> ReapResult:
                 conn,
                 min_archived_age_seconds=float(settings.workspace_reaper_min_archived_age_seconds),
             )
+            # Live-clone keep-set (Fix 2): every non-archived session's workspace
+            # path, realpath-normalized. Read in the SAME critical section as the
+            # candidate set so the two reads see one consistent DB snapshot.
+            live_paths = await queries.unscoped_live_workspace_volume_paths(conn)
     except (asyncpg.PostgresError, OSError):
         # fail-closed: a DB hiccup must never be read as "everything is dead".
+        # If EITHER read fails (candidates or live keep-set) we reap nothing this
+        # pass — an absent keep-set must never be treated as "no live clones".
         log.exception("workspace_reaper.candidate_read_failed")
         return ReapResult()
+
+    # Normalize the live keep-set once (sync helper — keeps os.path off the
+    # async path; see _live_workspace_realpath_keepset for the drop semantics).
+    live_workspace_realpaths = _live_workspace_realpath_keepset(live_paths)
 
     reaped = bytes_freed = skip_conf = skip_missing = skip_fresh = skip_error = 0
     for row in candidates:
@@ -257,6 +358,7 @@ async def sweep_archived_workspaces(pool: asyncpg.Pool[Any]) -> ReapResult:
             stored_path=row["workspace_volume_path"],
             workspace_root=workspace_root,
             mtime_cutoff=mtime_cutoff,
+            live_workspace_realpaths=live_workspace_realpaths,
         )
         if reason == "confinement":
             skip_conf += 1

--- a/src/aios/harness/workspace_reaper.py
+++ b/src/aios/harness/workspace_reaper.py
@@ -1,0 +1,315 @@
+"""Archived-session ``/workspace`` reaper (#40 — the "45G hole").
+
+The per-session workspace dir (``<workspace_root>/<account_id>/<session_id>``,
+bind-mounted into the container at ``/workspace``) is **never deleted** when a
+session ends — ``volumes.py`` calls cleanup "a Phase 6 polish item" that was
+never built. Across thousands of ended sessions this reached ~45GB on Server B
+and is the largest un-reaped store the #1192 reaper does NOT cover (that one
+handles ``_session_repos`` clones and ``_runs`` scratch, not the workspace).
+
+This reaper closes that gap. It is the P1 piece of the disk control loop
+(``eumemic-company/architecture/disk-control-loop.md``).
+
+What is reaped vs. what is sacred (never-delete — sessions ARE the company)
+---------------------------------------------------------------------------
+REAPED: the **workspace files on disk** — the ephemeral repo checkout + scratch
+the session wrote under ``/workspace`` while running. For an *archived* session
+these are terminal: nothing ever re-reads them.
+
+NOT REAPED — sacred durable state, none of which lives under the workspace dir:
+the session DB row (``sessions``), its event/message history, its memory stores
+(``_memory_stores/`` — a SIBLING root under ``workspace_root``, never nested),
+its attachments/uploads (``_attachments``/``_uploads`` — siblings), its snapshot
+pointer, its outputs. ``rmtree`` of the workspace dir touches none of these.
+
+The reap predicate (canonical-path, DB-driven)
+----------------------------------------------
+Unlike the #1192 reaper (filesystem-driven: scan dirs, parse the id off the
+name), the workspace path is **DB-authoritative** (``sessions.workspace_volume_
+path``) and may be a **user override** — the clone primitive explicitly lets two
+sessions *share* one volume (``clone_session`` docstring). You cannot parse a
+session id off such a path, and reaping a shared/overridden path would delete a
+*different, possibly live* session's ``/workspace``.
+
+So the reaper is DB-driven with a **canonical-path** confinement gate. For each
+archived-and-aged session it derives the canonical default path
+``<workspace_root>/<account_id>/<session_id>`` from the row's OWN id+account and
+reaps **only** that, and **only** when the stored ``workspace_volume_path``
+``resolve()``s equal to it. Consequences, all in the safe direction:
+
+* A user-overridden / clone-shared / aliased / nested path never equals the
+  canonical path ⇒ it is skipped (a space leak, never a wrong delete).
+* The canonical path is always two levels under ``workspace_root`` ⇒ it can
+  never be ``workspace_root`` itself or a reserved sibling root (``_runs`` …).
+* A relative / empty / out-of-tree stored value never resolves-equal ⇒ skipped.
+
+A symlink AT the canonical leaf is additionally never followed (its target may
+be a live sibling session's dir, or escape the root). The symlink check runs on
+the UN-resolved leaf — the path handed to ``rmtree`` is never symlink-
+dereferenced — so a symlink swap can't redirect the delete onto a real victim.
+
+Six guardrails (irreversible deletion — never-delete care)
+----------------------------------------------------------
+1. archived-only — ``archived_at IS NOT NULL`` (the DB query). A live/idle/
+   running session is structurally excluded.
+2. DB-liveness keep-set — the same query also requires ``NOT (active)`` using
+   the wake sweep's predicate, read fresh at sweep time; a session with work
+   still pending is never a candidate even if archived.
+3. min-age floor — ``archived_at < now() - min_archived_age`` (DB time, default
+   24h) plus a belt-and-suspenders dir-mtime floor (a dir touched recently —
+   e.g. a step mid-write at archive — is left).
+4. fail-closed — any uncertainty (DB error, unresolvable/mismatched path, stat
+   failure, symlink) skips that item and deletes nothing on doubt. A DB error
+   reaps nothing the whole sweep.
+5. kill-switch — ``workspace_reaper_enabled`` (default OFF/dark): ships disabled,
+   enabled after the seat's adversarial review. Disables the whole reaper with
+   no redeploy.
+6. dry-run + observability — ``workspace_reaper_dry_run`` logs what WOULD be
+   reaped (+ reclaimable bytes) and deletes nothing; every sweep emits a
+   structured ``ReapResult`` count for deploy verification.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+from aios.config import get_settings
+from aios.db import queries
+from aios.logging import get_logger
+
+log = get_logger("aios.harness.workspace_reaper")
+
+# Both ids are minted as ``<prefix>_<Crockford-ULID>`` (``aios.ids``), so a
+# well-formed id is a non-empty run of ``[A-Za-z0-9_]`` only. We re-assert that
+# here before interpolating an id into a delete-target path: the safety-relevant
+# invariant is that the id can carry NO path separator, ``..``, NUL, leading
+# ``.``, or whitespace — anything that could reshape ``<root>/<account>/<session>``
+# (deepen it, or walk out of the root). A value off this shape is
+# skipped-as-confinement, never reaped. Deliberately a character-class allowlist
+# (not the exact ULID length) — it forecloses the path-escape class without
+# coupling the reaper to the id minter's exact format.
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True, slots=True)
+class ReapResult:
+    """Structured per-sweep outcome — the observability surface (guardrail #6).
+
+    ``reaped`` / ``bytes_freed`` are what was (or, in dry-run, WOULD be) deleted.
+    The ``skipped_*`` counters partition every candidate that was *not* reaped,
+    so a deploy can confirm the keep-set is doing its job:
+
+    * ``skipped_confinement`` — stored path did not realpath-equal the canonical
+      ``<root>/<account>/<session>`` path (off-shape id / symlink leaf / relative
+      / out-of-tree / override / shared / aliased). The dominant safety skip.
+    * ``skipped_missing`` — canonical dir not on disk (already gone / never
+      provisioned). Benign.
+    * ``skipped_too_fresh`` — dir mtime is under the mtime floor.
+    * ``skipped_error`` — an ``rmtree`` raised (perm drift / read-only FS); the
+      dir is left for the next sweep to retry. Kept distinct from ``missing`` so
+      a recurring permission failure is visible, not masked as benign.
+    """
+
+    reaped: int = 0
+    bytes_freed: int = 0
+    skipped_confinement: int = 0
+    skipped_missing: int = 0
+    skipped_too_fresh: int = 0
+    skipped_error: int = 0
+    dry_run: bool = False
+
+
+def _dir_size_bytes(path: Path) -> int:
+    """Best-effort recursive on-disk size of ``path`` (apparent file sizes).
+
+    Used only for the reclaimable-bytes counter, so an unreadable entry is
+    skipped rather than fatal — the number is observability, not a gate.
+    """
+    total = 0
+    for child in path.rglob("*"):
+        try:
+            if child.is_symlink() or not child.is_file():
+                continue
+            total += child.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _canonical_workspace_path(account_id: str, session_id: str, workspace_root: Path) -> Path:
+    """The default per-session workspace dir ``<root>/<account>/<session>``.
+
+    Recomputed from the row's own ids (never the stored string) so an
+    override/shared/aliased ``workspace_volume_path`` can never be the reap
+    target — that is the load-bearing confinement move.
+
+    ``workspace_root`` must already be resolved by the caller. The leaf is NOT
+    ``resolve()``d here: resolving would dereference a symlink AT the leaf, and
+    the symlink check downstream must run on the un-dereferenced path (a symlink
+    swap at ``<root>/<acct>/<sess>`` pointing at a live sibling's dir would
+    otherwise be followed and reaped). This is the same un-resolved-leaf
+    discipline ``host_dir_reaper._scan_children`` uses.
+    """
+    return workspace_root / account_id / session_id
+
+
+def _resolve_reap_target(
+    *,
+    account_id: str,
+    session_id: str,
+    stored_path: str | None,
+    workspace_root: Path,
+    mtime_cutoff: float,
+) -> tuple[Path | None, str]:
+    """Decide whether (and where) to reap a single archived session's workspace.
+
+    Returns ``(path, reason)``. ``path`` is the canonical dir to ``rmtree`` (NOT
+    symlink-dereferenced), or ``None`` to skip; ``reason`` is one of ``"reap"`` /
+    ``"confinement"`` / ``"missing"`` / ``"too_fresh"``. Every branch is
+    fail-closed: anything we cannot positively confirm safe returns ``None``.
+
+    ``workspace_root`` MUST be already-resolved (the caller resolves it once).
+    """
+    # Id-shape gate: a well-formed id can't contain a separator/``..``, so an
+    # interpolated id can never reshape the path. Reject anything off-shape.
+    if not (_ID_RE.match(account_id) and _ID_RE.match(session_id)):
+        return None, "confinement"
+
+    canonical = _canonical_workspace_path(account_id, session_id, workspace_root)
+
+    # Never follow a symlink at the canonical leaf — its target may be a live
+    # sibling session's dir or escape the root. Checked on the UN-resolved path
+    # (``lstat``/``islink``), before any dereference, or this guard is dead.
+    if canonical.is_symlink():
+        return None, "confinement"
+
+    # Confinement: reap ONLY the canonical default path, and ONLY when the
+    # session's stored path points at the SAME real location. We compare on
+    # ``realpath`` (symlink-collapsed) so an override / shared / aliased /
+    # relative / out-of-tree stored value never matches ⇒ skipped, never reaped.
+    if not stored_path:
+        return None, "confinement"
+    try:
+        if os.path.realpath(stored_path) != os.path.realpath(canonical):
+            return None, "confinement"
+    except OSError:
+        return None, "confinement"
+
+    # Structural belt: a real dir that is exactly two levels under the root.
+    if not canonical.is_dir():
+        return None, "missing"
+    if canonical.parent.parent != workspace_root:
+        return None, "confinement"
+
+    try:
+        # lstat (not stat): mtime of the dir itself, never a dereferenced target
+        # (the leaf is already proven non-symlink above; belt-and-suspenders).
+        mtime = canonical.lstat().st_mtime
+    except OSError:
+        return None, "missing"
+    if mtime > mtime_cutoff:
+        return None, "too_fresh"
+
+    return canonical, "reap"
+
+
+async def sweep_archived_workspaces(pool: asyncpg.Pool[Any]) -> ReapResult:
+    """One reaper sweep over archived-session ``/workspace`` dirs.
+
+    Honors the kill-switch (``workspace_reaper_enabled``): disabled ⇒ deletes
+    nothing, never queries the DB, returns an empty result. Fail-closed on a DB
+    error: the candidate read is the only DB call, so a failure reaps nothing
+    this pass. ``workspace_reaper_dry_run`` deletes nothing but still computes
+    and logs the would-reap set + reclaimable bytes.
+    """
+    settings = get_settings()
+    if not settings.workspace_reaper_enabled:
+        return ReapResult()
+
+    dry_run = bool(settings.workspace_reaper_dry_run)
+    workspace_root = settings.workspace_root.resolve()
+    mtime_cutoff = time.time() - float(settings.workspace_reaper_min_mtime_age_seconds)
+
+    try:
+        async with pool.acquire() as conn:
+            candidates = await queries.unscoped_reapable_archived_workspaces(
+                conn,
+                min_archived_age_seconds=float(settings.workspace_reaper_min_archived_age_seconds),
+            )
+    except (asyncpg.PostgresError, OSError):
+        # fail-closed: a DB hiccup must never be read as "everything is dead".
+        log.exception("workspace_reaper.candidate_read_failed")
+        return ReapResult()
+
+    reaped = bytes_freed = skip_conf = skip_missing = skip_fresh = skip_error = 0
+    for row in candidates:
+        target, reason = _resolve_reap_target(
+            account_id=row["account_id"],
+            session_id=row["id"],
+            stored_path=row["workspace_volume_path"],
+            workspace_root=workspace_root,
+            mtime_cutoff=mtime_cutoff,
+        )
+        if reason == "confinement":
+            skip_conf += 1
+            continue
+        if reason == "missing":
+            skip_missing += 1
+            continue
+        if reason == "too_fresh":
+            skip_fresh += 1
+            continue
+        assert target is not None  # reason == "reap"
+
+        size = _dir_size_bytes(target)
+        if dry_run:
+            reaped += 1
+            bytes_freed += size
+            log.info(
+                "workspace_reaper.would_reap",
+                session_id=row["id"],
+                path=str(target),
+                bytes=size,
+            )
+            continue
+        try:
+            shutil.rmtree(target)
+        except OSError:
+            # One un-removable dir (perm drift, read-only FS) must not abort the
+            # rest of the sweep; the next sweep retries it.
+            log.exception("workspace_reaper.rmtree_failed", path=str(target))
+            skip_error += 1
+            continue
+        reaped += 1
+        bytes_freed += size
+
+    result = ReapResult(
+        reaped=reaped,
+        bytes_freed=bytes_freed,
+        skipped_confinement=skip_conf,
+        skipped_missing=skip_missing,
+        skipped_too_fresh=skip_fresh,
+        skipped_error=skip_error,
+        dry_run=dry_run,
+    )
+    if candidates:
+        log.info(
+            "workspace_reaper.swept",
+            reaped=result.reaped,
+            bytes_freed=result.bytes_freed,
+            skipped_confinement=result.skipped_confinement,
+            skipped_missing=result.skipped_missing,
+            skipped_too_fresh=result.skipped_too_fresh,
+            skipped_error=result.skipped_error,
+            dry_run=result.dry_run,
+            candidates=len(candidates),
+        )
+    return result

--- a/tests/e2e/test_archived_workspace_reaper_query.py
+++ b/tests/e2e/test_archived_workspace_reaper_query.py
@@ -1,0 +1,109 @@
+"""E2E: the archived-session workspace reaper's candidate SQL against real PG (#40).
+
+The unit tests inject the query result; this proves the SQL itself is valid and
+selects the right rows against a real Postgres — the ``make_interval`` age floor,
+the ``archived_at IS NOT NULL`` filter, and the composed
+``session_active_predicate`` (whose columns live on ``sessions``). Mirrors the
+existing ``unscoped_*`` reaper-query conventions.
+
+Asserts:
+* an archived, aged, not-active session IS returned (reap-eligible);
+* a NON-archived (live) session is NOT returned (archived-only);
+* a just-archived session is NOT returned while the age floor exceeds its age
+  (min-age floor on DB archive time);
+* an archived session with an unreacted stimulus (active) is NOT returned
+  (the not-active defense-in-depth keep-set).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+
+pytestmark = pytest.mark.docker
+
+
+async def _seed_fk_targets(pool: asyncpg.Pool[Any]) -> tuple[str, str]:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO agents (id, name, model, account_id) "
+            "VALUES ('agt_wsr', 'wsr', 'openrouter/x', 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, name, account_id) "
+            "VALUES ('env_wsr', 'env_wsr', 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+    return "agt_wsr", "env_wsr"
+
+
+async def _insert_session(
+    conn: asyncpg.Connection[Any],
+    *,
+    sid: str,
+    archived_age_seconds: float | None,
+    active: bool = False,
+) -> None:
+    """Insert a session row directly, controlling archived_at and active-ness.
+
+    ``archived_age_seconds=None`` ⇒ live (archived_at NULL). A positive value ⇒
+    ``archived_at = now() - that``. ``active=True`` sets an unreacted stimulus so
+    the active predicate is true.
+    """
+    await conn.execute(
+        """
+        INSERT INTO sessions (
+            id, agent_id, environment_id, title, metadata,
+            workspace_volume_path, account_id, archived_at,
+            last_stimulus_seq, last_reacted_seq, open_tool_call_count,
+            last_error_seq, last_user_seq
+        )
+        VALUES (
+            $1, 'agt_wsr', 'env_wsr', NULL, '{}'::jsonb,
+            $2, 'acc_test_stub',
+            CASE WHEN $3::double precision IS NULL THEN NULL
+                 ELSE now() - make_interval(secs => $3::double precision) END,
+            $4, 0, 0, 0, 0
+        )
+        ON CONFLICT (id) DO NOTHING
+        """,
+        sid,
+        f"/var/lib/aios/workspaces/acc_test_stub/{sid}",
+        archived_age_seconds,
+        1 if active else 0,  # last_stimulus_seq > last_reacted_seq(0) ⇒ active
+    )
+
+
+async def test_candidate_query_selects_only_archived_aged_inactive(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    await _seed_fk_targets(pool)
+    async with pool.acquire() as conn:
+        # archived 2h ago, not active ⇒ eligible under a 1h floor.
+        await _insert_session(conn, sid="ses_wsr_reap", archived_age_seconds=7200)
+        # live (never archived) ⇒ excluded.
+        await _insert_session(conn, sid="ses_wsr_live", archived_age_seconds=None)
+        # archived only 60s ago ⇒ excluded by the 1h floor.
+        await _insert_session(conn, sid="ses_wsr_fresh", archived_age_seconds=60)
+        # archived 2h ago BUT active (unreacted stimulus) ⇒ excluded by keep-set.
+        await _insert_session(conn, sid="ses_wsr_active", archived_age_seconds=7200, active=True)
+
+        rows = await queries.unscoped_reapable_archived_workspaces(
+            conn, min_archived_age_seconds=3600
+        )
+
+    ids = {r["id"] for r in rows}
+    assert "ses_wsr_reap" in ids, "archived+aged+inactive must be reap-eligible"
+    assert "ses_wsr_live" not in ids, "a live session must never be a candidate"
+    assert "ses_wsr_fresh" not in ids, "a just-archived session is held by the age floor"
+    assert "ses_wsr_active" not in ids, "an active (unreacted) session is held by the keep-set"
+
+    # The returned row carries exactly the fields the reaper confinement needs.
+    reap_row = next(r for r in rows if r["id"] == "ses_wsr_reap")
+    assert reap_row["account_id"] == "acc_test_stub"
+    assert reap_row["workspace_volume_path"].endswith("/acc_test_stub/ses_wsr_reap")

--- a/tests/unit/test_workspace_reaper.py
+++ b/tests/unit/test_workspace_reaper.py
@@ -65,18 +65,39 @@ def _mk_workspace(root: Path, account_id: str, session_id: str, *, age_s: float 
     return d
 
 
-def _fake_pool(candidates: list[dict[str, Any]] | Exception) -> MagicMock:
-    """Pool whose acquired conn returns ``candidates`` (or raises) from the query.
+def _fake_pool(
+    candidates: list[dict[str, Any]] | Exception,
+    *,
+    live_paths: list[str] | None = None,
+) -> MagicMock:
+    """Pool whose acquired conn answers the reaper's two ``conn.fetch`` calls.
 
-    ``candidates`` are the rows the DB query would yield — i.e. already filtered
-    to archived ∧ aged ∧ not-active by the SQL. Each is a dict with ``id``,
-    ``account_id``, ``workspace_volume_path``.
+    ``candidates`` are the rows the candidate query would yield — i.e. already
+    filtered to archived ∧ aged ∧ not-active by the SQL. Each is a dict with
+    ``id`` / ``account_id`` / ``workspace_volume_path``. Pass an ``Exception`` to
+    simulate a DB error on the candidate read.
+
+    ``live_paths`` are the stored ``workspace_volume_path`` values the LIVE-clone
+    keep-set query (``unscoped_live_workspace_volume_paths``) would return; the
+    reaper realpath-normalizes them and skips any candidate that collides. The
+    two fetches are routed by SQL text: the candidate query selects
+    ``archived_at IS NOT NULL``, the live query ``archived_at IS NULL``.
     """
+    live_paths = live_paths or []
     conn = MagicMock()
+
     if isinstance(candidates, Exception):
         conn.fetch = AsyncMock(side_effect=candidates)
     else:
-        conn.fetch = AsyncMock(return_value=candidates)
+
+        async def _route_fetch(sql: str, *_a: Any, **_k: Any) -> list[Any]:
+            if "archived_at IS NULL" in sql:
+                # the live-clone keep-set query: rows with workspace_volume_path
+                return [{"workspace_volume_path": p} for p in live_paths]
+            # the candidate query: archived ∧ aged ∧ not-active rows
+            return candidates
+
+        conn.fetch = AsyncMock(side_effect=_route_fetch)
 
     class _Cm:
         async def __aenter__(self) -> Any:
@@ -266,6 +287,89 @@ async def test_symlink_canonical_to_sibling_session_is_never_followed(
     assert result.skipped_confinement == 1
     assert victim.exists(), "a same-root symlink target (live sibling) must survive"
     assert (victim / "scratch.txt").exists()
+
+
+async def test_symlinked_account_component_to_live_sibling_is_never_followed(
+    env: dict[str, Any],
+) -> None:
+    """CRITICAL (#1395 never-delete breach): a symlink at the ACCOUNT component
+    ``<root>/<account_id>`` pointing at a real sibling account's dir must NOT be
+    followed — reaping the archived session's canonical leaf would ``rmtree`` the
+    LIVE victim's session dir under the symlinked-through account.
+
+    The leaf-only ``is_symlink()`` check is blind to a PARENT symlink, and
+    ``realpath(stored) == realpath(canonical)`` collapses the parent symlink
+    identically on both sides (so it matches and waves the candidate through).
+    Fix 1 confines on the FULLY-RESOLVED canonical path (no symlink anywhere in
+    the chain, realpath still two levels under the resolved root), so a
+    parent-component symlink breaks the realpath equality ⇒ skipped, never reaped.
+
+    Non-vacuous: against the unfixed leaf-only confinement this test FAILS —
+    ``reaped == 1`` and the victim's data is deleted; with Fix 1 it PASSES.
+    """
+    root = env["root"]
+    # The live victim: account ``acct_victim`` with a real, populated session dir.
+    victim_account = root / "acct_victim"
+    victim_account.mkdir()
+    victim_session = victim_account / "sess_victim"
+    victim_session.mkdir()
+    (victim_session / "live-data.txt").write_text("a LIVE cross-account session's files")
+
+    # The attacker account component is a SYMLINK to the victim account dir, so
+    # ``<root>/acct_attacker/sess_victim`` traverses the parent symlink to the
+    # victim's real session dir under the SAME root.
+    attacker_account = root / "acct_attacker"
+    attacker_account.symlink_to(victim_account)
+
+    # The archived session's stored path is its canonical default through the
+    # symlinked account — it realpath-collapses to the victim's real dir, exactly
+    # as the canonical recomputed from ids does (the bug the two old guards miss).
+    canonical_via_symlink = str(attacker_account / "sess_victim")
+    pool = _fake_pool([_row("acct_attacker", "sess_victim", canonical_via_symlink)])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0, "a parent-component symlink must never be followed into a delete"
+    assert result.skipped_confinement == 1
+    assert victim_session.exists(), "the LIVE cross-account victim's session dir must remain"
+    assert (victim_session / "live-data.txt").exists(), "the victim's live data must remain"
+
+
+async def test_live_clone_sharing_archived_parents_canonical_dir_is_skipped(
+    env: dict[str, Any],
+) -> None:
+    """Fix 2 (residual, same never-delete class): a LIVE session whose
+    ``workspace_volume_path`` realpath-equals an archived candidate's canonical
+    dir must cause the archived candidate to be SKIPPED.
+
+    ``clone_session`` lets a live clone share another session's volume — and a
+    live clone can point at an archived parent's OWN canonical default path. If
+    the reaper reaped the archived parent's row it would ``rmtree`` the directory
+    the live clone is actively using ⇒ cross-session live data loss. The
+    live-clone keep-set cross-check skips the parent when a live session collides.
+
+    Non-vacuous: without the keep-set cross-check the parent's canonical dir
+    passes every confinement check (its OWN stored path equals its OWN canonical),
+    so it is reaped (``reaped == 1``) and the live clone's volume is destroyed;
+    with Fix 2 the live collision skips it (``reaped == 0``).
+    """
+    # The archived parent's canonical default dir (its stored path == canonical).
+    parent_dir = _mk_workspace(env["root"], "acct1", "sess_parent")
+    parent_canonical = str(parent_dir)
+
+    # A LIVE clone shares the parent's directory (its stored workspace path is the
+    # parent's canonical dir). It is non-archived, so it is in the live keep-set.
+    pool = _fake_pool(
+        [_row("acct1", "sess_parent", parent_canonical)],
+        live_paths=[parent_canonical],
+    )
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0, "reaping a dir a LIVE clone shares would destroy the clone's volume"
+    assert result.skipped_confinement == 1
+    assert parent_dir.exists(), "the shared directory the live clone uses must remain"
+    assert (parent_dir / "scratch.txt").exists()
 
 
 async def test_off_shape_ids_are_never_reaped(env: dict[str, Any]) -> None:

--- a/tests/unit/test_workspace_reaper.py
+++ b/tests/unit/test_workspace_reaper.py
@@ -1,0 +1,431 @@
+"""Unit tests for ``aios.harness.workspace_reaper`` (#40 — the 45G hole).
+
+The reaper reclaims the per-session ``/workspace`` host dir
+(``<workspace_root>/<account_id>/<session_id>``) of archived sessions — the
+large un-reaped store the #1192 reaper does NOT cover.
+
+The load-bearing safety property is the **canonical-path confinement gate**:
+the reaper reaps ONLY the default ``<root>/<account>/<session>`` path derived
+from the row's own ids, and ONLY when the session's stored
+``workspace_volume_path`` resolves equal to it. This forecloses the
+data-loss vectors the design review found — a user-overridden / clone-shared /
+aliased / parent / out-of-tree / relative path never matches and is skipped
+(a space leak, never a wrong delete).
+
+These tests assert each of the six required guardrails directly:
+
+* archived-only + DB-liveness keep-set: only sessions the DB query returns
+  (archived ∧ aged ∧ not-active) are candidates; a running session's dir is
+  never reaped (proven via the query result, which the SQL itself enforces);
+* min-age floor: a dir under the mtime floor is skipped;
+* fail-closed: a DB error reaps nothing; a confinement mismatch skips;
+* kill-switch: ``workspace_reaper_enabled=False`` deletes nothing;
+* dry-run: deletes nothing but reports would-reap counts/bytes.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import asyncpg
+import pytest
+
+from aios.harness import workspace_reaper
+from aios.harness.workspace_reaper import sweep_archived_workspaces
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Point ``workspace_root`` at a tmpdir, drop floors to 0, reaper enabled."""
+    root = tmp_path / "workspaces"
+    root.mkdir()
+
+    settings = MagicMock()
+    settings.workspace_root = root
+    settings.workspace_reaper_enabled = True
+    settings.workspace_reaper_dry_run = False
+    settings.workspace_reaper_min_archived_age_seconds = 86_400
+    settings.workspace_reaper_min_mtime_age_seconds = 0
+    monkeypatch.setattr(workspace_reaper, "get_settings", lambda: settings)
+
+    return {"root": root, "settings": settings}
+
+
+def _mk_workspace(root: Path, account_id: str, session_id: str, *, age_s: float = 10_000.0) -> Path:
+    """Create the canonical ``<root>/<account>/<session>`` dir, aged past floors."""
+    d = root / account_id / session_id
+    d.mkdir(parents=True)
+    (d / "scratch.txt").write_text("model wrote this")
+    old = time.time() - age_s
+    os.utime(d, (old, old))
+    return d
+
+
+def _fake_pool(candidates: list[dict[str, Any]] | Exception) -> MagicMock:
+    """Pool whose acquired conn returns ``candidates`` (or raises) from the query.
+
+    ``candidates`` are the rows the DB query would yield — i.e. already filtered
+    to archived ∧ aged ∧ not-active by the SQL. Each is a dict with ``id``,
+    ``account_id``, ``workspace_volume_path``.
+    """
+    conn = MagicMock()
+    if isinstance(candidates, Exception):
+        conn.fetch = AsyncMock(side_effect=candidates)
+    else:
+        conn.fetch = AsyncMock(return_value=candidates)
+
+    class _Cm:
+        async def __aenter__(self) -> Any:
+            return conn
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+    pool = MagicMock()
+    pool.acquire.return_value = _Cm()
+    pool._conn = conn  # expose for assertions
+    return pool
+
+
+def _row(account_id: str, session_id: str, workspace_volume_path: str) -> dict[str, Any]:
+    return {
+        "id": session_id,
+        "account_id": account_id,
+        "workspace_volume_path": workspace_volume_path,
+    }
+
+
+# ── guardrail 1+2: archived-only + DB-liveness keep-set ──────────────────────
+
+
+async def test_archived_aged_inactive_session_dir_is_reaped(env: dict[str, Any]) -> None:
+    """A canonical-path workspace of an archived/aged/not-active session is reaped.
+
+    The DB query (whose result we inject) is what enforces archived ∧ aged ∧
+    NOT active — so a candidate reaching the reaper is by construction past the
+    keep-set; the reaper deletes its workspace files.
+    """
+    d = _mk_workspace(env["root"], "acct1", "sess_archived")
+    canonical = str(d)
+    pool = _fake_pool([_row("acct1", "sess_archived", canonical)])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 1
+    assert not d.exists(), "an archived/aged/not-active session's workspace must be reaped"
+    assert result.bytes_freed > 0
+
+
+async def test_running_session_never_in_candidate_set(env: dict[str, Any]) -> None:
+    """The keep-set: a live/running session is never a candidate, so its dir survives.
+
+    The query returns ONLY archived ∧ not-active rows; a running session is
+    absent. We model that by returning an empty candidate set while a running
+    session's dir exists on disk — it must be untouched.
+    """
+    live = _mk_workspace(env["root"], "acct1", "sess_running")
+    pool = _fake_pool([])  # query excludes the running session
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert live.exists(), "a running session's workspace dir must survive (keep-set)"
+
+
+# ── the CRITICAL confinement finding: shared / overridden / aliased paths ────
+
+
+async def test_shared_override_path_is_never_reaped(env: dict[str, Any]) -> None:
+    """A clone-shared / user-override workspace_volume_path is SKIPPED, not reaped.
+
+    The data-loss vector the review found: ``clone_session`` lets two sessions
+    share one volume. If session A is archived but its stored path is the SHARED
+    override (not its canonical default), reaping the stored path would delete a
+    possibly-live session B's ``/workspace``. The canonical-path gate skips it:
+    the stored override never equals ``<root>/<account>/<sessA>``.
+    """
+    # Session B's live workspace, which A's archived row points at via override.
+    shared = _mk_workspace(env["root"], "acct1", "sess_B_shared")
+    # A's canonical default does NOT exist on disk (A used the override instead).
+    pool = _fake_pool([_row("acct1", "sess_A_archived", str(shared))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 1
+    assert shared.exists(), "a shared/override workspace must never be reaped"
+
+
+async def test_parent_dir_path_is_never_reaped(env: dict[str, Any]) -> None:
+    """A stored path that is the account root (parent of all sessions) is skipped."""
+    account_root = env["root"] / "acct1"
+    account_root.mkdir()
+    other = _mk_workspace(env["root"], "acct1", "sess_other")
+    pool = _fake_pool([_row("acct1", "sess_archived", str(account_root))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 1
+    assert account_root.exists()
+    assert other.exists(), "reaping a parent path would have destroyed a sibling session"
+
+
+async def test_workspace_root_itself_is_never_reaped(env: dict[str, Any]) -> None:
+    """A stored path resolving to workspace_root (even via trailing slash) is skipped.
+
+    Defeats the catastrophic 'rmtree the whole root' case: the canonical path is
+    always two levels deep, so it can never equal the root, and a stored value
+    of the root (or root + trailing slash) never resolve-equals the canonical.
+    """
+    sibling = _mk_workspace(env["root"], "acct1", "sess_sibling")
+    pool = _fake_pool([_row("acct1", "sess_archived", str(env["root"]) + "/")])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 1
+    assert env["root"].exists()
+    assert sibling.exists()
+
+
+async def test_out_of_tree_path_is_never_reaped(env: dict[str, Any], tmp_path: Path) -> None:
+    """A stored path outside workspace_root never resolve-equals the canonical → skipped."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "precious").write_text("do not touch")
+    pool = _fake_pool([_row("acct1", "sess_archived", str(outside))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 1
+    assert (outside / "precious").exists()
+
+
+async def test_relative_or_empty_path_is_never_reaped(env: dict[str, Any]) -> None:
+    """Relative / empty stored paths never resolve-equal the canonical → skipped."""
+    _mk_workspace(env["root"], "acct1", "sess_archived")  # canonical exists
+    pool = _fake_pool(
+        [
+            _row("acct1", "sess_archived", ""),
+            _row("acct1", "sess_archived", "workspaces/acct1/sess_archived"),
+        ]
+    )
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 2
+    assert (env["root"] / "acct1" / "sess_archived").exists()
+
+
+async def test_symlink_canonical_to_outside_is_never_followed(
+    env: dict[str, Any], tmp_path: Path
+) -> None:
+    """A symlink AT the canonical location pointing OUTSIDE the root is skipped."""
+    outside = tmp_path / "outside_target"
+    outside.mkdir()
+    (outside / "precious").write_text("do not touch")
+    account_dir = env["root"] / "acct1"
+    account_dir.mkdir()
+    link = account_dir / "sess_archived"
+    link.symlink_to(outside)
+    # Stored path is the canonical leaf itself (the symlink) — it realpaths to
+    # the target, but the is_symlink leaf-check skips it before any compare.
+    pool = _fake_pool([_row("acct1", "sess_archived", str(link))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 1
+    assert outside.exists()
+    assert (outside / "precious").exists()
+
+
+async def test_symlink_canonical_to_sibling_session_is_never_followed(
+    env: dict[str, Any],
+) -> None:
+    """A symlink at the canonical leaf pointing at a LIVE SIBLING session's dir
+    under the SAME root is skipped — the data-loss case the resolve-on-leaf bug
+    would have caused (the symlink check must run on the UN-resolved leaf).
+    """
+    victim = _mk_workspace(env["root"], "acct1", "sess_victim")  # a live sibling
+    account_dir = env["root"] / "acct1"
+    link = account_dir / "sess_archived"  # canonical leaf of the archived session
+    link.symlink_to(victim)  # same-root target — defeats an out-of-tree-only belt
+    pool = _fake_pool([_row("acct1", "sess_archived", str(link))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 1
+    assert victim.exists(), "a same-root symlink target (live sibling) must survive"
+    assert (victim / "scratch.txt").exists()
+
+
+async def test_off_shape_ids_are_never_reaped(env: dict[str, Any]) -> None:
+    """An account/session id carrying a path separator or ``..`` is skipped.
+
+    Defense-in-depth: a corrupt/crafted id can't reshape the delete-target path.
+    """
+    _mk_workspace(env["root"], "acct1", "sess_archived")  # a real dir exists
+    pool = _fake_pool(
+        [
+            _row("acct1", "../sess_archived", str(env["root"] / "acct1" / "sess_archived")),
+            _row("..", "sess_archived", str(env["root"])),
+            _row("acct1", "a/b", str(env["root"] / "acct1" / "a" / "b")),
+        ]
+    )
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_confinement == 3
+    assert (env["root"] / "acct1" / "sess_archived").exists()
+
+
+# ── guardrail 3: min-age floor (mtime belt) ──────────────────────────────────
+
+
+async def test_fresh_dir_below_mtime_floor_is_kept(env: dict[str, Any]) -> None:
+    """A workspace touched more recently than the mtime floor is skipped."""
+    env["settings"].workspace_reaper_min_mtime_age_seconds = 3600
+    d = env["root"] / "acct1" / "sess_archived"
+    d.mkdir(parents=True)  # mtime ~= now, under the 1h floor
+    pool = _fake_pool([_row("acct1", "sess_archived", str(d.resolve()))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_too_fresh == 1
+    assert d.exists()
+
+
+# ── guardrail 4: fail-closed ─────────────────────────────────────────────────
+
+
+async def test_db_error_reaps_nothing(env: dict[str, Any]) -> None:
+    """A candidate-read failure reaps NOTHING (fail-closed)."""
+    d = _mk_workspace(env["root"], "acct1", "sess_archived")
+    pool = _fake_pool(asyncpg.PostgresError("boom"))
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.bytes_freed == 0
+    assert d.exists(), "fail-closed: a DB error must never delete anything"
+
+
+async def test_missing_canonical_dir_is_a_noop_skip(env: dict[str, Any]) -> None:
+    """An archived session whose canonical dir is already gone is a benign skip."""
+    pool = _fake_pool([_row("acct1", "sess_gone", str(env["root"] / "acct1" / "sess_gone"))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert result.skipped_missing == 1
+
+
+# ── guardrail 5: kill-switch ─────────────────────────────────────────────────
+
+
+async def test_kill_switch_disables_everything(env: dict[str, Any]) -> None:
+    """``workspace_reaper_enabled=False`` deletes nothing and never queries the DB."""
+    env["settings"].workspace_reaper_enabled = False
+    d = _mk_workspace(env["root"], "acct1", "sess_archived")
+    pool = _fake_pool([_row("acct1", "sess_archived", str(d))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert d.exists()
+    pool._conn.fetch.assert_not_awaited()  # disabled ⇒ no DB query at all
+
+
+async def test_default_settings_ship_dark() -> None:
+    """The shipped default is OFF (dark) — this reaper deletes real working files."""
+    from aios.config import Settings
+
+    field = Settings.model_fields["workspace_reaper_enabled"]
+    assert field.default is False, "workspace reaper must ship disabled (review-gated)"
+
+
+# ── guardrail 6: dry-run + observability ─────────────────────────────────────
+
+
+async def test_dry_run_deletes_nothing_but_reports(env: dict[str, Any]) -> None:
+    """Dry-run logs would-reap counts + reclaimable bytes but deletes nothing."""
+    env["settings"].workspace_reaper_dry_run = True
+    d = _mk_workspace(env["root"], "acct1", "sess_archived")
+    pool = _fake_pool([_row("acct1", "sess_archived", str(d))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.dry_run is True
+    assert result.reaped == 1, "dry-run still COUNTS what it would reap"
+    assert result.bytes_freed > 0, "dry-run still reports reclaimable bytes"
+    assert d.exists(), "dry-run must delete nothing"
+
+
+async def test_structured_counters_partition_candidates(
+    env: dict[str, Any], tmp_path: Path
+) -> None:
+    """Every candidate lands in exactly one bucket: reaped / confinement / missing / fresh."""
+    reaped = _mk_workspace(env["root"], "acct1", "sess_reap")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    rows = [
+        _row("acct1", "sess_reap", str(reaped)),  # → reaped
+        _row("acct1", "sess_override", str(outside)),  # → confinement
+        _row("acct1", "sess_gone", str(env["root"] / "acct1" / "sess_gone")),  # → missing
+    ]
+    pool = _fake_pool(rows)
+
+    result = await sweep_archived_workspaces(pool)
+
+    total = (
+        result.reaped
+        + result.skipped_confinement
+        + result.skipped_missing
+        + result.skipped_too_fresh
+        + result.skipped_error
+    )
+    assert total == len(rows)
+    assert result.reaped == 1
+    assert result.skipped_confinement == 1
+    assert result.skipped_missing == 1
+
+
+async def test_rmtree_failure_counts_as_error_not_missing(
+    env: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ``rmtree`` failure is recorded as ``skipped_error`` (distinct from missing)
+    and does not abort the sweep — a second valid candidate is still reaped.
+    """
+    import shutil as _shutil
+
+    bad = _mk_workspace(env["root"], "acct1", "sess_bad")
+    good = _mk_workspace(env["root"], "acct1", "sess_good")
+
+    real_rmtree = _shutil.rmtree
+
+    def _flaky_rmtree(path: Any, *a: Any, **k: Any) -> None:
+        if str(path) == str(bad):
+            raise OSError("read-only filesystem")
+        real_rmtree(path, *a, **k)
+
+    monkeypatch.setattr(_shutil, "rmtree", _flaky_rmtree)
+    pool = _fake_pool([_row("acct1", "sess_bad", str(bad)), _row("acct1", "sess_good", str(good))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.skipped_error == 1
+    assert result.skipped_missing == 0
+    assert result.reaped == 1, "a failure on one dir must not abort the sweep"
+    assert bad.exists(), "the un-removable dir is left for the next sweep"
+    assert not good.exists()


### PR DESCRIPTION
## What

The P1 reaper of the disk control loop (`eumemic-company/architecture/disk-control-loop.md`): GC the per-session `/workspace` host dir (`<workspace_root>/<account_id>/<session_id>`) of **archived** sessions — the largest un-reaped store the #1192 reaper (`_session_repos` / `_runs`) does NOT cover. `volumes.py` calls this cleanup "a Phase 6 polish item" that was never built; across thousands of ended sessions it reached ~45GB on Server B (the "45G hole").

## Ships DARK — do not enable without review

`AIOS_WORKSPACE_REAPER_ENABLED` defaults **OFF**. Unlike #1192 (which reaps reconstructible clones / terminal scratch and ships on), this deletes a session's actual working files, so it ships disabled and is enabled after the seat's adversarial review. This PR is **not** to be merged-and-promoted blindly — the seat reviews adversarially (irreversible deletion) and owns the deploy + the enable.

## What is and is NOT deleted

- **DELETED:** the workspace files on disk — the ephemeral repo checkout + scratch the session wrote under `/workspace`. For an *archived* session these are terminal; nothing re-reads them.
- **NOT DELETED (sacred — sessions ARE the company):** the session DB row, its event/message history, its memory stores (`_memory_stores/` — a **sibling** root under `workspace_root`, never nested under a session dir), attachments/uploads (siblings), snapshot pointer, outputs. `rmtree` of the workspace dir touches none of these.

## Design: DB-driven, canonical-path confinement gate

The inverse of #1192 (which is filesystem-driven: scan dirs, parse the id off the name). The workspace path is **DB-authoritative** (`sessions.workspace_volume_path`) and may be a **user override** — the clone primitive explicitly lets two sessions *share* one volume — so you cannot parse a session id off it, and reaping the stored path could delete a different, possibly-live session's `/workspace`.

So the reaper derives the canonical `<root>/<account>/<session>` path from the row's **own** ids and reaps **only** that, **only** when the stored `workspace_volume_path` realpath-equals it. An override / shared / aliased / parent / out-of-tree / relative / symlink path never matches ⇒ skipped (a space leak, never a wrong delete). The symlink check runs on the **un-resolved leaf** and the `rmtree` target is never symlink-dereferenced, so a same-root symlink swap can't redirect the delete onto a live sibling.

## Six guardrails (each with a proving test)

1. **archived-only** — `archived_at IS NOT NULL` (SQL). A live/idle/running session is structurally excluded.
2. **DB-liveness keep-set** — the SQL also requires `NOT (active)` using the wake sweep's own predicate, read fresh at sweep time.
3. **min-age floor** — `archived_at < now() - min_age` (DB time, default 24h) + a belt-and-suspenders dir-mtime floor.
4. **fail-closed** — a DB error reaps nothing the whole sweep; per-item doubt (off-shape id, path mismatch, symlink, stat error) skips that item.
5. **kill-switch** — `AIOS_WORKSPACE_REAPER_ENABLED` default OFF; disables the whole reaper with no redeploy.
6. **dry-run + observability** — `AIOS_WORKSPACE_REAPER_DRY_RUN` deletes nothing but logs the would-reap set + bytes; every sweep emits a structured `ReapResult` (`reaped` / `bytes_freed` / `skipped_{confinement,missing,too_fresh,error}`).

## Tests

- 18 unit tests covering every guardrail **and** the design-review data-loss vectors: shared-override, parent-dir, workspace-root (trailing-slash), out-of-tree, same-root symlink → live sibling, off-shape id, rmtree-error isolation, kill-switch (asserts no DB query), dry-run, fail-closed.
- 1 e2e test validates the candidate SQL against real Postgres (archived-only, age floor, active keep-set).
- Full suite green: `ruff`, `mypy` (1182 files), 3263 unit + connector tests, zero regressions.

## Reviewer notes / residuals

- **Provenance:** the design was red-teamed by two adversarial reviewers before any code; the canonical-path gate is the fix for the shared-override data-loss vector they found. A code review then caught a real bug — a `.resolve()` on the leaf that made the symlink guard dead code (a same-root symlink would have been followed) — now fixed (un-resolved-leaf check) with a dedicated failing-then-passing test.
- **Phantom-unarchive (latent, named):** `registry.py` retains archived sessions' snapshots citing "unarchive exists," but there is **no** code path that clears `sessions.archived_at` today — session archival is terminal. If session-unarchive ever lands, this reaper must re-key off a positively-terminal condition rather than `archived_at`; flagging so the contract is resolved before that capability ships.

Closes eumemic-company task #107 (the disk-control-loop P1 line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)