### PR TITLE
perf: per-turn sweep-guard adds ~3.8-5.2s to every session step (worker-wide, blocks turns) — fast-path early-out + pool-wait spans + asymptotic guard

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -56,7 +56,7 @@ from aios.harness.step_context import (
     compute_step_prelude,
     prelude_overhead_local,
 )
-from aios.harness.sweep import find_sessions_needing_inference
+from aios.harness.sweep import find_sessions_needing_inference, session_has_pending_work
 from aios.harness.tokens import approx_tokens, approx_tokens_by_class
 from aios.harness.tool_dispatch import launch_mcp_tool_calls, launch_tool_calls
 from aios.harness.tool_disposition import classify_tool_call
@@ -496,10 +496,28 @@ async def _run_session_step_body(
     # Prevents wasted DB/model calls from stale or duplicate wakes.
     #
     # Bracket with a ``sweep_start``/``sweep_end`` span pair (site="entry").
-    # Only ``find_sessions_needing_inference`` runs here — no ghost repair,
-    # no ``defer_wake`` — so ``repaired_ghosts`` is always 0. ``woken_sessions``
+    # Only the wake-detection query runs here — no ghost repair, no
+    # ``defer_wake`` — so ``repaired_ghosts`` is always 0. ``woken_sessions``
     # at ``site="entry"`` is 0 or 1: it records whether the guard determined
     # this specific session had work. 0 indicates a wasted wake.
+    #
+    # (A) Fast-path early-out (#1659). The full multi-CTE
+    # ``find_sessions_needing_inference`` measured a worker-wide 3.8-5.2s median
+    # on the per-turn entry path (worker-pool / event-loop contention, not query
+    # cost). Replace it here with ``session_has_pending_work`` — a single
+    # PK-scoped boolean that is a PROVEN OVER-APPROXIMATION of the full sweep
+    # (TRUE whenever the full sweep could return this session). Safety by
+    # construction (the wedge-class constraint): early-out ONLY on a provable
+    # ``False`` ("no work"); on ``True`` ("maybe work") FALL THROUGH to the full
+    # ``find_sessions_needing_inference``. A wrong predicate then costs at most an
+    # extra full sweep, never a missed wake → never a wedged session.
+    #
+    # (C) Observability spans (#1659). Bracket the two guard sub-costs so the
+    # currently-inferred split is measured: ``sweep.pool_acquire`` around the
+    # connection acquire and ``sweep.query_exec`` around the SQL. Then
+    # ``(sweep_end - sweep_start) - query_exec - pool_acquire ~= event-loop
+    # time-share`` -- which gates whether (B) pool/concurrency tuning is the
+    # load-bearing follow-up.
     sweep_start = await sessions_service.append_event(
         pool,
         session_id,
@@ -507,11 +525,46 @@ async def _run_session_step_body(
         {"event": "sweep_start", "site": "entry"},
         account_id=account_id,
     )
-    needs: set[str] = set()
+    has_work = False
     try:
-        needs = await find_sessions_needing_inference(
-            pool, inflight_tool_registry, session_id=session_id
+        pool_acquire_start = await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {"event": "sweep.pool_acquire_start"},
+            account_id=account_id,
         )
+        async with pool.acquire() as fast_conn:
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "span",
+                {
+                    "event": "sweep.pool_acquire_end",
+                    "start_id": pool_acquire_start.id,
+                },
+                account_id=account_id,
+            )
+            query_exec_start = await sessions_service.append_event(
+                pool,
+                session_id,
+                "span",
+                {"event": "sweep.query_exec_start"},
+                account_id=account_id,
+            )
+            try:
+                has_work = await session_has_pending_work(fast_conn, session_id)
+            finally:
+                await sessions_service.append_event(
+                    pool,
+                    session_id,
+                    "span",
+                    {
+                        "event": "sweep.query_exec_end",
+                        "start_id": query_exec_start.id,
+                    },
+                    account_id=account_id,
+                )
     finally:
         await sessions_service.append_event(
             pool,
@@ -521,12 +574,26 @@ async def _run_session_step_body(
                 "event": "sweep_end",
                 "sweep_start_id": sweep_start.id,
                 "repaired_ghosts": 0,
-                "woken_sessions": 1 if session_id in needs else 0,
+                "woken_sessions": 1 if has_work else 0,
+                "fast_path": True,
             },
             account_id=account_id,
         )
-    if session_id not in needs:
+    if not has_work:
+        # Provably no work — the fast path is a proven over-approximation, so a
+        # ``False`` here is authoritative. Skip the full sweep entirely.
         log.debug("step.early_out", session_id=session_id, cause=cause)
+        return _StepResult()
+
+    # Fast path said "maybe work" — fall through to the authoritative full sweep.
+    # It can still find no work (e.g. an incomplete tool batch the scalar gate
+    # can't see), in which case we early-out here; the cost of a wrong fast-path
+    # predicate is bounded to this occasional extra full sweep, never a wedge.
+    needs = await find_sessions_needing_inference(
+        pool, inflight_tool_registry, session_id=session_id
+    )
+    if session_id not in needs:
+        log.debug("step.early_out", session_id=session_id, cause=cause, via="full_sweep")
         return _StepResult()
 
     # Cancel leaf (cancel-design §4/§6): a session carrying an unharvested cancel-marker

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -56,6 +56,7 @@ __all__ = [
     "confirmed_unresolved_predicate",
     "session_active_predicate",
     "session_errored_predicate",
+    "session_has_pending_work",
     "wake_sessions_needing_inference",
 ]
 
@@ -281,6 +282,81 @@ ERRORED_SESSIONS_SQL = f"""
        AND {session_errored_predicate("s")}
        {{scope_clause}}
 """
+
+# ─── fast-path admission gate (#1659) ────────────────────────────────────────
+#
+# ``FAST_PATH_PENDING_WORK_SQL`` is the per-turn admission guard's cheap
+# necessary-condition gate. It is a SINGLE PK-scoped lookup on ``sessions``
+# (``id = $1``, served by ``sessions_pkey``) plus a lateral EXISTS over the tiny
+# ``session_cancel_markers`` table — no CTEs, no cross-session materialization,
+# no correlated ``NOT EXISTS`` over ``events``, and asymptotically O(1) in event
+# count (the plan does not touch ``events`` at all).
+#
+# SAFETY (the wedge-class constraint, issue #1659 comment): this predicate is a
+# proven **over-approximation** of ``find_sessions_needing_inference`` — it is
+# TRUE whenever the full sweep could return this session, so a ``False`` result
+# means there is *provably* no pending work. The caller may therefore ONLY
+# early-out on ``False``; on ``True`` ("maybe work") it MUST fall through to the
+# full ``find_sessions_needing_inference``. A wrong predicate is then bounded to
+# an occasional *extra* full sweep (cheap), NEVER a missed wake (a wedged
+# session).
+#
+# WHY IT IS AN OVER-APPROXIMATION — the full sweep returns a session iff:
+#   (a/b) it is ``session_active_predicate``-true AND survives the incomplete-
+#         batch filter (``_filter_incomplete_batches`` can only REMOVE, never
+#         add — so ``active`` is a superset of the (a/b) contribution);
+#   (c)   it has a confirmed-but-unresolved tool call. Such a call is an
+#         assistant tool_call with no result → it contributes to
+#         ``open_tool_call_count > 0`` and the session is non-errored (confirmed
+#         is subtracted by ``errored``) → it is ALREADY covered by
+#         ``session_active_predicate``; confirmed ⊆ active.
+#   (cancel) it carries an unharvested cancel-marker — UNIONed BELOW the errored
+#         subtraction, so it can fire on an idle/errored-parked session. This is
+#         the ONE return path ``session_active_predicate`` does not subsume, so
+#         it is OR-ed in explicitly via the marker EXISTS.
+# Hence ``active OR has-unharvested-cancel-marker`` is TRUE on every session the
+# full sweep could return: a proven over-approximation. The ``archived_at IS
+# NULL`` fence matches both the sweep's candidate WHERE and the marker join.
+FAST_PATH_PENDING_WORK_SQL = f"""
+    SELECT
+        s.archived_at IS NULL
+        AND (
+            {session_active_predicate("s")}
+            OR EXISTS (
+                SELECT 1 FROM session_cancel_markers m
+                 WHERE m.session_id = s.id
+                   AND m.harvested_at IS NULL
+            )
+        ) AS has_pending_work
+      FROM sessions s
+     WHERE s.id = $1
+"""
+
+
+async def session_has_pending_work(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+) -> bool:
+    """Cheap necessary-condition gate for the per-turn admission guard (#1659).
+
+    Returns ``True`` when the session *may* need inference and ``False`` only
+    when there is **provably** no pending work. A proven over-approximation of
+    :func:`find_sessions_needing_inference` (see ``FAST_PATH_PENDING_WORK_SQL``):
+    the caller may early-out on ``False`` but MUST fall through to the full sweep
+    on ``True`` — so a wrong predicate costs at most an extra full sweep, never a
+    missed wake.
+
+    A single PK-scoped lookup on ``sessions`` (no CTEs, no ``events`` scan), so
+    it does not grow with event history — the whole point of the fast path
+    versus the multi-CTE ``find_sessions_needing_inference``.
+
+    A missing session (``id`` not found) returns ``False``: no row → no work.
+    """
+    row = await conn.fetchrow(FAST_PATH_PENDING_WORK_SQL, session_id)
+    if row is None:
+        return False
+    return bool(row["has_pending_work"])
+
 
 # ─── ghost repair ────────────────────────────────────────────────────────────
 

--- a/tests/e2e/test_fast_path_admission_gate.py
+++ b/tests/e2e/test_fast_path_admission_gate.py
@@ -83,9 +83,7 @@ async def _append_assistant_reacting_to_tail(pool: asyncpg.Pool[Any], sid: str) 
     """Append an assistant message reacting to the current tail, driving the
     session idle (``last_reacted_seq`` catches up to ``last_stimulus_seq``)."""
     async with pool.acquire() as conn:
-        tail = await conn.fetchval(
-            "SELECT last_event_seq FROM sessions WHERE id = $1", sid
-        )
+        tail = await conn.fetchval("SELECT last_event_seq FROM sessions WHERE id = $1", sid)
     await sessions_service.append_event(
         pool,
         sid,
@@ -101,9 +99,7 @@ async def _fast_path(pool: asyncpg.Pool[Any], sid: str) -> bool:
 
 
 async def _full_sweep_has_work(pool: asyncpg.Pool[Any], sid: str) -> bool:
-    result = await find_sessions_needing_inference(
-        pool, InflightToolRegistry(), session_id=sid
-    )
+    result = await find_sessions_needing_inference(pool, InflightToolRegistry(), session_id=sid)
     return sid in result
 
 
@@ -190,9 +186,7 @@ async def _state_errored(pool: asyncpg.Pool[Any]) -> str:
 async def _state_archived(pool: asyncpg.Pool[Any]) -> str:
     sid = await _state_pending_user(pool)
     async with pool.acquire() as conn:
-        await conn.execute(
-            "UPDATE sessions SET archived_at = now() WHERE id = $1", sid
-        )
+        await conn.execute("UPDATE sessions SET archived_at = now() WHERE id = $1", sid)
     return sid
 
 
@@ -279,9 +273,7 @@ class TestFastPathOverApproximation:
         )
 
     @pytest.mark.parametrize("state", sorted(_NO_WORK_STATES))
-    async def test_no_work_states_early_out(
-        self, db_pool: asyncpg.Pool[Any], state: str
-    ) -> None:
+    async def test_no_work_states_early_out(self, db_pool: asyncpg.Pool[Any], state: str) -> None:
         """On genuinely-quiescent states the gate early-outs (False) — the whole
         point of the fast path (skip the multi-CTE sweep on wasted wakes)."""
         sid = await _STATE_BUILDERS[state](db_pool)

--- a/tests/e2e/test_fast_path_admission_gate.py
+++ b/tests/e2e/test_fast_path_admission_gate.py
@@ -1,0 +1,299 @@
+"""Equivalence + safety tests for the per-turn fast-path admission gate (#1659).
+
+The per-turn entry guard (``harness/loop.py``) now runs a cheap PK-scoped
+``session_has_pending_work`` gate BEFORE the multi-CTE
+``find_sessions_needing_inference``. To be safe against the wedge class
+(a missed wake → a stuck session), the gate must be a proven
+**over-approximation** of the full sweep:
+
+    fast_path_says_no_work  ⟹  full_sweep_says_no_work
+
+i.e. the gate may only early-out ("no work") when there is *provably* no
+pending work; on any "maybe work" it falls through to the full sweep. A wrong
+predicate is then bounded to an occasional *extra* full sweep (cheap), NEVER a
+missed wake (unbounded — a wedged session).
+
+These tests lock that implication across a matrix of session states:
+
+- pending unreacted user stimulus            (active → both say work)
+- fully reacted / idle                        (both say no work)
+- open (unresolved) tool call                 (active via open_tool_call_count)
+- confirmed-but-unresolved tool call          (case (c) ⊆ active)
+- errored + unreacted                         (parked → both say no work)
+- archived                                    (fenced out → both say no work)
+- unharvested cancel-marker on an idle session (the ONE full-sweep path the
+  active predicate does not subsume — the gate must still say "maybe work")
+
+The equivalence assertion is the core fence; the directional "gate found it
+too" assertions document why the early-out is safe on each shape.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool
+from aios.harness.inflight_tool_registry import InflightToolRegistry
+from aios.harness.sweep import (
+    find_sessions_needing_inference,
+    session_has_pending_work,
+)
+from aios.models.events import ERRORED_LIFECYCLE_STATUS, ERRORED_LIFECYCLE_STOP_REASON
+from aios.services import sessions as sessions_service
+from tests.conftest import needs_docker
+
+pytestmark = pytest.mark.docker
+
+_ACCOUNT = "acc_test_stub"
+
+
+async def _ensure_agent_and_env(pool: asyncpg.Pool[Any]) -> tuple[str, str]:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO agents (id, name, model, account_id) "
+            "VALUES ('agt_fp', 'fp', 'openrouter/x', 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, name, account_id) "
+            "VALUES ('env_fp', 'env_fp', 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+    return "agt_fp", "env_fp"
+
+
+async def _new_session(pool: asyncpg.Pool[Any]) -> str:
+    agent_id, environment_id = await _ensure_agent_and_env(pool)
+    session = await sessions_service.create_session(
+        pool,
+        agent_id=agent_id,
+        environment_id=environment_id,
+        title=None,
+        metadata={},
+        account_id=_ACCOUNT,
+    )
+    return session.id
+
+
+async def _append_assistant_reacting_to_tail(pool: asyncpg.Pool[Any], sid: str) -> None:
+    """Append an assistant message reacting to the current tail, driving the
+    session idle (``last_reacted_seq`` catches up to ``last_stimulus_seq``)."""
+    async with pool.acquire() as conn:
+        tail = await conn.fetchval(
+            "SELECT last_event_seq FROM sessions WHERE id = $1", sid
+        )
+    await sessions_service.append_event(
+        pool,
+        sid,
+        "message",
+        {"role": "assistant", "content": "ok", "reacting_to": tail},
+        account_id=_ACCOUNT,
+    )
+
+
+async def _fast_path(pool: asyncpg.Pool[Any], sid: str) -> bool:
+    async with pool.acquire() as conn:
+        return await session_has_pending_work(conn, sid)
+
+
+async def _full_sweep_has_work(pool: asyncpg.Pool[Any], sid: str) -> bool:
+    result = await find_sessions_needing_inference(
+        pool, InflightToolRegistry(), session_id=sid
+    )
+    return sid in result
+
+
+@pytest.fixture
+async def db_pool(aios_env: dict[str, str]) -> AsyncIterator[asyncpg.Pool[Any]]:
+    pool = await create_pool(aios_env["AIOS_DB_URL"], min_size=1, max_size=2)
+    try:
+        yield pool
+    finally:
+        await pool.close()
+
+
+# ─── state builders (one per matrix row) ─────────────────────────────────────
+
+
+async def _state_pending_user(pool: asyncpg.Pool[Any]) -> str:
+    sid = await _new_session(pool)
+    await sessions_service.append_user_message(pool, sid, "hi", account_id=_ACCOUNT)
+    return sid
+
+
+async def _state_idle(pool: asyncpg.Pool[Any]) -> str:
+    sid = await _new_session(pool)
+    await sessions_service.append_user_message(pool, sid, "hi", account_id=_ACCOUNT)
+    await _append_assistant_reacting_to_tail(pool, sid)
+    return sid
+
+
+async def _state_open_tool_call(pool: asyncpg.Pool[Any]) -> str:
+    sid = await _new_session(pool)
+    await sessions_service.append_user_message(pool, sid, "run it", account_id=_ACCOUNT)
+    # Assistant message with a tool_call that has no result → open_tool_call_count = 1.
+    await sessions_service.append_event(
+        pool,
+        sid,
+        "message",
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "tc_open",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": "{}"},
+                }
+            ],
+            "reacting_to": 1,
+        },
+        account_id=_ACCOUNT,
+    )
+    return sid
+
+
+async def _state_confirmed_unresolved(pool: asyncpg.Pool[Any]) -> str:
+    sid = await _state_open_tool_call(pool)
+    # A ``tool_confirmed``/``allow`` lifecycle for the still-open call — case (c).
+    await sessions_service.append_event(
+        pool,
+        sid,
+        "lifecycle",
+        {"event": "tool_confirmed", "result": "allow", "tool_call_id": "tc_open"},
+        account_id=_ACCOUNT,
+    )
+    return sid
+
+
+async def _state_errored(pool: asyncpg.Pool[Any]) -> str:
+    sid = await _new_session(pool)
+    await sessions_service.append_user_message(pool, sid, "hi", account_id=_ACCOUNT)
+    await sessions_service.append_event(
+        pool,
+        sid,
+        "lifecycle",
+        {
+            "event": "turn_ended",
+            "status": ERRORED_LIFECYCLE_STATUS,
+            "stop_reason": ERRORED_LIFECYCLE_STOP_REASON,
+        },
+        account_id=_ACCOUNT,
+    )
+    return sid
+
+
+async def _state_archived(pool: asyncpg.Pool[Any]) -> str:
+    sid = await _state_pending_user(pool)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE sessions SET archived_at = now() WHERE id = $1", sid
+        )
+    return sid
+
+
+async def _state_idle_with_cancel_marker(pool: asyncpg.Pool[Any]) -> str:
+    """An IDLE session (no active stimulus) carrying an unharvested cancel-marker.
+
+    This is the ONE full-sweep return path ``session_active_predicate`` does not
+    subsume (it is UNIONed BELOW the errored subtraction), so it is the load-
+    bearing case for the OR-ed marker EXISTS in the fast-path gate: an
+    over-approximation that dropped it would let the gate early-out on a session
+    the full sweep would return — a missed cancel-leaf.
+    """
+    sid = await _state_idle(pool)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO session_cancel_markers (session_id, request_id, account_id) "
+            "VALUES ($1, 'req_cancel', $2)",
+            sid,
+            _ACCOUNT,
+        )
+    return sid
+
+
+_STATE_BUILDERS = {
+    "pending_user": _state_pending_user,
+    "idle": _state_idle,
+    "open_tool_call": _state_open_tool_call,
+    "confirmed_unresolved": _state_confirmed_unresolved,
+    "errored": _state_errored,
+    "archived": _state_archived,
+    "idle_with_cancel_marker": _state_idle_with_cancel_marker,
+}
+
+# States where BOTH the fast path and the full sweep must agree there is work.
+_HAS_WORK_STATES = {
+    "pending_user",
+    "open_tool_call",
+    "confirmed_unresolved",
+    "idle_with_cancel_marker",
+}
+# States where the full sweep returns no work.
+_NO_WORK_STATES = {"idle", "errored", "archived"}
+
+
+@needs_docker
+class TestFastPathOverApproximation:
+    @pytest.mark.parametrize("state", sorted(_STATE_BUILDERS))
+    async def test_gate_is_over_approximation_of_full_sweep(
+        self, db_pool: asyncpg.Pool[Any], state: str
+    ) -> None:
+        """Core safety fence: ``fast_path_says_no_work ⟹ full_sweep_says_no_work``.
+
+        Whenever the cheap gate early-outs ("no work"), the authoritative full
+        sweep must also find no work — so the early-out can never drop a wake.
+        """
+        sid = await _STATE_BUILDERS[state](db_pool)
+
+        gate = await _fast_path(db_pool, sid)
+        full = await _full_sweep_has_work(db_pool, sid)
+
+        if not gate:
+            assert not full, (
+                f"OVER-APPROXIMATION VIOLATED for state={state!r}: the fast-path gate "
+                f"said 'no work' but the full sweep would wake the session — this is a "
+                f"MISSED WAKE (wedge-class bug). The gate must be TRUE whenever the "
+                f"full sweep could return the session."
+            )
+
+    @pytest.mark.parametrize("state", sorted(_HAS_WORK_STATES))
+    async def test_has_work_states_fall_through(
+        self, db_pool: asyncpg.Pool[Any], state: str
+    ) -> None:
+        """On every state the full sweep would wake, the gate says "maybe work"
+        (True) → the guard falls through to the full sweep. This exercises the
+        fall-through path (the uncertain branch) for each work-bearing shape."""
+        sid = await _STATE_BUILDERS[state](db_pool)
+
+        assert await _full_sweep_has_work(db_pool, sid), (
+            f"fixture bug: state={state!r} was expected to be work-bearing"
+        )
+        assert await _fast_path(db_pool, sid), (
+            f"state={state!r} needs work but the gate early-outs — the guard would "
+            f"skip the full sweep and MISS the wake."
+        )
+
+    @pytest.mark.parametrize("state", sorted(_NO_WORK_STATES))
+    async def test_no_work_states_early_out(
+        self, db_pool: asyncpg.Pool[Any], state: str
+    ) -> None:
+        """On genuinely-quiescent states the gate early-outs (False) — the whole
+        point of the fast path (skip the multi-CTE sweep on wasted wakes)."""
+        sid = await _STATE_BUILDERS[state](db_pool)
+
+        assert not await _full_sweep_has_work(db_pool, sid), (
+            f"fixture bug: state={state!r} was expected to be quiescent"
+        )
+        assert not await _fast_path(db_pool, sid), (
+            f"state={state!r} has no work but the gate did not early-out — the fast "
+            f"path buys nothing here (wasted-wake path stays on the heavy sweep)."
+        )
+
+    async def test_missing_session_is_no_work(self, db_pool: asyncpg.Pool[Any]) -> None:
+        """A gone/unknown session id → no row → no work (idempotent no-op wake)."""
+        assert not await _fast_path(db_pool, "sess_does_not_exist")

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -697,8 +697,12 @@ class TestFastPathPlanShapeAsymptotic:
     Seed the SAME session at N=10 and N=10 000 events, ``EXPLAIN (FORMAT JSON)``
     the ``FAST_PATH_PENDING_WORK_SQL`` at both, and assert:
 
-    - it is served by an **Index Scan on ``sessions_pkey``** (the PK lookup);
-    - there is **no Seq Scan on ``events``** (nor any ``events`` scan at all);
+    - there is **no Seq Scan on ``events``** (nor any ``events`` scan at all) —
+      the load-bearing #1659 regression guard;
+    - the ``sessions`` row is reached (the fast path is a single-row PK-scoped
+      lookup) — WITHOUT pinning a specific access method, since at tiny N the
+      planner legitimately picks a Seq Scan over ``sessions_pkey`` and that
+      choice varies with table size (not a stable signal);
     - the plan **node shape is identical across N** — so the plan does not grow
       with event history.
 
@@ -739,17 +743,18 @@ class TestFastPathPlanShapeAsymptotic:
                 assert not seq_scans_events, (
                     f"session_has_pending_work has a Seq Scan on ``events`` at N={n}."
                 )
-                # The ``sessions`` row is reached by its PK index.
-                pk_scans = [
-                    n2
-                    for n2 in nodes
-                    if n2.get("Relation Name") == "sessions"
-                    and n2.get("Index Name") == "sessions_pkey"
-                ]
-                assert pk_scans, (
-                    f"session_has_pending_work does not reach ``sessions`` via "
-                    f"``sessions_pkey`` at N={n}; nodes over sessions: "
-                    f"{[(x.get('Node Type'), x.get('Index Name')) for x in nodes if x.get('Relation Name') == 'sessions']}"
+                # The ``sessions`` row is reached (the fast path is a single-row
+                # PK-scoped lookup, ``WHERE id = $1``). We deliberately do NOT
+                # assert a specific access method here: at tiny N the planner
+                # legitimately prefers a Seq Scan over ``sessions_pkey`` because a
+                # seq scan is cheaper for a handful of rows, and that choice varies
+                # with table size — it is not a stable, load-bearing signal. The
+                # durable #1659 invariant is "no ``events`` scan + O(1) in event
+                # count" (asserted above and by the shape-identity check below).
+                sessions_nodes = [n2 for n2 in nodes if n2.get("Relation Name") == "sessions"]
+                assert sessions_nodes, (
+                    f"session_has_pending_work does not touch ``sessions`` at N={n}; "
+                    f"nodes: {[(x.get('Node Type'), x.get('Relation Name')) for x in nodes]}"
                 )
                 shapes[n] = _plan_node_shape(plan)
 

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -628,9 +628,7 @@ def _plan_node_shape(plan_node: dict[str, Any]) -> list[tuple[str, str, str]]:
     ]
 
 
-async def _seed_fast_path_session(
-    pool: asyncpg.Pool[Any], session_id: str, n_events: int
-) -> None:
+async def _seed_fast_path_session(pool: asyncpg.Pool[Any], session_id: str, n_events: int) -> None:
     """Seed one session at ``n_events`` user/assistant message events, then
     reconcile the migration-0066 scalar columns (the fast-path reads only these,
     never ``events``). Used by the plan-shape guard at N=10 and N=10 000 to prove
@@ -736,8 +734,7 @@ class TestFastPathPlanShapeAsymptotic:
                 seq_scans_events = [
                     n2
                     for n2 in nodes
-                    if n2.get("Node Type") == "Seq Scan"
-                    and n2.get("Relation Name") == "events"
+                    if n2.get("Node Type") == "Seq Scan" and n2.get("Relation Name") == "events"
                 ]
                 assert not seq_scans_events, (
                     f"session_has_pending_work has a Seq Scan on ``events`` at N={n}."

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -32,6 +32,7 @@ from aios.db.queries import _SESSION_STATUS_EXPR
 from aios.harness.sweep import (
     CANDIDATE_ROWS_SQL,
     ERRORED_SESSIONS_SQL,
+    FAST_PATH_PENDING_WORK_SQL,
     GHOST_ASST_SQL,
     GHOST_SPAN_START_SQL,
     UNREACTED_ROWS_SQL,
@@ -599,3 +600,234 @@ def _total_buffer_hits(plan_node: dict[str, Any]) -> int:
     for child in plan_node.get("Plans", []):
         total += _total_buffer_hits(child)
     return total
+
+
+# ─── fast-path admission gate (#1659) ────────────────────────────────────────
+
+
+def _collect_nodes(plan_node: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten the plan tree into a list of nodes (pre-order)."""
+    out = [plan_node]
+    for child in plan_node.get("Plans", []):
+        out.extend(_collect_nodes(child))
+    return out
+
+
+def _plan_node_shape(plan_node: dict[str, Any]) -> list[tuple[str, str, str]]:
+    """A structural fingerprint of the plan: the ordered ``(Node Type, Relation
+    Name, Index Name)`` triples across the tree. Deliberately excludes any
+    cost/row *estimates* — the invariant is that the SHAPE is identical across
+    N, not that the numbers match."""
+    return [
+        (
+            str(n.get("Node Type", "")),
+            str(n.get("Relation Name", "")),
+            str(n.get("Index Name", "")),
+        )
+        for n in _collect_nodes(plan_node)
+    ]
+
+
+async def _seed_fast_path_session(
+    pool: asyncpg.Pool[Any], session_id: str, n_events: int
+) -> None:
+    """Seed one session at ``n_events`` user/assistant message events, then
+    reconcile the migration-0066 scalar columns (the fast-path reads only these,
+    never ``events``). Used by the plan-shape guard at N=10 and N=10 000 to prove
+    the ``session_has_pending_work`` plan does not grow with event history."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO agents (id, name, model, account_id) "
+            "VALUES ('agt_perf', 'perf', 'openrouter/x', 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+        await conn.execute(
+            "INSERT INTO environments (id, name, account_id) "
+            "VALUES ('env_perf', 'env_perf', 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING"
+        )
+        await conn.execute(
+            "INSERT INTO sessions (id, agent_id, environment_id, workspace_volume_path, account_id) "
+            "VALUES ($1, 'agt_perf', 'env_perf', '/tmp/ws_' || $1, 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING",
+            session_id,
+        )
+        rows: list[tuple[Any, ...]] = []
+        for i in range(n_events):
+            role = "user" if i % 2 == 0 else "assistant"
+            data: dict[str, Any] = {"role": role, "content": f"m{i}"}
+            if role == "assistant":
+                data["reacting_to"] = i
+            rows.append(
+                (f"ev_{session_id}_{i}", session_id, i + 1, "message", json.dumps(data), role)
+            )
+        await conn.executemany(
+            "INSERT INTO events (id, session_id, seq, kind, data, role, account_id) "
+            "VALUES ($1, $2, $3, $4, $5::jsonb, $6, 'acc_test_stub') "
+            "ON CONFLICT (id) DO NOTHING",
+            rows,
+        )
+        # Reconcile the maintained scalar columns (mirrors migration 0066).
+        await conn.execute(
+            """
+            UPDATE sessions s
+               SET last_event_seq = COALESCE(
+                       (SELECT MAX(e.seq) FROM events e WHERE e.session_id = s.id), 0),
+                   last_user_seq = COALESCE(
+                       (SELECT MAX(e.seq) FROM events e WHERE e.session_id = s.id
+                          AND e.kind = 'message' AND e.role = 'user'), 0),
+                   last_stimulus_seq = COALESCE(
+                       (SELECT MAX(e.seq) FROM events e WHERE e.session_id = s.id
+                          AND e.kind = 'message' AND e.role <> 'assistant'), 0),
+                   last_reacted_seq = COALESCE(
+                       (SELECT MAX(COALESCE((e.data->>'reacting_to')::bigint, e.seq))
+                          FROM events e WHERE e.session_id = s.id
+                          AND e.kind = 'message' AND e.role = 'assistant'), 0)
+             WHERE s.id = $1
+            """,
+            session_id,
+        )
+        await conn.execute("ANALYZE events")
+        await conn.execute("ANALYZE sessions")
+
+
+@needs_docker
+class TestFastPathPlanShapeAsymptotic:
+    """Guard 1 (issue #1659): the per-turn fast-path ``session_has_pending_work``
+    is asymptotically O(1) in event count.
+
+    Seed the SAME session at N=10 and N=10 000 events, ``EXPLAIN (FORMAT JSON)``
+    the ``FAST_PATH_PENDING_WORK_SQL`` at both, and assert:
+
+    - it is served by an **Index Scan on ``sessions_pkey``** (the PK lookup);
+    - there is **no Seq Scan on ``events``** (nor any ``events`` scan at all);
+    - the plan **node shape is identical across N** — so the plan does not grow
+      with event history.
+
+    This is a plan-SHAPE assertion (present-vs-absent + shape identity), never a
+    wall-clock threshold — the 3.1↔4.7↔5.2s spread in the profile proves a
+    wall-clock gate would flake.
+    """
+
+    async def test_pk_indexed_no_events_scan_and_shape_stable_across_n(
+        self, aios_env: dict[str, str]
+    ) -> None:
+        from aios.db.pool import create_pool
+
+        pool = await create_pool(aios_env["AIOS_DB_URL"], min_size=1, max_size=2)
+        try:
+            shapes: dict[int, list[tuple[str, str, str]]] = {}
+            for n in (10, 10_000):
+                sid = f"sess_fastpath_n{n}"
+                await _seed_fast_path_session(pool, sid, n)
+                plan = await _explain(pool, FAST_PATH_PENDING_WORK_SQL, sid)
+                nodes = _collect_nodes(plan)
+
+                # No scan of ``events`` at any node — the fast path reads only the
+                # maintained scalar columns on ``sessions`` (+ the tiny cancel-marker
+                # table), never the event log.
+                events_scans = [n2 for n2 in nodes if n2.get("Relation Name") == "events"]
+                assert not events_scans, (
+                    f"session_has_pending_work scans ``events`` at N={n} "
+                    f"({[s.get('Node Type') for s in events_scans]}) — the fast path "
+                    f"must be O(1) in event count, reading only sessions scalar columns."
+                )
+                # No Seq Scan on events specifically (the explicit #1659 assertion).
+                seq_scans_events = [
+                    n2
+                    for n2 in nodes
+                    if n2.get("Node Type") == "Seq Scan"
+                    and n2.get("Relation Name") == "events"
+                ]
+                assert not seq_scans_events, (
+                    f"session_has_pending_work has a Seq Scan on ``events`` at N={n}."
+                )
+                # The ``sessions`` row is reached by its PK index.
+                pk_scans = [
+                    n2
+                    for n2 in nodes
+                    if n2.get("Relation Name") == "sessions"
+                    and n2.get("Index Name") == "sessions_pkey"
+                ]
+                assert pk_scans, (
+                    f"session_has_pending_work does not reach ``sessions`` via "
+                    f"``sessions_pkey`` at N={n}; nodes over sessions: "
+                    f"{[(x.get('Node Type'), x.get('Index Name')) for x in nodes if x.get('Relation Name') == 'sessions']}"
+                )
+                shapes[n] = _plan_node_shape(plan)
+
+            assert shapes[10] == shapes[10_000], (
+                "session_has_pending_work plan SHAPE changed between N=10 and "
+                f"N=10 000 — it must not grow with event history.\n"
+                f"N=10:    {shapes[10]}\nN=10000: {shapes[10_000]}"
+            )
+        finally:
+            await pool.close()
+
+
+class TestFastPathSpanCompositionInvariant:
+    """Guard 2 (issue #1659): the per-turn entry guard calls the CHEAP fast-path
+    ``session_has_pending_work`` (single PK lookup), NOT the heavy multi-CTE
+    ``find_sessions_needing_inference`` — the full sweep is only reached on
+    fall-through.
+
+    This makes "the entry guard silently regains the heavy sweep" a RED test
+    (caught here), not a latency mystery found months later. It is a pure
+    call-graph assertion on ``_run_session_step_body`` — no DB, no docker.
+    """
+
+    async def test_entry_guard_uses_fast_path_then_falls_through(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from aios.harness.loop import run_session_step
+
+        fast_path = AsyncMock(return_value=False)
+        full_sweep = AsyncMock(return_value=set())
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_inflight_tool_registry",
+                return_value=MagicMock(),
+            ),
+            patch("aios.harness.loop.session_has_pending_work", fast_path),
+            patch("aios.harness.loop.find_sessions_needing_inference", full_sweep),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+        ):
+            await run_session_step("sess_x", cause="message")
+
+        # The cheap fast path IS on the hot path.
+        fast_path.assert_awaited_once()
+        # And when it early-outs (False), the heavy multi-CTE sweep is NOT run —
+        # the entry guard has not silently regained the full sweep.
+        full_sweep.assert_not_awaited()
+
+    async def test_full_sweep_reached_only_on_fall_through(self) -> None:
+        """The complementary half: when the fast path says "maybe work" (True),
+        the entry guard DOES fall through to ``find_sessions_needing_inference``
+        (so a wrong fast-path predicate can never miss a wake)."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from aios.harness.loop import run_session_step
+
+        fast_path = AsyncMock(return_value=True)
+        full_sweep = AsyncMock(return_value=set())
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
+
+        with (
+            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch(
+                "aios.harness.loop.runtime.require_inflight_tool_registry",
+                return_value=MagicMock(),
+            ),
+            patch("aios.harness.loop.session_has_pending_work", fast_path),
+            patch("aios.harness.loop.find_sessions_needing_inference", full_sweep),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+        ):
+            await run_session_step("sess_x", cause="message")
+
+        fast_path.assert_awaited_once()
+        full_sweep.assert_awaited_once()

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -119,10 +119,18 @@ class TestTailSweepSpan:
 # ─── entry site (loop._run_session_step_body guard) ──────────────────────────
 
 
+def _acm_pool() -> MagicMock:
+    """A pool mock whose ``acquire()`` is an async context manager (MagicMock
+    auto-provides ``__aenter__``/``__aexit__`` as AsyncMocks), so the fast-path
+    guard's ``async with pool.acquire() as conn`` works under mock — the guard
+    never touches the yielded conn (``session_has_pending_work`` is patched)."""
+    return MagicMock()
+
+
 @pytest.fixture
 def mock_runtime() -> Iterator[None]:
     with (
-        patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+        patch("aios.harness.loop.runtime.require_pool", return_value=_acm_pool()),
         patch(
             "aios.harness.loop.runtime.require_inflight_tool_registry",
             return_value=MagicMock(),
@@ -133,17 +141,21 @@ def mock_runtime() -> Iterator[None]:
 
 class TestEntrySweepSpan:
     async def test_wasted_wake_marks_woken_sessions_zero(self, mock_runtime: None) -> None:
-        """Guard early-out: find_sessions_needing_inference returns empty set.
-        ``sweep_end`` stamps ``woken_sessions=0`` — the profiler's wasted-wake signal.
+        """Guard early-out: the fast-path ``session_has_pending_work`` returns
+        ``False`` (provably no work), so the full ``find_sessions_needing_inference``
+        is never called and ``sweep_end`` stamps ``woken_sessions=0`` — the
+        profiler's wasted-wake signal.
         """
         from aios.harness.loop import run_session_step
 
         append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
+        full_sweep = AsyncMock(return_value=set())
         with (
             patch(
-                "aios.harness.loop.find_sessions_needing_inference",
-                AsyncMock(return_value=set()),
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=False),
             ),
+            patch("aios.harness.loop.find_sessions_needing_inference", full_sweep),
             patch("aios.harness.loop.sessions_service.append_event", append_event),
         ):
             await run_session_step("sess_x", cause="message")
@@ -156,7 +168,44 @@ class TestEntrySweepSpan:
             "sweep_start_id": "ev_sweep",
             "repaired_ghosts": 0,
             "woken_sessions": 0,
+            "fast_path": True,
         }
