### PR TITLE
read() inlines sandbox images at full resolution — >20 accumulated + one >2000px hard-rejects (400) every wake → session wedge

### DIFF
--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -41,7 +41,14 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from aios.harness.image_resize import (
+    ImageDownsampleError,
+    _blocking_downsample,
+    is_oversize_image,
+)
 from aios.harness.vision import (
+    INLINE_MAX_DIMENSION,
+    INLINE_SIZE_CAP_BYTES,
     PROVIDER_INLINE_IMAGE_FORMATS,
     can_inline_image,
     correct_image_mime_b64,
@@ -802,6 +809,99 @@ def _correct_image_data_url_mimes(messages: list[dict[str, Any]]) -> None:
             messages[msg_idx] = {**msg, "content": new_content}
 
 
+def _clamp_oversize_image_data_urls(messages: list[dict[str, Any]]) -> None:
+    """Downscale persisted ``data:<mime>;base64,...`` image parts whose
+    decoded longest edge exceeds :data:`INLINE_MAX_DIMENSION` (2000px).
+
+    Sibling pass to :func:`_correct_image_data_url_mimes`, called in the
+    same place on every ``build_messages``. ``read()`` now downsamples on
+    the inline path (issue #1616 Part A), but an image frozen at full
+    resolution in a historical ``tool_result`` event from BEFORE that fix
+    replays verbatim forever — and once >20 such parts accumulate and one
+    is >2000px on a side, Anthropic HARD-REJECTS the many-image request
+    (400, no server-side resize), wedging every wake. This pass re-checks
+    persisted parts each build and rewrites any oversize one to a bounded
+    copy, so an already-wedged session self-heals on its next build with
+    no manual log surgery.
+
+    Decode cost is bounded: ``_blocking_downsample`` does a header-only
+    size check first and returns ``None`` (no decode, bytes untouched)
+    for any part already <=2000px/side and <=cap — which, after Part A
+    ships, is everything except the pre-fix backlog.
+
+    Mutates by *replacing* part dicts with fresh copies — never in place —
+    matching :func:`_correct_image_data_url_mimes`'s contract (the message
+    list aliases the immutable ``Event.data``). A part that cannot be
+    downscaled (undecodable / above the pre-resize ceiling) degrades to a
+    short inert text placeholder rather than being dropped, preserving the
+    surrounding content-list / message structure.
+    """
+    for msg_idx, msg in enumerate(messages):
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        new_content: list[Any] | None = None
+        for i, part in enumerate(content):
+            if not isinstance(part, dict) or part.get("type") != "image_url":
+                continue
+            image_url = part.get("image_url")
+            if not isinstance(image_url, dict):
+                continue
+            url = image_url.get("url")
+            if not isinstance(url, str) or not url.startswith("data:"):
+                continue
+            head, sep, data_b64 = url.partition(",")
+            if not sep or ";base64" not in head:
+                continue
+            try:
+                raw = base64.b64decode(data_b64, validate=True)
+            except Exception:
+                # Malformed base64 — leave it; the mime corrector and the
+                # provider's own decode handle that orthogonal failure.
+                continue
+            # Header-only oversize check first: this pass is scoped to the
+            # DIMENSION wedge only. A part that already fits both caps is left
+            # exactly as the mime corrector produced it (an undecodable-but-
+            # small part is the mime corrector's / provider's concern, not a
+            # dimension wedge — degrading it here would clobber that contract).
+            if not is_oversize_image(raw):
+                continue
+            try:
+                # Blocking (not awaited): build_messages is sync. We only
+                # reach here for genuine >2000px (or over-cap) parts — the
+                # pre-fix backlog — so the re-encode cost is bounded.
+                resized = _blocking_downsample(raw, INLINE_SIZE_CAP_BYTES, INLINE_MAX_DIMENSION)
+            except ImageDownsampleError:
+                # Oversize AND un-shrinkable (above the pre-resize ceiling, or
+                # the byte cap is unreachable even at the bottom of the quality
+                # ladder): a part we cannot bound is a wedge if left in place.
+                # Replace it with an inert text placeholder, preserving list
+                # shape rather than dropping the message.
+                if new_content is None:
+                    new_content = list(content)
+                new_content[i] = {
+                    "type": "text",
+                    "text": "[image omitted: too large to display inline]",
+                }
+                continue
+            if resized is None:
+                # Header check said oversize but the downsample disagreed
+                # (e.g. a race on the cap boundary) — nothing to rewrite.
+                continue
+            encoded = base64.b64encode(resized.data).decode("ascii")
+            if new_content is None:
+                new_content = list(content)
+            new_content[i] = {
+                **part,
+                "image_url": {
+                    **image_url,
+                    "url": f"data:{resized.content_type};base64,{encoded}",
+                },
+            }
+        if new_content is not None:
+            messages[msg_idx] = {**msg, "content": new_content}
+
+
 def _is_replayable_thinking_block(block: Any) -> bool:
     """Whether a persisted thinking block is safe to replay to the provider.
 
@@ -1245,6 +1345,7 @@ def build_messages(
         messages.insert(0, {"role": "system", "content": system_prompt})
 
     _correct_image_data_url_mimes(messages)
+    _clamp_oversize_image_data_urls(messages)
 
     # Resolve the thinking-capability sniff through the shared provider-quirk
     # resolver in ``completion.py`` (consolidated from the prior inline

--- a/src/aios/harness/image_resize.py
+++ b/src/aios/harness/image_resize.py
@@ -110,6 +110,31 @@ async def maybe_downsample(
     return await asyncio.to_thread(_blocking_downsample, data, cap_bytes, max_dim)
 
 
+def is_oversize_image(
+    data: bytes,
+    *,
+    cap_bytes: int = INLINE_SIZE_CAP_BYTES,
+    max_dim: int = INLINE_MAX_DIMENSION,
+) -> bool:
+    """Whether ``data`` exceeds either inline cap (dimension or byte size).
+
+    Header-only — parses ``.width``/``.height`` via ``Image.open`` without
+    decoding pixels, so it is cheap to call on every persisted part. Returns
+    ``False`` for bytes Pillow can't even open a header for: an undecodable
+    part is not a *dimension* wedge and is handled by the orthogonal mime /
+    provider-decode path; callers scoping work to the dimension cap must not
+    treat it as oversize.
+    """
+    if len(data) > cap_bytes:
+        return True
+    pil = _pillow()
+    try:
+        img = pil.open(io.BytesIO(data))
+        return bool(img.width > max_dim or img.height > max_dim)
+    except Exception:
+        return False
+
+
 def _blocking_downsample(
     data: bytes,
     cap_bytes: int,

--- a/src/aios/tools/read.py
+++ b/src/aios/tools/read.py
@@ -21,6 +21,7 @@ from typing import Any
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
+from aios.harness.image_resize import ImageDownsampleError, maybe_downsample
 from aios.harness.vision import (
     INLINE_SIZE_CAP_BYTES,
     PROVIDER_INLINE_IMAGE_FORMATS,
@@ -294,6 +295,36 @@ async def _read_image(
             ),
             is_error=False,
         )
+
+    # Downscale full-resolution bytes to the inline dimension cap before
+    # encoding. ``read()`` previously inlined the raw bytes at full
+    # resolution; once >20 such images accumulate in a window and at least
+    # one exceeds 2000px on a side, Anthropic HARD-REJECTS the many-image
+    # request (400, no server-side resize), wedging every subsequent wake
+    # (the bytes are frozen in the tool_result event and replayed verbatim).
+    # ``maybe_downsample`` returns ``None`` for the common case (already
+    # <=2000px on each side and <=cap) via a header-only check, so the hot
+    # path pays no decode/re-encode cost and loses no quality.
+    try:
+        resized = await maybe_downsample(data, mime)
+    except ImageDownsampleError as err:
+        # Oversize-beyond-ceiling or undecodable: degrade to a text marker
+        # the model can still act on — same stance as the non-inlinable
+        # branches above. Do NOT inline the oversize original; that is the
+        # wedge vector.
+        return ToolResult(
+            content=(
+                f"Image at {path} ({human_size(size)}, {mime}) is present but could "
+                f"not be prepared for inline viewing ({err}). Use other tools to "
+                f"process it, or capture/downscale it to <=2000px on the longest edge."
+            ),
+            is_error=False,
+        )
+    if resized is not None:
+        # Use the RETURNED content_type — ``maybe_downsample`` switches an
+        # opaque PNG to JPEG, so reusing the original ``mime`` would mislabel
+        # the data URI.
+        data, mime, size = resized.data, resized.content_type, len(resized.data)
 
     encoded = base64.b64encode(data).decode("ascii")
     return ToolResult(

--- a/tests/helpers/images.py
+++ b/tests/helpers/images.py
@@ -46,3 +46,39 @@ def valid_tiff_bytes() -> bytes:
     provider accepts for inlining, used to exercise the render boundary's
     provider-format gate. See :func:`_valid_image`."""
     return _valid_image("TIFF")
+
+
+def large_png_bytes(side: int = 4000, *, noisy: bool = False) -> bytes:
+    """A genuinely-decodable opaque RGB PNG ``side``x``side`` px.
+
+    Used by the read()-inline and replay-clamp tests to exercise the
+    dimension-downscale path: an opaque image >2000px must come back
+    re-encoded as JPEG and <=2000px on each side. ``noisy`` fills the
+    image with high-entropy pixels so the JPEG/PNG re-encode can't trivially
+    compress it to nothing (useful for cap-pressure tests).
+    """
+    from PIL import Image
+
+    if noisy:
+        import os
+
+        img = Image.frombytes("RGB", (side, side), os.urandom(side * side * 3))
+    else:
+        img = Image.new("RGB", (side, side), (10, 20, 30))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def large_transparent_png_bytes(side: int = 4000) -> bytes:
+    """A genuinely-decodable RGBA PNG ``side``x``side`` px with transparency.
+
+    Used to assert the read()-inline / replay-clamp transparency path keeps
+    a PNG (or palette-PNG) content type rather than flattening to JPEG.
+    """
+    from PIL import Image
+
+    img = Image.new("RGBA", (side, side), (10, 20, 30, 128))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -403,6 +403,136 @@ class TestBuildMessages:
             f"walker should have corrected image/png → image/jpeg, got {url[:40]}"
         )
 
