### PR TITLE
unify-obligations #7: keep create_goal as the canonical reflexive-OPEN verb (terminology of record; no set_goal)

### DIFF
--- a/docs/design/1523-create-goal-terminology-of-record.md
+++ b/docs/design/1523-create-goal-terminology-of-record.md
@@ -1,0 +1,74 @@
+# `create_goal` — the canonical reflexive-OPEN verb (terminology of record)
+
+*unify-obligations epic #1516, child #1523. Decision + documentation child (minimal code).*
+
+> **Companion:** the source of record for this decision is the module docstring of
+> [`src/aios/tools/goal_management.py`](../../src/aios/tools/goal_management.py); this note is the
+> epic-linked design record so the #1414 naming is not re-litigated.
+
+## Decision
+
+The unify-obligations epic retires every goal-specific lifecycle verb **except OPEN** into the
+uniform, source-agnostic obligation verbs. What remains goal-named is **exactly one verb**:
+**`create_goal`** — the canonical *reflexive-OPEN* verb. It is kept **as-is** (no rename to
+`set_goal`, no signature change).
+
+A **GOAL is the reflexive call**: a self-referential **awaited** obligation whose
+`caller == servicer == self` (the #1414 self-goal path — `caller={kind:"session", id:<this session>}`,
+target = the same session, `awaited=true`). It is a *label* for that one shape of obligation, **not a
+subsystem**: there is no separate goal store, gate, or lifecycle. The quiescence guard already refuses
+to let a session quiesce past any open awaited obligation, self-goals included.
+
+## Terminology of record (the verb mapping)
+
+| Goal action | Canonical verb(s) | Authority |
+|-------------|-------------------|-----------|
+| **OPEN** a goal | `create_goal` | the session opens its own reflexive edge |
+| **CLOSE** a goal | `return` / `error` (by `goal_id` as `request_id`) | servicer authority, schema-validated |
+| **LIST** open goals | `list_obligations` / `list_calls` (origin=self) | — |
+| **DROP / CANCEL** a goal | `cancel_call` (by `tool_call_id`) | caller authority |
+
+- **`create_goal`** opens the self-referential awaited edge via `sessions_service.invoke` with
+  `target=session_id` and `caller={kind:"session", id:session_id}`. `output_schema` is **REQUIRED**
+  (#1512/#1513) — there is no schemaless goal; the schema persists on the `request_opened` frame the
+  same way `call_*` carry it, and is the completion contract `return` validates servicer-side. The
+  open is a **no-park self-edge** (parking would self-deadlock; the quiescence guard, not a park, holds
+  the session) and enforces the per-session open-goal admission cap
+  (`Settings.session_open_goals_max`, counted via `_open_self_goals`). It returns a `goal_id`
+  (= the edge's `request_id`).
+- **Closing** a goal is `return(request_id=<goal_id>, value=…)` (the persisted `output_schema` is
+  enforced by `return`'s own schema gate — a non-conforming value is rejected as
+  `output_schema_violation` and the goal stays open) or `error(request_id=<goal_id>, message=…)`.
+  The self-only `complete_goal`/`fail_goal` were retired (#1518 → #1525).
+- **Listing** open goals is the general open-obligation enumeration filtered to self-caller edges:
+  `list_obligations` / `list_calls` with `origin=self` (epic children #6/#3). The legacy `list_goals`
+  shim is retained only until child #3 folds it in.
+- **Dropping** a goal is `cancel_call` by `tool_call_id` (epic child #5). There is no `cancel_goal`.
+
+There is **no** `set_goal`, **no** `cancel_goal`, **no** `complete_goal`/`fail_goal`, **no**
+`update_goal`, and **no** long-term `list_goals`. `create_goal` is the only goal-named verb.
+Revision stays explicit: `error` the goal, then `create_goal` a revised one — the value is goals that
+*don't move*.
+
+## #1414 disposition (declined)
+
+Open issue **#1414** ("set_goal / cancel_goal: self-issued awaited-request 'goals' for always-on
+agents") proposed a `set_goal`/`cancel_goal` naming. The chairman-ratified decision in epic #1516 is
+to **keep `create_goal` and NOT rename to `set_goal`**, and to **NOT add `cancel_goal`** — dropping a
+goal is the uniform `cancel_call` (child #5). #1414 can be closed as **resolved-by-#1516** by the
+seat/chairman; this note records that disposition so the naming is not re-litigated.
+
+## Scope of this child
+
+Decision + documentation only. `create_goal`'s behavior ships correct at origin/master `7869686f`
+(#1508/#1511 + #1512/#1513) and is unchanged here: the no-park self-edge open, the required
+`output_schema`, and the open-goal admission cap all stay exactly as-is. This child only pins the
+terminology of record and the #1414 disposition, and cleans up the docstring/description references.
+
+## Sequencing
+
+The description-reference cleanup depends on children #2 (close verbs retired — landed, #1525),
+#3 (`list_goals` → `list_obligations`/`list_calls`), and #5 (`cancel_call` exists). This child lands
+the decision and the terminology of record now; the docstring/description name the canonical verbs of
+record even where #3/#5 have not yet merged, and the legacy `list_goals` shim is explicitly flagged as
+transitional until #3 retires it.

--- a/src/aios/tools/goal_management.py
+++ b/src/aios/tools/goal_management.py
@@ -1,18 +1,61 @@
 """Explicit goal-management model tools (#1508) over the obligation/quiescence gate.
 
-A **self-goal** is a session's first-class definition-of-done that it is then held
-to until met: a self-referential **awaited** obligation (#1123 ``request_opened``
-with ``caller={kind:"session", id:<this session>}``, ``awaited=true``) that the
-quiescence guard refuses to let the session quiesce past. The *gating* already
-exists and works — an open awaited obligation drives the quiescence-guard
-nudge / ``no_return`` loop (``db/queries/sessions.py`` + ``harness/context.py``
-``_agent_owes_response``) and renders in the "Open obligations" tail block
-(``harness/obligations.py``). The ONLY way to open a self-goal used to be the
-cryptic ``call_session(session_id=<its own id>, input=…)`` awaited self-call
-(#1414) — undiscoverable, awkward, easy to forget.
+Terminology of record (unify-obligations epic #1516, child #1523)
+================================================================
+A **GOAL is the reflexive call**: a self-referential **awaited** obligation whose
+``caller == servicer == self`` (#1123 ``request_opened`` with
+``caller={kind:"session", id:<this session>}``, ``awaited=true``, target = the same
+session). It is a *label* for that one shape of obligation, **not a subsystem** —
+there is no separate goal store, gate, or lifecycle. The quiescence guard refuses
+to let a session quiesce past any open awaited obligation, self-goals included.
 
-These two tools are the **explicit, first-class surface** over that EXISTING
-mechanism (they do NOT reinvent the gate):
+Because a goal is just an obligation with a self-caller, the **uniform,
+source-agnostic obligation verbs** already cover its whole lifecycle, and they —
+not goal-named duplicates — are the canonical verbs of record:
+
+* **OPEN** a goal → ``create_goal`` (the one reflexive-OPEN verb; see below).
+* **CLOSE** a goal → ``return``/``error`` (servicer authority, schema-validated):
+  ``return(request_id=<goal_id>, value=…)`` completes it (the session's persisted
+  ``output_schema`` is enforced servicer-side by ``return``'s own schema gate,
+  ``workflow_completion._enforce_output_schema`` → ``_validate_value``, so a
+  non-conforming value is rejected with ``output_schema_violation`` and the goal
+  stays open) and ``error(request_id=<goal_id>, message=…)`` abandons it.
+* **LIST** open goals → ``list_obligations`` (origin=self) and/or ``list_calls``
+  (origin=self) — the general open-obligation enumeration filtered to self-caller
+  edges. (``list_obligations``/``list_calls`` arrive with epic children #6/#3; until
+  then the legacy ``list_goals`` shim below still enumerates the same self-caller
+  set.)
+* **DROP/CANCEL** a goal → ``cancel_call`` (caller authority, by ``tool_call_id``;
+  epic child #5). There is no ``cancel_goal``.
+
+``create_goal`` is therefore the ONLY goal-named verb in the surface. There is **no**
+``set_goal``, **no** ``cancel_goal``, **no** ``complete_goal``/``fail_goal``
+(retired #1518/#1525), **no** ``list_goals`` long-term (folds into
+``list_obligations``/``list_calls``, child #3), and **no** silent ``update_goal``.
+Revision stays explicit: ``error`` the goal, then ``create_goal`` a revised one (the
+value is goals that *don't move* — the "invent a 7% tolerance mid-flight"
+anti-pattern).
+
+Declined: #1414 ``set_goal``/``cancel_goal``
+--------------------------------------------
+Open issue #1414 ("set_goal / cancel_goal: self-issued awaited-request 'goals' for
+always-on agents") proposed a ``set_goal``/``cancel_goal`` naming. The
+chairman-ratified decision in epic #1516 is to **keep ``create_goal`` and NOT rename
+to ``set_goal``**, and to **NOT add ``cancel_goal``** — dropping a goal is the
+uniform ``cancel_call`` (child #5). This module is the terminology of record for that
+decision so #1414's naming is not re-litigated; #1414 may be closed as
+resolved-by-#1516 by the seat/chairman.
+
+The mechanism (unchanged)
+-------------------------
+The *gating* already exists and works — an open awaited obligation drives the
+quiescence-guard nudge / ``no_return`` loop (``db/queries/sessions.py`` +
+``harness/context.py`` ``_agent_owes_response``) and renders in the "Open
+obligations" tail block (``harness/obligations.py``). The ONLY way to open a
+self-goal used to be the cryptic ``call_session(session_id=<its own id>, input=…)``
+awaited self-call (#1414) — undiscoverable, awkward, easy to forget; ``create_goal``
+is the explicit, first-class surface over that SAME mechanism (it does NOT reinvent
+the gate):
 
 * ``create_goal(goal, output_schema)`` — open a self-goal: write the same
   self-referential awaited edge a ``call_session(self)`` opens (reusing the #1414
@@ -24,22 +67,10 @@ mechanism (they do NOT reinvent the gate):
   ``goal_id`` (the ``request_id`` of the opened edge). Enforces the per-session
   open-goal admission cap (``Settings.session_open_goals_max``) with a clear error
   on exceed.
-* ``list_goals()`` — enumerate the session's OPEN self-goals (the open-obligation
-  set filtered to self-caller edges), each with ``goal_id``, ``goal`` text, and
-  ``age``.
-
-There is **no** ``complete_goal``/``fail_goal`` and **no** silent ``update_goal``
-(#1518). A self-goal IS an owed obligation, so the general source-agnostic answer
-verbs already close it: ``return(request_id=<goal_id>, value=…)`` completes it (the
-session's persisted ``output_schema`` is enforced servicer-side by ``return``'s own
-schema gate, ``workflow_completion._enforce_output_schema`` → ``_validate_value``,
-so a non-conforming value is rejected with ``output_schema_violation`` and the goal
-stays open) and ``error(request_id=<goal_id>, message=…)`` abandons it. Both surface
-on any open obligation (``step_context`` sets ``owes_request = bool(obligations)``),
-self-goals included, so carrying a self-only duplicate close surface was pure bloat.
-Revision stays explicit: ``error`` the goal, then ``create_goal`` a revised one (the
-value is goals that *don't move* — the "invent a 7% tolerance mid-flight"
-anti-pattern).
+* ``list_goals()`` — legacy enumeration of the session's OPEN self-goals (the
+  open-obligation set filtered to self-caller edges), each with ``goal_id``,
+  ``goal`` text, and ``age``. This folds into ``list_obligations``/``list_calls``
+  (origin=self) under epic child #3; it is retained here only until that lands.
 
 Unlike the parking ``call_*`` builtins, ``create_goal`` does NOT park on the
 edge — a self-goal's servicer IS the session, so parking would deadlock. The tool
@@ -214,9 +245,12 @@ CREATE_GOAL_DESCRIPTION = (
     "the goal with the general answer verbs using that goal_id as the request_id: "
     "`return(request_id=<goal_id>, value=...)` when done (the value is validated "
     "against output_schema — a non-conforming value is rejected and the goal stays "
-    "open), or `error(request_id=<goal_id>, message=...)` to abandon it. This is the "
-    "highest-leverage way to actually close a task: declare a checkable 'done' up "
-    "front, then you can't quiesce until a conforming result proves it."
+    "open), or `error(request_id=<goal_id>, message=...)` to abandon it. List your "
+    "open goals with `list_obligations`/`list_calls` (origin=self) and drop one with "
+    "`cancel_call` (by its tool_call_id) — there is no separate goal-list or "
+    "goal-cancel verb. This is the highest-leverage way to actually close a task: "
+    "declare a checkable 'done' up front, then you can't quiesce until a conforming "
+    "result proves it."
 )
 LIST_GOALS_DESCRIPTION = (
     "List your open self-goals (the goals you've pinned with create_goal that you "

--- a/tests/unit/test_goal_management_tools.py
+++ b/tests/unit/test_goal_management_tools.py
@@ -222,3 +222,57 @@ def test_complete_fail_goal_no_longer_registered(name: str) -> None:
     from aios.tools.registry import registry
 
     assert not registry.has(name), f"{name} should be retired (#1518), closed via return/error"
+
+
+# ─── terminology of record: create_goal is the sole goal-named verb (#1523) ───
+
+
+def test_create_goal_is_registered_with_required_output_schema() -> None:
+    """#1523: ``create_goal`` stays the canonical reflexive-OPEN verb under that exact
+    name, with its current signature — a REQUIRED ``output_schema`` (no schemaless
+    goal). The chairman-ratified decision keeps this name; it is NOT renamed to
+    ``set_goal``."""
+    from aios.tools.registry import registry
+
+    assert registry.has("create_goal")
+    schema = registry.get("create_goal").parameters_schema
+    props = schema.get("properties", {})
+    assert "goal" in props and "output_schema" in props
+    assert "output_schema" in schema.get("required", [])
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["set_goal", "cancel_goal", "update_goal", "complete_goal", "fail_goal"],
+)
+def test_no_goal_named_verb_other_than_create_and_list(name: str) -> None:
+    """#1523 terminology of record: the ONLY goal-named verbs are ``create_goal``
+    (the reflexive-OPEN verb) and — until child #3 retires it — ``list_goals``.
+    #1414's proposed ``set_goal``/``cancel_goal`` naming is explicitly DECLINED:
+    a goal close is ``return``/``error``, a goal list is ``list_obligations`` /
+    ``list_calls`` (origin=self), a goal drop is ``cancel_call`` (#5). No
+    ``set_goal``/``cancel_goal``/``update_goal`` is ever registered."""
+    from aios.tools.registry import registry
+
+    assert not registry.has(name)
+
+
+def test_terminology_of_record_documented() -> None:
+    """#1523: the module docstring + ``create_goal`` description record the
+    terminology of record (goal = reflexive call; close = return/error; list =
+    list_obligations/list_calls; drop = cancel_call) and cite the declined #1414
+    naming, so the decision is not re-litigated."""
+    from aios.tools import goal_management
+
+    doc = goal_management.__doc__ or ""
+    assert "reflexive" in doc.lower()
+    assert "#1414" in doc
+    # the canonical close/list/drop verbs of record are named in the module doc.
+    assert "return" in doc and "error" in doc
+    assert "list_obligations" in doc
+    assert "cancel_call" in doc
+    # and the declined rename is recorded.
+    assert "set_goal" in doc
+
+    desc = goal_management.CREATE_GOAL_DESCRIPTION
+    assert "return" in desc and "error" in desc


### PR DESCRIPTION
Automated dev-pipeline build for issue #1523.