+        # (A): a provable "no work" from the fast path never touches the full sweep.
+        full_sweep.assert_not_awaited()
+
+    async def test_fast_path_pool_and_query_spans_emitted(self, mock_runtime: None) -> None:
+        """(C) observability: the guard emits the ``sweep.pool_acquire`` and
+        ``sweep.query_exec`` child span pairs (nested inside the outer
+        ``sweep_start``/``sweep_end``) so the pool-wait vs event-loop-time-share
+        split is *measured*, not inferred."""
+        from aios.harness.loop import run_session_step
+
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
+        with (
+            patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=False),
+            ),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+        ):
+            await run_session_step("sess_x", cause="message")
+
+        # Only the guard's own spans (``sweep_*`` outer pair + ``sweep.*`` child
+        # pairs); other step spans (``step_start`` etc.) are filtered out.
+        events = [
+            e["event"]
+            for e in _span_events(append_event)
+            if str(e["event"]).startswith("sweep")
+        ]
+        # The child spans appear, bracketed by the outer sweep pair, in order.
+        assert events == [
+            "sweep_start",
+            "sweep.pool_acquire_start",
+            "sweep.pool_acquire_end",
+            "sweep.query_exec_start",
+            "sweep.query_exec_end",
+            "sweep_end",
+        ]
 
     async def test_happy_path_marks_woken_sessions_one(self) -> None:
         """Guard passes: session is in the needs set. ``woken_sessions=1``
@@ -186,10 +235,14 @@ class TestEntrySweepSpan:
         start_event = SimpleNamespace(id="ev_sweep")
 
         with (
-            patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
+            patch("aios.harness.loop.runtime.require_pool", return_value=_acm_pool()),
             patch(
                 "aios.harness.loop.runtime.require_inflight_tool_registry",
                 return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=True),
             ),
             patch(
                 "aios.harness.loop.find_sessions_needing_inference",
@@ -263,23 +316,20 @@ class TestEntrySweepSpan:
             "sweep_start_id": "ev_sweep",
             "repaired_ghosts": 0,
             "woken_sessions": 1,
+            "fast_path": True,
         }
 
-    async def test_sweep_end_fires_when_find_raises(self, mock_runtime: None) -> None:
-        """If ``find_sessions_needing_inference`` raises, the outer try/finally
-        in ``run_session_step`` still emits ``step_end``, and the body's own
-        try/finally still emits ``sweep_end`` (with ``woken_sessions=0``).
-
-        The exception propagates out of ``run_session_step`` because the
-        harness-error handler exhausts the retry budget (``_apply_retry_or_failure``
-        returns ``None``) and re-raises.
+    async def test_sweep_end_fires_when_fast_path_raises(self, mock_runtime: None) -> None:
+        """If the fast-path ``session_has_pending_work`` raises, the guard's own
+        try/finally still emits ``sweep_end`` (with ``woken_sessions=0``), and the
+        exception propagates out (budget exhausted → re-raise).
         """
         from aios.harness.loop import run_session_step
 
         append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
         with (
             patch(
-                "aios.harness.loop.find_sessions_needing_inference",
+                "aios.harness.loop.session_has_pending_work",
                 AsyncMock(side_effect=RuntimeError("db down")),
             ),
             patch("aios.harness.loop.sessions_service.append_event", append_event),
@@ -292,6 +342,36 @@ class TestEntrySweepSpan:
         sweep_events = _sweep_events(append_event)
         assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
         assert sweep_events[1]["woken_sessions"] == 0
+        assert sweep_events[1]["repaired_ghosts"] == 0
+
+    async def test_sweep_end_fires_when_full_sweep_raises(self, mock_runtime: None) -> None:
+        """When the fast path says "maybe work" (``True``) the guard falls through
+        to the full ``find_sessions_needing_inference``. If THAT raises, the guard's
+        try/finally still emits ``sweep_end`` and the exception propagates.
+        """
+        from aios.harness.loop import run_session_step
+
+        append_event = AsyncMock(return_value=SimpleNamespace(id="ev_sweep"))
+        with (
+            patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=True),
+            ),
+            patch(
+                "aios.harness.loop.find_sessions_needing_inference",
+                AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+            patch("aios.harness.loop.sessions_service.append_event", append_event),
+            patch("aios.harness.loop._apply_retry_or_failure", AsyncMock(return_value=None)),
+            pytest.raises(RuntimeError, match="db down"),
+        ):
+            await run_session_step("sess_x", cause="message")
+
+        sweep_events = _sweep_events(append_event)
+        assert [e["event"] for e in sweep_events] == ["sweep_start", "sweep_end"]
+        # The guard early-marked woken_sessions from the fast path (True → 1) —
+        # the sweep_end still closes even though the downstream full sweep raised.
+        assert sweep_events[1]["woken_sessions"] == 1
         assert sweep_events[1]["repaired_ghosts"] == 0
 
 

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -193,9 +193,7 @@ class TestEntrySweepSpan:
         # Only the guard's own spans (``sweep_*`` outer pair + ``sweep.*`` child
         # pairs); other step spans (``step_start`` etc.) are filtered out.
         events = [
-            e["event"]
-            for e in _span_events(append_event)
-            if str(e["event"]).startswith("sweep")
+            e["event"] for e in _span_events(append_event) if str(e["event"]).startswith("sweep")
         ]
         # The child spans appear, bracketed by the outer sweep pair, in order.
         assert events == [

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -172,9 +172,15 @@ class TestStepStartEndSpans:
 
         append_event = AsyncMock(return_value=SimpleNamespace(id="ev_step"))
         with (
+            # Fast path says "no work" → early-out (the wasted-wake path). The
+            # full sweep must NOT be reached; patch it to explode if it is.
+            patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=False),
+            ),
             patch(
                 "aios.harness.loop.find_sessions_needing_inference",
-                AsyncMock(return_value=set()),
+                AsyncMock(side_effect=AssertionError("full sweep must not run on early-out")),
             ),
             patch(
                 "aios.harness.loop.sessions_service.append_event",
@@ -183,11 +189,16 @@ class TestStepStartEndSpans:
         ):
             await run_session_step("sess_x", cause="message")
 
