### PR TITLE
P0: connector sessions silently wedge — API-origin wakes route to dead 'default' queue (ae0c0064 regression)

### DIFF
--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -51,6 +51,7 @@ from aios.harness.sweep import (
 )
 from aios.harness.trigger_runner import sweep_trigger_fires
 from aios.harness.workspace_reaper import sweep_archived_workspaces
+from aios.jobs.app import WORKER_POLLED_QUEUES
 from aios.jobs.app import app as procrastinate_app
 from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool
@@ -489,7 +490,11 @@ async def worker_main() -> None:
 
         worker_task = asyncio.create_task(
             procrastinate_app.run_worker_async(
-                queues=["sessions", "workflows"],
+                # Sorted for a deterministic startup log; the set is the single
+                # source of truth shared with the defer-time routing guard so a
+                # queue can never be polled here yet unroutable there, or vice
+                # versa (issue #1699).
+                queues=sorted(WORKER_POLLED_QUEUES),
                 concurrency=settings.worker_concurrency,
                 wait=True,
                 install_signal_handlers=True,

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -51,7 +51,7 @@ from aios.harness.sweep import (
 )
 from aios.harness.trigger_runner import sweep_trigger_fires
 from aios.harness.workspace_reaper import sweep_archived_workspaces
-from aios.jobs.app import WORKER_POLLED_QUEUES
+from aios.jobs.app import WORKER_POLLED_QUEUES as WORKER_POLLED_QUEUES
 from aios.jobs.app import app as procrastinate_app
 from aios.logging import configure_logging, get_logger
 from aios.mcp.pool import McpSessionPool

--- a/src/aios/jobs/app.py
+++ b/src/aios/jobs/app.py
@@ -40,6 +40,44 @@ if TYPE_CHECKING:
 log = get_logger("aios.jobs.app")
 
 
+# ── Queue routing (single source of truth) ─────────────────────────────
+# Registered-task queues live in ``aios.harness.tasks`` (``@app.task(queue=...)``),
+# but those decorators only bind in the *worker* process. The api process defers
+# by name string with ``allow_unknown=True`` and NEVER imports the harness graph,
+# so ``configure_task`` cannot read the registered ``queue=`` and silently falls
+# back to procrastinate's ``"default"`` queue -- which the worker never polls
+# (regression, ae0c0064; issue #1699). Routing therefore must NOT depend on
+# task-registration being present in the calling process: every API-side
+# ``configure_task`` passes an EXPLICIT ``queue=`` drawn from these constants,
+# and :func:`_polled_queue` asserts the resolved queue is one the worker fetches.
+QUEUE_SESSIONS = "sessions"
+QUEUE_WORKFLOWS = "workflows"
+
+# The exact set the worker polls (``run_worker_async(queues=...)`` in
+# :mod:`aios.harness.worker`). A ``harness.*`` job deferred onto any queue
+# outside this set sits ``todo`` forever -- the wedge #1699 describes. Kept here,
+# beside the deferral primitives, as the one authority both the worker and the
+# defer-time guard read.
+WORKER_POLLED_QUEUES: frozenset[str] = frozenset({QUEUE_SESSIONS, QUEUE_WORKFLOWS})
+
+
+def _polled_queue(queue: str) -> str:
+    """Return *queue* iff the worker polls it; raise loud otherwise.
+
+    Belt-and-suspenders for #1699 acceptance #3: no ``harness.*`` job may be
+    created on a queue the worker does not fetch. Called at defer time so a
+    routing regression fails at enqueue -- a caught, logged, obvious error --
+    rather than silently wedging a live connector session for hours.
+    """
+    if queue not in WORKER_POLLED_QUEUES:
+        raise ValueError(
+            f"refusing to defer onto queue {queue!r}: not in the worker's polled "
+            f"set {sorted(WORKER_POLLED_QUEUES)!r} -- the job would sit todo forever "
+            "(issue #1699). Route to an explicit worker-polled queue."
+        )
+    return queue
+
+
 def _sync_dsn(db_url: str) -> str:
     """Strip any +async driver suffix from a Postgres DSN.
 
@@ -137,6 +175,11 @@ async def defer_wake(
     # configure_task accepts schedule_in=None (treated as "no schedule").
     deferrer = app.configure_task(
         "harness.wake_session",
+        # Explicit ``queue=`` — the api process registers no tasks, so
+        # ``configure_task`` cannot read the ``@app.task(queue="sessions")``
+        # registration and would fall back to the unpolled ``default`` queue
+        # (issue #1699). Guarded so a bad queue fails at enqueue, never silently.
+        queue=_polled_queue(QUEUE_SESSIONS),
         lock=session_id,
         queueing_lock=session_id,
         priority=priority,
@@ -175,6 +218,10 @@ async def defer_run_wake(run_id: str, *, batch: bool = False) -> None:
     window = get_settings().workflow_wake_batch_seconds if batch else 0.0
     deferrer = app.configure_task(
         "harness.wake_workflow",
+        # Explicit ``queue=`` for the same reason as ``defer_wake`` (#1699):
+        # a defer from a process without the harness registration must still
+        # route to the worker-polled ``workflows`` queue, not ``default``.
+        queue=_polled_queue(QUEUE_WORKFLOWS),
         lock=run_id,
         queueing_lock=run_id,
         priority=_BACKGROUND_PRIORITY,  # workflow run steps yield to foreground too
@@ -201,6 +248,11 @@ async def defer_trigger_fire(trigger_id: str, trigger_run_id: str) -> None:
     try:
         await app.configure_task(
             "harness.run_trigger",
+            # ``harness.run_trigger`` is registered on ``sessions`` too; the
+            # scheduler that fires it may run in a process without the harness
+            # registration, so route explicitly to avoid the ``default`` wedge
+            # (issue #1699).
+            queue=_polled_queue(QUEUE_SESSIONS),
             queueing_lock=f"trigger_run:{trigger_run_id}",
         ).defer_async(trigger_id=trigger_id, trigger_run_id=trigger_run_id)
     except procrastinate_exceptions.AlreadyEnqueued:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -90,11 +90,30 @@ async def in_memory_app() -> AsyncIterator[App]:
 
     Tests can read ``app.connector.jobs`` directly to inspect deferred
     job rows (lock, queueing_lock, schedule, args).
+
+    The ``app`` is a module-level singleton, so task registration performed by
+    one test (importing ``aios.harness.tasks``) leaks into every later test in
+    the same process. Under ``pytest -n`` that ordering is non-deterministic and
+    silently defeats the ``_assert_no_registered_tasks`` guard in the wake
+    routing tests (issue #1699): a test that imported the harness graph earlier
+    in the same worker leaves ``harness.*`` registered, so the guard trips even
+    though the code under test is correct.
+
+    Snapshot ``app.tasks`` and reset it to the pristine, task-free state the api
+    process actually has on entry; restore the snapshot on exit. Each test that
+    needs the registration (``TestRoutingMatchesRegistration``) re-imports
+    ``aios.harness.tasks`` inside its body, which re-registers on demand.
     """
     from aios.jobs.app import app
 
-    with app.replace_connector(InMemoryConnector()) as patched:
-        yield patched
+    saved_tasks = dict(app.tasks)
+    app.tasks.clear()
+    try:
+        with app.replace_connector(InMemoryConnector()) as patched:
+            yield patched
+    finally:
+        app.tasks.clear()
+        app.tasks.update(saved_tasks)
 
 
 def fake_pool_yielding_conn(conn: Any, **kwargs: Any) -> Any:

--- a/tests/unit/test_wake_queue_routing.py
+++ b/tests/unit/test_wake_queue_routing.py
@@ -108,7 +108,17 @@ class TestRoutingMatchesRegistration:
     """
 
     async def test_explicit_queue_equals_registered_queue(self, in_memory_app: App) -> None:
-        import aios.harness.tasks  # noqa: F401 — registers the tasks on the app
+        import importlib
+
+        import aios.harness.tasks
+
+        # The ``in_memory_app`` fixture resets ``app.tasks`` to the pristine,
+        # task-free state the api process has (so the ``_assert_no_registered_tasks``
+        # guard above is order-independent under ``pytest -n``). ``@app.task``
+        # decorators only bind on first import, so a plain ``import`` here would
+        # NOT re-register after that reset — reload to re-run the decorators and
+        # actually populate ``app.tasks`` for this registration-side test.
+        importlib.reload(aios.harness.tasks)
         from aios.jobs.app import defer_run_wake, defer_trigger_fire, defer_wake
 
         # Now the tasks ARE registered; read their decorator-level queues.

--- a/tests/unit/test_wake_queue_routing.py
+++ b/tests/unit/test_wake_queue_routing.py
@@ -1,0 +1,161 @@
+"""Pin the queue a ``harness.*`` job lands on when deferred from a process
+with no registered tasks (the aios-api process).
+
+Regression for issue #1699: after ``ae0c0064`` the api process registers no
+procrastinate tasks (worker-only), so ``configure_task`` can no longer read the
+``@app.task(queue="sessions")`` registration and procrastinate falls back to the
+``"default"`` queue. The worker only polls ``sessions``/``workflows``, so an
+API-origin wake (``inbound`` / ``connector_tool_result``) sat ``todo`` forever
+and its ``queueing_lock`` then swallowed every subsequent wake — a permanent
+wedge of a live connector agent.
+
+The fix is an EXPLICIT ``queue=`` on every API-side ``configure_task`` call, so
+routing never depends on task-registration being present in the calling process.
+The ``in_memory_app`` fixture deliberately does NOT import ``aios.harness.tasks``,
+so it faithfully reproduces the api process's no-registered-tasks condition.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from procrastinate import App
+from procrastinate.testing import InMemoryConnector
+
+
+def _job_rows(app: App) -> list[dict[str, Any]]:
+    connector = app.connector
+    assert isinstance(connector, InMemoryConnector)
+    return list(connector.jobs.values())
+
+
+def _assert_no_registered_tasks(app: App) -> None:
+    """Guard the premise: the fixture reproduces the api process (no tasks).
+
+    If a future refactor made the fixture register ``aios.harness.tasks``,
+    ``configure_task`` would read the registered queue and these tests would
+    pass *without* the explicit ``queue=`` — silently defeating the regression
+    guard. Assert the fixture stays task-free so the tests keep their teeth.
+    """
+    assert "harness.wake_session" not in app.tasks
+    assert "harness.wake_workflow" not in app.tasks
+
+
+class TestApiOriginWakeRouting:
+    """Acceptance #1 + #2: API-origin wakes land on the worker-polled queue."""
+
+    @pytest.mark.parametrize("cause", ["inbound", "connector_tool_result", "api_invoke"])
+    async def test_wake_session_routes_to_sessions_not_default(
+        self, in_memory_app: App, cause: str
+    ) -> None:
+        _assert_no_registered_tasks(in_memory_app)
+        from aios.jobs.app import defer_wake
+
+        pool = MagicMock()
+        with patch("aios.jobs.app.queries.append_event", AsyncMock()):
+            await defer_wake(pool, "sess_api", cause=cause, account_id="acc")
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1
+        # The crux of #1699: NOT "default".
+        assert rows[0]["queue_name"] == "sessions"
+        assert rows[0]["task_name"] == "harness.wake_session"
+
+    async def test_delayed_wake_still_routes_to_sessions(self, in_memory_app: App) -> None:
+        """The reschedule / debounce path (``delay_seconds``) routes too."""
+        from aios.jobs.app import defer_wake
+
+        pool = MagicMock()
+        with patch("aios.jobs.app.queries.append_event", AsyncMock()):
+            await defer_wake(
+                pool, "sess_delayed", cause="reschedule", delay_seconds=2, account_id="acc"
+            )
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1
+        assert rows[0]["queue_name"] == "sessions"
+
+    async def test_run_wake_routes_to_workflows_not_default(self, in_memory_app: App) -> None:
+        _assert_no_registered_tasks(in_memory_app)
+        from aios.jobs.app import defer_run_wake
+
+        await defer_run_wake("run_api")
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1
+        assert rows[0]["queue_name"] == "workflows"
+        assert rows[0]["task_name"] == "harness.wake_workflow"
+
+    async def test_trigger_fire_routes_to_sessions_not_default(self, in_memory_app: App) -> None:
+        from aios.jobs.app import defer_trigger_fire
+
+        await defer_trigger_fire("trig_1", "trun_1")
+
+        rows = _job_rows(in_memory_app)
+        assert len(rows) == 1
+        assert rows[0]["queue_name"] == "sessions"
+        assert rows[0]["task_name"] == "harness.run_trigger"
+
+
+class TestRoutingMatchesRegistration:
+    """The explicit ``queue=`` must equal what the worker actually registers.
+
+    An explicit-but-wrong queue reintroduces the wedge. This test pins the
+    hardcoded routing constants against the ``@app.task(queue=…)`` decorators in
+    ``aios.harness.tasks`` (imported here — the worker's registration side).
+    """
+
+    async def test_explicit_queue_equals_registered_queue(self, in_memory_app: App) -> None:
+        import aios.harness.tasks  # noqa: F401 — registers the tasks on the app
+        from aios.jobs.app import defer_run_wake, defer_trigger_fire, defer_wake
+
+        # Now the tasks ARE registered; read their decorator-level queues.
+        registered = {name: task.queue for name, task in in_memory_app.tasks.items()}
+
+        pool = MagicMock()
+        with patch("aios.jobs.app.queries.append_event", AsyncMock()):
+            await defer_wake(pool, "sess_reg", cause="message", account_id="acc")
+        await defer_run_wake("run_reg")
+        await defer_trigger_fire("trig_reg", "trun_reg")
+
+        rows = {row["task_name"]: row["queue_name"] for row in _job_rows(in_memory_app)}
+        for task_name, deferred_queue in rows.items():
+            assert deferred_queue == registered[task_name], (
+                f"{task_name} deferred to {deferred_queue!r} but registered on "
+                f"{registered[task_name]!r} — routing drift wedges the worker (#1699)"
+            )
+
+
+class TestNoUnpolledQueue:
+    """Acceptance #3: no ``harness.*`` job may be created on an unpolled queue."""
+
+    def test_polled_queue_guard_accepts_worker_queues(self) -> None:
+        from aios.jobs.app import (
+            QUEUE_SESSIONS,
+            QUEUE_WORKFLOWS,
+            WORKER_POLLED_QUEUES,
+            _polled_queue,
+        )
+
+        assert _polled_queue(QUEUE_SESSIONS) == "sessions"
+        assert _polled_queue(QUEUE_WORKFLOWS) == "workflows"
+        assert {QUEUE_SESSIONS, QUEUE_WORKFLOWS} == set(WORKER_POLLED_QUEUES)
+
+    def test_polled_queue_guard_rejects_default(self) -> None:
+        from aios.jobs.app import _polled_queue
+
+        with pytest.raises(ValueError, match="default"):
+            _polled_queue("default")
+
+    def test_worker_polls_exactly_the_routing_constants(self) -> None:
+        """The worker's polled set is the shared constant, not a separate list.
+
+        Guards against the two drifting apart (a queue polled but unroutable,
+        or routable but unpolled) — the class of bug #1699 is.
+        """
+        from aios.harness import worker
+        from aios.jobs.app import WORKER_POLLED_QUEUES
+
+        assert worker.WORKER_POLLED_QUEUES is WORKER_POLLED_QUEUES


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/eumemic-ops#322.