### PR TITLE
fix(tools): fail-loud — web_fetch truncated flag (#24) + http_request preserves duplicate headers (#34)

### DIFF
--- a/src/aios/services/outbound_suppression.py
+++ b/src/aios/services/outbound_suppression.py
@@ -59,12 +59,14 @@ def http_synthesized_response(status: int) -> dict[str, Any]:
     """The synthesized success an HTTP write observes under suppression.
 
     Mirrors the real ``http_request`` return shape (``status``/``headers``/
-    ``body``) so the agent can't tell it apart from a real success. The body is
+    ``body``) so the agent can't tell it apart from a real success — including
+    ``headers`` being a list of ``[name, value]`` pairs (empty here), not a dict,
+    so a suppressed write can't be fingerprinted by the headers' type. The body is
     empty (``""``) — enough for v1; a per-route synthetic-response template is
     explicitly deferred until a real test hits the limitation (e.g. a write that
     returns the created entity's id).
     """
-    return {"status": status, "headers": {}, "body": ""}
+    return {"status": status, "headers": [], "body": ""}
 
 
 def mcp_synthesized_result() -> dict[str, Any]:

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -6,7 +6,11 @@ matches the path against the ``HttpServerSpec``'s route allowlist and
 authors the ``Authorization`` header from the session's vault. Secret
 never enters the sandbox.
 
-Return shape: ``{"status": int, "headers": {...}, "body": "..."}``.
+Return shape: ``{"status": int, "headers": [[name, value], ...], "body": "..."}``.
+``headers`` is a list of ``[name, value]`` pairs, not a dict: a dict collapses
+duplicate header names, and HTTP *requires* some (notably ``Set-Cookie``) be
+multi-valued — so a response setting two cookies would silently lose one. The
+pair-list preserves every occurrence in wire order.
 On error: ``{"error": "..."}``.
 """
 
@@ -391,7 +395,10 @@ async def _do_http_request(
     body_text, truncated = _decode_body(response)
     result: dict[str, Any] = {
         "status": response.status_code,
-        "headers": dict(response.headers),
+        # A list of ``[name, value]`` pairs, NOT a dict: ``dict(headers)`` collapses
+        # duplicate names, silently dropping all but the last ``Set-Cookie`` (HTTP
+        # requires it be multi-valued). ``multi_items()`` preserves every occurrence.
+        "headers": [[k, v] for k, v in response.headers.multi_items()],
         "body": body_text,
     }
     # Signal a cut body explicitly (aios#1294). The flag is present ONLY when the

--- a/src/aios/tools/web_fetch.py
+++ b/src/aios/tools/web_fetch.py
@@ -7,6 +7,9 @@ Return shape: {"url": "...", "title": "...", "content": "markdown..."}
 The ``title`` is derived from the markdown's first heading: Tavily's /extract
 response carries only ``url`` + ``raw_content`` (no title field — that belongs
 to /search), so reading a ``title`` key returned ``""`` on every real call.
+When the content is cut at the char cap the result also carries ``"truncated":
+True`` (present only when truncated, mirroring ``http_request``) so the model
+never mistakes a cut page for a complete one.
 On error: {"error": "..."}
 """
 
@@ -46,7 +49,9 @@ def _title_from_markdown(content: str) -> str:
 WEB_FETCH_DESCRIPTION = (
     "Fetch a URL and return its content as markdown. Uses Tavily's "
     "extract endpoint for HTML-to-markdown conversion. Content is "
-    "truncated to 100k characters. Private/internal URLs are blocked."
+    "truncated to 100k characters; when content is cut the result carries "
+    '"truncated": true so you never mistake a truncated page for a complete '
+    "one. Private/internal URLs are blocked."
 )
 
 WEB_FETCH_PARAMETERS_SCHEMA: dict[str, Any] = {
@@ -74,8 +79,19 @@ async def web_fetch_handler(session_id: str, arguments: dict[str, Any]) -> dict[
         # /extract returns only ``raw_content`` (markdown); there is no ``title``
         # or ``content`` field to read (those are /search fields), so derive the
         # title from the markdown's first heading.
-        content = (result.get("raw_content") or "")[:_MAX_CONTENT_CHARS]
-        return {"url": url, "title": _title_from_markdown(content), "content": content}
+        raw = result.get("raw_content") or ""
+        content = raw[:_MAX_CONTENT_CHARS]
+        out: dict[str, Any] = {
+            "url": url,
+            "title": _title_from_markdown(content),
+            "content": content,
+        }
+        # Signal a cut page explicitly, opt-in like ``http_request`` (aios#1294):
+        # the flag is present ONLY when truncated, so the model can branch on its
+        # mere presence. ``>`` strictly — exactly-100k is complete, not cut.
+        if len(raw) > _MAX_CONTENT_CHARS:
+            out["truncated"] = True
+        return out
     except WebToolError:
         raise
     except httpx.HTTPStatusError as exc:

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -543,6 +543,42 @@ class TestHttpRequestHandler:
         # A complete body never carries the truncated flag.
         assert "truncated" not in result
 
+    async def test_duplicate_response_headers_preserved(self, _stub_runtime: Any) -> None:
+        """``headers`` is a list of ``[name, value]`` pairs so every occurrence
+        survives in wire order — the contract the module docstring promises. A dict
+        would collapse duplicate names, silently dropping all but the last; HTTP
+        *requires* some be multi-valued (the canonical ``Set-Cookie``, but also
+        ``Link`` etc.). We interleave distinct names with TWO duplicate names — one
+        cookie, one non-cookie — so the assertion pins both cross-name order and the
+        pair-list's generality (a fix that special-cased only ``Set-Cookie`` and
+        ``dict()``'d the rest would fail here)."""
+        sent = [
+            ["x-first", "1"],
+            ["set-cookie", "a=1"],
+            ["link", "</p1>; rel=next"],
+            ["set-cookie", "b=2"],
+            ["link", "</p2>; rel=prev"],
+            ["x-last", "9"],
+        ]
+        response = httpx.Response(200, headers=[(k, v) for k, v in sent], content=b"ok")
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        stub = _make_stub_client(response=response)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),
+            _patch_safe_url(),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        # Filter to just the names we set (httpx auto-injects content-length); the
+        # surviving sublist must equal our input verbatim — same order, both dups.
+        names = {k for k, _ in sent}
+        preserved = [[k.lower(), v] for k, v in result["headers"] if k.lower() in names]
+        assert preserved == sent
+
     async def test_over_cap_body_sets_truncated_flag(
         self, _stub_runtime: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -893,7 +929,7 @@ class TestOutboundSuppressionHttp:
                 },
             )
         # Synthesized success — looks like a real response, no upstream dispatch.
-        assert result == {"status": 200, "headers": {}, "body": ""}
+        assert result == {"status": 200, "headers": [], "body": ""}
         assert "url" not in captured
         # Audit event recorded with the un-suppressed intent.
         record.assert_awaited_once()
@@ -951,7 +987,7 @@ class TestOutboundSuppressionHttp:
                 "sess_x",
                 {"server_ref": "hue", "path": "/trigger/1", "method": "GET"},
             )