-        # Entry-site sweep spans wrap the guard check even on the
-        # wasted-wake path, so the profiler can see the SQL cost.
+        # Entry-site sweep spans wrap the guard check even on the wasted-wake
+        # path, so the profiler can see the (fast-path) cost — including the
+        # pool-acquire and query-exec child spans of the fast-path gate.
         assert _span_event_names(append_event) == [
             "step_start",
             "sweep_start",
+            "sweep.pool_acquire_start",
+            "sweep.pool_acquire_end",
+            "sweep.query_exec_start",
+            "sweep.query_exec_end",
             "sweep_end",
             "step_end",
         ]
@@ -240,6 +251,10 @@ class TestStepStartEndSpans:
             patch(
                 "aios.harness.loop.runtime.require_inflight_tool_registry",
                 return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=True),
             ),
             patch(
                 "aios.harness.loop.find_sessions_needing_inference",
@@ -345,6 +360,10 @@ class TestStepStartEndSpans:
                 return_value=MagicMock(),
             ),
             patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=True),
+            ),
+            patch(
                 "aios.harness.loop.find_sessions_needing_inference",
                 AsyncMock(return_value={"sess_x"}),
             ),
@@ -411,6 +430,10 @@ class TestStepStartEndSpans:
         assert _span_event_names(append_event) == [
             "step_start",
             "sweep_start",
+            "sweep.pool_acquire_start",
+            "sweep.pool_acquire_end",
+            "sweep.query_exec_start",
+            "sweep.query_exec_end",
             "sweep_end",
             "compute_prelude_start",
             "compute_prelude_end",
@@ -462,6 +485,10 @@ class TestStepStartEndSpans:
             patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
             patch(
                 "aios.harness.loop.runtime.require_inflight_tool_registry", return_value=MagicMock()
+            ),
+            patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=True),
             ),
             patch(
                 "aios.harness.loop.find_sessions_needing_inference",
@@ -564,6 +591,10 @@ class TestStepStartEndSpans:
                 "aios.harness.loop.runtime.require_inflight_tool_registry", return_value=MagicMock()
             ),
             patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=True),
