### PR TITLE
unify-obligations #8: rename Session.owed_requests → obligations; collapse OwedRequest into Obligation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Three properties no task-scoped framework has, each a direct consequence of the 
 
 **Tools never block the model.** A user message landing mid-tool is processed by the very next step. You can redirect an agent in the middle of a 90-second fetch, fan out a dozen sub-agents without freezing the conversation, and cancel in-flight work cleanly — because a tool call is a detached task, not a blocking call inside a controller loop.
 
-**The event log *is* the assistant — derived state can't lie.** One append-only, gapless Postgres journal per session is the single source of truth. There is no stored status column: `active/idle/archived/errored`, token spend, `awaiting` ("what is it blocked on"), and `owed_requests` ("what does it owe an answer to") are all SQL arithmetic over the log. The read path and the worker's wake sweep share the **identical** predicate, so they cannot drift — designing out a whole class of "worker wakes with no work / skips a session" bugs. Context is a strictly monotonic function of the log, so the prompt prefix cache stays hot, and scrolled-out history is recalled losslessly with the `search_events` SQL tool.
+**The event log *is* the assistant — derived state can't lie.** One append-only, gapless Postgres journal per session is the single source of truth. There is no stored status column: `active/idle/archived/errored`, token spend, `awaiting` ("what is it blocked on"), and `obligations` ("what does it owe an answer to") are all SQL arithmetic over the log. The read path and the worker's wake sweep share the **identical** predicate, so they cannot drift — designing out a whole class of "worker wakes with no work / skips a session" bugs. Context is a strictly monotonic function of the log, so the prompt prefix cache stays hot, and scrolled-out history is recalled losslessly with the `search_events` SQL tool.
 
 **Durable, replayable workflows whose orchestration spends zero model tokens.** A workflow is the dual of an agent: deterministic Python where the model would be. A run's entire state is an append-only journal, replayed from memo on each wake — crash-, deploy-, and month-long-suspension-durable — while the orchestration logic itself costs **nothing**. The replayed steps are real LLM-agent invocations; the glue between them is free.
 
@@ -288,7 +288,7 @@ The harness turns the event log into a running agent. There is no controller loo
 - **Clone/fork at head** — copy the full event prefix (plus vaults, resources, triggers with counters reset) into a fresh session yielding a byte-identical next-step context. A/B a different model from an identical history.
 - **`archive_when_idle`** — self-reclaiming one-shot sessions that soft-archive the first time they go idle owing nothing (workflow children launch with this set).
 - **Outbound-suppression mode** — reads pass through to real credentials while writes return a *synthesized* success the agent can't distinguish from production, with an audit span. The atomic flip-v1→v2 lever for parallel-run cutovers.
-- **Two derived views** — `awaiting` (tool calls the session is blocked on) and `owed_requests` (requests it must answer), both computed from the log and surviving context-windowing erasure.
+- **Two derived views** — `awaiting` (tool calls the session is blocked on) and `obligations` (requests it must answer), both computed from the log and surviving context-windowing erasure.
 
 <details>
 <summary><b>Session & agent endpoints</b></summary>
@@ -297,7 +297,7 @@ The harness turns the event log into a running agent. There is no controller loo
 |---|---|---|
 | POST | `/v1/sessions` | Create (agent + env; optional version pin, vaults, resources, triggers, initial message). |
 | GET | `/v1/sessions` | Keyset-paginated list with derived-status filters. |
-| GET | `/v1/sessions/{id}` | Read view: derived status, `stop_reason`, `awaiting`, `owed_requests`, usage. |
+| GET | `/v1/sessions/{id}` | Read view: derived status, `stop_reason`, `awaiting`, `obligations`, usage. |
 | PUT | `/v1/sessions/{id}` | Rebind agent/version/model; flip outbound suppression. |
 | POST | `/v1/sessions/{id}/clone` | Fork at head (idle parents only). |
 | POST | `/v1/sessions/{id}/archive` | Soft-archive (terminal). |

--- a/openapi.json
+++ b/openapi.json
@@ -14491,29 +14491,7 @@
         "title": "OAuthStartResponse",
         "description": "The authorization URL to redirect the user to, plus the flow's CSRF state."
       },
