### PR TITLE
feat(connector-subsystem): connector capability descriptor (typed `capabilities` sibling on the `connectors` catalog row)

### DIFF
--- a/migrations/versions/0113_connector_capabilities.py
+++ b/migrations/versions/0113_connector_capabilities.py
@@ -1,0 +1,41 @@
+"""Connector capability descriptor — a ``tools_schema`` sibling on the
+``connectors`` catalog row (#1381).
+
+Purely-additive ``ADD COLUMN connectors.capabilities jsonb NOT NULL
+DEFAULT '{}'::jsonb`` — the exact same shape as the ``tools_schema`` sibling
+seeded at migration 0033 (``DEFAULT '[]'``).  The ``'{}'`` default means every
+existing connector row reads as "no declared capabilities" (all sub-descriptors
+absent) — the conservative/plain-text rendering floor.  No backfill needed; the
+default IS the floor.
+
+Safe across the new-code/old-schema deploy window per CLAUDE.md: an additive
+``ADD COLUMN`` is invisible to the running container until complete, old code
+never reads the new column, and there is no expand/contract.  Reversible via
+``DROP COLUMN``.  (No ``@dataclass`` in the migration body — alembic loads
+versions under synthetic module names and a dataclass there crashes.)
+
+Revision ID: 0113
+Revises: 0112
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0113"
+down_revision: str = "0112"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE connectors "
+        "ADD COLUMN capabilities jsonb NOT NULL DEFAULT '{}'::jsonb"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE connectors DROP COLUMN capabilities")

--- a/migrations/versions/0114_connector_capabilities.py
+++ b/migrations/versions/0114_connector_capabilities.py
@@ -14,7 +14,7 @@ never reads the new column, and there is no expand/contract.  Reversible via
 ``DROP COLUMN``.  (No ``@dataclass`` in the migration body — alembic loads
 versions under synthetic module names and a dataclass there crashes.)
 
-Revision ID: 0113
+Revision ID: 0114
 Revises: 0112
 """
 
@@ -24,7 +24,7 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0113"
+revision: str = "0114"
 down_revision: str = "0112"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/openapi.json
+++ b/openapi.json
@@ -7475,6 +7475,73 @@
         }
       }
     },
