### PR TITLE
_inbound_drop_error: re-switch over InboundDrop stringly with a catch-all 500 — make the mapping total over the enum

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -23,7 +23,7 @@ Section banners (``# ───`) below mark the boundary.
 from __future__ import annotations
 
 import json
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, assert_never
 
 from fastapi import APIRouter, File, Form, UploadFile, status
 from pydantic import BaseModel, ConfigDict
@@ -86,31 +86,44 @@ class ConnectorInboundResponse(BaseModel):
     deduped: bool
 
 
-def _inbound_drop_error(drop_reason: str) -> AiosError:
+def _inbound_drop_error(drop_reason: inbound_service.InboundDrop) -> AiosError:
     """Pick the right :class:`AiosError` subclass for a drop_reason.
 
     Each drop maps onto an existing error type — preserving HTTP status
     contracts without inventing a new error_type for every reason.
     Detail carries ``drop_reason`` so clients can branch on the
     machine-readable value.
+
+    The ``match`` is exhaustive over :class:`InboundDrop` by construction:
+    every member has an explicit arm and the final ``assert_never`` makes a
+    newly-added member a ``mypy`` error rather than a silent catch-all 500.
     """
-    detail = {"drop_reason": drop_reason}
-    msg = f"inbound dropped ({drop_reason})"
-    if drop_reason == "payload_too_large":
-        return PayloadTooLargeError(msg, detail=detail)
-    if drop_reason == "rate_limited":
-        # Per-counterparty inbound budget exceeded (#1504). 429 is a routine,
-        # NON-FATAL drop for the connector-http runner: ``_is_fatal_inbound_status``
-        # treats only 401/403/5xx as fatal (crash-restarts the container,
-        # killing every sibling connection), so a single over-budget stranger
-        # cannot take the container down — it just drops one envelope.
-        return RateLimitedError(msg, detail=detail)
-    if drop_reason in ("detached", "archived_template", "denied_by_policy"):
-        return ValidationError(msg, detail=detail)
-    if drop_reason == "session_missing":
-        return NotFoundError(msg, detail=detail)
-    # attachment_staging_failed (and any unrecognised reason) → 500.
-    return AiosError(msg, detail=detail)
+    detail = {"drop_reason": drop_reason.value}
+    msg = f"inbound dropped ({drop_reason.value})"
+    match drop_reason:
+        case inbound_service.InboundDrop.PAYLOAD_TOO_LARGE:
+            return PayloadTooLargeError(msg, detail=detail)
+        case inbound_service.InboundDrop.RATE_LIMITED:
+            # Per-counterparty inbound budget exceeded (#1504). 429 is a routine,
+            # NON-FATAL drop for the connector-http runner: ``_is_fatal_inbound_status``
+            # treats only 401/403/5xx as fatal (crash-restarts the container,
+            # killing every sibling connection), so a single over-budget stranger
+            # cannot take the container down — it just drops one envelope.
+            return RateLimitedError(msg, detail=detail)
+        case (
+            inbound_service.InboundDrop.DETACHED
+            | inbound_service.InboundDrop.ARCHIVED_TEMPLATE
+            | inbound_service.InboundDrop.DENIED_BY_POLICY
+        ):
+            # DENIED_BY_POLICY maps to a non-fatal 422 (#1504): a denied stranger
+            # must not be able to crash-restart the connector container.
+            return ValidationError(msg, detail=detail)
+        case inbound_service.InboundDrop.SESSION_MISSING:
+            return NotFoundError(msg, detail=detail)
+        case inbound_service.InboundDrop.ATTACHMENT_STAGING_FAILED:
+            return AiosError(msg, detail=detail)  # base class → 500
+        case _ as unreachable:
+            assert_never(unreachable)
 
 
 _DEFAULT_ATTACHMENT_CONTENT_TYPE = "application/octet-stream"
@@ -193,7 +206,7 @@ async def _do_inbound(
         account_id=account_id,
     )
     if result.drop_reason is not None:
-        raise _inbound_drop_error(result.drop_reason.value)
+        raise _inbound_drop_error(result.drop_reason)
     return ConnectorInboundResponse(
         appended_event_id=result.appended_event_id,
         session_id=result.session_id,

--- a/tests/unit/test_inbound_admission.py
+++ b/tests/unit/test_inbound_admission.py
@@ -113,7 +113,7 @@ async def test_resolve_passes_through_stored_policy() -> None:
 
 
 def test_denied_by_policy_maps_to_validation_error_422() -> None:
-    err = _inbound_drop_error("denied_by_policy")
+    err = _inbound_drop_error(InboundDrop.DENIED_BY_POLICY)
     assert isinstance(err, ValidationError)
     assert err.status_code == 422
     assert err.detail == {"drop_reason": "denied_by_policy"}

--- a/tests/unit/test_inbound_budget.py
+++ b/tests/unit/test_inbound_budget.py
@@ -159,7 +159,7 @@ async def test_session_budget_decision(recent: int, threshold: int, expected: bo
 
 
 def test_rate_limited_maps_to_429() -> None:
-    err = _inbound_drop_error("rate_limited")
+    err = _inbound_drop_error(InboundDrop.RATE_LIMITED)
     assert isinstance(err, RateLimitedError)
     assert err.status_code == 429
     assert err.detail == {"drop_reason": "rate_limited"}
@@ -169,7 +169,7 @@ def test_rate_limited_status_is_not_fatal() -> None:
     """Regression pin (mirrors the spine's DENIED_BY_POLICY → 422 pin): the
     chosen throttle status must be non-fatal so a throttle never crash-restarts
     the connector container."""
-    status = _inbound_drop_error("rate_limited").status_code
+    status = _inbound_drop_error(InboundDrop.RATE_LIMITED).status_code
     assert status == 429
     assert _is_fatal_inbound_status(status) is False
     # The two non-fatal candidates the issue calls out both hold.

--- a/tests/unit/test_inbound_drop_error.py
+++ b/tests/unit/test_inbound_drop_error.py
@@ -1,0 +1,33 @@
+"""Exhaustiveness/coverage pin for ``_inbound_drop_error`` (#1544).
+
+The status mapping is now a total ``match`` over :class:`InboundDrop` ending in
+``assert_never``; ``set(_EXPECTED) == set(InboundDrop)`` forces any future enum
+member to be wired through both this table and the ``match`` (or mypy fails first).
+"""
+
+import pytest
+
+from aios.api.routers.connectors import _inbound_drop_error
+from aios.services.inbound import InboundDrop
+
+_EXPECTED = {
+    InboundDrop.PAYLOAD_TOO_LARGE: 413,
+    InboundDrop.DETACHED: 422,
+    InboundDrop.ARCHIVED_TEMPLATE: 422,
+    InboundDrop.DENIED_BY_POLICY: 422,
+    InboundDrop.RATE_LIMITED: 429,
+    InboundDrop.ATTACHMENT_STAGING_FAILED: 500,
+    InboundDrop.SESSION_MISSING: 404,
+}
+
+
+def test_every_inbound_drop_member_has_an_explicit_status() -> None:
+    # Guards the whole enum: a new arm with no mapping fails here AND at mypy.
+    assert set(_EXPECTED) == set(InboundDrop)
+
+
+@pytest.mark.parametrize("reason, status", _EXPECTED.items())
+def test_inbound_drop_status_mapping(reason: InboundDrop, status: int) -> None:
+    err = _inbound_drop_error(reason)
+    assert err.status_code == status
+    assert err.detail == {"drop_reason": reason.value}


### PR DESCRIPTION
Automated dev-pipeline build for issue #1544.