### PR TITLE
read tool description omits image-inlining → agents cannot discover they can view sandbox images

### DIFF
--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -55,14 +55,21 @@ class ReadArgumentError(AiosError):
 
 
 READ_DESCRIPTION = (
-    "Read a text file inside the session's sandbox. Returns content "
-    "prefixed with 1-indexed line numbers in `LINE_NUM<TAB>CONTENT` "
+    "Read a file inside the session's sandbox. For text files, returns "
+    "content prefixed with 1-indexed line numbers in `LINE_NUM<TAB>CONTENT` "
     "format. Use `offset` and `limit` to page through large files — "
     "`offset` is a 1-indexed line number to start from (default 1), "
     "`limit` is the max number of lines to return (default 2000). "
     "Paths may be absolute or relative to /workspace. Prefer this "
     "over `cat`/`head`/`tail` via the bash tool when you want "
-    "structured line-numbered output; use bash for one-off inspection."
+    "structured line-numbered output; use bash for one-off inspection. "
+    "For images (PNG/JPEG/GIF/WEBP), reading the file inlines the image "
+    "into your visual context so you can actually see it — use this to "
+    "view screenshots and other sandbox images directly (no need to "
+    "describe or measure them indirectly). This works when the bound "
+    "model supports vision and the file fits the inline cap (~3.75 MiB); "
+    "a larger image returns an explanatory text result instead of the "
+    "pixels, so capture at viewport size or downscale/JPEG to fit."
 )
 
 READ_PARAMETERS_SCHEMA: dict[str, Any] = {
@@ -70,7 +77,12 @@ READ_PARAMETERS_SCHEMA: dict[str, Any] = {
     "properties": {
         "path": {
             "type": "string",
-            "description": "Path to the file. Absolute or relative to /workspace.",
+            "description": (
+                "Path to the file. Absolute or relative to /workspace. An "
+                "image path (PNG/JPEG/GIF/WEBP) returns the image into your "
+                "visual context instead of text (vision-capable models, "
+                "images up to ~3.75 MiB)."
+            ),
         },
         "offset": {
             "type": "integer",

--- a/tests/unit/test_read_handler.py
+++ b/tests/unit/test_read_handler.py
@@ -190,3 +190,37 @@ class TestErrorPath:
             f"pipe exit code; without it, missing files silently return empty "
             f"content. Got: {cmd!r}"
         )
+
+
+class TestReadDescriptionDocumentsImages:
+    """The tool's description + path param are the model's only capability
+    surface. The handler inlines sandbox-local images into the model's visual
+    context (``_read_image``), but issue #1564 documents a live incident where
+    an agent never tried because the description advertised only text. These
+    tests pin the image capability into the description so it stays
+    discoverable.
+    """
+
+    def test_description_documents_image_inlining(self) -> None:
+        from aios.tools.read import READ_DESCRIPTION
+
+        desc = READ_DESCRIPTION.lower()
+        assert "image" in desc, (
+            "READ_DESCRIPTION must mention images so agents can discover that "
+            "read inlines sandbox images into the model's visual context."
+        )
+        # The supported formats should be named so the model knows what works.
+        for fmt in ("png", "jpeg", "gif", "webp"):
+            assert fmt in desc, f"READ_DESCRIPTION should name the {fmt} image format"
+        # Vision-gating and the inline size cap are the two operational caveats.
+        assert "vision" in desc
+        assert "3.75" in desc or "mib" in desc
+
+    def test_path_param_description_mentions_images(self) -> None:
+        from aios.tools.read import READ_PARAMETERS_SCHEMA
+
+        path_desc = READ_PARAMETERS_SCHEMA["properties"]["path"]["description"].lower()
+        assert "image" in path_desc, (
+            "The path param description should note that an image path returns "
+            "the image into the model's visual context."
+        )


### PR DESCRIPTION
Automated dev-pipeline build for issue #1564.