### PR TITLE
Hoist harness step-timeout to config: delete the hand-maintained _HARNESS_STEP_TIMEOUT_S mirror (whose comment already drifted 300→960)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -16,15 +16,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from aios.models.vaults import OAuthProviderApp
 
-# Hardcoded mirror of ``aios.harness.loop._JOB_TIMEOUT_S`` (300.0). We
-# don't import it because ``aios.harness.loop`` itself imports config
-# at module load — a top-level import here would risk a cycle, and a
-# lazy one inside the validator is more noise than the constant is
-# worth. If ``_JOB_TIMEOUT_S`` ever moves, update this too; the failure
-# mode is a config validator that no longer matches reality, not a
-# crash. ``test_github_clone_session_timeout_below_step_budget``
-# cross-checks the two values stay aligned.
-_HARNESS_STEP_TIMEOUT_S: float = 960.0
+# Wall-clock cap on a single ``run_session_step`` call (the harness step
+# budget). Imported by ``aios.harness.loop`` as the job-level asyncio.wait_for
+# timeout; the validators below reject per-phase budgets that meet or exceed it.
+HARNESS_STEP_TIMEOUT_S: float = 960.0
 
 
 class Settings(BaseSettings):
@@ -753,11 +748,11 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _model_call_deadline_under_step_budget(self) -> Settings:
-        if self.model_call_deadline_s >= _HARNESS_STEP_TIMEOUT_S:
+        if self.model_call_deadline_s >= HARNESS_STEP_TIMEOUT_S:
             raise ValueError(
                 f"AIOS_MODEL_CALL_DEADLINE_S={self.model_call_deadline_s} must be "
                 f"strictly less than the harness step budget "
-                f"({_HARNESS_STEP_TIMEOUT_S}s, aios.harness.loop._JOB_TIMEOUT_S)."
+                f"({HARNESS_STEP_TIMEOUT_S}s)."
             )
         return self
 
@@ -768,12 +763,12 @@ class Settings(BaseSettings):
         # burn a whole user turn before the step-level cap fires. Reject
         # misconfiguration loudly at startup rather than letting an
         # operator silently defeat the fix.
-        if self.github_clone_session_timeout_seconds >= _HARNESS_STEP_TIMEOUT_S:
+        if self.github_clone_session_timeout_seconds >= HARNESS_STEP_TIMEOUT_S:
             raise ValueError(
                 f"AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS="
                 f"{self.github_clone_session_timeout_seconds} must be strictly less than "
-                f"the harness step budget ({_HARNESS_STEP_TIMEOUT_S}s, "
-                f"aios.harness.loop._JOB_TIMEOUT_S); otherwise a hung clone "
+                f"the harness step budget ({HARNESS_STEP_TIMEOUT_S}s); "
+                f"otherwise a hung clone "
                 f"burns a whole user turn before the step-level cap fires. "
                 f"See issue #697."
             )

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 import litellm.exceptions as litellm_exceptions
 from structlog.contextvars import bind_contextvars, clear_contextvars
 
+from aios.config import HARNESS_STEP_TIMEOUT_S as HARNESS_STEP_TIMEOUT_S
 from aios.config import get_settings
 from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
@@ -72,13 +73,13 @@ log = get_logger("aios.harness.loop")
 
 _RETRY_BACKOFF_SECONDS: list[float] = [2, 8, 30, 120]
 
-# Wall-clock cap on a single ``run_session_step`` call. The harness's
+# ``HARNESS_STEP_TIMEOUT_S`` (imported from ``aios.config`` above) is the
+# wall-clock cap on a single ``run_session_step`` call. The harness's
 # zero-hang guarantee: per-call timeouts (LiteLLM, MCP, tool dispatch, etc.)
 # are the precise instruments, but if any future code path bypasses them
 # this cap fires and forces a clean rescheduling. Sized as the default 900s
 # model-call deadline plus 60s of headroom for prologue, context-build, and
 # epilogue work that no longer compete with the model budget.
-_JOB_TIMEOUT_S = 960.0
 
 # litellm's standardized ``finish_reason`` for a safety refusal. Anthropic's
 # ``stop_reason: "refusal"`` maps here; OpenAI/Azure ``content_filter`` lands
@@ -339,13 +340,15 @@ async def run_session_step(
                         cause=cause,
                         account_id=account_id,
                     ),
