### PR TITLE
Bare DELETE idempotency: thread idempotent=True across all 4 archive families (sessions/vaults/credentials, not just memory-stores)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1952,7 +1952,7 @@
           "sessions"
         ],
         "summary": "Delete",
-        "description": "Soft-archive a session (bare DELETE = soft-archive; T2 convention).\n\nSets ``archived_at`` and hides the session from default lists (same\nbehavior as ``archive_session``); events, vaults, and bindings are\nretained. Bare DELETE is never silently destructive; for the\nirreversible hard-delete (cascade of events / vaults / bindings) use\n``POST /v1/sessions/{session_id}/purge``.",
+        "description": "Soft-archive a session (bare DELETE = soft-archive; T2 convention).\n\nSets ``archived_at`` and hides the session from default lists (same\nbehavior as ``archive_session``); events, vaults, and bindings are\nretained. Bare DELETE is never silently destructive; for the\nirreversible hard-delete (cascade of events / vaults / bindings) use\n``POST /v1/sessions/{session_id}/purge``.\n\nIdempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns\nthe existing archived row with 200, not 404.",
         "operationId": "delete_session",
         "parameters": [
           {
@@ -4578,7 +4578,7 @@
           "vaults"
         ],
         "summary": "Delete",
-        "description": "Soft-archive a vault (bare DELETE = soft-archive; T2 convention).\n\nSets ``archived_at`` and hides the vault from default lists, zeroing the\nencrypted secret material of its credentials (same behavior as\n``archive_vault``). The rows persist for audit and history is retained.\nBare DELETE is never silently destructive; for the irreversible\nhard-delete use ``POST /v1/vaults/{vault_id}/purge``.",
+        "description": "Soft-archive a vault (bare DELETE = soft-archive; T2 convention).\n\nSets ``archived_at`` and hides the vault from default lists, zeroing the\nencrypted secret material of its credentials (same behavior as\n``archive_vault``). The rows persist for audit and history is retained.\nBare DELETE is never silently destructive; for the irreversible\nhard-delete use ``POST /v1/vaults/{vault_id}/purge``.\n\nIdempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns\nthe existing archived row with 200, not 404.",
         "operationId": "delete_vault",
         "parameters": [
           {
@@ -5203,7 +5203,7 @@
           "vaults"
         ],
         "summary": "Delete Credential",
-        "description": "Soft-archive a credential (bare DELETE = soft-archive; T2 convention).\n\nSets ``archived_at``, hides the credential from default lists, and zeroes\nits encrypted secret payload (same behavior as\n``archive_vault_credential``). The row persists for audit. Bare DELETE is\nnever silently destructive; for the irreversible hard-delete use\n``POST /v1/vaults/{vault_id}/credentials/{credential_id}/purge``.",
+        "description": "Soft-archive a credential (bare DELETE = soft-archive; T2 convention).\n\nSets ``archived_at``, hides the credential from default lists, and zeroes\nits encrypted secret payload (same behavior as\n``archive_vault_credential``). The row persists for audit. Bare DELETE is\nnever silently destructive; for the irreversible hard-delete use\n``POST /v1/vaults/{vault_id}/credentials/{credential_id}/purge``.\n\nIdempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns\nthe existing archived row with 200, not 404.",
         "operationId": "delete_vault_credential",
         "parameters": [
           {

--- a/packages/aios-sdk/aios_sdk/_generated/api/sessions/delete_session.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/sessions/delete_session.py
@@ -77,6 +77,9 @@ def sync_detailed(
     irreversible hard-delete (cascade of events / vaults / bindings) use
     ``POST /v1/sessions/{session_id}/purge``.
 
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
+
     Args:
         session_id (str):
         authorization (None | str | Unset):
@@ -117,6 +120,9 @@ def sync(
     irreversible hard-delete (cascade of events / vaults / bindings) use
     ``POST /v1/sessions/{session_id}/purge``.
 
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
+
     Args:
         session_id (str):
         authorization (None | str | Unset):
@@ -151,6 +157,9 @@ async def asyncio_detailed(
     retained. Bare DELETE is never silently destructive; for the
     irreversible hard-delete (cascade of events / vaults / bindings) use
     ``POST /v1/sessions/{session_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
 
     Args:
         session_id (str):
@@ -189,6 +198,9 @@ async def asyncio(
     retained. Bare DELETE is never silently destructive; for the
     irreversible hard-delete (cascade of events / vaults / bindings) use
     ``POST /v1/sessions/{session_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
 
     Args:
         session_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/delete_vault.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/delete_vault.py
@@ -77,6 +77,9 @@ def sync_detailed(
     Bare DELETE is never silently destructive; for the irreversible
     hard-delete use ``POST /v1/vaults/{vault_id}/purge``.
 
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
+
     Args:
         vault_id (str):
         authorization (None | str | Unset):
@@ -117,6 +120,9 @@ def sync(
     Bare DELETE is never silently destructive; for the irreversible
     hard-delete use ``POST /v1/vaults/{vault_id}/purge``.
 
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
+
     Args:
         vault_id (str):
         authorization (None | str | Unset):
@@ -151,6 +157,9 @@ async def asyncio_detailed(
     ``archive_vault``). The rows persist for audit and history is retained.
     Bare DELETE is never silently destructive; for the irreversible
     hard-delete use ``POST /v1/vaults/{vault_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
 
     Args:
         vault_id (str):
@@ -189,6 +198,9 @@ async def asyncio(
     ``archive_vault``). The rows persist for audit and history is retained.
     Bare DELETE is never silently destructive; for the irreversible
     hard-delete use ``POST /v1/vaults/{vault_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
 
     Args:
         vault_id (str):

--- a/packages/aios-sdk/aios_sdk/_generated/api/vaults/delete_vault_credential.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/vaults/delete_vault_credential.py
@@ -80,6 +80,9 @@ def sync_detailed(
     never silently destructive; for the irreversible hard-delete use
     ``POST /v1/vaults/{vault_id}/credentials/{credential_id}/purge``.
 
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
+
     Args:
         vault_id (str):
         credential_id (str):
@@ -123,6 +126,9 @@ def sync(
     never silently destructive; for the irreversible hard-delete use
     ``POST /v1/vaults/{vault_id}/credentials/{credential_id}/purge``.
 
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
+
     Args:
         vault_id (str):
         credential_id (str):
@@ -160,6 +166,9 @@ async def asyncio_detailed(
     ``archive_vault_credential``). The row persists for audit. Bare DELETE is
     never silently destructive; for the irreversible hard-delete use
     ``POST /v1/vaults/{vault_id}/credentials/{credential_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
 
     Args:
         vault_id (str):
@@ -201,6 +210,9 @@ async def asyncio(
     ``archive_vault_credential``). The row persists for audit. Bare DELETE is
     never silently destructive; for the irreversible hard-delete use
     ``POST /v1/vaults/{vault_id}/credentials/{credential_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
 
     Args:
         vault_id (str):

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -489,8 +489,11 @@ async def delete(session_id: str, pool: PoolDep, account_id: AccountIdDep) -> Se
     retained. Bare DELETE is never silently destructive; for the
     irreversible hard-delete (cascade of events / vaults / bindings) use
     ``POST /v1/sessions/{session_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
     """
-    return await service.archive_session(pool, session_id, account_id=account_id)
+    return await service.archive_session(pool, session_id, account_id=account_id, idempotent=True)
 
 
 @router.post(

--- a/src/aios/api/routers/vaults.py
+++ b/src/aios/api/routers/vaults.py
@@ -115,8 +115,11 @@ async def delete(vault_id: str, pool: PoolDep, account_id: AccountIdDep) -> Vaul
     ``archive_vault``). The rows persist for audit and history is retained.
     Bare DELETE is never silently destructive; for the irreversible
     hard-delete use ``POST /v1/vaults/{vault_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
     """
-    return await service.archive_vault(pool, vault_id, account_id=account_id)
+    return await service.archive_vault(pool, vault_id, account_id=account_id, idempotent=True)
 
 
 @router.post(
@@ -316,9 +319,12 @@ async def delete_credential(
     ``archive_vault_credential``). The row persists for audit. Bare DELETE is
     never silently destructive; for the irreversible hard-delete use
     ``POST /v1/vaults/{vault_id}/credentials/{credential_id}/purge``.
+
+    Idempotent: a repeat bare DELETE (or a DELETE after ``/archive``) returns
+    the existing archived row with 200, not 404.
     """
     return await service.archive_vault_credential(
-        pool, vault_id, credential_id, account_id=account_id
+        pool, vault_id, credential_id, account_id=account_id, idempotent=True
     )
 
 

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -1416,7 +1416,7 @@ async def update_session(
 
 
 async def archive_session(
-    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, idempotent: bool = False
 ) -> Session:
     row = await _archive_scoped(
         conn,
@@ -1424,6 +1424,7 @@ async def archive_session(
         id_=session_id,
         account_id=account_id,
         noun="session",
+        idempotent=idempotent,
     )
     return _row_to_session(row)
 

--- a/src/aios/db/queries/vaults.py
+++ b/src/aios/db/queries/vaults.py
@@ -141,12 +141,21 @@ async def update_vault(
     return _row_to_vault(row)
 
 
-async def archive_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account_id: str) -> Vault:
+async def archive_vault(
+    conn: asyncpg.Connection[Any], vault_id: str, *, account_id: str, idempotent: bool = False
+) -> Vault:
     """Archive a vault and purge the encrypted blobs of its active credentials.
 
     Archive is an UPDATE, so ``ON DELETE CASCADE`` on the FK does not fire
     here — child credentials must be archived and zeroed explicitly. Both
     operations run in one transaction.
+
+    When ``idempotent`` is set, an already-archived (but still present) vault
+    is not an error: the existing row is returned unchanged. This backs the
+    bare ``DELETE`` verb (T2 soft-archive) — a second DELETE, or a DELETE
+    after an explicit ``/archive``, still reports the archived row with 200
+    rather than 404. Mirrors the ``_archive_scoped`` fallback used by the
+    other archive families.
     """
     async with conn.transaction():
         row = await conn.fetchrow(
@@ -156,6 +165,14 @@ async def archive_vault(conn: asyncpg.Connection[Any], vault_id: str, *, account
             account_id,
         )
         if row is None:
+            if idempotent:
+                existing = await conn.fetchrow(
+                    "SELECT * FROM vaults WHERE id = $1 AND account_id = $2",
+                    vault_id,
+                    account_id,
+                )
+                if existing is not None:
+                    return _row_to_vault(existing)
             raise NotFoundError(
                 f"vault {vault_id} not found or already archived",
                 detail={"id": vault_id},
@@ -535,12 +552,20 @@ async def archive_vault_credential(
     credential_id: str,
     *,
     account_id: str,
+    idempotent: bool = False,
 ) -> VaultCredential:
     """Archive a credential and zero out its encrypted secret payload.
 
     The bytes are scrubbed at archive time so a future DB dump or query
     cannot leak the secret, even though ``WHERE archived_at IS NULL``
     filters in the read path already prevent resolution.
+
+    When ``idempotent`` is set, an already-archived (but still present)
+    credential is not an error: the existing row is returned unchanged. This
+    backs the bare ``DELETE`` verb (T2 soft-archive) — a second DELETE, or a
+    DELETE after an explicit ``/archive``, still reports the archived row with
+    200 rather than 404. Mirrors the ``_archive_scoped`` fallback used by the
+    other archive families.
     """
     row = await conn.fetchrow(
         "UPDATE vault_credentials "
@@ -552,6 +577,16 @@ async def archive_vault_credential(
         account_id,
     )
     if row is None:
+        if idempotent:
+            existing = await conn.fetchrow(
+                "SELECT * FROM vault_credentials "
+                "WHERE id = $1 AND vault_id = $2 AND account_id = $3",
+                credential_id,
+                vault_id,
+                account_id,
+            )
+            if existing is not None:
+                return _row_to_vault_credential(existing)
         raise NotFoundError(
             f"credential {credential_id} not found or already archived",
             detail={"id": credential_id, "vault_id": vault_id},

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -2131,7 +2131,9 @@ async def increment_usage(
         )
 
 
-async def archive_session(pool: asyncpg.Pool[Any], session_id: str, *, account_id: str) -> Session:
+async def archive_session(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str, idempotent: bool = False
+) -> Session:
     # Archiving a workflow child that still owes its agent() response is a
     # COMPLETION: fail its open requests through write_child_response (error
     # child_gone) FIRST — before the archived_at flip, because append_event is
@@ -2145,7 +2147,9 @@ async def archive_session(pool: asyncpg.Pool[Any], session_id: str, *, account_i
         parent_run_id = await fail_open_child_requests_conn(
             conn, session_id, account_id=account_id, error={"kind": "child_gone"}
         )
-        session = await queries.archive_session(conn, session_id, account_id=account_id)
+        session = await queries.archive_session(
+            conn, session_id, account_id=account_id, idempotent=idempotent
+        )
         session = await _enrich_session(conn, session, account_id=account_id)
     # Wake any consumer LISTENing on this session's events channel (#906): the
     # await primitive, the long-poll /wait endpoint, the SSE /stream. Archival

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -376,9 +376,13 @@ async def update_vault(
         )
 
 
-async def archive_vault(pool: asyncpg.Pool[Any], vault_id: str, *, account_id: str) -> Vault:
+async def archive_vault(
+    pool: asyncpg.Pool[Any], vault_id: str, *, account_id: str, idempotent: bool = False
+) -> Vault:
     async with pool.acquire() as conn:
-        archived = await queries.archive_vault(conn, vault_id, account_id=account_id)
+        archived = await queries.archive_vault(
+            conn, vault_id, account_id=account_id, idempotent=idempotent
+        )
     # Archiving a vault retires (zeroes) all its credentials' secrets, so the
     # pooled MCP sessions keyed on this vault must be evicted too (#1030).
     await _notify_evict_vault(pool, vault_id)
@@ -603,10 +607,11 @@ async def archive_vault_credential(
     credential_id: str,
     *,
     account_id: str,
+    idempotent: bool = False,
 ) -> VaultCredential:
     async with pool.acquire() as conn:
         archived = await queries.archive_vault_credential(
-            conn, vault_id, credential_id, account_id=account_id
+            conn, vault_id, credential_id, account_id=account_id, idempotent=idempotent
         )
     # Evict the pooled MCP session: the credential's secret is now retired (#1030).
     await _notify_evict_vault(pool, vault_id)

--- a/tests/e2e/test_delete_soft_archive_t2.py
+++ b/tests/e2e/test_delete_soft_archive_t2.py
@@ -153,3 +153,114 @@ class TestSessionDeleteIsSoft:
 
         r = await http_client.get(f"/v1/sessions/{session_id}")
         assert r.status_code == 404, r.text
+
+
+class TestBareDeleteIsIdempotent:
+    """A *second* bare DELETE must return 200 + the existing archived row, not
+    404, across all four archive families (#1492).
+
+    #1486 threaded ``idempotent=True`` so the repeat-DELETE-is-200 contract
+    held for memory-stores; this proves the same contract now holds for
+    sessions, vaults, and vault credentials — the asymmetry #1492 closes.
+    """
+
+    @pytest.fixture
+    async def session_id(self, pool: Any) -> str:
+        account_id = "acc_test_stub"
+        from aios.db import queries
+        from aios.services import agents as agents_svc
+        from aios.services import sessions as sessions_svc
+
+        async with pool.acquire() as conn:
+            env = await queries.insert_environment(
+                conn, name=f"idem-env-{_uniq()}", account_id=account_id
+            )
+        agent = await agents_svc.create_agent(
+            pool,
+            name=f"idem-agent-{_uniq()}",
+            model="openai/gpt-4o-mini",
+            system="",
+            tools=[],
+            description=None,
+            metadata={},
+            window_min=50_000,
+            window_max=150_000,
+            account_id=account_id,
+        )
+        session = await sessions_svc.create_session(
+            pool,
+            agent_id=agent.id,
+            environment_id=env.id,
+            title="idem-delete",
+            metadata={},
+            account_id=account_id,
+        )
+        return session.id
+
+    async def test_second_delete_memory_store_is_200(self, http_client: httpx.AsyncClient) -> None:
+        r = await http_client.post("/v1/memory-stores", json={"name": f"ms-{_uniq()}"})
+        assert r.status_code == 201, r.text
+        store_id = r.json()["id"]
+
+        r1 = await http_client.delete(f"/v1/memory-stores/{store_id}")
+        assert r1.status_code == 200, r1.text
+        assert r1.json()["archived_at"] is not None
+
+        r2 = await http_client.delete(f"/v1/memory-stores/{store_id}")
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["archived_at"] is not None
+        # Idempotent: the second DELETE reports the *same* archived row.
+        assert r2.json()["archived_at"] == r1.json()["archived_at"]
+
+    async def test_second_delete_vault_is_200(self, http_client: httpx.AsyncClient) -> None:
+        r = await http_client.post("/v1/vaults", json={"display_name": f"v-{_uniq()}"})
+        assert r.status_code == 201, r.text
+        vault_id = r.json()["id"]
+
+        r1 = await http_client.delete(f"/v1/vaults/{vault_id}")
+        assert r1.status_code == 200, r1.text
+        assert r1.json()["archived_at"] is not None
+
+        r2 = await http_client.delete(f"/v1/vaults/{vault_id}")
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["archived_at"] is not None
+        assert r2.json()["archived_at"] == r1.json()["archived_at"]
+
+    async def test_second_delete_vault_credential_is_200(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        r = await http_client.post("/v1/vaults", json={"display_name": f"v-{_uniq()}"})
+        assert r.status_code == 201, r.text
+        vault_id = r.json()["id"]
+
+        r = await http_client.post(
+            f"/v1/vaults/{vault_id}/credentials",
+            json={
+                "target_url": "https://mcp.example.com/api",
+                "auth_type": "bearer_header",
+                "token": "secret-token",
+            },
+        )
+        assert r.status_code == 201, r.text
+        cred_id = r.json()["id"]
+
+        r1 = await http_client.delete(f"/v1/vaults/{vault_id}/credentials/{cred_id}")
+        assert r1.status_code == 200, r1.text
+        assert r1.json()["archived_at"] is not None
+
+        r2 = await http_client.delete(f"/v1/vaults/{vault_id}/credentials/{cred_id}")
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["archived_at"] is not None
+        assert r2.json()["archived_at"] == r1.json()["archived_at"]
+
+    async def test_second_delete_session_is_200(
+        self, http_client: httpx.AsyncClient, session_id: str
+    ) -> None:
+        r1 = await http_client.delete(f"/v1/sessions/{session_id}")
+        assert r1.status_code == 200, r1.text
+        assert r1.json()["archived_at"] is not None
+
+        r2 = await http_client.delete(f"/v1/sessions/{session_id}")
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["archived_at"] is not None
+        assert r2.json()["archived_at"] == r1.json()["archived_at"]


### PR DESCRIPTION
Automated dev-pipeline build for issue #1492.