### PR TITLE
fix(tools): disambiguate the cancel vs stop_task model surface (#1458)

### DIFF
--- a/src/aios/tools/cancel.py
+++ b/src/aios/tools/cancel.py
@@ -32,11 +32,14 @@ CANCEL_DESCRIPTION = (
     "`tool_call_id` is provided, detaches from that specific tool call; "
     "if omitted, detaches from all currently running tool calls. The "
     "tool call reports a cancelled error result so you can move on. "
-    "Note: this stops you waiting on the call, but an already-running "
-    "bash command keeps executing inside the sandbox until it finishes "
-    "or hits its own timeout — it is not killed. Avoid re-running a "
-    "non-idempotent command (build, migration, network write) on the "
-    "assumption that cancel stopped it."
+    "Note: this stops you waiting on the call, but the underlying work is "
+    "NOT stopped. An already-running bash command keeps executing inside "
+    "the sandbox until it finishes or hits its own timeout — it is not "
+    "killed. For an in-flight call_session / call_agent / call_workflow, "
+    "this only detaches your await — the child keeps running (and spending "
+    "budget); use stop_task to durably stop the child itself. Avoid "
+    "re-running a non-idempotent command (build, migration, network write) "
+    "on the assumption that cancel stopped it."
 )
 
 CANCEL_PARAMETERS_SCHEMA: dict[str, Any] = {

--- a/src/aios/tools/tasks.py
+++ b/src/aios/tools/tasks.py
@@ -137,10 +137,12 @@ async def list_tasks_handler(session_id: str, arguments: dict[str, Any]) -> dict
 STOP_TASK_DESCRIPTION = (
     "Stop (cancel) one of your in-flight tasks — a call_session / call_agent / call_workflow "
     "you launched and are still awaiting — by its tool_call_id (the id of that pending tool "
-    "call, as listed by list_tasks). The task and everything it is itself awaiting are "
-    "cancelled, and the original call then resolves as cancelled. Use this to abandon a call "
-    "you no longer need or one that is stuck. Reports 'already resolved' if the task finished "
-    "before the stop landed, or an error if no open task matches that tool_call_id."
+    "call, as listed by list_tasks). This DURABLY stops the child itself: the task and "
+    "everything it is itself awaiting are cancelled, and the original call then resolves as "
+    "cancelled. (Contrast `cancel`, which only stops YOUR waiting and leaves the child "
+    "running.) Use this to abandon a call you no longer need or one that is stuck. Reports "
+    "'already resolved' if the task finished before the stop landed, or an error if no open "
+    "task matches that tool_call_id."
 )
 LIST_TASKS_DESCRIPTION = (
     "List your open tasks — the call_session / call_agent / call_workflow calls you have "


### PR DESCRIPTION
## What

Ships **option 1** of #1458 — the shovel-ready, no-decision-needed slice: make the `cancel` vs `stop_task` distinction visible to the model.

`cancel` (detach my local await; child keeps running) and `stop_task` (durably cancel the child) are two **deliberately distinct** verbs, but the difference lived only in a source docstring the model never sees. A model wanting to stop a runaway `call_agent` could reach for `cancel` (the more inviting word), see `"cancelled"`, and wrongly believe the child stopped — while it keeps spending budget.

Both descriptions now cross-reference:
- **`cancel`** — for an in-flight `call_session`/`call_agent`/`call_workflow`, it only detaches your await; the child keeps running (and spending budget). Use `stop_task` to durably stop the child itself.
- **`stop_task`** — DURABLY stops the child, contrasting `cancel` which only stops your waiting and leaves the child running.

## Notes

- The test-pinned `"keeps executing inside the sandbox"` phrase (`test_docker_exec_timeout_argv.py`) is preserved.
- Tool descriptions reach the model via the tool registry (`to_openai_tools`), not FastAPI introspection — **no `openapi.json` / SDK regen** (confirmed: no drift).
- This does **not** touch `cancel`'s deliberate role (local detach — the only verb that can also detach a non-park in-flight built-in like a slow async `bash`). The two follow-ups left open in #1458 — the rename `cancel`→`stop_waiting`/`detach` (needs a ToolSpec migration) and the post-restart restart-coherence fix — are the `needs-decision` parts.

Refs #1458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)