### PR TITLE
configure_per_chat does not validate session_template_id → cross-tenant existence oracle + silent mis-bind

### DIFF
--- a/packages/aios-sdk/tests/test_errors.py
+++ b/packages/aios-sdk/tests/test_errors.py
@@ -96,9 +96,7 @@ def test_raw_request_prunes_none_params() -> None:
         return httpx.Response(200, json={"data": []})
 
     with _mock_client(handler) as client:
-        raw_request(
-            client, "GET", "/v1/agents", params={"limit": 5, "after": None, "kind": None}
-        )
+        raw_request(client, "GET", "/v1/agents", params={"limit": 5, "after": None, "kind": None})
     assert "limit=5" in seen["qs"]
     assert "after" not in seen["qs"]
     assert "kind" not in seen["qs"]

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -416,6 +416,28 @@ async def configure_per_chat(
                 f"connection {connection_id} is archived; cannot configure",
                 detail={"id": connection_id},
             )
+        # Validate the template account-scoped *inside the tx*, mirroring
+        # ``attach_connection``'s ``get_session_bare`` check. Without this,
+        # a caller-supplied ``session_template_id`` goes straight into
+        # ``insert_binding`` and the single-column FK (migration 0033,
+        # deliberately non-tenant-composite per 0110) only enforces global
+        # existence — leaking a cross-tenant existence oracle (200 when the
+        # id lives in *any* account vs 404 when nowhere) and silently
+        # mis-binding a foreign template. ``get_session_template`` raises
+        # ``NotFoundError`` unless the row exists in *this* account.
+        template = await queries.get_session_template(
+            conn, session_template_id, account_id=account_id
+        )
+        # Refuse an archived template at bind time (see ``attach_connection``):
+        # the FK accepts archived rows, so without this ``insert_binding``
+        # would 200 on an archived recipe and the mis-bind would only surface
+        # later, as a DETACH from a different actor at inbound resolution.
+        if template.archived_at is not None:
+            raise ConflictError(
+                f"session template {session_template_id} is archived; "
+                "cannot configure per_chat",
+                detail={"id": connection_id, "session_template_id": session_template_id},
+            )
         await queries.insert_binding(
             conn,
             connection_id=connection_id,

--- a/src/aios/services/connections.py
+++ b/src/aios/services/connections.py
@@ -434,8 +434,7 @@ async def configure_per_chat(
         # later, as a DETACH from a different actor at inbound resolution.
         if template.archived_at is not None:
             raise ConflictError(
-                f"session template {session_template_id} is archived; "
-                "cannot configure per_chat",
+                f"session template {session_template_id} is archived; cannot configure per_chat",
                 detail={"id": connection_id, "session_template_id": session_template_id},
             )
         await queries.insert_binding(

--- a/tests/integration/test_configure_per_chat_template_validation.py
+++ b/tests/integration/test_configure_per_chat_template_validation.py
@@ -36,9 +36,7 @@ from aios.services import session_templates as session_templates_service
 pytestmark = pytest.mark.integration
 
 
-async def _make_template(
-    pool: asyncpg.Pool[Any], *, account_id: str, name: str
-) -> Any:
+async def _make_template(pool: asyncpg.Pool[Any], *, account_id: str, name: str) -> Any:
     agent = await agents_service.create_agent(
         pool,
         account_id=account_id,
@@ -119,8 +117,7 @@ async def test_foreign_template_raises_not_found(
     # No binding row landed.
     async with pool.acquire() as conn:
         active = await conn.fetchval(
-            "SELECT COUNT(*) FROM bindings "
-            "WHERE connection_id = $1 AND archived_at IS NULL",
+            "SELECT COUNT(*) FROM bindings WHERE connection_id = $1 AND archived_at IS NULL",
             connection_id,
         )
     assert active == 0
@@ -134,9 +131,7 @@ async def test_archived_own_template_raises_conflict(
     """
     pool, connection_id = pool_two_tenants
     template = await _make_template(pool, account_id="acc_a", name="archived")
-    await session_templates_service.archive_session_template(
-        pool, template.id, account_id="acc_a"
-    )
+    await session_templates_service.archive_session_template(pool, template.id, account_id="acc_a")
 
     with pytest.raises(ConflictError):
         await connections_service.configure_per_chat(
@@ -148,8 +143,7 @@ async def test_archived_own_template_raises_conflict(
 
     async with pool.acquire() as conn:
         active = await conn.fetchval(
-            "SELECT COUNT(*) FROM bindings "
-            "WHERE connection_id = $1 AND archived_at IS NULL",
+            "SELECT COUNT(*) FROM bindings WHERE connection_id = $1 AND archived_at IS NULL",
             connection_id,
         )
     assert active == 0

--- a/tests/integration/test_configure_per_chat_template_validation.py
+++ b/tests/integration/test_configure_per_chat_template_validation.py
@@ -1,0 +1,179 @@
+"""Integration test: ``configure_per_chat`` must validate the caller-supplied
+``session_template_id`` account-scoped (and refuse archived templates) *inside
+the bind transaction* — mirroring ``attach_connection``'s session check.
+
+Pre-fix (#1708), ``configure_per_chat`` dropped ``session_template_id`` straight
+into ``insert_binding`` with no scoped get. The ``bindings.session_template_id``
+FK is single-column (migration 0033; deliberately non-tenant-composite per
+0110), so it only enforces *global* existence. Consequences:
+
+* a cross-tenant **existence oracle** — binding a template id that lives in
+  *another* account returned 200 (id exists globally) while a nowhere id
+  returned 404; the 200/404 split leaks the id's existence across tenants;
+* a **silent mis-bind** of a foreign or archived template that only surfaces
+  later, as a DETACH from a different actor at inbound resolution.
+
+The fix calls ``get_session_template(conn, id, account_id=account_id)`` and
+refuses ``archived_at is not None`` before ``insert_binding``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db import queries
+from aios.db.pool import create_pool
+from aios.errors import ConflictError, NotFoundError
+from aios.services import agents as agents_service
+from aios.services import connections as connections_service
+from aios.services import environments as environments_service
+from aios.services import session_templates as session_templates_service
+
+pytestmark = pytest.mark.integration
+
+
+async def _make_template(
+    pool: asyncpg.Pool[Any], *, account_id: str, name: str
+) -> Any:
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=account_id,
+        name=f"agent-{name}",
+        model="openrouter/test",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=50_000,
+        window_max=150_000,
+    )
+    env = await environments_service.create_environment(
+        pool, account_id=account_id, name=f"env-{name}"
+    )
+    return await session_templates_service.create_session_template(
+        pool,
+        account_id=account_id,
+        name=f"tpl-{name}",
+        agent_id=agent.id,
+        environment_id=env.id,
+        agent_version=agent.version,
+        vault_ids=[],
+        memory_store_ids=[],
+        metadata={},
+    )
+
+
+@pytest.fixture
+async def pool_two_tenants(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], str]]:
+    """Yield ``(pool, connection_id)`` where ``connection_id`` is an
+    unbound connection owned by ``acc_a``. Two sibling tenants
+    (``acc_a`` / ``acc_b``) exist so cross-tenant template ids are
+    exercisable.
+    """
+    pool = await create_pool(migrated_db_url, min_size=2, max_size=8)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
+                VALUES ('acc_root', NULL,       TRUE,  'tenant-root'),
+                       ('acc_a',    'acc_root', FALSE, 'tenant-a'),
+                       ('acc_b',    'acc_root', FALSE, 'tenant-b')
+                """
+            )
+            connection = await queries.insert_connection(
+                conn,
+                account_id="acc_a",
+                connector="signal",
+                external_account_id="+15550001",
+                metadata={},
+            )
+        yield pool, connection.id
+    finally:
+        await pool.close()
+
+
+async def test_foreign_template_raises_not_found(
+    pool_two_tenants: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """A template that exists only in *another* account must be refused
+    with ``NotFoundError`` — closing the cross-tenant existence oracle.
+    """
+    pool, connection_id = pool_two_tenants
+    foreign = await _make_template(pool, account_id="acc_b", name="foreign")
+
+    with pytest.raises(NotFoundError):
+        await connections_service.configure_per_chat(
+            pool,
+            connection_id,
+            account_id="acc_a",
+            session_template_id=foreign.id,
+        )
+
+    # No binding row landed.
+    async with pool.acquire() as conn:
+        active = await conn.fetchval(
+            "SELECT COUNT(*) FROM bindings "
+            "WHERE connection_id = $1 AND archived_at IS NULL",
+            connection_id,
+        )
+    assert active == 0
+
+
+async def test_archived_own_template_raises_conflict(
+    pool_two_tenants: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """An own-account but *archived* template must be refused at bind
+    time (``ConflictError``) rather than silently binding.
+    """
+    pool, connection_id = pool_two_tenants
+    template = await _make_template(pool, account_id="acc_a", name="archived")
+    await session_templates_service.archive_session_template(
+        pool, template.id, account_id="acc_a"
+    )
+
+    with pytest.raises(ConflictError):
+        await connections_service.configure_per_chat(
+            pool,
+            connection_id,
+            account_id="acc_a",
+            session_template_id=template.id,
+        )
+
+    async with pool.acquire() as conn:
+        active = await conn.fetchval(
+            "SELECT COUNT(*) FROM bindings "
+            "WHERE connection_id = $1 AND archived_at IS NULL",
+            connection_id,
+        )
+    assert active == 0
+
+
+async def test_own_live_template_binds(
+    pool_two_tenants: tuple[asyncpg.Pool[Any], str],
+) -> None:
+    """Regression guard: an own-account, un-archived template still binds."""
+    pool, connection_id = pool_two_tenants
+    template = await _make_template(pool, account_id="acc_a", name="live")
+
+    connection = await connections_service.configure_per_chat(
+        pool,
+        connection_id,
+        account_id="acc_a",
+        session_template_id=template.id,
+    )
+    assert connection.id == connection_id
+
+    async with pool.acquire() as conn:
+        bound = await conn.fetchval(
+            "SELECT session_template_id FROM bindings "
+            "WHERE connection_id = $1 AND mode = 'per_chat' AND archived_at IS NULL",
+            connection_id,
+        )
+    assert bound == template.id

--- a/tests/unit/test_inbound_policy_operator_surface.py
+++ b/tests/unit/test_inbound_policy_operator_surface.py
@@ -294,6 +294,14 @@ async def test_configure_per_chat_defaults_inbound_policy_closed(
 
     conn_obj = _connection(inbound_policy=DenyAll())
     pool, conn = _bind_pool()
+    # configure_per_chat now validates the template account-scoped inside the
+    # tx (#1708); mock a live (un-archived) own-account template so the bind
+    # proceeds to the policy default under test.
+    template = MagicMock(archived_at=None)
+    monkeypatch.setattr(
+        "aios.services.connections.queries.get_session_template",
+        AsyncMock(return_value=template),
+    )
     monkeypatch.setattr("aios.services.connections.queries.insert_binding", AsyncMock())
     default_mock = AsyncMock()
     monkeypatch.setattr(


### PR DESCRIPTION
Automated dev-pipeline build for issue #1708.