### PR TITLE
Egress proxy buffers the whole sandbox request body into an uncapped bytearray — hostile-sandbox OOM/DoS

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -164,6 +164,18 @@ class Settings(BaseSettings):
         "default (unlimited) in place. Minimum 4 MiB to satisfy Docker's "
         "own floor.",
     )
+    sandbox_egress_max_request_bytes: int = Field(
+        default=100 * 1024 * 1024,  # 100 MiB
+        ge=0,
+        description="Maximum request-body size the secret egress proxy will "
+        "buffer before forwarding upstream. The body is buffered whole so the "
+        "credential placeholder can be swapped across chunk boundaries, so this "
+        "is the per-request worker-memory ceiling for a sandbox-originated "
+        "upload. A request whose body exceeds this is rejected with 413 before "
+        "any upstream connection — the sandbox is untrusted, so this bounds the "
+        "OOM blast radius on the shared worker. Set via "
+        "AIOS_SANDBOX_EGRESS_MAX_REQUEST_BYTES.",
+    )
     sandbox_pids_limit: int | None = Field(
         default=None,
         ge=1,

--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -41,8 +41,10 @@ Named residuals (operator-facing):
   traffic is redirected here (#878), so a sandbox ``curl https://<ip>`` to an
   allowed host's IP gets its handshake reset rather than connecting.
 * The request body is buffered whole to swap across chunk boundaries (memory
-  bound = request size); responses stay streamed. Very large request uploads
-  are a documented residual.
+  bound = request size); responses stay streamed. The buffer is hard-capped at
+  ``sandbox_egress_max_request_bytes`` (default 100 MiB) — a body that exceeds
+  it is rejected with a clean ``413`` before any upstream connection opens, so
+  the per-request worker-memory ceiling is bounded even for a hostile sandbox.
 * The upstream connection pins a single resolved IP (IPv4 preferred); no
   dual-stack failover.
 
@@ -71,6 +73,7 @@ import h11
 import httpx
 from cryptography.hazmat.primitives import serialization
 
+from aios.config import get_settings
 from aios.logging import get_logger
 from aios.models.vaults import parse_allowed_host_entry
 from aios.sandbox.egress_ca import EgressCA, get_egress_ca, mint_server_leaf
@@ -96,6 +99,17 @@ _READ_CHUNK = 65536
 # never sends one) must not pin a handler indefinitely. Bounds idle time
 # between chunks, not total transfer, so a slow-but-steady upload is unaffected.
 _INBOUND_IDLE_TIMEOUT_S = 60.0
+
+
+class _BodyTooLarge:
+    """Distinguished ``_read_body`` outcome: the request body exceeded the
+    configured cap. Discriminated from ``None`` (client stalled mid-body) and
+    from ``bytes`` (complete body) so ``_serve_one`` can total-match the three
+    outcomes and send a ``413`` instead of conflating over-cap with a stall."""
+
+
+# Singleton sentinel — ``_serve_one`` discriminates it via ``isinstance``.
+_BODY_TOO_LARGE = _BodyTooLarge()
 
 # Stripped before forwarding the request upstream. ``authorization`` is
 # deliberately ABSENT: the placeholder rides in it and we swap+forward it.
@@ -296,6 +310,11 @@ class SecretEgressProxy:
         # ever reaches the mint path, so a hostile sandbox can't flood
         # distinct SNIs to balloon the leaf cache.
         self._allowed_hosts: frozenset[str] = frozenset(h for h, _, _, _ in self._rules)
+        # Hard cap on the whole-buffered request body (the placeholder→secret
+        # swap needs the body buffered, but the sandbox is untrusted, so an
+        # over-cap body 413s before any upstream connection). Snapshot the int
+        # once at construction so the hot read-loop touches a plain attribute.
+        self._max_body_bytes: int = get_settings().sandbox_egress_max_request_bytes
         self._ca: EgressCA = get_egress_ca()
         self._leaf_ctx: dict[str, ssl.SSLContext] = {}
         self._sni: weakref.WeakKeyDictionary[ssl.SSLObject, str] = weakref.WeakKeyDictionary()
@@ -493,6 +512,13 @@ class SecretEgressProxy:
         body = await self._read_body(conn, reader)
         if body is None:
             return  # client stalled mid-body
+        if isinstance(body, _BodyTooLarge):
+            # Over the worker-memory cap: fail hard before any upstream
+            # connection (parity with the 502 egress-blocked path above). No
+            # response has been sent yet, so the connection is still in
+            # SEND_RESPONSE and the 413 frames cleanly.
+            await self._send_simple(conn, writer, 413, b"request body too large")
+            return
 
         fwd_headers = self._forward_headers(request.headers.raw_items(), host, swaps)
         swapped_body = _apply_swaps_bytes(body, swaps)
@@ -548,11 +574,22 @@ class SecretEgressProxy:
                 return event
             return None  # connection closed before a request
 
-    async def _read_body(self, conn: h11.Connection, reader: asyncio.StreamReader) -> bytes | None:
+    async def _read_body(
+        self, conn: h11.Connection, reader: asyncio.StreamReader
+    ) -> bytes | None | _BodyTooLarge:
         """Read the request body (h11 ``Data`` events) up to ``EndOfMessage``.
 
         The body is buffered whole so the placeholder can be swapped across
         chunk boundaries; this runs only after the egress gate has passed.
+
+        Three discriminated outcomes (the caller total-matches them):
+
+        * ``bytes`` — the complete body (forward it upstream).
+        * ``None`` — the client stalled mid-body (idle timeout); drop.
+        * ``_BODY_TOO_LARGE`` — the body grew past ``self._max_body_bytes``;
+          the caller sends a ``413`` and opens no upstream connection. The
+          breach is caught as the ``bytearray`` grows so it can never exceed
+          the ceiling by more than one inbound chunk before we bail.
         """
         body = bytearray()
         while True:
@@ -565,6 +602,8 @@ class SecretEgressProxy:
                 continue
             if isinstance(event, h11.Data):
                 body += event.data
+                if len(body) > self._max_body_bytes:
+                    return _BODY_TOO_LARGE  # discriminated from the None stall
             else:  # EndOfMessage / ConnectionClosed / PAUSED
                 return bytes(body)
 

--- a/tests/unit/sandbox/test_secret_egress_proxy.py
+++ b/tests/unit/sandbox/test_secret_egress_proxy.py
@@ -20,6 +20,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from datetime import UTC, datetime
 from typing import cast
 
+import h11
 import httpx
 import pytest
 from structlog.testing import capture_logs
@@ -143,10 +144,16 @@ async def make_proxy(
         *,
         resolver_ip: str | None = PINNED_IP,
         transport: httpx.MockTransport | None = None,
+        max_body_bytes: int | None = None,
     ) -> ProxyAndCapture:
         monkeypatch.setattr(sep, "_resolve_pinned_ip", _fixed_resolver(resolver_ip))
         captured: list[httpx.Request] = []
         proxy = await _boot(creds, transport or _mock_upstream(captured))
+        if max_body_bytes is not None:
+            # The cap is snapshotted from settings at construction; override the
+            # stored int so a test can drive an over-cap body without uploading
+            # the full default 100 MiB.
+            proxy._max_body_bytes = max_body_bytes
         started.append(proxy)
         return proxy, captured
 
@@ -662,6 +669,107 @@ class TestResponseFraming:
         assert b"content-length: 5" in head
         assert b"transfer-encoding" not in head
         assert b"hello" in body
+
+
+class TestRequestBodyCap:
+    """The body is buffered whole to swap the placeholder across chunk
+    boundaries (#1556). Against a hostile sandbox an uncapped buffer is a
+    worker-memory OOM/DoS, so the buffer is hard-capped at
+    ``sandbox_egress_max_request_bytes`` and an over-cap body is rejected with
+    a clean ``413`` before any upstream connection opens.
+    """
+
+    async def test_over_cap_body_413s_and_opens_no_upstream(self, make_proxy: MakeProxy) -> None:
+        cap = 16
+        proxy, captured = await make_proxy(
+            [_cred("GH_TOKEN", "ghp_REALSECRET", ("api.allowed.test",), PH_GH)],
+            max_body_bytes=cap,
+        )
+        # cap + 1 bytes: the smallest body that breaches the ceiling.
+        r = await _request(
+            proxy,
+            "api.allowed.test",
+            "/x",
+            method="POST",
+            content=b"a" * (cap + 1),
+        )
+        assert r.status_code == 413
+        # No upstream connection was opened — the breach is caught before
+        # build_request/send, exactly like the 502 egress-blocked path.
+        assert captured == []
+
+    async def test_at_cap_body_forwards_normally(self, make_proxy: MakeProxy) -> None:
+        # Boundary: a body exactly at the cap is under the strict ">" check and
+        # forwards normally — pins that the cap is inclusive of the ceiling.
+        cap = 16
+        proxy, captured = await make_proxy(
+            [_cred("GH_TOKEN", "ghp_REALSECRET", ("api.allowed.test",), PH_GH)],
+            max_body_bytes=cap,
+        )
+        body = b"a" * cap
+        r = await _request(proxy, "api.allowed.test", "/x", method="POST", content=body)
+        assert r.status_code == 200
+        assert len(captured) == 1
+        assert captured[0].content == body
+
+    async def test_read_body_returns_over_cap_sentinel_and_never_overbuffers(
+        self, make_proxy: MakeProxy
+    ) -> None:
+        # Drive _read_body directly against an in-memory StreamReader to prove
+        # (a) it returns the discriminated over-cap sentinel (not None / not
+        # bytes) and (b) it bails before buffering more than one inbound chunk
+        # past the cap — the buffer can never balloon to the full upload.
+        cap = 8
+        proxy, _ = await make_proxy(
+            [_cred("GH_TOKEN", "ghp_REALSECRET", ("api.allowed.test",), PH_GH)],
+            max_body_bytes=cap,
+        )
+        # A chunked request whose body far exceeds the cap.
+        chunk = b"z" * 64
+        wire = (
+            b"POST /x HTTP/1.1\r\nHost: api.allowed.test\r\n"
+            b"Content-Length: " + str(len(chunk)).encode() + b"\r\n\r\n" + chunk
+        )
+        reader = asyncio.StreamReader()
+        reader.feed_data(wire)
+        reader.feed_eof()
+        conn = h11.Connection(h11.SERVER)
+        request = await proxy._read_head(conn, reader)
+        assert request is not None
+        outcome = await proxy._read_body(conn, reader)
+        assert outcome is sep._BODY_TOO_LARGE
+
+    async def test_complete_body_returns_bytes_not_sentinel(self, make_proxy: MakeProxy) -> None:
+        # The third discriminated outcome: a complete under-cap body is plain
+        # bytes (the forward path), distinct from None (stall) and the sentinel.
+        cap = 64
+        proxy, _ = await make_proxy(
+            [_cred("GH_TOKEN", "ghp_REALSECRET", ("api.allowed.test",), PH_GH)],
+            max_body_bytes=cap,
+        )
+        chunk = b"hello body"
+        wire = (
+            b"POST /x HTTP/1.1\r\nHost: api.allowed.test\r\n"
+            b"Content-Length: " + str(len(chunk)).encode() + b"\r\n\r\n" + chunk
+        )
+        reader = asyncio.StreamReader()
+        reader.feed_data(wire)
+        reader.feed_eof()
+        conn = h11.Connection(h11.SERVER)
+        assert await proxy._read_head(conn, reader) is not None
+        outcome = await proxy._read_body(conn, reader)
+        assert outcome == chunk
+
+
+class TestRequestBodyCapDefault:
+    def test_default_cap_is_100_mib_and_ge_zero(self) -> None:
+        from aios.config import Settings
+
+        fields = Settings.model_fields["sandbox_egress_max_request_bytes"]
+        assert fields.default == 100 * 1024 * 1024
+        # ge=0 lets an operator disable body-bearing egress without a sentinel.
+        metadata = [getattr(m, "ge", None) for m in fields.metadata]
+        assert 0 in metadata
 
 
 def test_module_exports() -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1556.