### PR TITLE
fix(dev-pipeline): make shovel-ready ⊥ underspecified at both labeling gates

### DIFF
--- a/src/aios/workflows/dev_pipeline.py
+++ b/src/aios/workflows/dev_pipeline.py
@@ -404,12 +404,19 @@ async def main(input):
     ok, reason = spec_ok(issue, kind, comments)
     if not ok:
         log("spec gate failed:", reason)
+        # `underspecified` and `shovel-ready` are MUTUALLY EXCLUSIVE on the spec-readiness axis:
+        # an issue the spec-gate just rejected is, by definition, NOT shovel-ready. Strip the
+        # `shovel-ready` claim as we stamp `underspecified`, so the spec-gate's verdict can never
+        # leave the contradictory `shovel-ready ∧ underspecified` pair on the board (the upstream
+        # mislabel that #1075/#1076/#1081/#1087 were stuck in). The strip is best-effort and
+        # idempotent (a 404 = already absent); it does not gate the failure path.
         # Label-before-comment + maker-marker dedup (aios#1292): apply the `underspecified`
         # label FIRST (idempotent/additive), then post the explanation comment ONLY if the
         # already-fetched thread doesn't already carry the marker — so an at-least-once replay
         # doesn't post a second "spec not ready" comment.
         await gh("POST", _ipath(repo, "/issues/%d/labels" % issue_number),
                  {"labels": ["underspecified"]})
+        await _unlabel(repo, issue_number, "shovel-ready")
         await post_comment_once(repo, issue_number, MARKER_SPEC_NOT_READY,
                                 MARKER_SPEC_NOT_READY + "\n\n" + reason, comments)
         return await _fail(repo, issue_number, {"state": "spec_failed", "reason": reason})

--- a/src/aios/workflows/dev_pipeline_reconciler.py
+++ b/src/aios/workflows/dev_pipeline_reconciler.py
@@ -109,6 +109,13 @@ LABEL_PIPELINE_V2 = "pipeline:v2"
 LABEL_SHOVEL_READY = "shovel-ready"
 LABEL_APPROVED = "approved"
 LABEL_DISPATCHED = "dispatched"
+# `underspecified` is the spec-gate's "NOT spec-complete" verdict — the OPPOSITE pole of
+# `shovel-ready` on the spec-readiness axis. The two MUST NOT coexist; the spec-gate strips
+# `shovel-ready` when it stamps `underspecified`. The dispatch gate ALSO treats its presence as a
+# hard build disqualifier (defense in depth): an issue is build-eligible only if NOT underspecified,
+# so a mislabeled `shovel-ready ∧ underspecified` issue can never be picked for a build even if some
+# path leaves the contradiction on the board (the #1075/#1076/#1081/#1087 mislabel class).
+LABEL_UNDERSPECIFIED = "underspecified"
 # Stamped on the issue once the implement agent has produced a diff (the design's row-1 ``→
 # autodev:built`` marker). It is the at-least-once dedup for the implement agent itself: a build
 # re-driven by a crash mid-implement re-reads this marker (and the PR branch's commit count) and
@@ -247,6 +254,7 @@ def _render_constants(
         # the reconciler's own routing / claim / escalation / advisory labels + markers
         _py("LABEL_PIPELINE_V2", LABEL_PIPELINE_V2),
         _py("LABEL_SHOVEL_READY", LABEL_SHOVEL_READY),
+        _py("LABEL_UNDERSPECIFIED", LABEL_UNDERSPECIFIED),
         _py("LABEL_APPROVED", LABEL_APPROVED),
         _py("LABEL_DISPATCHED", LABEL_DISPATCHED),
         _py("LABEL_BUILT", LABEL_BUILT),
@@ -378,9 +386,14 @@ def owner(item):
 
     if kind == "issue":
         # 1. build-eligible issue → PR-FIRST build. The dispatch gate is the two-axis model:
-        # shovel-ready ∧ approved ∧ ¬dispatched, plus no PR already open for it.
+        # shovel-ready ∧ approved ∧ ¬dispatched, plus no PR already open for it — AND NOT
+        # `underspecified`. `shovel-ready` and `underspecified` are opposite poles of the
+        # spec-readiness axis and must never coexist; the `¬underspecified` clause is defense in
+        # depth so a mislabeled `shovel-ready ∧ underspecified` issue is NEVER picked for a build
+        # (the #1075/#1076/#1081/#1087 mislabel class). An `underspecified` issue is terminal here.
         if (item.get("shovel_ready") and item.get("approved")
                 and not item.get("dispatched")
+                and not item.get("underspecified")
                 and not item.get("has_open_pr")):
             return (item, "build")
         # Any other issue (needs-design/needs-decision/blocked/already-dispatched/has-open-PR) is
@@ -664,6 +677,7 @@ def _build_eligible_issue(repo, issue, open_prs):
         "shovel_ready": LABEL_SHOVEL_READY in labels,
         "approved": LABEL_APPROVED in labels,
         "dispatched": LABEL_DISPATCHED in labels,
+        "underspecified": LABEL_UNDERSPECIFIED in labels,
         "has_open_pr": has_open_pr,
         "title": issue.get("title", ""), "body": issue.get("body", ""),
     }
