### PR TITLE
Structural eval assertions over the event log (extend the read-only harness helpers)

### DIFF
--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -267,6 +267,7 @@ def assert_tool_called(events: list[Event], name: str) -> dict[str, Any]:
     the FIRST matching tool_call dict."""
     for e in events:
         if e.kind == "message" and e.data.get("role") == "assistant":
+            tc: dict[str, Any]
             for tc in e.data.get("tool_calls") or []:
                 if tc.get("function", {}).get("name") == name:
                     return tc

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -200,6 +200,121 @@ def msg_text(msg: dict[str, Any]) -> str:
     return str(content)
 
 
+# ─── structural assertion helpers ────────────────────────────────────────────
+#
+# These extend the read-only block above. They never replace
+# first_tool_result/tool_results/last_assistant_content/msg_text. They assert
+# the *shape* of a turn — which tools were called, that each call got a paired
+# result, in what order, and that the turn cleanly ended — by folding over the
+# captured event log. They append nothing and wake nothing.
+#
+# The pairing mechanism is the existing tool_call_id join: an assistant
+# event carries data["tool_calls"][*]["id"]; the matching tool-role event
+# carries data["tool_call_id"] (the same key the context builder uses).
+#
+# events()/all_events() rule (load-bearing): the lifecycle helpers
+# (terminal_lifecycle/assert_ended) MUST be fed all_events() because a
+# turn_ended marker is a kind=="lifecycle" event; Harness.events() returns
+# message-kind events only and will never carry it. The other helpers accept
+# either, but the canonical call site passes all_events() so a test never
+# silently misses a lifecycle.
+
+
+def requested_tool_calls(events: list[Event]) -> list[tuple[str, str, str]]:
+    """(tool_call_id, name, raw_arguments_json) for every assistant tool_call,
+    in log order. Reads e.data['tool_calls'][*].{id, function.name, function.arguments}.
+    arguments is the raw JSON string the model emitted (the harness's tool_call()
+    helper stores it as a JSON string)."""
+    out: list[tuple[str, str, str]] = []
+    for e in events:
+        if e.kind == "message" and e.data.get("role") == "assistant":
+            for tc in e.data.get("tool_calls") or []:
+                fn = tc.get("function", {})
+                out.append((tc["id"], fn.get("name", ""), fn.get("arguments", "")))
+    return out
+
+
+def result_for(events: list[Event], tool_call_id: str) -> dict[str, Any] | None:
+    """The tool-role message event data whose data['tool_call_id'] == tool_call_id,
+    else None (unresolved / in-flight). Last write wins if duplicated."""
+    found: dict[str, Any] | None = None
+    for e in events:
+        if (
+            e.kind == "message"
+            and e.data.get("role") == "tool"
+            and e.data.get("tool_call_id") == tool_call_id
+        ):
+            found = e.data
+    return found
+
+
+def paired_calls(
+    events: list[Event],
+) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
+    """(assistant tool_call dict, matching tool result data | None) by tool_call_id,
+    in request order. None == genuinely unresolved (in-flight or absent) — never a
+    silent skip."""
+    pairs: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+    for e in events:
+        if e.kind == "message" and e.data.get("role") == "assistant":
+            for tc in e.data.get("tool_calls") or []:
+                pairs.append((tc, result_for(events, tc["id"])))
+    return pairs
+
+
+def assert_tool_called(events: list[Event], name: str) -> dict[str, Any]:
+    """Raise AssertionError if no assistant tool_call with that name; else return
+    the FIRST matching tool_call dict."""
+    for e in events:
+        if e.kind == "message" and e.data.get("role") == "assistant":
+            for tc in e.data.get("tool_calls") or []:
+                if tc.get("function", {}).get("name") == name:
+                    return tc
+    raise AssertionError(f"tool {name!r} was never called")
+
+
+def assert_tool_result_contains(events: list[Event], name: str, needle: str) -> None:
+    """Assert SOME result of a call to `name` contains `needle` in its content.
+    Raises AssertionError if the tool was never called, never resulted, or no
+    result content contains the needle."""
+    matched_any = False
+    for e in events:
+        if e.kind == "message" and e.data.get("role") == "assistant":
+            for tc in e.data.get("tool_calls") or []:
+                if tc.get("function", {}).get("name") != name:
+                    continue
+                res = result_for(events, tc["id"])
+                if res is None:
+                    continue
+                matched_any = True
+                if needle in msg_text(res):
+                    return
+    if not matched_any:
+        raise AssertionError(f"tool {name!r} produced no result to search")
+    raise AssertionError(f"no {name!r} result contained {needle!r}")
+
+
+def terminal_lifecycle(events: list[Event]) -> dict[str, Any] | None:
+    """The LAST kind=='lifecycle' event data marking turn end, or None.
+    Matches data['event'] in {turn_ended, interrupted} OR data['status']=='terminated'
+    — mirrors chat.py:_is_turn_end. MUST be fed all_events() (kind!='message');
+    events() filters to message kind and will never contain it."""
+    found: dict[str, Any] | None = None
+    for e in events:
+        if e.kind != "lifecycle":
+            continue
+        d = e.data
+        if d.get("event") in {"turn_ended", "interrupted"} or d.get("status") == "terminated":
+            found = d
+    return found
+
+
+def assert_ended(events: list[Event]) -> None:
+    """Assert terminal_lifecycle(events) is present. Feed all_events()."""
+    if terminal_lifecycle(events) is None:
+        raise AssertionError("no terminal lifecycle event (turn_ended/interrupted/terminated)")
+
+
 # ─── the harness ─────────────────────────────────────────────────────────────
 
 

--- a/tests/e2e/test_eval_assertions.py
+++ b/tests/e2e/test_eval_assertions.py
@@ -1,0 +1,142 @@
+"""E2E tests for the structural eval assertion helpers (issue #1350).
+
+These exercise the read-only helpers appended to ``tests/e2e/harness.py``
+(``requested_tool_calls`` / ``result_for`` / ``paired_calls`` /
+``assert_tool_called`` / ``assert_tool_result_contains`` /
+``terminal_lifecycle`` / ``assert_ended``) that assert the *shape* of a
+turn over the captured event log.
+
+Deterministic: scripted model, no real LLM. The round-trip uses the
+built-in ``bash``/``read`` tools, so it runs in the full (Docker) tier
+alongside the other scripted-tool round-trips in ``test_step_model.py``.
+The pure-function semantics of ``result_for``/``paired_calls`` on an
+unresolved (in-flight / absent) call are pinned with synthetic events so
+the ``None``-means-unresolved invariant is codified independently of tool
+dispatch internals.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from aios.models.events import Event
+from tests.conftest import needs_docker
+from tests.e2e.harness import (
+    Harness,
+    assert_ended,
+    assert_tool_called,
+    assert_tool_result_contains,
+    assistant,
+    bash,
+    paired_calls,
+    requested_tool_calls,
+    result_for,
+    terminal_lifecycle,
+    tool_call,
+)
+
+pytestmark = pytest.mark.docker
+
+
+def _msg_event(seq: int, data: dict[str, Any]) -> Event:
+    """Build a synthetic message Event for pure-function helper tests."""
+    return Event(
+        id=f"evt_{seq}",
+        session_id="ses_synthetic",
+        seq=seq,
+        kind="message",
+        data=data,
+        created_at=datetime.now(UTC),
+    )
+
+
+def test_unresolved_call_yields_none() -> None:
+    """``result_for``/``paired_calls`` report an explicit ``None`` for a call
+    with no matching tool result — never a silent skip. Pure-function check on
+    synthetic events so the invariant is pinned independently of dispatch.
+    """
+    events = [
+        _msg_event(0, {"role": "user", "content": "go"}),
+        _msg_event(
+            1,
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    tool_call("bash", {"command": "echo hi"}, call_id="call_1"),
+                    tool_call("read", {"path": "/x"}, call_id="call_2"),
+                ],
+            },
+        ),
+        # Only call_1 ever resolved; call_2 is genuinely in-flight / absent.
+        _msg_event(2, {"role": "tool", "tool_call_id": "call_1", "content": "hi"}),
+    ]
+
+    assert result_for(events, "call_1") is not None
+    assert result_for(events, "call_2") is None
+
+    pairs = paired_calls(events)
+    assert len(pairs) == 2
+    assert pairs[0][1] is not None  # bash resolved
+    assert pairs[1][1] is None  # read unresolved -> explicit None, not skipped
+
+
+@needs_docker  # built-in bash/read run in the testcontainer sandbox
+class TestStructuralAssertions:
+    async def test_structural_assertions_over_scripted_round_trip(self, harness: Harness) -> None:
+        """Every helper, against a scripted two-tool (bash then read) round-trip."""
+        harness.script_model(
+            [
+                assistant(
+                    tool_calls=[
+                        bash("echo hi", call_id="call_1"),
+                        tool_call("read", {"path": "/x"}, call_id="call_2"),
+                    ]
+                ),
+                assistant("done"),
+            ]
+        )
+        session = await harness.start("go", tools=["bash", "read"])
+        await harness.run_until_idle(session.id)
+        events = await harness.all_events(session.id)
+
+        # 3. requested_tool_calls: two entries, scripted ids/names, in log order.
+        reqs = requested_tool_calls(events)
+        assert len(reqs) == 2
+        assert reqs[0][0] == "call_1"
+        assert reqs[0][1] == "bash"
+        assert reqs[1][0] == "call_2"
+        assert reqs[1][1] == "read"
+
+        # 4. paired_calls: each call joined to its result by tool_call_id; both
+        # resolved (no None) on the canonical run.
+        pairs = paired_calls(events)
+        assert len(pairs) == 2
+        assert all(result is not None for _, result in pairs)
+        assert result_for(events, "call_1") is not None
+        assert result_for(events, "call_2") is not None
+
+        # 5. assert_tool_called: hit returns the call dict; miss raises.
+        called = assert_tool_called(events, "bash")
+        assert called["function"]["name"] == "bash"
+        with pytest.raises(AssertionError):
+            assert_tool_called(events, "nonexistent")
+
+        # 6. assert_tool_result_contains: matching needle passes; wrong raises.
+        assert_tool_result_contains(events, "bash", "hi")
+        with pytest.raises(AssertionError):
+            assert_tool_result_contains(events, "bash", "this-is-not-in-the-output")
+
+        # 7. terminal_lifecycle / assert_ended over all_events(); the
+        # message-only read raises (guards the events()/all_events() rule).
+        term = terminal_lifecycle(events)
+        assert term is not None
+        assert term.get("event") == "turn_ended"
+        assert_ended(events)
+
+        msg_only = await harness.events(session.id)
+        with pytest.raises(AssertionError):
+            assert_ended(msg_only)


### PR DESCRIPTION
Automated dev-pipeline build for issue #1350.