### PR TITLE
make list_runs/get_run run-callable — unblock the immune-system dead-men (#1396)

### DIFF
--- a/src/aios/workflows/run_tools.py
+++ b/src/aios/workflows/run_tools.py
@@ -31,16 +31,23 @@ from typing import Any
 import asyncpg
 
 from aios.db.queries import workflows as wf_queries
+from aios.errors import AiosError
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.mcp.client import resolve_auth_for_target_url_run
 from aios.models.workflows import WfRun
+from aios.services import workflows as wf_service
 from aios.services.wake import defer_run_wake
 from aios.tools.http_request import _do_http_request, _find_server, _match_route, _split_query
 from aios.tools.invoke import validate_arguments
 from aios.tools.registry import registry
 from aios.tools.web_fetch import web_fetch_handler
 from aios.tools.web_search import web_search_handler
+from aios.tools.workflow_management import (
+    _RUN_ECHO_EXCLUDE,
+    _GetRunArgs,
+    _ListRunsArgs,
+)
 from aios.workflows.idempotency_key import (
     AIOS_IDEMPOTENCY_KEY_SENTINEL,
     idempotency_key,
@@ -75,10 +82,16 @@ def _substitute_idempotency_sentinel(
 # The builtins a run may call directly. The network/credential trio run on the
 # worker (:func:`invoke_run_tool`); ``bash`` runs in the run's provisioned sandbox
 # (:mod:`aios.workflows.run_sandbox`) — the step routes by the tool's execution
-# class. The other sandbox builtins (read/write/edit/glob/grep) and authed-MCP /
-# search_events stay out of scope (later slices), so a ``tool('read')`` is a
-# recoverable not-callable value at the run frontier.
-RUN_TOOLS: frozenset[str] = frozenset({"web_search", "web_fetch", "http_request", "bash"})
+# class. ``list_runs`` / ``get_run`` are the run-journal READ pair (#1396): they run
+# on the worker too, dispatched to the workflow service ACCOUNT-SCOPED to ``run.account_id``
+# (never a launcher-session filter, never cross-account) — the substrate the standing
+# immune-system dead-men (``gate_reaper`` #1386, ``telemetry_observer`` #1326) read to
+# correlate the GitHub blackboard against which runs are live. The other sandbox builtins
+# (read/write/edit/glob/grep) and authed-MCP / search_events stay out of scope (later
+# slices), so a ``tool('read')`` is a recoverable not-callable value at the run frontier.
+RUN_TOOLS: frozenset[str] = frozenset(
+    {"web_search", "web_fetch", "http_request", "bash", "list_runs", "get_run"}
+)
 
 # Per-worker in-flight tool tasks, keyed (run_id, call_key). Gates *launching* (so a
 # sibling-triggered re-wake — e.g. parallel([tool(), agent()]) — doesn't double-dispatch a
@@ -171,6 +184,63 @@ def gate_run_tool(run: WfRun, tool_name: str) -> dict[str, Any] | None:
     return None
 
 
+async def _read_run_journal(
+    *, account_id: str, tool_name: str, args: dict[str, Any]
+) -> dict[str, Any]:
+    """The run-journal READ pair — ``list_runs`` / ``get_run`` from inside a run (#1396).
+
+    Dispatches to the workflow service ACCOUNT-SCOPED to the calling run's account, never
+    a launcher-session filter, never cross-account:
+
+      * ``list_runs`` — ``launcher_session_id=None`` (a run has no launching session; the
+        only meaningful scope is the whole account). The ``account_wide`` arg is therefore
+        a no-op here — a run is *always* account-scoped, never narrower; we accept it for
+        schema parity with the session tool and ignore it. The run sees its OWN account's
+        runs and only those, because ``account_id=account_id`` is the run's own account
+        (``run.account_id``, threaded by :func:`invoke_run_tool`) — the isolation boundary
+        is the same one the http-credential resolver and the get_run NotFound scope enforce.
+      * ``get_run`` — the account-scoped single-run read. A cross-account / missing id
+        raises :class:`NotFoundError` in the query layer; we catch it (and any client-class
+        :class:`AiosError`) and return it as a recoverable ``{"error": …}`` value, so the
+        contract "``invoke_run_tool`` never raises; errors are values the script branches on"
+        holds — and a run can never read another account's run.
+
+    The returned shape MATCHES the session tools (``{"runs": [...]}`` / the full WfRun
+    dict, both with the heavy script/surface blobs trimmed by ``_RUN_ECHO_EXCLUDE``), so a
+    workflow's reader code is identical whether the same tool is called from a session or a
+    run.
+    """
+    pool = runtime.require_pool()
+    try:
+        if tool_name == "list_runs":
+            parsed = _ListRunsArgs.model_validate(args)
+            runs = await wf_service.list_runs(
+                pool,
+                account_id=account_id,
+                limit=parsed.limit,
+                after=parsed.after,
+                workflow_id=parsed.workflow_id,
+                status=parsed.status,
+                parent_run_id=parsed.parent_run_id,
+                # A run is account-scoped, never launcher-scoped: a run has no launching
+                # session to filter on. account_wide is accepted for schema parity and
+                # has no effect (the run is always account-wide within its OWN account).
+                launcher_session_id=None,
+            )
+            return {"runs": [r.model_dump(mode="json", exclude=_RUN_ECHO_EXCLUDE) for r in runs]}
+        # get_run
+        parsed_get = _GetRunArgs.model_validate(args)
+        run = await wf_service.get_run(pool, parsed_get.run_id, account_id=account_id)
+        return run.model_dump(mode="json", exclude=_RUN_ECHO_EXCLUDE)
+    except AiosError as exc:
+        # A denied/not-found read (e.g. a cross-account get_run id) is a recoverable value
+        # the script branches on — never a run-terminal raise (matching the agent()/
+        # http_request "errors resolve" contract). The 4xx isolation boundary holds: the
+        # query is account-scoped, so a foreign id reads NotFound, never another account's
+        # run.
+        return {"error": str(exc)}
+
+
 async def invoke_run_tool(
     *, run: WfRun, call_key: str, account_id: str, tool_name: str, tool_input: Any
 ) -> dict[str, Any]:
@@ -188,6 +258,8 @@ async def invoke_run_tool(
     if schema_error is not None:
         return {"error": schema_error}
 
+    if tool_name in ("list_runs", "get_run"):
+        return await _read_run_journal(account_id=account_id, tool_name=tool_name, args=args)
     if tool_name == "http_request":
         # A route an operator marked ``always_ask`` requires per-call human confirmation —
         # which a run has no channel for. Deny rather than execute unconfirmed, so a run is

--- a/tests/unit/test_run_tools.py
+++ b/tests/unit/test_run_tools.py
@@ -345,3 +345,120 @@ async def test_sentinel_substitution_does_not_mutate_caller_input() -> None:
 
     # The original author dict still carries the sentinel, not the substituted token.
     assert headers["Idempotency-Key"] == AIOS_IDEMPOTENCY_KEY_SENTINEL
+
+
+# ─── the run-journal READ pair (list_runs / get_run from inside a run, #1396) ──
+
+
+def test_journal_reads_are_in_run_tools() -> None:
+    # The run-journal read pair is now run-callable — the gate that made the gate_reaper
+    # (#1386) and telemetry_observer (#1326) dead-men inert ("not callable from a workflow
+    # run") is gone, scoped to the run's OWN account.
+    assert "list_runs" in run_tools.RUN_TOOLS
+    assert "get_run" in run_tools.RUN_TOOLS
+
+
+async def test_list_runs_is_account_scoped_never_launcher_scoped() -> None:
+    """A run's list_runs dispatches to the service with the RUN's account and NO
+    launcher-session filter (a run has no launching session). account_wide is accepted for
+    schema parity but is a no-op — a run is always account-scoped within its own account."""
+    run = _run(tools=[ToolSpec(type="list_runs")])
+    fake_run = SimpleNamespace(model_dump=lambda **_: {"id": "wfr_seen", "status": "running"})
+    svc = AsyncMock(return_value=[fake_run])
+    with (
+        patch("aios.harness.runtime.require_pool", return_value="POOL"),
+        patch("aios.workflows.run_tools.wf_service.list_runs", new=svc),
+    ):
+        out = await invoke_run_tool(
+            run=run,
+            call_key="sha:k#0",
+            account_id="acc_t",
+            tool_name="list_runs",
+            tool_input={"workflow_id": "wf_dev", "status": "running", "account_wide": True},
+        )
+    assert out == {"runs": [{"id": "wfr_seen", "status": "running"}]}
+    assert svc.await_args is not None  # the service was actually dispatched to
+    kwargs = svc.await_args.kwargs
+    assert kwargs["account_id"] == "acc_t"  # the RUN's own account — the isolation boundary
+    assert kwargs["launcher_session_id"] is None  # never a session filter — account-scoped
+    assert kwargs["workflow_id"] == "wf_dev"
+    assert kwargs["status"] == "running"
+
+
+async def test_get_run_is_account_scoped() -> None:
+    run = _run(tools=[ToolSpec(type="get_run")])
+    fake_run = SimpleNamespace(model_dump=lambda **_: {"id": "wfr_x", "status": "completed"})
+    svc = AsyncMock(return_value=fake_run)
+    with (
+        patch("aios.harness.runtime.require_pool", return_value="POOL"),
+        patch("aios.workflows.run_tools.wf_service.get_run", new=svc),
+    ):
+        out = await invoke_run_tool(
+            run=run,
+            call_key="sha:k#0",
+            account_id="acc_t",
+            tool_name="get_run",
+            tool_input={"run_id": "wfr_x"},
+        )
+    assert out == {"id": "wfr_x", "status": "completed"}
+    assert svc.await_args is not None  # the service was actually dispatched to
+    assert svc.await_args.args == ("POOL", "wfr_x")
+    assert svc.await_args.kwargs["account_id"] == "acc_t"  # the run reads ONLY its own account
+
+
+async def test_cross_account_get_run_is_a_recoverable_error_not_a_raise() -> None:
+    """The isolation boundary: a get_run for an id outside the run's account raises
+    NotFoundError in the query layer (account-scoped read) — surfaced as a recoverable
+    {"error": ...} value, NEVER a run-terminal raise and NEVER another account's run."""
+    from aios.errors import NotFoundError
+
+    run = _run(tools=[ToolSpec(type="get_run")])
+    with (
+        patch("aios.harness.runtime.require_pool", return_value="POOL"),
+        patch(
+            "aios.workflows.run_tools.wf_service.get_run",
+            new=AsyncMock(side_effect=NotFoundError("workflow run wfr_other not found")),
+        ),
+    ):
+        out = await invoke_run_tool(
+            run=run,
+            call_key="sha:k#0",
+            account_id="acc_t",
+            tool_name="get_run",
+            tool_input={"run_id": "wfr_other"},
+        )
+    assert "error" in out and "not found" in out["error"]
+
+
+async def test_undeclared_journal_tool_is_recoverable_error() -> None:
+    # list_runs is run-callable, but a workflow that didn't DECLARE it still can't call it
+    # (the declared-surface half of the gate is unchanged).
+    run = _run(tools=[])
+    out = await invoke_run_tool(
+        run=run,
+        call_key="sha:k#0",
+        account_id="acc_t",
+        tool_name="list_runs",
+        tool_input={},
+    )
+    assert "error" in out and "declared" in out["error"]
+
+
+def test_standing_dead_men_declared_tools_are_actually_run_callable() -> None:
+    """The class-preventing guard (#1396 — why no test caught it). The standing
+    immune-system workflows declare a tool surface, but a DECLARED tool that is not also
+    RUN_CALLABLE is silently inert in a live run ("not callable from a workflow run") — the
+    exact defect that left both dead-men no-ops. This pins the invariant: every worker tool
+    a standing dead-man declares must be in RUN_TOOLS (bash is run-callable via the sandbox
+    path; http_request via the worker; the run-journal pair via #1396). If a future dead-man
+    declares a NEW worker tool without adding it to RUN_TOOLS, this fails LOUD at author
+    time instead of silently no-op'ing in production."""
+    from aios.workflows.gate_reaper import REQUIRED_TOOLS as REAPER_TOOLS
+    from aios.workflows.telemetry_observer import REQUIRED_TOOLS as OBSERVER_TOOLS
+
+    for required in (REAPER_TOOLS, OBSERVER_TOOLS):
+        for spec in required:
+            assert spec.type in run_tools.RUN_TOOLS, (
+                f"{spec.type!r} is declared by a standing dead-man but is NOT run-callable "
+                "(not in RUN_TOOLS) — it would be silently inert in a live run"
+            )


### PR DESCRIPTION
Closes #1396.

## Design verdict: **(a) oversight, not an intentional isolation gate** — with a scoping requirement

`list_runs` / `get_run` were registered `transport="agent_tool"` (session-only; `tools/workflow_management.py`) and the run-tools slicing deferred the run-journal read to "later slices" (`run_tools.py` `RUN_TOOLS`). There is **no isolation reason** barring a run from reading its **own account's** run journal — the handlers' `account_id`-from-`session_id` resolution was a session-shaped convenience, not a security boundary against runs. The issue itself proposes this fix as the cleanest path.

Both inert consumers — the gate-reaper dead-man (#1386/#1387) and `telemetry_observer.py` (#1326) — read the run journal from inside a run (`await tool("list_runs", {... "account_wide": True})`) to correlate the GitHub blackboard against which PRs/issues have a live run. The first call returned `"tool 'list_runs' is not callable from a workflow run"` and both were silent no-ops.

## Scoping decision + rationale

**A run lists/reads runs in its OWN account, never cross-account.**

- `list_runs` → `wf_service.list_runs(account_id=run.account_id, launcher_session_id=None, ...)`. A run has no launching session, so the only meaningful scope is the whole account; `account_wide` is accepted for **schema parity** with the session tool and is a **no-op** (a run is always account-scoped within its own account — never narrower, never wider). This is exactly what both consumers already request (`account_wide=True`).
- `get_run` → `wf_service.get_run(account_id=run.account_id, ...)`. A cross-account / missing id raises `NotFoundError` in the account-scoped query layer; caught (along with any client-class `AiosError`) and surfaced as a recoverable `{"error": ...}` value — honoring `invoke_run_tool`'s "never raises; errors are values the script branches on" contract.

The account scope is threaded from `run.account_id` (the same boundary the run-scoped HTTP credential resolver already uses), so the new path reuses the established run-scoping pattern rather than the session-resolution shim. Returned shapes match the session tools (`{"runs": [...]}` / full `WfRun`, both `_RUN_ECHO_EXCLUDE`-trimmed) so reader code is identical session-vs-run.

## Isolation implications the seat should weigh before merge

- **No cross-account read is introduced.** A run sees only `run.account_id`'s runs; a foreign `get_run` id reads `NotFound`, never another account's run. Test `test_cross_account_get_run_is_a_recoverable_error_not_a_raise` pins this.
- **No new mutation.** This is a READ pair only; no `create_run`/`cancel_run`/`resume_gate` is added to `RUN_TOOLS`. The reaper's "can never auto-resolve a gate" structural rule is untouched.
- **Within-account visibility widens slightly**: a run can now enumerate sibling runs in its account (lean rows, no script/surface blobs). This is the *intended* substrate for the immune-system dead-men and is the same visibility any agent session in the account already has via the session tools. No tenant boundary is crossed.

## Tests

`tests/unit/test_run_tools.py` (5 new + 1 class-preventing guard):
- `list_runs` is account-scoped, `launcher_session_id=None`, `account_wide` a no-op; filters (`workflow_id`/`status`) passed through.
- `get_run` is account-scoped (`account_id=run.account_id`).
- cross-account/NotFound `get_run` → recoverable `{"error": ...}`, not a raise.
- undeclared `list_runs` still gated by the declared-surface half.
- **class-preventing guard** (`test_standing_dead_men_declared_tools_are_actually_run_callable`): every worker tool a standing dead-man (`gate_reaper`, `telemetry_observer`) declares **must** be in `RUN_TOOLS` — this would have failed loud at author time (the issue's "why no test caught it"), foreclosing the inert-dead-man class.

Full suite green: 3315 unit + connectors, mypy clean (1189 files), ruff clean.

## Unblock confirmed

The exact `_run_index` call the reaper makes resolves to a valid page (`{"runs": [...]}`) instead of the not-callable error; both consumers' declared tools (`{list_runs, http_request}` / `{get_run, list_runs}`) now pass `gate_run_tool` (admitted = `None`). The dead-men are unblocked — re-arm the `gate-reaper-sweep-30m` triggers once this is deployed (deploy-on-merge / re-registration still required for the live worker to pick it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)