+    "/v1/connectors/{connector}/capabilities": {
+      "put": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Put Capabilities",
+        "description": "Publish the runtime container's typed capability descriptor for a\nconnector type.\n\nA sibling to :func:`put_tools_schema` (same root-only publication path),\nkept on its own route so capability churn is decoupled from a full\n``tools_schema`` republish.  The runtime container is the source of truth\nfor what richer renderings it supports; it publishes the descriptor at\nstartup, replacing whatever was on the ``connectors.capabilities`` row\nwholesale.\n\nAuthorization: the runtime bearer's ``connector`` must match the path's\n``connector``; publication itself is root-only (enforced in the service\nlayer \u2014 connectors are root-owned, the same cross-tenant rationale as\n``tools_schema``).  Capabilities declare NO authority: they constrain\nRENDERING, never what any principal may invoke.",
+        "operationId": "put_connector_capabilities",
+        "parameters": [
+          {
+            "name": "connector",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Connector"
+            }
+          },
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CapabilitiesUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/connectors/connections": {
       "get": {
         "tags": [
@@ -11059,6 +11126,20 @@
         "title": "BoundChat",
         "description": "Read view of one ``chat_sessions`` row.\n\nReturned by ``GET /v1/connections/{id}/bound-chats``.  Operator-bound\nrows and per-chat-spawned rows are returned together \u2014 the table\ndoesn't tag the writer."
       },
+      "CapabilitiesUpdate": {
+        "properties": {
+          "capabilities": {
+            "$ref": "#/components/schemas/ConnectorCapabilities"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "capabilities"
+        ],
+        "title": "CapabilitiesUpdate",
+        "description": "Body for ``PUT /v1/connectors/{connector}/capabilities``.\n\nA sibling to :class:`ToolsSchemaUpdate` \u2014 kept separate so capability churn\nis decoupled from a full ``tools_schema`` republish and the shipped\n``tools_schema`` body contract stays untouched."
+      },
       "Connection": {
         "properties": {
           "id": {
@@ -11258,6 +11339,34 @@
         "title": "ConnectionSetSecrets",
         "description": "Request body for ``PUT /v1/connections/{id}/secrets``.\n\nReplaces the connection's secrets dict wholesale.  Encrypted at\nrest server-side via ``AIOS_VAULT_KEY``; the operator never reads\nthem back.\n\nPass an empty dict to clear secrets."
       },
+      "ConnectorCapabilities": {
+        "properties": {
+          "draft_streaming": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DraftStreaming"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "native_buttons": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NativeButtons"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "ConnectorCapabilities",
+        "description": "Typed richness descriptor \u2014 a ``tools_schema`` sibling on the catalog\nrow.  Each field is a present/absent typed sub-object (a declared KIND),\nnever a bool flag.  An absent field == capability not declared == the\nconservative rendering floor."
+      },
       "ConnectorInboundResponse": {
         "properties": {
           "appended_event_id": {
@@ -11369,6 +11478,25 @@
         ],
         "title": "CronSource",
         "description": "Recurring source: a standard 5-field cron expression in UTC.\n\nStructure-only here \u2014 grammar/occurrence checks live on the write\nmodels (``TriggerCreate`` / ``TriggerUpdate``) so the read path accepts\nevery row the write path ever accepted (see module docstring + \u00a72.2 of\nthe design contract). A future additive ``timezone`` field (IANA name;\nabsent = UTC) lands without touching this model or the DB CHECK."
+      },
+      "DraftStreaming": {
+        "properties": {
+          "overflow_limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Overflow Limit"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "DraftStreaming",
+        "description": "Present == connector can render in-progress assistant deltas as an\neditable draft.  Absent == connector waits for the committed message."
       },
       "Environment": {
         "properties": {
@@ -13704,6 +13832,21 @@
           "plaintext_key"
         ],
         "title": "MintKeyResponse"
+      },
+      "NativeButtons": {
+        "properties": {
+          "max_buttons": {
+            "type": "integer",
+            "title": "Max Buttons"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "max_buttons"
+        ],
+        "title": "NativeButtons",
+        "description": "Present == connector renders externally-executed tool-confirmations as\ninbound platform buttons; a button-tap maps to the existing\n``POST /sessions/:id/tool-confirmations``.  Absent == text-prompt fallback."
       },
       "OAuthCompleteRequest": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/connectors/put_connector_capabilities.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/connectors/put_connector_capabilities.py
@@ -1,0 +1,275 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.capabilities_update import CapabilitiesUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    connector: str,
+    *,
+    body: CapabilitiesUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(authorization, Unset):
+        headers["Authorization"] = authorization
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/v1/connectors/{connector}/capabilities".format(
+            connector=quote(str(connector), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | HTTPValidationError]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: CapabilitiesUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Put Capabilities
+
+     Publish the runtime container's typed capability descriptor for a
+    connector type.
+
+    A sibling to :func:`put_tools_schema` (same root-only publication path),
+    kept on its own route so capability churn is decoupled from a full
+    ``tools_schema`` republish.  The runtime container is the source of truth
+    for what richer renderings it supports; it publishes the descriptor at
+    startup, replacing whatever was on the ``connectors.capabilities`` row
+    wholesale.
+
+    Authorization: the runtime bearer's ``connector`` must match the path's
+    ``connector``; publication itself is root-only (enforced in the service
+    layer — connectors are root-owned, the same cross-tenant rationale as
+    ``tools_schema``).  Capabilities declare NO authority: they constrain
+    RENDERING, never what any principal may invoke.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+        body (CapabilitiesUpdate): Body for ``PUT /v1/connectors/{connector}/capabilities``.
+
+            A sibling to :class:`ToolsSchemaUpdate` — kept separate so capability churn
+            is decoupled from a full ``tools_schema`` republish and the shipped
+            ``tools_schema`` body contract stays untouched.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: CapabilitiesUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Put Capabilities
+
+     Publish the runtime container's typed capability descriptor for a
+    connector type.
+
+    A sibling to :func:`put_tools_schema` (same root-only publication path),
+    kept on its own route so capability churn is decoupled from a full
+    ``tools_schema`` republish.  The runtime container is the source of truth
+    for what richer renderings it supports; it publishes the descriptor at
+    startup, replacing whatever was on the ``connectors.capabilities`` row
+    wholesale.
+
+    Authorization: the runtime bearer's ``connector`` must match the path's
+    ``connector``; publication itself is root-only (enforced in the service
+    layer — connectors are root-owned, the same cross-tenant rationale as
+    ``tools_schema``).  Capabilities declare NO authority: they constrain
+    RENDERING, never what any principal may invoke.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+        body (CapabilitiesUpdate): Body for ``PUT /v1/connectors/{connector}/capabilities``.
+
+            A sibling to :class:`ToolsSchemaUpdate` — kept separate so capability churn
+            is decoupled from a full ``tools_schema`` republish and the shipped
+            ``tools_schema`` body contract stays untouched.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return sync_detailed(
+        connector=connector,
+        client=client,
+        body=body,
+        authorization=authorization,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: CapabilitiesUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Response[Any | HTTPValidationError]:
+    """Put Capabilities
+
+     Publish the runtime container's typed capability descriptor for a
+    connector type.
+
+    A sibling to :func:`put_tools_schema` (same root-only publication path),
+    kept on its own route so capability churn is decoupled from a full
+    ``tools_schema`` republish.  The runtime container is the source of truth
+    for what richer renderings it supports; it publishes the descriptor at
+    startup, replacing whatever was on the ``connectors.capabilities`` row
+    wholesale.
+
+    Authorization: the runtime bearer's ``connector`` must match the path's
+    ``connector``; publication itself is root-only (enforced in the service
+    layer — connectors are root-owned, the same cross-tenant rationale as
+    ``tools_schema``).  Capabilities declare NO authority: they constrain
+    RENDERING, never what any principal may invoke.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+        body (CapabilitiesUpdate): Body for ``PUT /v1/connectors/{connector}/capabilities``.
+
+            A sibling to :class:`ToolsSchemaUpdate` — kept separate so capability churn
+            is decoupled from a full ``tools_schema`` republish and the shipped
+            ``tools_schema`` body contract stays untouched.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | HTTPValidationError]
+    """
+
+    kwargs = _get_kwargs(
+        connector=connector,
+        body=body,
+        authorization=authorization,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector: str,
+    *,
+    client: AuthenticatedClient | Client,
+    body: CapabilitiesUpdate,
+    authorization: None | str | Unset = UNSET,
+) -> Any | HTTPValidationError | None:
+    """Put Capabilities
+
+     Publish the runtime container's typed capability descriptor for a
+    connector type.
+
+    A sibling to :func:`put_tools_schema` (same root-only publication path),
+    kept on its own route so capability churn is decoupled from a full
+    ``tools_schema`` republish.  The runtime container is the source of truth
+    for what richer renderings it supports; it publishes the descriptor at
+    startup, replacing whatever was on the ``connectors.capabilities`` row
+    wholesale.
+
+    Authorization: the runtime bearer's ``connector`` must match the path's
+    ``connector``; publication itself is root-only (enforced in the service
+    layer — connectors are root-owned, the same cross-tenant rationale as
+    ``tools_schema``).  Capabilities declare NO authority: they constrain
+    RENDERING, never what any principal may invoke.
+
+    Args:
+        connector (str):
+        authorization (None | str | Unset):
+        body (CapabilitiesUpdate): Body for ``PUT /v1/connectors/{connector}/capabilities``.
+
+            A sibling to :class:`ToolsSchemaUpdate` — kept separate so capability churn
+            is decoupled from a full ``tools_schema`` republish and the shipped
+            ``tools_schema`` body contract stays untouched.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | HTTPValidationError
+    """
+
+    return (
+        await asyncio_detailed(
+            connector=connector,
+            client=client,
+            body=body,
+            authorization=authorization,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -27,6 +27,7 @@ from .body_upload_session_file import BodyUploadSessionFile
 from .bootstrap_request import BootstrapRequest
 from .bootstrap_response import BootstrapResponse
 from .bound_chat import BoundChat
+from .capabilities_update import CapabilitiesUpdate
 from .connection import Connection
 from .connection_attach import ConnectionAttach
 from .connection_configure_per_chat import ConnectionConfigurePerChat
@@ -37,6 +38,7 @@ from .connection_metadata import ConnectionMetadata
 from .connection_reparent import ConnectionReparent
 from .connection_set_secrets import ConnectionSetSecrets
 from .connection_set_secrets_secrets import ConnectionSetSecretsSecrets
+from .connector_capabilities import ConnectorCapabilities
 from .connector_inbound_response import ConnectorInboundResponse
 from .connector_secrets import ConnectorSecrets
 from .connector_secrets_secrets import ConnectorSecretsSecrets
@@ -44,6 +46,7 @@ from .context_response import ContextResponse
 from .context_response_messages_item import ContextResponseMessagesItem
 from .context_response_tools_item import ContextResponseToolsItem
 from .cron_source import CronSource
+from .draft_streaming import DraftStreaming
 from .environment import Environment
 from .environment_config import EnvironmentConfig
 from .environment_config_env_type_0 import EnvironmentConfigEnvType0
@@ -136,6 +139,7 @@ from .mint_account_request import MintAccountRequest
 from .mint_account_response import MintAccountResponse
 from .mint_key_request import MintKeyRequest
 from .mint_key_response import MintKeyResponse
+from .native_buttons import NativeButtons
 from .o_auth_complete_request import OAuthCompleteRequest
 from .o_auth_start_request import OAuthStartRequest
 from .o_auth_start_request_token_endpoint_auth_method_type_0 import (
@@ -341,6 +345,7 @@ __all__ = (
     "BootstrapRequest",
     "BootstrapResponse",
     "BoundChat",
+    "CapabilitiesUpdate",
     "Connection",
     "ConnectionAttach",
     "ConnectionConfigurePerChat",
@@ -351,6 +356,7 @@ __all__ = (
     "ConnectionReparent",
     "ConnectionSetSecrets",
     "ConnectionSetSecretsSecrets",
+    "ConnectorCapabilities",
     "ConnectorInboundResponse",
     "ConnectorSecrets",
     "ConnectorSecretsSecrets",
@@ -358,6 +364,7 @@ __all__ = (
     "ContextResponseMessagesItem",
     "ContextResponseToolsItem",
     "CronSource",
+    "DraftStreaming",
     "Environment",
     "EnvironmentConfig",
     "EnvironmentConfigEnvType0",
@@ -444,6 +451,7 @@ __all__ = (
     "MintAccountResponse",
     "MintKeyRequest",
     "MintKeyResponse",
+    "NativeButtons",
     "OAuthCompleteRequest",
     "OAuthStartRequest",
     "OAuthStartRequestTokenEndpointAuthMethodType0",

--- a/packages/aios-sdk/aios_sdk/_generated/models/capabilities_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/capabilities_update.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+
+if TYPE_CHECKING:
+    from ..models.connector_capabilities import ConnectorCapabilities
+
+
+T = TypeVar("T", bound="CapabilitiesUpdate")
+
+
+@_attrs_define
+class CapabilitiesUpdate:
+    """Body for ``PUT /v1/connectors/{connector}/capabilities``.
+
+    A sibling to :class:`ToolsSchemaUpdate` — kept separate so capability churn
+    is decoupled from a full ``tools_schema`` republish and the shipped
+    ``tools_schema`` body contract stays untouched.
+
+        Attributes:
+            capabilities (ConnectorCapabilities): Typed richness descriptor — a ``tools_schema`` sibling on the catalog
+                row.  Each field is a present/absent typed sub-object (a declared KIND),
+                never a bool flag.  An absent field == capability not declared == the
+                conservative rendering floor.
+    """
+
+    capabilities: ConnectorCapabilities
+
+    def to_dict(self) -> dict[str, Any]:
+        capabilities = self.capabilities.to_dict()
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "capabilities": capabilities,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.connector_capabilities import ConnectorCapabilities
+
+        d = dict(src_dict)
+        capabilities = ConnectorCapabilities.from_dict(d.pop("capabilities"))
+
+        capabilities_update = cls(
+            capabilities=capabilities,
+        )
+
+        return capabilities_update

--- a/packages/aios-sdk/aios_sdk/_generated/models/connector_capabilities.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/connector_capabilities.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.draft_streaming import DraftStreaming
+    from ..models.native_buttons import NativeButtons
+
+
+T = TypeVar("T", bound="ConnectorCapabilities")
+
+
+@_attrs_define
+class ConnectorCapabilities:
+    """Typed richness descriptor — a ``tools_schema`` sibling on the catalog
+    row.  Each field is a present/absent typed sub-object (a declared KIND),
+    never a bool flag.  An absent field == capability not declared == the
+    conservative rendering floor.
+
+        Attributes:
+            draft_streaming (DraftStreaming | None | Unset):
+            native_buttons (NativeButtons | None | Unset):
+    """
+
+    draft_streaming: DraftStreaming | None | Unset = UNSET
+    native_buttons: NativeButtons | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.draft_streaming import DraftStreaming
+        from ..models.native_buttons import NativeButtons
+
+        draft_streaming: dict[str, Any] | None | Unset
+        if isinstance(self.draft_streaming, Unset):
+            draft_streaming = UNSET
+        elif isinstance(self.draft_streaming, DraftStreaming):
+            draft_streaming = self.draft_streaming.to_dict()
+        else:
+            draft_streaming = self.draft_streaming
+
+        native_buttons: dict[str, Any] | None | Unset
+        if isinstance(self.native_buttons, Unset):
+            native_buttons = UNSET
+        elif isinstance(self.native_buttons, NativeButtons):
+            native_buttons = self.native_buttons.to_dict()
+        else:
+            native_buttons = self.native_buttons
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if draft_streaming is not UNSET:
+            field_dict["draft_streaming"] = draft_streaming
+        if native_buttons is not UNSET:
+            field_dict["native_buttons"] = native_buttons
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.draft_streaming import DraftStreaming
+        from ..models.native_buttons import NativeButtons
+
+        d = dict(src_dict)
+
+        def _parse_draft_streaming(data: object) -> DraftStreaming | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                draft_streaming_type_0 = DraftStreaming.from_dict(data)
+
+                return draft_streaming_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(DraftStreaming | None | Unset, data)
+
+        draft_streaming = _parse_draft_streaming(d.pop("draft_streaming", UNSET))
+
+        def _parse_native_buttons(data: object) -> NativeButtons | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                native_buttons_type_0 = NativeButtons.from_dict(data)
+
+                return native_buttons_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(NativeButtons | None | Unset, data)
+
+        native_buttons = _parse_native_buttons(d.pop("native_buttons", UNSET))
+
+        connector_capabilities = cls(
+            draft_streaming=draft_streaming,
+            native_buttons=native_buttons,
+        )
+
+        return connector_capabilities

--- a/packages/aios-sdk/aios_sdk/_generated/models/draft_streaming.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/draft_streaming.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="DraftStreaming")
+
+
+@_attrs_define
+class DraftStreaming:
+    """Present == connector can render in-progress assistant deltas as an
+    editable draft.  Absent == connector waits for the committed message.
+
+        Attributes:
+            overflow_limit (int | None | Unset):
+    """
+
+    overflow_limit: int | None | Unset = UNSET
+
+    def to_dict(self) -> dict[str, Any]:
+        overflow_limit: int | None | Unset
+        if isinstance(self.overflow_limit, Unset):
+            overflow_limit = UNSET
+        else:
+            overflow_limit = self.overflow_limit
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update({})
+        if overflow_limit is not UNSET:
+            field_dict["overflow_limit"] = overflow_limit
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_overflow_limit(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        overflow_limit = _parse_overflow_limit(d.pop("overflow_limit", UNSET))
+
+        draft_streaming = cls(
+            overflow_limit=overflow_limit,
+        )
+
+        return draft_streaming

--- a/packages/aios-sdk/aios_sdk/_generated/models/native_buttons.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/native_buttons.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+
+T = TypeVar("T", bound="NativeButtons")
+
+
+@_attrs_define
+class NativeButtons:
+    """Present == connector renders externally-executed tool-confirmations as
+    inbound platform buttons; a button-tap maps to the existing
+    ``POST /sessions/:id/tool-confirmations``.  Absent == text-prompt fallback.
+
+        Attributes:
+            max_buttons (int):
+    """
+
+    max_buttons: int
+
+    def to_dict(self) -> dict[str, Any]:
+        max_buttons = self.max_buttons
+
+        field_dict: dict[str, Any] = {}
+
+        field_dict.update(
+            {
+                "max_buttons": max_buttons,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        max_buttons = d.pop("max_buttons")
+
+        native_buttons = cls(
+            max_buttons=max_buttons,
+        )
+
+        return native_buttons

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -59,6 +59,7 @@ from aios.errors import (
 )
 from aios.logging import get_logger
 from aios.models.connections import ConnectorSecrets
+from aios.models.connectors import ConnectorCapabilities
 from aios.services import connections as connections_service
 from aios.services import connectors as connectors_service
 from aios.services import inbound as inbound_service
@@ -203,6 +204,19 @@ class ToolsSchemaUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     tools: list[dict[str, Any]]
+
+
+class CapabilitiesUpdate(BaseModel):
+    """Body for ``PUT /v1/connectors/{connector}/capabilities``.
+
+    A sibling to :class:`ToolsSchemaUpdate` — kept separate so capability churn
+    is decoupled from a full ``tools_schema`` republish and the shipped
+    ``tools_schema`` body contract stays untouched.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    capabilities: ConnectorCapabilities
 
 
 class RuntimeToolResultRequest(BaseModel):
@@ -413,6 +427,39 @@ async def put_tools_schema(
     # service layer so the route stays a thin shim.
     await connectors_service.update_tools_schema(
         pool, connector=connector, account_id=account_id, tools_schema=body.tools
+    )
+
+
+@router.put(
+    "/{connector}/capabilities",
+    operation_id="put_connector_capabilities",
+)
+async def put_capabilities(
+    connector: str,
+    body: CapabilitiesUpdate,
+    pool: PoolDep,
+    auth: RuntimeAuthDep,
+) -> None:
+    """Publish the runtime container's typed capability descriptor for a
+    connector type.
+
+    A sibling to :func:`put_tools_schema` (same root-only publication path),
+    kept on its own route so capability churn is decoupled from a full
+    ``tools_schema`` republish.  The runtime container is the source of truth
+    for what richer renderings it supports; it publishes the descriptor at
+    startup, replacing whatever was on the ``connectors.capabilities`` row
+    wholesale.
+
+    Authorization: the runtime bearer's ``connector`` must match the path's
+    ``connector``; publication itself is root-only (enforced in the service
+    layer — connectors are root-owned, the same cross-tenant rationale as
+    ``tools_schema``).  Capabilities declare NO authority: they constrain
+    RENDERING, never what any principal may invoke.
+    """
+    _, auth_connector, account_id, _scope = auth
+    _check_runtime_scope(auth_connector, connector)
+    await connectors_service.update_capabilities(
+        pool, connector=connector, account_id=account_id, capabilities=body.capabilities
     )
 
 

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -63,6 +63,11 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
     "put_connector_tools_schema": (
         "Called by connector containers via runtime token; not for operators."
     ),
+    "put_connector_capabilities": (
+        "Called by connector containers via runtime token; not for operators. "
+        "Sibling to put_connector_tools_schema: the runtime container publishes "
+        "its typed capability descriptor at startup; operators don't hand-write it."
+    ),
     # ── Infra/orchestrator probe ─────────────────────────────────────
     "get_ready": (
         "Readiness probe (SELECT 1 under a short timeout) consumed by the "

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -312,6 +312,7 @@ from .connections import (  # noqa: E402
     insert_connection,
     insert_management_call,
     list_chat_sessions_for_connection,
+    list_connection_capabilities_for_session,
     list_connection_tools_for_session,
     list_connections,
     list_pending_management_calls_for_connector,
@@ -326,6 +327,7 @@ from .connections import (  # noqa: E402
     reparent_connection,
     set_connection_secrets,
     try_record_inbound_ack,
+    update_connector_capabilities,
     update_connector_tools_schema,
 )
 from .environments import (  # noqa: E402
@@ -720,6 +722,7 @@ __all__ = [
     "list_chat_sessions_for_connection",
     "list_child_accounts",
     "list_confirmed_unresolved_tool_calls",
+    "list_connection_capabilities_for_session",
     "list_connection_tools_for_session",
     "list_connections",
     "list_environments",
@@ -813,6 +816,7 @@ __all__ = [
     "unscoped_set_session_snapshot",
     "update_account",
     "update_agent",
+    "update_connector_capabilities",
     "update_connector_tools_schema",
     "update_environment",
     "update_memory_store",

--- a/src/aios/db/queries/connections.py
+++ b/src/aios/db/queries/connections.py
@@ -28,6 +28,7 @@ from aios.ids import (
     make_id,
 )
 from aios.models.connections import BindingMode, Connection, ConnectionMode
+from aios.models.connectors import ConnectorCapabilities
 
 # ─── bindings (#328 PR 7 — unit of curation, succeeded the in-place
 #                          ``connections.session_id`` / ``session_template_id``
@@ -522,6 +523,57 @@ async def list_connection_tools_for_session(
     for row in rows:
         out.extend(parse_jsonb(row["tools"]))
     return out
+
+
+async def list_connection_capabilities_for_session(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    *,
+    account_id: str,
+) -> dict[str, ConnectorCapabilities]:
+    """Typed capability descriptors for every connector type whose active
+    connection is bound to ``session_id``, keyed by connector type.
+
+    The capability sibling to :func:`list_connection_tools_for_session`: walks
+    the same two lineage paths to the active connections bound to this session,
+    then JOINs to ``connectors.capabilities`` — the runtime container is the
+    source of truth for what richer renderings its connector type supports.
+
+    A connector row carrying the empty ``'{}'`` row-default validates to the
+    empty-floor :class:`ConnectorCapabilities` (every sub-descriptor absent),
+    so the caller never has to special-case "no declared capabilities".
+
+    This is the read seam #1335's outbound delta renderer plugs into: it reads
+    the declared KIND (``caps.draft_streaming``/``caps.native_buttons``) rather
+    than a ``connector == 'slack'`` identity branch.  No in-tree consumer calls
+    it yet (the prelude read site is deferred to #1335) — a deliberate seam,
+    exercised by the read-symmetry integration test.
+    """
+    rows = await conn.fetch(
+        f"""
+        SELECT cat.connector AS connector, cat.capabilities AS capabilities
+          FROM connectors cat
+         WHERE cat.connector IN (
+                SELECT DISTINCT c.connector
+                  FROM connections c
+                 WHERE c.archived_at IS NULL
+                   AND c.account_id = $2
+                   AND {
+            _session_bound_to_connection_predicate(
+                connection_alias="c", session_param_index=1, account_id_param_index=2
+            )
+        }
+            )
+        """,
+        session_id,
+        account_id,
+    )
+    return {
+        row["connector"]: ConnectorCapabilities.model_validate(
+            parse_jsonb(row["capabilities"]) or {}
+        )
+        for row in rows
+    }
 
 
 async def get_connection_for_account(
@@ -1124,6 +1176,35 @@ async def update_connector_tools_schema(
         """,
         connector,
         json.dumps(tools_schema),
+    )
+
+
+async def update_connector_capabilities(
+    conn: asyncpg.Connection[Any],
+    connector: str,
+    *,
+    account_id: str,
+    capabilities: dict[str, Any],
+) -> None:
+    """Upsert ``connectors.capabilities`` for ``connector`` wholesale.
+
+    The capability sibling to :func:`update_connector_tools_schema`, on the
+    same single-row-per-connector-type catalog.  The runtime container
+    publishes its typed richness descriptor via
+    ``PUT /v1/connectors/{connector}/capabilities``; a brand-new connector type
+    can publish its capabilities before its first connection exists.  The
+    ``ON CONFLICT (connector)`` upsert keeps one row per type.
+    """
+    await conn.execute(
+        """
+        INSERT INTO connectors (connector, capabilities, created_at, updated_at)
+        VALUES ($1, $2::jsonb, now(), now())
+        ON CONFLICT (connector) DO UPDATE
+           SET capabilities = EXCLUDED.capabilities,
+               updated_at   = now()
+        """,
+        connector,
+        json.dumps(capabilities),
     )
 
 

--- a/src/aios/models/connectors.py
+++ b/src/aios/models/connectors.py
@@ -1,0 +1,63 @@
+"""Typed connector-capability descriptor — a ``tools_schema`` sibling.
+
+The connector subsystem renders the SAME externally-executed dispatch (an
+``always_ask`` tool-confirmation, an in-progress assistant delta) differently
+per platform: Slack can show inline buttons and edit a draft message; a plain
+text channel can only post a prompt and wait for the committed message.  This
+module is the *declared, typed channel* through which a connector advertises
+which richer renderings it supports, so shared rendering code can branch on a
+declared **KIND** (``capabilities.draft_streaming is not None``) instead of a
+``connector == 'slack'`` identity shim.
+
+**Variation is a KIND, not a flag.**  Each capability is a present/absent
+typed sub-object — never a boolean.  ``supports_draft_streaming: bool`` is
+rejected in favour of ``draft_streaming: DraftStreaming | None``: the
+present/absent object subsumes the boolean and binds its parameters into the
+same KIND, so an illegal combo (capability "on" but its parameters missing) is
+unrepresentable rather than runtime-guarded.
+
+This descriptor sits as a sibling to the connector-type catalog's existing
+``tools_schema`` (``connectors.capabilities jsonb`` — migration 0109), is
+published on the same root-only path, and is read alongside the same
+per-session query.  It declares NO authority: capabilities constrain RENDERING
+(how a surface displays), never what any principal may invoke, so a capability
+descriptor is never consulted in an authorization decision.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NativeButtons(BaseModel):
+    """Present == connector renders externally-executed tool-confirmations as
+    inbound platform buttons; a button-tap maps to the existing
+    ``POST /sessions/:id/tool-confirmations``.  Absent == text-prompt fallback.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_buttons: int  # platform cap (Slack 5, Telegram rows, …)
+
+
+class DraftStreaming(BaseModel):
+    """Present == connector can render in-progress assistant deltas as an
+    editable draft.  Absent == connector waits for the committed message.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    overflow_limit: int | None = None  # chars before truncate/finalize; None == unbounded
+
+
+class ConnectorCapabilities(BaseModel):
+    """Typed richness descriptor — a ``tools_schema`` sibling on the catalog
+    row.  Each field is a present/absent typed sub-object (a declared KIND),
+    never a bool flag.  An absent field == capability not declared == the
+    conservative rendering floor.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    draft_streaming: DraftStreaming | None = None
+    native_buttons: NativeButtons | None = None

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -30,6 +30,7 @@ from aios.models.connections import (
     ConnectionMode,
     RecentChat,
 )
+from aios.models.connectors import ConnectorCapabilities
 from aios.services.sessions import _evict_sandbox_for_resource_change
 
 
@@ -131,6 +132,26 @@ async def list_tools_for_session(
     """
     async with pool.acquire() as conn:
         return await queries.list_connection_tools_for_session(
+            conn, session_id, account_id=account_id
+        )
+
+
+async def list_capabilities_for_session(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
+) -> dict[str, ConnectorCapabilities]:
+    """Typed capability descriptors for every connector type bound to
+    ``session_id``, keyed by connector type.
+
+    The capability sibling to :func:`list_tools_for_session`: reached from the
+    ``ToolProvider`` Protocol seam
+    (:class:`aios_connectors.providers.SubsystemToolProvider`).  Surfaces the
+    declared richness descriptor so shared rendering code can branch on a
+    declared KIND rather than a ``connector == '<type>'`` identity shim.  The
+    only consumer — the #1335 outbound delta renderer — is not yet in-tree;
+    this is the deliberate read seam it plugs into.
+    """
+    async with pool.acquire() as conn:
+        return await queries.list_connection_capabilities_for_session(
             conn, session_id, account_id=account_id
         )
 

--- a/src/aios/services/connectors.py
+++ b/src/aios/services/connectors.py
@@ -16,6 +16,7 @@ import asyncpg
 
 from aios.db import queries
 from aios.errors import ForbiddenError
+from aios.models.connectors import ConnectorCapabilities
 
 
 async def update_tools_schema(
@@ -49,4 +50,36 @@ async def update_tools_schema(
             )
         await queries.update_connector_tools_schema(
             conn, connector, account_id=account_id, tools_schema=tools_schema
+        )
+
+
+async def update_capabilities(
+    pool: asyncpg.Pool[Any],
+    *,
+    connector: str,
+    account_id: str,
+    capabilities: ConnectorCapabilities,
+) -> None:
+    """Publish ``connector``'s typed capability descriptor.  Root-only.
+
+    The capability sibling to :func:`update_tools_schema`, carrying the
+    byte-identical root-gate.  ``capabilities`` is a property of the connector
+    *type* (one row per type, shared across every tenant), so a child tenant
+    publishing it would overwrite the global row and change how every other
+    tenant's session bound to a connection of that type is rendered.  The
+    cross-tenant rationale that motivates the ``tools_schema`` root-gate applies
+    identically — capabilities are render metadata at the same altitude.
+
+    Restricting publication to the root account preserves the "connectors
+    configured by root, connections added by tenants" architectural invariant.
+    """
+    async with pool.acquire() as conn:
+        account = await queries.get_account(conn, account_id)
+        if account is None or account.parent_account_id is not None:
+            raise ForbiddenError(
+                "publishing a connector's capabilities is reserved for the root account",
+                detail={"connector": connector},
+            )
+        await queries.update_connector_capabilities(
+            conn, connector, account_id=account_id, capabilities=capabilities.model_dump()
         )

--- a/src/aios/tools/providers.py
+++ b/src/aios/tools/providers.py
@@ -15,6 +15,8 @@ from typing import Any, Protocol, runtime_checkable
 
 import asyncpg
 
+from aios.models.connectors import ConnectorCapabilities
+
 
 @runtime_checkable
 class ToolProvider(Protocol):
@@ -28,5 +30,20 @@ class ToolProvider(Protocol):
         Each dict is a ToolSpec ready for ``ToolSpec.model_validate`` —
         the same shape ``services.connections.list_tools_for_session``
         returns today.
+        """
+        ...
+
+    async def list_capabilities_for_session(
+        self, pool: asyncpg.Pool[Any], session_id: str
+    ) -> dict[str, ConnectorCapabilities]:
+        """Return the typed capability descriptors for ``session_id``,
+        keyed by connector type.
+
+        The capability sibling to :meth:`list_tools_for_session`.  Shared
+        rendering code branches on a declared KIND
+        (``caps.draft_streaming is not None``) instead of a
+        ``connector == '<type>'`` identity shim.  The only consumer (the #1335
+        outbound delta renderer) is not yet in-tree; this is the seam it plugs
+        into when it lands.
         """
         ...

--- a/src/aios_connectors/providers.py
+++ b/src/aios_connectors/providers.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import asyncpg
 
+from aios.models.connectors import ConnectorCapabilities
 from aios.services import connections as connections_service
 from aios.services import sessions as sessions_service
 
@@ -34,5 +35,13 @@ class SubsystemToolProvider:
     ) -> list[dict[str, Any]]:
         account_id = await sessions_service.load_session_account_id(pool, session_id)
         return await connections_service.list_tools_for_session(
+            pool, session_id, account_id=account_id
+        )
+
+    async def list_capabilities_for_session(
+        self, pool: asyncpg.Pool[Any], session_id: str
+    ) -> dict[str, ConnectorCapabilities]:
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
+        return await connections_service.list_capabilities_for_session(
             pool, session_id, account_id=account_id
         )

--- a/tests/integration/test_connector_capabilities_read_symmetry.py
+++ b/tests/integration/test_connector_capabilities_read_symmetry.py
@@ -1,0 +1,143 @@
+"""Integration test: ``list_connection_capabilities_for_session`` surfaces a
+connector type's typed capability descriptor per session through the same
+lineage walk as ``list_connection_tools_for_session`` (#1381).
+
+Bind a session to an ``echo`` connection, publish capabilities for ``echo`` as
+root, and assert the per-session read returns the published descriptor keyed by
+connector type.  A connector whose row carries the empty ``'{}'`` row-default
+reads back as the empty-floor model — the caller never special-cases
+"no declared capabilities".
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.models.connectors import (
+    ConnectorCapabilities,
+    DraftStreaming,
+    NativeButtons,
+)
+from aios.services import agents as agents_service
+from aios.services import connectors as connectors_service
+from aios.services import environments as environments_service
+
+pytestmark = pytest.mark.integration
+
+
+async def _seed_session_bound_to_echo(pool: asyncpg.Pool[Any]) -> str:
+    """Create an acc_a session with an active single_session binding to an
+    acc_a ``echo`` connection (which upserts the ``echo`` connectors row)."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+            VALUES ('acc_root', NULL,       TRUE,  'tenant-root'),
+                   ('acc_a',    'acc_root', FALSE, 'tenant-a')
+            """
+        )
+
+    agent_a = await agents_service.create_agent(
+        pool,
+        account_id="acc_a",
+        name="a-agent",
+        model="openrouter/test",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    env_a = await environments_service.create_environment(
+        pool,
+        account_id="acc_a",
+        name="a-env",
+    )
+    async with pool.acquire() as conn:
+        session = await queries.insert_session(
+            conn,
+            account_id="acc_a",
+            agent_id=agent_a.id,
+            environment_id=env_a.id,
+            agent_version=agent_a.version,
+            title=None,
+            metadata={},
+        )
+        connection = await queries.insert_connection(
+            conn,
+            account_id="acc_a",
+            connector="echo",
+            external_account_id="echo-1",
+            metadata={},
+        )
+        await queries.insert_binding(
+            conn,
+            account_id="acc_a",
+            connection_id=connection.id,
+            mode="single_session",
+            session_id=session.id,
+        )
+    return session.id
+
+
+@pytest.fixture
+async def pool_session_bound_to_echo(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        session_id = await _seed_session_bound_to_echo(pool)
+        yield pool, session_id
+    finally:
+        await pool.close()
+
+
+async def test_published_capabilities_surface_per_session(
+    pool_session_bound_to_echo: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    pool, session_id = pool_session_bound_to_echo
+
+    published = ConnectorCapabilities(
+        draft_streaming=DraftStreaming(overflow_limit=4000),
+        native_buttons=NativeButtons(max_buttons=5),
+    )
+    await connectors_service.update_capabilities(
+        pool,
+        connector="echo",
+        account_id="acc_root",
+        capabilities=published,
+    )
+
+    async with pool.acquire() as conn:
+        caps = await queries.list_connection_capabilities_for_session(
+            conn, session_id, account_id="acc_a"
+        )
+
+    assert caps == {"echo": published}
+    # The payoff: shared rendering code branches on a declared KIND.
+    assert caps["echo"].draft_streaming is not None
+    assert caps["echo"].native_buttons is not None
+
+
+async def test_empty_row_default_reads_as_floor(
+    pool_session_bound_to_echo: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """With no capabilities published, the ``'{}'`` row-default surfaces as the
+    empty-floor model (every sub-descriptor absent)."""
+    pool, session_id = pool_session_bound_to_echo
+
+    async with pool.acquire() as conn:
+        caps = await queries.list_connection_capabilities_for_session(
+            conn, session_id, account_id="acc_a"
+        )
+
+    assert caps == {"echo": ConnectorCapabilities()}
+    assert caps["echo"].draft_streaming is None
+    assert caps["echo"].native_buttons is None

--- a/tests/integration/test_connector_capabilities_root_only.py
+++ b/tests/integration/test_connector_capabilities_root_only.py
@@ -1,0 +1,144 @@
+"""Integration tests: publishing a connector's ``capabilities`` is root-only,
+and the per-session read query surfaces them through the same lineage walk as
+``tools_schema`` (#1381).
+
+``capabilities`` is a typed richness descriptor sibling to ``tools_schema`` on
+the single-row-per-connector-type catalog.  It rides the same root-only
+publication path: a child tenant publishing it would overwrite the global row
+and change how every other tenant's session bound to a connection of that type
+is rendered — the same cross-tenant rationale that motivates the
+``tools_schema`` root-gate.  And it reads per session through the same lineage
+walk so the descriptor surfaces without a second concept.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.errors import ForbiddenError
+from aios.models.connectors import (
+    ConnectorCapabilities,
+    DraftStreaming,
+    NativeButtons,
+)
+from aios.services import connectors as connectors_service
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def root_and_child(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, root_account_id, child_account_id)`` with a seeded
+    ``echo`` connector row.  Mirrors the ``tools_schema`` root-only fixture."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_root',  NULL,      TRUE,  'tenant-root'),
+                       ('acc_child', 'acc_root', FALSE, 'tenant-child')
+                """
+            )
+            await conn.execute(
+                "INSERT INTO connectors (connector) VALUES ('echo') ON CONFLICT DO NOTHING"
+            )
+        yield pool, "acc_root", "acc_child"
+    finally:
+        await pool.close()
+
+
+async def test_default_row_reads_as_empty_floor(
+    root_and_child: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """A freshly-seeded ``connectors`` row carries the ``'{}'`` default — the
+    conservative rendering floor (all sub-descriptors absent)."""
+    pool, _root_id, _child_id = root_and_child
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT capabilities FROM connectors WHERE connector = 'echo'")
+    assert row is not None
+    raw = row["capabilities"]
+    caps_dict = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+    assert caps_dict == {}
+    floor = ConnectorCapabilities.model_validate(caps_dict)
+    assert floor.draft_streaming is None
+    assert floor.native_buttons is None
+
+
+async def test_child_account_cannot_publish_capabilities(
+    root_and_child: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """A child account's runtime token must not publish capabilities — it
+    would poison the global row and change every other tenant's rendering."""
+    pool, _root_id, child_id = root_and_child
+
+    with pytest.raises(ForbiddenError) as excinfo:
+        await connectors_service.update_capabilities(
+            pool,
+            connector="echo",
+            account_id=child_id,
+            capabilities=ConnectorCapabilities(native_buttons=NativeButtons(max_buttons=5)),
+        )
+
+    detail = excinfo.value.detail
+    assert detail is not None
+    assert detail.get("connector") == "echo"
+
+    # Defense-in-depth: the row must not have been written.
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT capabilities FROM connectors WHERE connector = 'echo'")
+    assert row is not None
+    raw = row["capabilities"]
+    caps_dict = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+    assert caps_dict == {}  # untouched JSONB default
+
+
+async def test_root_account_can_publish_capabilities(
+    root_and_child: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """The root account remains authorized — the connector type is a
+    root-owned configuration; the published JSON lands on the row."""
+    pool, root_id, _child_id = root_and_child
+
+    published = ConnectorCapabilities(
+        draft_streaming=DraftStreaming(overflow_limit=4000),
+        native_buttons=NativeButtons(max_buttons=5),
+    )
+    await connectors_service.update_capabilities(
+        pool,
+        connector="echo",
+        account_id=root_id,
+        capabilities=published,
+    )
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow("SELECT capabilities FROM connectors WHERE connector = 'echo'")
+    assert row is not None
+    raw = row["capabilities"]
+    caps_dict = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+    assert ConnectorCapabilities.model_validate(caps_dict) == published
+
+
+async def test_unknown_account_id_is_rejected(
+    root_and_child: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """A bogus account id (forged/stale token resolve) is rejected, not
+    treated as root."""
+    pool, _root_id, _child_id = root_and_child
+
+    with pytest.raises(ForbiddenError):
+        await connectors_service.update_capabilities(
+            pool,
+            connector="echo",
+            account_id="acc_does_not_exist",
+            capabilities=ConnectorCapabilities(),
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -53,6 +53,9 @@ def _unit_runtime_tool_provider() -> Iterator[None]:
         async def list_tools_for_session(self, pool: Any, session_id: str) -> list[Any]:
             return []
 
+        async def list_capabilities_for_session(self, pool: Any, session_id: str) -> dict[str, Any]:
+            return {}
+
     runtime.tool_provider = _NoopToolProvider()
     try:
         yield

--- a/tests/unit/test_connector_capabilities.py
+++ b/tests/unit/test_connector_capabilities.py
@@ -1,0 +1,94 @@
+"""Unit tests for the typed connector-capability descriptor.
+
+``ConnectorCapabilities`` is a *tools_schema sibling* on the connector-type
+catalog row: a typed richness descriptor whose every field is a present/absent
+typed sub-object (a declared KIND), never a boolean flag.  These tests pin the
+"variation is a KIND, not a flag" invariant — the bool-bag is unrepresentable,
+illegal-combo (capability on but parameters absent) is unrepresentable, and an
+empty descriptor is the conservative/plain-text rendering floor.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aios.models.connectors import (
+    ConnectorCapabilities,
+    DraftStreaming,
+    NativeButtons,
+)
+
+
+def test_empty_descriptor_is_the_floor() -> None:
+    """An empty (or row-default ``{}``) descriptor reads as "no declared
+    capabilities" — every sub-descriptor absent, the conservative floor."""
+    caps = ConnectorCapabilities.model_validate({})
+    assert caps.draft_streaming is None
+    assert caps.native_buttons is None
+
+
+def test_draft_streaming_present_carries_its_parameters() -> None:
+    caps = ConnectorCapabilities.model_validate({"draft_streaming": {"overflow_limit": 4000}})
+    assert caps.draft_streaming is not None
+    assert caps.draft_streaming.overflow_limit == 4000
+    # The other KIND stays absent — independent present/absent objects.
+    assert caps.native_buttons is None
+
+
+def test_draft_streaming_overflow_limit_defaults_to_unbounded() -> None:
+    caps = ConnectorCapabilities.model_validate({"draft_streaming": {}})
+    assert caps.draft_streaming is not None
+    assert caps.draft_streaming.overflow_limit is None  # unbounded
+
+
+def test_native_buttons_present_carries_its_parameters() -> None:
+    caps = ConnectorCapabilities.model_validate({"native_buttons": {"max_buttons": 5}})
+    assert caps.native_buttons is not None
+    assert caps.native_buttons.max_buttons == 5
+    assert caps.draft_streaming is None
+
+
+def test_native_buttons_rejects_extra_keys() -> None:
+    """``extra="forbid"`` on the sub-descriptor rejects drifted parameters."""
+    with pytest.raises(ValidationError):
+        ConnectorCapabilities.model_validate({"native_buttons": {"max_buttons": 5, "bogus": 1}})
+
+
+def test_capabilities_rejects_extra_top_level_keys() -> None:
+    with pytest.raises(ValidationError):
+        ConnectorCapabilities.model_validate({"supports_draft_streaming": True})
+
+
+def test_bool_where_object_expected_is_unrepresentable() -> None:
+    """A bool where a KIND sub-object is expected raises — proving the
+    boolean-bag (``supports_draft_streaming: bool``) is unrepresentable."""
+    with pytest.raises(ValidationError):
+        ConnectorCapabilities.model_validate({"draft_streaming": True})
+
+
+def test_native_buttons_requires_max_buttons() -> None:
+    """``max_buttons`` is a required KIND parameter — capability-on but
+    parameters-missing is unrepresentable rather than runtime-guarded."""
+    with pytest.raises(ValidationError):
+        ConnectorCapabilities.model_validate({"native_buttons": {}})
+
+
+def test_both_kinds_present() -> None:
+    caps = ConnectorCapabilities.model_validate(
+        {
+            "draft_streaming": {"overflow_limit": 2000},
+            "native_buttons": {"max_buttons": 3},
+        }
+    )
+    assert caps.draft_streaming == DraftStreaming(overflow_limit=2000)
+    assert caps.native_buttons == NativeButtons(max_buttons=3)
+
+
+def test_model_dump_round_trips() -> None:
+    caps = ConnectorCapabilities(
+        draft_streaming=DraftStreaming(overflow_limit=4000),
+        native_buttons=NativeButtons(max_buttons=5),
+    )
+    dumped = caps.model_dump()
+    assert ConnectorCapabilities.model_validate(dumped) == caps

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0112``."""
+    """The migration ladder has exactly one head: ``0113``."""
     script = _script_directory()
-    assert script.get_heads() == ["0112"]
+    assert script.get_heads() == ["0113"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -28,7 +28,7 @@ def _script_directory() -> ScriptDirectory:
 def test_single_head() -> None:
     """The migration ladder has exactly one head: ``0113``."""
     script = _script_directory()
-    assert script.get_heads() == ["0113"]
+    assert script.get_heads() == ["0114"]
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1381.