### PR TITLE
Durable await-resume: re-park lost call_* invocations on crash (#1431)

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -489,6 +489,7 @@ from .skills import (  # noqa: E402
 from .trace import (  # noqa: E402
     ChildNode,
     children_of,
+    find_parked_servicer,
     read_run_journal_batched,
     read_run_meta_batched,
     read_session_journal_batched,
@@ -643,6 +644,7 @@ __all__ = [
     "fetch_and_claim_due_triggers",
     "fetch_next_trigger_event",
     "finalize_trigger_run",
+    "find_parked_servicer",
     "find_tool_confirmed_event",
     "find_tool_result_event",
     "gc_snapshot_session_states",

--- a/src/aios/db/queries/trace.py
+++ b/src/aios/db/queries/trace.py
@@ -171,6 +171,64 @@ async def children_of(
     )
 
 
+async def find_parked_servicer(
+    conn: asyncpg.Connection[Any],
+    *,
+    caller_session_id: str,
+    tool_call_id: str,
+    account_id: str,
+) -> tuple[NodeKind, str, str | None, dict[str, Any] | None] | None:
+    """Resolve the servicer a session's parked ``call_*`` invocation was awaiting (#1431).
+
+    The durable counterpart of the in-memory park handle: a ``call_*`` handler stamps its
+    own ``tool_call_id`` onto the servicer's edge ``caller`` (``request_opened.data.caller``
+    for a session servicer, ``wf_runs.caller`` for a run), so crash-recovery can re-derive
+    everything ``_park_and_resolve`` needs — ``(servicer_kind, servicer_id, request_id,
+    output_schema)`` — from the edge alone. This is the same trusted "children-of by caller"
+    direction :func:`children_of` walks, narrowed to one ``tool_call_id`` and projecting the
+    per-request ``output_schema`` so the resume re-validates the answer exactly as the live
+    handler would. Returns ``None`` when no such edge exists (the launch crashed before the
+    servicer/edge was durable → recovery errors the call as retryable rather than re-parking
+    on nothing). ``request_id`` is ``None`` for a run servicer (it parks on its terminal row,
+    not a request edge).
+
+    Both lookups key on the 0103 reverse caller indexes
+    (``events_request_opened_caller_idx`` / ``wf_runs_caller_idx``: ``(account_id,
+    caller.kind, caller.id)``) and add the ``tool_call_id`` filter on top; the caller is
+    always ``kind='session'`` here (only the model-facing ``call_*`` handlers stamp a
+    ``tool_call_id``). A session servicer is preferred when — impossibly — both match.
+    """
+    sess = await conn.fetchrow(
+        "SELECT e.session_id AS id, e.data->>'request_id' AS request_id, "
+        "e.data->'output_schema' AS output_schema FROM events e "
+        "WHERE e.account_id = $1 AND e.kind = 'lifecycle' "
+        "AND e.data->>'event' = 'request_opened' "
+        "AND e.data->'caller'->>'kind' = 'session' AND e.data->'caller'->>'id' = $2 "
+        "AND e.data->'caller'->>'tool_call_id' = $3 LIMIT 1",
+        account_id,
+        caller_session_id,
+        tool_call_id,
+    )
+    if sess is not None:
+        schema = sess["output_schema"]
+        return ("session", sess["id"], sess["request_id"], parse_jsonb(schema) if schema else None)
+
+    run = await conn.fetchrow(
+        "SELECT r.id AS id, r.request_output_schema AS output_schema FROM wf_runs r "
+        "WHERE r.account_id = $1 "
+        "AND r.caller->>'kind' = 'session' AND r.caller->>'id' = $2 "
+        "AND r.caller->>'tool_call_id' = $3 LIMIT 1",
+        account_id,
+        caller_session_id,
+        tool_call_id,
+    )
+    if run is not None:
+        schema = run["output_schema"]
+        return ("run", run["id"], None, parse_jsonb(schema) if schema else None)
+
+    return None
+
+
 async def read_session_meta_batched(
     conn: asyncpg.Connection[Any],
     session_ids: list[str],

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 from aios.config import get_settings
 from aios.db.queries import (
     confirmed_unresolved_predicate,
+    find_parked_servicer,
     list_session_ids_with_unharvested_cancel_marker,
     parse_jsonb,
     session_active_predicate,
@@ -295,7 +296,7 @@ async def find_and_repair_ghosts(
     *,
     session_id: str | None = None,
 ) -> list[tuple[str, str]]:
-    """Find ghost tool calls and append synthetic error results.
+    """Recover ghost tool calls: re-park resumable invocations, error-repair the rest.
 
     A ghost is a tool_call_id from an assistant message where:
 
@@ -304,6 +305,15 @@ async def find_and_repair_ghosts(
     - The harness would have dispatched the tool (i.e. it's not a
       custom tool or an unconfirmed ``always_ask`` tool still waiting
       for client action).
+
+    A ghost whose tool is a parking ``call_*`` builtin (``PARKING_TOOL_NAMES``) is a
+    **pure-await** that crash-recovery RE-PARKS rather than error-repairs (#1431): its
+    servicer is re-derived from the durable edge (:func:`queries.find_parked_servicer`) and
+    a fresh resume task is launched (a pure read of durable state) so the servicer's
+    exactly-once answer lands in the original tool result. Only a resumable ghost whose edge
+    is absent — the launch crashed before it was durable — falls through to a retryable
+    ``launch_lost`` error. Every other ghost keeps the side-effect-conservative
+    error-repair below.
 
     Plus a second, age-bounded category — **abandoned client-side tool
     calls** (#752). A *client-result-pending* call (the non-MCP,
@@ -452,6 +462,65 @@ async def find_and_repair_ghosts(
             # to wait on the user.
             abandoned.append(c)
 
+    # #1431: a parked ``call_*`` ghost is a PURE-AWAIT, not a side-effectful tool — its
+    # servicer is still running and will answer exactly once. Re-derive the servicer from
+    # the durable edge (the ``tool_call_id`` the handler stamped onto ``caller``) and
+    # RE-PARK it (a pure read), so the answer lands in the original tool result instead of
+    # being orphaned by a synthetic error. Only when no edge exists (the launch crashed
+    # before it was durable) does the call fall through to a retryable ``launch_lost`` error.
+    # Lazy imports: ``sweep`` ↔ ``tool_dispatch`` is a mutual-lazy-import pair (the
+    # symmetric counterpart of ``_trigger_sweep``'s lazy ``sweep`` import); ``invoke_session``
+    # registers tools at import and isn't needed at ``sweep`` module load.
+    from aios.harness.tool_dispatch import relaunch_parked_invocation
+    from aios.tools.invoke_session import PARKING_TOOL_NAMES
+
+    resumable = [c for c in ghosts if c.tool_name in PARKING_TOOL_NAMES]
+    ghosts = [c for c in ghosts if c.tool_name not in PARKING_TOOL_NAMES]
+    launch_lost: list[_Candidate] = []
+    for c in resumable:
+        # Per-ghost isolation, matching the error-repair + wake-defer loops below: this
+        # runs cross-session (boot sweep), so one gone caller (``NotFoundError`` from
+        # ``load_session_account_id``) or a transient DB error must NOT abort recovery of
+        # the other tenants' ghosts. A gone caller has nothing to resume → log + skip.
+        try:
+            c_account_id = await sessions_service.load_session_account_id(pool, c.session_id)
+            async with pool.acquire() as conn:
+                handle = await find_parked_servicer(
+                    conn,
+                    caller_session_id=c.session_id,
+                    tool_call_id=c.tool_call_id,
+                    account_id=c_account_id,
+                )
+            if handle is None:
+                launch_lost.append(c)
+                continue
+            servicer_kind, servicer_id, request_id, output_schema = handle
+            relaunch_parked_invocation(
+                pool,
+                c.session_id,
+                call={
+                    "id": c.tool_call_id,
+                    "function": {"name": c.tool_name, "arguments": c.arguments},
+                },
+                servicer_kind=servicer_kind,
+                servicer_id=servicer_id,
+                request_id=request_id,
+                output_schema=output_schema,
+                account_id=c_account_id,
+            )
+        except Exception:
+            log.exception(
+                "sweep.repark_failed", session_id=c.session_id, tool_call_id=c.tool_call_id
+            )
+            continue
+        log.info(
+            "sweep.invocation_reparked",
+            session_id=c.session_id,
+            tool_call_id=c.tool_call_id,
+            servicer_kind=servicer_kind,
+            servicer_id=servicer_id,
+        )
+
     # ``tool_execute_start`` span presence per (session, tcid) — drives the
     # two-branch recovery message below (#685).  Tcids missing from this set
     # never reached the lifecycle body, so the tool definitely did not run;
@@ -516,6 +585,18 @@ async def find_and_repair_ghosts(
                 f"Tool call abandoned: the client returned no result within "
                 f"{client_max_age}s. The client is no longer connected; do not "
                 f"wait for this result.",
+            )
+        )
+    for c in launch_lost:
+        # #1431: a resumable ``call_*`` ghost with no servicer edge — the launch crashed
+        # before the request reached a servicer, so nothing is running to await. Safe to
+        # retry (no servicer was created or served), unlike the may-have-completed branch.
+        repair_items.append(
+            (
+                c,
+                "launch_lost",
+                "The invocation did not start before the worker restarted; "
+                "nothing was launched. You may retry.",
             )
         )
 

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -30,7 +30,7 @@ from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from types import EllipsisType
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import asyncpg
 
@@ -41,6 +41,9 @@ from aios.models.agents import McpServerSpec
 from aios.services import sessions as sessions_service
 from aios.tools.invoke import ToolBail, invoke_builtin, parse_arguments
 from aios.tools.registry import ToolResult
+
+if TYPE_CHECKING:
+    from aios.services.invocations import ServicerKind
 
 log = get_logger("aios.harness.tool_dispatch")
 
@@ -108,11 +111,19 @@ async def _tool_lifecycle(
     account_id: str,
     log_prefix: str,
     on_exception: Callable[[str], None] | None = None,
+    write_start_span: bool = True,
 ) -> AsyncIterator[_ToolCall]:
     """Bracket a tool call with the ``tool_execute_*`` span pair plus
     try/except/finally + tail sweep (#78).  ``on_exception`` runs on
     generic ``Exception`` only — built-in passes the sandbox-eviction
     hook; MCP leaves it ``None`` because it doesn't use the sandbox.
+
+    ``write_start_span=False`` skips the ``tool_execute_*`` span pair: the
+    crash-resume re-park (:func:`_resume_parked_async`) is a pure read of durable
+    state, and a fresh ``tool_execute_start`` span would mislead a later ghost
+    classification into the side-effect-conservative "may have completed" branch
+    (the span is the only side-effect evidence ``sweep.find_and_repair_ghosts``
+    has). The dedup-guarded result append + tail sweep are still reused.
     """
     call_id = call.get("id") or "unknown"
     function = call.get("function") or {}
@@ -134,16 +145,20 @@ async def _tool_lifecycle(
     # (see the branch comment in ``sweep.find_and_repair_ghosts``).  This is
     # the conservatively-safe direction; the alternative (suppress the span
     # on cancellation) would risk under-pessimism on real side effects.
-    span_start = await sessions_service.append_event(
-        pool,
-        session_id,
-        "span",
-        {
-            "event": "tool_execute_start",
-            "tool_call_id": call_id,
-            "tool_name": name,
-        },
-        account_id=account_id,
+    span_start = (
+        await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {
+                "event": "tool_execute_start",
+                "tool_call_id": call_id,
+                "tool_name": name,
+            },
+            account_id=account_id,
+        )
+        if write_start_span
+        else None
     )
     bound_log = log.bind(session_id=session_id, tool_call_id=call_id, tool_name=name)
     tc = _ToolCall(call_id=call_id, name=name, raw_args=raw_args, bound_log=bound_log)
@@ -168,19 +183,20 @@ async def _tool_lifecycle(
             pool, session_id, call_id, name, account_id=account_id, error=message
         )
     finally:
-        await sessions_service.append_event(
-            pool,
-            session_id,
-            "span",
-            {
-                "event": "tool_execute_end",
-                "tool_execute_start_id": span_start.id,
-                "tool_call_id": call_id,
-                "tool_name": name,
-                "is_error": tc.is_error,
-            },
-            account_id=account_id,
-        )
+        if span_start is not None:
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "span",
+                {
+                    "event": "tool_execute_end",
+                    "tool_execute_start_id": span_start.id,
+                    "tool_call_id": call_id,
+                    "tool_name": name,
+                    "is_error": tc.is_error,
+                },
+                account_id=account_id,
+            )
         await _trigger_sweep(pool, session_id, account_id=account_id)
 
 
@@ -238,24 +254,8 @@ async def _execute_tool_async(
         log_prefix="tool",
         on_exception=_evict_session_container,
     ) as tc:
-        result = await invoke_builtin(session_id, tc.name, tc.raw_args)
-        event_data: dict[str, Any] = {
-            "role": "tool",
-            "tool_call_id": tc.call_id,
-            "name": tc.name,
-        }
-        if isinstance(result, ToolResult):
-            if isinstance(result.content, (str, list)):
-                event_data["content"] = result.content
-            else:
-                event_data["content"] = json.dumps(result.content, ensure_ascii=False)
-            if result.metadata:
-                event_data["metadata"] = result.metadata
-            if result.is_error:
-                event_data["is_error"] = True
-                tc.is_error = True
-        else:
-            event_data["content"] = json.dumps(result, ensure_ascii=False)
+        result = await invoke_builtin(session_id, tc.name, tc.raw_args, tool_call_id=tc.call_id)
+        event_data = _shape_tool_result(tc, result)
         tc.bound_log.info("tool.completed")
         await _append_tool_result_event(
             pool,
@@ -264,6 +264,120 @@ async def _execute_tool_async(
             event_data,
             account_id=account_id,
             tool_parent_channel=parent_focal_at_arrival,
+        )
+
+
+def _shape_tool_result(tc: _ToolCall, result: ToolResult | dict[str, Any]) -> dict[str, Any]:
+    """Shape a handler result into a ``role:"tool"`` event payload, marking ``tc.is_error``.
+
+    Shared by the live dispatch (:func:`_execute_tool_async`) and the crash-resume re-park
+    (:func:`_resume_parked_async`) so both land an identically-shaped tool-role event.
+    """
+    event_data: dict[str, Any] = {
+        "role": "tool",
+        "tool_call_id": tc.call_id,
+        "name": tc.name,
+    }
+    if isinstance(result, ToolResult):
+        if isinstance(result.content, (str, list)):
+            event_data["content"] = result.content
+        else:
+            event_data["content"] = json.dumps(result.content, ensure_ascii=False)
+        if result.metadata:
+            event_data["metadata"] = result.metadata
+        if result.is_error:
+            event_data["is_error"] = True
+            tc.is_error = True
+    else:
+        event_data["content"] = json.dumps(result, ensure_ascii=False)
+    return event_data
+
+
+def relaunch_parked_invocation(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    *,
+    call: dict[str, Any],
+    servicer_kind: ServicerKind,
+    servicer_id: str,
+    request_id: str | None,
+    output_schema: dict[str, Any] | None,
+    account_id: str,
+) -> None:
+    """Re-park a ``call_*`` invocation whose in-memory park task was lost to a worker
+    crash (#1431). Returns immediately; the resume runs as a fire-and-forget tool task.
+
+    Routed through :func:`_launch_tasks` so the resume registers in the ``TaskRegistry``
+    synchronously — a concurrent sweep then sees it in-flight (``CANDIDATE`` filter) and
+    won't double-launch. The handle ``(servicer_kind, servicer_id, request_id)`` is
+    re-derived from the durable servicer edge (``queries.find_parked_servicer``); ``call``
+    is the original assistant tool_call dict (carries the ``tool_call_id`` + name the
+    tool-role result needs).
+    """
+    _launch_tasks(
+        session_id,
+        [call],
+        lambda c: _resume_parked_async(
+            pool,
+            session_id,
+            c,
+            servicer_kind=servicer_kind,
+            servicer_id=servicer_id,
+            request_id=request_id,
+            output_schema=output_schema,
+            account_id=account_id,
+        ),
+        prefix="repark",
+    )
+
+
+async def _resume_parked_async(
+    pool: asyncpg.Pool[Any],
+    session_id: str,
+    call: dict[str, Any],
+    *,
+    servicer_kind: ServicerKind,
+    servicer_id: str,
+    request_id: str | None,
+    output_schema: dict[str, Any] | None,
+    account_id: str,
+) -> None:
+    """Re-park on the servicer and append the resolved tool-role result.
+
+    Reuses :func:`_tool_lifecycle` (``write_start_span=False``) for the dedup-guarded
+    result append + tail sweep — the dedup makes a re-park that races a real result safe
+    (first commit wins). :func:`aios.tools.invoke_session._park_and_resolve` is a pure read
+    of durable state, so this is side-effect-free apart from that single result append.
+    """
+    async with _tool_lifecycle(
+        pool,
+        session_id,
+        call,
+        account_id=account_id,
+        log_prefix="repark",
+        write_start_span=False,
+    ) as tc:
+        # Imported inside the bracket (``invoke_session`` ↔ ``tool_dispatch`` import order)
+        # so even an import failure lands a tool-role error result rather than escaping the
+        # task as an unobserved exception with no result.
+        from aios.tools.invoke_session import _park_and_resolve
+
+        result = await _park_and_resolve(
+            pool,
+            servicer_kind=servicer_kind,
+            servicer_id=servicer_id,
+            request_id=request_id,
+            account_id=account_id,
+            output_schema=output_schema,
+        )
+        event_data = _shape_tool_result(tc, result)
+        tc.bound_log.info("repark.completed")
+        await _append_tool_result_event(
+            pool,
+            session_id,
+            tc.call_id,
+            event_data,
+            account_id=account_id,
         )
 
 

--- a/src/aios/tools/invoke.py
+++ b/src/aios/tools/invoke.py
@@ -16,12 +16,29 @@ decides what to do with them (log + sandbox eviction on the model path;
 
 from __future__ import annotations
 
+import contextvars
 import json
 from typing import Any
 
 import jsonschema
 
 from aios.tools.registry import ToolNotFoundError, ToolResult, registry
+
+# The id of the tool_call the running handler is servicing, scoped per tool task.
+# Set by :func:`invoke_builtin` around the handler call on the model dispatch path
+# (the sandbox CLI broker and any caller that omits ``tool_call_id`` leave it ``None``).
+# The parking ``call_*`` handlers read it via :func:`current_tool_call_id` to stamp their
+# own ``tool_call_id`` onto the servicer edge, so a parked invocation can be re-derived and
+# re-parked after a worker restart (#1431) — a builtin's only honest channel to its call id,
+# which the ``(session_id, arguments)`` handler signature deliberately doesn't carry.
+_CURRENT_TOOL_CALL_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_tool_call_id", default=None
+)
+
+
+def current_tool_call_id() -> str | None:
+    """The id of the tool_call the current handler is servicing, or ``None`` outside one."""
+    return _CURRENT_TOOL_CALL_ID.get()
 
 
 class ToolBail(Exception):
@@ -84,6 +101,8 @@ async def invoke_builtin(
     session_id: str,
     tool_name: str,
     raw_arguments: Any,
+    *,
+    tool_call_id: str | None = None,
 ) -> ToolResult | dict[str, Any]:
     """Run a built-in tool: parse args, look up the handler, validate, call.
 
@@ -96,6 +115,10 @@ async def invoke_builtin(
     Does NOT append events, trigger the sweep, or touch sandbox state.
     The model path wraps this with ``_tool_lifecycle`` + event append +
     sweep; the CLI broker wraps with HTTP response serialisation.
+
+    ``tool_call_id`` (model dispatch path) is exposed to the handler for the
+    duration of the call via :func:`current_tool_call_id` — the parking ``call_*``
+    handlers read it to stamp the servicer edge for crash-resume (#1431).
     """
     arguments = parse_arguments(raw_arguments)
     if arguments is None:
@@ -107,4 +130,8 @@ async def invoke_builtin(
     schema_error = validate_arguments(arguments, tool.parameters_schema)
     if schema_error is not None:
         raise ToolBail(schema_error)
-    return await tool.handler(session_id, arguments)
+    token = _CURRENT_TOOL_CALL_ID.set(tool_call_id)
+    try:
+        return await tool.handler(session_id, arguments)
+    finally:
+        _CURRENT_TOOL_CALL_ID.reset(token)

--- a/src/aios/tools/invoke_session.py
+++ b/src/aios/tools/invoke_session.py
@@ -34,20 +34,17 @@ rejected before the handler runs.
 
 All register ``transport="agent_tool"`` (model-only; the CLI broker refuses them).
 
-**Crash recovery = ghost-repair, not re-dispatch.** The request edge is written
-*before* the park, so it is durable; the fire-and-forget tool task is not. On a worker
-crash mid-park the harness does NOT re-run the handler — there is no builtin re-dispatch
-path (only ``always_ask``-confirmed tools are re-dispatched). Instead the periodic
-ghost-repair sweep resolves the lost ``tool_call_id`` to a synthetic *may-have-completed*
-error ("the tool may have completed and side effects may have committed; verify before
-retrying"), because the ``tool_execute_start`` span had committed and the target may in
-fact have been serviced. The servicer's response is still written exactly-once and
-durably, but it is *orphaned* for the crashed caller's ``request_id`` — nothing harvests
-it back into the now-errored tool result. A *second* request edge appears only if the
-**model** retries (its own decision on seeing the error), never from a harness re-dispatch.
-Single-shot is the per-call contract, not a crash-exactly-once guarantee. Deterministic
-request-id keying (call-key dedup, as the workflow ``agent()`` path does) is a future
-hardening, not v1 scope.
+**Crash recovery = re-park, not error (#1431).** The request edge is written *before* the
+park and carries the launching ``tool_call_id`` on its ``caller`` (via :func:`_caller`), so
+the caller↔servicer link is durable; only the fire-and-forget park task is lost on a worker
+crash. The harness does NOT re-run the handler (no builtin re-dispatch path) — instead the
+ghost-repair sweep re-derives the servicer from that edge
+(``queries.find_parked_servicer``) and **re-parks** the lost ``tool_call_id`` via
+:func:`_park_and_resolve`: a pure read of durable state that re-attaches to the servicer's
+exactly-once response and lands the original tool result. If the launch crashed *before* its
+edge was durable, no servicer is found and the call resolves to a retryable error instead. A
+*second* request edge appears only if the **model** retries that error — never from a harness
+re-dispatch. Single-shot is the per-call contract.
 """
 
 from __future__ import annotations
@@ -64,7 +61,7 @@ from aios.models.invocations import AwaitResponse
 from aios.services import invocations as invocations_service
 from aios.services import sessions as sessions_service
 from aios.services import workflows as wf_service
-from aios.tools.invoke import ToolBail
+from aios.tools.invoke import ToolBail, current_tool_call_id
 from aios.tools.registry import ToolResult, registry
 
 # Per-park await budget. The tool task is fire-and-forget (implicit-async), so a
@@ -203,6 +200,53 @@ async def _park_on_invocation(
             return resp
 
 
+async def _park_and_resolve(
+    pool: Any,
+    *,
+    servicer_kind: invocations_service.ServicerKind,
+    servicer_id: str,
+    request_id: str | None,
+    account_id: str,
+    output_schema: dict[str, Any] | None,
+) -> dict[str, Any] | ToolResult:
+    """Park on the servicer, then resolve to a model-visible ``{ok | error}``.
+
+    The shared tail of every ``call_*`` handler AND the crash-resume path
+    (:func:`aios.harness.tool_dispatch.relaunch_parked_invocation`). It is a **pure read**
+    of durable state — re-entrant, so re-parking after a worker restart re-reads the same
+    servicer edge with zero side effects; the resolved tool result is the only write it
+    drives. ``output_schema`` is validated caller-side (a run/peer answer can bypass the
+    servicer's own ``return`` gate).
+    """
+    resp = await _park_on_invocation(
+        pool,
+        servicer_kind=servicer_kind,
+        servicer_id=servicer_id,
+        request_id=request_id,
+        account_id=account_id,
+    )
+    if resp.outcome != "ok":
+        return _error_result(resp.error)
+    violation = _validate_output(resp.result, output_schema)
+    return violation if violation is not None else _ok_result(resp.result)
+
+
+def _caller(session_id: str) -> dict[str, Any]:
+    """Trusted caller provenance for a model-launched invocation: THIS session's id plus
+    the launching ``tool_call_id`` (#1431).
+
+    The ``tool_call_id`` rides onto the servicer's edge ``caller`` so a parked invocation
+    can be re-derived from durable state and re-parked after a worker restart
+    (``queries.find_parked_servicer``). Omitted (not written as ``null``) when no tool
+    context is set — e.g. a non-dispatch caller — keeping the edge clean.
+    """
+    caller: dict[str, Any] = {"kind": "session", "id": session_id}
+    tool_call_id = current_tool_call_id()
+    if tool_call_id is not None:
+        caller["tool_call_id"] = tool_call_id
+    return caller
+
+
 # ─── handlers ────────────────────────────────────────────────────────────────
 
 
@@ -221,19 +265,16 @@ async def call_session_handler(
         target=args.session_id,
         input=args.input,
         output_schema=args.output_schema,
-        caller={"kind": "session", "id": session_id},
+        caller=_caller(session_id),
     )
-    resp = await _park_on_invocation(
+    return await _park_and_resolve(
         pool,
         servicer_kind="session",
         servicer_id=handle.servicer_id,
         request_id=handle.request_id,
         account_id=account_id,
+        output_schema=args.output_schema,
     )
-    if resp.outcome != "ok":
-        return _error_result(resp.error)
-    violation = _validate_output(resp.result, args.output_schema)
-    return violation if violation is not None else _ok_result(resp.result)
 
 
 async def call_agent_handler(
@@ -255,19 +296,16 @@ async def call_agent_handler(
         output_schema=args.output_schema,
         environment_id=session.environment_id,
         crypto_box=runtime.require_crypto_box(),
-        caller={"kind": "session", "id": session_id},
+        caller=_caller(session_id),
     )
-    resp = await _park_on_invocation(
+    return await _park_and_resolve(
         pool,
         servicer_kind="session",
         servicer_id=handle.servicer_id,
         request_id=handle.request_id,
         account_id=account_id,
+        output_schema=args.output_schema,
     )
-    if resp.outcome != "ok":
-        return _error_result(resp.error)
-    violation = _validate_output(resp.result, args.output_schema)
-    return violation if violation is not None else _ok_result(resp.result)
 
 
 async def call_workflow_handler(
@@ -285,27 +323,31 @@ async def call_workflow_handler(
         workflow_id=args.workflow_id,
         environment_id=session.environment_id,
         input=args.input,
-        caller={"kind": "session", "id": session_id},
+        caller=_caller(session_id),
         output_schema=args.output_schema,
         launcher_session_id=session_id,
         parent_run_id=session.parent_run_id,
         vault_ids=args.vault_ids,
         budget_usd=args.budget_usd,
     )
-    resp = await _park_on_invocation(
+    return await _park_and_resolve(
         pool,
         servicer_kind="run",
         servicer_id=run.id,
         request_id=None,
         account_id=account_id,
+        output_schema=args.output_schema,
     )
-    if resp.outcome != "ok":
-        return _error_result(resp.error)
-    violation = _validate_output(resp.result, args.output_schema)
-    return violation if violation is not None else _ok_result(resp.result)
 
 
 # ─── descriptions + registration ─────────────────────────────────────────────
+
+# The model-facing parking builtins: a ``call_*`` tool whose handler parks
+# (:func:`_park_and_resolve`) on a servicer and is therefore a **pure-await** —
+# safe to re-park on crash-recovery rather than error-repair (#1431). The
+# ghost-repair sweep uses this set as the resumability discriminant; it MUST stay
+# in lockstep with the names registered in :func:`_register` below.
+PARKING_TOOL_NAMES = frozenset({"call_session", "call_agent", "call_workflow"})
 
 CALL_SESSION_DESCRIPTION = (
     "Call an existing same-account session: deliver `input` to it as a trusted "

--- a/tests/integration/test_durable_await_resume.py
+++ b/tests/integration/test_durable_await_resume.py
@@ -1,0 +1,387 @@
+"""Integration tests for durable await-resume of parked ``call_*`` invocations (#1431).
+
+DB-backed (testcontainer Postgres). On a worker crash a parked ``call_*`` tool task is
+lost; recovery must re-derive its servicer from the durable edge (the ``tool_call_id`` the
+handler stamped onto ``caller``) and RE-PARK it — re-attaching the servicer's exactly-once
+answer to the original tool result — rather than orphaning it behind a synthetic error.
+
+Covers:
+
+* ``find_parked_servicer`` — the locator: resolves a session servicer (with its
+  ``request_id`` + ``output_schema``) and a run servicer from the caller edge, and ``None``
+  when no edge matches (the launch crashed before it was durable).
+* ``find_and_repair_ghosts`` routing — a resumable ``call_*`` ghost with a live edge is
+  RE-PARKED (not error-repaired); one with no edge falls through to a retryable
+  ``launch_lost`` error; a non-``call_*`` ghost keeps the existing error-repair.
+* the resume mechanism — ``_resume_parked_async`` lands the servicer's answer as the
+  original tool result and writes NO ``tool_execute_start`` span (the span-less bracket, so
+  a second-crash classification can't be misled into "may have completed").
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.db.queries import workflows as wf_queries
+from aios.harness import runtime
+from aios.harness.sweep import find_and_repair_ghosts
+from aios.harness.task_registry import TaskRegistry
+from aios.models.agents import ToolSpec
+from aios.services import workflows as wf_service
+from aios.tools import workflow_completion
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT = "acc_resume"
+_FROZEN: dict[str, list[Any]] = {"tools": [], "mcp_servers": [], "http_servers": []}
+
+
+@pytest.fixture
+async def env(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, account_id, migrated_db_url)`` with the worker runtime wired so
+    recovery + resume can run without a live worker (wakes are patched out)."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev_pool, prev_reg = runtime.pool, runtime.task_registry
+    runtime.pool = pool
+    runtime.task_registry = TaskRegistry()
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'resume-root')",
+                _ACCOUNT,
+            )
+        with (
+            mock.patch("aios.services.wake.defer_wake", new=AsyncMock()),
+            mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
+        ):
+            yield pool, _ACCOUNT, migrated_db_url
+    finally:
+        runtime.pool, runtime.task_registry = prev_pool, prev_reg
+        await pool.close()
+
+
+def _assistant(tool_calls: list[tuple[str, str]]) -> dict[str, Any]:
+    """An assistant turn issuing ``(tool_call_id, tool_name)`` calls, no results."""
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": tcid, "type": "function", "function": {"name": name, "arguments": "{}"}}
+            for tcid, name in tool_calls
+        ],
+    }
+
+
+async def _seed_session(pool: asyncpg.Pool[Any], prefix: str, *, tools: list[ToolSpec]) -> str:
+    _agent, _env, session = await seed_agent_env_session(
+        pool, account_id=_ACCOUNT, prefix=prefix, tools=tools
+    )
+    return session.id
+
+
+async def _write_session_edge(
+    pool: asyncpg.Pool[Any],
+    *,
+    servicer_id: str,
+    caller_session_id: str,
+    tool_call_id: str,
+    request_id: str,
+    output_schema: dict[str, Any] | None = None,
+) -> None:
+    """Write the servicer's ``request_opened`` edge carrying the caller's tool_call_id —
+    exactly what a ``call_session``/``call_agent`` handler stamps via ``_caller``."""
+    async with pool.acquire() as conn, conn.transaction():
+        await queries.append_request_opened(
+            conn,
+            session_id=servicer_id,
+            account_id=_ACCOUNT,
+            request_id=request_id,
+            caller={"kind": "session", "id": caller_session_id, "tool_call_id": tool_call_id},
+            depth=1,
+            environment_id="env_x",
+            frozen_surface=_FROZEN,
+            vault_ids=[],
+            output_schema=output_schema,
+        )
+
+
+async def _tool_results(
+    pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str
+) -> list[dict[str, Any]]:
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT data FROM events WHERE session_id = $1 AND kind = 'message' "
+            "AND role = 'tool' AND data->>'tool_call_id' = $2",
+            session_id,
+            tool_call_id,
+        )
+    return [queries.parse_jsonb(r["data"]) for r in rows]
+
+
+# ─── find_parked_servicer (the locator) ──────────────────────────────────────
+
+
+async def test_find_parked_servicer_session(env: tuple[asyncpg.Pool[Any], str, str]) -> None:
+    pool, account_id, _ = env
+    caller = await _seed_session(pool, "loc-caller", tools=[ToolSpec(type="call_session")])
+    servicer = await _seed_session(pool, "loc-servicer", tools=[ToolSpec(type="bash")])
+    schema = {"type": "object"}
+    await _write_session_edge(
+        pool,
+        servicer_id=servicer,
+        caller_session_id=caller,
+        tool_call_id="tc_sess",
+        request_id="req_sess",
+        output_schema=schema,
+    )
+
+    async with pool.acquire() as conn:
+        handle = await queries.find_parked_servicer(
+            conn, caller_session_id=caller, tool_call_id="tc_sess", account_id=account_id
+        )
+    assert handle == ("session", servicer, "req_sess", schema)
+
+
+async def test_find_parked_servicer_run(env: tuple[asyncpg.Pool[Any], str, str]) -> None:
+    pool, account_id, _ = env
+    _agent, environment, caller_session = await seed_agent_env_session(
+        pool, account_id=account_id, prefix="loc-run-caller", tools=[ToolSpec(type="call_workflow")]
+    )
+    caller = caller_session.id
+    wf = await wf_service.create_workflow(
+        pool,
+        account_id=account_id,
+        name="resume-loc-wf",
+        script="async def main(input):\n    return None\n",
+        description=None,
+        tools=[],
+    )
+    async with pool.acquire() as conn:
+        run = await wf_queries.insert_wf_run(
+            conn,
+            account_id=account_id,
+            workflow_id=wf.id,
+            environment_id=environment.id,
+            parent_run_id=None,
+            launcher_session_id=caller,
+            request_id="req_run",
+            caller={"kind": "session", "id": caller, "tool_call_id": "tc_run"},
+            script=wf.script,
+            script_sha="x" * 64,
+            host_semantics_epoch=1,
+            input=None,
+            tools=[],
+            mcp_servers=[],
+            http_servers=[],
+            budget_usd=None,
+            default_child_model="openrouter/test",
+            depth=10,
+        )
+
+    async with pool.acquire() as conn:
+        handle = await queries.find_parked_servicer(
+            conn, caller_session_id=caller, tool_call_id="tc_run", account_id=account_id
+        )
+    # A run parks on its terminal row, so request_id is None for the park handle.
+    assert handle == ("run", run.id, None, None)
+
+
+async def test_find_parked_servicer_absent(env: tuple[asyncpg.Pool[Any], str, str]) -> None:
+    pool, account_id, _ = env
+    caller = await _seed_session(pool, "loc-absent", tools=[ToolSpec(type="call_session")])
+    servicer = await _seed_session(pool, "loc-absent-srv", tools=[ToolSpec(type="bash")])
+    await _write_session_edge(
+        pool,
+        servicer_id=servicer,
+        caller_session_id=caller,
+        tool_call_id="tc_real",
+        request_id="req_real",
+    )
+    async with pool.acquire() as conn:
+        # A different tool_call_id (and a different caller) must not match.
+        assert (
+            await queries.find_parked_servicer(
+                conn, caller_session_id=caller, tool_call_id="tc_other", account_id=account_id
+            )
+            is None
+        )
+        assert (
+            await queries.find_parked_servicer(
+                conn, caller_session_id="ses_nobody", tool_call_id="tc_real", account_id=account_id
+            )
+            is None
+        )
+
+
+# ─── find_and_repair_ghosts routing ──────────────────────────────────────────
+
+
+async def test_sweep_reparks_resumable_ghost_routing(
+    env: tuple[asyncpg.Pool[Any], str, str], monkeypatch: Any
+) -> None:
+    """A ``call_*`` ghost with a live edge is RE-PARKED (not error-repaired); one with no
+    edge → retryable ``launch_lost``; a ``bash`` ghost → the existing error-repair."""
+    pool, account_id, _ = env
+    caller = await _seed_session(
+        pool, "route-caller", tools=[ToolSpec(type="call_session"), ToolSpec(type="bash")]
+    )
+    servicer = await _seed_session(pool, "route-servicer", tools=[ToolSpec(type="bash")])
+    # tc_live: call_session with a durable edge → re-park. tc_lost: call_session, NO edge →
+    # launch_lost. tc_bash: a side-effectful ghost → unchanged error-repair.
+    async with pool.acquire() as conn:
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=caller,
+            kind="message",
+            data=_assistant(
+                [("tc_live", "call_session"), ("tc_lost", "call_session"), ("tc_bash", "bash")]
+            ),
+        )
+    await _write_session_edge(
+        pool,
+        servicer_id=servicer,
+        caller_session_id=caller,
+        tool_call_id="tc_live",
+        request_id="req_live",
+    )
+
+    relaunch = mock.Mock()
+    monkeypatch.setattr("aios.harness.tool_dispatch.relaunch_parked_invocation", relaunch)
+
+    repaired = await find_and_repair_ghosts(
+        pool, runtime.require_task_registry(), session_id=caller
+    )
+
+    # tc_live: re-parked — relaunch called with the session servicer handle, NOT error-repaired.
+    relaunch.assert_called_once()
+    kwargs = relaunch.call_args.kwargs
+    assert kwargs["servicer_kind"] == "session"
+    assert kwargs["servicer_id"] == servicer
+    assert kwargs["request_id"] == "req_live"
+    assert kwargs["call"]["id"] == "tc_live"
+    repaired_ids = {tcid for _sid, tcid in repaired}
+    assert "tc_live" not in repaired_ids
+
+    # tc_lost (no edge) and tc_bash both get an error-repair result.
+    assert {"tc_lost", "tc_bash"} <= repaired_ids
+    lost = await _tool_results(pool, caller, "tc_lost")
+    assert len(lost) == 1 and lost[0]["is_error"] is True
+    assert "did not start" in lost[0]["content"]
+    bash = await _tool_results(pool, caller, "tc_bash")
+    assert len(bash) == 1 and bash[0]["is_error"] is True
+    # tc_live got NO synthetic result (it is being re-parked, not error-repaired).
+    assert await _tool_results(pool, caller, "tc_live") == []
+
+
+# ─── the resume mechanism (span-less, lands the servicer answer) ──────────────
+
+
+async def test_resume_parked_lands_answer_without_start_span(
+    env: tuple[asyncpg.Pool[Any], str, str], monkeypatch: Any
+) -> None:
+    """``_resume_parked_async`` re-parks a call whose servicer already answered (the
+    answered-during-downtime case) and lands the answer as the original tool result — and
+    writes NO ``tool_execute_start`` span (the span-less bracket)."""
+    from aios.harness import tool_dispatch
+
+    pool, account_id, db_url = env
+    caller = await _seed_session(pool, "resume-caller", tools=[ToolSpec(type="call_session")])
+    servicer = await _seed_session(pool, "resume-servicer", tools=[ToolSpec(type="bash")])
+    await _write_session_edge(
+        pool,
+        servicer_id=servicer,
+        caller_session_id=caller,
+        tool_call_id="tc_done",
+        request_id="req_done",
+    )
+    # The servicer already answered during the worker's downtime.
+    await workflow_completion.respond_to_request(
+        pool, servicer, request_id="req_done", is_error=False, result={"v": 42}, error=None
+    )
+    # _park_on_invocation reads the LISTEN db_url off settings; point it at the test DB.
+    monkeypatch.setattr(
+        "aios.tools.invoke_session.get_settings", lambda: SimpleNamespace(db_url=db_url)
+    )
+
+    await tool_dispatch._resume_parked_async(
+        pool,
+        caller,
+        {"id": "tc_done", "function": {"name": "call_session", "arguments": "{}"}},
+        servicer_kind="session",
+        servicer_id=servicer,
+        request_id="req_done",
+        output_schema=None,
+        account_id=account_id,
+    )
+
+    results = await _tool_results(pool, caller, "tc_done")
+    assert len(results) == 1
+    assert results[0].get("is_error") is not True
+    assert json.loads(results[0]["content"]) == {"ok": {"v": 42}}
+
+    # Span-less: the re-park wrote no tool_execute_start span, so a later ghost
+    # classification can't be misled into the "may have completed" branch (#1431 hazard).
+    async with pool.acquire() as conn:
+        spans = await conn.fetchval(
+            "SELECT count(*) FROM events WHERE session_id = $1 AND kind = 'span' "
+            "AND data->>'event' = 'tool_execute_start' AND data->>'tool_call_id' = $2",
+            caller,
+            "tc_done",
+        )
+    assert spans == 0
+
+
+async def test_recovery_isolates_per_ghost_failure(
+    env: tuple[asyncpg.Pool[Any], str, str], monkeypatch: Any
+) -> None:
+    """A transient failure resolving one resumable ghost must NOT abort recovery of the
+    others — the cross-session sweep needs the same per-item isolation the error-repair
+    loop has, or one gone caller strands every other tenant's parked invocation."""
+    pool, account_id, _ = env
+    caller = await _seed_session(pool, "iso-caller", tools=[ToolSpec(type="call_session")])
+    async with pool.acquire() as conn:
+        await queries.append_event(
+            conn,
+            account_id=account_id,
+            session_id=caller,
+            kind="message",
+            data=_assistant([("tc_boom", "call_session"), ("tc_ok", "call_session")]),
+        )
+
+    async def flaky(
+        conn: Any, *, caller_session_id: str, tool_call_id: str, account_id: str
+    ) -> Any:
+        if tool_call_id == "tc_boom":
+            raise RuntimeError("transient db error")
+        return None  # tc_ok → no edge → launch_lost
+
+    monkeypatch.setattr("aios.harness.sweep.find_parked_servicer", flaky)
+
+    # Must return normally despite tc_boom raising mid-loop.
+    repaired = await find_and_repair_ghosts(
+        pool, runtime.require_task_registry(), session_id=caller
+    )
+    repaired_ids = {tcid for _sid, tcid in repaired}
+
+    # The healthy ghost was still recovered (launch_lost error), the failed one isolated
+    # (no result — left for the next sweep), and recovery did not abort.
+    assert "tc_ok" in repaired_ids
+    assert "tc_boom" not in repaired_ids
+    assert await _tool_results(pool, caller, "tc_boom") == []
+    ok = await _tool_results(pool, caller, "tc_ok")
+    assert len(ok) == 1 and ok[0]["is_error"] is True

--- a/tests/unit/test_invoke_session_tools.py
+++ b/tests/unit/test_invoke_session_tools.py
@@ -221,3 +221,82 @@ async def test_invoke_workflow_output_schema_violation(monkeypatch: Any) -> None
     assert isinstance(out, ToolResult)
     assert out.is_error
     assert isinstance(out.content, str) and "output_schema_violation" in out.content
+
+
+# ─── #1431: caller tool_call_id on the edge (crash-resume link) ───────────────
+
+
+async def test_caller_carries_tool_call_id(monkeypatch: Any) -> None:
+    """The launching ``tool_call_id`` rides onto the servicer edge via ``caller`` so a
+    parked invocation can be re-derived and re-parked after a worker crash (#1431)."""
+    inv_mock = AsyncMock(return_value=_handle())
+    monkeypatch.setattr("aios.services.sessions.invoke", inv_mock)
+    monkeypatch.setattr(
+        "aios.services.invocations.await_invocation",
+        AsyncMock(return_value=AwaitResponse(outcome="ok", result="r")),
+    )
+    await invoke_builtin(
+        _CALLER, "call_session", {"session_id": "ses_target"}, tool_call_id="tc_42"
+    )
+    assert inv_mock.await_args is not None
+    assert inv_mock.await_args.kwargs["caller"] == {
+        "kind": "session",
+        "id": _CALLER,
+        "tool_call_id": "tc_42",
+    }
+
+
+async def test_caller_omits_tool_call_id_when_unset(monkeypatch: Any) -> None:
+    """Outside a dispatched tool (no ``tool_call_id``) the caller edge stays clean — the
+    key is omitted, never written as ``null``."""
+    inv_mock = AsyncMock(return_value=_handle())
+    monkeypatch.setattr("aios.services.sessions.invoke", inv_mock)
+    monkeypatch.setattr(
+        "aios.services.invocations.await_invocation",
+        AsyncMock(return_value=AwaitResponse(outcome="ok", result="r")),
+    )
+    await invoke_builtin(_CALLER, "call_session", {"session_id": "ses_target"})
+    assert inv_mock.await_args is not None
+    assert "tool_call_id" not in inv_mock.await_args.kwargs["caller"]
+
+
+async def test_workflow_caller_carries_tool_call_id(monkeypatch: Any) -> None:
+    """The run servicer's ``caller`` (wf_runs.caller) carries the tool_call_id too — the
+    crash-resume link is kind-uniform."""
+    run_mock = AsyncMock(return_value=SimpleNamespace(id="run_1"))
+    monkeypatch.setattr("aios.services.workflows.create_run", run_mock)
+    monkeypatch.setattr(
+        "aios.services.invocations.await_invocation",
+        AsyncMock(return_value=AwaitResponse(outcome="ok", result="r")),
+    )
+    await invoke_builtin(_CALLER, "call_workflow", {"workflow_id": "wf_1"}, tool_call_id="tc_7")
+    assert run_mock.await_args is not None
+    caller = run_mock.await_args.kwargs["caller"]
+    assert caller["tool_call_id"] == "tc_7"
+    assert caller["kind"] == "session" and caller["id"] == _CALLER
+    assert caller["awaited"] is True  # launch_awaited_run stamps the Ask bit
+
+
+async def test_current_tool_call_id_scoped_to_call(monkeypatch: Any) -> None:
+    """The contextvar is scoped to the handler call — ``None`` before and after."""
+    from aios.tools.invoke import current_tool_call_id
+
+    monkeypatch.setattr("aios.services.sessions.invoke", AsyncMock(return_value=_handle()))
+    monkeypatch.setattr(
+        "aios.services.invocations.await_invocation",
+        AsyncMock(return_value=AwaitResponse(outcome="ok", result="r")),
+    )
+    assert current_tool_call_id() is None
+    await invoke_builtin(_CALLER, "call_session", {"session_id": "ses_target"}, tool_call_id="tc_9")
+    assert current_tool_call_id() is None
+
+
+def test_parking_tool_names_match_registered() -> None:
+    """``PARKING_TOOL_NAMES`` (the sweep's resumability discriminant) must stay in lockstep
+    with the registered ``call_*`` builtins."""
+    from aios.tools.invoke_session import PARKING_TOOL_NAMES
+    from aios.tools.registry import registry
+
+    assert set(PARKING_TOOL_NAMES) == {"call_session", "call_agent", "call_workflow"}
+    for name in PARKING_TOOL_NAMES:
+        assert registry.get(name).transport == "agent_tool"


### PR DESCRIPTION
## What & why

A session that calls `call_session`/`call_agent`/`call_workflow` **parks** in a fire-and-forget asyncio task awaiting the servicer's answer. On a hard worker restart that task is lost — and the ghost-repair sweep resolved the caller's tool_call to a synthetic *"may-have-completed"* error **while the durable servicer kept running and answered**. The answer was **orphaned**: nothing re-attached it to the caller's tool result. This fired on *any* crash during a park, which can last minutes/hours.

This makes the parked await **durable**: bring the system down and back up, and a session + all its in-flight `call_*` children resume — the await re-attaches and resolves from durable state, with zero re-execution side effects. Closes the model-facing half of #1431.

## How

The servicer's edge already records its caller (`{kind,id}`). We add the caller's **`tool_call_id`** to that `caller` dict — it flows onto `request_opened.data.caller` (session servicer) / `wf_runs.caller` (run), reusing the **0103 reverse caller indexes** built for the trace walk / cancel cascade. The link is now **atomic-by-construction** with the servicer's creation (it *is* the servicer's edge — no orphan window, no record-first ordering, no pre-mint), and it mirrors the existing `awaited`-on-`caller` bit precisely.

On recovery, `find_and_repair_ghosts`:
- detects a `call_*` ghost (tool name ∈ `PARKING_TOOL_NAMES` — a tested-lockstep set), re-derives the servicer via `queries.find_parked_servicer`, and **re-parks** it (`relaunch_parked_invocation`) — a pure read of durable state — instead of error-repairing;
- if no edge is found (launch crashed before durable) → a retryable `launch_lost` error;
- every other ghost keeps the existing side-effect-conservative error-repair.

The re-park reuses `_tool_lifecycle` with `write_start_span=False` — a re-park is a pure read, and a fresh `tool_execute_start` span would mislead a *second-crash* classification into the over-pessimistic "may have completed" branch. The dedup-guarded result append makes a re-park racing a real result safe (first commit wins). The caller's `tool_call_id` reaches the handler via a `ContextVar` set by `invoke_builtin` (the builtin's only honest channel to its own call id, which the `(session_id, arguments)` handler signature deliberately doesn't carry).

## Notes
- **No DDL / migration** — `caller` is existing JSONB; the 0103 indexes already exist.
- **Run-callers unaffected** — durable via deterministic journal replay.
- Reviewed: `/simplify` (used the existing `ServicerKind` alias; single-partitioned the sweep block) + adversarial `/code-review` (added per-item isolation to the recovery loop matching the 3 sibling loops; moved the resume import inside the result-guaranteeing bracket; regression test pins the isolation).

## Tests
- Unit (`test_invoke_session_tools.py`): `tool_call_id` on the caller edge (session + run), omitted when unset, contextvar scoping, `PARKING_TOOL_NAMES` ↔ registration lockstep.
- Integration (`test_durable_await_resume.py`, testcontainer PG): `find_parked_servicer` (session/run/absent), sweep routing (re-park vs `launch_lost` vs unchanged error-repair), end-to-end resume lands the servicer's answer + writes no start span, and per-ghost isolation under a transient failure.
- Full suite green: mypy (1210), ruff, unit (3484), connectors (577), affected integration. No openapi/SDK drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)