+            ),
+            patch(
                 "aios.harness.loop.find_sessions_needing_inference",
                 AsyncMock(return_value={"sess_x"}),
             ),
@@ -657,6 +688,10 @@ class TestStepStartEndSpans:
             patch(
                 "aios.harness.loop.runtime.require_inflight_tool_registry",
                 return_value=MagicMock(),
+            ),
+            patch(
+                "aios.harness.loop.session_has_pending_work",
+                AsyncMock(return_value=True),
             ),
             patch(
                 "aios.harness.loop.find_sessions_needing_inference",
@@ -756,6 +791,9 @@ async def _harness_with_guard(
     with (
         patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
         patch("aios.harness.loop.runtime.require_inflight_tool_registry", return_value=MagicMock()),
+        patch(
+            "aios.harness.loop.session_has_pending_work", AsyncMock(return_value=True)
+        ),
         patch(
             "aios.harness.loop.find_sessions_needing_inference", AsyncMock(return_value={"sess_x"})
         ),

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -791,9 +791,7 @@ async def _harness_with_guard(
     with (
         patch("aios.harness.loop.runtime.require_pool", return_value=MagicMock()),
         patch("aios.harness.loop.runtime.require_inflight_tool_registry", return_value=MagicMock()),
-        patch(
-            "aios.harness.loop.session_has_pending_work", AsyncMock(return_value=True)
-        ),
+        patch("aios.harness.loop.session_has_pending_work", AsyncMock(return_value=True)),
         patch(
             "aios.harness.loop.find_sessions_needing_inference", AsyncMock(return_value={"sess_x"})
         ),


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/eumemic-ops#320.