### PR TITLE
Inbound-budget count(*) seq-scans events on unindexed (account_id, orig_channel) — add the partial index the docstring already claims

### DIFF
--- a/migrations/versions/0128_events_inbound_budget_index.py
+++ b/migrations/versions/0128_events_inbound_budget_index.py
@@ -1,0 +1,72 @@
+"""Add the ``events_inbound_budget_idx`` partial index behind the
+per-counterparty inbound rate budget's rolling-window count (#1557).
+
+``_count_recent_inbounds`` (``src/aios/services/inbound_budget.py``) is the
+rolling-window aggregate the inbound rate budget reads once per admitted
+inbound at the connector-write boundary. Its ``WHERE`` leads with the two
+equality predicates ``(account_id, orig_channel)`` — and *neither* leads any
+existing index on ``events`` (every ``CREATE INDEX … ON events`` leads with
+``session_id``; ``orig_channel`` was added unindexed by mig 0017). The
+planner's only access path was therefore a sequential scan of the entire
+``events`` log — the highest-write, fastest-growing table — paid synchronously
+on the hot inbound admission path the budget exists to keep cheap.
+
+This migration adds the composite partial index that matches the query's
+access path:
+
+* Leading ``(account_id, orig_channel)`` — the two equality predicates — gives
+  the planner an equality seek into the matching rows, replacing the full scan;
+  ``account_id`` first preserves per-tenant scoping as the outermost key.
+* Trailing ``created_at`` lets the rolling-window range be satisfied within the
+  same index, so the count is an index-range over the seeked prefix rather than
+  a heap filter.
+* The partial predicate mirrors the query's ``_INFERENCE_BEARING_PREDICATE``
+  verbatim — an admitted inbound message (``kind='message'`` /
+  ``role='user'``) OR a wake-bearing connector lifecycle (``kind='lifecycle'``
+  stamped ``wake=True``). Keeping the partial predicate identical to the
+  query's constant predicate is what lets the planner prove the index
+  applicable while keeping the index to exactly the rows the budget counts (a
+  small fraction of ``events``). This mirrors how 0099/0103 use partials to
+  keep events-indexes narrow.
+
+Only the sibling ``orig_channel``-keyed helper is fixed here;
+``_count_recent_session_inbounds`` leads with ``session_id`` — the leading
+column of ``events_session_seq_idx`` (mig 0080) — so it already gets an index
+seek and is left untouched (#1557 Out of scope).
+
+Purely additive — a single ``CREATE INDEX CONCURRENTLY`` built inside
+``op.get_context().autocommit_block()`` so it never takes an ACCESS EXCLUSIVE
+lock on the live-written ``events`` table (same pattern as 0069 / 0097 / 0099).
+Safe in the post-deploy new-code/old-schema window: the index only speeds the
+read; new-code reads/writes work against the old schema until it completes, and
+it is invisible to the running container while building.
+
+Revision ID: 0128
+Revises: 0127
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0128"
+down_revision: str = "0127"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_inbound_budget_idx "
+            "ON events (account_id, orig_channel, created_at) "
+            "WHERE (kind = 'message' AND data->>'role' = 'user') "
+            "OR (kind = 'lifecycle' AND (data->>'wake')::boolean IS TRUE)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_inbound_budget_idx")

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -688,8 +688,7 @@ class Settings(BaseSettings):
         "boundary. The budget is a per-``(connection_id, chat_id)`` rolling "
         "COUNT of admitted inbound messages over this window, keyed on the "
         '``orig_channel`` (``f"{connector}/{external_account_id}/{chat_id}"``) '
-        "stamped on each ``role=user`` event — the same ``events``-log window "
-        "shape as ``count_recent_wakes_from``, ``account_id``-scoped (so two "
+        "stamped on each ``role=user`` event, ``account_id``-scoped (so two "
         "tenants holding the same external ``chat_id`` get independent "
         "budgets). When an admitted counterparty exceeds "
         "``inbound_rate_max_per_window`` messages inside this window the "

--- a/src/aios/services/inbound_budget.py
+++ b/src/aios/services/inbound_budget.py
@@ -83,9 +83,16 @@ async def _count_recent_inbounds(
     """Count admitted ``role=user`` inbound events on ``orig_channel`` in the
     last ``window_seconds`` — the rolling-window aggregate the budget reads.
 