-      "OneShotSource": {
-        "properties": {
-          "kind": {
-            "type": "string",
-            "const": "one_shot",
-            "title": "Kind",
-            "default": "one_shot"
-          },
-          "fire_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Fire At"
-          }
-        },
-        "additionalProperties": false,
-        "type": "object",
-        "required": [
-          "fire_at"
-        ],
-        "title": "OneShotSource",
-        "description": "One-shot source: fires once at an absolute UTC time, then self-deletes."
-      },
-      "OwedRequest": {
+      "Obligation": {
         "properties": {
           "request_id": {
             "type": "string",
@@ -14569,8 +14547,30 @@
           "caller_kind",
           "opened_at"
         ],
-        "title": "OwedRequest",
-        "description": "Read-model projection of an open obligation on the :class:`Session` view (#1413).\n\nParallel to ``Session.awaiting`` (tool-call-only), but for the request edges\nthe session owes a response to. Projected from the same ``get_open_obligations``\nrows. Load-bearing for the operator-cancel path (#1414) \u2014 it cannot enumerate\na session's open goal_ids otherwise.\n\n``output_schema`` (#1522) carries the request's acceptance contract \u2014 the same\nadditive projection added to :class:`Obligation`, from which this view is\nderived."
+        "title": "Obligation",
+        "description": "One still-open **awaited** request the session owes a response to (#1413).\n\nThe dual of :class:`AwaitingToolCall`: that view lists tool calls the session\nis *blocked on*; this one lists requests the session *owes an answer to*. An\nobligation is an open ``request_opened`` edge (#1123) \u2014 ``awaited=true``, with\nno paired ``request_response`` \u2014 and is the in-context surface the model reads\nto know which ``request_id`` to echo back to ``return``/``error``.\n\nDerived (oldest-first) from the trusted ``request_opened`` lifecycle frame via\n:func:`aios.db.queries.sessions.get_open_obligations`, NEVER the forgeable\n``metadata.request`` user-message blob (#1131-proof). ``caller_kind`` is the\ntrusted ``caller.kind`` (``api``|``session``|``run``); ``opened_at`` is the\nedge's ``created_at`` (for age); ``summary`` is a short truncated preview of\nthe request input (absent on pre-#1413 frames \u2192 ``None``, rendered id-only).\n\n``output_schema`` (#1522) is the JSON Schema the request demands of its\nresponse ``value`` \u2014 the **acceptance contract** the session must produce to\nanswer. It is the same datum :func:`aios.db.queries.sessions.get_request_output_schema`\nreads off the ``request_opened`` frame, now projected directly onto the owed\nread-model so a single renderer can show \"here is what you owe **and the\nformat**\". Additive: ``None`` when the request demands no schema (the common\ncase) or on a pre-#1522 frame \u2014 no migration."
+      },
+      "OneShotSource": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "one_shot",
+            "title": "Kind",
+            "default": "one_shot"
+          },
+          "fire_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Fire At"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "fire_at"
+        ],
+        "title": "OneShotSource",
+        "description": "One-shot source: fires once at an absolute UTC time, then self-deletes."
       },
       "RecentChat": {
         "properties": {
@@ -15214,12 +15214,12 @@
             "type": "array",
             "title": "Awaiting"
           },
-          "owed_requests": {
+          "obligations": {
             "items": {
-              "$ref": "#/components/schemas/OwedRequest"
+              "$ref": "#/components/schemas/Obligation"
             },
             "type": "array",
-            "title": "Owed Requests"
+            "title": "Obligations"
           },
           "vault_ids": {
             "items": {
@@ -15368,7 +15368,7 @@
           "updated_at"
         ],
         "title": "Session",
-        "description": "Read view of a session. Internal-only columns are not exposed.\n\n``status`` ({active, idle}) is derived per read from the event log; see\n:data:`SessionStatus`. ``stop_reason`` records why the most recent step\nended. Possible ``type`` values: ``\"end_turn\"``, ``\"interrupt\"``,\n``\"rescheduling\"``, ``\"error\"`` (``idle`` + ``error`` = the errored\nlanding pad). ``awaiting`` lists tool calls the session is blocked on\n(derived per read from the event log + agent tool specs). ``owed_requests``\nlists the still-open **awaited** request edges the session owes a response to\n(derived per read from the ``request_opened`` lifecycle frame \u2014 #1413)."
+        "description": "Read view of a session. Internal-only columns are not exposed.\n\n``status`` ({active, idle}) is derived per read from the event log; see\n:data:`SessionStatus`. ``stop_reason`` records why the most recent step\nended. Possible ``type`` values: ``\"end_turn\"``, ``\"interrupt\"``,\n``\"rescheduling\"``, ``\"error\"`` (``idle`` + ``error`` = the errored\nlanding pad). ``awaiting`` lists tool calls the session is blocked on\n(derived per read from the event log + agent tool specs). ``obligations``\nlists the still-open **awaited** request edges the session owes a response to\n(derived per read from the ``request_opened`` lifecycle frame \u2014 #1413)."
       },
       "SessionAwaitResponse": {
         "properties": {

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -147,9 +147,9 @@ from .o_auth_start_request_token_endpoint_auth_method_type_0 import (
     OAuthStartRequestTokenEndpointAuthMethodType0,
 )
 from .o_auth_start_response import OAuthStartResponse
+from .obligation import Obligation
+from .obligation_output_schema_type_0 import ObligationOutputSchemaType0
 from .one_shot_source import OneShotSource
-from .owed_request import OwedRequest
-from .owed_request_output_schema_type_0 import OwedRequestOutputSchemaType0
 from .post_connector_runtime_chat_lifecycle_response_post_connector_runtime_chat_lifecycle import (
     PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle,
 )
@@ -461,9 +461,9 @@ __all__ = (
     "OAuthStartRequest",
     "OAuthStartRequestTokenEndpointAuthMethodType0",
     "OAuthStartResponse",
+    "Obligation",
+    "ObligationOutputSchemaType0",
     "OneShotSource",
-    "OwedRequest",
-    "OwedRequestOutputSchemaType0",
     "PostConnectorRuntimeChatLifecycleResponsePostConnectorRuntimeChatLifecycle",
     "PostConnectorRuntimeLifecycleResponsePostConnectorRuntimeLifecycle",
     "PostConnectorRuntimeSessionLifecycleResponsePostConnectorRuntimeSessionLifecycle",

--- a/packages/aios-sdk/aios_sdk/_generated/models/obligation.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/obligation.py
@@ -11,24 +11,36 @@ from dateutil.parser import isoparse
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-    from ..models.owed_request_output_schema_type_0 import OwedRequestOutputSchemaType0
+    from ..models.obligation_output_schema_type_0 import ObligationOutputSchemaType0
 
 
-T = TypeVar("T", bound="OwedRequest")
+T = TypeVar("T", bound="Obligation")
 
 
 @_attrs_define
-class OwedRequest:
-    """Read-model projection of an open obligation on the :class:`Session` view (#1413).
+class Obligation:
+    """One still-open **awaited** request the session owes a response to (#1413).
 
-    Parallel to ``Session.awaiting`` (tool-call-only), but for the request edges
-    the session owes a response to. Projected from the same ``get_open_obligations``
-    rows. Load-bearing for the operator-cancel path (#1414) — it cannot enumerate
-    a session's open goal_ids otherwise.
+    The dual of :class:`AwaitingToolCall`: that view lists tool calls the session
+    is *blocked on*; this one lists requests the session *owes an answer to*. An
+    obligation is an open ``request_opened`` edge (#1123) — ``awaited=true``, with
+    no paired ``request_response`` — and is the in-context surface the model reads
+    to know which ``request_id`` to echo back to ``return``/``error``.
 
-    ``output_schema`` (#1522) carries the request's acceptance contract — the same
-    additive projection added to :class:`Obligation`, from which this view is
-    derived.
+    Derived (oldest-first) from the trusted ``request_opened`` lifecycle frame via
+    :func:`aios.db.queries.sessions.get_open_obligations`, NEVER the forgeable
+    ``metadata.request`` user-message blob (#1131-proof). ``caller_kind`` is the
+    trusted ``caller.kind`` (``api``|``session``|``run``); ``opened_at`` is the
+    edge's ``created_at`` (for age); ``summary`` is a short truncated preview of
+    the request input (absent on pre-#1413 frames → ``None``, rendered id-only).
+
+    ``output_schema`` (#1522) is the JSON Schema the request demands of its
+    response ``value`` — the **acceptance contract** the session must produce to
+    answer. It is the same datum :func:`aios.db.queries.sessions.get_request_output_schema`
+    reads off the ``request_opened`` frame, now projected directly onto the owed
+    read-model so a single renderer can show "here is what you owe **and the
+    format**". Additive: ``None`` when the request demands no schema (the common
+    case) or on a pre-#1522 frame — no migration.
 
         Attributes:
             request_id (str):
@@ -36,7 +48,7 @@ class OwedRequest:
             opened_at (datetime.datetime):
             caller_id (None | str | Unset):
             summary (None | str | Unset):
-            output_schema (None | OwedRequestOutputSchemaType0 | Unset):
+            output_schema (None | ObligationOutputSchemaType0 | Unset):
     """
 
     request_id: str
@@ -44,13 +56,11 @@ class OwedRequest:
     opened_at: datetime.datetime
     caller_id: None | str | Unset = UNSET
     summary: None | str | Unset = UNSET
-    output_schema: None | OwedRequestOutputSchemaType0 | Unset = UNSET
+    output_schema: None | ObligationOutputSchemaType0 | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.owed_request_output_schema_type_0 import (
-            OwedRequestOutputSchemaType0,
-        )
+        from ..models.obligation_output_schema_type_0 import ObligationOutputSchemaType0
 
         request_id = self.request_id
 
@@ -73,7 +83,7 @@ class OwedRequest:
         output_schema: dict[str, Any] | None | Unset
         if isinstance(self.output_schema, Unset):
             output_schema = UNSET
-        elif isinstance(self.output_schema, OwedRequestOutputSchemaType0):
+        elif isinstance(self.output_schema, ObligationOutputSchemaType0):
             output_schema = self.output_schema.to_dict()
         else:
             output_schema = self.output_schema
@@ -98,9 +108,7 @@ class OwedRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.owed_request_output_schema_type_0 import (
-            OwedRequestOutputSchemaType0,
-        )
+        from ..models.obligation_output_schema_type_0 import ObligationOutputSchemaType0
 
         d = dict(src_dict)
         request_id = d.pop("request_id")
@@ -129,7 +137,7 @@ class OwedRequest:
 
         def _parse_output_schema(
             data: object,
-        ) -> None | OwedRequestOutputSchemaType0 | Unset:
+        ) -> None | ObligationOutputSchemaType0 | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -137,16 +145,16 @@ class OwedRequest:
             try:
                 if not isinstance(data, dict):
                     raise TypeError()
-                output_schema_type_0 = OwedRequestOutputSchemaType0.from_dict(data)
+                output_schema_type_0 = ObligationOutputSchemaType0.from_dict(data)
 
                 return output_schema_type_0
             except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(None | OwedRequestOutputSchemaType0 | Unset, data)
+            return cast(None | ObligationOutputSchemaType0 | Unset, data)
 
         output_schema = _parse_output_schema(d.pop("output_schema", UNSET))
 
-        owed_request = cls(
+        obligation = cls(
             request_id=request_id,
             caller_kind=caller_kind,
             opened_at=opened_at,
@@ -155,8 +163,8 @@ class OwedRequest:
             output_schema=output_schema,
         )
 
-        owed_request.additional_properties = d
-        return owed_request
+        obligation.additional_properties = d
+        return obligation
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/aios-sdk/aios_sdk/_generated/models/obligation_output_schema_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/obligation_output_schema_type_0.py
@@ -6,11 +6,11 @@ from typing import Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-T = TypeVar("T", bound="OwedRequestOutputSchemaType0")
+T = TypeVar("T", bound="ObligationOutputSchemaType0")
 
 
 @_attrs_define
-class OwedRequestOutputSchemaType0:
+class ObligationOutputSchemaType0:
     """ """
 
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -25,10 +25,10 @@ class OwedRequestOutputSchemaType0:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        owed_request_output_schema_type_0 = cls()
+        obligation_output_schema_type_0 = cls()
 
-        owed_request_output_schema_type_0.additional_properties = d
-        return owed_request_output_schema_type_0
+        obligation_output_schema_type_0.additional_properties = d
+        return obligation_output_schema_type_0
 
     @property
     def additional_keys(self) -> list[str]:

--- a/packages/aios-sdk/aios_sdk/_generated/models/session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/session.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ..models.awaiting_tool_call import AwaitingToolCall
     from ..models.github_repository_resource_echo import GithubRepositoryResourceEcho
     from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
-    from ..models.owed_request import OwedRequest
+    from ..models.obligation import Obligation
     from ..models.session_metadata import SessionMetadata
     from ..models.session_stop_reason_type_0 import SessionStopReasonType0
     from ..models.session_usage import SessionUsage
@@ -36,7 +36,7 @@ class Session:
     ended. Possible ``type`` values: ``"end_turn"``, ``"interrupt"``,
     ``"rescheduling"``, ``"error"`` (``idle`` + ``error`` = the errored
     landing pad). ``awaiting`` lists tool calls the session is blocked on
-    (derived per read from the event log + agent tool specs). ``owed_requests``
+    (derived per read from the event log + agent tool specs). ``obligations``
     lists the still-open **awaited** request edges the session owes a response to
     (derived per read from the ``request_opened`` lifecycle frame — #1413).
 
@@ -54,7 +54,7 @@ class Session:
             updated_at (datetime.datetime):
             model (None | str | Unset):
             awaiting (list[AwaitingToolCall] | Unset):
-            owed_requests (list[OwedRequest] | Unset):
+            obligations (list[Obligation] | Unset):
             vault_ids (list[str] | Unset):
             usage (SessionUsage | Unset): Cumulative token usage across all model calls in a session.
             resources (list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset):
@@ -83,7 +83,7 @@ class Session:
     updated_at: datetime.datetime
     model: None | str | Unset = UNSET
     awaiting: list[AwaitingToolCall] | Unset = UNSET
-    owed_requests: list[OwedRequest] | Unset = UNSET
+    obligations: list[Obligation] | Unset = UNSET
     vault_ids: list[str] | Unset = UNSET
     usage: SessionUsage | Unset = UNSET
     resources: list[GithubRepositoryResourceEcho | MemoryStoreResourceEcho] | Unset = (
@@ -149,12 +149,12 @@ class Session:
                 awaiting_item = awaiting_item_data.to_dict()
                 awaiting.append(awaiting_item)
 
-        owed_requests: list[dict[str, Any]] | Unset = UNSET
-        if not isinstance(self.owed_requests, Unset):
-            owed_requests = []
-            for owed_requests_item_data in self.owed_requests:
-                owed_requests_item = owed_requests_item_data.to_dict()
-                owed_requests.append(owed_requests_item)
+        obligations: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.obligations, Unset):
+            obligations = []
+            for obligations_item_data in self.obligations:
+                obligations_item = obligations_item_data.to_dict()
+                obligations.append(obligations_item)
 
         vault_ids: list[str] | Unset = UNSET
         if not isinstance(self.vault_ids, Unset):
@@ -246,8 +246,8 @@ class Session:
             field_dict["model"] = model
         if awaiting is not UNSET:
             field_dict["awaiting"] = awaiting
-        if owed_requests is not UNSET:
-            field_dict["owed_requests"] = owed_requests
+        if obligations is not UNSET:
+            field_dict["obligations"] = obligations
         if vault_ids is not UNSET:
             field_dict["vault_ids"] = vault_ids
         if usage is not UNSET:
@@ -284,7 +284,7 @@ class Session:
             GithubRepositoryResourceEcho,
         )
         from ..models.memory_store_resource_echo import MemoryStoreResourceEcho
-        from ..models.owed_request import OwedRequest
+        from ..models.obligation import Obligation
         from ..models.session_metadata import SessionMetadata
         from ..models.session_stop_reason_type_0 import SessionStopReasonType0
         from ..models.session_usage import SessionUsage
@@ -359,14 +359,14 @@ class Session:
 
                 awaiting.append(awaiting_item)
 
-        _owed_requests = d.pop("owed_requests", UNSET)
-        owed_requests: list[OwedRequest] | Unset = UNSET
-        if _owed_requests is not UNSET:
-            owed_requests = []
-            for owed_requests_item_data in _owed_requests:
-                owed_requests_item = OwedRequest.from_dict(owed_requests_item_data)
+        _obligations = d.pop("obligations", UNSET)
+        obligations: list[Obligation] | Unset = UNSET
+        if _obligations is not UNSET:
+            obligations = []
+            for obligations_item_data in _obligations:
+                obligations_item = Obligation.from_dict(obligations_item_data)
 
-                owed_requests.append(owed_requests_item)
+                obligations.append(obligations_item)
 
         vault_ids = cast(list[str], d.pop("vault_ids", UNSET))
 
@@ -501,7 +501,7 @@ class Session:
             updated_at=updated_at,
             model=model,
             awaiting=awaiting,
-            owed_requests=owed_requests,
+            obligations=obligations,
             vault_ids=vault_ids,
             usage=usage,
             resources=resources,

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -532,7 +532,7 @@ async def get_open_obligations(
     ``awaited=true`` COALESCE filter (so a fire-and-forget ``Tell`` edge is
     excluded), same ``ORDER BY req.seq ASC`` (oldest-first, deterministic). But
     instead of bare ``request_id``s it projects a full :class:`Obligation` per open
-    edge so the tail-injected obligations block (and the ``owed_requests`` read
+    edge so the tail-injected obligations block (and the ``obligations`` read
     model) can render it: ``caller_kind`` (``req.data->'caller'->>'kind'`` — the
     **trusted** frame, not the forgeable ``metadata.request`` blob), ``opened_at``
     (``req.created_at``, for age), and a short ``summary`` (``req.data->>'summary'``,

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -203,27 +203,6 @@ class Obligation(BaseModel):
     output_schema: dict[str, Any] | None = None
 
 
-class OwedRequest(BaseModel):
-    """Read-model projection of an open obligation on the :class:`Session` view (#1413).
-
-    Parallel to ``Session.awaiting`` (tool-call-only), but for the request edges
-    the session owes a response to. Projected from the same ``get_open_obligations``
-    rows. Load-bearing for the operator-cancel path (#1414) — it cannot enumerate
-    a session's open goal_ids otherwise.
-
-    ``output_schema`` (#1522) carries the request's acceptance contract — the same
-    additive projection added to :class:`Obligation`, from which this view is
-    derived.
-    """
-
-    request_id: str
-    caller_kind: str
-    caller_id: str | None = None
-    opened_at: datetime
-    summary: str | None = None
-    output_schema: dict[str, Any] | None = None
-
-
 class SessionCreate(BaseModel):
     """Request body for `POST /v1/sessions`."""
 
@@ -392,7 +371,7 @@ class Session(BaseModel):
     ended. Possible ``type`` values: ``"end_turn"``, ``"interrupt"``,
     ``"rescheduling"``, ``"error"`` (``idle`` + ``error`` = the errored
     landing pad). ``awaiting`` lists tool calls the session is blocked on
-    (derived per read from the event log + agent tool specs). ``owed_requests``
+    (derived per read from the event log + agent tool specs). ``obligations``
     lists the still-open **awaited** request edges the session owes a response to
     (derived per read from the ``request_opened`` lifecycle frame — #1413).
     """
@@ -407,7 +386,7 @@ class Session(BaseModel):
     status: SessionStatus
     stop_reason: dict[str, Any] | None
     awaiting: list[AwaitingToolCall] = Field(default_factory=list)
-    owed_requests: list[OwedRequest] = Field(default_factory=list)
+    obligations: list[Obligation] = Field(default_factory=list)
     vault_ids: list[str] = Field(default_factory=list)
     last_event_seq: int
     usage: SessionUsage = Field(default_factory=SessionUsage)

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -42,7 +42,7 @@ from aios.models.memory_stores import MemoryStoreResource
 from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
     AwaitingToolCall,
-    OwedRequest,
+    Obligation,
     Session,
     SessionAwaitResponse,
     SessionResource,
@@ -1075,10 +1075,10 @@ async def compute_awaiting(
     return out
 
 
-async def compute_owed_requests(
+async def compute_obligations(
     pool: asyncpg.Pool[Any], sessions: list[Session], *, account_id: str
-) -> dict[str, list[OwedRequest]]:
-    """Compute the ``owed_requests`` read-model view for a batch of sessions (#1413).
+) -> dict[str, list[Obligation]]:
+    """Compute the ``obligations`` read-model view for a batch of sessions (#1413).
 
     The dual of :func:`compute_awaiting`: that view lists tool calls a session is
     blocked on; this lists the still-open **awaited** request edges the session
@@ -1089,7 +1089,7 @@ async def compute_owed_requests(
     """
     if not sessions:
         return {}
-    out: dict[str, list[OwedRequest]] = {}
+    out: dict[str, list[Obligation]] = {}
     async with pool.acquire() as conn:
         for session in sessions:
             obligations = await queries.get_open_obligations(
@@ -1097,7 +1097,7 @@ async def compute_owed_requests(
             )
             if obligations:
                 out[session.id] = [
-                    OwedRequest(
+                    Obligation(
                         request_id=o.request_id,
                         caller_kind=o.caller_kind,
                         caller_id=o.caller_id,
@@ -1121,11 +1121,11 @@ async def get_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: s
         session = await queries.get_session(conn, session_id, account_id=account_id)
         session = await _enrich_session(conn, session, account_id=account_id)
     awaiting_by_sid = await compute_awaiting(pool, [session], account_id=account_id)
-    owed_by_sid = await compute_owed_requests(pool, [session], account_id=account_id)
+    obligations_by_sid = await compute_obligations(pool, [session], account_id=account_id)
     return session.model_copy(
         update={
             "awaiting": awaiting_by_sid.get(session_id, []),
-            "owed_requests": owed_by_sid.get(session_id, []),
+            "obligations": obligations_by_sid.get(session_id, []),
         }
     )
 
@@ -1248,7 +1248,7 @@ async def list_sessions(
             conn, sid_list, account_id=account_id
         )
     awaiting_by_sid = await compute_awaiting(pool, sessions, account_id=account_id)
-    owed_by_sid = await compute_owed_requests(pool, sessions, account_id=account_id)
+    obligations_by_sid = await compute_obligations(pool, sessions, account_id=account_id)
     enriched: list[Session] = [
         s.model_copy(
             update={
@@ -1256,7 +1256,7 @@ async def list_sessions(
                 "resources": echoes_map[s.id],
                 "triggers": trigger_map[s.id],
                 "awaiting": awaiting_by_sid.get(s.id, []),
-                "owed_requests": owed_by_sid.get(s.id, []),
+                "obligations": obligations_by_sid.get(s.id, []),
             }
         )
         for s in sessions

--- a/tests/unit/test_session_obligations_field.py
+++ b/tests/unit/test_session_obligations_field.py
@@ -1,0 +1,55 @@
+"""unify-obligations #8 (#1526): the Session HTTP view exposes the owed set as
+``Session.obligations: list[Obligation]`` — the off-terminology ``owed_requests``
+field and the duplicate ``OwedRequest`` model are gone (clean break, no alias).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import aios.models.sessions as sessions_models
+import aios.services.sessions as sessions_service
+from aios.models.sessions import Obligation, Session
+
+
+def test_owed_request_model_is_deleted() -> None:
+    """``OwedRequest`` collapsed into ``Obligation`` — the duplicate name is gone."""
+    assert not hasattr(sessions_models, "OwedRequest")
+
+
+def test_compute_owed_requests_renamed_to_compute_obligations() -> None:
+    assert hasattr(sessions_service, "compute_obligations")
+    assert not hasattr(sessions_service, "compute_owed_requests")
+
+
+def test_session_exposes_obligations_field_typed_as_obligation() -> None:
+    """The owed set is ``Session.obligations: list[Obligation]``; no ``owed_requests``."""
+    assert "obligations" in Session.model_fields
+    assert "owed_requests" not in Session.model_fields
+
+    ob = Obligation(
+        request_id="req-1",
+        caller_kind="run",
+        caller_id="run-1",
+        opened_at=datetime(2025, 1, 1, tzinfo=UTC),
+        summary="do the thing",
+    )
+    session = Session(
+        id="s1",
+        agent_id="a1",
+        environment_id="e1",
+        agent_version=1,
+        title=None,
+        metadata={},
+        status="idle",
+        stop_reason=None,
+        obligations=[ob],
+        last_event_seq=0,
+        created_at=datetime(2025, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+    assert session.obligations == [ob]
+    # The serialized HTTP view carries the on-terminology key.
+    dumped = session.model_dump()
+    assert "obligations" in dumped
+    assert "owed_requests" not in dumped


### PR DESCRIPTION
Automated dev-pipeline build for issue #1526.