### PR TITLE
dev_pipeline gates journal only {capability,gate_nonce} — persist structured gate spec (kind/tier/reason/sha) into call_started

### DIFF
--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -694,13 +694,20 @@ async def _run_workflow_step_body(
                 continue  # already resolved, or already open (an idempotent re-emit)
             if cap.capability_id == "gate":
                 nonce = secrets.token_urlsafe(32)
+                # Persist the gate's structured spec (e.g. the dev_pipeline's
+                # kind/tier/reason/sha) into the journal alongside the nonce, mirroring
+                # the agent arm's persistence of its structured annotations. This is
+                # append-only enrichment: the nonce and existing resume path are
+                # untouched, and journal readers (e.g. the ops-agent gate-PREMISE
+                # auditor) can re-derive a gate's premise from its recorded spec instead
+                # of being blind to it. (aios#1660)
                 await wf_queries.append_run_event(
                     conn,
                     account_id=account_id,
                     run_id=run_id,
                     type="call_started",
                     call_key=cap.call_key,
-                    payload={"capability": "gate", "gate_nonce": nonce},
+                    payload={"capability": "gate", "gate_nonce": nonce, "spec": cap.spec},
                 )
                 if run.launcher_session_id is not None:
                     await write_gate_opened(

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -310,6 +310,43 @@ async def test_gate_suspend_resume_replay_roundtrip(wf_runtime: asyncpg.Pool[Any
     ]
 
 
+async def test_gate_call_started_persists_structured_spec(
+    wf_runtime: asyncpg.Pool[Any],
+) -> None:
+    """A dev_pipeline gate emits a rich structured spec (kind/tier/reason/sha); the
+    ``call_started`` event must carry that spec verbatim (alongside the nonce) so a
+    journal reader can re-derive the gate's premise. Regression guard for aios#1660."""
+    pool = wf_runtime
+    spec = {
+        "kind": "decision",
+        "tier": "master",
+        "reason": "master_red",
+        "sha": "14ea747dcafe0000000000000000000000000000",
+    }
+    script = (
+        "async def main(input):\n"
+        f"    r = await gate({spec!r})\n"
+        "    return {'answer': r}\n"
+    )
+    run_id = await _make_run(pool, script)
+
+    await run_workflow_step(run_id)
+    async with pool.acquire() as conn:
+        gate_event = next(
+            e
+            for e in await wf_queries.list_run_events(conn, run_id)
+            if e.type == "call_started"
+        )
+    # Existing readers are unaffected: nonce + capability tag are still present.
+    assert gate_event.payload["capability"] == "gate"
+    assert isinstance(gate_event.payload["gate_nonce"], str)
+    # New: the structured spec is journaled intact.
+    assert gate_event.payload["spec"] == spec
+    # C1 premise-read: reason + sha are parseable straight from the journal.
+    assert gate_event.payload["spec"]["reason"] == "master_red"
+    assert gate_event.payload["spec"]["sha"] == spec["sha"]
+
+
 async def test_launcher_receives_gate_opened_and_resume_gate_happy_path(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -323,19 +323,13 @@ async def test_gate_call_started_persists_structured_spec(
         "reason": "master_red",
         "sha": "14ea747dcafe0000000000000000000000000000",
     }
-    script = (
-        "async def main(input):\n"
-        f"    r = await gate({spec!r})\n"
-        "    return {'answer': r}\n"
-    )
+    script = f"async def main(input):\n    r = await gate({spec!r})\n    return {{'answer': r}}\n"
     run_id = await _make_run(pool, script)
 
     await run_workflow_step(run_id)
     async with pool.acquire() as conn:
         gate_event = next(
-            e
-            for e in await wf_queries.list_run_events(conn, run_id)
-            if e.type == "call_started"
+            e for e in await wf_queries.list_run_events(conn, run_id) if e.type == "call_started"
         )
     # Existing readers are unaffected: nonce + capability tag are still present.
     assert gate_event.payload["capability"] == "gate"


### PR DESCRIPTION
Automated dev-pipeline build for issue #1660.