### PR TITLE
Unify the duplicated provision-cleanup envelopes in build_spec_from_session / build_spec_from_run behind one shared teardown helper

### DIFF
--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -87,6 +87,13 @@ if TYPE_CHECKING:
     # own ``aios.tools`` import (see that module's import-graph note).
     from aios.sandbox.secret_egress_proxy import SecretEgressProxy
 
+    # Typing-only: a runtime ``from aios.sandbox.tool_broker import ToolBroker``
+    # would re-enter the spec↔tools import cycle (``tool_broker`` →
+    # ``aios.tools`` → ``aios.tools.bash`` → ``aios.sandbox.spec``). The type is
+    # only used as a parameter annotation on ``_release_provision_allocations``,
+    # so a TYPE_CHECKING import keeps it honest without coupling at import time.
+    from aios.sandbox.tool_broker import ToolBroker
+
 log = get_logger("aios.sandbox.spec")
 
 # Path inside the sandbox container where the worker's tool-broker UDS
@@ -145,6 +152,48 @@ def cleanup_session_secret_file(session_id: str, tool_socket_host_path: Path | N
             path=str(secret_path),
             error=str(exc),
         )
+
+
+async def _release_provision_allocations(
+    *,
+    owner_id: str,
+    tool_broker: ToolBroker,
+    broker_registered: bool,
+    tool_socket_host_path: Path | None,
+    git_proxy: GitProxy | None,
+    secret_proxy: SecretEgressProxy | None,
+) -> None:
+    """Unwind every worker-process allocation a provision made before it
+    returns a :class:`ProvisioningPlan`.
+
+    Single teardown envelope for BOTH provision paths
+    (:func:`build_spec_from_session` and :func:`build_spec_from_run`), so the
+    cleanup can never drift between session and run. ``owner_id`` is the
+    session-OR-run ULID (the opaque owner label). Each proxy stop is guarded so
+    one failing teardown can't mask the primary exception or abort a sibling
+    teardown; ``git_proxy`` is ``None`` for the run path (a run never allocates
+    one). Idempotent against partial allocation: ``broker_registered`` gates the
+    broker/secret-file drop, and each ``*_proxy is None`` short-circuits.
+
+    Sibling of (but deliberately not unified with) the registry-side
+    ``registry._stop_proxy_silently`` quiet-stop — that one also destroys the
+    backend handle and mutates the registry's proxy-tracking maps, which this
+    pre-plan-return envelope has no business doing.
+    """
+    if broker_registered:
+        tool_broker.unregister_session(owner_id)
+        cleanup_session_secret_file(owner_id, tool_socket_host_path)
+    for proxy, kind in ((git_proxy, "git_proxy"), (secret_proxy, "secret_proxy")):
+        if proxy is None:
+            continue
+        try:
+            await proxy.stop()
+        except Exception as cleanup_err:
+            log.warning(
+                f"sandbox.{kind}_cleanup_after_spec_failure",
+                owner_id=owner_id,
+                error=str(cleanup_err),
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -668,28 +717,16 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
         # (ports, token maps, secret-to-session bindings). Anything that
         # raises before we hand back a plan must clean up everything
         # allocated so far on the way out, otherwise state leaks for the
-        # worker's lifetime.
-        if broker_registered:
-            tool_broker.unregister_session(session_id)
-            cleanup_session_secret_file(session_id, tool_socket_host_path)
-        if git_proxy is not None:
-            try:
-                await git_proxy.stop()
-            except Exception as cleanup_err:
-                log.warning(
-                    "sandbox.git_proxy_cleanup_after_spec_failure",
-                    session_id=session_id,
-                    error=str(cleanup_err),
-                )
-        if secret_proxy is not None:
-            try:
-                await secret_proxy.stop()
-            except Exception as cleanup_err:
-                log.warning(
-                    "sandbox.secret_proxy_cleanup_after_spec_failure",
-                    session_id=session_id,
-                    error=str(cleanup_err),
-                )
+        # worker's lifetime. Shared with the run path's envelope so the
+        # teardown can never drift between session and run.
+        await _release_provision_allocations(
+            owner_id=session_id,
+            tool_broker=tool_broker,
+            broker_registered=broker_registered,
+            tool_socket_host_path=tool_socket_host_path,
+            git_proxy=git_proxy,
+            secret_proxy=secret_proxy,
+        )
         raise
 
 
@@ -785,18 +822,17 @@ async def build_spec_from_run(run_id: str) -> ProvisioningPlan:
         )
     except BaseException:
         # Drop every worker-side allocation made before a plan is returned.
