### PR TITLE
MCP tool-cache binding_id duck-types agent.id → version-pinned + workflow-child sessions collide on "?:version", poisoning the #1391 cache

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -49,6 +49,8 @@ from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
 from aios.harness.tool_disposition import classify_tool_call
 from aios.logging import get_logger
 from aios.models.agents import (
+    Agent,
+    AgentVersion,
     McpServerSpec,
     is_mcp_tool_name,
 )
@@ -1060,7 +1062,7 @@ def _classify_tool_call(
 async def discover_session_mcp_tools(
     pool: Any,
     session_id: str,
-    agent: Any,
+    agent: Agent | AgentVersion,
     *,
     account_id: str,
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
@@ -1076,9 +1078,9 @@ async def discover_session_mcp_tools(
     from aios.tools.registry import effective_transport
 
     enabled_server_names: set[str] = set()
-    for spec in agent.tools:
-        if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name:
-            enabled_server_names.add(spec.mcp_server_name)
+    for tool_spec in agent.tools:
+        if tool_spec.type == "mcp_toolset" and tool_spec.enabled and tool_spec.mcp_server_name:
+            enabled_server_names.add(tool_spec.mcp_server_name)
     servers: list[McpServerSpec] = [s for s in agent.mcp_servers if s.name in enabled_server_names]
     if not servers:
         return [], {}
@@ -1092,7 +1094,7 @@ async def discover_session_mcp_tools(
     # pays no per-step ``list_tools()`` RPC. Frozen-surface / version-pinned
     # sessions keep one (id, version) for the session lifetime, so they serve
     # from cache for the whole session with no rediscovery.
-    binding_id = f"{getattr(agent, 'id', '?')}:{getattr(agent, 'version', '?')}"
+    binding_id = agents_service.tool_cache_binding_id(agent, session_id)
 
     # Circuit breaker (#1391): skip a server whose discovery recently timed out /
     # failed so one unresponsive server can't re-stall the prelude every step —

--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -65,10 +65,13 @@ from aios.errors import AiosError
 from aios.logging import get_logger
 from aios.mcp.client import call_mcp_tool, discover_mcp_tools
 from aios.models.agents import (
+    Agent,
+    AgentVersion,
     McpServerSpec,
     ToolSpec,
     resolve_mcp_enabled,
 )
+from aios.services import agents as agents_service
 from aios.tools.invoke import ToolBail, invoke_builtin
 from aios.tools.registry import ToolResult, effective_transport, registry
 
@@ -115,17 +118,6 @@ def _find_mcp_toolset(agent_tools: list[ToolSpec], server_name: str) -> ToolSpec
         if spec.type == "mcp_toolset" and spec.enabled and spec.mcp_server_name == server_name:
             return spec
     return None
-
-
-def _binding_id(agent: Any) -> str:
-    """Binding identity for the shared MCP tool-list cache (#1391).
-
-    The broker re-discovers on every model-initiated introspection
-    (``mcp list-methods`` / ``mcp schema``); keying the cache on the SAME
-    ``agent id + version`` the step prelude uses lets the two share a single
-    cached tool list instead of each re-paying a ``list_tools()`` RPC.
-    """
-    return f"{getattr(agent, 'id', '?')}:{getattr(agent, 'version', '?')}"
 
 
 def _find_builtin_spec(agent_tools: list[ToolSpec], name: str) -> ToolSpec | None:
@@ -389,7 +381,7 @@ class ToolBroker:
             return _err(403, "forbidden: unknown or expired secret")
         return session_id
 
-    async def _load_agent(self, session_id: str) -> Any:
+    async def _load_agent(self, session_id: str) -> Agent | AgentVersion:
         """Fetch the agent (or agent_version) attached to ``session_id``.
 
         Mirrors the loading dance in
@@ -398,7 +390,6 @@ class ToolBroker:
         avoid an import cycle at module load.
         """
         from aios.harness import runtime
-        from aios.services import agents as agents_service
         from aios.services import sessions as sessions_service
 
         pool = runtime.require_pool()
@@ -546,7 +537,7 @@ class ToolBroker:
 
     async def _resolve_mcp(
         self, request: Request, *, require_tool: bool
-    ) -> tuple[str, McpServerSpec, ToolSpec, str | None, Any] | Response:
+    ) -> tuple[str, McpServerSpec, ToolSpec, str | None, Agent | AgentVersion] | Response:
         """Resolve session, server, toolset, and (optionally) tool for an
         MCP route.
 
@@ -584,8 +575,6 @@ class ToolBroker:
                 f"{server_name!r} (transport={transport!r}). The model can "
                 f"still call it.",
             )
-        from aios.services import agents as agents_service
-
         perm = agents_service.effective_mcp_permission(qualified, agent.tools)
         if perm != "always_allow":
             return _err(
@@ -611,7 +600,7 @@ class ToolBroker:
                 headers,
                 server.name,
                 spec_headers=server.headers,
-                binding_id=_binding_id(agent),
+                binding_id=agents_service.tool_cache_binding_id(agent, session_id),
             )
         except Exception as exc:
             log.warning(
@@ -621,8 +610,6 @@ class ToolBroker:
                 exc_info=True,
             )
             return _transport_err(server.name, exc)
-
-        from aios.services import agents as agents_service
 
         out: list[dict[str, Any]] = []
         # Pass a single-element list containing this toolset to the
@@ -660,7 +647,7 @@ class ToolBroker:
                 headers,
                 server.name,
                 spec_headers=server.headers,
-                binding_id=_binding_id(agent),
+                binding_id=agents_service.tool_cache_binding_id(agent, session_id),
             )
         except Exception as exc:
             log.warning(
@@ -737,7 +724,6 @@ class ToolBroker:
     ) -> bool:
         """Whether an MCP call from the sandbox CLI is suppressed (#710)."""
         from aios.models.agents import mcp_tool_suppressed
-        from aios.services import agents as agents_service
         from aios.services import sessions as sessions_service
 
         session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -333,6 +333,23 @@ async def _load_for_session_conn(
     return await queries.get_agent(conn, session.agent_id, account_id=account_id)
 
 
+def tool_cache_binding_id(agent: Agent | AgentVersion, session_id: str) -> str:
+    """Stable identity for the #1391 MCP tool-list cache key.
+
+    The cached tool set is static for a given *binding identity* — the
+    precondition that lets sibling sessions of the same agent/version share
+    one discovery. A real agent's identity is agent-level so siblings share;
+    a generic workflow child (no agent_id) has only its own attenuated
+    per-run surface, so it must key on its own session (no cross-session
+    sharing — surfaces differ).
+    """
+    if isinstance(agent, Agent):
+        return f"{agent.id}:{agent.version}"
+    if agent.agent_id:
+        return f"{agent.agent_id}:{agent.version}"
+    return f"child:{session_id}"
+
+
 async def load_for_session(
     pool: asyncpg.Pool[Any],
     session: Any,

--- a/tests/unit/sandbox/test_tool_broker.py
+++ b/tests/unit/sandbox/test_tool_broker.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
-from types import SimpleNamespace
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
@@ -22,6 +22,7 @@ import pytest
 
 from aios.errors import CryptoDecryptError, ForbiddenError
 from aios.models.agents import (
+    AgentVersion,
     McpPermissionPolicy,
     McpServerSpec,
     McpToolConfig,
@@ -38,8 +39,21 @@ def _agent(
     *,
     tools: list[ToolSpec] | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
-) -> SimpleNamespace:
-    return SimpleNamespace(tools=tools or [], mcp_servers=mcp_servers or [])
+) -> AgentVersion:
+    return AgentVersion(
+        agent_id="agt_1",
+        version=3,
+        model="test/dummy",
+        system="sys",
+        tools=tools or [],
+        skills=[],
+        mcp_servers=mcp_servers or [],
+        http_servers=[],
+        litellm_extra={},
+        window_min=1000,
+        window_max=100000,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
 
 
 def _server(name: str = "tav", url: str = "https://tav.example/mcp") -> McpServerSpec:

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -9,13 +9,13 @@ test here.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aios.models.agents import McpServerSpec, ToolSpec
+from aios.models.agents import AgentVersion, McpServerSpec, ToolSpec
 
 
 @pytest.fixture(autouse=True)
@@ -31,10 +31,20 @@ def _mock_crypto_box() -> Any:
 def _agent(
     mcp_servers: list[McpServerSpec] | None = None,
     tools: list[ToolSpec] | None = None,
-) -> Any:
-    return SimpleNamespace(
-        mcp_servers=mcp_servers or [],
+) -> AgentVersion:
+    return AgentVersion(
+        agent_id="agt_1",
+        version=3,
+        model="test/dummy",
+        system="sys",
         tools=tools or [],
+        skills=[],
+        mcp_servers=mcp_servers or [],
+        http_servers=[],
+        litellm_extra={},
+        window_min=1000,
+        window_max=100000,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
 
 

--- a/tests/unit/test_mcp_discovery_cache.py
+++ b/tests/unit/test_mcp_discovery_cache.py
@@ -19,6 +19,7 @@ All MCP SDK + httpx interactions are mocked. No network calls.
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,6 +32,8 @@ from aios.mcp.client import (
     discover_mcp_tools,
 )
 from aios.mcp.pool import McpSessionPool
+from aios.models.agents import Agent, AgentVersion, ToolSpec
+from aios.services.agents import tool_cache_binding_id
 
 URL = "https://m.example/"
 EMPTY_KEY = _headers_key(None)
@@ -154,6 +157,120 @@ class TestDiscoveryResultCache:
             await discover_mcp_tools(URL, "v", {}, "s", binding_id="agt_1:3")
 
         assert session.list_tools.await_count == 2
+
+
+# ── binding-identity accessor (#1554) ───────────────────────────────────────
+
+
+_DT = datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def _agent_version(*, agent_id: str, version: int, tools: list[ToolSpec]) -> AgentVersion:
+    return AgentVersion(
+        agent_id=agent_id,
+        version=version,
+        model="test/dummy",
+        system="sys",
+        tools=tools,
+        skills=[],
+        mcp_servers=[],
+        http_servers=[],
+        litellm_extra={},
+        window_min=1000,
+        window_max=100000,
+        created_at=_DT,
+    )
+
+
+def _latest_agent(*, id: str, version: int) -> Agent:
+    return Agent(
+        id=id,
+        version=version,
+        name="a",
+        model="test/dummy",
+        system="sys",
+        tools=[],
+        skills=[],
+        mcp_servers=[],
+        http_servers=[],
+        description="d",
+        metadata={},
+        litellm_extra={},
+        window_min=1000,
+        window_max=100000,
+        created_at=_DT,
+        updated_at=_DT,
+    )
+
+
+class TestToolCacheBindingId:
+    """#1554: the binding identity that keys the #1391 tool-list cache must
+    distinguish distinct agents/sessions, never collapse them onto ``"?:..."``.
+    """
+
+    def test_distinct_version_pinned_agents_same_version_get_distinct_ids(self) -> None:
+        """Two version-pinned ``AgentVersion``s of *different* agents pinned to
+        the same version number must NOT collide. On master both duck-type to
+        ``"?:3"`` (the old ``getattr(agent, 'id', '?')``) — this asserts the
+        post-fix ``"agt_A:3"`` / ``"agt_B:3"`` and so fails on master."""
+        a = _agent_version(agent_id="agt_A", version=3, tools=[])
+        b = _agent_version(agent_id="agt_B", version=3, tools=[])
+        id_a = tool_cache_binding_id(a, "ses_1")
+        id_b = tool_cache_binding_id(b, "ses_2")
+        assert id_a == "agt_A:3"
+        assert id_b == "agt_B:3"
+        assert id_a != id_b
+
+    def test_distinct_generic_children_get_distinct_session_anchored_ids(self) -> None:
+        """Two generic workflow children (``agent_id=""``, ``version=0``) carry
+        distinct attenuated per-run surfaces; they must key on their own
+        ``session_id`` and so differ. On master both collapse to ``"?:0"``."""
+        a = _agent_version(agent_id="", version=0, tools=[])
+        b = _agent_version(agent_id="", version=0, tools=[])
+        id_a = tool_cache_binding_id(a, "ses_child_a")
+        id_b = tool_cache_binding_id(b, "ses_child_b")
+        assert id_a == "child:ses_child_a"
+        assert id_b == "child:ses_child_b"
+        assert id_a != id_b
+
+    def test_latest_agent_path_unchanged(self) -> None:
+        """The latest-``Agent`` path keeps its ``"<id>:<version>"`` form —
+        the one path that was already correct."""
+        agent = _latest_agent(id="agt_1", version=3)
+        assert tool_cache_binding_id(agent, "ses_x") == "agt_1:3"
+
+    async def test_cross_agent_pool_key_not_poisoned(self, pool_runtime: McpSessionPool) -> None:
+        """End-to-end: agent A's discovered tool list is NOT served to a
+        version-pinned agent B sharing one ``_PoolKey`` (same url/vault/headers).
+        On master both bind to ``"?:3"`` → B is served A's tools."""
+        a = _agent_version(agent_id="agt_A", version=3, tools=[])
+        b = _agent_version(agent_id="agt_B", version=3, tools=[])
+        bind_a = tool_cache_binding_id(a, "ses_a")
+        bind_b = tool_cache_binding_id(b, "ses_b")
+        # Distinct agents pinned to the same version must NOT share a cache slot.
+        assert bind_a != bind_b
+
+        # One transport session (same ``_PoolKey``) whose tool set changes between
+        # the two discoveries — A then B. If B shared A's cache key it would be
+        # served A's stale tool list (await_count stays 1); with distinct keys B
+        # re-discovers and sees its own.
+        session = _make_mock_session(["tool_for_A"])
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(session)),
+        ):
+            tools_a, _ = await discover_mcp_tools(URL, "v", {}, "s", binding_id=bind_a)
+            assert session.list_tools.await_count == 1
+
+            result_b = MagicMock()
+            result_b.tools = [_make_mock_tool("tool_for_B")]
+            session.list_tools = AsyncMock(return_value=result_b)
+            tools_b, _ = await discover_mcp_tools(URL, "v", {}, "s", binding_id=bind_b)
+
+        # B re-discovers (distinct key) and gets its own tool, not A's cached one.
+        assert session.list_tools.await_count == 1
+        assert tools_a[0]["function"]["name"] == "mcp__s__tool_for_A"
+        assert tools_b[0]["function"]["name"] == "mcp__s__tool_for_B"
 
 
 # ── per-server discovery timeout ────────────────────────────────────────────


### PR DESCRIPTION
Automated dev-pipeline build for issue #1554.