### PR TITLE
feat(drift): phantom forward-ref canary + fix the 6 current phantoms (#1433 Guard B)

### DIFF
--- a/.github/workflows/phantom-ref-canary.yml
+++ b/.github/workflows/phantom-ref-canary.yml
@@ -1,0 +1,141 @@
+name: Phantom issue-reference canary
+
+# Scheduled guard against forward-looking issue references that have gone stale.
+#
+# A comment like "until #877 lands" or "TODO(#1131)" promises future work gated on
+# another issue. When that issue later closes or merges — often in a DIFFERENT PR
+# than the one that wrote the comment — no PR-time check ever sees the now-stale
+# reference. This weekly canary closes that gap: the offline scanner
+# (src/aios/_drift/forward_refs.py) finds the promissory phrases, this workflow
+# checks each referenced issue's live state, and files a drift issue listing the
+# ones that are closed or missing (the promise landed or was abandoned, yet the
+# prose still says "pending").
+#
+# Why a scheduled canary and not a unit test: an issue's open/closed state needs
+# the GitHub API (the unit suite is strictly offline), and "until #877 lands" rots
+# when #877 merges in some OTHER PR — invisible to any PR-time check. So the verdict
+# has to be re-evaluated on a clock, not at merge.
+#
+# Security: no untrusted ${{ }} expression is interpolated into run: commands. The
+# issue title and label are workflow-authored constants; the issue body is built
+# ONLY from the repo's own committed source text (via the scanner's JSON) and is
+# passed as a quoted shell value, never eval'd. Only trusted contexts
+# (secrets.GITHUB_TOKEN, github.repository) are referenced.
+
+on:
+  schedule:
+    # Weekly, Monday 06:17 UTC. Off-minute by design (not :00/:30) so this doesn't
+    # land in the top-of-hour scheduler stampede.
+    - cron: "17 6 * * 1"
+  workflow_dispatch: {}
+
+# Serialize, and never cancel an in-flight run mid-filing: this is the
+# authoritative "are there phantom refs" verdict, and a later run must not abort
+# one whose drift-issue write is still in progress.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Scan for phantom forward-refs and report drift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The scanner is dependency-free (stdlib only) and imports nothing from
+          # the aios package, so run the file directly — no `uv sync`, no package
+          # import, seconds not minutes.
+          python src/aios/_drift/forward_refs.py src > candidates.json
+          echo "candidates:"; cat candidates.json
+
+          # Resolve each referenced issue's live state. HARD-FAIL the run on any
+          # API error that is NOT a clean 404 — a rate-limit/5xx must never be
+          # misread as "issue still open", which would silently drop a real phantom.
+          # A 404 (issue genuinely gone) is itself a violation, recorded as "missing".
+          echo '{}' > states.json
+          for n in $(jq -r '.[].number' candidates.json); do
+            if out=$(gh api "repos/${REPO}/issues/${n}" \
+                       --jq '{state: .state, is_pr: (.pull_request != null)}' 2>api_err); then
+              jq --arg n "$n" --argjson v "$out" '. + {($n): $v}' states.json > states.tmp
+            elif grep -qi 'not found' api_err; then
+              jq --arg n "$n" '. + {($n): {state: "missing", is_pr: false}}' states.json > states.tmp
+            else
+              echo "::error::gh api failed for #${n} (not a 404): $(cat api_err)"
+              exit 1
+            fi
+            mv states.tmp states.json
+          done
+
+          # A violation = a candidate whose issue is closed or missing AND is not a
+          # pull request. A forward reference to a PR ("blocked on #1234" where 1234
+          # is a PR) is a different beast — a merged PR is the expected end state, so
+          # skip PR-typed refs rather than flag them.
+          jq -n \
+            --slurpfile c candidates.json \
+            --slurpfile s states.json '
+            $c[0] | map(
+              . as $item
+              | ($s[0][($item.number | tostring)]) as $st
+              | select(($st.is_pr | not) and ($st.state == "closed" or $st.state == "missing"))
+              | $item + {state: $st.state}
+            )' > violations.json
+
+          COUNT=$(jq 'length' violations.json)
+          if [ "${COUNT}" -eq 0 ]; then
+            echo "No phantom forward-refs — every referenced issue is still open."
+            exit 0
+          fi
+
+          TITLE="Phantom issue references detected on master"
+          BODY=$(jq -r '
+            "Forward-looking issue references on `master` now point at **closed or missing** issues — the promised work has landed or been abandoned, but the prose still says it is pending. Fix forward by rewriting each phrase (a past-tense citation, or a numberless future for genuinely untracked work), or reopen the issue if the work truly remains.\n\n"
+            + (map(
+                "- **#\(.number)** (\(.state)):\n"
+                + (.occurrences | map("    - `\(.path):\(.line)` — \(.text)") | join("\n"))
+              ) | join("\n\n"))
+            + "\n\n---\nDetected by `.github/workflows/phantom-ref-canary.yml` via the offline scanner `src/aios/_drift/forward_refs.py`. This issue is NOT auto-closed — close it yourself once the references are fixed."
+          ' violations.json)
+
+          # A dedicated, non-incident label: a phantom ref is docs-hygiene drift,
+          # not a production outage, so it must not land in the incident queue.
+          # Created idempotently (it may not exist yet).
+          gh label create drift \
+            --color FBCA04 \
+            --description "Stale in-code signal surfaced by a drift canary" \
+            2>/dev/null || true
+
+          # One drift issue, its body REPLACED (not appended) each run, so a
+          # deliberately deferred phantom doesn't pile a fresh comment every week.
+          # List by label (the REST list is immediately consistent, unlike the
+          # search index) and exact-match the title in jq so reruns update the one
+          # issue instead of spawning duplicates.
+          EXISTING=$(gh issue list --label drift --state open --limit 100 \
+            --json number,title \
+            --jq "[.[] | select(.title == \"${TITLE}\")][0].number // empty" || echo "")
+
+          if [ -n "${EXISTING}" ]; then
+            echo "Updating existing drift issue #${EXISTING} (body replaced)."
+            gh issue edit "${EXISTING}" --body "${BODY}"
+          else
+            echo "Filing new drift issue."
+            gh issue create --title "${TITLE}" --label drift --body "${BODY}"
+          fi
+
+          echo "::error::${COUNT} phantom forward-ref(s) detected; drift issue filed/updated."
+          exit 1

--- a/src/aios/_drift/__init__.py
+++ b/src/aios/_drift/__init__.py
@@ -1,0 +1,9 @@
+"""Drift-detection tooling that runs over the source tree itself.
+
+These modules scan aios's own code/comments for signals that rot — references
+that lie once the thing they point at changes. They are pure/offline (no network,
+no DB); the online half (e.g. checking an issue's live state) lives in the
+``.github/workflows`` canary that drives them.
+"""
+
+from __future__ import annotations

--- a/src/aios/_drift/forward_refs.py
+++ b/src/aios/_drift/forward_refs.py
@@ -1,0 +1,156 @@
+"""Offline scanner for phantom forward-looking issue references.
+
+A *forward-looking* reference promises future work gated on another issue —
+``"When #332 lands"``, ``"until #1131 retires it"``, ``"deferred to #1335"``,
+``"TODO(#1131)"``. When that issue later closes or merges (often in a *different*
+PR than the one that wrote the comment), the promise rots: the gated work is done
+or abandoned, yet the prose still says ``"until it lands"``. The signal now lies.
+
+This module finds the *candidates* — the promissory phrases — purely offline. It
+does NOT decide whether a referenced issue is actually closed; that needs the
+GitHub API and lives in ``.github/workflows/phantom-ref-canary.yml``, so the unit
+suite stays offline. The scanner's job is precision against the dangerous class: a
+*closed* issue cited **historically** (``"the #1132 cap"``, an ``"#1131-proof"``
+invariant, a bare ``"(#878)"`` citation) must NOT be a candidate, or the canary
+would file a false incident about it.
+
+Precision comes from keying on the **phrase, never the bare number**: one issue
+can be a forward-phantom on one line (``"until #1131 retires it"``) and a
+legitimate historical citation on another (``"#1131-proof"``) in the same file.
+The discriminator is that a forward reference makes the issue the grammatical
+*subject* of a forward connective (``until``/``once``/``when`` immediately followed
+by the ref), or uses one of three connective-free promissory idioms — whereas a
+citation puts the number in parentheses or apposition.
+
+Scope, stated so nobody mistakes this for a total drift solution: it catches
+"forward-connective bound to ``#N``" plus ``TODO(#N)`` / ``deferred to #N`` /
+``blocked on #N`` only. Numberless forward-state prose (``"once the prune-cron
+exemption lands"``) and negated-verb idioms (``"(#953) deliberately NOT shipped"``)
+are out of scope by design — they are ambiguous, and widening recall trades false
+negatives for false alarms. Extend the patterns only alongside a fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Issue numbers below this floor are structural ordinals ("invariant #6",
+# "step #3", "Layer #2"), never issue refs. The repo's tracked issues sit far
+# above it; no real forward-ref points below 100.
+_MIN_ISSUE_NUMBER = 100
+
+# (1) A forward connective whose grammatical subject IS the issue ref: the ref
+# immediately follows ``until``/``once``/``when`` (optionally a ``/``-list and/or a
+# possessive). This directness — not a verb list — is what separates a promissory
+# clause from a bare parenthetical citation: ``"Once #878 redirects ... here"``
+# matches, while ``"(#878)"``, ``"the #1132 cap"``, and ``"deduped once (#725)
+# per ..."`` do not.
+_CONNECTIVE_SUBJECT = re.compile(
+    r"\b(?:until|once|when)\s+#\d+(?:/#\d+)*(?:'s)?\b",
+    re.IGNORECASE,
+)
+
+# (2) Connective-free idioms that are promissory on their own.
+_IDIOM = re.compile(
+    r"TODO\(#\d+\)|\bdeferred to #\d+|\bblocked on #\d+",
+    re.IGNORECASE,
+)
+
+_PATTERNS = (_CONNECTIVE_SUBJECT, _IDIOM)
+
+# Every issue ref inside a matched span — ``findall`` so the two-issue
+# ``"#1127/#1128 land"`` form enumerates both numbers.
+_ISSUE_REF = re.compile(r"#(\d+)")
+
+# The scanner's own package: its docstrings carry example forward-ref phrases by
+# necessity, so scanning it would self-flag. Excluded by directory name.
+_SELF_PACKAGE = "_drift"
+
+# Default tree the canary scans (the repo runs it from the root).
+_DEFAULT_ROOT = Path("src")
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """One forward-ref occurrence: an issue number used promissorily on a line."""
+
+    path: str  # repo-relative POSIX path
+    line: int  # 1-based
+    number: int
+    text: str  # the stripped source line, for the incident body
+
+
+def _numbers_in_span(line: str, start: int, end: int) -> list[int]:
+    """Issue numbers inside ``line[start:end]`` that clear the number floor.
+
+    No structural-ordinal exclusion is needed: a number is only examined here when
+    it sits inside a matched span, whose first token is the connective or idiom
+    keyword — so the token immediately before ``#N`` is never ``invariant``/``step``/
+    ``phase``/``Layer``. ``until phase #200 lands`` simply doesn't match (the ref
+    isn't directly after the connective)."""
+    numbers: list[int] = []
+    for m in _ISSUE_REF.finditer(line, start, end):
+        number = int(m.group(1))
+        if number >= _MIN_ISSUE_NUMBER:
+            numbers.append(number)
+    return numbers
+
+
+def scan_text(path: str, text: str) -> list[Finding]:
+    """Findings for one file's text. Public so tests can drive it without disk."""
+    findings: list[Finding] = []
+    seen: set[tuple[int, int]] = set()  # (line, number) — dedup across patterns
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for pattern in _PATTERNS:
+            for match in pattern.finditer(line):
+                for number in _numbers_in_span(line, match.start(), match.end()):
+                    if (line_no, number) not in seen:
+                        seen.add((line_no, number))
+                        findings.append(Finding(path, line_no, number, line.strip()))
+    return findings
+
+
+def scan_tree(root: Path = _DEFAULT_ROOT) -> list[Finding]:
+    """Findings across every ``*.py`` under ``root``, excluding the scanner's own
+    package (whose docstrings hold example phrases)."""
+    findings: list[Finding] = []
+    for py in sorted(root.rglob("*.py")):
+        if _SELF_PACKAGE in py.parts:
+            continue
+        findings.extend(scan_text(py.as_posix(), py.read_text(encoding="utf-8")))
+    return findings
+
+
+def group_by_number(findings: list[Finding]) -> dict[int, list[Finding]]:
+    """Group findings by issue number (the canary checks each number's state once)."""
+    grouped: dict[int, list[Finding]] = {}
+    for f in findings:
+        grouped.setdefault(f.number, []).append(f)
+    return grouped
+
+
+def _main(argv: list[str]) -> int:
+    """Emit the candidate forward-refs as JSON, grouped by number, for the canary.
+
+    ``[{"number": 332, "occurrences": [{"path": ..., "line": ..., "text": ...}]}]``
+    """
+    root = Path(argv[1]) if len(argv) > 1 else _DEFAULT_ROOT
+    grouped = group_by_number(scan_tree(root))
+    payload = [
+        {
+            "number": number,
+            "occurrences": [{"path": f.path, "line": f.line, "text": f.text} for f in occ],
+        }
+        for number, occ in sorted(grouped.items())
+    ]
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -494,8 +494,9 @@ async def get_open_request_ids(
 
     Reads the trusted ``request_opened`` frame rather than the forgeable
     ``metadata.request`` user-message blob (which #1123 still dual-writes for the
-    legacy run path until #1131 retires it). Both halves are partial-indexed
-    (``events_request_opened_idx`` / ``events_request_response_idx``) so this stays
+    legacy run path until a future contract migration retires it). Both halves
+    are partial-indexed (``events_request_opened_idx`` /
+    ``events_request_response_idx``) so this stays
     a point lookup rather than a per-wake history scan.
     """
     rows: list[asyncpg.Record] = await conn.fetch(

--- a/src/aios/db/queries/trace.py
+++ b/src/aios/db/queries/trace.py
@@ -5,9 +5,9 @@ Two responsibilities, both pure reads:
 * **the reverse "children-of by caller" lookup** — for a node ``(kind, id)``,
   the set of child nodes it invoked. It is the **union of the trusted edge and
   the still-live structural FK columns** (``parent_run_id`` /
-  ``launcher_session_id``), because on master today (#1131 unmerged, dual-write
-  era) neither alone is complete. When #1131 retires the FK columns the FK half
-  simply drops out and the edge covers everything.
+  ``launcher_session_id``), because in the current dual-write/dual-read era
+  neither alone is complete. When a future contract migration retires the FK
+  columns the FK half simply drops out and the edge covers everything.
 * **batched journal reads** — once the node-id set is resolved, the per-node
   event streams are read with ``= ANY($1)`` set-membership (no N+1).
 
@@ -118,7 +118,7 @@ async def children_of(
             ),
         )
 
-    # ── live FK half (until #1131) ───────────────────────────────────────────
+    # ── live FK half (until the FK columns are retired) ──────────────────────
     # These cover pre-#1123/#1129 subtrees and the *detached* session→run launches
     # (the ``create_run`` tool, the trigger ``workflow`` action) that write no
     # caller edge — the awaited ``call_workflow``/``invoke_workflow`` path now does

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -653,11 +653,12 @@ class RunChildrenUsage(NamedTuple):
 async def run_children_usage(
     conn: asyncpg.Connection[Any], run_id: str, *, account_id: str
 ) -> RunChildrenUsage:
-    # TODO(#1131): this point-reads ``sessions.parent_run_id`` directly. When #1131
-    # subsumes ``parent_run_id`` into the ``request_opened`` edge and retires the
-    # column, this filter becomes a join through the ``request_opened`` lifecycle
-    # events (``caller.kind='run' AND caller.id = $1``). #1123 leaves it untouched —
-    # the dual-write keeps ``parent_run_id`` live for the migration owner to flip.
+    # TODO: this point-reads ``sessions.parent_run_id`` directly. The edge now
+    # also carries it (``parent_run_id`` was subsumed into the ``request_opened``
+    # edge in #1131); once a future contract migration retires the column, this
+    # filter becomes a join through the ``request_opened`` lifecycle events
+    # (``caller.kind='run' AND caller.id = $1``). #1123 leaves it untouched — the
+    # dual-write keeps ``parent_run_id`` live for that future contract migration.
     row = await conn.fetchrow(
         """
         SELECT

--- a/src/aios/harness/memory_stores.py
+++ b/src/aios/harness/memory_stores.py
@@ -13,8 +13,9 @@ from aios.errors import MemoryPreconditionFailedError
 from aios.harness._text import join_blocks
 from aios.models.memory_stores import MAX_CONTENT_BYTES, MemoryStoreResourceEcho
 
-# When #332 lands (bash writes durably persisted to the memory version log),
-# drop the bash-bypass clause in the "Handling write failures" section below.
+# Bash writes to /mnt/memory bypass the version log by design (#332, closed as
+# "incomplete by design"), so the bash-bypass clause in the "Handling write
+# failures" section below is intentional and permanent.
 _PLAYBOOK = f"""\
 The store mounts above are network-backed: expect non-trivial per-operation
 latency, a hard {MAX_CONTENT_BYTES // 1024} KiB per-file limit, and occasional transient errors. Use

--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -37,8 +37,8 @@ Security posture:
 Named residuals (operator-facing):
 
 * IP-literal HTTPS destinations have no SNI and are therefore rejected by
-  construction — the proxy serves hostname-addressed egress only. Once #878
-  redirects allowed-host traffic here, a sandbox ``curl https://<ip>`` to an
+  construction — the proxy serves hostname-addressed egress only. Allowed-host
+  traffic is redirected here (#878), so a sandbox ``curl https://<ip>`` to an
   allowed host's IP gets its handshake reset rather than connecting.
 * The request body is buffered whole to swap across chunk boundaries (memory
   bound = request size); responses stay streamed. Very large request uploads
@@ -48,7 +48,7 @@ Named residuals (operator-facing):
 
 Lifecycle mirrors ``git_proxy``: started per session, stopped on release /
 recycle. Wiring into provisioning, the iptables chokepoint, and
-recycle-on-rotation are follow-ups (#877/#878).
+recycle-on-rotation landed in #877/#878.
 """
 
 from __future__ import annotations

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -198,8 +198,8 @@ def _evict_sandbox_for_resource_change(session_id: str) -> None:
     (url, vault_id). In-place vault credential rotation (refresh_credential
     / ciphertext overwrite) does NOT evict: the pool keys on (url, vault_id)
     and a rotation overwrites the row contents, so the stable key already
-    serves the new secret — and a live sandbox keeps its already-
-    materialized env-var set until #877's drift handling lands. Layer 2's
+    serves the new secret — and the live sandbox recycles to re-materialize its
+    env-var set on rotation, via the ``updated_at`` drift key (#877). Layer 2's
     triggers stay off the connection tables — that asymmetry is intentional.
     """
     from aios.harness import runtime

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -31,8 +31,8 @@ credentials DO feed the sandbox spec builder
 (:func:`resolve_session_env_var_credentials` below): vault BINDING
 changes now bump ``spec_version`` (migration 0082) so a live sandbox
 recycles, while credential-LEVEL drift in a still-bound vault (rotation,
-create/archive) stays invisible to a live sandbox until #877's drift
-key.
+create/archive) now recycles the sandbox too, via the ``updated_at`` drift
+key (#877).
 """
 
 from __future__ import annotations

--- a/src/aios/workflows/service.py
+++ b/src/aios/workflows/service.py
@@ -24,7 +24,7 @@ from aios.workflows.determinism import HOST_SEMANTICS_EPOCH
 
 # The single shared trusted invoke-depth budget (#1124): how many trusted
 # hops a chain of invoke-edges (run→run sub-launches, run→session ``agent()``
-# children, and — once #1127/#1128 land their call sites — session→session and
+# children, and — since #1127/#1128 landed their call sites — session→session and
 # api→session) may take before refusal. The DOWN-counter that replaces the
 # run-only ``parent_run_id`` ancestor walk (the deleted ``run_ancestor_depth``
 # CTE): every trusted edge carries ``parent.depth - 1`` and an edgeless root

--- a/tests/unit/test_forward_ref_scanner.py
+++ b/tests/unit/test_forward_ref_scanner.py
@@ -1,0 +1,104 @@
+"""Fixture corpus for the phantom-forward-ref scanner (``aios._drift.forward_refs``).
+
+The scanner finds promissory issue references ("until #N lands") so the
+phantom-ref canary can flag the ones whose issue has since closed. Its whole
+value rests on *precision*: it must flag forward-looking phrases and must NOT
+flag the far more common historical citation of the same number — otherwise the
+canary files a false incident every week.
+
+This is the guard-for-the-guard. The POSITIVE corpus is every promissory shape
+seen in the tree (drawn from the real phantoms #332/#877/#878/#1127/#1128/#1131
+and the open #1335). The NEGATIVE corpus is the citation/structural shapes that
+share a number with a forward-ref but must stay silent — the exact false-positive
+modes the design rejected. Extend a pattern only by first extending a corpus here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aios._drift.forward_refs import scan_text, scan_tree
+
+# ── Positive: promissory phrases the scanner MUST flag ───────────────────────
+# (source line, the issue numbers it must yield)
+_POSITIVE: list[tuple[str, set[int]]] = [
+    # connective whose subject is the ref — the dominant shape
+    ("# When #332 lands (bash writes persisted), drop the bash-bypass clause.", {332}),
+    ("materialized env-var set until #877's drift handling lands. Layer 2 ...", {877}),
+    # the #878 case the literal verb-list missed: a domain verb ("redirects")
+    ("the proxy serves hostname egress only. Once #878 redirects host traffic here", {878}),
+    # two-issue slash form — findall must enumerate BOTH
+    ("children, and — once #1127/#1128 land their call sites — session→session", {1127, 1128}),
+    ("legacy run path until #1131 retires it). Both halves are partial-indexed", {1131}),
+    ("    # ── live FK half (until #1131) ──────────────────────────────────", {1131}),
+    # connective-free idioms
+    ("    # TODO(#1131): this point-reads sessions.parent_run_id directly.", {1131}),
+    ("    No in-tree consumer yet (the read site is deferred to #1335) — a seam.", {1335}),
+    ("    # blocked on #1234 — cannot land the read path until then.", {1234}),
+]
+
+# ── Negative: shapes that share a number with a forward-ref but must stay silent
+_NEGATIVE: list[str] = [
+    # historical citation of a (closed) issue — the dangerous false-positive class
+    "applies the #1132 cap to bound the recovery sweep (see the #1132 discussion).",
+    "the #1131-proof structural invariant holds across the dual-write era.",
+    "blocking the host is #878's job once the proxy owns egress.",  # apposition, no connective
+    "this mirrors the git_proxy precedent. (#878)",  # bare parenthetical
+    "recycle-on-rotation are follow-ups (#877/#878).",  # parenthetical list
+    "deduped once (#725) per the dedupe pass, not per call.",  # temporal adverb + paren
+    "on master today (#1131 unmerged, dual-write era) neither half alone is complete.",
+    "after #205 was removed the 'connectors' queue subscription is dead.",  # wrong connective
+    "When ``connection_ids`` is non-``None`` (#350) the stream filters.",  # ref not the subject
+    "needs CLI; tracked in #1446 (memory-stores group)",  # the NEEDS_CLI_TRACKED citation form
+    "see #1294 for the http_request truncation flag.",  # bare 'see #N'
+    # structural ordinals — never matched: the ref isn't the immediate subject of a
+    # forward connective. `until phase #200` doesn't match even at a high number
+    # (the connective isn't directly before `#N`), so no structural exclusion needed.
+    "invariant #6 (gapless seq per session) — every append locks the row.",
+    "Layer #2's triggers stay off the connection tables.",
+    "until phase #200 lands, the ladder stays linear.",
+    # below the issue-number floor
+    "the placeholder stayed until #42 lands, long ago.",
+]
+
+
+def _numbers(text: str) -> set[int]:
+    return {f.number for f in scan_text("sample.py", text)}
+
+
+def test_positive_corpus_is_flagged() -> None:
+    for text, expected in _POSITIVE:
+        assert _numbers(text) == expected, f"expected {expected} from: {text!r}"
+
+
+def test_negative_corpus_is_silent() -> None:
+    for text in _NEGATIVE:
+        found = scan_text("sample.py", text)
+        assert found == [], f"false positive {[(f.number, f.text) for f in found]} from: {text!r}"
+
+
+def test_one_line_two_patterns_dedupes() -> None:
+    """A line matched by both ``TODO(#N)`` and ``When #N`` yields one finding."""
+    line = "# TODO(#1131): point-read parent_run_id. When #1131 subsumes it, drop this."
+    findings = scan_text("sample.py", line)
+    assert [f.number for f in findings] == [1131], findings
+
+
+def test_finding_carries_path_line_and_text() -> None:
+    findings = scan_text("src/aios/foo.py", "x = 1\nuntil #1234 lands here\n")
+    assert len(findings) == 1
+    f = findings[0]
+    assert (f.path, f.line, f.number) == ("src/aios/foo.py", 2, 1234)
+    assert f.text == "until #1234 lands here"
+
+
+def test_scan_tree_excludes_the_scanner_package(tmp_path: Path) -> None:
+    """``scan_tree`` skips ``_drift/`` so the scanner's own example phrases — and
+    this kind of phrasing in any future drift tooling — never self-flag."""
+    (tmp_path / "_drift").mkdir()
+    (tmp_path / "_drift" / "scanner.py").write_text('# example: "until #999 lands"\n')
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "real.py").write_text("# until #1234 lands, keep the shim\n")
+
+    numbers = {f.number for f in scan_tree(tmp_path)}
+    assert numbers == {1234}, numbers

--- a/tests/unit/test_phantom_ref_canary_workflow.py
+++ b/tests/unit/test_phantom_ref_canary_workflow.py
@@ -1,0 +1,173 @@
+"""Load-bearing-property checks for the phantom-ref canary workflow.
+
+``.github/workflows/phantom-ref-canary.yml`` is a scheduled guard: weekly it runs
+the offline scanner (``src/aios/_drift/forward_refs.py``), checks each referenced
+issue's live GitHub state, and files a drift issue for the closed/missing ones.
+This module pins the canary's load-bearing properties so a careless future edit
+can't silently disable or weaken it — e.g. dropping the schedule, defaulting an
+API error to "open" (and dropping a real phantom), appending instead of replacing
+the issue body, auto-closing it, or flagging PR-typed refs.
+
+Pure-Python: parses the workflow YAML with PyYAML; no DB, no Docker, no network.
+
+PyYAML gotcha: the bare mapping key ``on:`` parses as the boolean ``True`` (the
+"Norway problem"), so the trigger mapping is resolved via ``doc.get(True)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]  # types-PyYAML not in the dep set
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WF = _REPO_ROOT / ".github" / "workflows" / "phantom-ref-canary.yml"
+
+_ISSUE_TITLE = "Phantom issue references detected on master"
+_SCANNER_PATH = "src/aios/_drift/forward_refs.py"
+
+
+def _doc() -> dict[Any, Any]:
+    # Keys are `str`, except `on:` which PyYAML parses as the bool `True` (the
+    # Norway problem) — hence an `Any`-keyed mapping rather than `dict[str, ...]`.
+    doc: dict[Any, Any] = yaml.safe_load(_WF.read_text())
+    return doc
+
+
+def _triggers(doc: dict[Any, Any]) -> dict[str, Any]:
+    triggers = doc.get("on", doc.get(True))
+    assert isinstance(triggers, dict), f"{_WF} has no `on:` trigger mapping; resolved {triggers!r}."
+    return triggers
+
+
+def _canary_run(doc: dict[Any, Any]) -> str:
+    """The single ``run:`` step body (the scan + check + file-drift-issue logic)."""
+    runs = [s["run"] for s in doc["jobs"]["canary"]["steps"] if "run" in s]
+    assert len(runs) == 1, f"expected exactly one run step in the canary job, found {len(runs)}"
+    run = runs[0]
+    assert isinstance(run, str)
+    return run
+
+
+def test_workflow_parses_to_nonempty_dict() -> None:
+    assert _WF.exists(), (
+        f"{_WF} is missing; the phantom-ref canary must exist so stale forward "
+        f"references are caught on a schedule."
+    )
+    doc = _doc()
+    assert isinstance(doc, dict) and doc, f"{_WF} did not parse to a non-empty dict."
+
+
+def test_runs_weekly_on_an_off_minute_cron() -> None:
+    """A scheduled cron drives it, at an off-minute (not :00/:30).
+
+    The state of a referenced issue changes outside any PR, so the verdict must be
+    re-evaluated on a clock. Off-minute avoids the top-of-hour scheduler stampede.
+    """
+    schedule = _triggers(_doc())["schedule"]
+    crons = [entry["cron"] for entry in schedule]
+    assert crons, f"{_WF} on.schedule must define at least one cron; found {schedule!r}."
+    for cron in crons:
+        minute = cron.split()[0]
+        assert minute not in {"0", "30"}, (
+            f"{_WF} cron {cron!r} fires on a stampede minute; pick an off-minute (not :00/:30)."
+        )
+
+
+def test_supports_manual_dispatch() -> None:
+    """``workflow_dispatch`` so the canary can be run on demand (and dry-run once merged)."""
+    assert "workflow_dispatch" in _triggers(_doc()), (
+        f"{_WF} must allow workflow_dispatch for manual/dry-run invocation."
+    )
+
+
+def test_permissions_are_minimal_and_sufficient() -> None:
+    perms = _doc()["permissions"]
+    assert perms["issues"] == "write", (
+        f"{_WF} permissions.issues must be 'write' so it can file the drift issue; "
+        f"found {perms.get('issues')!r}."
+    )
+    assert perms["contents"] == "read", (
+        f"{_WF} permissions.contents must be 'read'; found {perms.get('contents')!r}."
+    )
+
+
+def test_concurrency_does_not_cancel_in_progress() -> None:
+    """``cancel-in-progress`` must stay false so a later run can't abort one
+    mid-issue-write. PyYAML parses the unquoted ``false`` as Python ``False``."""
+    assert _doc()["concurrency"]["cancel-in-progress"] is False, (
+        "cancel-in-progress must stay false so a scheduled run can't cancel an "
+        "in-flight canary mid drift-issue write."
+    )
+
+
+def test_runs_the_offline_scanner() -> None:
+    """The canary's verdict is driven by the committed offline scanner, not an
+    ad-hoc inline grep that could drift from the fixture-tested patterns."""
+    assert _SCANNER_PATH in _canary_run(_doc()), (
+        f"{_WF} must invoke the offline scanner {_SCANNER_PATH!r} so its verdict tracks "
+        f"the fixture-tested patterns."
+    )
+
+
+def test_hard_fails_on_non_404_api_error() -> None:
+    """A non-404 API error must abort the run, never default the issue state.
+
+    Defaulting a rate-limit/5xx to "open" would silently drop a real phantom; the
+    only error that maps to a verdict is a clean 404 ('missing'). Pin both: an
+    explicit hard-fail path AND a 404→missing branch.
+    """
+    run = _canary_run(_doc())
+    assert "gh api" in run, f"{_WF} must query issue state via `gh api`."
+    assert "not a 404" in run and "exit 1" in run, (
+        f"{_WF} must hard-fail (exit 1) on an API error that is not a 404, rather than "
+        f"defaulting the issue state."
+    )
+    assert "missing" in run, f"{_WF} must map a clean 404 to a 'missing' verdict."
+
+
+def test_skips_pull_request_refs() -> None:
+    """A forward ref to a PR (a merged PR is the expected end state) must be skipped,
+    not flagged — pinned via the ``is_pr`` filter on the issues API ``pull_request``."""
+    run = _canary_run(_doc())
+    assert "pull_request" in run and "is_pr" in run, (
+        f"{_WF} must distinguish PR-typed refs (via the issues API `pull_request` field) "
+        f"and skip them."
+    )
+
+
+def test_drift_issue_body_is_replaced_not_appended() -> None:
+    """The issue body is REPLACED each run (``gh issue edit --body``), never appended
+    (``gh issue comment``), so a deferred phantom doesn't pile a weekly comment."""
+    run = _canary_run(_doc())
+    assert "gh issue edit" in run and "--body" in run, (
+        f"{_WF} must update the existing drift issue with `gh issue edit --body` (replace)."
+    )
+    assert "gh issue comment" not in run, (
+        f"{_WF} must NOT append via `gh issue comment` — the body is a replacement so a "
+        f"standing phantom doesn't accrete weekly comments."
+    )
+
+
+def test_drift_issue_is_not_auto_closed() -> None:
+    """No auto-close: a clean run is silent, but a previously-filed issue is left for a
+    human to close (auto-close-on-clean flaps when a referenced issue is reopened)."""
+    assert "gh issue close" not in _canary_run(_doc()), (
+        f"{_WF} must never auto-close the drift issue; a clean run exits silently and "
+        f"leaves any standing issue for a human."
+    )
+
+
+def test_drift_issue_title_and_dedicated_label() -> None:
+    """The stable title is present, and the issue is filed under the dedicated
+    non-incident ``drift`` label (a phantom ref is hygiene, not a production outage),
+    created idempotently before use."""
+    run = _canary_run(_doc())
+    assert _ISSUE_TITLE in run, (
+        f"{_WF} must reference the stable title {_ISSUE_TITLE!r} so reruns de-duplicate."
+    )
+    assert "gh label create drift" in run, f"{_WF} must create the `drift` label idempotently."
+    assert "gh issue create" in run and "--label drift" in run, (
+        f"{_WF} must file the issue under the dedicated `drift` label, not the incident queue."
+    )


### PR DESCRIPTION
## What

Second of the **#1433 CI drift-guards** (Guard B). A comment like `until eumemic/aios#877 lands` or `TODO(#1131)` promises future work gated on another issue. When that issue later closes/merges — often in a **different** PR than the one that wrote the comment — no PR-time check ever sees the now-stale reference. This adds a scheduled canary that catches them, and fixes the 6 that exist today.

## The scanner — `src/aios/_drift/forward_refs.py`

Offline, stdlib-only. Precision is the whole game: it keys on the **phrase, never the bare number**, so a *closed* issue cited **historically** is never flagged. The discriminator is that a forward reference makes the issue the grammatical **subject** of a forward connective (`until`/`once`/`when` immediately followed by `#N`), or uses one of three connective-free idioms (`TODO(#N)`, `deferred to #N`, `blocked on #N`).

This was derived **empirically** from the tree, not from eumemic/aios#1433's stated list — which mattered: eumemic/aios#1131 is *simultaneously* a forward-phantom (`until eumemic/aios#1131 retires it`, 4 lines) and a legitimate `#1131-proof` citation (~13 lines) in the same files; eumemic/aios#878 is one forward-ref (`Once eumemic/aios#878 redirects…`) amid 7 citations. Number-keying would flag all of them. The empirical pass also caught that eumemic/aios#878's verb (`redirects`) isn't in the plan's literal `lands|retires|merges|ships` set — the connective-**subject** rule catches it where a verb-list wouldn't.

Fixture-locked with **positive + negative corpora** (`tests/unit/test_forward_ref_scanner.py`) — the negative corpus *is* the set of false-positive modes the design rejects (`the eumemic/aios#1132 cap`, `(#878)`, `once (#725)`, `invariant eumemic/aios#6`, `tracked in eumemic/aios#1446`, …).

## The canary — `.github/workflows/phantom-ref-canary.yml`

Weekly (off-minute cron) + `workflow_dispatch`. Runs the scanner, checks each referenced issue's live GitHub state, files a drift issue for the **closed or missing** ones. Hardening (each shape-pinned by `tests/unit/test_phantom_ref_canary_workflow.py`):

- **Hard-fails on any non-404 API error** — a rate-limit/5xx must never be misread as "still open" (which would silently drop a real phantom). Only a clean 404 maps to a `missing` verdict.
- **Skips PR-typed refs** (a merged PR is the expected end state).
- **Dedicated `drift` label**, not the `incident` queue — a stale comment is hygiene, not an outage.
- **Body replacement, not append** — a deliberately-deferred phantom doesn't pile a weekly comment.
- **Never auto-closes** — a clean run is silent; a standing issue is left for a human.

Why a scheduled canary and not a unit test: issue state needs the GitHub API (the unit suite is strictly offline), and `until eumemic/aios#877 lands` rots when eumemic/aios#877 merges in some *other* PR — invisible to any PR-time check.

## Fix-forward (so master is clean on the first run)

All 6 phantoms live today are **closed-as-completed**; each is rewritten to truthful present-tense prose, verified against the current code:

| # | resolution | rewrite |
|---|---|---|
| eumemic/aios#332 | "incomplete by design" | bash-bypass clause is intentional & permanent |
| eumemic/aios#877 | recycle-on-rotation landed | cites the `updated_at` drift key |
| eumemic/aios#878 | egress-redirect landed | "traffic is redirected here (#878)" |
| eumemic/aios#1127/#1128 | caller surfaces landed | "since eumemic/aios#1127/#1128 landed" |
| eumemic/aios#1131 ×4 | expand landed; column-drop **untracked** | numberless "future contract migration" |

After fix-forward the scanner reports **only the still-open eumemic/aios#1335**, so the canary is silent on first run (dry-run verified: clean case → 0 violations; synthetic closed/missing/PR mix → flags only closed+missing non-PR).

## Verification

- Scanner fixture tests (positive + negative corpora) + shape-pin tests green; full gate green (ruff + mypy + 3519 unit + 577 connector).
- Scanner over current `src/` returns exactly `{1335}` (open).
- Adversarially reviewed (regex FP/FN, shell hard-fail paths, fix-forward internal consistency) — no defects.

Guard A is eumemic/aios#1451. Guard C (built-but-uncalled query writers) was dropped from eumemic/aios#1433 — see the re-scope comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)