### PR TITLE
Sandbox template-prewarm: amortize egress-CA + package install via an operator-baked, base-labelled prewarm image

### DIFF
--- a/migrations/versions/0114_connector_capabilities.py
+++ b/migrations/versions/0114_connector_capabilities.py
@@ -31,10 +31,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "ALTER TABLE connectors "
-        "ADD COLUMN capabilities jsonb NOT NULL DEFAULT '{}'::jsonb"
-    )
+    op.execute("ALTER TABLE connectors ADD COLUMN capabilities jsonb NOT NULL DEFAULT '{}'::jsonb")
 
 
 def downgrade() -> None:

--- a/migrations/versions/0114_connector_capabilities.py
+++ b/migrations/versions/0114_connector_capabilities.py
@@ -31,7 +31,10 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TABLE connectors ADD COLUMN capabilities jsonb NOT NULL DEFAULT '{}'::jsonb")
+    op.execute(
+        "ALTER TABLE connectors "
+        "ADD COLUMN capabilities jsonb NOT NULL DEFAULT '{}'::jsonb"
+    )
 
 
 def downgrade() -> None:

--- a/src/aios/cli/app.py
+++ b/src/aios/cli/app.py
@@ -101,6 +101,7 @@ from aios.cli.commands import dev as _dev  # noqa: E402
 from aios.cli.commands import envs as _envs  # noqa: E402
 from aios.cli.commands import invocations as _invocations  # noqa: E402
 from aios.cli.commands import ops as _ops  # noqa: E402
+from aios.cli.commands import sandbox as _sandbox  # noqa: E402
 from aios.cli.commands import session_templates as _session_templates  # noqa: E402
 from aios.cli.commands import sessions as _sessions  # noqa: E402
 from aios.cli.commands import signal as _signal  # noqa: E402
@@ -128,6 +129,7 @@ app.add_typer(_workflows.runs_app, name="runs")
 app.add_typer(_invocations.app, name="invocations")
 
 _ops.register(app)
+_sandbox.register(app)
 _status.register(app)
 _chat.register(app)
 _tail.register(app)

