### PR TITLE
cache-breakpoint tail detection: replace `━━━ Channels ━━━` substring-match with an out-of-band ephemeral-tail marker (the always-on obligations tail already silently busts the Anthropic prefix cache)

### DIFF
--- a/src/aios/harness/channels.py
+++ b/src/aios/harness/channels.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from aios.harness._text import join_blocks
+from aios.harness.context import EPHEMERAL_TAIL_KEY
 from aios.models.events import Event
 
 MONOLOGUE_PREFIX = "INTERNAL_MONOLOGUE_NOT_SEEN_BY_USER: "
@@ -229,7 +230,7 @@ def build_channels_tail_block(
             lines.append(f"○ channel_id={addr} — {count} unread{preview_clause}")
         else:
             lines.append(f"○ channel_id={addr} — 0 unread")
-    return {"role": "user", "content": "\n".join(lines)}
+    return {"role": "user", "content": "\n".join(lines), EPHEMERAL_TAIL_KEY: True}
 
 
 def _switch_marker(e: Event) -> dict[str, Any] | None:

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any
 import litellm
 
 from aios.config import get_settings
-from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT
+from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT, EPHEMERAL_TAIL_KEY
 
 # Anthropic rejects empty text blocks that some OpenRouter models emit on
 # tool-call-only turns; modify_params tells LiteLLM to sanitize them.
@@ -347,10 +347,16 @@ def inject_cache_breakpoints(
     1. **System message** — cache-stable across steps.
     2. **Last tool definition** — cache-stable while tools don't change.
     3. **Last stable conversation message** — the last event-sourced
-       message, skipping the trailing channels tail block (which
-       mutates every step: unread counts, previews) and any
-       empty-assistant separator inserted before it by
+       message, skipping any trailing per-step-ephemeral tail block
+       (the channels tail — unread counts, previews; and the open-
+       obligations tail — ages, obligation set), identified by its
+       out-of-band :data:`~aios.harness.context.EPHEMERAL_TAIL_KEY`
+       marker, and any empty-assistant separator inserted before it by
        :func:`~aios.harness.context.merge_adjacent_user_messages`.
+
+    The marker is stripped from every message before the wire on every
+    path (including the non-Anthropic early-out), so it never reaches a
+    provider.
 
     Skipping the tail is load-bearing: with the breakpoint on the tail
     itself, the conversation prefix never gets its own cache entry and
@@ -360,18 +366,27 @@ def inject_cache_breakpoints(
     """
     if not messages:
         return
-    if model_descriptor(model).cache_channel is not CacheChannel.ANTHROPIC:
-        return
 
-    if messages[0].get("role") == "system":
-        _set_content_block_cache(messages[0])
+    if model_descriptor(model).cache_channel is CacheChannel.ANTHROPIC:
+        if messages[0].get("role") == "system":
+            _set_content_block_cache(messages[0])
 
-    if tools:
-        tools[-1]["cache_control"] = _CACHE_CONTROL
+        if tools:
+            tools[-1]["cache_control"] = _CACHE_CONTROL
 
-    idx = _last_stable_message_index(messages)
-    if idx is not None and messages[idx].get("role") != "system":
-        _set_content_block_cache(messages[idx])
+        # Consume the ephemeral-tail markers (via _is_ephemeral_tail) to
+        # place the prefix breakpoint, THEN strip the markers below.
+        idx = _last_stable_message_index(messages)
+        if idx is not None and messages[idx].get("role") != "system":
+            _set_content_block_cache(messages[idx])
+
+    # Strip the out-of-band marker from every message on EVERY path,
+    # including the non-Anthropic early-out above. The marker is a
+    # non-standard message key (Anthropic rejects unknown fields) and must
+    # never reach a provider — non-Anthropic routes place no breakpoint but
+    # still carry these dicts to the wire, so the strip is unconditional.
+    for msg in messages:
+        msg.pop(EPHEMERAL_TAIL_KEY, None)
 
 
 def _last_stable_message_index(messages: list[dict[str, Any]]) -> int | None:
@@ -379,9 +394,10 @@ def _last_stable_message_index(messages: list[dict[str, Any]]) -> int | None:
 
     Walks backward from the end, skipping:
 
-    * The channels tail block — identified by its content signature
-      ``━━━ Channels ━━━`` (always the last user-role message when
-      present).
+    * Any per-step-ephemeral tail block — identified by its out-of-band
+      :data:`~aios.harness.context.EPHEMERAL_TAIL_KEY` marker
+      (the channels tail and the open-obligations tail, set at
+      construction; always trailing user-role messages when present).
     * Any role-transition separator — inserted by
       the former separator mechanism (now
       :func:`~aios.harness.context.merge_adjacent_user_messages`) to
@@ -393,32 +409,25 @@ def _last_stable_message_index(messages: list[dict[str, Any]]) -> int | None:
     """
     for i in range(len(messages) - 1, -1, -1):
         msg = messages[i]
-        if _is_tail_block(msg) or _is_separator_placeholder(msg):
+        if _is_ephemeral_tail(msg) or _is_separator_placeholder(msg):
             continue
         return i
     return None
 
 
-def _is_tail_block(msg: dict[str, Any]) -> bool:
-    """Detect the channels tail block by its content signature.
+def _is_ephemeral_tail(msg: dict[str, Any]) -> bool:
+    """Detect a per-step-ephemeral tail block by its out-of-band marker.
 
-    The tail block renders with a ``━━━ Channels ━━━`` header as the
-    first line of its user-role content.  That string is unlikely to
-    appear in genuine peer text, so a substring-match is safe enough
-    for cache-breakpoint placement.
+    The tail producers (``build_channels_tail_block``,
+    ``build_obligations_tail_block``) tag their dict at construction with
+    :data:`~aios.harness.context.EPHEMERAL_TAIL_KEY`; the marker is sticky
+    under :func:`~aios.harness.context._concat_user_messages` merges. We
+    read the structural marker — never the rendered prose — so the
+    recognizer can't drift from the producers and can't be fooled by peer
+    text. Mirrors the out-of-band ``metadata`` handshake on switch_channel
+    tool-result dicts (``channels.py``).
     """
-    if msg.get("role") != "user":
-        return False
-    content = msg.get("content")
-    if isinstance(content, str):
-        return content.startswith("━━━ Channels ━━━")
-    if isinstance(content, list):
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text")
-                if isinstance(text, str) and text.startswith("━━━ Channels ━━━"):
-                    return True
-    return False
+    return bool(msg.get(EPHEMERAL_TAIL_KEY))
 
 
 def _is_separator_placeholder(msg: dict[str, Any]) -> bool:

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -1376,6 +1376,28 @@ def stub_missing_reasoning_content(
     return messages
 
 
+EPHEMERAL_TAIL_KEY = "_aios_ephemeral_tail"
+"""Out-of-band marker key tagging a per-step-ephemeral tail message.
+
+Set to ``True`` at construction on the render-only tail blocks
+(:func:`~aios.harness.channels.build_channels_tail_block`,
+:func:`~aios.harness.obligations.build_obligations_tail_block`) whose
+content mutates every step (unread counts/previews; obligation ages/sets).
+
+The cache-breakpoint recognizer in ``completion.py`` reads this marker —
+never the rendered prose — to decide which message must NOT host the
+conversation prefix ``cache_control`` breakpoint.  It is a *property*
+("this message is per-step-ephemeral"), not a discriminated kind, so a
+boolean is the honest shape.
+
+The marker is non-standard (Anthropic rejects unknown message fields) and
+is stripped from every message by ``inject_cache_breakpoints`` before any
+provider call — on every route, including non-Anthropic early returns.
+``_concat_user_messages`` propagates it under OR so a merge of any
+ephemeral message with anything stays ephemeral.
+"""
+
+
 _USER_MESSAGE_SEPARATOR_CONTENT = "."
 """Single-byte placeholder for the role-transition separator.
 
@@ -1444,7 +1466,15 @@ def _concat_user_messages(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any
     """
     ca, cb = a.get("content"), b.get("content")
     if isinstance(ca, str) and isinstance(cb, str):
-        return {"role": "user", "content": f"{ca}\n\n{cb}"}
-    la = ca if isinstance(ca, list) else [{"type": "text", "text": ca or ""}]
-    lb = cb if isinstance(cb, list) else [{"type": "text", "text": cb or ""}]
-    return {"role": "user", "content": [*la, *lb]}
+        merged: dict[str, Any] = {"role": "user", "content": f"{ca}\n\n{cb}"}
+    else:
+        la = ca if isinstance(ca, list) else [{"type": "text", "text": ca or ""}]
+        lb = cb if isinstance(cb, list) else [{"type": "text", "text": cb or ""}]
+        merged = {"role": "user", "content": [*la, *lb]}
+    # Propagate the ephemeral-tail marker under OR: a dict that contains
+    # *any* per-step-mutating content cannot host the stable-prefix cache
+    # breakpoint, so the merge of any ephemeral message with anything is
+    # ephemeral. This fixes the trailing-inbound + obligations merge case.
+    if a.get(EPHEMERAL_TAIL_KEY) or b.get(EPHEMERAL_TAIL_KEY):
+        merged[EPHEMERAL_TAIL_KEY] = True
+    return merged

--- a/src/aios/harness/obligations.py
+++ b/src/aios/harness/obligations.py
@@ -27,6 +27,8 @@ import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from aios.harness.context import EPHEMERAL_TAIL_KEY
+
 if TYPE_CHECKING:
     from aios.models.sessions import Obligation
 
@@ -164,7 +166,7 @@ def build_obligations_tail_block(
     remaining = len(obligations) - len(rendered)
     if remaining > 0:
         lines.append(f"…(+{remaining} more)")
-    return {"role": "user", "content": "\n".join(lines)}
+    return {"role": "user", "content": "\n".join(lines), EPHEMERAL_TAIL_KEY: True}
 
 
 def render_owed_entry(obligation: Obligation, *, session_id: str, now: datetime) -> dict[str, Any]:

--- a/tests/unit/test_channels_helpers.py
+++ b/tests/unit/test_channels_helpers.py
@@ -16,6 +16,7 @@ from aios.harness.channels import (
     build_channels_tail_block,
     build_focal_paradigm_block,
 )
+from aios.harness.context import EPHEMERAL_TAIL_KEY
 from aios.models.events import Event
 
 
@@ -184,7 +185,11 @@ class TestBuildChannelsTailBlock:
         assert block is not None
         assert block["role"] == "user"
         assert isinstance(block["content"], str)
-        assert set(block.keys()) <= {"role", "content"}
+        # The block is tagged out-of-band as a per-step-ephemeral tail so the
+        # cache-breakpoint recognizer skips it without re-parsing prose; the
+        # marker is stripped before the wire by ``inject_cache_breakpoints``.
+        assert block[EPHEMERAL_TAIL_KEY] is True
+        assert set(block.keys()) <= {"role", "content", EPHEMERAL_TAIL_KEY}
 
     def test_zero_unread_non_focal_still_listed(self) -> None:
         block = build_channels_tail_block(

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -14,6 +14,7 @@ import pytest
 
 from aios.harness.channels import build_channels_tail_block
 from aios.harness.context import (
+    EPHEMERAL_TAIL_KEY,
     _approx_count,
     _concat_user_messages,
     _is_degenerate_empty_assistant,
@@ -1828,6 +1829,25 @@ class TestConcatUserMessages:
                 {"type": "image_url", "image_url": {"url": "u"}},
             ],
         }
+
+    def test_ephemeral_marker_sticky_under_or(self) -> None:
+        """#1535: the ephemeral-tail marker propagates under OR — a merge of
+        any ephemeral message with anything is ephemeral (a dict containing
+        *any* per-step-mutating content cannot host the stable-prefix cache
+        breakpoint). Covers the trailing real-inbound + obligations case."""
+        inbound = {"role": "user", "content": "real peer text"}
+        ephemeral = {"role": "user", "content": "tail", EPHEMERAL_TAIL_KEY: True}
+        # ephemeral on either side -> merged dict is ephemeral.
+        assert _concat_user_messages(inbound, ephemeral).get(EPHEMERAL_TAIL_KEY) is True
+        assert _concat_user_messages(ephemeral, inbound).get(EPHEMERAL_TAIL_KEY) is True
+        # both ephemeral -> still ephemeral.
+        assert _concat_user_messages(ephemeral, ephemeral).get(EPHEMERAL_TAIL_KEY) is True
+
+    def test_no_marker_when_neither_ephemeral(self) -> None:
+        """Plain inbound + plain inbound stays unmarked - no spurious marker."""
+        a = {"role": "user", "content": "one"}
+        b = {"role": "user", "content": "two"}
+        assert EPHEMERAL_TAIL_KEY not in _concat_user_messages(a, b)
 
 
 class TestIsDegenerateEmptyAssistant:

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -13,6 +13,7 @@ from aios.harness.completion import (
     inject_cache_breakpoints,
     model_descriptor,
 )
+from aios.harness.context import EPHEMERAL_TAIL_KEY
 
 
 @pytest.fixture(autouse=True)
@@ -152,6 +153,13 @@ def _msg(role: str, content: str = "") -> dict[str, Any]:
     return {"role": role, "content": content}
 
 
+def _tail(content: str) -> dict[str, Any]:
+    """Build an ephemeral-tail user message, tagged out-of-band like the
+    real channels/obligations tail producers (carries
+    :data:`EPHEMERAL_TAIL_KEY`)."""
+    return {"role": "user", "content": content, EPHEMERAL_TAIL_KEY: True}
+
+
 def _tool_def(name: str) -> dict[str, Any]:
     """Build a minimal OpenAI-format tool definition."""
     return {
@@ -236,7 +244,7 @@ class TestInjectCacheBreakpoints:
         cache never hits.  Breakpoint goes on the last *stable*
         message (the event-sourced one just before the tail).
         """
-        tail = _msg("user", "━━━ Channels ━━━\n▸ channel_id=x (focal)")
+        tail = _tail("━━━ Channels ━━━\n▸ channel_id=x (focal)")
         msgs = [
             _msg("system", "sys"),
             _msg("user", "hi there"),
@@ -263,7 +271,7 @@ class TestInjectCacheBreakpoints:
         still recognise one from any other source — pinned here against a
         hand-constructed separator.
         """
-        tail = _msg("user", "━━━ Channels ━━━\n▸ channel_id=x (focal)")
+        tail = _tail("━━━ Channels ━━━\n▸ channel_id=x (focal)")
         stable = _msg("user", "real peer message")
         separator = {"role": "assistant", "content": "."}
         msgs = [_msg("system", "sys"), stable, separator, tail]
@@ -280,7 +288,7 @@ class TestInjectCacheBreakpoints:
         """Degenerate case: only system + tail.  No stable conversation
         message exists — the last-stable-message rule produces nothing,
         but the system breakpoint still applies."""
-        tail = _msg("user", "━━━ Channels ━━━\n▸ channel_id=x (focal)")
+        tail = _tail("━━━ Channels ━━━\n▸ channel_id=x (focal)")
         msgs = [_msg("system", "sys"), tail]
         inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert msgs[0]["content"] == [
@@ -303,6 +311,68 @@ class TestInjectCacheBreakpoints:
         inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
         assert "cache_control" not in msgs[1]["content"][0]
         assert msgs[1]["content"][1]["cache_control"] == _CACHE_CONTROL
+
+    def test_obligations_tail_after_tool_result_skipped_via_marker(self) -> None:
+        """Regression for #1535: an Anthropic-route session owing a response
+        (last log line a tool result) appends the always-on obligations tail
+        as the final user-role line. The breakpoint must land on the last
+        *stable* message (the tool result), NOT on the per-step-mutating
+        obligations block — which the old ``━━━ Channels ━━━`` substring
+        recognizer never matched, so it busted the prefix cache every step.
+        """
+        from aios.harness.obligations import _HEADER as _OBLIGATIONS_HEADER
+
+        obligations_tail = _tail(f"{_OBLIGATIONS_HEADER}\n• req_1 [api] (open 3s)")
+        msgs = [
+            _msg("system", "sys"),
+            _msg("user", "do the thing"),
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "a"}]},
+            {"role": "tool", "tool_call_id": "a", "content": "tool done"},
+            obligations_tail,
+        ]
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
+        # Breakpoint on the tool result (last stable), not the obligations tail.
+        assert msgs[3]["content"] == [
+            {"type": "text", "text": "tool done", "cache_control": _CACHE_CONTROL}
+        ]
+        # Obligations tail stays bare (content unchanged) and carries no marker.
+        assert msgs[4]["content"] == obligations_tail["content"]
+        assert EPHEMERAL_TAIL_KEY not in msgs[4]
+
+    def test_merged_inbound_plus_obligation_is_ephemeral(self) -> None:
+        """A trailing real user inbound + an open obligation fold into one
+        ``user`` dict via ``merge_adjacent_user_messages``; the merged dict
+        must inherit the ephemeral marker (sticky under OR) so the breakpoint
+        skips it. This is the latent merged-dict case the old substring
+        recognizer silently mishandled.
+        """
+        from aios.harness.context import merge_adjacent_user_messages
+
+        inbound = _msg("user", "real peer message")
+        obligation = _tail(
+            "━━━ Open obligations (answer with return/error) ━━━\n• r [api] (open 3s)"
+        )
+        merged = merge_adjacent_user_messages([inbound, obligation])
+        assert len(merged) == 1  # folded into one user turn
+        assert merged[0][EPHEMERAL_TAIL_KEY] is True  # marker is sticky
+
+        msgs = [_msg("system", "sys"), _msg("assistant", "hello"), merged[0]]
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
+        # Breakpoint lands on the stable assistant turn, skipping the merged
+        # ephemeral user dict.
+        assert msgs[1]["content"] == [
+            {"type": "text", "text": "hello", "cache_control": _CACHE_CONTROL}
+        ]
+        assert "cache_control" not in str(msgs[2].get("content"))
+        assert EPHEMERAL_TAIL_KEY not in msgs[2]
+
+    def test_marker_stripped_on_anthropic_route(self) -> None:
+        """No ``_aios_ephemeral_tail`` key may reach a provider: strip runs on
+        the Anthropic path after the recognizer consumes the markers."""
+        tail = _tail("━━━ Channels ━━━\n▸ channel_id=x (focal)")
+        msgs = [_msg("system", "sys"), _msg("user", "hi"), tail]
+        inject_cache_breakpoints(msgs, None, _ANTHROPIC_MODEL)
+        assert not any(EPHEMERAL_TAIL_KEY in m for m in msgs)
 
 
 class TestInjectCacheBreakpointsProviderGuard:
@@ -378,6 +448,19 @@ class TestInjectCacheBreakpointsProviderGuard:
         assert msgs[1]["content"] == [
             {"type": "text", "text": "hi", "cache_control": _CACHE_CONTROL}
         ]
+
+    def test_marker_stripped_on_non_anthropic_route(self) -> None:
+        """The ephemeral-tail marker is non-standard and must never reach a
+        provider — even on non-Anthropic routes that place no breakpoint but
+        still carry the tail dict to the wire (#1535: strip is unconditional,
+        not gated behind the Anthropic early return)."""
+        tail = _tail("━━━ Channels ━━━\n▸ channel_id=x (focal)")
+        msgs = [_msg("system", "sys"), _msg("user", "hi"), tail]
+        inject_cache_breakpoints(msgs, None, "openai/gpt-4o")
+        # Gate held: no cache_control injected (content stays a plain string)…
+        assert msgs[1]["content"] == "hi"
+        # …but the marker is still stripped from every message.
+        assert not any(EPHEMERAL_TAIL_KEY in m for m in msgs)
 
 
 class TestModelDescriptor:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1535.