### PR TITLE
fix(memory): never mass-delete a memory store whose after-scan dropped out (#1705)

### DIFF
--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -20,6 +20,7 @@ Design constraints:
 from __future__ import annotations
 
 import hashlib
+from collections import Counter
 from pathlib import Path
 
 from aios.harness import runtime
@@ -118,20 +119,29 @@ def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
 
 def _snapshot_with_bytes(
     session_id: str,
-) -> _BytesMap:
-    """Return raw bytes for all eligible writable materialized mounts.
+) -> tuple[_BytesMap, set[str]]:
+    """Return raw bytes and the set of successfully-scanned stores.
 
     Called internally by both ``snapshot_memory_mounts`` (which only needs
     sha digests) and ``reconcile_memory_mounts`` (which needs bytes to avoid
     a second scan).
 
-    Returns ``bytes_map``: ``(store_id, store_path) -> raw_bytes``.  A file that
-    is enumerated but whose ``read_bytes()`` raises ``OSError`` is recorded
-    under the ``UNREADABLE`` sentinel instead of being dropped, so the path
-    stays present in the snapshot and is never mistaken for a deletion.
+    Returns ``(bytes_map, scanned_store_ids)``:
+
+    - ``bytes_map``: ``(store_id, store_path) -> raw_bytes``.  A file that is
+      enumerated but whose ``read_bytes()`` raises ``OSError`` is recorded under
+      the ``UNREADABLE`` sentinel instead of being dropped, so the path stays
+      present in the snapshot and is never mistaken for a deletion.
+    - ``scanned_store_ids``: every writable store that passed the echo-cache +
+      ``host_dir.exists()`` + ``.materialized`` marker gates, INCLUDING stores
+      that scanned to zero files.  This is the store-level analog of the
+      ``UNREADABLE`` file sentinel: a store that is NOT in this set was not
+      actually observed in the after-pass, so its ``before`` paths are UNKNOWN
+      (not deleted) and must never be reconciled as deletions (#1705).
     """
     echoes = runtime.get_session_memory_mounts(session_id)
     bytes_map: _BytesMap = {}
+    scanned_store_ids: set[str] = set()
 
     for echo in echoes:
         if echo.access == "read_only":
@@ -144,6 +154,12 @@ def _snapshot_with_bytes(
         if not marker.exists():
             continue
 
+        # Store passed every gate — record it as scanned even if it has zero
+        # files, so the deleted-files diff can tell "scanned, now empty"
+        # (a genuine delete-all) apart from "dropped out of the scan"
+        # (an untrustworthy view that must suppress deletes).
+        scanned_store_ids.add(store_id)
+
         for fpath, store_path in _walk_store_files(host_dir):
             try:
                 raw: bytes | _Unreadable = fpath.read_bytes()
@@ -154,7 +170,7 @@ def _snapshot_with_bytes(
                 raw = UNREADABLE
             bytes_map[(store_id, store_path)] = raw
 
-    return bytes_map
+    return bytes_map, scanned_store_ids
 
 
 def snapshot_memory_mounts(session_id: str) -> _Snapshot:
@@ -170,7 +186,7 @@ def snapshot_memory_mounts(session_id: str) -> _Snapshot:
     - Stores whose host directory does not exist yet.
     - Stores that have not been materialized (marker file absent).
     """
-    by_bytes = _snapshot_with_bytes(session_id)
+    by_bytes, _scanned = _snapshot_with_bytes(session_id)
     return _bytes_map_to_sha_map(by_bytes)
 
 
@@ -240,6 +256,37 @@ def _warn_unreadable(
     )
 
 
+def _warn_store_unscannable(
+    store_id: str,
+    suppressed_deletes: int,
+    warnings: list[str],
+    session_id: str,
+) -> None:
+    """Surface a store that dropped out of the after-scan; suppress its deletes.
+
+    The store-level twin of :func:`_warn_unreadable` (#1705).  A store present
+    in ``before`` but absent from the after-pass ``scanned_store_ids`` was not
+    actually observed after ``sandbox.exec`` — its mount echo-cache was cleared
+    mid-bash (``SandboxRegistry.release``/``evict``/idle-reaper), or its host dir
+    or ``.materialized`` marker vanished.  Its ``before`` paths therefore read as
+    "deleted" only because the after-view is UNKNOWN, not because the files were
+    removed (they are still on disk and in the DB).  Deleting on that view is the
+    mass-delete data-loss path, so every delete for the store is suppressed and
+    the store is surfaced instead — emitted once per store, not once per file.
+    """
+    warnings.append(
+        f"store {store_id}: not scannable after exec (mount cache cleared or "
+        f"host dir/marker absent); suppressed {suppressed_deletes} deletion(s) "
+        f"to avoid data loss"
+    )
+    log.warning(
+        "memory_reconcile.store_unscannable",
+        session_id=session_id,
+        store_id=store_id,
+        suppressed_deletes=suppressed_deletes,
+    )
+
+
 async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[str]:
     """Diff memory mount state against ``before``; write DB changes.
 
@@ -257,7 +304,10 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
     account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
     # Build after snapshot as (store_id, store_path) -> bytes in one pass.
     # Using bytes avoids re-reading files during the create/modify loops.
-    after_bytes = _snapshot_with_bytes(session_id)
+    # ``after_scanned_stores`` is the set of stores actually observed in this
+    # after-pass; a ``before`` store missing from it is UNKNOWN, not empty, and
+    # its deletes must be suppressed (#1705).
+    after_bytes, after_scanned_stores = _snapshot_with_bytes(session_id)
     pool = runtime.require_pool()
     actor = SessionActor(session_id=session_id)
     warnings: list[str] = []
@@ -367,9 +417,26 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
         )
 
     # ── Deleted files ────────────────────────────────────────────────────────
+    # Count before-paths per store so an unscannable store can report how many
+    # deletions it suppressed (the #1705 incident wrote 159 durable deletes in
+    # 1.79s from a read-only bash while the mount cache was cleared under it).
+    before_path_counts = Counter(store_id for store_id, _store_path in before)
+    unscannable_warned: set[str] = set()
     for store_id, store_path in before:
         if (store_id, store_path) in after:
             continue  # still exists
+        if store_id not in after_scanned_stores:
+            # The store was NOT observed in the after-pass (mount echo-cache
+            # cleared mid-bash, host dir/marker vanished, or materialization
+            # incomplete). Its before paths are UNKNOWN, not deleted — never
+            # delete on an untrustworthy view. Store-level twin of the
+            # per-file UNREADABLE sentinel (#1571 → #1705). Warn once per store.
+            if store_id not in unscannable_warned:
+                unscannable_warned.add(store_id)
+                _warn_store_unscannable(
+                    store_id, before_path_counts[store_id], warnings, session_id
+                )
+            continue
         existing = await memory_service.get_memory_by_path(
             pool, store_id, store_path, include_content=False, account_id=account_id
         )

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -533,6 +533,81 @@ class TestReconcile:
         mock_update.assert_not_awaited()
         assert any("/notes.md" in w for w in warnings)
 
+    async def test_store_unscannable_after_not_deleted(self, tmp_path: Path) -> None:
+        """Whole store drops out of the after-scan (echo-cache cleared mid-bash):
+        every delete is suppressed and the store is warned — the direct #1705
+        regression guard and the store-level analog of
+        ``test_unreadable_after_file_not_deleted``.
+
+        Reproduces the production incident: a real ``before`` snapshot is taken
+        while the mount is materialized, then ``clear_session_memory_mounts``
+        (what ``SandboxRegistry.release``/``evict``/idle-reaper actually call)
+        fires before the reconcile. The files are STILL on disk and in the DB
+        (``get_memory_by_path`` returns a row), yet every ``before`` path reads
+        as "deleted". Pre-fix this issued one ``delete_memory`` per path (159 in
+        the incident); post-fix zero deletes and one per-store warning.
+        """
+        from aios.tools.bash_memory_reconcile import (
+            reconcile_memory_mounts,
+            snapshot_memory_mounts,
+        )
+
+        host_dir = self._make_host_dir(tmp_path)
+        (host_dir / "notes.md").write_text("notes content\n")
+        (host_dir / "log.md").write_text("log content\n")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        # before: a real snapshot while the mount is present + materialized.
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            before = snapshot_memory_mounts(SESSION_ID)
+        assert (STORE_A, "/notes.md") in before
+        assert (STORE_A, "/log.md") in before
+
+        # Simulate the mount echo-cache clearing between before and reconcile
+        # (SandboxRegistry.release/evict/idle-reaper). The store now drops out
+        # of the after-scan entirely even though its files remain on disk + DB.
+        runtime.clear_session_memory_mounts(SESSION_ID)
+
+        # get_memory_by_path returns a live row: the files are genuinely present
+        # in the DB, so the only thing standing between the incident and 159
+        # deletes is the store-unscannable guard (not the existing-is-None one).
+        fake_memory = MagicMock()
+        fake_memory.id = "mem_01FAKE0000000000000000004"
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                new_callable=AsyncMock,
+                return_value=fake_memory,
+            ) as mock_get,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                new_callable=AsyncMock,
+            ) as mock_update,
+            patch(
+                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+
+        mock_delete.assert_not_awaited()
+        mock_create.assert_not_awaited()
+        mock_update.assert_not_awaited()
+        # Guard short-circuits before the DB lookup — no read attempted either.
+        mock_get.assert_not_awaited()
+        # One warning for the store (not one per file), naming the store and the
+        # suppressed-delete count.
+        assert len(warnings) == 1
+        assert STORE_A in warnings[0]
+        assert "2" in warnings[0]
+
     async def test_unreadable_in_both_snapshots_is_unchanged(self, tmp_path: Path) -> None:
         """Path unreadable in both before and after: no DB call, no warning."""
         from aios.tools.bash_memory_reconcile import (


### PR DESCRIPTION
Fixes #1705.

## The bug
`bash_memory_reconcile`'s post-exec reconcile rebuilds its `after` view from the in-memory mount echo-cache. If a concurrent `runtime.clear_session_memory_mounts` (SandboxRegistry `release()`/`evict()`/idle-reaper) fires between the `before` snapshot and the `finally` reconcile, the store drops out of `after` entirely, so **every** `before` path reads as "deleted" → mass `delete_memory`. In production this wiped `ultron-memory` (159 durable `deleted` rows in 1.79s) from a read-only `rg /mnt/memory/`. The existing `existing is None` guard does not save it (files are still on disk and in the DB). This is the **store-level analog of #1571** (the per-file `UNREADABLE` sentinel): "file unreadable" was fixed to never read as deleted, but "store unscannable in after" still read as "all files deleted."

## The fix (invariant)
Reconcile may DELETE a `before` path only when its store was **actually scanned** in the after-pass. A store that drops out of the after-scan for any reason (empty echo cache / missing host-dir / absent `.materialized` marker / incomplete materialization) is **UNKNOWN, not EMPTY → zero deletes.**

## Files + lines changed
- **`src/aios/tools/bash_memory_reconcile.py`** (+85/−9):
  - Added `from collections import Counter`.
  - `_snapshot_with_bytes` now returns `tuple[_BytesMap, set[str]]` — the second element is `scanned_store_ids`, populated once a store passes the echo-cache + `host_dir.exists()` + `.materialized` gates, **including zero-file stores** (distinguishes "scanned, now empty" = a genuine delete-all from "dropped out of scan" = untrustworthy view).
  - `snapshot_memory_mounts` unpacks and discards the set (`by_bytes, _scanned = ...`).
  - `reconcile_memory_mounts` unpacks `after_bytes, after_scanned_stores = _snapshot_with_bytes(...)`.
  - New helper `_warn_store_unscannable` (mirrors `_warn_unreadable`): surfaces `memory_reconcile.store_unscannable` with the suppressed-delete count, once per store.
  - Deleted-files loop: `if store_id not in after_scanned_stores: <warn once + continue>` **before** any `get_memory_by_path`/`delete_memory` call. Store-level twin of the `UNREADABLE` per-file sentinel.
- **`tests/unit/test_bash_memory_reconcile.py`** (+75): new test `TestReconcile::test_store_unscannable_after_not_deleted`.

## New test
`tests/unit/test_bash_memory_reconcile.py::TestReconcile::test_store_unscannable_after_not_deleted` — takes a real `snapshot_memory_mounts` while the mount is materialized (2 files), then fires `runtime.clear_session_memory_mounts(SESSION_ID)` (exactly what `release()`/`evict()`/idle-reaper call) before `reconcile_memory_mounts`. `get_memory_by_path` returns a live row (files genuinely present in DB). Asserts `delete_memory`/`create_memory`/`update_memory` **not awaited**, `get_memory_by_path` not awaited (guard short-circuits before the DB lookup), and exactly **one** per-store warning naming the store + suppressed count. This is the direct store-level analog of the existing `test_unreadable_after_file_not_deleted`.

## Load-bearing counterfactual (proof the test catches the bug)
Temporarily disabled the guard (`if False and store_id not in after_scanned_stores:`) and ran only the new test → **FAILED** at `mock_delete.assert_not_awaited()` (`delete_memory` was awaited with the store_id/memory_id — reproducing the mass-delete). Restored the guard → the test **passes**.

## Suite results
- `pytest tests/unit -q -n 4`: **4143 passed**.
- Regression guard `test_deleted_file_calls_delete_memory` still passes (a genuine `rm` with the store still scannable still deletes — only untrustworthy-view deletes are suppressed).
- `ruff check`, `ruff format --check`, `mypy` (on `bash_memory_reconcile.py` + `bash.py`): clean. Pre-commit ran the full unit + connectors suites green.

## Deliberately out of scope (follow-ups)
- **Item 3** (RCA): capture the store set once at the `before` snapshot (`bash.py:141`) and reuse it for the after-pass, so a concurrent clear can't change the store set under the diff — also restores create-recording (create-suppression is the acceptable, non-data-loss half). Not done here to keep the change minimal/typed; items 1–2 alone stop the data loss.
- **Item 4** (RCA): reaper/`_last_used` defense-in-depth — bump `_last_used` on `exec` or gate `release()` on an active-step flag so an in-flight bash defends against teardown. Separate PR.
- **E2E** (`tests/e2e/test_memory_cross_session_sync.py`): the issue's suggested end-to-end variant is not added here; the unit test exercises the same reconcile code path with the real snapshot + real `clear_session_memory_mounts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)