### PR TITLE
fix(attenuation): meet dup-path_pattern http routes via method union

### DIFF
--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -340,6 +340,20 @@ def _meet_methods(
     return sorted(set(declared) & set(launcher))
 
 
+def _join_methods(
+    declared: list[HttpMethod] | None, other: list[HttpMethod] | None
+) -> list[HttpMethod] | None:
+    """Set-union JOIN of two method sets — the dual of :func:`_meet_methods`. ``None``
+    is the top (all verbs), so ``join(None, X) == None`` and ``join(X, None) == None``;
+    two concrete sets join to their (sorted) union. Used to aggregate a child's grant
+    for a ``path_pattern`` it declares on more than one route: request-time admission
+    (``http_request._match_route``) is first-match-wins, so a pattern's effective verb
+    grant is the union across its same-pattern routes, not the first one."""
+    if declared is None or other is None:
+        return None
+    return sorted(set(declared) | set(other))
+
+
 def _canon_http_server(s: HttpServerSpec) -> HttpServerSpec:
     """Resolve an http server to its normal form: identity/headers/route order kept
     verbatim, each route's ``methods`` normalized (sorted/deduped, ``None`` preserved)."""
@@ -353,20 +367,30 @@ def _meet_http_server(declared: HttpServerSpec, launcher: HttpServerSpec) -> Htt
     Path patterns, ordering, ``description``, ``enabled`` and ``permission_policy`` are
     **launcher-verbatim** (parent-wins-frozen: a child cannot re-order, re-gate, or add
     routes — preserving first-match-wins permission gates). The single dimension a child
-    may narrow is ``methods``: for each launcher route, if the child declares a route with
-    the same ``path_pattern``, the output route's methods are ``meet(launcher, child)``
-    (set intersection; ``None`` = all). A child that does not declare a matching path leaves
-    that launcher route's methods unchanged. The result is emitted in launcher route order.
+    may narrow is ``methods``: for each launcher route, the output methods are
+    ``meet(child_grant, launcher)`` (set intersection; ``None`` = all), where ``child_grant``
+    is the **union** of the methods of every child route sharing that ``path_pattern``. A
+    pattern may legitimately appear on multiple routes with disjoint verbs and
+    ``http_request._match_route`` admits a verb if any same-pattern route matches, so the
+    child's grant for the pattern is their join — collapsing to the first declaration would
+    silently demote later same-pattern routes to deny-all and break ``attenuate(x, x) ==
+    canonicalize(x)``. A child that declares no route for a launcher pattern leaves that
+    route's methods unchanged. The result is emitted in launcher route order.
     """
-    declared_by_pattern: dict[str, HttpRouteSpec] = {}
+    declared_methods: dict[str, list[HttpMethod] | None] = {}
     for r in declared.routes:
-        declared_by_pattern.setdefault(r.path_pattern, r)  # first child declaration wins
+        if r.path_pattern in declared_methods:
+            declared_methods[r.path_pattern] = _join_methods(
+                declared_methods[r.path_pattern], r.methods
+            )
+        else:
+            declared_methods[r.path_pattern] = _norm_methods(r.methods)
     out_routes: list[HttpRouteSpec] = []
     for lr in launcher.routes:
-        child = declared_by_pattern.get(lr.path_pattern)
-        methods = (
-            _norm_methods(lr.methods) if child is None else _meet_methods(child.methods, lr.methods)
-        )
+        # An undeclared pattern yields ``None`` (the method-lattice top), and
+        # ``meet(None, x) == _norm_methods(x)`` — so a route the child did not
+        # narrow is emitted launcher-verbatim without a separate branch.
+        methods = _meet_methods(declared_methods.get(lr.path_pattern), lr.methods)
         out_routes.append(lr.model_copy(update={"methods": methods}))
     return launcher.model_copy(update={"routes": out_routes})
 

--- a/tests/unit/test_attenuation.py
+++ b/tests/unit/test_attenuation.py
@@ -288,6 +288,49 @@ class TestServerSurvival:
         once = att(dec, lau)
         assert att(once, lau) == once
 
+    def test_http_route_meet_duplicate_path_pattern_preserves_each_verb(self) -> None:
+        # A server may legitimately carry two routes sharing a path_pattern but with
+        # disjoint methods (e.g. GET with allow_query for pagination + POST gated
+        # always_ask) — validate_http_servers dedups only base_url, and _match_route
+        # is first-match-wins on method precisely so [/x GET, /x POST] grants both.
+        # The meet must narrow each launcher route against the UNION of the child's
+        # same-pattern grants, not collapse them to the first declaration. Otherwise
+        # the second route is demoted to deny-all and the stated fixpoint law breaks.
+        srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[
+                HttpRouteSpec(path_pattern="/x", methods=["GET"]),
+                HttpRouteSpec(path_pattern="/x", methods=["POST"]),
+            ],
+        )
+        x = Surface([], [], [srv])
+        out = att(x, x)
+        # Each route keeps its own verb — the POST route is NOT silently denied.
+        assert [r.methods for r in out.http_servers[0].routes] == [["GET"], ["POST"]]
+        assert out == canon(x)  # attenuate(x, x) == canonicalize(x) holds for dup patterns
+
+    def test_http_route_meet_unions_child_same_pattern_grants(self) -> None:
+        # The child declares one pattern twice with disjoint verbs; its grant for the
+        # pattern is the UNION of both routes. The buggy first-declaration-wins meet
+        # silently drops the second route's verb, narrowing an all-verbs launcher route
+        # to GET-only instead of GET+POST.
+        l_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[HttpRouteSpec(path_pattern="/x")],  # methods=None → all verbs (top)
+        )
+        d_srv = HttpServerSpec(
+            name="api",
+            base_url="https://api",
+            routes=[
+                HttpRouteSpec(path_pattern="/x", methods=["GET"]),
+                HttpRouteSpec(path_pattern="/x", methods=["POST"]),
+            ],
+        )
+        out = att(Surface([], [], [d_srv]), Surface([], [], [l_srv]))
+        assert out.http_servers[0].routes[0].methods == ["GET", "POST"]
+
     def test_http_server_absent_is_dropped(self) -> None:
         d_srv = HttpServerSpec(name="api", base_url="https://api")
         out = att(Surface([], [], [d_srv]), Surface([], [], []))
@@ -465,8 +508,20 @@ def _gnarly_surfaces() -> list[Surface]:
             )
         ],
     )
+    # A server with one path_pattern declared on two routes with disjoint verbs — a
+    # valid construction the meet must not collapse (its own base_url so it only ever
+    # meets against itself, exercising the fixpoint law for duplicate patterns).
+    http_dup = HttpServerSpec(
+        name="api2",
+        base_url="https://api2",
+        routes=[
+            HttpRouteSpec(path_pattern="/x", methods=["GET"]),
+            HttpRouteSpec(path_pattern="/x", methods=["POST"]),
+        ],
+    )
     return [
         Surface([], [], []),
+        Surface([], [], [http_dup]),
         Surface([ToolSpec(type="bash"), ToolSpec(type="read", permission="always_ask")], [], []),
         Surface(
             [


### PR DESCRIPTION
## Summary

- `_meet_http_server` mapped each route `path_pattern` to its **first** declared route (`setdefault`) and met every launcher route against that single route. A server may legitimately carry two routes sharing a `path_pattern` with disjoint methods — `tools/http_request.py:_match_route` is first-match-wins on method (so `[/x GET, /x POST]` grants both), and per-route `permission_policy`/`allow_query`/`suppress` motivate splitting. For such a server the second launcher route was met against the *first* declared route, silently demoting a granted verb to deny-all (`[]`).
- This broke the module's stated normal-form law **`attenuate(x, x) == canonicalize(x)`**. Because the author-edge `surface_diff` is identity-only on http, the mangled surface passed the gate and was **frozen into the run/child-session surface row** at every clamp (`create_run`, child-session birth) — silently eroding granted authority into a wrongly-denied `http_request`.
- **Root-cause fix:** a pattern's child grant is the **union** of its same-pattern routes' methods, via a new `_join_methods` (the lattice dual of `_meet_methods`; `None` = top/all-verbs, `[]` = bottom/deny-all). This matches `_match_route`'s admit-if-any semantics. Undeclared patterns stay launcher-verbatim via `meet(None, x) == norm(x)`; explicit `[]` (deny) and all-verbs `None` remain correctly distinguished.

Found via a hypothesis-driven parallel risk audit; the adversarial-verify pass plus a dedicated correctness review confirmed the union is the correct lattice op, the trichotomy (`absent`/`[]`/`None`) is sound, and single-route (common-case) behavior is byte-identical.

## Test plan

- [x] Type-checker (mypy, 725 files) — clean
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — 3595 passed; 2 new targeted tests (`test_http_route_meet_duplicate_path_pattern_preserves_each_verb`, `test_http_route_meet_unions_child_same_pattern_grants`) red→green, plus a duplicate-pattern surface added to `_gnarly_surfaces()` so the `test_self_meet_equals_canonicalize` property guard covers it durably
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)