### PR TITLE
Request-response answers: replace flattened (is_error, result, error) triple with a discriminated Ok | Err kind

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -26,6 +26,7 @@ from typing import Any
 import asyncpg
 
 from aios.errors import NotFoundError
+from aios.models.sessions import Err, Ok, Outcome
 
 # ─── shared scoping helpers ──────────────────────────────────────────────────
 #
@@ -284,6 +285,39 @@ def open_request_anti_join(*, sid: str, acct: str, awaited_only: bool) -> str:
         "    AND resp.kind = 'lifecycle' AND resp.data->>'event' = 'request_response' "
         "    AND resp.data->>'request_id' = req.data->>'request_id') "
     )
+
+
+# ─── request-answer outcome codec (#1555) ────────────────────────────────────
+#
+# The single serialize/deserialize pair where the discriminated ``Ok | Err``
+# answer kind meets the on-disk JSONB. This is the ONLY code that names the flat
+# ``is_error`` / ``result`` / ``error`` keys for the request-answer domain — the
+# kind is the source of truth, the flat keys are a derived echo. The flat keys
+# are kept on disk (additive, no migration) so an old reader during the deploy
+# window still parses new events and a new reader still parses old ones.
+
+
+def outcome_to_jsonb(outcome: Outcome) -> dict[str, Any]:
+    """Serialize an ``Outcome`` to the flat ``request_response`` JSONB shape.
+
+    Additive: keeps the ``is_error`` / ``result`` / ``error`` keys readable by an
+    old reader across the deploy window, but DERIVES them from the kind — the kind
+    is the source of truth, the flat keys are echo.
+    """
+    if outcome.kind == "ok":
+        return {"is_error": False, "result": outcome.result, "error": None}
+    return {"is_error": True, "result": None, "error": outcome.error}
+
+
+def outcome_from_jsonb(data: dict[str, Any]) -> Outcome:
+    """Deserialize a flat ``{is_error, result, error}`` JSONB blob to an ``Outcome``.
+
+    Read-tolerant of both the new (kind-derived) and any legacy flat shape: the
+    ``is_error`` discriminant alone picks the arm.
+    """
+    if data.get("is_error"):
+        return Err(error=data["error"])
+    return Ok(result=data.get("result"))
 
 
 # ─── re-exports ──────────────────────────────────────────────────────────────
