### PR TITLE
Migration generator: bin/aios-retire emits expand/backfill/contract migrations from a descriptor (batched, EXISTS-pre-checked, abort-guard)

### DIFF
--- a/bin/aios-retire
+++ b/bin/aios-retire
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""``aios-retire`` — emit a retirement's three lifecycle migrations from a descriptor.
+
+The migration generator (#1578, epic #1572) turns each new pattern retirement
+into a *fill-in-the-descriptor* exercise instead of three hand-written
+migrations. Given the name of a descriptor declared as data in
+``aios.retirements.registry`` (#1573), it emits the three lifecycle migrations in
+chain order on top of the current migration head:
+
+  * **expand**   (rev N)   — open the ledger (no data change),
+  * **backfill** (rev N+1) — EXISTS-pre-checked, batched, epoch-stamping rewrite,
+  * **contract** (rev N+2) — stamp the ledger + in-transaction abort-guard.
+
+The emitted SQL matches the merged 0116/0120/0122 shape and slots into the
+linear alembic ladder, so the migration-chain test stays green.
+
+Usage:
+  bin/aios-retire <DESCRIPTOR>            write the three migrations into migrations/versions/
+  bin/aios-retire <DESCRIPTOR> --dry-run  print the three files to stdout, write nothing
+  bin/aios-retire --list                  list the registered descriptor names
+  bin/aios-retire --help                  show this help
+
+``<DESCRIPTOR>`` is the module-level constant name in
+``aios.retirements.registry`` (e.g. ``LEGACY_BUILTIN_RENAMES``).
+
+Exit codes:
+  0  success
+  1  bad usage / unknown descriptor / non-single-headed ladder
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make ``src`` importable when run from a source checkout without an install.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC = _REPO_ROOT / "src"
+if _SRC.is_dir() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from aios.retirements import Retirement  # noqa: E402
+from aios.retirements.migration_gen import (  # noqa: E402
+    current_head,
+    generate,
+    resolve_descriptor,
+)
+
+_MIGRATIONS_DIR = _REPO_ROOT / "migrations"
+_VERSIONS_DIR = _MIGRATIONS_DIR / "versions"
+
+
+def _list_descriptors() -> int:
+    from aios.retirements import registry as reg
+
+    names = sorted(attr for attr in dir(reg) if isinstance(getattr(reg, attr), Retirement))
+    for name in names:
+        desc: Retirement = getattr(reg, name)
+        toks = ", ".join(desc.tokens)
+        print(f"{name}\t[{desc.domain}/{desc.action}] {toks}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = list(argv)
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__)
+        return 0 if args[:1] in ([], ["-h"], ["--help"]) else 1
+    if args[0] == "--list":
+        return _list_descriptors()
+
+    dry_run = False
+    if "--dry-run" in args:
+        dry_run = True
+        args.remove("--dry-run")
+    if len(args) != 1:
+        print(__doc__, file=sys.stderr)
+        return 1
+
+    descriptor_name = args[0]
+    try:
+        retirement, name = resolve_descriptor(descriptor_name)
+    except KeyError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    try:
+        head = current_head(str(_MIGRATIONS_DIR))
+    except RuntimeError as exc:
+        print(f"cannot generate: {exc}", file=sys.stderr)
+        return 1
+
+    chain = generate(retirement, head, descriptor_name=name)
+
+    if dry_run:
+        for migration in chain:
+            print(f"# ── {migration.filename} ".ljust(80, "─"))
+            print(migration.source)
+            print()
+        return 0
+
+    for migration in chain:
+        path = _VERSIONS_DIR / migration.filename
+        path.write_text(migration.source)
+        print(f"wrote {path.relative_to(_REPO_ROOT)} (rev {migration.revision})")
+    print(
+        f"generated expand/backfill/contract for {name} "
+        f"on top of head {head}: {chain.expand.revision} → "
+        f"{chain.backfill.revision} → {chain.contract.revision}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/aios/retirements/migration_gen.py
+++ b/src/aios/retirements/migration_gen.py
@@ -1,0 +1,540 @@
+"""Migration generator — emit expand/backfill/contract migrations from a descriptor.
+
+This is the *data-migration generator* arm of the pattern-retirement lifecycle
+(#1578, epic #1572). Given a single :class:`~aios.retirements.Retirement`
+descriptor (declared as data in :mod:`aios.retirements.registry`, #1573), it
+emits the **three lifecycle migrations** so each new retirement is a
+fill-in-the-descriptor exercise, not three hand-written migrations:
+
+1. **Expand** (rev ``N``) — no-op on data; inserts the descriptor's ledger row
+   (``phase = 'expand'``, ``contract_rev = NULL``, ``sla_days``). This is the
+   span during which the registry-driven read-tolerance shim
+   (:func:`aios.retirements.registry.tolerated_rename_map`, gated on
+   ``contract_rev IS NULL``) keeps remapping the retired tokens on read.
+
+2. **Backfill** (rev ``N+1``) — the real data rewrite. ``EXISTS``-pre-checked,
+   **batched** set-based ``UPDATE`` / jsonb edit across *all* the descriptor's
+   surfaces. High-cardinality surfaces (``wf_runs``, ``agent_versions``, …) are
+   rewritten in bounded ``ctid``-keyed batches to cap how long any single
+   statement holds its row locks — the 0066 lesson (a single unbounded
+   ``UPDATE`` over a high-cardinality table holds locks for the whole table and
+   can wedge concurrent writers). Re-runnable: every statement is
+   ``EXISTS``-guarded so it no-ops on already-fixed rows, and a partial run that
+   is resumed simply finishes the remaining rows. Stamps
+   ``tools_vocab_epoch = N+1`` on each rewritten surface (the epoch column is the
+   additive #1576 migration; the live exercise sequences it before this runs).
+
+3. **Contract** (rev ``N+2``) — stamps the ledger row's ``contract_rev = N+2``
+   (which removes the descriptor's tokens from the read-tolerance map: the shim
+   stops remapping and a stale legacy value would then correctly fail
+   validation) and carries the in-transaction **abort-guard**: a residue scan
+   over every surface that, on finding *any* unmigrated row, raises inside the
+   migration transaction. Because the raise is in-transaction,
+   ``alembic_version`` never advances to ``N+2`` (the contract rev), so the boot
+   gate (#1575), which refuses to tear down a shim whose ``contract_rev`` has not
+   been reached everywhere, holds the line. The guard is a *belt* over the
+   backfill's *braces*: the backfill should have left zero residue, but a row
+   written between backfill and contract (or missed by a surface bug) must abort
+   rather than silently contract.
+
+The emitted SQL deliberately matches the merged 0116/0120/0122 shape: a single
+``op.execute`` per surface, ``jsonb_array_elements`` predicates, order-preserving
+``jsonb_agg``, a ``rename``-vs-``drop`` element transform, and a no-op
+``downgrade`` (these rewrites are forward-only). The chain pointers are wired so
+the three migrations apply in order on top of the current head.
+
+This module is pure (no DB, no Docker): it reads the descriptor and the on-disk
+migration ladder and returns file contents as strings. ``bin/aios-retire`` is a
+thin CLI over :func:`generate`.
+
+Ledger schema contract
+----------------------
+The generated migrations read/write a ``retirement_ledger`` table — the
+boot-gate's source of truth (#1575) — with at least these columns::
+
+    domain        text     -- the retirement's domain
+    token         text     -- one row per retired token
+    phase         text     -- 'expand' then 'contract'
+    contract_rev  text     -- NULL until the contract migration stamps it
+    sla_days      integer  -- teardown grace after contract_rev runs everywhere
+
+The expand migration inserts one row per token (``phase='expand'``,
+``contract_rev=NULL``); the contract migration updates those rows to
+``phase='contract'``, ``contract_rev=<N+2>``. The ledger table itself is created
+by the registry/boot-gate issue (#1575); this generator only writes rows. The
+``INSERT`` is ``ON CONFLICT DO NOTHING`` and the ``UPDATE`` is idempotent so a
+re-run of either migration is a no-op.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from aios.retirements import Retirement, Surface
+
+# ── Tunables ──────────────────────────────────────────────────────────────────
+
+#: Surfaces whose tables are high-cardinality enough that a single unbounded
+#: ``UPDATE`` would hold row locks too long (the 0066 lesson). The backfill
+#: rewrites these in bounded ``ctid`` batches; everything else gets one
+#: ``EXISTS``-guarded statement. Keyed by table name (a surface's column does
+#: not change its cardinality class).
+HIGH_CARDINALITY_TABLES: frozenset[str] = frozenset({"wf_runs", "agent_versions", "sessions"})
+
+#: Rows per batch on a high-cardinality surface. Bounds the lock-hold window;
+#: small enough to keep each statement short, large enough to keep the loop
+#: count sane on a big table.
+DEFAULT_BATCH_SIZE = 5000
+
+#: The ledger table the boot-gate (#1575) owns; this generator only writes rows.
+LEDGER_TABLE = "retirement_ledger"
+
+#: The epoch column the backfill stamps (additive migration #1576).
+EPOCH_COLUMN = "tools_vocab_epoch"
+
+
+# ── Result type ───────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GeneratedMigration:
+    """One emitted migration file: its revision, filename, and full source."""
+
+    revision: str
+    filename: str
+    source: str
+
+
+@dataclass(frozen=True)
+class GeneratedChain:
+    """The three lifecycle migrations for one descriptor, in chain order."""
+
+    expand: GeneratedMigration
+    backfill: GeneratedMigration
+    contract: GeneratedMigration
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        yield self.expand
+        yield self.backfill
+        yield self.contract
+
+
+# ── Revision helpers ──────────────────────────────────────────────────────────
+
+
+def next_revisions(head: str, count: int = 3) -> list[str]:
+    """The next ``count`` zero-padded numeric revisions after ``head``.
+
+    The aios ladder uses zero-padded integer revisions (``0116``, ``0123``, …);
+    we continue that scheme. ``head`` must be such a numeric revision.
+    """
+
+    m = re.fullmatch(r"(\d+)", head)
+    if not m:
+        raise ValueError(
+            f"head revision {head!r} is not a zero-padded integer; "
+            "the generator only extends the numeric aios ladder"
+        )
+    width = len(head)
+    start = int(head)
+    return [str(start + i).zfill(width) for i in range(1, count + 1)]
+
+
+# ── SQL fragment builders ─────────────────────────────────────────────────────
+
+
+def _quote_sql_str(value: str) -> str:
+    """Single-quote a SQL string literal, escaping embedded quotes."""
+
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _token_list_sql(retirement: Retirement) -> str:
+    """``'a', 'b', …`` — the retired tokens as a SQL ``IN`` list."""
+
+    return ", ".join(_quote_sql_str(t) for t in retirement.tokens)
+
+
+def _exists_predicate(surface: Surface, retirement: Retirement) -> str:
+    """A surface's ``EXISTS(...)`` residue predicate for *any* retired token.
+
+    The descriptor's shared ``predicate_sql`` is parameterised by ``:token``;
+    for a multi-token retirement we widen it to an ``IN (...)`` over all tokens
+    by rewriting the predicate's ``e->>'type' = :token`` into an ``IN`` list.
+    This keeps the single shared predicate template authoritative (the column is
+    already substituted) while covering every token in one scan.
+    """
+
+    token_list = _token_list_sql(retirement)
+    # The shared tool_surface predicate compares ``e->>'type' = :token``; widen
+    # the bound single token into the full IN list. Fall back to a literal
+    # substitution for any other predicate shape.
+    widened = re.sub(
+        r"=\s*:token\b",
+        f"IN ({token_list})",
+        surface.predicate_sql,
+    )
+    if widened == surface.predicate_sql:
+        # Predicate did not use the canonical ``= :token`` form; bind the first
+        # token literally so the fragment is at least valid for single-token
+        # retirements.
+        widened = surface.predicate_sql.replace(":token", _quote_sql_str(retirement.tokens[0]))
+    return widened
+
+
+def _element_transform_sql(retirement: Retirement) -> str:
+    """The per-element jsonb transform: rename → ``jsonb_set``, drop → filter.
+
+    Returns a SQL ``SELECT ... FROM jsonb_array_elements(...)`` expression body
+    that, given a ``tools`` jsonb array, returns the rewritten array. For a
+    ``rename`` it maps each retired ``type`` to its successor and dedupes by the
+    resulting builtin name (custom/mcp_toolset never deduped), first-occurrence
+    wins, order otherwise preserved — the 0116 shape. For a ``drop`` it filters
+    out every retired element, order preserved — the 0120/0122 shape.
+    """
+
+    if retirement.action == "rename":
+        case_arms = "\n".join(
+            f"                            WHEN {_quote_sql_str(tok)} THEN {_quote_sql_str(succ)}"
+            for tok, succ in retirement.token_map().items()
+            if succ is not None
+        )
+        return f"""
+            SELECT coalesce(jsonb_agg(elem ORDER BY ord), '[]'::jsonb)
+            FROM (
+                SELECT DISTINCT ON (dedup_key) elem, ord
+                FROM (
+                    SELECT
+                        jsonb_set(e, '{{type}}', to_jsonb(new_type)) AS elem,
+                        ord,
+                        CASE WHEN new_type IN ('custom', 'mcp_toolset')
+                             THEN 'pos:' || ord::text
+                             ELSE new_type END AS dedup_key
+                    FROM jsonb_array_elements(tools) WITH ORDINALITY AS arr(e, ord)
+                    CROSS JOIN LATERAL (
+                        SELECT CASE e->>'type'
+{case_arms}
+                            ELSE e->>'type'
+                        END AS new_type
+                    ) mapped
+                ) m
+                ORDER BY dedup_key, ord
+            ) deduped"""
+    # drop
+    token_list = _token_list_sql(retirement)
+    return f"""
+            SELECT coalesce(jsonb_agg(elem ORDER BY ord), '[]'::jsonb)
+            FROM jsonb_array_elements(tools) WITH ORDINALITY AS arr(elem, ord)
+            WHERE elem->>'type' NOT IN ({token_list})"""
+
+
+def _function_name(retirement: Retirement, revision: str) -> str:
+    """A unique pg function name for this descriptor's backfill transform."""
+
+    slug = re.sub(r"[^a-z0-9]+", "_", retirement.domain.lower()).strip("_")
+    verb = "rename" if retirement.action == "rename" else "drop"
+    return f"_aios_retire_{slug}_{verb}_{revision}"
+
+
+# ── Per-migration source builders ─────────────────────────────────────────────
+
+
+def _module_header(message: str, revision: str, down_revision: str, docstring: str) -> str:
+    return f'''"""{message}
+
+{docstring}
+
+Revision ID: {revision}
+Revises: {down_revision}
+
+Generated by ``bin/aios-retire`` from the registry descriptor — do not hand-edit;
+regenerate from the descriptor instead (#1578, epic #1572).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "{revision}"
+down_revision: str | None = "{down_revision}"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+'''
+
+
+def build_expand(retirement: Retirement, revision: str, down_revision: str) -> str:
+    """Source for the expand migration: insert the ledger row(s), no data edit."""
+
+    rows = ",\n".join(
+        "            ("
+        f"{_quote_sql_str(retirement.domain)}, {_quote_sql_str(tok)}, "
+        f"'expand', NULL, {int(retirement.sla_days)})"
+        for tok in retirement.tokens
+    )
+    header = _module_header(
+        f"Expand: open the {retirement.domain!r} retirement ledger (no data change).",
+        revision,
+        down_revision,
+        "No-op on data. Inserts one ``retirement_ledger`` row per retired token with\n"
+        "``phase='expand'``, ``contract_rev=NULL``, and the descriptor's ``sla_days``.\n"
+        "While these rows have ``contract_rev IS NULL`` the registry-driven read-\n"
+        "tolerance shim keeps remapping the tokens on read; the contract migration\n"
+        "(rev N+2) stamps ``contract_rev`` to close that span. ``ON CONFLICT DO\n"
+        "NOTHING`` makes the insert re-runnable.",
+    )
+    return f'''{header}
+
+# (domain, token, phase, contract_rev, sla_days) — one row per retired token.
+_LEDGER_ROWS_SQL = """
+    INSERT INTO {LEDGER_TABLE} (domain, token, phase, contract_rev, sla_days)
+    VALUES
+{rows}
+    ON CONFLICT (domain, token) DO NOTHING
+"""
+
+
+def upgrade() -> None:
+    # Expand is a no-op on persisted data: it only records that this retirement
+    # has entered its expand span. The read-tolerance shim does the live work.
+    op.execute(_LEDGER_ROWS_SQL)
+
+
+def downgrade() -> None:
+    # Forward-only lifecycle: removing the ledger row would re-open a span the
+    # backfill/contract may already have closed. Nothing to reverse.
+    pass
+'''
+
+
+def _backfill_statement(surface: Surface, retirement: Retirement, fn: str, revision: str) -> str:
+    """One surface's backfill ``op.execute`` block (batched if high-cardinality)."""
+
+    exists = _exists_predicate(surface, retirement)
+    null_guard = f"{surface.jsonb_col} IS NOT NULL AND " if surface.nullable else ""
+    set_clause = f"{surface.jsonb_col} = {fn}({surface.jsonb_col}), {EPOCH_COLUMN} = {revision}"
+
+    if surface.table in HIGH_CARDINALITY_TABLES:
+        # Batched: rewrite at most DEFAULT_BATCH_SIZE rows per statement, looping
+        # until no residue remains. ctid-keyed so each batch is a bounded,
+        # index-free slice; EXISTS-guarded so it is re-runnable and converges.
+        return f'''    # {surface.table}.{surface.jsonb_col}: high-cardinality → batched to bound
+    # lock-hold (the 0066 lesson). Loop until no residue remains.
+    op.execute("""
+        DO $do$
+        DECLARE
+            updated integer;
+        BEGIN
+            LOOP
+                UPDATE {surface.table} SET {set_clause}
+                WHERE ctid IN (
+                    SELECT ctid FROM {surface.table}
+                    WHERE {null_guard}{exists}
+                    LIMIT {DEFAULT_BATCH_SIZE}
+                );
+                GET DIAGNOSTICS updated = ROW_COUNT;
+                EXIT WHEN updated = 0;
+            END LOOP;
+        END
+        $do$;
+    """)'''
+    return f'''    # {surface.table}.{surface.jsonb_col}: single EXISTS-guarded set-based UPDATE.
+    op.execute("""
+        UPDATE {surface.table} SET {set_clause}
+        WHERE {null_guard}{exists}
+    """)'''
+
+
+def build_backfill(retirement: Retirement, revision: str, down_revision: str) -> str:
+    """Source for the backfill migration: batched, EXISTS-pre-checked, epoch-stamping."""
+
+    fn = _function_name(retirement, revision)
+    transform = _element_transform_sql(retirement)
+    statements = "\n\n".join(
+        _backfill_statement(s, retirement, fn, revision) for s in retirement.surfaces
+    )
+    header = _module_header(
+        f"Backfill: rewrite persisted {retirement.domain!r} surfaces to canonical.",
+        revision,
+        down_revision,
+        "EXISTS-pre-checked, batched, set-based rewrite across every surface the\n"
+        "descriptor declares. High-cardinality surfaces are rewritten in bounded\n"
+        "``ctid`` batches to cap lock-hold (the 0066 lesson); every statement is\n"
+        "``EXISTS``-guarded so it no-ops on already-fixed rows and is fully\n"
+        f"re-runnable. Stamps ``{EPOCH_COLUMN} = {revision}`` on each rewritten\n"
+        "surface. ``downgrade`` is a no-op (forward-only).",
+    )
+    return f'''{header}
+
+
+def upgrade() -> None:
+    # Order-preserving per-element transform, applied set-based per surface.
+    op.execute(r"""
+        CREATE FUNCTION {fn}(tools jsonb) RETURNS jsonb
+        LANGUAGE sql IMMUTABLE AS $fn${transform}
+        $fn$
+    """)
+
+{statements}
+
+    op.execute("DROP FUNCTION {fn}(jsonb)")
+
+
+def downgrade() -> None:
+    # Forward-only: canonicalised rows cannot be un-rewritten. Nothing to reverse.
+    pass
+'''
+
+
+def _contract_residue_predicate(retirement: Retirement) -> str:
+    """A single ``OR``-joined residue predicate across all surfaces for the guard."""
+
+    parts = []
+    for s in retirement.surfaces:
+        exists = _exists_predicate(s, retirement)
+        guard = f"{s.jsonb_col} IS NOT NULL AND " if s.nullable else ""
+        parts.append(f"        SELECT count(*) FROM {s.table} WHERE {guard}{exists}")
+    return "\n        UNION ALL\n".join(parts)
+
+
+def build_contract(retirement: Retirement, revision: str, down_revision: str) -> str:
+    """Source for the contract migration: stamp the ledger + in-txn abort-guard."""
+
+    residue = _contract_residue_predicate(retirement)
+    header = _module_header(
+        f"Contract: close the {retirement.domain!r} retirement (stamp ledger + abort-guard).",
+        revision,
+        down_revision,
+        "Stamps the ledger rows ``phase='contract'``, ``contract_rev=<this rev>`` —\n"
+        "which drops the descriptor's tokens out of the read-tolerance map, so the\n"
+        "shim stops remapping them and a stale legacy value would then correctly\n"
+        "fail validation. Carries the in-transaction **abort-guard**: a residue scan\n"
+        "over every surface that RAISES on any unmigrated row. Because the raise is\n"
+        "in-transaction the migration aborts and ``alembic_version`` never reaches\n"
+        "this contract rev, so the boot gate (#1575) holds the line. The guard is a\n"
+        "belt over the backfill's braces.",
+    )
+    update_rows = (
+        f"UPDATE {LEDGER_TABLE} SET phase = 'contract', contract_rev = '{revision}'\n"
+        f"        WHERE domain = {_quote_sql_str(retirement.domain)}\n"
+        f"          AND token IN ({_token_list_sql(retirement)})"
+    )
+    return f'''{header}
+
+
+def upgrade() -> None:
+    # Belt: abort the whole migration in-transaction if ANY surface still holds a
+    # retired token. The backfill (rev N+1) should have left zero residue; a row
+    # written between backfill and contract, or missed by a surface bug, MUST
+    # abort here rather than silently contract. On abort, alembic_version never
+    # advances to this contract rev, so the boot gate (#1575) keeps the shim.
+    op.execute("""
+        DO $guard$
+        DECLARE
+            residue bigint;
+        BEGIN
+            SELECT sum(c) INTO residue FROM (
+{residue}
+            ) scan(c);
+            IF residue IS NOT NULL AND residue > 0 THEN
+                RAISE EXCEPTION
+                    'retirement contract abort: % unmigrated row(s) remain for {retirement.domain}; '
+                    'run the backfill (rev {down_revision}) to convergence before contracting',
+                    residue;
+            END IF;
+        END
+        $guard$;
+    """)
+
+    # Braces held: stamp the ledger. Idempotent (re-running sets the same values).
+    op.execute("""
+        {update_rows}
+    """)
+
+
+def downgrade() -> None:
+    # Forward-only: un-stamping contract_rev would re-open a closed retirement.
+    pass
+'''
+
+
+# ── Public entry point ────────────────────────────────────────────────────────
+
+
+def generate(
+    retirement: Retirement,
+    head: str,
+    *,
+    descriptor_name: str | None = None,
+) -> GeneratedChain:
+    """Emit the three lifecycle migrations for ``retirement`` on top of ``head``.
+
+    ``head`` is the current single head of the migration ladder (the caller
+    resolves it via alembic's ``ScriptDirectory`` so the chain stays linear).
+    ``descriptor_name`` is only used to name the generated files; it defaults to
+    the descriptor's domain.
+    """
+
+    expand_rev, backfill_rev, contract_rev = next_revisions(head, 3)
+    name = descriptor_name or retirement.domain
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+
+    expand = GeneratedMigration(
+        revision=expand_rev,
+        filename=f"{expand_rev}_retire_{slug}_expand.py",
+        source=build_expand(retirement, expand_rev, head),
+    )
+    backfill = GeneratedMigration(
+        revision=backfill_rev,
+        filename=f"{backfill_rev}_retire_{slug}_backfill.py",
+        source=build_backfill(retirement, backfill_rev, expand_rev),
+    )
+    contract = GeneratedMigration(
+        revision=contract_rev,
+        filename=f"{contract_rev}_retire_{slug}_contract.py",
+        source=build_contract(retirement, contract_rev, backfill_rev),
+    )
+    return GeneratedChain(expand=expand, backfill=backfill, contract=contract)
+
+
+def resolve_descriptor(name: str) -> tuple[Retirement, str]:
+    """Resolve a registry descriptor by its module-level constant name.
+
+    ``bin/aios-retire <descriptor>`` names one of the constants in
+    :mod:`aios.retirements.registry` (e.g. ``LEGACY_BUILTIN_RENAMES``). Returns
+    the descriptor and its canonical name. Raises ``KeyError`` with the available
+    names if ``name`` is not a registered descriptor.
+    """
+
+    from aios.retirements import registry as _registry
+
+    candidate = getattr(_registry, name, None)
+    if isinstance(candidate, Retirement):
+        return candidate, name
+    available = sorted(
+        attr for attr in dir(_registry) if isinstance(getattr(_registry, attr), Retirement)
+    )
+    raise KeyError(f"no retirement descriptor named {name!r}; available: {', '.join(available)}")
+
+
+def current_head(migrations_dir: str) -> str:
+    """The single head revision of the on-disk migration ladder.
+
+    Resolves via alembic's ``ScriptDirectory`` (the same source the migration-
+    chain test trusts) so the generated chain extends the real head and the
+    ladder stays linear. Raises if the ladder is not single-headed.
+    """
+
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    cfg = Config()
+    cfg.set_main_option("script_location", migrations_dir)
+    script = ScriptDirectory.from_config(cfg)
+    heads: Sequence[str] = script.get_heads()
+    if len(heads) != 1:
+        raise RuntimeError(f"expected a single migration head, found {heads}")
+    return heads[0]

--- a/tests/unit/test_retirement_migration_gen.py
+++ b/tests/unit/test_retirement_migration_gen.py
@@ -1,0 +1,325 @@
+"""Unit tests for the retirement migration generator (#1578, epic #1572).
+
+``bin/aios-retire <descriptor>`` emits the three lifecycle migrations
+(expand/backfill/contract) from a registry descriptor. These tests assert the
+acceptance criteria as pure-Python checks over the generated source — no DB, no
+Docker:
+
+* all three migrations are generated in chain order on top of a given head;
+* the backfill is EXISTS-pre-checked, batched on high-cardinality surfaces,
+  re-runnable, and stamps the epoch;
+* the contract stamps the ledger and carries the in-transaction abort-on-nonzero
+  guard;
+* every emitted file is valid Python that declares the linear chain pointers and
+  matches the 0116/0120 shape;
+* the whole on-disk ladder (with a generated chain written in) keeps a single
+  linear head — the migration-chain invariant.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from aios.retirements import Retirement
+from aios.retirements.migration_gen import (
+    EPOCH_COLUMN,
+    HIGH_CARDINALITY_TABLES,
+    LEDGER_TABLE,
+    GeneratedChain,
+    current_head,
+    generate,
+    next_revisions,
+    resolve_descriptor,
+)
+from aios.retirements.registry import (
+    LEGACY_BUILTIN_RENAMES,
+    REGISTRY,
+    RETIRED_GOAL_OUTCOME_BUILTINS,
+)
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "migrations"
+
+
+def _chain(retirement: Retirement, head: str = "0123") -> GeneratedChain:
+    return generate(retirement, head, descriptor_name="UNDER_TEST")
+
+
+def _module(source: str) -> ast.Module:
+    """Parse generated source, failing the test with a clear message on a syntax error."""
+
+    try:
+        return ast.parse(source)
+    except SyntaxError as exc:  # pragma: no cover - failure path
+        pytest.fail(f"generated migration is not valid Python: {exc}\n\n{source}")
+
+
+# ── Chain shape & revision wiring ─────────────────────────────────────────────
+
+
+def test_next_revisions_extends_numeric_ladder() -> None:
+    assert next_revisions("0123", 3) == ["0124", "0125", "0126"]
+    assert next_revisions("0009", 3) == ["0010", "0011", "0012"]
+
+
+def test_next_revisions_rejects_non_numeric_head() -> None:
+    with pytest.raises(ValueError):
+        next_revisions("0046_reencrypt", 3)
+
+
+def test_generates_three_migrations_in_chain_order() -> None:
+    chain = _chain(LEGACY_BUILTIN_RENAMES, head="0123")
+    assert [m.revision for m in chain] == ["0124", "0125", "0126"]
+    # Chain pointers: expand→head, backfill→expand, contract→backfill.
+    assert 'down_revision: str | None = "0123"' in chain.expand.source
+    assert 'revision: str = "0124"' in chain.expand.source
+    assert 'down_revision: str | None = "0124"' in chain.backfill.source
+    assert 'revision: str = "0125"' in chain.backfill.source
+    assert 'down_revision: str | None = "0125"' in chain.contract.source
+    assert 'revision: str = "0126"' in chain.contract.source
+
+
+def test_filenames_carry_phase_and_revision() -> None:
+    chain = _chain(LEGACY_BUILTIN_RENAMES)
+    assert chain.expand.filename.endswith("_expand.py")
+    assert chain.backfill.filename.endswith("_backfill.py")
+    assert chain.contract.filename.endswith("_contract.py")
+    for m in chain:
+        assert m.filename.startswith(m.revision + "_")
+
+
+@pytest.mark.parametrize("retirement", REGISTRY)
+def test_all_generated_sources_are_valid_python(retirement: Retirement) -> None:
+    for migration in _chain(retirement):
+        mod = _module(migration.source)
+        funcs = {n.name for n in mod.body if isinstance(n, ast.FunctionDef)}
+        assert {"upgrade", "downgrade"} <= funcs
+
+
+@pytest.mark.parametrize("retirement", REGISTRY)
+def test_downgrade_is_a_noop_forward_only(retirement: Retirement) -> None:
+    # Every emitted migration is forward-only: downgrade() is a bare pass.
+    for migration in _chain(retirement):
+        mod = _module(migration.source)
+        (downgrade,) = [
+            n for n in mod.body if isinstance(n, ast.FunctionDef) and n.name == "downgrade"
+        ]
+        assert all(isinstance(stmt, (ast.Pass, ast.Expr)) for stmt in downgrade.body)
+        assert not any(isinstance(stmt, ast.Call) for stmt in downgrade.body)
+
+
+# ── Expand ────────────────────────────────────────────────────────────────────
+
+
+def test_expand_inserts_ledger_rows_and_no_data_change() -> None:
+    chain = _chain(LEGACY_BUILTIN_RENAMES)
+    src = chain.expand.source
+    assert f"INSERT INTO {LEDGER_TABLE}" in src
+    assert "phase" in src and "'expand'" in src
+    assert "contract_rev" in src and "NULL" in src
+    # sla_days carried from the descriptor.
+    assert str(LEGACY_BUILTIN_RENAMES.sla_days) in src
+    # One ledger row per token.
+    for token in LEGACY_BUILTIN_RENAMES.tokens:
+        assert f"'{token}'" in src
+    # Re-runnable insert.
+    assert "ON CONFLICT" in src and "DO NOTHING" in src
+    # No data UPDATE on tool surfaces in expand.
+    assert "UPDATE agents" not in src
+    assert "jsonb_set" not in src
+
+
+# ── Backfill ──────────────────────────────────────────────────────────────────
+
+
+def test_backfill_covers_every_surface() -> None:
+    src = _chain(LEGACY_BUILTIN_RENAMES).backfill.source
+    for surface in LEGACY_BUILTIN_RENAMES.surfaces:
+        # Each surface's table+column appears in an UPDATE.
+        assert re.search(rf"UPDATE {surface.table} SET {surface.jsonb_col} =", src), (
+            f"missing UPDATE for surface {surface.table}.{surface.jsonb_col}"
+        )
+
+
+def test_backfill_is_exists_pre_checked() -> None:
+    src = _chain(LEGACY_BUILTIN_RENAMES).backfill.source
+    # Every surface UPDATE is guarded by an EXISTS over its jsonb column.
+    for surface in LEGACY_BUILTIN_RENAMES.surfaces:
+        assert f"jsonb_array_elements({surface.jsonb_col})" in src
+    assert "EXISTS(" in src
+
+
+def test_backfill_batches_high_cardinality_surfaces_only() -> None:
+    src = _chain(LEGACY_BUILTIN_RENAMES).backfill.source
+    # High-cardinality surfaces use the bounded ctid LIMIT loop.
+    for surface in LEGACY_BUILTIN_RENAMES.surfaces:
+        block = _surface_block(src, surface.table)
+        if surface.table in HIGH_CARDINALITY_TABLES:
+            assert "LOOP" in block and "LIMIT" in block and "ctid" in block, (
+                f"high-cardinality surface {surface.table} must be batched"
+            )
+        else:
+            assert "LOOP" not in block, (
+                f"low-cardinality surface {surface.table} should be a single UPDATE"
+            )
+
+
+def test_backfill_stamps_the_epoch() -> None:
+    chain = _chain(LEGACY_BUILTIN_RENAMES, head="0123")
+    src = chain.backfill.source
+    # Epoch stamped to the backfill's own revision number on every surface: one
+    # SET-clause occurrence per surface (the docstring mention is not a SET).
+    set_clause = f", {EPOCH_COLUMN} = {chain.backfill.revision}"
+    assert src.count(set_clause) == len(LEGACY_BUILTIN_RENAMES.surfaces)
+
+
+def test_backfill_rename_maps_tokens_to_successors() -> None:
+    src = _chain(LEGACY_BUILTIN_RENAMES).backfill.source
+    for token, successor in LEGACY_BUILTIN_RENAMES.token_map().items():
+        assert successor is not None
+        assert f"WHEN '{token}' THEN '{successor}'" in src
+    # Order-preserving dedupe, 0116 shape.
+    assert "jsonb_agg(elem ORDER BY ord)" in src
+    assert "DISTINCT ON (dedup_key)" in src
+
+
+def test_backfill_drop_filters_tokens() -> None:
+    src = _chain(RETIRED_GOAL_OUTCOME_BUILTINS).backfill.source
+    # 0120/0122 drop shape: filter out retired elements, no jsonb_set/CASE remap.
+    assert "WHERE elem->>'type' NOT IN (" in src
+    assert "jsonb_set" not in src
+    for token in RETIRED_GOAL_OUTCOME_BUILTINS.tokens:
+        assert f"'{token}'" in src
+
+
+def test_backfill_guards_nullable_surfaces() -> None:
+    src = _chain(LEGACY_BUILTIN_RENAMES).backfill.source
+    nullable = [s for s in LEGACY_BUILTIN_RENAMES.surfaces if s.nullable]
+    assert nullable, "fixture should have a nullable surface to exercise the guard"
+    for surface in nullable:
+        block = _surface_block(src, surface.table)
+        assert f"{surface.jsonb_col} IS NOT NULL" in block
+
+
+def test_backfill_creates_and_drops_its_transform_function() -> None:
+    src = _chain(LEGACY_BUILTIN_RENAMES).backfill.source
+    assert "CREATE FUNCTION" in src
+    assert "DROP FUNCTION" in src
+
+
+# ── Contract ──────────────────────────────────────────────────────────────────
+
+
+def test_contract_stamps_ledger_contract_rev() -> None:
+    chain = _chain(LEGACY_BUILTIN_RENAMES)
+    src = chain.contract.source
+    assert f"UPDATE {LEDGER_TABLE}" in src
+    assert f"contract_rev = '{chain.contract.revision}'" in src
+    assert "phase = 'contract'" in src
+    for token in LEGACY_BUILTIN_RENAMES.tokens:
+        assert f"'{token}'" in src
+
+
+def test_contract_has_in_transaction_abort_on_nonzero_guard() -> None:
+    chain = _chain(LEGACY_BUILTIN_RENAMES)
+    src = chain.contract.source
+    # Residue scan over every surface.
+    for surface in LEGACY_BUILTIN_RENAMES.surfaces:
+        assert f"SELECT count(*) FROM {surface.table}" in src
+    # Abort-on-nonzero inside the migration transaction (RAISE EXCEPTION in a DO
+    # block runs in the migration txn, so alembic_version never reaches the
+    # contract rev on abort).
+    assert "RAISE EXCEPTION" in src
+    assert "residue > 0" in src
+    # The guard runs BEFORE the ledger stamp (belt before the contract is recorded).
+    assert src.index("RAISE EXCEPTION") < src.index(f"UPDATE {LEDGER_TABLE}")
+
+
+def test_contract_guard_references_the_backfill_revision() -> None:
+    chain = _chain(LEGACY_BUILTIN_RENAMES)
+    # The abort message points operators back at the backfill rev to re-run.
+    assert chain.backfill.revision in chain.contract.source
+
+
+# ── Descriptor resolution ─────────────────────────────────────────────────────
+
+
+def test_resolve_descriptor_by_constant_name() -> None:
+    retirement, name = resolve_descriptor("LEGACY_BUILTIN_RENAMES")
+    assert retirement is LEGACY_BUILTIN_RENAMES
+    assert name == "LEGACY_BUILTIN_RENAMES"
+
+
+def test_resolve_descriptor_unknown_lists_available() -> None:
+    with pytest.raises(KeyError) as exc:
+        resolve_descriptor("NOPE")
+    assert "LEGACY_BUILTIN_RENAMES" in str(exc.value)
+
+
+# ── Ladder integration: a generated chain keeps the ladder single-headed ──────
+
+
+def test_current_head_matches_alembic() -> None:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
+    script = ScriptDirectory.from_config(cfg)
+    (expected,) = script.get_heads()
+    assert current_head(str(_MIGRATIONS_DIR)) == expected
+
+
+def test_generated_chain_stays_single_headed_and_linear(tmp_path: Path) -> None:
+    """Writing a generated chain onto a copy of the ladder keeps one linear head."""
+
+    # Copy the real versions dir into a temp ladder.
+    src_versions = _MIGRATIONS_DIR / "versions"
+    dst = tmp_path / "migrations"
+    dst.mkdir()
+    (dst / "versions").mkdir()
+    # Minimal env so ScriptDirectory can load; copy script.py.mako + env.py.
+    for fname in ("env.py", "script.py.mako"):
+        (dst / fname).write_text((_MIGRATIONS_DIR / fname).read_text())
+    for f in src_versions.glob("*.py"):
+        (dst / "versions" / f.name).write_text(f.read_text())
+
+    head = current_head(str(dst))
+    chain = generate(LEGACY_BUILTIN_RENAMES, head, descriptor_name="LEGACY_BUILTIN_RENAMES")
+    for migration in chain:
+        (dst / "versions" / migration.filename).write_text(migration.source)
+
+    cfg = Config()
+    cfg.set_main_option("script_location", str(dst))
+    script = ScriptDirectory.from_config(cfg)
+    heads = list(script.get_heads())
+    assert heads == [chain.contract.revision], heads
+
+    # Whole chain linear: every revision has a single (str|None) parent.
+    for rev in script.walk_revisions():
+        assert rev.down_revision is None or isinstance(rev.down_revision, str)
+    bases = [r.revision for r in script.walk_revisions() if r.down_revision is None]
+    assert len(bases) == 1
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _surface_block(src: str, table: str) -> str:
+    """The slice of backfill source belonging to one surface's UPDATE block.
+
+    Each surface is rendered as one ``op.execute(...)`` call; we return the
+    op.execute call whose body mentions ``UPDATE <table> ``. Splitting on the
+    call boundary (rather than on the comment) is robust to multi-line comments.
+    """
+
+    needle = f"UPDATE {table} SET"
+    pos = src.index(needle)
+    # Walk back to the start of the enclosing op.execute( call ...
+    start = src.rindex("op.execute(", 0, pos)
+    # ... and forward to the next op.execute( or the DROP FUNCTION line.
+    after = src.find("op.execute(", pos)
+    end = after if after != -1 else len(src)
+    return src[start:end]


### PR DESCRIPTION
Automated dev-pipeline build for issue #1578.