### PR TITLE
ToolSpec load-tolerance + data migration: retired complete_goal/fail_goal poison old persisted agent rows (wedged Ultron 2026-06-26)

### DIFF
--- a/migrations/versions/0122_drop_retired_goal_outcome_tool_names.py
+++ b/migrations/versions/0122_drop_retired_goal_outcome_tool_names.py
@@ -1,0 +1,78 @@
+"""Drop the retired ``complete_goal``/``fail_goal`` builtin tool names from persisted ``tools`` JSONB.
+
+#1525 (unify-obligations #2, commit 1c6e6d09) removed ``complete_goal``/``fail_goal`` from the
+``BuiltinToolType`` Literal + the tool registry, but shipped **no read-tolerance shim and no data
+migration**. Long-lived agents whose persisted ``agents.tools`` (and ``agent_versions.tools``)
+JSONB still listed those builtins fail ``ToolSpec.model_validate`` on read — a pre-context-build
+throw that wedged the affected agent (the live kedalion-ultron agent) into an infinite
+reschedule. ``return``/``error`` are general step verbs, not model-listed builtins, so the retired
+tools have NO canonical successor → REMOVE, do not remap.
+
+This migration removes every ``{"type": "complete_goal"}`` / ``{"type": "fail_goal"}`` element
+from every agent/workflow ``ToolSpec`` surface — ``agents``, ``agent_versions``, ``workflows``,
+``workflow_versions``, ``wf_runs`` (the launch-pinned surface), and ``sessions`` (the frozen
+child surface, nullable). Order-preserving; a list that was only ``[complete_goal, fail_goal]``
+collapses to ``[]``; clean rows are untouched. The model code carries a matching read-tolerance
+shim (``_RETIRED_BUILTINS`` + ``load_tool_specs`` in ``models/agents.py``) for the
+post-deploy/pre-migrate window and for any future respawn from an unmigrated row; both can be
+removed once this has run everywhere.
+
+This is the same "remove a builtin from BuiltinToolType + registry → ship the shim-and-migration
+pair" discipline that #1419 (migration 0116) / #1428 (migration 0117) / #1458 (migration 0120)
+established; #1525 omitted both halves and this closes the gap. Part of #1516 / #1562.
+
+``downgrade()`` is a no-op: the tools are gone, so there is nothing to restore.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0122"
+down_revision: str = "0121"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Tables with a NOT-NULL ``tools`` JSONB surface column.
+_TOOLS_TABLES = ("agents", "agent_versions", "workflows", "workflow_versions", "wf_runs")
+# Retired builtin tool ``type`` values (no canonical successor → dropped, not remapped).
+_RETIRED_NAMES_SQL = "'complete_goal', 'fail_goal'"
+
+
+def upgrade() -> None:
+    # Drop every retired-builtin element from a tools array, order-preserving.
+    op.execute(rf"""
+        CREATE FUNCTION _aios_drop_retired_goal_tools(tools jsonb) RETURNS jsonb
+        LANGUAGE sql IMMUTABLE AS $fn$
+            SELECT coalesce(jsonb_agg(elem ORDER BY ord), '[]'::jsonb)
+            FROM jsonb_array_elements(tools) WITH ORDINALITY AS arr(elem, ord)
+            WHERE elem->>'type' NOT IN ({_RETIRED_NAMES_SQL})
+        $fn$
+    """)
+
+    for table in _TOOLS_TABLES:
+        op.execute(f"""
+            UPDATE {table} SET tools = _aios_drop_retired_goal_tools(tools)
+            WHERE EXISTS (
+                SELECT 1 FROM jsonb_array_elements(tools) e
+                WHERE e->>'type' IN ({_RETIRED_NAMES_SQL})
+            )
+        """)
+
+    # sessions.tools is nullable (only frozen child sessions carry a surface).
+    op.execute(f"""
+        UPDATE sessions SET tools = _aios_drop_retired_goal_tools(tools)
+        WHERE tools IS NOT NULL AND EXISTS (
+            SELECT 1 FROM jsonb_array_elements(tools) e
+            WHERE e->>'type' IN ({_RETIRED_NAMES_SQL})
+        )
+    """)
+
+    op.execute("DROP FUNCTION _aios_drop_retired_goal_tools(jsonb)")
+
+
+def downgrade() -> None:
+    # Forward-only: the complete_goal/fail_goal tools are retired, nothing to restore.
+    pass

--- a/src/aios/db/queries/agents.py
+++ b/src/aios/db/queries/agents.py
@@ -28,7 +28,14 @@ from aios.ids import (
     AGENT,
     make_id,
 )
-from aios.models.agents import Agent, AgentVersion, HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.agents import (
+    Agent,
+    AgentVersion,
+    HttpServerSpec,
+    McpServerSpec,
+    ToolSpec,
+    load_tool_specs,
+)
 from aios.models.skills import AgentSkillRef
 
 # ─── agents ───────────────────────────────────────────────────────────────────
@@ -47,7 +54,7 @@ def _row_to_agent(row: asyncpg.Record) -> Agent:
         name=row["name"],
         model=row["model"],
         system=row["system"],
-        tools=[ToolSpec.model_validate(t) for t in tools_data],
+        tools=load_tool_specs(tools_data),
         skills=[AgentSkillRef.model_validate(s) for s in skills_data],
         mcp_servers=[McpServerSpec.model_validate(s) for s in (mcp_data or [])],
         http_servers=[HttpServerSpec.model_validate(s) for s in (http_data or [])],
@@ -73,7 +80,7 @@ def _row_to_agent_version(row: asyncpg.Record) -> AgentVersion:
         version=row["version"],
         model=row["model"],
         system=row["system"],
-        tools=[ToolSpec.model_validate(t) for t in tools_data],
+        tools=load_tool_specs(tools_data),
         skills=[AgentSkillRef.model_validate(s) for s in skills_data],
         mcp_servers=[McpServerSpec.model_validate(s) for s in (mcp_data or [])],
         http_servers=[HttpServerSpec.model_validate(s) for s in (http_data or [])],

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -32,7 +32,7 @@ from aios.ids import (
     TRIGGER,
     make_id,
 )
-from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, load_tool_specs
 from aios.models.attenuation import Surface
 from aios.models.sessions import Obligation, Session, SessionStatus, SessionUsage
 
@@ -335,7 +335,7 @@ async def get_session_frozen_surface(
     if not row["surface_frozen"]:
         return None
     return Surface(
-        tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
+        tools=load_tool_specs(parse_jsonb(row["tools"])),
         mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
         http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
     )

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -31,7 +31,7 @@ from aios.db.queries import (
 )
 from aios.errors import ConflictError, NotFoundError
 from aios.ids import WORKFLOW, WORKFLOW_EVENT, WORKFLOW_RUN, make_id
-from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec
+from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, load_tool_specs
 from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
     WfRun,
@@ -61,7 +61,7 @@ def _row_to_workflow(row: asyncpg.Record) -> Workflow:
         input_schema=parse_jsonb(row["input_schema"]),
         output_schema=parse_jsonb(row["output_schema"]),
         description=row["description"],
-        tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
+        tools=load_tool_specs(parse_jsonb(row["tools"])),
         mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
         http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
         created_at=row["created_at"],
@@ -79,7 +79,7 @@ def _row_to_workflow_version(row: asyncpg.Record) -> WorkflowVersion:
         input_schema=parse_jsonb(row["input_schema"]),
         output_schema=parse_jsonb(row["output_schema"]),
         description=row["description"],
-        tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
+        tools=load_tool_specs(parse_jsonb(row["tools"])),
         mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
         http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
         created_at=row["created_at"],
@@ -102,7 +102,7 @@ def _row_to_wf_run(row: asyncpg.Record) -> WfRun:
         script_sha=row["script_sha"],
         source_version=row.get("source_version"),
         host_semantics_epoch=row["host_semantics_epoch"],
-        tools=[ToolSpec.model_validate(t) for t in parse_jsonb(row["tools"])],
+        tools=load_tool_specs(parse_jsonb(row["tools"])),
         mcp_servers=[McpServerSpec.model_validate(s) for s in parse_jsonb(row["mcp_servers"])],
         http_servers=[HttpServerSpec.model_validate(s) for s in parse_jsonb(row["http_servers"])],
         status=row["status"],

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -424,14 +424,14 @@ async def find_and_repair_ghosts(
             """,
             candidate_sids,
         )
