### PR TITLE
fix(connectors): forward-tolerant connector→api intake (extra="ignore") (#1407)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -13797,7 +13797,6 @@
             "default": false
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "connection_id",
@@ -13841,7 +13840,6 @@
             "title": "Data"
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "connection_id",
@@ -13916,7 +13914,6 @@
             "default": false
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "connection_id",
@@ -14139,7 +14136,6 @@
             "default": false
           }
         },
-        "additionalProperties": false,
         "type": "object",
         "required": [
           "connection_id",

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_chat_lifecycle_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_chat_lifecycle_request.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -61,6 +62,7 @@ class RuntimeChatLifecycleRequest:
     reason: None | str | Unset = UNSET
     data: None | RuntimeChatLifecycleRequestDataType0 | Unset = UNSET
     wake: bool | Unset = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.runtime_chat_lifecycle_request_data_type_0 import (
@@ -90,7 +92,7 @@ class RuntimeChatLifecycleRequest:
         wake = self.wake
 
         field_dict: dict[str, Any] = {}
-
+        field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "connection_id": connection_id,
@@ -159,4 +161,21 @@ class RuntimeChatLifecycleRequest:
             wake=wake,
         )
 
+        runtime_chat_lifecycle_request.additional_properties = d
         return runtime_chat_lifecycle_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_lifecycle_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_lifecycle_request.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -44,6 +45,7 @@ class RuntimeLifecycleRequest:
     event: str
     reason: None | str | Unset = UNSET
     data: None | RuntimeLifecycleRequestDataType0 | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.runtime_lifecycle_request_data_type_0 import (
@@ -69,7 +71,7 @@ class RuntimeLifecycleRequest:
             data = self.data
 
         field_dict: dict[str, Any] = {}
-
+        field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "connection_id": connection_id,
@@ -129,4 +131,21 @@ class RuntimeLifecycleRequest:
             data=data,
         )
 
+        runtime_lifecycle_request.additional_properties = d
         return runtime_lifecycle_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_session_lifecycle_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_session_lifecycle_request.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -48,6 +49,7 @@ class RuntimeSessionLifecycleRequest:
     reason: None | str | Unset = UNSET
     data: None | RuntimeSessionLifecycleRequestDataType0 | Unset = UNSET
     wake: bool | Unset = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.runtime_session_lifecycle_request_data_type_0 import (
@@ -77,7 +79,7 @@ class RuntimeSessionLifecycleRequest:
         wake = self.wake
 
         field_dict: dict[str, Any] = {}
-
+        field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "connection_id": connection_id,
@@ -146,4 +148,21 @@ class RuntimeSessionLifecycleRequest:
             wake=wake,
         )
 
+        runtime_session_lifecycle_request.additional_properties = d
         return runtime_session_lifecycle_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
+from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
@@ -39,6 +40,7 @@ class RuntimeToolResultRequest:
     content: list[RuntimeToolResultRequestContentType1Item] | str
     is_error: bool | Unset = False
     no_reaction: bool | Unset = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         connection_id = self.connection_id
@@ -62,7 +64,7 @@ class RuntimeToolResultRequest:
         no_reaction = self.no_reaction
 
         field_dict: dict[str, Any] = {}
-
+        field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "connection_id": connection_id,
@@ -128,4 +130,21 @@ class RuntimeToolResultRequest:
             no_reaction=no_reaction,
         )
 
+        runtime_tool_result_request.additional_properties = d
         return runtime_tool_result_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -213,7 +213,13 @@ class RuntimeToolResultRequest(BaseModel):
     has to name the target connection.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    # extra="ignore" (forward-tolerant): a connector deployed AHEAD of the api
+    # on a coupled-schema change can send a field this api does not yet know;
+    # ignore it (known fields still validated/processed) instead of 422-ing,
+    # which would crash-loop the connector and wedge the session. This is the
+    # forward half of the #1398 deploy-skew symmetry (the backward half:
+    # defaulting an omitted field for an older connector).
+    model_config = ConfigDict(extra="ignore")
 
     connection_id: str
     session_id: str
