### PR TITLE
Unify the copy-pasted `request_opened MINUS request_response` open-request anti-join into one shared SQL fragment (5 hand-synced copies, drifted twice)

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -269,6 +269,42 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def open_request_anti_join(*, sid: str, acct: str, awaited_only: bool) -> str:
+    """SQL predicate for the open-request anti-join: a ``request_opened`` edge on
+    (``sid``, ``acct``) with no answering ``request_response``.
+
+    ``sid`` / ``acct`` are the SQL expressions for the session-id and account-id
+    columns at the call site (e.g. ``"$1"``, ``"s.id"``) — always static literals
+    chosen by service code, never user input, so f-string interpolation carries
+    no injection risk (same contract as :func:`_get_scoped` et al.). This is the
+    single source of truth for the ``asked(request_opened) MINUS
+    answered(request_response)`` open set; every reader composes it instead of
+    inlining the literal, so the awaited discriminator can no longer drift.
+
+    ``awaited_only`` is the #1197 discriminator and MUST be passed explicitly so
+    each reader's inclusion/omission of it is a visible compositional choice, not
+    an accidental copy divergence:
+      * True  → only awaited (Ask-arm) edges; a ``Tell(NewSession)``
+                fire-and-forget spawn (``awaited=false``) owes no response and is
+                excluded. Absent field reads as awaited=true (additive/legacy),
+                so pre-#1197 rows keep their obligation.
+      * False → every still-open edge, awaited or not (e.g. wake-priority
+                demotion keys off any triggering edge, including a background
+                fan-out's unawaited ``Tell`` child).
+    """
+    awaited = "AND COALESCE((req.data->>'awaited')::boolean, TRUE) " if awaited_only else ""
+    return (
+        f"req.session_id = {sid} AND req.account_id = {acct} "
+        "AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
+        "AND req.data->>'request_id' IS NOT NULL "
+        f"{awaited}"
+        "AND NOT EXISTS (SELECT 1 FROM events resp "
+        f"    WHERE resp.session_id = {sid} AND resp.account_id = {acct} "
+        "    AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
+        "    AND resp.data->>'request_id' = req.data->>'request_id') "
+    )
+
+
 # ─── re-exports ──────────────────────────────────────────────────────────────
 #
 # Every public query plus every underscore-helper / class / constant each
