### PR TITLE
Single-source persisted-enum value sets: tighten str writers to Literal + a CI drift-test pinning each CHECK to get_args(Literal)

### DIFF
--- a/migrations/versions/0111_drop_redundant_persisted_enum_checks.py
+++ b/migrations/versions/0111_drop_redundant_persisted_enum_checks.py
@@ -1,0 +1,118 @@
+"""Drop the redundant value-enum ``CHECK`` constraints now single-sourced from
+the Python ``Literal`` via a typed writer (#1081).
+
+Every persisted enum's value set used to be hand-synced in TWO independently
+editable places — the Python ``Literal`` and a DB ``CHECK`` widened in lockstep
+by a paired migration. A forgotten paired migration was a *prod-only* runtime
+``CHECK`` violation (every insert raises), invisible to CI. This migration
+removes the duplication for the columns whose write path now *provably* flows
+from a ``Literal``-typed parameter, so the ``Literal`` becomes the single
+editable source:
+
+  (A) writer was already ``Literal``-typed and the value flows from it — the
+      CHECK was genuinely redundant:
+        * ``vault_credentials.auth_type``   (insert ... auth_type: AuthType)
+        * ``triggers.last_fire_status``     (record_trigger_fire(status: TriggerFireStatus))
+        * ``wf_run_events.type``            (append_run_event(type: WfRunEventType))
+        * ``wf_run_signals.kind``           (insert_run_signal(kind: WfRunSignalKind))
+
+  (B) writer was plain ``str`` and is tightened to its ``Literal`` in the same
+      change *first*, so the formerly-silent illegal write is now a static type
+      error; only *then* is the CHECK redundant:
+        * ``wf_runs.status``
+              (set_run_status / set_run_terminal / _commit_terminal_and_dispatch
+               now ``status: WfRunStatus``)
+        * ``session_memory_stores.access``  (insert_session_memory_store(access: Access))
+        * ``memory_versions.created_by_type``
+              (the ``actor_type: ActorType`` writers, via ``_actor_columns``)
+
+Deliberately NOT dropped (out of scope — these stay pinned to their ``Literal``
+by the (C) drift-test that reads the live CHECK):
+
+  * ``memory_versions.operation`` — written as a *hardcoded SQL literal*
+    (``'created'``/``'modified'``/``'deleted'``), so no bad param can drift it;
+    the CHECK is its only value-set guard, kept and drift-tested.
+  * ``memory_versions.redacted_by_type`` — a nullable ``IS NULL OR IN (...)``
+    value-enum; kept and drift-tested.
+  * ``trigger_runs.status`` — a *wider lifecycle* enum (``pending``/``running``
+    plus the ``TriggerFireStatus`` terminals) with no single backing ``Literal``
+    and several ``str``/hardcoded writers; not a single-sourced value-enum, so
+    out of scope entirely.
+  * the ``memory_stores`` *structural* CHECKs (path regex,
+    ``content_size_bytes = octet_length(content)``, ``rank BETWEEN 0 AND 7``,
+    ``length(instructions) <= 4096``) — not value-enums, untouched.
+
+Pure DDL, no data rewrite. Downgrade re-adds each CHECK with the value set it
+held at HEAD (the current ``get_args`` of each ``Literal``); a later widening
+of a ``Literal`` would make ``downgrade`` re-create a *narrower* CHECK than the
+data, but downgrade is a rollback-to-this-revision operation, so the value set
+frozen here is the correct one for that revision.
+
+Revision ID: 0111
+Revises: 0110
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0111"
+down_revision: str = "0110"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (constraint_name, table, CHECK body to restore on downgrade)
+_DROPPED_CHECKS: tuple[tuple[str, str, str], ...] = (
+    # (A) rows
+    (
+        "vault_credentials_auth_type_check",
+        "vault_credentials",
+        "auth_type IN ('bearer_header','oauth2_refresh','basic',"
+        "'custom_header','environment_variable')",
+    ),
+    (
+        "triggers_last_fire_status_check",
+        "triggers",
+        "last_fire_status IN ('ok','error','timeout','skipped')",
+    ),
+    (
+        "wf_run_events_type_check",
+        "wf_run_events",
+        "type IN ('run_started','call_started','call_result','run_completed',"
+        "'annotation','frontier_deferred','request_response')",
+    ),
+    (
+        "wf_run_signals_kind_check",
+        "wf_run_signals",
+        "kind IN ('gate_resume','child_done','cancel','tool_result')",
+    ),
+    # (B) rows (writers tightened to the Literal in the same change)
+    (
+        "wf_runs_status_check",
+        "wf_runs",
+        "status IN ('pending','running','suspended','completed','errored','cancelled')",
+    ),
+    (
+        "session_memory_stores_access_check",
+        "session_memory_stores",
+        "access IN ('read_only','read_write')",
+    ),
+    (
+        "memory_versions_created_by_type_check",
+        "memory_versions",
+        "created_by_type IN ('api_actor','session_actor')",
+    ),
+)
+
+
+def upgrade() -> None:
+    for name, table, _body in _DROPPED_CHECKS:
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT {name}")
+
+
+def downgrade() -> None:
+    for name, table, body in _DROPPED_CHECKS:
+        op.execute(f"ALTER TABLE {table} ADD CONSTRAINT {name} CHECK ({body})")

--- a/src/aios/db/queries/memory_stores.py
+++ b/src/aios/db/queries/memory_stores.py
@@ -35,7 +35,9 @@ from aios.ids import (
 )
 from aios.models.github_repositories import GithubRepositoryResourceEcho
 from aios.models.memory_stores import (
+    Access,
     Actor,
+    ActorType,
     Memory,
     MemoryPrefix,
     MemoryStore,
@@ -285,7 +287,7 @@ async def insert_memory_with_version(
     path: str,
     content: str,
     content_sha256: str,
-    actor_type: str,
+    actor_type: ActorType,
     actor_ref: str,
 ) -> Memory:
     """Insert a new memory + its initial ``created`` version in one txn.
