### PR TITLE
fire-and-forget connector results don't re-wake the session (rebase of #1121, credit @mattquest)

### DIFF
--- a/connectors/signal/src/aios_signal/connector.py
+++ b/connectors/signal/src/aios_signal/connector.py
@@ -437,7 +437,7 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
 
     # ── model-facing tools ────────────────────────────────────────────
 
-    @tool()
+    @tool(fire_and_forget=True)
     async def signal_send(
         self,
         text: str,
@@ -609,7 +609,7 @@ class SignalConnector(SignalManagementMixin, HttpConnector):
         )
         return {"status": "ok"}
 
-    @tool()
+    @tool(fire_and_forget=True)
     async def signal_react(
         self,
         target_author_uuid: str,

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -128,12 +128,14 @@ async def test_signal_send_dispatch_resolves_sandbox_path(
 
     # The dispatch_call → _post_tool_result path hits the generated SDK
     # op which doesn't tolerate an AsyncMock client; override with a
-    # no-op so the test focuses on the SandboxPath resolution, not the
+    # capture so the test focuses on the SandboxPath resolution, not the
     # result POST.
-    async def _noop_result(*_args: Any, **_kwargs: Any) -> None:
-        return None
+    captured: list[dict[str, Any]] = []
 
-    monkeypatch.setattr(connector, "_post_tool_result", _noop_result)
+    async def _capture_result(*_args: Any, **kwargs: Any) -> None:
+        captured.append(kwargs)
+
+    monkeypatch.setattr(connector, "_post_tool_result", _capture_result)
 
     await connector.dispatch_call(
         {
@@ -149,6 +151,12 @@ async def test_signal_send_dispatch_resolves_sandbox_path(
 
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["attachments"] == [str(ws / "cat.jpg")]
+    # ``signal_send`` is fire-and-forget: a successful dispatch flags
+    # ``no_reaction`` so the delivery ack doesn't wake the session. The
+    # success path leaves ``is_error`` at its default (not passed), so only
+    # ``no_reaction`` is asserted here.
+    assert len(captured) == 1
+    assert captured[0]["no_reaction"] is True
 
 
 async def test_signal_send_dispatch_traversal_returns_error_result(
@@ -173,6 +181,7 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
         tool_call_id: str,
         content: Any,
         is_error: bool = False,
+        no_reaction: bool = False,
     ) -> None:
         del client
         captured.append(
@@ -182,6 +191,7 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
                 "tool_call_id": tool_call_id,
                 "content": content,
                 "is_error": is_error,
+                "no_reaction": no_reaction,
             }
         )
 
@@ -202,6 +212,9 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
     connector._daemon.rpc.call.assert_not_awaited()  # type: ignore[union-attr]
     assert len(captured) == 1
     assert captured[0]["is_error"] is True
+    # A FAILED fire-and-forget send must still wake — the error branch never
+    # sets ``no_reaction`` (it AND-gates with ``not is_error`` at the intake).
+    assert captured[0]["no_reaction"] is False
 
 
 # ── quote / reply ─────────────────────────────────────────────────────

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -389,7 +389,7 @@ class TelegramConnector(HttpConnector):
 
     # ── model-facing tools ────────────────────────────────────────────
 
-    @tool()
+    @tool(fire_and_forget=True)
     async def telegram_send(
         self,
         text: str,
@@ -498,7 +498,7 @@ class TelegramConnector(HttpConnector):
             "chat_type": _chat_kind(sent_group[0].chat.type),
         }
 
-    @tool()
+    @tool(fire_and_forget=True)
     async def telegram_typing(
         self,
         action: Literal[
@@ -589,7 +589,7 @@ class TelegramConnector(HttpConnector):
         await state.application.bot.delete_message(chat_id=chat_id_int, message_id=message_id)
         return {"status": "ok"}
 
-    @tool()
+    @tool(fire_and_forget=True)
     async def telegram_react(
         self,
         message_id: int,

--- a/connectors/telegram/src/aios_telegram/connector.py
+++ b/connectors/telegram/src/aios_telegram/connector.py
@@ -498,7 +498,11 @@ class TelegramConnector(HttpConnector):
             "chat_type": _chat_kind(sent_group[0].chat.type),
         }
 
-    @tool(fire_and_forget=True)
+    # NOT fire_and_forget: typing is a PRECURSOR — the model calls it *before*
+    # doing slow work, so its result MUST wake the session to take the follow-up
+    # step that does the work and sends the reply. Marking it fire_and_forget
+    # stranded a typing-only turn idle, never sending (#1121 review).
+    @tool()
     async def telegram_typing(
         self,
         action: Literal[

--- a/connectors/telegram/tests/test_telegram_send.py
+++ b/connectors/telegram/tests/test_telegram_send.py
@@ -100,6 +100,19 @@ def test_telegram_connector_subclasses_http_connector() -> None:
     assert expected <= set(c._tools)
 
 
+def test_message_tools_are_fire_and_forget_but_typing_is_not() -> None:
+    """Categorization guard (#1121 review): ``fire_and_forget`` marks a
+    *terminal* delivery confirmation the model needn't react to, so the runtime
+    skips the re-wake (closing the duplicate-send loop). ``telegram_typing`` is
+    a *precursor* the model calls before slow work — it MUST stay a normal
+    (waking) tool, or a typing-only turn settles idle and never sends.
+    """
+    tools = TelegramConnector()._tools
+    assert tools["telegram_send"].fire_and_forget is True
+    assert tools["telegram_react"].fire_and_forget is True
+    assert tools["telegram_typing"].fire_and_forget is False
+
+
 @pytest.fixture
 def bot() -> Any:
     b = MagicMock()

--- a/connectors/whatsapp/src/aios_whatsapp/connector.py
+++ b/connectors/whatsapp/src/aios_whatsapp/connector.py
@@ -225,7 +225,7 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
 
     # ── tools ──────────────────────────────────────────────────────────
 
-    @tool()
+    @tool(fire_and_forget=True)
     async def whatsapp_send(
         self,
         text: str,
@@ -292,7 +292,7 @@ class WhatsappConnector(WhatsappManagementMixin, HttpConnector):
             "chat_type": _chat_type_from_jid(chat_id),
         }
 
-    @tool()
+    @tool(fire_and_forget=True)
     async def whatsapp_react(
         self,
         message_id: str,

--- a/openapi.json
+++ b/openapi.json
@@ -14132,6 +14132,11 @@
             "type": "boolean",
             "title": "Is Error",
             "default": false
+          },
+          "no_reaction": {
+            "type": "boolean",
+            "title": "No Reaction",
+            "default": false
           }
         },
         "additionalProperties": false,

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -163,7 +163,12 @@ def tool(
     A *failed* result always wakes regardless — the runner only sets
     ``no_reaction`` on the post-success path.  Leave it ``False`` for
     list/create/get/edit/delete tools whose results carry data the model
-    must consume.
+    must consume — and, crucially, for any *precursor* action the model
+    calls before doing more work, such as a "typing…"/presence indicator.
+    Its result is benign, but it is the only thing that would wake the
+    follow-up step; suppressing it strands a typing-only turn idle, never
+    sending (#1121).  Rule of thumb: fire-and-forget iff the turn is *over*
+    after this tool — not merely "the result is uninteresting."
     """
 
     def _wrap(f: ToolFn) -> ToolFn:

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -107,6 +107,7 @@ ToolFn = Callable[..., Awaitable[Any]]
 log: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
 _TOOL_ATTR = "__aios_http_tool__"
+_TOOL_FAF_ATTR = "__aios_http_tool_fire_and_forget__"
 _MGMT_ATTR = "__aios_http_management__"
 
 
@@ -140,6 +141,7 @@ def _is_fatal_inbound_status(status_code: int) -> bool:
 def tool(
     *,
     name: str | None = None,
+    fire_and_forget: bool = False,
 ) -> Callable[[ToolFn], ToolFn]:
     """Decorate a method as a connector tool.
 
@@ -151,10 +153,22 @@ def tool(
     The runner publishes a derived JSON Schema for every ``@tool`` once
     at startup via ``PUT /v1/connectors/{connector}/tools_schema``;
     individual connections inherit it from the type catalog.
+
+    ``fire_and_forget`` declares the tool's result a *delivery
+    confirmation* the model has nothing to react to — a message send or
+    reaction whose only output is a ``{"sent_at_ms": N}`` ack.  A
+    *successful* result for such a tool is POSTed with ``no_reaction=true``
+    so aios appends it to the log (the model still sees it) but does NOT
+    wake the session to react to its own send (the duplicate-send loop).
+    A *failed* result always wakes regardless — the runner only sets
+    ``no_reaction`` on the post-success path.  Leave it ``False`` for
+    list/create/get/edit/delete tools whose results carry data the model
+    must consume.
     """
 
     def _wrap(f: ToolFn) -> ToolFn:
         setattr(f, _TOOL_ATTR, name or f.__name__)
+        setattr(f, _TOOL_FAF_ATTR, fire_and_forget)
         return f
 
     return _wrap
@@ -167,6 +181,7 @@ class _ToolMeta:
     fn: ToolFn
     focal_params: frozenset[str]
     sandbox_params: tuple[tuple[str, str], ...]  # (param_name, "scalar" | "list")
+    fire_and_forget: bool = False
 
 
 def management_handler(
@@ -1215,12 +1230,18 @@ class HttpConnector:
         # POSTed in its native list shape below.
         serialized_result = result if isinstance(result, str) else json.dumps(result)
         await self._mark_answered(tool_call_id, serialized_result)
+        # Post-success path only: a fire-and-forget tool's successful result
+        # is a delivery ack the model has nothing to react to, so flag it
+        # ``no_reaction`` to keep aios from waking the session to react to its
+        # own send (the duplicate-send loop).  The error branches above NEVER
+        # set this — a failed send always wakes.
         await self._post_tool_result(
             client,
             connection_id=connection_id,
             session_id=session_id,
             tool_call_id=tool_call_id,
             content=result,
+            no_reaction=meta.fire_and_forget,
         )
         log.info(
             "connector.tool_call.completed",
@@ -1387,8 +1408,14 @@ class HttpConnector:
         tool_call_id: str,
         content: str | list[dict[str, Any]],
         is_error: bool = False,
+        no_reaction: bool = False,
     ) -> None:
-        """POST one tool result via the generated runtime op."""
+        """POST one tool result via the generated runtime op.
+
+        ``no_reaction`` marks a successful fire-and-forget result so the
+        intake appends it without waking the session to react.  Only the
+        post-success caller sets it; the error callers leave it False.
+        """
         # The generated model's list branch is typed as
         # ``list[RuntimeToolResultRequestContentType1Item]``; that item type is
         # a thin ``additional_properties`` bag whose ``from_dict``/``to_dict``
@@ -1405,6 +1432,7 @@ class HttpConnector:
             tool_call_id=tool_call_id,
             content=body_content,
             is_error=is_error,
+            no_reaction=no_reaction,
         )
         response = await _post_runtime_tool_result(client=client, body=body)
         if response.status_code >= 400:
@@ -1460,7 +1488,13 @@ def _build_tool_meta(fn: ToolFn) -> _ToolMeta:
         kind = _sandbox_path_kind(hint)
         if kind is not None:
             sandbox.append((param_name, kind))
-    return _ToolMeta(fn=fn, focal_params=focal, sandbox_params=tuple(sandbox))
+    fire_and_forget = bool(getattr(fn, _TOOL_FAF_ATTR, False))
+    return _ToolMeta(
+        fn=fn,
+        focal_params=focal,
+        sandbox_params=tuple(sandbox),
+        fire_and_forget=fire_and_forget,
+    )
 
 
 class SandboxPathError(ValueError):

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -74,6 +74,18 @@ class _ProbeConnector(HttpConnector):
         self.calls.append(("say_struct", {"n": n}))
         return {"doubled": n * 2}
 
+    @tool(fire_and_forget=True)
+    async def deliver(self, *, text: str) -> dict[str, int]:
+        """A fire-and-forget send: its result is a delivery ack."""
+        self.calls.append(("deliver", {"text": text}))
+        return {"sent_at_ms": 123}
+
+    @tool(fire_and_forget=True)
+    async def deliver_boom(self) -> str:
+        """A fire-and-forget send that fails — its error must still wake."""
+        self.calls.append(("deliver_boom", {}))
+        raise RuntimeError("delivery failed")
+
     async def _post_tool_result(  # type: ignore[override]
         self,
         client: Any,
@@ -83,6 +95,7 @@ class _ProbeConnector(HttpConnector):
         tool_call_id: str,
         content: str | list[dict[str, Any]],
         is_error: bool = False,
+        no_reaction: bool = False,
     ) -> None:
         del client
         self.results.append(
@@ -92,6 +105,7 @@ class _ProbeConnector(HttpConnector):
                 tool_call_id=tool_call_id,
                 content=content,
                 is_error=is_error,
+                no_reaction=no_reaction,
             )
         )
 
@@ -178,6 +192,70 @@ class TestDispatch:
         # as an error result, NOT a crash.
         r = probe.results[0]
         assert r.kwargs["is_error"] is True
+
+
+class TestFireAndForget:
+    """``@tool(fire_and_forget=True)`` → ``no_reaction`` on the SUCCESS POST."""
+
+    async def test_meta_records_fire_and_forget(self, probe: _ProbeConnector) -> None:
+        # The decorator freezes the flag onto the per-tool meta; a plain
+        # ``@tool()`` tool stays False.
+        assert probe._tools["deliver"].fire_and_forget is True
+        assert probe._tools["deliver_boom"].fire_and_forget is True
+        assert probe._tools["shout"].fire_and_forget is False
+        assert probe._tools["say_struct"].fire_and_forget is False
+
+    async def test_successful_fire_and_forget_sets_no_reaction(
+        self, probe: _ProbeConnector
+    ) -> None:
+        await probe.dispatch_call(
+            {
+                "connection_id": "conn_1",
+                "tool_call_id": "call_d",
+                "session_id": "sess_d",
+                "name": "deliver",
+                "arguments": json.dumps({"text": "hi"}),
+            }
+        )
+        r = probe.results[0]
+        assert r.kwargs["is_error"] is False
+        assert r.kwargs["no_reaction"] is True
+        # The result content (the delivery ack) is still posted — the model sees it.
+        assert json.loads(r.kwargs["content"]) == {"sent_at_ms": 123}
+
+    async def test_failed_fire_and_forget_does_not_set_no_reaction(
+        self, probe: _ProbeConnector
+    ) -> None:
+        # A failure goes through the error branch, which never passes
+        # ``no_reaction`` — so a failed send still wakes.
+        await probe.dispatch_call(
+            {
+                "connection_id": "conn_1",
+                "tool_call_id": "call_db",
+                "session_id": "sess_db",
+                "name": "deliver_boom",
+                "arguments": "{}",
+            }
+        )
+        r = probe.results[0]
+        assert r.kwargs["is_error"] is True
+        assert r.kwargs["no_reaction"] is False
+
+    async def test_non_fire_and_forget_success_does_not_set_no_reaction(
+        self, probe: _ProbeConnector
+    ) -> None:
+        await probe.dispatch_call(
+            {
+                "connection_id": "conn_1",
+                "tool_call_id": "call_s",
+                "session_id": "sess_s",
+                "name": "shout",
+                "arguments": json.dumps({"text": "hi"}),
+            }
+        )
+        r = probe.results[0]
+        assert r.kwargs["is_error"] is False
+        assert r.kwargs["no_reaction"] is False
 
 
 class TestToolCollection:
@@ -268,6 +346,7 @@ class _IdempotencyConnector(_ProbeConnector):
         tool_call_id: str,
         content: str | list[dict[str, Any]],
         is_error: bool = False,
+        no_reaction: bool = False,
     ) -> None:
         self.post_attempts += 1
         if self.fail_posts > 0:
@@ -280,6 +359,7 @@ class _IdempotencyConnector(_ProbeConnector):
             tool_call_id=tool_call_id,
             content=content,
             is_error=is_error,
+            no_reaction=no_reaction,
         )
 
 
@@ -965,6 +1045,32 @@ class TestPostToolResultSerialization:
         )
         assert len(captured) == 1
         assert captured[0]["content"] == "hello"
+
+    async def test_no_reaction_serializes_on_the_wire(self) -> None:
+        """``no_reaction=True`` reaches the POST body via the generated model."""
+        client, captured = self._client_capturing_body()
+        await HttpConnector._post_tool_result(
+            client,
+            connection_id="conn_1",
+            session_id="sess_1",
+            tool_call_id="call_1",
+            content="hello",
+            no_reaction=True,
+        )
+        assert len(captured) == 1
+        assert captured[0]["no_reaction"] is True
+
+    async def test_no_reaction_default_false_on_the_wire(self) -> None:
+        client, captured = self._client_capturing_body()
+        await HttpConnector._post_tool_result(
+            client,
+            connection_id="conn_1",
+            session_id="sess_1",
+            tool_call_id="call_1",
+            content="hello",
+        )
+        assert len(captured) == 1
+        assert captured[0]["no_reaction"] is False
 
 
 class TestWaitConnectionServed:

--- a/packages/aios-connector-http/tests/test_sandbox.py
+++ b/packages/aios-connector-http/tests/test_sandbox.py
@@ -243,6 +243,7 @@ class _PathConsumer(HttpConnector):
         tool_call_id: str,
         content: Any,
         is_error: bool = False,
+        no_reaction: bool = False,
     ) -> None:
         del client
         self.tool_results.append(
@@ -252,6 +253,7 @@ class _PathConsumer(HttpConnector):
                 "tool_call_id": tool_call_id,
                 "content": content,
                 "is_error": is_error,
+                "no_reaction": no_reaction,
             }
         )
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
@@ -30,6 +30,7 @@ class RuntimeToolResultRequest:
             tool_call_id (str):
             content (list[RuntimeToolResultRequestContentType1Item] | str):
             is_error (bool | Unset):  Default: False.
+            no_reaction (bool | Unset):  Default: False.
     """
 
     connection_id: str
@@ -37,6 +38,7 @@ class RuntimeToolResultRequest:
     tool_call_id: str
     content: list[RuntimeToolResultRequestContentType1Item] | str
     is_error: bool | Unset = False
+    no_reaction: bool | Unset = False
 
     def to_dict(self) -> dict[str, Any]:
         connection_id = self.connection_id
@@ -57,6 +59,8 @@ class RuntimeToolResultRequest:
 
         is_error = self.is_error
 
+        no_reaction = self.no_reaction
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -69,6 +73,8 @@ class RuntimeToolResultRequest:
         )
         if is_error is not UNSET:
             field_dict["is_error"] = is_error
+        if no_reaction is not UNSET:
+            field_dict["no_reaction"] = no_reaction
 
         return field_dict
 
@@ -111,12 +117,15 @@ class RuntimeToolResultRequest:
 
         is_error = d.pop("is_error", UNSET)
 
+        no_reaction = d.pop("no_reaction", UNSET)
+
         runtime_tool_result_request = cls(
             connection_id=connection_id,
             session_id=session_id,
             tool_call_id=tool_call_id,
             content=content,
             is_error=is_error,
+            no_reaction=no_reaction,
         )
 
         return runtime_tool_result_request

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -220,6 +220,16 @@ class RuntimeToolResultRequest(BaseModel):
     tool_call_id: str
     content: str | list[dict[str, Any]]
     is_error: bool = False
+    # The connector declares (via ``@tool(fire_and_forget=True)``) that a
+    # *successful* result for this tool is a delivery confirmation the model
+    # has nothing to react to (a message send/reaction ack).  When set, the
+    # result is still appended to the log — the model sees it — but the
+    # session is NOT woken to react to its own send (closes the duplicate-send
+    # loop).  A failed result NEVER carries this (the runner only sets it
+    # on the post-success path); the intake also AND-gates it with
+    # ``not is_error`` so a failure always wakes.  Default False keeps a
+    # not-yet-redeployed connector's omitted field behaving exactly as before.
+    no_reaction: bool = False
 
 
 class RuntimeLifecycleRequest(BaseModel):
@@ -780,15 +790,28 @@ async def post_runtime_tool_result(
                     "connection_id": body.connection_id,
                 },
             )
+        # A failure ALWAYS wakes: AND-gate the connector's ``no_reaction`` flag
+        # with ``not is_error`` so only a successful fire-and-forget result is
+        # excluded from the wake decision.
+        no_reaction = body.no_reaction and not body.is_error
         event = await sessions_service.append_tool_result(
             conn,
             session_id=body.session_id,
             tool_call_id=body.tool_call_id,
             content=body.content,
             is_error=body.is_error,
+            no_reaction=no_reaction,
             account_id=account_id,
         )
-    await defer_wake(pool, body.session_id, cause="connector_tool_result", account_id=account_id)
+    # The result is ALWAYS appended (tool-always-appends-result invariant). Only
+    # the wake is conditional: a successful fire-and-forget result stamps
+    # ``data['no_reaction']=true`` and skips ``defer_wake`` — its row is excluded
+    # from the wake gate so the session settles instead of re-inferring to react
+    # to its own delivery confirmation.
+    if not no_reaction:
+        await defer_wake(
+            pool, body.session_id, cause="connector_tool_result", account_id=account_id
+        )
     return event
 
 

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -781,7 +781,16 @@ async def append_event(
     # the active predicate. This is deliberately broader than ``is_user_message``
     # (the error latch) — an unreacted tool result keeps the session active, but
     # must NOT clear an error. See ``_SESSION_ACTIVE_EXPR``.
-    is_stimulus = kind == "message" and role != "assistant"
+    #
+    # A fire-and-forget tool result (``data['no_reaction'] == True``, stamped by
+    # ``append_tool_result`` for a connector that declared the tool
+    # fire-and-forget) is a delivery confirmation the model has nothing to react
+    # to — it is NOT a stimulus, so it must not bump ``last_stimulus_seq`` and
+    # make the session a wake candidate (the duplicate-send loop). The result is
+    # still appended (the model sees it); only the wake decision excludes it.
+    # ``data.get`` is missing → falsy on every historical/unmarked result, so
+    # those keep counting as stimulus exactly as before (backward-compat).
+    is_stimulus = kind == "message" and role != "assistant" and not data.get("no_reaction")
     is_error_lifecycle = kind == "lifecycle" and data.get("stop_reason") == "error"
     is_assistant_message = kind == "message" and role == "assistant"
     tool_call_count_delta = (

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -210,6 +210,14 @@ CONFIRMED_ROWS_SQL = f"""
 # JOIN; it does NOT recompute the watermark. Re-deriving the formula here (the
 # pre-#1080 ``session_max_reacting`` CTE) re-introduces the #155-class drift
 # the deletion in #1080 foreclosed — keep this an equality JOIN, not a CTE.
+# The ``no_reaction`` clause excludes fire-and-forget delivery confirmations (a
+# connector ``signal_send``/``telegram_react``/… success, stamped
+# ``data['no_reaction']=true`` by ``append_tool_result``) from the unreacted-
+# stimulus set the batch filter inspects — matching the scalar gate, where such
+# a result does not bump ``last_stimulus_seq`` (``append_event``'s
+# ``is_stimulus``). ``IS DISTINCT FROM 'true'`` is NULL-safe: a missing key →
+# NULL → TRUE → the row still counts (every historical/unmarked result wakes
+# exactly as before); only the literal JSON ``true`` is excluded.
 UNREACTED_ROWS_SQL = """
     SELECT e.session_id, e.data
       FROM events e
@@ -217,6 +225,7 @@ UNREACTED_ROWS_SQL = """
      WHERE e.session_id = ANY($1::text[])
        AND e.kind = 'message'
        AND e.role <> 'assistant'
+       AND e.data->>'no_reaction' IS DISTINCT FROM 'true'
        AND e.seq > s.last_reacted_seq
 """
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1267,6 +1267,7 @@ async def append_tool_result(
     tool_call_id: str,
     content: str | list[dict[str, Any]],
     is_error: bool = False,
+    no_reaction: bool = False,
 ) -> Event:
     """Append a tool-role event for a custom tool call (#133).
 
@@ -1325,6 +1326,12 @@ async def append_tool_result(
     # GC's referenced-set sees it as live (#1093).  Done before the precompute
     # so the stored event and its token estimate reflect the same shape.
     record_spill_attachment(data, spill_attachment)
+    # Fire-and-forget delivery confirmation: stamp the marker so the wake gate
+    # (``CANDIDATE_ROWS_SQL`` via the scalar ``last_stimulus_seq``, and
+    # ``UNREACTED_ROWS_SQL``) excludes this row.  The model still sees the
+    # result in its context — only the WAKE decision skips it.
+    if no_reaction:
+        data["no_reaction"] = True
     precomputed = await queries.precompute_event_append(
         conn,
         account_id=account_id,

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -27,7 +27,7 @@ import pytest
 
 from tests.conftest import needs_docker
 from tests.e2e.conftest import live_aios_server
-from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
+from tests.e2e.harness import Harness, assistant, tool_call
 from tests.helpers.connections import authed_client, issue_runtime_token
 
 pytestmark = pytest.mark.docker
@@ -382,7 +382,6 @@ class TestSignalMultiConnection:
                         )
                     ]
                 ),
-                assistant("done"),
             ]
         )
         await sess_svc.append_user_message(
@@ -430,10 +429,14 @@ class TestSignalMultiConnection:
                     raise AssertionError("tool_result event never persisted")
                 await asyncio.sleep(0.1)
 
-            # Drive the wrap-up step so harness state stays clean.
-            await harness.run_step(session_a.id)
-            events = await harness.events(session_a.id)
-            assert last_assistant_content(events) == "done"
+            # ``signal_send`` is fire-and-forget: the successful delivery
+            # confirmation is appended to the session log (the model still
+            # sees it) but must NOT re-wake the session to react to its own
+            # send.  That re-wake was the duplicate-send loop ("same DM
+            # delivered 4x").  Drain any in-flight tool tasks, then assert
+            # the sweep does not consider session A ready for inference.
+            await harness.wait_for_tools(session_a.id)
+            assert session_a.id not in await harness.sessions_needing_inference(session_a.id)
         finally:
             connector_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/e2e/test_telegram_connector.py
+++ b/tests/e2e/test_telegram_connector.py
@@ -26,7 +26,7 @@ import pytest
 
 from tests.conftest import needs_docker
 from tests.e2e.conftest import live_aios_server
-from tests.e2e.harness import Harness, assistant, last_assistant_content, tool_call
+from tests.e2e.harness import Harness, assistant, tool_call
 from tests.helpers.connections import authed_client, issue_runtime_token
 
 pytestmark = pytest.mark.docker
@@ -230,7 +230,6 @@ class TestTelegramMultiConnection:
                         )
                     ]
                 ),
-                assistant("done"),
             ]
         )
         await sess_svc.append_user_message(
@@ -284,10 +283,14 @@ class TestTelegramMultiConnection:
                     raise AssertionError("tool_result event never persisted")
                 await asyncio.sleep(0.1)
 
-            # Drive the wrap-up step so harness state stays clean.
-            await harness.run_step(session_a.id)
-            events = await harness.events(session_a.id)
-            assert last_assistant_content(events) == "done"
+            # ``telegram_send`` is fire-and-forget: the successful delivery
+            # confirmation is appended to the session log (the model still
+            # sees it) but must NOT re-wake the session to react to its own
+            # send.  That re-wake was the duplicate-send loop ("same DM
+            # delivered 4x").  Drain any in-flight tool tasks, then assert
+            # the sweep does not consider session A ready for inference.
+            await harness.wait_for_tools(session_a.id)
+            assert session_a.id not in await harness.sessions_needing_inference(session_a.id)
         finally:
             connector_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/integration/test_no_reaction_tool_result.py
+++ b/tests/integration/test_no_reaction_tool_result.py
@@ -1,0 +1,311 @@
+"""Integration suite for the fire-and-forget (``no_reaction``) tool-result wake fix.
+
+The bug
+-------
+A session runs one agent across connector channels. When the model calls a
+message-delivery tool (``signal_send`` / ``signal_react`` and the telegram /
+whatsapp equivalents), the connector runtime executes it and POSTs the result
+(``{"sent_at_ms": N}``) to ``POST /v1/connectors/runtime/tool-results``. The
+intake unconditionally ``defer_wake``\\ s, and the wake gate counts the
+``role='tool'`` result as new unreacted stimulus — so the session RE-INFERS to
+react to its own delivery confirmation. There is nothing to react to; a
+less-disciplined model RE-SENDS the same message (the duplicate-send loop).
+
+The fix
+-------
+The connector declares the tool fire-and-forget; on a *successful* result the
+runner sets ``no_reaction=true`` on the POST. The intake computes
+``no_reaction = body.no_reaction AND NOT body.is_error`` and, when true, appends
+the result WITH ``data['no_reaction']=true`` (so the model still sees it) but
+SKIPS ``defer_wake``. ``append_event`` then treats a ``no_reaction`` tool result
+as a NON-stimulus (it does not bump ``last_stimulus_seq``), and the sweep's
+``UNREACTED_ROWS_SQL`` excludes the marked row. Both layers agree, so the
+session settles instead of re-inferring.
+
+What this suite pins
+--------------------
+- ``append_tool_result(no_reaction=True)`` stamps ``data['no_reaction']=true``
+  and does NOT advance ``last_stimulus_seq`` → the session is NOT a wake
+  candidate (loop closed).
+- A FAILED send (``is_error=True``) still wakes — the marker is never stamped
+  on the error path (the intake AND-gates with ``not is_error``).
+- A non-fire-and-forget result (``no_reaction=False``) still wakes.
+- An UNMARKED result (historical / not-yet-redeployed connector) still wakes
+  exactly as before (backward-compat: missing key → counts as stimulus).
+- A co-pending REAL user message still wakes even when a fire-and-forget result
+  is also unreacted (no false negative).
+- The model still SEES the result in the log (it stays appended).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.harness.sweep import find_sessions_needing_inference
+from aios.harness.task_registry import TaskRegistry
+from aios.models.agents import ToolSpec
+from aios.services import sessions as sessions_service
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+
+def _assistant(tool_call_ids: list[str], *, reacting_to: int | None = None) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": tcid,
+                "type": "function",
+                "function": {"name": "signal_send", "arguments": "{}"},
+            }
+            for tcid in tool_call_ids
+        ],
+    }
+    if reacting_to is not None:
+        data["reacting_to"] = reacting_to
+    return data
+
+
+async def _scalars(pool: asyncpg.Pool[Any], session_id: str) -> dict[str, int]:
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT last_stimulus_seq, last_reacted_seq FROM sessions WHERE id = $1",
+            session_id,
+        )
+    assert row is not None
+    return dict(row)
+
+
+async def _status(pool: asyncpg.Pool[Any], session_id: str, account_id: str) -> str:
+    async with pool.acquire() as conn:
+        session = await queries.get_session(conn, session_id, account_id=account_id)
+    return session.status
+
+
+async def _result_marker(pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str) -> Any:
+    """Return ``data->>'no_reaction'`` for the tool-result row, or None."""
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT data->>'no_reaction' FROM events "
+            "WHERE session_id = $1 AND kind = 'message' AND role = 'tool' "
+            "AND data->>'tool_call_id' = $2",
+            session_id,
+            tool_call_id,
+        )
+
+
+@pytest.fixture
+async def pool_account_session(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """``(pool, account_id, session_id)`` for a fresh session whose agent
+    declares a tool the parent ``tool_calls`` entry can resolve a name from."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        account_id = "acc_no_reaction"
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, $2)",
+                account_id,
+                "no-reaction",
+            )
+        _agent, _env, session = await seed_agent_env_session(
+            pool,
+            account_id=account_id,
+            prefix="no-reaction",
+            tools=[ToolSpec(type="bash")],
+        )
+        yield pool, account_id, session.id
+    finally:
+        await pool.close()
+
+
+async def _drive_one_send_turn(
+    pool: asyncpg.Pool[Any],
+    account_id: str,
+    session_id: str,
+    *,
+    tool_call_id: str,
+    no_reaction: bool,
+    is_error: bool = False,
+) -> None:
+    """User → assistant(tool_call) → reacted → tool result. Mirrors the live
+    flow: the assistant has already reacted to the user, so the only thing
+    left in the log after the result is the result itself."""
+    async with pool.acquire() as conn:
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data={"role": "user", "content": "say hi to alice"},
+        )
+        # Assistant reacts to the user (seq 1) and issues the send tool call.
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            kind="message",
+            data=_assistant([tool_call_id], reacting_to=1),
+        )
+    # The connector POSTs the result. ``append_tool_result`` is the shared
+    # intake target; ``no_reaction`` is what the API handler computes
+    # (``body.no_reaction AND NOT body.is_error``).
+    async with pool.acquire() as conn:
+        await sessions_service.append_tool_result(
+            conn,
+            account_id=account_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            content='{"sent_at_ms": 123}',
+            is_error=is_error,
+            no_reaction=no_reaction,
+        )
+
+
+class TestFireAndForgetSettles:
+    async def test_successful_fire_and_forget_does_not_wake(
+        self,
+        pool_account_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_account_session
+        await _drive_one_send_turn(
+            pool, account_id, session_id, tool_call_id="tc_send", no_reaction=True
+        )
+
+        # The result is appended WITH the marker — the model still sees it.
+        assert await _result_marker(pool, session_id, "tc_send") == "true"
+
+        # The marker keeps the result from counting as a stimulus: the scalar
+        # gate (last_stimulus_seq) does not advance past the reacted watermark.
+        scalars = await _scalars(pool, session_id)
+        assert scalars["last_stimulus_seq"] <= scalars["last_reacted_seq"]
+        assert await _status(pool, session_id, account_id) == "idle"
+
+        registry = TaskRegistry()
+        needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id not in needs, (
+            "a successful fire-and-forget delivery confirmation must NOT wake the "
+            "session — that is the duplicate-send loop"
+        )
+
+    async def test_failed_send_still_wakes(
+        self,
+        pool_account_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_account_session
+        # The intake AND-gates ``no_reaction`` with ``not is_error``; a failure
+        # arrives with no_reaction already False (the runner's error branches
+        # never set it). Pass no_reaction=False to model that.
+        await _drive_one_send_turn(
+            pool,
+            account_id,
+            session_id,
+            tool_call_id="tc_fail",
+            no_reaction=False,
+            is_error=True,
+        )
+
+        assert await _result_marker(pool, session_id, "tc_fail") is None
+        assert await _status(pool, session_id, account_id) == "active"
+
+        registry = TaskRegistry()
+        needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id in needs, "a FAILED send must wake so the model can recover"
+
+    async def test_non_fire_and_forget_result_still_wakes(
+        self,
+        pool_account_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        pool, account_id, session_id = pool_account_session
+        # A list/get/edit-style tool result carries data the model must consume.
+        await _drive_one_send_turn(
+            pool, account_id, session_id, tool_call_id="tc_list", no_reaction=False
+        )
+
+        assert await _result_marker(pool, session_id, "tc_list") is None
+        assert await _status(pool, session_id, account_id) == "active"
+
+        registry = TaskRegistry()
+        needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id in needs
+
+    async def test_unmarked_result_wakes_backward_compat(
+        self,
+        pool_account_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A historical event / not-yet-redeployed connector omits the field.
+        ``append_event`` sees no ``no_reaction`` key → stimulus → wakes; the
+        sweep's ``IS DISTINCT FROM 'true'`` is NULL-safe → row still counts."""
+        pool, account_id, session_id = pool_account_session
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "say hi"},
+            )
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data=_assistant(["tc_old"], reacting_to=1),
+            )
+            # Append the tool-result event directly with NO no_reaction key —
+            # exactly what a pre-fix / historical row looks like.
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "tc_old",
+                    "content": "ok",
+                    "name": "signal_send",
+                },
+            )
+
+        assert await _result_marker(pool, session_id, "tc_old") is None
+        assert await _status(pool, session_id, account_id) == "active"
+
+        registry = TaskRegistry()
+        needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id in needs
+
+    async def test_copending_user_message_still_wakes(
+        self,
+        pool_account_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A real user message landing alongside the fire-and-forget result
+        must still wake — the user stimulus is independent of the ack."""
+        pool, account_id, session_id = pool_account_session
+        await _drive_one_send_turn(
+            pool, account_id, session_id, tool_call_id="tc_send", no_reaction=True
+        )
+        # The fire-and-forget result alone settled the session; now a real user
+        # message arrives.
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "actually, also tell bob"},
+            )
+
+        assert await _status(pool, session_id, account_id) == "active"
+        registry = TaskRegistry()
+        needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id in needs, "a co-pending real user message must still wake"

--- a/tests/integration/test_session_status_scalars.py
+++ b/tests/integration/test_session_status_scalars.py
@@ -488,6 +488,52 @@ class TestDerivedStatus:
             )
             assert row is not None and row["last_stimulus_seq"] == 3
 
+    async def test_no_reaction_tool_result_is_not_a_stimulus(
+        self,
+        pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+    ) -> None:
+        """A fire-and-forget tool result (``data['no_reaction']=true``) is a
+        delivery confirmation the model has nothing to react to: it must NOT
+        bump ``last_stimulus_seq``, so the session settles idle instead of
+        re-inferring to react to its own send (the duplicate-send loop)."""
+        pool, account_id, session_id = pool_and_session
+        async with pool.acquire() as conn:
+            # user (seq 1)
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "say hi to alice"},
+            )
+            # assistant reacts to the user (seq 2)
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "assistant", "content": "on it", "reacting_to": 1},
+            )
+            # fire-and-forget delivery ack (seq 3) — NOT a stimulus
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "tc_send",
+                    "content": '{"sent_at_ms": 1}',
+                    "no_reaction": True,
+                },
+            )
+            s = await _scalars(conn, session_id)
+            session = await queries.get_session(conn, session_id, account_id=account_id)
+        # last_stimulus_seq stays at 1 (the user) — the ack did not advance it.
+        assert s["last_stimulus_seq"] == 1
+        assert s["last_reacted_seq"] == 1
+        assert session.status == "idle"
+
     async def test_status_active_rescheduling_after_failed_step(
         self,
         pool_and_session: tuple[asyncpg.Pool[Any], str, str],


### PR DESCRIPTION
## Replacement for #1121 (rebased onto current master)

This is a **design-aware rebase** of @mattquest's PR #1121 onto current `master`. **All credit for the fix and its design goes to @mattquest** — this branch only re-expresses their two commits over the refactors that landed underneath the original PR (#1204, #1308, #1315). Their commit authorship is preserved on both commits. The original #1121 is closed in favor of this branch because it could not be pushed to an external fork.

## Why a rebase was needed (verified, not assumed)

I first verified the bug **still reproduces on current master** before touching anything:

- `no_reaction` / `fire_and_forget` appears **nowhere** in `src/`, `packages/`, or `connectors/` on master — the fix is genuinely absent.
- On master, `is_stimulus = kind == "message" and role != "assistant"` (`db/queries/events.py`), so a `role="tool"` delivery-confirmation result **advances `last_stimulus_seq`**, which makes `_SESSION_ACTIVE_EXPR` (`last_stimulus_seq > last_reacted_seq`) true → the session re-wakes to react to its own send. The duplicate-send loop is live.
- **#1204 did not fix it** — it *restructured* the predicate into the single-source `session_active_predicate` generator. That is exactly the surface this fix targets, which is why @mattquest's `events.py` / `sweep.py` / `connectors.py` changes apply cleanly onto it.

## What the rebase touched (the conflicts the underlying PRs caused)

- **`runner.py` (dispatch_call success path)** — #1308 added "persist before POST" (`_mark_answered(serialized_result)`). Combined with @mattquest's `no_reaction=meta.fire_and_forget` arg; both retained.
- **`services/sessions.py` (`append_tool_result`)** — #1093 added `record_spill_attachment`. Combined with @mattquest's `no_reaction` marker-stamp; both retained, in order.
- **`packages/aios-connector-http/tests/test_runner.py`** — #1308's `_IdempotencyConnector` test fixture (which postdates the original PR's base) overrides `_post_tool_result` without the new `no_reaction` kwarg, so the success-path call `TypeError`'d. Added `no_reaction: bool = False` to that fixture's override + forwarded to `super()`, mirroring how the original PR updated the `_ProbeConnector` fixture.
- **telegram precursor fix** — @mattquest's second commit (typing is a *precursor*, not fire-and-forget) re-applied cleanly; `telegram_send`/`telegram_react` stay `fire_and_forget=True`, `telegram_typing` is a normal waking tool.

## Validation (local, against current master)

- Unit: **3341 passed** (includes `test_openapi_snapshot_matches_committed` + `test_sdk_generated_matches_committed` — the regenerated schema is still in sync with master's app).
- Connectors: signal 187 · telegram 100 · whatsapp 157 · connector-http 128 — all green (incl. the new fire-and-forget categorization guards).
- Integration (testcontainers Postgres): **29 passed** — `test_no_reaction_tool_result.py` (successful F&F does not wake / failed send still wakes / backward-compat unmarked wakes / co-pending user message still wakes) + `test_session_status_scalars.py`. This is the end-to-end proof the loop is closed against #1204's predicate surface.
- `ruff check` / `ruff format --check` / `mypy` — clean.

## Not merged

Held for CEO-seat review: this is a behavioral change to the wake gate **and** an external human's work. Reviewer settles the merge.

---
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