-    from aios.models.agents import HttpServerSpec, ToolSpec
+    from aios.models.agents import HttpServerSpec, load_tool_specs
 
     agent_surface_by_session: dict[str, _SweepAgentSurface] = {}
     for r in agent_rows:
         tools_list = parse_jsonb(r["tools"])
         http_list = parse_jsonb(r["http_servers"])
         agent_surface_by_session[r["session_id"]] = _SweepAgentSurface(
-            tools=[ToolSpec.model_validate(t) for t in (tools_list or [])],
+            tools=load_tool_specs(tools_list or []),
             http_servers=[HttpServerSpec.model_validate(h) for h in (http_list or [])],
         )
 

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -9,6 +9,7 @@ the full history. The ``model`` field is a free-form LiteLLM model string
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from datetime import datetime
 from typing import Any, Literal, get_args
 
@@ -107,6 +108,44 @@ _LEGACY_BUILTIN_RENAMES: dict[str, str] = {
     # window. The data migration (0117) rewrites persisted rows; this shim covers the window.
     "cancel_run": "stop_task",
 }
+
+# Read-tolerance for RETIRED builtins that have NO canonical successor (#1562). Unlike a
+# rename (mapped above), a retired builtin's persisted ``tools`` entry is DROPPED on read —
+# there is no model-listed tool to remap it to. #1525 (unify-obligations #2) removed
+# ``complete_goal``/``fail_goal`` from ``BuiltinToolType`` + the registry but shipped neither a
+# read shim nor a data migration, so any long-lived agent whose ``agents.tools`` JSONB still
+# listed them failed ``ToolSpec.model_validate`` on every wake — a pre-context-build throw that
+# wedged the agent into an infinite reschedule (only the live kedalion-ultron agent hit it).
+# ``return``/``error`` are general step verbs, not model-listed builtins, so there is no
+# successor — REMOVE, do not remap. The data migration (0122) rewrites persisted rows; this set
+# + :func:`load_tool_specs` cover the post-deploy/pre-migrate window and any future respawn from
+# an unmigrated row. (Teardown can drop both once 0122 has run everywhere.)
+_RETIRED_BUILTINS: frozenset[str] = frozenset({"complete_goal", "fail_goal"})
+
+
+def load_tool_specs(raw: Iterable[Any]) -> list[ToolSpec]:
+    """Validate a persisted ``tools`` JSONB array into ``ToolSpec``\\ s, with read-tolerance.
+
+    The DB read path persists historical ``tools`` arrays; an entry whose ``type`` is a
+    :data:`_RETIRED_BUILTINS` member (a builtin removed from ``BuiltinToolType`` + the registry
+    with no canonical successor — #1562's ``complete_goal``/``fail_goal``) is **dropped**, not
+    remapped: there is no model-listed tool to validate it against, and ``ToolSpec.model_validate``
+    would otherwise raise on the now-illegal Literal, poisoning the whole row's hydration.
+
+    This is the list-level counterpart to the per-entry ``mode="before"`` *rename* shim
+    (:data:`_LEGACY_BUILTIN_RENAMES`): a rename can be done in-place inside a single ``ToolSpec``,
+    but dropping an element must happen where the array is iterated. Order is preserved; a row
+    that listed only retired builtins hydrates to ``[]``. Use this anywhere a persisted ``tools``
+    array is loaded so the tolerance is uniform across agents / agent_versions / workflows /
+    workflow_versions / wf_runs / sessions.
+    """
+    out: list[ToolSpec] = []
+    for entry in raw:
+        if isinstance(entry, dict) and entry.get("type") in _RETIRED_BUILTINS:
+            continue
+        out.append(ToolSpec.model_validate(entry))
+    return out
+
 
 # Header names the MCP streamable-http transport authors on every request
 # (see ``mcp.client.streamable_http._prepare_headers``). A spec header named

