### PR TITLE
create_child_session: replace the awaited:bool shim + runtime guards with a direct AskNewSession | TellNewSession parameter

### DIFF
--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -522,7 +522,7 @@ async def stimulate(pool: asyncpg.Pool[Any], stim: Stimulus, *, account_id: str)
     `True`).
     """
     if isinstance(stim, AskNewSession | TellNewSession):
-        return await _stimulate_new_session(pool, stim, account_id=account_id)
+        return await create_child_session(pool, stim, account_id=account_id)
     if isinstance(stim, AskExistingSession):
         return await _stimulate_existing_ask(pool, stim, account_id=account_id)
     return await _stimulate_existing_tell(pool, stim, account_id=account_id)
@@ -544,19 +544,49 @@ def _obligation_summary(content: str) -> str:
     return preview
 
 
-async def _stimulate_new_session(
+async def create_child_session(
     pool: asyncpg.Pool[Any],
     stim: AskNewSession | TellNewSession,
     *,
     account_id: str,
 ) -> bool:
-    """The NewSession arm of the spine — idempotently spawn a child + deliver.
+    """Idempotently spawn a workflow ``agent()`` child and inject the first request.
 
-    Shared by `Ask(NewSession)` (`awaited=true`, carries `output_schema`) and
-    `Tell(NewSession)` (`awaited=false`, no `output_schema`). Behavior-preserving
-    over the legacy `create_child_session`: same `ON CONFLICT (id) DO NOTHING`
-    first-spawn guard (a replayed wake never re-delivers), same one-transaction
-    insert → freeze surface → bind vaults → deliver → open edge.
+    The single public NewSession writer and the NewSession arm of the spine: the
+    ``Ask``/``Tell`` kind **is** the discriminant. It materializes-or-resolves the
+    child servicer, appends the stimulus, threads lineage, applies the #794 clamp +
+    vault binding, opens the ``request_opened`` edge with the correct ``awaited``
+    bit, and wakes. Both arms share the same ``ON CONFLICT (id) DO NOTHING``
+    first-spawn guard, so a replayed wake never re-delivers.
+
+    **Ask (`AskNewSession`):** the child's first user message **is a request** --
+    its content is ``input``, and ``metadata.request`` carries
+    ``{request_id, caller}`` so the target can correlate its response and the caller
+    (the run) can be resumed. The child must answer this request via
+    ``return``/``error`` (exactly once); the required ``request_id`` is surfaced to
+    the model as a render-time marker (see ``render_user_event``). ``output_schema``
+    (optional, an ``Ask``-only field) is the JSON Schema the request demands of the
+    response ``value``.
+
+    **Tell (`TellNewSession`, #1197):** a fire-and-forget spawn -- create + deliver +
+    wake with an **unawaited** edge -- still decrements SPAWN depth and applies the
+    #794 clamp (it creates a servicer), only the **response obligation** is dropped.
+    A ``Tell`` carries no ``output_schema`` (it owes no response); its required
+    ``request_id`` keys the unawaited edge so lineage/depth/surface have a carrier
+    (the natural Tell call shape mints its own id at the construction site).
+
+    ``surface`` is the child's **frozen, run-attenuated** capability surface
+    (``attenuate(agent, run)`` -- #794); ``litellm_extra`` is the child's **frozen,
+    clamped model identity** (``api_base`` foremost -- #823), validated against the
+    operator trusted-endpoint allowlist at the spawn edge before this call.
+    ``vault_ids`` is the run's vault bindings, copied into the child's
+    ``session_vaults``. All three are written **only on a real insert**, inside the
+    one transaction and pinned under ``ON CONFLICT (id) DO NOTHING``, so a replay
+    never re-freezes a shifted surface, re-points a since-changed endpoint, or
+    re-binds vaults.
+
+    Returns ``True`` on first spawn, ``False`` on conflict (replay -> the caller
+    harvests the response instead of re-spawning).
     """
     awaited = isinstance(stim, AskNewSession)
     output_schema = stim.output_schema if isinstance(stim, AskNewSession) else None
