### PR TITLE
MCP tool discovery is re-polled uncached every step with no per-server timeout — one slow MCP server stalls the whole turn

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -975,12 +975,40 @@ async def discover_session_mcp_tools(
 
     crypto_box = runtime.require_crypto_box()
 
+    # Binding identity for the discovery result cache (#1391): the agent id +
+    # version. The tool set is agent-definition-level and immutable within a
+    # version, so caching on this key is correct — a version bump lands on a
+    # fresh key (re-discovers), while a static binding serves from cache and
+    # pays no per-step ``list_tools()`` RPC. Frozen-surface / version-pinned
+    # sessions keep one (id, version) for the session lifetime, so they serve
+    # from cache for the whole session with no rediscovery.
+    binding_id = f"{getattr(agent, 'id', '?')}:{getattr(agent, 'version', '?')}"
+
+    # Circuit breaker (#1391): skip a server whose discovery recently timed out /
+    # failed so one unresponsive server can't re-stall the prelude every step —
+    # the agent proceeds degraded on the healthy servers' (possibly cached) tools.
+    from aios.mcp.client import _DISCOVERY_UNHEALTHY_BACKOFF_S
+
     async def _discover_one(spec: McpServerSpec) -> tuple[list[dict[str, Any]], str | None]:
         vault_id, headers = await resolve_auth_for_target_url(
             pool, crypto_box, session_id, spec.url, account_id=account_id
         )
+        _pool = runtime.mcp_session_pool
+        if _pool is not None:
+            from aios.mcp.client import _headers_key
+
+            hkey = _headers_key(spec.headers)
+            # A cached result is always served (cheap, no RPC) even while the
+            # circuit is open; only an uncached discovery is short-circuited.
+            if _pool.get_cached_tools(spec.url, vault_id, hkey, binding_id) is None and (
+                _pool.is_unhealthy(spec.url, vault_id, hkey)
+            ):
+                raise TimeoutError(
+                    f"MCP server {spec.name!r} discovery skipped: "
+                    f"in backoff ({_DISCOVERY_UNHEALTHY_BACKOFF_S:.0f}s) after a prior timeout"
+                )
         return await discover_mcp_tools(
-            spec.url, vault_id, headers, spec.name, spec_headers=spec.headers
+            spec.url, vault_id, headers, spec.name, spec_headers=spec.headers, binding_id=binding_id
         )
 
     # Discovery runs as part of the step prelude — a process the model

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -406,9 +406,7 @@ async def discover_mcp_tools(
                 result = await _list_tools_timed(entry.session)
             except BaseException:
                 await asyncio.shield(_pool.discard(url, vault_id, hkey, entry))
-                _pool.mark_unhealthy(
-                    url, vault_id, hkey, backoff_s=_DISCOVERY_UNHEALTHY_BACKOFF_S
-                )
+                _pool.mark_unhealthy(url, vault_id, hkey, backoff_s=_DISCOVERY_UNHEALTHY_BACKOFF_S)
                 raise
             else:
                 await asyncio.shield(_pool.release(url, vault_id, hkey, entry))
@@ -443,9 +441,7 @@ async def discover_mcp_tools(
     if _pool is not None and binding_id is not None:
         # Cache the freshly-discovered result so the next step (same binding
         # identity, no list_changed) serves it without a list_tools() RPC (#1391).
-        _pool.set_cached_tools(
-            url, vault_id, hkey, binding_id, tools, init_result.instructions
-        )
+        _pool.set_cached_tools(url, vault_id, hkey, binding_id, tools, init_result.instructions)
     return tools, init_result.instructions
 
 

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -105,6 +105,20 @@ MAX_TOOLS_PER_SERVER = 128
 # ``harness/completion.py``.
 _TOOL_CALL_TIMEOUT_S = 120.0
 
+# Per-server bound for discovery ``list_tools()`` (#1391). Previously discovery
+# had no ceiling but the httpx read timeout + the 960s step budget, so a single
+# unresponsive server could starve the whole turn prelude until the step budget
+# fired (then re-hang on retry). This caps each server's discovery so a slow one
+# is skipped — degraded, not dead — rather than stalling every prelude. Tighter
+# than ``_TOOL_CALL_TIMEOUT_S`` because discovery is a synchronous prelude leg the
+# model didn't initiate, not real work.
+_DISCOVERY_TIMEOUT_S = 30.0
+
+# Backoff applied to a transport key whose discovery timed out / failed, so the
+# next several preludes skip it fast via the pool circuit breaker instead of
+# re-stalling each step (#1391).
+_DISCOVERY_UNHEALTHY_BACKOFF_S = 60.0
+
 # httpx client bounds for MCP transport. ``read`` is the longest leg —
 # tool calls that do real work (DB lookups, external APIs) commonly take
 # tens of seconds. Connect/write/pool are tight because they're network
@@ -313,6 +327,19 @@ async def _auth_from_credential(
     return vault_id, headers
 
 
+async def _list_tools_timed(session: ClientSession) -> Any:
+    """``session.list_tools()`` under a per-server discovery timeout (#1391).
+
+    The discovery RPC previously had no finite ceiling other than the httpx read
+    timeout and the outer 960s step budget, so a hung server starved the entire
+    turn prelude. Wrapping it in ``asyncio.timeout`` mirrors the proven
+    ``_call_tool_fast`` bound on invocation and converts a stall into a prompt
+    ``TimeoutError`` the caller can mark unhealthy + skip.
+    """
+    async with asyncio.timeout(_DISCOVERY_TIMEOUT_S):
+        return await session.list_tools()
+
+
 async def discover_mcp_tools(
     url: str,
     vault_id: str | None,
@@ -320,6 +347,7 @@ async def discover_mcp_tools(
     server_name: str,
     *,
     spec_headers: dict[str, str] | None = None,
+    binding_id: str | None = None,
 ) -> tuple[list[dict[str, Any]], str | None]:
     """Connect to an MCP server and discover available tools.
 
@@ -332,12 +360,26 @@ async def discover_mcp_tools(
       any. Used by the harness to compose per-connector affordance prose
       into the system prompt.
 
-    Raises on transport / protocol / auth failure. Callers decide how to
-    surface the error: the step prelude (``discover_session_mcp_tools``)
-    logs at WARN and filters the failed server out of the tools and
-    instructions it returns, since the model didn't consciously initiate
-    that discovery. The broker HTTP handlers translate it into a 502
-    response because the sandboxed model DID initiate the call.
+    When ``binding_id`` is supplied and the worker pool is present, the
+    ``(tools, instructions)`` result is cached on the pool keyed on the
+    transport identity + ``binding_id`` (#1391). A cache hit skips the
+    ``list_tools()`` RPC entirely, so the per-step prelude no longer re-polls a
+    static tool set every turn; the cache is invalidated by a binding-identity
+    bump (a fresh key misses) or the server's ``tools/list_changed``
+    notification. ``binding_id`` is ``None`` for the API-process / test path
+    (no caching).
+
+    The discovery ``list_tools()`` is bounded by ``_DISCOVERY_TIMEOUT_S``; on a
+    timeout / transport failure the transport key is marked unhealthy on the
+    pool so subsequent preludes can skip it fast (circuit breaker) rather than
+    re-stalling every step.
+
+    Raises on transport / protocol / auth failure (including discovery
+    timeout). Callers decide how to surface the error: the step prelude
+    (``discover_session_mcp_tools``) logs at WARN and filters the failed server
+    out of the tools and instructions it returns, since the model didn't
+    consciously initiate that discovery. The broker HTTP handlers translate it
+    into a 502 response because the sandboxed model DID initiate the call.
     """
     from aios.harness import runtime
 
@@ -345,20 +387,28 @@ async def discover_mcp_tools(
     merged = _merge_headers(spec_headers, headers)
     hkey = _headers_key(spec_headers)
 
+    if _pool is not None and binding_id is not None:
+        cached = _pool.get_cached_tools(url, vault_id, hkey, binding_id)
+        if cached is not None:
+            return cached[0], cached[1]
+
     if _pool is not None:
         # Pool path: check out a session; on a transport/protocol error discard
         # it and retry once with a fresh one. Always release-or-discard so the
         # per-key cap slot is freed.
         entry = await _pool.acquire(url, vault_id, hkey, merged)
         try:
-            result = await entry.session.list_tools()
+            result = await _list_tools_timed(entry.session)
         except Exception:
             await asyncio.shield(_pool.discard(url, vault_id, hkey, entry))
             entry = await _pool.acquire(url, vault_id, hkey, merged)
             try:
-                result = await entry.session.list_tools()
+                result = await _list_tools_timed(entry.session)
             except BaseException:
                 await asyncio.shield(_pool.discard(url, vault_id, hkey, entry))
+                _pool.mark_unhealthy(
+                    url, vault_id, hkey, backoff_s=_DISCOVERY_UNHEALTHY_BACKOFF_S
+                )
                 raise
             else:
                 await asyncio.shield(_pool.release(url, vault_id, hkey, entry))
@@ -371,11 +421,12 @@ async def discover_mcp_tools(
         else:
             await asyncio.shield(_pool.release(url, vault_id, hkey, entry))
         init_result = entry.init_result
+        _pool.mark_healthy(url, vault_id, hkey)
     else:
         # Fallback: fresh connection per call (API process, tests).
         async with AsyncExitStack() as stack:
             session, init_result = await _open_session(url, merged, stack)
-            result = await session.list_tools()
+            result = await _list_tools_timed(session)
 
     if len(result.tools) > MAX_TOOLS_PER_SERVER:
         log.warning(
@@ -389,6 +440,12 @@ async def discover_mcp_tools(
         make_function_tool(f"mcp__{server_name}__{tool.name}", tool)
         for tool in result.tools[:MAX_TOOLS_PER_SERVER]
     ]
+    if _pool is not None and binding_id is not None:
+        # Cache the freshly-discovered result so the next step (same binding
+        # identity, no list_changed) serves it without a list_tools() RPC (#1391).
+        _pool.set_cached_tools(
+            url, vault_id, hkey, binding_id, tools, init_result.instructions
+        )
     return tools, init_result.instructions
 
 

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -51,7 +51,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import httpx
-from mcp.client.session import ClientSession
+from mcp.client.session import ClientSession, MessageHandlerFnT
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import InitializeResult
 
@@ -202,6 +202,22 @@ class McpSessionPool:
         # before close() unwinds the owner task's contexts — defeating
         # the leak fix.
         self._close_tasks: set[asyncio.Task[None]] = set()
+        # Discovered-tool-list result cache (#1391). Keyed on
+        # ``(_PoolKey, binding_id)`` where ``binding_id`` is the caller's
+        # binding identity (agent id + version, or the frozen-surface hash) —
+        # the precondition that makes the tool set static across steps. Caches
+        # the FULL ``(tools, instructions)`` discovery result so the per-step
+        # prelude no longer re-pays a ``list_tools()`` RPC every turn ("connection
+        # reuse" was never "result reuse"). Invalidated on a binding-identity
+        # change (a new key never hits) or a ``tools/list_changed`` notification
+        # (which drops every binding's entry for the affected _PoolKey).
+        self._tool_cache: dict[tuple[_PoolKey, str], tuple[list[Any], str | None]] = {}
+        # Per-_PoolKey circuit breaker (#1391). When discovery times out or the
+        # transport fails, the key is marked unhealthy until ``unhealthy_until``
+        # (monotonic seconds) so the next prelude SKIPS it fast instead of
+        # re-stalling for the per-server timeout every step. A successful
+        # discovery clears the entry.
+        self._unhealthy_until: dict[_PoolKey, float] = {}
 
     def _condition_for(self, key: _PoolKey) -> asyncio.Condition:
         cond = self._conditions.get(key)
@@ -236,7 +252,31 @@ class McpSessionPool:
         self._close_tasks.add(task)
         task.add_done_callback(self._close_tasks.discard)
 
-    async def _open_entry(self, url: str, headers: dict[str, str]) -> _Entry:
+    def _make_list_changed_handler(self, key: _PoolKey) -> MessageHandlerFnT:
+        """Build a ``ClientSession`` message handler that invalidates the tool
+        cache on a ``tools/list_changed`` notification (#1391).
+
+        The MCP spec's ``notifications/tools/list_changed`` is the protocol's
+        own cache-invalidation signal — previously unhandled, so aios ignored it
+        and unconditionally re-polled. Registering this handler lets a server
+        push an updated tool set: the cached ``(tools, instructions)`` for every
+        binding on this transport key is dropped, and the next prelude
+        re-discovers. Non-notification messages (server requests, exceptions)
+        are passed through unchanged.
+        """
+        from mcp.types import ServerNotification, ToolListChangedNotification
+
+        async def _handler(message: Any) -> None:
+            if isinstance(message, ServerNotification) and isinstance(
+                message.root, ToolListChangedNotification
+            ):
+                self._invalidate_tools_for_pool_key(key)
+
+        return _handler
+
+    async def _open_entry(
+        self, url: str, headers: dict[str, str], key: _PoolKey | None = None
+    ) -> _Entry:
         """Open a fresh session inside a dedicated long-lived owner task.
 
         The contexts (httpx client, streamable-http client, ClientSession)
@@ -244,11 +284,16 @@ class McpSessionPool:
         the anyio cancel-scope constraint. The task signals ``ready`` once
         the session is initialized, then awaits ``shutdown`` so the
         contexts stay open for the entry's lifetime.
+
+        When ``key`` is supplied, a ``tools/list_changed`` message handler is
+        registered on the session so the server's own invalidation signal drops
+        the cached tool list for that transport key (#1391).
         """
         ready = asyncio.Event()
         shutdown = asyncio.Event()
         sink = HttpErrorSink()
         result: dict[str, Any] = {}
+        message_handler = self._make_list_changed_handler(key) if key is not None else None
 
         async def _own() -> None:
             try:
@@ -264,7 +309,7 @@ class McpSessionPool:
                         streamable_http_client(url, http_client=http_client)
                     )
                     session = await stack.enter_async_context(
-                        ClientSession(read_stream, write_stream)
+                        ClientSession(read_stream, write_stream, message_handler=message_handler)
                     )
                     result["session"] = session
                     result["init"] = await session.initialize()
@@ -324,7 +369,7 @@ class McpSessionPool:
                     return entry
                 if len(self._in_use.get(key, set())) < MAX_SESSIONS_PER_KEY:
                     log.info("mcp_pool.connecting", url=url)
-                    entry = await self._open_entry(url, headers)
+                    entry = await self._open_entry(url, headers, key)
                     self._in_use.setdefault(key, set()).add(entry)
                     log.info("mcp_pool.connected", url=url)
                     return entry
@@ -432,6 +477,9 @@ class McpSessionPool:
                 for entry in self._in_use.get(key, set()):
                     entry.discard_on_release = True
                     flagged += 1
+        # Drop any cached tool lists discovered under the rotated identity so a
+        # re-auth re-discovers rather than serving the stale-identity set (#1391).
+        self.invalidate_tools_by_vault(vault_id)
         if idle_closed or flagged:
             log.info(
                 "mcp_pool.evict_by_vault",
@@ -439,6 +487,97 @@ class McpSessionPool:
                 idle_closed=idle_closed,
                 in_use_flagged=flagged,
             )
+
+    # ── tool-list result cache (#1391) ────────────────────────────────────
+
+    def get_cached_tools(
+        self, url: str, vault_id: str | None, headers_key: str, binding_id: str
+    ) -> tuple[list[Any], str | None] | None:
+        """Return the cached ``(tools, instructions)`` for this binding, or ``None``.
+
+        The cache key folds the transport identity (``_PoolKey``) together with
+        the caller's ``binding_id`` (agent id + version, or frozen-surface hash).
+        A binding-identity bump (agent-version change) therefore lands on a fresh
+        key and misses — propagating the new tool set to the next step with no
+        explicit invalidation (#1391 staleness guard).
+        """
+        key: _PoolKey = (url, vault_id, headers_key)
+        return self._tool_cache.get((key, binding_id))
+
+    def set_cached_tools(
+        self,
+        url: str,
+        vault_id: str | None,
+        headers_key: str,
+        binding_id: str,
+        tools: list[Any],
+        instructions: str | None,
+    ) -> None:
+        """Cache a successful ``(tools, instructions)`` discovery for this binding."""
+        key: _PoolKey = (url, vault_id, headers_key)
+        self._tool_cache[(key, binding_id)] = (tools, instructions)
+
+    def _invalidate_tools_for_pool_key(self, key: _PoolKey) -> None:
+        """Drop every binding's cached tool list for one transport key.
+
+        Fired by the ``tools/list_changed`` notification handler: the server
+        announced its tool set changed, so every binding that discovered against
+        this ``(url, vault_id, headers_key)`` must re-discover on its next step.
+        """
+        stale = [ck for ck in self._tool_cache if ck[0] == key]
+        for ck in stale:
+            del self._tool_cache[ck]
+        if stale:
+            log.info("mcp_pool.tools_cache_invalidated", url=key[0], dropped=len(stale))
+
+    def invalidate_tools_by_vault(self, vault_id: str) -> None:
+        """Drop cached tool lists for every key bound to ``vault_id``.
+
+        Called alongside :meth:`evict_by_vault` on a credential rotation so a
+        re-auth can't keep serving a tool list discovered under the old identity.
+        """
+        stale = [ck for ck in self._tool_cache if ck[0][1] == vault_id]
+        for ck in stale:
+            del self._tool_cache[ck]
+
+    # ── per-key discovery circuit breaker (#1391) ─────────────────────────
+
+    def is_unhealthy(
+        self, url: str, vault_id: str | None, headers_key: str, *, now: float | None = None
+    ) -> bool:
+        """True if this transport key is in a discovery backoff window.
+
+        The prelude consults this BEFORE attempting ``list_tools()`` so a server
+        that just timed out is skipped fast (agent runs degraded on the other
+        servers' tools) instead of re-stalling the turn prelude every step.
+        """
+        key: _PoolKey = (url, vault_id, headers_key)
+        until = self._unhealthy_until.get(key)
+        if until is None:
+            return False
+        if (now if now is not None else time.monotonic()) >= until:
+            del self._unhealthy_until[key]
+            return False
+        return True
+
+    def mark_unhealthy(
+        self,
+        url: str,
+        vault_id: str | None,
+        headers_key: str,
+        *,
+        backoff_s: float,
+        now: float | None = None,
+    ) -> None:
+        """Open the circuit for this transport key for ``backoff_s`` seconds."""
+        key: _PoolKey = (url, vault_id, headers_key)
+        self._unhealthy_until[key] = (now if now is not None else time.monotonic()) + backoff_s
+        log.warning("mcp_pool.marked_unhealthy", url=url, backoff_s=backoff_s)
+
+    def mark_healthy(self, url: str, vault_id: str | None, headers_key: str) -> None:
+        """Clear any backoff for this transport key (a successful discovery)."""
+        key: _PoolKey = (url, vault_id, headers_key)
+        self._unhealthy_until.pop(key, None)
 
     async def _reap_idle_once(self, *, idle_timeout: float, now: float) -> None:
         """Close idle entries unused longer than ``idle_timeout`` seconds.

--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -117,6 +117,17 @@ def _find_mcp_toolset(agent_tools: list[ToolSpec], server_name: str) -> ToolSpec
     return None
 
 
+def _binding_id(agent: Any) -> str:
+    """Binding identity for the shared MCP tool-list cache (#1391).
+
+    The broker re-discovers on every model-initiated introspection
+    (``mcp list-methods`` / ``mcp schema``); keying the cache on the SAME
+    ``agent id + version`` the step prelude uses lets the two share a single
+    cached tool list instead of each re-paying a ``list_tools()`` RPC.
+    """
+    return f"{getattr(agent, 'id', '?')}:{getattr(agent, 'version', '?')}"
+
+
 def _find_builtin_spec(agent_tools: list[ToolSpec], name: str) -> ToolSpec | None:
     """Find the agent's ToolSpec for a built-in by name.
 
@@ -535,7 +546,7 @@ class ToolBroker:
 
     async def _resolve_mcp(
         self, request: Request, *, require_tool: bool
-    ) -> tuple[str, McpServerSpec, ToolSpec, str | None] | Response:
+    ) -> tuple[str, McpServerSpec, ToolSpec, str | None, Any] | Response:
         """Resolve session, server, toolset, and (optionally) tool for an
         MCP route.
 
@@ -559,7 +570,7 @@ class ToolBroker:
             return _err(404, f"MCP server {server_name!r} has no URL configured")
 
         if not require_tool:
-            return session_id, server, toolset, None
+            return session_id, server, toolset, None, agent
 
         tool_name = request.path_params["tool"]
         qualified = f"mcp__{server_name}__{tool_name}"
@@ -584,18 +595,23 @@ class ToolBroker:
                 f"synchronous confirmation bridge is not built. Use the "
                 f"model-tool path.",
             )
-        return session_id, server, toolset, tool_name
+        return session_id, server, toolset, tool_name, agent
 
     async def _mcp_list_methods(self, request: Request) -> Response:
         resolved = await self._resolve_mcp(request, require_tool=False)
         if isinstance(resolved, Response):
             return resolved
-        session_id, server, toolset, _ = resolved
+        session_id, server, toolset, _, agent = resolved
 
         vault_id, headers = await self._load_auth_for(session_id, server.url)
         try:
             tool_dicts, _instructions = await discover_mcp_tools(
-                server.url, vault_id, headers, server.name, spec_headers=server.headers
+                server.url,
+                vault_id,
+                headers,
+                server.name,
+                spec_headers=server.headers,
+                binding_id=_binding_id(agent),
             )
         except Exception as exc:
             log.warning(
@@ -633,13 +649,18 @@ class ToolBroker:
         resolved = await self._resolve_mcp(request, require_tool=True)
         if isinstance(resolved, Response):
             return resolved
-        session_id, server, _toolset, tool_name = resolved
+        session_id, server, _toolset, tool_name, agent = resolved
         assert tool_name is not None  # require_tool=True
 
         vault_id, headers = await self._load_auth_for(session_id, server.url)
         try:
             tool_dicts, _ = await discover_mcp_tools(
-                server.url, vault_id, headers, server.name, spec_headers=server.headers
+                server.url,
+                vault_id,
+                headers,
+                server.name,
+                spec_headers=server.headers,
+                binding_id=_binding_id(agent),
             )
         except Exception as exc:
             log.warning(
@@ -674,7 +695,7 @@ class ToolBroker:
         resolved = await self._resolve_mcp(request, require_tool=True)
         if isinstance(resolved, Response):
             return resolved
-        session_id, server, _toolset, tool_name = resolved
+        session_id, server, _toolset, tool_name, _agent = resolved
         assert tool_name is not None
 
         # Outbound suppression (#710): MCP is default-deny under suppression.

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -274,3 +274,65 @@ class TestDiscoverSessionMcpTools:
             "Failed server must NOT appear in the instructions dict — the system "
             "prompt would otherwise list a server the model can't actually use"
         )
+
+    async def test_unhealthy_server_is_skipped_via_circuit_breaker(self) -> None:
+        """#1391: a server whose discovery recently timed out is in backoff on
+        the pool; the prelude skips its (uncached) discovery fast — it never
+        calls ``discover_mcp_tools`` for it — while a healthy server proceeds.
+        The agent runs degraded on the healthy server's tools, not stalled.
+        """
+        from aios.harness import runtime
+        from aios.harness.loop import discover_session_mcp_tools
+        from aios.mcp.client import _headers_key
+        from aios.mcp.pool import McpSessionPool
+
+        agent = _agent(
+            mcp_servers=[
+                McpServerSpec(name="slow", url="https://mcp.slow"),
+                McpServerSpec(name="ok", url="https://mcp.ok"),
+            ],
+            tools=[
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="slow"),
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="ok"),
+            ],
+        )
+
+        pool = McpSessionPool()
+        # Mark the slow server's transport key unhealthy (as a prior discovery
+        # timeout would). vault_id is None here (resolve mocked to no-cred).
+        pool.mark_unhealthy("https://mcp.slow", None, _headers_key(None), backoff_s=60.0)
+
+        discovered: list[str] = []
+
+        async def _discover(
+            _url: str,
+            _vault_id: str | None,
+            _headers: dict[str, str],
+            name: str,
+            **_kwargs: Any,
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            discovered.append(name)
+            return [{"name": f"mcp__{name}__t"}], None
+
+        prior = runtime.mcp_session_pool
+        runtime.mcp_session_pool = pool
+        try:
+            with (
+                patch(
+                    "aios.mcp.client.resolve_auth_for_target_url", new_callable=AsyncMock
+                ) as resolve,
+                patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+            ):
+                resolve.return_value = (None, {})
+                tools, _instructions = await discover_session_mcp_tools(
+                    pool=AsyncMock(),
+                    session_id="sess_x",
+                    agent=agent,
+                    account_id="acc_test_stub",
+                )
+        finally:
+            runtime.mcp_session_pool = prior
+
+        # The slow server was short-circuited (never discovered); only 'ok' ran.
+        assert discovered == ["ok"]
+        assert {t["name"] for t in tools} == {"mcp__ok__t"}

--- a/tests/unit/test_mcp_discovery_cache.py
+++ b/tests/unit/test_mcp_discovery_cache.py
@@ -1,0 +1,263 @@
+"""Unit tests for MCP discovery caching + per-server timeout / circuit breaker (#1391).
+
+A single unresponsive MCP server used to stall the whole turn prelude: discovery
+re-polled ``list_tools()`` live every step (no result cache) with no per-server
+timeout, so one hung server starved the turn until the 960s step budget fired.
+
+These tests cover the fix:
+
+* the pool's ``(tools, instructions)`` result cache, keyed on transport identity
+  + binding identity, so a static tool set is paid once per binding (no per-step
+  RPC) and re-discovered only on a binding-identity bump or ``list_changed``;
+* the per-server discovery timeout (``_DISCOVERY_TIMEOUT_S``) that bounds
+  ``list_tools()``;
+* the per-key circuit breaker that skips a recently-failed server fast.
+
+All MCP SDK + httpx interactions are mocked. No network calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.harness import runtime
+from aios.mcp.client import (
+    _DISCOVERY_TIMEOUT_S,
+    _headers_key,
+    discover_mcp_tools,
+)
+from aios.mcp.pool import McpSessionPool
+
+URL = "https://m.example/"
+EMPTY_KEY = _headers_key(None)
+
+
+def _make_mock_tool(name: str) -> MagicMock:
+    tool = MagicMock()
+    tool.name = name
+    tool.description = f"desc {name}"
+    tool.inputSchema = {"type": "object"}
+    return tool
+
+
+def _make_mock_session(tool_names: list[str], instructions: str | None = None) -> AsyncMock:
+    session = AsyncMock()
+    init = MagicMock()
+    init.instructions = instructions
+    session.initialize = AsyncMock(return_value=init)
+    result = MagicMock()
+    result.tools = [_make_mock_tool(n) for n in tool_names]
+    session.list_tools = AsyncMock(return_value=result)
+    return session
+
+
+def _transport_mock() -> MagicMock:
+    t = MagicMock()
+    t.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock(), MagicMock()))
+    t.__aexit__ = AsyncMock(return_value=False)
+    return t
+
+
+def _session_ctx(session: AsyncMock) -> MagicMock:
+    cls = MagicMock()
+    cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return cls
+
+
+@pytest.fixture
+def pool_runtime() -> Any:
+    """Install a fresh ``McpSessionPool`` on ``runtime`` for the test, restoring after."""
+    prior = runtime.mcp_session_pool
+    pool = McpSessionPool()
+    runtime.mcp_session_pool = pool
+    try:
+        yield pool
+    finally:
+        runtime.mcp_session_pool = prior
+
+
+# ── result cache ────────────────────────────────────────────────────────────
+
+
+class TestDiscoveryResultCache:
+    async def test_second_discovery_same_binding_skips_list_tools_rpc(
+        self, pool_runtime: McpSessionPool
+    ) -> None:
+        """Acceptance: with caching on, the SECOND discovery for the same
+        binding identity serves from cache and issues NO ``list_tools()`` RPC —
+        removing it from the per-step hot path."""
+        session = _make_mock_session(["create_issue"])
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            tools1, instr1 = await discover_mcp_tools(
+                URL, "v", {}, "github", binding_id="agt_1:3"
+            )
+            assert session.list_tools.await_count == 1
+            tools2, instr2 = await discover_mcp_tools(
+                URL, "v", {}, "github", binding_id="agt_1:3"
+            )
+
+        # Cache hit: no further RPC, identical result.
+        assert session.list_tools.await_count == 1
+        assert tools2 == tools1
+        assert instr2 == instr1
+        assert tools1[0]["function"]["name"] == "mcp__github__create_issue"
+
+    async def test_binding_version_bump_rediscovers(
+        self, pool_runtime: McpSessionPool
+    ) -> None:
+        """Acceptance: a binding-identity bump (agent-version change) re-pays
+        discovery — the new tool set propagates with no staleness."""
+        session = _make_mock_session(["tool_v3"])
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            await discover_mcp_tools(URL, "v", {}, "s", binding_id="agt_1:3")
+            assert session.list_tools.await_count == 1
+            # New version → fresh cache key → re-discovers.
+            await discover_mcp_tools(URL, "v", {}, "s", binding_id="agt_1:4")
+
+        assert session.list_tools.await_count == 2
+
+    async def test_no_binding_id_never_caches(self, pool_runtime: McpSessionPool) -> None:
+        """The API/test path (``binding_id=None``) is never cached — every call
+        re-polls (preserving legacy uncached behaviour for the broker-less path)."""
+        session = _make_mock_session(["t"])
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            await discover_mcp_tools(URL, "v", {}, "s")
+            await discover_mcp_tools(URL, "v", {}, "s")
+
+        assert session.list_tools.await_count == 2
+
+    async def test_list_changed_notification_invalidates_cache(
+        self, pool_runtime: McpSessionPool
+    ) -> None:
+        """Acceptance: the MCP ``tools/list_changed`` notification invalidates
+        the cache so the next discovery re-polls (no staleness regression)."""
+        session = _make_mock_session(["t"])
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            await discover_mcp_tools(URL, "v", {}, "s", binding_id="agt_1:3")
+            assert session.list_tools.await_count == 1
+
+            # Simulate the server pushing a tools/list_changed notification by
+            # invoking the same invalidation the registered handler performs.
+            pool_runtime._invalidate_tools_for_pool_key((URL, "v", EMPTY_KEY))
+
+            await discover_mcp_tools(URL, "v", {}, "s", binding_id="agt_1:3")
+
+        assert session.list_tools.await_count == 2
+
+
+# ── per-server discovery timeout ────────────────────────────────────────────
+
+
+class TestDiscoveryTimeout:
+    async def test_slow_list_tools_times_out_and_marks_unhealthy(
+        self, pool_runtime: McpSessionPool
+    ) -> None:
+        """Acceptance: a hung ``list_tools()`` is bounded by the per-server
+        timeout (does not hang forever) and the key is marked unhealthy."""
+
+        async def _never_returns() -> Any:
+            await asyncio.sleep(3600)
+
+        session = _make_mock_session(["t"])
+        session.list_tools = AsyncMock(side_effect=_never_returns)
+
+        # Speed: patch the timeout to a tiny value so the test is fast.
+        with (
+            patch("aios.mcp.client._DISCOVERY_TIMEOUT_S", 0.05),
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+            pytest.raises(TimeoutError),
+        ):
+            await asyncio.wait_for(
+                discover_mcp_tools(URL, "v", {}, "s", binding_id="agt_1:3"),
+                timeout=5.0,
+            )
+
+        # The key is now in backoff so the next prelude can skip it fast.
+        assert pool_runtime.is_unhealthy(URL, "v", EMPTY_KEY)
+
+    async def test_default_discovery_timeout_is_finite_and_tight(self) -> None:
+        """The discovery timeout exists and is well under the 960s step budget —
+        the precondition that prevents a prelude stall (#1391)."""
+        assert 0 < _DISCOVERY_TIMEOUT_S < 960
+
+
+# ── circuit breaker bookkeeping ─────────────────────────────────────────────
+
+
+class TestCircuitBreaker:
+    def test_mark_unhealthy_then_healthy(self) -> None:
+        pool = McpSessionPool()
+        assert not pool.is_unhealthy(URL, "v", EMPTY_KEY, now=100.0)
+        pool.mark_unhealthy(URL, "v", EMPTY_KEY, backoff_s=60.0, now=100.0)
+        # Inside the window → unhealthy.
+        assert pool.is_unhealthy(URL, "v", EMPTY_KEY, now=130.0)
+        # After the window → healthy again (and the entry is reaped).
+        assert not pool.is_unhealthy(URL, "v", EMPTY_KEY, now=200.0)
+        # A successful discovery clears the breaker explicitly.
+        pool.mark_unhealthy(URL, "v", EMPTY_KEY, backoff_s=60.0, now=300.0)
+        pool.mark_healthy(URL, "v", EMPTY_KEY)
+        assert not pool.is_unhealthy(URL, "v", EMPTY_KEY, now=310.0)
+
+    def test_cache_get_set_and_invalidate(self) -> None:
+        pool = McpSessionPool()
+        assert pool.get_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3") is None
+        pool.set_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3", [{"x": 1}], "instr")
+        assert pool.get_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3") == ([{"x": 1}], "instr")
+        # Different binding → independent entry.
+        assert pool.get_cached_tools(URL, "v", EMPTY_KEY, "agt_1:4") is None
+        # list_changed drops every binding for the key.
+        pool.set_cached_tools(URL, "v", EMPTY_KEY, "agt_1:4", [{"y": 2}], None)
+        pool._invalidate_tools_for_pool_key((URL, "v", EMPTY_KEY))
+        assert pool.get_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3") is None
+        assert pool.get_cached_tools(URL, "v", EMPTY_KEY, "agt_1:4") is None
+
+    async def test_list_changed_handler_invalidates_only_on_tool_change(self) -> None:
+        """The ``ClientSession`` message handler the pool registers (#1391)
+        drops the cache on ``tools/list_changed`` but ignores other server
+        notifications — so an unrelated notification can't thrash the cache."""
+        import mcp.types as t
+
+        pool = McpSessionPool()
+        key = (URL, "v", EMPTY_KEY)
+        handler = pool._make_list_changed_handler(key)
+
+        pool.set_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3", [{"x": 1}], None)
+        await handler(t.ServerNotification(t.ToolListChangedNotification()))
+        assert pool.get_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3") is None
+
+        pool.set_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3", [{"x": 1}], None)
+        await handler(
+            t.ServerNotification(
+                t.LoggingMessageNotification(
+                    params=t.LoggingMessageNotificationParams(level="info", data="hi")
+                )
+            )
+        )
+        assert pool.get_cached_tools(URL, "v", EMPTY_KEY, "agt_1:3") is not None
+
+    def test_invalidate_by_vault(self) -> None:
+        pool = McpSessionPool()
+        pool.set_cached_tools(URL, "vlt_1", EMPTY_KEY, "agt_1:3", [{"a": 1}], None)
+        pool.set_cached_tools(URL, "vlt_2", EMPTY_KEY, "agt_1:3", [{"b": 2}], None)
+        pool.invalidate_tools_by_vault("vlt_1")
+        assert pool.get_cached_tools(URL, "vlt_1", EMPTY_KEY, "agt_1:3") is None
+        # Other vaults' entries survive.
+        assert pool.get_cached_tools(URL, "vlt_2", EMPTY_KEY, "agt_1:3") is not None

--- a/tests/unit/test_mcp_discovery_cache.py
+++ b/tests/unit/test_mcp_discovery_cache.py
@@ -96,13 +96,9 @@ class TestDiscoveryResultCache:
             patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
             patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
         ):
-            tools1, instr1 = await discover_mcp_tools(
-                URL, "v", {}, "github", binding_id="agt_1:3"
-            )
+            tools1, instr1 = await discover_mcp_tools(URL, "v", {}, "github", binding_id="agt_1:3")
             assert session.list_tools.await_count == 1
-            tools2, instr2 = await discover_mcp_tools(
-                URL, "v", {}, "github", binding_id="agt_1:3"
-            )
+            tools2, instr2 = await discover_mcp_tools(URL, "v", {}, "github", binding_id="agt_1:3")
 
         # Cache hit: no further RPC, identical result.
         assert session.list_tools.await_count == 1
@@ -110,9 +106,7 @@ class TestDiscoveryResultCache:
         assert instr2 == instr1
         assert tools1[0]["function"]["name"] == "mcp__github__create_issue"
 
-    async def test_binding_version_bump_rediscovers(
-        self, pool_runtime: McpSessionPool
-    ) -> None:
+    async def test_binding_version_bump_rediscovers(self, pool_runtime: McpSessionPool) -> None:
         """Acceptance: a binding-identity bump (agent-version change) re-pays
         discovery — the new tool set propagates with no staleness."""
         session = _make_mock_session(["tool_v3"])


### PR DESCRIPTION
Automated dev-pipeline build for issue #1391. The implement agent fills in the diff.