### PR TITLE
fix(sandbox): explicitly disable IPv6 egress on the sandbox network (belt-and-suspenders for the IPv4-only lockdown) — #978 follow-up

### DIFF
--- a/src/aios/sandbox/network.py
+++ b/src/aios/sandbox/network.py
@@ -37,8 +37,19 @@ async def ensure_sandbox_network() -> None:
     that split ``--hostname`` from ``--name`` will fail here.
     """
     if not await _network_exists(SANDBOX_NETWORK_NAME):
+        # ``--ipv6=false`` makes the IPv4-only egress lockdown's no-IPv6
+        # invariant explicit at create time rather than relying on the Docker
+        # default (#1207). NOTE this is the WEAKEST of the v6-disable changes:
+        # it is redundant against the current Docker default, does NOT defend a
+        # daemon configured with default-IPv6-on, and is INERT for an
+        # already-running network (which constraint #4 forbids us from
+        # recreating). The load-bearing protection is the per-session
+        # ``ip6tables -P OUTPUT DROP`` applied in the lockdown sidecar (see
+        # ``setup.build_iptables_script``); this flag is belt-and-suspenders on
+        # top of it, NOT a substitute, and must never be "fixed" by tearing
+        # down and recreating the live prod network.
         rc, _, stderr_bytes = await run_docker_cli(
-            ["docker", "network", "create", SANDBOX_NETWORK_NAME]
+            ["docker", "network", "create", "--ipv6=false", SANDBOX_NETWORK_NAME]
         )
         if rc == 0:
             log.info("sandbox.network_created", network=SANDBOX_NETWORK_NAME)

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -195,6 +195,51 @@ _IPTABLES_BACKEND_SELECT = (
 )
 
 
+# Same legacy-vs-nft backend selection as ``_IPTABLES_BACKEND_SELECT`` but for
+# the IPv6 ``ip6tables`` command (#1207). gVisor's netstack (``runsc``)
+# implements the *legacy* netfilter ABI, so a bare ``ip6tables`` would fail with
+# ``Failed to initialize nft: Protocol not supported`` and — under ``set -e`` —
+# abort the entire lockdown apply, failing every Limited provision closed-noisily
+# (a self-inflicted outage). We always prefer ``ip6tables-legacy`` when present
+# and fall back to ``ip6tables`` on runc hosts whose image lacks it. Debian's
+# ``iptables`` package ships BOTH the v4 and v6 legacy alternatives, so the
+# operator sidecar image (settings.docker_image) that already carries
+# ``iptables-legacy`` for the v4 path carries ``ip6tables-legacy`` too.
+_IP6TABLES_BACKEND_SELECT = (
+    "if command -v ip6tables-legacy >/dev/null 2>&1; then IP6T=ip6tables-legacy; "
+    "else IP6T=ip6tables; fi"
+)
+
+
+# Belt-and-suspenders IPv6 egress denial (#1207). The IPv4-only egress lockdown
+# rests on the ``aios-sandbox`` network being created without ``--ipv6`` so no
+# v6 route exists — an implicit, undocumented invariant. The moment a v6 route
+# appears (network recreated with ``--ipv6``, or a Docker default flips), the
+# IPv4-only ``-P OUTPUT DROP`` is silently bypassable over IPv6 (fail-open).
+# This block makes v6 egress impossible *by construction*: flush the v6 OUTPUT
+# chain, allow only loopback (so any in-netns v6 localhost/DNS still works), and
+# set the default OUTPUT policy to DROP — mirroring the v4 DROP. It is emitted
+# only on the Limited lockdown path (total-egress-denial intent); the
+# Unrestricted DNAT-only path deliberately leaves all egress open.
+#
+# This is the LOAD-BEARING prod protection for the IPv6 gap: it is applied
+# per-session in the sidecar netns regardless of how the (already-running, never
+# recreated — constraint #4) prod network was created. The ``--ipv6=false``
+# network-create flag is the weakest of the three changes — redundant against
+# the current Docker default and inert for the live network — so the real
+# defense is this per-session DROP.
+_IP6TABLES_LOCKDOWN_LINES = (
+    "",
+    "# Belt-and-suspenders: deny ALL IPv6 egress (#1207). The IPv4 -P OUTPUT DROP",
+    "# above is iptables-only; without this an IPv6 route would bypass it.",
+    _IP6TABLES_BACKEND_SELECT,
+    '"$IP6T" -F OUTPUT',
+    "# Allow v6 loopback so in-netns localhost/DNS still works; deny everything else.",
+    '"$IP6T" -A OUTPUT -o lo -j ACCEPT',
+    '"$IP6T" -P OUTPUT DROP',
+)
+
+
 # Emitted shell helper that resolves a hostname to its **IPv4 addresses only**,
 # one per line. Centralizes the IPv4-only resolution shared by every host
 # lookup in the lockdown scripts (the allowed-host loops, the extra-host-ports
@@ -283,6 +328,14 @@ def build_iptables_script(
     and any additional ``(host, port)`` pairs in ``extra_host_ports``.
     Everything else is dropped.
 
+    As a belt-and-suspenders measure (#1207) the script ALSO denies all IPv6
+    egress: it flushes the ``ip6tables`` OUTPUT chain, allows v6 loopback, and
+    sets ``-P OUTPUT DROP``. The IPv4 ``iptables`` DROP is IPv4-only, so without
+    this an IPv6 route appearing on the sandbox network (currently created
+    without ``--ipv6``) would silently bypass the lockdown over v6. The v6 path
+    uses the same legacy-vs-nft backend selection as the v4 path so a bare
+    ``ip6tables`` never aborts the apply under runsc's legacy-only netstack.
+
     The extra-host-ports surface exists because the credential proxy
     binds to a non-standard ephemeral port; without it, in-sandbox
     git traffic to the proxy would be dropped by the default policy.
@@ -355,6 +408,10 @@ def build_iptables_script(
     lines.append("# Drop everything else")
     lines.append('"$IPT" -P OUTPUT DROP')
 
+    # Belt-and-suspenders: mirror the v4 DROP on IPv6 so the IPv4-only lockdown
+    # cannot be bypassed over v6 if a v6 route ever appears (#1207).
+    lines.extend(_IP6TABLES_LOCKDOWN_LINES)
+
     return "\n".join(lines)
 
 
@@ -426,10 +483,15 @@ def build_lockdown_verify_script(
 
     When ``assert_drop`` (the default), asserts the filter-table default OUTPUT
     policy is ``DROP`` — proof the lockdown actually landed in the shared netns,
-    not merely that the apply script exited 0. The DNAT-only Unrestricted path
-    (#1153) passes ``assert_drop=False``: that script deliberately leaves the
-    filter policy at ``ACCEPT``, so there is no DROP to assert (asserting it
-    would always fail).
+    not merely that the apply script exited 0. It ALSO asserts the IPv6
+    ``ip6tables`` OUTPUT policy is ``DROP`` (#1207): the apply installs a
+    belt-and-suspenders v6 DROP, and leaving it unverified would re-create the
+    exact "green verify while open" gap one layer down. The v6 assertion uses
+    the same legacy-backend selection as the apply so it reads the right table
+    under runsc. The DNAT-only Unrestricted path (#1153) passes
+    ``assert_drop=False``: that script deliberately leaves the filter policy at
+    ``ACCEPT`` and installs no v6 DROP, so there is no DROP (v4 or v6) to assert
+    (asserting it would always fail).
 
     When ``dnat_hosts`` is non-empty it ALSO asserts the nat table carries at
     least one ``DNAT`` OUTPUT rule. Without this, a credential host whose
@@ -451,6 +513,13 @@ def build_lockdown_verify_script(
     lines = [_IPTABLES_BACKEND_SELECT]
     if assert_drop:
         lines.append("\"$IPT\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'")
+        # Extend the read-back verify to v6 (#1207): without asserting the
+        # ip6tables policy too, the new v6 DROP is itself unverified — re-creating
+        # the exact "green verify while open" gap one layer down. Selects the same
+        # legacy backend the apply wrote to, so the verify reads the right table
+        # under runsc.
+        lines.append(_IP6TABLES_BACKEND_SELECT)
+        lines.append("\"$IP6T\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'")
     if dnat_hosts:
         lines.append("\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'")
     return "\n".join(lines)

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -228,15 +228,38 @@ _IP6TABLES_BACKEND_SELECT = (
 # network-create flag is the weakest of the three changes — redundant against
 # the current Docker default and inert for the live network — so the real
 # defense is this per-session DROP.
+#
+# The whole block is GUARDED on the v6 ``filter`` table being initializable
+# (``"$IP6T" -S OUTPUT`` succeeds). On hosts where the ``ip6_tables`` kernel
+# module is not loaded — common on CI runners and any IPv6-disabled host —
+# ``ip6tables`` aborts with ``can't initialize ip6tables table 'filter': Table
+# does not exist (do you need to insmod?)``. Under ``set -e`` that would abort
+# the entire lockdown apply and fail every Limited provision closed-noisily — a
+# self-inflicted outage triggered by the absence of the very v6 stack we are
+# trying to lock down. But that absence is itself the security property: with no
+# v6 ``filter`` table there is no v6 netfilter path to leak through, so skipping
+# the DROP is safe. When the table IS present (a v6 route/stack exists — the
+# exact case the DROP defends), the flush/loopback/DROP run and any failure
+# there is a real error. We deliberately do NOT ``modprobe ip6_tables`` (the
+# sidecar holds no module-load capability and forcing the module on just to drop
+# would re-introduce a v6 surface where none existed).
 _IP6TABLES_LOCKDOWN_LINES = (
     "",
     "# Belt-and-suspenders: deny ALL IPv6 egress (#1207). The IPv4 -P OUTPUT DROP",
     "# above is iptables-only; without this an IPv6 route would bypass it.",
     _IP6TABLES_BACKEND_SELECT,
-    '"$IP6T" -F OUTPUT',
-    "# Allow v6 loopback so in-netns localhost/DNS still works; deny everything else.",
-    '"$IP6T" -A OUTPUT -o lo -j ACCEPT',
-    '"$IP6T" -P OUTPUT DROP',
+    "# Guard on the v6 filter table being initializable: if ip6_tables is not",
+    "# loaded (no v6 netfilter path to leak through) skip rather than abort under",
+    "# set -e; when it IS present the DROP below is enforced and verified.",
+    'if "$IP6T" -S OUTPUT >/dev/null 2>&1; then',
+    '  "$IP6T" -F OUTPUT',
+    "  # Allow v6 loopback so in-netns localhost/DNS still works; deny everything else.",
+    '  "$IP6T" -A OUTPUT -o lo -j ACCEPT',
+    '  "$IP6T" -P OUTPUT DROP',
+    "else",
+    '  echo "ip6tables filter table unavailable (ip6_tables not loaded); '
+    'no IPv6 egress path to lock down — skipping v6 DROP" >&2',
+    "fi",
 )
 
 
@@ -517,9 +540,18 @@ def build_lockdown_verify_script(
         # ip6tables policy too, the new v6 DROP is itself unverified — re-creating
         # the exact "green verify while open" gap one layer down. Selects the same
         # legacy backend the apply wrote to, so the verify reads the right table
-        # under runsc.
+        # under runsc. The assertion is GUARDED the same way the apply is: when
+        # the v6 ``filter`` table is not initializable (``ip6_tables`` not loaded
+        # — no v6 netfilter path to leak through, so the apply correctly skipped
+        # its DROP) there is no policy to read back and the verify passes. When
+        # the table IS present, ``-S OUTPUT`` succeeds and the DROP policy must be
+        # there (a missing DROP fails the verify, closing the "green verify while
+        # open" gap for the case the DROP actually defends).
         lines.append(_IP6TABLES_BACKEND_SELECT)
-        lines.append("\"$IP6T\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'")
+        lines.append(
+            'if v6_output="$("$IP6T" -S OUTPUT 2>/dev/null)"; then '
+            "printf '%s\\n' \"$v6_output\" | grep -qx -- '-P OUTPUT DROP'; fi"
+        )
     if dnat_hosts:
         lines.append("\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'")
     return "\n".join(lines)

--- a/src/aios/sandbox/setup.py
+++ b/src/aios/sandbox/setup.py
@@ -533,7 +533,20 @@ def build_lockdown_verify_script(
     verify always carries a positive nat-DNAT assertion and never degenerates
     to a no-op.
     """
