### PR TITLE
fix(connectors): always wake on connector tool-result intake

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -874,9 +874,9 @@ async def post_runtime_tool_result(
                     "connection_id": body.connection_id,
                 },
             )
-        # A failure ALWAYS wakes: AND-gate the connector's ``no_reaction`` flag
-        # with ``not is_error`` so only a successful fire-and-forget result is
-        # excluded from the wake decision.
+        # ``no_reaction`` stamps the row so the wake GATE excludes it: a successful
+        # fire-and-forget result is not itself a stimulus to react to. A failure must
+        # react (so the model can recover), hence AND-gate with ``not is_error``.
         no_reaction = body.no_reaction and not body.is_error
         event = await sessions_service.append_tool_result(
             conn,
@@ -887,15 +887,13 @@ async def post_runtime_tool_result(
             no_reaction=no_reaction,
             account_id=account_id,
         )
-    # The result is ALWAYS appended (tool-always-appends-result invariant). Only
-    # the wake is conditional: a successful fire-and-forget result stamps
-    # ``data['no_reaction']=true`` and skips ``defer_wake`` — its row is excluded
-    # from the wake gate so the session settles instead of re-inferring to react
-    # to its own delivery confirmation.
-    if not no_reaction:
-        await defer_wake(
-            pool, body.session_id, cause="connector_tool_result", account_id=account_id
-        )
+    # Always append (tool-always-appends-result) and always wake: the wake GATE — not
+    # this intake — decides whether to infer. The gate excludes the ``no_reaction`` row,
+    # so a LONE delivery confirmation makes the woken step re-gate and no-op (settles, no
+    # re-inference on its own ack); but a ``no_reaction`` result COMPLETING a mixed batch
+    # still surfaces the unreacted real sibling, which must run. This intake can't see the
+    # worker's in-flight sibling tasks, so it cannot make that call itself.
+    await defer_wake(pool, body.session_id, cause="connector_tool_result", account_id=account_id)
     return event
 
 

--- a/tests/integration/test_no_reaction_tool_result.py
+++ b/tests/integration/test_no_reaction_tool_result.py
@@ -41,10 +41,13 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
+from unittest.mock import AsyncMock
 
 import asyncpg
 import pytest
 
+from aios.api.routers import connectors as connectors_router
+from aios.api.routers.connectors import RuntimeToolResultRequest
 from aios.db import queries
 from aios.db.pool import create_pool
 from aios.harness.inflight_tool_registry import InflightToolRegistry
@@ -309,3 +312,121 @@ class TestFireAndForgetSettles:
         registry = InflightToolRegistry()
         needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
         assert session_id in needs, "a co-pending real user message must still wake"
+
+
+_CONNECTOR = "signal"
+
+
+async def _bind_connection(pool: asyncpg.Pool[Any], account_id: str, session_id: str) -> str:
+    """Create a ``signal`` connection and bind ``session_id`` to it; return its id —
+    the runtime intake requires the session to be bound to ``body.connection_id``."""
+    async with pool.acquire() as conn:
+        connection = await queries.insert_connection(
+            conn,
+            account_id=account_id,
+            connector=_CONNECTOR,
+            external_account_id="+15550000000",
+            metadata={},
+        )
+        await queries.insert_binding(
+            conn,
+            account_id=account_id,
+            connection_id=connection.id,
+            mode="single_session",
+            session_id=session_id,
+        )
+    return connection.id
+
+
+class TestMixedBatchWake:
+    async def test_no_reaction_completing_mixed_batch_still_wakes(
+        self,
+        pool_account_session: tuple[asyncpg.Pool[Any], str, str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A turn emits BOTH a real builtin (``bash``) AND a fire-and-forget connector
+        send. The real result lands first (unreacted; batch still incomplete), then the
+        ``no_reaction`` send result lands LAST via the connector-runtime intake, COMPLETING
+        the batch. The session now has an unreacted real result and must be woken — but the
+        intake's ``no_reaction`` wake-skip drops the wake, stranding the real result until
+        the 30s periodic sweep (~30s of dead air). The wake decision belongs to the gate
+        (which excludes the ``no_reaction`` row), not this intake site, which cannot see the
+        in-flight real sibling."""
+        pool, account_id, session_id = pool_account_session
+        connection_id = await _bind_connection(pool, account_id, session_id)
+
+        async with pool.acquire() as conn:
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={"role": "user", "content": "run ls and tell alice"},
+            )
+            # Assistant reacts to user@1 and emits a MIXED batch: a real builtin + a send.
+            await queries.append_event(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                kind="message",
+                data={
+                    "role": "assistant",
+                    "content": "",
+                    "reacting_to": 1,
+                    "tool_calls": [
+                        {
+                            "id": "tc_real",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "{}"},
+                        },
+                        {
+                            "id": "tc_send",
+                            "type": "function",
+                            "function": {"name": "signal_send", "arguments": "{}"},
+                        },
+                    ],
+                },
+            )
+            # The REAL tool result lands first: unreacted, and the batch is still
+            # incomplete (tc_send pending), so nothing wakes yet — correct.
+            await sessions_service.append_tool_result(
+                conn,
+                account_id=account_id,
+                session_id=session_id,
+                tool_call_id="tc_real",
+                content="file1\nfile2",
+                is_error=False,
+                no_reaction=False,
+            )
+
+        # The fire-and-forget send result lands LAST, through the connector-runtime
+        # intake — the site whose wake decision is under test.
+        defer_wake_mock = AsyncMock()
+        monkeypatch.setattr(connectors_router, "defer_wake", defer_wake_mock)
+        auth = ("runtime-token", _CONNECTOR, account_id, None)
+        await connectors_router.post_runtime_tool_result(
+            RuntimeToolResultRequest(
+                connection_id=connection_id,
+                session_id=session_id,
+                tool_call_id="tc_send",
+                content='{"sent_at_ms": 1}',
+                is_error=False,
+                no_reaction=True,
+            ),
+            pool,
+            auth,
+        )
+
+        # The gate agrees there is work: the real bash result is unreacted and the
+        # batch is now complete (this assertion holds on buggy code too — the gate is
+        # correct; the bug is the missing wake to act on it).
+        registry = InflightToolRegistry()
+        needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
+        assert session_id in needs
+
+        # The intake MUST enqueue a wake. Skipping it on no_reaction stranded the real
+        # sibling until the periodic sweep — the bug.
+        assert defer_wake_mock.called, (
+            "a no_reaction result completing a mixed batch with an unreacted real "
+            "sibling must wake the session, not strand it until the 30s periodic sweep"
+        )


### PR DESCRIPTION
## Summary

- `post_runtime_tool_result` (connector-runtime tool-result intake) skipped `defer_wake` for a successful fire-and-forget (`no_reaction`) result. When that result **completes a mixed batch** whose real sibling result (e.g. `bash`) is still unreacted, skipping the wake **stranded the real result until the 30s periodic sweep** — ~30s of user-facing dead air on the common "do work **and** notify" turn (bash/edit + `signal_send`).
- The wake decision is **non-local** (it depends on a sibling's unreacted state + worker-local in-flight task state), so only the wake **gate** (`find_sessions_needing_inference`, worker process) can make it. The API-process intake can't see the worker's in-flight siblings, so it must not try: **always `defer_wake`** and let the woken step re-gate.
- A **lone** delivery confirmation still settles: the gate already excludes the `no_reaction` row (`UNREACTED_ROWS_SQL ... IS DISTINCT FROM 'true'`), so the woken step re-gates and no-ops (no re-inference on its own ack). #1398's anti-duplicate-send goal is preserved by that **gate exclusion**, not the buggy wake-skip. Cost: one cheap re-gate (no model call) per lone confirmation — the "wasted wake" the entry-gate already anticipates — rather than duplicating gate logic across the process boundary (the #1437 drift hazard).

Found via a hypothesis-driven deep-core audit (inference-gate dimension); adversarially verified with an executed red test, and three structural-quality agents confirmed the fix lands at the right depth (intake dumb, gate is the single source of truth).

## Test plan

- [x] Type-checker (mypy) — clean
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — 3596 passed
- [x] Integration (local, testcontainer Postgres) — new `TestMixedBatchWake.test_no_reaction_completing_mixed_batch_still_wakes` red→green; full `test_no_reaction_tool_result.py` 6/6 (incl. the lone-confirmation-settles regression guard)
- [ ] CI runs the full e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)