### PR TITLE
refactor(tools): structural `resumable` tool property; retire PARKING_TOOL_NAMES (closes #1431)

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -306,8 +306,9 @@ async def find_and_repair_ghosts(
       custom tool or an unconfirmed ``always_ask`` tool still waiting
       for client action).
 
-    A ghost whose tool is a parking ``call_*`` builtin (``PARKING_TOOL_NAMES``) is a
-    **pure-await** that crash-recovery RE-PARKS rather than error-repairs (#1431): its
+    A ghost whose tool is a registered ``resumable`` builtin
+    (:meth:`registry.resumable_tool_names`) is a **pure-await** that crash-recovery
+    RE-PARKS rather than error-repairs (#1431): its
     servicer is re-derived from the durable edge (:func:`queries.find_parked_servicer`) and
     a fresh resume task is launched (a pure read of durable state) so the servicer's
     exactly-once answer lands in the original tool result. Only a resumable ghost whose edge
@@ -468,14 +469,16 @@ async def find_and_repair_ghosts(
     # RE-PARK it (a pure read), so the answer lands in the original tool result instead of
     # being orphaned by a synthetic error. Only when no edge exists (the launch crashed
     # before it was durable) does the call fall through to a retryable ``launch_lost`` error.
-    # Lazy imports: ``sweep`` ↔ ``tool_dispatch`` is a mutual-lazy-import pair (the
-    # symmetric counterpart of ``_trigger_sweep``'s lazy ``sweep`` import); ``invoke_session``
-    # registers tools at import and isn't needed at ``sweep`` module load.
+    # Lazy import: ``sweep`` ↔ ``tool_dispatch`` is a mutual-lazy-import pair (the
+    # symmetric counterpart of ``_trigger_sweep``'s lazy ``sweep`` import). The tool
+    # registry is the single source of truth for which builtins are pure-await
+    # resumables (``resumable=True`` at registration); no separate name list.
     from aios.harness.tool_dispatch import relaunch_parked_task
-    from aios.tools.invoke_session import PARKING_TOOL_NAMES
+    from aios.tools.registry import registry
 
-    resumable = [c for c in ghosts if c.tool_name in PARKING_TOOL_NAMES]
-    ghosts = [c for c in ghosts if c.tool_name not in PARKING_TOOL_NAMES]
+    resumable_names = registry.resumable_tool_names()
+    resumable = [c for c in ghosts if c.tool_name in resumable_names]
+    ghosts = [c for c in ghosts if c.tool_name not in resumable_names]
     launch_lost: list[_Candidate] = []
     for c in resumable:
         # Per-ghost isolation, matching the error-repair + wake-defer loops below: this

--- a/src/aios/tools/invoke_session.py
+++ b/src/aios/tools/invoke_session.py
@@ -342,13 +342,6 @@ async def call_workflow_handler(
 
 # ─── descriptions + registration ─────────────────────────────────────────────
 
-# The model-facing parking builtins: a ``call_*`` tool whose handler parks
-# (:func:`_park_and_resolve`) on a servicer and is therefore a **pure-await** —
-# safe to re-park on crash-recovery rather than error-repair (#1431). The
-# ghost-repair sweep uses this set as the resumability discriminant; it MUST stay
-# in lockstep with the names registered in :func:`_register` below.
-PARKING_TOOL_NAMES = frozenset({"call_session", "call_agent", "call_workflow"})
-
 CALL_SESSION_DESCRIPTION = (
     "Call an existing same-account session: deliver `input` to it as a trusted "
     "request and wait for its single answer ({ok: value} on success, an error "
@@ -372,12 +365,17 @@ CALL_WORKFLOW_DESCRIPTION = (
 
 
 def _register() -> None:
+    # ``resumable=True``: each handler parks (:func:`_park_and_resolve`) on a durable
+    # servicer edge — a pure-await, safe for the ghost-repair sweep to re-park rather
+    # than error-repair on crash recovery (#1431). The sweep derives its discriminant
+    # from this flag; no separate name list to keep in lockstep.
     registry.register(
         name="call_session",
         description=CALL_SESSION_DESCRIPTION,
         parameters_schema=_CallSessionArgs.model_json_schema(),
         handler=call_session_handler,
         transport="agent_tool",
+        resumable=True,
     )
     registry.register(
         name="call_agent",
@@ -385,6 +383,7 @@ def _register() -> None:
         parameters_schema=_CallAgentArgs.model_json_schema(),
         handler=call_agent_handler,
         transport="agent_tool",
+        resumable=True,
     )
     registry.register(
         name="call_workflow",
@@ -392,6 +391,7 @@ def _register() -> None:
         parameters_schema=_CallWorkflowArgs.model_json_schema(),
         handler=call_workflow_handler,
         transport="agent_tool",
+        resumable=True,
     )
 
 

--- a/src/aios/tools/registry.py
+++ b/src/aios/tools/registry.py
@@ -108,6 +108,14 @@ class ToolDefinition:
     The workflow-run step reads it to route a ``tool('bash')`` call to the
     run-sandbox executor; the session path doesn't consult it (every built-in
     already runs against the session's own sandbox there).
+
+    ``resumable`` marks a **pure-await** tool: its handler parks on a durable
+    servicer edge (a pure read of the log), so the ghost-repair sweep RE-PARKS it
+    on crash recovery instead of synthesizing an error result — re-reading the
+    durable answer is side-effect-free, unlike bash/http (#1431). The sweep derives
+    its resumable set from this flag (:meth:`ToolRegistry.resumable_tool_names`), so
+    a new parking tool just sets ``resumable=True`` here at registration — there is
+    no separate hand-maintained name list to keep in lockstep.
     """
 
     name: str
@@ -117,6 +125,7 @@ class ToolDefinition:
     transport: ToolTransport = "both"
     executes: Literal["worker", "sandbox"] = "worker"
     classify_permission: ClassifyPermission | None = None
+    resumable: bool = False
 
 
 @dataclass(slots=True)
@@ -135,11 +144,12 @@ class ToolRegistry:
         transport: ToolTransport = "both",
         executes: Literal["worker", "sandbox"] = "worker",
         classify_permission: ClassifyPermission | None = None,
+        resumable: bool = False,
     ) -> None:
         """Register a tool. Raises :class:`DuplicateToolError` on name clash.
 
         Intended to be called at module import time from tool modules
-        (e.g. :mod:`aios.tools.bash`).
+        (e.g. :mod:`aios.tools.bash`). See :class:`ToolDefinition` for ``resumable``.
         """
         if name in self._tools:
             raise DuplicateToolError(
@@ -154,7 +164,14 @@ class ToolRegistry:
             transport=transport,
             executes=executes,
             classify_permission=classify_permission,
+            resumable=resumable,
         )
+
+    def resumable_tool_names(self) -> frozenset[str]:
+        """Names of the registered pure-await tools (``resumable=True``) — the
+        ghost-repair sweep's re-park discriminant. Single source of truth: derived
+        from the registrations, never a hand-maintained list (#1431)."""
+        return frozenset(name for name, tool in self._tools.items() if tool.resumable)
 
     def get(self, name: str) -> ToolDefinition:
         """Return the registered tool. Raises :class:`ToolNotFoundError` if absent."""

--- a/tests/unit/test_invoke_session_tools.py
+++ b/tests/unit/test_invoke_session_tools.py
@@ -291,12 +291,20 @@ async def test_current_tool_call_id_scoped_to_call(monkeypatch: Any) -> None:
     assert current_tool_call_id() is None
 
 
-def test_parking_tool_names_match_registered() -> None:
-    """``PARKING_TOOL_NAMES`` (the sweep's resumability discriminant) must stay in lockstep
-    with the registered ``call_*`` builtins."""
-    from aios.tools.invoke_session import PARKING_TOOL_NAMES
-    from aios.tools.registry import registry
+def test_resumable_tools_are_exactly_the_parking_call_builtins() -> None:
+    """The ghost-repair sweep re-parks exactly the registered ``resumable`` builtins
+    (:meth:`ToolRegistry.resumable_tool_names` — its single source of truth). The one place
+    a tool declares itself pure-await is ``resumable=True`` at registration; this assertion
+    is a tripwire that fails if the derived set changes, forcing a deliberate confirmation
+    the change was intended (#1431). A parking tool left ``resumable=False`` would be
+    silently error-repaired = re-orphaned on restart; a side-effectful tool wrongly marked
+    ``resumable`` would be re-parked-and-re-read as if pure — a double-execution risk."""
+    from aios.tools.registry import registry  # ``aios.tools`` imported at module top
 
-    assert set(PARKING_TOOL_NAMES) == {"call_session", "call_agent", "call_workflow"}
-    for name in PARKING_TOOL_NAMES:
+    assert registry.resumable_tool_names() == frozenset(
+        {"call_session", "call_agent", "call_workflow"}
+    )
+    for name in registry.resumable_tool_names():
         assert registry.get(name).transport == "agent_tool"
+    # The default is non-resumable: a side-effectful tool must never be re-parked.
+    assert registry.get("bash").resumable is False


### PR DESCRIPTION
## What

Closes the last residual of #1431 (durable await-resume). The core — the durable edge↔`tool_call_id` join + kind-aware re-park — shipped in #1434. The one thing the issue body explicitly asked for and #1434 left as a name-match was: *"recovery should be kind-aware, declared structurally on the tool (a `resumable` property / tool kind, not a name-match)."*

The ghost-repair sweep decides whether a crashed tool task is **re-parked** (a pure-await `call_*` whose handler reads a durable servicer edge — re-reading is side-effect-free) or **error-repaired** (a side-effectful tool that may have committed). That discriminant was a hand-maintained frozenset `PARKING_TOOL_NAMES` in `tools/invoke_session.py` — a **shadow list** separate from the registrations. Its guard only pinned the set to a literal, so a *new* parking tool registered without being added would pass the test and then **silently error-repair = re-orphan its still-running child** on the next restart (the exact failure #1431 prevents).

## The change

- `ToolDefinition` gains `resumable: bool = False` — a **pure-runtime** registry field (no `openapi.json` / SDK ripple, confirmed); `registry.register` accepts it; `registry.resumable_tool_names()` derives the set.
- The three `call_*` builtins register `resumable=True`, **co-located** with their handlers (one `_register()` block).
- `harness/sweep.py` reads `registry.resumable_tool_names()` instead of importing the frozenset — **single source of truth**.
- `PARKING_TOOL_NAMES` deleted; its weak guard rewritten into a real drift tripwire that pins the registry-derived set, asserts each is `transport="agent_tool"`, and asserts a side-effectful tool (`bash`) defaults `resumable=False`.

## Why correct-by-construction (and its honest limit)

The sweep and the test now read the **same** derived set — they can't diverge the way the shadow frozenset could. The marker lives where you write the handler, so it's hard to forget. The one inherent residual (acknowledged in the test docstring): there's no *independent* "this handler parks" signal to cross-check `resumable=True` against — any such second declaration would just recreate the shadow-list problem one level over. Co-location is the correct mitigation.

`resumable: bool` (vs a 2-arm `Literal` like the sibling `executes` field) was chosen because this is a genuine yes/no predicate with no illegal-combination risk.

## Verification

Full gate green; the durable-await-resume integration suite passes (re-park routing works off the derived set); **no openapi/SDK drift**. Reviewed via a refute-by-default workflow on the committed diff — correctness lens (registration-timing: the worker's `import aios.tools` at startup populates the registry before any sweep; derived set == the old three; no missed readers) came back clean.

Closes #1431. Remaining full-tree "cancel them" cascade + depth re-validation are tracked under #1152 / #788 / #1405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)