+    def test_oversize_persisted_image_clamped_at_replay(self) -> None:
+        """A session whose tool_result log already holds a >2000px persisted
+        ``data:`` image part (the pre-Part-A backlog, e.g. Ultron) must, on its
+        next build_messages, assemble a message list in which that part is
+        <=2000px on each side — self-healing the wedge without manual log edits.
+        Opaque image switches PNG -> JPEG; the sibling text part and message
+        structure are preserved.
+        """
+        import base64 as _b64
+        import io as _io
+
+        from PIL import Image as _Image
+
+        from aios.harness.vision import INLINE_MAX_DIMENSION
+
+        buf = _io.BytesIO()
+        _Image.new("RGB", (4000, 4000), (10, 20, 30)).save(buf, format="PNG")
+        big_b64 = _b64.b64encode(buf.getvalue()).decode("ascii")
+        big_url = f"data:image/png;base64,{big_b64}"
+        events = [
+            _evt(1, "user", content="show photo"),
+            _evt(2, "assistant", tool_calls=[_tc("a", name="read")]),
+            Event(
+                id="evt_3",
+                session_id="sess_01TEST",
+                seq=3,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "a",
+                    "content": [
+                        {"type": "text", "text": "Image: huge.png"},
+                        {"type": "image_url", "image_url": {"url": big_url}},
+                    ],
+                },
+                created_at=datetime.now(tz=UTC),
+                orig_channel=None,
+                focal_channel_at_arrival=None,
+            ),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        tool_msg = msgs[2]
+        assert tool_msg["role"] == "tool"
+        # Sibling text part preserved, list structure intact.
+        assert tool_msg["content"][0] == {"type": "text", "text": "Image: huge.png"}
+        url = tool_msg["content"][1]["image_url"]["url"]
+        head, _, b64 = url.partition(",")
+        mime = head.removeprefix("data:").split(";", 1)[0]
+        img = _Image.open(_io.BytesIO(_b64.b64decode(b64)))
+        assert img.width <= INLINE_MAX_DIMENSION
+        assert img.height <= INLINE_MAX_DIMENSION
+        assert mime == "image/jpeg"  # opaque -> JPEG
+
+    def test_persisted_small_image_untouched_at_replay(self) -> None:
+        """An already <=2000px/side, <=cap persisted ``data:`` part is replayed
+        with its bytes UNTOUCHED — the header-only fast path returns None, no
+        re-encode (the by-reference-equivalent acceptance criterion)."""
+        import base64 as _b64
+        import io as _io
+
+        from PIL import Image as _Image
+
+        buf = _io.BytesIO()
+        _Image.new("RGB", (64, 64), (10, 20, 30)).save(buf, format="PNG")
+        small_b64 = _b64.b64encode(buf.getvalue()).decode("ascii")
+        small_url = f"data:image/png;base64,{small_b64}"
+        events = [
+            _evt(1, "user", content="show photo"),
+            _evt(2, "assistant", tool_calls=[_tc("a", name="read")]),
+            Event(
+                id="evt_3",
+                session_id="sess_01TEST",
+                seq=3,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "a",
+                    "content": [
+                        {"type": "text", "text": "Image: small.png"},
+                        {"type": "image_url", "image_url": {"url": small_url}},
+                    ],
+                },
+                created_at=datetime.now(tz=UTC),
+                orig_channel=None,
+                focal_channel_at_arrival=None,
+            ),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        assert msgs[2]["content"][1]["image_url"]["url"] == small_url
+
+    def test_undecodable_persisted_image_degrades_to_placeholder(self) -> None:
+        """A persisted ``data:`` image part whose bytes can't be downscaled
+        (undecodable / over the pre-resize ceiling) degrades to a short inert
+        text placeholder rather than being dropped — list structure preserved,
+        no wedge."""
+        import base64 as _b64
+
+        # Valid PNG magic, garbage body — Pillow can't decode it. Padded
+        # past the byte cap so is_oversize_image flags it (the dimension
+        # clamp only acts on oversize parts; a small undecodable part is left
+        # to the mime/provider path).
+        corrupt = b"\x89PNG\r\n\x1a\n" + b"not-a-real-png" * (4 * 1024 * 1024 // 14)
+        bad_url = f"data:image/png;base64,{_b64.b64encode(corrupt).decode('ascii')}"
+        events = [
+            _evt(1, "user", content="show photo"),
+            _evt(2, "assistant", tool_calls=[_tc("a", name="read")]),
+            Event(
+                id="evt_3",
+                session_id="sess_01TEST",
+                seq=3,
+                kind="message",
+                data={
+                    "role": "tool",
+                    "tool_call_id": "a",
+                    "content": [
+                        {"type": "text", "text": "Image: broken.png"},
+                        {"type": "image_url", "image_url": {"url": bad_url}},
+                    ],
+                },
+                created_at=datetime.now(tz=UTC),
+                orig_channel=None,
+                focal_channel_at_arrival=None,
+            ),
+        ]
+        msgs = build_messages(events, system_prompt=None).messages
+        content = msgs[2]["content"]
+        assert content[0] == {"type": "text", "text": "Image: broken.png"}
+        assert content[1]["type"] == "text"
+        assert "image omitted" in content[1]["text"]
+
     def test_prune_orphan_tool_results_at_start(self) -> None:
         """If DB windowing drops an assistant but keeps its tool results,
         those orphan tool results should be pruned from the start."""

--- a/tests/unit/test_image_resize.py
+++ b/tests/unit/test_image_resize.py
@@ -175,3 +175,33 @@ class TestResultShape:
         assert isinstance(result.content_type, str)
         assert isinstance(result.width, int)
         assert isinstance(result.height, int)
+
+
+class TestIsOversizeImage:
+    """Header-only oversize predicate used by the replay-time dimension clamp
+    (issue #1616 Part B). Scoped to the dimension/byte caps; undecodable input
+    is deliberately NOT flagged (it is the mime/provider path's concern)."""
+
+    def test_small_image_is_not_oversize(self) -> None:
+        from aios.harness.image_resize import is_oversize_image
+
+        data = _encode(_noisy_rgb(64, 64), "PNG")
+        assert is_oversize_image(data) is False
+
+    def test_dimension_over_cap_is_oversize(self) -> None:
+        from aios.harness.image_resize import is_oversize_image
+
+        data = _encode(Image.new("RGB", (INLINE_MAX_DIMENSION + 1, 10)), "PNG")
+        assert is_oversize_image(data) is True
+
+    def test_byte_size_over_cap_is_oversize(self) -> None:
+        from aios.harness.image_resize import is_oversize_image
+
+        # Header check never reached: byte length alone exceeds the cap.
+        blob = b"\x89PNG\r\n\x1a\n" + b"\x00" * (INLINE_SIZE_CAP_BYTES + 1)
+        assert is_oversize_image(blob) is True
+
+    def test_undecodable_small_is_not_oversize(self) -> None:
+        from aios.harness.image_resize import is_oversize_image
+
+        assert is_oversize_image(b"\x89PNG\r\n\x1a\ngarbage") is False

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -20,12 +20,26 @@ from aios.sandbox.volumes import session_attachments_dir, workspace_dir_for
 from aios.tools.read import read_handler
 from aios.tools.registry import ToolResult
 from tests.helpers.images import (
+    large_png_bytes,
+    large_transparent_png_bytes,
     valid_gif_bytes,
     valid_jpeg_bytes,
     valid_png_bytes,
     valid_tiff_bytes,
     valid_webp_bytes,
 )
+
+
+def _decode_data_uri_image(url: str) -> tuple[str, Any]:
+    """Return ``(declared_mime, PIL.Image)`` for a ``data:...;base64,`` URI."""
+    import base64 as _b64
+    import io as _io
+
+    from PIL import Image as _Image
+
+    head, _, b64 = url.partition(",")
+    mime = head.removeprefix("data:").split(";", 1)[0]
+    return mime, _Image.open(_io.BytesIO(_b64.b64decode(b64)))
 
 
 class _StubRegistry:
@@ -151,6 +165,117 @@ class TestImageBranch:
             "type": "image_url",
             "image_url": {"url": f"data:image/png;base64,{base64.b64encode(payload).decode()}"},
         }
