### PR TITLE
Outbound attachment reject is a dead-end: SandboxPath schema hint is dropped + reject error names no remedy

### DIFF
--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -1662,7 +1662,10 @@ def _resolve_one(value: Any, *, session_id: str, workspace_path: Path | None, na
             )
             raise SandboxPathError(f"{name!r}: workspace bind-mount unavailable for this call")
         raise SandboxPathError(
-            f"{name!r}: path {value!r} is outside /workspace/ and /mnt/attachments/"
+            f"{name!r}: path {value!r} is outside the connector-readable mounts. "
+            f"The connector can only read files under /workspace/ or /mnt/attachments/; "
+            f"files written elsewhere in the sandbox (e.g. /tmp) are invisible to it. "
+            f"Copy the file into /workspace/ and resend with that /workspace/ path."
         )
     return resolved
 

--- a/packages/aios-connector-http/aios_connector_http/schema.py
+++ b/packages/aios-connector-http/aios_connector_http/schema.py
@@ -61,7 +61,7 @@ import types
 from collections.abc import Callable
 from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
 
-from .sandbox import _SandboxPathMarker
+from .sandbox import _SandboxPathMarker, _SANDBOX_PATH_DESCRIPTION
 
 _INJECTED_PARAMS: frozenset[str] = frozenset({"connection_id", "external_account_id", "chat_id"})
 
@@ -100,7 +100,10 @@ def derive_tool_spec(name: str, fn: Callable[..., Any]) -> dict[str, Any]:
         else:
             prop["default"] = param.default
         if param_name in param_docs:
-            prop["description"] = param_docs[param_name]
+            existing = prop.get("description")
+            prop["description"] = (
+                f"{param_docs[param_name]} {existing}" if existing else param_docs[param_name]
+            )
         properties[param_name] = prop
     input_schema: dict[str, Any] = {"type": "object", "properties": properties}
     if required:
@@ -120,7 +123,9 @@ def _annotation_to_schema(hint: Any, *, param: str) -> dict[str, Any]:
     """Recursive type → JSON schema mapping.  See module docstring."""
     inner, nullable = _split_optional(hint)
     if _is_sandbox_path(inner):
-        return _wrap_nullable({"type": "string"}, nullable)
+        return _wrap_nullable(
+            {"type": "string", "description": _SANDBOX_PATH_DESCRIPTION}, nullable
+        )
     origin = get_origin(inner)
     if origin is Literal:
         values = list(get_args(inner))

--- a/packages/aios-connector-http/aios_connector_http/schema.py
+++ b/packages/aios-connector-http/aios_connector_http/schema.py
@@ -61,7 +61,7 @@ import types
 from collections.abc import Callable
 from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
 
-from .sandbox import _SandboxPathMarker, _SANDBOX_PATH_DESCRIPTION
+from .sandbox import _SANDBOX_PATH_DESCRIPTION, _SandboxPathMarker
 
 _INJECTED_PARAMS: frozenset[str] = frozenset({"connection_id", "external_account_id", "chat_id"})
 

--- a/packages/aios-connector-http/tests/test_sandbox.py
+++ b/packages/aios-connector-http/tests/test_sandbox.py
@@ -327,6 +327,8 @@ class TestDispatchSandboxPathResolution:
         assert result["is_error"] is True
         body = json.loads(result["content"])
         assert "outside" in body["error"]
+        assert "/tmp" in body["error"]
+        assert "Copy the file into /workspace/" in body["error"]
 
     async def test_workspace_path_missing_surfaces_error(self, consumer: _PathConsumer) -> None:
         """Without ``workspace_path`` in the call dict, the resolver fails

--- a/packages/aios-connector-http/tests/test_schema.py
+++ b/packages/aios-connector-http/tests/test_schema.py
@@ -123,6 +123,41 @@ class TestListTypes:
         prop = spec["input_schema"]["properties"]["files"]
         assert prop["type"] == "array"
         assert prop["items"]["type"] == "string"
+        assert "/workspace/" in prop["items"]["description"]
+        assert "cp into /workspace/" in prop["items"]["description"]
+
+    def test_scalar_sandbox_path_carries_marker_description(self) -> None:
+        class C(_DummyForBindings):
+            @tool()
+            async def t(self, *, f: SandboxPath) -> int:
+                return 1
+
+        spec = derive_tool_spec("t", C().t)
+        prop = spec["input_schema"]["properties"]["f"]
+        assert prop["type"] == "string"
+        assert "/workspace/" in prop["description"]
+        assert "/mnt/attachments/" in prop["description"]
+        assert "cp into /workspace/" in prop["description"]
+
+    def test_sandbox_path_docstring_merges_with_marker(self) -> None:
+        """An author ``Args:`` docstring on a ``SandboxPath`` param must be
+        preserved and the marker remedy appended, not clobbered.
+        """
+
+        class C(_DummyForBindings):
+            @tool()
+            async def t(self, *, f: SandboxPath) -> int:
+                """Do a thing.
+
+                Args:
+                    f: Author supplied hint here.
+                """
+                return 1
+
+        spec = derive_tool_spec("t", C().t)
+        prop = spec["input_schema"]["properties"]["f"]
+        assert "Author supplied hint here." in prop["description"]
+        assert "cp into /workspace/" in prop["description"]
 
 
 class TestRequiredAndDefaults:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1586.