### PR TITLE
Generalize the mode=before quarantine validator: registry-driven tolerance + retirement_tolerance_hits telemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,8 @@ module = [
     "pytz",
     "pytz.*",
     "jsonschema",
+    "prometheus_client",
+    "prometheus_client.*",
 ]
 ignore_missing_imports = true
 

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -16,6 +16,8 @@ from typing import Any, Literal, get_args
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from aios.models.skills import AgentSkillRef
+from aios.retirements.registry import tolerated_rename_map
+from aios.retirements.telemetry import record_tolerance_hit
 
 # Built-in tool types. Custom tools use type="custom" with extra fields.
 BuiltinToolType = Literal[
@@ -92,22 +94,17 @@ _BUILTIN_NAMES: frozenset[str] = frozenset(get_args(BuiltinToolType))
 # names in their `tools` JSONB; without a map they'd fail `ToolSpec` validation on read (a
 # deploy-breaker — every agent that exposed the renamed tool to its model would 500). The
 # `mode="before"` validator below maps them so old rows still load; the two-step
-# create_run/await_run launch tools fold into the unified `call_workflow`. The data migrations
-# (0116 for #1419, 0117 for #1428) rewrite the persisted rows to canonical; once they have run
-# everywhere this map + the validator can be removed (teardown tracked: #1432).
-_LEGACY_BUILTIN_RENAMES: dict[str, str] = {
-    "invoke": "call_session",
-    "invoke_agent": "call_agent",
-    "invoke_workflow": "call_workflow",
-    "create_run": "call_workflow",
-    "await_run": "call_workflow",
-    # #1428: the cancel_run MODEL tool is superseded by stop_task (which reaches a session
-    # servicer too, keyed on tool_call_id). The wf_service.cancel_run SERVICE is unaffected.
-    # Maps to a REGISTERED name (stop_task) — load-bearing: to_openai_tools' registry.get
-    # raises on an unregistered type, which would 500 every affected agent in the post-deploy
-    # window. The data migration (0117) rewrites persisted rows; this shim covers the window.
-    "cancel_run": "stop_task",
-}
+# create_run/await_run launch tools fold into the unified `call_workflow`.
+#
+# #1574: the rename map is no longer a hand-maintained constant here — it is sourced from the
+# retirement REGISTRY (#1573) via `tolerated_rename_map`, which tolerates a token ONLY while its
+# descriptor's `contract_rev IS NULL` (the data migration that rewrites persisted rows has not
+# yet been declared as the contract-point). Once a descriptor stamps `contract_rev`, its tokens
+# drop out of the map and the validator stops remapping them, so a stale legacy `type` then
+# correctly fails validation. Each tolerance fire emits `retirement_tolerance_hits{token}` +
+# stamps `last_seen` (corroboration only — NEVER the gate). Keeping this in a `mode="before"`
+# validator is deliberate: it travels to every `ToolSpec.model_validate` site automatically (the
+# eight read sites), so no loader choke-point is needed and the per-site property is preserved.
 
 # Read-tolerance for RETIRED builtins that have NO canonical successor (#1562). Unlike a
 # rename (mapped above), a retired builtin's persisted ``tools`` entry is DROPPED on read —
@@ -133,8 +130,10 @@ def load_tool_specs(raw: Iterable[Any]) -> list[ToolSpec]:
     would otherwise raise on the now-illegal Literal, poisoning the whole row's hydration.
 
     This is the list-level counterpart to the per-entry ``mode="before"`` *rename* shim
-    (:data:`_LEGACY_BUILTIN_RENAMES`): a rename can be done in-place inside a single ``ToolSpec``,
-    but dropping an element must happen where the array is iterated. Order is preserved; a row
+    (:meth:`ToolSpec._map_legacy_builtin_names`, now registry-driven via
+    :func:`aios.retirements.registry.tolerated_rename_map`): a rename can be done in-place inside a
+    single ``ToolSpec``, but dropping an element must happen where the array is iterated. Order is
+    preserved; a row
     that listed only retired builtins hydrates to ``[]``. Use this anywhere a persisted ``tools``
     array is loaded so the tolerance is uniform across agents / agent_versions / workflows /
     workflow_versions / wf_runs / sessions.
@@ -517,14 +516,30 @@ class ToolSpec(BaseModel):
         ``invoke``/``invoke_agent``/``invoke_workflow``/``create_run``/``await_run`` set or the
         #1428 ``cancel_run`` — still validates against the post-rename ``BuiltinToolType``
         Literal. The ``create_run``/``await_run`` collapse to ``call_workflow`` is deduped at the
-        list level (``to_openai_tools`` + migrations 0116/0117), not here. Temporary shim —
-        remove once 0116/0117 have rewritten all persisted rows. See
-        :data:`_LEGACY_BUILTIN_RENAMES`.
+        list level (``to_openai_tools`` + migrations 0116/0117), not here.
+
+        #1574: the tolerance map is read from the retirement REGISTRY (#1573) via
+        :func:`aios.retirements.registry.tolerated_rename_map`, which yields a token's canonical
+        successor ONLY while its descriptor's ``contract_rev IS NULL``. A token whose descriptor
+        has stamped ``contract_rev`` is absent from the map, so it is no longer remapped and would
+        correctly fail validation against the post-rename Literal. Staying ``mode="before"`` keeps
+        this per-site: it travels to every ``ToolSpec.model_validate`` site automatically.
+
+        Each fire records ``retirement_tolerance_hits{token}`` + stamps ``last_seen`` via
+        :func:`aios.retirements.telemetry.record_tolerance_hit` — **corroboration / telemetry
+        only**. The gate is the registry's ``contract_rev IS NULL`` predicate above; the telemetry
+        is never consulted to decide whether to tolerate, and a metrics failure can never wedge a
+        read.
         """
         if isinstance(data, dict):
             t = data.get("type")
-            if isinstance(t, str) and t in _LEGACY_BUILTIN_RENAMES:
-                data = {**data, "type": _LEGACY_BUILTIN_RENAMES[t]}
+            if isinstance(t, str):
+                # Registry-sourced, contract_rev-gated map (the GATE).
+                successor = tolerated_rename_map().get(t)
+                if successor is not None:
+                    # Corroboration only — NEVER the gate. Recorded after the gate decided.
+                    record_tolerance_hit(t)
+                    data = {**data, "type": successor}
         return data
 
     @model_validator(mode="after")

--- a/src/aios/retirements/registry.py
+++ b/src/aios/retirements/registry.py
@@ -75,9 +75,17 @@ TOOL_SURFACES: tuple[Surface, ...] = (
 #: tools ``invoke``→``call_session``, ``invoke_agent``→``call_agent``, and the
 #: ``invoke_workflow``/``create_run``/``await_run`` launch trio folded into the
 #: unified ``call_workflow``; ``cancel_run``→``stop_task`` followed in #1428.
-#: The read-tolerance shim lives as ``_LEGACY_BUILTIN_RENAMES`` in
-#: ``models/agents.py`` (introduced with migration 0116); the data migrations
-#: 0116 (#1419) and 0117 (#1428) rewrite persisted rows to canonical.
+#: The read-tolerance shim is the ``mode="before"`` validator in
+#: ``models/agents.py`` (introduced with migration 0116), now registry-driven via
+#: :func:`tolerated_rename_map` (#1574); the data migrations 0116 (#1419) and
+#: 0117 (#1428) rewrite persisted rows to canonical.
+#:
+#: ``contract_rev`` is ``None``: this retirement is still in its **expand span**,
+#: so the registry-driven before-validator keeps tolerating these tokens at every
+#: ``ToolSpec.model_validate`` site (no regression to the pre-#1574 unconditional
+#: shim). Stamping ``contract_rev`` here is what makes the validator stop
+#: remapping these tokens — that post-contract teardown is sequenced + exercised
+#: in the live-exercise issue, not #1574.
 LEGACY_BUILTIN_RENAMES = Retirement(
     domain=TOOL_SURFACE_DOMAIN,
     action="rename",
@@ -91,7 +99,7 @@ LEGACY_BUILTIN_RENAMES = Retirement(
     ),
     surfaces=TOOL_SURFACES,
     introduced_rev="0116",
-    contract_rev="0117",
+    contract_rev=None,
     sla_days=30,
 )
 
@@ -123,3 +131,44 @@ REGISTRY: tuple[Retirement, ...] = (
     LEGACY_BUILTIN_RENAMES,
     RETIRED_GOAL_OUTCOME_BUILTINS,
 )
+
+
+def tolerated_rename_map(
+    domain: str = TOOL_SURFACE_DOMAIN,
+    *,
+    registry: tuple[Retirement, ...] = REGISTRY,
+) -> dict[str, str]:
+    """``token -> successor`` for every *still-tolerated* rename in ``domain``.
+
+    This is the gate the ``mode="before"`` read-tolerance validator
+    (``models/agents.py``) consults instead of a hand-maintained constant: a
+    token is tolerated (mapped to its canonical successor on read) **only while
+    its descriptor's ``contract_rev IS NULL``** — i.e. the data migration that
+    rewrites persisted rows to canonical has not yet been declared. Once a
+    descriptor names a ``contract_rev``, its tokens drop out of this map and the
+    validator stops remapping them, so a stale legacy ``type`` would then
+    correctly fail ``ToolSpec`` validation (the post-contract behaviour exercised
+    in the live-exercise issue).
+
+    Only ``action="rename"`` descriptors contribute — a ``drop`` has no successor
+    to map to and is handled at the list level (``load_tool_specs``), not by the
+    per-``ToolSpec`` before-validator. ``registry`` is injectable so callers and
+    tests can scope the lookup to a synthetic set of descriptors.
+
+    The ``contract_rev IS NULL`` predicate here is the single tolerance gate;
+    :mod:`aios.retirements.telemetry` records fires only as corroboration and is
+    never consulted to decide tolerance.
+    """
+
+    out: dict[str, str] = {}
+    for retirement in registry:
+        if retirement.domain != domain:
+            continue
+        if retirement.action != "rename":
+            continue
+        if retirement.contract_rev is not None:
+            continue
+        for token, successor in retirement.token_map().items():
+            if successor is not None:
+                out[token] = successor
+    return out

--- a/src/aios/retirements/telemetry.py
+++ b/src/aios/retirements/telemetry.py
@@ -1,0 +1,101 @@
+"""Retirement read-tolerance telemetry — corroboration only, NEVER the gate.
+
+When the ``mode="before"`` read-tolerance validator (``models/agents.py``) maps a
+persisted legacy tool ``type`` to its canonical successor, it fires a *tolerance
+hit*: evidence that an unmigrated row is still being read. This module records
+those fires as **corroboration / telemetry only**:
+
+* a per-token Prometheus counter ``retirement_tolerance_hits{token=...}``, and
+* the wall-clock ``last_seen`` of the most recent fire per token.
+
+Nothing here is load-bearing. The gate that decides whether a token is *tolerated*
+is the registry's ``contract_rev IS NULL`` predicate (see
+:func:`aios.retirements.registry.tolerated_rename_map`); a teardown decision is
+made from the registry + boot-gate, never from these counters. Reading or
+clearing these values must never change validation behavior.
+
+#1324 metrics surface
+---------------------
+The epic wires these counters through the shared Prometheus surface introduced in
+#1324. That surface is an *optional* sink here: if ``prometheus_client`` (the
+backing library the #1324 surface uses) is importable, each fire increments a
+real ``Counter``; otherwise the in-process tallies below are the sole record.
+Either way the in-process ``hits``/``last_seen`` snapshots are always maintained,
+so this module is self-contained and testable without the metrics deployment —
+and a fire is never silently lost if the surface is absent.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from datetime import UTC, datetime
+
+# ── Optional Prometheus sink (the #1324 metrics surface) ──────────────────────
+#
+# The #1324 surface is built on ``prometheus_client``. We bind to it lazily and
+# tolerate its absence: the validator must never fail to load a row just because
+# the metrics deployment is missing. A tolerance hit is recorded in-process
+# regardless; the Counter is incremented in addition when the library is present.
+try:  # pragma: no cover - exercised only where prometheus_client is installed
+    from prometheus_client import Counter as _PromCounter
+
+    _RETIREMENT_TOLERANCE_HITS = _PromCounter(
+        "retirement_tolerance_hits",
+        "Read-tolerance fires per retired token (corroboration only; NEVER a gate).",
+        ["token"],
+    )
+except Exception:  # pragma: no cover - the common path in this repo today
+    _RETIREMENT_TOLERANCE_HITS = None
+
+
+# ── In-process tallies (always maintained) ────────────────────────────────────
+
+_lock = threading.Lock()
+_hits: dict[str, int] = {}
+_last_seen: dict[str, datetime] = {}
+
+
+def record_tolerance_hit(token: str, *, now: datetime | None = None) -> None:
+    """Record one read-tolerance fire for ``token`` — corroboration only.
+
+    Increments ``retirement_tolerance_hits{token}`` (Prometheus, when the #1324
+    surface is present) and stamps ``last_seen[token]`` with the fire time. This
+    is telemetry: callers MUST NOT branch validation/teardown on its result, and
+    this function MUST NOT raise — a metrics failure can never wedge a read.
+
+    ``now`` is injectable for deterministic tests; it defaults to the current UTC
+    time.
+    """
+
+    stamp = now or datetime.now(UTC)
+    with _lock:
+        _hits[token] = _hits.get(token, 0) + 1
+        _last_seen[token] = stamp
+    if _RETIREMENT_TOLERANCE_HITS is not None:  # pragma: no cover
+        # Telemetry is never load-bearing: swallow any metrics-sink error so a
+        # broken surface can never wedge a read.
+        with contextlib.suppress(Exception):
+            _RETIREMENT_TOLERANCE_HITS.labels(token=token).inc()
+
+
+def tolerance_hits(token: str) -> int:
+    """In-process count of tolerance fires for ``token`` (corroboration only)."""
+
+    with _lock:
+        return _hits.get(token, 0)
+
+
+def last_seen(token: str) -> datetime | None:
+    """Wall-clock time of the most recent tolerance fire for ``token``, or ``None``."""
+
+    with _lock:
+        return _last_seen.get(token)
+
+
+def reset() -> None:
+    """Clear the in-process tallies. Test helper; has no effect on the gate."""
+
+    with _lock:
+        _hits.clear()
+        _last_seen.clear()

