### PR TITLE
Error-class-aware model-call retry: fail terminal litellm error classes fast instead of burning the backoff ladder

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
+import litellm.exceptions as litellm_exceptions
 from structlog.contextvars import bind_contextvars, clear_contextvars
 
 from aios.config import get_settings
@@ -101,6 +102,45 @@ _REFUSAL_STOP_REASON_MESSAGE = (
 _SPEND_CAP_STOP_REASON_MESSAGE = (
     "This account has reached its spend limit, so no model calls can be made. "
     "The account operator can raise the limit (account config spend_limit_usd) to resume."
+)
+
+# litellm's already-typed terminal model-call errors: requests that will NEVER
+# succeed on retry of the SAME prompt. Routing these straight to the errored
+# latch skips the [2,8,30,120]s backoff ladder, which on a terminal error only
+# burns ~160s + up to 4 doomed prompt-token round-trips. Kept as a small FAMILY
+# rule over litellm's exception hierarchy (generalize-over-enumerate) — NOT a
+# per-provider-string enum. ContextWindowExceededError and
+# ContentPolicyViolationError both subclass BadRequestError, so they are already
+# covered by isinstance against BadRequestError alone; they are listed only to
+# DOCUMENT the covered 400-subclasses (redundant for matching, not required).
+_TERMINAL_MODEL_ERRORS: tuple[type[Exception], ...] = (
+    litellm_exceptions.BadRequestError,             # 400: malformed/invalid prompt
+    litellm_exceptions.ContextWindowExceededError,  # 400 subclass: prompt too long
+    litellm_exceptions.ContentPolicyViolationError, # 400 subclass: policy block
+    litellm_exceptions.AuthenticationError,         # 401: bad/expired key
+    litellm_exceptions.PermissionDeniedError,       # 403: key lacks model access
+    litellm_exceptions.NotFoundError,               # 404: unknown model id
+    litellm_exceptions.UnprocessableEntityError,    # 422: schema-invalid request
+)
+
+
+def _is_terminal_model_error(exc: BaseException) -> bool:
+    """True iff ``exc`` is a litellm error that retrying the SAME prompt cannot fix.
+
+    Fail-SAFE: anything NOT matched here (RateLimitError / APIConnectionError /
+    InternalServerError / Timeout / ServiceUnavailableError, or any non-litellm
+    Exception) falls through to the existing backoff ladder — current behavior.
+    A misclassified *transient* therefore degrades to burning the ladder, never
+    the reverse.
+    """
+    return isinstance(exc, _TERMINAL_MODEL_ERRORS)
+
+
+_MODEL_TERMINAL_ERROR_STOP_REASON_MESSAGE = (
+    "The model call failed with a terminal error that retrying cannot fix "
+    "(e.g. invalid request, context-window exceeded, content policy, or auth). "
+    "To recover, post a message to the session, optionally after switching the "
+    "agent's model or trimming the conversation."
 )
 
 
@@ -617,7 +657,24 @@ async def _run_session_step_body(
         return _StepResult(
             retry_delay=await _apply_retry_or_failure(pool, session_id, account_id=account_id)
         )
-    except Exception:
+    except Exception as exc:
+        if _is_terminal_model_error(exc):
+            log.warning(
+                "step.model_terminal_error",
+                session_id=session_id,
+                error_class=type(exc).__name__,
+            )
+            await _append_model_request_error_span(
+                pool, session_id, start_event_id=start_event.id, account_id=account_id
+            )
+            await _latch_errored_turn(
+                pool,
+                session_id,
+                error_kind="model_terminal_error",
+                stop_message=_MODEL_TERMINAL_ERROR_STOP_REASON_MESSAGE,
+                account_id=account_id,
+            )
+            return _StepResult()  # no retry_delay → no defer_wake → session parks errored
         log.exception("step.litellm_failed", session_id=session_id)
         await _append_model_request_error_span(
             pool, session_id, start_event_id=start_event.id, account_id=account_id

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -114,13 +114,13 @@ _SPEND_CAP_STOP_REASON_MESSAGE = (
 # covered by isinstance against BadRequestError alone; they are listed only to
 # DOCUMENT the covered 400-subclasses (redundant for matching, not required).
 _TERMINAL_MODEL_ERRORS: tuple[type[Exception], ...] = (
-    litellm_exceptions.BadRequestError,             # 400: malformed/invalid prompt
+    litellm_exceptions.BadRequestError,  # 400: malformed/invalid prompt
     litellm_exceptions.ContextWindowExceededError,  # 400 subclass: prompt too long
-    litellm_exceptions.ContentPolicyViolationError, # 400 subclass: policy block
-    litellm_exceptions.AuthenticationError,         # 401: bad/expired key
-    litellm_exceptions.PermissionDeniedError,       # 403: key lacks model access
-    litellm_exceptions.NotFoundError,               # 404: unknown model id
-    litellm_exceptions.UnprocessableEntityError,    # 422: schema-invalid request
+    litellm_exceptions.ContentPolicyViolationError,  # 400 subclass: policy block
+    litellm_exceptions.AuthenticationError,  # 401: bad/expired key
+    litellm_exceptions.PermissionDeniedError,  # 403: key lacks model access
+    litellm_exceptions.NotFoundError,  # 404: unknown model id
+    litellm_exceptions.UnprocessableEntityError,  # 422: schema-invalid request
 )
 
 

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -39,14 +39,14 @@ def _make_litellm_error(cls: type[Exception]) -> Exception:
     """
     request = httpx.Request("POST", "https://example.test/v1")
     response = httpx.Response(400, request=request)
-    common = {"message": "boom", "model": "x", "llm_provider": "y"}
+    kwargs: dict[str, Any] = {"message": "boom", "model": "x", "llm_provider": "y"}
     if cls in (
         litellm_exceptions.PermissionDeniedError,
         litellm_exceptions.UnprocessableEntityError,
         litellm_exceptions.ServiceUnavailableError,
     ):
-        return cls(response=response, **common)
-    return cls(**common)
+        kwargs["response"] = response
+    return cls(**kwargs)
 
 
 _TERMINAL_ERROR_CLASSES = [

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -15,15 +15,57 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
+import httpx
+import litellm.exceptions as litellm_exceptions
 import pytest
 
 from aios.harness.completion import ModelCallDeadlineError
 from aios.harness.loop import (
     _count_consecutive_rescheduling,
+    _is_terminal_model_error,
     _retry_delay_for_attempt,
     run_session_step,
 )
 from aios.harness.window import WindowedEvents
+
+
+def _make_litellm_error(cls: type[Exception]) -> Exception:
+    """Construct a litellm exception instance, supplying per-class required args.
+
+    Some 4xx/5xx classes (PermissionDeniedError, UnprocessableEntityError,
+    ServiceUnavailableError) require an httpx ``response``; others don't. This
+    builds a valid instance of each so the tests exercise real litellm types
+    through the predicate / handler rather than stand-ins.
+    """
+    request = httpx.Request("POST", "https://example.test/v1")
+    response = httpx.Response(400, request=request)
+    common = {"message": "boom", "model": "x", "llm_provider": "y"}
+    if cls in (
+        litellm_exceptions.PermissionDeniedError,
+        litellm_exceptions.UnprocessableEntityError,
+        litellm_exceptions.ServiceUnavailableError,
+    ):
+        return cls(response=response, **common)
+    return cls(**common)
+
+
+_TERMINAL_ERROR_CLASSES = [
+    litellm_exceptions.BadRequestError,
+    litellm_exceptions.AuthenticationError,
+    litellm_exceptions.ContextWindowExceededError,
+    litellm_exceptions.ContentPolicyViolationError,
+    litellm_exceptions.PermissionDeniedError,
+    litellm_exceptions.NotFoundError,
+    litellm_exceptions.UnprocessableEntityError,
+]
+
+_TRANSIENT_ERROR_CLASSES = [
+    litellm_exceptions.RateLimitError,
+    litellm_exceptions.APIConnectionError,
+    litellm_exceptions.InternalServerError,
+    litellm_exceptions.ServiceUnavailableError,
+    litellm_exceptions.Timeout,
+]
 
 
 class TestRetryDelayForAttempt:
@@ -392,3 +434,66 @@ class TestRunSessionStepOnModelError:
             "model_usage": {},
             "cost_usd": None,
         } in span_payloads
+
+
+class TestIsTerminalModelError:
+    """Pure-predicate table test for ``_is_terminal_model_error``."""
+
+    @pytest.mark.parametrize("cls", _TERMINAL_ERROR_CLASSES)
+    def test_terminal_classes_are_terminal(self, cls: type[Exception]) -> None:
+        assert _is_terminal_model_error(_make_litellm_error(cls)) is True
+
+    @pytest.mark.parametrize("cls", _TRANSIENT_ERROR_CLASSES)
+    def test_transient_classes_are_not_terminal(self, cls: type[Exception]) -> None:
+        assert _is_terminal_model_error(_make_litellm_error(cls)) is False
+
+    def test_bare_runtime_error_is_not_terminal(self) -> None:
+        # Pins the fixture's default ``RuntimeError("provider boom")`` path as
+        # still-transient (falls through to the backoff ladder).
+        assert _is_terminal_model_error(RuntimeError("provider boom")) is False
+
+
+class TestRunSessionStepOnTerminalModelError:
+    """The terminal-first branch inside the generic model-call ``except``."""
+
+    @pytest.mark.parametrize("cls", _TERMINAL_ERROR_CLASSES)
+    async def test_terminal_class_latches_errored_without_retry(
+        self, mock_step_dependencies: Any, cls: type[Exception]
+    ) -> None:
+        mock_step_dependencies.stream_litellm.side_effect = _make_litellm_error(cls)
+
+        # Crucially WITHOUT patching ``_count_consecutive_rescheduling`` high:
+        # the ladder must be bypassed regardless of attempt count.
+        await run_session_step("sess_x")  # must NOT raise
+
+        mock_step_dependencies.defer_wake.assert_not_awaited()
+
+        recorded_reasons = [
+            call.args[2] for call in mock_step_dependencies.set_stop_reason.call_args_list
+        ]
+        # Subset check: the terminal latch passes ``stop_message``, so the
+        # recorded reason is ``{"type": "error", "message": ...}``.
+        assert any(
+            {"type": "error"}.items() <= recorded.items() for recorded in recorded_reasons
+        )
+
+        mock_step_dependencies.fail_all_open_requests.assert_awaited_once_with(
+            ANY, "sess_x", account_id=ANY, error={"kind": "model_terminal_error"}
+        )
+
+    @pytest.mark.parametrize("cls", _TRANSIENT_ERROR_CLASSES)
+    async def test_transient_class_keeps_backoff_ladder(
+        self, mock_step_dependencies: Any, cls: type[Exception]
+    ) -> None:
+        mock_step_dependencies.stream_litellm.side_effect = _make_litellm_error(cls)
+
+        with patch(
+            "aios.harness.loop._count_consecutive_rescheduling",
+            AsyncMock(return_value=0),
+        ):
+            await run_session_step("sess_x")
+
+        mock_step_dependencies.defer_wake.assert_awaited_once_with(
+            ANY, "sess_x", cause="reschedule", delay_seconds=2, account_id=ANY
+        )
+        mock_step_dependencies.fail_all_open_requests.assert_not_awaited()

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -473,9 +473,7 @@ class TestRunSessionStepOnTerminalModelError:
         ]
         # Subset check: the terminal latch passes ``stop_message``, so the
         # recorded reason is ``{"type": "error", "message": ...}``.
-        assert any(
-            {"type": "error"}.items() <= recorded.items() for recorded in recorded_reasons
-        )
+        assert any({"type": "error"}.items() <= recorded.items() for recorded in recorded_reasons)
 
         mock_step_dependencies.fail_all_open_requests.assert_awaited_once_with(
             ANY, "sess_x", account_id=ANY, error={"kind": "model_terminal_error"}


### PR DESCRIPTION
Automated dev-pipeline build for issue #1355.