### PR TITLE
Sandbox $HOME=/home/aios is uid-1000-owned but the agent runs as root → ownership-checking tools (Firefox/Camoufox, ssh, gpg) refuse; fix: HOME=/root (image ENV + _flatten restore)

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -72,18 +72,22 @@ RUN chmod 0755 /usr/local/bin/tool
 # DELIBERATELY no top-level `USER aios` directive. The image runs on a
 # one-shot-exec model: `CMD ["/usr/bin/tail","-f","/dev/null"]` keeps the
 # container alive as **root**, and every tool call is a separate
-# `docker exec`. The agent uid is supplied per-exec via
-# `docker exec --user 1000:1000 ...` (follow-up seam issue), never as the
-# image default. Root must remain the default exec uid because setup
-# execs run apt and the iptables networking lockdown, which require uid 0
-# (the contract test `test_runs_as_root` asserts this).
+# `docker exec`. The agent always runs as root (uid 0): aios uses the
+# agent-root model (root-on-Docker, safe-root via microVM/gVisor isolation;
+# ref aios#1014). There is no privilege-drop -- the planned `--user 1000:1000`
+# exec-user seam (aios#806/#850) is CLOSED / NOT_PLANNED. Root is required
+# because setup execs run apt and the iptables networking lockdown, which need
+# uid 0 (the contract test `test_runs_as_root` asserts this).
 #
-# `--create-home` makes /home/aios owned by uid 1000 so the agent exec can
-# write there; `ENV HOME=/home/aios` applies to every exec (docker
-# `--user` does not reset HOME), so both root and uid-1000 execs see it.
-# This is inert until the follow-up flips agent execs to `--user 1000:1000`.
+# `HOME` MUST point at a home owned by the running uid, or ownership-checking
+# tools (Firefox/Camoufox, ssh, gpg, sudo) refuse to run when $HOME's owner
+# != the running uid. The agent is root, so HOME=/root (root-owned, present in
+# the base image). The legacy uid-1000-owned /home/aios is no longer used by
+# anything (the uid-1000 exec phase it was scaffolded for is dead). The `aios`
+# user is kept only so a `--user 1000:1000` exec still resolves to a named
+# user; nothing depends on /home/aios.
 RUN groupadd --gid 1000 aios && useradd --uid 1000 --gid 1000 --create-home --home-dir /home/aios aios
-ENV HOME=/home/aios
+ENV HOME=/root
 
 # Default broker URL for bash scripts inside the sandbox that read
 # $TOOL_BROKER_URL directly (the python ``tool`` CLI has its own

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -647,7 +647,7 @@ class DockerBackend:
         changes = [
             'CMD ["/usr/bin/tail","-f","/dev/null"]',
             "WORKDIR /workspace",
-            "ENV HOME=/home/aios",
+            "ENV HOME=/root",
             f"LABEL {MANAGED_LABEL_KEY}={MANAGED_LABEL_VALUE}",
             f"LABEL {FLATTENED_LABEL_KEY}={FLATTENED_LABEL_VALUE}",
         ]

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -274,9 +274,7 @@ class TestRuntimeBehaviour:
             "-c",
             'test "$(stat -c %u "$HOME")" = "$(id -u)" && echo ok',
         )
-        assert r.returncode == 0, (
-            f"$HOME owner != running uid: {r.stderr or r.stdout}"
-        )
+        assert r.returncode == 0, f"$HOME owner != running uid: {r.stderr or r.stdout}"
         assert r.stdout.strip() == "ok", f"expected ok, got {r.stdout.strip()!r}"
 
     def test_trust_store_layout_is_debian(self, pulled_image: str) -> None:

--- a/tests/e2e/test_sandbox_image_contract.py
+++ b/tests/e2e/test_sandbox_image_contract.py
@@ -231,28 +231,53 @@ class TestRuntimeBehaviour:
         assert r.returncode == 0, r.stderr
         assert r.stdout.strip() == "aios", f"expected user aios, got {r.stdout.strip()!r}"
 
-    def test_user_1000_has_writable_home(self, pulled_image: str) -> None:
-        """uid 1000 owns /home/aios (created via --create-home) and ENV
-        HOME=/home/aios applies under `--user` (docker --user does not reset
-        HOME), so the agent can write to $HOME."""
+    def test_user_1000_owns_aios_home(self, pulled_image: str) -> None:
+        """The `aios` user (uid 1000) and its --create-home /home/aios are kept
+        as harmless leftovers (so a `--user 1000:1000` exec still resolves to a
+        named user with a writable home), but nothing depends on them: the
+        agent runs as root with HOME=/root. /home/aios stays owned by uid 1000
+        — note this is exactly the ownership mismatch that made HOME=/home/aios
+        a footgun for the root agent, which is why HOME no longer points here.
+
+        ENV HOME is unconditional (docker --user does not reset HOME), so a
+        uid-1000 exec would see HOME=/root, not /home/aios; this test probes
+        /home/aios directly rather than via $HOME."""
         r = _docker_run(
             pulled_image,
             "bash",
             "-c",
-            "touch $HOME/.probe && echo ok",
+            "touch /home/aios/.probe && echo ok",
             user="1000:1000",
         )
         assert r.returncode == 0, r.stderr
         assert r.stdout.strip() == "ok", (
-            f"expected writable $HOME, got {r.stdout.strip()!r}: {r.stderr}"
+            f"expected uid 1000 to own/write /home/aios, got {r.stdout.strip()!r}: {r.stderr}"
         )
 