-        if broker_registered:
-            tool_broker.unregister_session(run_id)
-            cleanup_session_secret_file(run_id, tool_socket_host_path)
-        if secret_proxy is not None:
-            try:
-                await secret_proxy.stop()
-            except Exception as cleanup_err:
-                log.warning(
-                    "sandbox.secret_proxy_cleanup_after_spec_failure",
-                    session_id=run_id,
-                    error=str(cleanup_err),
-                )
+        # Shared envelope with the session path; a run never allocates a
+        # ``GitProxy``, so the git_proxy arm is dropped by passing the inert
+        # ``None`` rather than by omitting code.
+        await _release_provision_allocations(
+            owner_id=run_id,
+            tool_broker=tool_broker,
+            broker_registered=broker_registered,
+            tool_socket_host_path=tool_socket_host_path,
+            git_proxy=None,
+            secret_proxy=secret_proxy,
+        )
         raise
 
 

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -445,6 +445,96 @@ async def test_secret_proxy_start_failure_does_not_double_stop() -> None:
     broker.register_session.assert_not_called()
 
 
+async def test_session_and_run_cleanup_share_one_envelope() -> None:
+    """Drift-guard: BOTH ``build_spec_from_session`` and ``build_spec_from_run``
+    route their post-``register_session`` failure cleanup through the single
+    shared ``_release_provision_allocations`` helper.
+
+    This is the thing that fails on master (where the helper doesn't exist, so
+    the ``patch`` target is missing → ``AttributeError`` at patch time) and that
+    would re-fail if someone later re-inlines a teardown into one envelope but
+    not the other. Each builder is driven to a raise AFTER the broker secret is
+    registered (the reserved-image gate), and we assert the helper is awaited
+    exactly once with the path-appropriate ``owner_id`` / ``git_proxy``:
+    the session passes its live ``git_proxy``; the run passes ``None``.
+    """
+    from aios.sandbox.spec import build_spec_from_run
+
+    from .test_spec_run_env_var_credentials import _RUN_ID, _patch_run_spec_deps
+
+    # --- session path: a started secret_proxy + a registered broker, then a
+    # reserved-image ValueError trips the failure envelope. ---
+    git_proxy = MagicMock()
+    git_proxy.stop = AsyncMock()
+    secret_proxy = MagicMock()
+    secret_proxy.start = AsyncMock()
+    secret_proxy.stop = AsyncMock()
+    broker = MagicMock()
+    broker.port = 54321
+    broker.register_session = MagicMock()
+    broker.unregister_session = MagicMock()
+    env_config = MagicMock()
+    env_config.image = "aios-sbx-victim"
+    env_config.networking = LimitedNetworking(type="limited", allowed_hosts=["api.github.com"])
+
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(
+            env_config=env_config,
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
+            github_clones=AsyncMock(return_value=([], git_proxy)),
+            tool_broker=broker,
+        ):
+            stack.enter_context(ctx)
+        stack.enter_context(
+            patch("aios.sandbox.spec.SecretEgressProxy", MagicMock(return_value=secret_proxy))
+        )
+        release = stack.enter_context(
+            patch("aios.sandbox.spec._release_provision_allocations", new_callable=AsyncMock)
+        )
+        with pytest.raises(ValueError, match="reserved"):
+            await build_spec_from_session("sess_01TEST")
+
+    release.assert_awaited_once()
+    assert release.await_args is not None
+    session_kwargs = release.await_args.kwargs
+    assert session_kwargs["owner_id"] == "sess_01TEST"
+    assert session_kwargs["git_proxy"] is git_proxy
+
+    # --- run path: same failure shape (reserved image), but the run never
+    # allocates a GitProxy, so the shared helper receives git_proxy=None. ---
+    run_broker = MagicMock()
+    run_broker.port = 54321
+    run_broker.register_session = MagicMock()
+    run_broker.unregister_session = MagicMock()
+    run_secret_proxy = MagicMock()
+    run_secret_proxy.start = AsyncMock()
+    run_secret_proxy.stop = AsyncMock()
+    run_env_config = MagicMock()
+    run_env_config.image = "aios-sbx-victim"
+    run_env_config.networking = LimitedNetworking(type="limited", allowed_hosts=["api.github.com"])
+    run_env_config.env = {}
+
+    with contextlib.ExitStack() as stack:
+        for ctx in _patch_run_spec_deps(
+            env_config=run_env_config,
+            env_var_credentials=AsyncMock(return_value=(_CRED,)),
+            broker=run_broker,
+            secret_proxy_instance=run_secret_proxy,
+        ):
+            stack.enter_context(ctx)
+        release_run = stack.enter_context(
+            patch("aios.sandbox.spec._release_provision_allocations", new_callable=AsyncMock)
+        )
+        with pytest.raises(ValueError, match="reserved"):
+            await build_spec_from_run(_RUN_ID)
+
+    release_run.assert_awaited_once()
+    assert release_run.await_args is not None
+    run_kwargs = release_run.await_args.kwargs
+    assert run_kwargs["owner_id"] == _RUN_ID
+    assert run_kwargs["git_proxy"] is None
+
+
 def test_placeholder_is_stable_across_recycle() -> None:
     """The placeholder is a pure function of ``(account_salt, session_id,
     credential_id)`` — two mints with the same ids are equal.


### PR DESCRIPTION
Automated dev-pipeline build for issue #1541.