### PR TITLE
web_fetch/web_search evict the sandbox on httpx transport faults (ConnectError/ReadError/…) — narrow except set + docstring overclaims the ToolBail conversion

### DIFF
--- a/src/aios/tools/web_fetch.py
+++ b/src/aios/tools/web_fetch.py
@@ -10,8 +10,12 @@ to /search), so reading a ``title`` key returned ``""`` on every real call.
 When the content is cut at the char cap the result also carries ``"truncated":
 True`` (present only when truncated, mirroring ``http_request``) so the model
 never mistakes a cut page for a complete one.
-On an expected failure (SSRF block, non-2xx, timeout, empty response) raises
-:class:`~aios.tools.invoke.ToolBail`; a TAVILY-config failure raises the client-class
+On an expected failure (SSRF block, non-2xx, timeout, any httpx transport fault —
+ConnectError / ReadError / RemoteProtocolError / PoolTimeout — or empty response) raises
+:class:`~aios.tools.invoke.ToolBail`; the raw httpx error is never propagated (it would
+reach ``_classify_tool_error`` → ``evict=True`` → tear down the sandbox on a benign
+network blip, aios#1697). The transport-fault catch is as broad as ``http_request``'s
+``httpx.HTTPError`` (aios#1697). A TAVILY-config failure raises the client-class
 :class:`~aios.tools.tavily.WebToolError`. The single event writer stamps ``is_error``
 (session path) — #1680. On the workflow-run path these raises are translated back to
 value-shaped ``{"error": ...}`` dicts at the ``invoke_run_tool`` seam, preserving the
@@ -112,6 +116,15 @@ async def web_fetch_handler(session_id: str, arguments: dict[str, Any]) -> dict[
         raise ToolBail(f"HTTP {exc.response.status_code}: {exc.response.text[:200]}") from exc
     except httpx.TimeoutException as exc:
         raise ToolBail("Request timed out fetching URL") from exc
+    except httpx.HTTPError as exc:
+        # The broader transport-error family — ConnectError / ReadError /
+        # RemoteProtocolError / PoolTimeout — is an EXPECTED benign network blip,
+        # not an internal fault. Catch it as broadly as ``http_request`` does
+        # (``httpx.HTTPError`` is the base of every httpx transport/protocol error)
+        # so a transient Tavily/upstream connection fault becomes a ToolBail the
+        # model reads, NOT a raw httpx error that _classify_tool_error would treat
+        # as internal → evict the sandbox on a benign failure (aios#1697).
+        raise ToolBail(f"HTTP transport error fetching URL: {type(exc).__name__}: {exc}") from exc
     except (KeyError, IndexError) as exc:
         raise ToolBail("No content returned for URL") from exc
 

--- a/src/aios/tools/web_search.py
+++ b/src/aios/tools/web_search.py
@@ -4,8 +4,12 @@ Uses Tavily's /search endpoint. Returns a list of results with
 title, URL, and description.
 
 Return shape: {"results": [{"title": "...", "url": "...", "description": "..."}]}
-On an expected failure (non-2xx, timeout, empty response) raises
-:class:`~aios.tools.invoke.ToolBail`; a TAVILY-config failure raises the client-class
+On an expected failure (non-2xx, timeout, any httpx transport fault — ConnectError /
+ReadError / RemoteProtocolError / PoolTimeout — or empty response) raises
+:class:`~aios.tools.invoke.ToolBail`; the raw httpx error is never propagated (it would
+reach ``_classify_tool_error`` → ``evict=True`` → tear down the sandbox on a benign
+network blip, aios#1697). The transport-fault catch is as broad as ``http_request``'s
+``httpx.HTTPError`` (aios#1697). A TAVILY-config failure raises the client-class
 :class:`~aios.tools.tavily.WebToolError` (#1680). On the workflow-run path these raises
 are translated back to value-shaped ``{"error": ...}`` dicts at the ``invoke_run_tool``
 seam, preserving the runs errors-as-values contract.
@@ -90,6 +94,15 @@ async def web_search_handler(session_id: str, arguments: dict[str, Any]) -> dict
         raise ToolBail(f"HTTP {exc.response.status_code}: {exc.response.text[:200]}") from exc
     except httpx.TimeoutException as exc:
         raise ToolBail("Search request timed out") from exc
+    except httpx.HTTPError as exc:
+        # The broader transport-error family — ConnectError / ReadError /
+        # RemoteProtocolError / PoolTimeout — is an EXPECTED benign network blip,
+        # not an internal fault. Catch it as broadly as ``http_request`` does
+        # (``httpx.HTTPError`` is the base of every httpx transport/protocol error)
+        # so a transient Tavily/upstream connection fault becomes a ToolBail the
+        # model reads, NOT a raw httpx error that _classify_tool_error would treat
+        # as internal → evict the sandbox on a benign failure (aios#1697).
+        raise ToolBail(f"HTTP transport error during search: {type(exc).__name__}: {exc}") from exc
     except (KeyError, IndexError) as exc:
         # A 200 response missing the 'results' key — surface a legible tool
         # error instead of letting the KeyError escape and evict the sandbox.

--- a/tests/unit/test_web_fetch_handler.py
+++ b/tests/unit/test_web_fetch_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from aios.tools.invoke import ToolBail
@@ -125,3 +126,39 @@ class TestWebFetchHandler:
         result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
         assert result["content"] == ""
         assert result["title"] == ""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectError("connection refused"),
+            httpx.ReadError("read failed"),
+            httpx.RemoteProtocolError("protocol error"),
+            httpx.PoolTimeout("pool exhausted"),
+            httpx.TimeoutException("timed out"),
+        ],
+    )
+    async def test_transport_faults_raise_toolbail_not_raw_httpx(
+        self, mock_tavily: AsyncMock, mock_safe_url: Any, exc: httpx.HTTPError
+    ) -> None:
+        """A benign upstream transport blip (ConnectError/ReadError/… — the whole
+        ``httpx.TransportError`` family, plus timeouts) must convert to ``ToolBail``,
+        NOT propagate raw. A raw httpx error reaches ``_classify_tool_error`` →
+        ``evict=True`` → the sandbox is torn down on a transient network failure
+        (aios#1697). Mirrors ``http_request``'s broad ``httpx.HTTPError`` catch."""
+        mock_tavily.side_effect = exc
+        with pytest.raises(ToolBail):
+            await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
+
+    async def test_http_status_error_raises_toolbail(
+        self, mock_tavily: AsyncMock, mock_safe_url: Any
+    ) -> None:
+        """A non-2xx from Tavily/upstream is an expected failure → ``ToolBail``
+        carrying the status, never the raw httpx error (which would evict)."""
+        request = httpx.Request("GET", "https://example.com")
+        response = httpx.Response(503, text="upstream down", request=request)
+        mock_tavily.side_effect = httpx.HTTPStatusError(
+            "server error", request=request, response=response
+        )
+        with pytest.raises(ToolBail) as excinfo:
+            await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
+        assert "503" in excinfo.value.message

--- a/tests/unit/test_web_search_handler.py
+++ b/tests/unit/test_web_search_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 from aios.tools.invoke import ToolBail
@@ -90,3 +91,37 @@ class TestWebSearchHandler:
         mock_tavily.return_value = {}
         with pytest.raises(ToolBail):
             await web_search_handler("sess_01TEST", {"query": "x"})
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectError("connection refused"),
+            httpx.ReadError("read failed"),
+            httpx.RemoteProtocolError("protocol error"),
+            httpx.PoolTimeout("pool exhausted"),
+            httpx.TimeoutException("timed out"),
+        ],
+    )
+    async def test_transport_faults_raise_toolbail_not_raw_httpx(
+        self, mock_tavily: AsyncMock, exc: httpx.HTTPError
+    ) -> None:
+        """A benign upstream transport blip (ConnectError/ReadError/… — the whole
+        ``httpx.TransportError`` family, plus timeouts) must convert to ``ToolBail``,
+        NOT propagate raw. A raw httpx error reaches ``_classify_tool_error`` →
+        ``evict=True`` → the sandbox is torn down on a transient network failure
+        (aios#1697). Mirrors ``http_request``'s broad ``httpx.HTTPError`` catch."""
+        mock_tavily.side_effect = exc
+        with pytest.raises(ToolBail):
+            await web_search_handler("sess_01TEST", {"query": "x"})
+
+    async def test_http_status_error_raises_toolbail(self, mock_tavily: AsyncMock) -> None:
+        """A non-2xx from Tavily/upstream is an expected failure → ``ToolBail``
+        carrying the status, never the raw httpx error (which would evict)."""
+        request = httpx.Request("GET", "https://example.com")
+        response = httpx.Response(503, text="upstream down", request=request)
+        mock_tavily.side_effect = httpx.HTTPStatusError(
+            "server error", request=request, response=response
+        )
+        with pytest.raises(ToolBail) as excinfo:
+            await web_search_handler("sess_01TEST", {"query": "x"})
+        assert "503" in excinfo.value.message


### PR DESCRIPTION
Automated dev-pipeline build for issue #1697.