-    def test_home_env_is_aios_home_for_root(self, pulled_image: str) -> None:
-        """Root (default) execs inherit ENV HOME=/home/aios too — the ENV is
-        unconditional, not gated on uid."""
+    def test_home_env_is_root_home_for_root(self, pulled_image: str) -> None:
+        """Root (default) execs inherit ENV HOME=/root — root's natural,
+        root-owned home, so $HOME's owner matches the running uid and
+        ownership-checking tools (Firefox/Camoufox, ssh, gpg) don't refuse."""
         r = _docker_run(pulled_image, "bash", "-c", "echo $HOME")
         assert r.returncode == 0, r.stderr
-        assert r.stdout.strip() == "/home/aios", f"expected /home/aios, got {r.stdout.strip()!r}"
+        assert r.stdout.strip() == "/root", f"expected /root, got {r.stdout.strip()!r}"
+
+    def test_home_owner_equals_running_uid(self, pulled_image: str) -> None:
+        """The exact invariant ownership-aware tools (Firefox/Camoufox, ssh,
+        gpg, sudo) enforce: $HOME's owner uid == the running uid. A regression
+        that re-points HOME at a foreign-owned dir (the historical
+        HOME=/home/aios footgun, /home/aios owned by uid 1000 while the agent
+        runs as root) fails here."""
+        r = _docker_run(
+            pulled_image,
+            "bash",
+            "-c",
+            'test "$(stat -c %u "$HOME")" = "$(id -u)" && echo ok',
+        )
+        assert r.returncode == 0, (
+            f"$HOME owner != running uid: {r.stderr or r.stdout}"
+        )
+        assert r.stdout.strip() == "ok", f"expected ok, got {r.stdout.strip()!r}"
 
     def test_trust_store_layout_is_debian(self, pulled_image: str) -> None:
         """The trust-store contract the egress-CA wiring depends on: a

--- a/tests/e2e/test_sandbox_persistence.py
+++ b/tests/e2e/test_sandbox_persistence.py
@@ -217,9 +217,14 @@ async def test_resume_integrity_path_home_pwd(
 
     A plain commit PRESERVES the base image's HOME (so the resumed value equals
     a fresh base container's HOME); flatten strips all config and RESTORES the
-    sandbox's canonical ``/home/aios``. (In a current deployment the base sets
-    HOME=/home/aios, so both are /home/aios; capturing the base HOME keeps the
-    test robust to base-image build variance.)"""
+    sandbox's canonical ``/root``. (In a current deployment the base sets
+    HOME=/root, so both are /root; capturing the base HOME keeps the test
+    robust to base-image build variance.)
+
+    Either way the resumed container must satisfy the ownership invariant
+    ownership-checking tools enforce -- ``stat -c %u "$HOME" == id -u`` -- so a
+    HOME/uid regression that only manifests post-thaw (e.g. ``_flatten``
+    restoring a foreign-owned HOME) fails here."""
     backend, instance_id, session_id, workspace = daemon
     tag = snapshot_tag(instance_id, session_id)
 
@@ -266,9 +271,18 @@ async def test_resume_integrity_path_home_pwd(
         rc, path = await run_sandbox(backend, h2, 'printf %s "$PATH"')
         assert rc == 0 and path.strip(), "resumed container has an empty PATH (CMD would not exec)"
         rc, home = await run_sandbox(backend, h2, 'printf %s "$HOME"')
-        expected_home = "/home/aios" if flatten else base_home
+        expected_home = "/root" if flatten else base_home
         assert home.strip() == expected_home, (
             f"HOME mismatch: got {home!r}, expected {expected_home!r} (flatten={flatten})"
+        )
+        # The ownership invariant ownership-checking tools enforce: $HOME's
+        # owner uid == the running uid, surviving the (possibly flattened)
+        # round-trip.
+        rc, owner_ok = await run_sandbox(
+            backend, h2, 'test "$(stat -c %u "$HOME")" = "$(id -u)" && echo ok'
+        )
+        assert rc == 0 and owner_ok.strip() == "ok", (
+            f"$HOME owner != running uid after resume (flatten={flatten}): {owner_ok!r}"
         )
         rc, pwd = await run_sandbox(backend, h2, "pwd")
         assert pwd.strip() == "/workspace", f"pwd not /workspace: {pwd!r}"

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -294,7 +294,7 @@ class TestFlattenConfigRestore:
         _producer, consumer = fake_docker.pipelines[0]
         joined = " ".join(consumer)
         assert "WORKDIR /workspace" in joined
-        assert "ENV HOME=/home/aios" in joined
+        assert "ENV HOME=/root" in joined
         assert 'CMD ["/usr/bin/tail","-f","/dev/null"]' in joined
         assert "aios.flattened=true" in joined
         assert "aios.base_image=ghcr.io/eumemic/aios-sandbox:latest" in joined


### PR DESCRIPTION
Automated dev-pipeline build for issue #1615.