### PR TITLE
MCP fault isolation: one dead/401'ing MCP server must never mute a session (bulkhead the pool boundary)

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1552,20 +1552,22 @@ async def discover_session_mcp_tools(
     # session running degraded.
     _pool = runtime.mcp_session_pool
     if _pool is not None:
-        url_to_name = {s.url: s.name for s in agent.mcp_servers}
-        for down_url in _pool.drain_degraded_events():
-            await sessions_service.append_event(
-                pool,
-                session_id,
-                "span",
-                {
-                    "event": "mcp_server_unavailable",
-                    "server": url_to_name.get(down_url, down_url),
-                    "url": down_url,
-                    "is_error": False,
-                },
-                account_id=account_id,
-            )
+        down_urls = _pool.drain_degraded_events()
+        if down_urls:
+            url_to_name = {s.url: s.name for s in agent.mcp_servers}
+            for down_url in down_urls:
+                await sessions_service.append_event(
+                    pool,
+                    session_id,
+                    "span",
+                    {
+                        "event": "mcp_server_unavailable",
+                        "server": url_to_name.get(down_url, down_url),
+                        "url": down_url,
+                        "is_error": False,
+                    },
+                    account_id=account_id,
+                )
     return tools, instructions_by_server
 
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1541,6 +1541,31 @@ async def discover_session_mcp_tools(
             tools.append(td)
         if instructions:
             instructions_by_server[name] = instructions
+
+    # Observability (#1698 (e)): emit exactly one durable ``mcp_server_unavailable``
+    # session event per breaker DOWN transition. The breaker arms in the pool
+    # (``acquire``/discovery) which has no session context, so it records the
+    # edge and we drain + stamp it here where session_id is in scope. Deduped on
+    # the breaker edge (drain empties the queue), ``is_error:false`` keeps it out
+    # of error-filtered views but queryable — mirrors the ``step_timeout``
+    # telemetry precedent. Gives the ops-agent an external artifact to detect a
+    # session running degraded.
+    _pool = runtime.mcp_session_pool
+    if _pool is not None:
+        url_to_name = {s.url: s.name for s in agent.mcp_servers}
+        for down_url in _pool.drain_degraded_events():
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "span",
+                {
+                    "event": "mcp_server_unavailable",
+                    "server": url_to_name.get(down_url, down_url),
+                    "url": down_url,
+                    "is_error": False,
+                },
+                account_id=account_id,
+            )
     return tools, instructions_by_server
 
 

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -195,7 +195,17 @@ async def _tool_lifecycle(
         await _append_tool_result(
             pool, session_id, call_id, name, account_id=account_id, error="cancelled"
         )
-    except Exception as err:
+    except (Exception, BaseExceptionGroup) as err:
+        # Broadened to include ``BaseExceptionGroup`` (#1698 final backstop): a
+        # group whose non-Exception leaf (e.g. anyio's ``[HTTPError,
+        # CancelledError]``) makes it not an ``Exception`` would otherwise slip
+        # past this handler, the tool task would die with NO ``tool_result``
+        # appended, and the model's tool call would be left unresolved — the
+        # exact leg that muted the session. Catching the group here guarantees a
+        # tool call can NEVER be left unresolved: it always yields a
+        # ``tool_result`` with ``is_error=True``. A bare ``CancelledError`` (a
+        # ``BaseException`` that is NOT an ``ExceptionGroup``) is still handled
+        # by the ``except asyncio.CancelledError`` clause above.
         tc.is_error = True
         evict, message, detail = _classify_tool_error(err)
         if evict:

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -398,15 +398,19 @@ async def discover_mcp_tools(
         # it and retry once with a fresh one. Always release-or-discard so the
         # per-key cap slot is freed.
         #
-        # ``acquire`` is INSIDE the try so a connect/init failure takes the
-        # discard-retry-then-mark_unhealthy path — and the first-attempt handler
-        # is ``(Exception, BaseExceptionGroup)`` so a group-shaped failure (the
-        # bare ``BaseExceptionGroup("unhandled errors in a TaskGroup", [...])``
-        # anyio can raise) is caught here rather than escaping through the
-        # no-breaker ``except BaseException`` below and aborting the prelude
-        # (#1698 (b)). ``acquire`` already converts connect failures to
-        # ``MCPUnavailable`` (an Exception), so this is belt-and-suspenders for
-        # the ``list_tools()`` RPC leg, which ``acquire`` never sees.
+        # The first ``acquire`` (immediately below) PRECEDES the ``try``: a
+        # connect/init failure there arms the breaker inside ``acquire`` (via
+        # ``_record_connect_failure``) and raises ``MCPUnavailable`` (an
+        # Exception), which propagates to the caller — the connect leg is handled
+        # by ``acquire`` itself, not here. The ``try`` covers only the
+        # ``list_tools()`` RPC leg, which ``acquire`` never sees: on failure it
+        # discards and retries once with a fresh session, and its first-attempt
+        # handler is ``(Exception, BaseExceptionGroup)`` so a group-shaped failure
+        # (the bare ``BaseExceptionGroup("unhandled errors in a TaskGroup", [...])``
+        # anyio can raise) is caught for the retry rather than escaping through
+        # the no-breaker ``except BaseException`` below. A second RPC failure then
+        # feeds the shared per-key breaker counter (``note_discovery_failure``) and
+        # forces the backoff window open (#1698 (b)/(d)).
         entry = await _pool.acquire(url, vault_id, hkey, merged)
         try:
             result = await _list_tools_timed(entry.session)

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -397,16 +397,31 @@ async def discover_mcp_tools(
         # Pool path: check out a session; on a transport/protocol error discard
         # it and retry once with a fresh one. Always release-or-discard so the
         # per-key cap slot is freed.
+        #
+        # ``acquire`` is INSIDE the try so a connect/init failure takes the
+        # discard-retry-then-mark_unhealthy path — and the first-attempt handler
+        # is ``(Exception, BaseExceptionGroup)`` so a group-shaped failure (the
+        # bare ``BaseExceptionGroup("unhandled errors in a TaskGroup", [...])``
+        # anyio can raise) is caught here rather than escaping through the
+        # no-breaker ``except BaseException`` below and aborting the prelude
+        # (#1698 (b)). ``acquire`` already converts connect failures to
+        # ``MCPUnavailable`` (an Exception), so this is belt-and-suspenders for
+        # the ``list_tools()`` RPC leg, which ``acquire`` never sees.
         entry = await _pool.acquire(url, vault_id, hkey, merged)
         try:
             result = await _list_tools_timed(entry.session)
-        except Exception:
+        except (Exception, BaseExceptionGroup):
             await asyncio.shield(_pool.discard(url, vault_id, hkey, entry))
             entry = await _pool.acquire(url, vault_id, hkey, merged)
             try:
                 result = await _list_tools_timed(entry.session)
             except BaseException:
                 await asyncio.shield(_pool.discard(url, vault_id, hkey, entry))
+                # Feed the shared per-key breaker counter (#1698 (d)); it opens
+                # after K consecutive failures. Also force the backoff window
+                # open now so this prelude doesn't re-stall on the very next
+                # step even before the counter reaches K.
+                _pool.note_discovery_failure(url, vault_id, hkey)
                 _pool.mark_unhealthy(url, vault_id, hkey, backoff_s=_DISCOVERY_UNHEALTHY_BACKOFF_S)
                 raise
             else:
@@ -508,6 +523,21 @@ async def call_mcp_tool(
         hkey = _headers_key(spec_headers)
 
         if _pool is not None:
+            # Circuit breaker (#1698 (d)): if this transport key is in a backoff
+            # window (K consecutive connect/discovery failures), fast-return the
+            # degraded error dict instead of re-stalling on another dead connect.
+            # The model sees a typed, retriable ``transport_error`` (via #1680's
+            # is_error channel) rather than the call hanging or the session
+            # muting. The window auto-expires, so a later call re-probes.
+            if _pool.is_unhealthy(url, vault_id, hkey):
+                log.info("mcp.call_skipped_unhealthy", url=url, tool_name=tool_name)
+                return {
+                    "error": (
+                        f"MCP server temporarily unavailable (circuit open): {url}. "
+                        "The server failed repeatedly; it will be re-probed shortly."
+                    ),
+                    "code": "transport_error",
+                }
             entry = await _pool.acquire(url, vault_id, hkey, merged)
             try:
                 result = await _call_tool_fast(
@@ -557,7 +587,16 @@ async def call_mcp_tool(
             "error": f"MCP server returned HTTP {err.status}: {detail}",
             "code": "transport_error",
         }
-    except Exception as err:
+    except (Exception, BaseExceptionGroup) as err:
+        # Broadened to catch a residual ``BaseExceptionGroup`` (#1698 (c)): a
+        # group whose non-Exception leaf makes it slip past ``except Exception``
+        # would otherwise escape ``call_mcp_tool`` unhandled and mute the
+        # session. ``acquire`` already converts connect failures to
+        # ``MCPUnavailable`` (an Exception), but this collapses any residual
+        # group at the call/RPC leg into the typed ``transport_error`` envelope
+        # — flowing through #1680's is_error channel as a model-visible tool
+        # result, never a raise. A genuine ``CancelledError`` (a bare
+        # ``BaseException``, not an ``ExceptionGroup``) still propagates.
         log.warning(
             "mcp.call_failed",
             url=url,

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -60,6 +60,45 @@ from aios.mcp._constants import _MCP_HTTPX_TIMEOUT as _MCP_HTTPX_TIMEOUT_SHARED
 
 log = get_logger("aios.mcp.pool")
 
+# Consecutive acquire/discovery failures per ``_PoolKey`` before the circuit
+# breaker opens (#1698). Bulkheads a dead/401'ing MCP server: after K straight
+# failures the key is marked unhealthy and the next prelude/call skips connect
+# fast (degraded, not muted) until the ``_DISCOVERY_UNHEALTHY_BACKOFF_S``
+# cooldown auto-re-probes. A single healthy acquire resets the counter.
+_BREAKER_FAILURE_THRESHOLD = 3
+
+# Cooldown applied when the breaker opens (#1698). Matches the discovery backoff
+# (``client._DISCOVERY_UNHEALTHY_BACKOFF_S`` = 60s) so discovery and call-time
+# share one window; kept here to avoid a client→pool import cycle.
+_BREAKER_UNHEALTHY_BACKOFF_S = 60.0
+
+
+class MCPUnavailable(Exception):
+    """A pooled MCP transport failed to connect/initialize (#1698).
+
+    Raised by :meth:`McpSessionPool.acquire` (and the discovery/call paths that
+    build on it) as the *single* typed failure the pool ever surfaces on a
+    connect/init error. It carries the server ``url`` and chains the original
+    cause via ``__cause__`` / ``__context__``.
+
+    Motivation: anyio's ``streamable_http_client`` task group, cancelling its
+    SSE-reader sibling while unwinding a failed ``initialize()``, can raise a
+    bare ``BaseExceptionGroup("unhandled errors in a TaskGroup", [HTTPError,
+    CancelledError])``. A ``BaseExceptionGroup`` whose leaves include a
+    non-``Exception`` (``CancelledError``) is itself **not** an ``Exception``
+    (``isinstance(grp, Exception) is False``), so it slips past every
+    ``except Exception`` on the call path and propagates unhandled — muting the
+    whole session. Converting it to this ``Exception`` subclass at the pool
+    boundary means every existing upstream ``except Exception`` catches it: a
+    failing server degrades *capability* (its tools vanish), never
+    *availability* (the agent goes mute).
+    """
+
+    def __init__(self, url: str) -> None:
+        super().__init__(f"MCP server unavailable: {url}")
+        self.url = url
+
+
 # httpx client bounds for MCP transport — single definition in
 # :mod:`aios.mcp._constants`, shared with the per-call client transport
 # (re-exported here so existing ``pool._MCP_HTTPX_TIMEOUT`` references and their
@@ -220,6 +259,23 @@ class McpSessionPool:
         # re-stalling for the per-server timeout every step. A successful
         # discovery clears the entry.
         self._unhealthy_until: dict[_PoolKey, float] = {}
+        # Per-_PoolKey consecutive-failure counter feeding the breaker (#1698).
+        # Every ``acquire``/discovery connect-or-init failure bumps the count;
+        # the breaker opens once it reaches ``_BREAKER_FAILURE_THRESHOLD`` (K).
+        # ``mark_healthy`` (a successful discovery/acquire) resets it to 0.
+        self._failure_count: dict[_PoolKey, int] = {}
+        # URLs whose breaker is currently OPEN, keyed by url. Backs
+        # :meth:`degraded_servers` and dedupes the ``mcp_server_unavailable``
+        # observability event to the DOWN transition (the breaker's open edge),
+        # not every failure while it stays open (#1698).
+        self._degraded_urls: set[str] = set()
+        # DOWN-transition edges (URLs) recorded since the last drain. The
+        # breaker arms in ``acquire``/discovery — code with no session context —
+        # so it records the edge here; a caller WITH session context
+        # (``discover_session_mcp_tools``) drains this via
+        # :meth:`drain_degraded_events` and emits exactly one durable
+        # ``mcp_server_unavailable`` session event per edge (#1698 (e)).
+        self._pending_degraded_events: list[str] = []
 
     def _condition_for(self, key: _PoolKey) -> asyncio.Condition:
         cond = self._conditions.get(key)
@@ -327,11 +383,28 @@ class McpSessionPool:
         task = asyncio.create_task(_own(), name=f"mcp-pool:{url}")
         await ready.wait()
         if "error" in result:
-            # The task already raised; await it to surface the original
-            # exception cleanly (and clear the unhandled-exception slot).
-            await task
-            # Defensive — unreachable in practice.
-            raise RuntimeError("mcp pool owner task signalled ready but produced no session")
+            # The task already raised; await it to clear the unhandled-exception
+            # slot on the owner task. We do NOT let that await re-raise the raw
+            # failure here: anyio's ``streamable_http_client`` task group can
+            # unwind a failed ``initialize()`` as a bare ``BaseExceptionGroup``
+            # (leaves ``[HTTPError, CancelledError]``), which is not an
+            # ``Exception`` and would escape every ``except Exception`` upstream
+            # (the #1698 session-mute bug). Swallow the await's propagation and
+            # raise the captured cause as :class:`MCPUnavailable` (an
+            # ``Exception``) instead — ``acquire`` re-wraps into the same type,
+            # so the pool NEVER re-raises a bare group. ``CancelledError`` is a
+            # ``BaseException`` (not caught here), so a genuine cancellation of
+            # the acquiring task still propagates for prompt teardown.
+            with contextlib.suppress(BaseException):
+                await task
+            captured = result["error"]
+            if isinstance(captured, asyncio.CancelledError):
+                # A genuine cancellation of the owner task (shutdown/drain) is a
+                # BaseException, not a transport failure — propagate it as-is so
+                # cancellation semantics are preserved rather than laundered into
+                # a retriable MCPUnavailable.
+                raise captured
+            raise MCPUnavailable(url) from captured
         return _Entry(result["session"], result["init"], shutdown, task, time.monotonic(), sink)
 
     async def acquire(
@@ -355,6 +428,14 @@ class McpSessionPool:
         the cap is strict (no thundering-herd over-open). An ``_open_entry``
         failure propagates out, releasing the Condition; no slot is consumed and
         no waiter is notified — the next waiter to wake simply retries.
+
+        **Fault isolation (#1698).** A fresh-open failure is converted at this
+        boundary into :class:`MCPUnavailable` — an ``Exception`` subclass — so a
+        bare ``BaseExceptionGroup`` from anyio's transport task group can NEVER
+        escape the pool. Every upstream ``except Exception`` therefore catches
+        it, and the failing server degrades *capability* (its tools vanish), not
+        *availability* (the agent goes mute). The conversion also arms the
+        per-key circuit breaker (K consecutive failures → open).
         """
         if self._closed:
             raise RuntimeError("McpSessionPool is closed")
@@ -371,7 +452,25 @@ class McpSessionPool:
                     return entry
                 if len(self._in_use.get(key, set())) < MAX_SESSIONS_PER_KEY:
                     log.info("mcp_pool.connecting", url=url)
-                    entry = await self._open_entry(url, headers, key)
+                    try:
+                        entry = await self._open_entry(url, headers, key)
+                    except MCPUnavailable:
+                        # Already the typed boundary error (from _open_entry's
+                        # own group-guard). Record the failure for the breaker
+                        # and re-raise unchanged — no double-wrapping.
+                        self._record_connect_failure(key, url)
+                        raise
+                    except (Exception, BaseExceptionGroup) as exc:
+                        # Any residual connect/init failure — including a bare
+                        # ``BaseExceptionGroup`` whose non-Exception leaf makes
+                        # it slip past ``except Exception`` — is converted here
+                        # so the pool's ONLY connect-failure surface is
+                        # ``MCPUnavailable`` (an Exception). ``BaseException``
+                        # (e.g. a genuine ``CancelledError`` cancelling this
+                        # acquire) is deliberately NOT caught: it propagates for
+                        # prompt teardown.
+                        self._record_connect_failure(key, url)
+                        raise MCPUnavailable(url) from exc
                     self._in_use.setdefault(key, set()).add(entry)
                     log.info("mcp_pool.connected", url=url)
                     return entry
@@ -482,6 +581,12 @@ class McpSessionPool:
         # Drop any cached tool lists discovered under the rotated identity so a
         # re-auth re-discovers rather than serving the stale-identity set (#1391).
         self.invalidate_tools_by_vault(vault_id)
+        # Clear breaker state for every key bound to this vault so a fresh
+        # credential re-probes immediately rather than sitting out the cooldown
+        # from failures under the OLD (e.g. expired) secret (#1698 composes with
+        # #1030). A stale-token 401 that opened the breaker must not keep the
+        # newly-rotated secret's server dark.
+        self._clear_breaker_by_vault(vault_id)
         if idle_closed or flagged:
             log.info(
                 "mcp_pool.evict_by_vault",
@@ -542,16 +647,20 @@ class McpSessionPool:
         for ck in stale:
             del self._tool_cache[ck]
 
-    # ── per-key discovery circuit breaker (#1391) ─────────────────────────
+    # ── per-key discovery/connect circuit breaker (#1391 + #1698) ─────────
 
     def is_unhealthy(
         self, url: str, vault_id: str | None, headers_key: str, *, now: float | None = None
     ) -> bool:
-        """True if this transport key is in a discovery backoff window.
+        """True if this transport key is in a discovery/connect backoff window.
 
-        The prelude consults this BEFORE attempting ``list_tools()`` so a server
-        that just timed out is skipped fast (agent runs degraded on the other
-        servers' tools) instead of re-stalling the turn prelude every step.
+        The prelude AND ``call_mcp_tool`` consult this BEFORE attempting a
+        connect (``list_tools()`` / ``acquire``) so a server that just failed is
+        skipped fast (agent runs degraded on the other servers' tools) instead
+        of re-stalling every step. On expiry the window is cleared here so the
+        next probe re-attempts the connect (auto-re-probe); the DOWN marker in
+        ``_degraded_urls`` is retained until an explicit heal/failure edge so a
+        cooldown lapse alone doesn't spuriously fire an UP event.
         """
         key: _PoolKey = (url, vault_id, headers_key)
         until = self._unhealthy_until.get(key)
@@ -562,6 +671,61 @@ class McpSessionPool:
             return False
         return True
 
+    def _record_connect_failure(self, key: _PoolKey, url: str) -> bool:
+        """Count one consecutive connect/init failure; open the breaker at K.
+
+        Returns ``True`` on the DOWN transition (the breaker's open edge) — the
+        failure that first opens the circuit — so a caller with session context
+        can emit exactly one ``mcp_server_unavailable`` event (#1698 (e)).
+        Failures while already open return ``False`` (deduped on the edge).
+
+        Shared by ``acquire``'s new failure path and (via
+        :meth:`note_discovery_failure`) the discovery caller, so discovery and
+        call-time arm ONE breaker per key.
+        """
+        count = self._failure_count.get(key, 0) + 1
+        self._failure_count[key] = count
+        if count < _BREAKER_FAILURE_THRESHOLD:
+            return False
+        # At/over threshold: (re)open the circuit for the cooldown window.
+        self._unhealthy_until[key] = time.monotonic() + _BREAKER_UNHEALTHY_BACKOFF_S
+        transitioned_down = url not in self._degraded_urls
+        self._degraded_urls.add(url)
+        if transitioned_down:
+            # Record the edge for a session-context caller to emit exactly one
+            # durable ``mcp_server_unavailable`` event (#1698 (e)).
+            self._pending_degraded_events.append(url)
+            log.warning(
+                "mcp_pool.breaker_opened",
+                url=url,
+                failures=count,
+                backoff_s=_BREAKER_UNHEALTHY_BACKOFF_S,
+            )
+        return transitioned_down
+
+    def drain_degraded_events(self) -> list[str]:
+        """Pop and return the DOWN-transition URLs recorded since the last drain.
+
+        A session-context caller (the per-turn discovery prelude) calls this and
+        emits one durable ``mcp_server_unavailable`` session event per URL, so
+        each breaker DOWN edge surfaces exactly once regardless of which path
+        (connect vs discovery) armed it (#1698 (e)).
+        """
+        drained = self._pending_degraded_events
+        self._pending_degraded_events = []
+        return drained
+
+    def note_discovery_failure(self, url: str, vault_id: str | None, headers_key: str) -> bool:
+        """Record a discovery-path failure against the shared breaker (#1698).
+
+        The discovery caller (``discover_mcp_tools``) sees ``list_tools()``
+        failures that ``acquire`` itself can't (the connect succeeded but the RPC
+        failed), so it feeds them into the SAME per-key counter. Returns the
+        DOWN-transition flag like :meth:`_record_connect_failure`.
+        """
+        key: _PoolKey = (url, vault_id, headers_key)
+        return self._record_connect_failure(key, url)
+
     def mark_unhealthy(
         self,
         url: str,
@@ -571,15 +735,59 @@ class McpSessionPool:
         backoff_s: float,
         now: float | None = None,
     ) -> None:
-        """Open the circuit for this transport key for ``backoff_s`` seconds."""
+        """Open the circuit for this transport key for ``backoff_s`` seconds.
+
+        Retained for the discovery retry path that forces the window open
+        directly. Also marks the URL degraded so it surfaces in
+        :meth:`degraded_servers`; the DOWN-transition event is emitted off the
+        counter path (:meth:`note_discovery_failure`), so this returns nothing.
+        """
         key: _PoolKey = (url, vault_id, headers_key)
         self._unhealthy_until[key] = (now if now is not None else time.monotonic()) + backoff_s
+        self._degraded_urls.add(url)
         log.warning("mcp_pool.marked_unhealthy", url=url, backoff_s=backoff_s)
 
     def mark_healthy(self, url: str, vault_id: str | None, headers_key: str) -> None:
-        """Clear any backoff for this transport key (a successful discovery)."""
+        """Clear backoff + failure counter for this key (a successful connect).
+
+        Resets the consecutive-failure counter so the breaker re-arms from zero,
+        clears any open window, and drops the URL from ``_degraded_urls`` unless
+        another key on the same URL is still open — a successful re-probe
+        re-closes the circuit (AC #4).
+        """
         key: _PoolKey = (url, vault_id, headers_key)
         self._unhealthy_until.pop(key, None)
+        self._failure_count.pop(key, None)
+        if not self._url_has_open_breaker(url):
+            self._degraded_urls.discard(url)
+
+    def _url_has_open_breaker(self, url: str) -> bool:
+        """True if any key on ``url`` still has an unexpired backoff window."""
+        now = time.monotonic()
+        return any(k[0] == url and until > now for k, until in self._unhealthy_until.items())
+
+    def _clear_breaker_by_vault(self, vault_id: str) -> None:
+        """Drop breaker state (window + counter) for every key on ``vault_id``.
+
+        Called from :meth:`evict_by_vault` so a rotated credential re-probes
+        immediately instead of serving out a cooldown opened under the old
+        secret (#1698 composes with #1030).
+        """
+        for key in [k for k in self._unhealthy_until if k[1] == vault_id]:
+            del self._unhealthy_until[key]
+        for key in [k for k in self._failure_count if k[1] == vault_id]:
+            del self._failure_count[key]
+        # A URL with no remaining open key on any vault leaves the degraded set.
+        self._degraded_urls = {u for u in self._degraded_urls if self._url_has_open_breaker(u)}
+
+    def degraded_servers(self) -> list[str]:
+        """Return the URLs whose breaker is currently OPEN (#1698 (e)).
+
+        Gives the ops-agent an external artifact to detect a session running
+        degraded — the MCP servers whose tools are currently absent because
+        their transport keeps failing.
+        """
+        return sorted(self._degraded_urls)
 
     async def _reap_idle_once(self, *, idle_timeout: float, now: float) -> None:
         """Close idle entries unused longer than ``idle_timeout`` seconds.

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -262,7 +262,12 @@ class McpSessionPool:
         # Per-_PoolKey consecutive-failure counter feeding the breaker (#1698).
         # Every ``acquire``/discovery connect-or-init failure bumps the count;
         # the breaker opens once it reaches ``_BREAKER_FAILURE_THRESHOLD`` (K).
-        # ``mark_healthy`` (a successful discovery/acquire) resets it to 0.
+        # A successful ``acquire`` resets it to 0 at the pool boundary (the
+        # fresh-open success path — call-time success is covered because every
+        # ``call_mcp_tool`` acquires before use); ``mark_healthy`` (the
+        # uncached-discovery success) and ``_clear_breaker_by_vault`` (credential
+        # rotation) also reset it. So the count is truly *consecutive*: any
+        # intervening success breaks the streak.
         self._failure_count: dict[_PoolKey, int] = {}
         # URLs whose breaker is currently OPEN, keyed by url. Backs
         # :meth:`degraded_servers` and dedupes the ``mcp_server_unavailable``
@@ -471,6 +476,16 @@ class McpSessionPool:
                         # prompt teardown.
                         self._record_connect_failure(key, url)
                         raise MCPUnavailable(url) from exc
+                    # This connect succeeded, so the consecutive-failure streak is
+                    # broken — reset the per-key breaker counter (F1 / #1698 AC4:
+                    # the count is *consecutive*, not cumulative). This is the
+                    # single call-time reset site at the pool boundary; every
+                    # ``call_mcp_tool`` acquires before use, so a successful call
+                    # resets it here too (no separate call-path reset needed). An
+                    # open breaker is skipped before ``acquire`` via
+                    # ``is_unhealthy``, so a reset only follows a genuinely healthy
+                    # connect.
+                    self._failure_count.pop(key, None)
                     self._in_use.setdefault(key, set()).add(entry)
                     log.info("mcp_pool.connected", url=url)
                     return entry
@@ -783,9 +798,11 @@ class McpSessionPool:
     def degraded_servers(self) -> list[str]:
         """Return the URLs whose breaker is currently OPEN (#1698 (e)).
 
-        Gives the ops-agent an external artifact to detect a session running
-        degraded — the MCP servers whose tools are currently absent because
-        their transport keeps failing.
+        This is an in-memory, per-worker accessor (reflecting only THIS worker's
+        breaker state, not persisted) for tests and in-process introspection; the
+        wired external artifact the ops-agent consumes is the durable
+        ``mcp_server_unavailable`` session event emitted on the breaker's DOWN
+        edge (see :meth:`drain_degraded_events`), not this accessor.
         """
         return sorted(self._degraded_urls)
 

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -9,6 +9,7 @@ test here.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -343,3 +344,109 @@ class TestDiscoverSessionMcpTools:
         # The slow server was short-circuited (never discovered); only 'ok' ran.
         assert discovered == ["ok"]
         assert {t["name"] for t in tools} == {"mcp__ok__t"}
+
+    async def test_group_raising_server_omitted_healthy_returned(self) -> None:
+        """#1698 (b): a server whose discovery raises a bare
+        ``BaseExceptionGroup`` (non-Exception leaf) is omitted from the returned
+        tools/instructions; the healthy servers' tools are still returned. The
+        group must not abort the whole prelude."""
+        from aios.harness.loop import discover_session_mcp_tools
+
+        agent = _agent(
+            mcp_servers=[
+                McpServerSpec(name="gh", url="https://mcp.github"),
+                McpServerSpec(name="grp", url="https://mcp.grp"),
+            ],
+            tools=[
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="gh"),
+                ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="grp"),
+            ],
+        )
+
+        async def _discover(
+            _url: str,
+            _vault_id: str | None,
+            _headers: dict[str, str],
+            name: str,
+            **_kwargs: Any,
+        ) -> tuple[list[dict[str, Any]], str | None]:
+            if name == "grp":
+                raise BaseExceptionGroup(
+                    "unhandled errors in a TaskGroup",
+                    [ConnectionError("401"), asyncio.CancelledError()],
+                )
+            return [{"name": f"mcp__{name}__t"}], f"{name}-instructions"
+
+        with (
+            patch("aios.mcp.client.resolve_auth_for_target_url", new_callable=AsyncMock) as resolve,
+            patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+        ):
+            resolve.return_value = (None, {})
+            tools, instructions = await discover_session_mcp_tools(
+                pool=AsyncMock(),
+                session_id="sess_x",
+                agent=agent,
+                account_id="acc_test_stub",
+            )
+
+        assert {t["name"] for t in tools} == {"mcp__gh__t"}, (
+            "group-raising server omitted; healthy server's tools returned"
+        )
+        assert set(instructions) == {"gh"}
+
+    async def test_down_transition_emits_one_mcp_server_unavailable_event(self) -> None:
+        """#1698 (e): a breaker DOWN transition (drained from the pool) emits
+        exactly one durable ``mcp_server_unavailable`` span event, keyed by
+        server name + url, with ``is_error: false``."""
+        from unittest.mock import MagicMock
+
+        from aios.harness import runtime
+        from aios.harness.loop import discover_session_mcp_tools
+        from aios.mcp.pool import McpSessionPool
+
+        agent = _agent(
+            mcp_servers=[McpServerSpec(name="ultron", url="https://mcp.down")],
+            tools=[ToolSpec(type="mcp_toolset", enabled=True, mcp_server_name="ultron")],
+        )
+
+        pool = McpSessionPool()
+        # Simulate the breaker having recorded a DOWN edge for this url.
+        pool._pending_degraded_events.append("https://mcp.down")
+
+        async def _discover(*_a: Any, **_k: Any) -> tuple[list[dict[str, Any]], str | None]:
+            return [], None
+
+        emitted: list[dict[str, Any]] = []
+
+        async def _append_event(_pool: Any, _sid: str, _kind: str, data: Any, **_k: Any) -> Any:
+            emitted.append(data)
+            return MagicMock()
+
+        prior = runtime.mcp_session_pool
+        runtime.mcp_session_pool = pool
+        try:
+            with (
+                patch(
+                    "aios.mcp.client.resolve_auth_for_target_url", new_callable=AsyncMock
+                ) as resolve,
+                patch("aios.mcp.client.discover_mcp_tools", side_effect=_discover),
+                patch("aios.harness.loop.sessions_service.append_event", side_effect=_append_event),
+            ):
+                resolve.return_value = (None, {})
+                await discover_session_mcp_tools(
+                    pool=AsyncMock(),
+                    session_id="sess_x",
+                    agent=agent,
+                    account_id="acc_test_stub",
+                )
+        finally:
+            runtime.mcp_session_pool = prior
+
+        unavailable = [e for e in emitted if e.get("event") == "mcp_server_unavailable"]
+        assert len(unavailable) == 1
+        ev = unavailable[0]
+        assert ev["server"] == "ultron"
+        assert ev["url"] == "https://mcp.down"
+        assert ev["is_error"] is False
+        # Deduped: the edge queue is drained, so a re-run emits nothing.
+        assert pool.drain_degraded_events() == []

--- a/tests/unit/test_mcp_call_fast_fail.py
+++ b/tests/unit/test_mcp_call_fast_fail.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import asyncio
 import time
 from typing import Any
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from aios.mcp.client import _call_tool_fast, _McpHttpError
@@ -68,3 +70,73 @@ async def test_error_hook_records_4xx_only() -> None:
     assert sink.event.is_set()
     assert sink.status == 403
     assert "nope" in sink.body
+
+
+# ── #1698 (c): a group-shaped failure at call-time → typed error dict, no raise
+
+
+class _GroupSession:
+    """A ClientSession whose ``call_tool`` raises a bare ``BaseExceptionGroup``
+    (the incident's ``[HTTPError, CancelledError]`` shape — not an
+    ``Exception``, so it slips past ``except Exception``)."""
+
+    async def call_tool(self, name: str, args: Any, *, meta: Any = None) -> Any:
+        raise BaseExceptionGroup(
+            "unhandled errors in a TaskGroup",
+            [httpx.HTTPError("401"), asyncio.CancelledError()],
+        )
+
+
+async def test_call_time_group_becomes_transport_error_dict(monkeypatch: Any) -> None:
+    """A ``BaseExceptionGroup`` surfacing at call-time collapses into the typed
+    ``{"code": "transport_error"}`` envelope — never an unhandled raise."""
+    from aios.harness import runtime
+    from aios.mcp import client as mcp_client
+    from aios.mcp.client import call_mcp_tool
+    from aios.mcp.pool import McpSessionPool
+
+    pool = McpSessionPool()
+
+    async def _fake_acquire(*_a: Any, **_k: Any) -> Any:
+        entry = MagicMock()
+        entry.session = _GroupSession()
+        entry.error_sink = MagicMock()
+        return entry
+
+    async def _noop(*_a: Any, **_k: Any) -> None:
+        return None
+
+    monkeypatch.setattr(pool, "acquire", _fake_acquire)
+    monkeypatch.setattr(pool, "discard", _noop)
+    monkeypatch.setattr(pool, "release", _noop)
+    monkeypatch.setattr(pool, "is_unhealthy", lambda *_a, **_k: False)
+    monkeypatch.setattr(mcp_client, "_TOOL_CALL_TIMEOUT_S", 5.0)
+    monkeypatch.setattr(runtime, "mcp_session_pool", pool)
+
+    result = await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
+    assert result["code"] == "transport_error"
+    assert "error" in result
+
+
+async def test_call_time_fast_returns_when_breaker_open(monkeypatch: Any) -> None:
+    """AC #4: with the breaker open, ``call_mcp_tool`` fast-returns the degraded
+    error dict WITHOUT attempting a connect (``acquire`` not called)."""
+    from aios.harness import runtime
+    from aios.mcp.client import call_mcp_tool
+    from aios.mcp.pool import McpSessionPool
+
+    pool = McpSessionPool()
+    acquired = False
+
+    async def _acquire(*_a: Any, **_k: Any) -> Any:
+        nonlocal acquired
+        acquired = True
+        raise AssertionError("acquire must not run while the breaker is open")
+
+    monkeypatch.setattr(pool, "acquire", _acquire)
+    monkeypatch.setattr(pool, "is_unhealthy", lambda *_a, **_k: True)
+    monkeypatch.setattr(runtime, "mcp_session_pool", pool)
+
+    result = await call_mcp_tool("https://m.example/", "v", {}, "do_thing", {})
+    assert result["code"] == "transport_error"
+    assert acquired is False

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -778,3 +778,162 @@ class TestCallMcpToolWithPool:
 
         assert result.get("code") == "transport_error"
         assert s_a.call_tool.await_count == 1
+
+
+# ── #1698: MCP fault isolation / bulkhead the pool boundary ─────────────────
+
+
+def _failing_session_ctx(exc: BaseException) -> MagicMock:
+    """A ClientSession whose ``initialize()`` raises ``exc`` on ``__aenter__``.
+
+    Models the connect/init failure surface: the streamable-http task group
+    unwinds ``initialize()`` and can raise a bare ``BaseExceptionGroup``.
+    """
+    session = AsyncMock()
+    session.initialize = AsyncMock(side_effect=exc)
+    cls = MagicMock()
+    cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    return cls
+
+
+def _incident_group() -> BaseExceptionGroup:
+    """The exact leaf shape from the incident: a group whose non-Exception leaf
+    (``CancelledError``) makes the group itself NOT an ``Exception``."""
+    grp = BaseExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [httpx.HTTPError("401 Unauthorized"), asyncio.CancelledError()],
+    )
+    # Guard the premise of the whole fix: this group is not an Exception, so it
+    # slips past every ``except Exception`` — which is why acquire must convert.
+    assert not isinstance(grp, Exception)
+    return grp
+
+
+class TestPoolBulkhead:
+    async def test_acquire_converts_base_exception_group_to_mcp_unavailable(self) -> None:
+        """AC #3: a bare ``BaseExceptionGroup`` from the transport is converted
+        to ``MCPUnavailable`` (an ``Exception``) — it NEVER escapes the pool."""
+        from aios.mcp.pool import MCPUnavailable
+
+        grp = _incident_group()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _failing_session_ctx(grp)),
+        ):
+            pool = McpSessionPool()
+            with pytest.raises(MCPUnavailable) as exc:
+                await pool.acquire(URL, "v", EMPTY_KEY, {})
+
+        assert isinstance(exc.value, Exception)  # the crux of the fix
+        assert exc.value.url == URL
+        # the original group is chained as the cause for diagnosis
+        assert exc.value.__cause__ is grp or isinstance(exc.value.__cause__, BaseExceptionGroup)
+
+    async def test_acquire_converts_plain_exception_to_mcp_unavailable(self) -> None:
+        """A plain connect exception is also normalized to ``MCPUnavailable``."""
+        from aios.mcp.pool import MCPUnavailable
+
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch(
+                "aios.mcp.pool.ClientSession",
+                _failing_session_ctx(httpx.ConnectError("boom")),
+            ),
+        ):
+            pool = McpSessionPool()
+            with pytest.raises(MCPUnavailable) as exc:
+                await pool.acquire(URL, "v", EMPTY_KEY, {})
+        assert exc.value.url == URL
+
+    async def test_breaker_opens_after_k_consecutive_failures(self) -> None:
+        """AC #4: the circuit opens after K=3 consecutive connect failures;
+        the failing URL then surfaces in ``degraded_servers()``."""
+        from aios.mcp.pool import _BREAKER_FAILURE_THRESHOLD, MCPUnavailable
+
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _failing_session_ctx(_incident_group())),
+        ):
+            pool = McpSessionPool()
+            assert _BREAKER_FAILURE_THRESHOLD == 3
+            for _ in range(_BREAKER_FAILURE_THRESHOLD - 1):
+                with pytest.raises(MCPUnavailable):
+                    await pool.acquire(URL, "v", EMPTY_KEY, {})
+                assert not pool.is_unhealthy(URL, "v", EMPTY_KEY), "breaker must stay closed pre-K"
+                assert pool.degraded_servers() == []
+            # The K-th failure opens the breaker.
+            with pytest.raises(MCPUnavailable):
+                await pool.acquire(URL, "v", EMPTY_KEY, {})
+            assert pool.is_unhealthy(URL, "v", EMPTY_KEY), "breaker must be open after K failures"
+            assert pool.degraded_servers() == [URL]
+
+    async def test_breaker_emits_exactly_one_down_event_on_edge(self) -> None:
+        """AC #5: exactly one DOWN-transition edge is queued for the event,
+        deduped across further failures while the breaker stays open."""
+        from aios.mcp.pool import _BREAKER_FAILURE_THRESHOLD, MCPUnavailable
+
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _failing_session_ctx(_incident_group())),
+        ):
+            pool = McpSessionPool()
+            for _ in range(_BREAKER_FAILURE_THRESHOLD + 2):
+                with pytest.raises(MCPUnavailable):
+                    await pool.acquire(URL, "v", EMPTY_KEY, {})
+            drained = pool.drain_degraded_events()
+            assert drained == [URL], "exactly one DOWN edge despite repeated failures"
+            # A second drain is empty (deduped).
+            assert pool.drain_degraded_events() == []
+
+    async def test_breaker_reprobes_after_cooldown_and_recloses_on_success(self) -> None:
+        """AC #4: after the cooldown the key re-probes; a successful acquire
+        re-closes the breaker and drops it from ``degraded_servers()``."""
+        from aios.mcp.pool import _BREAKER_FAILURE_THRESHOLD, MCPUnavailable
+
+        good = _make_mock_session()
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _failing_session_ctx(_incident_group())),
+        ):
+            pool = McpSessionPool()
+            for _ in range(_BREAKER_FAILURE_THRESHOLD):
+                with pytest.raises(MCPUnavailable):
+                    await pool.acquire(URL, "v", EMPTY_KEY, {})
+            assert pool.is_unhealthy(URL, "v", EMPTY_KEY)
+
+        # Cooldown elapsed → is_unhealthy clears the window (auto-re-probe).
+        far_future = time.monotonic() + 10_000
+        assert not pool.is_unhealthy(URL, "v", EMPTY_KEY, now=far_future)
+
+        # A successful acquire re-closes the breaker: counter reset + not degraded.
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(good)),
+        ):
+            entry = await pool.acquire(URL, "v", EMPTY_KEY, {})
+            pool.mark_healthy(URL, "v", EMPTY_KEY)
+        assert entry.session is good
+        assert pool.degraded_servers() == []
+        assert not pool.is_unhealthy(URL, "v", EMPTY_KEY)
+
+    async def test_evict_by_vault_clears_breaker_state(self) -> None:
+        """AC #6 / composes with #1030: ``evict_by_vault`` clears breaker state
+        so a fresh credential re-probes immediately."""
+        from aios.mcp.pool import _BREAKER_FAILURE_THRESHOLD, MCPUnavailable
+
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _failing_session_ctx(_incident_group())),
+        ):
+            pool = McpSessionPool()
+            for _ in range(_BREAKER_FAILURE_THRESHOLD):
+                with pytest.raises(MCPUnavailable):
+                    await pool.acquire(URL, "vault_x", EMPTY_KEY, {})
+            assert pool.is_unhealthy(URL, "vault_x", EMPTY_KEY)
+            assert pool.degraded_servers() == [URL]
+
+        await pool.evict_by_vault("vault_x")
+        assert not pool.is_unhealthy(URL, "vault_x", EMPTY_KEY), "breaker cleared on eviction"
+        assert pool.degraded_servers() == []
+        assert pool._failure_count == {}

--- a/tests/unit/test_mcp_pool.py
+++ b/tests/unit/test_mcp_pool.py
@@ -917,6 +917,56 @@ class TestPoolBulkhead:
         assert pool.degraded_servers() == []
         assert not pool.is_unhealthy(URL, "v", EMPTY_KEY)
 
+    async def test_successful_acquire_between_failures_resets_counter(self) -> None:
+        """F1 / AC #4 (consecutive): a successful ``acquire`` at the pool boundary
+        resets the consecutive-failure counter WITHOUT a manual ``mark_healthy``.
+
+        FAIL → acquire-SUCCESS → FAIL → FAIL must NOT open the breaker: the
+        success breaks the streak (the count is consecutive, not cumulative), so
+        the two trailing failures only bring the counter back to 2 (< K). Without
+        the pool-boundary reset the pre-success failure would persist and the
+        third failure overall would trip the breaker (the hair-trigger F1 flags).
+        """
+        from aios.mcp.pool import _BREAKER_FAILURE_THRESHOLD, MCPUnavailable
+
+        assert _BREAKER_FAILURE_THRESHOLD == 3
+        key = (URL, "v", EMPTY_KEY)
+        pool = McpSessionPool()
+        good = _make_mock_session()
+
+        async def _fail_once() -> None:
+            with (
+                patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+                patch("aios.mcp.pool.ClientSession", _failing_session_ctx(_incident_group())),
+                pytest.raises(MCPUnavailable),
+            ):
+                await pool.acquire(URL, "v", EMPTY_KEY, {})
+
+        # 1st failure: counter 0 → 1, breaker still closed.
+        await _fail_once()
+        assert pool._failure_count.get(key) == 1
+        assert not pool.is_unhealthy(URL, "v", EMPTY_KEY)
+
+        # Interleaved SUCCESS — no manual ``mark_healthy`` — resets the counter to
+        # 0 at the fresh-open success path. Left checked out (not released) so the
+        # next acquire opens a fresh (failing) session rather than reusing an idle
+        # one.
+        with (
+            patch("aios.mcp.pool.streamable_http_client", return_value=_transport_mock()),
+            patch("aios.mcp.pool.ClientSession", _session_ctx(good)),
+        ):
+            entry = await pool.acquire(URL, "v", EMPTY_KEY, {})
+        assert entry.session is good
+        assert pool._failure_count.get(key, 0) == 0, "success must reset the counter to 0"
+
+        # Two more failures: because the streak was broken, the counter climbs
+        # 0 → 1 → 2 and the breaker stays CLOSED (2 < K).
+        await _fail_once()
+        await _fail_once()
+        assert pool._failure_count.get(key) == 2
+        assert not pool.is_unhealthy(URL, "v", EMPTY_KEY), "breaker must stay closed after reset"
+        assert pool.degraded_servers() == []
+
     async def test_evict_by_vault_clears_breaker_state(self) -> None:
         """AC #6 / composes with #1030: ``evict_by_vault`` clears breaker state
         so a fresh credential re-probes immediately."""


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/eumemic-ops#321.