--- a/tests/integration/test_migrations_0122_drop_retired_goal_tool_names.py
+++ b/tests/integration/test_migrations_0122_drop_retired_goal_tool_names.py
@@ -1,0 +1,96 @@
+"""Migration 0122 drops the retired ``complete_goal``/``fail_goal`` builtin tool names.
+
+#1525 removed ``complete_goal``/``fail_goal`` from ``BuiltinToolType`` + the registry without a
+read shim or a data migration, so any persisted ``tools`` JSONB still carrying them poisons
+``ToolSpec`` validation on read (the kedalion-ultron wedge, #1562). Migration 0122 scrubs both
+retired ``type`` values from every surface table; this exercises ``_aios_drop_retired_goal_tools``
+on ``workflows`` (the minimal seed; the same helper scrubs all six surface tables): the retired
+elements are removed with order + custom-tool preservation, a retired-only list collapses to
+``[]``, and the EXISTS gate leaves a clean row byte-untouched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+from typing import Any, cast
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+# wf_goal: both retired verbs amid a plain builtin + a custom tool.
+# wf_only: complete_goal + fail_goal alone → collapses to [].
+# wf_clean: no retired verb (left untouched by the EXISTS gate).
+_SEED_SQL = """
+INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+VALUES ('acc_root', NULL, TRUE, 'root');
+INSERT INTO workflows (id, account_id, name, version, script, tools)
+VALUES
+  ('wf_goal', 'acc_root', 'goal', 1, 'S',
+   '[{"type":"bash"},{"type":"complete_goal"},
+     {"type":"custom","name":"foo","description":"d","input_schema":{}},
+     {"type":"fail_goal"}]'::jsonb),
+  ('wf_only', 'acc_root', 'only', 1, 'S',
+   '[{"type":"complete_goal"},{"type":"fail_goal"}]'::jsonb),
+  ('wf_clean', 'acc_root', 'clean', 1, 'S',
+   '[{"type":"bash"},{"type":"create_goal"}]'::jsonb);
+"""
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _fetch_tools(db_url: str, wf_id: str) -> list[dict[str, Any]]:
+    conn = await asyncpg.connect(db_url)
+    try:
+        raw = await conn.fetchval("SELECT tools FROM workflows WHERE id = $1", wf_id)
+        parsed = json.loads(raw) if isinstance(raw, str) else raw
+        return cast("list[dict[str, Any]]", parsed)
+    finally:
+        await conn.close()
+
+
+async def _execute(db_url: str, sql: str) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+@needs_docker
+@pytest.mark.integration
+def test_retired_goal_tool_names_dropped(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+
+    # Seed AFTER 0121 (the pre-0122 head) so the retired rows are pristine.
+    up = _run_alembic(["upgrade", "0121"], db_url)
+    assert up.returncode == 0, f"upgrade to 0121 failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_execute(db_url, _SEED_SQL))
+
+    up = _run_alembic(["upgrade", "0122"], db_url)
+    assert up.returncode == 0, f"upgrade to 0122 failed:\n{up.stderr}\n{up.stdout}"
+
+    # Both retired verbs removed; bash + custom untouched, original order preserved.
+    goal = asyncio.run(_fetch_tools(db_url, "wf_goal"))
+    assert [t["type"] for t in goal] == ["bash", "custom"]
+    assert goal[1]["name"] == "foo"  # custom spec preserved verbatim
+
+    # A retired-only list collapses to [].
+    only = asyncio.run(_fetch_tools(db_url, "wf_only"))
+    assert only == []
+
+    # Clean row: no retired verb → left byte-untouched by the EXISTS gate.
+    clean = asyncio.run(_fetch_tools(db_url, "wf_clean"))
+    assert [t["type"] for t in clean] == ["bash", "create_goal"]

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,9 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0121``."""
+    """The migration ladder has exactly one head: ``0122``."""
     script = _script_directory()