@@ -504,7 +506,7 @@ async def update_memory_with_version(
     new_content_sha256: str | None,
     new_path: str | None,
     precondition_sha256: str | None,
-    actor_type: str,
+    actor_type: ActorType,
     actor_ref: str,
 ) -> Memory:
     """Update content and/or path; record a ``modified`` version.
@@ -617,7 +619,7 @@ async def delete_memory_with_version(
     account_id: str,
     store_id: str,
     memory_id: str,
-    actor_type: str,
+    actor_type: ActorType,
     actor_ref: str,
 ) -> None:
     """Soft-delete: tombstone version row + ``deleted_at`` on the memory."""
@@ -721,7 +723,7 @@ async def redact_memory_version(
     account_id: str,
     store_id: str,
     version_id: str,
-    actor_type: str,
+    actor_type: ActorType,
     actor_ref: str,
 ) -> MemoryVersion:
     """Strip content fields from a version while keeping the audit trail.
@@ -1190,7 +1192,7 @@ async def insert_session_memory_store(
     *,
     memory_store_id: str,
     rank: int,
-    access: str,
+    access: Access,
     instructions: str,
     name_at_attach: str,
     description_at_attach: str,

--- a/src/aios/db/queries/vaults.py
+++ b/src/aios/db/queries/vaults.py
@@ -687,9 +687,9 @@ async def resolve_vault_credential(
     target_url: str,
 ) -> tuple[EncryptedBlob, AuthType] | None:
     """Look up a credential in a specific vault by ``target_url`` — no
-    ``session_vaults`` join.  The DB's CHECK constraint guarantees
-    ``auth_type`` is one of the ``AuthType`` literals, so the cast on
-    the way out is exhaustively safe.
+    ``session_vaults`` join.  ``auth_type`` is written only through the
+    ``AuthType``-typed ``insert`` writer (single-sourced from the Literal,
+    #1081), so the cast on the way out is exhaustively safe.
     """
     row = await conn.fetchrow(
         """
@@ -727,8 +727,9 @@ async def resolve_session_credential(
     ``(EncryptedBlob, auth_type, vault_id)`` for the first match, or
     ``None`` if no credential exists. The ``vault_id`` is needed by the
     OAuth refresh path to scope ``SELECT … FOR UPDATE`` to a specific row.
-    The DB's CHECK constraint guarantees ``auth_type`` is one of the
-    ``AuthType`` literals, so the cast on the way out is exhaustively safe.
+    ``auth_type`` is written only through the ``AuthType``-typed ``insert``
+    writer (single-sourced from the Literal, #1081), so the cast on the way
+    out is exhaustively safe.
     """
     row = await conn.fetchrow(
         """

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -31,6 +31,7 @@ from aios.models.workflows import (
     WfRunEventType,
     WfRunSignal,
     WfRunSignalKind,
+    WfRunStatus,
     Workflow,
 )
 
@@ -764,7 +765,7 @@ async def get_run_for_step(conn: asyncpg.Connection[Any], run_id: str) -> WfRun 
 
 
 async def set_run_status(
-    conn: asyncpg.Connection[Any], run_id: str, status: str, *, account_id: str
+    conn: asyncpg.Connection[Any], run_id: str, status: WfRunStatus, *, account_id: str
 ) -> None:
     """Set a NON-terminal status transition. Never overwrites a terminal status:
     under procrastinate dual execution (a reaped stale worker resuming next to its
@@ -785,7 +786,7 @@ async def set_run_terminal(
     conn: asyncpg.Connection[Any],
     run_id: str,
     *,
-    status: str,
+    status: WfRunStatus,
     output: Any,
     account_id: str,
 ) -> None:

--- a/src/aios/services/memory_stores.py
+++ b/src/aios/services/memory_stores.py
@@ -24,6 +24,7 @@ from aios.db import queries
 from aios.errors import ConflictError, MemoryStoreArchivedError, RateLimitedError
 from aios.models.memory_stores import (
     MAX_STORES_PER_SESSION,
+    ActorType,
     Memory,
     MemoryPrefix,
     MemoryStore,
@@ -50,7 +51,7 @@ class SessionActor:
 Actor = ApiActor | SessionActor
 
 
-def _actor_columns(actor: Actor) -> tuple[str, str]:
+def _actor_columns(actor: Actor) -> tuple[ActorType, str]:
     if isinstance(actor, SessionActor):
         return "session_actor", actor.session_id
     return "api_actor", "api"

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -46,7 +46,7 @@ from aios.errors import ConflictError, ForbiddenError, NotFoundError, RateLimite
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.models.attenuation import api_base_of, surface_of
-from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent
+from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent, WfRunStatus
 from aios.services import attenuation as attenuation_service
 from aios.services.sessions import (
     create_child_session,
@@ -1281,7 +1281,7 @@ async def _commit_terminal_and_dispatch(
     conn: asyncpg.Connection[Any],
     run: WfRun,
     *,
-    status: str,
+    status: WfRunStatus,
     payload: dict[str, Any],
     output: Any,
 ) -> None:

--- a/tests/integration/test_persisted_enum_check_drift.py
+++ b/tests/integration/test_persisted_enum_check_drift.py
@@ -60,7 +60,7 @@ def _check_value_set(constraintdef: str) -> set[str]:
 
 
 async def _constraintdef(conn: asyncpg.Connection[Any], name: str) -> str | None:
-    return await conn.fetchval(
+    result: str | None = await conn.fetchval(
         """
         SELECT pg_get_constraintdef(c.oid)
           FROM pg_constraint c
@@ -68,6 +68,7 @@ async def _constraintdef(conn: asyncpg.Connection[Any], name: str) -> str | None
         """,
         name,
     )
+    return result
 
 
 @needs_docker

--- a/tests/integration/test_persisted_enum_check_drift.py
+++ b/tests/integration/test_persisted_enum_check_drift.py
@@ -1,0 +1,109 @@
+"""Single-source guard for persisted-enum value sets — the live-``CHECK`` half
+(#1081).
+
+Companion to ``tests/unit/test_persisted_enum_writer_drift.py`` (the
+writer-signature half). Together they make the Python ``Literal`` the *single*
+editable source for every persisted enum's value set, so a forgotten paired
+migration can no longer ship a prod-only runtime ``CHECK`` violation.
+
+This module introspects the *live* migrated schema via
+``pg_catalog.pg_get_constraintdef`` — the project's sanctioned drift idiom,
+modelled on ``tests/unit/test_agent_tooltype_registry_drift.py``'s
+``get_args(...)`` set-equality and on the ``pg_get_constraintdef`` reads in
+``tests/integration/test_migrations_0110_bindings_cascade.py``. It asserts:
+
+  1. Every value-enum ``CHECK`` that is *kept* (the (C) rows whose writer is a
+     hardcoded SQL literal, or a nullable value-enum) still equals
+     ``set(get_args(<its Literal>))`` — pinning the surviving CHECK to the
+     Literal so the two cannot drift apart and pass CI.
+
+  2. Every value-enum ``CHECK`` that migration 0111 *drops* (the (A)/(B) rows,
+     now single-sourced from the typed writer the unit test pins) is actually
+     absent — so a re-introduced redundant CHECK is caught here.
+
+The value set is parsed straight out of ``pg_get_constraintdef`` text
+(``... IN ('a', 'b', ...)`` / ``ANY (ARRAY['a'::text, ...])``), so no test data
+or write round-trip is needed — pure ``get_args`` set algebra against a
+``pg_catalog`` read.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, get_args
+
+import asyncpg
+import pytest
+
+from aios.models.memory_stores import ActorType, MemoryOperation
+from tests.conftest import needs_docker
+
+# Constraints migration 0111 drops (the (A)/(B) rows). They must be ABSENT.
+_DROPPED_CHECKS: tuple[str, ...] = (
+    "vault_credentials_auth_type_check",
+    "triggers_last_fire_status_check",
+    "wf_run_events_type_check",
+    "wf_run_signals_kind_check",
+    "wf_runs_status_check",
+    "session_memory_stores_access_check",
+    "memory_versions_created_by_type_check",
+)
+
+_QUOTED = re.compile(r"'([^']*)'")
+
+
+def _check_value_set(constraintdef: str) -> set[str]:
+    """Parse the single-quoted literals out of a ``pg_get_constraintdef`` body
+    (handles both ``col IN ('a','b')`` and ``col = ANY (ARRAY['a'::text,...])``
+    renderings — both are just single-quoted tokens)."""
+    return set(_QUOTED.findall(constraintdef))
+
+
+async def _constraintdef(conn: asyncpg.Connection[Any], name: str) -> str | None:
+    return await conn.fetchval(
+        """
+        SELECT pg_get_constraintdef(c.oid)
+          FROM pg_constraint c
+         WHERE c.contype = 'c' AND c.conname = $1
+        """,
+        name,
+    )
+
+
+@needs_docker
+@pytest.mark.integration
+async def test_kept_value_enum_checks_match_their_literal(migrated_db_url: str) -> None:
+    """Each surviving value-enum CHECK's value set == ``get_args(<Literal>)``."""
+    kept: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("memory_versions_operation_check", get_args(MemoryOperation)),
+        ("memory_versions_redacted_by_type_check", get_args(ActorType)),
+    )
+    conn = await asyncpg.connect(migrated_db_url)
+    try:
+        for name, literal_args in kept:
+            cdef = await _constraintdef(conn, name)
+            assert cdef is not None, f"expected CHECK {name} to still exist"
+            assert _check_value_set(cdef) == set(literal_args), (
+                f"CHECK {name} value set {_check_value_set(cdef)} drifted from "
+                f"its Literal {set(literal_args)} — single-source violated"
+            )
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+async def test_redundant_value_enum_checks_are_dropped(migrated_db_url: str) -> None:
+    """The (A)/(B) CHECKs are single-sourced from the typed writer (pinned by
+    the unit drift-test); re-introducing one here is a regression."""
+    conn = await asyncpg.connect(migrated_db_url)
+    try:
+        for name in _DROPPED_CHECKS:
+            cdef = await _constraintdef(conn, name)
+            assert cdef is None, (
+                f"CHECK {name} should have been dropped in migration 0111 "
+                f"(its column is single-sourced from a Literal-typed writer); "
+                f"found: {cdef}"
+            )
+    finally:
+        await conn.close()

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -33,6 +33,7 @@ from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.attenuation import Surface
 from aios.models.sessions import Session
 from aios.models.vaults import VaultCredentialCreate
+from aios.models.workflows import WfRunStatus
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 from aios.services import vaults as vaults_service
@@ -3303,7 +3304,7 @@ async def test_lease_flips_before_the_harvest(wf_runtime: asyncpg.Pool[Any]) -> 
 
     real_set_run_status = wf_queries.set_run_status
 
-    async def exploding_flip(conn: Any, rid: str, status: str, *, account_id: str) -> None:
+    async def exploding_flip(conn: Any, rid: str, status: WfRunStatus, *, account_id: str) -> None:
         if status == "running":
             raise RuntimeError("died at the lease flip")
         await real_set_run_status(conn, rid, status, account_id=account_id)

--- a/tests/integration/test_wf_sweep.py
+++ b/tests/integration/test_wf_sweep.py
@@ -19,7 +19,7 @@ import pytest
 
 from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
-from aios.models.workflows import WfRunSignalKind
+from aios.models.workflows import WfRunSignalKind, WfRunStatus
 from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 from aios.workflows.sweep import wake_runs_needing_step
 
@@ -56,7 +56,7 @@ def test_wake_workflow_task_registered_on_workflows_queue() -> None:
     assert app.tasks["harness.wake_workflow"].queue == "workflows"
 
 
-async def _make_run(pool: asyncpg.Pool[Any], *, status: str = "suspended") -> str:
+async def _make_run(pool: asyncpg.Pool[Any], *, status: WfRunStatus = "suspended") -> str:
     async with pool.acquire() as conn:
         wf = await wf_queries.insert_workflow(
             conn,
@@ -133,8 +133,10 @@ async def test_status_clauses(sweep_pool: asyncpg.Pool[Any]) -> None:
     lease: any mid-step crash) are ALWAYS swept; a bare parked run and terminals
     never are."""
     pool = sweep_pool
-    runs = {s: await _make_run(pool, status=s) for s in ("pending", "running", "suspended")}
-    for s in ("completed", "errored", "cancelled"):
+    seeded: tuple[WfRunStatus, ...] = ("pending", "running", "suspended")
+    runs = {s: await _make_run(pool, status=s) for s in seeded}
+    terminal: tuple[WfRunStatus, ...] = ("completed", "errored", "cancelled")
+    for s in terminal:
         runs[s] = await _make_run(pool, status=s)
     assert await _needing(pool) == {runs["pending"], runs["running"]}
 

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0110``."""
+    """The migration ladder has exactly one head: ``0111``."""
     script = _script_directory()
-    assert script.get_heads() == ["0110"]
+    assert script.get_heads() == ["0111"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_persisted_enum_writer_drift.py
+++ b/tests/unit/test_persisted_enum_writer_drift.py
@@ -1,0 +1,90 @@
+"""Single-source guard for persisted-enum value sets (#1081).
+
+Every persisted enum's value set must have exactly ONE editable source: the
+Python ``Literal``. A forgotten paired migration used to ship a *prod-only*
+runtime ``CHECK`` violation (invisible to CI). This module closes the gap from
+the *writer* side: for every column whose redundant value-enum ``CHECK`` is
+dropped in migration ``0111`` (the (A)/(B) rows of #1081), the write path is now
+``Literal``-typed, so an illegal write is a static type error rather than a
+silent landing or a prod-only constraint trip.
+
+This is the writer-signature half of the drift guard, modelled on
+``tests/unit/test_agent_tooltype_registry_drift.py``'s ``get_args(...)``
+set-equality idiom. It needs no DB — pure ``inspect.signature`` + ``get_args``
+set algebra. The companion ``tests/integration/test_persisted_enum_check_drift``
+covers the live-``CHECK`` half (the (C) rows whose constraint is *kept*, pinned
+to its ``Literal`` via ``pg_get_constraintdef``), and asserts the dropped
+``CHECK``s are actually absent.
+
+If a ``Literal`` and the writer that feeds the column diverge — e.g. someone
+widens ``WfRunStatus`` but forgets to retype ``set_run_status`` — this test
+fails at build time, *and* mypy flags the illegal call site. The two copies can
+no longer be authored independently and pass CI.
+"""
+
+from __future__ import annotations
+
+import sys
+import typing
+from typing import Any, get_args
+
+from aios.db.queries import memory_stores as memory_store_queries
+from aios.db.queries import workflows as workflow_queries
+from aios.models.memory_stores import Access, ActorType
+from aios.models.workflows import WfRunStatus
+from aios.workflows import step as workflow_step
+
+
+def _param_literal_args(func: Any, param: str) -> tuple[object, ...]:
+    """``get_args`` of ``func``'s ``param`` annotation, resolving the stringized
+    (``from __future__ import annotations``) hint against the *function's own*
+    module globals. Returns ``()`` when the annotation is absent or not a
+    ``Literal`` so the assertion message is informative.
+
+    We resolve a single parameter rather than calling ``get_type_hints`` on the
+    whole function because other params (e.g. ``conn: asyncpg.Connection[Any]``)
+    carry annotations that are not subscriptable at runtime and would raise."""
+    raw = func.__annotations__.get(param)
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        module_globals = getattr(sys.modules.get(func.__module__), "__dict__", {})
+        raw = eval(raw, {"typing": typing, **module_globals})
+    return get_args(raw)
+
+
+def test_wf_run_status_writers_are_literal_typed() -> None:
+    """The (B) ``wf_runs.status`` writers must be ``WfRunStatus``-typed, not
+    plain ``str`` — that is what converts ``set_run_status(conn, run_id,
+    "pasued", ...)`` from a silent landing into a static type error once its
+    redundant ``wf_runs_status_check`` is dropped."""
+    expected = set(get_args(WfRunStatus))
+    for func, param in (
+        (workflow_queries.set_run_status, "status"),
+        (workflow_queries.set_run_terminal, "status"),
+        (workflow_step._commit_terminal_and_dispatch, "status"),
+    ):
+        assert set(_param_literal_args(func, param)) == expected, (
+            f"{func.__qualname__}'s '{param}' must be typed WfRunStatus "
+            f"(single-sourced with the Literal); got "
+            f"{_param_literal_args(func, param)!r}"
+        )
+
+
+def test_memory_store_value_enum_writers_are_literal_typed() -> None:
+    """The (B) ``memory_stores`` value-enum writers must carry the model
+    ``Literal``, not plain ``str``: ``created_by_type`` flows from
+    ``actor_type`` (``ActorType``) and ``session_memory_stores.access`` from
+    ``access`` (``Access``)."""
+    for func, param, literal in (
+        (memory_store_queries.insert_memory_with_version, "actor_type", ActorType),
+        (memory_store_queries.update_memory_with_version, "actor_type", ActorType),
+        (memory_store_queries.delete_memory_with_version, "actor_type", ActorType),
+        (memory_store_queries.redact_memory_version, "actor_type", ActorType),
+        (memory_store_queries.insert_session_memory_store, "access", Access),
+    ):
+        assert set(_param_literal_args(func, param)) == set(get_args(literal)), (
+            f"{func.__qualname__}'s '{param}' must be typed "
+            f"{literal} (single-sourced with the Literal); got "
+            f"{_param_literal_args(func, param)!r}"
+        )


### PR DESCRIPTION
Automated dev-pipeline build for issue #1081.