### PR TITLE
[workflows-as-models] Binding authorization — runtime guard across all spawn paths

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -472,10 +472,11 @@ class Settings(BaseSettings):
         "allowlist; otherwise the spawn fails closed with an "
         "``untrusted_api_base`` rejection. Empty (the default) means *no* "
         "redirected endpoint is trusted: a child may only run on the default "
-        "endpoint. This is sound today (``create_agent`` is operator-only, so no "
-        "runtime principal can mint a hostile ``api_base``); the clamp makes the "
-        "boundary real and frozen ahead of native self-management, where the "
-        "trusted-catalog precondition lapses. Values are matched verbatim against "
+        "endpoint. The clamp makes this boundary real and frozen independent of "
+        "native self-management: the api_base axis is enforced at the spawn edge "
+        "regardless of who authored the agent (the ``workflow:`` model-binding "
+        "privilege, #1636, is the companion runtime guard on the orthogonal "
+        "model/binding axis). Values are matched verbatim against "
         "the agent's ``litellm_extra['api_base']`` string.",
     )
 

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -25,6 +25,7 @@ from aios.models.agents import (
 from aios.models.attenuation import Surface, surface_diff, surface_of
 from aios.models.skills import AgentSkillRef
 from aios.services import skills as skills_service
+from aios.services.model_binding_authz import enforce_workflow_binding_privilege
 from aios.workflows.generic_child import GENERIC_CHILD_SYSTEM
 
 
@@ -118,6 +119,10 @@ async def create_agent(
     surface ⊆ the run at spawn time and is unchanged by this path.
     """
     if creator_session_id is not None:
+        # #1636: the model-binding privilege. A ``creator_session_id`` IS a
+        # self-authoring (non-operator) principal — it may not bind a ``workflow:``
+        # model. The operator/HTTP path (no creator) passes ``is_operator=True``.
+        enforce_workflow_binding_privilege(model, is_operator=False)
         await _enforce_surface_attenuation(
             pool,
             account_id=account_id,
@@ -204,6 +209,11 @@ async def update_agent(
     updated.
     """
     if editor_session_id is not None:
+        # #1636: the model-binding privilege, keyed on the editor being a
+        # self-authoring (non-operator) principal. ``model is None`` (the field is
+        # being preserved) introduces no new binding and is a no-op; a non-None
+        # ``workflow:`` model is rejected. The operator/HTTP path skips this.
+        enforce_workflow_binding_privilege(model, is_operator=False)
         current = await get_agent(pool, agent_id, account_id=account_id)
         await _enforce_surface_attenuation(
             pool,

--- a/src/aios/services/model_binding_authz.py
+++ b/src/aios/services/model_binding_authz.py
@@ -1,0 +1,65 @@
+"""The ``workflow:`` model-binding privilege — one runtime guard, all spawn paths (#1636).
+
+Part of the **Workflows-as-Models** epic. The :mod:`aios.harness.model_binding`
+boundary recognises a ``model = "workflow:<id>[@version]"`` binding and dispatches
+the step's inference through a workflow run. This module owns the **authorization**
+question that boundary never asked: *who may bind or select such a model?*
+
+**Why a runtime guard, not an author-time one.** ``_enforce_surface_attenuation``
+(``services.agents``) clamps the tool/mcp/http axis but NOT the model/api_base axis,
+and a computed ``workflow:`` model string is invisible to the static authoring
+validator. There are three distinct inference-spawning paths that can introduce a
+``workflow:`` binding:
+
+* ``create_agent`` / ``update_agent`` — the free-form ``model`` field (``services.agents``).
+* the per-call ``agent(model=…)`` override (``workflows.step``).
+* the **generic agentless child** (``agent()`` with no ``agent_id``), which carries
+  the run's resolved model and previously had no model check at all.
+
+Rather than bolt a separate check onto each, the privilege is enforced at the
+**runtime dispatch seam** each path funnels through, keyed on the run/session's
+**owning principal** — operator vs self-authoring — read at call time, not assumed
+at author time. The privilege is **operator-only to start**: a self-authoring
+(non-operator) principal may neither bind nor select a ``workflow:`` model via any
+path; an operator may. This is a property of the guard, not a precondition — the
+legacy "``create_agent`` is operator-only" assumption in ``config.py`` is stale.
+
+The companion #823 api_base spawn-edge clamp (``workflows.step``) is orthogonal and
+stays: it bounds *where* a child's inference routes; this guard bounds *whether* a
+principal may route inference through a workflow at all.
+"""
+
+from __future__ import annotations
+
+from aios.errors import ForbiddenError
+from aios.harness.model_binding import is_workflow_model
+
+
+def is_workflow_binding(model: str | None) -> bool:
+    """True iff ``model`` is a ``workflow:`` binding (``None``/raw provider → False)."""
+    return model is not None and is_workflow_model(model)
+
+
+def enforce_workflow_binding_privilege(model: str | None, *, is_operator: bool) -> None:
+    """Raise :class:`ForbiddenError` if a non-operator principal binds/selects a
+    ``workflow:`` model.
+
+    The single privilege check shared by every spawn path. ``model`` is the model
+    string a path is about to bind or select (the ``create_agent``/``update_agent``
+    ``model`` field, the per-call ``agent(model=…)`` override, or a generic child's
+    resolved model). ``is_operator`` is whether the **owning principal** of the
+    acting run/session is the operator (an operator/HTTP-launched edge) rather than
+    a self-authoring agent.
+
+    A no-op for a raw provider model (the overwhelmingly common case) or ``None``.
+    For a ``workflow:`` binding it permits the operator and fails closed for a
+    self-authoring principal — the binding privilege is operator-only to start.
+    """
+    if is_operator:
+        return
+    if is_workflow_binding(model):
+        raise ForbiddenError(
+            "binding or selecting a workflow: model is operator-only; a self-authoring "
+            "principal may not route inference through a workflow",
+            detail={"model": model},
+        )

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -50,6 +50,7 @@ from aios.models.attenuation import api_base_of, surface_of
 from aios.models.sessions import Err, Outcome
 from aios.models.workflows import TERMINAL_RUN_STATUSES, WfRun, WfRunEvent, WfRunStatus
 from aios.services import attenuation as attenuation_service
+from aios.services.model_binding_authz import is_workflow_binding
 from aios.services.sessions import (
     AskNewSession,
     create_child_session,
@@ -1122,6 +1123,23 @@ async def _open_agent_capability(
                 f"endpoint ({redirect!r}); add it to the operator "
                 f"trusted_inference_api_bases allowlist to permit this spawn",
             )
+    # #1636: the ``workflow:`` model-binding privilege at the spawn-edge dispatch seam,
+    # keyed on the RUN's owning principal — operator iff the run is operator/HTTP-launched
+    # (no launcher session). Covers BOTH unnamed paths: the per-call ``agent(model=…)``
+    # override and the generic agentless child's resolved model (``stamped_model``); a
+    # NAMED child additionally inherits the agent's stored ``model`` when no override is
+    # given, so that string is checked too. A self-authoring run may neither select nor
+    # bind a ``workflow:`` model — a catchable rejection, before any child row exists.
+    # Orthogonal to the #823 api_base clamp above (that bounds *where* inference routes;
+    # this bounds *whether* it may route through a workflow at all).
+    is_operator_run = run.launcher_session_id is None
+    selected_model = stamped_model if agent_id is None else (model or agent.model)
+    if not is_operator_run and is_workflow_binding(selected_model):
+        return await _reject(
+            "workflow_model_forbidden",
+            f"selecting a workflow: model ({selected_model!r}) is operator-only; this "
+            "self-authoring run may not route a child's inference through a workflow",
+        )
     # Lifetime cap (H1) enforced HERE — past every rejection gate, before the child is
     # created — so only caps that genuinely spawn count. ``agent_spawns`` already excludes
     # rejected caps; this child would be the (agent_spawns + 1)-th, so cap it on strict ``>``.

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -984,6 +984,133 @@ async def test_generic_agent_spawn_creates_agentless_child_with_run_surface(
     assert frozen == Surface(tools=[ToolSpec(type="web_search")], mcp_servers=[], http_servers=[])
 
 
+# ── #1636: the workflow: model-binding privilege at the spawn-edge seam ──────────
+#
+# The runtime guard keys on the run's owning principal: a run with a
+# ``launcher_session_id`` (an agent launched it) is self-authoring (non-operator)
+# and may NOT select a ``workflow:`` model for a child; an edgeless operator/HTTP
+# run may. Covers the two unnamed spawn arms — the per-call ``agent(model=…)``
+# override and the generic agentless child's resolved model.
+
+
+async def _make_agent_launched_run(pool: asyncpg.Pool[Any], script: str, agent_id: str) -> str:
+    """A run LAUNCHED BY AN AGENT (self-authoring principal): ``launcher_session_id``
+    is set, so ``run.launcher_session_id is None`` is False and the binding privilege
+    treats it as non-operator."""
+    launcher = await _make_launcher_session(pool, agent_id)
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(
+            conn, account_id="acc_wf", name="self-authored-w", script=script
+        )
+    run = await service.create_run(
+        pool,
+        account_id="acc_wf",
+        workflow_id=wf.id,
+        environment_id="env_wf",
+        launcher_session_id=launcher.id,
+    )
+    return run.id
+
+
+async def test_self_authoring_run_cannot_select_workflow_model_generic_child(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """#1636: a self-authoring (agent-launched) run may NOT route a generic agentless
+    child's inference through a ``workflow:`` model. The spawn edge journals a
+    catchable ``workflow_model_forbidden`` rejection BEFORE any child row exists."""
+    pool = wf_runtime
+    script = "async def main(input):\n    return await agent('go', model='workflow:wf_bound')\n"
+    run_id = await _make_agent_launched_run(pool, script, wf_agent_id)
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    result_evt = next(e for e in events if e.type == "call_result")
+    assert result_evt.payload["error"]["kind"] == "workflow_model_forbidden"
+    assert children == 0  # refused before write — no child session created
+
+
+async def test_self_authoring_run_cannot_override_named_agent_to_workflow_model(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """#1636: the per-call ``agent(model=…)`` override arm — a self-authoring run may
+    not redirect even a NAMED agent's child onto a ``workflow:`` model."""
+    pool = wf_runtime
+    script = (
+        "async def main(input):\n"
+        f"    return await agent('go', agent_id={wf_agent_id!r}, model='workflow:wf_bound')\n"
+    )
+    run_id = await _make_agent_launched_run(pool, script, wf_agent_id)
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    result_evt = next(e for e in events if e.type == "call_result")
+    assert result_evt.payload["error"]["kind"] == "workflow_model_forbidden"
+    assert children == 0
+
+
+async def test_self_authoring_run_cannot_select_workflow_bound_named_agent(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """#1636: a NAMED agent whose stored ``model`` is a ``workflow:`` binding cannot be
+    SELECTED by a self-authoring run either (no override needed) — the guard reads the
+    agent's own model when no per-call override is given."""
+    pool = wf_runtime
+    bound = await agents_service.create_agent(
+        pool,
+        account_id="acc_wf",
+        name="workflow-bound-agent",
+        model="workflow:wf_bound",  # operator-authored binding (HTTP/operator path)
+        system="bound child",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=1000,
+        window_max=100000,
+    )
+    script = f"async def main(input):\n    return await agent('go', agent_id={bound.id!r})\n"
+    run_id = await _make_agent_launched_run(pool, script, bound.id)
+    await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+        children = await conn.fetchval(
+            "SELECT count(*) FROM sessions WHERE parent_run_id = $1", run_id
+        )
+    result_evt = next(e for e in events if e.type == "call_result")
+    assert result_evt.payload["error"]["kind"] == "workflow_model_forbidden"
+    assert children == 0
+
+
+async def test_operator_run_may_select_workflow_model_generic_child(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """#1636: the operator arm — an edgeless operator/HTTP run (no launcher session) MAY
+    route a generic child's inference through a ``workflow:`` model; the child spawns and
+    its model is stamped with the binding."""
+    pool = wf_runtime
+    script = "async def main(input):\n    return await agent('go', model='workflow:wf_bound')\n"
+    run_id = await _make_run(pool, script)  # edgeless root → operator-owned
+    with mock.patch("aios.workflows.step.defer_wake", new=AsyncMock()):
+        await run_workflow_step(run_id)
+
+    async with pool.acquire() as conn:
+        events = await wf_queries.list_run_events(conn, run_id)
+        started = next(e for e in events if e.type == "call_started")
+        child = await db_queries.get_session_bare(
+            conn, started.payload["child_session_id"], account_id="acc_wf"
+        )
+    assert not [e for e in events if e.type == "call_result"]  # no rejection journaled
+    assert child.model == "workflow:wf_bound"  # the binding is admitted + stamped
+
+
 async def test_agent_spawn_idempotent_on_replay(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/unit/test_agent_management.py
+++ b/tests/unit/test_agent_management.py
@@ -255,7 +255,7 @@ class TestWorkflowModelBindingPrivilege:
         # rejects a workflow: model before _enforce_surface_attenuation hits the DB.
         with pytest.raises(ForbiddenError, match="operator-only"):
             await agents_service.create_agent(
-                None,  # type: ignore[arg-type]  # guard fires before the pool is touched
+                None,  # guard fires before the pool is touched
                 account_id="acc_x",
                 name="a",
                 model="workflow:wf_1",
@@ -271,7 +271,7 @@ class TestWorkflowModelBindingPrivilege:
     async def test_update_agent_self_authoring_workflow_model_forbidden(self) -> None:
         with pytest.raises(ForbiddenError, match="operator-only"):
             await agents_service.update_agent(
-                None,  # type: ignore[arg-type]
+                None,
                 "agt_1",
                 account_id="acc_x",
                 expected_version=1,
@@ -307,7 +307,7 @@ class TestWorkflowModelBindingPrivilege:
         # The guard must NOT raise; the AssertionError below proves we passed it.
         with pytest.raises(AssertionError, match="reached the insert"):
             await agents_service.create_agent(
-                _FakePool(),  # type: ignore[arg-type]
+                _FakePool(),
                 account_id="acc_x",
                 name="a",
                 model="test/dummy",

--- a/tests/unit/test_agent_management.py
+++ b/tests/unit/test_agent_management.py
@@ -31,6 +31,7 @@ import pytest
 import aios.tools  # noqa: F401 — registers the builtins
 from aios.errors import ConflictError, CryptoDecryptError, ForbiddenError
 from aios.models.agents import Agent
+from aios.services import agents as agents_service
 from aios.tools import agent_management as am
 from aios.tools.invoke import ToolBail, invoke_builtin
 from aios.tools.registry import openai_tool_entry, registry
@@ -236,6 +237,88 @@ class TestErrorPropagation:
         )
         with pytest.raises(CryptoDecryptError):
             await am.create_agent_handler("ses_1", {"name": "a", "model": "test/dummy"})
+
+
+class TestWorkflowModelBindingPrivilege:
+    """#1636: a self-authoring (non-operator) principal — the create/update_agent
+    model-tool path always carries a ``creator_session_id`` / ``editor_session_id``
+    — may NOT bind a ``workflow:`` model. The guard fires BEFORE any DB call, so it
+    exercises the real service with a ``None`` pool.
+
+    The companion spawn-edge arms (per-call ``agent(model=…)`` override + the generic
+    agentless child) live in the workflow-step integration suite, where a run row and
+    its owning principal exist.
+    """
+
+    async def test_create_agent_self_authoring_workflow_model_forbidden(self) -> None:
+        # The real service: a creator_session_id is set, so the binding privilege
+        # rejects a workflow: model before _enforce_surface_attenuation hits the DB.
+        with pytest.raises(ForbiddenError, match="operator-only"):
+            await agents_service.create_agent(
+                None,  # type: ignore[arg-type]  # guard fires before the pool is touched
+                account_id="acc_x",
+                name="a",
+                model="workflow:wf_1",
+                system="s",
+                tools=[],
+                description=None,
+                metadata={},
+                window_min=1000,
+                window_max=100000,
+                creator_session_id="ses_self",
+            )
+
+    async def test_update_agent_self_authoring_workflow_model_forbidden(self) -> None:
+        with pytest.raises(ForbiddenError, match="operator-only"):
+            await agents_service.update_agent(
+                None,  # type: ignore[arg-type]
+                "agt_1",
+                account_id="acc_x",
+                expected_version=1,
+                model="workflow:wf_1@2",
+                editor_session_id="ses_self",
+            )
+
+    async def test_create_agent_self_authoring_raw_model_passes_guard(
+        self, monkeypatch: Any
+    ) -> None:
+        # A raw provider model is admissible for a self-authoring principal — the
+        # guard is a no-op and the flow proceeds to the surface-attenuation clamp
+        # (stubbed here to a no-op) and the insert (stubbed to return an agent).
+        monkeypatch.setattr(
+            "aios.services.agents._enforce_surface_attenuation", AsyncMock(return_value=None)
+        )
+        monkeypatch.setattr(
+            "aios.services.agents.skills_service.resolve_skill_refs",
+            AsyncMock(return_value=[]),
+        )
+        monkeypatch.setattr(
+            "aios.services.agents.skills_service.serialize_skills_for_snapshot",
+            lambda *a, **k: "[]",
+        )
+
+        class _FakePool:
+            def acquire(self) -> Any:
+                raise AssertionError("reached the insert — guard admitted the raw model")
+
+        monkeypatch.setattr(
+            "aios.services.agents.queries.insert_agent", AsyncMock(return_value=_agent())
+        )
+        # The guard must NOT raise; the AssertionError below proves we passed it.
+        with pytest.raises(AssertionError, match="reached the insert"):
+            await agents_service.create_agent(
+                _FakePool(),  # type: ignore[arg-type]
+                account_id="acc_x",
+                name="a",
+                model="test/dummy",
+                system="s",
+                tools=[],
+                description=None,
+                metadata={},
+                window_min=1000,
+                window_max=100000,
+                creator_session_id="ses_self",
+            )
 
 
 class TestReturnShape:

--- a/tests/unit/test_model_binding_authz.py
+++ b/tests/unit/test_model_binding_authz.py
@@ -1,0 +1,55 @@
+"""Unit tests for the ``workflow:`` model-binding privilege guard (#1636).
+
+The pure authorization helper shared by every spawn path: it decides whether a
+principal may bind/select a ``workflow:`` model, keyed on operator vs self-authoring.
+A raw provider model is always admissible; a ``workflow:`` binding is operator-only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aios.errors import ForbiddenError
+from aios.services.model_binding_authz import (
+    enforce_workflow_binding_privilege,
+    is_workflow_binding,
+)
+
+
+class TestIsWorkflowBinding:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("workflow:wf_1", True),
+            ("workflow:wf_1@3", True),
+            ("workflow:", True),  # prefix probe is cheap; parse-validity is a separate gate
+            ("test/dummy", False),
+            ("anthropic/claude", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_probe(self, model: str | None, expected: bool) -> None:
+        assert is_workflow_binding(model) is expected
+
+
+class TestEnforceWorkflowBindingPrivilege:
+    def test_operator_may_bind_workflow_model(self) -> None:
+        # An operator principal binds a workflow: model freely — no raise.
+        enforce_workflow_binding_privilege("workflow:wf_1", is_operator=True)
+
+    def test_self_authoring_cannot_bind_workflow_model(self) -> None:
+        with pytest.raises(ForbiddenError) as exc:
+            enforce_workflow_binding_privilege("workflow:wf_1", is_operator=False)
+        # The denied binding is surfaced in the structured detail.
+        assert exc.value.detail == {"model": "workflow:wf_1"}
+
+    def test_self_authoring_raw_provider_model_is_allowed(self) -> None:
+        # The common case: a self-authoring principal binding an ordinary provider
+        # model is untouched — the guard is a no-op for non-workflow bindings.
+        enforce_workflow_binding_privilege("test/dummy", is_operator=False)
+
+    def test_none_model_is_noop_for_both_principals(self) -> None:
+        # ``None`` (e.g. update_agent preserving the field) introduces no binding.
+        enforce_workflow_binding_privilege(None, is_operator=False)
+        enforce_workflow_binding_privilege(None, is_operator=True)


### PR DESCRIPTION
Automated dev-pipeline build for issue #1636.