--- a/tests/unit/test_retirement_tolerance_validator.py
+++ b/tests/unit/test_retirement_tolerance_validator.py
@@ -1,0 +1,170 @@
+"""Registry-driven, telemetered read-tolerance for the ``mode="before"`` ToolSpec validator (#1574).
+
+The ``mode="before"`` validator on :class:`ToolSpec` no longer reads a hand-maintained rename
+constant; it consults the retirement REGISTRY (#1573) via
+:func:`aios.retirements.registry.tolerated_rename_map`, which tolerates a token ONLY while its
+descriptor's ``contract_rev IS NULL``. Every tolerance fire emits
+``retirement_tolerance_hits{token}`` + stamps ``last_seen`` as **corroboration only** — never the
+gate. These tests pin the #1574 acceptance:
+
+* the validator consults the registry (a token absent from the still-tolerated map is NOT remapped);
+* a token whose descriptor has ``contract_rev`` set is no longer tolerated (it raises);
+* every fire records the metric + ``last_seen``, and the telemetry is gate-free.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+import aios.models.agents as agents_mod
+from aios.models.agents import ToolSpec
+from aios.retirements import Retirement, telemetry
+from aios.retirements import registry as reg
+
+
+@pytest.fixture(autouse=True)
+def _clear_telemetry() -> None:
+    telemetry.reset()
+    yield
+    telemetry.reset()
+
+
+# ── The validator consults the registry (no hand-maintained constant) ─────────
+
+
+def test_no_hand_maintained_rename_constant_remains() -> None:
+    """The pre-#1574 ``_LEGACY_BUILTIN_RENAMES`` constant is gone; the map is registry-sourced."""
+    assert not hasattr(agents_mod, "_LEGACY_BUILTIN_RENAMES")
+
+
+def test_validator_uses_registry_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token present in the registry-driven map is remapped to its successor on read."""
+    # A synthetic still-tolerated rename (contract_rev IS NULL) overrides the lookup.
+    fake = {"legacy_synthetic": "bash"}
+    monkeypatch.setattr(agents_mod, "tolerated_rename_map", lambda: fake)
+    assert ToolSpec.model_validate({"type": "legacy_synthetic"}).type == "bash"
+
+
+def test_token_absent_from_map_is_not_remapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A legacy token NOT in the still-tolerated map is left untouched (→ fails the Literal)."""
+    monkeypatch.setattr(agents_mod, "tolerated_rename_map", lambda: {})
+    with pytest.raises(ValidationError):
+        ToolSpec.model_validate({"type": "invoke"})
+
+
+# ── The contract_rev gate ─────────────────────────────────────────────────────
+
+
+def _expand_span_rename() -> Retirement:
+    return Retirement(
+        domain=reg.TOOL_SURFACE_DOMAIN,
+        action="rename",
+        mappings=(("oldtok", "bash"),),
+        surfaces=reg.TOOL_SURFACES,
+        introduced_rev="9000",
+        contract_rev=None,  # still expanding → tolerated
+    )
+
+
+def _contracted_rename() -> Retirement:
+    return Retirement(
+        domain=reg.TOOL_SURFACE_DOMAIN,
+        action="rename",
+        mappings=(("oldtok", "bash"),),
+        surfaces=reg.TOOL_SURFACES,
+        introduced_rev="9000",
+        contract_rev="9001",  # contract migration declared → NO LONGER tolerated
+    )
+
+
+def test_contract_rev_null_token_is_tolerated() -> None:
+    m = reg.tolerated_rename_map(registry=(_expand_span_rename(),))
+    assert m == {"oldtok": "bash"}
+
+
+def test_contract_rev_set_token_drops_out_of_map() -> None:
+    m = reg.tolerated_rename_map(registry=(_contracted_rename(),))
+    assert m == {}
+
+
+def test_contract_rev_set_token_is_no_longer_tolerated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With a contract_rev stamped, the validator no longer remaps the token → it raises."""
+    contracted = _contracted_rename()
+    monkeypatch.setattr(
+        agents_mod,
+        "tolerated_rename_map",
+        lambda: reg.tolerated_rename_map(registry=(contracted,)),
+    )
+    with pytest.raises(ValidationError):
+        ToolSpec.model_validate({"type": "oldtok"})
+
+
+def test_drop_descriptors_never_contribute_to_rename_map() -> None:
+    """``action="drop"`` retirements have no successor → absent from the rename map."""
+    m = reg.tolerated_rename_map(registry=(reg.RETIRED_GOAL_OUTCOME_BUILTINS,))
+    assert m == {}
+
+
+# ── Telemetry: corroboration only, NEVER the gate ─────────────────────────────
+
+
+def test_every_fire_increments_hits_and_stamps_last_seen() -> None:
+    assert telemetry.tolerance_hits("invoke") == 0
+    assert telemetry.last_seen("invoke") is None
+
+    ToolSpec.model_validate({"type": "invoke"})
+    ToolSpec.model_validate({"type": "invoke"})
+
+    assert telemetry.tolerance_hits("invoke") == 2
+    assert telemetry.last_seen("invoke") is not None
+
+
+def test_telemetry_is_keyed_per_token() -> None:
+    ToolSpec.model_validate({"type": "invoke"})
+    ToolSpec.model_validate({"type": "cancel_run"})
+    assert telemetry.tolerance_hits("invoke") == 1
+    assert telemetry.tolerance_hits("cancel_run") == 1
+    assert telemetry.tolerance_hits("invoke_agent") == 0
+
+
+def test_canonical_name_does_not_fire_telemetry() -> None:
+    ToolSpec.model_validate({"type": "call_workflow"})
+    assert telemetry.tolerance_hits("call_workflow") == 0
+
+
+def test_telemetry_sink_failure_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blowing-up Prometheus sink must not propagate — telemetry is never load-bearing."""
+
+    class _BoomCounter:
+        def labels(self, **_kwargs: object) -> _BoomCounter:
+            return self
+
+        def inc(self) -> None:
+            raise RuntimeError("metrics surface down")
+
+    monkeypatch.setattr(telemetry, "_RETIREMENT_TOLERANCE_HITS", _BoomCounter())
+    # The sink raises internally, but the call returns normally and the in-process tally is kept.
+    telemetry.record_tolerance_hit("invoke")  # must not raise
+    assert telemetry.tolerance_hits("invoke") == 1
+
+
+def test_validator_maps_token_even_when_sink_is_broken(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A broken telemetry sink must never wedge a read — the gate decision still applies."""
+
+    class _BoomCounter:
+        def labels(self, **_kwargs: object) -> _BoomCounter:
+            return self
+
+        def inc(self) -> None:
+            raise RuntimeError("metrics surface down")
+
+    monkeypatch.setattr(telemetry, "_RETIREMENT_TOLERANCE_HITS", _BoomCounter())
+    assert ToolSpec.model_validate({"type": "invoke"}).type == "call_session"
+
+
+def test_telemetry_not_consulted_as_gate() -> None:
+    """Pre-seeding hit counts must not change whether a token is tolerated."""
+    telemetry.record_tolerance_hit("call_workflow")  # nonsense corroboration for a canonical name
+    # call_workflow is canonical; it is never remapped regardless of any recorded hits.
+    assert ToolSpec.model_validate({"type": "call_workflow"}).type == "call_workflow"

--- a/tests/unit/test_retirement_tolerance_validator.py
+++ b/tests/unit/test_retirement_tolerance_validator.py
@@ -14,6 +14,8 @@ gate. These tests pin the #1574 acceptance:
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 from pydantic import ValidationError
 
@@ -24,7 +26,7 @@ from aios.retirements import registry as reg
 
 
 @pytest.fixture(autouse=True)
-def _clear_telemetry() -> None:
+def _clear_telemetry() -> Iterator[None]:
     telemetry.reset()
     yield
     telemetry.reset()


### PR DESCRIPTION
Automated dev-pipeline build for issue #1574.