### PR TITLE
memory_stores: list_memories has_more is wrong both ways (spurious at =limit; false-negative under depth → silent omission)

### DIFF
--- a/src/aios/api/routers/memory_stores.py
+++ b/src/aios/api/routers/memory_stores.py
@@ -210,7 +210,13 @@ async def list_memories(
     fetch (cursor pagination not yet supported; use ``path_prefix`` to
     narrow scope when a store has thousands of memories).
     """
-    items = await service.list_memories(
+    # The service fetches ``limit + 1`` raw rows and reports ``has_more`` from
+    # that raw fetch *before* any depth-collapse (mirroring
+    # ``ListResponse.paginate``). Deriving it post-collapse would be a
+    # false-negative under depth — collapsed prefixes hide the truncation and
+    # silently omit memories — so ``has_more`` is computed in the query layer
+    # and propagated here verbatim.
+    items, has_more = await service.list_memories(
         pool,
         store_id,
         path_prefix=path_prefix,
@@ -219,12 +225,6 @@ async def list_memories(
         limit=limit,
         account_id=account_id,
     )
-    # ``has_more`` signals the SQL cap was hit; depth aggregation may have
-    # collapsed those raw rows into fewer response entries, so compare the
-    # underlying memory count (entries that aren't MemoryPrefix) plus
-    # collapsed prefix groups against the limit.
-    raw_count = sum(1 for it in items if not isinstance(it, MemoryPrefix))
-    has_more = raw_count == limit
     return ListResponse[Memory | MemoryPrefix](data=items, has_more=has_more)
 
 

--- a/src/aios/db/queries/memory_stores.py
+++ b/src/aios/db/queries/memory_stores.py
@@ -445,7 +445,7 @@ async def list_memories(
     order_by: str = "created_at",
     depth: int | None = None,
     limit: int = 100,
-) -> list[Memory | MemoryPrefix]:
+) -> tuple[list[Memory | MemoryPrefix], bool]:
     """List memories, optionally filtered by ``path_prefix`` and depth-clipped.
 
     ``depth`` requires ``order_by='path'`` (matches Anthropic's wire validation).
@@ -454,6 +454,15 @@ async def list_memories(
     ``limit`` caps the raw-row fetch — depth aggregation may then collapse
     that into fewer response entries, but the SQL bound prevents unbounded
     payloads on stores with thousands of memories.
+
+    Returns ``(items, has_more)``. Following the ``ListResponse.paginate``
+    idiom, the SQL fetches ``limit + 1`` raw rows and ``has_more`` is derived
+    from the *raw* fetch **before** any depth-collapse, then the extra row is
+    trimmed. Computing ``has_more`` from the raw fetch is essential: under
+    depth-collapse the raw rows fold into a few synthetic prefixes, so a
+    post-collapse count would understate truncation and silently drop
+    memories (any deep directory with more than ``limit`` entries would
+    otherwise be un-listable-to-completion at depth with no warning).
     """
     if depth is not None and order_by != "path":
         raise ConflictError(
@@ -470,14 +479,21 @@ async def list_memories(
         args.append(_escape_like(path_prefix))
         where += f" AND (path = ${len(args) - 1} OR path LIKE ${len(args)} || '%')"
     order_sql = "path ASC" if order_by == "path" else "created_at DESC"
-    args.append(limit)
+    # Fetch one extra row so we can detect a further page without a COUNT —
+    # mirrors ``ListResponse.paginate``.
+    args.append(limit + 1)
     rows = await conn.fetch(
         f"SELECT * FROM memories WHERE {where} ORDER BY {order_sql} LIMIT ${len(args)}", *args
     )
 
+    # ``has_more`` is decided from the raw fetch, before depth-collapse, then
+    # the sentinel extra row is trimmed.
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+
     memories = [_row_to_memory(r, include_content=False) for r in rows]
     if depth is None:
-        return list(memories)
+        return list(memories), has_more
 
     base = path_prefix.rstrip("/") if path_prefix else ""
     out: list[Memory | MemoryPrefix] = []
@@ -494,7 +510,7 @@ async def list_memories(
             continue
         seen_prefixes.add(prefix_path)
         out.append(MemoryPrefix(path=prefix_path))
-    return out
+    return out, has_more
 
 
 async def update_memory_with_version(

--- a/src/aios/services/memory_stores.py
+++ b/src/aios/services/memory_stores.py
@@ -232,7 +232,7 @@ async def list_memories(
     order_by: str = "created_at",
     depth: int | None = None,
     limit: int = 100,
-) -> list[Memory | MemoryPrefix]:
+) -> tuple[list[Memory | MemoryPrefix], bool]:
     async with pool.acquire() as conn:
         return await queries.list_memories(
             conn,

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -189,9 +189,7 @@ class TestMemoryListLimit:
             "exactly limit rows means the page is complete; has_more must be False."
         )
 
-    async def test_has_more_true_under_depth_collapse(
-        self, http_client: httpx.AsyncClient
-    ) -> None:
+    async def test_has_more_true_under_depth_collapse(self, http_client: httpx.AsyncClient) -> None:
         """Mode B: depth-collapse must not hide a truncated raw fetch.
 
         Seed K > limit memories all under one deep directory so ``depth=1``

--- a/tests/e2e/test_memory_stores_api.py
+++ b/tests/e2e/test_memory_stores_api.py
@@ -167,6 +167,71 @@ class TestMemoryListLimit:
         assert len(body["data"]) == 5
         assert body["has_more"] is True
 
+    async def test_has_more_false_when_count_equals_limit(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Mode A: a store with exactly ``limit`` memories has no next page.
+
+        Pre-fix the router computed ``has_more = raw_count == limit``, so a
+        store with exactly ``limit`` rows reported ``has_more=True`` (the
+        classic ``count == limit`` off-by-one) even though the page was
+        complete.
+        """
+        store = await _create_store(http_client)
+        store_id = store["id"]
+        for i in range(5):
+            await _create_memory(http_client, store_id, f"/x-{i:03d}.md", f"b{i}")
+        r = await http_client.get(f"/v1/memory-stores/{store_id}/memories", params={"limit": 5})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body["data"]) == 5
+        assert body["has_more"] is False, (
+            "exactly limit rows means the page is complete; has_more must be False."
+        )
+
+    async def test_has_more_true_under_depth_collapse(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Mode B: depth-collapse must not hide a truncated raw fetch.
+
+        Seed K > limit memories all under one deep directory so ``depth=1``
+        collapses them into a single ``MemoryPrefix``. Pre-fix the raw fetch
+        was capped at ``limit`` and ``has_more`` was derived from the
+        post-collapse memory count (which excludes prefixes), so it dropped
+        below ``limit`` → ``has_more=False`` even though the raw fetch was
+        truncated and memories were silently omitted.
+        """
+        store = await _create_store(http_client)
+        store_id = store["id"]
+        for i in range(8):
+            await _create_memory(http_client, store_id, f"/a/deep/x{i:03d}.md", f"b{i}")
+        r = await http_client.get(
+            f"/v1/memory-stores/{store_id}/memories",
+            params={"order_by": "path", "depth": 1, "limit": 3},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["has_more"] is True, (
+            "the raw fetch was truncated at the limit; depth-collapse must not "
+            "turn that into a false has_more=False (silent data loss)."
+        )
+
+    async def test_has_more_false_under_depth_when_complete(
+        self, http_client: httpx.AsyncClient
+    ) -> None:
+        """Depth-collapse with the full result set fitting under the limit."""
+        store = await _create_store(http_client)
+        store_id = store["id"]
+        for i in range(3):
+            await _create_memory(http_client, store_id, f"/a/deep/x{i:03d}.md", f"b{i}")
+        r = await http_client.get(
+            f"/v1/memory-stores/{store_id}/memories",
+            params={"order_by": "path", "depth": 1, "limit": 10},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["has_more"] is False
+
 
 class TestMemoryCrud:
     async def test_create_retrieve_round_trip(self, http_client: httpx.AsyncClient) -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1494.