### PR TITLE
chore(cli): file deferred CLI-coverage issues + guard against aios#TBD (#1433 Guard A)

### DIFF
--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -9,9 +9,10 @@ containers, not operators), multipart upload, long-poll, one-shot
 deployment bootstrap.
 
 ``NEEDS_CLI_TRACKED`` — operations that *should* get a CLI command but
-haven't yet. Each entry points at a tracking issue (or ``aios#TBD`` if
-filed at the same time as this allowlist). When the CLI command lands,
-remove the entry and decorate the new command with ``@covers(...)``.
+haven't yet. Each entry MUST cite a real filed tracking issue (e.g.
+``#1446``); ``test_cli_coverage`` fails CI on a leftover ``aios#TBD``
+placeholder, so a deferral can never ship untracked. When the CLI command
+lands, remove the entry and decorate the new command with ``@covers(...)``.
 
 The coverage test treats both categories identically for pass/fail —
 they're separated only so dead-entry detection (and future grepping)
@@ -114,40 +115,40 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
 
 NEEDS_CLI_TRACKED: dict[str, str] = {
     # ── Memory stores (followup) ─────────────────────────────────────
-    # Tracked: aios#TBD — single followup issue for `aios memory-stores ...`
+    # Tracked: #1446 — single followup issue for `aios memory-stores ...`
     # and `aios memory-stores memories ...` command groups.
-    "list_memory_stores": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "get_memory_store": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "create_memory_store": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "update_memory_store": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "delete_memory_store": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "archive_memory_store": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "list_memories": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "get_memory": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "create_memory": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "update_memory": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "delete_memory": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "list_memory_versions": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "get_memory_version": "needs CLI; tracked in aios#TBD (memory-stores group)",
-    "redact_memory_version": "needs CLI; tracked in aios#TBD (memory-stores group)",
+    "list_memory_stores": "needs CLI; tracked in #1446 (memory-stores group)",
+    "get_memory_store": "needs CLI; tracked in #1446 (memory-stores group)",
+    "create_memory_store": "needs CLI; tracked in #1446 (memory-stores group)",
+    "update_memory_store": "needs CLI; tracked in #1446 (memory-stores group)",
+    "delete_memory_store": "needs CLI; tracked in #1446 (memory-stores group)",
+    "archive_memory_store": "needs CLI; tracked in #1446 (memory-stores group)",
+    "list_memories": "needs CLI; tracked in #1446 (memory-stores group)",
+    "get_memory": "needs CLI; tracked in #1446 (memory-stores group)",
+    "create_memory": "needs CLI; tracked in #1446 (memory-stores group)",
+    "update_memory": "needs CLI; tracked in #1446 (memory-stores group)",
+    "delete_memory": "needs CLI; tracked in #1446 (memory-stores group)",
+    "list_memory_versions": "needs CLI; tracked in #1446 (memory-stores group)",
+    "get_memory_version": "needs CLI; tracked in #1446 (memory-stores group)",
+    "redact_memory_version": "needs CLI; tracked in #1446 (memory-stores group)",
     # ── Runtime tokens (followup) ────────────────────────────────────
-    # Tracked: aios#TBD — single followup issue for `aios runtime-tokens ...`.
-    "list_runtime_tokens": "needs CLI; tracked in aios#TBD (runtime-tokens group)",
-    "issue_runtime_token": "needs CLI; tracked in aios#TBD (runtime-tokens group)",
-    "revoke_runtime_token": "needs CLI; tracked in aios#TBD (runtime-tokens group)",
+    # Tracked: #1447 — single followup issue for `aios runtime-tokens ...`.
+    "list_runtime_tokens": "needs CLI; tracked in #1447 (runtime-tokens group)",
+    "issue_runtime_token": "needs CLI; tracked in #1447 (runtime-tokens group)",
+    "revoke_runtime_token": "needs CLI; tracked in #1447 (runtime-tokens group)",
     # ── Session resources / context (followup) ───────────────────────
-    # Tracked: aios#TBD — extend `aios sessions` with `context`.
+    # Tracked: #1448 — extend `aios sessions` with `context`.
     # list/add/remove/rotate resources now have `aios sessions resources …`
     # commands (#270); get_session_resource has no CLI yet.
-    "get_session_context": "needs CLI; tracked in aios#TBD (sessions context/resources)",
-    "get_session_resource": "needs CLI; tracked in aios#TBD (sessions context/resources)",
+    "get_session_context": "needs CLI; tracked in #1448 (sessions context/resources)",
+    "get_session_resource": "needs CLI; tracked in #1448 (sessions context/resources)",
     # ── Account usage (followup) ─────────────────────────────────────
-    # Tracked: aios#TBD — add `aios accounts usage <ID>`.
-    "get_account_usage": "needs CLI; tracked in aios#TBD (accounts usage)",
+    # Tracked: #1449 — add `aios accounts usage <ID>`.
+    "get_account_usage": "needs CLI; tracked in #1449 (accounts usage)",
     # ── Session events (followup) ────────────────────────────────────
     # Single-event lookup landed via #598 (events API gaps fix).
-    # Tracked: aios#TBD — extend `aios sessions events` with `get <event-id>`.
-    "get_session_event": "needs CLI; tracked in aios#TBD (sessions events get)",
+    # Tracked: #1450 — extend `aios sessions events` with `get <event-id>`.
+    "get_session_event": "needs CLI; tracked in #1450 (sessions events get)",
 }
 
 