-        assert result == {"status": 200, "headers": {}, "body": ""}
+        assert result == {"status": 200, "headers": [], "body": ""}
         assert "url" not in captured
         record.assert_awaited_once()
 

--- a/tests/unit/test_web_fetch_handler.py
+++ b/tests/unit/test_web_fetch_handler.py
@@ -96,6 +96,21 @@ class TestWebFetchHandler:
         }
         result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
         assert len(result["content"]) == 100_000
+        # A cut page is flagged so the model never mistakes it for a complete one.
+        assert result["truncated"] is True
+
+    async def test_complete_content_has_no_truncated_flag(
+        self, mock_tavily: AsyncMock, mock_safe_url: Any
+    ) -> None:
+        """The flag is opt-in: present ONLY when cut. Exactly-at-cap content is
+        complete (``>`` is strict), so no ``truncated`` key appears."""
+        exact = "y" * 100_000
+        mock_tavily.return_value = {
+            "results": [{"url": "https://example.com", "raw_content": exact}]
+        }
+        result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
+        assert len(result["content"]) == 100_000
+        assert "truncated" not in result
 
     async def test_empty_raw_content_yields_empty_content(
         self, mock_tavily: AsyncMock, mock_safe_url: Any


### PR DESCRIPTION
## What

Two model-facing tool handlers silently degraded their output — each a direct violation of the codebase's bedrock rule, *fail hard, no silent degradation*. Both are Tier-1 items from the [#1433 re-triage](https://github.com/eumemic/aios/issues/1433), and each has an existing correct pattern to mirror.

### #24 — `web_fetch` truncated flag
`web_fetch` truncated fetched markdown at 100k chars and returned **no signal**, so the model couldn't tell a complete page from a cut one. The sibling tool `http_request` already solved exactly this in #1294 (a 100 KB cut mid-JSON broke a triage scan) with an opt-in `"truncated": true` flag — that fix was never propagated.

- The flag is present **only** when `len(raw) > _MAX_CONTENT_CHARS` (strict `>` — exactly-at-cap is complete, matching `_decode_body`'s `len(text) > cap`).
- No shared helper: `http_request._decode_body` also handles content-type / binary refusal that a pure markdown char-slice doesn't need — a shared helper would be a premature abstraction over two genuinely different truncation logics.

### #34 — `http_request` preserves duplicate response headers
`http_request` built its result headers with `dict(response.headers)`, which **collapses duplicate header names**. HTTP *requires* some (notably `Set-Cookie`) be multi-valued: a response setting two cookies silently lost one.

- A dict cannot represent a multimap, so the faithful shape is a **list of `[name, value]` pairs** via `response.headers.multi_items()`, preserving every occurrence in wire order.
- `headers` result shape changes `{...}` → `[[name, value], ...]` (empty case `{}` → `[]`).
- `http_synthesized_response` (the outbound-suppression mirror) follows `{}` → `[]` so a suppressed write still can't be fingerprinted by the headers' *type*.

## Why it's safe

- **No production consumer of `result["headers"]`.** Verified across all three downstream paths (session `tool_dispatch`, sandbox `tool_broker`, workflow-run `run_tools`) — each treats the result as an opaque JSON blob (`json.dumps` to the model / verbatim pass-through as `run.output`). Only tests asserted the shape.
- **Tool handlers, not FastAPI routes.** The result dicts reach the model via the tool registry, not OpenAPI introspection — so **no `openapi.json` / SDK regen** (confirmed: `regen-openapi.sh` produces no diff).

## Tests

- `test_web_fetch_handler.py`: extended `test_content_truncation` to assert `truncated is True`; added `test_complete_content_has_no_truncated_flag` (exactly-100k ⇒ no flag, pinning the strict boundary).
- `test_http_request.py`: added `test_duplicate_response_headers_preserved` — interleaves distinct names with **two** duplicate names (one cookie, one non-cookie `Link`) and asserts the full preserved sublist equals the wire-order input, pinning both cross-name order *and* the pair-list's generality (a Set-Cookie-only special-case would fail it). Two suppression-path assertions `{}` → `[]`.

## Process

Plan → adversarial review workflow (16 agents, refute-by-default: confirmed no broken consumer, no missed mirror site, migration complete; folded its two test-adequacy findings into the strengthened duplicate-headers test) → `/simplify` (clean; two suggestions skipped as false positives — one diverged the documented list shape, one would break mypy) → full pre-commit gate green.

Closes the two #1433 Tier-1 fail-loud items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)