@@ -743,7 +757,14 @@ async def _do_build(repo, item):
     ok, reason = spec_ok(issue_obj, "issue", comments)
     if not ok:
         log("build: spec gate failed on #%d:" % number, reason)
+        # `underspecified` and `shovel-ready` are MUTUALLY EXCLUSIVE on the spec-readiness axis:
+        # the spec-gate just judged this issue NOT spec-complete, so it is NOT shovel-ready. Stamp
+        # `underspecified` and STRIP the stale `shovel-ready` claim together, so a spec-gate
+        # rejection can never leave the contradictory `shovel-ready ∧ underspecified` pair on the
+        # board (the upstream mislabel #1075/#1076/#1081/#1087 were stuck in). The strip is
+        # best-effort/idempotent (404 = already absent).
         await _label(repo, number, "underspecified")
+        await _unlabel(repo, number, LABEL_SHOVEL_READY)
         await post_comment_once(repo, number, MARKER_SPEC_NOT_READY,
                                 MARKER_SPEC_NOT_READY + "\n\n" + reason, comments)
         await _label(repo, number, NEEDS_HUMAN_SPEC)
@@ -1108,7 +1129,7 @@ async def _do_escalate(repo, item):
     diag = {k: (sorted(item[k]) if isinstance(item.get(k), frozenset) else item.get(k))
             for k in ("kind", "labels", "closed", "draft", "needs_rebase", "ci_verdict",
                       "human_blocked", "risk_tier", "shovel_ready", "approved", "dispatched",
-                      "has_open_pr")
+                      "underspecified", "has_open_pr")
             if k in item}
     await post_markered_comment(
         repo, number, MARKER_STUCK,

--- a/tests/integration/test_wf_dev_pipeline_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_fixture.py
@@ -546,6 +546,11 @@ async def test_spec_gate_short_circuits_without_spawning_agents() -> None:
     # item 3: a spec failure is a terminal NON-gate failure -> labelled autodev:failed
     assert "autodev:failed" in scn.labels_added
     assert "autodev:in-progress" in scn.labels_removed
+    # `shovel-ready` and `underspecified` are mutually exclusive on the spec-readiness axis: the
+    # spec-gate stamps `underspecified` AND strips the stale `shovel-ready` claim, so a rejection
+    # can never leave the contradictory pair (the #1075/#1076/#1081/#1087 mislabel class).
+    assert "underspecified" in scn.labels_added
+    assert "shovel-ready" in scn.labels_removed
 
 
 async def test_spec_gate_blocks_unresolved_marker() -> None:

--- a/tests/integration/test_wf_dev_pipeline_reconciler_fixture.py
+++ b/tests/integration/test_wf_dev_pipeline_reconciler_fixture.py
@@ -387,6 +387,11 @@ async def test_build_spec_gate_failure_parks_needs_human_no_agent() -> None:
     assert "needs:human/spec" in scn.labels_added.get(12, [])
     assert "build-12" not in scn.agent_labels  # no implement agent spent
     assert "underspecified" in scn.labels_added.get(12, [])
+    # `shovel-ready` and `underspecified` are mutually exclusive on the spec-readiness axis: the
+    # spec-gate STRIPS the stale `shovel-ready` claim as it stamps `underspecified`, so a rejection
+    # can never leave the contradictory `shovel-ready ∧ underspecified` pair (the #1075/#1076/#1081/
+    # #1087 mislabel class).
+    assert "shovel-ready" in scn.labels_removed.get(12, [])
 
 
 async def test_build_dispatched_issue_is_not_re_built() -> None:

--- a/tests/unit/test_dev_pipeline_reconciler_owner.py
+++ b/tests/unit/test_dev_pipeline_reconciler_owner.py
@@ -56,6 +56,7 @@ def _issue(
     shovel_ready: bool = False,
     approved: bool = False,
     dispatched: bool = False,
+    underspecified: bool = False,
     has_open_pr: bool = False,
     closed: bool = False,
     labels: frozenset[str] = frozenset(),
@@ -68,6 +69,7 @@ def _issue(
         "shovel_ready": shovel_ready,
         "approved": approved,
         "dispatched": dispatched,
+        "underspecified": underspecified,
         "has_open_pr": has_open_pr,
     }
 
@@ -152,9 +154,18 @@ def _pr_cross_product() -> list[dict[str, Any]]:
 
 def _issue_cross_product() -> list[dict[str, Any]]:
     out = []
-    for sr, ap, disp, has_pr, closed in itertools.product(_BOOLS, _BOOLS, _BOOLS, _BOOLS, _BOOLS):
+    for sr, ap, disp, under, has_pr, closed in itertools.product(
+        _BOOLS, _BOOLS, _BOOLS, _BOOLS, _BOOLS, _BOOLS
+    ):
         out.append(
-            _issue(shovel_ready=sr, approved=ap, dispatched=disp, has_open_pr=has_pr, closed=closed)
+            _issue(
+                shovel_ready=sr,
+                approved=ap,
+                dispatched=disp,
+                underspecified=under,
+                has_open_pr=has_pr,
+                closed=closed,
+            )
         )
     return out
 
@@ -303,6 +314,23 @@ def test_advanced_build_issue_is_not_re_picked() -> None:
     assert _transition(after) is None  # dispatched -> no longer build-eligible
     after_pr = _issue(shovel_ready=True, approved=True, dispatched=False, has_open_pr=True)
     assert _transition(after_pr) is None  # a PR already exists -> no re-build
+
+
+def test_underspecified_issue_is_never_build_eligible() -> None:
+    # `shovel-ready` and `underspecified` are opposite poles of the spec-readiness axis and must
+    # never coexist. The dispatch gate treats `underspecified` as a HARD disqualifier (defense in
+    # depth): even a mislabeled `shovel-ready ∧ approved ∧ underspecified` issue (the
+    # #1075/#1076/#1081/#1087 mislabel class) is NEVER picked for a build.
+    eligible = _issue(shovel_ready=True, approved=True, dispatched=False, has_open_pr=False)
+    assert _transition(eligible) == "build"
+    mislabeled = _issue(
+        shovel_ready=True,
+        approved=True,
+        dispatched=False,
+        has_open_pr=False,
+        underspecified=True,
+    )
+    assert _transition(mislabeled) is None  # underspecified -> not build-eligible
 
 
 def test_advanced_review_pr_is_not_re_reviewed_at_same_head() -> None:


### PR DESCRIPTION
## The root cause

Issues #1075/#1076/#1081/#1087 were stuck carrying BOTH `shovel-ready` AND `underspecified` (+ `approved`) — a contradiction. The dispatch gate read them as ready (`shovel-ready ∧ approved`); the spec-gate kept refusing to build them.

The label timeline (e.g. #1075) shows the cause precisely: `shovel-ready` was applied at intake (correct — the bodies are complete `/kaikaku` specs), then when the issue was dispatched the **dev-pipeline spec-gate** stamped `underspecified` + `needs:human/spec` **without stripping `shovel-ready`**, leaving the contradictory pair. The triage pipeline (which *applies* `shovel-ready`) never re-touches a triaged issue, so it did not create the contradiction — the spec-gate did, downstream.

The spec-gate bounced these complete specs only because each body has a section literally headed `## Open questions` (whose content says "None architectural" / "build-time confirmations, not design forks"), which matches the `\bopen question` SPEC_BLOCKER. (The four issue bodies have been reworked + relabeled separately so they now pass.)

## The fix — at the labeling gates, not one-by-one downstream

1. **Spec-gate** (`dev_pipeline.py` + `dev_pipeline_reconciler.py`): when stamping `underspecified`, also strip `shovel-ready`. The two are opposite poles of the spec-readiness axis and must never coexist; a spec-gate rejection can no longer leave the contradiction on the board.
2. **Dispatch gate** (reconciler `owner()`): `underspecified` is now a hard build disqualifier (defense in depth) — an issue is build-eligible only if `shovel_ready ∧ approved ∧ ¬dispatched ∧ ¬underspecified ∧ no-open-PR`. So even if some other path leaves the contradiction, the build is never picked. Surfaced `underspecified` on the normalized item + escalate diagnostic; rendered the new `LABEL_UNDERSPECIFIED` constant into the spliced script header.

## Tests
- `owner()`: expanded the issue cross-product (totality over the new `underspecified` axis) + a focused `underspecified ⇒ not build-eligible` unit test.
- Both pipeline fixtures (`test_wf_dev_pipeline_fixture` / `..._reconciler_fixture`) now assert the spec-gate strips `shovel-ready` alongside stamping `underspecified`.

Full unit + connectors suite green (pre-commit ran 3310 + 565).

🤖 Generated with [Claude Code](https://claude.com/claude-code)