-                    timeout=_JOB_TIMEOUT_S,
+                    timeout=HARNESS_STEP_TIMEOUT_S,
                 )
             except TimeoutError:
                 # Job-level safety net: a per-call timeout was missing or didn't
                 # fire. Force a reschedulable error state so the next wake can
                 # proceed (matches what the body's litellm-error handler does).
-                log.exception("step.job_timeout", session_id=session_id, timeout=_JOB_TIMEOUT_S)
+                log.exception(
+                    "step.job_timeout", session_id=session_id, timeout=HARNESS_STEP_TIMEOUT_S
+                )
                 result = _StepResult(
                     retry_delay=await _handle_step_timeout(pool, session_id, account_id=account_id)
                 )
@@ -1442,7 +1445,7 @@ async def _handle_step_timeout(pool: Any, session_id: str, *, account_id: str) -
         pool,
         session_id,
         "span",
-        {"event": "step_timeout", "timeout_seconds": _JOB_TIMEOUT_S, "is_error": True},
+        {"event": "step_timeout", "timeout_seconds": HARNESS_STEP_TIMEOUT_S, "is_error": True},
         account_id=account_id,
     )
     return await _apply_retry_or_failure(pool, session_id, account_id=account_id)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -130,12 +130,11 @@ def test_model_call_deadline_rejects_step_budget_or_above(
 ) -> None:
     from pydantic import ValidationError
 
-    from aios.config import Settings
-    from aios.harness.loop import _JOB_TIMEOUT_S
+    from aios.config import HARNESS_STEP_TIMEOUT_S, Settings
 
     secrets = tmp_path / "secrets.env"
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_EGRESS_CA_KEY=e\nAIOS_DB_URL=postgresql://x/y\n")
-    monkeypatch.setenv("AIOS_MODEL_CALL_DEADLINE_S", str(_JOB_TIMEOUT_S))
+    monkeypatch.setenv("AIOS_MODEL_CALL_DEADLINE_S", str(HARNESS_STEP_TIMEOUT_S))
 
     with pytest.raises(ValidationError, match="AIOS_MODEL_CALL_DEADLINE_S"):
         Settings(_env_file=(str(secrets),))
@@ -148,15 +147,14 @@ def test_github_clone_session_timeout_below_step_budget(
     fit strictly inside the harness step budget so a hung clone doesn't
     burn the full harness turn.
     """
-    from aios.config import Settings
-    from aios.harness.loop import _JOB_TIMEOUT_S
+    from aios.config import HARNESS_STEP_TIMEOUT_S, Settings
 
     secrets = tmp_path / "secrets.env"
     secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_EGRESS_CA_KEY=e\nAIOS_DB_URL=postgresql://x/y\n")
     monkeypatch.delenv("AIOS_GITHUB_CLONE_SESSION_TIMEOUT_SECONDS", raising=False)
 
     s = Settings(_env_file=(str(secrets),))
-    assert s.github_clone_session_timeout_seconds < _JOB_TIMEOUT_S
+    assert s.github_clone_session_timeout_seconds < HARNESS_STEP_TIMEOUT_S
 
 
 def test_github_clone_session_timeout_env_override(
@@ -193,17 +191,16 @@ def test_github_clone_session_timeout_rejects_above_step_budget(
         Settings(_env_file=(str(secrets),))
 
 
-def test_github_clone_session_timeout_mirror_matches_harness_constant(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The config-module mirror of ``_JOB_TIMEOUT_S`` must stay in sync with
-    the harness's own constant — otherwise the validator above starts
-    rejecting (or admitting) misconfigurations using a stale bound.
-    """
-    from aios.config import _HARNESS_STEP_TIMEOUT_S
-    from aios.harness.loop import _JOB_TIMEOUT_S
+def test_step_timeout_single_source() -> None:
+    """The harness step budget is defined once in config and consumed by the
+    Settings validators; no second copy exists to drift out of sync."""
+    import aios.config as config_mod
+    import aios.harness.loop as loop_mod
 
-    assert _HARNESS_STEP_TIMEOUT_S == _JOB_TIMEOUT_S
+    assert config_mod.HARNESS_STEP_TIMEOUT_S == 960.0
+    # loop imports the same object, not a private duplicate.
+    assert not hasattr(loop_mod, "_JOB_TIMEOUT_S")
+    assert loop_mod.HARNESS_STEP_TIMEOUT_S is config_mod.HARNESS_STEP_TIMEOUT_S
 
 
 def test_sandbox_snapshot_budget_bytes_default(


### PR DESCRIPTION
Automated dev-pipeline build for issue #1545.