### PR TITLE
Fail-closed boot-admission gate: assert_retirements_admissible() refuses readiness until live-DB residue==0 AND alembic>=contract_rev

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -32,7 +32,7 @@
     "/ready": {
       "get": {
         "summary": "Ready",
-        "description": "Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.\n\nReturns 200 ``{\"status\": \"ready\"}`` when Postgres answers, 503\n``{\"status\": \"unavailable\"}`` when the pool can't be acquired, the query\nraises, or it exceeds the 2 s budget. This is the signal the Docker/compose\nhealthcheck watches, so a silent post-startup DB outage becomes a visibly\nunhealthy container instead of a 200-returning black hole.",
+        "description": "Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.\n\nReturns 200 ``{\"status\": \"ready\"}`` when Postgres answers AND the\nfail-closed boot-admission gate (#1575) has admitted this process; 503\n``{\"status\": \"unavailable\"}`` when the pool can't be acquired, the query\nraises, it exceeds the 2 s budget, OR the boot-gate has not yet admitted.\nThis is the signal the Docker/compose healthcheck watches, so a silent\npost-startup DB outage becomes a visibly unhealthy container instead of a\n200-returning black hole.\n\nThe boot-gate flag (``app.state.retirements_ok``) stays ``False`` from\nprocess start until the gate proves the live DB is safe for this code\n(alembic at/past every ``contract_rev`` AND zero live residue). Under a\nrolling deploy this keeps the NEW container unready \u2014 so the OLD healthy\ncontainer keeps serving \u2014 until the post-deploy migrate lands. Checked\nBEFORE the DB round-trip: an un-admitted process is unready regardless of\nDB liveness.",
         "operationId": "get_ready",
         "responses": {
           "200": {

--- a/packages/aios-sdk/aios_sdk/_generated/api/default/get_ready.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/default/get_ready.py
@@ -49,11 +49,21 @@ def sync_detailed(
 
      Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.
 
-    Returns 200 ``{\"status\": \"ready\"}`` when Postgres answers, 503
+    Returns 200 ``{\"status\": \"ready\"}`` when Postgres answers AND the
+    fail-closed boot-admission gate (#1575) has admitted this process; 503
     ``{\"status\": \"unavailable\"}`` when the pool can't be acquired, the query
-    raises, or it exceeds the 2 s budget. This is the signal the Docker/compose
-    healthcheck watches, so a silent post-startup DB outage becomes a visibly
-    unhealthy container instead of a 200-returning black hole.
+    raises, it exceeds the 2 s budget, OR the boot-gate has not yet admitted.
+    This is the signal the Docker/compose healthcheck watches, so a silent
+    post-startup DB outage becomes a visibly unhealthy container instead of a
+    200-returning black hole.
+
+    The boot-gate flag (``app.state.retirements_ok``) stays ``False`` from
+    process start until the gate proves the live DB is safe for this code
+    (alembic at/past every ``contract_rev`` AND zero live residue). Under a
+    rolling deploy this keeps the NEW container unready — so the OLD healthy
+    container keeps serving — until the post-deploy migrate lands. Checked
+    BEFORE the DB round-trip: an un-admitted process is unready regardless of
+    DB liveness.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -80,11 +90,21 @@ async def asyncio_detailed(
 
      Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.
 
-    Returns 200 ``{\"status\": \"ready\"}`` when Postgres answers, 503
+    Returns 200 ``{\"status\": \"ready\"}`` when Postgres answers AND the
+    fail-closed boot-admission gate (#1575) has admitted this process; 503
     ``{\"status\": \"unavailable\"}`` when the pool can't be acquired, the query
-    raises, or it exceeds the 2 s budget. This is the signal the Docker/compose
-    healthcheck watches, so a silent post-startup DB outage becomes a visibly
-    unhealthy container instead of a 200-returning black hole.
+    raises, it exceeds the 2 s budget, OR the boot-gate has not yet admitted.
+    This is the signal the Docker/compose healthcheck watches, so a silent
+    post-startup DB outage becomes a visibly unhealthy container instead of a
+    200-returning black hole.
+
+    The boot-gate flag (``app.state.retirements_ok``) stays ``False`` from
+    process start until the gate proves the live DB is safe for this code
+    (alembic at/past every ``contract_rev`` AND zero live residue). Under a
+    rolling deploy this keeps the NEW container unready — so the OLD healthy
+    container keeps serving — until the post-deploy migrate lands. Checked
+    BEFORE the DB round-trip: an un-admitted process is unready regardless of
+    DB liveness.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -8,6 +8,7 @@ operate the management plane via the same Bearer auth as the HTTP API.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager
@@ -42,7 +43,37 @@ from aios.errors import install_exception_handlers
 from aios.harness import runtime
 from aios.harness.procrastinate_app import app as procrastinate_app
 from aios.logging import configure_logging, get_logger
+from aios.retirements.boot_gate import (
+    RetirementsNotAdmissible,
+    assert_retirements_admissible,
+)
 from aios.sandbox.volumes import attachments_root, memory_stores_root, uploads_root
+
+# How long the api startup loops between boot-admission proof attempts while the
+# DB is behind / unreachable. Short enough that readiness flips green promptly
+# once the post-deploy migrate lands; long enough not to hammer the DB.
+_BOOT_GATE_RETRY_SECONDS = 2.0
+
+
+async def _await_retirements_admissible(pool: Any, log: Any) -> None:
+    """Loop the fail-closed boot-admission gate until the DB is provably safe.
+
+    Refuses to return — keeping the api unready (``app.state.retirements_ok``
+    stays ``False``, so ``/ready`` answers 503) — until
+    :func:`assert_retirements_admissible` passes. Under Coolify's rolling
+    deploy this is exactly the window where the old healthy container keeps
+    serving while the new one waits out the post-deploy migrate (#1575).
+    """
+    logged_wait = False
+    while True:
+        try:
+            await assert_retirements_admissible(pool)
+            return
+        except RetirementsNotAdmissible as exc:
+            if not logged_wait:
+                log.warning("api.boot_gate.refusing_readiness", reason=str(exc))
+                logged_wait = True
+            await asyncio.sleep(_BOOT_GATE_RETRY_SECONDS)
 
 
 def create_app() -> FastAPI:
@@ -60,6 +91,11 @@ def create_app() -> FastAPI:
         app.state.crypto_box = crypto_box
         app.state.procrastinate = procrastinate_app
         app.state.db_url = settings.db_url
+        # Readiness stays RED until the fail-closed boot-admission gate proves
+        # the live DB is safe for this code. ``/ready`` reads this flag, so a
+        # behind / residue-bearing / unreachable DB never lets the new
+        # container serve while the old one is still healthy (#1575).
+        app.state.retirements_ok = False
 
         # #959: the api runs as uid 1000 and can't repair ownership (no
         # CAP_CHOWN). If the worker (root) created a shared root first and
@@ -94,6 +130,15 @@ def create_app() -> FastAPI:
         prev_tool_provider = runtime.tool_provider
         runtime.crypto_box = crypto_box
         runtime.tool_provider = SubsystemToolProvider()
+
+        # Fail-closed boot-admission gate (#1575): block here — readiness RED —
+        # until the live DB is proven safe for this code (alembic at/past every
+        # contract_rev AND zero live residue on every registered surface). This
+        # runs on EVERY boot, including raw restores, and is never cached.
+        await _await_retirements_admissible(pool, log)
+        app.state.retirements_ok = True
+        log.info("api.boot_gate.admitted")
+
         try:
             yield
         finally:

--- a/src/aios/api/routers/health.py
+++ b/src/aios/api/routers/health.py
@@ -29,12 +29,24 @@ async def health() -> dict[str, str]:
 async def ready(request: Request) -> Response:
     """Readiness probe. Unauthenticated; ``SELECT 1`` under a short timeout.
 
-    Returns 200 ``{"status": "ready"}`` when Postgres answers, 503
+    Returns 200 ``{"status": "ready"}`` when Postgres answers AND the
+    fail-closed boot-admission gate (#1575) has admitted this process; 503
     ``{"status": "unavailable"}`` when the pool can't be acquired, the query
-    raises, or it exceeds the 2 s budget. This is the signal the Docker/compose
-    healthcheck watches, so a silent post-startup DB outage becomes a visibly
-    unhealthy container instead of a 200-returning black hole.
+    raises, it exceeds the 2 s budget, OR the boot-gate has not yet admitted.
+    This is the signal the Docker/compose healthcheck watches, so a silent
+    post-startup DB outage becomes a visibly unhealthy container instead of a
+    200-returning black hole.
+
+    The boot-gate flag (``app.state.retirements_ok``) stays ``False`` from
+    process start until the gate proves the live DB is safe for this code
+    (alembic at/past every ``contract_rev`` AND zero live residue). Under a
+    rolling deploy this keeps the NEW container unready — so the OLD healthy
+    container keeps serving — until the post-deploy migrate lands. Checked
+    BEFORE the DB round-trip: an un-admitted process is unready regardless of
+    DB liveness.
     """
+    if not getattr(request.app.state, "retirements_ok", False):
+        return JSONResponse(status_code=503, content={"status": "unavailable"})
     pool = request.app.state.pool
     try:
         # The timeout intentionally covers both ``pool.acquire()`` and the query: a

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -52,6 +52,10 @@ from aios.harness.trigger_runner import sweep_trigger_fires
 from aios.harness.workspace_reaper import sweep_archived_workspaces
 from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool
+from aios.retirements.boot_gate import (
+    RetirementsNotAdmissible,
+    assert_retirements_admissible,
+)
 from aios.sandbox.backends import select_sandbox_backend
 from aios.sandbox.network import ensure_sandbox_network, is_running_in_container
 from aios.sandbox.registry import SandboxRegistry
@@ -79,6 +83,38 @@ _WORKER_SINGLETON_LOCK_KEY_TEXT = "aios_worker_connector_supervisor"
 _HEARTBEAT_FILENAME = "aios-worker-alive"
 _CONTAINER_HEARTBEAT_FILE = Path("/var/run") / _HEARTBEAT_FILENAME
 _HEARTBEAT_INTERVAL_SECONDS = 15
+
+# How long the worker startup loops between boot-admission proof attempts while
+# the DB is behind / unreachable. Matches the api gate's cadence.
+_BOOT_GATE_RETRY_SECONDS = 2.0
+
+
+async def _await_retirements_admissible(
+    pool: asyncpg.Pool[Any],
+    log: Any,
+    latch: asyncio.Event,
+) -> None:
+    """Loop the fail-closed boot-admission gate until the DB is provably safe.
+
+    Refuses to return — keeping the worker pre-heartbeat, so the container
+    HEALTHCHECK reports unhealthy — until
+    :func:`assert_retirements_admissible` passes (#1575). The ``latch`` is the
+    worker's supervision/shutdown event: if it fires while we're waiting
+    (SIGTERM, a supervised task died), abandon the wait so shutdown isn't
+    blocked behind an unreachable DB.
+    """
+    logged_wait = False
+    while not latch.is_set():
+        try:
+            await assert_retirements_admissible(pool)
+            return
+        except RetirementsNotAdmissible as exc:
+            if not logged_wait:
+                log.warning("worker.boot_gate.refusing_readiness", reason=str(exc))
+                logged_wait = True
+            with contextlib.suppress(asyncio.TimeoutError):
+                # Wake early if shutdown fires; otherwise retry after the delay.
+                await asyncio.wait_for(latch.wait(), timeout=_BOOT_GATE_RETRY_SECONDS)
 
 
 def _resolve_heartbeat_path() -> Path:
@@ -260,6 +296,18 @@ async def worker_main() -> None:
         repaired = await asyncio.to_thread(repair_workspace_ownership)
         if repaired:
             log.info("worker.workspace_ownership_repaired", count=repaired)
+
+        # Fail-closed boot-admission gate (#1575): before this worker does ANY
+        # work — before it opens procrastinate, sweeps, or touches the liveness
+        # heartbeat that the container HEALTHCHECK watches — prove the live DB
+        # is safe for this code (alembic at/past every contract_rev AND zero
+        # live residue on every registered surface). A behind / residue-bearing
+        # / unreachable DB loops here, keeping the heartbeat file absent, so the
+        # new container reports unhealthy and the old one keeps serving under a
+        # rolling deploy. The proof re-runs on EVERY boot, including raw
+        # restores, and is never cached.
+        await _await_retirements_admissible(pool, log, supervised_latch)
+        log.info("worker.boot_gate.admitted")
 
         await procrastinate_app.open_async()
         procrastinate_opened = True

--- a/src/aios/retirements/boot_gate.py
+++ b/src/aios/retirements/boot_gate.py
@@ -1,0 +1,237 @@
+"""The fail-closed boot-admission gate (#1575, epic #1572).
+
+This is the *keystone* provability invariant of the pattern-retirement
+mechanism. It moves the "is this DB safe for this code to read?" proof OFF the
+migration — which in prod runs **POST-deploy**, after the new container already
+serves (``aios migrate`` is the api app's post-deployment command; the
+eumemic-ops audit FAILS the build if it is configured pre-deploy) — and ONTO the
+code itself, at startup, *before* readiness flips green.
+
+:func:`assert_retirements_admissible` is called from BOTH the api and the worker
+startup path, gating readiness. For every contracted descriptor (one whose
+``contract_rev`` is set, i.e. whose data migration has been written) it proves:
+
+1. **alembic head**: the live ``alembic_version`` is ``>= contract_rev``. If the
+   DB is behind — the post-deploy migrate has not run yet, OR a restore pointed
+   new code at an old DB — the proof FAILS. This is the startup alembic-head
+   assertion that did not exist before (the only prior startup version check was
+   the unrelated wf-version drift check at ``workflows/service.py``).
+2. **live residue == 0**: once the rev is satisfied, the per-surface residue
+   aggregate ``SUM over descriptor.surfaces of count(rows WHERE predicate(token))``
+   must be zero. If any surface still carries a retired token the proof FAILS and
+   an *algedonic* alert is emitted (a migration that was supposed to have
+   rewritten those rows did not).
+3. **fail-closed**: any DB / connection failure FAILS the proof. No connection
+   ⇒ not admissible ⇒ not ready.
+
+The caller (api lifespan / worker startup) loops on a raised
+:class:`RetirementsNotAdmissible`, keeping the health/readiness signal RED and
+*never serving*, while under Coolify's rolling deploy the old healthy container
+keeps serving. This converts "new code meets old rows" from a per-row crash-loop
+(the #1525 failure) into a single clean readiness-refusal BEFORE any request is
+served. The proof is re-executed on **every** boot (including raw restores) and
+never cached.
+
+The gate reads the contracted descriptors and their surface predicates from the
+registry (:mod:`aios.retirements.registry`) and nothing else; if a surface is
+missing there it is missing here, by construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncpg
+
+from aios.logging import get_logger
+from aios.retirements import Retirement
+from aios.retirements.registry import REGISTRY
+
+log = get_logger("aios.retirements.boot_gate")
+
+
+class RetirementsNotAdmissible(RuntimeError):
+    """The boot-admission proof failed; the process must NOT flip ready.
+
+    Raised by :func:`assert_retirements_admissible` for every refusal reason —
+    behind-DB (alembic_version < contract_rev), nonzero live residue on a
+    registered surface, or a fail-closed DB/connection error. The caller treats
+    any instance identically: refuse readiness, hold, and retry on the next
+    loop tick. The distinct subclasses exist only to make the *reason* legible
+    in logs and tests; callers should catch the base class.
+    """
+
+
+class DatabaseBehindContract(RetirementsNotAdmissible):
+    """``alembic_version`` is behind a descriptor's ``contract_rev``.
+
+    The post-deploy migrate has not run yet, or a restore pointed new code at an
+    old DB. Refuse readiness and loop; the old container keeps serving until the
+    migrate lands.
+    """
+
+
+class LiveResidueDetected(RetirementsNotAdmissible):
+    """A registered surface still carries a retired token after its contract.
+
+    The contract migration was supposed to have rewritten these rows to
+    canonical but did not (it never ran everywhere, or a stale row slipped in).
+    Serving would re-introduce the #1525 per-row read crash-loop, so refuse
+    readiness and emit an algedonic alert.
+    """
+
+
+class DatabaseUnavailable(RetirementsNotAdmissible):
+    """No DB connection / a query raised: fail-closed ⇒ not admissible."""
+
+
+def _contracted(registry: tuple[Retirement, ...]) -> list[Retirement]:
+    """Descriptors whose data migration has been written (``contract_rev`` set).
+
+    A descriptor with no ``contract_rev`` has no migration yet — there is
+    nothing to assert "the rows have been rewritten by" — so it is not gated.
+    """
+
+    return [r for r in registry if r.contract_rev is not None]
+
+
+def _bind_token_param(predicate_sql: str) -> str:
+    """Rewrite the descriptor's ``:token`` named bind to asyncpg's ``$1``.
+
+    Surface predicates are declared with a SQLAlchemy-style ``:token`` named
+    parameter (one shared template per domain); asyncpg uses positional ``$N``
+    binds. Every tool-surface predicate references ``:token`` exactly once, so a
+    literal substitution to ``$1`` is exact and order-stable.
+    """
+
+    return predicate_sql.replace(":token", "$1")
+
+
+async def _current_alembic_version(conn: asyncpg.Connection[Any]) -> str | None:
+    """Return the live ``alembic_version.version_num`` (``None`` if unstamped).
+
+    A fresh DB with no ``alembic_version`` table (never migrated) reads as
+    ``None`` — which is unconditionally behind any ``contract_rev``, so the gate
+    refuses, exactly as it must for an unmigrated DB.
+    """
+
+    table = await conn.fetchval("SELECT to_regclass('alembic_version')")
+    if table is None:
+        return None
+    version: str | None = await conn.fetchval("SELECT version_num FROM alembic_version LIMIT 1")
+    return version
+
+
+async def assert_retirements_admissible(pool: asyncpg.Pool[Any]) -> None:
+    """Prove the live DB is safe for this code, or refuse readiness.
+
+    Raises :class:`RetirementsNotAdmissible` (one of its subclasses) on any
+    refusal reason; returns ``None`` when every contracted descriptor's proof
+    passes. The caller loops on the exception, keeping readiness RED.
+
+    For each contracted descriptor:
+
+    1. ``alembic_version >= contract_rev`` — else :class:`DatabaseBehindContract`.
+       Revisions are 4-digit zero-padded strings on a linear chain, so a string
+       comparison is the same as the migration order.
+    2. ``SUM over surfaces of count(rows matching the token predicate) == 0`` —
+       else :class:`LiveResidueDetected` plus an algedonic alert.
+
+    Any DB/connection failure raises :class:`DatabaseUnavailable` (fail-closed).
+    """
+
+    contracted = _contracted(REGISTRY)
+    if not contracted:
+        # Nothing contracted yet ⇒ nothing to prove ⇒ admissible. (The gate is
+        # still wired in, so the proof goes live the instant a descriptor gains
+        # a contract_rev.)
+        return
+
+    try:
+        async with pool.acquire() as conn:
+            version = await _current_alembic_version(conn)
+
+            # (1) alembic-head assertion. The DB must be at or past EVERY
+            # contracted descriptor's contract_rev before any residue scan is
+            # even meaningful — a behind DB hasn't run the rewrite yet, so its
+            # rows are expected to still carry the token.
+            for retirement in contracted:
+                contract_rev = retirement.contract_rev
+                assert contract_rev is not None  # _contracted filtered these
+                if version is None or version < contract_rev:
+                    log.info(
+                        "boot_gate.behind_contract",
+                        domain=retirement.domain,
+                        alembic_version=version,
+                        contract_rev=contract_rev,
+                    )
+                    raise DatabaseBehindContract(
+                        f"DB at alembic_version={version!r} is behind "
+                        f"contract_rev={contract_rev!r} for domain "
+                        f"{retirement.domain!r}; refusing readiness until the "
+                        "post-deploy migrate runs"
+                    )
+
+            # (2) per-surface live-residue aggregate. The rev is satisfied, so
+            # the rewrite was supposed to have run; any surviving token is a
+            # real, alert-worthy contract breach.
+            for retirement in contracted:
+                await _assert_no_residue(conn, retirement)
+    except RetirementsNotAdmissible:
+        raise
+    except (asyncpg.PostgresError, OSError, ConnectionError, TimeoutError) as exc:
+        # Fail-closed: no DB / a query that raised ⇒ not admissible. The caller
+        # loops and retries; never serve on an unprovable DB.
+        log.warning("boot_gate.db_unavailable", error=str(exc))
+        raise DatabaseUnavailable(
+            f"cannot prove retirement admissibility (DB unavailable): {exc}"
+        ) from exc
+
+
+async def _assert_no_residue(conn: asyncpg.Connection[Any], retirement: Retirement) -> None:
+    """Assert every surface of ``retirement`` carries zero rows of any token.
+
+    The aggregate is per-surface and per-token: for every ``(surface, token)``
+    pair, count the rows matching the surface's predicate bound to that token,
+    summed across the descriptor. A nonzero total on ANY surface fails the
+    proof. ``nullable`` columns are guarded with ``IS NOT NULL`` so the scan
+    never trips over an absent JSONB column.
+    """
+
+    tokens = retirement.tokens
+    breaches: list[dict[str, Any]] = []
+    for surface in retirement.surfaces:
+        predicate = _bind_token_param(surface.predicate_sql)
+        where = predicate
+        if surface.nullable:
+            where = f"{surface.jsonb_col} IS NOT NULL AND ({predicate})"
+        sql = f"SELECT count(*) FROM {surface.table} WHERE {where}"
+        for token in tokens:
+            count = await conn.fetchval(sql, token)
+            if count:
+                breaches.append(
+                    {
+                        "table": surface.table,
+                        "jsonb_col": surface.jsonb_col,
+                        "token": token,
+                        "count": int(count),
+                    }
+                )
+
+    if breaches:
+        # Algedonic alert: a contract migration that was supposed to have
+        # rewritten these rows to canonical did not. ``algedonic=True`` marks
+        # the highest-severity operator pain signal; serving here would
+        # re-open the #1525 per-row read crash-loop.
+        log.error(
+            "boot_gate.live_residue",
+            algedonic=True,
+            domain=retirement.domain,
+            contract_rev=retirement.contract_rev,
+            breaches=breaches,
+        )
+        raise LiveResidueDetected(
+            f"live residue on {len(breaches)} surface/token pair(s) for domain "
+            f"{retirement.domain!r} (contract_rev={retirement.contract_rev!r}): "
+            f"{breaches!r}; refusing readiness"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,18 @@ def _truncate_sql(migrated_db_url: str) -> str:
     async def fetch() -> str:
         conn = await asyncpg.connect(migrated_db_url)
         try:
-            rows = await conn.fetch("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+            rows = await conn.fetch(
+                # ``alembic_version`` is schema-version *metadata*, not test
+                # data: it is stamped once by :func:`migrated_db_url` and must
+                # survive the per-test reset.  Truncating it leaves the DB
+                # reading as "unmigrated" (``version_num`` empty), which the
+                # boot-admission gate (tests/integration/test_boot_admission_gate_db.py)
+                # correctly treats as behind every ``contract_rev`` — so the
+                # clean-DB case wrongly raises ``DatabaseBehindContract``.
+                # Exclude it from the truncate so reset clears rows, not schema.
+                "SELECT tablename FROM pg_tables "
+                "WHERE schemaname = 'public' AND tablename <> 'alembic_version'"
+            )
         finally:
             await conn.close()
         if not rows:

--- a/tests/helpers/connections.py
+++ b/tests/helpers/connections.py
@@ -72,6 +72,12 @@ def wired_app(pool: Any) -> FastAPI:
     app.state.crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
     app.state.db_url = settings.db_url
     app.state.procrastinate = mock.MagicMock()
+    # The real lifespan flips this True only after the boot-admission gate
+    # (#1575) proves the DB safe; these helpers bind state directly without
+    # running the lifespan, and the test DB is migrated to head with no
+    # retired-token residue, so mark the process admitted so ``/ready`` and
+    # the routes behave as they would post-gate.
+    app.state.retirements_ok = True
     return app
 
 

--- a/tests/integration/test_boot_admission_gate_db.py
+++ b/tests/integration/test_boot_admission_gate_db.py
@@ -1,0 +1,102 @@
+"""Integration test: the boot-admission gate against a real migrated DB (#1575).
+
+The unit tests pin the gate's branch logic with a fake connection; this test
+proves the gate runs its real SQL — the alembic-head read and the per-surface
+residue aggregate — against an actual Postgres migrated to head with the seeded
+registry's surface predicates. It covers:
+
+* a clean migrated DB (alembic at head ≥ every contract_rev, zero residue) is
+  admissible, and
+* a retired token planted on a registered surface trips the live-residue
+  refusal + algedonic alert.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+import structlog
+
+from aios.db.pool import create_pool
+from aios.retirements.boot_gate import (
+    LiveResidueDetected,
+    assert_retirements_admissible,
+)
+from aios.services import agents as agents_service
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT = "acc_boot_gate"
+
+
+@pytest.fixture
+async def pool(migrated_db_url: str, _reset_db_state: None) -> AsyncIterator[asyncpg.Pool[Any]]:
+    p = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        yield p
+    finally:
+        await p.close()
+
+
+async def test_clean_migrated_db_is_admissible(pool: asyncpg.Pool[Any]) -> None:
+    """A DB migrated to head with no retired-token residue passes the gate.
+
+    The conftest migrates to head (≥ every seeded ``contract_rev``) and the
+    truncate-reset leaves no rows carrying a retired token, so the gate must
+    return cleanly — readiness may flip green.
+    """
+    await assert_retirements_admissible(pool)
+
+
+async def test_residue_on_real_surface_refuses(pool: asyncpg.Pool[Any]) -> None:
+    """A retired token planted in ``agents.tools`` trips the live-residue refusal.
+
+    ``complete_goal`` is a seeded ``drop`` retirement whose contract migration
+    (0122) ran in the migrate-to-head; planting it back onto the real
+    ``agents.tools`` JSONB surface is exactly the "new code meets old rows"
+    residue the gate exists to refuse — cleanly, with an algedonic alert,
+    instead of the #1525 per-row crash-loop.
+    """
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+            "VALUES ($1, NULL, TRUE, 'boot-gate-test')",
+            _ACCOUNT,
+        )
+    # Create a valid agent via the real service, then UPDATE its tools JSONB to
+    # plant a retired builtin directly — modelling an old row written before the
+    # token was retired (the model layer would reject it on construction today).
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=_ACCOUNT,
+        name="residue-agent",
+        model="openrouter/test",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE agents SET tools = $2::jsonb WHERE id = $1",
+            agent.id,
+            '[{"type": "complete_goal"}]',
+        )
+
+    with structlog.testing.capture_logs() as logs, pytest.raises(LiveResidueDetected):
+        await assert_retirements_admissible(pool)
+
+    alerts = [
+        r
+        for r in logs
+        if r.get("event") == "boot_gate.live_residue" and r.get("algedonic") is True
+    ]
+    assert alerts, logs
+    # The breach names the real surface it found the token on.
+    breaches = alerts[0]["breaches"]
+    assert any(b["table"] == "agents" and b["token"] == "complete_goal" for b in breaches)

--- a/tests/integration/test_boot_admission_gate_db.py
+++ b/tests/integration/test_boot_admission_gate_db.py
@@ -92,9 +92,7 @@ async def test_residue_on_real_surface_refuses(pool: asyncpg.Pool[Any]) -> None:
         await assert_retirements_admissible(pool)
 
     alerts = [
-        r
-        for r in logs
-        if r.get("event") == "boot_gate.live_residue" and r.get("algedonic") is True
+        r for r in logs if r.get("event") == "boot_gate.live_residue" and r.get("algedonic") is True
     ]
     assert alerts, logs
     # The breach names the real surface it found the token on.

--- a/tests/unit/test_boot_admission_gate.py
+++ b/tests/unit/test_boot_admission_gate.py
@@ -119,8 +119,7 @@ def _single_contracted() -> Retirement:
                 table="agents",
                 jsonb_col="tools",
                 predicate_sql=(
-                    "EXISTS(SELECT 1 FROM jsonb_array_elements(tools) e "
-                    "WHERE e->>'type' = :token)"
+                    "EXISTS(SELECT 1 FROM jsonb_array_elements(tools) e WHERE e->>'type' = :token)"
                 ),
             ),
         ),
@@ -171,9 +170,7 @@ async def test_nonzero_residue_refuses_and_alerts(patch_registry: Any) -> None:
     assert any(token == "complete_goal" for _sql, token in conn.count_queries)
     # An algedonic alert was emitted.
     alerts = [
-        r
-        for r in logs
-        if r.get("event") == "boot_gate.live_residue" and r.get("algedonic") is True
+        r for r in logs if r.get("event") == "boot_gate.live_residue" and r.get("algedonic") is True
     ]
     assert alerts, logs
 

--- a/tests/unit/test_boot_admission_gate.py
+++ b/tests/unit/test_boot_admission_gate.py
@@ -1,0 +1,258 @@
+"""Tests for the fail-closed boot-admission gate (#1575, epic #1572).
+
+The gate (:func:`aios.retirements.boot_gate.assert_retirements_admissible`) is
+the keystone provability invariant: it runs at api + worker startup, BEFORE
+readiness flips green, and refuses readiness unless the live DB is proven safe
+for this code. These tests pin the four acceptance branches with a fake asyncpg
+pool/connection so no Postgres is needed:
+
+* alembic_version >= contract_rev (behind-DB ⇒ refuse, the process loops),
+* per-surface live residue == 0 (nonzero ⇒ refuse + algedonic alert),
+* fail-closed (no DB / connection error ⇒ refuse),
+* admissible (rev satisfied + zero residue ⇒ return cleanly).
+
+The proof reads the contracted descriptors and their surface predicates from
+the registry, so the assertions exercise the real seeded surfaces.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import structlog
+
+from aios.retirements import Retirement, Surface, boot_gate
+from aios.retirements.boot_gate import (
+    DatabaseBehindContract,
+    DatabaseUnavailable,
+    LiveResidueDetected,
+    RetirementsNotAdmissible,
+    assert_retirements_admissible,
+)
+
+# The highest contract_rev among the seeded descriptors; the DB must be at or
+# past this to even reach the residue scan.
+_AHEAD_REV = "9999"
+_BEHIND_REV = "0001"
+
+
+class _FakeConn:
+    """A minimal asyncpg-conn stub driving the gate's two query shapes.
+
+    * ``SELECT to_regclass('alembic_version')`` → a non-None truthy unless
+      ``alembic_table_missing``.
+    * ``SELECT version_num FROM alembic_version ...`` → ``version``.
+    * ``SELECT count(*) FROM <table> WHERE ...`` → ``residue_counts[table]``
+      (default 0), recording the bound token for assertions.
+
+    A ``raise_on`` substring makes the matching ``fetchval`` raise the supplied
+    exception, modelling a DB error mid-proof.
+    """
+
+    def __init__(
+        self,
+        *,
+        version: str | None,
+        alembic_table_missing: bool = False,
+        residue_counts: dict[str, int] | None = None,
+        raise_on: tuple[str, Exception] | None = None,
+    ) -> None:
+        self.version = version
+        self.alembic_table_missing = alembic_table_missing
+        self.residue_counts = residue_counts or {}
+        self.raise_on = raise_on
+        self.count_queries: list[tuple[str, Any]] = []
+
+    async def fetchval(self, sql: str, *args: Any) -> Any:
+        if self.raise_on is not None and self.raise_on[0] in sql:
+            raise self.raise_on[1]
+        if "to_regclass('alembic_version')" in sql:
+            return None if self.alembic_table_missing else "alembic_version"
+        if "version_num FROM alembic_version" in sql:
+            return self.version
+        if sql.startswith("SELECT count(*) FROM "):
+            self.count_queries.append((sql, args[0] if args else None))
+            # table name is the token after FROM: SELECT count(*) FROM <t> WHERE ...
+            tokens = sql.split()
+            table = tokens[tokens.index("FROM") + 1]
+            return self.residue_counts.get(table, 0)
+        raise AssertionError(f"unexpected query: {sql!r}")
+
+
+class _FakePool:
+    """Acquire-context wrapper around a single :class:`_FakeConn`.
+
+    ``acquire_error`` makes ``acquire()`` itself raise, modelling a pool that
+    can't hand out a connection (the fail-closed no-DB case).
+    """
+
+    def __init__(
+        self, conn: _FakeConn | None = None, *, acquire_error: Exception | None = None
+    ) -> None:
+        self._conn = conn
+        self._acquire_error = acquire_error
+
+    def acquire(self) -> Any:
+        pool = self
+
+        class _Ctx:
+            async def __aenter__(self) -> _FakeConn:
+                if pool._acquire_error is not None:
+                    raise pool._acquire_error
+                assert pool._conn is not None
+                return pool._conn
+
+            async def __aexit__(self, *exc: Any) -> None:
+                return None
+
+        return _Ctx()
+
+
+def _single_contracted() -> Retirement:
+    """A one-surface, one-token contracted descriptor for focused assertions."""
+    return Retirement(
+        domain="tool_surface",
+        action="drop",
+        surfaces=(
+            Surface(
+                table="agents",
+                jsonb_col="tools",
+                predicate_sql=(
+                    "EXISTS(SELECT 1 FROM jsonb_array_elements(tools) e "
+                    "WHERE e->>'type' = :token)"
+                ),
+            ),
+        ),
+        introduced_rev="0500",
+        contract_rev="0500",
+        token="complete_goal",
+    )
+
+
+@pytest.fixture
+def patch_registry(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Return a helper that swaps :data:`boot_gate.REGISTRY` for a test set."""
+
+    def _set(registry: tuple[Retirement, ...]) -> None:
+        monkeypatch.setattr(boot_gate, "REGISTRY", registry)
+
+    return _set
+
+
+async def test_behind_db_refuses_readiness(patch_registry: Any) -> None:
+    """alembic_version < contract_rev ⇒ DatabaseBehindContract (the loop case)."""
+    patch_registry((_single_contracted(),))
+    pool = _FakePool(_FakeConn(version=_BEHIND_REV))
+    with pytest.raises(DatabaseBehindContract) as exc:
+        await assert_retirements_admissible(pool)
+    assert isinstance(exc.value, RetirementsNotAdmissible)
+    # The residue scan must NOT have run while the DB is behind.
+    conn = pool._conn
+    assert conn is not None
+    assert conn.count_queries == []
+
+
+async def test_unmigrated_db_is_behind(patch_registry: Any) -> None:
+    """No alembic_version table at all ⇒ behind (refuse), never a crash."""
+    patch_registry((_single_contracted(),))
+    pool = _FakePool(_FakeConn(version=None, alembic_table_missing=True))
+    with pytest.raises(DatabaseBehindContract):
+        await assert_retirements_admissible(pool)
+
+
+async def test_nonzero_residue_refuses_and_alerts(patch_registry: Any) -> None:
+    """Residue on a surface ⇒ LiveResidueDetected + an algedonic alert."""
+    patch_registry((_single_contracted(),))
+    conn = _FakeConn(version=_AHEAD_REV, residue_counts={"agents": 3})
+    with structlog.testing.capture_logs() as logs, pytest.raises(LiveResidueDetected):
+        await assert_retirements_admissible(_FakePool(conn))
+    # The token was bound into the predicate, not interpolated.
+    assert any(token == "complete_goal" for _sql, token in conn.count_queries)
+    # An algedonic alert was emitted.
+    alerts = [
+        r
+        for r in logs
+        if r.get("event") == "boot_gate.live_residue" and r.get("algedonic") is True
+    ]
+    assert alerts, logs
+
+
+async def test_no_db_connection_fails_closed(patch_registry: Any) -> None:
+    """A pool that can't acquire ⇒ DatabaseUnavailable (fail-closed)."""
+    patch_registry((_single_contracted(),))
+    pool = _FakePool(acquire_error=ConnectionError("no route to db"))
+    with pytest.raises(DatabaseUnavailable) as exc:
+        await assert_retirements_admissible(pool)
+    assert isinstance(exc.value, RetirementsNotAdmissible)
+
+
+async def test_query_error_mid_proof_fails_closed(patch_registry: Any) -> None:
+    """A query raising mid-proof ⇒ DatabaseUnavailable, not an escaping error."""
+    patch_registry((_single_contracted(),))
+    conn = _FakeConn(
+        version=_AHEAD_REV,
+        raise_on=("count(*)", ConnectionResetError("dropped mid-scan")),
+    )
+    with pytest.raises(DatabaseUnavailable):
+        await assert_retirements_admissible(_FakePool(conn))
+
+
+async def test_admissible_when_ahead_and_clean(patch_registry: Any) -> None:
+    """Rev satisfied + zero residue everywhere ⇒ returns cleanly."""
+    patch_registry((_single_contracted(),))
+    conn = _FakeConn(version=_AHEAD_REV)
+    await assert_retirements_admissible(_FakePool(conn))
+    # The residue scan ran (and found nothing).
+    assert conn.count_queries
+
+
+async def test_uncontracted_descriptor_is_skipped(patch_registry: Any) -> None:
+    """A descriptor with no contract_rev is not gated — nothing to prove yet."""
+    uncontracted = Retirement(
+        domain="tool_surface",
+        action="drop",
+        surfaces=(
+            Surface(
+                table="agents",
+                jsonb_col="tools",
+                predicate_sql="EXISTS(SELECT 1 FROM jsonb_array_elements(tools) e "
+                "WHERE e->>'type' = :token)",
+            ),
+        ),
+        introduced_rev="0500",
+        contract_rev=None,
+        token="not_yet",
+    )
+    patch_registry((uncontracted,))
+    # Even a behind/empty DB is admissible because nothing is contracted; the
+    # gate must not even query.
+    conn = _FakeConn(version=_BEHIND_REV)
+    await assert_retirements_admissible(_FakePool(conn))
+    assert conn.count_queries == []
+
+
+async def test_nullable_surface_guards_is_not_null(
+    patch_registry: Any,
+) -> None:
+    """A nullable surface's residue query guards the column with IS NOT NULL."""
+    nullable_desc = Retirement(
+        domain="tool_surface",
+        action="drop",
+        surfaces=(
+            Surface(
+                table="sessions",
+                jsonb_col="tools",
+                predicate_sql="EXISTS(SELECT 1 FROM jsonb_array_elements(tools) e "
+                "WHERE e->>'type' = :token)",
+                nullable=True,
+            ),
+        ),
+        introduced_rev="0500",
+        contract_rev="0500",
+        token="complete_goal",
+    )
+    patch_registry((nullable_desc,))
+    conn = _FakeConn(version=_AHEAD_REV)
+    await assert_retirements_admissible(_FakePool(conn))
+    assert any("IS NOT NULL" in sql for sql, _token in conn.count_queries)

--- a/tests/unit/test_ready_route.py
+++ b/tests/unit/test_ready_route.py
@@ -56,10 +56,14 @@ class _FakePool:
         return _FakeAcquireCM(_FakeConn(self._fetchval_impl))
 
 
-def _app_with_pool(pool: Any) -> FastAPI:
+def _app_with_pool(pool: Any, *, retirements_ok: bool = True) -> FastAPI:
     app = FastAPI()
     app.include_router(health.router)
     app.state.pool = pool
+    # The boot-admission gate (#1575) flips this True only after it has proven
+    # the live DB is safe for this code. Default True here so the DB-path tests
+    # exercise the SELECT-1 branch; the gate-refusal case sets it False.
+    app.state.retirements_ok = retirements_ok
     return app
 
 
@@ -105,6 +109,36 @@ def test_ready_503_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("aios.api.routers.health.asyncio.timeout", _tiny_timeout)
     client = TestClient(_app_with_pool(_FakePool(_slow)))
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    assert resp.json() == {"status": "unavailable"}
+
+
+def test_ready_503_when_boot_gate_not_admitted() -> None:
+    """Before the boot-admission gate (#1575) flips green, ``/ready`` is 503.
+
+    Even with a perfectly healthy DB, an un-admitted process (the boot gate is
+    still looping on a behind / residue-bearing DB) must report unready — that
+    is what keeps the NEW container out of rotation while the OLD healthy one
+    serves under a rolling deploy. The DB is never even queried.
+    """
+
+    async def _ok(_query: str) -> int:
+        raise AssertionError("/ready must not query the DB while un-admitted")
+
+    client = TestClient(_app_with_pool(_FakePool(_ok), retirements_ok=False))
+    resp = client.get("/ready")
+    assert resp.status_code == 503
+    assert resp.json() == {"status": "unavailable"}
+
+
+def test_ready_503_when_retirements_flag_absent() -> None:
+    """A missing ``retirements_ok`` attribute fails closed (unready)."""
+    app = FastAPI()
+    app.include_router(health.router)
+    app.state.pool = _FakePool(lambda _q: None)
+    # Deliberately do NOT set app.state.retirements_ok.
+    client = TestClient(app)
     resp = client.get("/ready")
     assert resp.status_code == 503
     assert resp.json() == {"status": "unavailable"}


### PR DESCRIPTION
Automated dev-pipeline build for issue #1575.