### PR TITLE
fix(migrations): renumber duplicate 0122 → 0123 to restore single linear chain (#1591)

### DIFF
--- a/migrations/versions/0123_wf_runs_nullable_workflow_id.py
+++ b/migrations/versions/0123_wf_runs_nullable_workflow_id.py
@@ -19,8 +19,8 @@ A *registered* run still sets ``workflow_id`` and remains fully enforced. No
 data migration is needed: every existing row already has a non-NULL
 ``workflow_id``; this only relaxes the column so future inline rows may be NULL.
 
-Revision ID: 0122
-Revises: 0121
+Revision ID: 0123
+Revises: 0122
 Create Date: 2026-06-25
 """
 
@@ -30,8 +30,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0122"
-down_revision: str = "0121"
+revision: str = "0123"
+down_revision: str = "0122"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/tests/unit/test_migration_chain.py
+++ b/tests/unit/test_migration_chain.py
@@ -26,9 +26,18 @@ def _script_directory() -> ScriptDirectory:
 
 
 def test_single_head() -> None:
-    """The migration ladder has exactly one head: ``0122``."""
+    """The migration ladder has exactly one head (no fork, no duplicate revision).
+
+    Asserts the head *count*, not a pinned literal: pinning the head revision
+    was a per-migration maintenance tax that added no safety — a colliding
+    duplicate revision number (two files claiming the same id) is exactly the
+    fork this guards, and it trips the count check regardless of the literal.
+    #1591: two PRs both landed ``0122``; the pinned literal had to be bumped on
+    every migration yet did not prevent the collision.
+    """
     script = _script_directory()
-    assert script.get_heads() == ["0122"]
+    heads = script.get_heads()
+    assert len(heads) == 1, f"expected a single migration head, found {heads}"
 
 
 def test_chain_is_linear() -> None:


### PR DESCRIPTION
## Incident fix-forward — `aios#1591` (master red, forked alembic chain)

**Root cause:** #1563 (`0122_drop_retired_goal_outcome_tool_names`, the Ultron-wedge fix — **already deployed to prod, alembic_version=0122**) and #1552 (`0122_wf_runs_nullable_workflow_id`, merged minutes later) **both claimed revision `0122`**. They don't git-conflict (different filenames), so GitHub reported MERGEABLE while the alembic chain forked into two heads — the silent migration-collision class. `tests/unit/test_migration_chain.py::test_single_head` caught it on the merged master tree.

**Fix:** renumber the wf_runs migration to **`0123`** (`down_revision="0122"`). Prod is stamped `0122 = drop_retired_goal`, so that one is fixed at 0122 and the wf_runs migration chains after it → `0120 → 0121 → 0122 (drop_retired_goal) → 0123 (wf_runs_nullable)`. Prod-safe: prod runs `0123` on its next deploy, after its current `0122`. The two migrations are orthogonal (tools JSONB vs `wf_runs.workflow_id` nullability), so ordering is free.

**Also:** robustified `test_single_head` to assert the head **count** (`len(get_heads()) == 1`) rather than a pinned literal. The pinned `== ["0122"]` was a per-migration maintenance tax that added no safety and did not prevent this collision; the count check catches any fork without a per-migration edit.

**Verification:** full pre-commit suite green locally (3748 unit + 579 connector tests, ruff, mypy); `test_migration_chain.py` (3 tests, incl. the canary `test_single_head`) passes; `alembic heads` → single `0123`.

Closes #1591