### PR TITLE
Single-source the env-var credential FROM/WHERE across owners — the run query inlines a copy of the session "can-NEVER-diverge" security predicate

### DIFF
--- a/src/aios/db/queries/vaults.py
+++ b/src/aios/db/queries/vaults.py
@@ -826,25 +826,46 @@ class EnvVarCredentialEcho(NamedTuple):
     updated_at: datetime
 
 
-# Shared FROM/WHERE/ORDER-BY body for the two session env-var credential
-# queries below. The account-scoping (``sv.account_id``/``vc.account_id =
-# $2``), archival (``archived_at IS NULL``), DISTINCT-ON-rank predicate and
-# first-vault-wins ordering live here ONCE so the provision-set
-# (:func:`list_session_env_var_credentials`) and the per-step drift echo-set
-# (:func:`list_session_env_var_credential_echoes`) can NEVER silently diverge:
-# a future account-scoping or security fix to this body applies to both. The
-# two queries differ ONLY in their SELECT columns (and return type). ``$1`` is
-# the session id, ``$2`` the account id.
-_SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE = """
-          FROM session_vaults sv
-          JOIN vault_credentials vc ON vc.vault_id = sv.vault_id
-         WHERE sv.session_id = $1
+# Owner-parameterized FROM/WHERE/ORDER-BY body for the env-var credential
+# membership/resolution predicate — the security-critical scope shared by ALL
+# three credential queries below (the two session sets *and* the run set). The
+# cross-tenant scope (``account_id = $2`` on BOTH the binding row and the
+# credential row), archival filter (``archived_at IS NULL``), DISTINCT-ON-rank
+# predicate and first-vault-wins ordering live here ONCE, across BOTH owners,
+# so the provision-set (:func:`list_session_env_var_credentials`), the per-step
+# drift echo-set (:func:`list_session_env_var_credential_echoes`) and the
+# workflow-run set (:func:`list_run_env_var_credentials`) can NEVER silently
+# diverge: a future account-scoping or security fix to this body applies to all
+# three. ``$1`` is the owner id (session/run), ``$2`` the account id — bind
+# positions are identical across owners, so no call-site change.
+#
+# The interpolated names (``table``/``a``/``owner_col``) are static module
+# literals — never user input, so no injection risk — matching the already
+# blessed f-string interpolation idiom in ``db/queries/__init__.py``
+# (``_get_scoped``/``_list_scoped`` interpolate ``{table}``/``{column}``).
+_ENV_VAR_CREDENTIALS_FROM_WHERE = """
+          FROM {table} {a}
+          JOIN vault_credentials vc ON vc.vault_id = {a}.vault_id
+         WHERE {a}.{owner_col} = $1
            AND vc.auth_type = 'environment_variable'
            AND vc.archived_at IS NULL
-           AND sv.account_id = $2
+           AND {a}.account_id = $2
            AND vc.account_id = $2