--- a/src/aios/cli/commands/sandbox.py
+++ b/src/aios/cli/commands/sandbox.py
@@ -127,9 +127,7 @@ async def _load_environment_config(
     return env_config
 
 
-async def _run_prewarm_async(
-    tag: str, environment_id: str | None, account_id: str | None
-) -> int:
+async def _run_prewarm_async(tag: str, environment_id: str | None, account_id: str | None) -> int:
     from aios.config import get_settings
     from aios.sandbox.backends.docker import DockerBackend
 

--- a/src/aios/cli/commands/sandbox.py
+++ b/src/aios/cli/commands/sandbox.py
@@ -1,0 +1,183 @@
+"""Operator subcommand: ``sandbox-prewarm`` (#1348).
+
+Bakes an operator-side *prewarm* image from the configured sandbox base
+(``settings.docker_image``) with the per-deployment egress CA — and,
+optionally, one environment's packages — already installed, then stamps it
+with the labels the cold-start skip gate reads. Reusing such an image as
+``AIOS_DOCKER_IMAGE`` removes ``install_egress_ca`` / ``install_packages``
+from the cold-start hot path (a pure latency optimization; never a
+correctness dependency — the skipped steps are idempotent and the gate
+fails toward running them).
+
+It is an **operator** command, NOT a client CLI command: it needs
+``AIOS_EGRESS_CA_KEY`` (the CA is an HKDF subkey of it, so the bake is
+structurally operator-side — public CI has no such secret) and shells out
+to ``docker`` on the host. It therefore follows the operator-command
+pattern (``api``/``worker``/``migrate``/``rekey`` in ``ops.py``) — no
+``--url``/``--api-key``, it does not talk to the API.
+
+What it does (synchronous, host-side):
+
+1. ``docker run --detach`` the base — a plain run, NO managed/instance/
+   session labels.
+2. Build a transient :class:`SandboxHandle` and ``install_egress_ca``; if
+   ``--environment`` is given, load its :class:`EnvironmentConfig` and
+   ``install_packages``.
+3. ``docker commit`` the container to ``--tag``, stamping BOTH
+   ``BASE_IMAGE_LABEL_KEY=<base>`` AND ``PREWARM_LABEL_KEY=<base>``.
+4. ``docker rm -f`` the transient container; print the tag.
+
+It deliberately does NOT stamp ``MANAGED_LABEL_KEY`` /
+``INSTANCE_LABEL_KEY`` / ``SESSION_LABEL_KEY`` — that is what keeps the
+prewarm image out of the image GC's reapable set (it is treated like the
+base image, an external operator-managed dependency).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import typer
+
+from aios.models.environments import EnvironmentConfig
+from aios.sandbox.backends.base import (
+    BASE_IMAGE_LABEL_KEY,
+    PREWARM_LABEL_KEY,
+    SandboxBackend,
+    SandboxBackendError,
+    SandboxHandle,
+)
+from aios.sandbox.setup import install_egress_ca, install_packages
+
+
+async def bake_prewarm_image(
+    backend: SandboxBackend,
+    *,
+    base_image: str,
+    tag: str,
+    environment_id: str | None = None,
+    account_id: str | None = None,
+) -> str:
+    """Bake a prewarm image from ``base_image`` to ``tag`` and return ``tag``.
+
+    Pure composition of the shipped #916 snapshot/label primitive (run the
+    base out-of-band, install setup, commit + stamp labels). Backend-typed so
+    it is unit-testable against a fake backend with no Docker daemon.
+    """
+    # 1. Plain run of the base — no managed/instance/session labels. A prewarm
+    #    image must NOT enter the GC's reapable set; see module docstring.
+    sandbox_id = await backend.prewarm_run(base_image)
+    handle = SandboxHandle(
+        owner_id="prewarm",
+        sandbox_id=sandbox_id,
+        workspace_path=Path("/workspace"),
+    )
+    try:
+        # 2. The idempotent setup execs being amortized into the bake.
+        await install_egress_ca(backend, handle)
+        if environment_id is not None:
+            env_config = await _load_environment_config(environment_id, account_id)
+            await install_packages(backend, handle, env_config)
+
+        # 3. Commit + stamp BOTH labels. The container ran from ``base_image``,
+        #    so that is the base ref both labels record.
+        await backend.prewarm_commit(
+            sandbox_id,
+            tag,
+            labels={
+                BASE_IMAGE_LABEL_KEY: base_image,
+                PREWARM_LABEL_KEY: base_image,
+            },
+        )
+    finally:
+        # 4. ``docker rm -f`` the transient container (best-effort).
+        await backend.prewarm_remove(sandbox_id)
+    return tag
+
+
+async def _load_environment_config(
+    environment_id: str, account_id: str | None
+) -> EnvironmentConfig:
+    """Load one environment's :class:`EnvironmentConfig` for the package bake.
+
+    ``get_environment_config_for_id`` is account-scoped (a run can never read
+    another tenant's env config), so ``--account`` is required alongside
+    ``--environment``.
+    """
+    from aios.config import get_settings
+    from aios.db import queries
+    from aios.db.pool import create_pool
+
+    if account_id is None:
+        raise typer.BadParameter("--account is required when --environment is given")
+    settings = get_settings()
+    pool = await create_pool(settings.db_url, min_size=1, max_size=1)
+    try:
+        async with pool.acquire() as conn:
+            env_config = await queries.get_environment_config_for_id(
+                conn, environment_id, account_id=account_id
+            )
+    finally:
+        await pool.close()
+    if env_config is None:
+        raise typer.BadParameter(
+            f"environment {environment_id!r} not found for account {account_id!r}"
+        )
+    return env_config
+
+
+async def _run_prewarm_async(
+    tag: str, environment_id: str | None, account_id: str | None
+) -> int:
+    from aios.config import get_settings
+    from aios.sandbox.backends.docker import DockerBackend
+
+    base_image = get_settings().docker_image
+    backend = DockerBackend()
+    baked = await bake_prewarm_image(
+        backend,
+        base_image=base_image,
+        tag=tag,
+        environment_id=environment_id,
+        account_id=account_id,
+    )
+    typer.echo(baked)
+    return 0
+
+
+def _run_prewarm(tag: str, environment_id: str | None, account_id: str | None) -> int:
+    try:
+        return asyncio.run(_run_prewarm_async(tag, environment_id, account_id))
+    except SandboxBackendError as err:
+        typer.echo(f"sandbox-prewarm failed: {err}", err=True)
+        return 1
+
+
+def register(app: typer.Typer) -> None:
+    """Attach the ``sandbox-prewarm`` operator command to the root app."""
+
+    @app.command(
+        "sandbox-prewarm",
+        help=(
+            "Bake an operator prewarm image from the configured sandbox base "
+            "(AIOS_DOCKER_IMAGE) with the egress CA (and optionally one "
+            "environment's packages) pre-installed, stamped with the prewarm "
+            "labels the cold-start skip gate reads. Point AIOS_DOCKER_IMAGE at "
+            "the resulting tag to amortize cold-start setup."
+        ),
+    )
+    def sandbox_prewarm(
+        tag: str = typer.Option(..., "--tag", help="Image ref to commit the prewarm bake to."),
+        environment: str | None = typer.Option(
+            None,
+            "--environment",
+            help="Environment id whose packages to bake in (requires --account).",
+        ),
+        account: str | None = typer.Option(
+            None,
+            "--account",
+            help="Account id that owns --environment (env config is account-scoped).",
+        ),
+    ) -> None:
+        raise typer.Exit(_run_prewarm(tag, environment, account))

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -509,9 +509,7 @@ class SandboxBackend(Protocol):
         """
         ...
 
-    async def prewarm_commit(
-        self, sandbox_id: str, tag: str, *, labels: dict[str, str]
-    ) -> None:
+    async def prewarm_commit(self, sandbox_id: str, tag: str, *, labels: dict[str, str]) -> None:
         """``docker commit`` ``sandbox_id`` to ``tag``, stamping ``labels``.
 
         Operator prewarm bake (#1348). Stamps exactly the labels given

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -499,6 +499,36 @@ class SandboxBackend(Protocol):
         """
         ...
 
+    async def prewarm_run(self, image: str) -> str:
+        """``docker run --detach`` ``image`` as a transient prewarm container.
+
+        Operator prewarm bake (#1348). A PLAIN run — no managed/instance/
+        session labels, no spec — so the committed prewarm image never enters
+        the image GC's reapable set. Returns the new container's id. Raises
+        :class:`SandboxBackendError` on launch failure.
+        """
+        ...
+
+    async def prewarm_commit(
+        self, sandbox_id: str, tag: str, *, labels: dict[str, str]
+    ) -> None:
+        """``docker commit`` ``sandbox_id`` to ``tag``, stamping ``labels``.
+
+        Operator prewarm bake (#1348). Stamps exactly the labels given
+        (``BASE_IMAGE_LABEL_KEY`` + ``PREWARM_LABEL_KEY``) and DELIBERATELY
+        none of ``MANAGED_LABEL_KEY``/``INSTANCE_LABEL_KEY``/
+        ``SESSION_LABEL_KEY`` — that is what keeps the prewarm image out of the
+        GC's reapable set. Raises :class:`SandboxBackendError` on failure.
+        """
+        ...
+
+    async def prewarm_remove(self, sandbox_id: str) -> None:
+        """``docker rm -f`` the transient prewarm container (#1348).
+
+        Idempotent / best-effort: a container already gone is a no-op.
+        """
+        ...
+
     async def is_alive(self, handle: SandboxHandle) -> bool:
         """Return True iff ``handle``'s sandbox is still running.
 
@@ -550,3 +580,20 @@ ENV_KEYS_LABEL_KEY = "aios.env_keys"
 BASE_IMAGE_LABEL_KEY = "aios.base_image"
 FLATTENED_LABEL_KEY = "aios.flattened"
 FLATTENED_LABEL_VALUE = "true"
+
+# ── Operator prewarm label (#1348) ──────────────────────────────────────────
+#
+# A prewarm image is an operator-baked image that has ``install_egress_ca`` /
+# ``install_packages`` already applied against the base, so the cold-start hot
+# path can skip those (idempotent) setup execs. It is distinguished from a
+# tenant snapshot PURELY by labels (variation-as-KIND-via-labels, consistent
+# with ``MANAGED_LABEL_KEY``/``SESSION_LABEL_KEY``/``FLATTENED_LABEL_KEY``) — no
+# new image-class flag. ``PREWARM_LABEL_KEY``'s VALUE is the base ref this image
+# was baked against; the cold-start skip gate only fires when that value equals
+# the CURRENT base ref (``spec.image``), so a base change disables the skip —
+# the same equality discipline as the #916 base-drift gate. A prewarm image
+# deliberately carries ``PREWARM_LABEL_KEY`` + ``BASE_IMAGE_LABEL_KEY`` but NOT
+# ``MANAGED_LABEL_KEY``/``INSTANCE_LABEL_KEY``/``SESSION_LABEL_KEY``, so it never
+# enters the image GC's reapable set (it is treated like the base image — an
+# external operator-managed dependency).
+PREWARM_LABEL_KEY = "aios.prewarmed"  # value = the base ref this image was baked against

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -475,9 +475,7 @@ class DockerBackend:
             )
         return stdout_bytes.decode("utf-8", errors="replace").strip()
 
-    async def prewarm_commit(
-        self, sandbox_id: str, tag: str, *, labels: dict[str, str]
-    ) -> None:
+    async def prewarm_commit(self, sandbox_id: str, tag: str, *, labels: dict[str, str]) -> None:
         """``docker commit`` ``sandbox_id`` to ``tag``, stamping exactly ``labels``.
 
         Stamps only the caller-supplied labels (``BASE_IMAGE_LABEL_KEY`` +
@@ -498,9 +496,7 @@ class DockerBackend:
 
     async def prewarm_remove(self, sandbox_id: str) -> None:
         """``docker rm -f`` the transient prewarm container (idempotent)."""
-        rc, _stdout, stderr_bytes = await run_docker_cli(
-            ["docker", "rm", "--force", sandbox_id]
-        )
+        rc, _stdout, stderr_bytes = await run_docker_cli(["docker", "rm", "--force", sandbox_id])
         if rc != 0:
             stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
             if _is_no_such_container(stderr):

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -451,6 +451,62 @@ class DockerBackend:
             return False
         return stdout_bytes.decode("utf-8", errors="replace").strip() == "true"
 
+    # ── operator prewarm bake (#1348) ───────────────────────────────────────
+
+    async def prewarm_run(self, image: str) -> str:
+        """``docker run --detach`` ``image`` as a transient prewarm container.
+
+        A plain run: keep stdin open and exec the same keepalive CMD a session
+        container uses so the container stays up for the setup execs, but stamp
+        NO ``aios.*`` labels (so the committed image is invisible to the GC) and
+        none of the session resource caps / mounts / network policy (the bake
+        only needs a live shell to install the CA / packages into the rootfs).
+        ``--pull always`` when ``image`` is a registry ref, mirroring create().
+        """
+        argv = ["docker", "run", "--detach", "--interactive"]
+        if _is_registry_image(image):
+            argv.extend(["--pull", "always"])
+        argv.extend([image, "/usr/bin/tail", "-f", "/dev/null"])
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(argv)
+        if rc != 0:
+            raise SandboxBackendError(
+                f"docker run failed (exit {rc}) for prewarm of {image}: "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+        return stdout_bytes.decode("utf-8", errors="replace").strip()
+
+    async def prewarm_commit(
+        self, sandbox_id: str, tag: str, *, labels: dict[str, str]
+    ) -> None:
+        """``docker commit`` ``sandbox_id`` to ``tag``, stamping exactly ``labels``.
+
+        Stamps only the caller-supplied labels (``BASE_IMAGE_LABEL_KEY`` +
+        ``PREWARM_LABEL_KEY``) via ``--change "LABEL k=v"`` — deliberately NOT
+        the managed/instance/session labels, so the prewarm image never enters
+        the image GC's reapable set.
+        """
+        argv = ["docker", "commit"]
+        for key, value in labels.items():
+            argv.extend(["--change", f"LABEL {key}={value}"])
+        argv.extend([sandbox_id, tag])
+        rc, _stdout, stderr_bytes = await run_docker_cli(argv)
+        if rc != 0:
+            raise SandboxBackendError(
+                f"docker commit failed (exit {rc}) for prewarm {tag}: "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+
+    async def prewarm_remove(self, sandbox_id: str) -> None:
+        """``docker rm -f`` the transient prewarm container (idempotent)."""
+        rc, _stdout, stderr_bytes = await run_docker_cli(
+            ["docker", "rm", "--force", sandbox_id]
+        )
+        if rc != 0:
+            stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+            if _is_no_such_container(stderr):
+                return
+            log.warning("sandbox.prewarm_rm_nonzero", container_id=sandbox_id[:12], stderr=stderr)
+
     # ── durable-session-sandbox verbs (§5.2) ────────────────────────────────
 
     async def stop(self, sandbox_id: str) -> None:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -45,6 +45,7 @@ from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
     FLATTENED_LABEL_KEY,
     FLATTENED_LABEL_VALUE,
+    PREWARM_LABEL_KEY,
     SESSION_LABEL_KEY,
     CommandResult,
     ManagedImage,
@@ -407,6 +408,27 @@ class SandboxRegistry:
                 pool, session_id, "span", end_payload, account_id=account_id
             )
 
+    async def _prewarmed_setup_satisfied(self, spec: SandboxSpec) -> bool:
+        """True iff the image the container ran from is a prewarm bake of the
+        CURRENT base — then ``install_egress_ca`` / ``install_packages`` are
+        redundant and skippable (#1348).
+
+        Fails toward False (do the work) on any mismatch/absence. Reading off
+        ``run_image`` (``spec.snapshot_image or spec.image``, mirroring
+        ``docker.py:217``) is load-bearing:
+
+        - On a **resume** ``run_image`` is a tenant snapshot tag whose
+          ``PREWARM_LABEL_KEY`` is absent ⇒ False ⇒ the (cheap, idempotent)
+          CA/package execs still run (a resumed rootfs may post-date the bake).
+        - On a **cold start** ``run_image == spec.image``; the gate is True only
+          when that base was itself prewarmed against the CURRENT base ref, so a
+          base change (``PREWARM_LABEL_KEY != spec.image``) disables the skip,
+          identical to the #916 drift gate.
+        """
+        run_image = spec.snapshot_image or spec.image  # mirror docker.py:217
+        labels = await self._backend.image_labels(run_image)
+        return labels is not None and labels.get(PREWARM_LABEL_KEY) == spec.image
+
     async def _provision(self, session_id: str) -> SandboxHandle:
         """Salvage corpses, resolve the snapshot, create the sandbox, run setup.
 
@@ -463,8 +485,13 @@ class SandboxRegistry:
         # sandbox down so we don't leak an empty container alongside
         # the proxy.
         try:
-            await install_egress_ca(self._backend, handle)
-            await install_packages(self._backend, handle, plan.env_config)
+            # Cold-start latency optimization (#1348): skip the idempotent CA /
+            # package execs when the image the container ran from is a prewarm
+            # bake of the CURRENT base. NEVER skip ``_apply_egress_rules`` — the
+            # iptables lockdown is never baked (§5.8 netns-lockdown-not-in-FS).
+            if not await self._prewarmed_setup_satisfied(spec):
+                await install_egress_ca(self._backend, handle)
+                await install_packages(self._backend, handle, plan.env_config)
             await self._apply_egress_rules(handle, plan)
         except BaseException:
             await self._destroy_quietly(handle, session_id)
@@ -558,8 +585,13 @@ class SandboxRegistry:
             raise
 
         try:
-            await install_egress_ca(self._backend, handle)
-            await install_packages(self._backend, handle, plan.env_config)
+            # Same cold-start skip as the session path (#1348). A run never
+            # resolves a snapshot (``plan.spec.snapshot_image is None``), so
+            # ``run_image == plan.spec.image`` and the gate fires only when the
+            # base is itself a prewarm of the current base. Lockdown still runs.
+            if not await self._prewarmed_setup_satisfied(plan.spec):
+                await install_egress_ca(self._backend, handle)
+                await install_packages(self._backend, handle, plan.env_config)
             await self._apply_egress_rules(handle, plan)
         except BaseException:
             await self._destroy_run_quietly(run_id, handle)

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -431,9 +431,21 @@ def prewarm_image(pulled_image: str) -> str:
 
     # 1. Plain run of the base (keepalive CMD), no aios.* labels.
     run = subprocess.run(
-        ["docker", "run", "--detach", "--name", container, pulled_image,
-         "/usr/bin/tail", "-f", "/dev/null"],
-        capture_output=True, text=True, check=False, timeout=60,
+        [
+            "docker",
+            "run",
+            "--detach",
+            "--name",
+            container,
+            pulled_image,
+            "/usr/bin/tail",
+            "-f",
+            "/dev/null",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
     )
     assert run.returncode == 0, f"prewarm run failed: {run.stderr.strip()}"
 
@@ -441,20 +453,40 @@ def prewarm_image(pulled_image: str) -> str:
     #    the PEM via ``docker exec --env`` so it lands INSIDE the container
     #    (host env is not forwarded into the container shell).
     install = subprocess.run(
-        ["docker", "exec", "--env", f"CA_PEM={_TEST_CA_PEM}", container, "bash", "-c",
-         "printf '%s' \"$CA_PEM\" > /usr/local/share/ca-certificates/aios-egress.crt "
-         "&& update-ca-certificates"],
-        capture_output=True, text=True, check=False, timeout=60,
+        [
+            "docker",
+            "exec",
+            "--env",
+            f"CA_PEM={_TEST_CA_PEM}",
+            container,
+            "bash",
+            "-c",
+            "printf '%s' \"$CA_PEM\" > /usr/local/share/ca-certificates/aios-egress.crt "
+            "&& update-ca-certificates",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
     )
     assert install.returncode == 0, f"prewarm CA install failed: {install.stderr.strip()}"
 
     # 3. Commit + stamp BOTH prewarm labels (and NONE of managed/instance/session).
     commit = subprocess.run(
-        ["docker", "commit",
-         "--change", f"LABEL {_BASE_IMAGE_LABEL_KEY}={pulled_image}",
-         "--change", f"LABEL {_PREWARM_LABEL_KEY}={pulled_image}",
-         container, tag],
-        capture_output=True, text=True, check=False, timeout=120,
+        [
+            "docker",
+            "commit",
+            "--change",
+            f"LABEL {_BASE_IMAGE_LABEL_KEY}={pulled_image}",
+            "--change",
+            f"LABEL {_PREWARM_LABEL_KEY}={pulled_image}",
+            container,
+            tag,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
     )
     assert commit.returncode == 0, f"prewarm commit failed: {commit.stderr.strip()}"
     # 4. Remove the transient container.
@@ -463,7 +495,9 @@ def prewarm_image(pulled_image: str) -> str:
     try:
         yield tag
     finally:
-        subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)
+        subprocess.run(
+            ["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30
+        )
         subprocess.run(["docker", "rmi", "-f", tag], capture_output=True, check=False, timeout=30)
 
 
@@ -473,7 +507,10 @@ class TestPrewarmBake:
         the managed/instance/session labels (GC-invisibility by construction)."""
         result = subprocess.run(
             ["docker", "image", "inspect", "--format", "{{json .Config.Labels}}", prewarm_image],
-            capture_output=True, text=True, check=False, timeout=15,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
         )
         assert result.returncode == 0, result.stderr.strip()
         labels = json.loads(result.stdout.strip()) or {}
@@ -487,7 +524,10 @@ class TestPrewarmBake:
         genuinely redundant for a container started from the prewarm image."""
         result = _docker_run(
             prewarm_image,
-            "grep", "-l", "aios-prewarm-test-ca", "/etc/ssl/certs/ca-certificates.crt",
+            "grep",
+            "-l",
+            "aios-prewarm-test-ca",
+            "/etc/ssl/certs/ca-certificates.crt",
             timeout=30,
         )
         # grep -l prints the filename on a match; a baked CA ⇒ rc 0.
@@ -501,19 +541,38 @@ class TestPrewarmBake:
         from the prewarmed image starts with an open OUTPUT policy and the
         lockdown can still be applied fresh (proving it is not persisted)."""
         container = "aios-prewarm-e2e-lockdown"
-        subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)
+        subprocess.run(
+            ["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30
+        )
         try:
             run = subprocess.run(
-                ["docker", "run", "--detach", "--name", container, "--cap-add", "NET_ADMIN",
-                 prewarm_image, "/usr/bin/tail", "-f", "/dev/null"],
-                capture_output=True, text=True, check=False, timeout=60,
+                [
+                    "docker",
+                    "run",
+                    "--detach",
+                    "--name",
+                    container,
+                    "--cap-add",
+                    "NET_ADMIN",
+                    prewarm_image,
+                    "/usr/bin/tail",
+                    "-f",
+                    "/dev/null",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
             )
             if run.returncode != 0:
                 pytest.skip(f"could not start NET_ADMIN container: {run.stderr.strip()}")
             # Baked image must NOT carry a DROP policy (lockdown never baked).
             before = subprocess.run(
                 ["docker", "exec", container, "iptables-legacy", "-S", "OUTPUT"],
-                capture_output=True, text=True, check=False, timeout=30,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
             )
             assert before.returncode == 0, before.stderr.strip()
             assert "-P OUTPUT DROP" not in before.stdout, (
@@ -522,13 +581,21 @@ class TestPrewarmBake:
             # The lockdown can be applied fresh — proving it runs at provision time.
             applied = subprocess.run(
                 ["docker", "exec", container, "iptables-legacy", "-P", "OUTPUT", "DROP"],
-                capture_output=True, text=True, check=False, timeout=30,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
             )
             assert applied.returncode == 0, applied.stderr.strip()
             after = subprocess.run(
                 ["docker", "exec", container, "iptables-legacy", "-S", "OUTPUT"],
-                capture_output=True, text=True, check=False, timeout=30,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
             )
             assert "-P OUTPUT DROP" in after.stdout
         finally:
-            subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)
+            subprocess.run(
+                ["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30
+            )

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -370,3 +370,165 @@ class TestArchitecture:
         output = result.stdout + result.stderr
         assert "linux/amd64" in output, f"amd64 not found in manifest: {output[:500]}"
         assert "linux/arm64" in output, f"arm64 not found in manifest: {output[:500]}"
+
+
+# -- operator prewarm bake (#1348) ---------------------------------------------
+#
+# These shell out to the Docker CLI directly (no aios harness): bake a prewarm
+# image from the base by committing a CA-installed container with the two
+# prewarm labels, then assert (a) the labels are stamped exactly (and the
+# managed/instance/session labels are NOT — GC-invisibility by construction),
+# (b) the egress CA is already in the trust store in the baked image (so the
+# cold-start CA exec is genuinely redundant), and (c) the iptables lockdown
+# DROP policy can STILL be applied against a container started from the
+# prewarmed image — the lockdown is never baked (§5.8). Label key strings are
+# inlined to keep this module free of aios package imports (see module
+# docstring); they mirror ``PREWARM_LABEL_KEY``/``BASE_IMAGE_LABEL_KEY`` etc.
+# in ``src/aios/sandbox/backends/base.py``.
+
+_PREWARM_LABEL_KEY = "aios.prewarmed"
+_BASE_IMAGE_LABEL_KEY = "aios.base_image"
+_MANAGED_LABEL_KEY = "aios.managed"
+_INSTANCE_LABEL_KEY = "aios.instance_id"
+_SESSION_LABEL_KEY = "aios.session_id"
+
+# A self-signed CA cert generated once at import time so the bake test does not
+# depend on AIOS_EGRESS_CA_KEY (the real CA derivation is operator-side; the
+# trust-store mechanism under test is identical for any PEM).
+_TEST_CA_PEM = subprocess.run(
+    [
+        "openssl",
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-keyout",
+        "/dev/null",
+        "-subj",
+        "/CN=aios-prewarm-test-ca",
+        "-days",
+        "1",
+    ],
+    capture_output=True,
+    text=True,
+    check=False,
+    timeout=30,
+).stdout
+
+
+@pytest.fixture()
+def prewarm_image(pulled_image: str) -> str:
+    """Bake a prewarm image from the base: run → install CA → commit + labels.
+
+    Mirrors the operator ``bake_prewarm_image`` path with the Docker CLI. Yields
+    the prewarm tag and force-removes it (and any leftover container) on teardown.
+    """
+    tag = "aios-prewarm-e2e:test"
+    container = "aios-prewarm-e2e-bake"
+    subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)
+    subprocess.run(["docker", "rmi", "-f", tag], capture_output=True, check=False, timeout=30)
+
+    # 1. Plain run of the base (keepalive CMD), no aios.* labels.
+    run = subprocess.run(
+        ["docker", "run", "--detach", "--name", container, pulled_image,
+         "/usr/bin/tail", "-f", "/dev/null"],
+        capture_output=True, text=True, check=False, timeout=60,
+    )
+    assert run.returncode == 0, f"prewarm run failed: {run.stderr.strip()}"
+
+    # 2. Install the CA into the trust store (the amortized setup exec). Pass
+    #    the PEM via ``docker exec --env`` so it lands INSIDE the container
+    #    (host env is not forwarded into the container shell).
+    install = subprocess.run(
+        ["docker", "exec", "--env", f"CA_PEM={_TEST_CA_PEM}", container, "bash", "-c",
+         "printf '%s' \"$CA_PEM\" > /usr/local/share/ca-certificates/aios-egress.crt "
+         "&& update-ca-certificates"],
+        capture_output=True, text=True, check=False, timeout=60,
+    )
+    assert install.returncode == 0, f"prewarm CA install failed: {install.stderr.strip()}"
+
+    # 3. Commit + stamp BOTH prewarm labels (and NONE of managed/instance/session).
+    commit = subprocess.run(
+        ["docker", "commit",
+         "--change", f"LABEL {_BASE_IMAGE_LABEL_KEY}={pulled_image}",
+         "--change", f"LABEL {_PREWARM_LABEL_KEY}={pulled_image}",
+         container, tag],
+        capture_output=True, text=True, check=False, timeout=120,
+    )
+    assert commit.returncode == 0, f"prewarm commit failed: {commit.stderr.strip()}"
+    # 4. Remove the transient container.
+    subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)
+
+    try:
+        yield tag
+    finally:
+        subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)
+        subprocess.run(["docker", "rmi", "-f", tag], capture_output=True, check=False, timeout=30)
+
+
+class TestPrewarmBake:
+    def test_prewarm_labels_stamped_exactly(self, prewarm_image: str, pulled_image: str) -> None:
+        """The prewarm image carries BOTH prewarm labels = base ref and NONE of
+        the managed/instance/session labels (GC-invisibility by construction)."""
+        result = subprocess.run(
+            ["docker", "image", "inspect", "--format", "{{json .Config.Labels}}", prewarm_image],
+            capture_output=True, text=True, check=False, timeout=15,
+        )
+        assert result.returncode == 0, result.stderr.strip()
+        labels = json.loads(result.stdout.strip()) or {}
+        assert labels.get(_PREWARM_LABEL_KEY) == pulled_image
+        assert labels.get(_BASE_IMAGE_LABEL_KEY) == pulled_image
+        for forbidden in (_MANAGED_LABEL_KEY, _INSTANCE_LABEL_KEY, _SESSION_LABEL_KEY):
+            assert forbidden not in labels, f"prewarm image must not carry {forbidden}"
+
+    def test_egress_ca_already_in_trust_store(self, prewarm_image: str) -> None:
+        """The CA is baked into the trust store, so the cold-start CA exec is
+        genuinely redundant for a container started from the prewarm image."""
+        result = _docker_run(
+            prewarm_image,
+            "grep", "-l", "aios-prewarm-test-ca", "/etc/ssl/certs/ca-certificates.crt",
+            timeout=30,
+        )
+        # grep -l prints the filename on a match; a baked CA ⇒ rc 0.
+        assert result.returncode == 0, (
+            "egress CA not found in the prewarm image trust store: "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+    def test_lockdown_still_appliable_against_prewarm_image(self, prewarm_image: str) -> None:
+        """The iptables DROP lockdown is NEVER baked (§5.8): a container started
+        from the prewarmed image starts with an open OUTPUT policy and the
+        lockdown can still be applied fresh (proving it is not persisted)."""
+        container = "aios-prewarm-e2e-lockdown"
+        subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)
+        try:
+            run = subprocess.run(
+                ["docker", "run", "--detach", "--name", container, "--cap-add", "NET_ADMIN",
+                 prewarm_image, "/usr/bin/tail", "-f", "/dev/null"],
+                capture_output=True, text=True, check=False, timeout=60,
+            )
+            if run.returncode != 0:
+                pytest.skip(f"could not start NET_ADMIN container: {run.stderr.strip()}")
+            # Baked image must NOT carry a DROP policy (lockdown never baked).
+            before = subprocess.run(
+                ["docker", "exec", container, "iptables-legacy", "-S", "OUTPUT"],
+                capture_output=True, text=True, check=False, timeout=30,
+            )
+            assert before.returncode == 0, before.stderr.strip()
+            assert "-P OUTPUT DROP" not in before.stdout, (
+                "prewarm image must not ship a baked DROP policy"
+            )
+            # The lockdown can be applied fresh — proving it runs at provision time.
+            applied = subprocess.run(
+                ["docker", "exec", container, "iptables-legacy", "-P", "OUTPUT", "DROP"],
+                capture_output=True, text=True, check=False, timeout=30,
+            )
+            assert applied.returncode == 0, applied.stderr.strip()
+            after = subprocess.run(
+                ["docker", "exec", container, "iptables-legacy", "-S", "OUTPUT"],
+                capture_output=True, text=True, check=False, timeout=30,
+            )
+            assert "-P OUTPUT DROP" in after.stdout
+        finally:
+            subprocess.run(["docker", "rm", "-f", container], capture_output=True, check=False, timeout=30)

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -522,16 +522,30 @@ class TestPrewarmBake:
 
     def test_egress_ca_already_in_trust_store(self, prewarm_image: str) -> None:
         """The CA is baked into the trust store, so the cold-start CA exec is
-        genuinely redundant for a container started from the prewarm image."""
+        genuinely redundant for a container started from the prewarm image.
+
+        ``update-ca-certificates`` concatenates the raw PEM (DER base64) into
+        the aggregate bundle WITHOUT a human-readable subject comment, so the
+        CA's CN never appears as plaintext there. Match instead on a unique
+        line of the cert's own base64 body, which IS appended verbatim to the
+        bundle — that is the real "the CA is in the trust store" signal.
+        """
+        # Pick a distinctive interior base64 line of the test CA (skip the
+        # PEM armor lines) and assert it is present in the aggregate bundle.
+        body_lines = [
+            ln.strip() for ln in _TEST_CA_PEM.splitlines() if ln.strip() and "-----" not in ln
+        ]
+        assert body_lines, f"test CA PEM has no body lines: {_TEST_CA_PEM!r}"
+        needle = body_lines[len(body_lines) // 2]
         result = _docker_run(
             prewarm_image,
             "grep",
-            "-l",
-            "aios-prewarm-test-ca",
+            "-qF",
+            needle,
             "/etc/ssl/certs/ca-certificates.crt",
             timeout=30,
         )
-        # grep -l prints the filename on a match; a baked CA ⇒ rc 0.
+        # grep -qF: fixed-string match of the cert body ⇒ rc 0 when baked.
         assert result.returncode == 0, (
             "egress CA not found in the prewarm image trust store: "
             f"stdout={result.stdout!r} stderr={result.stderr!r}"

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -16,6 +16,7 @@ import os
 import platform
 import re
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -418,7 +419,7 @@ _TEST_CA_PEM = subprocess.run(
 
 
 @pytest.fixture()
-def prewarm_image(pulled_image: str) -> str:
+def prewarm_image(pulled_image: str) -> Iterator[str]:
     """Bake a prewarm image from the base: run → install CA → commit + labels.
 
     Mirrors the operator ``bake_prewarm_image`` path with the Docker CLI. Yields

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -203,6 +203,28 @@ class FakeBackend:
             kind="committed", image_id=f"sha256:{tag}", unique_bytes=1024, depth=1
         )
 
+    # ── operator prewarm bake (#1348) ───────────────────────────────────────
+    # ``prewarm_run`` returns this id; ``prewarm_commit`` records the (tag,
+    # labels) it stamped so a test can assert the right labels were applied and
+    # that none of the managed/instance/session labels were.
+    next_prewarm_id: str = "prewarm_container_id"
+    prewarm_commits: list[tuple[str, dict[str, str]]] = field(default_factory=list)
+
+    async def prewarm_run(self, image: str) -> str:
+        self.calls.append(("prewarm_run", {"image": image}))
+        return self.next_prewarm_id
+
+    async def prewarm_commit(
+        self, sandbox_id: str, tag: str, *, labels: dict[str, str]
+    ) -> None:
+        self.calls.append(
+            ("prewarm_commit", {"sandbox_id": sandbox_id, "tag": tag, "labels": dict(labels)})
+        )
+        self.prewarm_commits.append((tag, dict(labels)))
+
+    async def prewarm_remove(self, sandbox_id: str) -> None:
+        self.calls.append(("prewarm_remove", {"sandbox_id": sandbox_id}))
+
     async def list_managed_images(self, *, instance_id: str) -> list[ManagedImage]:
         self.calls.append(("list_managed_images", {"instance_id": instance_id}))
         return list(self.managed_images)

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -214,9 +214,7 @@ class FakeBackend:
         self.calls.append(("prewarm_run", {"image": image}))
         return self.next_prewarm_id
 
-    async def prewarm_commit(
-        self, sandbox_id: str, tag: str, *, labels: dict[str, str]
-    ) -> None:
+    async def prewarm_commit(self, sandbox_id: str, tag: str, *, labels: dict[str, str]) -> None:
         self.calls.append(
             ("prewarm_commit", {"sandbox_id": sandbox_id, "tag": tag, "labels": dict(labels)})
         )

--- a/tests/unit/test_sandbox_prewarm.py
+++ b/tests/unit/test_sandbox_prewarm.py
@@ -120,7 +120,13 @@ class TestColdStartSkipGate:
 
         ca = AsyncMock()
         pkgs = AsyncMock()
-        patches = (*_patch_provision_preamble(registry, plan), patch("aios.sandbox.registry.install_egress_ca", ca), patch("aios.sandbox.registry.install_packages", pkgs), patch.object(registry, "_apply_egress_rules", AsyncMock()), patch("aios.sandbox.registry.log", MagicMock()))
+        patches = (
+            *_patch_provision_preamble(registry, plan),
+            patch("aios.sandbox.registry.install_egress_ca", ca),
+            patch("aios.sandbox.registry.install_packages", pkgs),
+            patch.object(registry, "_apply_egress_rules", AsyncMock()),
+            patch("aios.sandbox.registry.log", MagicMock()),
+        )
         _enter(patches)
         try:
             await registry._provision("sess_01TEST")
@@ -151,7 +157,13 @@ class TestColdStartSkipGate:
 
         ca = AsyncMock()
         pkgs = AsyncMock()
-        patches = (*_patch_provision_preamble(registry, plan), patch("aios.sandbox.registry.install_egress_ca", ca), patch("aios.sandbox.registry.install_packages", pkgs), patch.object(registry, "_apply_egress_rules", AsyncMock()), patch("aios.sandbox.registry.log", MagicMock()))
+        patches = (
+            *_patch_provision_preamble(registry, plan),
+            patch("aios.sandbox.registry.install_egress_ca", ca),
+            patch("aios.sandbox.registry.install_packages", pkgs),
+            patch.object(registry, "_apply_egress_rules", AsyncMock()),
+            patch("aios.sandbox.registry.log", MagicMock()),
+        )
         _enter(patches)
         try:
             await registry._provision("sess_01TEST")
@@ -211,7 +223,14 @@ class TestColdStartSkipGate:
         runtime = MagicMock()
         runtime.require_tool_broker = MagicMock(return_value=tool_broker)
 
-        patches = (*_patch_provision_preamble(registry, plan), patch("aios.sandbox.registry.install_egress_ca", AsyncMock()), patch("aios.sandbox.registry.install_packages", AsyncMock()), patch("aios.sandbox.registry.apply_network_lockdown", lockdown), patch("aios.harness.runtime.require_tool_broker", runtime.require_tool_broker), patch("aios.sandbox.registry.log", MagicMock()))
+        patches = (
+            *_patch_provision_preamble(registry, plan),
+            patch("aios.sandbox.registry.install_egress_ca", AsyncMock()),
+            patch("aios.sandbox.registry.install_packages", AsyncMock()),
+            patch("aios.sandbox.registry.apply_network_lockdown", lockdown),
+            patch("aios.harness.runtime.require_tool_broker", runtime.require_tool_broker),
+            patch("aios.sandbox.registry.log", MagicMock()),
+        )
         _enter(patches)
         try:
             await registry._provision("sess_01TEST")

--- a/tests/unit/test_sandbox_prewarm.py
+++ b/tests/unit/test_sandbox_prewarm.py
@@ -1,0 +1,288 @@
+"""Unit tests for the operator prewarm optimization (#1348).
+
+Two surfaces, no Docker:
+
+- The **cold-start skip gate** (``_prewarmed_setup_satisfied`` applied at both
+  ``_provision`` and ``_provision_run``): ``install_egress_ca`` /
+  ``install_packages`` are skipped iff the image the container RAN FROM is a
+  prewarm bake of the CURRENT base; the gate fails toward DOING the work on any
+  mismatch/absence; and ``apply_network_lockdown`` (via ``_apply_egress_rules``)
+  is NEVER skipped.
+- The **operator bake command** (``bake_prewarm_image``): the committed image is
+  stamped ``PREWARM_LABEL_KEY``+``BASE_IMAGE_LABEL_KEY`` and NOT the
+  managed/instance/session labels.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.cli.commands.sandbox import bake_prewarm_image
+from aios.sandbox.backends.base import (
+    BASE_IMAGE_LABEL_KEY,
+    INSTANCE_LABEL_KEY,
+    MANAGED_LABEL_KEY,
+    PREWARM_LABEL_KEY,
+    SESSION_LABEL_KEY,
+    Mount,
+    SandboxSpec,
+    Unrestricted,
+)
+from aios.sandbox.registry import SandboxRegistry
+from aios.sandbox.spec import ProvisioningPlan
+from tests.helpers.sandbox import FakeBackend, limited_env
+
+BASE = "ghcr.io/eumemic/aios-sandbox:latest"
+
+
+def _make_spec(*, snapshot_image: str | None = None, image: str = BASE) -> SandboxSpec:
+    return SandboxSpec(
+        session_id="sess_01TEST",
+        instance_id="inst_TEST",
+        workspace=Mount(host_path=Path("/tmp/w"), sandbox_path="/workspace"),
+        extra_mounts=(),
+        environment={},
+        labels={},
+        network_policy=Unrestricted(),
+        host_gateway_alias=None,
+        image=image,
+        snapshot_image=snapshot_image,
+    )
+
+
+def _make_plan(spec: SandboxSpec, *, env_config: object = None) -> ProvisioningPlan:
+    return ProvisioningPlan(
+        spec=spec,
+        env_config=env_config,
+        memory_echoes=[],
+        github_echoes=[],
+        git_proxy=None,
+        env_var_credentials=(),
+    )
+
+
+# ── shared fixtures for driving _provision / _provision_run ──────────────────
+
+
+def _patch_provision_preamble(registry: SandboxRegistry, plan: ProvisioningPlan):
+    """Patch the session ``_provision`` preamble so it reaches the setup execs.
+
+    ``_resolve_snapshot`` is patched to return ``plan.spec`` unchanged — the
+    gate must read labels off ``spec.snapshot_image or spec.image``, which the
+    resolved spec carries.
+    """
+    return (
+        patch(
+            "aios.sandbox.registry.build_spec_from_session",
+            AsyncMock(return_value=plan),
+        ),
+        patch.object(registry, "_salvage_session_corpses", AsyncMock()),
+        patch.object(registry, "_reconcile_pointer_from_local", AsyncMock()),
+        patch.object(registry, "_resolve_snapshot", AsyncMock(return_value=plan.spec)),
+    )
+
+
+def _enter(patches):
+    ctxs = [p.__enter__() for p in patches]
+    return ctxs
+
+
+def _exit(patches):
+    for p in reversed(patches):
+        p.__exit__(None, None, None)
+
+
+class TestColdStartSkipGate:
+    @pytest.mark.parametrize(
+        ("labels_by_ref", "expect_skipped"),
+        [
+            # Prewarm of the current base → skip.
+            ({BASE: {PREWARM_LABEL_KEY: BASE, BASE_IMAGE_LABEL_KEY: BASE}}, True),
+            # Prewarm of an OLD base → do the work (base-drift discipline).
+            ({BASE: {PREWARM_LABEL_KEY: "old-base", BASE_IMAGE_LABEL_KEY: "old-base"}}, False),
+            # No prewarm label at all → do the work.
+            ({BASE: {BASE_IMAGE_LABEL_KEY: BASE}}, False),
+            # image_labels returns None (absent) → do the work.
+            ({BASE: None}, False),
+            # image_labels has no entry for the ref → do the work.
+            ({}, False),
+        ],
+    )
+    async def test_provision_skip_matrix(
+        self, labels_by_ref: dict[str, object], expect_skipped: bool
+    ) -> None:
+        backend = FakeBackend(image_labels_by_ref=labels_by_ref)
+        registry = SandboxRegistry(backend=backend)
+        plan = _make_plan(_make_spec())
+
+        ca = AsyncMock()
+        pkgs = AsyncMock()
+        patches = (*_patch_provision_preamble(registry, plan), patch("aios.sandbox.registry.install_egress_ca", ca), patch("aios.sandbox.registry.install_packages", pkgs), patch.object(registry, "_apply_egress_rules", AsyncMock()), patch("aios.sandbox.registry.log", MagicMock()))
+        _enter(patches)
+        try:
+            await registry._provision("sess_01TEST")
+        finally:
+            _exit(patches)
+
+        if expect_skipped:
+            ca.assert_not_awaited()
+            pkgs.assert_not_awaited()
+        else:
+            ca.assert_awaited_once()
+            pkgs.assert_awaited_once()
+
+    async def test_resume_never_skips(self) -> None:
+        """On a resume ``run_image`` is the tenant snapshot tag, whose labels
+        lack ``PREWARM_LABEL_KEY`` — the execs MUST run even though the base
+        image happens to be a prewarm of the current base."""
+        snap = "aios-snap:sess_01TEST"
+        backend = FakeBackend(
+            image_labels_by_ref={
+                # Base IS a prewarm — but we run from the snapshot, not the base.
+                BASE: {PREWARM_LABEL_KEY: BASE, BASE_IMAGE_LABEL_KEY: BASE},
+                snap: {BASE_IMAGE_LABEL_KEY: BASE},  # tenant snapshot: no prewarm label
+            }
+        )
+        registry = SandboxRegistry(backend=backend)
+        plan = _make_plan(_make_spec(snapshot_image=snap))
+
+        ca = AsyncMock()
+        pkgs = AsyncMock()
+        patches = (*_patch_provision_preamble(registry, plan), patch("aios.sandbox.registry.install_egress_ca", ca), patch("aios.sandbox.registry.install_packages", pkgs), patch.object(registry, "_apply_egress_rules", AsyncMock()), patch("aios.sandbox.registry.log", MagicMock()))
+        _enter(patches)
+        try:
+            await registry._provision("sess_01TEST")
+        finally:
+            _exit(patches)
+
+        ca.assert_awaited_once()
+        pkgs.assert_awaited_once()
+
+    @pytest.mark.parametrize("expect_skipped", [True, False])
+    async def test_provision_run_parity(self, expect_skipped: bool) -> None:
+        labels = (
+            {PREWARM_LABEL_KEY: BASE, BASE_IMAGE_LABEL_KEY: BASE}
+            if expect_skipped
+            else {PREWARM_LABEL_KEY: "old-base"}
+        )
+        backend = FakeBackend(image_labels_by_ref={BASE: labels})
+        registry = SandboxRegistry(backend=backend)
+        # Runs never resolve a snapshot ⇒ snapshot_image is None ⇒ run from base.
+        plan = _make_plan(_make_spec(snapshot_image=None))
+
+        ca = AsyncMock()
+        pkgs = AsyncMock()
+        patches = (
+            patch("aios.sandbox.registry.build_spec_from_run", AsyncMock(return_value=plan)),
+            patch("aios.sandbox.registry.install_egress_ca", ca),
+            patch("aios.sandbox.registry.install_packages", pkgs),
+            patch.object(registry, "_apply_egress_rules", AsyncMock()),
+            patch("aios.sandbox.registry.log", MagicMock()),
+        )
+        _enter(patches)
+        try:
+            await registry._provision_run("wfr_01TEST")
+        finally:
+            _exit(patches)
+
+        if expect_skipped:
+            ca.assert_not_awaited()
+            pkgs.assert_not_awaited()
+        else:
+            ca.assert_awaited_once()
+            pkgs.assert_awaited_once()
+
+    async def test_lockdown_never_skipped_even_when_prewarmed(self) -> None:
+        """Load-bearing negative: a Limited session against a prewarmed base
+        still runs ``apply_network_lockdown`` (and thus ``run_netns_sidecar``).
+        The skip gates only the CA/package execs, NOT ``_apply_egress_rules``."""
+        backend = FakeBackend(
+            image_labels_by_ref={BASE: {PREWARM_LABEL_KEY: BASE, BASE_IMAGE_LABEL_KEY: BASE}}
+        )
+        registry = SandboxRegistry(backend=backend)
+        plan = _make_plan(_make_spec(), env_config=limited_env("pypi.org"))
+
+        lockdown = AsyncMock()
+        tool_broker = MagicMock()
+        tool_broker.port = 54321
+        runtime = MagicMock()
+        runtime.require_tool_broker = MagicMock(return_value=tool_broker)
+
+        patches = (*_patch_provision_preamble(registry, plan), patch("aios.sandbox.registry.install_egress_ca", AsyncMock()), patch("aios.sandbox.registry.install_packages", AsyncMock()), patch("aios.sandbox.registry.apply_network_lockdown", lockdown), patch("aios.harness.runtime.require_tool_broker", runtime.require_tool_broker), patch("aios.sandbox.registry.log", MagicMock()))
+        _enter(patches)
+        try:
+            await registry._provision("sess_01TEST")
+        finally:
+            _exit(patches)
+
+        lockdown.assert_awaited_once()
+
+
+class TestPrewarmBakeCommand:
+    async def test_bake_stamps_prewarm_and_base_labels_only(self) -> None:
+        backend = FakeBackend()
+        with (
+            patch("aios.cli.commands.sandbox.install_egress_ca", AsyncMock()) as ca,
+            patch("aios.cli.commands.sandbox.install_packages", AsyncMock()) as pkgs,
+        ):
+            tag = await bake_prewarm_image(backend, base_image=BASE, tag="aios-prewarm:latest")
+
+        assert tag == "aios-prewarm:latest"
+        # CA installed; no --environment ⇒ packages not installed.
+        ca.assert_awaited_once()
+        pkgs.assert_not_awaited()
+
+        # Exactly one commit, stamped with both prewarm labels = base ref, and
+        # NONE of the managed/instance/session labels.
+        assert len(backend.prewarm_commits) == 1
+        committed_tag, labels = backend.prewarm_commits[0]
+        assert committed_tag == "aios-prewarm:latest"
+        assert labels[PREWARM_LABEL_KEY] == BASE
+        assert labels[BASE_IMAGE_LABEL_KEY] == BASE
+        for forbidden in (MANAGED_LABEL_KEY, INSTANCE_LABEL_KEY, SESSION_LABEL_KEY):
+            assert forbidden not in labels
+
+        # Plain run of the base, and the transient container is torn down.
+        verbs = [c[0] for c in backend.calls]
+        assert "prewarm_run" in verbs
+        assert "prewarm_remove" in verbs
+
+    async def test_bake_with_environment_installs_packages(self) -> None:
+        backend = FakeBackend()
+        env_config = limited_env("pypi.org")
+        with (
+            patch("aios.cli.commands.sandbox.install_egress_ca", AsyncMock()),
+            patch("aios.cli.commands.sandbox.install_packages", AsyncMock()) as pkgs,
+            patch(
+                "aios.cli.commands.sandbox._load_environment_config",
+                AsyncMock(return_value=env_config),
+            ),
+        ):
+            await bake_prewarm_image(
+                backend,
+                base_image=BASE,
+                tag="aios-prewarm:env",
+                environment_id="env_X",
+                account_id="acct_X",
+            )
+
+        pkgs.assert_awaited_once()
+        _tag, labels = backend.prewarm_commits[0]
+        assert labels[PREWARM_LABEL_KEY] == BASE
+
+    async def test_bake_removes_container_even_on_commit_failure(self) -> None:
+        from aios.sandbox.backends.base import SandboxBackendError
+
+        backend = FakeBackend()
+        backend.prewarm_commit = AsyncMock(side_effect=SandboxBackendError("boom"))  # type: ignore[method-assign]
+        with (
+            patch("aios.cli.commands.sandbox.install_egress_ca", AsyncMock()),
+            patch("aios.cli.commands.sandbox.install_packages", AsyncMock()),
+            pytest.raises(SandboxBackendError),
+        ):
+            await bake_prewarm_image(backend, base_image=BASE, tag="aios-prewarm:latest")
+
+        assert ("prewarm_remove", {"sandbox_id": "prewarm_container_id"}) in backend.calls

--- a/tests/unit/test_sandbox_prewarm.py
+++ b/tests/unit/test_sandbox_prewarm.py
@@ -16,11 +16,13 @@ Two surfaces, no Docker:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from aios.cli.commands.sandbox import bake_prewarm_image
+from aios.models.environments import EnvironmentConfig
 from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
     INSTANCE_LABEL_KEY,
@@ -53,7 +55,9 @@ def _make_spec(*, snapshot_image: str | None = None, image: str = BASE) -> Sandb
     )
 
 
-def _make_plan(spec: SandboxSpec, *, env_config: object = None) -> ProvisioningPlan:
+def _make_plan(
+    spec: SandboxSpec, *, env_config: EnvironmentConfig | None = None
+) -> ProvisioningPlan:
     return ProvisioningPlan(
         spec=spec,
         env_config=env_config,
@@ -67,7 +71,7 @@ def _make_plan(spec: SandboxSpec, *, env_config: object = None) -> ProvisioningP
 # ── shared fixtures for driving _provision / _provision_run ──────────────────
 
 
-def _patch_provision_preamble(registry: SandboxRegistry, plan: ProvisioningPlan):
+def _patch_provision_preamble(registry: SandboxRegistry, plan: ProvisioningPlan) -> tuple[Any, ...]:
     """Patch the session ``_provision`` preamble so it reaches the setup execs.
 
     ``_resolve_snapshot`` is patched to return ``plan.spec`` unchanged — the
@@ -85,12 +89,12 @@ def _patch_provision_preamble(registry: SandboxRegistry, plan: ProvisioningPlan)
     )
 
 
-def _enter(patches):
+def _enter(patches: tuple[Any, ...]) -> list[Any]:
     ctxs = [p.__enter__() for p in patches]
     return ctxs
 
 
-def _exit(patches):
+def _exit(patches: tuple[Any, ...]) -> None:
     for p in reversed(patches):
         p.__exit__(None, None, None)
 
@@ -112,7 +116,7 @@ class TestColdStartSkipGate:
         ],
     )
     async def test_provision_skip_matrix(
-        self, labels_by_ref: dict[str, object], expect_skipped: bool
+        self, labels_by_ref: dict[str, dict[str, str] | None], expect_skipped: bool
     ) -> None:
         backend = FakeBackend(image_labels_by_ref=labels_by_ref)
         registry = SandboxRegistry(backend=backend)


### PR DESCRIPTION
Automated dev-pipeline build for issue #1348.