### PR TITLE
GC corpse-salvage pass is not run-aware: a wfr_ run corpse is force-removed by coincidence of an always-empty sessions lookup

### DIFF
--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -1585,16 +1585,13 @@ class SandboxRegistry:
         then removed. Best-effort — a snapshot failure leaves the corpse for
         the next tick (the GC never raises). Each corpse is handled under the
         per-session lock with the cached-handle re-check.
+
+        Routes on owner kind up front (mirroring :meth:`_release_owner`): a
+        workflow-run (``wfr_``) corpse is the corpse-collection analog of
+        :meth:`release_run` — ephemeral scratch, never salvageable, never in
+        ``sessions`` — so it is bare-destroyed by kind, without any session
+        retain logic.
         """
-        # NOTE (#995): this pass is NOT run-aware. ``ref.session_id`` carries the
-        # owner label, which for a workflow-run sandbox is a ``wfr_…`` id (#988) —
-        # never present in the ``sessions`` table, so its ``states`` lookup below is
-        # always ``None`` ⇒ ``keep_fs`` False ⇒ ``force_remove`` with NO snapshot.
-        # That is correct-by-coincidence today because a run sandbox is ephemeral
-        # scratch with no durable rootfs to salvage, but it is a latent footgun: if
-        # M2 ever gives run sandboxes a durable rootfs, a ``wfr_`` corpse would be
-        # dropped here without a commit. Make this owner-kind aware
-        # (:func:`aios.ids.is_run_owner_id`) before that lands.
         for ref in containers:
             sid = ref.session_id
             if sid is None:
@@ -1605,6 +1602,14 @@ class SandboxRegistry:
                 cached = self._handles.get(sid)
                 if cached is not None and cached.sandbox_id == ref.sandbox_id:
                     continue  # the live, in-use container — never touch it
+                if is_run_owner_id(sid):
+                    # A workflow-run sandbox is ephemeral scratch with no durable
+                    # rootfs, no pointer, no proxies — the corpse-collection analog
+                    # of release_run. Never salvageable; never in `sessions`. Bare
+                    # destroy, no DB lookup.
+                    await self._backend.force_remove(ref.sandbox_id)
+                    continue
+                # ── session corpse: retain rule + under-lock dormancy re-verify ──
                 ttl = settings.sandbox_snapshot_ttl_seconds
                 state = states.get(sid)
                 keep_fs = state is not None and not _is_session_dormant(state, now, ttl)

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -19,6 +19,7 @@ import pytest
 
 from aios.config import get_settings
 from aios.harness import runtime
+from aios.ids import make_id
 from aios.sandbox.backends.base import ManagedImage, ManagedSandboxRef
 from aios.sandbox.registry import GcImageVerdict, SandboxRegistry, SessionSnapshotState
 from aios.sandbox.spec import snapshot_tag
@@ -141,6 +142,31 @@ async def test_corpse_pass_drops_deleted_session(
 
     assert not any(c[0] == "snapshot" for c in backend.calls)
     assert any(c[0] == "force_remove" for c in backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_corpse_pass_run_owner_dropped_without_db_lookup_or_snapshot(
+    fake_pool: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A workflow-run (wfr_) corpse is bare-destroyed by owner kind — never
+    routed through the session retain path (no gc_snapshot_session_states
+    query, no snapshot)."""
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    fresh = AsyncMock(return_value=[])
+    monkeypatch.setattr("aios.sandbox.registry.queries.gc_snapshot_session_states", fresh)
+    run_id = make_id("wfr")  # a valid wfr_ ULID-shaped owner id
+    container = ManagedSandboxRef(sandbox_id="cid", session_id=run_id, running=False)
+
+    await registry._gc_corpse_pass(
+        [container], {}, _NOW, get_settings(), get_settings().instance_id
+    )
+
+    assert any(c[0] == "force_remove" for c in backend.calls)
+    assert not any(c[0] == "snapshot" for c in backend.calls)
+    # The run branch must NOT consult the sessions table at all — on master
+    # the coincidence-path issues this guaranteed-empty query.
+    fresh.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Automated dev-pipeline build for issue #1537.