### PR TITLE
Lifecycle stop_reason/status literals are writer↔reader-coupled across a JSONB Any boundary — a flip silently breaks the errored-session park

### DIFF
--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -29,7 +29,12 @@ from aios.ids import (
     EVENT,
     make_id,
 )
-from aios.models.events import MODEL_VISIBLE_LIFECYCLE_EVENTS, Event, EventKind
+from aios.models.events import (
+    MODEL_VISIBLE_LIFECYCLE_EVENTS,
+    Event,
+    EventKind,
+    is_errored_lifecycle_event,
+)
 
 # ─── events ───────────────────────────────────────────────────────────────────
 
@@ -791,7 +796,12 @@ async def append_event(
     # ``data.get`` is missing → falsy on every historical/unmarked result, so
     # those keep counting as stimulus exactly as before (backward-compat).
     is_stimulus = kind == "message" and role != "assistant" and not data.get("no_reaction")
-    is_error_lifecycle = kind == "lifecycle" and data.get("stop_reason") == "error"
+    # ``is_errored_lifecycle_event`` reads the SAME constant the error latch
+    # writes (``harness/loop.py:_latch_errored_turn``). The read is off the JSONB
+    # ``data`` (type ``Any``), which cannot bind to the write literal — see the
+    # constant's definition (#1084) — so the binding lives in the shared module
+    # and is pinned by ``test_errored_lifecycle_coupling.py``.
+    is_error_lifecycle = is_errored_lifecycle_event(kind, data)
     is_assistant_message = kind == "message" and role == "assistant"
     tool_call_count_delta = (
         len(data.get("tool_calls") or [])

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -50,6 +50,10 @@ from aios.models.agents import (
     McpServerSpec,
     is_mcp_tool_name,
 )
+from aios.models.events import (
+    ERRORED_LIFECYCLE_STATUS,
+    ERRORED_LIFECYCLE_STOP_REASON,
+)
 from aios.services import accounts as accounts_service
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
@@ -1140,8 +1144,18 @@ async def _latch_errored_turn(
     await sessions_service.set_session_stop_reason(
         pool, session_id, stop_reason, account_id=account_id
     )
+    # The lifecycle ``status``/``stop_reason`` here are the SAME shared constants
+    # ``append_event`` reads to bump ``last_error_seq`` and park the errored
+    # session. Routing both write and read through ``aios.models.events`` is the
+    # binding that survives the JSONB ``Any`` boundary (#1084); the coupling is
+    # pinned by ``test_errored_lifecycle_coupling.py``.
     await _append_lifecycle(
-        pool, session_id, "turn_ended", "errored", "error", account_id=account_id
+        pool,
+        session_id,
+        "turn_ended",
+        ERRORED_LIFECYCLE_STATUS,
+        ERRORED_LIFECYCLE_STOP_REASON,
+        account_id=account_id,
     )
 
 

--- a/src/aios/models/events.py
+++ b/src/aios/models/events.py
@@ -65,6 +65,39 @@ MODEL_VISIBLE_LIFECYCLE_EVENTS: frozenset[str] = frozenset(
 )
 
 
+# ── Error-latch lifecycle vocabulary (#1084) ──────────────────────────────
+# The error latch (``harness/loop.py``) writes a ``turn_ended`` lifecycle event
+# with this exact ``stop_reason`` string; ``append_event``
+# (``db/queries/events.py``) reads the SAME constant to recognize the event and
+# bump ``last_error_seq`` (which drives ``_SESSION_ERRORED_EXPR`` and so the
+# sweep's errored-session park). The value round-trips writer → ``json.dumps``
+# → Postgres JSONB → asyncpg → ``dict[str, Any]``, so the read is type ``Any``
+# and the checker CANNOT bind the write literal to the read literal. Two free
+# strings on either side of that ``Any`` boundary type-check and pass CI even
+# when they DIVERGE — flip one (e.g. the tempting ``"errored"`` transposition
+# to match ``ERRORED_LIFECYCLE_STATUS``) and the park silently breaks: the
+# session busy-wakes forever with no progress (#155 class). Routing BOTH sides
+# through this single ``Literal`` constant is the binding; the coupling is
+# pinned by ``tests/unit/test_errored_lifecycle_coupling.py`` (the floor), which
+# the ``Any`` read can otherwise evaporate.
+ERRORED_LIFECYCLE_STOP_REASON: Literal["error"] = "error"
+ERRORED_LIFECYCLE_STATUS: Literal["errored"] = "errored"
+
+
+def is_errored_lifecycle_event(kind: str, data: dict[str, Any]) -> bool:
+    """The errored-park predicate: does this lifecycle event latch the session
+    into ``errored``?
+
+    ``data`` is the JSONB-round-tripped event payload (``dict[str, Any]``), so
+    the ``stop_reason`` it carries is type ``Any`` — the checker cannot bind it
+    to the writer's literal. This helper is the SINGLE read site
+    (``db/queries/events.py:append_event`` calls it to bump ``last_error_seq``)
+    and reads the SAME ``ERRORED_LIFECYCLE_STOP_REASON`` the latch writes, so the
+    write↔read coupling is one constant rather than two free strings (#1084).
+    """
+    return kind == "lifecycle" and data.get("stop_reason") == ERRORED_LIFECYCLE_STOP_REASON
+
+
 class Event(BaseModel):
     """Read view of a single event from the session log.
 

--- a/tests/e2e/test_errored_session_sweep.py
+++ b/tests/e2e/test_errored_session_sweep.py
@@ -19,6 +19,7 @@ import pytest
 from aios.db.pool import create_pool
 from aios.harness.inflight_tool_registry import InflightToolRegistry
 from aios.harness.sweep import find_sessions_needing_inference
+from aios.models.events import ERRORED_LIFECYCLE_STATUS, ERRORED_LIFECYCLE_STOP_REASON
 from aios.services import sessions as sessions_service
 from tests.conftest import needs_docker
 
@@ -69,7 +70,11 @@ async def _seed_session_with_unreacted_message(
             pool,
             session.id,
             "lifecycle",
-            {"event": "turn_ended", "status": "errored", "stop_reason": "error"},
+            {
+                "event": "turn_ended",
+                "status": ERRORED_LIFECYCLE_STATUS,
+                "stop_reason": ERRORED_LIFECYCLE_STOP_REASON,
+            },
             account_id=account_id,
         )
     return session.id

--- a/tests/unit/test_errored_lifecycle_coupling.py
+++ b/tests/unit/test_errored_lifecycle_coupling.py
@@ -1,0 +1,124 @@
+"""Writer↔reader coupling for the errored-session park (#1084).
+
+The error latch (``harness/loop.py:_latch_errored_turn``) writes a
+``turn_ended`` lifecycle event whose ``status``/``stop_reason`` the sweep's
+errored-park predicate reads back to bump ``last_error_seq`` and skip the
+session. That value round-trips writer → ``json.dumps`` → Postgres JSONB →
+asyncpg → ``dict[str, Any]``: the read is type ``Any``, so the type checker
+*cannot* bind the write literal to the read literal. Two free strings on either
+side of that boundary type-check and pass CI even when they DIVERGE — flip the
+writer to ``stop_reason='errored'`` (the tempting transposition matching
+``status``) and the park silently breaks, busy-waking the session forever
+(#155 class).
+
+These tests are the FLOOR: they assert the latch's actual write is exactly what
+the park predicate accepts, so a future literal flip on either side fails
+deterministically — the coupling the ``Any`` read would otherwise evaporate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aios.harness import loop
+from aios.models.events import (
+    ERRORED_LIFECYCLE_STATUS,
+    ERRORED_LIFECYCLE_STOP_REASON,
+    is_errored_lifecycle_event,
+)
+
+
+async def _capture_latch_lifecycle_event() -> dict[str, Any]:
+    """Run the real error latch with its DB deps mocked and return the exact
+    lifecycle ``data`` payload it appends.
+
+    Nothing here re-states the literal: the payload is whatever
+    ``_latch_errored_turn`` → ``_append_lifecycle`` → ``append_event`` actually
+    writes, so a flip of the writer literal flows straight into the assertions.
+    """
+    appended: list[dict[str, Any]] = []
+
+    async def _record_append(
+        pool: Any, session_id: str, kind: str, data: dict[str, Any], **kwargs: Any
+    ) -> Any:
+        if kind == "lifecycle":
+            appended.append(data)
+        return None
+
+    with (
+        patch.object(loop, "fail_all_open_requests", new=AsyncMock(return_value=None)),
+        patch.object(
+            loop.sessions_service, "set_session_stop_reason", new=AsyncMock(return_value=None)
+        ),
+        patch.object(loop.sessions_service, "append_event", side_effect=_record_append),
+    ):
+        await loop._latch_errored_turn(
+            pool=object(),
+            session_id="ses_x",
+            error_kind="test_error",
+            account_id="acc_test",
+        )
+
+    lifecycle_events = [d for d in appended if d.get("event") == "turn_ended"]
+    assert len(lifecycle_events) == 1, (
+        "the error latch must append exactly one turn_ended lifecycle event"
+    )
+    return lifecycle_events[0]
+
+
+@pytest.mark.asyncio
+async def test_error_latch_write_is_read_by_errored_park_predicate() -> None:
+    """The CORE coupling: the lifecycle event the latch writes is recognized by
+    the sweep's errored-park predicate.
+
+    If a future edit flips the writer literal (e.g.
+    ``stop_reason='errored'``) WITHOUT flipping the reader, this fails — the
+    regression the bug describes (park silently breaks) is caught here even
+    though both literals would type-check across the JSONB ``Any`` boundary.
+    """
+    data = await _capture_latch_lifecycle_event()
+
+    assert is_errored_lifecycle_event("lifecycle", data), (
+        "the lifecycle event the error latch writes must be recognized by the "
+        "errored-park predicate (is_errored_lifecycle_event); a divergence "
+        "between the writer and reader literals silently busy-wakes the session "
+        "forever (#1084 / #155 class)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_error_latch_uses_shared_lifecycle_constants() -> None:
+    """The latch must write the SHARED constants, not re-stated free strings —
+    so the write and the read have one source of truth.
+    """
+    data = await _capture_latch_lifecycle_event()
+
+    assert data["stop_reason"] == ERRORED_LIFECYCLE_STOP_REASON
+    assert data["status"] == ERRORED_LIFECYCLE_STATUS
+
+
+def test_errored_park_predicate_rejects_non_error_stop_reasons() -> None:
+    """Guard the predicate's discrimination: only the error stop_reason latches.
+
+    Without this, a predicate that returned True for every lifecycle event would
+    satisfy the coupling test above yet wrongly park (e.g.) rescheduling turns.
+    """
+    assert not is_errored_lifecycle_event(
+        "lifecycle", {"event": "turn_ended", "stop_reason": "rescheduling"}
+    )
+    assert not is_errored_lifecycle_event("lifecycle", {"event": "turn_started"})
+    # A non-lifecycle event carrying the same string must NOT park.
+    assert not is_errored_lifecycle_event("message", {"stop_reason": ERRORED_LIFECYCLE_STOP_REASON})
+
+
+def test_status_and_stop_reason_constants_are_distinct() -> None:
+    """The transposition the bug names: ``status='errored'`` and
+    ``stop_reason='error'`` are DIFFERENT strings. Pinning them distinct keeps a
+    careless "make them match" edit from collapsing the two fields.
+    """
+    assert ERRORED_LIFECYCLE_STOP_REASON != ERRORED_LIFECYCLE_STATUS
+    assert ERRORED_LIFECYCLE_STOP_REASON == "error"
+    assert ERRORED_LIFECYCLE_STATUS == "errored"

--- a/tests/unit/test_errored_lifecycle_coupling.py
+++ b/tests/unit/test_errored_lifecycle_coupling.py
@@ -29,6 +29,7 @@ from aios.models.events import (
     ERRORED_LIFECYCLE_STOP_REASON,
     is_errored_lifecycle_event,
 )
+from aios.services import sessions as sessions_service
 
 
 async def _capture_latch_lifecycle_event() -> dict[str, Any]:
@@ -50,10 +51,8 @@ async def _capture_latch_lifecycle_event() -> dict[str, Any]:
 
     with (
         patch.object(loop, "fail_all_open_requests", new=AsyncMock(return_value=None)),
-        patch.object(
-            loop.sessions_service, "set_session_stop_reason", new=AsyncMock(return_value=None)
-        ),
-        patch.object(loop.sessions_service, "append_event", side_effect=_record_append),
+        patch.object(sessions_service, "set_session_stop_reason", new=AsyncMock(return_value=None)),
+        patch.object(sessions_service, "append_event", side_effect=_record_append),
     ):
         await loop._latch_errored_turn(
             pool=object(),
@@ -119,6 +118,9 @@ def test_status_and_stop_reason_constants_are_distinct() -> None:
     ``stop_reason='error'`` are DIFFERENT strings. Pinning them distinct keeps a
     careless "make them match" edit from collapsing the two fields.
     """
-    assert ERRORED_LIFECYCLE_STOP_REASON != ERRORED_LIFECYCLE_STATUS
+    # Compare via ``str`` so mypy does not narrow these distinct ``Literal``
+    # types to a statically-known (non-overlapping) result and reject the
+    # equality check — the assertion guards a runtime invariant, not a type one.
+    assert str(ERRORED_LIFECYCLE_STOP_REASON) != str(ERRORED_LIFECYCLE_STATUS)
     assert ERRORED_LIFECYCLE_STOP_REASON == "error"
     assert ERRORED_LIFECYCLE_STATUS == "errored"


### PR DESCRIPTION
Automated dev-pipeline build for issue #1084.