### PR TITLE
refactor(tasks): finish the #1154 task-disambiguation — cancel_task collision + doc clarity

### DIFF
--- a/src/aios/db/queries/trace.py
+++ b/src/aios/db/queries/trace.py
@@ -254,7 +254,7 @@ async def list_caller_tasks(
     caller_session_id: str,
     account_id: str,
 ) -> list[CallerTask]:
-    """Every ``call_*`` task a session launched — its outbound task roster (#1428).
+    """Every ``call_*`` task a session launched — its outbound roster (#1428).
 
     The set-returning sibling of :func:`find_parked_servicer`, on the same 0103 reverse-caller
     indexes (``events_request_opened_caller_idx`` / ``wf_runs_caller_idx``: ``(account_id,

--- a/src/aios/harness/inflight_tool_registry.py
+++ b/src/aios/harness/inflight_tool_registry.py
@@ -35,7 +35,7 @@ class InflightToolRegistry:
             if not session_tasks:
                 del self._tasks[session_id]
 
-    def cancel_task(self, session_id: str, tool_call_id: str) -> bool:
+    def cancel_tool_task(self, session_id: str, tool_call_id: str) -> bool:
         """Cancel one tool task. Returns True if the task was found and cancelled."""
         session_tasks = self._tasks.get(session_id)
         if session_tasks is None:

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -55,7 +55,7 @@ def _launch_tasks(
     *,
     prefix: str,
 ) -> None:
-    """Shared launcher: spawn one asyncio task per tool call, register in task registry."""
+    """Shared launcher: spawn one asyncio task per tool call, register in the InflightToolRegistry."""
     inflight_reg = runtime.require_inflight_tool_registry()
     for call in tool_calls:
         call_id = call.get("id") or "unknown"
@@ -304,7 +304,7 @@ def relaunch_parked_task(
     output_schema: dict[str, Any] | None,
     account_id: str,
 ) -> None:
-    """Re-park a ``call_*`` task whose in-memory park task was lost to a worker
+    """Re-park a ``call_*`` task whose in-memory asyncio park task was lost to a worker
     crash (#1431). Returns immediately; the resume runs as a fire-and-forget tool task.
 
     Routed through :func:`_launch_tasks` so the resume registers in the ``InflightToolRegistry``

--- a/src/aios/tools/cancel.py
+++ b/src/aios/tools/cancel.py
@@ -62,7 +62,7 @@ async def cancel_handler(session_id: str, arguments: dict[str, Any]) -> dict[str
     if tool_call_id is not None:
         if not isinstance(tool_call_id, str):
             raise CancelArgumentError("tool_call_id must be a string")
-        cancelled = inflight_reg.cancel_task(session_id, tool_call_id)
+        cancelled = inflight_reg.cancel_tool_task(session_id, tool_call_id)
         return {"cancelled": cancelled, "tool_call_id": tool_call_id}
 
     count = inflight_reg.cancel_session(session_id)

--- a/src/aios/tools/tasks.py
+++ b/src/aios/tools/tasks.py
@@ -143,7 +143,7 @@ STOP_TASK_DESCRIPTION = (
     "before the stop landed, or an error if no open task matches that tool_call_id."
 )
 LIST_TASKS_DESCRIPTION = (
-    "List your open tasks — the call_session / call_agent / call_workflow tasks you have "
+    "List your open tasks — the call_session / call_agent / call_workflow calls you have "
     "launched that are still running and awaiting an answer. Each entry carries the "
     "tool_call_id (pass it to stop_task to cancel), the servicer kind (session or run), the "
     "target id, and when it was opened. A point-in-time snapshot; answered or cancelled calls "

--- a/tests/unit/test_inflight_tool_registry.py
+++ b/tests/unit/test_inflight_tool_registry.py
@@ -45,13 +45,13 @@ class TestCancellation:
         reg = InflightToolRegistry()
         task = asyncio.create_task(_sleeper())
         reg.add("sess_1", "call_a", task)
-        assert reg.cancel_task("sess_1", "call_a") is True
+        assert reg.cancel_tool_task("sess_1", "call_a") is True
         await asyncio.sleep(0)  # let the task process CancelledError
         assert task.cancelled()
 
     async def test_cancel_unknown_returns_false(self) -> None:
         reg = InflightToolRegistry()
-        assert reg.cancel_task("sess_1", "call_nope") is False
+        assert reg.cancel_tool_task("sess_1", "call_nope") is False
 
     async def test_cancel_session(self) -> None:
         reg = InflightToolRegistry()


### PR DESCRIPTION
A `/simplify` follow-up to **#1154** (PR #1444, merged) — it merged while the `/simplify` pass was still running, so these cleanups land separately.

## The substantive fix: the `cancel_task` collision
#1154 renamed the durable service fn `cancel_invocation` → `cancel_task`. That collided **by bare name** with the pre-existing `InflightToolRegistry.cancel_task`, which cancels an in-flight **asyncio** tool task. So two `cancel_task`s came to mean opposite things, called one file apart:
- `tools/cancel.py` → `inflight_reg.cancel_task(...)` (local asyncio detach)
- `tools/tasks.py` → `tasks_service.cancel_task(...)` (durable task cancel)

That is precisely the "task" overload #1154 set out to kill (it even renamed `TaskRegistry`→`InflightToolRegistry` for the same reason) — so the disambiguation was left incomplete at the method level. This renames the registry method to **`cancel_tool_task`** (matching its own docstring *"Cancel one tool task."* and the `InflightToolRegistry` class). The durable `tasks_service.cancel_task` keeps its name — it **is** the user-facing `cancel_task` operation.

## Three prose clarity fixes the word-swap introduced
- `tool_dispatch.py` `relaunch_parked_task` docstring: "in-memory park task" → "in-memory **asyncio** park task" (the line used "call_* task" and "park task" for different things in one breath).
- `tool_dispatch.py` `_launch_tasks` docstring: "register in **task registry**" → "register in the **InflightToolRegistry**" (a half-rename left in the same file).
- `tools/tasks.py` `LIST_TASKS_DESCRIPTION` (model-facing): "open tasks — the call_* **tasks** you have launched" → "...**calls** you have launched" (stutter; the blurb already uses "calls" as the referent).
- `db/queries/trace.py` `list_caller_tasks` docstring: "its outbound **task** roster" → "its outbound roster".

Pure rename/doc change — **no behavior change**. mypy + ruff + 3503 unit + 577 connector tests green; openapi/SDK unaffected (the registry method and tool-description strings aren't part of the wire contract).

Found by the 4-lens `/simplify` review (altitude lens flagged the collision as the one spot the disambiguation stopped short of its own goal). +8/−8 across 6 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)