### PR TITLE
fix(harness): resolve a cancel on the tool start-span append in-task (#1433)

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -548,14 +548,17 @@ async def find_and_repair_ghosts(
         # connector send) on the model's retry — see #685.
         #
         # The "may have completed" branch is conservatively over-pessimistic:
-        # it also fires for crashes/cancels in the window between the span
-        # commit and the actual side-effectful invoke (MCP auth resolve,
-        # parameter validation, ``asyncio.CancelledError`` arriving inside
-        # the span ``await``).  Those produce false "verify the outcome"
-        # advice but never the dangerous false "safe to retry" that this
-        # design eliminates.  Tighter classification would require a second
-        # marker written immediately before each tool's side-effectful call
-        # — deferred until the over-pessimism is shown to matter.
+        # it also fires for a crash in the window between the span commit and
+        # the actual side-effectful invoke (an MCP auth resolve / parameter
+        # validation dying mid-flight, or worker death). A cancel landing on the
+        # span ``await`` is normally NOT among these — ``_tool_lifecycle`` resolves
+        # it eagerly as ``cancelled`` (the body provably never ran). It only reaches
+        # this branch if a *second* cancel interrupts that eager cleanup, where this
+        # is the backstop. The remaining crash cases produce false "verify the
+        # outcome" advice but never the dangerous false "safe to retry" that this
+        # design eliminates. Tighter classification would need a second marker
+        # before each tool's side-effectful call — deferred until the residual
+        # over-pessimism is shown to matter.
         if (c.session_id, c.tool_call_id) in started:
             repair_items.append(
                 (

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -13,8 +13,13 @@ per tool call. Each task:
 The contract: **every task MUST append exactly one tool-role event and
 trigger the sweep before returning.** This is enforced by the
 :func:`_tool_lifecycle` async context manager, which both dispatch
-paths drive. Only a worker SIGKILL can break it — and the periodic
-sweep recovers from that.
+paths drive — including a cancel that lands on the start-span append
+(the model's ``cancel`` tool, the interrupt listener, and a graceful
+drain all deliver one). Three things can still leave a task without an
+*in-task* result: worker death (SIGKILL/OOM), a DB failure writing the
+start span, or a *second* cancel interrupting the first cancel's cleanup
+awaits (the same exposure the in-body cancel handler has). The
+ghost-repair sweep recovers all three (≤30s).
 
 Tool tasks run on the worker's event loop and outlive the procrastinate
 job handler that spawned them. They're tracked in the per-worker
@@ -138,28 +143,41 @@ async def _tool_lifecycle(
     # first action in this lifecycle — only pure-Python preamble (arg
     # extraction, no I/O) is permitted above.
     #
-    # The span is intentionally OUTSIDE the try/except below: an
-    # ``asyncio.CancelledError`` arriving mid-await leaves the span possibly
-    # committed and the body never entered, surfacing as "may have completed"
-    # — an over-pessimistic outcome that the recovery message acknowledges
-    # (see the branch comment in ``sweep.find_and_repair_ghosts``).  This is
-    # the conservatively-safe direction; the alternative (suppress the span
-    # on cancellation) would risk under-pessimism on real side effects.
-    span_start = (
-        await sessions_service.append_event(
-            pool,
-            session_id,
-            "span",
-            {
-                "event": "tool_execute_start",
-                "tool_call_id": call_id,
-                "tool_name": name,
-            },
-            account_id=account_id,
+    # The span append has its OWN try/except below: a ``CancelledError`` landing on this
+    # await (the model's ``cancel`` tool, the interrupt listener, or a graceful worker
+    # drain) strikes inside ``__aenter__`` — before the main try/finally — so without
+    # handling it the task would escape with no result and no tail sweep, leaving the call
+    # unresolved until the next sweep (≤30s) and then ghost-classified as the pessimistic
+    # "may have completed". But the body provably never ran (the cancel struck while writing
+    # the start marker), so we resolve it in-task as a clean ``cancelled`` and re-raise. (A
+    # *second* cancel can still interrupt the cleanup awaits below — same exposure as the
+    # in-body cancel handler; the ghost sweep is the backstop for that, for worker death, and
+    # for a DB failure writing this span.)
+    try:
+        span_start = (
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "span",
+                {
+                    "event": "tool_execute_start",
+                    "tool_call_id": call_id,
+                    "tool_name": name,
+                },
+                account_id=account_id,
+            )
+            if write_start_span
+            else None
         )
-        if write_start_span
-        else None
-    )
+    except asyncio.CancelledError:
+        log.bind(session_id=session_id, tool_call_id=call_id, tool_name=name).info(
+            f"{log_prefix}.cancelled_before_start"
+        )
+        await _append_tool_result(
+            pool, session_id, call_id, name, account_id=account_id, error="cancelled"
+        )
+        await _trigger_sweep(pool, session_id, account_id=account_id)
+        raise
     bound_log = log.bind(session_id=session_id, tool_call_id=call_id, tool_name=name)
     tc = _ToolCall(call_id=call_id, name=name, raw_args=raw_args, bound_log=bound_log)
     try:

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -9,6 +9,7 @@ or a genuine failure (also evicts the sandbox).
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -182,6 +183,59 @@ class TestToolLifecycleEviction:
         evicted, append_result = await self._drive(monkeypatch, ValueError("oops"))
         assert evicted == ["ses_1"]
         assert append_result.await_args.kwargs["error"] == "ValueError: oops"
+
+
+class TestCancelDuringStartSpan:
+    """A (single) cancel landing on the ``tool_execute_start`` append — which happens inside
+    ``__aenter__``, before the main try/finally (the model's ``cancel`` tool, the interrupt
+    listener, and a graceful drain all deliver one) — must still resolve the call in-task:
+    a clean ``cancelled`` result + a tail sweep, with the body never running. Without the
+    targeted handler the task would escape with no result and no sweep, stranding the call
+    until the ≤30s ghost sweep and then misclassifying it as 'may have completed'. (A *second*
+    cancel interrupting the cleanup awaits falls back to that ghost sweep — same exposure as
+    the in-body cancel handler — so it is the documented backstop, not pinned here.)"""
+
+    async def test_cancel_during_start_span_appends_cancelled_and_sweeps(
+        self, monkeypatch: Any
+    ) -> None:
+        span_committed = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_append_event(
+            _pool: Any, _session_id: str, _kind: str, data: dict[str, Any], **_kw: Any
+        ) -> Any:
+            # Model the start-span write: signal it committed server-side, then hold the
+            # client await open (suspended, cancellable) so the cancel lands right here.
+            if data.get("event") == "tool_execute_start":
+                span_committed.set()
+                await release.wait()
+            return MagicMock(id="span_1")
+
+        monkeypatch.setattr(sessions_service, "append_event", fake_append_event)
+        append_result: Any = AsyncMock()
+        trigger_sweep = AsyncMock()
+        monkeypatch.setattr(tool_dispatch, "_append_tool_result", append_result)
+        monkeypatch.setattr(tool_dispatch, "_trigger_sweep", trigger_sweep)
+
+        body_ran = asyncio.Event()
+        call = {"id": "tc_1", "function": {"name": "demo", "arguments": "{}"}}
+
+        async def driver() -> None:
+            async with _tool_lifecycle(
+                MagicMock(), "ses_1", call, account_id="acc_1", log_prefix="tool"
+            ):
+                body_ran.set()  # must NOT happen — the cancel struck during the start span
+
+        task = asyncio.create_task(driver())
+        await span_committed.wait()  # span "committed"; the lifecycle is suspended on it
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert not body_ran.is_set()  # the body provably never ran
+        assert append_result.await_count == 1  # resolved in-task, not left to the sweep
+        assert append_result.await_args.kwargs["error"] == "cancelled"
+        assert trigger_sweep.await_count == 1  # tail sweep fired so the step wakes now
 
 
 class TestParentChannelThreading:


### PR DESCRIPTION
## The bug (confirmed, with a deterministic repro)

`_tool_lifecycle` is an `@asynccontextmanager`, so the `tool_execute_start` span append runs in `__aenter__` — **before** the main `try/finally`. A `CancelledError` landing on that `await` (the model's `cancel` tool, the pg-notify interrupt listener, or a graceful worker drain all deliver one — *not* only a SIGKILL) escaped `__aenter__` with **no tool result appended and no tail sweep**. The call then stayed unresolved until the next ghost sweep (≤30s), which — seeing the committed start span but no result — synthesized the pessimistic *"may have completed, verify before retrying"* even though the body **provably never ran** (the cancel struck while writing the start marker). So a deliberately-cancelled, never-started tool got a misleading side-effects warning ≤30s late. The module docstring's *"only a worker SIGKILL can break it"* was simply false.

## The fix

Wrap the span append in its own `except asyncio.CancelledError` that appends a clean `cancelled` result (dedup-guarded, mirroring the in-body cancel handler) + triggers the tail sweep, then **re-raises** so the body never runs and the task ends cancelled. The fix lives in the shared `_tool_lifecycle`, so it covers the built-in **and** MCP paths by construction; the re-park path (`write_start_span=False`) has no `await` there and is unaffected.

Also: corrected the module docstring; updated the `sweep.py` ghost-classifier comment (the cancel-on-span case is now resolved eagerly); added `TestCancelDuringStartSpan` (drives a cancel onto a *held* start-span await; asserts the body never ran, exactly one `cancelled` result, the sweep fired — vs `await_count==0` on pre-fix code).

## Honest scope — a double-cancel caveat (surfaced by adversarial review)

The adversarial re-review reproduced a real edge: if a **second** `task.cancel()` lands while the handler is suspended in its cleanup awaits, it re-arms `_must_cancel`, interrupts the await, and strands the result + sweep — falling back to the ≤30s ghost sweep (and `may_have_completed` if the span had committed). This is **reachable** (the interrupt listener calls `cancel_session` on every pg-notify) but:
- it is the **same exposure the existing in-body cancel handler already has** (not introduced here),
- the ghost-sweep backstop **fully preserves correctness** — no permanent loss, no double-result (dedup-guarded), and
- the fix is still a strict improvement for the common single-cancel case.

I took the **narrow-the-claims** path (docstrings/comments now name the double-cancel fallback honestly) rather than `asyncio.shield`-ing the cleanup — consistent with the project's fail-to-the-backstop / no-belt-and-suspenders stance, and to avoid an inconsistency with the in-body handler.

**Sign-off welcome:** if you'd rather *close* the double-cancel window (option (a): `shield` the cleanup so a re-cancel can't strand it — also applied to the in-body handler for consistency), say so and I'll do it as a follow-up. Default is to leave the backstop as the recovery.

Refs #1433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)