-         ORDER BY vc.secret_name, sv.rank
+         ORDER BY vc.secret_name, {a}.rank
 """.strip()
+
+# Session owner: shared by the two session queries (provision set + drift echo
+# set) so they can't diverge. ``$1`` is the session id, ``$2`` the account id.
+_SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE = _ENV_VAR_CREDENTIALS_FROM_WHERE.format(
+    table="session_vaults", a="sv", owner_col="session_id"
+)
+
+# Run owner: the workflow-run twin, derived from the SAME template — its body
+# can no longer drift from the session predicate by a dropped hand-edit.
+# ``$1`` is the run id, ``$2`` the account id.
+_RUN_ENV_VAR_CREDENTIALS_FROM_WHERE = _ENV_VAR_CREDENTIALS_FROM_WHERE.format(
+    table="wf_run_vaults", a="rv", owner_col="run_id"
+)
 
 
 async def list_run_env_var_credentials(
@@ -860,20 +881,18 @@ async def list_run_env_var_credentials(
     ``secret_name`` resolves first-vault-wins by ``wf_run_vaults.rank``.
     Runs have no per-step drift echo, so this is the only run env-var
     credential membership query.
+
+    Embeds ``_RUN_ENV_VAR_CREDENTIALS_FROM_WHERE``, derived from the SAME
+    owner-parameterized ``_ENV_VAR_CREDENTIALS_FROM_WHERE`` template the two
+    session queries derive their body from, so the cross-tenant credential
+    predicate can't diverge between the session and run execution paths.
     """
     rows = await conn.fetch(
-        """
+        f"""
         SELECT DISTINCT ON (vc.secret_name)
                vc.id, vc.secret_name, vc.allowed_hosts,
                vc.ciphertext, vc.nonce, vc.updated_at
-          FROM wf_run_vaults rv
-          JOIN vault_credentials vc ON vc.vault_id = rv.vault_id
-         WHERE rv.run_id = $1
-           AND vc.auth_type = 'environment_variable'
-           AND vc.archived_at IS NULL
-           AND rv.account_id = $2
-           AND vc.account_id = $2
-         ORDER BY vc.secret_name, rv.rank
+        {_RUN_ENV_VAR_CREDENTIALS_FROM_WHERE}
         """,
         run_id,
         account_id,

--- a/tests/unit/db/test_env_var_credentials_single_sourced.py
+++ b/tests/unit/db/test_env_var_credentials_single_sourced.py
@@ -1,0 +1,92 @@
+"""Structural drift-guard for the env-var credential ``FROM/WHERE`` predicate (#1075).
+
+The membership/resolution predicate that scopes which ``environment_variable``
+credentials a session/run can read is the *cross-tenant credential-isolation
+guarantee*: the double ``account_id = $2`` tenant scoping (binding row *and*
+credential row), the ``archived_at IS NULL`` revocation filter, and the
+``DISTINCT ON (secret_name)`` first-vault-wins ordering. It is embedded by three
+query sites across two owners:
+
+* ``list_session_env_var_credentials`` — provision-time set,
+* ``list_session_env_var_credential_echoes`` — per-step drift echo (#877),
+* ``list_run_env_var_credentials`` — workflow-run set (#882/#1011).
+
+Before #1075 the run query inlined a *byte-identical copy* of the session body —
+the exact "can NEVER silently diverge" failure the author's shared const exists
+to prevent, reproduced one function away. Now both owner constants are derived
+from a single ``_ENV_VAR_CREDENTIALS_FROM_WHERE`` template, so a future
+scoping/revocation edit lands on session and run together by construction.
+
+This test pins that single-sourcing structurally: the rendered session and run
+bodies must be IDENTICAL after substituting back the owner tokens — i.e. they may
+differ ONLY in ``session_vaults``/``sv``/``session_id`` vs
+``wf_run_vaults``/``rv``/``run_id``. Modeled on
+``test_terminal_status_vocabulary_single_sourced``. Pure introspection — no
+Postgres.
+"""
+
+from __future__ import annotations
+
+from aios.db.queries import vaults
+
+
+def _normalize(body: str, table: str, alias: str, owner_col: str) -> str:
+    """Replace this owner's table/alias/owner-column with neutral tokens so two
+    owners' bodies are comparable iff they are structurally identical."""
+    return (
+        body.replace(table, "<TABLE>")
+        .replace(owner_col, "<OWNER_COL>")
+        .replace(alias, "<A>")
+    )
+
+
+def test_env_var_predicate_single_sourced_across_owners() -> None:
+    """Session and run env-var credential bodies are the SAME template — they
+    differ ONLY in owner table/alias/column, so the cross-tenant credential
+    predicate can't drift between the session and run execution paths."""
+    session_normalized = _normalize(
+        vaults._SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE,
+        table="session_vaults",
+        alias="sv",
+        owner_col="session_id",
+    )
+    run_normalized = _normalize(
+        vaults._RUN_ENV_VAR_CREDENTIALS_FROM_WHERE,
+        table="wf_run_vaults",
+        alias="rv",
+        owner_col="run_id",
+    )
+    assert session_normalized == run_normalized
+
+
+def test_owner_constants_derive_from_one_template() -> None:
+    """Both owner constants must be ``.format()`` renderings of the single
+    ``_ENV_VAR_CREDENTIALS_FROM_WHERE`` template (the one home of the
+    predicate), not hand-written twins."""
+    assert vaults._SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE == (
+        vaults._ENV_VAR_CREDENTIALS_FROM_WHERE.format(
+            table="session_vaults", a="sv", owner_col="session_id"
+        )
+    )
+    assert vaults._RUN_ENV_VAR_CREDENTIALS_FROM_WHERE == (
+        vaults._ENV_VAR_CREDENTIALS_FROM_WHERE.format(
+            table="wf_run_vaults", a="rv", owner_col="run_id"
+        )
+    )
+
+
+def test_security_predicate_present_in_template() -> None:
+    """The security-load-bearing clauses must live in the single template, so a
+    scoping/revocation edit there reaches every owner. Guards against someone
+    'simplifying' the template and dropping a tenant scope or the archival
+    filter."""
+    template = vaults._ENV_VAR_CREDENTIALS_FROM_WHERE
+    # Double cross-tenant scope: the binding row AND the credential row.
+    assert "{a}.account_id = $2" in template
+    assert "vc.account_id = $2" in template
+    # Revocation filter.
+    assert "vc.archived_at IS NULL" in template
+    # Owner scope and first-vault-wins ordering.
+    assert "{a}.{owner_col} = $1" in template
+    assert "ORDER BY vc.secret_name, {a}.rank" in template
+    assert "vc.auth_type = 'environment_variable'" in template

--- a/tests/unit/db/test_env_var_credentials_single_sourced.py
+++ b/tests/unit/db/test_env_var_credentials_single_sourced.py
@@ -33,11 +33,7 @@ from aios.db.queries import vaults
 def _normalize(body: str, table: str, alias: str, owner_col: str) -> str:
     """Replace this owner's table/alias/owner-column with neutral tokens so two
     owners' bodies are comparable iff they are structurally identical."""
-    return (
-        body.replace(table, "<TABLE>")
-        .replace(owner_col, "<OWNER_COL>")
-        .replace(alias, "<A>")
-    )
+    return body.replace(table, "<TABLE>").replace(owner_col, "<OWNER_COL>").replace(alias, "<A>")
 
 
 def test_env_var_predicate_single_sourced_across_owners() -> None:
@@ -63,16 +59,16 @@ def test_owner_constants_derive_from_one_template() -> None:
     """Both owner constants must be ``.format()`` renderings of the single
     ``_ENV_VAR_CREDENTIALS_FROM_WHERE`` template (the one home of the
     predicate), not hand-written twins."""
-    assert vaults._SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE == (
+    assert (
         vaults._ENV_VAR_CREDENTIALS_FROM_WHERE.format(
             table="session_vaults", a="sv", owner_col="session_id"
         )
-    )
-    assert vaults._RUN_ENV_VAR_CREDENTIALS_FROM_WHERE == (
+    ) == vaults._SESSION_ENV_VAR_CREDENTIALS_FROM_WHERE
+    assert (
         vaults._ENV_VAR_CREDENTIALS_FROM_WHERE.format(
             table="wf_run_vaults", a="rv", owner_col="run_id"
         )
-    )
+    ) == vaults._RUN_ENV_VAR_CREDENTIALS_FROM_WHERE
 
 
 def test_security_predicate_present_in_template() -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1075.