### PR TITLE
fix(tools): offload blocking SSRF DNS check off the event loop (#33)

### DIFF
--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -16,6 +16,7 @@ On error: ``{"error": "..."}``.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -365,7 +366,9 @@ async def _do_http_request(
             return synthesized
 
     full_url = server.base_url.rstrip("/") + "/" + path.lstrip("/")
-    if not is_safe_url(full_url):
+    # is_safe_url does a blocking getaddrinfo; offload it so the SSRF pre-flight
+    # never stalls the event loop (matches services/vault_oauth._guard_url).
+    if not await asyncio.to_thread(is_safe_url, full_url):
         return {"error": f"Blocked: URL targets a private/internal address: {full_url}"}
 
     _vault_id, auth_headers = await resolve_auth(server.base_url)

--- a/src/aios/tools/web_fetch.py
+++ b/src/aios/tools/web_fetch.py
@@ -15,6 +15,7 @@ On error: {"error": "..."}
 
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import Any
 
@@ -70,7 +71,9 @@ async def web_fetch_handler(session_id: str, arguments: dict[str, Any]) -> dict[
     if not isinstance(url, str) or not url.strip():
         raise WebFetchArgumentError("web_fetch tool requires a non-empty 'url' string")
 
-    if not is_safe_url(url):
+    # is_safe_url does a blocking getaddrinfo; offload it so the SSRF pre-flight
+    # never stalls the event loop (matches services/vault_oauth._guard_url).
+    if not await asyncio.to_thread(is_safe_url, url):
         return {"error": "Blocked: URL targets a private/internal address"}
 
     try:

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -353,6 +353,26 @@ class TestHttpRequestHandler:
         assert "error" in result
         assert "does not match any enabled route" in result["error"]
 
+    async def test_ssrf_blocked_url_returns_error(self, _stub_runtime: Any) -> None:
+        """The SSRF pre-flight blocks a private/internal target after the route
+        matches but before any upstream dispatch — coverage parity with
+        web_fetch's guard test (the offload to a worker thread doesn't change
+        this functional contract)."""
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        with (
+            _patch_load_agent(agent),
+            _patch_safe_url(False),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        assert "private/internal" in result["error"]
+        assert "url" not in captured  # blocked before any upstream dispatch
+
     async def test_method_not_allowed_returns_error(self, _stub_runtime: Any) -> None:
         # A route scoped to GET refuses a POST at the gate (no upstream dispatch).
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*", methods=["GET"])])])


### PR DESCRIPTION
## What

`is_safe_url()` (`src/aios/tools/url_safety.py`) is the SSRF pre-flight: it resolves the target hostname via a **blocking `socket.getaddrinfo()`** and rejects private/internal/CGNAT/cloud-metadata addresses. Two async tool handlers called it **inline, un-awaited**, so the DNS resolve ran *on the asyncio event loop* — stalling every other coroutine the worker was servicing (other sessions' inference, tool results, streaming) for the duration of the lookup, which can be seconds on a slow or unreachable resolver.

- `src/aios/tools/web_fetch.py` — `web_fetch_handler`
- `src/aios/tools/http_request.py` — `_do_http_request`

## Fix

Wrap both call sites in `await asyncio.to_thread(is_safe_url, ...)`, **exactly mirroring the existing precedent for this same function** at `services/vault_oauth._guard_url` (whose docstring already notes *"`is_safe_url` is blocking (`getaddrinfo`), so it runs in a worker thread"*). `asyncio.to_thread` is the codebase's dominant blocking-offload idiom (~6 sites; `anyio` is not a dependency). The two handlers simply never adopted the wrapper.

- `is_safe_url` stays **sync** — its contract is unchanged, and the secret-egress proxy still uses its non-DNS helpers (`is_blocked_hostname`/`is_blocked_ip`) directly. (Rejected making it `async`: that would force `vault_oauth` to drop its now-redundant wrap and introduce an async-resolver pattern used nowhere else — more churn, no benefit.)
- Because `_do_http_request` is the **shared core** (called by both `http_request_handler` and the workflow-run dispatcher `run_tools.py`), the single change fixes the blocking on **both** the session and workflow-run paths.

## Tests

Existing SSRF tests pass **unchanged**: they patch `is_safe_url` to a mock, and `await asyncio.to_thread(mock, url)` invokes it and returns its value — so the blocked/allowed assertions still hold and aren't vacuous.

While here, added `test_ssrf_blocked_url_returns_error` to `TestHttpRequestHandler`. The adversarial review's **mutation test** showed `_do_http_request`'s `"Blocked: private/internal"` branch had **zero coverage** — `web_fetch` already had the equivalent guard test, and the `_patch_safe_url(False)` affordance existed but was never exercised. Brings the two sibling handlers to coverage parity on the security-relevant reject path.

No `openapi.json` / SDK regen (tool handlers, not FastAPI routes — confirmed no drift).

## Process

Plan → 11-agent adversarial review (refute-by-default: correctness/completeness/altitude lenses clean — no other un-wrapped call sites, no other blocking calls in the handlers, call-site wrap is the right altitude; folded its one confirmed finding, the pre-existing http_request SSRF-block coverage gap, into this PR) → full pre-commit gate green.

#1433 Tier-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)