--- a/tests/unit/test_cli_coverage.py
+++ b/tests/unit/test_cli_coverage.py
@@ -100,3 +100,21 @@ def test_allowlist_categories_are_disjoint() -> None:
         "Allowlist categories overlap — an operation is either deliberately not for "
         "CLI or waiting on a CLI followup, not both:\n  " + "\n  ".join(overlap)
     )
+
+
+def test_needs_cli_tracked_cite_real_issues() -> None:
+    """Every deferred-CLI entry cites a real filed issue, never ``aios#TBD``.
+
+    ``aios#TBD`` meant "tracking issue filed alongside this allowlist" — but those
+    issues (the followups #370 promised) went unfiled, so the deferrals were
+    untracked in practice. Filing them and asserting the placeholder is gone makes
+    a deferred CLI command unable to ship untracked again (#1433 drift guard). We
+    check dict *values* rather than scanning the source so this guard doesn't match
+    its own needle (the docstring legitimately names ``aios#TBD``).
+    """
+    untracked = sorted(op for op, reason in NEEDS_CLI_TRACKED.items() if "aios#TBD" in reason)
+    assert not untracked, (
+        f"{len(untracked)} NEEDS_CLI_TRACKED entry(ies) cite the placeholder aios#TBD "
+        "instead of a real filed issue — file a tracking issue and cite its #number:\n  "
+        + "\n  ".join(untracked)
+    )


### PR DESCRIPTION
## What

First of the **#1433 CI drift-guards** (Guard A): structurally stop the
`NEEDS_CLI_TRACKED` allowlist from citing a placeholder that was never filed.

`src/aios/cli/allowlist.py` deferred 21 OpenAPI operations to "a tracking issue
filed alongside this allowlist" via an `aios#TBD` placeholder — the followups
eumemic/eumemic-ops#347 explicitly promised. They were never filed, so the deferrals were untracked
in practice and the placeholder pointed at nothing.

## Changes

- **Filed the five grouped followup issues** and swapped each `aios#TBD` for the
  real number:
  - eumemic/aios#1446 — `aios memory-stores …` (14 ops: stores + memories + versions)
  - eumemic/aios#1447 — `aios runtime-tokens …` (3 ops)
  - eumemic/aios#1448 — `aios sessions context` + `sessions resources get` (2 ops)
  - eumemic/aios#1449 — `aios accounts usage <ID>` (1 op)
  - eumemic/aios#1450 — `aios sessions events get <event-id>` (1 op)
- **Added `test_needs_cli_tracked_cite_real_issues`** to the existing
  `tests/unit/test_cli_coverage.py` — fails CI on any leftover `aios#TBD`, so a
  deferred CLI command can never ship untracked again.

## Why this shape

The assertion checks `NEEDS_CLI_TRACKED` **values**, not a source `rglob` — so
the guard doesn't match its own needle. The module docstring still names
`aios#TBD` to document exactly what the guard rejects; a source scan would flag
that legitimate mention. Reusing the existing coverage-test module (which already
imports and structure-checks `NEEDS_CLI_TRACKED`) keeps the new invariant beside
its three siblings rather than in a new file.

This is correct-by-construction and zero-false-positive: the 27 hits are all in
one structured dict, so there's nothing to misclassify.

## Verification

- `grep -rn 'aios#TBD' src` → only the docstring mention remains (intentional).
- Full gate green via `scripts/run-checks.sh` (ruff + mypy + 3504 unit + 577
  connector tests). The new assertion is red before the swap, green after
  (guard-the-guard verified).

Guard B (the scheduled phantom-forward-ref canary) follows as a separate PR.
Guard C (built-but-uncalled query writers) is dropped — see the eumemic/aios#1433 re-scope
comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)