### PR TITLE
feat(goals): give create_goal/complete_goal the output_schema mechanism (built with free-text instead of reusing it)

### DIFF
--- a/src/aios/tools/goal_management.py
+++ b/src/aios/tools/goal_management.py
@@ -268,9 +268,7 @@ async def _close_goal(
         # the SAME _validate_output the call_* output_schema path uses. create_goal
         # makes a schema mandatory, so a confirmed-open goal always has one.
         async with pool.acquire() as conn:
-            schema = await queries.get_request_output_schema(
-                conn, session_id, request_id=goal_id
-            )
+            schema = await queries.get_request_output_schema(conn, session_id, request_id=goal_id)
         violation = _validate_output(result, schema)
         if violation is not None:
             return violation

--- a/src/aios/tools/goal_management.py
+++ b/src/aios/tools/goal_management.py
@@ -14,17 +14,24 @@ cryptic ``call_session(session_id=<its own id>, input=…)`` awaited self-call
 These four tools are the **explicit, first-class surface** over that EXISTING
 mechanism (they do NOT reinvent the gate):
 
-* ``create_goal(goal, acceptance_criteria?)`` — open a self-goal: write the same
+* ``create_goal(goal, output_schema)`` — open a self-goal: write the same
   self-referential awaited edge a ``call_session(self)`` opens (reusing the #1414
   self-goal path via ``sessions_service.invoke``), so the quiescence guard holds
-  the session to it automatically. Returns a ``goal_id`` (the ``request_id`` of
-  the opened edge). Enforces the per-session open-goal admission cap
-  (``Settings.session_open_goals_max``) with a clear error on exceed.
+  the session to it automatically. ``output_schema`` is **REQUIRED** (#1512): a JSON
+  Schema expressing the checkable acceptance criteria as the shape the completion
+  ``result`` must satisfy, persisted on the ``request_opened`` frame the same way
+  ``call_*`` carry ``output_schema``. There is no schemaless goal. Returns a
+  ``goal_id`` (the ``request_id`` of the opened edge). Enforces the per-session
+  open-goal admission cap (``Settings.session_open_goals_max``) with a clear error
+  on exceed.
 * ``list_goals()`` — enumerate the session's OPEN self-goals (the open-obligation
   set filtered to self-caller edges), each with ``goal_id``, ``goal`` text, and
   ``age``.
-* ``complete_goal(goal_id, evidence?)`` — close a goal as DONE (the ``return``
-  arm via ``respond_to_request``); ``evidence`` is recorded on the response value.
+* ``complete_goal(goal_id, result)`` — close a goal as DONE (the ``return``
+  arm via ``respond_to_request``). ``result`` is **always validated against the
+  goal's ``output_schema``** (reusing ``invoke_session._validate_output`` /
+  the ``output_schema_violation`` path, #1512); a non-conforming result is rejected
+  exactly like ``call_*`` and the goal stays open.
 * ``fail_goal(goal_id, reason)`` — close a goal as abandoned (the ``error`` arm),
   with a reason.
 
@@ -57,6 +64,7 @@ from aios.harness.obligations import _format_age
 from aios.models.sessions import Obligation
 from aios.services import sessions as sessions_service
 from aios.tools.invoke import ToolBail
+from aios.tools.invoke_session import _validate_output
 from aios.tools.registry import ToolResult, registry
 from aios.tools.workflow_completion import respond_to_request
 
@@ -76,10 +84,13 @@ class _CreateGoalArgs(BaseModel):
         "this goal. You will be held to it (you cannot go idle until you "
         "complete_goal or fail_goal it).",
     )