+        assert result.is_error is False
+
+    async def test_oversize_image_downscaled_to_dimension_cap_on_inline(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """A read() on a 4000x4000 opaque PNG must inline an image_url whose
+        decoded dimensions are <=2000px on EACH side (re-decode the emitted
+        data URI). Opaque images switch PNG -> JPEG (issue #1616 Part A)."""
+        from aios.harness.vision import INLINE_MAX_DIMENSION
+
+        stub_get_session_model.value = "model/vision"
+        _stage_workspace_image("sess_01TEST", "huge.png", large_png_bytes(4000))
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/huge.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        url = result.content[1]["image_url"]["url"]
+        mime, img = _decode_data_uri_image(url)
+        assert img.width <= INLINE_MAX_DIMENSION
+        assert img.height <= INLINE_MAX_DIMENSION
+        # Opaque PNG -> JPEG; the text marker and data URI use the returned mime.
+        assert mime == "image/jpeg"
+        assert "image/jpeg" in result.content[0]["text"]
+        assert result.is_error is False
+
+    async def test_oversize_transparent_image_keeps_png_path(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """A transparent >2000px PNG downscales but stays PNG (or palette PNG),
+        never flattening transparency to JPEG."""
+        from aios.harness.vision import INLINE_MAX_DIMENSION
+
+        stub_get_session_model.value = "model/vision"
+        _stage_workspace_image("sess_01TEST", "huge_alpha.png", large_transparent_png_bytes(4000))
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/huge_alpha.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        url = result.content[1]["image_url"]["url"]
+        mime, img = _decode_data_uri_image(url)
+        assert img.width <= INLINE_MAX_DIMENSION
+        assert img.height <= INLINE_MAX_DIMENSION
+        assert mime == "image/png"
+        assert result.is_error is False
+
+    async def test_small_image_inlined_unchanged_no_reencode(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+    ) -> None:
+        """An image already <=2000px/side and <=cap inlines the ORIGINAL bytes
+        unchanged — maybe_downsample returns None, no re-encode/quality loss."""
+        stub_get_session_model.value = "model/vision"
+        payload = valid_png_bytes()
+        _stage_workspace_image("sess_01TEST", "small.png", payload)
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/small.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, list)
+        assert result.content[1]["image_url"]["url"] == (
+            f"data:image/png;base64,{base64.b64encode(payload).decode()}"
+        )
+
+    async def test_uses_maybe_downsample_on_inline_path(self) -> None:
+        """Regression guard for the two-inline-paths-drift recurrence (#1564):
+        read.py must import and call maybe_downsample so the read() inline path
+        cannot silently diverge from the bounded attachment path again."""
+        import inspect
+
+        from aios.tools import read as read_module
+
+        assert hasattr(read_module, "maybe_downsample")
+        src = inspect.getsource(read_module._read_image)
+        assert "maybe_downsample(" in src
+
+    async def test_undecodable_oversize_returns_marker_not_inline(
+        self,
+        temp_workspace_root: Path,
+        stub_runtime: Any,
+        stub_get_session_model: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When maybe_downsample raises ImageDownsampleError (above ceiling or
+        undecodable past the format gate), read() degrades to a text marker —
+        never a raised exception, never a full-res inline (the wedge)."""
+        from aios.harness.image_resize import ImageDownsampleError
+
+        stub_get_session_model.value = "model/vision"
+        _stage_workspace_image("sess_01TEST", "weird.png", valid_png_bytes())
+
+        async def boom(_data: bytes, _mime: str, **_kw: Any) -> Any:
+            raise ImageDownsampleError("simulated undecodable/over-ceiling")
+
+        monkeypatch.setattr("aios.tools.read.maybe_downsample", boom)
+
+        result = await read_handler("sess_01TEST", {"path": "/workspace/weird.png"})
+
+        assert isinstance(result, ToolResult)
+        assert isinstance(result.content, str)
+        assert "image_url" not in result.content
+        assert "could not be prepared for inline viewing" in result.content
         assert result.is_error is False
 
     async def test_undecodable_or_unsupported_image_returns_marker_not_inline(


### PR DESCRIPTION
Automated dev-pipeline build for issue #1616.