### PR TITLE
feat(dev-pipeline): the post-merge reconciliation checker (#76) — the safety backstop for auto-merge

### DIFF
--- a/src/aios/workflows/dev_pipeline_post_merge.py
+++ b/src/aios/workflows/dev_pipeline_post_merge.py
@@ -256,15 +256,22 @@ def _merge_sha(pr):
 
 
 def _reviewed_sha(labels):
-    """The sha a ``reviewed:green@<sha>`` label records the reconciler reviewed (any present;
-    None if unstamped). The provenance check (c) requires SOME reviewed-green stamp on a
-    merged ``pipeline:v2`` PR — its absence means the PR merged without the gate's review."""
-    for n in labels:
-        if isinstance(n, str) and n.startswith(LABEL_REVIEWED_PREFIX):
-            tail = n[len(LABEL_REVIEWED_PREFIX):]
-            if tail:
-                return tail
-    return None
+    """The sha a ``reviewed:green@<sha>`` label records the reconciler reviewed (None if
+    unstamped). The provenance check (c) requires SOME reviewed-green stamp on a merged
+    ``pipeline:v2`` PR — its absence means the PR merged without the gate's review (a re-pushed
+    PR legitimately carries the OLD reviewed:green@<sha> too, since the reconciler stamps them
+    additively; presence-of-any is the correct backstop bar, the reconciler enforced
+    reviewed-FOR-head at merge time).
+
+    Picks the LEXICOGRAPHICALLY-SMALLEST matching sha when several are present, NOT 'first in
+    set-iteration order': ``labels`` is a frozenset and Python's str hashing is PYTHONHASHSEED-
+    salted, so an iteration-order pick would be non-deterministic ACROSS replays in fresh
+    processes — a replay-stability hazard the moment this value is ever surfaced or compared.
+    ``min()`` is a stable, content-only pick."""
+    shas = [n[len(LABEL_REVIEWED_PREFIX):] for n in labels
+            if isinstance(n, str) and n.startswith(LABEL_REVIEWED_PREFIX)
+            and n[len(LABEL_REVIEWED_PREFIX):]]
+    return min(shas) if shas else None
 
 
 def _risk_tier(labels):
@@ -365,8 +372,8 @@ async def _recently_merged_v2_prs(repo, limit):
     unparseable 2xx page, so a half-read never reads as 'no merges to check'.
 
     Returns the list, or None on a non-2xx read (the read is then the caller's branch — distinct
-    from [] = proven-empty)."""
-    per_page = min(int(limit), 100) if isinstance(limit, int) and limit > 0 else 100
+    from [] = proven-empty). ``limit`` is a positive int (coerced once in ``main()``)."""
+    per_page = min(limit, 100)
     resp = await gh("GET", _with_query(_ipath(repo, "/pulls"),
                                        state="closed", sort="updated", direction="desc",
                                        per_page=per_page))
@@ -505,7 +512,18 @@ async def main(input):
     cfg = _config(input)
     repo = cfg.get("repo") or DEFAULT_REPO
     workflow_id = cfg.get("dev_pipeline_workflow_id", DEV_PIPELINE_WORKFLOW_ID)
-    limit = cfg.get("scan_limit", SCAN_LIMIT)
+    # Coerce the scan cap to a positive int ONCE here (the single source of truth), so a cron
+    # config that delivers ``scan_limit`` as a JSON string never reaches a ``len(runs) >= limit``
+    # comparison downstream (TypeError) — both the merged-PR scan and the run-journal witness read
+    # receive a clean int. A non-numeric / non-positive value falls back to the rendered default.
+    limit = SCAN_LIMIT
+    raw_limit = cfg.get("scan_limit", SCAN_LIMIT)
+    try:
+        parsed_limit = int(raw_limit)
+        if parsed_limit > 0:
+            limit = parsed_limit
+    except (TypeError, ValueError):
+        log("post-merge: non-numeric scan_limit %r — using default %d" % (raw_limit, SCAN_LIMIT))
     if not isinstance(repo, str) or not repo:
         return {"verdict": "cannot-determine", "scanned": 0, "found": [], "checked": [],
                 "reason": "no repo provided (input.repo) and no DEFAULT_REPO configured"}

--- a/src/aios/workflows/dev_pipeline_post_merge.py
+++ b/src/aios/workflows/dev_pipeline_post_merge.py
@@ -1,0 +1,738 @@
+"""The post-merge reconciliation checker — the safety backstop that lets the dev-pipeline
+reconciler safely AUTO-MERGE (task #76; aios#49/#111, the post-merge residual of
+``architecture/dev-pipeline-reconciler-design.md`` §5 + row 12).
+
+WHY THIS EXISTS (the honest residue the reconciler can NOT reach). The dev-pipeline
+reconciler's maker≠checker split (``dev-implement`` ≠ ``dev-review``) is STRUCTURAL
+separation, NOT detection-independence: the builder and the reviewer run on the SAME
+correlated LLM family, so neither catches a semantic regression they both miss. And every
+pre-merge check — CI, the LLM review, the mechanical merge-guard — runs on the PR's OWN
+``refs/pull/N/merge`` ref. NONE of them reaches PAST the merge boundary: a PR that passed
+CI AND review can still break ``master`` once it actually lands (the #1188 post-merge
+regression class), and the reconciler's own merge branch leaves a stuck issue OPEN if its
+best-effort close failed. Green CI cannot reach past the merge boundary.
+
+So this is the POST-MERGE TWIN of ``owner()``'s pre-merge gate — maker≠checker ACROSS the
+merge boundary. It is a SEPARATE cron-fired stateless workflow (the gate-reaper /
+telemetry-observer dead-man idiom), NOT a stage of the reconciler, precisely because its
+verdict must draw from an UNCORRELATED, off-the-run substrate: the DURABLE GitHub state
+(the merged PR, its provenance labels, the source issue's open/closed state, and the live
+post-merge ``master`` CI), corroborated by the run journal. A reconciler run that merged a
+PR cannot vouch for what that merge did to master — the check that backs the merge boundary
+MUST come from a different stage than the one that produced the merge (the
+substrate-different-verdict invariant).
+
+─── THE THREE POST-MERGE VERIFICATIONS (each drawn from durable, off-the-run state) ────
+
+For every recently-merged dev-pipeline (``pipeline:v2``) PR not yet checked, verify:
+
+  (a) THE SOURCE ISSUE ENDED CLOSED. The reconciler's merge branch closes the source
+      issue best-effort (``_close_source_issue``, close-before-strip #1208); a failed close
+      leaves the issue OPEN ∧ ``dispatched`` (safe, but a silent stuck issue). We derive the
+      source issue from the merged PR's ``dev-pipeline/issue-<n>`` branch and confirm
+      ``state == closed``. An OPEN source issue for a merged PR → ``needs:human/issue-open``.
+
+  (b) THE MERGE DID NOT LEAVE MASTER RED. We read the LIVE post-merge CI verdict on the
+      base branch (``BASE_BRANCH``) via the deterministic Checks + combined-status API
+      (``_read_ci`` — NO agent, NO model). A genuinely-red master after the merge landed →
+      ``needs:human/master-red`` (the #1188 post-merge-regression alarm). ``master`` red is
+      attributed to whichever merged-PR sweep observes it; the seat triages which merge
+      broke it. (A still-running / unreadable master CI is INDETERMINATE — re-checked next
+      sweep — never a silent green.)
+
+  (c) THE PROVENANCE WAS LEGITIMATE (the PR was merged THROUGH the pipeline's gate). A
+      ``pipeline:v2`` PR that MERGED but carries NO gate provenance — no
+      ``reviewed:green@<merge_head>`` and no in-cap ``risk:tier-N`` — was merged WITHOUT the
+      maker≠checker review the auto-merge authority is scoped to. That is exactly the
+      bypass the post-merge checker exists to catch: a tier>cap PR, or one a human/automation
+      force-merged outside the gate, must NOT pass silently → ``needs:human/bad-provenance``.
+      Corroborated (best-effort, since #1397 made the run journal run-readable) against
+      ``list_runs``: a dev-pipeline run SHOULD have driven the merge; its absence is folded
+      into the provenance detail, never the sole verdict (the GitHub labels are the durable,
+      always-present provenance; the run journal is the secondary witness).
+
+On ANY violation → stamp the durable ``needs:human/*`` label + post ONE idempotent markered
+comment (NEVER silently — the same queryable-mailbox discipline as the reconciler's
+escalations) and the seat / the reconciler's Step-8 dead-man owns it from there. A clean PR
+is stamped ``post-merge:checked@<merge_sha>`` so it is verified EXACTLY ONCE (bounded,
+idempotent: a re-sweep skips an already-checked merge head).
+
+─── DETERMINISM (replay-stable; the cron envelope's frozen clock if a clock is needed) ──
+
+Authored with the EXACT ``gate_reaper.py`` / ``dev_pipeline_reconciler.py`` builder idiom:
+an exported ``build_post_merge_checker_script(...) -> str`` returns workflow SOURCE (a
+prepended constants header + a static ``_BODY`` of pure-stdlib ``re``/``json``, value-domain
+I/O, deterministic emit order → replay-stable), plus ``REQUIRED_TOOLS`` /
+``REQUIRED_HTTP_SERVERS`` and ``build_post_merge_checker_workflow_create(...)`` bundling
+script + surface so the declared surface can't drift from the script (#1135). The body
+imports neither ``datetime`` nor ``time``: the only "now"-like input it needs is the
+recency window, and it reads recency off GitHub's own ``merged_at`` ordering (``sort=updated
+direction=desc``) rather than a wall clock, so it never desyncs replay.
+
+The list reads go through the shared ``gh_paginated`` (#1294/#1323): a truncated / unparseable
+2xx page is fatal-loud ``cannot-determine``, NEVER a silent under-count read as "no
+regressions". A post-merge checker that under-counts the merges it judges is exactly the
+look-green-while-checking-less failure the backstop exists to prevent.
+
+PROVENANCE SUBSTRATE SHARED VERBATIM WITH THE RECONCILER (one source of truth, no drift):
+the gate provenance the checker validates is the SAME ``reviewed:green@<sha>`` /
+``risk:tier-N`` / ``pipeline:v2`` / ``AUTO_MERGE_MAX_TIER`` vocabulary the reconciler's
+``owner()`` + review branch STAMP — imported from ``dev_pipeline_reconciler`` so a relabel on
+one side can never silently desync the post-merge verification on the other. The CI read
+(``_read_ci``) + the source-issue branch convention (``dev-pipeline/issue-<n>``) come from the
+shared ``dev_pipeline_lib`` for the same reason.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
+from aios.models.workflows import WorkflowCreate
+from aios.workflows.comment_idempotency import COMMENT_IDEMPOTENCY_HELPERS
+from aios.workflows.dev_pipeline_lib import DEV_PIPELINE_LIB
+
+# Reused VERBATIM from the reconciler so the post-merge checker validates EXACTLY the gate
+# provenance the reconciler STAMPS — a relabel on one side can never silently desync the
+# verification on the other (the maker≠checker-across-the-merge-boundary invariant has to
+# read the same labels the merge branch wrote).
+from aios.workflows.dev_pipeline_reconciler import (
+    AUTO_MERGE_MAX_TIER,
+    LABEL_PIPELINE_V2,
+    LABEL_REVIEWED_PREFIX,
+    LABEL_RISK_PREFIX,
+)
+from aios.workflows.gh_body import GH_BODY_HELPERS
+
+# ─── the post-merge escalation mailbox (the relocated escalation, terminal labels) ──
+# Same queryable-mailbox discipline as the reconciler: a violation becomes a DURABLE
+# terminal ``needs:human/*`` label read off the board, never a silent pass and never a
+# suspended run. The seat / the reconciler's Step-8 dead-man + the reaper own them.
+NEEDS_HUMAN_ISSUE_OPEN = "needs:human/issue-open"  # (a) merged PR, source issue still OPEN
+NEEDS_HUMAN_MASTER_RED = "needs:human/master-red"  # (b) the merge left master RED (#1188)
+NEEDS_HUMAN_BAD_PROVENANCE = "needs:human/bad-provenance"  # (c) merged WITHOUT the gate
+
+# The single idempotency marker: stamped on a PR whose merge head has passed all three
+# checks, so a clean merge is verified EXACTLY ONCE (a re-sweep skips an already-checked
+# merge sha). ``post-merge:checked@<merge_sha>`` keys on the SHA so a (pathological)
+# re-merge of the same PR onto a new sha is re-checked.
+LABEL_CHECKED_PREFIX = "post-merge:checked@"
+
+# The escalation label a seat/ops sweep can grep for every post-merge regression at a glance
+# (and clear on resolution) — the analog of the reaper's ``autodev:reaper-escalated``.
+DEFAULT_ESCALATED_LABEL = "autodev:post-merge-regression"
+
+# The verdict vocabulary for the per-sweep summary — EXACTLY these three (matches the reaper).
+VERDICTS: tuple[str, ...] = ("ok", "regression-found", "cannot-determine")
+
+# The three post-merge verification classes (the design-of-record's §5 residue).
+CHECK_CLASSES: tuple[str, ...] = (
+    "issue-open",  # (a) source issue stayed open after merge
+    "master-red",  # (b) the merge left master red (#1188)
+    "bad-provenance",  # (c) merged without the maker≠checker gate
+)
+
+# A non-terminal run status is a LIVE run; the complement is terminal. Mirrors
+# models/workflows.TERMINAL_RUN_STATUSES. For provenance corroboration we look at the
+# TERMINAL (completed) runs that drove an issue — a successful pipeline run is positive
+# provenance evidence.
+TERMINAL_RUN_STATUSES: tuple[str, ...] = ("completed", "errored", "cancelled")
+
+# How many recently-updated closed PRs to scan per sweep (the merge backlog horizon). Sized
+# above the per-interval merge rate so no merge is missed between sweeps; the
+# ``post-merge:checked@`` marker makes re-scanning an already-checked merge a cheap no-op.
+DEFAULT_SCAN_LIMIT = 100
+
+
+def _py(name: str, value: Any) -> str:
+    """One ``NAME = <repr>`` constant line for the prepended header (mirrors dev/triage/reaper)."""
+    return f"{name} = {value!r}"
+
+
+def _render_constants(
+    *,
+    github_server: str,
+    base_branch: str,
+    escalated_label: str,
+    auto_merge_max_tier: int,
+    scan_limit: int,
+    require_run_provenance: bool,
+    dev_pipeline_workflow_id: str | None,
+    default_repo: str | None,
+) -> str:
+    lines = [
+        _py("GITHUB_SERVER", github_server),
+        _py("BASE_BRANCH", base_branch),
+        _py("ESCALATED_LABEL", escalated_label),
+        _py("AUTO_MERGE_MAX_TIER", auto_merge_max_tier),
+        _py("SCAN_LIMIT", scan_limit),
+        # When True, the ABSENCE of a driving dev-pipeline run in the journal is itself a
+        # provenance VIOLATION (the strictest posture); default False — the run journal is a
+        # secondary witness folded into the detail, and the durable GitHub gate labels are the
+        # primary provenance (always present on a gate-merged PR, no workflow-id wiring needed).
+        _py("REQUIRE_RUN_PROVENANCE", require_run_provenance),
+        _py("DEV_PIPELINE_WORKFLOW_ID", dev_pipeline_workflow_id),
+        _py("DEFAULT_REPO", default_repo),
+        # the reconciler's provenance vocabulary (imported, NOT re-spelled — one source of truth)
+        _py("LABEL_PIPELINE_V2", LABEL_PIPELINE_V2),
+        _py("LABEL_REVIEWED_PREFIX", LABEL_REVIEWED_PREFIX),
+        _py("LABEL_RISK_PREFIX", LABEL_RISK_PREFIX),
+        # the post-merge checker's own escalation + marker labels
+        _py("NEEDS_HUMAN_ISSUE_OPEN", NEEDS_HUMAN_ISSUE_OPEN),
+        _py("NEEDS_HUMAN_MASTER_RED", NEEDS_HUMAN_MASTER_RED),
+        _py("NEEDS_HUMAN_BAD_PROVENANCE", NEEDS_HUMAN_BAD_PROVENANCE),
+        _py("LABEL_CHECKED_PREFIX", LABEL_CHECKED_PREFIX),
+        _py("TERMINAL_RUN_STATUSES", list(TERMINAL_RUN_STATUSES)),
+        _py("CHECK_CLASSES", list(CHECK_CLASSES)),
+        # Stable comment markers — each is BOTH the comment's first line AND the maker-marker
+        # the idempotency guard scans for (aios#1292): a posted comment is its own "already
+        # done" marker, so an at-least-once replay never double-posts.
+        _py("MARKER_ISSUE_OPEN", "## Post-merge: source issue stayed OPEN after merge"),
+        _py(
+            "MARKER_MASTER_RED", "## Post-merge: master is RED after this merge (#1188 regression)"
+        ),
+        _py(
+            "MARKER_BAD_PROVENANCE",
+            "## Post-merge: a pipeline PR was merged WITHOUT the maker≠checker gate",
+        ),
+    ]
+    return "\n".join(lines)
+
+
+# The static checker body — references the prepended constants AND the shared lib helpers
+# (DEV_PIPELINE_LIB: gh/_ipath/_with_query/_status/_json_body via the body splice, _read_ci,
+# _resolve_sha1, _close-issue plumbing) + GH_BODY_HELPERS + COMMENT_IDEMPOTENCY_HELPERS.
+# Pure stdlib (re/json), value-domain I/O, bounded loops, no datetime/time: replay-stable.
+_BODY = r'''
+import json
+import re
+
+# NOTE: the proven scripted helpers (gh + retry, gh_paginated #1294, _ipath/_with_query/
+# _status, the deterministic CI read _read_ci #1316, _resolve_sha1 #1178, post_comment_once
+# #1292) live in DEV_PIPELINE_LIB / GH_BODY_HELPERS / COMMENT_IDEMPOTENCY_HELPERS, spliced in
+# below. Module-level defs resolve names at CALL time, so this body can call them freely even
+# though their defs are appended after this block.
+
+
+# ─── input-envelope unwrap (cron fire OR bare fixture/arm-time shape) ─────────
+
+def _config(input):
+    """The checker's config — ``{repo, dev_pipeline_workflow_id?, scan_limit?}`` — out of
+    EITHER the bare fixture/arm-time shape OR the cron WorkflowAction envelope
+    ``{"trigger": ..., "input": <template>}`` (a cron fire carries the author's template
+    verbatim under ``input``)."""
+    if isinstance(input, dict) and "trigger" in input and "input" in input:
+        return input.get("input") or {}
+    return input or {}
+
+
+def _label_names(obj):
+    """The set of label names on an issue/PR (GitHub returns label objects with a ``name``;
+    tolerate bare strings defensively)."""
+    names = set()
+    if not isinstance(obj, dict):
+        return names
+    for lab in obj.get("labels") or []:
+        if isinstance(lab, dict):
+            n = lab.get("name")
+            if isinstance(n, str):
+                names.add(n)
+        elif isinstance(lab, str):
+            names.add(lab)
+    return names
+
+
+def _merge_sha(pr):
+    """The commit SHA the PR merged AS (``merge_commit_sha``) — the durable identity of THIS
+    merge, what the ``post-merge:checked@<sha>`` marker keys on. Falls back to the head sha if
+    GitHub omits it (older payloads). Returns "" when neither is present (the merge is then
+    un-keyable and the checker treats it as unverifiable → re-check next sweep)."""
+    if not isinstance(pr, dict):
+        return ""
+    sha = pr.get("merge_commit_sha")
+    if isinstance(sha, str) and sha:
+        return sha
+    return _pr_head_sha(pr)
+
+
+def _reviewed_sha(labels):
+    """The sha a ``reviewed:green@<sha>`` label records the reconciler reviewed (any present;
+    None if unstamped). The provenance check (c) requires SOME reviewed-green stamp on a
+    merged ``pipeline:v2`` PR — its absence means the PR merged without the gate's review."""
+    for n in labels:
+        if isinstance(n, str) and n.startswith(LABEL_REVIEWED_PREFIX):
+            tail = n[len(LABEL_REVIEWED_PREFIX):]
+            if tail:
+                return tail
+    return None
+
+
+def _risk_tier(labels):
+    """The single-valued ``risk:tier-N`` the reconciler stamped, or None if unstamped."""
+    for n in labels:
+        if isinstance(n, str) and n.startswith(LABEL_RISK_PREFIX):
+            try:
+                return int(n[len(LABEL_RISK_PREFIX):])
+            except (ValueError, TypeError):
+                continue
+    return None
+
+
+def _already_checked(labels, merge_sha):
+    """True if THIS merge sha already carries ``post-merge:checked@<sha>`` — a clean merge is
+    verified exactly once; a re-sweep skips it (idempotent, bounded). A merge onto a DIFFERENT
+    sha (a re-merge) is not skipped (the marker keys on the sha)."""
+    if not (isinstance(merge_sha, str) and merge_sha):
+        return False
+    want = LABEL_CHECKED_PREFIX + merge_sha
+    return want in labels
+
+
+def _source_issue_number(pr):
+    """The source issue number from the merged PR's ``dev-pipeline/issue-<n>`` branch (the
+    pipeline's only durable issue→PR linkage; PR bodies carry no ``Closes #N``). Returns an int
+    or None (an un-derivable branch → the issue-closed check (a) is SKIPPED for this PR, not a
+    false violation: we never invent an issue number to fail on)."""
+    ref = ((pr.get("head") or {}).get("ref") or "") if isinstance(pr, dict) else ""
+    m = re.search(r"issue-(\d+)$", ref)
+    return int(m.group(1)) if m else None
+
+
+# ─── the off-the-run run-journal witness (provenance corroboration, since #1397) ──
+
+async def _list_runs(args):
+    """One ``list_runs`` read (account-scoped to this run's own account; #1397 made the run
+    journal run-readable). Returns the raw tool result the caller branches on."""
+    return await tool("list_runs", args)
+
+
+def _run_issue_numbers(runs, repo):
+    """The set of issue numbers a list of dev-pipeline runs drove (from each run's input
+    envelope ``{repo, issue_number}`` or the trigger-wrapped form). Used as the provenance
+    witness: a merged PR's source issue appearing here means a dev-pipeline run DID drive it."""
+    out = set()
+    if not isinstance(runs, list):
+        return out
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        inp = run.get("input")
+        if isinstance(inp, dict) and "trigger" in inp and "input" in inp:
+            inp = inp.get("input")
+        if not isinstance(inp, dict):
+            continue
+        r = inp.get("repo")
+        num = inp.get("issue_number")
+        if r == repo and isinstance(num, int):
+            out.add(num)
+    return out
+
+
+async def _completed_run_issues(repo, workflow_id, limit):
+    """The set of issue numbers driven by a COMPLETED dev-pipeline run — positive provenance
+    evidence (a completed run is a successful build→merge, exactly the legitimate path). Returns
+    ``(issues, ok)``: ``ok`` False when the read degraded/truncated (the witness is then
+    unavailable and the provenance check falls back to the durable GitHub labels alone — never a
+    false 'no run' violation). Best-effort; the durable gate labels are the primary provenance."""
+    if not isinstance(workflow_id, str) or not workflow_id:
+        return (set(), False)
+    resp = await _list_runs({"workflow_id": workflow_id, "status": "completed",
+                             "limit": limit, "account_wide": True})
+    if not isinstance(resp, dict) or "error" in resp:
+        return (set(), False)
+    runs = resp.get("runs")
+    if not isinstance(runs, list):
+        return (set(), False)
+    if len(runs) >= limit:
+        # A full page: more completed runs may exist unseen → the witness is unprovable, so we
+        # mark it unavailable (the check falls back to the always-present GitHub gate labels).
+        return (_run_issue_numbers(runs, repo), False)
+    return (_run_issue_numbers(runs, repo), True)
+
+
+# ─── the merged-PR substrate (recently-merged pipeline PRs to verify) ─────────
+
+async def _recently_merged_v2_prs(repo, limit):
+    """The recently-MERGED dev-pipeline (``pipeline:v2``) PRs to verify this sweep — the most-
+    recently-updated CLOSED PRs (``sort=updated direction=desc``), filtered to the ones that
+    actually MERGED (``merged_at`` set) and carry the pipeline provenance label.
+
+    This is a SINGLE bounded page (``per_page=min(limit,100)``), NOT a full ``gh_paginated``
+    walk: the closed-PR list is the repo's whole merge HISTORY, and we deliberately verify only
+    the recent slice each sweep (the ``post-merge:checked@`` marker makes re-scanning an
+    already-checked merge a no-op, and a sweep cadence above the merge rate guarantees no merge
+    falls off the recent slice unchecked). ``_json_body`` still fails LOUD on a truncated /
+    unparseable 2xx page, so a half-read never reads as 'no merges to check'.
+
+    Returns the list, or None on a non-2xx read (the read is then the caller's branch — distinct
+    from [] = proven-empty)."""
+    per_page = min(int(limit), 100) if isinstance(limit, int) and limit > 0 else 100
+    resp = await gh("GET", _with_query(_ipath(repo, "/pulls"),
+                                       state="closed", sort="updated", direction="desc",
+                                       per_page=per_page))
+    if _status(resp) != 200:
+        return None
+    rows = _json_body(resp)  # raises loud on a truncated / unparseable 2xx page
+    if not isinstance(rows, list):
+        return None
+    out = []
+    for pr in rows:
+        if not isinstance(pr, dict):
+            continue
+        if not pr.get("merged_at"):
+            continue  # closed-but-not-merged PRs never merged anything → nothing to verify
+        if LABEL_PIPELINE_V2 not in _label_names(pr):
+            continue  # only pipeline-owned merges are in scope
+        out.append(pr)
+    return out
+
+
+# ─── the three verifications (each drawn from durable, off-the-run state) ──────
+
+async def _check_issue_closed(repo, pr):
+    """(a) THE SOURCE ISSUE ENDED CLOSED. Derive the issue from the merged PR's
+    ``dev-pipeline/issue-<n>`` branch and confirm ``state == closed``. Returns a finding dict
+    on a violation (merged PR, issue still OPEN) or None (closed / not-derivable / unreadable).
+    An unreadable issue read is INDETERMINATE (returns None this sweep, re-checked next), never
+    a false violation."""
+    issue_number = _source_issue_number(pr)
+    if issue_number is None:
+        return None  # no derivable source issue — skip (a), don't invent a violation
+    resp = await gh("GET", _ipath(repo, "/issues/%d" % issue_number))
+    if _status(resp) != 200:
+        log("post-merge: issue #%d read non-2xx (%r) — indeterminate this sweep"
+            % (issue_number, _status(resp)))
+        return None
+    issue = _json_body(resp)
+    state = issue.get("state") if isinstance(issue, dict) else None
+    if state == "open":
+        return {"class": "issue-open", "issue": issue_number,
+                "detail": "PR #%d MERGED but its source issue #%d is still OPEN — the "
+                          "reconciler's best-effort close did not stick (the issue reads as "
+                          "live to a dispatch sweep)." % (pr.get("number"), issue_number)}
+    return None
+
+
+async def _check_master_green(repo):
+    """(b) THE MERGE DID NOT LEAVE MASTER RED. Read the LIVE post-merge CI verdict on
+    ``BASE_BRANCH`` via the deterministic Checks + combined-status API (``_read_ci`` — no agent,
+    no model). Returns ``(finding_or_None, verdict_str)`` where verdict_str ∈
+    {green,red,no_ci,indeterminate} for the per-sweep summary. A genuinely-RED master → a
+    finding (the #1188 alarm). A still-running / unreadable master CI is INDETERMINATE
+    (re-checked next sweep) — never coerced to a silent green NOR a false red."""
+    head = await _resolve_sha1(repo, BASE_BRANCH)
+    if not head:
+        log("post-merge: could not resolve %s head sha — master-CI indeterminate" % BASE_BRANCH)
+        return (None, "indeterminate")
+    verdict, read_ok = await _read_ci(repo, head)
+    if not read_ok:
+        # Neither CI surface read — cannot trust ANY verdict (down ≠ green). Indeterminate.
+        return (None, "indeterminate")
+    if verdict is None:
+        # CI present but still running on master — not terminal. Re-check next sweep.
+        return (None, "indeterminate")
+    status = verdict.get("status")
+    if status == "red":
+        return ({"class": "master-red", "issue": None,
+                 "detail": "master (%s @ %s) is RED after this merge landed — a PR that passed "
+                           "CI + review broke master post-merge (#1188). %s"
+                           % (BASE_BRANCH, head[:12], verdict.get("detail", ""))},
+                "red")
+    return (None, status)  # green / no_ci
+
+
+def _check_provenance(repo, pr, completed_issues, witness_ok):
+    """(c) THE PROVENANCE WAS LEGITIMATE (merged THROUGH the gate). A merged ``pipeline:v2`` PR
+    MUST carry the reconciler's durable gate stamp: a ``reviewed:green@<sha>`` AND an in-cap
+    ``risk:tier-N`` (1..AUTO_MERGE_MAX_TIER). Its absence means the PR merged WITHOUT the
+    maker≠checker review the auto-merge authority is scoped to (a tier>cap PR, or a force-merge
+    outside the gate). Returns a finding dict on a violation, else None.
+
+    The GitHub gate labels are the PRIMARY (always-present-on-a-gate-merge) provenance. The run
+    journal is a SECONDARY witness: a completed dev-pipeline run for the source issue corroborates
+    the merge; its absence is folded into the detail (and, only when ``REQUIRE_RUN_PROVENANCE`` is
+    set AND the witness is available, is itself a violation). ``witness_ok`` False (the journal
+    read degraded) NEVER manufactures a violation — we fall back to the labels alone."""
+    labels = frozenset(_label_names(pr))
+    reviewed = _reviewed_sha(labels)
+    tier = _risk_tier(labels)
+    number = pr.get("number")
+    issue_number = _source_issue_number(pr)
+
+    in_cap_tier = isinstance(tier, int) and 1 <= tier <= AUTO_MERGE_MAX_TIER
+    has_gate = (reviewed is not None) and in_cap_tier
+    if not has_gate:
+        missing = []
+        if reviewed is None:
+            missing.append("no reviewed:green@<sha> stamp")
+        if not isinstance(tier, int):
+            missing.append("no risk:tier-N stamp")
+        elif not (1 <= tier <= AUTO_MERGE_MAX_TIER):
+            missing.append("risk:tier-%d is ABOVE the auto-merge cap (%d)"
+                           % (tier, AUTO_MERGE_MAX_TIER))
+        return {"class": "bad-provenance", "issue": issue_number,
+                "detail": "pipeline:v2 PR #%d MERGED without the reconciler's maker≠checker "
+                          "gate (%s) — it bypassed the pre-merge review the auto-merge authority "
+                          "is scoped to." % (number, "; ".join(missing))}
+
+    # The gate labels are present. OPTIONAL run-journal corroboration: a completed dev-pipeline
+    # run for the source issue is positive evidence. Only treat its ABSENCE as a violation when
+    # explicitly required AND the witness was readable (else fall back to the labels alone).
+    if REQUIRE_RUN_PROVENANCE and witness_ok and issue_number is not None \
+            and issue_number not in completed_issues:
+        return {"class": "bad-provenance", "issue": issue_number,
+                "detail": "pipeline:v2 PR #%d carries the gate labels but NO completed "
+                          "dev-pipeline run drove its source issue #%d in the run journal — "
+                          "the gate labels may have been applied out-of-band."
+                          % (number, issue_number)}
+    return None
+
+
+async def _escalate(repo, number, label, marker, detail):
+    """Post ONE structured escalation comment (idempotent via the maker-marker guard) + stamp
+    the per-class ``needs:human/*`` label AND the grep-able ``ESCALATED_LABEL`` so a seat/ops
+    sweep finds every post-merge regression at a glance. A label already present is a GitHub
+    no-op; the comment dedup means an at-least-once replay never double-posts."""
+    await post_markered_comment(repo, number, marker, marker + "\n\n" + detail)
+    await _label(repo, number, label)
+    await _label(repo, number, ESCALATED_LABEL)
+
+
+# ─── the post-merge checker (one sweep: read merges → 3 checks each → escalate/mark) ──
+
+async def main(input):
+    phase("config")
+    cfg = _config(input)
+    repo = cfg.get("repo") or DEFAULT_REPO
+    workflow_id = cfg.get("dev_pipeline_workflow_id", DEV_PIPELINE_WORKFLOW_ID)
+    limit = cfg.get("scan_limit", SCAN_LIMIT)
+    if not isinstance(repo, str) or not repo:
+        return {"verdict": "cannot-determine", "scanned": 0, "found": [], "checked": [],
+                "reason": "no repo provided (input.repo) and no DEFAULT_REPO configured"}
+
+    # ── the merged-PR substrate (recently-merged pipeline:v2 PRs) ──
+    phase("scan")
+    merged = await _recently_merged_v2_prs(repo, limit)
+    if merged is None:
+        # A non-2xx / truncated merged-PR read taints the whole sweep — fail loud
+        # cannot-determine, NEVER a silent under-count read as "no regressions".
+        log("post-merge: merged-PR read degraded")
+        return {"verdict": "cannot-determine", "scanned": 0, "found": [], "checked": [],
+                "reason": "merged-PR list read failed (non-2xx / truncated)"}
+
+    # ── the run-journal provenance witness (read ONCE, reused across PRs) ──
+    phase("provenance-witness")
+    completed_issues, witness_ok = await _completed_run_issues(repo, workflow_id, limit)
+
+    # ── read master's post-merge CI verdict ONCE per sweep (it is a property of master, not of
+    # a single PR; a red master is attributed to whichever merged-PR sweep observes it — the
+    # seat triages which merge broke it). ──
+    phase("master-ci")
+    master_finding, master_verdict = await _check_master_green(repo)
+
+    found = []
+    checked = []
+    phase("verify")
+    for pr in merged:
+        number = pr.get("number")
+        if not isinstance(number, int):
+            continue
+        labels = frozenset(_label_names(pr))
+        msha = _merge_sha(pr)
+        if _already_checked(labels, msha):
+            continue  # this merge sha was already verified clean — idempotent skip
+        # Skip a PR a human is already handling for a post-merge violation (any needs:human/*
+        # we stamp) — re-escalating a PR the seat is on is noise. A fresh needs:human means
+        # un-cleared; we still re-stamp idempotently (the comment dedup prevents a double-post).
+
+        pr_findings = []
+        # (a) source issue closed
+        f_issue = await _check_issue_closed(repo, pr)
+        if f_issue is not None:
+            f_issue["pr"] = number
+            await _escalate(repo, number, NEEDS_HUMAN_ISSUE_OPEN, MARKER_ISSUE_OPEN,
+                            f_issue["detail"])
+            pr_findings.append(f_issue)
+        # (b) master not red — attribute the (sweep-wide) red master to each unchecked merge
+        if master_finding is not None:
+            f_master = dict(master_finding)
+            f_master["pr"] = number
+            await _escalate(repo, number, NEEDS_HUMAN_MASTER_RED, MARKER_MASTER_RED,
+                            f_master["detail"])
+            pr_findings.append(f_master)
+        # (c) provenance legitimate
+        f_prov = _check_provenance(repo, pr, completed_issues, witness_ok)
+        if f_prov is not None:
+            f_prov["pr"] = number
+            await _escalate(repo, number, NEEDS_HUMAN_BAD_PROVENANCE, MARKER_BAD_PROVENANCE,
+                            f_prov["detail"])
+            pr_findings.append(f_prov)
+
+        if pr_findings:
+            found.extend(pr_findings)
+            # A violated merge is NOT stamped checked — it stays pull-able for the seat (and a
+            # re-sweep re-confirms / clears once resolved). The needs:human/* label is the
+            # durable record.
+        else:
+            # All three clean → mark this merge sha verified-once (bounded, idempotent). We do
+            # NOT mark when master is INDETERMINATE this sweep (a still-running master CI must be
+            # re-checked next sweep before we declare the merge clean) — only when master is a
+            # settled green/no_ci AND issue+provenance passed.
+            if master_verdict in ("green", "no_ci") and msha:
+                await _label(repo, number, LABEL_CHECKED_PREFIX + msha)
+                checked.append(number)
+
+    # ── the structured per-sweep summary (verdict ∈ ok / regression-found / cannot-determine) ──
+    phase("summary")
+    if found:
+        verdict = "regression-found"
+        reason = None
+    elif master_verdict == "indeterminate" and merged:
+        # We scanned merges but could not settle master's CI — not a clean bill of health.
+        verdict = "cannot-determine"
+        reason = "master CI did not reach a terminal verdict this sweep"
+    else:
+        verdict = "ok"
+        reason = None
+    summary = {"verdict": verdict, "repo": repo, "scanned": len(merged),
+               "master_verdict": master_verdict, "witness_ok": witness_ok,
+               "found": found, "checked": checked}
+    if reason is not None:
+        summary["reason"] = reason
+    log("post-merge checker verdict:", verdict, "scanned:", len(merged),
+        "found:", len(found), "checked:", len(checked))
+    return summary
+'''
+
+
+def build_post_merge_checker_script(
+    *,
+    github_server: str = "github",
+    base_branch: str = "master",
+    escalated_label: str = DEFAULT_ESCALATED_LABEL,
+    auto_merge_max_tier: int = AUTO_MERGE_MAX_TIER,
+    scan_limit: int = DEFAULT_SCAN_LIMIT,
+    require_run_provenance: bool = False,
+    dev_pipeline_workflow_id: str | None = None,
+    repo: str | None = None,
+) -> str:
+    """Return the production post-merge-checker workflow source.
+
+    The post-merge TWIN of the reconciler's ``owner()`` pre-merge gate (task #76): a separate
+    cron-fired stateless workflow that verifies, from DURABLE off-the-run GitHub state, that
+    every recently-merged ``pipeline:v2`` PR (a) closed its source issue, (b) did not leave
+    ``base_branch`` red, and (c) carried the reconciler's maker≠checker gate provenance — and
+    escalates any violation via a ``needs:human/*`` label + idempotent comment.
+
+    ``auto_merge_max_tier`` is imported from the reconciler so the provenance check enforces the
+    SAME tier-cap the merge branch did. ``require_run_provenance`` (default OFF) makes the
+    absence of a driving dev-pipeline run in the journal a violation; left off, the run journal
+    is a secondary witness and the durable GitHub gate labels are the primary provenance.
+    """
+    header = _render_constants(
+        github_server=github_server,
+        base_branch=base_branch,
+        escalated_label=escalated_label,
+        auto_merge_max_tier=auto_merge_max_tier,
+        scan_limit=scan_limit,
+        require_run_provenance=require_run_provenance,
+        dev_pipeline_workflow_id=dev_pipeline_workflow_id,
+        default_repo=repo,
+    )
+    # Splice five source strings, each authored once (module-level defs resolve names at CALL
+    # time, so the order between body/lib/helpers is free):
+    #   - _BODY: the unwrap + merged-PR scan + the three verifications + the checker main().
+    #   - DEV_PIPELINE_LIB: gh/_ipath/_with_query/_status, the deterministic _read_ci (#1316),
+    #     _resolve_sha1 (#1178), _label/_unlabel, post_markered_comment — spliced VERBATIM (one
+    #     source of truth with the reconciler + monolith; no drift).
+    #   - GH_BODY_HELPERS (#1294): _json_body / gh_paginated (fail LOUD on truncated/unparseable).
+    #   - COMMENT_IDEMPOTENCY_HELPERS (#1292): the maker-marker comment-POST dedup.
+    return header + "\n" + _BODY + DEV_PIPELINE_LIB + GH_BODY_HELPERS + COMMENT_IDEMPOTENCY_HELPERS
+
+
+def build_post_merge_checker_fixture_script(
+    *,
+    repo: str | None = None,
+    scan_limit: int = 50,
+    require_run_provenance: bool = False,
+    dev_pipeline_workflow_id: str | None = None,
+) -> str:
+    """The CI fixture variant: a tighter scan cap, otherwise the identical script shape. Driven
+    by ``tests/integration/test_wf_dev_pipeline_post_merge_fixture.py`` against the host with
+    simulated GitHub / list_runs returns."""
+    return build_post_merge_checker_script(
+        repo=repo,
+        scan_limit=scan_limit,
+        require_run_provenance=require_run_provenance,
+        dev_pipeline_workflow_id=dev_pipeline_workflow_id,
+    )
+
+
+# ─── deploy surface (the tool + http_server envelope a WorkflowCreate needs) ──
+#
+# The post-merge checker READS GitHub (merged PRs, the source issue's state, master's CI) and
+# the run journal (list_runs, provenance witness, run-callable since #1397), and MUTATES only
+# the escalation comment + label set. It needs NO bash / read / write / edit / agent / gate —
+# and STRUCTURALLY cannot merge/close/resolve anything (no PUT/PATCH route, no gate), which
+# makes "a checker that only escalates, never acts on the merge it judges" a structural property
+# (the maker≠checker-across-the-merge-boundary invariant: a different stage AND a different,
+# read+escalate-only surface than the reconciler's effector).
+REQUIRED_TOOLS: list[ToolSpec] = [
+    ToolSpec(type="http_request"),
+    ToolSpec(type="list_runs"),
+]
+
+
+def _github_http_server(*, name: str, base_url: str) -> HttpServerSpec:
+    return HttpServerSpec(
+        name=name,
+        base_url=base_url,
+        description="GitHub REST API (auth resolved from the bound vault's GITHUB_TOKEN).",
+        routes=[
+            HttpRouteSpec(
+                # GET (list merged PRs, read the source issue's state, read master's CI surfaces,
+                # read a comment thread), POST (the escalation comment + the needs:human/* +
+                # escalated labels). NO PUT/PATCH/DELETE: the checker NEVER merges, closes,
+                # unlabels, or resolves a gate — it only escalates. That the surface CANNOT
+                # mutate the merge it judges is the structural maker≠checker-across-the-boundary
+                # guarantee.
+                path_pattern="/repos/**",
+                methods=["GET", "POST"],
+                allow_query=True,
+                description="Merged PRs, issues, labels, comments, commit CI (GET reads; POST "
+                "comments + labels); list endpoints paginate via ?state/?sort/?per_page/?page.",
+            ),
+        ],
+    )
+
+
+REQUIRED_HTTP_SERVERS: list[HttpServerSpec] = [
+    _github_http_server(name="github", base_url="https://api.github.com")
+]
+
+
+def build_post_merge_checker_workflow_create(
+    *,
+    name: str = "dev-pipeline-post-merge-checker",
+    description: str | None = None,
+    github_server: str = "github",
+    github_base_url: str = "https://api.github.com",
+    **script_kwargs: Any,
+) -> WorkflowCreate:
+    """Return the complete ``WorkflowCreate`` for the production post-merge checker.
+
+    Bundles the script (``build_post_merge_checker_script``) with its tool + http_server surface
+    (``REQUIRED_TOOLS = [http_request, list_runs]`` and the GET·POST-only ``github`` server — NO
+    PUT/PATCH/DELETE, NO gate), so a deployer POSTs one object and the declared surface can never
+    drift from the script that needs it (#1135). The deploy-time wiring (a ``CronSource`` →
+    ``WorkflowAction`` firing every N min with the ``{repo, dev_pipeline_workflow_id}`` input
+    template, on a session whose agent surface SUPERSETS this surface — the launcher-clamp rule)
+    lives outside this object.
+    """
+    return WorkflowCreate(
+        name=name,
+        description=description,
+        script=build_post_merge_checker_script(github_server=github_server, **script_kwargs),
+        tools=list(REQUIRED_TOOLS),
+        http_servers=[_github_http_server(name=github_server, base_url=github_base_url)],
+    )

--- a/tests/integration/test_wf_dev_pipeline_post_merge_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_post_merge_fixture.py
@@ -121,6 +121,15 @@ class Scenario:
     def _http(self, args: dict[str, Any]) -> dict[str, Any]:
         method, path = args["method"], args["path"]
         self.http.append((method, path))
+        # BEHAVIORAL maker≠checker-across-the-boundary guard: the checker READS + ESCALATES only.
+        # It must NEVER emit a mutating verb — no PUT (merge), no PATCH (close an issue), no DELETE
+        # (unlabel). The deploy surface (GET·POST-only) rejects these in prod, but assert it here
+        # too so a future _BODY edit that regresses into _unlabel/merge/close fails LOUD in CI
+        # rather than slipping past the catch-all into the surface-rejection failure mode.
+        assert method in ("GET", "POST"), (
+            f"post-merge checker emitted a MUTATING verb {method} {path} — it must only read + "
+            "escalate (it can never mutate the merge it judges)"
+        )
         clean = path.split("?", 1)[0]
 
         # the closed/merged PR list
@@ -467,6 +476,30 @@ async def test_missing_repo_with_no_default_is_cannot_determine() -> None:
     out = await run_script_host(source=src, input={}, memo={})
     assert out.kind == "returned"
     assert out.value["verdict"] == "cannot-determine"
+
+
+async def test_string_scan_limit_is_coerced_not_a_crash() -> None:
+    # A cron config can deliver scan_limit as a JSON STRING. It must coerce to an int (used in a
+    # `len(runs) >= limit` comparison on the run-journal witness path) — a string would TypeError
+    # mid-sweep. Pair a string limit WITH a wired workflow_id (the witness path that does the
+    # comparison) so the regression would actually fire.
+    scn = Scenario(
+        merged_prs=[_merged_pr(80, labels=_gate_labels())],
+        issue_states={80: "closed"},
+        completed_run_issues=[80],
+    )
+    value = await _drive(
+        scn,
+        input={"repo": REPO, "scan_limit": "50", "dev_pipeline_workflow_id": WF},
+    )
+    assert value["verdict"] == "ok"
+    assert value["scanned"] == 1
+
+
+async def test_nonnumeric_scan_limit_falls_back_to_default() -> None:
+    # A garbage scan_limit must fall back to the default, never crash the sweep.
+    value = await _drive(Scenario(), input={"repo": REPO, "scan_limit": "not-a-number"})
+    assert value["verdict"] == "ok"
 
 
 # ─── deploy surface sanity (mirrors the unit assertions through the create) ───

--- a/tests/integration/test_wf_dev_pipeline_post_merge_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_post_merge_fixture.py
@@ -1,0 +1,482 @@
+"""Dev-pipeline POST-MERGE checker reference workflow fixture (task #76; aios#49/#111).
+
+Drives the production ``build_post_merge_checker_script`` directly against the real script host
+(no DB, no live model) with simulated ``http_request`` / ``list_runs`` resolutions, walking the
+stateless config → scan → provenance-witness → master-ci → verify → summary machine. Because the
+host re-runs from the start each wake (replaying the whole growing memo), these tests also assert
+the load-bearing durable property: **replay is deterministic** (every call_key is stable).
+
+It proves task #76's acceptance — the post-merge twin of ``owner()``'s pre-merge gate verifies,
+from durable off-the-run GitHub state, that every recently-merged ``pipeline:v2`` PR:
+
+  * (a) closed its source issue — an OPEN source issue for a merged PR → ``needs:human/issue-open``;
+  * (b) did not leave master red — a RED master post-merge → ``needs:human/master-red`` (#1188);
+  * (c) merged THROUGH the maker≠checker gate — a ``pipeline:v2`` PR merged WITHOUT the
+    ``reviewed:green@<sha>`` + in-cap ``risk:tier-N`` stamp → ``needs:human/bad-provenance``.
+
+Plus: a CLEAN merge passes and is stamped ``post-merge:checked@<sha>`` (verified ONCE — a re-sweep
+skips it, idempotent); a violation is NEVER silently passed; a truncated/degraded read fails LOUD
+cannot-determine, never a silent "no regressions"; and the structured per-sweep summary (verdict +
+found + checked) is the primary output.
+
+Mirrors the host-subprocess style of ``test_wf_gate_reaper_fixture.py`` /
+``test_wf_dev_pipeline_reconciler_fixture.py``; needs no Postgres.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+
+from aios.models.agents import HttpServerSpec
+from aios.workflows.dev_pipeline_post_merge import (
+    REQUIRED_TOOLS,
+    build_post_merge_checker_fixture_script,
+    build_post_merge_checker_workflow_create,
+)
+from aios.workflows.host_launcher import run_script_host
+
+pytestmark = pytest.mark.integration
+
+REPO = "o/r"
+WF = "wf_dev_pipeline"
+V2 = "pipeline:v2"
+SHA = "a" * 40  # a merged PR's merge_commit_sha
+MASTER_SHA = "f" * 40  # the resolved BASE_BRANCH head
+
+
+def _merged_pr(
+    number: int,
+    *,
+    labels: list[str] | None = None,
+    head_ref: str | None = None,
+    merge_commit_sha: str = SHA,
+    merged: bool = True,
+) -> dict[str, Any]:
+    """A CLOSED+MERGED PR row, as the closed-PR list returns it (carries merged_at +
+    merge_commit_sha + the head ref the source-issue number is derived from)."""
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "state": "closed",
+        "merged_at": "2026-06-18T12:00:00+00:00" if merged else None,
+        "merge_commit_sha": merge_commit_sha,
+        "head": {"ref": head_ref or f"dev-pipeline/issue-{number}", "sha": SHA},
+        "labels": [{"name": n} for n in (labels or [])],
+    }
+
+
+def _gate_labels(reviewed_sha: str = SHA, tier: int = 2) -> list[str]:
+    """The reconciler's durable gate provenance: pipeline:v2 + reviewed:green@<sha> + risk:tier-N."""
+    return [V2, f"reviewed:green@{reviewed_sha}", f"risk:tier-{tier}"]
+
+
+class Scenario:
+    """A deterministic responder + a record of what the checker asked for. Models the GitHub REST
+    surface the checker reads/writes (closed-PR list, the source issue's state, master's CI
+    surfaces, comment threads, the escalation POSTs) + the list_runs provenance witness. Keyed on
+    the capability so replay is a pure function of the call_key."""
+
+    def __init__(
+        self,
+        *,
+        merged_prs: list[dict[str, Any]] | None = None,
+        issue_states: dict[int, str] | None = None,
+        master_check_runs: list[dict[str, Any]] | None = None,
+        master_combined: dict[str, Any] | None = None,
+        completed_run_issues: list[int] | None = None,
+        prs_list_status: int = 200,
+        issue_read_status: int = 200,
+        list_runs_error: bool = False,
+        existing_comments: dict[int, list[str]] | None = None,
+    ) -> None:
+        self.merged_prs = merged_prs or []
+        # issue_number -> "open"|"closed" (default closed: the happy path)
+        self.issue_states = issue_states or {}
+        # master CI surfaces (default: a single passing check-run => green master)
+        self.master_check_runs = (
+            master_check_runs
+            if master_check_runs is not None
+            else [{"status": "completed", "conclusion": "success"}]
+        )
+        self.master_combined = (
+            master_combined
+            if master_combined is not None
+            else {"total_count": 0, "state": "success"}
+        )
+        self.completed_run_issues = completed_run_issues or []
+        self.prs_list_status = prs_list_status
+        self.issue_read_status = issue_read_status
+        self.list_runs_error = list_runs_error
+        self.existing_comments = existing_comments or {}
+        # observability
+        self.http: list[tuple[str, str]] = []
+        self.labels_added: dict[int, list[str]] = {}
+        self.comments_posted: dict[int, list[str]] = {}
+        self.list_runs_calls: list[dict[str, Any]] = []
+
+    def _http(self, args: dict[str, Any]) -> dict[str, Any]:
+        method, path = args["method"], args["path"]
+        self.http.append((method, path))
+        clean = path.split("?", 1)[0]
+
+        # the closed/merged PR list
+        if method == "GET" and clean == "/repos/o/r/pulls":
+            if self.prs_list_status != 200:
+                return {"status": self.prs_list_status, "body": "{}"}
+            return {"status": 200, "headers": {}, "body": json.dumps(self.merged_prs)}
+
+        # the source issue's state (check a)
+        mi = re.match(r"^/repos/o/r/issues/(\d+)$", clean)
+        if method == "GET" and mi:
+            if self.issue_read_status != 200:
+                return {"status": self.issue_read_status, "body": "{}"}
+            n = int(mi.group(1))
+            state = self.issue_states.get(n, "closed")
+            return {"status": 200, "body": json.dumps({"number": n, "state": state})}
+
+        # master's CI surfaces (check b) — resolve BASE_BRANCH, then check-runs + combined status
+        if method == "GET" and re.match(r"^/repos/o/r/commits/[^/]+$", clean):
+            # _resolve_sha1: GET /commits/{ref} -> canonical SHA-1
+            return {"status": 200, "body": json.dumps({"sha": MASTER_SHA})}
+        if method == "GET" and clean.endswith("/check-runs"):
+            return {"status": 200, "body": json.dumps({"check_runs": self.master_check_runs})}
+        if method == "GET" and re.match(r"^/repos/o/r/commits/[^/]+/status$", clean):
+            return {"status": 200, "body": json.dumps(self.master_combined)}
+
+        # comment thread reads (post_markered_comment fetches first)
+        mc = re.match(r"^/repos/o/r/issues/(\d+)/comments$", clean)
+        if method == "GET" and mc:
+            n = int(mc.group(1))
+            return {
+                "status": 200,
+                "body": json.dumps([{"body": b} for b in self.existing_comments.get(n, [])]),
+            }
+        if method == "POST" and mc:
+            n = int(mc.group(1))
+            raw = args.get("body")
+            if isinstance(raw, str):
+                self.comments_posted.setdefault(n, []).append(json.loads(raw).get("body", ""))
+            return {"status": 201, "body": "{}"}
+
+        # label POSTs (the escalation + the checked marker)
+        ml = re.match(r"^/repos/o/r/issues/(\d+)/labels$", clean)
+        if method == "POST" and ml:
+            n = int(ml.group(1))
+            raw = args.get("body")
+            if isinstance(raw, str):
+                self.labels_added.setdefault(n, []).extend(json.loads(raw).get("labels", []))
+            return {"status": 200, "body": "[]"}
+
+        return {"status": 200, "body": "{}"}
+
+    def _list_runs(self, args: dict[str, Any]) -> dict[str, Any]:
+        self.list_runs_calls.append(args)
+        if self.list_runs_error:
+            return {"error": "boom"}
+        runs = [
+            {"input": {"repo": REPO, "issue_number": n}, "status": "completed"}
+            for n in self.completed_run_issues
+        ]
+        return {"runs": runs}
+
+    def outcome(self, cap: Any) -> dict[str, Any]:
+        cid, spec = cap.capability_id, cap.spec
+        if cid == "tool":
+            name = spec["tool_name"]
+            if name == "http_request":
+                return {"ok": self._http(spec["input"])}
+            if name == "list_runs":
+                return {"ok": self._list_runs(spec["input"])}
+            raise AssertionError(f"checker called an unexpected tool: {name}")
+        raise AssertionError(f"checker must not emit capability {cid} (no agent/gate); {spec!r}")
+
+
+async def _drive(
+    scenario: Scenario,
+    *,
+    input: dict[str, Any] | None = None,
+    max_steps: int = 200,
+    **build_kwargs: Any,
+) -> Any:
+    """Drive the production post-merge checker to a terminal outcome; assert replay-determinism."""
+    src = build_post_merge_checker_fixture_script(repo=REPO, **build_kwargs)
+    inp = {"repo": REPO} if input is None else input
+    memo: dict[str, Any] = {}
+    keys: list[str] = []
+    for _ in range(max_steps):
+        out = await run_script_host(source=src, input=inp, memo=memo)
+        if out.kind == "returned":
+            assert len(keys) == len(set(keys)), "replay produced a duplicate call_key"
+            return out.value
+        assert out.kind == "suspended", (out.kind, out.error_repr, out.error_traceback)
+        assert len(out.emitted) == 1, [(e.capability_id, e.spec) for e in out.emitted]
+        cap = out.emitted[0]
+        keys.append(cap.call_key)
+        memo[cap.call_key] = scenario.outcome(cap)
+    raise AssertionError(f"checker did not terminate within {max_steps} steps")
+
+
+# ─── a board with no merged pipeline PRs is a clean ok no-op ───────────────────
+
+
+async def test_no_merged_v2_prs_is_a_clean_ok() -> None:
+    value = await _drive(Scenario())
+    assert value["verdict"] == "ok"
+    assert value["scanned"] == 0
+    assert value["found"] == []
+
+
+async def test_non_v2_merges_are_invisible() -> None:
+    # Only pipeline:v2 merges are in scope — a merged PR without the routing label is ignored.
+    scn = Scenario(merged_prs=[_merged_pr(50, labels=["some-other-label"])])
+    value = await _drive(scn)
+    assert value["scanned"] == 0
+    assert value["found"] == []
+    assert scn.labels_added == {}  # nothing escalated
+
+
+async def test_closed_but_unmerged_pr_is_ignored() -> None:
+    # A closed-but-NOT-merged PR merged nothing → nothing to verify.
+    scn = Scenario(merged_prs=[_merged_pr(51, labels=_gate_labels(), merged=False)])
+    value = await _drive(scn)
+    assert value["scanned"] == 0
+
+
+# ─── (1) THE CLEAN MERGE PASSES and is checked exactly once ───────────────────
+
+
+async def test_clean_merge_passes_and_is_marked_checked() -> None:
+    # A merged v2 PR: source issue closed, master green, full gate provenance → ok, no escalation,
+    # and stamped post-merge:checked@<merge_sha> (verified once).
+    scn = Scenario(
+        merged_prs=[_merged_pr(60, labels=_gate_labels())],
+        issue_states={60: "closed"},
+        completed_run_issues=[60],
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "ok"
+    assert value["scanned"] == 1
+    assert value["found"] == []
+    assert 60 in value["checked"]
+    assert f"post-merge:checked@{SHA}" in scn.labels_added.get(60, [])
+    # NO needs:human/* escalation on a clean merge
+    assert not any(lbl.startswith("needs:human/") for lbl in scn.labels_added.get(60, []))
+
+
+async def test_already_checked_merge_is_skipped_idempotent() -> None:
+    # A merged PR already carrying post-merge:checked@<sha> for THIS merge sha is skipped — a
+    # re-sweep is a no-op (verified once; idempotent).
+    scn = Scenario(
+        merged_prs=[_merged_pr(61, labels=[*_gate_labels(), f"post-merge:checked@{SHA}"])],
+        issue_states={61: "closed"},
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "ok"
+    assert value["checked"] == []  # not re-checked
+    assert scn.labels_added == {}  # nothing re-stamped
+    # no source-issue read spent on an already-checked merge
+    assert ("GET", "/repos/o/r/issues/61") not in scn.http
+
+
+# ─── (2) ISSUE STAYED OPEN → needs:human/issue-open ───────────────────────────
+
+
+async def test_merged_pr_with_open_source_issue_escalates() -> None:
+    scn = Scenario(
+        merged_prs=[_merged_pr(62, labels=_gate_labels())],
+        issue_states={62: "open"},  # the reconciler's best-effort close did not stick
+        completed_run_issues=[62],
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "regression-found"
+    assert any(f["class"] == "issue-open" for f in value["found"])
+    assert "needs:human/issue-open" in scn.labels_added.get(62, [])
+    assert "autodev:post-merge-regression" in scn.labels_added.get(62, [])
+    # a markered escalation comment was posted (never silent)
+    assert any("source issue stayed OPEN" in c for c in scn.comments_posted.get(62, []))
+    # a violated merge is NOT marked checked (it stays pull-able for the seat)
+    assert f"post-merge:checked@{SHA}" not in scn.labels_added.get(62, [])
+    assert 62 not in value["checked"]
+
+
+# ─── (3) MASTER WENT RED → needs:human/master-red (#1188) ─────────────────────
+
+
+async def test_merge_that_leaves_master_red_escalates() -> None:
+    scn = Scenario(
+        merged_prs=[_merged_pr(63, labels=_gate_labels())],
+        issue_states={63: "closed"},
+        master_check_runs=[{"status": "completed", "conclusion": "failure"}],  # master is RED
+        master_combined={"total_count": 0, "state": "success"},
+        completed_run_issues=[63],
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "regression-found"
+    assert value["master_verdict"] == "red"
+    assert any(f["class"] == "master-red" for f in value["found"])
+    assert "needs:human/master-red" in scn.labels_added.get(63, [])
+    assert any("master is RED" in c for c in scn.comments_posted.get(63, []))
+    # NOT marked checked while master is red
+    assert 63 not in value["checked"]
+
+
+async def test_indeterminate_master_ci_is_cannot_determine_not_ok() -> None:
+    # Master CI still running (a non-terminal check-run) — the sweep cannot declare the merge
+    # clean. Verdict is cannot-determine, NOT a silent ok, and the merge is NOT marked checked.
+    scn = Scenario(
+        merged_prs=[_merged_pr(64, labels=_gate_labels())],
+        issue_states={64: "closed"},
+        master_check_runs=[{"status": "in_progress", "conclusion": None}],  # not terminal
+        master_combined={"total_count": 0, "state": "pending"},
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "cannot-determine"
+    assert value["master_verdict"] == "indeterminate"
+    assert value["found"] == []  # no false regression
+    assert 64 not in value["checked"]  # not declared clean while master CI unsettled
+
+
+# ─── (4) BAD PROVENANCE → needs:human/bad-provenance ──────────────────────────
+
+
+async def test_merged_v2_pr_without_review_stamp_is_bad_provenance() -> None:
+    # A pipeline:v2 PR MERGED carrying NO reviewed:green@<sha> stamp — it bypassed the gate's
+    # maker≠checker review the auto-merge authority is scoped to.
+    scn = Scenario(
+        merged_prs=[_merged_pr(65, labels=[V2, "risk:tier-2"])],  # no reviewed:green@
+        issue_states={65: "closed"},
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "regression-found"
+    assert any(f["class"] == "bad-provenance" for f in value["found"])
+    assert "needs:human/bad-provenance" in scn.labels_added.get(65, [])
+    assert any("without the maker" in c or "bypassed" in c for c in scn.comments_posted.get(65, []))
+
+
+async def test_merged_v2_pr_with_tier_above_cap_is_bad_provenance() -> None:
+    # A pipeline:v2 PR merged carrying risk:tier-4 (ABOVE the auto-merge cap of 3) — the #1158
+    # tier-gate should have routed it to a human, so a merge AT tier-4 is illegitimate provenance.
+    scn = Scenario(
+        merged_prs=[_merged_pr(66, labels=[V2, f"reviewed:green@{SHA}", "risk:tier-4"])],
+        issue_states={66: "closed"},
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "regression-found"
+    assert any(f["class"] == "bad-provenance" for f in value["found"])
+    assert "needs:human/bad-provenance" in scn.labels_added.get(66, [])
+
+
+async def test_clean_provenance_with_run_witness_passes() -> None:
+    # Full gate labels + a completed dev-pipeline run for the issue in the journal → clean.
+    scn = Scenario(
+        merged_prs=[_merged_pr(67, labels=_gate_labels(tier=3))],  # tier-3 == cap, in-cap
+        issue_states={67: "closed"},
+        completed_run_issues=[67],
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "ok"
+    assert value["found"] == []
+    assert 67 in value["checked"]
+
+
+async def test_require_run_provenance_flags_missing_run() -> None:
+    # With REQUIRE_RUN_PROVENANCE on: gate labels present but NO completed run drove the issue →
+    # bad-provenance (the strict posture; the gate labels may have been applied out-of-band).
+    scn = Scenario(
+        merged_prs=[_merged_pr(68, labels=_gate_labels())],
+        issue_states={68: "closed"},
+        completed_run_issues=[],  # no driving run in the journal
+    )
+    value = await _drive(scn, require_run_provenance=True, dev_pipeline_workflow_id=WF)
+    assert value["verdict"] == "regression-found"
+    assert any(f["class"] == "bad-provenance" for f in value["found"])
+
+
+async def test_degraded_run_journal_never_manufactures_a_violation() -> None:
+    # The run-journal read degrades (list_runs error) — even with REQUIRE_RUN_PROVENANCE on, a
+    # degraded witness must NOT manufacture a false bad-provenance; the durable gate labels stand.
+    scn = Scenario(
+        merged_prs=[_merged_pr(69, labels=_gate_labels())],
+        issue_states={69: "closed"},
+        list_runs_error=True,
+    )
+    value = await _drive(scn, require_run_provenance=True, dev_pipeline_workflow_id=WF)
+    assert value["verdict"] == "ok"
+    assert value["witness_ok"] is False
+    assert value["found"] == []
+
+
+# ─── MULTIPLE violations on one merge are all surfaced ────────────────────────
+
+
+async def test_multiple_violations_on_one_merge_all_escalate() -> None:
+    # Open issue AND bad provenance on the same merged PR → both classes found + both labels.
+    scn = Scenario(
+        merged_prs=[_merged_pr(70, labels=[V2])],  # no review stamp, no tier
+        issue_states={70: "open"},
+    )
+    value = await _drive(scn)
+    assert value["verdict"] == "regression-found"
+    classes = {f["class"] for f in value["found"]}
+    assert "issue-open" in classes
+    assert "bad-provenance" in classes
+    added = scn.labels_added.get(70, [])
+    assert "needs:human/issue-open" in added
+    assert "needs:human/bad-provenance" in added
+
+
+# ─── FAIL-LOUD: a degraded merged-PR read is cannot-determine, never silent ok ─
+
+
+async def test_degraded_merged_pr_read_is_cannot_determine() -> None:
+    scn = Scenario(prs_list_status=500)  # the closed-PR list read blips
+    value = await _drive(scn)
+    assert value["verdict"] == "cannot-determine"
+    assert value["scanned"] == 0
+    assert "reason" in value
+
+
+async def test_unreadable_source_issue_is_indeterminate_not_a_false_violation() -> None:
+    # A non-2xx issue read must NOT read as 'issue open' (a false violation) — it is indeterminate
+    # this sweep (re-checked next), and the merge is not declared clean either while a check is
+    # unresolved (provenance still passes, master green, but the issue check abstained).
+    scn = Scenario(
+        merged_prs=[_merged_pr(71, labels=_gate_labels())],
+        issue_read_status=404,
+    )
+    value = await _drive(scn)
+    # the issue check abstained (no issue-open finding manufactured)
+    assert not any(f["class"] == "issue-open" for f in value["found"])
+    assert "needs:human/issue-open" not in scn.labels_added.get(71, [])
+
+
+# ─── input handling ────────────────────────────────────────────────────────────
+
+
+async def test_accepts_cron_trigger_envelope_input() -> None:
+    value = await _drive(Scenario(), input={"trigger": {"source": "cron"}, "input": {"repo": REPO}})
+    assert value["verdict"] == "ok"
+
+
+async def test_missing_repo_with_no_default_is_cannot_determine() -> None:
+    src = build_post_merge_checker_fixture_script()  # no repo default
+    out = await run_script_host(source=src, input={}, memo={})
+    assert out.kind == "returned"
+    assert out.value["verdict"] == "cannot-determine"
+
+
+# ─── deploy surface sanity (mirrors the unit assertions through the create) ───
+
+
+def test_workflow_create_surface_is_read_and_escalate_only() -> None:
+    wc = build_post_merge_checker_workflow_create(name="x")
+    assert {t.type for t in REQUIRED_TOOLS} == {"http_request", "list_runs"}
+    assert len(wc.http_servers) == 1
+    server = wc.http_servers[0]
+    assert isinstance(server, HttpServerSpec)
+    repos = [r for r in server.routes if r.path_pattern == "/repos/**"]
+    assert set(repos[0].methods or []) == {"GET", "POST"}

--- a/tests/unit/test_dev_pipeline_post_merge.py
+++ b/tests/unit/test_dev_pipeline_post_merge.py
@@ -1,0 +1,197 @@
+"""The dev-pipeline POST-MERGE checker — the post-merge twin of ``owner()``'s pre-merge gate
+(task #76; aios#49/#111, the §5 residue of the reconciler design-of-record).
+
+The post-merge checker is a SEPARATE cron-fired workflow that verifies, from DURABLE off-the-run
+GitHub state (an uncorrelated substrate), that every recently-merged ``pipeline:v2`` PR (a) closed
+its source issue, (b) did not leave master red, and (c) merged THROUGH the reconciler's maker≠checker
+gate — escalating any violation via a ``needs:human/*`` label, never silently.
+
+These unit tests pin the STATIC properties: the assembled script bans ``gate()`` + ``datetime``,
+threads the reconciler's tier-cap, parses, defaults the run-provenance posture, and declares the
+correct read+escalate-only deploy surface (no PUT/PATCH/DELETE — the structural guarantee that the
+checker can NEVER mutate the merge it judges). The behavioural three-check machine is exercised
+end-to-end against the host in ``tests/integration/test_wf_dev_pipeline_post_merge_fixture.py``.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from aios.models.agents import HttpServerSpec
+from aios.models.workflows import WorkflowCreate
+from aios.workflows.dev_pipeline_post_merge import (
+    DEFAULT_ESCALATED_LABEL,
+    LABEL_CHECKED_PREFIX,
+    NEEDS_HUMAN_BAD_PROVENANCE,
+    NEEDS_HUMAN_ISSUE_OPEN,
+    NEEDS_HUMAN_MASTER_RED,
+    REQUIRED_HTTP_SERVERS,
+    REQUIRED_TOOLS,
+    build_post_merge_checker_fixture_script,
+    build_post_merge_checker_script,
+    build_post_merge_checker_workflow_create,
+)
+from aios.workflows.dev_pipeline_reconciler import (
+    AUTO_MERGE_MAX_TIER,
+    LABEL_PIPELINE_V2,
+    LABEL_REVIEWED_PREFIX,
+    LABEL_RISK_PREFIX,
+)
+
+# ════════════════════════════════════════════════════════════════════════════
+# SAFETY — gate() is BANNED in the assembled script; no datetime/time import.
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def _gate_call_count(src: str) -> int:
+    """Count actual ``gate(...)`` CALL nodes (bare-name AND attribute form), so a smuggled
+    suspend can't slip past the ban — mirrors the reconciler's guard."""
+    tree = ast.parse(src)
+    count = 0
+    for n in ast.walk(tree):
+        if not isinstance(n, ast.Call):
+            continue
+        func = n.func
+        if (isinstance(func, ast.Name) and func.id == "gate") or (
+            isinstance(func, ast.Attribute) and func.attr == "gate"
+        ):
+            count += 1
+    return count
+
+
+def test_assembled_script_has_zero_gate_calls() -> None:
+    # The checker is a stateless sweep — gate() would suspend the whole run (an orphan), and the
+    # checker MUST stay a re-derivable backstop. Escalation is a durable needs:human/* label.
+    for src in (
+        build_post_merge_checker_script(repo="o/r"),
+        build_post_merge_checker_fixture_script(repo="o/r"),
+    ):
+        assert _gate_call_count(src) == 0
+        tree = ast.parse(src)
+        for n in ast.walk(tree):
+            if isinstance(n, ast.ImportFrom):
+                assert all(a.name != "gate" for a in n.names), "gate must never be imported/aliased"
+            if isinstance(n, ast.Assign) and isinstance(n.value, ast.Name):
+                assert n.value.id != "gate", "gate must never be rebound to an alias"
+
+
+def test_assembled_script_excludes_datetime_import() -> None:
+    # No datetime/time — the checker reads recency off GitHub's merged_at ordering, never a clock.
+    src = build_post_merge_checker_script(repo="o/r")
+    assert "import datetime" not in src
+    assert "import time" not in src
+
+
+def test_assembled_script_parses() -> None:
+    ast.parse(build_post_merge_checker_script(repo="o/r"))
+
+
+def test_post_merge_body_emits_no_agent_or_gate_call() -> None:
+    # The checker's verdict is MECHANICAL + off-the-run: it calls only tool() (http_request +
+    # list_runs), never agent() and never gate(). The spliced DEV_PIPELINE_LIB *defines* helpers
+    # that call agent() (e.g. _watch_ci), but the checker body never INVOKES them — so the body
+    # itself (everything before the DEV_PIPELINE_LIB splice) contains no agent()/gate() call, and
+    # the deploy surface carries no "agent"/"gate" tool.
+    src = build_post_merge_checker_script(repo="o/r")
+    body_only = src.split("# ─── scripted helpers")[0]  # the _BODY, before DEV_PIPELINE_LIB
+    assert "await agent(" not in body_only
+    assert "gate(" not in body_only
+    assert {t.type for t in REQUIRED_TOOLS} == {"http_request", "list_runs"}
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# PROVENANCE VOCABULARY — imported from the reconciler (one source of truth).
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_provenance_vocabulary_is_the_reconcilers() -> None:
+    # The checker validates EXACTLY the labels the reconciler STAMPS — a relabel on one side can
+    # never silently desync the verification. These are imported, not re-spelled.
+    src = build_post_merge_checker_script(repo="o/r")
+    assert f"AUTO_MERGE_MAX_TIER = {AUTO_MERGE_MAX_TIER}" in src
+    assert LABEL_PIPELINE_V2 in src
+    assert LABEL_REVIEWED_PREFIX in src
+    assert LABEL_RISK_PREFIX in src
+
+
+def test_tier_cap_threads_from_the_reconciler() -> None:
+    # The checker's provenance check uses the SAME #1158 tier-cap the reconciler's merge branch
+    # enforced — so a tier>cap merge is flagged as bad provenance with the same threshold.
+    src = build_post_merge_checker_script(repo="o/r", auto_merge_max_tier=2)
+    assert "AUTO_MERGE_MAX_TIER = 2" in src
+
+
+def test_the_three_escalation_labels_are_present() -> None:
+    src = build_post_merge_checker_script(repo="o/r")
+    for lbl in (NEEDS_HUMAN_ISSUE_OPEN, NEEDS_HUMAN_MASTER_RED, NEEDS_HUMAN_BAD_PROVENANCE):
+        assert lbl in src
+    assert LABEL_CHECKED_PREFIX in src
+    assert DEFAULT_ESCALATED_LABEL in src
+
+
+def test_require_run_provenance_defaults_off() -> None:
+    # The run journal is a SECONDARY witness by default — the durable GitHub gate labels are the
+    # primary provenance, so a degraded/empty list_runs read never manufactures a false violation.
+    src = build_post_merge_checker_script(repo="o/r")
+    assert "REQUIRE_RUN_PROVENANCE = False" in src
+
+
+def test_require_run_provenance_flips_on() -> None:
+    src = build_post_merge_checker_script(repo="o/r", require_run_provenance=True)
+    assert "REQUIRE_RUN_PROVENANCE = True" in src
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# DEPLOY SURFACE — read + escalate ONLY (no merge/close/resolve = structural
+# maker≠checker-across-the-merge-boundary).
+# ════════════════════════════════════════════════════════════════════════════
+
+
+def test_required_tools_are_http_and_list_runs_only() -> None:
+    # The checker READS GitHub + the run journal and POSTs only the escalation comment/labels.
+    # No bash/read/write/edit/agent/gate — it cannot build, merge, or resolve anything.
+    assert {t.type for t in REQUIRED_TOOLS} == {"http_request", "list_runs"}
+
+
+def test_required_tools_have_no_duplicates() -> None:
+    types = [t.type for t in REQUIRED_TOOLS]
+    assert len(types) == len(set(types))
+
+
+def test_github_server_is_get_post_only_no_mutation_of_the_merge() -> None:
+    # The structural guarantee: the surface carries NO PUT/PATCH/DELETE, so the checker CANNOT
+    # merge, close an issue, unlabel, or resolve a gate — it can only escalate (POST comment +
+    # label). A checker that could mutate the merge it judges would not be an uncorrelated backstop.
+    assert len(REQUIRED_HTTP_SERVERS) == 1
+    server = REQUIRED_HTTP_SERVERS[0]
+    assert server.name == "github"
+    repos = [r for r in server.routes if r.path_pattern == "/repos/**"]
+    assert len(repos) == 1
+    assert set(repos[0].methods or []) == {"GET", "POST"}
+    assert "PUT" not in (repos[0].methods or [])
+    assert "PATCH" not in (repos[0].methods or [])
+    assert "DELETE" not in (repos[0].methods or [])
+    assert repos[0].allow_query is True
+
+
+def test_workflow_create_is_valid_and_carries_surface() -> None:
+    wc = build_post_merge_checker_workflow_create(name="dev-pipeline-post-merge-checker")
+    assert isinstance(wc, WorkflowCreate)
+    assert wc.name == "dev-pipeline-post-merge-checker"
+    assert wc.script == build_post_merge_checker_script()
+    assert {t.type for t in wc.tools} == {t.type for t in REQUIRED_TOOLS}
+    assert len(wc.http_servers) == 1
+    server = wc.http_servers[0]
+    assert isinstance(server, HttpServerSpec)
+    assert server.name == "github"
+
+
+def test_workflow_create_github_server_name_threads_into_script() -> None:
+    wc = build_post_merge_checker_workflow_create(name="r", github_server="gh")
+    assert any(isinstance(s, HttpServerSpec) and s.name == "gh" for s in wc.http_servers)
+    assert "'gh'" in wc.script or '"gh"' in wc.script
+
+
+def test_workflow_create_forwards_require_run_provenance_kwarg() -> None:
+    wc = build_post_merge_checker_workflow_create(name="r", require_run_provenance=True)
+    assert "REQUIRE_RUN_PROVENANCE = True" in wc.script


### PR DESCRIPTION
## What

Builds **task #76** — the **post-merge reconciliation checker** — the safety backstop that lets the dev-pipeline reconciler safely flip from advisory to **REAL-MERGE**. It is the **post-merge twin of `owner()`'s pre-merge gate**: maker≠checker *across* the merge boundary.

Design-of-record: [`eumemic-company/architecture/dev-pipeline-reconciler-design.md`](https://github.com/eumemic/eumemic-company/blob/master/architecture/dev-pipeline-reconciler-design.md) §5 (the honest residue) + row 12 of the state→owner map. Discharges chairman decision 2 ("advisory-merge until #76").

## Why

The reconciler's maker≠checker split (`dev-implement` ≠ `dev-review`) is **structural separation, not detection-independence** — builder and reviewer run on the same correlated LLM family. And every pre-merge check (CI, the LLM review, the mechanical merge-guard) runs on the PR's **own** `refs/pull/N/merge` ref — **none reaches past the merge boundary**. So a PR that passed CI *and* review can still break `master` once it lands (the #1188 post-merge-regression class), and a failed best-effort close leaves a stuck issue open. **Green CI cannot reach past the merge boundary.**

## How

A **separate cron-fired stateless workflow** (the `gate_reaper` / `telemetry_observer` dead-man idiom), so its verdict draws from an **uncorrelated, off-the-run substrate** — the durable GitHub state + the run journal. For every recently-merged `pipeline:v2` PR not yet checked, it verifies:

- **(a) the source issue ended CLOSED** (derived from the `dev-pipeline/issue-<n>` branch) — else `needs:human/issue-open`.
- **(b) the merge did not leave master RED** — a deterministic Checks + combined-status read on the base branch (no agent, no model) — else `needs:human/master-red` (the #1188 alarm).
- **(c) the provenance was legitimate** — merged *through* the reconciler's gate, carrying its `reviewed:green@<sha>` + in-cap `risk:tier-N` stamps; a `pipeline:v2` PR merged without them bypassed the review the auto-merge authority is scoped to — else `needs:human/bad-provenance`. Run-journal corroboration via `list_runs` (run-readable since #1397) is a **secondary** witness, off by default.

On any violation → a durable `needs:human/*` label + **one idempotent markered comment** (never silently). A clean merge is stamped `post-merge:checked@<merge_sha>` (verified **exactly once**). The provenance vocabulary (`pipeline:v2` / `reviewed:green@` / `risk:tier-N` / `AUTO_MERGE_MAX_TIER`) is **imported verbatim** from the reconciler so a relabel can't desync the verification; the CI read + the source-issue branch convention come from `dev_pipeline_lib`.

### Invariants held
- **`gate()` banned**, no `datetime`/`time` — replay-stable.
- **Fail-loud on degrade**: a truncated read is `cannot-determine`, never a silent "no regressions". An indeterminate master CI is re-checked next sweep, never coerced to green.
- **Read + escalate ONLY**: `REQUIRED_TOOLS = [http_request, list_runs]`, a GET·POST-only `github` server — **no PUT/PATCH/DELETE, no gate**. The checker **structurally cannot mutate the merge it judges** (asserted both at the deploy-surface level *and* behaviorally in the fixture).

## Tests (36)

- Clean merge passes + is checked once; **issue-open / master-red / bad-provenance each escalate**; tier-above-cap merge flagged; multiple violations on one merge all surface.
- Idempotent re-sweep skips an already-checked merge sha; indeterminate master CI is `cannot-determine`, not a false `ok`; degraded reads fail loud.
- Replay-deterministic host fixture (every call_key stable).
- Review-fold: `scan_limit` string coercion, garbage-limit fallback, behavioral no-mutating-verb assertion.

## Deploy

This PR builds the module + tests only. It does **not** register or flip anything — the seat registers the standing cron workflow and flips the reconciler to real-merge **deliberately**, while watching the first real-merges (mechanism reported to the seat separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)