@@ -249,7 +255,13 @@ class RuntimeLifecycleRequest(BaseModel):
     context (current device count, last successful timestamp, etc.).
     """
 
-    model_config = ConfigDict(extra="forbid")
+    # extra="ignore" (forward-tolerant): a connector deployed AHEAD of the api
+    # on a coupled-schema change can send a field this api does not yet know;
+    # ignore it (known fields still validated/processed) instead of 422-ing,
+    # which would crash-loop the connector and wedge the session. This is the
+    # forward half of the #1398 deploy-skew symmetry (the backward half:
+    # defaulting an omitted field for an older connector).
+    model_config = ConfigDict(extra="ignore")
 
     connection_id: str
     event: str
@@ -274,7 +286,13 @@ class RuntimeSessionLifecycleRequest(BaseModel):
     caller opts into the wake.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    # extra="ignore" (forward-tolerant): a connector deployed AHEAD of the api
+    # on a coupled-schema change can send a field this api does not yet know;
+    # ignore it (known fields still validated/processed) instead of 422-ing,
+    # which would crash-loop the connector and wedge the session. This is the
+    # forward half of the #1398 deploy-skew symmetry (the backward half:
+    # defaulting an omitted field for an older connector).
+    model_config = ConfigDict(extra="ignore")
 
     connection_id: str
     session_id: str
@@ -314,7 +332,13 @@ class RuntimeChatLifecycleRequest(BaseModel):
     defaults ``False`` (visible-on-next-turn).
     """
 
-    model_config = ConfigDict(extra="forbid")
+    # extra="ignore" (forward-tolerant): a connector deployed AHEAD of the api
+    # on a coupled-schema change can send a field this api does not yet know;
+    # ignore it (known fields still validated/processed) instead of 422-ing,
+    # which would crash-loop the connector and wedge the session. This is the
+    # forward half of the #1398 deploy-skew symmetry (the backward half:
+    # defaulting an omitted field for an older connector).
+    model_config = ConfigDict(extra="ignore")
 
     connection_id: str
     chat_id: str

--- a/tests/unit/test_connector_intake_forward_tolerant.py
+++ b/tests/unit/test_connector_intake_forward_tolerant.py
@@ -1,0 +1,121 @@
+"""Unit tests pinning the connector→api intake forward-tolerance fix (#1407).
+
+The bug
+-------
+The connector-facing runtime intake models in
+``src/aios/api/routers/connectors.py`` set ``model_config =
+ConfigDict(extra="forbid")``. When a connector runs **ahead** of the api on a
+coupled-schema change (a newer connector sends a field the older api doesn't
+know yet), the api ``422``\\ s the POST (``{"type":"extra_forbidden", ...}``)
+instead of degrading gracefully — the connector retries → crash-loops, the
+tool-result never folds back → the session wedges (the 2026-06-19 Ultron
+deploy-skew incident, memory ``project-ultron-422-deploy-skew-2026-06-19``).
+
+The fix
+-------
+The connector-runtime intake models are made **forward-tolerant**
+(``extra="ignore"``): an unknown extra field is silently dropped, the known
+fields still validate and process. This is the forward half of the symmetry
+#1398 established backward (a *newer* api defaulting ``no_reaction`` for an
+*older* connector that omits it).
+
+What this suite pins
+--------------------
+- Each connector-runtime intake model ACCEPTS a body carrying an unknown extra
+  field (no ``ValidationError``) and parses the known fields normally.
+- The unknown field is dropped (``extra="ignore"`` semantics) — it does not
+  leak onto the model.
+- The existing backward-compat behaviour (``no_reaction`` omitted → default
+  ``False``) is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from aios.api.routers.connectors import (
+    RuntimeChatLifecycleRequest,
+    RuntimeLifecycleRequest,
+    RuntimeSessionLifecycleRequest,
+    RuntimeToolResultRequest,
+)
+
+# (model, minimal-valid-body) for every connector-runtime intake a
+# deployed-ahead connector POSTs to. These are exactly the models on the
+# connector→api skew boundary; each must tolerate an unknown extra field.
+_INTAKES: list[tuple[type[BaseModel], dict[str, object]]] = [
+    (
+        RuntimeToolResultRequest,
+        {
+            "connection_id": "conn_1",
+            "session_id": "sess_1",
+            "tool_call_id": "tc_1",
+            "content": "ok",
+        },
+    ),
+    (
+        RuntimeLifecycleRequest,
+        {"connection_id": "conn_1", "event": "signal.daemon.exited"},
+    ),
+    (
+        RuntimeSessionLifecycleRequest,
+        {"connection_id": "conn_1", "session_id": "sess_1", "event": "sms.delivery.failed"},
+    ),
+    (
+        RuntimeChatLifecycleRequest,
+        {"connection_id": "conn_1", "chat_id": "+15550001", "event": "sms.delivery.failed"},
+    ),
+]
+
+
+@pytest.mark.parametrize("model,body", _INTAKES, ids=lambda v: getattr(v, "__name__", ""))
+def test_intake_accepts_unknown_extra_field(
+    model: type[BaseModel], body: dict[str, object]
+) -> None:
+    """A connector running AHEAD of the api adds a field the api doesn't know.
+    The intake must accept it (2xx, not 422) and parse the known fields."""
+    forward = {**body, "future_field": True}
+
+    parsed = model.model_validate(forward)
+
+    # Known fields are still parsed/validated and reachable to the handler.
+    for key, value in body.items():
+        assert getattr(parsed, key) == value
+    # extra="ignore": the unknown field is dropped, not retained.
+    assert not hasattr(parsed, "future_field")
+    assert "future_field" not in parsed.model_dump()
+
+
+class TestRuntimeToolResultRequest:
+    """The intake that 422'd in the incident — pinned directly."""
+
+    def test_tool_result_accepts_unknown_field(self) -> None:
+        parsed = RuntimeToolResultRequest.model_validate(
+            {
+                "connection_id": "conn_1",
+                "session_id": "sess_1",
+                "tool_call_id": "tc_1",
+                "content": "ok",
+                "no_reaction": True,
+                # exactly the incident shape: a newer connector adds a field
+                # the older api has never heard of.
+                "future_field": "anything",
+            }
+        )
+        assert parsed.connection_id == "conn_1"
+        assert parsed.no_reaction is True
+        assert not hasattr(parsed, "future_field")
+
+    def test_no_reaction_backward_compat_default_unchanged(self) -> None:
+        """An older connector that OMITS ``no_reaction`` still defaults False —
+        the backward half of the symmetry (#1398) is untouched."""
+        parsed = RuntimeToolResultRequest.model_validate(
+            {
+                "connection_id": "conn_1",
+                "session_id": "sess_1",
+                "tool_call_id": "tc_1",
+                "content": "ok",
+            }
+        )
+        assert parsed.no_reaction is False


