### PR TITLE
Close the surface_of/ToolProvider attenuation-visibility gap: clamp provider-injected tools against the session's effective surface

### DIFF
--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -288,6 +288,18 @@ async def compute_step_prelude(
     )
     if connection_tool_dicts:
         connection_tools = [ToolSpec.model_validate(d) for d in connection_tool_dicts]
+        if session.parent_run_id is not None:
+            # Born clamped (#794, #1627): a workflow-spawned child's ``agent.tools`` is
+            # already the frozen effective surface (services/agents.py load_for_session
+            # overlays it), so ``surface_of(agent)`` IS the clamped surface. Clamp the
+            # provider-injected tools against it so the ToolProvider seam can't re-grant
+            # a connector tool the run dropped. A foreground session (parent_run_id is
+            # None) declared its own surface and never had the connector tools in
+            # ``surface_of(agent)``, so it passes through unchanged (connector UX intact).
+            from aios.models.attenuation import surface_of
+            from aios.services.attenuation import admit_provider
+
+            connection_tools = admit_provider(connection_tools, surface_of(agent))
         tools.extend(to_openai_tools(connection_tools))
 
     skill_versions = (

--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -498,6 +498,45 @@ def attenuate(
     return Surface(out_tools, out_mcp, out_http)
 
 
+def admit_provider_tools(
+    provider: list[ToolSpec],
+    effective: Surface,
+    *,
+    default_mcp_permission: PermissionPolicy,
+    builtin_transports: dict[str, ToolTransport],
+) -> list[ToolSpec]:
+    """Clamp provider-injected tools against an already-frozen effective surface.
+
+    The per-step prelude injects ``ToolProvider`` tools (connection-declared custom
+    tools) AFTER the declared-surface tools, with no attenuation pass. For a workflow
+    child / run whose declared surface was clamped (#794), this re-grants authority the
+    run dropped — a live #794-class ambient-authority gap. This helper closes it: a
+    provider tool survives iff its ``_tool_key`` is present in ``effective`` (the frozen
+    clamped surface, ``surface_of(agent)`` for a born-clamped child); the surviving entry
+    carries the per-dimension meet (``always_ask`` wins, transport GLB).
+
+    A clamped child that legitimately wants a connector tool must DECLARE it (so the run
+    grants it) — silent re-grant via the provider seam is exactly the bug. Reuses the
+    exact meet-loop body of :func:`attenuate` (the ``_tool_key`` join + ``_meet_builtin``);
+    it adds no new primitive.
+    """
+    canon = canonicalize(
+        effective,
+        default_mcp_permission=default_mcp_permission,
+        builtin_transports=builtin_transports,
+    )
+    eff = {_tool_key(t): t for t in canon.tools}
+    out: list[ToolSpec] = []
+    for t in provider:
+        match = eff.get(_tool_key(t))
+        if match is None:
+            continue
+        met = _meet_builtin(_canon_builtin(t, transport_default="both"), match)
+        if met is not None:
+            out.append(met)
+    return out
+
+
 def surface_diff(expected: Surface, actual: Surface) -> dict[str, list[str]]:
     """Per-section identity-keys present in ``expected`` but dropped/narrowed in ``actual``.
 

--- a/src/aios/services/attenuation.py
+++ b/src/aios/services/attenuation.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 from typing import Any
 
 from aios.config import get_settings
-from aios.models.agents import PermissionPolicy, ToolTransport
+from aios.models.agents import PermissionPolicy, ToolSpec, ToolTransport
 from aios.models.attenuation import (
     Surface,
+    admit_provider_tools,
     api_base_of,
     api_base_trusted,
     attenuate,
@@ -35,6 +36,22 @@ def clamp(declared: Surface, launcher: Surface) -> Surface:
     return attenuate(
         declared,
         launcher,
+        default_mcp_permission=default_mcp,
+        builtin_transports=builtin_transports,
+    )
+
+
+def admit_provider(provider: list[ToolSpec], effective: Surface) -> list[ToolSpec]:
+    """``admit_provider_tools`` bound to this process's operator defaults (#1627).
+
+    Clamps provider-injected (connection-declared) tools against an already-frozen
+    effective surface, closing the per-step prelude's attenuation-visibility gap for a
+    born-clamped workflow child.
+    """
+    default_mcp, builtin_transports = _defaults()
+    return admit_provider_tools(
+        provider,
+        effective,
         default_mcp_permission=default_mcp,
         builtin_transports=builtin_transports,
     )

--- a/tests/unit/test_admit_provider_tools.py
+++ b/tests/unit/test_admit_provider_tools.py
@@ -44,9 +44,7 @@ def test_admit_provider_tools_drops_absent() -> None:
     provider = [_custom("X")]
     effective = Surface([_custom("Y")], [], [])  # X's key is not present
     assert (
-        admit_provider_tools(
-            provider, effective, default_mcp_permission=DMP, builtin_transports=BT
-        )
+        admit_provider_tools(provider, effective, default_mcp_permission=DMP, builtin_transports=BT)
         == []
     )
 

--- a/tests/unit/test_admit_provider_tools.py
+++ b/tests/unit/test_admit_provider_tools.py
@@ -1,0 +1,116 @@
+"""The provider-tool clamp (``admit_provider_tools``) — pure unit tests (#1627).
+
+Pure in-memory: no Postgres, no Docker. Covers the two pure-helper acceptance cases
+from #1627: a provider tool whose ``_tool_key`` is ABSENT from the effective (frozen,
+clamped) surface is dropped, and a provider tool that is PRESENT but narrowed survives
+carrying the exact per-dimension meet (``always_ask`` wins, transport GLB) — byte-equal
+to what ``_meet_builtin`` produces. This closes the prelude attenuation-visibility gap:
+the ToolProvider seam can no longer re-grant authority a workflow run dropped.
+"""
+
+from __future__ import annotations
+
+from aios.models.agents import PermissionPolicy, ToolSpec, ToolTransport
+from aios.models.attenuation import (
+    Surface,
+    _canon_builtin,
+    _meet_builtin,
+    admit_provider_tools,
+)
+
+# Controlled defaults so the meet-logic tests are independent of the live registry.
+DMP: PermissionPolicy = "always_ask"
+BT: dict[str, ToolTransport] = {}
+
+
+def _custom(
+    name: str,
+    *,
+    permission: PermissionPolicy | None = None,
+    transport: ToolTransport | None = None,
+) -> ToolSpec:
+    return ToolSpec(
+        type="custom",
+        name=name,
+        description=f"the {name} connector tool",
+        input_schema={"type": "object"},
+        permission=permission,
+        transport=transport,
+    )
+
+
+def test_admit_provider_tools_drops_absent() -> None:
+    """A provider tool whose ``_tool_key`` is absent from ``effective`` is dropped."""
+    provider = [_custom("X")]
+    effective = Surface([_custom("Y")], [], [])  # X's key is not present
+    assert (
+        admit_provider_tools(
+            provider, effective, default_mcp_permission=DMP, builtin_transports=BT
+        )
+        == []
+    )
+
+
+def test_admit_provider_tools_empty_effective_drops_all() -> None:
+    """An empty effective surface (a maximally-clamped child) drops every provider tool."""
+    provider = [_custom("X"), _custom("Z")]
+    assert (
+        admit_provider_tools(
+            provider, Surface([], [], []), default_mcp_permission=DMP, builtin_transports=BT
+        )
+        == []
+    )
+
+
+def test_admit_provider_tools_meets_present() -> None:
+    """A present-but-narrowed provider tool survives carrying the exact meet.
+
+    ``effective`` narrows X to ``always_ask`` + ``cli`` transport; the provider entry is
+    the wider ``always_allow``/``both``. The surviving entry is byte-equal to
+    ``_meet_builtin`` output: ``always_ask`` wins, transport GLB → ``cli``.
+    """
+    provider_x = _custom("X")  # wide: permission/transport None → always_allow/both
+    eff_x = _custom("X", permission="always_ask", transport="cli")
+    effective = Surface([eff_x], [], [])
+
+    got = admit_provider_tools(
+        [provider_x], effective, default_mcp_permission=DMP, builtin_transports=BT
+    )
+
+    # Reference meet: canonicalize both sides exactly as the operator/helper do.
+    expected = _meet_builtin(
+        _canon_builtin(provider_x, transport_default="both"),
+        _canon_builtin(eff_x, transport_default="both"),
+    )
+    assert got == [expected]
+    assert got[0].permission == "always_ask"  # always_ask wins
+    assert got[0].transport == "cli"  # transport GLB(both, cli) = cli
+
+
+def test_admit_provider_tools_definition_from_provider() -> None:
+    """The surviving entry keeps the provider tool's definition (name/description/schema)."""
+    provider_x = _custom("X")
+    eff_x = ToolSpec(
+        type="custom",
+        name="X",
+        description="effective-side description (ignored by the meet emit)",
+        input_schema={"type": "object", "properties": {"a": {}}},
+        permission="always_ask",
+    )
+    [got] = admit_provider_tools(
+        [provider_x], Surface([eff_x], [], []), default_mcp_permission=DMP, builtin_transports=BT
+    )
+    # ``_meet_builtin`` emits the *declared* (provider) definition with the met policy.
+    assert got.name == "X"
+    assert got.description == "the X connector tool"
+    assert got.input_schema == {"type": "object"}
+
+
+def test_admit_provider_tools_subset_filter() -> None:
+    """Only the provider tools present in ``effective`` survive; order follows provider."""
+    provider = [_custom("A"), _custom("B"), _custom("C")]
+    effective = Surface([_custom("C"), _custom("A")], [], [])
+    got = admit_provider_tools(
+        provider, effective, default_mcp_permission=DMP, builtin_transports=BT
+    )
+    assert [t.name for t in got] == ["A", "C"]

--- a/tests/unit/test_step_context_provider_clamp.py
+++ b/tests/unit/test_step_context_provider_clamp.py
@@ -1,0 +1,141 @@
+"""The per-step prelude's provider-tool clamp branch (#1627).
+
+Unit-level: no Postgres, no Docker. ``compute_step_prelude`` only touches the pool for
+``get_open_obligations`` (one acquire), so we hand it a stub pool whose acquired
+connection returns no obligations, a stub ``ToolProvider`` that injects one known custom
+tool, and an in-memory ``Agent``. The two cases nail the new branch:
+
+* foreground session (``parent_run_id is None``) → the provider tool passes through
+  UNCHANGED (today's connector UX; no regression);
+* born-clamped child (``parent_run_id`` set) whose ``agent.tools`` (the frozen effective
+  surface) excludes that tool's ``_tool_key`` → the tool is DROPPED. This is the headline
+  assertion that the #794-class ambient-authority hole is closed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.harness import runtime
+from aios.harness.step_context import compute_step_prelude
+from aios.models.agents import Agent, ToolSpec
+
+pytestmark = pytest.mark.asyncio
+
+_ACCOUNT = "acc_1627"
+_SESSION = "sess_1627"
+
+# The connector-injected custom tool the ToolProvider returns each step.
+_PROVIDER_TOOL = {
+    "type": "custom",
+    "name": "connector_send",
+    "description": "send via the connector",
+    "input_schema": {"type": "object"},
+}
+
+
+def _agent(tools: list[ToolSpec]) -> Agent:
+    now = datetime.now(UTC)
+    return Agent(
+        id="agt_1627",
+        version=1,
+        name="a",
+        model="gpt-test",
+        system="you are a test agent",
+        tools=tools,
+        mcp_servers=[],
+        http_servers=[],
+        description=None,
+        metadata={},
+        window_min=1,
+        window_max=10,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _session(*, parent_run_id: str | None) -> Any:
+    """A minimal stand-in carrying the only field the clamp branch reads."""
+    return mock.Mock(id=_SESSION, parent_run_id=parent_run_id)
+
+
+class _StubConn:
+    async def __aenter__(self) -> _StubConn:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class _StubPool:
+    """Only ``acquire()`` is exercised (for ``get_open_obligations``)."""
+
+    def acquire(self) -> _StubConn:
+        return _StubConn()
+
+
+def _stub_tool_provider() -> Any:
+    tp = mock.Mock()
+    tp.list_tools_for_session = AsyncMock(return_value=[dict(_PROVIDER_TOOL)])
+    return tp
+
+
+async def _prelude_tool_names(agent: Agent, session: Any) -> list[str]:
+    prev = runtime.tool_provider
+    runtime.tool_provider = _stub_tool_provider()
+    try:
+        with mock.patch(
+            "aios.db.queries.get_open_obligations", new=AsyncMock(return_value=[])
+        ):
+            prelude = await compute_step_prelude(
+                _StubPool(),  # type: ignore[arg-type]
+                _SESSION,
+                account_id=_ACCOUNT,
+                session=session,
+                agent=agent,
+                channels=[],
+                memory_store_echoes=[],
+            )
+    finally:
+        runtime.tool_provider = prev
+    return [t["function"]["name"] for t in prelude.tools]
+
+
+async def test_prelude_foreground_admits_provider_tool() -> None:
+    """A foreground session (``parent_run_id is None``) keeps the injected provider tool."""
+    # The agent did NOT declare the connector tool (foreground declares its own surface).
+    agent = _agent(tools=[ToolSpec(type="bash")])
+    names = await _prelude_tool_names(agent, _session(parent_run_id=None))
+    assert "connector_send" in names
+
+
+async def test_prelude_clamped_child_drops_provider_tool() -> None:
+    """HEADLINE (#1627): a born-clamped child whose frozen surface excludes the provider
+    tool's ``_tool_key`` does NOT receive it — the ToolProvider seam can't re-grant it."""
+    # agent.tools is the overlaid frozen effective surface; it excludes connector_send.
+    agent = _agent(tools=[ToolSpec(type="bash")])
+    names = await _prelude_tool_names(agent, _session(parent_run_id="run_abc"))
+    assert "connector_send" not in names
+
+
+async def test_prelude_clamped_child_admits_declared_provider_tool() -> None:
+    """A clamped child whose frozen surface DOES carry the connector tool's key keeps it
+    (the run granted it) — proving the gate is a clamp, not a blanket drop."""
+    agent = _agent(
+        tools=[
+            ToolSpec(type="bash"),
+            ToolSpec(
+                type="custom",
+                name="connector_send",
+                description="send via the connector",
+                input_schema={"type": "object"},
+            ),
+        ]
+    )
+    names = await _prelude_tool_names(agent, _session(parent_run_id="run_abc"))
+    assert "connector_send" in names

--- a/tests/unit/test_step_context_provider_clamp.py
+++ b/tests/unit/test_step_context_provider_clamp.py
@@ -89,9 +89,7 @@ async def _prelude_tool_names(agent: Agent, session: Any) -> list[str]:
     prev = runtime.tool_provider
     runtime.tool_provider = _stub_tool_provider()
     try:
-        with mock.patch(
-            "aios.db.queries.get_open_obligations", new=AsyncMock(return_value=[])
-        ):
+        with mock.patch("aios.db.queries.get_open_obligations", new=AsyncMock(return_value=[])):
             prelude = await compute_step_prelude(
                 _StubPool(),  # type: ignore[arg-type]
                 _SESSION,

--- a/tests/unit/test_step_context_provider_clamp.py
+++ b/tests/unit/test_step_context_provider_clamp.py
@@ -91,7 +91,7 @@ async def _prelude_tool_names(agent: Agent, session: Any) -> list[str]:
     try:
         with mock.patch("aios.db.queries.get_open_obligations", new=AsyncMock(return_value=[])):
             prelude = await compute_step_prelude(
-                _StubPool(),  # type: ignore[arg-type]
+                _StubPool(),
                 _SESSION,
                 account_id=_ACCOUNT,
                 session=session,


### PR DESCRIPTION
Automated dev-pipeline build for issue #1627.