### PR TITLE
fix(triggers): accept valid leap-day cron schedules at create

### DIFF
--- a/src/aios/models/triggers.py
+++ b/src/aios/models/triggers.py
@@ -51,7 +51,14 @@ MAX_INPUT_TEMPLATE_BYTES = 16_384  # compact-JSON serialized; enforced WRITE-PAT
 # or oversized probe must never reach the resolver or the carrier INSERT).
 MAX_INGEST_EVENT_BYTES = 65536
 
-CRON_OCCURRENCE_HORIZON_YEARS = 1
+# 8 = the maximum gap between consecutive fires of any valid 5-field cron. A
+# leap-day schedule (`0 0 29 2 *`) skips the non-leap century year — 2096 fires,
+# 2100 does not (not divisible by 400), 2104 fires — an 8-year gap. The horizon
+# must cover that worst case so a genuinely-recurring schedule is accepted; a
+# smaller value (the original 1) false-rejected leap-day crons as "no occurrence"
+# in ~3 of every 4 years. Truly-impossible crons (`0 0 30 2 *`) never match at
+# any horizon, so raising it does not let them slip through.
+CRON_OCCURRENCE_HORIZON_YEARS = 8
 
 TriggerFireStatus = Literal["ok", "error", "timeout", "skipped"]  # was ScheduledTaskStatus
 

--- a/tests/unit/test_triggers_models.py
+++ b/tests/unit/test_triggers_models.py
@@ -95,7 +95,29 @@ class TestCronSource:
 
     def test_rejects_no_occurrence_within_horizon(self) -> None:
         # Grammar-valid but never fires (Feb 30 doesn't exist) — rejected at
-        # write time by the 1-year occurrence horizon (#818 §7).
+        # write time by the occurrence horizon (#818 §7).
+        with pytest.raises(ValidationError, match="no occurrence"):
+            _spec(source={"kind": "cron", "schedule": "0 0 30 2 *"})
+
+    def test_accepts_leap_day_schedule(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A quadrennial leap-day cron (Feb 29) is a VALID recurring schedule: it
+        # fires up to 8 years apart across the 2096→2104 century skip (2100 is
+        # not a leap year). The write-path occurrence horizon must accept it —
+        # only truly-impossible crons (Feb 30) may be rejected. The read path
+        # already tolerates this exact cron (TestReadPathAcceptsRareCron), so the
+        # write path must not 422 a value the read path admits.
+        import aios.models.triggers as trig
+
+        class _PinnedNow(datetime):
+            @classmethod
+            def now(cls, tz: object = None) -> datetime:  # type: ignore[override]
+                # Worst-case anchor: just after a leap day, so the next Feb-29
+                # fire is the full century-skip gap away (2096-03-01 → 2104).
+                return datetime(2096, 3, 1, tzinfo=UTC)
+
+        monkeypatch.setattr(trig, "datetime", _PinnedNow)
+        _spec(source={"kind": "cron", "schedule": "0 0 29 2 *"})  # must NOT raise
+        # ...a genuinely-impossible cron is still rejected (the horizon's real job).
         with pytest.raises(ValidationError, match="no occurrence"):
             _spec(source={"kind": "cron", "schedule": "0 0 30 2 *"})
 


### PR DESCRIPTION
## Summary

- `_validate_cron_expression` (write-path only) rejects a grammar-valid cron when croniter finds **no occurrence within `CRON_OCCURRENCE_HORIZON_YEARS`** — intended to catch crons that *never* fire (e.g. `0 0 30 2 *`, Feb 30). But the horizon was **1 year**, while a leap-day cron `0 0 29 2 *` fires every 4 years — up to **8** across the 2096→2104 century skip (2100 is not a leap year, not divisible by 400).
- So a genuinely-recurring leap-day schedule was `422`'d at `TriggerCreate`/`TriggerUpdate` with a misleading *"no occurrence within 1 year(s)"* message in ~3 of every 4 calendar years (including now — next Feb 29 is 2028). The **read path already tolerates this exact cron** (`TestReadPathAcceptsRareCron`), so the write-path rejection was a read/write inconsistency the team had already flagged (#818 §2.2).
- **Fix:** widen `CRON_OCCURRENCE_HORIZON_YEARS` 1 → **8**, the provably-tight maximum inter-fire gap of any valid 5-field cron (the Feb-29 century skip). Truly-impossible crons never match at *any* finite horizon, so they are still rejected — empirically confirmed at horizons 8/9/10/50.

Found via a hypothesis-driven parallel risk audit (scheduling/time dimension); the adversarial-verify pass plus three structural-quality agents confirmed the bound is exact and the fix lands at the right depth.

## Test plan

- [x] Type-checker (mypy) — clean
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — 3596 passed; new `test_accepts_leap_day_schedule` pins the clock to the worst-case anchor (2096-03-01) and asserts the leap-day cron is accepted **and** the impossible `0 0 30 2 *` is still rejected (red→green)
- [ ] CI runs e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)