-    assert script.get_heads() == ["0121"]
+    assert script.get_heads() == ["0122"]
 
 
 def test_chain_is_linear() -> None:

--- a/tests/unit/test_retired_goal_tool_tolerance.py
+++ b/tests/unit/test_retired_goal_tool_tolerance.py
@@ -1,0 +1,98 @@
+"""Read-tolerance for the RETIRED ``complete_goal``/``fail_goal`` builtins (#1562).
+
+#1525 removed ``complete_goal``/``fail_goal`` from ``BuiltinToolType`` + the registry but shipped
+neither a read shim nor a data migration. A long-lived agent whose persisted ``tools`` JSONB still
+listed those builtins then failed ``ToolSpec`` validation on every wake — a pre-context-build throw
+that wedged the agent into an infinite reschedule (the kedalion-ultron incident). They have NO
+canonical successor (``return``/``error`` are general step verbs, not model-listed builtins), so
+the entries are DROPPED, not remapped.
+
+``load_tool_specs`` is the list-level read-tolerance choke point used by every DB read path
+(agents / agent_versions / workflows / workflow_versions / wf_runs / sessions); these tests pin
+the drop + order/preservation semantics, and ``test_agent_row_with_retired_builtin_hydrates_clean``
+is the CI-gap test the incident calls for: test agents are born from the *current* catalog so none
+carry retired builtins, which is exactly why the wedge was invisible to CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.models.agents import load_tool_specs
+
+
+def test_retired_builtin_entry_is_dropped() -> None:
+    specs = load_tool_specs([{"type": "bash"}, {"type": "complete_goal"}, {"type": "read"}])
+    assert [s.type for s in specs] == ["bash", "read"]
+
+
+@pytest.mark.parametrize("retired", ["complete_goal", "fail_goal"])
+def test_each_retired_builtin_is_dropped(retired: str) -> None:
+    specs = load_tool_specs([{"type": retired}, {"type": "bash"}])
+    assert [s.type for s in specs] == ["bash"]
+
+
+def test_retired_only_list_hydrates_to_empty() -> None:
+    assert load_tool_specs([{"type": "complete_goal"}, {"type": "fail_goal"}]) == []
+
+
+def test_clean_list_is_untouched_and_validates() -> None:
+    specs = load_tool_specs([{"type": "bash"}, {"type": "create_goal"}])
+    assert [s.type for s in specs] == ["bash", "create_goal"]
+
+
+def test_order_preserved_with_custom_and_mcp_entries() -> None:
+    specs = load_tool_specs(
+        [
+            {"type": "bash"},
+            {"type": "fail_goal"},
+            {"type": "custom", "name": "foo", "description": "d", "input_schema": {}},
+            {"type": "complete_goal"},
+            {"type": "mcp_toolset", "mcp_server_name": "srv"},
+        ]
+    )
+    assert [s.type for s in specs] == ["bash", "custom", "mcp_toolset"]
+
+
+def test_retired_drop_composes_with_legacy_rename() -> None:
+    """A row mixing a retired builtin and a legacy-renamed builtin: the retired one is dropped,
+    the legacy one is still remapped to its canonical name (the two shims compose)."""
+    specs = load_tool_specs([{"type": "complete_goal"}, {"type": "invoke_workflow"}])
+    assert [s.type for s in specs] == ["call_workflow"]
+
+
+def test_agent_row_with_retired_builtin_hydrates_clean() -> None:
+    """CI-gap regression: an agent whose persisted ``tools`` JSONB carries a retired builtin
+    hydrates without raising — the exact wedge #1525 introduced and CI missed (test agents are
+    born from the current catalog, so none carry retired builtins)."""
+    from datetime import UTC, datetime
+
+    from aios.db.queries.agents import _row_to_agent
+
+    now = datetime.now(UTC)
+    row = {
+        "id": "agt_wedged",
+        "version": 3,
+        "name": "ultron",
+        "model": "anthropic/claude-opus-4-6",
+        "system": "",
+        # Pool reads arrive already parsed (the jsonb codec decodes), so ``parse_jsonb`` is a
+        # passthrough — pass parsed Python here, exactly what ``_row_to_agent`` receives in prod.
+        "tools": [{"type": "bash"}, {"type": "complete_goal"}, {"type": "fail_goal"}],
+        "skills": [],
+        "mcp_servers": [],
+        "http_servers": [],
+        "description": None,
+        "metadata": {},
+        "litellm_extra": {},
+        "window_min": 1,
+        "window_max": 10,
+        "created_at": now,
+        "updated_at": now,
+        "archived_at": None,
+    }
+
+    agent = _row_to_agent(row)  # type: ignore[arg-type]
+
+    # The retired builtins are gone; the legitimate one survives. No exception = no wedge.
+    assert [t.type for t in agent.tools] == ["bash"]

--- a/tests/unit/test_retired_goal_tool_tolerance.py
+++ b/tests/unit/test_retired_goal_tool_tolerance.py
@@ -92,7 +92,7 @@ def test_agent_row_with_retired_builtin_hydrates_clean() -> None:
         "archived_at": None,
     }
 
-    agent = _row_to_agent(row)  # type: ignore[arg-type]
+    agent = _row_to_agent(row)
 
     # The retired builtins are gone; the legitimate one survives. No exception = no wedge.
     assert [t.type for t in agent.tools] == ["bash"]


### PR DESCRIPTION
Automated dev-pipeline build for issue #1562.