@@ -727,106 +757,6 @@ async def tell_existing_session(
     event = await append_user_message(pool, session_id, content, account_id=account_id)
     await defer_wake(pool, session_id, cause=cause, account_id=account_id)
     return event
-
-
-async def create_child_session(
-    pool: asyncpg.Pool[Any],
-    *,
-    session_id: str,
-    account_id: str,
-    agent_id: str | None,
-    environment_id: str,
-    agent_version: int | None,
-    model: str | None,
-    parent_run_id: str,
-    surface: Surface,
-    vault_ids: list[str],
-    input: Any,
-    request_id: str | None = None,
-    output_schema: dict[str, Any] | None = None,
-    depth: int = 0,
-    litellm_extra: dict[str, Any] | None = None,
-    awaited: bool = True,
-) -> bool:
-    """Idempotently spawn a workflow ``agent()`` child and inject the first request.
-
-    A thin caller of the private :func:`stimulate` spine's NewSession arm: it
-    builds the matching ``Ask | Tell`` stimulus and delegates the
-    materialize → deliver → open-edge → (the caller wakes) middle. Both arms share
-    the same ``ON CONFLICT (id) DO NOTHING`` first-spawn guard, so a replayed wake
-    never re-delivers.
-
-    **Ask (``awaited=true``, the default — `invoke_agent`):** the child's first
-    user message **is a request** — its content is ``input``, and
-    ``metadata.request`` carries ``{request_id, caller}`` so the target can
-    correlate its response and the caller (the run) can be resumed. The child must
-    answer this request via ``return``/``error`` (exactly once); the ``request_id``
-    is surfaced to the model as a render-time marker on the message (see
-    ``render_user_event``) so it knows which id to echo back. ``output_schema``
-    (optional) is the JSON Schema the request demands of the response ``value``.
-
-    **Tell (``awaited=false`` — fire-and-forget spawn, #1197):** create + deliver
-    + wake with an **unawaited** edge — still decrements SPAWN depth and applies the
-    #794 clamp (it creates a servicer), only the **response obligation** is dropped.
-    ``output_schema`` is not permitted (a Tell owes no response). When no
-    ``request_id`` is supplied (the natural Tell call shape) one is minted to key
-    the unawaited edge so lineage/depth/surface have a carrier.
-
-    ``surface`` is the child's **frozen, run-attenuated** capability surface
-    (``attenuate(agent, run)`` — #794); ``litellm_extra`` is the child's **frozen,
-    clamped model identity** (``api_base`` foremost — #823), validated against the
-    operator trusted-endpoint allowlist at the spawn edge before this call.
-    ``vault_ids`` is the run's vault bindings, copied into the child's
-    ``session_vaults``. All three are written **only on a real insert**, inside the
-    one transaction and pinned under ``ON CONFLICT (id) DO NOTHING``, so a replay
-    never re-freezes a shifted surface, re-points a since-changed endpoint, or
-    re-binds vaults.
-
-    Returns ``True`` on first spawn, ``False`` on conflict (replay → the caller
-    harvests the response instead of re-spawning).
-    """
-    if awaited:
-        if request_id is None:
-            raise ValidationError(
-                "Ask(NewSession) requires a request_id (the response obligation key)",
-                detail={"awaited": True},
-            )
-        stim: AskNewSession | TellNewSession = AskNewSession(
-            session_id=session_id,
-            agent_id=agent_id,
-            environment_id=environment_id,
-            agent_version=agent_version,
-            model=model,
-            parent_run_id=parent_run_id,
-            surface=surface,
-            vault_ids=vault_ids,
-            request_id=request_id,
-            input=input,
-            output_schema=output_schema,
-            depth=depth,
-            litellm_extra=litellm_extra,
-        )
-    else:
-        if output_schema is not None:
-            raise ValidationError(
-                "Tell(NewSession) cannot carry an output_schema (it owes no response)",
-                detail={"awaited": False},
-            )
-        stim = TellNewSession(
-            session_id=session_id,
-            agent_id=agent_id,
-            environment_id=environment_id,
-            agent_version=agent_version,
-            model=model,
-            parent_run_id=parent_run_id,
-            surface=surface,
-            vault_ids=vault_ids,
-            request_id=request_id if request_id is not None else make_id(REQUEST),
-            input=input,
-            depth=depth,
-            litellm_extra=litellm_extra,
-        )
-    return await _stimulate_new_session(pool, stim, account_id=account_id)
 
 
 async def invoke(

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -49,6 +49,7 @@ from aios.models.attenuation import api_base_of, surface_of
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent, WfRunStatus
 from aios.services import attenuation as attenuation_service
 from aios.services.sessions import (
+    AskNewSession,
     create_child_session,
     fail_open_child_requests_conn,
     write_gate_opened,
@@ -997,20 +998,22 @@ async def _open_agent_capability(
 
     created = await create_child_session(
         pool,
-        session_id=child_id,
+        AskNewSession(
+            session_id=child_id,
+            agent_id=agent_id,
+            environment_id=run.environment_id,
+            agent_version=pinned,
+            model=stamped_model,
+            parent_run_id=run.id,
+            surface=child_surface,
+            vault_ids=run_vaults,
+            request_id=cap.call_key,  # the agent() call IS the request the child must answer
+            input=spec.get("input"),
+            output_schema=output_schema,
+            depth=run.depth - 1,
+            litellm_extra=child_litellm_extra,  # #823: frozen, clamped model identity
+        ),
         account_id=account_id,
-        agent_id=agent_id,
-        environment_id=run.environment_id,
-        agent_version=pinned,
-        model=stamped_model,
-        parent_run_id=run.id,
-        surface=child_surface,
-        vault_ids=run_vaults,
-        request_id=cap.call_key,  # the agent() call IS the request the child must answer
-        input=spec.get("input"),
-        output_schema=output_schema,
-        depth=run.depth - 1,
-        litellm_extra=child_litellm_extra,  # #823: frozen, clamped model identity
     )
     # On replay the row already carries its first-spawn version — journal THAT, so
     # call_started.child_agent_version always matches the version the child runs under.

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -22,8 +22,10 @@ import pytest
 
 from aios.db import queries
 from aios.db.pool import create_pool
+from aios.ids import REQUEST, make_id
 from aios.models.attenuation import Surface
 from aios.services import sessions as service
+from aios.services.sessions import AskNewSession, TellNewSession
 from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
@@ -194,18 +196,20 @@ async def test_create_child_session_opens_exactly_one_edge_and_replay_idempotent
 
     created = await service.create_child_session(
         pool,
-        session_id=child_id,
+        AskNewSession(
+            session_id=child_id,
+            agent_id=agent_id,
+            environment_id=env_id,
+            agent_version=1,
+            model="openrouter/test",
+            parent_run_id=parent_run_id,
+            surface=surface,
+            vault_ids=[],
+            request_id="req-child",
+            input="hello",
+            depth=1,
+        ),
         account_id=account_id,
-        agent_id=agent_id,
-        environment_id=env_id,
-        agent_version=1,
-        model="openrouter/test",
-        parent_run_id=parent_run_id,
-        surface=surface,
-        vault_ids=[],
-        request_id="req-child",
-        input="hello",
-        depth=1,
     )
     assert created is True
 
@@ -231,18 +235,20 @@ async def test_create_child_session_opens_exactly_one_edge_and_replay_idempotent
     # Replay: a second spawn hits ON CONFLICT → returns False → no second edge.
     replayed = await service.create_child_session(
         pool,
-        session_id=child_id,
+        AskNewSession(
+            session_id=child_id,
+            agent_id=agent_id,
+            environment_id=env_id,
+            agent_version=1,
+            model="openrouter/test",
+            parent_run_id=parent_run_id,
+            surface=surface,
+            vault_ids=[],
+            request_id="req-child",
+            input="hello",
+            depth=1,
+        ),
         account_id=account_id,
-        agent_id=agent_id,
-        environment_id=env_id,
-        agent_version=1,
-        model="openrouter/test",
-        parent_run_id=parent_run_id,
-        surface=surface,
-        vault_ids=[],
-        request_id="req-child",
-        input="hello",
-        depth=1,
     )
     assert replayed is False
     async with pool.acquire() as conn:
@@ -322,18 +328,20 @@ async def test_ask_create_child_session_writes_awaited_true(
 
     created = await service.create_child_session(
         pool,
-        session_id=child_id,
+        AskNewSession(
+            session_id=child_id,
+            agent_id=agent_id,
+            environment_id=env_id,
+            agent_version=1,
+            model="openrouter/test",
+            parent_run_id=parent_run_id,
+            surface=surface,
+            vault_ids=[],
+            request_id="req-ask",
+            input="hello",
+            depth=1,
+        ),
         account_id=account_id,
-        agent_id=agent_id,
-        environment_id=env_id,
-        agent_version=1,
-        model="openrouter/test",
-        parent_run_id=parent_run_id,
-        surface=surface,
-        vault_ids=[],
-        request_id="req-ask",
-        input="hello",
-        depth=1,
     )
     assert created is True
     async with pool.acquire() as conn:
@@ -362,18 +370,20 @@ async def test_tell_new_session_writes_unawaited_edge_with_no_obligation(
 
     created = await service.create_child_session(
         pool,
-        session_id=child_id,
+        TellNewSession(
+            session_id=child_id,
+            agent_id=agent_id,
+            environment_id=env_id,
+            agent_version=1,
+            model="openrouter/test",
+            parent_run_id=parent_run_id,
+            surface=surface,
+            vault_ids=[],
+            request_id=make_id(REQUEST),  # the natural Tell shape mints its own id
+            input="fire-and-forget",
+            depth=1,
+        ),
         account_id=account_id,
-        agent_id=agent_id,
-        environment_id=env_id,
-        agent_version=1,
-        model="openrouter/test",
-        parent_run_id=parent_run_id,
-        surface=surface,
-        vault_ids=[],
-        input="fire-and-forget",
-        depth=1,
-        awaited=False,  # the Tell arm — no request_id needed
     )
     assert created is True
     async with pool.acquire() as conn:
@@ -393,17 +403,15 @@ async def test_tell_new_session_writes_unawaited_edge_with_no_obligation(
 async def test_tell_new_session_rejects_output_schema(
     pool_env: tuple[asyncpg.Pool[Any], str, str, str],
 ) -> None:
-    """A ``Tell`` cannot carry an ``output_schema`` (it owes no response)."""
-    from aios.errors import ValidationError
-
+    """A ``Tell`` cannot carry an ``output_schema`` (it owes no response) — the
+    illegal state is unrepresentable, so ``TellNewSession`` refuses the field at
+    construction (``TypeError``), not via a service-layer ``ValidationError``."""
     pool, account_id, agent_id, env_id = pool_env
     parent_run_id = await _seed_parent_run(pool, account_id=account_id, environment_id=env_id)
     surface = Surface(tools=[], mcp_servers=[], http_servers=[])
-    with pytest.raises(ValidationError):
-        await service.create_child_session(
-            pool,
+    with pytest.raises(TypeError):
+        TellNewSession(
             session_id="ses_tell_bad",
-            account_id=account_id,
             agent_id=agent_id,
             environment_id=env_id,
             agent_version=1,
@@ -411,10 +419,10 @@ async def test_tell_new_session_rejects_output_schema(
             parent_run_id=parent_run_id,
             surface=surface,
             vault_ids=[],
+            request_id=make_id(REQUEST),
             input="x",
             depth=1,
-            awaited=False,
-            output_schema={"type": "object"},
+            output_schema={"type": "object"},  # type: ignore[call-arg]
         )
 
 

--- a/tests/integration/test_trigger_event_fires.py
+++ b/tests/integration/test_trigger_event_fires.py
@@ -269,6 +269,7 @@ async def test_timer_fire_threads_owner_lineage(trig_runtime: asyncpg.Pool[Any])
     a past-fire_at one-shot is create_run with a 0s delay)."""
     from aios.models.attenuation import Surface
     from aios.services import sessions as sessions_service
+    from aios.services.sessions import AskNewSession
 
     pool = trig_runtime
     agent, env, _ = await seed_agent_env_session(pool, account_id=ACC, prefix="lineage")
@@ -280,17 +281,19 @@ async def test_timer_fire_threads_owner_lineage(trig_runtime: asyncpg.Pool[Any])
     child_id = "sess_" + "0" * 22 + "TRIG"
     await sessions_service.create_child_session(
         pool,
-        session_id=child_id,
+        AskNewSession(
+            session_id=child_id,
+            agent_id=agent.id,
+            environment_id=env.id,
+            agent_version=agent.version,
+            model=None,
+            parent_run_id=parent_run.id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id="req#0",
+            input="hi",
+        ),
         account_id=ACC,
-        agent_id=agent.id,
-        environment_id=env.id,
-        agent_version=agent.version,
-        model=None,
-        parent_run_id=parent_run.id,
-        surface=Surface([], [], []),
-        vault_ids=[],
-        request_id="req#0",
-        input="hi",
     )
     tid = await _add_trigger(
         pool,

--- a/tests/integration/test_wf_run_vaults.py
+++ b/tests/integration/test_wf_run_vaults.py
@@ -47,7 +47,7 @@ from aios.services import attenuation as attenuation_service
 from aios.services import sessions as sessions_service
 from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
-from aios.services.sessions import create_child_session
+from aios.services.sessions import AskNewSession, create_child_session
 from aios.tools import workflow_management as wm
 from aios.workflows import service as wf_service_module
 from aios.workflows.child_id import child_session_id
@@ -1073,17 +1073,19 @@ async def _spawn_child(
     cid = child_session_id(run_id, "0")
     await create_child_session(
         pool,
-        session_id=cid,
+        AskNewSession(
+            session_id=cid,
+            agent_id=agent.id,
+            environment_id=ENV,
+            agent_version=agent.version,
+            model=None,
+            parent_run_id=run_id,
+            surface=surface,
+            vault_ids=vault_ids or [],
+            request_id="0",
+            input="hi",
+        ),
         account_id=ACC,
-        agent_id=agent.id,
-        environment_id=ENV,
-        agent_version=agent.version,
-        model=None,
-        parent_run_id=run_id,
-        surface=surface,
-        vault_ids=vault_ids or [],
-        request_id="0",
-        input="hi",
     )
     return await sessions_service.get_session_basic(pool, cid, account_id=ACC)
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -29,6 +29,7 @@ from aios.db.pool import create_pool
 from aios.db.queries import workflows as wf_queries
 from aios.errors import ForbiddenError, NotFoundError
 from aios.harness import runtime
+from aios.ids import REQUEST, make_id
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.attenuation import Surface
 from aios.models.sessions import Session
@@ -39,6 +40,7 @@ from aios.services import sessions as sessions_service
 from aios.services import tasks as tasks_service
 from aios.services import vaults as vaults_service
 from aios.services import workflows as wf_service
+from aios.services.sessions import AskNewSession, TellNewSession
 from aios.workflows import run_tools, service
 from aios.workflows.child_id import child_session_id
 from aios.workflows.determinism import HOST_SEMANTICS_EPOCH, CallKeyer
@@ -159,18 +161,20 @@ async def _spawn_child(
     cid = child_session_id(run_id, ordinal)
     await sessions_service.create_child_session(
         pool,
-        session_id=cid,
+        AskNewSession(
+            session_id=cid,
+            agent_id=agent_id,
+            environment_id="env_wf",
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id=ordinal,
+            input="hi",
+            output_schema=output_schema,
+        ),
         account_id="acc_wf",
-        agent_id=agent_id,
-        environment_id="env_wf",
-        agent_version=1,
-        model=None,
-        parent_run_id=run_id,
-        surface=Surface([], [], []),
-        vault_ids=[],
-        request_id=ordinal,
-        input="hi",
-        output_schema=output_schema,
     )
     return run_id, cid
 
@@ -187,33 +191,37 @@ async def test_create_child_session_idempotent(
 
     created = await sessions_service.create_child_session(
         pool,
-        session_id=cid,
+        AskNewSession(
+            session_id=cid,
+            agent_id=wf_agent_id,
+            environment_id="env_wf",
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id="sha:x#0",
+            input={"q": "hi"},
+        ),
         account_id="acc_wf",
-        agent_id=wf_agent_id,
-        environment_id="env_wf",
-        agent_version=1,
-        model=None,
-        parent_run_id=run_id,
-        surface=Surface([], [], []),
-        vault_ids=[],
-        request_id="sha:x#0",
-        input={"q": "hi"},
     )
     assert created is True
     # A replay (same id) is a rowcount-0 no-op — no double row, no double request.
     again = await sessions_service.create_child_session(
         pool,
-        session_id=cid,
+        AskNewSession(
+            session_id=cid,
+            agent_id=wf_agent_id,
+            environment_id="env_wf",
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id="sha:x#0",
+            input={"q": "hi"},
+        ),
         account_id="acc_wf",
-        agent_id=wf_agent_id,
-        environment_id="env_wf",
-        agent_version=1,
-        model=None,
-        parent_run_id=run_id,
-        surface=Surface([], [], []),
-        vault_ids=[],
-        request_id="sha:x#0",
-        input={"q": "hi"},
     )
     assert again is False
     async with pool.acquire() as conn:
@@ -1838,17 +1846,19 @@ async def test_tell_spawned_child_reaches_idle_with_zero_nudges(
     cid = child_session_id(run_id, "sha:tell#0")
     created = await sessions_service.create_child_session(
         pool,
-        session_id=cid,
+        TellNewSession(
+            session_id=cid,
+            agent_id=wf_agent_id,
+            environment_id="env_wf",
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id=make_id(REQUEST),  # the natural Tell shape mints its own id
+            input="fire-and-forget",
+        ),
         account_id="acc_wf",
-        agent_id=wf_agent_id,
-        environment_id="env_wf",
-        agent_version=1,
-        model=None,
-        parent_run_id=run_id,
-        surface=Surface([], [], []),
-        vault_ids=[],
-        input="fire-and-forget",
-        awaited=False,  # the Tell arm
     )
     assert created is True
 
@@ -2075,17 +2085,19 @@ async def test_per_request_count_is_independent_stuck_sibling_still_no_returns(
     cid = child_session_id(run_id, "sha:a#0")
     await sessions_service.create_child_session(
         pool,
-        session_id=cid,
+        AskNewSession(
+            session_id=cid,
+            agent_id=wf_agent_id,
+            environment_id="env_wf",
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id="sha:a#0",
+            input="hi",
+        ),
         account_id="acc_wf",
-        agent_id=wf_agent_id,
-        environment_id="env_wf",
-        agent_version=1,
-        model=None,
-        parent_run_id=run_id,
-        surface=Surface([], [], []),
-        vault_ids=[],
-        request_id="sha:a#0",
-        input="hi",
     )
     async with pool.acquire() as conn:
         # A second open awaited request edge + its delivered user message.

--- a/tests/unit/test_request_opened_edge.py
+++ b/tests/unit/test_request_opened_edge.py
@@ -20,6 +20,22 @@ from aios.db.queries import sessions as sessions_q
 from aios.services import sessions as sessions_svc
 
 
+def test_create_child_session_takes_union_not_boolean() -> None:
+    """The Ask/Tell kind is the discriminant — no awaited:bool shim, no
+    request_id/output_schema re-derivation kwargs (KINDS NOT BOOLEANS)."""
+    params = inspect.signature(sessions_svc.create_child_session).parameters
+    assert "awaited" not in params  # FAILS on master (awaited:bool=True present)
+    assert "output_schema" not in params
+    assert "request_id" not in params
+    # the kind-bearing union is the first positional parameter
+    stim_param = next(
+        p
+        for p in params.values()
+        if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD) and p.name not in ("pool",)
+    )
+    assert "AskNewSession" in str(stim_param.annotation)
+
+
 def _src(obj: Callable[..., object]) -> str:
     return textwrap.dedent(inspect.getsource(obj))
 
@@ -100,10 +116,10 @@ def test_create_child_session_calls_append_request_opened_after_first_spawn_guar
     ``if child is None: return False`` first-spawn guard, so a replayed wake (which
     early-returns at the guard) never re-opens the edge — exactly-once. Since #1197
     factored the three near-copy creation paths onto the private ``stimulate``
-    spine, the edge writer lives in ``_stimulate_new_session`` (the NewSession arm
-    ``create_child_session`` is now a thin caller of).
+    spine, the edge writer lives in ``create_child_session`` (the NewSession arm
+    of the spine, now the single public NewSession writer).
     """
-    func = _func_def(sessions_svc._stimulate_new_session, "_stimulate_new_session")
+    func = _func_def(sessions_svc.create_child_session, "create_child_session")
 
     # Find the line of `if child is None: return False`.
     guard_line: int | None = None
@@ -131,7 +147,7 @@ def test_create_child_session_opens_edge_inside_transaction() -> None:
 
     The edge writer lives in the spine's NewSession arm (#1197).
     """
-    func = _func_def(sessions_svc._stimulate_new_session, "_stimulate_new_session")
+    func = _func_def(sessions_svc.create_child_session, "create_child_session")
     txn = next(node for node in ast.walk(func) if isinstance(node, ast.AsyncWith))
     end = max(
         (n.lineno for n in ast.walk(txn) if hasattr(n, "lineno")),
@@ -324,11 +340,11 @@ def _writer_passes_summary(obj: Callable[..., object]) -> bool:
 
 
 def test_both_writers_pass_summary_to_append_request_opened() -> None:
-    """Both edge writers — the workflow-child (``_stimulate_new_session``) and the
+    """Both edge writers — the workflow-child (``create_child_session``) and the
     peer/api-invoke (``_stimulate_existing_ask``) — feed the additive #1413 summary
     so the obligations block has a human-readable preview (Issue C's set_goal
     inherits it free through ``_stimulate_existing_ask``)."""
-    assert _writer_passes_summary(sessions_svc._stimulate_new_session)
+    assert _writer_passes_summary(sessions_svc.create_child_session)
     assert _writer_passes_summary(sessions_svc._stimulate_existing_ask)
 
 


### PR DESCRIPTION
Automated dev-pipeline build for issue #1540.