### PR TITLE
Lifecycle-route inbound budget never counts its own wake-bearing traffic — the rate limit is a no-op on this path

### DIFF
--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -67,7 +67,11 @@ from aios.services import inbound as inbound_service
 from aios.services import management_calls
 from aios.services import sessions as sessions_service
 from aios.services.attachment_staging import InboundAttachment
-from aios.services.inbound_budget import check_inbound_budget, check_inbound_budget_session
+from aios.services.inbound_budget import (
+    check_inbound_budget,
+    check_inbound_budget_session,
+    inbound_orig_channel,
+)
 from aios.services.wake import defer_wake
 
 log = get_logger("aios.api.routers.connectors")
@@ -775,6 +779,13 @@ async def post_runtime_session_lifecycle(
             "inbound rate budget exceeded for this session",
             detail={"drop_reason": "rate_limited", "session_id": body.session_id},
         )
+    if body.wake:
+        # Stamp the wake intent that fired the ``defer_wake`` so the budget's
+        # session-grain window can meter this inference-bearing write (#1558).
+        # The no-wake append stays byte-identical (no marker, uncounted); only
+        # ``wake=True`` lifecycle rows carry ``wake`` so internal harness
+        # lifecycle transitions (no ``wake`` key) never burn a budget.
+        payload["wake"] = True
     event = await sessions_service.append_event(
         pool,
         body.session_id,
@@ -895,12 +906,26 @@ async def post_runtime_chat_lifecycle(
                 "chat_id": body.chat_id,
             },
         )