-    acceptance_criteria: str | None = Field(
-        default=None,
-        description="Optional explicit acceptance criteria — the concrete, checkable "
-        "conditions that must hold for the goal to count as met.",
+    output_schema: dict[str, Any] = Field(
+        description="REQUIRED JSON Schema expressing the concrete, checkable "
+        "acceptance criteria as the shape the completion `result` must satisfy. "
+        "complete_goal validates its `result` against this schema (a non-conforming "
+        "result is rejected), so 'done' is a contract fixed up front, not prose. "
+        "There is no schemaless goal — every goal declares a checkable completion "
+        "contract.",
     )
 
 
@@ -93,10 +104,11 @@ class _CompleteGoalArgs(BaseModel):
     goal_id: str = Field(
         description="The id of the open goal to close as done (from create_goal or list_goals)."
     )
-    evidence: str | None = Field(
-        default=None,
-        description="Optional evidence that the goal's acceptance criteria are met "
-        "(recorded on the closing response).",
+    result: Any = Field(
+        description="The completion result — validated against the goal's output_schema "
+        "(the contract pinned by create_goal). A result that does not conform is "
+        "rejected with output_schema_violation and the goal stays open, exactly like "
+        "the call_* output_schema path.",
     )
 
 
@@ -174,11 +186,11 @@ async def create_goal_handler(
             is_error=True,
         )
 
-    # The goal text + optional acceptance criteria become the request input (the
-    # definition-of-done the obligation carries; the tail block renders a preview).
+    # The goal text becomes the request input (the definition-of-done preview the
+    # tail block renders); the REQUIRED output_schema becomes the completion contract,
+    # persisted on the same request_opened frame the way call_* carry output_schema
+    # (#1512) — complete_goal validates its result against it via _validate_output.
     goal_input: dict[str, Any] = {"goal": args.goal}
-    if args.acceptance_criteria is not None:
-        goal_input["acceptance_criteria"] = args.acceptance_criteria
 
     handle = await sessions_service.invoke(
         pool,
@@ -186,6 +198,7 @@ async def create_goal_handler(
         target_kind="session",
         target=session_id,  # the target IS this session — a self-goal (#1414).
         input=goal_input,
+        output_schema=args.output_schema,
         caller={"kind": "session", "id": session_id},
     )
     return {
@@ -223,6 +236,7 @@ async def _close_goal(
     is_error: bool,
     result: Any,
     error: dict[str, Any] | None,
+    validate_result: bool = False,
 ) -> dict[str, Any] | ToolResult:
     """Close a self-goal by writing the ``request_response`` half via the shared
     :func:`respond_to_request` core (the same exactly-once writer ``return``/
@@ -230,6 +244,12 @@ async def _close_goal(
     self-goals — so the goal surface can't be used to answer a caller-assigned
     (``api``/``run``/peer-``session``) obligation, which must go through
     ``return``/``error``.
+
+    When ``validate_result`` is set (the ``complete_goal`` path), the ``result`` is
+    validated against the goal's persisted ``output_schema`` AFTER the membership
+    check — reusing :func:`_validate_output` / the ``output_schema_violation`` path
+    (#1512). A non-conforming result is rejected before any response is written, so
+    the goal stays open.
     """
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
@@ -242,6 +262,18 @@ async def _close_goal(
             ),
             is_error=True,
         )
+    if validate_result:
+        # The goal's output_schema is the completion contract create_goal pinned up
+        # front (#1512) — read off the trusted request_opened edge and enforced with
+        # the SAME _validate_output the call_* output_schema path uses. create_goal
+        # makes a schema mandatory, so a confirmed-open goal always has one.
+        async with pool.acquire() as conn:
+            schema = await queries.get_request_output_schema(
+                conn, session_id, request_id=goal_id
+            )
+        violation = _validate_output(result, schema)
+        if violation is not None:
+            return violation
     status = await respond_to_request(
         pool,
         session_id,
@@ -264,14 +296,24 @@ async def _close_goal(
 async def complete_goal_handler(
     session_id: str, arguments: dict[str, Any]
 ) -> dict[str, Any] | ToolResult:
-    """Close a goal as DONE (the ``return`` arm). ``evidence`` is recorded on the
-    closing response value."""
+    """Close a goal as DONE (the ``return`` arm).
+
+    The ``result`` is **always validated against the goal's ``output_schema``** —
+    the completion contract ``create_goal`` pinned up front (#1512). The schema is
+    read off the trusted ``request_opened`` edge (``get_request_output_schema``) and
+    enforced via :func:`_validate_output`, reusing the exact ``output_schema_violation``
+    path the ``call_*`` tools use: a non-conforming ``result`` is rejected and no
+    response is written (the goal stays open), so a goal can only be closed by a
+    conforming proof.
+    """
     args = _parse(_CompleteGoalArgs, arguments)
-    result: dict[str, Any] = {"completed": True}
-    if args.evidence is not None:
-        result["evidence"] = args.evidence
     return await _close_goal(
-        session_id, goal_id=args.goal_id, is_error=False, result=result, error=None
+        session_id,
+        goal_id=args.goal_id,
+        is_error=False,
+        result=args.result,
+        error=None,
+        validate_result=True,
     )
 
 
@@ -295,9 +337,11 @@ CREATE_GOAL_DESCRIPTION = (
     "Self-assign a goal: pin a definition-of-done up front that you are then held "
     "to. Opens a self-goal that the quiescence guard refuses to let you go idle "
     "past — you stay re-prompted until you complete_goal or fail_goal it. `goal` is "
-    "what 'done' means; optionally add explicit `acceptance_criteria`. Returns a "
-    "`goal_id`. This is the highest-leverage way to actually close a task: declare "
-    "done up front, then you can't quiesce until it's met."
+    "what 'done' means in words; `output_schema` (REQUIRED, a JSON Schema) is the "
+    "checkable completion contract — the shape complete_goal's `result` must satisfy. "
+    "Returns a `goal_id`. This is the highest-leverage way to actually close a task: "
+    "declare a checkable 'done' up front, then you can't quiesce until a conforming "
+    "result proves it."
 )
 LIST_GOALS_DESCRIPTION = (
     "List your open self-goals (the goals you've pinned with create_goal that you "
@@ -305,8 +349,10 @@ LIST_GOALS_DESCRIPTION = (
 )
 COMPLETE_GOAL_DESCRIPTION = (
     "Close one of your open goals as DONE — its definition-of-done is met. `goal_id` "
-    "is the id from create_goal or list_goals; optionally record `evidence` that the "
-    "acceptance criteria are satisfied. Closing the last open goal lets you quiesce."
+    "is the id from create_goal or list_goals; `result` is the completion value, which "
+    "is validated against the goal's output_schema (the contract you pinned up front). "
+    "A non-conforming result is rejected (output_schema_violation) and the goal stays "
+    "open. Closing the last open goal lets you quiesce."
 )
 FAIL_GOAL_DESCRIPTION = (
     "Abandon one of your open goals — you will not meet its definition-of-done. "

--- a/tests/integration/test_goal_management.py
+++ b/tests/integration/test_goal_management.py
@@ -131,9 +131,7 @@ async def test_create_goal_opens_holding_self_obligation(
     # The completion contract is persisted on the trusted request_opened edge, the
     # same way call_* carry output_schema (#1512) — complete_goal reads it from here.
     async with pool.acquire() as conn:
-        persisted = await queries.get_request_output_schema(
-            conn, session_id, request_id=goal_id
-        )
+        persisted = await queries.get_request_output_schema(conn, session_id, request_id=goal_id)
     assert persisted == _SCHEMA
 
 
@@ -166,9 +164,7 @@ async def test_complete_goal_drains_open_set(
     the request_response half so the session may quiesce (#1512)."""
     pool, _account, session_id = pool_session
     goal_id = _gid(
-        await invoke_builtin(
-            session_id, "create_goal", {"goal": "do it", "output_schema": _SCHEMA}
-        )
+        await invoke_builtin(session_id, "create_goal", {"goal": "do it", "output_schema": _SCHEMA})
     )
     assert await _open_ids(pool, session_id) == [goal_id]
 
@@ -196,9 +192,7 @@ async def test_fail_goal_drains_open_set(
 ) -> None:
     pool, _account, session_id = pool_session
     goal_id = _gid(
-        await invoke_builtin(
-            session_id, "create_goal", {"goal": "do it", "output_schema": _SCHEMA}
-        )
+        await invoke_builtin(session_id, "create_goal", {"goal": "do it", "output_schema": _SCHEMA})
     )
     assert await _open_ids(pool, session_id) == [goal_id]
 

--- a/tests/integration/test_goal_management.py
+++ b/tests/integration/test_goal_management.py
@@ -1,18 +1,23 @@
-"""Integration tests for the explicit goal-management builtins (#1508).
+"""Integration tests for the explicit goal-management builtins (#1508, #1512).
 
 DB-backed (testcontainer Postgres). These drive the REAL service/query path —
 ``create_goal`` opening a self-referential awaited obligation via
-``sessions_service.invoke`` (#1414 self-goal), and ``complete_goal`` / ``fail_goal``
-writing the ``request_response`` half via ``respond_to_request`` — and assert the
-acceptance criteria against the same open-obligation queries the quiescence guard
-and the obligations tail block read:
+``sessions_service.invoke`` (#1414 self-goal) carrying the REQUIRED ``output_schema``
+on its ``request_opened`` frame, and ``complete_goal`` / ``fail_goal`` writing the
+``request_response`` half via ``respond_to_request`` — and assert the acceptance
+criteria against the same open-obligation queries the quiescence guard and the
+obligations tail block read:
 
 * ``create_goal`` opens an obligation that lands in the session's OPEN set
   (``get_open_request_ids`` / ``get_open_obligations``) as a ``self`` caller — so
-  the quiescence guard holds the session (it cannot go idle) until it's closed;
+  the quiescence guard holds the session (it cannot go idle) until it's closed —
+  and persists its ``output_schema`` on the trusted ``request_opened`` edge
+  (``get_request_output_schema``), the same way ``call_*`` carry it (#1512);
 * ``list_goals`` enumerates exactly the open self-goals;
-* ``complete_goal`` / ``fail_goal`` emit the ``request_response`` half, draining the
-  open set so the session may quiesce;
+* ``complete_goal`` validates its ``result`` against that persisted schema — a
+  conforming result drains the open set; a non-conforming one is rejected with
+  ``output_schema_violation`` and the obligation stays open (#1512);
+* ``fail_goal`` emits the ``request_response`` half, draining the open set;
 * the per-session open-goal admission cap is enforced with a clear error.
 """
 
@@ -37,6 +42,13 @@ from tests.integration.conftest import seed_agent_env_session
 pytestmark = pytest.mark.asyncio
 
 _ACCOUNT = "acc_goal_mgmt"
+
+# The completion contract a goal pins up front (#1512) — a representative output_schema.
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"shipped": {"type": "boolean"}},
+    "required": ["shipped"],
+}
 
 
 @pytest.fixture
@@ -102,7 +114,7 @@ async def test_create_goal_opens_holding_self_obligation(
     assert await _open_ids(pool, session_id) == []  # nothing owed yet
 
     out = await invoke_builtin(
-        session_id, "create_goal", {"goal": "ship the feature", "acceptance_criteria": "tests pass"}
+        session_id, "create_goal", {"goal": "ship the feature", "output_schema": _SCHEMA}
     )
     assert isinstance(out, dict)
     goal_id = out["goal_id"]
@@ -116,14 +128,29 @@ async def test_create_goal_opens_holding_self_obligation(
     # A self-goal: a ``session`` caller that is the session ITSELF (#1414).
     assert ob.caller_kind == "session"
     assert ob.caller_id == session_id
+    # The completion contract is persisted on the trusted request_opened edge, the
+    # same way call_* carry output_schema (#1512) — complete_goal reads it from here.
+    async with pool.acquire() as conn:
+        persisted = await queries.get_request_output_schema(
+            conn, session_id, request_id=goal_id
+        )
+    assert persisted == _SCHEMA
 
 
 async def test_list_goals_enumerates_open_self_goals(
     pool_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
     _pool, _account, session_id = pool_session
-    g1 = _gid(await invoke_builtin(session_id, "create_goal", {"goal": "goal one"}))
-    g2 = _gid(await invoke_builtin(session_id, "create_goal", {"goal": "goal two"}))
+    g1 = _gid(
+        await invoke_builtin(
+            session_id, "create_goal", {"goal": "goal one", "output_schema": _SCHEMA}
+        )
+    )
+    g2 = _gid(
+        await invoke_builtin(
+            session_id, "create_goal", {"goal": "goal two", "output_schema": _SCHEMA}
+        )
+    )
 
     out = await invoke_builtin(session_id, "list_goals", {})
     assert isinstance(out, dict)
@@ -135,13 +162,29 @@ async def test_list_goals_enumerates_open_self_goals(
 async def test_complete_goal_drains_open_set(
     pool_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
-    """complete_goal emits the request_response half so the session may quiesce."""
+    """complete_goal validates result against the goal's output_schema, then emits
+    the request_response half so the session may quiesce (#1512)."""
     pool, _account, session_id = pool_session
-    goal_id = _gid(await invoke_builtin(session_id, "create_goal", {"goal": "do it"}))
+    goal_id = _gid(
+        await invoke_builtin(
+            session_id, "create_goal", {"goal": "do it", "output_schema": _SCHEMA}
+        )
+    )
     assert await _open_ids(pool, session_id) == [goal_id]
 
+    # A non-conforming result is rejected (output_schema_violation) — the goal stays open.
+    bad = await invoke_builtin(
+        session_id, "complete_goal", {"goal_id": goal_id, "result": {"shipped": "nope"}}
+    )
+    assert isinstance(bad, ToolResult)
+    assert bad.is_error
+    assert isinstance(bad.content, str)
+    assert "output_schema_violation" in bad.content
+    assert await _open_ids(pool, session_id) == [goal_id]  # still owed
+
+    # A conforming result closes it.
     out = await invoke_builtin(
-        session_id, "complete_goal", {"goal_id": goal_id, "evidence": "verified"}
+        session_id, "complete_goal", {"goal_id": goal_id, "result": {"shipped": True}}
     )
     assert out == {"goal_id": goal_id, "status": "completed"}
     # Obligation closed → open set empty → quiescence guard no longer holds.
@@ -152,7 +195,11 @@ async def test_fail_goal_drains_open_set(
     pool_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
     pool, _account, session_id = pool_session
-    goal_id = _gid(await invoke_builtin(session_id, "create_goal", {"goal": "do it"}))
+    goal_id = _gid(
+        await invoke_builtin(
+            session_id, "create_goal", {"goal": "do it", "output_schema": _SCHEMA}
+        )
+    )
     assert await _open_ids(pool, session_id) == [goal_id]
 
     out = await invoke_builtin(
@@ -169,11 +216,17 @@ async def test_open_goal_cap_enforced(
     cap = get_settings().session_open_goals_max
     with mock.patch("aios.tools.goal_management.get_settings") as gs:
         gs.return_value = mock.Mock(session_open_goals_max=2)
-        a = await invoke_builtin(session_id, "create_goal", {"goal": "g1"})
-        b = await invoke_builtin(session_id, "create_goal", {"goal": "g2"})
+        a = await invoke_builtin(
+            session_id, "create_goal", {"goal": "g1", "output_schema": _SCHEMA}
+        )
+        b = await invoke_builtin(
+            session_id, "create_goal", {"goal": "g2", "output_schema": _SCHEMA}
+        )
         assert isinstance(a, dict) and isinstance(b, dict)
         assert "goal_id" in a and "goal_id" in b
-        over = await invoke_builtin(session_id, "create_goal", {"goal": "g3"})
+        over = await invoke_builtin(
+            session_id, "create_goal", {"goal": "g3", "output_schema": _SCHEMA}
+        )
         assert isinstance(over, ToolResult)
         assert over.is_error
         assert isinstance(over.content, str)
@@ -184,8 +237,12 @@ async def test_open_goal_cap_enforced(
     # Freeing a slot re-admits (concurrency cap, not a lifetime budget).
     with mock.patch("aios.tools.goal_management.get_settings") as gs:
         gs.return_value = mock.Mock(session_open_goals_max=2)
-        await invoke_builtin(session_id, "complete_goal", {"goal_id": a["goal_id"]})
-        c = await invoke_builtin(session_id, "create_goal", {"goal": "g4"})
+        await invoke_builtin(
+            session_id, "complete_goal", {"goal_id": a["goal_id"], "result": {"shipped": True}}
+        )
+        c = await invoke_builtin(
+            session_id, "create_goal", {"goal": "g4", "output_schema": _SCHEMA}
+        )
         assert isinstance(c, dict)
         assert "goal_id" in c
     # Sanity: the global default cap is comfortably above 0.

--- a/tests/unit/test_goal_management_tools.py
+++ b/tests/unit/test_goal_management_tools.py
@@ -1,4 +1,4 @@
-"""Unit tests for the explicit goal-management builtins (#1508).
+"""Unit tests for the explicit goal-management builtins (#1508, #1512).
 
 These stub the worker pool + services so they need no live Postgres. They cover:
 
@@ -8,12 +8,19 @@ These stub the worker pool + services so they need no live Postgres. They cover:
 * **create_goal opens a self-goal** — the handler writes the self-referential
   awaited edge via ``service.invoke`` with ``target_kind="session"``,
   ``target=<this session>``, ``caller={kind:session, id:<this session>}`` (the
-  #1414 self-goal path), and returns the opened edge's ``request_id`` as ``goal_id``.
+  #1414 self-goal path), carrying the REQUIRED ``output_schema`` (the completion
+  contract), and returns the opened edge's ``request_id`` as ``goal_id``.
+* **output_schema is mandatory** — a ``create_goal`` without an ``output_schema``
+  is rejected by the tool schema before the handler runs (#1512: no schemaless goal).
 * **admission cap** — at/over the per-session open-goal cap ``create_goal`` returns
   a clear error and opens no edge.
 * **list_goals** filters the open-obligation set to self-caller goals only.
 * **complete_goal / fail_goal** close an open self-goal via ``respond_to_request``
   (the return / error arms), and reject a goal_id that isn't an open self-goal.
+* **complete_goal validates result** — the ``result`` is checked against the goal's
+  persisted ``output_schema`` (reusing ``_validate_output`` / the
+  ``output_schema_violation`` path from ``invoke_session.py``); a non-conforming
+  result is rejected and no response is written.
 """
 
 from __future__ import annotations
@@ -33,6 +40,13 @@ from aios.tools.registry import ToolResult
 
 _SELF = "ses_self"
 _ACCOUNT = "acc_x"
+
+# A representative output_schema — the completion contract a goal pins up front.
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"shipped": {"type": "boolean"}},
+    "required": ["shipped"],
+}
 
 
 @pytest.fixture(autouse=True)
@@ -83,19 +97,35 @@ def _stub_open_obligations(monkeypatch: Any, obligations: list[Obligation]) -> N
     )
 
 
+def _stub_goal_schema(monkeypatch: Any, schema: dict[str, Any] | None) -> None:
+    """Stub the goal's persisted ``output_schema`` read (``get_request_output_schema``)
+    that ``complete_goal`` resolves to validate the result against."""
+    monkeypatch.setattr(
+        "aios.db.queries.get_request_output_schema", AsyncMock(return_value=schema)
+    )
+
+
 # ─── create_goal ─────────────────────────────────────────────────────────────
 
 
 async def test_create_goal_arg_schema_forbids_caller() -> None:
     with pytest.raises(ToolBail):
         await invoke_builtin(
-            _SELF, "create_goal", {"goal": "x", "caller": {"kind": "session", "id": "evil"}}
+            _SELF,
+            "create_goal",
+            {"goal": "x", "output_schema": _SCHEMA, "caller": {"kind": "session", "id": "evil"}},
         )
 
 
 async def test_create_goal_requires_nonempty_goal() -> None:
     with pytest.raises(ToolBail):
-        await invoke_builtin(_SELF, "create_goal", {"goal": ""})
+        await invoke_builtin(_SELF, "create_goal", {"goal": "", "output_schema": _SCHEMA})
+
+
+async def test_create_goal_requires_output_schema() -> None:
+    """#1512: output_schema is mandatory — a schemaless goal is rejected up front."""
+    with pytest.raises(ToolBail):
+        await invoke_builtin(_SELF, "create_goal", {"goal": "ship it"})
 
 
 async def test_create_goal_opens_self_goal_edge(monkeypatch: Any) -> None:
@@ -106,7 +136,7 @@ async def test_create_goal_opens_self_goal_edge(monkeypatch: Any) -> None:
     monkeypatch.setattr("aios.services.sessions.invoke", inv)
 
     out = await invoke_builtin(
-        _SELF, "create_goal", {"goal": "ship it", "acceptance_criteria": "tests pass"}
+        _SELF, "create_goal", {"goal": "ship it", "output_schema": _SCHEMA}
     )
 
     assert out == {"goal_id": "req_goal", "goal": "ship it", "status": "open"}
@@ -116,7 +146,9 @@ async def test_create_goal_opens_self_goal_edge(monkeypatch: Any) -> None:
     assert kwargs["target_kind"] == "session"
     assert kwargs["target"] == _SELF
     assert kwargs["caller"] == {"kind": "session", "id": _SELF}
-    assert kwargs["input"] == {"goal": "ship it", "acceptance_criteria": "tests pass"}
+    assert kwargs["input"] == {"goal": "ship it"}
+    # The completion contract is persisted on the edge, the same way call_* carry it.
+    assert kwargs["output_schema"] == _SCHEMA
 
 
 async def test_create_goal_cap_enforced(monkeypatch: Any) -> None:
@@ -127,7 +159,9 @@ async def test_create_goal_cap_enforced(monkeypatch: Any) -> None:
     inv = AsyncMock()
     monkeypatch.setattr("aios.services.sessions.invoke", inv)
 
-    out = await invoke_builtin(_SELF, "create_goal", {"goal": "one too many"})
+    out = await invoke_builtin(
+        _SELF, "create_goal", {"goal": "one too many", "output_schema": _SCHEMA}
+    )
 
     assert isinstance(out, ToolResult)
     assert out.is_error
@@ -148,7 +182,9 @@ async def test_create_goal_cap_ignores_foreign_obligations(monkeypatch: Any) -> 
     )
     monkeypatch.setattr("aios.services.sessions.invoke", inv)
 
-    out = await invoke_builtin(_SELF, "create_goal", {"goal": "still allowed"})
+    out = await invoke_builtin(
+        _SELF, "create_goal", {"goal": "still allowed", "output_schema": _SCHEMA}
+    )
 
     assert isinstance(out, dict)
     assert out["goal_id"] == "req_g"
@@ -186,17 +222,42 @@ async def test_list_goals_empty(monkeypatch: Any) -> None:
 
 async def test_complete_goal_closes_via_respond(monkeypatch: Any) -> None:
     _stub_open_obligations(monkeypatch, [_self_goal("g1")])
+    _stub_goal_schema(monkeypatch, _SCHEMA)
     respond = AsyncMock(return_value="responded")
     monkeypatch.setattr("aios.tools.goal_management.respond_to_request", respond)
 
-    out = await invoke_builtin(_SELF, "complete_goal", {"goal_id": "g1", "evidence": "all green"})
+    out = await invoke_builtin(
+        _SELF, "complete_goal", {"goal_id": "g1", "result": {"shipped": True}}
+    )
 
     assert out == {"goal_id": "g1", "status": "completed"}
     assert respond.await_args is not None
     kwargs = respond.await_args.kwargs
     assert kwargs["request_id"] == "g1"
     assert kwargs["is_error"] is False
-    assert kwargs["result"] == {"completed": True, "evidence": "all green"}
+    # The conforming result is recorded verbatim as the closing response value.
+    assert kwargs["result"] == {"shipped": True}
+
+
+async def test_complete_goal_rejects_nonconforming_result(monkeypatch: Any) -> None:
+    """#1512: the result is validated against the goal's output_schema; a
+    non-conforming result is rejected with output_schema_violation and no response
+    is written (same semantics as the call_* / return output_schema path)."""
+    _stub_open_obligations(monkeypatch, [_self_goal("g1")])
+    _stub_goal_schema(monkeypatch, _SCHEMA)
+    respond = AsyncMock()
+    monkeypatch.setattr("aios.tools.goal_management.respond_to_request", respond)
+
+    out = await invoke_builtin(
+        _SELF, "complete_goal", {"goal_id": "g1", "result": {"shipped": "nope"}}
+    )
+
+    assert isinstance(out, ToolResult)
+    assert out.is_error
+    assert isinstance(out.content, str)
+    assert "output_schema_violation" in out.content
+    # No response written on a schema mismatch — the goal stays open.
+    respond.assert_not_awaited()
 
 
 async def test_fail_goal_closes_with_error(monkeypatch: Any) -> None:
@@ -223,7 +284,7 @@ async def test_complete_goal_rejects_unknown_goal_id(monkeypatch: Any) -> None:
     respond = AsyncMock()
     monkeypatch.setattr("aios.tools.goal_management.respond_to_request", respond)
 
-    out = await invoke_builtin(_SELF, "complete_goal", {"goal_id": "nope"})
+    out = await invoke_builtin(_SELF, "complete_goal", {"goal_id": "nope", "result": {}})
 
     assert isinstance(out, ToolResult)
     assert out.is_error
@@ -237,7 +298,7 @@ async def test_complete_goal_rejects_foreign_obligation(monkeypatch: Any) -> Non
     respond = AsyncMock()
     monkeypatch.setattr("aios.tools.goal_management.respond_to_request", respond)
 
-    out = await invoke_builtin(_SELF, "complete_goal", {"goal_id": "a1"})
+    out = await invoke_builtin(_SELF, "complete_goal", {"goal_id": "a1", "result": {}})
 
     assert isinstance(out, ToolResult)
     assert out.is_error

--- a/tests/unit/test_goal_management_tools.py
+++ b/tests/unit/test_goal_management_tools.py
@@ -100,9 +100,7 @@ def _stub_open_obligations(monkeypatch: Any, obligations: list[Obligation]) -> N
 def _stub_goal_schema(monkeypatch: Any, schema: dict[str, Any] | None) -> None:
     """Stub the goal's persisted ``output_schema`` read (``get_request_output_schema``)
     that ``complete_goal`` resolves to validate the result against."""
-    monkeypatch.setattr(
-        "aios.db.queries.get_request_output_schema", AsyncMock(return_value=schema)
-    )
+    monkeypatch.setattr("aios.db.queries.get_request_output_schema", AsyncMock(return_value=schema))
 
 
 # ─── create_goal ─────────────────────────────────────────────────────────────
@@ -135,9 +133,7 @@ async def test_create_goal_opens_self_goal_edge(monkeypatch: Any) -> None:
     )
     monkeypatch.setattr("aios.services.sessions.invoke", inv)
 
-    out = await invoke_builtin(
-        _SELF, "create_goal", {"goal": "ship it", "output_schema": _SCHEMA}
-    )
+    out = await invoke_builtin(_SELF, "create_goal", {"goal": "ship it", "output_schema": _SCHEMA})
 
     assert out == {"goal_id": "req_goal", "goal": "ship it", "status": "open"}
     assert inv.await_args is not None


### PR DESCRIPTION
Automated dev-pipeline build for issue #1512.