### PR TITLE
mcp: shape_call_result drops structuredContent → model sees empty success for structured-only tool results

### DIFF
--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -460,6 +460,17 @@ def shape_call_result(result: Any) -> dict[str, Any]:
         else:
             parts.append(f"[{item.type} content]")
     content = "\n".join(parts) if parts else ""
+    # MCP 2025-06-18 makes the backward-compat serialized-JSON text block a
+    # SHOULD, not a MUST: a spec-compliant server that declares an
+    # ``outputSchema`` may return its payload **only** in ``structuredContent``
+    # with an empty ``content`` list. Without this fallback such a result
+    # collapses to an empty success and the entire payload is silently dropped
+    # (the model can't detect the loss or retry). Serialize the structured
+    # payload when ``content`` produced nothing usable. (#1493)
+    if not content:
+        structured = getattr(result, "structuredContent", None)
+        if structured is not None:
+            content = json.dumps(structured)
     if result.isError:
         return {"error": content, "code": "tool_error"}
     return {"content": content}

--- a/src/aios/mcp/schema.py
+++ b/src/aios/mcp/schema.py
@@ -32,12 +32,22 @@ def sanitize_mcp_schema(node: Any) -> Any:
 
 
 def make_function_tool(qualified_name: str, tool: Tool) -> dict[str, Any]:
-    """Build the envelope, applying :func:`sanitize_mcp_schema` to ``tool.inputSchema``."""
+    """Build the envelope, applying :func:`sanitize_mcp_schema` to ``tool.inputSchema``.
+
+    When the tool declares an ``outputSchema`` (MCP 2025-06-18 structured
+    output), propagate it so the model is told the tool produces structured
+    output. Without this the model only ever sees ``inputSchema`` and is blind
+    to the structured payload it will receive (#1493).
+    """
+    function: dict[str, Any] = {
+        "name": qualified_name,
+        "description": tool.description or "",
+        "parameters": sanitize_mcp_schema(tool.inputSchema),
+    }
+    output_schema = getattr(tool, "outputSchema", None)
+    if output_schema is not None:
+        function["outputSchema"] = sanitize_mcp_schema(output_schema)
     return {
         "type": "function",
-        "function": {
-            "name": qualified_name,
-            "description": tool.description or "",
-            "parameters": sanitize_mcp_schema(tool.inputSchema),
-        },
+        "function": function,
     }

--- a/tests/unit/test_mcp_shape_call_result.py
+++ b/tests/unit/test_mcp_shape_call_result.py
@@ -1,0 +1,102 @@
+"""Tests for :func:`aios.mcp.client.shape_call_result` and structured output.
+
+Regression coverage for #1493: a spec-compliant MCP server (2025-06-18) may
+declare an ``outputSchema`` and return its payload **only** in
+``structuredContent`` with an empty ``content`` list (the backward-compat
+serialized-JSON text block is a SHOULD, not a MUST). Before the fix,
+``shape_call_result`` ignored ``structuredContent`` entirely and yielded an
+empty-success envelope, silently dropping the whole payload.
+"""
+
+from __future__ import annotations
+
+import json
+
+from mcp.types import CallToolResult, TextContent, Tool
+
+from aios.mcp.client import shape_call_result
+from aios.mcp.schema import make_function_tool
+
+
+class TestShapeCallResult:
+    def test_text_content_passthrough(self) -> None:
+        r = CallToolResult(
+            content=[TextContent(type="text", text="hello")],
+            isError=False,
+        )
+        assert shape_call_result(r) == {"content": "hello"}
+
+    def test_structured_only_payload_is_serialized(self) -> None:
+        # Repro from the issue: empty content, payload only in structuredContent.
+        r = CallToolResult(
+            content=[],
+            structuredContent={"temperature": 21.5, "unit": "C"},
+            isError=False,
+        )
+        out = shape_call_result(r)
+        assert "error" not in out
+        assert out["content"] != ""
+        assert json.loads(out["content"]) == {"temperature": 21.5, "unit": "C"}
+
+    def test_text_content_wins_over_structured(self) -> None:
+        # When the backward-compat text block is present, it is authoritative;
+        # we don't double-up by also appending the structured serialization.
+        r = CallToolResult(
+            content=[TextContent(type="text", text="hello")],
+            structuredContent={"x": 1},
+            isError=False,
+        )
+        assert shape_call_result(r) == {"content": "hello"}
+
+    def test_structured_error_is_serialized(self) -> None:
+        r = CallToolResult(
+            content=[],
+            structuredContent={"reason": "bad"},
+            isError=True,
+        )
+        out = shape_call_result(r)
+        assert out["code"] == "tool_error"
+        assert json.loads(out["error"]) == {"reason": "bad"}
+
+    def test_empty_result_stays_empty(self) -> None:
+        r = CallToolResult(content=[], isError=False)
+        assert shape_call_result(r) == {"content": ""}
+
+    def test_falsy_structured_payload_is_serialized(self) -> None:
+        # A structured payload that is falsy-but-present (e.g. an empty list)
+        # is still real data and must not be dropped.
+        r = CallToolResult(
+            content=[],
+            structuredContent={"items": []},
+            isError=False,
+        )
+        out = shape_call_result(r)
+        assert json.loads(out["content"]) == {"items": []}
+
+
+class TestOutputSchemaPropagation:
+    def test_output_schema_propagated_to_function_tool(self) -> None:
+        tool = Tool(
+            name="get_weather",
+            description="weather",
+            inputSchema={"type": "object", "properties": {}},
+            outputSchema={
+                "type": "object",
+                "properties": {"temperature": {"type": "number"}},
+            },
+        )
+        env = make_function_tool("mcp__srv__get_weather", tool)
+        # The model must be told the tool produces structured output.
+        assert "outputSchema" in env["function"]
+        assert env["function"]["outputSchema"]["properties"]["temperature"] == {
+            "type": "number"
+        }
+
+    def test_no_output_schema_omits_key(self) -> None:
+        tool = Tool(
+            name="noop",
+            description="",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        env = make_function_tool("mcp__srv__noop", tool)
+        assert "outputSchema" not in env["function"]

--- a/tests/unit/test_mcp_shape_call_result.py
+++ b/tests/unit/test_mcp_shape_call_result.py
@@ -88,9 +88,7 @@ class TestOutputSchemaPropagation:
         env = make_function_tool("mcp__srv__get_weather", tool)
         # The model must be told the tool produces structured output.
         assert "outputSchema" in env["function"]
-        assert env["function"]["outputSchema"]["properties"]["temperature"] == {
-            "type": "number"
-        }
+        assert env["function"]["outputSchema"]["properties"]["temperature"] == {"type": "number"}
 
     def test_no_output_schema_omits_key(self) -> None:
         tool = Tool(


### PR DESCRIPTION
Automated dev-pipeline build for issue #1493.