+    # On the wake-bearing path, stamp the wake intent AND the per-counterparty
+    # ``orig_channel`` key so the chat-grain budget window counts this
+    # inference-bearing write on the same key the inbound path uses (#1558).
+    # ``_resolve_event_channel`` returns NULL for any non-``message`` kind, so
+    # stamping ``orig_channel`` on this ``kind='lifecycle'`` row is safe for the
+    # derived ``channel`` column. The no-wake append stays byte-identical (no
+    # marker, no ``orig_channel`` → uncounted).
+    lifecycle_orig_channel: str | None = None
+    if body.wake:
+        payload["wake"] = True
+        lifecycle_orig_channel = inbound_orig_channel(
+            connection.connector, connection.external_account_id, body.chat_id
+        )
     event = await sessions_service.append_event(
         pool,
         session_id,
         "lifecycle",
         payload,
         account_id=account_id,
+        orig_channel=lifecycle_orig_channel,
     )
     if body.wake:
         await defer_wake(

--- a/src/aios/services/inbound_budget.py
+++ b/src/aios/services/inbound_budget.py
@@ -46,6 +46,22 @@ import asyncpg
 
 from aios.config import get_settings
 
+# The "inference-bearing inbound" shape, defined ONCE and shared by both
+# ``_count_recent_*`` counters (single-source rather than duplicated-by-
+# vigilance). Every counted row pairs an append with a ``defer_wake`` → one
+# ``run_session_step`` → one model inference:
+#   * an admitted inbound message (``kind='message'``, ``role='user'``), and
+#   * a wake-bearing connector lifecycle (``kind='lifecycle'`` stamped with
+#     ``wake=True`` by the two single-target wake routes, #1558).
+# ``(data->>'wake')::boolean IS TRUE`` matches ONLY the ``wake=True`` lifecycle
+# writes: a no-wake lifecycle and every internal harness lifecycle transition
+# carry no ``wake`` key (``->>`` yields ``NULL`` → not true), so the free paths
+# stay uncounted by construction.
+_INFERENCE_BEARING_PREDICATE = """
+              (kind = 'message'   AND data->>'role' = 'user')
+           OR (kind = 'lifecycle' AND (data->>'wake')::boolean IS TRUE)
+"""
+
 
 def inbound_orig_channel(connector: str, external_account_id: str, chat_id: str) -> str:
     """Build the ``orig_channel`` key a ``role=user`` event is stamped with.
@@ -73,13 +89,12 @@ async def _count_recent_inbounds(
     """
     async with pool.acquire() as conn:
         count = await conn.fetchval(
-            """
+            f"""
             SELECT count(*)
             FROM events
             WHERE account_id = $1
               AND orig_channel = $2
-              AND kind = 'message'
-              AND data->>'role' = 'user'
+              AND ({_INFERENCE_BEARING_PREDICATE})
               AND created_at > now() - make_interval(secs => $3::bigint)
             """,
             account_id,
@@ -108,13 +123,12 @@ async def _count_recent_session_inbounds(
     """
     async with pool.acquire() as conn:
         count = await conn.fetchval(
-            """
+            f"""
             SELECT count(*)
             FROM events
             WHERE account_id = $1
               AND session_id = $2
-              AND kind = 'message'
-              AND data->>'role' = 'user'
+              AND ({_INFERENCE_BEARING_PREDICATE})
               AND created_at > now() - make_interval(secs => $3::bigint)
             """,
             account_id,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1241,11 +1241,24 @@ async def append_event(
     data: dict[str, Any],
     *,
     account_id: str,
+    orig_channel: str | None = None,
 ) -> Event:
-    """Append an arbitrary event. Used by the harness loop."""
+    """Append an arbitrary event. Used by the harness loop.
+
+    ``orig_channel`` is forwarded to :func:`queries.append_event` (which has
+    accepted it since #52). The wake-bearing chat-lifecycle route uses it to
+    stamp the per-counterparty budget key onto its ``kind='lifecycle'`` write so
+    the inbound rate budget can meter it (#1504/#1558); every other caller
+    leaves the default ``None`` and is byte-identical to pre-change.
+    """
     async with pool.acquire() as conn:
         return await queries.append_event(
-            conn, session_id=session_id, kind=kind, data=data, account_id=account_id
+            conn,
+            session_id=session_id,
+            kind=kind,
+            data=data,
+            account_id=account_id,
+            orig_channel=orig_channel,
         )
 
 

--- a/tests/unit/test_inbound_budget.py
+++ b/tests/unit/test_inbound_budget.py
@@ -291,3 +291,272 @@ async def test_within_budget_passes_into_resolution() -> None:
     check_budget.assert_awaited_once()
     resolve_target_session.assert_awaited_once()
     assert result.drop_reason is InboundDrop.DETACHED
+
+
+# ─── #1558: the inference-bearing union — wake-bearing lifecycle is counted ───
+
+
+def _pool_capturing_conn() -> tuple[MagicMock, MagicMock]:
+    """A pool whose acquired conn is the SAME ``MagicMock`` every time, so a
+    test can assert on the ``fetchval`` call args (the built SQL + params).
+    Returns ``(pool, conn)``."""
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=0)
+    pool = MagicMock()
+
+    class _Cm:
+        async def __aenter__(self) -> Any:
+            return conn
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+    pool.acquire.return_value = _Cm()
+    return pool, conn
+
+
+async def test_chat_counter_sql_includes_wake_lifecycle_arm() -> None:
+    """Predicate-level (master-failing): the chat-grain counter's SQL must
+    count the wake-bearing ``kind='lifecycle'`` arm, not just message/role.
+
+    On master the query has ONLY the ``kind = 'message' AND role='user'`` arm,
+    so the ``kind = 'lifecycle'`` ∧ ``wake`` assertion fails."""
+    pool, conn = _pool_capturing_conn()
+    await inbound_budget._count_recent_inbounds(
+        pool, account_id="acc_1", orig_channel="signal/+1/peer", window_seconds=3600
+    )
+    sql = _await_args(conn.fetchval).args[0]
+    # The new inference-bearing union arm.
+    assert "kind = 'lifecycle'" in sql
+    assert "data->>'wake')::boolean IS TRUE" in sql
+    # The original admitted-inbound arm is preserved.
+    assert "kind = 'message'" in sql
+    assert "data->>'role' = 'user'" in sql
+
+
+async def test_session_counter_sql_includes_wake_lifecycle_arm() -> None:
+    """Predicate-level (master-failing): same for the session-grain counter."""
+    pool, conn = _pool_capturing_conn()
+    await inbound_budget._count_recent_session_inbounds(
+        pool, account_id="acc_1", session_id="ses_1", window_seconds=3600
+    )
+    sql = _await_args(conn.fetchval).args[0]
+    assert "kind = 'lifecycle'" in sql
+    assert "data->>'wake')::boolean IS TRUE" in sql
+    assert "kind = 'message'" in sql
+    assert "data->>'role' = 'user'" in sql
+
+
+def test_both_counters_share_one_predicate_fragment() -> None:
+    """The inference-bearing shape is single-sourced (one shared SQL fragment),
+    not duplicated-by-vigilance, so the two counters can never drift apart."""
+    frag = inbound_budget._INFERENCE_BEARING_PREDICATE
+    assert "kind = 'message'" in frag
+    assert "data->>'role' = 'user'" in frag
+    assert "kind = 'lifecycle'" in frag
+    assert "(data->>'wake')::boolean IS TRUE" in frag
+
+
+# ─── #1558: route-level — the wake-bearing lifecycle write is stamped ─────────
+
+
+def _runtime_auth() -> tuple[str, str, str, list[str] | None]:
+    # (token, connector, account_id, connection_ids allowlist)
+    return ("tok", "signal", "acc_1", None)
+
+
+def _route_pool() -> MagicMock:
+    """A pool whose ``acquire()`` yields a conn usable for the routes' inline
+    ``async with pool.acquire() as conn`` lookups (all DB calls are patched at
+    the ``queries`` module, so the conn itself is an inert MagicMock)."""
+    pool = MagicMock()
+    conn = MagicMock()
+
+    class _Cm:
+        async def __aenter__(self) -> Any:
+            return conn
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+    pool.acquire.return_value = _Cm()
+    return pool
+
+
+def _fake_event() -> MagicMock:
+    ev = MagicMock()
+    ev.id = "evt_appended"
+    return ev
+
+
+def _await_args(mock: AsyncMock) -> Any:
+    """Return ``mock.await_args`` narrowed to non-``None`` (mypy/asserts)."""
+    call = mock.await_args
+    assert call is not None
+    return call
+
+
+async def test_session_lifecycle_wake_stamps_wake_marker() -> None:
+    """Route-level (master-failing): a ``wake=True`` session-lifecycle stamps
+    ``wake: True`` on the appended payload so the session-grain budget can meter
+    it. On master the payload has no ``wake`` key ⇒ this fails."""
+    from aios.api.routers.connectors import (
+        RuntimeSessionLifecycleRequest,
+        post_runtime_session_lifecycle,
+    )
+
+    body = RuntimeSessionLifecycleRequest(
+        connection_id="conn_1",
+        session_id="ses_1",
+        event="connector_delivery_failed",
+        wake=True,
+    )
+    append_event = AsyncMock(return_value=_fake_event())
+
+    with (
+        patch(
+            "aios.api.routers.connectors.queries.get_connection",
+            AsyncMock(return_value=_connection()),
+        ),
+        patch("aios.api.routers.connectors._check_runtime_scope", MagicMock()),
+        patch("aios.api.routers.connectors._check_runtime_connection_scope", MagicMock()),
+        patch(
+            "aios.api.routers.connectors.queries.is_session_bound_to_connection",
+            AsyncMock(return_value=True),
+        ),
+        # Budget enabled, and under threshold ⇒ admit (so we reach the append).
+        patch(
+            "aios.api.routers.connectors.check_inbound_budget_session", AsyncMock(return_value=True)
+        ),
+        patch("aios.api.routers.connectors.sessions_service.append_event", append_event),
+        patch("aios.api.routers.connectors.defer_wake", AsyncMock()),
+    ):
+        await post_runtime_session_lifecycle(body, _route_pool(), _runtime_auth())
+
+    call = _await_args(append_event)
+    payload = call.args[3]
+    assert payload["wake"] is True
+
+
+async def test_session_lifecycle_no_wake_omits_marker() -> None:
+    """Regression pin: a ``wake=False`` session-lifecycle writes NO ``wake``
+    marker (the free path stays byte-identical / uncounted)."""
+    from aios.api.routers.connectors import (
+        RuntimeSessionLifecycleRequest,
+        post_runtime_session_lifecycle,
+    )
+
+    body = RuntimeSessionLifecycleRequest(
+        connection_id="conn_1",
+        session_id="ses_1",
+        event="connector_message_delivered",
+        wake=False,
+    )
+    append_event = AsyncMock(return_value=_fake_event())
+    check = AsyncMock(return_value=True)
+
+    with (
+        patch(
+            "aios.api.routers.connectors.queries.get_connection",
+            AsyncMock(return_value=_connection()),
+        ),
+        patch("aios.api.routers.connectors._check_runtime_scope", MagicMock()),
+        patch("aios.api.routers.connectors._check_runtime_connection_scope", MagicMock()),
+        patch(
+            "aios.api.routers.connectors.queries.is_session_bound_to_connection",
+            AsyncMock(return_value=True),
+        ),
+        patch("aios.api.routers.connectors.check_inbound_budget_session", check),
+        patch("aios.api.routers.connectors.sessions_service.append_event", append_event),
+        patch("aios.api.routers.connectors.defer_wake", AsyncMock()),
+    ):
+        await post_runtime_session_lifecycle(body, _route_pool(), _runtime_auth())
+
+    call = _await_args(append_event)
+    payload = call.args[3]
+    assert "wake" not in payload
+    # The no-wake path never even consults the budget.
+    check.assert_not_called()
+
+
+async def test_chat_lifecycle_wake_stamps_wake_and_orig_channel() -> None:
+    """Route-level (master-failing): a ``wake=True`` chat-lifecycle stamps both
+    ``wake: True`` AND ``orig_channel`` (= ``inbound_orig_channel(...)``) so the
+    chat-grain budget counts it on the same key the inbound path uses. On
+    master neither is passed ⇒ this fails."""
+    from aios.api.routers.connectors import (
+        RuntimeChatLifecycleRequest,
+        post_runtime_chat_lifecycle,
+    )
+
+    connection = _connection()
+    body = RuntimeChatLifecycleRequest(
+        connection_id="conn_1",
+        chat_id="peer",
+        event="connector_delivery_failed",
+        wake=True,
+    )
+    append_event = AsyncMock(return_value=_fake_event())
+
+    with (
+        patch(
+            "aios.api.routers.connectors.queries.get_connection", AsyncMock(return_value=connection)
+        ),
+        patch("aios.api.routers.connectors._check_runtime_scope", MagicMock()),
+        patch("aios.api.routers.connectors._check_runtime_connection_scope", MagicMock()),
+        patch(
+            "aios.api.routers.connectors.queries.get_chat_session_row",
+            AsyncMock(return_value=("peer", "ses_resolved", datetime.now(UTC))),
+        ),
+        patch("aios.api.routers.connectors.check_inbound_budget", AsyncMock(return_value=True)),
+        patch("aios.api.routers.connectors.sessions_service.append_event", append_event),
+        patch("aios.api.routers.connectors.defer_wake", AsyncMock()),
+    ):
+        await post_runtime_chat_lifecycle(body, _route_pool(), _runtime_auth())
+
+    call = _await_args(append_event)
+    payload = call.args[3]
+    assert payload["wake"] is True
+    expected_oc = inbound_orig_channel(connection.connector, connection.external_account_id, "peer")
+    assert call.kwargs["orig_channel"] == expected_oc
+
+
+async def test_chat_lifecycle_no_wake_omits_wake_and_orig_channel() -> None:
+    """Regression pin: a ``wake=False`` chat-lifecycle writes no ``wake`` marker
+    and passes no ``orig_channel`` (free path stays uncounted)."""
+    from aios.api.routers.connectors import (
+        RuntimeChatLifecycleRequest,
+        post_runtime_chat_lifecycle,
+    )
+
+    body = RuntimeChatLifecycleRequest(
+        connection_id="conn_1",
+        chat_id="peer",
+        event="connector_message_delivered",
+        wake=False,
+    )
+    append_event = AsyncMock(return_value=_fake_event())
+    check = AsyncMock(return_value=True)
+
+    with (
+        patch(
+            "aios.api.routers.connectors.queries.get_connection",
+            AsyncMock(return_value=_connection()),
+        ),
+        patch("aios.api.routers.connectors._check_runtime_scope", MagicMock()),
+        patch("aios.api.routers.connectors._check_runtime_connection_scope", MagicMock()),
+        patch(
+            "aios.api.routers.connectors.queries.get_chat_session_row",
+            AsyncMock(return_value=("peer", "ses_resolved", datetime.now(UTC))),
+        ),
+        patch("aios.api.routers.connectors.check_inbound_budget", check),
+        patch("aios.api.routers.connectors.sessions_service.append_event", append_event),
+        patch("aios.api.routers.connectors.defer_wake", AsyncMock()),
+    ):
+        await post_runtime_chat_lifecycle(body, _route_pool(), _runtime_auth())
+
+    call = _await_args(append_event)
+    payload = call.args[3]
+    assert "wake" not in payload
+    assert call.kwargs.get("orig_channel") is None
+    check.assert_not_called()


### PR DESCRIPTION
Automated dev-pipeline build for issue #1558.