### PR TITLE
Extract the duplicated output_schema validity gate shared by the agent() and invoke_workflow() spawn arms in workflows/step.py

### DIFF
--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import contextlib
 import json
 import secrets
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, NamedTuple
 
@@ -839,6 +840,45 @@ class _SpawnResult(NamedTuple):
     quota_exceeded: bool = False
 
 
+async def _reject_invalid_output_schema(
+    output_schema: Any,
+    *,
+    call_name: str,
+    reject_kind: str,
+    reject: Callable[[str, str], Awaitable[_SpawnResult]],
+) -> _SpawnResult | None:
+    """The shared author-facing output_schema validity gate for the agent() and
+    invoke_workflow() spawn arms — the single definition of "is this a usable
+    structured-output schema". Returns a rejecting _SpawnResult (already journaled
+    via ``reject``) on the first failing branch, or None if the schema is usable.
+
+    Three sequentially-dependent author-facing failures, each an early reject:
+    a non-object schema (a bare boolean is valid JSON Schema, but ``false``
+    rejects every value and ``true`` disables enforcement), a structurally-invalid
+    schema, and one with an unresolvable reference (passes check_schema but raises
+    at validation time, bricking the child).
+    """
+    if not isinstance(output_schema, dict):
+        return await reject(
+            reject_kind,
+            f"{call_name} output_schema must be a JSON object schema, "
+            f"got {type(output_schema).__name__}",
+        )
+    try:
+        jsonschema.Draft202012Validator.check_schema(output_schema)
+    except jsonschema.SchemaError as exc:
+        return await reject(
+            reject_kind, f"{call_name} output_schema is not a valid JSON Schema: {exc.message}"
+        )
+    if (bad_ref := _unresolvable_ref(output_schema)) is not None:
+        return await reject(
+            reject_kind,
+            f"{call_name} output_schema has an unresolvable reference {bad_ref!r} "
+            "(references must resolve within the schema; remote refs are unsupported)",
+        )
+    return None
+
+
 async def _open_agent_capability(
     conn: asyncpg.Connection[Any],
     pool: asyncpg.Pool[Any],
@@ -890,33 +930,19 @@ async def _open_agent_capability(
     output_schema = (
         json.loads(output_schema_raw) if isinstance(output_schema_raw, str) else output_schema_raw
     )
-    if output_schema is not None:
-        # Structured output: the child must return a value matching this schema (the
-        # return tool enforces it; see workflow_completion). Reject a bad schema here —
-        # author-facing — rather than letting it brick the child when it applies the
-        # schema. Three sequentially-dependent author-facing failures, each an early
-        # reject: a non-object schema (a bare boolean is valid JSON Schema, but `false`
-        # rejects every value and `true` disables enforcement), a structurally-invalid
-        # schema, and one with an unresolvable reference (passes check_schema but raises
-        # at validation time).
-        if not isinstance(output_schema, dict):
-            return await _reject(
-                "bad_agent_call",
-                f"agent() output_schema must be a JSON object schema, "
-                f"got {type(output_schema).__name__}",
+    if (
+        output_schema is not None
+        and (
+            rejected := await _reject_invalid_output_schema(
+                output_schema,
+                call_name="agent()",
+                reject_kind="bad_agent_call",
+                reject=_reject,
             )
-        try:
-            jsonschema.Draft202012Validator.check_schema(output_schema)
-        except jsonschema.SchemaError as exc:
-            return await _reject(
-                "bad_agent_call", f"agent() output_schema is not a valid JSON Schema: {exc.message}"
-            )
-        if (bad_ref := _unresolvable_ref(output_schema)) is not None:
-            return await _reject(
-                "bad_agent_call",
-                f"agent() output_schema has an unresolvable reference {bad_ref!r} "
-                "(references must resolve within the schema; remote refs are unsupported)",
-            )
+        )
+        is not None
+    ):
+        return rejected
     agent_id = spec.get("agent_id")
     if agent_id is not None and not isinstance(agent_id, str):
         return await _reject(
@@ -1110,26 +1136,19 @@ async def _open_invoke_workflow_capability(
     output_schema = (
         json.loads(output_schema_raw) if isinstance(output_schema_raw, str) else output_schema_raw
     )
-    if output_schema is not None:
-        if not isinstance(output_schema, dict):
-            return await _reject(
-                "bad_invoke_workflow",
-                "invoke_workflow() output_schema must be a JSON object schema, "
-                f"got {type(output_schema).__name__}",
+    if (
+        output_schema is not None
+        and (
+            rejected := await _reject_invalid_output_schema(
+                output_schema,
+                call_name="invoke_workflow()",
+                reject_kind="bad_invoke_workflow",
+                reject=_reject,
             )
-        try:
-            jsonschema.Draft202012Validator.check_schema(output_schema)
-        except jsonschema.SchemaError as exc:
-            return await _reject(
-                "bad_invoke_workflow",
-                f"invoke_workflow() output_schema is not a valid JSON Schema: {exc.message}",
-            )
-        if (bad_ref := _unresolvable_ref(output_schema)) is not None:
-            return await _reject(
-                "bad_invoke_workflow",
-                f"invoke_workflow() output_schema has an unresolvable reference {bad_ref!r} "
-                "(references must resolve within the schema; remote refs are unsupported)",
-            )
+        )
+        is not None
+    ):
+        return rejected
 
     sub_run_id = child_run_id(run.id, cap.call_key)
     run_vaults = await wf_queries.get_run_vault_ids(conn, run.id, account_id=account_id)

--- a/tests/unit/test_workflow_output_schema.py
+++ b/tests/unit/test_workflow_output_schema.py
@@ -9,6 +9,7 @@ context builder renders into the child's request message.
 from __future__ import annotations
 
 import math
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 
 import pytest
@@ -16,7 +17,11 @@ import pytest
 from aios.harness.context import render_user_event
 from aios.tools.workflow_completion import _validate_value
 from aios.workflows.determinism import canonical_schema_json
-from aios.workflows.step import _unresolvable_ref
+from aios.workflows.step import (
+    _reject_invalid_output_schema,
+    _SpawnResult,
+    _unresolvable_ref,
+)
 
 _CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
 
@@ -96,3 +101,70 @@ def test_unresolvable_ref_accepts_valid_rejects_broken() -> None:
     )
     assert _unresolvable_ref({"$ref": "https://example.com/s.json"}) == "https://example.com/s.json"
     assert _unresolvable_ref({"properties": {"a": {"$dynamicRef": "#nope"}}}) == "#nope"
+
+
+@pytest.mark.asyncio
+async def test_reject_invalid_output_schema_parity_between_arms() -> None:
+    """The single-source output_schema validity gate must reject identically for the
+    agent() and invoke_workflow() arms, modulo the call-name prefix + reject-kind.
+
+    This is only expressible because the two arms now share ``_reject_invalid_output_schema``;
+    on master each arm had its own copy and there was no single helper to call. If a future
+    edit diverges one arm's message, the prefix-stripped tails stop matching and this fails.
+    """
+    invalid_schemas = [
+        True,  # non-dict (bare boolean)
+        {"type": "nonsense-keyword-value", "minimum": "x"},  # check_schema failure
+        {"$ref": "#/$defs/missing"},  # unresolvable ref
+    ]
+
+    arms = [
+        ("agent()", "bad_agent_call"),
+        ("invoke_workflow()", "bad_invoke_workflow"),
+    ]
+
+    def _make_recording_reject(
+        sink: list[tuple[str, str]],
+    ) -> Callable[[str, str], Awaitable[_SpawnResult]]:
+        async def _reject(kind: str, message: str) -> _SpawnResult:
+            sink.append((kind, message))
+            return _SpawnResult(rejected=True, needs_rewake=False)
+
+        return _reject
+
+    for schema in invalid_schemas:
+        tails = []
+        for call_name, reject_kind in arms:
+            recorded: list[tuple[str, str]] = []
+            result = await _reject_invalid_output_schema(
+                schema,
+                call_name=call_name,
+                reject_kind=reject_kind,
+                reject=_make_recording_reject(recorded),
+            )
+            # rejected → returns the (already-journaled) _SpawnResult, not None.
+            assert result is not None
+            assert result.rejected is True
+            assert len(recorded) == 1
+            kind, message = recorded[0]
+            assert kind == reject_kind  # the passed reject-kind is journaled verbatim
+            assert message.startswith(call_name)  # message carries the call-name prefix
+            tails.append(message[len(call_name) :])
+
+        # The ONLY legitimate divergence between arms is the prefix + kind: tails identical.
+        assert tails[0] == tails[1]
+
+    # A valid schema sails through both arms → None (no reject recorded).
+    async def _reject_must_not_fire(kind: str, message: str) -> _SpawnResult:  # pragma: no cover
+        raise AssertionError("valid schema must not reject")
+
+    for call_name, reject_kind in arms:
+        assert (
+            await _reject_invalid_output_schema(
+                {"type": "object"},
+                call_name=call_name,
+                reject_kind=reject_kind,
+                reject=_reject_must_not_fire,
+            )
+            is None
+        )


### PR DESCRIPTION
Automated dev-pipeline build for issue #1546.