### PR DESCRIPTION
## What

Makes the connector→api runtime intake contract **forward-tolerant** so a connector deployed *ahead* of the api on a coupled-schema change degrades gracefully instead of crash-looping.

Four connector-facing runtime intake models in `src/aios/api/routers/connectors.py` switch from `model_config = ConfigDict(extra="forbid")` to `extra="ignore"`:

- `RuntimeToolResultRequest` — `POST /v1/connectors/runtime/tool-results` (the one that 422'd in the incident)
- `RuntimeLifecycleRequest` — `POST /v1/connectors/runtime/lifecycle`
- `RuntimeSessionLifecycleRequest` — `POST /v1/connectors/runtime/session-lifecycle`
- `RuntimeChatLifecycleRequest` — `POST /v1/connectors/runtime/chat-lifecycle`

With `extra="ignore"` an unknown extra field a newer connector sends is silently dropped, while the known fields are still validated and processed — no 422.

## Why

Fixes #1407. In the 2026-06-19 Ultron deploy-skew incident, #1398 added a `no_reaction` field to the tool-result contract on both sides; the signal/telegram/whatsapp connectors deployed forward while aios-api/worker stayed behind on `extra="forbid"`, so every connector tool-result POST 422'd on the unknown `no_reaction` field → `signal_send` results never folded back → Ultron re-announce loop + the signal connector crash-looped.

#1398 already built the **backward** half of the symmetry (a newer api defaults an omitted `no_reaction: bool = False` so an older connector still validates). This PR adds the **forward** half (an older api tolerating a newer connector's unknown field). A coupled-schema change can't be deployed strictly atomically across api + N connectors, so the contract must tolerate transient skew in both directions. Per no-backcompat/one-right-way this isn't an alias for legacy clients — it's making the connector contract correctly forward-tolerant.

## Scope

Only the connector-runtime intake models a deployed-ahead connector posts to are changed. Operator/management-plane models and the Signal/WhatsApp pairing request bodies (whose producers deploy in lockstep with the api) stay at `extra="forbid"` — including `RuntimeManagementCallResultRequest`, `ToolsSchemaUpdate`, and the lifecycle PATCH bodies.

## Tests

- New pinned unit suite `tests/unit/test_connector_intake_forward_tolerant.py`: each of the four intake models accepts a body carrying an unknown extra field (no `ValidationError`), parses the known fields normally, and drops the unknown field (`extra="ignore"` semantics). The `RuntimeToolResultRequest` case is pinned directly with the incident shape (an unknown key alongside the valid fields).
- Verified test-first: the new assertions fail on the pre-fix `extra="forbid"` code (5 fail) and pass with the fix (6 pass).
- Backward-compat pinned unchanged: an older connector omitting `no_reaction` still defaults `False`.
- Regenerated `openapi.json` and the typed SDK `_generated/` tree (the four schemas lose `additionalProperties: false`); `test_openapi_snapshot`, `test_sdk_snapshot`, and `test_sdk_smoke` pass. ruff + mypy clean on the touched source.

The complementary detection/process gap (lockstep audit not covering connector↔api) is tracked separately in eumemic-ops.