### PR TITLE
refactor(harness): replace the Agent | AgentVersion step-surface union + sentinel generic-child (agent_id="", version=0) with a nominal StepSurface + discriminated binding kind — forecloses the #1554 cache-poisoning class

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -63,9 +63,8 @@ from aios.harness.tool_disposition import classify_tool_call
 from aios.jobs.app import defer_run_wake, defer_wake
 from aios.logging import get_logger
 from aios.models.agents import (
-    Agent,
-    AgentVersion,
     McpServerSpec,
+    StepSurface,
     is_mcp_tool_name,
 )
 from aios.models.events import (
@@ -1449,7 +1448,7 @@ def _classify_tool_call(
 async def discover_session_mcp_tools(
     pool: Any,
     session_id: str,
-    agent: Agent | AgentVersion,
+    agent: StepSurface,
     *,
     account_id: str,
 ) -> tuple[list[dict[str, Any]], dict[str, str]]:
@@ -1481,7 +1480,7 @@ async def discover_session_mcp_tools(
     # pays no per-step ``list_tools()`` RPC. Frozen-surface / version-pinned
     # sessions keep one (id, version) for the session lifetime, so they serve
     # from cache for the whole session with no rediscovery.
-    binding_id = agents_service.tool_cache_binding_id(agent, session_id)
+    binding_id = agents_service.tool_cache_binding_id(agent)
 
     # Circuit breaker (#1391): skip a server whose discovery recently timed out /
     # failed so one unresponsive server can't re-stall the prelude every step —

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -44,10 +44,9 @@ if TYPE_CHECKING:
     import asyncpg
 
     from aios.models.agents import (
-        Agent,
-        AgentVersion,
         HttpServerSpec,
         McpServerSpec,
+        StepSurface,
         ToolSpec,
     )
     from aios.models.events import Event
@@ -211,7 +210,7 @@ async def compute_step_prelude(
     *,
     account_id: str,
     session: Session,
-    agent: Agent | AgentVersion,
+    agent: StepSurface,
     channels: list[str],
     memory_store_echoes: list[MemoryStoreResourceEcho],
 ) -> StepPrelude:
@@ -429,7 +428,7 @@ async def compose_step_context(
     pool: asyncpg.Pool[Any],
     session: Session,
     account_id: str,
-    agent: Agent | AgentVersion,
+    agent: StepSurface,
     channels: list[str],
     prelude: StepPrelude,
     events: list[Event],

--- a/src/aios/harness/tool_disposition.py
+++ b/src/aios/harness/tool_disposition.py
@@ -41,7 +41,7 @@ from aios.models.agents import is_mcp_tool_name, resolve_permission
 from aios.services.agents import effective_mcp_permission
 
 if TYPE_CHECKING:
-    from aios.models.agents import Agent, AgentVersion
+    from aios.models.agents import StepSurface
 
 
 class ToolDisposition(Enum):
@@ -73,7 +73,7 @@ class ToolDisposition(Enum):
 def classify_tool_call(
     name: str,
     arguments: Any,
-    agent: Agent | AgentVersion,
+    agent: StepSurface,
     *,
     confirmation_resolved: bool,
     mcp_server_map: dict[str, Any] | None = None,

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Literal, get_args
+from typing import Annotated, Any, Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -678,6 +678,77 @@ class AgentVersion(BaseModel):
     window_min: int
     window_max: int
     created_at: datetime
+
+
+# ── Step surface (harness read-model) ────────────────────────────────────────
+
+
+class AgentBinding(BaseModel):
+    """The step surface's identity when it is backed by an agent.
+
+    Covers *all three* agented cases the harness resolves to an agent
+    identity: a "latest" ``Agent``, a version-pinned ``AgentVersion``, and an
+    **agented** workflow child (``parent_run_id`` set, ``agent_id`` present).
+    Sibling runs of the same ``(agent_id, version)`` share this identity so the
+    #1391 MCP raw-discovery cache keeps sharing across them.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["agent"] = "agent"
+    agent_id: str
+    version: int
+
+
+class GenericChildBinding(BaseModel):
+    """The step surface's identity for a generic workflow child (no agent).
+
+    A generic child (``parent_run_id`` set, ``agent_id`` is ``None``) carries
+    only its own per-run-attenuated surface. It keys the #1391 cache on its own
+    ``session_id`` — never on an agent identity — so distinct children never
+    share a discovery slot. Replaces the ``agent_id=""``/``version=0`` sentinel.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["generic_child"] = "generic_child"
+    session_id: str
+
+
+StepBinding = Annotated[
+    AgentBinding | GenericChildBinding,
+    Field(discriminator="kind"),
+]
+
+
+class StepSurface(BaseModel):
+    """What a session runs as at step time — the harness's single read-model.
+
+    Nominal replacement for the ``Agent | AgentVersion`` structural union (the
+    two wire read-models) plus the ``agent_id=""``/``version=0`` sentinel that
+    encoded "no agent at all". Carries **exactly** the nine config fields the
+    harness consumes off the loaded surface (verified by grep over every
+    caller — nothing reads ``name``/``metadata``/``description``/``created_at``
+    off it) plus a discriminated :data:`StepBinding` identity.
+
+    ``binding`` is a total, two-arm discriminated kind — no ``.id``/``.agent_id``
+    spelling divergence to duck-type across and no sentinel to forget, so a
+    d3695683-class identity misclassification (the #1554 cache poisoning) is a
+    mypy error at every consumer instead of a latent runtime bug.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tools: list[ToolSpec]
+    mcp_servers: list[McpServerSpec]
+    http_servers: list[HttpServerSpec] = Field(default_factory=list)
+    model: str
+    system: str
+    skills: list[AgentSkillRef] = Field(default_factory=list)
+    litellm_extra: dict[str, Any] = Field(default_factory=dict)
+    window_min: int
+    window_max: int
+    binding: StepBinding
 
 
 # ── Tool-name + permission helpers ───────────────────────────────────────────

--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -63,11 +63,19 @@ class Surface(NamedTuple):
 
 
 class HasSurface(Protocol):
-    """Anything carrying the surface triple — ``Agent``/``AgentVersion``/``Workflow``/``WfRun``."""
+    """Anything carrying the surface triple — ``Agent``/``AgentVersion``/``Workflow``/``WfRun``/``StepSurface``.
 
-    tools: list[ToolSpec]
-    mcp_servers: list[McpServerSpec]
-    http_servers: list[HttpServerSpec]
+    The members are declared read-only (properties) so both the mutable wire
+    models and the *frozen* :class:`aios.models.agents.StepSurface` satisfy the
+    protocol — ``surface_of`` only ever reads them.
+    """
+
+    @property
+    def tools(self) -> list[ToolSpec]: ...
+    @property
+    def mcp_servers(self) -> list[McpServerSpec]: ...
+    @property
+    def http_servers(self) -> list[HttpServerSpec]: ...
 
 
 def surface_of(principal: HasSurface) -> Surface:

--- a/src/aios/sandbox/tool_broker.py
+++ b/src/aios/sandbox/tool_broker.py
@@ -65,9 +65,8 @@ from aios.errors import AiosError
 from aios.logging import get_logger
 from aios.mcp.client import call_mcp_tool, discover_mcp_tools
 from aios.models.agents import (
-    Agent,
-    AgentVersion,
     McpServerSpec,
+    StepSurface,
     ToolSpec,
     resolve_mcp_enabled,
 )
@@ -381,7 +380,7 @@ class ToolBroker:
             return _err(403, "forbidden: unknown or expired secret")
         return session_id
 
-    async def _load_agent(self, session_id: str) -> Agent | AgentVersion:
+    async def _load_agent(self, session_id: str) -> StepSurface:
         """Fetch the agent (or agent_version) attached to ``session_id``.
 
         Mirrors the loading dance in
@@ -537,7 +536,7 @@ class ToolBroker:
 
     async def _resolve_mcp(
         self, request: Request, *, require_tool: bool
-    ) -> tuple[str, McpServerSpec, ToolSpec, str | None, Agent | AgentVersion] | Response:
+    ) -> tuple[str, McpServerSpec, ToolSpec, str | None, StepSurface] | Response:
         """Resolve session, server, toolset, and (optionally) tool for an
         MCP route.
 
@@ -600,7 +599,7 @@ class ToolBroker:
                 headers,
                 server.name,
                 spec_headers=server.headers,
-                binding_id=agents_service.tool_cache_binding_id(agent, session_id),
+                binding_id=agents_service.tool_cache_binding_id(agent),
             )
         except Exception as exc:
             log.warning(
@@ -647,7 +646,7 @@ class ToolBroker:
                 headers,
                 server.name,
                 spec_headers=server.headers,
-                binding_id=agents_service.tool_cache_binding_id(agent, session_id),
+                binding_id=agents_service.tool_cache_binding_id(agent),
             )
         except Exception as exc:
             log.warning(

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -15,10 +15,14 @@ from aios.db import queries
 from aios.errors import ForbiddenError
 from aios.models.agents import (
     Agent,
+    AgentBinding,
+    AgentCreate,
     AgentVersion,
+    GenericChildBinding,
     HttpServerSpec,
     McpServerSpec,
     PermissionPolicy,
+    StepSurface,
     ToolSpec,
     resolve_mcp_permission,
 )
@@ -285,9 +289,31 @@ async def validate_pinned_agent_version(
     await queries.get_agent_version(conn, agent_id, agent_version, account_id=account_id)
 
 
+def _surface_from_agent(agent: Agent | AgentVersion, binding: AgentBinding) -> StepSurface:
+    """Project a wire read-model (``Agent``/``AgentVersion``) onto the nominal
+    :class:`StepSurface`, carrying exactly the nine harness-consumed fields.
+
+    A missing field here is a compile-loud ``StepSurface`` construction error,
+    not a silent structural-overlap drift — the projection's drift surface is
+    mypy, not runtime.
+    """
+    return StepSurface(
+        tools=agent.tools,
+        mcp_servers=agent.mcp_servers,
+        http_servers=agent.http_servers,
+        model=agent.model,
+        system=agent.system,
+        skills=agent.skills,
+        litellm_extra=agent.litellm_extra,
+        window_min=agent.window_min,
+        window_max=agent.window_max,
+        binding=binding,
+    )
+
+
 async def _load_for_session_conn(
     conn: asyncpg.Connection[Any], session: Any, *, account_id: str
-) -> Agent | AgentVersion:
+) -> StepSurface:
     """Resolve a session's effective surface on a caller-supplied ``conn``.
 
     The body of :func:`load_for_session` — see that function's docstring for the
@@ -303,9 +329,13 @@ async def _load_for_session_conn(
                 "(parent_run_id set but surface_frozen is false)"
             )
         if session.agent_id is None:
-            return AgentVersion(
-                agent_id="",
-                version=0,
+            # Generic workflow child: no agent at all. Build the surface from
+            # ``AgentCreate``'s field defaults (window_min/window_max) so the
+            # old duplicated 50k/150k literals can't silently diverge, and give
+            # it an explicit ``generic_child`` binding keyed on its own session
+            # — no ``agent_id=""``/``version=0`` sentinel.
+            defaults = AgentCreate.model_fields
+            return StepSurface(
                 model=session.model,
                 system=GENERIC_CHILD_SYSTEM.format(model=session.model),
                 tools=frozen.tools,
@@ -313,9 +343,9 @@ async def _load_for_session_conn(
                 mcp_servers=frozen.mcp_servers,
                 http_servers=frozen.http_servers,
                 litellm_extra={},
-                window_min=50_000,
-                window_max=150_000,
-                created_at=session.created_at,
+                window_min=defaults["window_min"].default,
+                window_max=defaults["window_max"].default,
+                binding=GenericChildBinding(session_id=session.id),
             )
         version = await queries.get_agent_version(
             conn, session.agent_id, session.agent_version, account_id=account_id
@@ -335,29 +365,38 @@ async def _load_for_session_conn(
         }
         if session.model is not None:
             updates["model"] = session.model
-        return version.model_copy(update=updates)
+        # An **agented** workflow child keeps an ``agent`` binding on
+        # ``(agent_id, version)`` so sibling runs still share the #1391 raw
+        # discovery cache (trap 1: two arms, not three).
+        overlaid = version.model_copy(update=updates)
+        return _surface_from_agent(
+            overlaid, AgentBinding(agent_id=overlaid.agent_id, version=overlaid.version)
+        )
     if session.agent_version is not None:
-        return await queries.get_agent_version(
+        pinned = await queries.get_agent_version(
             conn, session.agent_id, session.agent_version, account_id=account_id
         )
-    return await queries.get_agent(conn, session.agent_id, account_id=account_id)
+        return _surface_from_agent(
+            pinned, AgentBinding(agent_id=pinned.agent_id, version=pinned.version)
+        )
+    latest = await queries.get_agent(conn, session.agent_id, account_id=account_id)
+    return _surface_from_agent(latest, AgentBinding(agent_id=latest.id, version=latest.version))
 
 
-def tool_cache_binding_id(agent: Agent | AgentVersion, session_id: str) -> str:
+def tool_cache_binding_id(surface: StepSurface) -> str:
     """Stable identity for the #1391 MCP tool-list cache key.
 
     The cached tool set is static for a given *binding identity* — the
     precondition that lets sibling sessions of the same agent/version share
-    one discovery. A real agent's identity is agent-level so siblings share;
-    a generic workflow child (no agent_id) has only its own attenuated
-    per-run surface, so it must key on its own session (no cross-session
-    sharing — surfaces differ).
+    one discovery. A total match on the discriminated ``binding.kind``: an
+    ``agent`` binding is agent-level so siblings (latest/pinned/agented child)
+    share; a ``generic_child`` has only its own attenuated per-run surface, so
+    it keys on its own session (no cross-session sharing — surfaces differ).
     """
-    if isinstance(agent, Agent):
-        return f"{agent.id}:{agent.version}"
-    if agent.agent_id:
-        return f"{agent.agent_id}:{agent.version}"
-    return f"child:{session_id}"
+    binding = surface.binding
+    if binding.kind == "agent":
+        return f"{binding.agent_id}:{binding.version}"
+    return f"child:{binding.session_id}"
 
 
 async def load_for_session(
@@ -366,8 +405,8 @@ async def load_for_session(
     *,
     account_id: str,
     conn: asyncpg.Connection[Any] | None = None,
-) -> Agent | AgentVersion:
-    """Load the Agent / AgentVersion the harness sees for ``session`` at step time.
+) -> StepSurface:
+    """Load the :class:`StepSurface` the harness sees for ``session`` at step time.
 
     A **workflow child** (``parent_run_id`` set) reads the surface **frozen at spawn**
     (#794: the ``attenuate(agent, run)`` clamp) over its pinned ``AgentVersion`` —

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -34,8 +34,7 @@ from aios.harness.window import WindowedEvents
 from aios.ids import GITHUB_REPOSITORY, MEMORY_STORE, REQUEST, make_id, split_id
 from aios.jobs.app import defer_run_wake, defer_wake
 from aios.models.agents import (
-    Agent,
-    AgentVersion,
+    StepSurface,
     is_mcp_tool_name,
 )
 from aios.models.attenuation import Surface, surface_of
@@ -900,7 +899,7 @@ async def _inject_api_request(
 
 def _classify_awaiting(
     tc: dict[str, Any],
-    agent: Agent | AgentVersion,
+    agent: StepSurface,
 ) -> AwaitingToolCall | None:
     """Classify an unresolved tool_call into an ``AwaitingToolCall``, or
     ``None`` if the session is not blocked on external action for it
@@ -968,7 +967,7 @@ async def compute_awaiting(
     # run-attenuated surface (#794), so two children of the same agent/version under
     # different runs would collide on the old key and misclassify authority — they key
     # per-session instead.
-    agent_cache: dict[str | tuple[str | None, int | None], Agent | AgentVersion] = {}
+    agent_cache: dict[str | tuple[str | None, int | None], StepSurface] = {}
     out: dict[str, list[AwaitingToolCall]] = {}
     for session in sessions:
         unresolved = unresolved_by_sid.get(session.id)

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -227,9 +227,7 @@ def _query_rejected_reason(route: HttpRouteSpec, path: str, query: str) -> str |
     return None
 
 
-def _classify_permission(
-    args: dict[str, Any], agent: StepSurface
-) -> PermissionPolicy | None:
+def _classify_permission(args: dict[str, Any], agent: StepSurface) -> PermissionPolicy | None:
     """Per-route permission lookup for the dispatch gate.
 
     Returns the matched route's ``permission_policy`` so the harness can

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -26,11 +26,10 @@ import httpx
 from aios.harness import runtime
 from aios.mcp.client import resolve_auth_for_target_url
 from aios.models.agents import (
-    Agent,
-    AgentVersion,
     HttpRouteSpec,
     HttpServerSpec,
     PermissionPolicy,
+    StepSurface,
     http_route_suppressed,
 )
 from aios.services import agents as agents_service
@@ -229,7 +228,7 @@ def _query_rejected_reason(route: HttpRouteSpec, path: str, query: str) -> str |
 
 
 def _classify_permission(
-    args: dict[str, Any], agent: Agent | AgentVersion
+    args: dict[str, Any], agent: StepSurface
 ) -> PermissionPolicy | None:
     """Per-route permission lookup for the dispatch gate.
 
@@ -262,7 +261,7 @@ def _classify_permission(
     return route.permission_policy.type
 
 
-async def _load_session_agent(session_id: str) -> tuple[Agent | AgentVersion, str, str]:
+async def _load_session_agent(session_id: str) -> tuple[StepSurface, str, str]:
     pool = runtime.require_pool()
     account_id = await sessions_service.load_session_account_id(pool, session_id)
     session = await sessions_service.get_session_basic(pool, session_id, account_id=account_id)

--- a/src/aios/tools/registry.py
+++ b/src/aios/tools/registry.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from aios.errors import AiosError
-from aios.models.agents import PermissionPolicy, ToolTransport
+from aios.models.agents import PermissionPolicy, StepSurface, ToolTransport
 from aios.models.agents import ToolSpec as AgentToolSpec
 
 
@@ -83,12 +83,12 @@ class ToolResult:
 ToolHandler = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any] | ToolResult]]
 
 # Arg-aware permission classifier. Lets a tool declare a permission policy
-# that depends on the parsed arguments and the agent config — used by
-# ``http_request`` to gate on per-route policy in ``agent.http_servers``
-# rather than a single tool-level policy. ``agent`` is left untyped here
-# to avoid a circular import; consumers pass an
-# :class:`aios.models.agents.Agent` or :class:`AgentVersion`.
-ClassifyPermission = Callable[[dict[str, Any], Any], PermissionPolicy | None]
+# that depends on the parsed arguments and the loaded step surface — used by
+# ``http_request`` to gate on per-route policy in ``surface.http_servers``
+# rather than a single tool-level policy. The surface is the
+# :class:`aios.models.agents.StepSurface` the harness resolves at step time
+# (``models.agents`` is already imported at module level — no cycle).
+ClassifyPermission = Callable[[dict[str, Any], StepSurface], PermissionPolicy | None]
 
 
 @dataclass(slots=True, frozen=True)

--- a/tests/e2e/test_connection_tools.py
+++ b/tests/e2e/test_connection_tools.py
@@ -111,7 +111,11 @@ class TestConnectionToolsInPrelude:
             session_id=session.id,
             account_id=account_id,
             session=await sess_svc.get_session(harness._pool, session.id, account_id=account_id),
-            agent=agent,
+            agent=await agents_service.load_for_session(
+                harness._pool,
+                await sess_svc.get_session(harness._pool, session.id, account_id=account_id),
+                account_id=account_id,
+            ),
             channels=[],
             memory_store_echoes=[],
         )
@@ -221,7 +225,11 @@ class TestConnectionToolsInPrelude:
             session_id=session.id,
             account_id=account_id,
             session=await sess_svc.get_session(harness._pool, session.id, account_id=account_id),
-            agent=agent,
+            agent=await agents_service.load_for_session(
+                harness._pool,
+                await sess_svc.get_session(harness._pool, session.id, account_id=account_id),
+                account_id=account_id,
+            ),
             channels=[],
             memory_store_echoes=[],
         )

--- a/tests/unit/sandbox/test_tool_broker.py
+++ b/tests/unit/sandbox/test_tool_broker.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
-from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import patch
 
@@ -22,11 +21,12 @@ import pytest
 
 from aios.errors import CryptoDecryptError, ForbiddenError
 from aios.models.agents import (
-    AgentVersion,
+    AgentBinding,
     McpPermissionPolicy,
     McpServerSpec,
     McpToolConfig,
     McpToolsetConfig,
+    StepSurface,
     ToolSpec,
 )
 from aios.sandbox.tool_broker import ToolBroker
@@ -39,10 +39,8 @@ def _agent(
     *,
     tools: list[ToolSpec] | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
-) -> AgentVersion:
-    return AgentVersion(
-        agent_id="agt_1",
-        version=3,
+) -> StepSurface:
+    return StepSurface(
         model="test/dummy",
         system="sys",
         tools=tools or [],
@@ -52,7 +50,7 @@ def _agent(
         litellm_extra={},
         window_min=1000,
         window_max=100000,
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        binding=AgentBinding(agent_id="agt_1", version=3),
     )
 
 

--- a/tests/unit/test_classify_awaiting.py
+++ b/tests/unit/test_classify_awaiting.py
@@ -17,29 +17,25 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from aios.models.agents import Agent, ToolSpec
+from aios.models.agents import AgentBinding, StepSurface, ToolSpec
 from aios.models.sessions import AwaitingToolCall
 from aios.services.sessions import _classify_awaiting
 
 PENDING_SINCE = datetime(2026, 6, 10, 12, 0, 0, tzinfo=UTC)
 
 
-def _make_agent(tools: list[ToolSpec]) -> Agent:
-    now = datetime(2026, 1, 1, tzinfo=UTC)
-    return Agent(
-        id="agt_test",
-        version=1,
-        name="test-agent",
+def _make_agent(tools: list[ToolSpec]) -> StepSurface:
+    return StepSurface(
         model="gpt-test",
         system="be helpful",
         tools=tools,
+        skills=[],
         mcp_servers=[],
-        description=None,
-        metadata={},
+        http_servers=[],
+        litellm_extra={},
         window_min=1,
         window_max=10,
-        created_at=now,
-        updated_at=now,
+        binding=AgentBinding(agent_id="agt_test", version=1),
     )
 
 

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -9,13 +9,12 @@ test here.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aios.models.agents import AgentVersion, McpServerSpec, ToolSpec
+from aios.models.agents import AgentBinding, McpServerSpec, StepSurface, ToolSpec
 
 
 @pytest.fixture(autouse=True)
@@ -31,10 +30,8 @@ def _mock_crypto_box() -> Any:
 def _agent(
     mcp_servers: list[McpServerSpec] | None = None,
     tools: list[ToolSpec] | None = None,
-) -> AgentVersion:
-    return AgentVersion(
-        agent_id="agt_1",
-        version=3,
+) -> StepSurface:
+    return StepSurface(
         model="test/dummy",
         system="sys",
         tools=tools or [],
@@ -44,7 +41,7 @@ def _agent(
         litellm_extra={},
         window_min=1000,
         window_max=100000,
-        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        binding=AgentBinding(agent_id="agt_1", version=3),
     )
 
 

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -11,11 +11,11 @@ import httpx
 import pytest
 
 from aios.models.agents import (
-    Agent,
-    AgentVersion,
+    GenericChildBinding,
     HttpPermissionPolicy,
     HttpRouteSpec,
     HttpServerSpec,
+    StepSurface,
     ToolSpec,
 )
 from aios.tools.http_request import (
@@ -33,8 +33,21 @@ _REAL_ASYNC_CLIENT = httpx.AsyncClient
 
 def _agent(
     *, http_servers: list[HttpServerSpec], tools: list[ToolSpec] | None = None
-) -> Agent | AgentVersion:
-    return cast(Agent | AgentVersion, SimpleNamespace(http_servers=http_servers, tools=tools or []))
+) -> StepSurface:
+    """A minimal ``StepSurface`` for the http_request path (which reads only
+    ``http_servers``/``tools``). The binding kind is irrelevant here."""
+    return StepSurface(
+        model="test/dummy",
+        system="",
+        tools=tools or [],
+        skills=[],
+        mcp_servers=[],
+        http_servers=http_servers,
+        litellm_extra={},
+        window_min=1000,
+        window_max=100000,
+        binding=GenericChildBinding(session_id="ses_test"),
+    )
 
 
 def _server(
@@ -168,7 +181,7 @@ class TestClassifyToolCallArguments:
     ``function.arguments`` (providers differ on which shape they emit)."""
 
     @staticmethod
-    def _make_agent() -> Agent | AgentVersion:
+    def _make_agent() -> StepSurface:
         return _agent(
             http_servers=[_server(routes=[_route("/lights/*", policy="always_allow")])],
             tools=[ToolSpec(type="http_request")],
@@ -277,7 +290,7 @@ def _stub_runtime() -> Iterator[SimpleNamespace]:
         yield SimpleNamespace(pool=pool, crypto_box=crypto_box)
 
 
-def _patch_load_agent(agent: Agent | AgentVersion, outbound_suppression: str = "off") -> Any:
+def _patch_load_agent(agent: StepSurface, outbound_suppression: str = "off") -> Any:
     return patch(
         "aios.tools.http_request._load_session_agent",
         AsyncMock(return_value=(agent, "acc_test_stub", outbound_suppression)),

--- a/tests/unit/test_mcp_discovery_cache.py
+++ b/tests/unit/test_mcp_discovery_cache.py
@@ -161,8 +161,6 @@ class TestDiscoveryResultCache:
 # ── binding-identity accessor (#1554) ───────────────────────────────────────
 
 
-
-
 def _agent_surface(*, agent_id: str, version: int, tools: list[ToolSpec]) -> StepSurface:
     """A ``StepSurface`` with an ``agent`` binding — the latest/pinned/agented-child
     identity that keys the #1391 cache on ``(agent_id, version)``."""

--- a/tests/unit/test_mcp_discovery_cache.py
+++ b/tests/unit/test_mcp_discovery_cache.py
@@ -19,7 +19,6 @@ All MCP SDK + httpx interactions are mocked. No network calls.
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -32,7 +31,7 @@ from aios.mcp.client import (
     discover_mcp_tools,
 )
 from aios.mcp.pool import McpSessionPool
-from aios.models.agents import Agent, AgentVersion, ToolSpec
+from aios.models.agents import AgentBinding, GenericChildBinding, StepSurface, ToolSpec
 from aios.services.agents import tool_cache_binding_id
 
 URL = "https://m.example/"
@@ -162,13 +161,12 @@ class TestDiscoveryResultCache:
 # ── binding-identity accessor (#1554) ───────────────────────────────────────
 
 
-_DT = datetime(2024, 1, 1, tzinfo=UTC)
 
 
-def _agent_version(*, agent_id: str, version: int, tools: list[ToolSpec]) -> AgentVersion:
-    return AgentVersion(
-        agent_id=agent_id,
-        version=version,
+def _agent_surface(*, agent_id: str, version: int, tools: list[ToolSpec]) -> StepSurface:
+    """A ``StepSurface`` with an ``agent`` binding — the latest/pinned/agented-child
+    identity that keys the #1391 cache on ``(agent_id, version)``."""
+    return StepSurface(
         model="test/dummy",
         system="sys",
         tools=tools,
@@ -178,75 +176,79 @@ def _agent_version(*, agent_id: str, version: int, tools: list[ToolSpec]) -> Age
         litellm_extra={},
         window_min=1000,
         window_max=100000,
-        created_at=_DT,
+        binding=AgentBinding(agent_id=agent_id, version=version),
     )
 
 
-def _latest_agent(*, id: str, version: int) -> Agent:
-    return Agent(
-        id=id,
-        version=version,
-        name="a",
+def _generic_child_surface(*, session_id: str, tools: list[ToolSpec]) -> StepSurface:
+    """A ``StepSurface`` with a ``generic_child`` binding — keys the #1391 cache
+    on its own ``session_id`` (no agent identity, no sentinel)."""
+    return StepSurface(
         model="test/dummy",
         system="sys",
-        tools=[],
+        tools=tools,
         skills=[],
         mcp_servers=[],
         http_servers=[],
-        description="d",
-        metadata={},
         litellm_extra={},
         window_min=1000,
         window_max=100000,
-        created_at=_DT,
-        updated_at=_DT,
+        binding=GenericChildBinding(session_id=session_id),
     )
 
 
 class TestToolCacheBindingId:
-    """#1554: the binding identity that keys the #1391 tool-list cache must
-    distinguish distinct agents/sessions, never collapse them onto ``"?:..."``.
+    """#1554/#1688: the binding identity that keys the #1391 tool-list cache
+    must distinguish distinct agents/sessions, never collapse them onto
+    ``"?:..."``. Post-#1688 the identity is a total match on ``binding.kind``.
     """
 
     def test_distinct_version_pinned_agents_same_version_get_distinct_ids(self) -> None:
-        """Two version-pinned ``AgentVersion``s of *different* agents pinned to
-        the same version number must NOT collide. On master both duck-type to
-        ``"?:3"`` (the old ``getattr(agent, 'id', '?')``) — this asserts the
-        post-fix ``"agt_A:3"`` / ``"agt_B:3"`` and so fails on master."""
-        a = _agent_version(agent_id="agt_A", version=3, tools=[])
-        b = _agent_version(agent_id="agt_B", version=3, tools=[])
-        id_a = tool_cache_binding_id(a, "ses_1")
-        id_b = tool_cache_binding_id(b, "ses_2")
+        """Two ``agent``-bound surfaces of *different* agents pinned to the same
+        version number must NOT collide — they bind to ``"agt_A:3"`` /
+        ``"agt_B:3"``. On master both duck-typed to ``"?:3"``."""
+        a = _agent_surface(agent_id="agt_A", version=3, tools=[])
+        b = _agent_surface(agent_id="agt_B", version=3, tools=[])
+        id_a = tool_cache_binding_id(a)
+        id_b = tool_cache_binding_id(b)
         assert id_a == "agt_A:3"
         assert id_b == "agt_B:3"
         assert id_a != id_b
 
     def test_distinct_generic_children_get_distinct_session_anchored_ids(self) -> None:
-        """Two generic workflow children (``agent_id=""``, ``version=0``) carry
-        distinct attenuated per-run surfaces; they must key on their own
-        ``session_id`` and so differ. On master both collapse to ``"?:0"``."""
-        a = _agent_version(agent_id="", version=0, tools=[])
-        b = _agent_version(agent_id="", version=0, tools=[])
-        id_a = tool_cache_binding_id(a, "ses_child_a")
-        id_b = tool_cache_binding_id(b, "ses_child_b")
+        """Two generic workflow children (``generic_child`` binding) carry
+        distinct attenuated per-run surfaces; they key on their own
+        ``session_id`` and so differ. On master both collapsed to ``"?:0"``."""
+        a = _generic_child_surface(session_id="ses_child_a", tools=[])
+        b = _generic_child_surface(session_id="ses_child_b", tools=[])
+        id_a = tool_cache_binding_id(a)
+        id_b = tool_cache_binding_id(b)
         assert id_a == "child:ses_child_a"
         assert id_b == "child:ses_child_b"
         assert id_a != id_b
 
     def test_latest_agent_path_unchanged(self) -> None:
-        """The latest-``Agent`` path keeps its ``"<id>:<version>"`` form —
+        """The latest-agent path keeps its ``"<id>:<version>"`` form —
         the one path that was already correct."""
-        agent = _latest_agent(id="agt_1", version=3)
-        assert tool_cache_binding_id(agent, "ses_x") == "agt_1:3"
+        agent = _agent_surface(agent_id="agt_1", version=3, tools=[])
+        assert tool_cache_binding_id(agent) == "agt_1:3"
+
+    def test_agented_child_shares_with_siblings(self) -> None:
+        """Trap 1 (#1688): an *agented* workflow child keeps an ``agent`` binding
+        on ``(agent_id, version)`` so sibling runs share the raw-discovery cache
+        — it must NOT be forced onto a per-session key like a generic child."""
+        child_run_1 = _agent_surface(agent_id="agt_X", version=5, tools=[])
+        child_run_2 = _agent_surface(agent_id="agt_X", version=5, tools=[])
+        assert tool_cache_binding_id(child_run_1) == tool_cache_binding_id(child_run_2) == "agt_X:5"
 
     async def test_cross_agent_pool_key_not_poisoned(self, pool_runtime: McpSessionPool) -> None:
         """End-to-end: agent A's discovered tool list is NOT served to a
         version-pinned agent B sharing one ``_PoolKey`` (same url/vault/headers).
         On master both bind to ``"?:3"`` → B is served A's tools."""
-        a = _agent_version(agent_id="agt_A", version=3, tools=[])
-        b = _agent_version(agent_id="agt_B", version=3, tools=[])
-        bind_a = tool_cache_binding_id(a, "ses_a")
-        bind_b = tool_cache_binding_id(b, "ses_b")
+        a = _agent_surface(agent_id="agt_A", version=3, tools=[])
+        b = _agent_surface(agent_id="agt_B", version=3, tools=[])
+        bind_a = tool_cache_binding_id(a)
+        bind_b = tool_cache_binding_id(b)
         # Distinct agents pinned to the same version must NOT share a cache slot.
         assert bind_a != bind_b
 

--- a/tests/unit/test_step_context_provider_clamp.py
+++ b/tests/unit/test_step_context_provider_clamp.py
@@ -14,7 +14,6 @@ tool, and an in-memory ``Agent``. The two cases nail the new branch:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock
@@ -23,7 +22,7 @@ import pytest
 
 from aios.harness import runtime
 from aios.harness.step_context import compute_step_prelude
-from aios.models.agents import Agent, ToolSpec
+from aios.models.agents import AgentBinding, StepSurface, ToolSpec
 
 pytestmark = pytest.mark.asyncio
 
@@ -39,23 +38,18 @@ _PROVIDER_TOOL = {
 }
 
 
-def _agent(tools: list[ToolSpec]) -> Agent:
-    now = datetime.now(UTC)
-    return Agent(
-        id="agt_1627",
-        version=1,
-        name="a",
+def _agent(tools: list[ToolSpec]) -> StepSurface:
+    return StepSurface(
         model="gpt-test",
         system="you are a test agent",
         tools=tools,
+        skills=[],
         mcp_servers=[],
         http_servers=[],
-        description=None,
-        metadata={},
+        litellm_extra={},
         window_min=1,
         window_max=10,
-        created_at=now,
-        updated_at=now,
+        binding=AgentBinding(agent_id="agt_1627", version=1),
     )
 
 
@@ -85,7 +79,7 @@ def _stub_tool_provider() -> Any:
     return tp
 
 
-async def _prelude_tool_names(agent: Agent, session: Any) -> list[str]:
+async def _prelude_tool_names(agent: StepSurface, session: Any) -> list[str]:
     prev = runtime.tool_provider
     runtime.tool_provider = _stub_tool_provider()
     try:

--- a/tests/unit/test_tool_disposition.py
+++ b/tests/unit/test_tool_disposition.py
@@ -16,16 +16,16 @@ lacked.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Any
 
 from aios.harness.tool_disposition import ToolDisposition, classify_tool_call
 from aios.models.agents import (
-    Agent,
+    AgentBinding,
     HttpPermissionPolicy,
     HttpRouteSpec,
     HttpServerSpec,
     McpServerSpec,
+    StepSurface,
     ToolSpec,
 )
 
@@ -50,27 +50,22 @@ def _agent(
     tools: list[ToolSpec] | None = None,
     http_servers: list[HttpServerSpec] | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
-) -> Agent:
-    now = datetime(2026, 1, 1, tzinfo=UTC)
-    return Agent(
-        id="agt_test",
-        version=1,
-        name="test-agent",
+) -> StepSurface:
+    return StepSurface(
         model="gpt-test",
         system="be helpful",
         tools=tools or [],
+        skills=[],
         mcp_servers=mcp_servers or [],
         http_servers=http_servers or [],
-        description=None,
-        metadata={},
+        litellm_extra={},
         window_min=1,
         window_max=10,
-        created_at=now,
-        updated_at=now,
+        binding=AgentBinding(agent_id="agt_test", version=1),
     )
 
 
-def _http_agent(policy: str) -> Agent:
+def _http_agent(policy: str) -> StepSurface:
     route = HttpRouteSpec(
         path_pattern="/lights/*",
         enabled=True,


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1688.