### PR TITLE
fix(image_resize): normalize non-canonical transparency modes to RGBA

### DIFF
--- a/src/aios/harness/image_resize.py
+++ b/src/aios/harness/image_resize.py
@@ -172,6 +172,14 @@ def _encode_with_transparency(img: PILImage.Image, cap_bytes: int) -> ImageDowns
     """Encode a transparency-bearing image, preferring PNG fidelity but
     falling back to palette PNG when the cap is tight."""
     pil = _pillow()
+    # Both encode steps below only accept some modes: PNG cannot write ``PA``/``La``,
+    # and ``convert("P", ADAPTIVE)`` rejects ``LA`` (a grayscale+alpha PNG — the common
+    # transparent-logo case — decodes to ``LA``). Normalize any non-canonical mode to
+    # ``RGBA`` (the full-alpha mode both steps accept) so the encode is total; ``P`` is
+    # already PNG-saveable and the palette target, so it is left as-is. Without this the
+    # raw ValueError/OSError escaped ImageDownsampleError → 500'd the connector inbound.
+    if img.mode not in ("RGBA", "P"):
+        img = img.convert("RGBA")
     buf = io.BytesIO()
     img.save(buf, format="PNG", optimize=True)
     if buf.tell() <= cap_bytes:

--- a/tests/unit/test_image_resize.py
+++ b/tests/unit/test_image_resize.py
@@ -53,6 +53,19 @@ def _noisy_rgb(width: int, height: int) -> Image.Image:
     return Image.frombytes("RGB", (width, height), data)
 
 
+@functools.cache
+def _noisy_la(width: int, height: int) -> Image.Image:
+    """Return a grayscale+alpha (mode ``LA``) noise image.
+
+    A grayscale logo/screenshot with a transparent background decodes to mode
+    ``LA`` via ``Image.open`` (PNG color type 4).  Noise keeps the encoded PNG
+    above the byte cap so the transparency encoder must reach its palette
+    fallback — the site that historically rejected ``LA``.
+    """
+    data = random.Random(f"LA{width}x{height}").randbytes(width * height * 2)
+    return Image.frombytes("LA", (width, height), data)
+
+
 class TestNoOp:
     async def test_returns_none_when_image_fits_both_caps(self) -> None:
         small = _encode(_noisy_rgb(50, 50), "JPEG", quality=90)
@@ -110,6 +123,22 @@ class TestPngTransparency:
         result = await maybe_downsample(data, "image/png")
         assert result is not None
         assert result.content_type == "image/jpeg"
+
+    async def test_grayscale_alpha_la_downsamples_without_crashing(self) -> None:
+        # A grayscale+alpha PNG decodes to mode LA. Oversized + noisy, so the
+        # first transparency PNG overshoots the cap and the encoder reaches its
+        # palette fallback — convert("P", ADAPTIVE) rejects LA, which previously
+        # raised a bare ValueError that escaped ImageDownsampleError, 500'd the
+        # connector inbound, and poisoned its retry loop. The encoder must
+        # normalize LA to RGBA and produce a valid downsampled PNG.
+        la = _noisy_la(INLINE_MAX_DIMENSION + 400, INLINE_MAX_DIMENSION + 400)
+        data = _encode(la, "PNG")
+        result = await maybe_downsample(data, "image/png")
+        assert result is not None
+        assert result.content_type == "image/png"
+        assert len(result.data) <= INLINE_SIZE_CAP_BYTES
+        assert result.width <= INLINE_MAX_DIMENSION
+        assert result.height <= INLINE_MAX_DIMENSION
 
 
 class TestCeiling:


### PR DESCRIPTION
## Summary

- `_encode_with_transparency` assumed its input was PNG-saveable and palette-convertible. A **grayscale+alpha PNG** (a transparent logo/screenshot — a common inbound attachment) decodes to Pillow mode **`LA`**, which `convert("P", ADAPTIVE)` rejects with a bare `ValueError` (modes `PA`/`La` fail the PNG save outright).
- The **decode** path already collapses Pillow errors into `ImageDownsampleError`, but the **encode** path was left unguarded. For an oversized `LA` image (overshooting the cap into the palette fallback), the raw `ValueError` escaped → **HTTP 500 on the connector inbound *before* the dedup ack committed** → the connector retried the same bytes indefinitely (**poisoned retry loop**) — the exact failure mode the surrounding comments (`attachment_staging.py`, `connectors.py`) warn against. Affects every connector (Signal/Telegram/WhatsApp/SMS) image inbound of such a mode.
- **Root-cause fix:** normalize any non-`RGBA`, non-`P` mode to `RGBA` (the full-alpha mode both encode steps accept) at the top of `_encode_with_transparency`, so the function is total over its inputs **and the image is delivered, not degraded** to a text marker. (Encode failures here are code bugs on an already-decoded trusted image — fix the operation, don't suppress.)

Found via a hypothesis-driven audit of the attachment/image surface; the verifier reproduced the crash *live* against the real `maybe_downsample`.

## Test plan

- [x] Type-checker (mypy) — clean
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — 3597 passed; new `TestPngTransparency::test_grayscale_alpha_la_downsamples_without_crashing` red→green (a noisy oversized `LA` PNG that overshoots the cap into the palette fallback), mirroring the existing `_noisy_rgb` deterministic-noise idiom
- [ ] CI runs the full e2e/integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)