-    Reuses the ``count_recent_wakes_from`` shape: a single ``SELECT count(*)``
-    over the ``events`` log, ``account_id``-scoped, no new table. Reads only
-    already-persisted state (no write on the allow path).
+    A single ``SELECT count(*)`` over the ``events`` log, ``account_id``-scoped,
+    no new table. Reads only already-persisted state (no write on the allow
+    path). Backed by the dedicated partial index ``events_inbound_budget_idx``
+    (``migrations/versions/0128_events_inbound_budget_index.py``), keyed
+    ``(account_id, orig_channel, created_at)`` partial on the inference-bearing
+    rows this count filters (admitted inbound user messages and wake-bearing
+    lifecycles), so the ``(account_id, orig_channel)`` equality prefix seeks the
+    index and the rolling-window ``created_at`` range is served within it —
+    rather than the full-``events`` sequential scan the predicate had no index
+    to satisfy before.
     """
     async with pool.acquire() as conn:
         count = await conn.fetchval(

--- a/tests/integration/test_migrations_0128_inbound_budget_index.py
+++ b/tests/integration/test_migrations_0128_inbound_budget_index.py
@@ -1,0 +1,204 @@
+"""Migration 0128 adds ``events_inbound_budget_idx`` — the composite partial
+index behind the per-counterparty inbound rate budget's rolling-window count
+(#1557).
+
+``_count_recent_inbounds`` leads its ``WHERE`` with the two equality predicates
+``(account_id, orig_channel)``, and *no* existing ``events`` index leads with
+that prefix, so before this migration the planner's only access path was a
+sequential scan of the entire ``events`` log — paid synchronously on the hot
+inbound admission path. These tests pin the fix two ways: the index exists in
+``pg_indexes`` after ``alembic upgrade head``, and an ``EXPLAIN (FORMAT JSON)``
+of the *exact* ``_count_recent_inbounds`` query (with real bind values) yields a
+plan whose scan node over ``events`` is an index scan on the new index rather
+than a ``Seq Scan``. On master (no index) the EXPLAIN assertion fails with a
+``Seq Scan`` — this is the master-failing pin.
+
+Mirrors the testcontainer-Postgres shape of
+``test_migrations_0097_unique_tool_result.py`` and the ``EXPLAIN (FORMAT
+JSON)`` plan-shape assertion style of ``tests/e2e/test_sweep_perf.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from tests.conftest import _docker_available, needs_docker
+from tests.integration.test_migrations import _alembic_url, _run_alembic
+
+# A minimal account/agent/env/session chain so admitted-inbound ``role=user``
+# events (and a wake-bearing lifecycle) have a session to hang off. The two
+# inbound events share one ``orig_channel`` so the budget window has rows to
+# count; the noise rows (assistant/tool/span/no-wake-lifecycle) exist so a
+# planner running on real data would have a reason to seek rather than scan.
+_CHAIN_SQL = """
+INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+VALUES ('acc_root', NULL, TRUE, 'root');
+INSERT INTO environments (id, name, account_id)
+VALUES ('env_a', 'env-a', 'acc_root');
+INSERT INTO agents (id, name, model, account_id)
+VALUES ('agent_a', 'agent-a', 'test/model', 'acc_root');
+INSERT INTO sessions (id, agent_id, environment_id, workspace_volume_path, account_id,
+                      last_event_seq)
+VALUES ('sess_a', 'agent_a', 'env_a', '/tmp/ws-a', 'acc_root', 4);
+"""
+
+_EVENTS_SQL = """
+INSERT INTO events (id, session_id, seq, kind, data, role, account_id, orig_channel)
+VALUES
+  ('evt_in1', 'sess_a', 1, 'message',
+   '{"role": "user", "content": "hi"}'::jsonb,
+   'user', 'acc_root', 'slack/ext1/chat1'),
+  ('evt_in2', 'sess_a', 2, 'message',
+   '{"role": "user", "content": "hi again"}'::jsonb,
+   'user', 'acc_root', 'slack/ext1/chat1'),
+  ('evt_wake', 'sess_a', 3, 'lifecycle',
+   '{"event": "external", "wake": true}'::jsonb,
+   NULL, 'acc_root', 'slack/ext1/chat1'),
+  ('evt_asst', 'sess_a', 4, 'message',
+   '{"role": "assistant", "content": "hello"}'::jsonb,
+   'assistant', 'acc_root', 'slack/ext1/chat1');
+"""
+
+# The EXACT ``_count_recent_inbounds`` query (predicate copied verbatim from
+# ``inbound_budget._INFERENCE_BEARING_PREDICATE``), so the plan we assert on is
+# the plan production runs — not a paraphrase.
+_COUNT_SQL = """
+SELECT count(*)
+FROM events
+WHERE account_id = $1
+  AND orig_channel = $2
+  AND ( (kind = 'message'   AND data->>'role' = 'user')
+     OR (kind = 'lifecycle' AND (data->>'wake')::boolean IS TRUE) )
+  AND created_at > now() - make_interval(secs => $3::bigint)
+"""
+
+_INDEX_NAME = "events_inbound_budget_idx"
+
+
+@pytest.fixture
+def postgres() -> Iterator[object]:
+    """Fresh function-scoped Postgres."""
+    if not _docker_available():
+        pytest.skip("Docker not available")
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+async def _execute(db_url: str, sql: str) -> None:
+    conn = await asyncpg.connect(db_url)
+    try:
+        await conn.execute(sql)
+    finally:
+        await conn.close()
+
+
+async def _fetchval(db_url: str, sql: str, *args: Any) -> Any:
+    conn = await asyncpg.connect(db_url)
+    try:
+        return await conn.fetchval(sql, *args)
+    finally:
+        await conn.close()
+
+
+def _collect_nodes(plan_node: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten the EXPLAIN plan tree into a list of nodes (pre-order)."""
+    nodes = [plan_node]
+    for child in plan_node.get("Plans", []):
+        nodes.extend(_collect_nodes(child))
+    return nodes
+
+
+@needs_docker
+@pytest.mark.integration
+def test_clean_database_creates_inbound_budget_index(postgres: object) -> None:
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "head"], db_url)
+    assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
+
+    indexdef = asyncio.run(
+        _fetchval(
+            db_url,
+            "SELECT indexdef FROM pg_indexes WHERE tablename = 'events' AND indexname = $1",
+            _INDEX_NAME,
+        )
+    )
+    assert indexdef is not None, f"{_INDEX_NAME} missing after upgrade"
+    indexdef = str(indexdef)
+    # Key columns in order, and partial predicate matching the query's rows.
+    assert "account_id, orig_channel, created_at" in indexdef, indexdef
+    assert "WHERE" in indexdef and "kind = 'message'" in indexdef, indexdef
+    assert "'role'::text) = 'user'" in indexdef, indexdef
+    assert "kind = 'lifecycle'" in indexdef and "'wake'" in indexdef, indexdef
+
+
+@needs_docker
+@pytest.mark.integration
+def test_count_query_uses_index_not_seq_scan(postgres: object) -> None:
+    """The master-failing pin: EXPLAIN of the exact ``_count_recent_inbounds``
+    query must seek the new index over ``events``, never a ``Seq Scan``. On
+    master (no index) the only ``events`` scan is a ``Seq Scan`` and this
+    assertion fails."""
+    db_url = _alembic_url(postgres)
+
+    up = _run_alembic(["upgrade", "head"], db_url)
+    assert up.returncode == 0, f"upgrade to head failed:\n{up.stderr}\n{up.stdout}"
+    asyncio.run(_execute(db_url, _CHAIN_SQL + _EVENTS_SQL))
+
+    async def _plan() -> dict[str, Any]:
+        conn = await asyncpg.connect(db_url)
+        try:
+            # Disable seq/bitmap-heap fallbacks the tiny test table would
+            # otherwise pick on cost alone, so the plan reflects the index's
+            # *applicability* to the predicate (the property #1557 is about),
+            # not the planner's row-count heuristics on a 4-row table.
+            await conn.execute("SET enable_seqscan = off")
+            result = await conn.fetchval(
+                f"EXPLAIN (FORMAT JSON) {_COUNT_SQL}",
+                "acc_root",
+                "slack/ext1/chat1",
+                3600,
+            )
+            if isinstance(result, str):
+                result = json.loads(result)
+            return result[0]["Plan"]  # type: ignore[no-any-return]
+        finally:
+            await conn.close()
+
+    plan = asyncio.run(_plan())
+    nodes = _collect_nodes(plan)
+
+    events_scans = [n for n in nodes if n.get("Relation Name") == "events"]
+    assert events_scans, f"no scan node over events in plan: {plan}"
+
+    seq_scans = [n for n in events_scans if n.get("Node Type") == "Seq Scan"]
+    assert not seq_scans, (
+        f"query still seq-scans events (missing {_INDEX_NAME}?): "
+        f"{[n.get('Node Type') for n in events_scans]}"
+    )
+
+    index_scans = [
+        n
+        for n in events_scans
+        if n.get("Node Type") in ("Index Scan", "Index Only Scan", "Bitmap Index Scan")
+        and n.get("Index Name") == _INDEX_NAME
+    ]
+    # Bitmap Index Scan lives on the node with the Index Name; the parent
+    # Bitmap Heap Scan carries the Relation Name. Cover both shapes.
+    bitmap_index_scans = [
+        n
+        for n in nodes
+        if n.get("Node Type") == "Bitmap Index Scan" and n.get("Index Name") == _INDEX_NAME
+    ]
+    assert index_scans or bitmap_index_scans, (
+        f"plan does not seek {_INDEX_NAME} over events; "
+        f"events scan nodes: {[(n.get('Node Type'), n.get('Index Name')) for n in events_scans]}"
+    )


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1557.