### PR TITLE
Give the tool-call authority disposition one home: one pure classifier, three thin projections (fixes the recovery-sweep route-refinement drift)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -44,12 +44,11 @@ from aios.harness.step_context import (
 from aios.harness.sweep import find_sessions_needing_inference
 from aios.harness.tokens import approx_tokens
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
+from aios.harness.tool_disposition import classify_tool_call
 from aios.logging import get_logger
 from aios.models.agents import (
     McpServerSpec,
-    PermissionPolicy,
     is_mcp_tool_name,
-    resolve_permission,
 )
 from aios.services import accounts as accounts_service
 from aios.services import agents as agents_service
@@ -903,48 +902,28 @@ def _classify_tool_call(
     * ``"unknown_mcp"`` — MCP-namespaced tool whose server is not
       registered.  Routed to immediate tool-error so the model can
       self-correct rather than leaving the call unresolved.
-    """
-    from aios.harness.tool_dispatch import _parse_mcp_tool_name
-    from aios.tools.invoke import parse_arguments
-    from aios.tools.registry import registry as tool_registry
 
+    Thin projection of the single-source disposition classifier
+    (:func:`aios.harness.tool_disposition.classify_tool_call`, #1076): the
+    permission ladder is walked exactly once there; the three consumers
+    (this dispatch path, the awaiting view, the recovery sweep) differ only
+    in their terminal projection.  ``ToolDispatchKind``'s literals are the
+    :class:`~aios.harness.tool_disposition.ToolDisposition` values verbatim.
+    """
+    # Thin projection of the single-source disposition classifier (#1076).
+    # A fresh dispatch is never pre-confirmed, so confirmation_resolved=False;
+    # the loop carries the mcp_server_map and so distinguishes unknown_mcp.
     function = tool_call.get("function") or {}
     name: str = function.get("name") or ""
 
-    if is_mcp_tool_name(name):
-        try:
-            server_name, _ = _parse_mcp_tool_name(name)
-        except ValueError:
-            return "unknown_mcp"
-        # hallucinated/unregistered server -> unknown_mcp tool error so the model self-corrects
-        if server_name not in mcp_server_map:
-            return "unknown_mcp"
-        perm = agents_service.effective_mcp_permission(name, agent.tools)
-        if perm == "always_allow":
-            return "mcp_immediate"
-        return "needs_confirm"
-
-    if not tool_registry.has(name):
-        return "custom"
-
-    tool_def = tool_registry.get(name)
-    perm_tool = resolve_permission(name, agent.tools)
-    perm_route: PermissionPolicy | None = None
-    if tool_def.classify_permission is not None:
-        # Arg-aware refinement: tools like ``http_request`` resolve a
-        # per-call policy from the parsed arguments + agent config
-        # (e.g. matched route's ``permission_policy`` on
-        # ``agent.http_servers``).  Malformed args fall through to
-        # dispatch so the schema validator emits a typed error the
-        # model can self-correct from.
-        args = parse_arguments(function.get("arguments"))
-        if args is not None:
-            perm_route = tool_def.classify_permission(args, agent)
-
-    if perm_tool == "always_ask" or perm_route == "always_ask":
-        return "needs_confirm"
-
-    return "immediate"
+    disposition = classify_tool_call(
+        name,
+        function.get("arguments"),
+        agent,
+        confirmation_resolved=False,
+        mcp_server_map=mcp_server_map,
+    )
+    return disposition.value
 
 
 async def discover_session_mcp_tools(

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 import asyncpg
 
 if TYPE_CHECKING:
-    from aios.models.agents import ToolSpec
+    from aios.models.agents import HttpServerSpec, ToolSpec
 
 from aios.config import get_settings
 from aios.db.queries import (
@@ -86,6 +86,27 @@ class _Candidate:
     tool_call_id: str
     tool_name: str
     created_at: dt.datetime
+    # Raw ``function.arguments`` (str or dict, provider-dependent), carried so
+    # the sweep can apply the SAME arg-aware route refinement the dispatch and
+    # read paths do (#1076). Already read at candidate construction; previously
+    # discarded. ``None`` for the rare malformed assistant turn with no
+    # ``function`` blob — the classifier falls through to the base permission.
+    arguments: Any | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _SweepAgentSurface:
+    """The minimal agent surface the disposition classifier (#1076) consumes.
+
+    The classifier reads only ``.tools`` (permission resolution) and
+    ``.http_servers`` (arg-aware route refinement for ``http_request``), so the
+    sweep builds this thin stand-in per candidate session rather than hydrating
+    a full :class:`~aios.models.agents.Agent`. Structurally a duck-typed
+    ``Agent`` for the two attributes the classifier touches.
+    """
+
+    tools: list[ToolSpec]
+    http_servers: list[HttpServerSpec]
 
 
 # ─── query constants ─────────────────────────────────────────────────────────
@@ -350,8 +371,11 @@ async def find_and_repair_ghosts(
             tcid = tc.get("id")
             if not tcid or tcid in existing_results or tcid in session_in_flight:
                 continue
-            name = (tc.get("function") or {}).get("name", "")
-            candidates.append(_Candidate(sid, tcid, name, created_at))
+            function = tc.get("function") or {}
+            name = function.get("name", "")
+            candidates.append(
+                _Candidate(sid, tcid, name, created_at, arguments=function.get("arguments"))
+            )
 
     if not candidates:
         return []
@@ -362,11 +386,15 @@ async def find_and_repair_ghosts(
     # bound). All other candidates are left alone (legitimately waiting).
     candidate_sids = list({c.session_id for c in candidates})
     async with pool.acquire() as conn:
-        # LEFT JOIN agent_versions to respect version pinning.
+        # LEFT JOIN agent_versions to respect version pinning. ``http_servers``
+        # is fetched alongside ``tools`` so the classifier can apply the
+        # arg-aware route refinement for ``http_request`` (#1076) — the same
+        # refinement the dispatch and read paths apply.
         agent_rows = await conn.fetch(
             """
             SELECT s.id AS session_id,
-                   COALESCE(av.tools, a.tools) AS tools
+                   COALESCE(av.tools, a.tools) AS tools,
+                   COALESCE(av.http_servers, a.http_servers) AS http_servers
               FROM sessions s
               JOIN agents a ON a.id = s.agent_id
               LEFT JOIN agent_versions av
@@ -375,15 +403,16 @@ async def find_and_repair_ghosts(
             """,
             candidate_sids,
         )
-    from aios.models.agents import ToolSpec
+    from aios.models.agents import HttpServerSpec, ToolSpec
 
-    agent_tools_by_session: dict[str, list[ToolSpec]] = {}
+    agent_surface_by_session: dict[str, _SweepAgentSurface] = {}
     for r in agent_rows:
-        raw = r["tools"]
-        tools_list = parse_jsonb(raw)
-        agent_tools_by_session[r["session_id"]] = [
-            ToolSpec.model_validate(t) for t in (tools_list or [])
-        ]
+        tools_list = parse_jsonb(r["tools"])
+        http_list = parse_jsonb(r["http_servers"])
+        agent_surface_by_session[r["session_id"]] = _SweepAgentSurface(
+            tools=[ToolSpec.model_validate(t) for t in (tools_list or [])],
+            http_servers=[HttpServerSpec.model_validate(h) for h in (http_list or [])],
+        )
 
     # Abandoned-client-call bound (#752): a client-result-pending call whose
     # assistant turn is older than this is treated as abandoned. The cutoff is
@@ -392,15 +421,17 @@ async def find_and_repair_ghosts(
     client_max_age = get_settings().client_tool_call_max_age_seconds
     abandoned_cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=client_max_age)
 
+    empty_surface = _SweepAgentSurface(tools=[], http_servers=[])
     ghosts: list[_Candidate] = []
     abandoned: list[_Candidate] = []
     for c in candidates:
         confirmed = confirmed_by_session.get(c.session_id, set())
-        agent_tools = agent_tools_by_session.get(c.session_id, [])
-        if _was_dispatched(c.tool_name, c.tool_call_id, confirmed, agent_tools):
+        surface = agent_surface_by_session.get(c.session_id, empty_surface)
+        if _was_dispatched(c, confirmed, surface):
             ghosts.append(c)
         elif (
-            _is_client_result_pending(c.tool_name, agent_tools) and c.created_at < abandoned_cutoff
+            _is_client_result_pending(c.tool_name, surface.tools)
+            and c.created_at < abandoned_cutoff
         ):
             # Not dispatched AND client-result-pending AND older than the bound:
             # the client disconnected and will never return a result. Without
@@ -532,35 +563,43 @@ async def find_and_repair_ghosts(
 
 
 def _was_dispatched(
-    name: str,
-    tool_call_id: str,
+    candidate: _Candidate,
     confirmed_ids: set[str],
-    agent_tools: list[ToolSpec],
+    surface: _SweepAgentSurface,
 ) -> bool:
     """Determine whether a tool call was dispatched by the harness.
 
     A dispatched tool that has no result and no in-flight task is a
     ghost. A tool that was never dispatched (custom, or unconfirmed
-    ``always_ask``) is legitimately waiting for the client.
+    ``always_ask``) is legitimately waiting for the client or the user.
 
-    Uses the same permission resolution as the step function.
+    Thin projection of the single-source disposition classifier (#1076): a call
+    counts as dispatched UNLESS it is a client-executed ``custom`` tool or an
+    ``always_ask`` confirmation that has NOT yet been satisfied. The
+    ``confirmation_resolved`` bit is this call's id ∈ ``confirmed_ids``, so a
+    confirmation-pending call projects to ``NEEDS_CONFIRM`` → not dispatched.
+
+    This is where the historical drift lived: the previous body applied only
+    ``resolve_permission`` (the tool's BASE permission) and **missed the
+    arg-aware route refinement** that the dispatch and read paths both apply —
+    so a route-gated ``always_ask`` ``http_request`` parked awaiting user
+    confirmation was wrongly reported dispatched, and the ghost-repair branch
+    fabricated an error result that killed the parked confirmation (the exact
+    outcome ``_is_client_result_pending``'s docstring forbids). Routing through
+    the single classifier closes that gap by construction: the refinement now
+    exists in exactly one place. No ``mcp_server_map`` here — the sweep doesn't
+    distinguish ``unknown_mcp`` (an unregistered MCP server resolves through the
+    normal MCP ladder, preserving prior behavior).
     """
-    from aios.models.agents import is_mcp_tool_name, resolve_permission
-    from aios.services.agents import effective_mcp_permission
-    from aios.tools.registry import registry
+    from aios.harness.tool_disposition import ToolDisposition, classify_tool_call
 
-    if is_mcp_tool_name(name):
-        if effective_mcp_permission(name, agent_tools) == "always_allow":
-            return True
-        return tool_call_id in confirmed_ids
-
-    if not registry.has(name):
-        return False
-
-    perm = resolve_permission(name, agent_tools)
-    if perm == "always_ask":
-        return tool_call_id in confirmed_ids
-    return True
+    disposition = classify_tool_call(
+        candidate.tool_name,
+        candidate.arguments,
+        surface,  # type: ignore[arg-type]  # duck-typed: classifier reads only .tools/.http_servers
+        confirmation_resolved=candidate.tool_call_id in confirmed_ids,
+    )
+    return disposition not in (ToolDisposition.NEEDS_CONFIRM, ToolDisposition.CUSTOM)
 
 
 def _is_client_result_pending(name: str, agent_tools: list[ToolSpec]) -> bool:

--- a/src/aios/harness/tool_disposition.py
+++ b/src/aios/harness/tool_disposition.py
@@ -1,0 +1,161 @@
+"""The single source of truth for the authority disposition of a tool call.
+
+The *authority disposition of an unresolved tool call* — is it dispatched by
+the harness now, an MCP ``always_allow`` immediate, a needs-confirmation
+``always_ask``, a client-executed ``custom`` tool, or an unknown MCP tool — is
+**one** domain concept.  Historically it was encoded as three independent
+hand-rolled decision trees (``loop._classify_tool_call``,
+``sessions._classify_awaiting``, ``sweep._was_dispatched``), each re-walking the
+identical primitive ladder::
+
+    is_mcp_tool_name → effective_mcp_permission
+                     → registry.has → resolve_permission
+                     → ToolDefinition.classify_permission   (route refinement)
+
+They were coupled only by prose ("uses the same permission resolution as the
+step function"), and they drifted: ``_was_dispatched`` was left without the
+``classify_permission`` route refinement, so a confirmation-pending route-gated
+``always_ask`` ``http_request`` was misclassified as *dispatched* by the
+recovery sweep — which then fabricated an error tool-result that killed a parked
+human-in-the-loop confirmation (the exact outcome
+``sweep._is_client_result_pending``'s docstring forbids).
+
+This module walks the ladder **once** and returns a :class:`ToolDisposition`.
+The three consumers become thin, one-line projections of the disposition; the
+route refinement now exists in exactly one place and *cannot* be present in two
+copies and absent in the third.
+
+Graph placement: this is a leaf — it imports no consumer.  The tool registry
+and the argument parser are **late-imported** inside :func:`classify_tool_call`
+(not at module load), preserving the existing cycle break documented in
+``services.sessions`` (``aios.tools`` package-init → ``services.wake`` →
+``services.sessions``).  Importing this module never triggers tool-package init.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from aios.models.agents import is_mcp_tool_name, resolve_permission
+from aios.services.agents import effective_mcp_permission
+
+if TYPE_CHECKING:
+    from aios.models.agents import Agent, AgentVersion
+
+
+class ToolDisposition(Enum):
+    """The five authority outcomes the system cares about for a tool call.
+
+    * :attr:`IMMEDIATE` — built-in/custom-registered tool whose effective
+      permission is ``always_allow`` (or whose ``always_ask`` gate has already
+      been resolved): the harness dispatches it now.
+    * :attr:`MCP_IMMEDIATE` — known MCP tool with ``always_allow``: dispatched
+      now via the MCP path.
+    * :attr:`NEEDS_CONFIRM` — built-in or MCP tool gated on an *unresolved*
+      ``always_ask`` confirmation: the harness holds it, waiting on the USER.
+    * :attr:`CUSTOM` — client-executed custom tool (name not in the registry,
+      not MCP-namespaced): the harness holds it, waiting on the CLIENT.
+    * :attr:`UNKNOWN_MCP` — MCP-namespaced tool whose server is not registered
+      on the agent: routed to an immediate tool-error so the model
+      self-corrects.  Only distinguishable when an ``mcp_server_map`` is
+      supplied (the dispatch path has one; the read/sweep paths do not and
+      treat an unknown MCP server like any other MCP tool).
+    """
+
+    IMMEDIATE = "immediate"
+    MCP_IMMEDIATE = "mcp_immediate"
+    NEEDS_CONFIRM = "needs_confirm"
+    CUSTOM = "custom"
+    UNKNOWN_MCP = "unknown_mcp"
+
+
+def classify_tool_call(
+    name: str,
+    arguments: Any,
+    agent: Agent | AgentVersion,
+    *,
+    confirmation_resolved: bool,
+    mcp_server_map: dict[str, Any] | None = None,
+) -> ToolDisposition:
+    """Classify a tool call into its authority :class:`ToolDisposition`.
+
+    This is the **one** walk of the permission ladder shared by all three
+    consumers.  It composes the four existing primitives exactly once:
+    ``is_mcp_tool_name`` / ``effective_mcp_permission`` (MCP branch),
+    ``registry.has`` + ``resolve_permission`` + ``ToolDefinition``-driven
+    ``classify_permission`` route refinement (built-in branch).
+
+    Parameters
+    ----------
+    name:
+        The tool-call function name (namespaced ``mcp__<server>__<tool>`` for
+        MCP tools).
+    arguments:
+        The raw ``function.arguments`` value (str or dict, provider-dependent),
+        used for arg-aware route refinement.  ``None`` / unparseable args fall
+        through to the tool's base permission — the schema validator then emits
+        a typed error the model can self-correct from.
+    agent:
+        The agent (or frozen agent version) whose ``tools`` carry the
+        permission policies.
+    confirmation_resolved:
+        Whether *this call's* ``always_ask`` gate has already been satisfied.
+        The three consumers each supply the same bit from their own world:
+        the loop's fresh dispatch is never pre-confirmed (``False``); the
+        awaiting view supplies ``has_allow_lifecycle``; the sweep supplies
+        ``tool_call_id in confirmed_ids``.  When ``True``, an otherwise
+        ``always_ask`` call projects to an immediate disposition (it is no
+        longer awaiting anyone).
+    mcp_server_map:
+        Optional map of registered MCP server names (the dispatch path passes
+        ``{s.name: s for s in agent.mcp_servers}``).  When supplied, an
+        MCP-namespaced tool whose server is absent classifies as
+        :attr:`ToolDisposition.UNKNOWN_MCP`.  When ``None`` (the read and
+        sweep paths, which carry no server map), the unknown-server case is not
+        distinguished — it resolves through the normal MCP permission ladder,
+        preserving those consumers' historical behavior.
+    """
+    # Late import: keeps this module a graph leaf and preserves the
+    # aios.tools package-init cycle break (services.wake → services.sessions).
+    from aios.tools.invoke import parse_arguments
+    from aios.tools.registry import registry as tool_registry
+
+    if is_mcp_tool_name(name):
+        if mcp_server_map is not None:
+            server_name = _mcp_server_name(name)
+            if server_name is None or server_name not in mcp_server_map:
+                return ToolDisposition.UNKNOWN_MCP
+        if effective_mcp_permission(name, agent.tools) == "always_allow":
+            return ToolDisposition.MCP_IMMEDIATE
+        if confirmation_resolved:
+            return ToolDisposition.MCP_IMMEDIATE
+        return ToolDisposition.NEEDS_CONFIRM
+
+    if not tool_registry.has(name):
+        # Unknown bare name → client-executed custom tool.
+        return ToolDisposition.CUSTOM
+
+    perm_tool = resolve_permission(name, agent.tools)
+    perm_route: str | None = None
+    tool_def = tool_registry.get(name)
+    if tool_def.classify_permission is not None:
+        # Arg-aware refinement: tools like ``http_request`` resolve a per-call
+        # policy from the parsed arguments + agent config (e.g. the matched
+        # route's ``permission_policy``).  Malformed args fall through to the
+        # base permission so the schema validator emits a typed error.
+        args = parse_arguments(arguments)
+        if args is not None:
+            perm_route = tool_def.classify_permission(args, agent)
+
+    if (perm_tool == "always_ask" or perm_route == "always_ask") and not confirmation_resolved:
+        return ToolDisposition.NEEDS_CONFIRM
+    return ToolDisposition.IMMEDIATE
+
+
+def _mcp_server_name(name: str) -> str | None:
+    """Server segment of a ``mcp__<server>__<tool>`` name, or ``None`` if malformed."""
+    parts = name.split("__", 2)
+    if len(parts) < 3 or not parts[1]:
+        return None
+    return parts[1]

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -34,7 +34,6 @@ from aios.models.agents import (
     Agent,
     AgentVersion,
     is_mcp_tool_name,
-    resolve_permission,
 )
 from aios.models.attenuation import Surface, surface_of
 from aios.models.events import Event, EventKind
@@ -710,42 +709,39 @@ def _classify_awaiting(
     ``ToolDefinition.classify_permission`` — so the view stays
     consistent with what the harness will do.
     """
-    # Late import: aios.tools package init pulls in services.wake which
-    # imports this module.
-    from aios.tools.invoke import parse_arguments
-    from aios.tools.registry import registry as tool_registry
+    # Late import: aios.tools package init (reached transitively via the
+    # disposition classifier's own late registry import) pulls in services.wake
+    # which imports this module — so the classifier is imported here, not at
+    # module load, to preserve that cycle break.
+    from aios.harness.tool_disposition import ToolDisposition, classify_tool_call
 
     name = tc["name"]
     tool_call_id = tc["tool_call_id"]
     has_allow_lifecycle = tc["has_allow_lifecycle"]
     pending_since = tc["pending_since"]
 
-    if is_mcp_tool_name(name):
-        if (
-            agents_service.effective_mcp_permission(name, agent.tools) == "always_ask"
-            and not has_allow_lifecycle
-        ):
-            return AwaitingToolCall(
-                tool_call_id=tool_call_id, name=name, kind="mcp", pending_since=pending_since
-            )
-        return None
-    if tool_registry.has(name):
-        perm_tool = resolve_permission(name, agent.tools)
-        perm_route: str | None = None
-        tool_def = tool_registry.get(name)
-        if tool_def.classify_permission is not None:
-            args = parse_arguments(tc.get("arguments"))
-            if args is not None:
-                perm_route = tool_def.classify_permission(args, agent)
-        if (perm_tool == "always_ask" or perm_route == "always_ask") and not has_allow_lifecycle:
-            return AwaitingToolCall(
-                tool_call_id=tool_call_id, name=name, kind="builtin", pending_since=pending_since
-            )
-        return None
-    # Unknown name: client-executed custom tool.
-    return AwaitingToolCall(
-        tool_call_id=tool_call_id, name=name, kind="custom", pending_since=pending_since
+    # Thin projection of the single-source disposition (#1076). The view is
+    # blocked on external action iff the call needs an unresolved confirmation
+    # or is a client-executed custom tool. ``has_allow_lifecycle`` is this
+    # call's "always_ask gate already satisfied" bit. No mcp_server_map here:
+    # the read path doesn't distinguish unknown_mcp (an unregistered MCP server
+    # surfaces as a normal awaiting MCP call, as before).
+    disposition = classify_tool_call(
+        name,
+        tc.get("arguments"),
+        agent,
+        confirmation_resolved=has_allow_lifecycle,
     )
+    if disposition is ToolDisposition.NEEDS_CONFIRM:
+        kind = "mcp" if is_mcp_tool_name(name) else "builtin"
+        return AwaitingToolCall(
+            tool_call_id=tool_call_id, name=name, kind=kind, pending_since=pending_since
+        )
+    if disposition is ToolDisposition.CUSTOM:
+        return AwaitingToolCall(
+            tool_call_id=tool_call_id, name=name, kind="custom", pending_since=pending_since
+        )
+    return None
 
 
 async def compute_awaiting(

--- a/tests/unit/test_sweep_isolation.py
+++ b/tests/unit/test_sweep_isolation.py
@@ -72,8 +72,8 @@ async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> No
         {"session_id": "sess_b", "tool_call_id": "tc_b"},
     ]
     agent_rows = [
-        {"session_id": "sess_a", "tools": []},
-        {"session_id": "sess_b", "tools": []},
+        {"session_id": "sess_a", "tools": [], "http_servers": []},
+        {"session_id": "sess_b", "tools": [], "http_servers": []},
     ]
     # find_and_repair_ghosts issues six ``conn.fetch`` calls in order:
     # GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
@@ -135,7 +135,7 @@ async def test_ghost_repair_branch_may_have_completed(monkeypatch: Any) -> None:
         {"session_id": "sess_a", "tool_call_id": "tc_a"},
     ]
     agent_rows = [
-        {"session_id": "sess_a", "tools": []},
+        {"session_id": "sess_a", "tools": [], "http_servers": []},
     ]
     # The span EXISTS for tc_a → routes the synthesis to the
     # "may have completed" branch.
@@ -186,7 +186,7 @@ async def test_ghost_repair_branch_did_not_run(monkeypatch: Any) -> None:
         {"session_id": "sess_a", "tool_call_id": "tc_a"},
     ]
     agent_rows = [
-        {"session_id": "sess_a", "tools": []},
+        {"session_id": "sess_a", "tools": [], "http_servers": []},
     ]
     # NO span for tc_a → routes the synthesis to the "did not run" branch.
     span_rows: list[dict[str, Any]] = []

--- a/tests/unit/test_sweep_route_gated_always_ask.py
+++ b/tests/unit/test_sweep_route_gated_always_ask.py
@@ -1,0 +1,208 @@
+"""The recovery sweep must NOT fabricate an error result for a
+confirmation-pending route-gated ``always_ask`` ``http_request`` (#1076).
+
+The historical drift: ``sweep._was_dispatched`` applied only
+``resolve_permission`` (the tool's BASE permission) and missed the arg-aware
+route refinement (``http_request`` refines a specific route to ``always_ask``).
+So a route-gated ``http_request`` parked awaiting a USER confirmation was
+reported ``dispatched=True`` → routed to the ghost-error branch → the sweep
+fabricated a synthetic error tool-result that KILLED the parked human-in-the-loop
+confirmation. That is the exact outcome ``_is_client_result_pending``'s docstring
+forbids.
+
+Routing all three consumers through the single classifier
+(``tool_disposition.classify_tool_call``) closes the gap by construction: the
+refinement now exists in exactly one place. This module is the explicit test for
+the forced behavior change — the sweep previously had NO coverage of the
+route-gated-``always_ask`` case.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aios.harness.sweep import (
+    _Candidate,
+    _SweepAgentSurface,
+    _was_dispatched,
+    find_and_repair_ghosts,
+)
+from aios.harness.task_registry import TaskRegistry
+from aios.models.agents import HttpPermissionPolicy, HttpRouteSpec, HttpServerSpec, ToolSpec
+from tests.unit.conftest import fake_pool_yielding_conn
+
+_NOW = dt.datetime.now(dt.UTC)
+
+
+def _http_surface(policy: str) -> _SweepAgentSurface:
+    route = HttpRouteSpec(
+        path_pattern="/lights/*",
+        enabled=True,
+        permission_policy=HttpPermissionPolicy(type=policy),
+        methods=None,
+    )
+    server = HttpServerSpec(name="hue", base_url="https://api.example.com/v1", routes=[route])
+    return _SweepAgentSurface(tools=[ToolSpec(type="http_request")], http_servers=[server])
+
+
+_HTTP_ARGS = '{"server_ref": "hue", "path": "/lights/1", "method": "GET"}'
+
+
+def _candidate(arguments: Any) -> _Candidate:
+    return _Candidate(
+        session_id="sess_a",
+        tool_call_id="tc_a",
+        tool_name="http_request",
+        created_at=_NOW,
+        arguments=arguments,
+    )
+
+
+# ── direct projection: _was_dispatched ───────────────────────────────────────
+
+
+class TestWasDispatchedRouteRefinement:
+    def test_route_gated_always_ask_unconfirmed_not_dispatched(self) -> None:
+        # THE FIX: a route-gated always_ask call awaiting the user is NOT
+        # dispatched — it must be left alone, not ghost-errored. Previously this
+        # returned True (route refinement was missing).
+        surface = _http_surface("always_ask")
+        assert (
+            _was_dispatched(_candidate(_HTTP_ARGS), confirmed_ids=set(), surface=surface) is False
+        )
+
+    def test_route_gated_always_ask_confirmed_dispatched(self) -> None:
+        # Once the user confirms, the call IS dispatched — a missing result is a
+        # genuine ghost.
+        surface = _http_surface("always_ask")
+        assert (
+            _was_dispatched(_candidate(_HTTP_ARGS), confirmed_ids={"tc_a"}, surface=surface) is True
+        )
+
+    def test_route_gated_always_allow_dispatched(self) -> None:
+        surface = _http_surface("always_allow")
+        assert _was_dispatched(_candidate(_HTTP_ARGS), confirmed_ids=set(), surface=surface) is True
+
+    def test_unparseable_args_fall_through_to_base_dispatched(self) -> None:
+        # No route refinement possible → base permission (None) → dispatched, so
+        # the schema validator emits a typed error the model self-corrects from.
+        surface = _http_surface("always_ask")
+        assert _was_dispatched(_candidate("not json"), confirmed_ids=set(), surface=surface) is True
+
+
+# ── end to end: the parked confirmation is NOT repaired ───────────────────────
+
+
+async def test_route_gated_always_ask_not_ghost_repaired(monkeypatch: Any) -> None:
+    """A parked route-gated always_ask http_request is left alone by the sweep.
+
+    With no result, no in-flight task, and no confirmation lifecycle event, the
+    OLD sweep would have fabricated an error tool-result (dispatched=True →
+    ghost branch). The fixed sweep classifies it NEEDS_CONFIRM → not dispatched
+    → ``append_tool_result`` is never called and nothing is repaired.
+    """
+    ghost_rows = [
+        {
+            "session_id": "sess_a",
+            "created_at": _NOW,
+            "data": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tc_a",
+                        "type": "function",
+                        "function": {"name": "http_request", "arguments": _HTTP_ARGS},
+                    }
+                ],
+            },
+        },
+    ]
+    # The route gates /lights/* to always_ask; the call is NOT confirmed.
+    route = {
+        "path_pattern": "/lights/*",
+        "enabled": True,
+        "permission_policy": {"type": "always_ask"},
+    }
+    agent_rows = [
+        {
+            "session_id": "sess_a",
+            "tools": [{"type": "http_request"}],
+            "http_servers": [
+                {"name": "hue", "base_url": "https://api.example.com/v1", "routes": [route]}
+            ],
+        }
+    ]
+    # Six fetches: GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
+    # GHOST_LIFECYCLE_SQL (no confirmation), agent_rows, GHOST_SPAN_START_SQL.
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], [], agent_rows, []])
+    pool = fake_pool_yielding_conn(conn)
+
+    append_mock = AsyncMock()
+    load_account_mock = AsyncMock(return_value="acc_test")
+
+    with (
+        patch("aios.harness.sweep.sessions_service.append_tool_result", append_mock),
+        patch("aios.harness.sweep.sessions_service.load_session_account_id", load_account_mock),
+    ):
+        repaired = await find_and_repair_ghosts(pool, TaskRegistry())
+
+    assert repaired == [], "a parked route-gated always_ask call must NOT be ghost-repaired"
+    append_mock.assert_not_called()
+
+
+async def test_route_gated_always_ask_confirmed_is_ghost_repaired(monkeypatch: Any) -> None:
+    """Once confirmed, a route-gated always_ask call with no result IS a ghost.
+
+    The confirmation lifecycle event makes it dispatched → a missing result is a
+    genuine ghost and the sweep repairs it. This pins the OTHER side of the
+    behavior so the fix can't silently over-correct into never-repairing.
+    """
+    ghost_rows = [
+        {
+            "session_id": "sess_a",
+            "created_at": _NOW,
+            "data": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tc_a",
+                        "type": "function",
+                        "function": {"name": "http_request", "arguments": _HTTP_ARGS},
+                    }
+                ],
+            },
+        },
+    ]
+    lifecycle_rows = [{"session_id": "sess_a", "tool_call_id": "tc_a"}]
+    route = {
+        "path_pattern": "/lights/*",
+        "enabled": True,
+        "permission_policy": {"type": "always_ask"},
+    }
+    agent_rows = [
+        {
+            "session_id": "sess_a",
+            "tools": [{"type": "http_request"}],
+            "http_servers": [
+                {"name": "hue", "base_url": "https://api.example.com/v1", "routes": [route]}
+            ],
+        }
+    ]
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, []])
+    pool = fake_pool_yielding_conn(conn)
+
+    append_mock = AsyncMock()
+    load_account_mock = AsyncMock(return_value="acc_test")
+
+    with (
+        patch("aios.harness.sweep.sessions_service.append_tool_result", append_mock),
+        patch("aios.harness.sweep.sessions_service.load_session_account_id", load_account_mock),
+    ):
+        repaired = await find_and_repair_ghosts(pool, TaskRegistry())
+
+    assert repaired == [("sess_a", "tc_a")], "a confirmed-then-lost always_ask call is a ghost"
+    append_mock.assert_awaited_once()

--- a/tests/unit/test_tool_disposition.py
+++ b/tests/unit/test_tool_disposition.py
@@ -1,0 +1,257 @@
+"""Test matrix for the single-source tool-call classifier (#1076).
+
+``aios.harness.tool_disposition.classify_tool_call`` is the ONE walk of the
+permission ladder shared by all three consumers (``loop._classify_tool_call``,
+``sessions._classify_awaiting``, ``sweep._was_dispatched``).  These tests
+exercise all five dispositions x the ``confirmation_resolved`` axis x the
+``mcp_server_map`` axis, replacing the scattered per-consumer fragments that
+previously had to be kept byte-consistent by hand.
+
+The load-bearing case for the live defect this issue fixes is
+``test_route_gated_always_ask_unconfirmed_needs_confirm``: a route-gated
+``http_request`` refined to ``always_ask`` and NOT yet confirmed must classify
+as ``NEEDS_CONFIRM`` — the route refinement that ``_was_dispatched`` historically
+lacked.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from aios.harness.tool_disposition import ToolDisposition, classify_tool_call
+from aios.models.agents import (
+    Agent,
+    HttpPermissionPolicy,
+    HttpRouteSpec,
+    HttpServerSpec,
+    McpServerSpec,
+    ToolSpec,
+)
+
+
+def test_dispatch_kind_literals_match_disposition_values() -> None:
+    """``loop.ToolDispatchKind``'s literals ARE ``ToolDisposition``'s values.
+
+    ``loop._classify_tool_call`` returns ``disposition.value`` directly, so the
+    two enumerations must stay byte-identical or the dispatch projection would
+    emit an out-of-Literal string. This guard converts that coupling from prose
+    into a checked invariant.
+    """
+    from typing import get_args
+
+    from aios.harness.loop import ToolDispatchKind
+
+    assert set(get_args(ToolDispatchKind.__value__)) == {d.value for d in ToolDisposition}
+
+
+def _agent(
+    *,
+    tools: list[ToolSpec] | None = None,
+    http_servers: list[HttpServerSpec] | None = None,
+    mcp_servers: list[McpServerSpec] | None = None,
+) -> Agent:
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    return Agent(
+        id="agt_test",
+        version=1,
+        name="test-agent",
+        model="gpt-test",
+        system="be helpful",
+        tools=tools or [],
+        mcp_servers=mcp_servers or [],
+        http_servers=http_servers or [],
+        description=None,
+        metadata={},
+        window_min=1,
+        window_max=10,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _http_agent(policy: str) -> Agent:
+    route = HttpRouteSpec(
+        path_pattern="/lights/*",
+        enabled=True,
+        permission_policy=HttpPermissionPolicy(type=policy),
+        methods=None,
+    )
+    server = HttpServerSpec(name="hue", base_url="https://api.example.com/v1", routes=[route])
+    return _agent(tools=[ToolSpec(type="http_request")], http_servers=[server])
+
+
+def _http_args() -> dict[str, Any]:
+    return {"server_ref": "hue", "path": "/lights/1", "method": "GET"}
+
+
+# ── built-in / custom branch ─────────────────────────────────────────────────
+
+
+class TestBuiltinBranch:
+    def test_always_allow_builtin_immediate(self) -> None:
+        agent = _agent(tools=[ToolSpec(type="bash", permission="always_allow")])
+        assert (
+            classify_tool_call("bash", "{}", agent, confirmation_resolved=False)
+            == ToolDisposition.IMMEDIATE
+        )
+
+    def test_no_permission_set_immediate(self) -> None:
+        # resolve_permission → None → not always_ask → immediate.
+        agent = _agent(tools=[ToolSpec(type="bash")])
+        assert (
+            classify_tool_call("bash", "{}", agent, confirmation_resolved=False)
+            == ToolDisposition.IMMEDIATE
+        )
+
+    def test_always_ask_builtin_unconfirmed_needs_confirm(self) -> None:
+        agent = _agent(tools=[ToolSpec(type="bash", permission="always_ask")])
+        assert (
+            classify_tool_call("bash", "{}", agent, confirmation_resolved=False)
+            == ToolDisposition.NEEDS_CONFIRM
+        )
+
+    def test_always_ask_builtin_confirmed_immediate(self) -> None:
+        # The confirmation gate has been satisfied → no longer awaiting → immediate.
+        agent = _agent(tools=[ToolSpec(type="bash", permission="always_ask")])
+        assert (
+            classify_tool_call("bash", "{}", agent, confirmation_resolved=True)
+            == ToolDisposition.IMMEDIATE
+        )
+
+    def test_unknown_bare_name_custom(self) -> None:
+        agent = _agent(tools=[])
+        assert (
+            classify_tool_call("some_client_tool", "{}", agent, confirmation_resolved=False)
+            == ToolDisposition.CUSTOM
+        )
+        # confirmation_resolved is irrelevant for custom tools.
+        assert (
+            classify_tool_call("some_client_tool", "{}", agent, confirmation_resolved=True)
+            == ToolDisposition.CUSTOM
+        )
+
+
+# ── route refinement (the #1076 defect) ──────────────────────────────────────
+
+
+class TestRouteRefinement:
+    def test_route_gated_always_allow_immediate(self) -> None:
+        agent = _http_agent("always_allow")
+        assert (
+            classify_tool_call("http_request", _http_args(), agent, confirmation_resolved=False)
+            == ToolDisposition.IMMEDIATE
+        )
+
+    def test_route_gated_always_ask_unconfirmed_needs_confirm(self) -> None:
+        # The live defect: ``_was_dispatched`` historically applied only
+        # ``resolve_permission`` (the tool's BASE permission, always_allow) and
+        # missed the route refinement → wrongly reported dispatched=True. The
+        # single classifier applies ``classify_permission`` → NEEDS_CONFIRM.
+        agent = _http_agent("always_ask")
+        assert (
+            classify_tool_call("http_request", _http_args(), agent, confirmation_resolved=False)
+            == ToolDisposition.NEEDS_CONFIRM
+        )
+
+    def test_route_gated_always_ask_confirmed_immediate(self) -> None:
+        agent = _http_agent("always_ask")
+        assert (
+            classify_tool_call("http_request", _http_args(), agent, confirmation_resolved=True)
+            == ToolDisposition.IMMEDIATE
+        )
+
+    def test_string_form_arguments_refined(self) -> None:
+        # Providers differ on str- vs dict-form arguments; parse_arguments
+        # normalizes both, so the route refinement fires either way.
+        agent = _http_agent("always_ask")
+        raw = '{"server_ref": "hue", "path": "/lights/1", "method": "GET"}'
+        assert (
+            classify_tool_call("http_request", raw, agent, confirmation_resolved=False)
+            == ToolDisposition.NEEDS_CONFIRM
+        )
+
+    def test_unparseable_arguments_fall_through_to_base(self) -> None:
+        # Malformed args → no route refinement → tool's base permission (None
+        # → not always_ask) → immediate, so the schema validator can emit a
+        # typed error the model self-corrects from.
+        agent = _http_agent("always_ask")
+        assert (
+            classify_tool_call("http_request", "not json", agent, confirmation_resolved=False)
+            == ToolDisposition.IMMEDIATE
+        )
+
+
+# ── MCP branch ───────────────────────────────────────────────────────────────
+
+
+class TestMcpBranch:
+    def test_mcp_always_allow_immediate(self) -> None:
+        agent = _agent(
+            tools=[ToolSpec(type="mcp_toolset", mcp_server_name="srv", permission="always_allow")]
+        )
+        assert (
+            classify_tool_call("mcp__srv__tool", "{}", agent, confirmation_resolved=False)
+            == ToolDisposition.MCP_IMMEDIATE
+        )
+
+    def test_mcp_default_always_ask_unconfirmed_needs_confirm(self) -> None:
+        # No matching mcp_toolset entry → effective permission defaults to
+        # always_ask.
+        agent = _agent(tools=[])
+        assert (
+            classify_tool_call("mcp__srv__tool", "{}", agent, confirmation_resolved=False)
+            == ToolDisposition.NEEDS_CONFIRM
+        )
+
+    def test_mcp_always_ask_confirmed_immediate(self) -> None:
+        agent = _agent(tools=[])
+        assert (
+            classify_tool_call("mcp__srv__tool", "{}", agent, confirmation_resolved=True)
+            == ToolDisposition.MCP_IMMEDIATE
+        )
+
+    def test_unknown_mcp_server_with_map_unknown_mcp(self) -> None:
+        # Dispatch path supplies a server map → unregistered server is unknown_mcp.
+        agent = _agent(tools=[])
+        assert (
+            classify_tool_call(
+                "mcp__ghost__tool",
+                "{}",
+                agent,
+                confirmation_resolved=False,
+                mcp_server_map={},
+            )
+            == ToolDisposition.UNKNOWN_MCP
+        )
+
+    def test_registered_mcp_server_with_map_not_unknown(self) -> None:
+        agent = _agent(tools=[])
+        server = McpServerSpec(name="srv", url="https://x.example")
+        assert (
+            classify_tool_call(
+                "mcp__srv__tool",
+                "{}",
+                agent,
+                confirmation_resolved=False,
+                mcp_server_map={"srv": server},
+            )
+            == ToolDisposition.NEEDS_CONFIRM
+        )
+
+    def test_unknown_mcp_server_without_map_falls_through(self) -> None:
+        # Read/sweep paths carry no server map → the unknown-server case is NOT
+        # distinguished; it resolves through the normal MCP ladder (default
+        # always_ask), preserving those consumers' historical behavior.
+        agent = _agent(tools=[])
+        assert (
+            classify_tool_call("mcp__ghost__tool", "{}", agent, confirmation_resolved=False)
+            == ToolDisposition.NEEDS_CONFIRM
+        )
+
+    def test_malformed_mcp_name_with_map_unknown_mcp(self) -> None:
+        agent = _agent(tools=[])
+        assert (
+            classify_tool_call("mcp__", "{}", agent, confirmation_resolved=False, mcp_server_map={})
+            == ToolDisposition.UNKNOWN_MCP
+        )


### PR DESCRIPTION
Automated dev-pipeline build for issue #1076.