@@ -618,6 +652,9 @@ __all__ = [
     "ClaimedTriggerRun",
     "EnvVarCredentialEcho",
     "EnvVarCredentialRow",
+    "Err",
+    "Ok",
+    "Outcome",
     "ResolvedExternalEventTrigger",
     "TriggerFireRef",
     "TriggerRow",
@@ -831,6 +868,8 @@ __all__ = [
     "notify_management_call_dispatch",
     "notify_management_call_result",
     "open_request_anti_join",
+    "outcome_from_jsonb",
+    "outcome_to_jsonb",
     "precompute_event_append",
     "prune_trigger_runs",
     "read_events",

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -34,7 +34,14 @@ from aios.ids import (
 )
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, load_tool_specs
 from aios.models.attenuation import Surface
-from aios.models.sessions import Obligation, Session, SessionStatus, SessionUsage
+from aios.models.sessions import (
+    Err,
+    Obligation,
+    Outcome,
+    Session,
+    SessionStatus,
+    SessionUsage,
+)
 
 # ─── sessions ─────────────────────────────────────────────────────────────────
 
@@ -444,7 +451,7 @@ async def get_wake_priority_context(
 
 async def read_request_response(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
-) -> dict[str, Any] | None:
+) -> Outcome | None:
     """A specific request's written **response** (`request_response` event), or
     ``None`` if none has been written.
 
@@ -468,7 +475,7 @@ async def read_request_response(
         account_id,
         request_id,
     )
-    return row["data"] if row is not None else None
+    return queries.outcome_from_jsonb(row["data"]) if row is not None else None
 
 
 async def get_open_request_ids(
@@ -680,7 +687,7 @@ async def count_request_nudges(
 
 async def derive_response(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str, request_id: str
-) -> dict[str, Any] | None:
+) -> Outcome | None:
     """A request's **terminal outcome**, or ``None`` if it is still pending.
 
     The single resolver the run harvest asks "what became of this ``agent()``?" — a
@@ -712,14 +719,9 @@ async def derive_response(
     )
     assert row is not None
     if row["response"] is not None:
-        response = row["response"]
-        return {
-            "result": response.get("result"),
-            "is_error": bool(response.get("is_error")),
-            "error": response.get("error"),
-        }
+        return queries.outcome_from_jsonb(row["response"])
     if not row["live"]:
-        return {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
+        return Err(error={"kind": "child_gone"})
     return None
 
 
@@ -789,9 +791,7 @@ async def write_response_if_absent(
     *,
     account_id: str,
     request_id: str,
-    is_error: bool,
-    result: Any,
-    error: dict[str, Any] | None,
+    outcome: Outcome,
 ) -> bool:
     """Write a request's response, **exactly once per request** (first-writer-wins).
 
@@ -826,9 +826,7 @@ async def write_response_if_absent(
             data={
                 "event": "request_response",
                 "request_id": request_id,
-                "is_error": is_error,
-                "result": result,
-                "error": error,
+                **queries.outcome_to_jsonb(outcome),
             },
         )
     return True

--- a/src/aios/db/queries/workflows.py
+++ b/src/aios/db/queries/workflows.py
@@ -31,6 +31,7 @@ from aios.db.queries import (
 from aios.errors import ConflictError, NotFoundError
 from aios.ids import WORKFLOW, WORKFLOW_EVENT, WORKFLOW_RUN, make_id
 from aios.models.agents import HttpServerSpec, McpServerSpec, ToolSpec, load_tool_specs
+from aios.models.sessions import Err, Ok, Outcome
 from aios.models.workflows import (
     TERMINAL_RUN_STATUSES,
     WfRun,
@@ -1191,7 +1192,7 @@ async def resolve_run_error(conn: asyncpg.Connection[Any], run_id: str) -> dict[
 
 async def derive_run_response(
     conn: asyncpg.Connection[Any], run_id: str, *, account_id: str
-) -> dict[str, Any] | None:
+) -> Outcome | None:
     """A run-servicer's **terminal outcome** for its inbound request, or ``None`` if pending.
 
     The run-kind branch of the kind-agnostic resolver (the dual of the session-side
@@ -1223,20 +1224,21 @@ async def derive_run_response(
         account_id,
     )
     if row is None:  # the run vanished entirely → can never answer
-        return {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
+        return Err(error={"kind": "child_gone"})
     status = row["status"]
     if status == "cancelled":
-        return {"result": None, "is_error": True, "error": {"kind": "cancelled"}}
+        return Err(error={"kind": "cancelled"})
     if status in ("completed", "errored"):
         completed = row["completed"] if row["completed"] is not None else {}
-        is_error = bool(completed.get("is_error"))
-        return {
-            "result": None if is_error else completed.get("output"),
-            "is_error": is_error,
-            "error": completed.get("error"),
-        }
+        # The run_completed bookend carries its OWN flat {output, is_error, error}
+        # triple (a second on-disk product, untouched here). Collapse it into the
+        # same Outcome kind at the read, rename-tolerant (output ↔ result), rather
+        # than re-pair the triple downstream.
+        if completed.get("is_error"):
+            return Err(error=completed["error"])
+        return Ok(result=completed.get("output"))
     if row["archived"]:  # non-terminal but archived → can never answer
-        return {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
+        return Err(error={"kind": "child_gone"})
     return None
 
 

--- a/src/aios/models/sessions.py
+++ b/src/aios/models/sessions.py
@@ -35,6 +35,37 @@ from aios.models.triggers import (
     validate_triggers,
 )
 
+# ─── request-answer outcome kind (#1555) ─────────────────────────────────────
+#
+# The canonical in-memory answer to a #1123 request: a discriminated ``Ok | Err``
+# union, constructed once at each answer site. ``Ok`` carries a result and has no
+# error slot; ``Err`` always carries an error. The legal states are exactly two,
+# so the six illegal ``(is_error, result, error)`` product combinations are
+# unrepresentable. The flat on-disk shape lives behind the single codec in
+# ``aios.db.queries`` (``outcome_to_jsonb`` / ``outcome_from_jsonb``).
+
+
+class Ok(BaseModel):
+    """A request answered successfully — carries a result, no error slot."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["ok"] = "ok"
+    result: Any = None
+
+
+class Err(BaseModel):
+    """A request answered with a failure — always carries an error kind."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["err"] = "err"
+    error: dict[str, Any]
+
+
+type Outcome = Annotated[Ok | Err, Field(discriminator="kind")]
+
+
 # Discriminated union over resource types. New types extend this union.
 SessionResource = Annotated[
     MemoryStoreResource | GithubRepositoryResource,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -42,7 +42,10 @@ from aios.models.memory_stores import MemoryStoreResource
 from aios.models.sessions import (
     MAX_USER_MESSAGE_CHARS,
     AwaitingToolCall,
+    Err,
     Obligation,
+    Ok,
+    Outcome,
     Session,
     SessionAwaitResponse,
     SessionResource,
@@ -1344,9 +1347,9 @@ async def write_gate_opened(
         session_id,
         account_id=account_id,
         request_id=request_id,
-        is_error=False,
-        result={"event": "gate_opened", "run_id": run_id, "gate_nonce": gate_nonce},
-        error=None,
+        outcome=Ok(
+            result={"event": "gate_opened", "run_id": run_id, "gate_nonce": gate_nonce}
+        ),
     )
 
 
@@ -1357,9 +1360,7 @@ async def write_child_response(
     account_id: str,
     parent_run_id: str,
     request_id: str,
-    is_error: bool,
-    result: Any,
-    error: dict[str, Any] | None,
+    outcome: Outcome,
 ) -> bool:
     """Write a workflow child's response AND its ``child_done`` side-marker, on the
     caller's open connection/transaction — THE seam for every external response
@@ -1376,9 +1377,7 @@ async def write_child_response(
         session_id,
         account_id=account_id,
         request_id=request_id,
-        is_error=is_error,
-        result=result,
-        error=error,
+        outcome=outcome,
     )
     if wrote:
         await wf_queries.insert_run_signal(
@@ -1433,9 +1432,7 @@ async def fail_open_child_requests_conn(
             account_id=account_id,
             parent_run_id=parent_run_id,
             request_id=request_id,
-            is_error=True,
-            result=None,
-            error=error,
+            outcome=Err(error=error),
         )
         wrote_any |= wrote
     return parent_run_id if wrote_any else None
@@ -1462,9 +1459,7 @@ async def respond_to_request_conn(
     session_id: str,
     *,
     request_id: str,
-    is_error: bool,
-    result: Any,
-    error: dict[str, Any] | None,
+    outcome: Outcome,
 ) -> RequestResponseWrite:
     """THE conn-level request-response writer + caller-kind router.
 
@@ -1504,9 +1499,7 @@ async def respond_to_request_conn(
             account_id=account_id,
             parent_run_id=parent_run_id,
             request_id=request_id,
-            is_error=is_error,
-            result=result,
-            error=error,
+            outcome=outcome,
         )
         return RequestResponseWrite(
             "responded" if wrote else "duplicate",
@@ -1519,9 +1512,7 @@ async def respond_to_request_conn(
         session_id,
         account_id=account_id,
         request_id=request_id,
-        is_error=is_error,
-        result=result,
-        error=error,
+        outcome=outcome,
     )
     wake_session_id = (
         caller["id"]
@@ -1579,9 +1570,7 @@ async def harvest_session_cancel_markers(
                 conn,
                 session_id,
                 request_id=marker.request_id,
-                is_error=True,
-                result=None,
-                error={"kind": "cancelled"},
+                outcome=Err(error={"kind": "cancelled"}),
             )
             wakes.append(write)
             await queries.mark_session_cancel_marker_harvested(
@@ -1726,9 +1715,7 @@ async def append_assistant_and_guard_quiescence(
                     conn,
                     session_id,
                     request_id=request_id,
-                    is_error=True,
-                    result=None,
-                    error={"kind": "no_return"},
+                    outcome=Err(error={"kind": "no_return"}),
                 )
                 if write.wake_run_id is not None:
                     autoerror_caller_run_id = write.wake_run_id

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1347,9 +1347,7 @@ async def write_gate_opened(
         session_id,
         account_id=account_id,
         request_id=request_id,
-        outcome=Ok(
-            result={"event": "gate_opened", "run_id": run_id, "gate_nonce": gate_nonce}
-        ),
+        outcome=Ok(result={"event": "gate_opened", "run_id": run_id, "gate_nonce": gate_nonce}),
     )
 
 

--- a/src/aios/services/tasks.py
+++ b/src/aios/services/tasks.py
@@ -39,6 +39,7 @@ from aios.db.listen import open_listen_for_events, open_listen_for_run_events
 from aios.db.queries import trace as trace_q
 from aios.db.queries import workflows as wf_queries
 from aios.errors import NotFoundError, ValidationError
+from aios.models.sessions import Err, Outcome
 from aios.models.tasks import AwaitResponse, OpenTask
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun
 from aios.services.await_completion import await_completion
@@ -96,7 +97,7 @@ async def _await_session(
         if await queries.read_session_watermarks(conn, session_id, account_id=account_id) is None:
             raise NotFoundError(f"session {session_id} not found", detail={"id": session_id})
 
-    async def _read() -> dict[str, Any] | None:
+    async def _read() -> Outcome | None:
         async with pool.acquire() as conn:
             return await queries.derive_response(
                 conn, session_id, account_id=account_id, request_id=request_id
@@ -160,23 +161,23 @@ async def _await_run(
     return AwaitResponse(outcome="errored", error=error)
 
 
-def _response_to_await(resolved: dict[str, Any] | None) -> AwaitResponse:
-    """Map a :func:`derive_response` ``{result, is_error, error}`` (or ``None``) to an envelope.
+def _response_to_await(resolved: Outcome | None) -> AwaitResponse:
+    """Map a :func:`derive_response` ``Outcome`` (or ``None``) to an envelope.
 
-    The one place the resolver's ``is_error`` bit becomes the 3-valued ``outcome``:
-    a ``cancelled``-kinded error surfaces as ``cancelled`` (uniform child-death
-    notify), any other error as ``errored``, a clean response as ``ok``. Keep the
+    The one place the resolved kind becomes the 3-valued ``outcome``: a
+    ``cancelled``-kinded ``Err`` surfaces as ``cancelled`` (uniform child-death
+    notify), any other ``Err`` as ``errored``, an ``Ok`` as ``ok``. Keep the
     error→outcome classification in lockstep with
     :func:`aios.services.trace_normalizer.normalize_response` (the display twin).
     """
     if resolved is None:
         return AwaitResponse(outcome=None)
-    if resolved.get("is_error"):
-        error = resolved.get("error")
+    if isinstance(resolved, Err):
+        error = resolved.error
         kind = error.get("kind") if isinstance(error, dict) else None
         outcome: Literal["errored", "cancelled"] = "cancelled" if kind == "cancelled" else "errored"
         return AwaitResponse(outcome=outcome, error=error)
-    return AwaitResponse(outcome="ok", result=resolved.get("result"))
+    return AwaitResponse(outcome="ok", result=resolved.result)
 
 
 async def cancel_task(

--- a/src/aios/services/trace.py
+++ b/src/aios/services/trace.py
@@ -31,6 +31,7 @@ from aios.config import get_settings
 from aios.db import queries
 from aios.db.queries import trace as trace_q
 from aios.db.queries import workflows as wf_queries
+from aios.models.sessions import Outcome
 from aios.models.trace import (
     TraceEntry,
     TraceResponse,
@@ -107,7 +108,7 @@ async def get_trace(
         run_journals = await trace_q.read_run_journal_batched(conn, run_ids, account_id=account_id)
         # Resolve each servicer node's caller's-eye response under the SAME
         # snapshot (reusing the #1126 resolvers).
-        responses: dict[str, dict[str, Any] | None] = {}
+        responses: dict[str, Outcome | None] = {}
         for n in nodes:
             if n.request_id is None:
                 continue
@@ -206,7 +207,7 @@ def build_entries(
     run_meta: dict[str, dict[str, Any]],
     session_journals: dict[str, list[dict[str, Any]]],
     run_journals: dict[str, list[dict[str, Any]]],
-    responses: dict[str, dict[str, Any] | None],
+    responses: dict[str, Outcome | None],
     verbose: bool,
     truncated: bool = False,
 ) -> list[TraceEntry]:
@@ -254,7 +255,7 @@ def build_entries(
 def _session_node_entry(
     node: _Node,
     session_meta: dict[str, dict[str, Any]],
-    responses: dict[str, dict[str, Any] | None],
+    responses: dict[str, Outcome | None],
 ) -> TraceEntry:
     meta = session_meta.get(node.id, {})
     if node.request_id is not None:
@@ -287,7 +288,7 @@ def _session_node_entry(
 def _run_node_entry(
     node: _Node,
     run_meta: dict[str, dict[str, Any]],
-    responses: dict[str, dict[str, Any] | None],
+    responses: dict[str, Outcome | None],
 ) -> TraceEntry:
     meta = run_meta.get(node.id, {})
     if node.request_id is not None:

--- a/src/aios/services/trace_normalizer.py
+++ b/src/aios/services/trace_normalizer.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from aios.models.sessions import Err, Outcome
 from aios.models.trace import TerminalState
 
 # Run statuses are persisted on ``wf_runs.status``; sessions have no status
@@ -22,24 +23,24 @@ from aios.models.trace import TerminalState
 _TERMINAL_RUN_STATUSES = {"completed", "errored", "cancelled"}
 
 
-def normalize_response(response: dict[str, Any] | None) -> tuple[TerminalState, str | None]:
+def normalize_response(response: Outcome | None) -> tuple[TerminalState, str | None]:
     """Normalize a **servicer** node's caller's-eye outcome from a resolved response.
 
-    ``response`` is the dict ``derive_response`` / ``derive_run_response``
+    ``response`` is the ``Outcome`` ``derive_response`` / ``derive_run_response``
     returns (or ``None`` when still pending):
 
     * ``None`` → still running (alive and unanswered). Note: an *absent* response
       means running — it is **never** ``no_return``. ``no_return`` is a
       *present* ``request_response`` with ``error.kind == 'no_return'`` (written
-      by the quiescence guard), so it lands in the ``is_error`` branch below.
-    * ``is_error`` → ``errored`` + the raw ``error.kind`` (``no_return``,
+      by the quiescence guard), so it lands in the ``Err`` branch below.
+    * ``Err`` → ``errored`` + the raw ``error.kind`` (``no_return``,
       ``child_gone``, …) passed through verbatim.
-    * otherwise → ``ok``.
+    * otherwise (``Ok``) → ``ok``.
     """
     if response is None:
         return "running", None
-    if response.get("is_error"):
-        error = response.get("error") or {}
+    if isinstance(response, Err):
+        error = response.error or {}
         kind = error.get("kind") if isinstance(error, dict) else None
         return "errored", kind
     return "ok", None

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -157,9 +157,7 @@ async def fail_all_open_requests(
     async with pool.acquire() as conn:
         open_ids = await queries.get_open_request_ids(conn, session_id, account_id=account_id)
     for request_id in open_ids:
-        await respond_to_request(
-            pool, session_id, request_id=request_id, outcome=Err(error=error)
-        )
+        await respond_to_request(pool, session_id, request_id=request_id, outcome=Err(error=error))
 
 
 async def _finish(

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -38,6 +38,7 @@ import jsonschema
 
 from aios.db import queries
 from aios.harness import runtime
+from aios.models.sessions import Err, Ok, Outcome
 from aios.services import sessions as sessions_service
 from aios.services.wake import defer_run_wake
 from aios.tools.registry import ToolResult, openai_tool_entry, registry
@@ -91,9 +92,7 @@ async def respond_to_request(
     session_id: str,
     *,
     request_id: str,
-    is_error: bool,
-    result: Any,
-    error: dict[str, Any] | None,
+    outcome: Outcome,
 ) -> str:
     """Write one request's response and wake its caller — the shared core behind
     every `invoke_session` response (``return``/``error``, the harness erroring
@@ -125,9 +124,7 @@ async def respond_to_request(
             conn,
             session_id,
             request_id=request_id,
-            is_error=is_error,
-            result=result,
-            error=error,
+            outcome=outcome,
         )
     if write.wake_run_id is not None:
         # batch: child completions are the high-frequency wake source — a fan-out's
@@ -161,12 +158,12 @@ async def fail_all_open_requests(
         open_ids = await queries.get_open_request_ids(conn, session_id, account_id=account_id)
     for request_id in open_ids:
         await respond_to_request(
-            pool, session_id, request_id=request_id, is_error=True, result=None, error=error
+            pool, session_id, request_id=request_id, outcome=Err(error=error)
         )
 
 
 async def _finish(
-    session_id: str, *, request_id: Any, is_error: bool, result: Any, error: dict[str, Any] | None
+    session_id: str, *, request_id: Any, outcome: Outcome
 ) -> dict[str, Any] | ToolResult:
     # ``request_id`` is model-supplied (possibly missing or wrong-typed); a value
     # that isn't an open request resolves to ``unknown_request`` → a tool error the
@@ -175,16 +172,14 @@ async def _finish(
         runtime.require_pool(),
         session_id,
         request_id=request_id,
-        is_error=is_error,
-        result=result,
-        error=error,
+        outcome=outcome,
     )
     if status == "not_a_child":
         return _NOT_A_CHILD
     if status == "unknown_request":
         return _UNKNOWN_REQUEST
     # responded | duplicate — either way the request now has exactly one response.
-    return {"status": "errored" if is_error else "returned"}
+    return {"status": "errored" if isinstance(outcome, Err) else "returned"}
 
 
 def _validate_value(value: Any, schema: dict[str, Any]) -> str | None:
@@ -245,9 +240,7 @@ async def return_handler(session_id: str, arguments: dict[str, Any]) -> dict[str
     return await _finish(
         session_id,
         request_id=arguments.get("request_id"),
-        is_error=False,
-        result=arguments.get("value"),
-        error=None,
+        outcome=Ok(result=arguments.get("value")),
     )
 
 
@@ -255,9 +248,7 @@ async def error_handler(session_id: str, arguments: dict[str, Any]) -> dict[str,
     return await _finish(
         session_id,
         request_id=arguments.get("request_id"),
-        is_error=True,
-        result=None,
-        error={"message": arguments.get("message")},
+        outcome=Err(error={"message": arguments.get("message")}),
     )
 
 

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -47,6 +47,7 @@ from aios.errors import ConflictError, ForbiddenError, NotFoundError, RateLimite
 from aios.harness import runtime
 from aios.logging import get_logger
 from aios.models.attenuation import api_base_of, surface_of
+from aios.models.sessions import Err, Outcome
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent, WfRunStatus
 from aios.services import attenuation as attenuation_service
 from aios.services.sessions import (
@@ -188,15 +189,16 @@ def _escalate(cur: StepDisposition, to: StepDisposition) -> StepDisposition:
     return to if _RANK[to] > _RANK[cur] else cur
 
 
-def _memo_outcome(call_result_payload: dict[str, Any]) -> dict[str, Any]:
-    """Map a ``call_result`` payload to the host memo's tagged outcome: a value the
-    driver fast-forwards into the await (``{"ok": value}``), or an error it throws
-    there as ``AgentError`` (``{"error": {...}}``). The discriminated union lets the
-    host tell "the agent answered" from "the agent failed" even when the answer is
-    itself a dict — the real value always nests one level under ``"ok"``."""
-    if call_result_payload.get("is_error"):
-        return {"error": call_result_payload.get("error")}
-    return {"ok": call_result_payload.get("result")}
+def _memo_outcome(outcome: Outcome) -> dict[str, Any]:
+    """Map an ``Outcome`` to the host memo's tagged shape: a value the driver
+    fast-forwards into the await (``{"ok": value}``), or an error it throws there as
+    ``AgentError`` (``{"error": {...}}``). The discriminated union lets the host tell
+    "the agent answered" from "the agent failed" even when the answer is itself a
+    dict — the real value always nests one level under ``"ok"``. The kind is the
+    discriminator; no ``is_error`` re-derivation."""
+    if outcome.kind == "ok":
+        return {"ok": outcome.result}
+    return {"error": outcome.error}
 
 
 async def _resolve_agent_call(
@@ -208,7 +210,7 @@ async def _resolve_agent_call(
     started_at: datetime,
     now: datetime,
     deadline: timedelta,
-) -> dict[str, Any] | None:
+) -> Outcome | None:
     """The outcome of one inflight ``agent()`` call, or ``None`` if it is still
     pending and within its wall-clock deadline.
 
@@ -235,9 +237,7 @@ async def _resolve_agent_call(
             child_id,
             account_id=account_id,
             request_id=request_id,
-            is_error=True,
-            result=None,
-            error={"kind": "timeout"},
+            outcome=Err(error={"kind": "timeout"}),
         )
     resolved = await db_queries.derive_response(
         conn, child_id, account_id=account_id, request_id=request_id
@@ -363,7 +363,7 @@ async def _run_workflow_step_body(
             return
 
         memo: dict[str, Any] = {
-            e.call_key: _memo_outcome(e.payload)
+            e.call_key: _memo_outcome(db_queries.outcome_from_jsonb(e.payload))
             for e in events
             if e.type == "call_result" and e.call_key is not None
         }
@@ -397,7 +397,7 @@ async def _run_workflow_step_body(
             if cap_payload.get("capability") == "agent":
                 # The child was invoked with request_id = call_key (the agent() call
                 # IS the request), so its outcome is derived under that same id.
-                result_payload = await _resolve_agent_call(
+                call_outcome = await _resolve_agent_call(
                     conn,
                     account_id=account_id,
                     child_id=cap_payload["child_session_id"],
@@ -406,11 +406,13 @@ async def _run_workflow_step_body(
                     now=now,
                     deadline=agent_deadline,
                 )
-                if result_payload is None:
+                if call_outcome is None:
                     continue  # still pending, within deadline — stay suspended
+                # Serialize the kind to the flat call_result JSONB once (the journal
+                # shape is unchanged), then merge the agent-only usage enrichment.
                 result_payload = await _enrich_agent_result(
                     conn,
-                    result_payload,
+                    db_queries.outcome_to_jsonb(call_outcome),
                     account_id=account_id,
                     child_id=cap_payload["child_session_id"],
                     started_at=cap_event.created_at,
@@ -424,13 +426,14 @@ async def _run_workflow_step_body(
                 # await: a replay re-drives this fold from the journaled
                 # call_result (memo already carries the outcome; this arm is not
                 # reached), and a fresh wake resolves it from the durable log.
-                result_payload = await wf_queries.derive_run_response(
+                call_outcome = await wf_queries.derive_run_response(
                     conn,
                     cap_payload["child_run_id"],
                     account_id=account_id,
                 )
-                if result_payload is None:
+                if call_outcome is None:
                     continue  # sub-run still in-flight and unanswered — stay suspended
+                result_payload = db_queries.outcome_to_jsonb(call_outcome)
             elif cap_payload.get("capability") == "tool":
                 sig = signals.get(call_key)
                 if sig is None and not run_tools.has_inflight(run_id, call_key):
@@ -482,7 +485,7 @@ async def _run_workflow_step_body(
             )
             # memo carries the host's tagged outcome (R3): an `{ok}` value to
             # fast-forward into the await, or an `{error}` to throw as AgentError.
-            memo[call_key] = _memo_outcome(result_payload)
+            memo[call_key] = _memo_outcome(db_queries.outcome_from_jsonb(result_payload))
             del inflight[call_key]
             harvested = True
 

--- a/tests/integration/test_await_session.py
+++ b/tests/integration/test_await_session.py
@@ -27,6 +27,7 @@ from aios.db.listen import open_listen_for_events
 from aios.db.pool import create_pool
 from aios.db.sse_lock import has_subscriber
 from aios.errors import NotFoundError
+from aios.models.sessions import Ok
 from aios.models.tasks import AwaitResponse
 from aios.services import sessions as service
 from aios.services import tasks as tasks_service
@@ -92,9 +93,7 @@ async def test_request_already_responded_ok_with_result(
             session_id,
             account_id=account_id,
             request_id="req1",
-            is_error=False,
-            result={"answer": 7},
-            error=None,
+            outcome=Ok(result={"answer": 7}),
         )
 
     resp = await _await_request(
@@ -161,9 +160,7 @@ async def test_request_wakes_on_response_during_wait(
                 session_id,
                 account_id=account_id,
                 request_id="req_race",
-                is_error=False,
-                result="hi",
-                error=None,
+                outcome=Ok(result="hi"),
             )
 
     resp, _ = await asyncio.gather(

--- a/tests/integration/test_durable_await_resume.py
+++ b/tests/integration/test_durable_await_resume.py
@@ -37,6 +37,7 @@ from aios.harness import runtime
 from aios.harness.inflight_tool_registry import InflightToolRegistry
 from aios.harness.sweep import find_and_repair_ghosts
 from aios.models.agents import ToolSpec
+from aios.models.sessions import Ok
 from aios.services import workflows as wf_service
 from aios.tools import workflow_completion
 from tests.integration.conftest import seed_agent_env_session
@@ -311,7 +312,7 @@ async def test_resume_parked_lands_answer_without_start_span(
     )
     # The servicer already answered during the worker's downtime.
     await workflow_completion.respond_to_request(
-        pool, servicer, request_id="req_done", is_error=False, result={"v": 42}, error=None
+        pool, servicer, request_id="req_done", outcome=Ok(result={"v": 42})
     )
     # _park_on_task reads the LISTEN db_url off settings; point it at the test DB.
     monkeypatch.setattr(

--- a/tests/integration/test_invoke_session.py
+++ b/tests/integration/test_invoke_session.py
@@ -183,7 +183,7 @@ async def test_non_child_session_answers_via_respond_to_request(
         resolved = await queries.derive_response(
             conn, target.id, account_id=account_id, request_id=handle.request_id
         )
-    assert resolved == {"result": {"answer": 7}, "is_error": False, "error": None}
+    assert resolved == Ok(result={"answer": 7})
     # Single-shot: the request is now answered (no longer open).
     async with pool.acquire() as conn:
         open_ids = await queries.get_open_request_ids(conn, target.id, account_id=account_id)

--- a/tests/integration/test_invoke_session.py
+++ b/tests/integration/test_invoke_session.py
@@ -32,6 +32,7 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import NotFoundError
 from aios.harness import runtime
+from aios.models.sessions import Ok
 from aios.services import sessions as service
 from aios.tools import workflow_completion
 from tests.integration.conftest import seed_agent_env_session
@@ -174,9 +175,7 @@ async def test_non_child_session_answers_via_respond_to_request(
         pool,
         target.id,
         request_id=handle.request_id,
-        is_error=False,
-        result={"answer": 7},
-        error=None,
+        outcome=Ok(result={"answer": 7}),
     )
     assert status == "responded"
 
@@ -215,7 +214,7 @@ async def test_session_owns_open_request_gate(
     assert await _owes()
 
     await workflow_completion.respond_to_request(
-        pool, target.id, request_id=handle.request_id, is_error=False, result="ok", error=None
+        pool, target.id, request_id=handle.request_id, outcome=Ok(result="ok")
     )
     assert not await _owes()
 
@@ -230,10 +229,10 @@ async def test_duplicate_answer_is_idempotent(
     )
 
     first = await workflow_completion.respond_to_request(
-        pool, target.id, request_id=handle.request_id, is_error=False, result=1, error=None
+        pool, target.id, request_id=handle.request_id, outcome=Ok(result=1)
     )
     second = await workflow_completion.respond_to_request(
-        pool, target.id, request_id=handle.request_id, is_error=False, result=2, error=None
+        pool, target.id, request_id=handle.request_id, outcome=Ok(result=2)
     )
     assert first == "responded"
     assert second == "duplicate"  # first-writer-wins

--- a/tests/integration/test_model_task_tools.py
+++ b/tests/integration/test_model_task_tools.py
@@ -29,6 +29,7 @@ from aios.db.queries import workflows as wf_queries
 from aios.harness import runtime
 from aios.harness.inflight_tool_registry import InflightToolRegistry
 from aios.models.agents import ToolSpec
+from aios.models.sessions import Ok
 from aios.services import tasks as tasks_service
 from aios.services import workflows as wf_service
 from aios.tools import tasks as task_tools
@@ -180,7 +181,7 @@ async def test_list_open_tasks_only_open_and_own(
         request_id="req_answered",
     )
     await workflow_completion.respond_to_request(
-        pool, servicer_done, request_id="req_answered", is_error=False, result={"v": 1}, error=None
+        pool, servicer_done, request_id="req_answered", outcome=Ok(result={"v": 1})
     )
     # tc_run: a run servicer, pending → listed.
     run_id = await _seed_run(
@@ -323,7 +324,7 @@ async def test_stop_task_already_resolved(env: tuple[asyncpg.Pool[Any], str]) ->
         request_id="req_done",
     )
     await workflow_completion.respond_to_request(
-        pool, servicer, request_id="req_done", is_error=False, result={"v": 9}, error=None
+        pool, servicer, request_id="req_done", outcome=Ok(result={"v": 9})
     )
 
     out = await task_tools.stop_task_handler(caller, {"tool_call_id": "tc_done"})

--- a/tests/integration/test_obligations_tail_block.py
+++ b/tests/integration/test_obligations_tail_block.py
@@ -28,6 +28,7 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.harness import runtime
 from aios.harness.step_context import compose_step_context, compute_step_prelude
+from aios.models.sessions import Ok
 from aios.services import agents as agents_service
 from aios.services import sessions as sessions_service
 from tests.integration.conftest import seed_agent_env_session
@@ -201,9 +202,7 @@ async def test_answering_drops_the_block_on_next_compose(
             session.id,
             account_id=account_id,
             request_id="req-drop",
-            is_error=False,
-            result={"ok": True},
-            error=None,
+            outcome=Ok(result={"ok": True}),
         )
 
     after = await _prelude_and_compose(

--- a/tests/integration/test_request_opened_edge.py
+++ b/tests/integration/test_request_opened_edge.py
@@ -24,6 +24,7 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.ids import REQUEST, make_id
 from aios.models.attenuation import Surface
+from aios.models.sessions import Ok
 from aios.services import sessions as service
 from aios.services.sessions import AskNewSession, TellNewSession
 from tests.integration.conftest import seed_agent_env_session
@@ -137,9 +138,7 @@ async def test_request_opened_appears_then_response_drops_it(
             session.id,
             account_id=account_id,
             request_id="req-1",
-            is_error=False,
-            result={"ok": True},
-            error=None,
+            outcome=Ok(result={"ok": True}),
         )
         assert wrote is True
     async with pool.acquire() as conn:
@@ -687,9 +686,7 @@ async def test_get_open_obligations_oldest_first_and_excludes_answered(
             session.id,
             account_id=account_id,
             request_id="req-2",
-            is_error=False,
-            result={"ok": True},
-            error=None,
+            outcome=Ok(result={"ok": True}),
         )
     async with pool.acquire() as conn:
         obs = await queries.get_open_obligations(conn, session.id, account_id=account_id)

--- a/tests/integration/test_session_cancel_leaf.py
+++ b/tests/integration/test_session_cancel_leaf.py
@@ -24,6 +24,7 @@ from aios.db.pool import create_pool
 from aios.errors import NotFoundError
 from aios.harness.inflight_tool_registry import InflightToolRegistry
 from aios.harness.sweep import find_sessions_needing_inference
+from aios.models.sessions import Err
 from aios.services import sessions as service
 from aios.services import tasks as tasks_service
 from tests.integration.conftest import seed_agent_env_session
@@ -110,7 +111,7 @@ async def test_cancel_marked_session_is_swept_then_leaf_answers_cancelled(
         resolved = await queries.derive_response(
             conn, session_id, account_id=_ACCOUNT, request_id="req_c"
         )
-        assert resolved == {"result": None, "is_error": True, "error": {"kind": "cancelled"}}
+        assert resolved == Err(error={"kind": "cancelled"})
         # The request is closed (answered), and the marker is harvested → no re-wake.
         assert await queries.get_open_request_ids(conn, session_id, account_id=_ACCOUNT) == []
         marker = await queries.get_session_cancel_marker(
@@ -166,7 +167,7 @@ async def test_cancel_task_session_seeds_tombstone_and_marker_end_to_end(
         resolved = await queries.derive_response(
             conn, session_id, account_id=_ACCOUNT, request_id="req_x"
         )
-        assert resolved == {"result": None, "is_error": True, "error": {"kind": "cancelled"}}
+        assert resolved == Err(error={"kind": "cancelled"})
 
     # Idempotent: re-cancelling the same edge is a no-op (ON CONFLICT).
     await tasks_service.cancel_task(

--- a/tests/integration/test_tasks.py
+++ b/tests/integration/test_tasks.py
@@ -30,6 +30,7 @@ from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import NotFoundError, ValidationError
 from aios.harness import runtime
+from aios.models.sessions import Ok
 from aios.services import sessions as service
 from aios.services import tasks as tasks_service
 from aios.services import workflows as wf_service
@@ -151,9 +152,7 @@ async def test_agent_request_correlates_await_to_response(
             handle.servicer_id,
             account_id=account_id,
             request_id=handle.request_id,
-            is_error=False,
-            result={"answer": 42},
-            error=None,
+            outcome=Ok(result={"answer": 42}),
         )
 
     resp = await tasks_service.await_task(

--- a/tests/integration/test_wake_priority_context.py
+++ b/tests/integration/test_wake_priority_context.py
@@ -21,6 +21,7 @@ import pytest
 
 from aios.db import queries
 from aios.db.pool import create_pool
+from aios.models.sessions import Ok
 from tests.integration.conftest import seed_agent_env_session
 
 pytestmark = pytest.mark.integration
@@ -98,9 +99,7 @@ async def _close_edge(pool: asyncpg.Pool[Any], *, session_id: str, request_id: s
             session_id,
             account_id=_ACCOUNT,
             request_id=request_id,
-            is_error=False,
-            result={"ok": True},
-            error=None,
+            outcome=Ok(result={"ok": True}),
         )
     assert wrote
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -32,7 +32,7 @@ from aios.harness import runtime
 from aios.ids import REQUEST, make_id
 from aios.models.agents import HttpRouteSpec, HttpServerSpec, ToolSpec
 from aios.models.attenuation import Surface
-from aios.models.sessions import Session
+from aios.models.sessions import Err, Ok, Session
 from aios.models.vaults import VaultCredentialCreate
 from aios.models.workflows import WfRunStatus
 from aios.services import agents as agents_service
@@ -336,8 +336,8 @@ async def test_launcher_receives_gate_opened_and_resume_gate_happy_path(
             conn, launcher.id, account_id="acc_wf", request_id=gate_event.call_key or ""
         )
     assert delivered is not None
-    assert delivered["is_error"] is False
-    assert delivered["result"] == {
+    assert isinstance(delivered, Ok)
+    assert delivered.result == {
         "event": "gate_opened",
         "run_id": run.id,
         "gate_nonce": gate_event.payload["gate_nonce"],
@@ -1316,7 +1316,7 @@ async def test_return_writes_response_and_wakes_caller_without_archiving(
         )
         signals = await wf_queries.list_run_signals(conn, run_id)
     assert response is not None
-    assert response["is_error"] is False and response["result"] == {"answer": 42}
+    assert isinstance(response, Ok) and response.result == {"answer": 42}
     # The child_done side-marker committed with the response (#780): a lost caller
     # wake stays SQL-visible to the needs-step sweep.
     assert [(s.call_key, s.kind) for s in signals] == [("sha:d2#0", "child_done")]
@@ -1341,8 +1341,8 @@ async def test_error_marker_carries_message(
         marker = await db_queries.read_request_response(
             conn, cid, account_id="acc_wf", request_id="sha:d2e#0"
         )
-    assert marker is not None and marker["is_error"] is True
-    assert marker["error"] == {"message": "nope"}
+    assert isinstance(marker, Err)
+    assert marker.error == {"message": "nope"}
 
 
 async def test_return_from_non_child_fails_closed(
@@ -1454,7 +1454,7 @@ async def test_return_real_dispatch_appends_result_and_does_not_archive(
     assert result is not None and not bool(result.data.get("is_error"))
     spans = [e.data.get("event") for e in events if e.kind == "span"]
     assert spans.count("tool_execute_start") == 1 and spans.count("tool_execute_end") == 1
-    assert marker is not None and marker["result"] == "ok"
+    assert isinstance(marker, Ok) and marker.result == "ok"
     child = await sessions_service.get_session_basic(pool, cid, account_id="acc_wf")
     assert child.archived_at is None  # un-archived → a sibling tool's appends won't crash
 
@@ -1675,7 +1675,7 @@ async def test_model_failure_writes_error_response_and_run_resolves(
             conn, child_id, account_id="acc_wf", request_id=rid
         )
     assert response is not None
-    assert response["is_error"] is True and response["error"] == {"kind": "child_errored"}
+    assert isinstance(response, Err) and response.error == {"kind": "child_errored"}
 
     await run_workflow_step(run_id)  # harvest the error response -> resolve (no hang)
     async with pool.acquire() as conn:
@@ -1722,7 +1722,7 @@ async def test_model_failure_does_not_clobber_a_prior_response(
         )
     assert len(rows) == 1  # still exactly one response
     response = rows[0]["data"]
-    assert response["is_error"] is False and response["result"] == "real"  # the return() won
+    assert isinstance(response, Ok) and response.result == "real"  # the return() won
 
 
 # ─── R4 — the session-quiescence totality guard (nudge → no_return) ───────────
@@ -1949,7 +1949,7 @@ async def test_open_request_is_auto_errored_after_nudge_budget(
         open_ids = await db_queries.get_open_request_ids(conn, cid, account_id="acc_wf")
         status = await db_queries.derive_session_status(conn, cid, account_id="acc_wf")
         signals = await wf_queries.list_run_signals(conn, run_id)
-    assert resp is not None and resp["is_error"] is True and resp["error"] == {"kind": "no_return"}
+    assert isinstance(resp, Err) and resp.error == {"kind": "no_return"}
     assert open_ids == []  # answered (by the backstop) → no longer open
     assert status == "idle"  # nothing owed → free to rest
     # The backstop is the SECOND response writer — it too leaves the child_done
@@ -2067,7 +2067,7 @@ async def test_no_return_after_exactly_n_consecutive_idle_turns(
         resp = await db_queries.read_request_response(
             conn, cid, account_id="acc_wf", request_id="sha:stuck#0"
         )
-    assert resp is not None and resp["is_error"] and resp["error"] == {"kind": "no_return"}
+    assert isinstance(resp, Err) and resp.error == {"kind": "no_return"}
 
 
 async def test_per_request_count_is_independent_stuck_sibling_still_no_returns(
@@ -2143,9 +2143,7 @@ async def test_per_request_count_is_independent_stuck_sibling_still_no_returns(
             cid,
             account_id="acc_wf",
             request_id="sha:a#0",
-            is_error=False,
-            result="done-A",
-            error=None,
+            outcome=Ok(result="done-A"),
         )
         assert wrote
         count_a = await db_queries.count_request_nudges(
@@ -2182,8 +2180,8 @@ async def test_per_request_count_is_independent_stuck_sibling_still_no_returns(
         resp_b = await db_queries.read_request_response(
             conn, cid, account_id="acc_wf", request_id="sha:b#0"
         )
-    assert resp_a is not None and resp_a["is_error"] is False  # A's real answer stands
-    assert resp_b is not None and resp_b["error"] == {"kind": "no_return"}  # sibling not spared
+    assert isinstance(resp_a, Ok)  # A's real answer stands
+    assert isinstance(resp_b, Err) and resp_b.error == {"kind": "no_return"}  # sibling not spared
 
 
 async def test_non_answering_child_resolves_run_via_agent_no_return_error(
@@ -2338,9 +2336,7 @@ async def test_child_reclaimed_on_quiescence_and_parent_still_harvests(
             cid,
             account_id="acc_wf",
             request_id="sha:reclaim#0",
-            is_error=False,
-            result={"answer": 42},
-            error=None,
+            outcome=Ok(result={"answer": 42}),
         )
     result = await sessions_service.append_assistant_and_guard_quiescence(
         pool, cid, await _idle_assistant_turn(pool, cid), account_id="acc_wf"
@@ -2357,7 +2353,7 @@ async def test_child_reclaimed_on_quiescence_and_parent_still_harvests(
         resp = await db_queries.derive_response(
             conn, cid, account_id="acc_wf", request_id="sha:reclaim#0"
         )
-    assert resp is not None and resp["is_error"] is False and resp["result"] == {"answer": 42}
+    assert isinstance(resp, Ok) and resp.result == {"answer": 42}
 
 
 async def test_archive_when_idle_persists_across_launch_surfaces(
@@ -2447,7 +2443,7 @@ async def test_operator_archived_child_resolves_run_as_child_gone(
         resolved = await db_queries.derive_response(
             conn, child_id, account_id="acc_wf", request_id=request_id
         )
-    assert resolved == {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
+    assert resolved == Err(error={"kind": "child_gone"})
 
     await run_workflow_step(run_id)  # harvest -> child_gone -> AgentError -> caught
     async with pool.acquire() as conn:
@@ -2526,8 +2522,8 @@ async def test_archive_child_commits_response_and_child_done_atomically(
             child_id,
             "acc_wf",
         )
-    assert response is not None and response["is_error"] is True
-    assert response["error"] == {"kind": "child_gone"}
+    assert isinstance(response, Err)
+    assert response.error == {"kind": "child_gone"}
     assert signal is not None and signal.kind == "child_done"
     assert archived_at is not None
 
@@ -3151,7 +3147,7 @@ async def test_agent_call_times_out_when_child_never_responds(
         child = await db_queries.get_session_bare(conn, child_id, account_id="acc_wf")
     assert run is not None and run.status == "completed"
     assert run.output == {"timed_out": "timeout"}
-    assert resp is not None and resp["is_error"] is True and resp["error"] == {"kind": "timeout"}
+    assert isinstance(resp, Err) and resp.error == {"kind": "timeout"}
     assert child.archived_at is None  # left running — responding ≠ terminating
 
 
@@ -3194,7 +3190,7 @@ async def test_past_deadline_child_that_already_responded_keeps_its_real_respons
             conn, child_id, account_id="acc_wf", request_id=rid
         )
     assert run is not None and run.status == "completed" and run.output == "real"
-    assert resp is not None and resp["is_error"] is False and resp["result"] == "real"
+    assert isinstance(resp, Ok) and resp.result == "real"
 
 
 async def test_past_deadline_gone_child_resolves_as_child_gone_not_timeout(
@@ -3420,8 +3416,8 @@ async def test_epoch_mismatch_fails_child_open_requests(
         )
         signals = await wf_queries.list_run_signals(conn, run_id)
     assert response is not None
-    assert response["is_error"] is True
-    assert response["error"] == {"kind": "engine_semantics_changed"}
+    assert isinstance(response, Err)
+    assert response.error == {"kind": "engine_semantics_changed"}
     assert any(s.call_key == request_id and s.kind == "child_done" for s in signals)
 
 
@@ -3453,8 +3449,8 @@ async def test_nondeterministic_replay_fails_child_open_requests(
         )
     assert run is not None and run.status == "errored"
     assert response is not None
-    assert response["is_error"] is True
-    assert response["error"] == {"kind": "nondeterministic_replay"}
+    assert isinstance(response, Err)
+    assert response.error == {"kind": "nondeterministic_replay"}
 
 
 async def test_gate_parked_run_detects_epoch_mismatch_on_next_wake(
@@ -3874,7 +3870,7 @@ async def test_return_enforces_output_schema(
         resp = await db_queries.read_request_response(
             conn, cid, account_id="acc_wf", request_id="se:1"
         )
-    assert resp is not None and resp["result"] == {"answer": "yes"}
+    assert isinstance(resp, Ok) and resp.result == {"answer": "yes"}
 
 
 async def test_malformed_output_schema_errors_the_run(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -4273,11 +4273,11 @@ async def test_derive_run_response_reads_the_terminal_record(
         cancelled = await wf_queries.derive_run_response(conn, cancelled_run, account_id="acc_wf")
         pending = await wf_queries.derive_run_response(conn, pending_run, account_id="acc_wf")
 
-    assert ok == {"result": 7, "is_error": False, "error": None}
-    assert err is not None and err["is_error"] is True and err["result"] is None
-    assert err["error"]["kind"] == "author_exception"
+    assert ok == Ok(result=7)
+    assert isinstance(err, Err)
+    assert err.error["kind"] == "author_exception"
     # The cancel semantic the §3.6 merge had to preserve: cancelled, not child_gone.
-    assert cancelled == {"result": None, "is_error": True, "error": {"kind": "cancelled"}}
+    assert cancelled == Err(error={"kind": "cancelled"})
     assert pending is None
 
 

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -1722,7 +1722,7 @@ async def test_model_failure_does_not_clobber_a_prior_response(
         )
     assert len(rows) == 1  # still exactly one response
     response = rows[0]["data"]
-    assert isinstance(response, Ok) and response.result == "real"  # the return() won
+    assert response["is_error"] is False and response["result"] == "real"  # the return() won
 
 
 # ─── R4 — the session-quiescence totality guard (nudge → no_return) ───────────

--- a/tests/unit/test_request_outcome.py
+++ b/tests/unit/test_request_outcome.py
@@ -1,0 +1,125 @@
+"""The request-answer ``Ok | Err`` outcome kind (#1555).
+
+Master-failing by construction: ``Ok`` / ``Err`` / ``Outcome`` and the
+``outcome_to_jsonb`` / ``outcome_from_jsonb`` codec do not exist on master, so
+this module fails to import there and passes after the change.
+
+It asserts the kind is **total** and **round-trips** through the one JSONB codec,
+and that the six illegal ``(is_error, result, error)`` product states are
+**unconstructable** — an ``Err`` with no error raises, and ``Ok`` has no error
+slot at all. A second block asserts the readers (``derive_response`` /
+``derive_run_response``) return an ``Err`` *kind* (not a flat ``is_error=True``
+dict) for the ``child_gone`` / ``cancelled`` arms.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from aios.db.queries import outcome_from_jsonb, outcome_to_jsonb
+from aios.models.sessions import Err, Ok, Outcome
+
+# ─── totality + round-trip ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        Ok(result=None),
+        Ok(result={"answer": 42}),
+        Ok(result=[1, 2, 3]),
+        Ok(result="a string"),
+        Ok(result=0),
+        Err(error={"kind": "timeout"}),
+        Err(error={"kind": "child_gone"}),
+        Err(error={"kind": "cancelled"}),
+        Err(error={"kind": "no_return"}),
+        Err(error={"message": "boom"}),
+    ],
+)
+def test_outcome_round_trips_through_the_codec(outcome: Outcome) -> None:
+    # outcome_from_jsonb(outcome_to_jsonb(o)) == o for every Ok / Err.
+    assert outcome_from_jsonb(outcome_to_jsonb(outcome)) == outcome
+
+
+def test_to_jsonb_derives_the_flat_echo_from_the_kind() -> None:
+    # The on-disk echo is derived from the kind, never hand-paired.
+    assert outcome_to_jsonb(Ok(result={"x": 1})) == {
+        "is_error": False,
+        "result": {"x": 1},
+        "error": None,
+    }
+    assert outcome_to_jsonb(Err(error={"kind": "timeout"})) == {
+        "is_error": True,
+        "result": None,
+        "error": {"kind": "timeout"},
+    }
+
+
+def test_from_jsonb_reads_the_flat_shape_back_into_a_kind() -> None:
+    ok = outcome_from_jsonb({"is_error": False, "result": {"x": 1}, "error": None})
+    assert isinstance(ok, Ok) and ok.result == {"x": 1}
+    err = outcome_from_jsonb({"is_error": True, "result": None, "error": {"kind": "child_gone"}})
+    assert isinstance(err, Err) and err.error == {"kind": "child_gone"}
+
+
+def test_from_jsonb_collapses_the_run_completed_shape() -> None:
+    # The run_completed bookend carries {output, is_error, error}; derive_run_response
+    # maps it through the same codec against ``output`` — assert the {is_error,result}
+    # arm reads identically (an old success row with only ``output`` is rename-handled
+    # at the reader, but a plain {is_error:False, result} still reads as Ok here).
+    assert outcome_from_jsonb({"is_error": False, "result": "child-result"}) == Ok(
+        result="child-result"
+    )
+    assert outcome_from_jsonb({"is_error": True, "error": {"message": "boom"}}) == Err(
+        error={"message": "boom"}
+    )
+
+
+# ─── illegal product states are unconstructable ──────────────────────────────
+
+
+def test_err_requires_an_error() -> None:
+    # Err always carries an error — `Err()` with no error is a ValidationError, so the
+    # illegal ``is_error=True, error=None`` pairing cannot be expressed.
+    with pytest.raises(ValidationError):
+        Err()  # type: ignore[call-arg]
+
+
+def test_ok_has_no_error_slot() -> None:
+    # There is no field on Ok that accepts an error — the illegal ``is_error=False``
+    # with a non-null error cannot be expressed (frozen models forbid extra fields by
+    # default; Pydantic ignores unknown kwargs, so the constructed Ok carries no error).
+    ok = Ok(result=1)
+    assert not hasattr(ok, "error")
+    # and the kind discriminant is fixed
+    assert ok.kind == "ok"
+    assert Err(error={}).kind == "err"
+
+
+def test_outcomes_are_frozen() -> None:
+    ok = Ok(result=1)
+    with pytest.raises(ValidationError):
+        ok.result = 2  # type: ignore[misc]
+
+
+# ─── the readers return the kind, not a flat dict ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ({"is_error": True, "result": None, "error": {"kind": "child_gone"}}, "child_gone"),
+        ({"is_error": True, "result": None, "error": {"kind": "cancelled"}}, "cancelled"),
+        ({"is_error": True, "result": None, "error": {"kind": "timeout"}}, "timeout"),
+    ],
+)
+def test_error_arms_deserialize_as_err_kind(data: dict[str, Any], expected: str) -> None:
+    # The synthesized child_gone / cancelled / timeout arms are an ``Err`` kind, not a
+    # ``{is_error: True}`` dict — assert against the kind a reader hands back.
+    out = outcome_from_jsonb(data)
+    assert isinstance(out, Err)
+    assert out.error == {"kind": expected}

--- a/tests/unit/test_trace_normalizer.py
+++ b/tests/unit/test_trace_normalizer.py
@@ -11,6 +11,7 @@ Pins the locked decisions:
 
 from __future__ import annotations
 
+from aios.models.sessions import Err, Ok
 from aios.services import trace_normalizer as norm
 
 # ─── servicer nodes (derive_response / derive_run_response output) ────────────
@@ -22,21 +23,19 @@ def test_absent_response_is_running_not_no_return() -> None:
 
 
 def test_no_return_is_a_present_errored_response() -> None:
-    resp = {"result": None, "is_error": True, "error": {"kind": "no_return"}}
-    assert norm.normalize_response(resp) == ("errored", "no_return")
+    assert norm.normalize_response(Err(error={"kind": "no_return"})) == ("errored", "no_return")
 
 
 def test_child_gone_passes_through_verbatim() -> None:
-    resp = {"result": None, "is_error": True, "error": {"kind": "child_gone"}}
-    assert norm.normalize_response(resp) == ("errored", "child_gone")
+    assert norm.normalize_response(Err(error={"kind": "child_gone"})) == ("errored", "child_gone")
 
 
 def test_ok_response() -> None:
-    assert norm.normalize_response({"result": 42, "is_error": False}) == ("ok", None)
+    assert norm.normalize_response(Ok(result=42)) == ("ok", None)
 
 
 def test_errored_without_error_kind_is_none() -> None:
-    assert norm.normalize_response({"is_error": True, "error": None}) == ("errored", None)
+    assert norm.normalize_response(Err(error={})) == ("errored", None)
 
 
 # ─── root runs (wf_runs.status + run_completed payload) ──────────────────────

--- a/tests/unit/test_trace_service.py
+++ b/tests/unit/test_trace_service.py
@@ -18,6 +18,7 @@ import asyncio
 from typing import Any
 
 from aios.db.queries.trace import ChildNode
+from aios.models.sessions import Ok
 from aios.services import trace as svc
 
 
@@ -53,9 +54,9 @@ def test_build_entries_dfs_preorder_and_depth() -> None:
         session_journals={},
         run_journals={},
         responses={
-            "sess_a": {"is_error": False},
-            "wfr_b": {"is_error": False},
-            "sess_c": {"is_error": False},
+            "sess_a": Ok(),
+            "wfr_b": Ok(),
+            "sess_c": Ok(),
         },
         verbose=False,
     )
@@ -98,7 +99,7 @@ def test_agent_call_frame_merged_into_child_not_double_listed() -> None:
         run_meta={"wfr_root": {"status": "running"}},
         session_journals={},
         run_journals=run_journals,
-        responses={"sess_child": {"is_error": False}},
+        responses={"sess_child": Ok()},
         verbose=True,
     )
     # The call_started for the spawned child is NOT emitted as a frame.


### PR DESCRIPTION
Automated dev-pipeline build for issue #1555.