@@ -813,6 +849,7 @@ __all__ = [
     "notify_connection_change",
     "notify_management_call_dispatch",
     "notify_management_call_result",
+    "open_request_anti_join",
     "parse_jsonb",
     "precompute_event_append",
     "prune_trigger_runs",

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -19,6 +19,7 @@ from aios.db.queries import (
     _build_set_assignments,
     _get_scoped,
     _list_scoped,
+    open_request_anti_join,
     parse_jsonb,
 )
 from aios.errors import (
@@ -400,8 +401,15 @@ async def get_wake_priority_context(
     - no ``request_opened`` edge (an ordinary root / fg-user session) → foreground.
 
     Derives the demotion from the **latest still-open** edge — the most-recent
-    ``request_opened`` not yet answered by a ``request_response`` (the same
-    ``asked MINUS answered`` open set as :func:`get_open_request_ids`). A session
+    ``request_opened`` not yet answered by a ``request_response``, composed from
+    the shared :func:`open_request_anti_join` fragment with ``awaited_only=False``
+    (**intentional here**, unlike :func:`get_open_request_ids`). The demotion keys
+    off *any* triggering up-link, including a background fan-out's **unawaited**
+    ``Tell(NewSession)`` child: a ``Tell``-spawned child of a background run is a
+    fan-out descendant and *should* wake at background, so this open set is
+    deliberately a **superset** of :func:`get_open_request_ids`'s (which excludes
+    the unawaited ``Tell`` edges) — it is every still-open edge, awaited or not,
+    not the response-owing subset. A session
     that has served several requests wakes at the priority of the edge that
     triggered *this* wake, not its oldest-ever edge — reachable since ``invoke``
     with ``target_kind='session'`` (#1128) appends a second edge to a live session:
@@ -425,15 +433,9 @@ async def get_wake_priority_context(
         "      ELSE FALSE "
         "    END "
         "    FROM events req "
-        "    WHERE req.session_id = s.id AND req.account_id = s.account_id "
-        "    AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
-        "    AND req.data->>'request_id' IS NOT NULL "
-        "    AND NOT EXISTS ("
-        "      SELECT 1 FROM events resp "
-        "      WHERE resp.session_id = s.id AND resp.account_id = s.account_id "
-        "      AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
-        "      AND resp.data->>'request_id' = req.data->>'request_id') "
-        "    ORDER BY req.seq DESC LIMIT 1"
+        "    WHERE "
+        + open_request_anti_join(sid="s.id", acct="s.account_id", awaited_only=False)
+        + "    ORDER BY req.seq DESC LIMIT 1"
         "  ), FALSE) AS is_background "
         "FROM sessions s WHERE s.id = $1",
         session_id,
@@ -500,22 +502,9 @@ async def get_open_request_ids(
     a point lookup rather than a per-wake history scan.
     """
     rows: list[asyncpg.Record] = await conn.fetch(
-        "SELECT req.data->>'request_id' AS rid FROM events req "
-        "WHERE req.session_id = $1 AND req.account_id = $2 "
-        "AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
-        "AND req.data->>'request_id' IS NOT NULL "
-        # #1197 awaited-triad filter: a ``Tell(NewSession)`` writes a real
-        # ``request_opened`` row with ``awaited=false`` (lineage/depth/surface
-        # carrier, no response obligation), so the open set must exclude it —
-        # else a fire-and-forget spawn would wrongly owe a response. An absent
-        # field reads as awaited=true (additive/legacy), so pre-#1197 rows keep
-        # their obligation.
-        "AND COALESCE((req.data->>'awaited')::boolean, TRUE) "
-        "AND NOT EXISTS (SELECT 1 FROM events resp "
-        "    WHERE resp.session_id = $1 AND resp.account_id = $2 "
-        "    AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
-        "    AND resp.data->>'request_id' = req.data->>'request_id') "
-        "ORDER BY req.seq ASC",
+        "SELECT req.data->>'request_id' AS rid FROM events req WHERE "
+        + open_request_anti_join(sid="$1", acct="$2", awaited_only=True)
+        + "ORDER BY req.seq ASC",
         session_id,
         account_id,
     )
@@ -528,9 +517,10 @@ async def get_open_obligations(
     """The session's still-open **awaited** obligations, oldest first (#1413).
 
     Modeled 1:1 on :func:`get_open_request_ids` — same
-    ``asked(request_opened) MINUS answered(request_response)`` anti-join, same
-    ``awaited=true`` COALESCE filter (so a fire-and-forget ``Tell`` edge is
-    excluded), same ``ORDER BY req.seq ASC`` (oldest-first, deterministic). But
+    ``asked(request_opened) MINUS answered(request_response)`` anti-join (the
+    shared :func:`open_request_anti_join` fragment, ``awaited_only=True`` so a
+    fire-and-forget ``Tell`` edge is excluded), same ``ORDER BY req.seq ASC``
+    (oldest-first, deterministic). But
     instead of bare ``request_id``s it projects a full :class:`Obligation` per open
     edge so the tail-injected obligations block (and the ``obligations`` read
     model) can render it: ``caller_kind`` (``req.data->'caller'->>'kind'`` — the
@@ -565,18 +555,9 @@ async def get_open_obligations(
         "req.created_at AS opened_at, "
         "req.data->>'summary' AS summary, "
         "req.data->'output_schema' AS output_schema "
-        "FROM events req "
-        "WHERE req.session_id = $1 AND req.account_id = $2 "
-        "AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
-        "AND req.data->>'request_id' IS NOT NULL "
-        # #1197 awaited-triad filter -- lockstep with get_open_request_ids: an
-        # unawaited Tell edge owes no response. Absent reads as awaited=true.
-        "AND COALESCE((req.data->>'awaited')::boolean, TRUE) "
-        "AND NOT EXISTS (SELECT 1 FROM events resp "
-        "    WHERE resp.session_id = $1 AND resp.account_id = $2 "
-        "    AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
-        "    AND resp.data->>'request_id' = req.data->>'request_id') "
-        "ORDER BY req.seq ASC",
+        "FROM events req WHERE "
+        + open_request_anti_join(sid="$1", acct="$2", awaited_only=True)
+        + "ORDER BY req.seq ASC",
         session_id,
         account_id,
     )

--- a/src/aios/db/queries/trace.py
+++ b/src/aios/db/queries/trace.py
@@ -23,7 +23,7 @@ from typing import Any, Literal
 
 import asyncpg
 
-from aios.db.queries import parse_jsonb
+from aios.db.queries import open_request_anti_join, parse_jsonb
 
 NodeKind = Literal["run", "session"]
 
@@ -344,14 +344,14 @@ async def read_session_meta_batched(
         return {}
     rows = await conn.fetch(
         "SELECT s.id, s.stop_reason, s.archived_at, s.title, s.agent_id, s.created_at, "
-        "  (SELECT array_agg(req.data->>'request_id') FROM events req "
-        "   WHERE req.session_id = s.id AND req.account_id = $2 "
-        "   AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
-        "   AND req.data->>'request_id' IS NOT NULL "
-        "   AND NOT EXISTS (SELECT 1 FROM events resp "
-        "       WHERE resp.session_id = s.id AND resp.account_id = $2 "
-        "       AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
-        "       AND resp.data->>'request_id' = req.data->>'request_id')) AS open_request_ids, "
+        # The "owes a request" liveness for archived-root green-washing must
+        # match get_open_request_ids: it owes a *response*, which an unawaited
+        # ``Tell(NewSession)`` edge does not — so this composes the shared
+        # open_request_anti_join with awaited_only=True (genuinely mirroring
+        # get_open_request_ids via the one fragment).
+        "  (SELECT array_agg(req.data->>'request_id') FROM events req WHERE "
+        + open_request_anti_join(sid="s.id", acct="$2", awaited_only=True)
+        + ") AS open_request_ids, "
         # The oldest open request's written response, if any (deterministic
         # oldest-first, mirroring get_open_request_ids). For an archived session
         # this is NULL (the request is open precisely because nothing answered it);

--- a/tests/integration/test_session_meta_owed_request.py
+++ b/tests/integration/test_session_meta_owed_request.py
@@ -1,0 +1,151 @@
+"""Integration tests for ``read_session_meta_batched``'s open-request liveness.
+
+The trace normalizer's archived-root green-washing check keys off
+``read_session_meta_batched(...)[sid]["open_request_ids"]`` ("does this archived
+root still owe a request?") and the derived ``owed_request_response``. That
+"owes a request" set must mean "owes a *response*" — exactly
+:func:`aios.db.queries.sessions.get_open_request_ids`'s awaited-only open set —
+so a ``Tell(NewSession)`` fire-and-forget spawn (an **unawaited**
+``request_opened`` edge that owes no response) does NOT count as open. Before
+#1536 this reader omitted the ``awaited`` filter, so an archived root whose only
+edge was an unawaited ``Tell`` spawn was wrongly counted as owing a request and
+the ``_resolve_owed_response`` path resolved that phantom obligation to
+``child_gone`` — mislabeling a clean archived root as errored.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.db.queries import trace as trace_q
+from tests.integration.conftest import seed_agent_env_session
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT = "acc_session_meta_owed"
+
+
+@pytest.fixture
+async def pool_env(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str, str]]:
+    """Yield ``(pool, agent_id, environment_id)`` for a fresh tenant."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'session-meta-owed-test')",
+                _ACCOUNT,
+            )
+        agent, env, _session = await seed_agent_env_session(
+            pool, account_id=_ACCOUNT, prefix="session-meta-owed"
+        )
+        yield pool, agent.id, env.id
+    finally:
+        await pool.close()
+
+
+async def _insert_session(pool: asyncpg.Pool[Any], *, agent_id: str, environment_id: str) -> str:
+    async with pool.acquire() as conn:
+        session = await queries.insert_session(
+            conn,
+            account_id=_ACCOUNT,
+            agent_id=agent_id,
+            environment_id=environment_id,
+            agent_version=1,
+            title=None,
+            metadata={},
+        )
+    return session.id
+
+
+async def _open_edge(
+    pool: asyncpg.Pool[Any],
+    *,
+    session_id: str,
+    request_id: str,
+    caller: dict[str, Any],
+    awaited: bool,
+) -> None:
+    async with pool.acquire() as conn, conn.transaction():
+        await queries.append_request_opened(
+            conn,
+            session_id=session_id,
+            account_id=_ACCOUNT,
+            request_id=request_id,
+            caller=caller,
+            depth=0,
+            environment_id="env_x",
+            frozen_surface={"tools": [], "mcp_servers": [], "http_servers": []},
+            vault_ids=[],
+            awaited=awaited,
+        )
+
+
+async def _archive(pool: asyncpg.Pool[Any], *, session_id: str) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE sessions SET archived_at = now() WHERE id = $1 AND account_id = $2",
+            session_id,
+            _ACCOUNT,
+        )
+
+
+async def test_archived_unawaited_tell_owes_nothing(
+    pool_env: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """An archived session whose only ``request_opened`` edge is an **unawaited**
+    ``Tell(NewSession)`` spawn (``awaited=false``, no ``request_response``) owes
+    nothing: ``open_request_ids == []`` and ``owed_request_response is None``.
+
+    On ``master`` this fails — the unawaited edge was wrongly counted as open and
+    the archived-root resolution turned it into a phantom ``child_gone`` (green-
+    washing a clean archived root into ``errored``). After #1536's shared
+    ``awaited_only=True`` fragment it passes.
+    """
+    pool, agent_id, env_id = pool_env
+    sid = await _insert_session(pool, agent_id=agent_id, environment_id=env_id)
+    await _open_edge(
+        pool,
+        session_id=sid,
+        request_id="req_tell",
+        caller={"kind": "run", "id": "wfr_tell"},
+        awaited=False,
+    )
+    await _archive(pool, session_id=sid)
+    async with pool.acquire() as conn:
+        meta = await trace_q.read_session_meta_batched(conn, [sid], account_id=_ACCOUNT)
+    assert meta[sid]["open_request_ids"] == []
+    assert meta[sid]["owed_request_response"] is None
+
+
+async def test_archived_awaited_ask_still_owes(
+    pool_env: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """The behavior-preserving control: an archived session with an **awaited**
+    (``Ask``-arm) open edge and no response still owes — ``open_request_ids`` is
+    non-empty and ``owed_request_response`` resolves to the ``child_gone``
+    terminal outcome (an archived session can never answer)."""
+    pool, agent_id, env_id = pool_env
+    sid = await _insert_session(pool, agent_id=agent_id, environment_id=env_id)
+    await _open_edge(
+        pool,
+        session_id=sid,
+        request_id="req_ask",
+        caller={"kind": "run", "id": "wfr_ask"},
+        awaited=True,
+    )
+    await _archive(pool, session_id=sid)
+    async with pool.acquire() as conn:
+        meta = await trace_q.read_session_meta_batched(conn, [sid], account_id=_ACCOUNT)
+    assert meta[sid]["open_request_ids"] == ["req_ask"]
+    owed = meta[sid]["owed_request_response"]
+    assert owed is not None and owed["is_error"] is True
+    assert owed["error"] == {"kind": "child_gone"}

--- a/tests/integration/test_wake_priority_context.py
+++ b/tests/integration/test_wake_priority_context.py
@@ -50,7 +50,12 @@ async def pool_env(
 
 
 async def _open_edge(
-    pool: asyncpg.Pool[Any], *, session_id: str, request_id: str, caller: dict[str, Any]
+    pool: asyncpg.Pool[Any],
+    *,
+    session_id: str,
+    request_id: str,
+    caller: dict[str, Any],
+    awaited: bool = True,
 ) -> None:
     async with pool.acquire() as conn, conn.transaction():
         await queries.append_request_opened(
@@ -63,6 +68,7 @@ async def _open_edge(
             environment_id="env_x",
             frozen_surface={"tools": [], "mcp_servers": [], "http_servers": []},
             vault_ids=[],
+            awaited=awaited,
         )
 
 
@@ -246,3 +252,32 @@ async def test_answered_edge_is_excluded(
     async with pool.acquire() as conn:
         ctx = await queries.get_wake_priority_context(conn, sid)
     assert ctx is not None and ctx[1] is False
+
+
+async def test_unawaited_tell_edge_still_demotes_background(
+    pool_env: tuple[asyncpg.Pool[Any], str, str, str],
+) -> None:
+    """A background-rooted session whose only open edge is an **unawaited**
+    ``Tell(NewSession)`` spawn (``awaited=false``, ``caller.kind='run'``) still
+    wakes **background**.
+
+    Pins the intentional ``awaited_only=False`` choice in
+    :func:`get_wake_priority_context`: the wake-priority demotion keys off *any*
+    triggering up-link — a ``Tell``-spawned child of a background run is a fan-out
+    descendant and must yield to user-facing sessions — so this query's open set
+    is deliberately a **superset** of :func:`get_open_request_ids`'s (which would
+    exclude this unawaited edge). A future "tidy" that adds the ``awaited`` filter
+    to this reader would break this case loudly.
+    """
+    pool, _account, agent_id, env_id = pool_env
+    sid = await _insert_session(pool, agent_id=agent_id, environment_id=env_id, origin="background")
+    await _open_edge(
+        pool,
+        session_id=sid,
+        request_id="req_tell",
+        caller={"kind": "run", "id": "wfr_tell"},
+        awaited=False,
+    )
+    async with pool.acquire() as conn:
+        ctx = await queries.get_wake_priority_context(conn, sid)
+    assert ctx is not None and ctx[1] is True

--- a/tests/unit/test_request_opened_edge.py
+++ b/tests/unit/test_request_opened_edge.py
@@ -179,7 +179,17 @@ def test_harness_append_path_has_no_route_to_request_opened() -> None:
 def _sql_literals(obj: Callable[..., object]) -> str:
     """Concatenate every string-constant literal in ``obj``'s body — i.e. the SQL
     fragments — EXCLUDING the docstring, so a docstring mention can't shadow the
-    real query text."""
+    real query text.
+
+    The open-request anti-join skeleton lives once in the shared
+    :func:`aios.db.queries.open_request_anti_join` builder (#1536), composed at
+    each reader instead of inlined. So when the body calls that builder, expand
+    the call to its produced SQL (with the call-site's ``awaited_only`` literal),
+    so a reader that *composes* the fragment reads the same as one that inlined
+    it — the structural guard now follows the literal into its single home.
+    """
+    from aios.db.queries import open_request_anti_join
+
     func = _func_def(obj, getattr(obj, "__name__", "?"))
     body = func.body[1:] if ast.get_docstring(func) is not None else func.body
     parts: list[str] = []
@@ -187,6 +197,19 @@ def _sql_literals(obj: Callable[..., object]) -> str:
         for node in ast.walk(stmt):
             if isinstance(node, ast.Constant) and isinstance(node.value, str):
                 parts.append(node.value)
+            elif isinstance(node, ast.Call) and _call_name(node) == "open_request_anti_join":
+                kwargs = {
+                    kw.arg: kw.value.value
+                    for kw in node.keywords
+                    if isinstance(kw.value, ast.Constant)
+                }
+                parts.append(
+                    open_request_anti_join(
+                        sid=str(kwargs.get("sid", "$1")),
+                        acct=str(kwargs.get("acct", "$2")),
+                        awaited_only=bool(kwargs.get("awaited_only", False)),
+                    )
+                )
     return "\n".join(parts)
 
 


### PR DESCRIPTION
Automated dev-pipeline build for issue #1536.