### PR TITLE
Gate stub_missing_reasoning_content on supports_thinking — stop mutating every assistant turn for one provider's quirk

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -1358,13 +1358,18 @@ def stub_missing_reasoning_content(
 ) -> list[dict[str, Any]]:
     """Ensure every assistant message carries ``reasoning_content``.
 
-    Thinking-mode models (DeepSeek V4 Flash, etc.) reject transcripts
-    whose assistant turns lack this field: ``The reasoning_content in the
-    thinking mode must be passed back to the API``.  Non-thinking models
-    (Anthropic / OpenAI / Gemini / Llama / DeepSeek v3 — all probed)
-    ignore the field entirely, so setting an empty stub unconditionally
-    costs nothing and lets cross-model sessions use thinking models for
-    a single turn without poisoning their replay on other providers.
+    **Call this only for thinking-capable targets** (gate the call on
+    ``model_descriptor(model).supports_thinking``).  Thinking-mode models
+    (DeepSeek V4 Flash, etc.) reject transcripts whose assistant turns
+    lack this field: ``The reasoning_content in the thinking mode must be
+    passed back to the API``.
+
+    Non-thinking targets must NOT receive this stub: ``_strip_to_spec``
+    (in ``build_messages``) deliberately removes ``reasoning_content``
+    from their assistant turns, and re-adding an empty one here would
+    contradict that strip pass — reintroducing a field for providers that
+    never asked for it.  Gating both passes on the single
+    ``supports_thinking`` verdict keeps them in agreement.
 
     Mutates messages in place and returns the list for chaining.  Skips
     messages that already have a reasoning_content set (from a prior

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -354,6 +354,32 @@ def _agent_owes_response(messages: list[dict[str, Any]]) -> bool:
     return False
 
 
+def _stub_reasoning_content_for_thinking_target(
+    messages: list[dict[str, Any]], model: str
+) -> list[dict[str, Any]]:
+    """Stub ``reasoning_content`` onto bare assistant turns **only** for a
+    thinking-capable target.
+
+    Gated on the same capability axis the message pipeline already computes
+    (``model_descriptor(model).supports_thinking``). For a non-thinking
+    target, ``_strip_to_spec`` (in ``build_messages``) has already removed
+    ``reasoning_content`` from assistant turns; re-adding an empty stub here
+    would contradict that strip pass, so we leave the list untouched. For a
+    thinking target (DeepSeek V4 Flash, Claude family, …), the provider
+    rejects replayed assistant turns lacking the field, so we stub it.
+
+    Mutates and returns the list (the stub pass is in-place); a no-op gate
+    returns the list unchanged.
+    """
+    # Function-local import mirrors context.build_messages to avoid an
+    # import cycle with completion.py.
+    from aios.harness.completion import model_descriptor
+
+    if model_descriptor(model).supports_thinking:
+        stub_missing_reasoning_content(messages)
+    return messages
+
+
 async def compose_step_context(
     *,
     pool: asyncpg.Pool[Any],
@@ -452,11 +478,12 @@ async def compose_step_context(
     # which degenerate-poisoned literal models like claude-fable-5.
     messages = merge_adjacent_user_messages(ctx.messages)
 
-    # Unblock thinking-mode models: DeepSeek V4 Flash rejects assistant
-    # turns without reasoning_content.  Empty stub is ignored by all
-    # non-thinking providers we've tested (Anthropic, OpenAI, Gemini,
-    # Llama, non-thinking DeepSeek).
-    stub_missing_reasoning_content(messages)
+    # Unblock thinking-mode targets only: DeepSeek V4 Flash and other
+    # reasoning models reject replayed assistant turns that lack
+    # reasoning_content.  Non-thinking targets had the field correctly
+    # stripped by _strip_to_spec (build_messages); do NOT re-add it for
+    # them — that re-introduces a field the strip pass just removed.
+    messages = _stub_reasoning_content_for_thinking_target(messages, agent.model)
 
     return StepContext(
         model=agent.model,

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -57,6 +57,27 @@ def _full_pipeline(
     return merge_adjacent_user_messages(ctx.messages)
 
 
+def _full_pipeline_for_model(
+    events: list[Event],
+    model: str,
+) -> list[dict[str, Any]]:
+    """Compose the final message list for a concrete target model, exercising
+    the SAME tail ``compose_step_context`` runs: ``build_messages`` (which
+    strips reasoning fields for non-thinking targets) -> adjacent-user merge
+    -> the production ``supports_thinking``-gated reasoning-stub helper.
+
+    The stub step calls the real
+    ``step_context._stub_reasoning_content_for_thinking_target`` — the exact
+    seam the composer uses — so a regression that ungates it (re-adding the
+    field for non-thinking targets) is caught here without a DB-backed
+    ``compose_step_context`` round-trip."""
+    from aios.harness.step_context import _stub_reasoning_content_for_thinking_target
+
+    ctx = build_messages(events, system_prompt=None, model=model)
+    messages = merge_adjacent_user_messages(ctx.messages)
+    return _stub_reasoning_content_for_thinking_target(messages, model)
+
+
 # Fixed receipt time so the per-message ``received=`` envelope field
 # (see ``_format_received``) renders deterministically across assertions.
 _FIXED_CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
@@ -1947,6 +1968,59 @@ class TestStubMissingReasoningContent:
         stub_missing_reasoning_content(msgs)
         assert msgs[0]["reasoning_content"] == ""
         assert msgs[0]["tool_calls"] == [{"id": "a"}]
+
+
+class TestReasoningContentStubGate:
+    """End-to-end checks that the ``reasoning_content`` stub pass is gated on
+    the target's ``supports_thinking`` verdict — the same axis ``build_messages``
+    uses to strip/keep reasoning fields. On a non-thinking target the strip
+    pass removes ``reasoning_content`` and the (gated-off) stub pass must NOT
+    re-add it; on a thinking target the stub fills the missing field."""
+
+    def test_non_thinking_target_no_reasoning_content_stub(self) -> None:
+        # Assistant turn lacks reasoning_content; non-thinking target must
+        # ship it WITHOUT a synthesized empty stub. Fails on master, where
+        # the unconditional stub adds ``reasoning_content: ""``.
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        msgs = _full_pipeline_for_model(events, "openai/gpt-4o-mini")
+        assistant = [m for m in msgs if m.get("role") == "assistant"]
+        assert assistant, "expected at least one assistant turn"
+        for msg in assistant:
+            assert "reasoning_content" not in msg
+
+    def test_thinking_target_gets_reasoning_content_stub(self) -> None:
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        msgs = _full_pipeline_for_model(events, "anthropic/claude-haiku-4-5")
+        assistant = [m for m in msgs if m.get("role") == "assistant"]
+        assert assistant, "expected at least one assistant turn"
+        for msg in assistant:
+            assert msg["reasoning_content"] == ""
+
+    def test_thinking_target_preserves_real_reasoning_content(self) -> None:
+        # A thinking target whose assistant turn already carries
+        # reasoning_content keeps it verbatim (strip preserves it, stub
+        # skips already-set fields).
+        events = [
+            _evt(1, "user", content="hi"),
+            _evt(2, "assistant", content="hey"),
+        ]
+        events[1].data["reasoning_content"] = "deep thoughts about hi"
+        msgs = _full_pipeline_for_model(events, "anthropic/claude-haiku-4-5")
+        assistant = [m for m in msgs if m.get("role") == "assistant"]
+        assert assistant[0]["reasoning_content"] == "deep thoughts about hi"
+
+    def test_gate_seam_capability_verdicts(self) -> None:
+        # The seam the call site gates on: non-thinking false, thinking true.
+        from aios.harness.completion import model_descriptor
+
+        assert model_descriptor("openai/gpt-4o-mini").supports_thinking is False
+        assert model_descriptor("anthropic/claude-haiku-4-5").supports_thinking is True
 
 
 class TestMergeAdjacentUserMessagesPipeline:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1547.