### PR TITLE
sweep: delete the admitted-redundant errored-session post-filter in find_and_repair_ghosts (belt-and-suspenders, no sign-off)

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -134,15 +134,10 @@ class _SweepAgentSurface:
 #
 # Also bounded by the errored-session predicate (#897): an errored session is
 # parked until a user message recovers it, so its open tool_calls are part of
-# the terminal landing pad and must NOT be reaped.  ``find_and_repair_ghosts``
-# already drops these via the Python ``_errored_session_ids`` post-filter;
-# pushing the same predicate here stops the wasted event-log fetch on every 30s
-# sweep for the small set of errored sessions that still carry open calls.  This
-# ``NOT`` is composed from the SAME single source ``session_errored_predicate``
-# that backs ``ERRORED_SESSIONS_SQL`` (and the read path) — both consume the
-# maintained scalar columns (migration 0066), so the SQL pre-filter's errored
-# set EQUALS the Python post-filter's; the post-filter is retained as defense in
-# depth.
+# the terminal landing pad and must NOT be reaped.  This is the SOLE errored-skip
+# for ghost repair — composed from the same single source
+# ``session_errored_predicate`` that backs ``ERRORED_SESSIONS_SQL`` and the read
+# path, all consuming the maintained scalar columns (migration 0066).
 GHOST_ASST_SQL = f"""
     SELECT e.session_id, e.data, e.created_at
       FROM events e
@@ -351,19 +346,6 @@ async def find_and_repair_ghosts(
             return []
 
         session_ids = list({r["session_id"] for r in asst_rows})
-
-        # Skip errored sessions: their dispatched-but-unresolved tool calls are
-        # part of the terminal landing pad and stay unreaped until a user
-        # message recovers the session (mirrors the pre-derivation status skip).
-        # ``GHOST_ASST_SQL`` already pushes the identical errored predicate, so
-        # ``asst_rows`` carries no errored session here; this post-filter is
-        # retained as defense in depth (#897).
-        errored = await _errored_session_ids(conn, session_id=session_id)
-        if errored:
-            asst_rows = [r for r in asst_rows if r["session_id"] not in errored]
-            if not asst_rows:
-                return []
-            session_ids = [s for s in session_ids if s not in errored]
 
         result_rows = await conn.fetch(ALL_RESULT_ROWS_SQL, session_ids)
         results_by_session: dict[str, set[str]] = {}

--- a/tests/integration/test_tool_actions_on_errored.py
+++ b/tests/integration/test_tool_actions_on_errored.py
@@ -160,7 +160,7 @@ async def test_ghost_repair_skips_errored_session(
     assert repaired == [], (
         f"ghost-repair attempted on an errored session (got {repaired}); "
         f"find_and_repair_ghosts is missing the derived-errored exclusion "
-        f"(_errored_session_ids)."
+        f"(GHOST_ASST_SQL's pushed-down errored predicate)."
     )
 
 

--- a/tests/unit/test_sweep_isolation.py
+++ b/tests/unit/test_sweep_isolation.py
@@ -10,6 +10,7 @@ import datetime as dt
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aios.harness import sweep
 from aios.harness.inflight_tool_registry import InflightToolRegistry
 from aios.harness.sweep import find_and_repair_ghosts, wake_sessions_needing_inference
 from tests.unit.conftest import fake_pool_yielding_conn
@@ -75,15 +76,14 @@ async def test_ghost_repair_failure_does_not_abort_batch(monkeypatch: Any) -> No
         {"session_id": "sess_a", "tools": [], "http_servers": []},
         {"session_id": "sess_b", "tools": [], "http_servers": []},
     ]
-    # find_and_repair_ghosts issues six ``conn.fetch`` calls in order:
-    # GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
-    # GHOST_LIFECYCLE_SQL, agents, GHOST_SPAN_START_SQL.  The empty errored
-    # and span results mean no session is parked-errored and both ghosts hit
+    # find_and_repair_ghosts issues five ``conn.fetch`` calls in order:
+    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents,
+    # GHOST_SPAN_START_SQL.  The empty span result means both ghosts hit
     # the "never started" branch of the recovery synthesis (#685) — which
     # is fine for this test, which only cares that per-ghost failures
     # don't abort the batch.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, []])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, []])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock(side_effect=[RuntimeError("first ghost db blip"), None])
@@ -142,11 +142,11 @@ async def test_ghost_repair_branch_may_have_completed(monkeypatch: Any) -> None:
     span_rows = [
         {"session_id": "sess_a", "tool_call_id": "tc_a"},
     ]
-    # find_and_repair_ghosts now issues six ``conn.fetch`` calls in order:
-    # GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
-    # GHOST_LIFECYCLE_SQL, agents, GHOST_SPAN_START_SQL.
+    # find_and_repair_ghosts now issues five ``conn.fetch`` calls in order:
+    # GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL, agents,
+    # GHOST_SPAN_START_SQL.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, span_rows])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, span_rows])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock(return_value=None)
@@ -190,10 +190,10 @@ async def test_ghost_repair_branch_did_not_run(monkeypatch: Any) -> None:
     ]
     # NO span for tc_a → routes the synthesis to the "did not run" branch.
     span_rows: list[dict[str, Any]] = []
-    # Six fetches: GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
-    # GHOST_LIFECYCLE_SQL, agents, GHOST_SPAN_START_SQL.
+    # Five fetches: GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL,
+    # agents, GHOST_SPAN_START_SQL.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, span_rows])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, span_rows])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock(return_value=None)
@@ -210,3 +210,50 @@ async def test_ghost_repair_branch_did_not_run(monkeypatch: Any) -> None:
     content = append_mock.await_args_list[0].kwargs["content"]
     assert "did not run" in content
     assert "You may retry" in content
+
+
+async def test_ghost_repair_does_not_refetch_errored_set(monkeypatch: Any) -> None:
+    """``find_and_repair_ghosts`` skips errored sessions solely via the
+    ``GHOST_ASST_SQL`` pushed-down predicate (#897/#1539): the redundant
+    ``_errored_session_ids`` post-filter is gone, so the function issues
+    exactly FIVE ``conn.fetch`` calls and never re-fetches
+    ``ERRORED_SESSIONS_SQL``.  On master this fails — the function issued six
+    fetches with ``ERRORED_SESSIONS_SQL`` among them, exhausting a 5-element
+    ``side_effect`` and raising ``StopAsyncIteration``."""
+    # one candidate ghost so the function runs to completion
+    ghost_rows = [
+        {
+            "session_id": "sess_a",
+            "created_at": _NOW,
+            "data": {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tc_a",
+                        "type": "function",
+                        "function": {"name": "bash", "arguments": "{}"},
+                    }
+                ],
+            },
+        }
+    ]
+    agent_rows = [{"session_id": "sess_a", "tools": [], "http_servers": []}]
+    conn = MagicMock()
+    # 5, not 6: GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL, GHOST_LIFECYCLE_SQL,
+    # agents, GHOST_SPAN_START_SQL — no ERRORED_SESSIONS_SQL slot.
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], agent_rows, []])
+
+    monkeypatch.setattr(
+        "aios.harness.sweep.sessions_service.load_session_account_id",
+        AsyncMock(return_value="acc_test"),
+    )
+    monkeypatch.setattr(
+        "aios.harness.sweep.sessions_service.append_tool_result",
+        AsyncMock(return_value=None),
+    )
+
+    await find_and_repair_ghosts(fake_pool_yielding_conn(conn), InflightToolRegistry())
+
+    fetched_sql = [c.args[0] for c in conn.fetch.await_args_list]
+    assert sweep.ERRORED_SESSIONS_SQL not in fetched_sql
+    assert conn.fetch.await_count == 5

--- a/tests/unit/test_sweep_route_gated_always_ask.py
+++ b/tests/unit/test_sweep_route_gated_always_ask.py
@@ -134,10 +134,10 @@ async def test_route_gated_always_ask_not_ghost_repaired(monkeypatch: Any) -> No
             ],
         }
     ]
-    # Six fetches: GHOST_ASST_SQL, ERRORED_SESSIONS_SQL, ALL_RESULT_ROWS_SQL,
+    # Five fetches: GHOST_ASST_SQL, ALL_RESULT_ROWS_SQL,
     # GHOST_LIFECYCLE_SQL (no confirmation), agent_rows, GHOST_SPAN_START_SQL.
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], [], agent_rows, []])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], agent_rows, []])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock()
@@ -192,7 +192,7 @@ async def test_route_gated_always_ask_confirmed_is_ghost_repaired(monkeypatch: A
         }
     ]
     conn = MagicMock()
-    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], [], lifecycle_rows, agent_rows, []])
+    conn.fetch = AsyncMock(side_effect=[ghost_rows, [], lifecycle_rows, agent_rows, []])
     pool = fake_pool_yielding_conn(conn)
 
     append_mock = AsyncMock()

--- a/tests/unit/test_wake_predicate_single_source.py
+++ b/tests/unit/test_wake_predicate_single_source.py
@@ -75,8 +75,9 @@ def test_errored_sessions_sql_generated_from_session_errored_predicate() -> None
 def test_ghost_asst_sql_generated_from_session_errored_predicate() -> None:
     """``GHOST_ASST_SQL`` pushes the errored bound to skip parked sessions; it
     composes the SAME ``session_errored_predicate`` source as
-    ``ERRORED_SESSIONS_SQL`` and the read path, so its SQL pre-filter's errored
-    set equals the Python ``_errored_session_ids`` post-filter's."""
+    ``ERRORED_SESSIONS_SQL`` and the read path — this single-source composition
+    is what makes the SQL pre-filter the sole load-bearing errored-skip for
+    ghost repair."""
     ghost = _norm(sweep.GHOST_ASST_SQL.format(scope_clause=""))
     assert _norm(queries.session_errored_predicate("s")) in ghost
 


### PR DESCRIPTION
Automated dev-pipeline build for issue #1539.