-    lines = [_IPTABLES_BACKEND_SELECT]
+    # ``set -e`` so EVERY assertion is independently fatal regardless of order.
+    # The sidecar runs this via ``bash -c <script>`` with NO ``-e``, so without
+    # this the script's exit status is its LAST command — and the v6 read-back
+    # block below ends in a guarded ``if ...; then ...; fi`` that returns 0 when
+    # the v6 ``filter`` table is unavailable (the common CI / IPv6-disabled-host
+    # case). That trailing 0 would MASK a failed earlier v4 ``-P OUTPUT DROP``
+    # assertion: verify passes GREEN while the box is open over IPv4 — a fail-open
+    # regression on the load-bearing v4 lockdown. ``set -e`` makes the v4 (and
+    # nat) assertions abort the script the instant they fail, before the v6 block
+    # can overwrite the exit status. The v6 block keeps its own internal ``if``
+    # guard so a missing v6 table is still a graceful skip (the guard's condition
+    # being false leaves ``$?`` at 0 and ``set -e`` does NOT fire on a tested
+    # condition), not a failure.
+    lines = ["set -e", _IPTABLES_BACKEND_SELECT]
     if assert_drop:
         lines.append("\"$IPT\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'")
         # Extend the read-back verify to v6 (#1207): without asserting the

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -103,6 +103,12 @@ def _docker_run(
         # lockdown sidecar selects iptables-legacy when present (#1022), so the
         # image MUST ship it. It's the iptables package's legacy alternative.
         "iptables-legacy",
+        # IPv6 belt-and-suspenders egress DROP (#1207). The Limited lockdown
+        # sidecar mirrors the v4 -P OUTPUT DROP on ip6tables, selecting the
+        # legacy backend (runsc netstack speaks the legacy ABI, not nft), so the
+        # operator image MUST ship both ip6tables and its legacy alternative.
+        "ip6tables",
+        "ip6tables-legacy",
         "update-ca-certificates",  # egress-CA trust install (sandbox/setup.py)
         "jq",  # JSON-from-bash composition, esp. piping `tool <name> '{...}'`
         "tool",  # sandbox-native broker CLI (baked from repo bin/tool; #635)

--- a/tests/e2e/test_sandbox_ipv6_lockdown.py
+++ b/tests/e2e/test_sandbox_ipv6_lockdown.py
@@ -1,0 +1,172 @@
+"""E2E test pinning the IPv6 belt-and-suspenders egress lockdown (#1207).
+
+The IPv4-only egress lockdown's IPv4-only-ness rested on an implicit,
+undocumented invariant: the ``aios-sandbox`` network is created without
+``--ipv6`` so no v6 route exists, and the lockdown's ``-P OUTPUT DROP`` is
+iptables-only (``ip6tables`` left at default ACCEPT). The moment a v6 route
+appears, the IPv4-only lockdown is silently bypassable over IPv6 (fail-open).
+
+This test provisions a real Limited sandbox, applies the real lockdown, and
+asserts the invariant is now pinned by construction:
+
+1. the sandbox has NO global IPv6 address and NO v6 default route, and
+2. the ``ip6tables`` OUTPUT policy is ``DROP`` (the per-session
+   belt-and-suspenders DROP — the load-bearing prod protection).
+
+It runs under the same Docker runtime matrix as the v4 lockdown: when
+``AIOS_SANDBOX_RUNTIME=runsc`` the sidecar runs under gVisor's netstack, so the
+runsc legacy-netfilter-ABI path for ``ip6tables-legacy`` is exercised, not just
+runc.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from aios.config import get_settings
+from aios.models.environments import LimitedNetworking
+from aios.sandbox.backends.base import (
+    INSTANCE_LABEL_KEY,
+    MANAGED_LABEL_KEY,
+    MANAGED_LABEL_VALUE,
+    SESSION_LABEL_KEY,
+    Limited,
+    Mount,
+    SandboxHandle,
+    SandboxSpec,
+)
+from aios.sandbox.backends.docker import DockerBackend
+from aios.sandbox.network import ensure_sandbox_network
+from aios.sandbox.setup import apply_network_lockdown
+from tests.conftest import needs_docker
+
+pytestmark = [needs_docker, pytest.mark.docker]
+
+IMAGE = "ghcr.io/eumemic/aios-sandbox:latest"
+
+
+@pytest.fixture
+async def _network_ready() -> None:
+    await ensure_sandbox_network()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    return ws
+
+
+@pytest.fixture
+async def limited_sandbox(
+    _network_ready: None, workspace: Path
+) -> AsyncIterator[tuple[DockerBackend, SandboxHandle]]:
+    """Provision a Limited sandbox and apply the real lockdown, threading the
+    configured Docker runtime (so ``AIOS_SANDBOX_RUNTIME=runsc`` exercises the
+    gVisor path). Tears down unconditionally so a failed assertion doesn't leak
+    the container."""
+    settings = get_settings()
+    image = os.environ.get("AIOS_DOCKER_IMAGE", settings.docker_image) or IMAGE
+    runtime = settings.sandbox_runtime
+
+    backend = DockerBackend()
+    instance_id = f"test_{uuid.uuid4().hex[:8]}"
+    session_id = f"sess_{uuid.uuid4().hex[:8]}"
+    spec = SandboxSpec(
+        session_id=session_id,
+        instance_id=instance_id,
+        workspace=Mount(host_path=workspace, sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={
+            MANAGED_LABEL_KEY: MANAGED_LABEL_VALUE,
+            INSTANCE_LABEL_KEY: instance_id,
+            SESSION_LABEL_KEY: session_id,
+        },
+        network_policy=Limited(allowed_hosts=frozenset({"example.com"})),
+        host_gateway_alias=None,
+        image=image,
+        runtime=runtime,
+    )
+    handle = await backend.create(spec)
+    try:
+        await apply_network_lockdown(
+            backend,
+            handle,
+            LimitedNetworking(type="limited", allowed_hosts=["example.com"]),
+            runtime=runtime,
+        )
+        yield backend, handle
+    finally:
+        await backend.destroy(handle)
+
+
+async def test_sandbox_has_no_global_ipv6_address(
+    limited_sandbox: tuple[DockerBackend, SandboxHandle],
+) -> None:
+    """No global-scope IPv6 address means there is no v6 source to egress from —
+    the implicit invariant the IPv4-only lockdown rested on, now asserted."""
+    backend, handle = limited_sandbox
+    result = await backend.exec(
+        handle,
+        "ip -6 addr show scope global 2>/dev/null || true",
+        timeout_seconds=15,
+        max_output_bytes=10_000,
+    )
+    # ``scope global`` filters out the always-present link-local (fe80::) addr;
+    # what must be absent is a routable global v6 address.
+    assert "inet6" not in result.stdout, (
+        f"sandbox has a global IPv6 address (v6 egress source exists): {result.stdout!r}"
+    )
+
+
+async def test_sandbox_has_no_ipv6_default_route(
+    limited_sandbox: tuple[DockerBackend, SandboxHandle],
+) -> None:
+    """No v6 default route means no path off-host over IPv6, so the IPv4-only
+    lockdown cannot be bypassed over v6 today."""
+    backend, handle = limited_sandbox
+    result = await backend.exec(
+        handle,
+        "ip -6 route show default 2>/dev/null || true",
+        timeout_seconds=15,
+        max_output_bytes=10_000,
+    )
+    assert "default" not in result.stdout, (
+        f"sandbox has an IPv6 default route (v6 egress path exists): {result.stdout!r}"
+    )
+
+
+async def test_ip6tables_output_policy_is_drop(
+    limited_sandbox: tuple[DockerBackend, SandboxHandle],
+) -> None:
+    """The belt-and-suspenders per-session DROP: even if a v6 route ever
+    appears, ``ip6tables -P OUTPUT DROP`` blocks egress. Read it back from the
+    shared netns via an operator-image sidecar (the sandbox itself holds no
+    NET_ADMIN), selecting the legacy backend so it works under runsc."""
+    backend, handle = limited_sandbox
+    settings = get_settings()
+    # Mirror the lockdown's legacy-backend selection so this reads the same
+    # table the apply wrote to under runsc.
+    script = (
+        "if command -v ip6tables-legacy >/dev/null 2>&1; then IP6T=ip6tables-legacy; "
+        "else IP6T=ip6tables; fi\n"
+        '"$IP6T" -S OUTPUT | grep -qx -- "-P OUTPUT DROP"'
+    )
+    result = await backend.run_netns_sidecar(
+        handle.sandbox_id,
+        image=settings.docker_image,
+        script=script,
+        timeout_seconds=15,
+        max_output_bytes=10_000,
+        runtime=settings.sandbox_runtime,
+    )
+    assert result.exit_code == 0, (
+        "ip6tables OUTPUT policy is not DROP after lockdown apply\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )

--- a/tests/e2e/test_sandbox_ipv6_lockdown.py
+++ b/tests/e2e/test_sandbox_ipv6_lockdown.py
@@ -148,15 +148,29 @@ async def test_ip6tables_output_policy_is_drop(
     """The belt-and-suspenders per-session DROP: even if a v6 route ever
     appears, ``ip6tables -P OUTPUT DROP`` blocks egress. Read it back from the
     shared netns via an operator-image sidecar (the sandbox itself holds no
-    NET_ADMIN), selecting the legacy backend so it works under runsc."""
+    NET_ADMIN), selecting the legacy backend so it works under runsc.
+
+    The assertion is guarded the same way the lockdown apply is: on hosts where
+    the ``ip6_tables`` kernel module is not loaded — common on CI runners and
+    any IPv6-disabled host — the v6 ``filter`` table cannot be initialized, so
+    there is no v6 netfilter path to leak through and the apply correctly skips
+    its DROP. In that case ``ip6tables -S OUTPUT`` fails to initialize and there
+    is no policy to read back; the test passes (there is nothing to secure).
+    When the v6 table IS present (the exact case the DROP defends), the policy
+    MUST be ``DROP``."""
     backend, handle = limited_sandbox
     settings = get_settings()
     # Mirror the lockdown's legacy-backend selection so this reads the same
-    # table the apply wrote to under runsc.
+    # table the apply wrote to under runsc, and its table-availability guard so
+    # a missing ip6_tables module is not a spurious failure.
     script = (
         "if command -v ip6tables-legacy >/dev/null 2>&1; then IP6T=ip6tables-legacy; "
         "else IP6T=ip6tables; fi\n"
-        '"$IP6T" -S OUTPUT | grep -qx -- "-P OUTPUT DROP"'
+        'if v6_output="$("$IP6T" -S OUTPUT 2>/dev/null)"; then\n'
+        '  printf "%s\\n" "$v6_output" | grep -qx -- "-P OUTPUT DROP"\n'
+        "else\n"
+        '  echo "ip6tables filter table unavailable; no v6 egress path to lock down" >&2\n'
+        "fi"
     )
     result = await backend.run_netns_sidecar(
         handle.sandbox_id,
@@ -167,6 +181,7 @@ async def test_ip6tables_output_policy_is_drop(
         runtime=settings.sandbox_runtime,
     )
     assert result.exit_code == 0, (
-        "ip6tables OUTPUT policy is not DROP after lockdown apply\n"
+        "ip6tables OUTPUT policy is not DROP after lockdown apply (and the v6 "
+        "filter table WAS initializable)\n"
         f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
     )

--- a/tests/unit/sandbox/test_sandbox_network.py
+++ b/tests/unit/sandbox/test_sandbox_network.py
@@ -74,6 +74,27 @@ class TestEnsureNetworkOnHost:
             ["docker", "network", "create"],
         ]
 
+    async def test_create_passes_ipv6_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """#1207: the network is created with ``--ipv6=false`` so the IPv4-only
+        egress lockdown's no-IPv6 invariant is explicit at create time rather
+        than resting on the Docker default. (This is the weakest of the three
+        v6-disable changes — the load-bearing protection is the per-session
+        ip6tables DROP — but the flag must be present on new creates.)"""
+
+        def responder(argv: list[str]) -> tuple[int, bytes, bytes]:
+            if argv[:3] == ["docker", "network", "inspect"]:
+                return 1, b"", b"Error: No such network"
+            if argv[:3] == ["docker", "network", "create"]:
+                return 0, b"netid\n", b""
+            pytest.fail(f"unexpected argv: {argv}")
+
+        calls = install_docker_responder(monkeypatch, responder)
+        await ensure_sandbox_network()
+        create = next(c for c in calls if c[:3] == ["docker", "network", "create"])
+        assert "--ipv6=false" in create
+        # The network name is still the final positional argument.
+        assert create[-1] == SANDBOX_NETWORK_NAME
+
 
 # ── ensure_sandbox_network: in-container worker ──────────────────────────────
 

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -267,6 +267,83 @@ class TestBuildIptablesScript:
         assert "--dport 80 -j DNAT" not in script
 
 
+# ── IPv6 belt-and-suspenders egress DROP (#1207) ──────────────────────────────
+
+
+class TestIPv6EgressLockdown:
+    """The Limited lockdown mirrors the v4 ``-P OUTPUT DROP`` on ip6tables so
+    the IPv4-only lockdown cannot be bypassed over IPv6 if a v6 route ever
+    appears (network recreated with ``--ipv6``, or a Docker default flips)."""
+
+    def test_emits_ip6tables_output_drop(self) -> None:
+        script = build_iptables_script(allowed_hosts={"api.example.com"})
+        assert '"$IP6T" -P OUTPUT DROP' in script
+
+    def test_flushes_ip6tables_output_chain(self) -> None:
+        script = build_iptables_script(allowed_hosts={"api.example.com"})
+        assert '"$IP6T" -F OUTPUT' in script
+        # The flush precedes the DROP policy so re-apply is idempotent.
+        assert script.index('"$IP6T" -F OUTPUT') < script.index('"$IP6T" -P OUTPUT DROP')
+
+    def test_allows_v6_loopback(self) -> None:
+        """Total v6 egress denial, but loopback stays open so any in-netns
+        v6 localhost/DNS still works (the spec's 'flush + DROP with loopback
+        allowed' form)."""
+        script = build_iptables_script(allowed_hosts={"api.example.com"})
+        assert '"$IP6T" -A OUTPUT -o lo -j ACCEPT' in script
+        # Loopback ACCEPT precedes the DROP policy (rules are order-independent
+        # for a policy, but the ACCEPT rule must exist alongside it).
+        assert script.index('"$IP6T" -A OUTPUT -o lo -j ACCEPT') < script.index(
+            '"$IP6T" -P OUTPUT DROP'
+        )
+
+    def test_selects_legacy_ip6tables_backend(self) -> None:
+        """runsc's netstack speaks the legacy netfilter ABI, not nft. A bare
+        ``ip6tables`` under ``set -e`` would error on runsc and abort the whole
+        lockdown apply, failing every Limited provision closed-noisily. So the
+        v6 path mirrors the v4 legacy-backend selection."""
+        script = build_iptables_script(allowed_hosts={"api.example.com"})
+        assert "command -v ip6tables-legacy" in script
+
+    def test_no_bare_ip6tables_invocations(self) -> None:
+        """Every v6 netfilter command goes through the ``$IP6T`` selector so it
+        never silently uses the nft default (which fails on runsc)."""
+        script = build_iptables_script(
+            allowed_hosts={"api.example.com"},
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        for line in script.splitlines():
+            stripped = line.strip()
+            # The detection preamble names the binaries; that's expected.
+            if "command -v ip6tables-legacy" in stripped:
+                continue
+            assert not stripped.startswith("ip6tables "), (
+                f"bare ip6tables invocation would use the nft default: {line!r}"
+            )
+
+    def test_v6_drop_present_with_dnat(self) -> None:
+        """The v6 DROP is on the lockdown (filter-DROP) path regardless of
+        credential DNAT, which only touches the v4 nat table."""
+        script = build_iptables_script(
+            allowed_hosts={"plain.example.com"},
+            extra_host_ports=[("aios-worker", 8765)],
+            dnat_hosts=["api.secret.com"],
+            dnat_target=("aios-worker", 49152),
+        )
+        assert '"$IP6T" -P OUTPUT DROP' in script
+
+    def test_dnat_only_script_has_no_v6_drop(self) -> None:
+        """The Unrestricted DNAT-only path leaves general egress open, so it
+        must NOT install a v6 DROP (which would deny v6 egress in an otherwise
+        open box)."""
+        script = build_secret_egress_dnat_script(
+            dnat_hosts=["api.secret.com"], dnat_target=("aios-worker", 49152)
+        )
+        assert "ip6tables" not in script
+        assert "-P OUTPUT DROP" not in script
+
+
 # ── IPv4-only host resolution (#978) ──────────────────────────────────────────
 
 
@@ -481,12 +558,35 @@ class TestBuildLockdownVerifyScript:
                 f"verify uses a bare iptables (nft default): {line!r}"
             )
 
+    def test_asserts_ip6tables_drop_policy(self) -> None:
+        """#1207: the v6 DROP installed by the apply must itself be verified —
+        without asserting ``ip6tables -S OUTPUT`` shows ``-P OUTPUT DROP`` the
+        new v6 DROP is unverified, re-creating the 'green verify while open' gap
+        one layer down."""
+        script = build_lockdown_verify_script()
+        assert "\"$IP6T\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'" in script
+
+    def test_v6_verify_uses_legacy_backend_no_bare_ip6tables(self) -> None:
+        """The v6 read-back selects the same legacy backend the apply wrote to,
+        so it reads the right table under runsc — and never a bare ip6tables."""
+        script = build_lockdown_verify_script(dnat_hosts=["api.secret.com"])
+        assert "command -v ip6tables-legacy" in script
+        for line in script.splitlines():
+            stripped = line.strip()
+            if "command -v ip6tables-legacy" in stripped:
+                continue
+            assert not stripped.startswith("ip6tables "), (
+                f"verify uses a bare ip6tables (nft default): {line!r}"
+            )
+
     def test_assert_drop_false_omits_drop_assertion(self) -> None:
         # The DNAT-only Unrestricted path (#1153) leaves the filter policy at
         # ACCEPT, so the verify must NOT assert a DROP policy (it would always
-        # fail) — but still asserts nat DNAT coverage.
+        # fail) — but still asserts nat DNAT coverage. The v6 DROP assertion is
+        # likewise omitted (the DNAT-only path installs no v6 DROP).
         script = build_lockdown_verify_script(dnat_hosts=["api.secret.com"], assert_drop=False)
         assert "OUTPUT DROP" not in script
+        assert "IP6T" not in script
         assert "\"$IPT\" -t nat -S OUTPUT | grep -q -- '-j DNAT'" in script
 
     def test_assert_drop_true_is_default(self) -> None:

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -279,6 +279,23 @@ class TestIPv6EgressLockdown:
         script = build_iptables_script(allowed_hosts={"api.example.com"})
         assert '"$IP6T" -P OUTPUT DROP' in script
 
+    def test_v6_block_guarded_on_table_availability(self) -> None:
+        """#1207 fix: the v6 flush/loopback/DROP must NOT abort the whole apply
+        under ``set -e`` when the ``ip6_tables`` kernel module is absent (the v6
+        ``filter`` table cannot initialize — common on CI runners and any
+        IPv6-disabled host). A missing v6 netfilter table means there is no v6
+        egress path to leak through, so the block is skipped, not fatal; when the
+        table IS present the DROP is enforced. Without this guard every Limited
+        provision in the docker e2e shard fails closed on such hosts."""
+        script = build_iptables_script(allowed_hosts={"api.example.com"})
+        # The v6 rules run only inside an ``if "$IP6T" -S OUTPUT`` guard.
+        assert 'if "$IP6T" -S OUTPUT >/dev/null 2>&1; then' in script
+        guard_idx = script.index('if "$IP6T" -S OUTPUT >/dev/null 2>&1; then')
+        drop_idx = script.index('"$IP6T" -P OUTPUT DROP')
+        assert guard_idx < drop_idx, "v6 DROP must be inside the table-available guard"
+        # There must be an else-branch that does not abort (no bare exit/false).
+        assert "\nelse\n" in script or "\nelse \n" in script or "else" in script
+
     def test_flushes_ip6tables_output_chain(self) -> None:
         script = build_iptables_script(allowed_hosts={"api.example.com"})
         assert '"$IP6T" -F OUTPUT' in script
@@ -562,9 +579,26 @@ class TestBuildLockdownVerifyScript:
         """#1207: the v6 DROP installed by the apply must itself be verified —
         without asserting ``ip6tables -S OUTPUT`` shows ``-P OUTPUT DROP`` the
         new v6 DROP is unverified, re-creating the 'green verify while open' gap
-        one layer down."""
+        one layer down. The assertion goes through ``$IP6T -S OUTPUT`` and
+        ``grep`` for the DROP policy."""
         script = build_lockdown_verify_script()
-        assert "\"$IP6T\" -S OUTPUT | grep -qx -- '-P OUTPUT DROP'" in script
+        assert '"$IP6T" -S OUTPUT' in script
+        assert "grep -qx -- '-P OUTPUT DROP'" in script
+
+    def test_v6_verify_guarded_on_table_availability(self) -> None:
+        """#1207 fix: the v6 read-back must NOT hard-fail when the ``ip6_tables``
+        kernel module is absent (the v6 ``filter`` table cannot initialize, so
+        the apply correctly skipped its DROP and there is no policy to read
+        back). The assertion is guarded on ``$IP6T -S OUTPUT`` succeeding, so a
+        missing module passes the verify (nothing to secure) while a present
+        table still requires the DROP. Without this guard the docker e2e shard
+        fails on CI runners that don't load ip6_tables."""
+        script = build_lockdown_verify_script()
+        # The v6 read-back is captured under a conditional, not a bare pipe that
+        # would propagate ip6tables' init failure as the script's exit status.
+        assert 'if v6_output="$("$IP6T" -S OUTPUT 2>/dev/null)"; then' in script
+        # Still asserts the DROP policy when the table IS readable.
+        assert "grep -qx -- '-P OUTPUT DROP'" in script
 
     def test_v6_verify_uses_legacy_backend_no_bare_ip6tables(self) -> None:
         """The v6 read-back selects the same legacy backend the apply wrote to,

--- a/tests/unit/test_networking.py
+++ b/tests/unit/test_networking.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import subprocess
+import tempfile
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -627,6 +631,83 @@ class TestBuildLockdownVerifyScript:
         # Backward-compat: the Limited callers pass no assert_drop and must keep
         # getting the DROP assertion.
         assert "OUTPUT DROP" in build_lockdown_verify_script(dnat_hosts=["api.secret.com"])
+
+    def test_emits_set_e_first(self) -> None:
+        """Every assertion must be independently fatal. The sidecar runs the
+        script via ``bash -c`` with NO ``-e`` flag, so the script's exit status
+        defaults to its LAST command — the trailing guarded v6 ``if`` that
+        returns 0 when the v6 table is unavailable. Without ``set -e`` at the top
+        that trailing 0 masks a failed earlier v4 DROP assertion (fail-open).
+        ``set -e`` must be the first line so the v4 (and nat) assertions abort the
+        script the instant they fail."""
+        for script in (
+            build_lockdown_verify_script(),
+            build_lockdown_verify_script(dnat_hosts=["api.secret.com"]),
+            build_lockdown_verify_script(dnat_hosts=["api.secret.com"], assert_drop=False),
+        ):
+            assert script.splitlines()[0] == "set -e"
+
+    def _run_verify(self, *, v4_policy: str, v6_mode: str, dnat_hosts: Sequence[str] = ()) -> int:
+        """Run the generated verify script under ``bash -c`` (exactly as the
+        sidecar does — no ``-e`` on the invocation) against fake legacy
+        binaries, returning its exit code.
+
+        ``v4_policy``/``v6_mode`` are the ``-S OUTPUT`` policies the fakes report
+        (``"DROP"``/``"ACCEPT"``); ``v6_mode="unavailable"`` makes ``ip6tables-S
+        OUTPUT`` fail to initialize (the no-``ip6_tables``-module / CI case).
+        """
+        script = build_lockdown_verify_script(dnat_hosts=dnat_hosts)
+        bindir = tempfile.mkdtemp()
+        v4 = (
+            f"#!/usr/bin/env bash\n"
+            f"if [ \"$1\" = '-S' ] && [ \"$2\" = 'OUTPUT' ]; then echo '-P OUTPUT {v4_policy}'; exit 0; fi\n"
+            f"# nat -S OUTPUT carries a DNAT rule so the nat assertion (if any) passes\n"
+            f"if [ \"$1\" = '-t' ] && [ \"$2\" = 'nat' ]; then echo '-A OUTPUT -j DNAT --to-destination 1.2.3.4:443'; exit 0; fi\n"
+            f"exit 0\n"
+        )
+        if v6_mode == "unavailable":
+            v6_body = "echo \"ip6tables: can't initialize table 'filter'\" >&2; exit 3;"
+        else:
+            v6_body = f"echo '-P OUTPUT {v6_mode}'; exit 0;"
+        v6 = (
+            f"#!/usr/bin/env bash\n"
+            f"if [ \"$1\" = '-S' ] && [ \"$2\" = 'OUTPUT' ]; then {v6_body} fi\n"
+            f"exit 0\n"
+        )
+        for name, body in (("iptables-legacy", v4), ("ip6tables-legacy", v6)):
+            p = os.path.join(bindir, name)
+            with open(p, "w") as f:
+                f.write(body)
+            os.chmod(p, 0o755)
+        env = dict(os.environ)
+        env["PATH"] = bindir + os.pathsep + env["PATH"]
+        return subprocess.run(
+            ["bash", "-c", script], env=env, capture_output=True, text=True
+        ).returncode
+
+    def test_v4_drop_absent_fails_even_when_v6_table_unavailable(self) -> None:
+        """REGRESSION (#1207 verify-ordering fail-open): when the v6 ``filter``
+        table is unavailable (no ``ip6_tables`` module — the common CI /
+        IPv6-disabled-host case) the trailing guarded v6 ``if`` returns 0. Without
+        ``set -e`` that trailing 0 OVERWRITES a failed earlier v4 ``-P OUTPUT
+        DROP`` assertion, so verify passes GREEN while the box is open over IPv4.
+        With ``set -e`` the v4 assertion aborts the script before the v6 block can
+        mask it — fail-closed."""
+        assert self._run_verify(v4_policy="ACCEPT", v6_mode="unavailable") != 0
+
+    def test_v4_drop_present_passes_when_v6_table_unavailable(self) -> None:
+        """The graceful-skip path still passes: v4 locked down + no v6 stack to
+        secure → verify is GREEN (the v6 ``if`` guard skips, ``set -e`` does not
+        fire on a tested condition)."""
+        assert self._run_verify(v4_policy="DROP", v6_mode="unavailable") == 0
+
+    def test_v6_drop_absent_fails_when_v6_table_present(self) -> None:
+        """When the v6 table IS present (the case the v6 DROP defends), a missing
+        v6 ``-P OUTPUT DROP`` still fails the verify."""
+        assert self._run_verify(v4_policy="DROP", v6_mode="ACCEPT") != 0
+
+    def test_both_drop_present_passes(self) -> None:
+        assert self._run_verify(v4_policy="DROP", v6_mode="DROP") == 0
 
 
 # ── docker backend translates network policy to docker run argv ────────────────


### PR DESCRIPTION
Automated dev-pipeline build for issue #1207.