### PR TITLE
fix(security): search_events AST allowlist + clone_session trigger cap + ingest-token log redaction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     # Inbound image downsampling at staging time so vision-capable models
     # see the pixels instead of a path marker.  See harness/image_resize.py.
     "pillow>=10.0",
+    "sqlglot>=30.12.0",
 ]
 
 [dependency-groups]

--- a/src/aios/api/_log_redaction.py
+++ b/src/aios/api/_log_redaction.py
@@ -1,0 +1,26 @@
+"""Leaf-module home for the request-log path redactor.
+
+Imports only the stdlib ``re`` — deliberately NOTHING from ``aios`` — so it can
+be imported from both the API layer (``aios.api.middleware``) and the
+foundational ``aios.errors`` (imported by ~39 db/harness/services/workflows
+modules) without dragging the starlette/API layer into that foundation or
+creating an import cycle.
+"""
+
+from __future__ import annotations
+
+import re
+
+_INGEST_PATH_RE = re.compile(r"^(/v1/triggers/ingest/)[^/]+")
+
+
+def redact_sensitive_path(path: str) -> str:
+    """Replace the per-trigger ingest bearer token in the URL path with a
+    placeholder so request/error logs never persist a live credential.
+
+    Only the one known secret-bearing route (``POST
+    /v1/triggers/ingest/{ingest_token}`` — see
+    ``aios.api.routers.triggers_ingest``) is rewritten; all other paths pass
+    through unchanged (a broad heuristic would risk mangling legitimate ids).
+    """
+    return _INGEST_PATH_RE.sub(r"\1<redacted>", path)

--- a/src/aios/api/middleware.py
+++ b/src/aios/api/middleware.py
@@ -16,6 +16,7 @@ import time
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from aios.api._log_redaction import redact_sensitive_path
 from aios.logging import get_logger
 
 log = get_logger(__name__)
@@ -52,7 +53,7 @@ class RequestLoggingMiddleware:
             log.info(
                 "api.request",
                 method=method,
-                path=path,
+                path=redact_sensitive_path(path),
                 status=status if status is not None else 500,
                 duration_ms=round((time.perf_counter() - start) * 1000, 2),
             )

--- a/src/aios/cli/commands/ops.py
+++ b/src/aios/cli/commands/ops.py
@@ -34,6 +34,13 @@ def _run_api() -> int:
         host=settings.api_host,
         port=settings.api_port,
         log_config=None,  # we configure structlog ourselves
+        # uvicorn's access log is redundant with our own RequestLoggingMiddleware
+        # (one api.request line per request) AND, with log_config=None, its
+        # `uvicorn.access` logger propagates to the root %(message)s handler and
+        # would log the raw request line — leaking the per-trigger ingest bearer
+        # token in `POST /v1/triggers/ingest/<token>` that the middleware/error
+        # log sites redact. Disable it so the redaction is not defeated.
+        access_log=False,
         proxy_headers=True,
         forwarded_allow_ips="*",
     )

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -34,6 +34,7 @@ from aios.db.queries.clone_policy import (
 from aios.errors import (
     ConflictError,
     NotFoundError,
+    RateLimitedError,
 )
 from aios.ids import (
     EVENT,
@@ -1566,12 +1567,42 @@ async def clone_session(
     own session_id, leaving the clone's expected event stream undefined.
     The clone primitive locks the parent row for the copy, so concurrent
     appenders serialize behind it and the copied seq range is gapless.
+
+    Since ``enabled``/``next_fire`` are copied verbatim, a clone of a
+    trigger-bearing session is itself a trigger-CREATING write path, so it
+    honors ``Settings.triggers_per_account_max``. EVERY clone acquires the
+    same ``acquire_account_triggers_lock`` advisory lock ``add_trigger`` /
+    ``update_trigger``'s re-enable / session-attach use — unconditionally, at
+    the very top of the transaction, BEFORE the parent ``FOR UPDATE`` — to
+    match the siblings' advisory-first / session-row-second lock order (they
+    take the advisory lock, then the session row via their INSERT's FK). A
+    clone that locked the session row first would invert that order and
+    deadlock against a concurrent ``add_trigger``. With the lock held, the
+    parent's enabled-trigger count is exact through the copy, so when the
+    parent owns any triggers this enforces the cap against the account's
+    existing enabled count plus the clone's — raising ``RateLimitedError``
+    (and rolling back the whole clone) on breach. A trigger-free parent still
+    takes the lock (for ordering) but skips the cap CHECK; its empty row set
+    is self-consistent with the copy INSERT, which copies nothing.
     """
     new_id = make_id(SESSION)
     if workspace_path is None:
         workspace_path = _default_workspace_path(account_id, new_id)
 
     async with conn.transaction():
+        # Take the per-account trigger advisory lock FIRST — before the parent
+        # session FOR UPDATE below — because the sibling trigger-creating paths
+        # (add_trigger / update_trigger re-enable / session-attach) all acquire
+        # it before the session-row lock their trigger INSERT's FK takes. A
+        # clone that took the session row lock first, then this advisory lock,
+        # would invert that order and deadlock (AB/BA) against a concurrent
+        # add_trigger on the same account+session. Unconditional for every clone
+        # (not gated on trigger_count): the lock ordering is what makes the cap
+        # contractual, so its acquisition can't depend on the racy trigger set.
+        # It is xact-scoped, so it's held across the whole clone — the deliberate
+        # cost of correct ordering; clones are infrequent and the lock is
+        # per-account.
+        await queries.acquire_account_triggers_lock(conn, account_id)
         row = await conn.fetchrow(
             f"SELECT archived_at, ({_SESSION_ACTIVE_EXPR}) AS active, "
             f"({_SESSION_ERRORED_EXPR}) AS errored "
@@ -1703,6 +1734,34 @@ async def clone_session(
             "SELECT COUNT(*) FROM triggers WHERE owner_session_id = $1",
             parent_session_id,
         )
+        if trigger_count:
+            # Clone copies triggers with enabled=COPY (TRIGGERS_POLICY), so it is a
+            # trigger-CREATING write path and must honor the per-account active
+            # cap like add_trigger / update_trigger re-enable / session-attach do.
+            # The account advisory lock is already held (acquired at the top of
+            # this transaction), so this enabled count is exact — or stricter,
+            # since unlocked disables only reduce it — through the INSERT below;
+            # a concurrent locked re-enable can't flip a row between the count and
+            # the copy. The cap CHECK is gated on trigger_count: a trigger-free
+            # clone copies nothing and needs no check (the lock is still taken
+            # unconditionally above, for ordering).
+            enabled_to_clone: int = await conn.fetchval(
+                "SELECT COUNT(*) FROM triggers WHERE owner_session_id = $1 AND enabled",
+                parent_session_id,
+            )
+            if enabled_to_clone:
+                from aios.config import get_settings
+
+                cap = get_settings().triggers_per_account_max
+                existing_account = await queries.count_account_triggers(
+                    conn, account_id=account_id, enabled_only=True
+                )
+                if existing_account + enabled_to_clone > cap:
+                    raise RateLimitedError(
+                        "cloning this session would exceed the active-trigger cap: "
+                        f"{existing_account} existing + {enabled_to_clone} cloned > {cap}. "
+                        "Disable or remove triggers to free slots before cloning."
+                    )
         new_trigger_ids = [make_id(TRIGGER) for _ in range(trigger_count)]
         # A fresh ingest-token hash per trigger row, used ONLY by the
         # source-conditional MINT_INGEST_TOKEN arm: an external_event trigger

--- a/src/aios/errors.py
+++ b/src/aios/errors.py
@@ -18,6 +18,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from aios.api._log_redaction import redact_sensitive_path
 from aios.logging import get_logger
 
 log = get_logger(__name__)
@@ -239,7 +240,7 @@ def _log_handler_error(event: str, request: Request, status: int, **fields: obje
     line carries it and an unauthenticated one simply omits the key.
     """
     log_fn = log.exception if status >= 500 else log.warning
-    log_fn(event, path=request.url.path, status=status, **fields)
+    log_fn(event, path=redact_sensitive_path(request.url.path), status=status, **fields)
 
 
 async def aios_error_handler(request: Request, exc: Exception) -> JSONResponse:

--- a/src/aios/tools/search_events.py
+++ b/src/aios/tools/search_events.py
@@ -19,10 +19,11 @@ below actually filter on.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 import asyncpg
+import sqlglot
+from sqlglot import exp
 
 from aios.harness import runtime
 from aios.logging import get_logger
@@ -34,83 +35,133 @@ log = get_logger(__name__)
 MAX_ROWS = 200
 QUERY_TIMEOUT_MS = 10_000
 
-_FORBIDDEN_KEYWORDS = re.compile(
-    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|EXECUTE|COPY|GRANT|REVOKE|SET_CONFIG|CALL)\b",
-    re.IGNORECASE,
+# The ONLY relations search_events may read: the per-session scoped view whose
+# own WHERE clause enforces ``session_id = current_setting('app.session_id')``.
+# The query runs on the privileged application pool with only ``app.session_id``
+# set and no Postgres row-level-security backstop, so reading anything else
+# returns other accounts' rows up to the row cap.  This is an ALLOWLIST, not a
+# denylist: it is fail-closed by construction — a table added to the schema
+# later is inaccessible by default, not accidentally exposed the way a
+# hand-maintained denylist leaves it every time the schema grows.
+#
+# ``memories_search`` is deliberately NOT allowlisted: that per-session view is
+# owned by the separate ``memory_search`` tool through a fixed parameterised
+# query (no raw-SQL surface), so search_events has no business reading it.
+#
+# Kept honest by the drift guard in
+# ``tests/unit/test_search_events_allowlist_drift.py``: every allowlisted name
+# must be a migration-defined view scoped by ``app.session_id``.
+_ALLOWED_RELATIONS = frozenset({"events_search"})
+
+# Schemas a table reference may live in: unqualified, or explicitly ``public``
+# (the search path's default, where ``events_search`` lives).  Anything else —
+# ``pg_catalog``, ``information_schema`` — is a catalogue-introspection surface.
+_ALLOWED_SCHEMAS = frozenset({"", "public"})
+
+# Statement nodes that mean the query is not a pure read.  ``exp.Command`` is
+# sqlglot's fallback for syntax it doesn't model as a first-class node —
+# ``COPY``, ``CALL``, ``SET``, ``GRANT``, ``VACUUM`` and friends all land here —
+# so rejecting it closes the whole long tail of non-SELECT statements in one
+# check.
+_WRITE_STATEMENTS = (
+    exp.Insert,
+    exp.Update,
+    exp.Delete,
+    exp.Merge,
+    exp.Drop,
+    exp.Create,
+    exp.Alter,
+    exp.Command,
 )
-
-# Identifiers that, if referenced, mean the query is reaching outside the
-# per-session ``events_search`` view.  Stamping the events table directly
-# bypasses the view's ``session_id = current_setting('app.session_id', true)``
-# scoping; querying any other application table leaks rows that belong to
-# other sessions and other accounts (multi-tenancy).  ``pg_*`` /
-# ``information_schema`` are the schema-introspection surfaces that would
-# enumerate the rest of the catalogue.  The check runs on the *literal-stripped*
-# SQL so a substring inside an ILIKE pattern (e.g. ``'%events%'``) doesn't
-# false-positive.
-_FORBIDDEN_REFERENCES = re.compile(
-    r"\b("
-    r"events|sessions|accounts|account_keys|agents|agent_versions|environments|"
-    r"connections|connectors|vaults|vault_credentials|memory_stores|memories|"
-    r"memory_versions|session_vaults|session_resources|session_memory_stores|"
-    r"session_github_repositories|session_templates|github_repositories|"
-    r"pending_management_calls|attachments|files|skills|skill_versions|"
-    r"procrastinate_\w+|pg_\w+|information_schema|pg_catalog"
-    r")\b",
-    re.IGNORECASE,
-)
-
-# Strip SQL string literals (single-quote and dollar-quoted) and comments so
-# the identifier check above runs against the structural SQL only.  Double-
-# quoted identifiers are NOT stripped — ``"events"`` is the events table,
-# not a string — and the structural regex's ``\b`` boundaries still match
-# inside them.
-_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
-_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
-_SINGLE_QUOTE_RE = re.compile(r"'(?:''|[^'])*'")
-_DOLLAR_QUOTE_RE = re.compile(r"\$(\w*)\$.*?\$\1\$", re.DOTALL)
-
-
-def _strip_string_literals(sql: str) -> str:
-    """Replace SQL string literals and comments with empty placeholders.
-
-    Double-quoted identifiers are intentionally preserved — they are how
-    Postgres references tables/columns with reserved-word or mixed-case
-    names, and ``\\b`` word boundaries still match identifiers inside
-    quotes.
-    """
-    sql = _LINE_COMMENT_RE.sub("", sql)
-    sql = _BLOCK_COMMENT_RE.sub("", sql)
-    sql = _SINGLE_QUOTE_RE.sub("''", sql)
-    sql = _DOLLAR_QUOTE_RE.sub("$$$$", sql)
-    return sql
 
 
 def _validate_sql(sql: str) -> str | None:
-    """Validate SQL is a safe SELECT query. Returns an error string or None.
+    """Validate SQL is a safe, read-only, single-relation SELECT.
 
-    The agent's SQL surface is exclusively the per-session ``events_search``
-    view.  Direct access to any other table — including the underlying
-    ``events`` table — bypasses the view's per-session scoping and leaks
-    rows belonging to other sessions and (post multi-tenancy v1) other
-    accounts.  The structural check runs on the literal-stripped SQL so
-    substring matches inside ``ILIKE`` patterns don't false-positive.
+    Returns an error string the model sees (and can act on), or ``None`` when
+    the query is safe to run.
+
+    A regex over SQL text is the wrong altitude for a tenant boundary: comma
+    cross-joins, ``UNION``, in-string comment tricks, ``TABLE``-primary forms
+    and ``pg_*`` functions in SELECT position all slip past a keyword/regex
+    scan.  Instead we parse the query into an AST with sqlglot and walk it:
+
+    * the root must be a read-only set-operation tree (SELECT / UNION /
+      INTERSECT / EXCEPT), and no write/DDL/command node may appear anywhere;
+    * **every** table reference (``exp.Table``) — in any join, subquery, CTE
+      body or set-operation arm — must resolve to an allowlisted relation in an
+      allowed schema.  CTE-defined names are legitimate local relations, so
+      they are added to the allowed set; a table-valued function in FROM parses
+      to a ``Table`` with an off name and is rejected (fail-closed);
+    * ``pg_*`` functions (``pg_read_file`` &c.) and ``set_config`` (which could
+      rewrite ``app.session_id`` even inside a read-only transaction) are
+      rejected wherever they appear.
+
+    The single per-session view remains the only real relation the model can
+    read — now enforced structurally rather than by pattern-matching text.
     """
     stripped = sql.strip()
-    if not stripped.upper().startswith("SELECT"):
-        return "Only SELECT queries are allowed"
+    if not stripped:
+        return "Empty query"
+    # A single statement only: a semicolon can only introduce a second one.
     if ";" in stripped:
         return "Multiple statements (semicolons) are not allowed"
-    kw_match = _FORBIDDEN_KEYWORDS.search(stripped)
-    if kw_match:
-        return f"Forbidden keyword '{kw_match.group()}' is not allowed in queries"
-    structural = _strip_string_literals(stripped)
-    ref_match = _FORBIDDEN_REFERENCES.search(structural)
-    if ref_match:
-        return (
-            f"Identifier {ref_match.group()!r} is not allowed; query the events_search view instead"
-        )
+
+    try:
+        tree = sqlglot.parse_one(stripped, read="postgres")
+    except Exception:
+        return "Query could not be parsed as a single read-only PostgreSQL SELECT"
+
+    # Read-only root: only set-operation trees over SELECT are allowed.
+    if not isinstance(tree, exp.Select | exp.Union | exp.Intersect | exp.Except):
+        return "Only SELECT queries are allowed"
+    # …and no write/DDL/command node anywhere inside it (e.g. a data-modifying
+    # CTE ``WITH x AS (DELETE ... RETURNING ...)``).
+    if any(isinstance(node, _WRITE_STATEMENTS) for node in tree.walk()):
+        return "Only SELECT queries are allowed"
+
+    # CTE names are local relations defined by the query itself — allow them
+    # (their bodies are still walked, so a CTE reading a forbidden table is
+    # caught on that table, not on the CTE name).
+    cte_names = {cte.alias_or_name.lower() for cte in tree.find_all(exp.CTE)}
+    allowed = {name.lower() for name in _ALLOWED_RELATIONS} | cte_names
+
+    for table in tree.find_all(exp.Table):
+        schema = (table.db or "").lower()
+        if schema not in _ALLOWED_SCHEMAS:
+            return (
+                f"Schema {schema!r} is not accessible; search_events may only read "
+                f"{', '.join(sorted(_ALLOWED_RELATIONS))}"
+            )
+        name = (table.name or "").lower()
+        if name not in allowed:
+            return (
+                f"Relation {name!r} is not allowed; search_events may only read "
+                f"{', '.join(sorted(_ALLOWED_RELATIONS))}"
+            )
+
+    for name in _function_names(tree):
+        if name.startswith("pg_") or name == "set_config":
+            return f"Function {name!r} is not allowed"
+
     return None
+
+
+def _function_names(tree: exp.Expression) -> set[str]:
+    """Lower-cased names of every function call in the AST.
+
+    Both branches matter: unknown functions parse to ``exp.Anonymous`` (name on
+    the node), while ones sqlglot models specially parse to an ``exp.Func``
+    subclass (name via ``sql_name()``).
+    """
+    names: set[str] = set()
+    for anon in tree.find_all(exp.Anonymous):
+        names.add((anon.name or "").lower())
+    for func in tree.find_all(exp.Func):
+        sql_name = func.sql_name()
+        if sql_name:
+            names.add(sql_name.lower())
+    return names
 
 
 def _format_results(rows: list[asyncpg.Record], truncated: bool) -> str:

--- a/tests/integration/test_clone_session_trigger_cap.py
+++ b/tests/integration/test_clone_session_trigger_cap.py
@@ -1,0 +1,317 @@
+"""Integration test: ``clone_session`` enforces the per-account enabled-trigger
+cap (Plan 004).
+
+Every OTHER write path that creates or re-enables a trigger enforces
+``Settings.triggers_per_account_max`` under ``acquire_account_triggers_lock``
+— ``add_trigger``, ``update_trigger``'s re-enable, and the create-session
+attach path (see ``tests/e2e/test_triggers.py::TestPerAccountCap`` and
+``TestAdvisoryLockSerializesCapCheck``). ``clone_session`` copies every parent
+trigger row with ``enabled`` and ``next_fire`` preserved (``TRIGGERS_POLICY``
+marks both ``Arm.COPY``), so without a cap check a tenant sitting at the cap
+could multiply enabled, armed triggers without bound by repeatedly cloning a
+trigger-bearing session.
+
+This pins the fix: EVERY clone acquires the SAME advisory lock the sibling
+paths use — unconditionally, before the parent ``FOR UPDATE`` — to match
+their advisory-first / session-row-second lock order (a session-row-first
+clone would AB/BA-deadlock a concurrent ``add_trigger``). With the lock held,
+the parent's enabled count is exact through the copy, so a trigger-bearing
+clone raises ``RateLimitedError`` if the account's existing enabled count
+plus the clone's would exceed the cap — atomically with the copy (same
+transaction), so a blocked clone leaves no partial state. A trigger-free
+parent still takes the lock (for ordering) but skips the cap CHECK.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import asyncpg
+import pytest
+
+from aios.db.pool import create_pool, register_jsonb_codec
+from aios.db.queries.sessions import clone_session
+from aios.errors import RateLimitedError
+from aios.ids import SESSION, TRIGGER, make_id
+
+pytestmark = pytest.mark.integration
+
+ACCOUNT = "acc_clone_trigcap"
+
+
+@pytest.fixture
+async def pool(migrated_db_url: str, _reset_db_state: None) -> AsyncIterator[asyncpg.Pool[Any]]:
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'clone-trigcap')",
+                ACCOUNT,
+            )
+        yield pool
+    finally:
+        await pool.close()
+
+
+async def _seed_agent_env(conn: asyncpg.Connection[Any]) -> tuple[str, str]:
+    agent_id = make_id("agent")
+    env_id = make_id("env")
+    await conn.execute(
+        "INSERT INTO agents (id, account_id, name, model, system, version) "
+        "VALUES ($1, $2, 'a', 'openrouter/test', '', 1)",
+        agent_id,
+        ACCOUNT,
+    )
+    await conn.execute(
+        "INSERT INTO environments (id, account_id, name) VALUES ($1, $2, 'e')",
+        env_id,
+        ACCOUNT,
+    )
+    return agent_id, env_id
+
+
+async def _insert_session(
+    conn: asyncpg.Connection[Any], agent_id: str, env_id: str, *, workspace: str
+) -> str:
+    session_id = make_id(SESSION)
+    await conn.execute(
+        """
+        INSERT INTO sessions (id, agent_id, environment_id, agent_version, title,
+            metadata, workspace_volume_path, env, account_id, last_event_seq)
+        VALUES ($1, $2, $3, 1, 't', '{}'::jsonb, $4, '{}'::jsonb, $5, 0)
+        """,
+        session_id,
+        agent_id,
+        env_id,
+        workspace,
+        ACCOUNT,
+    )
+    return session_id
+
+
+async def _insert_trigger(
+    conn: asyncpg.Connection[Any], owner_session_id: str, *, name: str, enabled: bool
+) -> str:
+    """A ``cron`` trigger — armed (``next_fire`` set) when enabled, per the
+    0130 ``triggers_schedulable_enabled_armed`` CHECK (enabled schedulable
+    rows must carry a non-NULL ``next_fire``)."""
+    trigger_id = make_id(TRIGGER)
+    await conn.execute(
+        f"""
+        INSERT INTO triggers (id, owner_session_id, account_id, name, source,
+            source_spec, action, enabled, next_fire)
+        VALUES ($1, $2, $3, $4, 'cron', '{{"schedule":"* * * * *"}}'::jsonb,
+            '{{"kind":"wake_owner","content":"hi"}}'::jsonb, $5, {"now()" if enabled else "NULL"})
+        """,
+        trigger_id,
+        owner_session_id,
+        ACCOUNT,
+        name,
+        enabled,
+    )
+    return trigger_id
+
+
+async def _count_account_enabled_triggers(conn: asyncpg.Connection[Any]) -> int:
+    result: int = await conn.fetchval(
+        "SELECT COUNT(*) FROM triggers WHERE account_id = $1 AND enabled",
+        ACCOUNT,
+    )
+    return result
+
+
+def _set_cap(monkeypatch: Any, cap: int) -> None:
+    """Patch the per-account trigger cap to ``cap``. ``clone_session`` reads it
+    via ``aios.config.get_settings`` (a function-local import), so that is the
+    symbol to patch."""
+    from aios.config import Settings
+
+    original = Settings()
+    monkeypatch.setattr(
+        "aios.config.get_settings",
+        lambda: original.model_copy(update={"triggers_per_account_max": cap}),
+    )
+
+
+async def test_clone_blocked_at_cap(pool: asyncpg.Pool[Any], monkeypatch: Any) -> None:
+    """Account already at the cap (via the parent's own enabled trigger) —
+    cloning would add another enabled trigger and breach it. The whole clone
+    must roll back: no new session, no new trigger rows."""
+    _set_cap(monkeypatch, 1)
+
+    async with pool.acquire() as conn:
+        await register_jsonb_codec(conn)
+        agent_id, env_id = await _seed_agent_env(conn)
+        parent = await _insert_session(conn, agent_id, env_id, workspace="/w/p")
+        await _insert_trigger(conn, parent, name="cron1", enabled=True)
+
+        session_count_before: int = await conn.fetchval("SELECT COUNT(*) FROM sessions")
+        trigger_count_before = await _count_account_enabled_triggers(conn)
+        assert trigger_count_before == 1
+
+        with pytest.raises(RateLimitedError, match="active-trigger cap"):
+            await clone_session(conn, parent, account_id=ACCOUNT, workspace_path="/w/clone")
+
+        session_count_after: int = await conn.fetchval("SELECT COUNT(*) FROM sessions")
+        assert session_count_after == session_count_before
+        assert await _count_account_enabled_triggers(conn) == trigger_count_before
+
+
+async def test_clone_allowed_under_cap(pool: asyncpg.Pool[Any], monkeypatch: Any) -> None:
+    """Account well under the cap — clone succeeds and the copied triggers
+    stay enabled + armed (existing copy semantics preserved)."""
+    _set_cap(monkeypatch, 5)
+
+    async with pool.acquire() as conn:
+        await register_jsonb_codec(conn)
+        agent_id, env_id = await _seed_agent_env(conn)
+        parent = await _insert_session(conn, agent_id, env_id, workspace="/w/p")
+        await _insert_trigger(conn, parent, name="cron1", enabled=True)
+        await _insert_trigger(conn, parent, name="cron2", enabled=True)
+
+        clone = await clone_session(conn, parent, account_id=ACCOUNT, workspace_path="/w/clone")
+
+        trows = await conn.fetch(
+            "SELECT * FROM triggers WHERE owner_session_id = $1 ORDER BY name", clone.id
+        )
+        assert len(trows) == 2
+        for row in trows:
+            assert row["enabled"] is True
+            assert row["next_fire"] is not None
+        assert await _count_account_enabled_triggers(conn) == 4  # 2 parent + 2 clone
+
+
+async def test_clone_trigger_free_unaffected_by_cap(
+    pool: asyncpg.Pool[Any], monkeypatch: Any
+) -> None:
+    """A parent with zero trigger rows clones fine even when the account is
+    already AT the cap from an unrelated session — a trigger-free parent still
+    takes the advisory lock (for ordering) but skips the cap CHECK, since its
+    empty row set means the copy INSERT definitively copies nothing."""
+    _set_cap(monkeypatch, 1)
+
+    async with pool.acquire() as conn:
+        await register_jsonb_codec(conn)
+        agent_id, env_id = await _seed_agent_env(conn)
+
+        # A sibling session pins the account at the cap.
+        capped = await _insert_session(conn, agent_id, env_id, workspace="/w/capped")
+        await _insert_trigger(conn, capped, name="cron-capped", enabled=True)
+
+        parent = await _insert_session(conn, agent_id, env_id, workspace="/w/p")
+        # No triggers on the parent at all.
+
+        clone = await clone_session(conn, parent, account_id=ACCOUNT, workspace_path="/w/clone")
+
+        trows = await conn.fetch("SELECT * FROM triggers WHERE owner_session_id = $1", clone.id)
+        assert trows == []
+
+
+async def test_clone_disabled_only_unaffected_by_cap(
+    pool: asyncpg.Pool[Any], monkeypatch: Any
+) -> None:
+    """A parent whose triggers are all disabled clones fine regardless of the
+    account cap — only enabled triggers count toward it, so the cap CHECK
+    passes (enabled_to_clone=0) even though the parent owns trigger rows."""
+    _set_cap(monkeypatch, 1)
+
+    async with pool.acquire() as conn:
+        await register_jsonb_codec(conn)
+        agent_id, env_id = await _seed_agent_env(conn)
+
+        # A sibling session pins the account at the cap.
+        capped = await _insert_session(conn, agent_id, env_id, workspace="/w/capped")
+        await _insert_trigger(conn, capped, name="cron-capped", enabled=True)
+
+        parent = await _insert_session(conn, agent_id, env_id, workspace="/w/p")
+        await _insert_trigger(conn, parent, name="paused1", enabled=False)
+        await _insert_trigger(conn, parent, name="paused2", enabled=False)
+
+        clone = await clone_session(conn, parent, account_id=ACCOUNT, workspace_path="/w/clone")
+
+        trows = await conn.fetch(
+            "SELECT * FROM triggers WHERE owner_session_id = $1 ORDER BY name", clone.id
+        )
+        assert len(trows) == 2
+        assert all(row["enabled"] is False for row in trows)
+
+
+async def test_clone_blocked_below_cap_by_added_copies(
+    pool: asyncpg.Pool[Any], monkeypatch: Any
+) -> None:
+    """The account is STRICTLY BELOW the cap, but the clone's copies would push
+    it over: cap=3, the parent is the account's only trigger owner with 2
+    enabled → existing_account=2 (below 3), the clone would add 2 more →
+    2 + 2 = 4 > 3, so it must raise and roll back. This isolates the
+    load-bearing ``+ enabled_to_clone`` addend: a regression to a bare
+    ``existing_account >= cap`` check would wrongly ALLOW this clone (2 < 3),
+    so no other test catches it.
+
+    (The parent must be the sole trigger owner because ``count_account_triggers``
+    counts the parent's OWN enabled rows in ``existing_account`` — a sibling
+    holding the other slots would push ``existing_account`` to/over the cap and
+    make even the regressed ``>=`` check fire, defeating the discrimination.)"""
+    _set_cap(monkeypatch, 3)
+
+    async with pool.acquire() as conn:
+        await register_jsonb_codec(conn)
+        agent_id, env_id = await _seed_agent_env(conn)
+
+        parent = await _insert_session(conn, agent_id, env_id, workspace="/w/p")
+        await _insert_trigger(conn, parent, name="cron1", enabled=True)
+        await _insert_trigger(conn, parent, name="cron2", enabled=True)
+
+        session_count_before: int = await conn.fetchval("SELECT COUNT(*) FROM sessions")
+        enabled_before = await _count_account_enabled_triggers(conn)
+        assert enabled_before == 2  # parent's 2, the account's only enabled rows — below cap 3
+
+        with pytest.raises(RateLimitedError, match="active-trigger cap"):
+            await clone_session(conn, parent, account_id=ACCOUNT, workspace_path="/w/clone")
+
+        # Whole clone rolled back: no new session, no copied triggers.
+        session_count_after: int = await conn.fetchval("SELECT COUNT(*) FROM sessions")
+        assert session_count_after == session_count_before
+        assert await _count_account_enabled_triggers(conn) == enabled_before
+
+
+async def test_concurrent_clones_serialize_on_account_lock(
+    pool: asyncpg.Pool[Any], monkeypatch: Any
+) -> None:
+    """Two concurrent clones of two DIFFERENT trigger-bearing parents (same
+    account, one enabled slot left) must serialize on the account advisory
+    lock: exactly one fits, the other raises ``RateLimitedError``. Distinct
+    parents matter — clones of the same parent already serialize on its
+    ``FOR UPDATE`` row lock, which would mask a missing advisory lock.
+    Mirrors ``tests/e2e/test_triggers.py::TestAdvisoryLockSerializesCapCheck``
+    for the clone path."""
+    import asyncio
+
+    _set_cap(monkeypatch, 3)
+
+    async with pool.acquire() as conn:
+        await register_jsonb_codec(conn)
+        agent_id, env_id = await _seed_agent_env(conn)
+        parents: list[str] = []
+        for n in range(2):
+            parent = await _insert_session(conn, agent_id, env_id, workspace=f"/w/p{n}")
+            await _insert_trigger(conn, parent, name=f"cron{n}", enabled=True)
+            parents.append(parent)
+    # Account at 2/3 enabled; each clone would add 1 — only one fits.
+
+    async def _clone(n: int, parent: str) -> bool:
+        async with pool.acquire() as conn:
+            await register_jsonb_codec(conn)
+            try:
+                await clone_session(conn, parent, account_id=ACCOUNT, workspace_path=f"/w/clone{n}")
+                return True
+            except RateLimitedError:
+                return False
+
+    results = await asyncio.gather(*(_clone(n, p) for n, p in enumerate(parents)))
+    successes = sum(results)
+    assert successes == 1, f"expected exactly 1 clone to fit the last slot, got {results}"
+
+    async with pool.acquire() as conn:
+        assert await _count_account_enabled_triggers(conn) == 3

--- a/tests/unit/test_log_redaction.py
+++ b/tests/unit/test_log_redaction.py
@@ -1,0 +1,109 @@
+"""Unit tests for ``redact_sensitive_path`` (plan 005).
+
+The per-trigger ingest bearer token (``aios_evt_…``) is a live credential
+carried in the URL path — the sole account-key-free auth for
+``POST /v1/triggers/ingest/{ingest_token}``. Before this change, the request
+log sites logged the raw path verbatim on every ingest call — including
+malformed/unknown-token probes. ``redact_sensitive_path`` replaces just the
+token segment of that one known route; every other path passes through
+unchanged.
+
+The middleware-integration counterpart of these tests lives in
+``test_request_logging_middleware.py`` (it reuses that file's ``_find_request_log``
+capture helper).
+
+These tests never use a real ``aios_evt_…``-prefixed token, only dummy
+literals, so no secret-scanner flags the fixtures.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from structlog.contextvars import clear_contextvars
+
+from aios.api._log_redaction import redact_sensitive_path
+from aios.errors import NotFoundError, install_exception_handlers
+from aios.logging import configure_logging
+
+_FAKE_TOKEN = "tok-not-a-real-secret"
+
+
+@pytest.fixture(autouse=True)
+def _clear_contextvars() -> object:
+    clear_contextvars()
+    yield
+    clear_contextvars()
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        _FAKE_TOKEN,
+        "0123456789abcdef",
+        "weird.chars_and-dashes~ok",
+    ],
+)
+def test_ingest_token_redacted_regardless_of_shape(token: str) -> None:
+    """The ingest route has nothing after the token segment, so any opaque
+    token shape in that position must be redacted."""
+    assert redact_sensitive_path(f"/v1/triggers/ingest/{token}") == "/v1/triggers/ingest/<redacted>"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/sessions/ses_123",
+        "/v1/triggers/tr_abc",
+        "/health",
+        "/v1/triggers",
+        "/v1/triggers/ingest",
+    ],
+)
+def test_other_paths_untouched(path: str) -> None:
+    assert redact_sensitive_path(path) == path
+
+
+def test_error_handler_log_redacts_ingest_token(caplog: pytest.LogCaptureFixture) -> None:
+    """Integration: the errors.py log site redacts the token on a 4xx/5xx
+    raised from the ingest-shaped path (e.g. the real route's uniform 404 on
+    an unknown/malformed token probe).
+
+    Captured via ``caplog`` (stdlib layer) with renderer-agnostic substring
+    assertions rather than ``capture_logs`` or JSON parsing. Two hazards make
+    the obvious approaches flaky here:
+
+    * ``errors.py``'s module logger is exercised across many test files and is
+      cached under ``cache_logger_on_first_use=True``; ``configure_logging``
+      installs a *fresh* processor-list instance on each call, so a logger
+      cached against an older list is NOT intercepted by ``capture_logs``
+      (which mutates only the current list) — yielding an order-dependent
+      empty capture.
+    * the line renders as JSON or ``key=value`` depending on
+      ``sys.stderr.isatty()`` (flips under ``pytest -s``), so JSON parsing is
+      fragile.
+
+    Reading the redacted path as a plain substring of the emitted stdlib record
+    is immune to both: ``caplog`` sees the record regardless of structlog proxy
+    caching, and the substring holds under either renderer."""
+    app = FastAPI()
+    install_exception_handlers(app)
+
+    @app.post("/v1/triggers/ingest/{ingest_token}")
+    async def _ingest(ingest_token: str) -> None:
+        raise NotFoundError("not found", detail={})
+
+    configure_logging("INFO")
+    client = TestClient(app, raise_server_exceptions=False)
+    with caplog.at_level(logging.WARNING):
+        resp = client.post(f"/v1/triggers/ingest/{_FAKE_TOKEN}", json={})
+    assert resp.status_code == 404
+
+    messages = [r.getMessage() for r in caplog.records if "api.error" in r.getMessage()]
+    assert messages, "no api.error log line captured"
+    msg = messages[0]
+    assert "/v1/triggers/ingest/<redacted>" in msg
+    assert _FAKE_TOKEN not in msg

--- a/tests/unit/test_request_logging_middleware.py
+++ b/tests/unit/test_request_logging_middleware.py
@@ -70,6 +70,31 @@ def test_request_log_line_emitted() -> None:
     assert rec["duration_ms"] >= 0
 
 
+def test_request_log_redacts_ingest_token() -> None:
+    """The per-trigger ingest bearer token (a live credential in the URL path)
+    is redacted on the api.request line, so it never persists in request logs.
+
+    ``_FAKE_TOKEN`` is a dummy literal (no real ``aios_evt_`` prefix); the route
+    has nothing after the token, so ``…/ingest/<anything>`` → ``…/ingest/<redacted>``.
+    """
+    fake_token = "tok-not-a-real-secret"
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.post("/v1/triggers/ingest/{ingest_token}")
+    async def _ingest(ingest_token: str) -> dict[str, bool]:
+        return {"ok": True}
+
+    client = TestClient(app)
+    with capture_logs() as entries:
+        resp = client.post(f"/v1/triggers/ingest/{fake_token}", json={})
+    assert resp.status_code == 200
+
+    rec = _find_request_log(entries)
+    assert rec is not None
+    assert rec["path"] == "/v1/triggers/ingest/<redacted>"
+
+
 def test_status_captured_for_404() -> None:
     app = FastAPI()
     app.add_middleware(RequestLoggingMiddleware)

--- a/tests/unit/test_search_events_allowlist_drift.py
+++ b/tests/unit/test_search_events_allowlist_drift.py
@@ -1,0 +1,95 @@
+"""Schema-drift guard for the ``search_events`` relation allowlist.
+
+``search_events`` runs the model's SQL on the privileged application pool with
+only ``SET LOCAL app.session_id`` — there is no Postgres row-level-security
+backstop. The sole tenancy guard is ``_ALLOWED_RELATIONS``: every table the
+parsed query reads must be one of those relations. That inverts the historical
+*denylist* (which failed open every time a table was added to the schema) into
+an *allowlist* (fail-closed by construction).
+
+The fail-closed default already covers new *tables* — they are inaccessible
+unless someone adds them to the allowlist. This guard covers the other
+direction: if someone *does* add a name to ``_ALLOWED_RELATIONS``, it must be a
+migration-defined view whose own body scopes rows by
+``current_setting('app.session_id')``. Allowlisting a name that is NOT so
+scoped would re-open the cross-tenant leak this fix closed.
+
+Pure-Python: scans ``migrations/versions/*.py`` off disk; no DB, no Docker.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from aios.tools.search_events import _ALLOWED_RELATIONS
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "migrations" / "versions"
+
+_CREATE_VIEW_RE = re.compile(
+    r"CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+(\w+)\s+AS",
+    re.IGNORECASE,
+)
+
+
+def _session_scoped_views() -> set[str]:
+    """Names of views created in the migrations whose own body references
+    ``current_setting('app.session_id')``.
+
+    Each view body is bounded to *its own* ``CREATE ... VIEW <name> AS`` — it
+    runs from the match to the next ``CREATE ... VIEW`` in the file or the
+    close of the surrounding ``op.execute(...)`` triple-quoted block, whichever
+    comes first — so two views defined in one block can't cross-contaminate (a
+    later view's ``app.session_id`` filter must not be attributed to an earlier
+    unscoped one). A view counts as session-scoped if *any* of its definitions
+    (upgrade or downgrade) filters on ``app.session_id``.
+
+    Heuristic caveat: textual presence of ``current_setting('app.session_id'``
+    in the body is a proxy — it doesn't prove the setting is used in a
+    *filtering* position (a WHERE/JOIN predicate) rather than, say, a projected
+    column. It's a drift tripwire, not a proof of scoping; the authoritative
+    scoping check is the migration's integration test.
+    """
+    scoped: set[str] = set()
+    for path in _VERSIONS_DIR.glob("*.py"):
+        src = path.read_text()
+        matches = list(_CREATE_VIEW_RE.finditer(src))
+        for i, m in enumerate(matches):
+            start = m.end()
+            bounds = [len(src)]
+            if i + 1 < len(matches):
+                bounds.append(matches[i + 1].start())
+            close = src.find('"""', start)
+            if close != -1:
+                bounds.append(close)
+            body = src[start : min(bounds)]
+            if "current_setting('app.session_id'" in body:
+                scoped.add(m.group(1))
+    return scoped
+
+
+# Computed once (globbing the migrations dir is not free) and shared by both
+# tests below.
+_SESSION_SCOPED_VIEWS = _session_scoped_views()
+
+
+def test_parser_finds_the_known_session_scoped_views() -> None:
+    """Sanity check the scanner against the two views we know exist, so a
+    regression that makes it match *nothing* can't vacuously pass the subset
+    assertion below."""
+    assert "events_search" in _SESSION_SCOPED_VIEWS
+    assert "memories_search" in _SESSION_SCOPED_VIEWS
+
+
+def test_allowlist_is_subset_of_session_scoped_views() -> None:
+    """Every allowlisted relation must be a migration-defined, session-scoped
+    view. A strict subset is fine — ``memories_search`` is session-scoped but
+    intentionally excluded (owned by the ``memory_search`` tool); the guard
+    only checks that whatever IS allowlisted enforces ``app.session_id``."""
+    unscoped = _ALLOWED_RELATIONS - _SESSION_SCOPED_VIEWS
+    assert not unscoped, (
+        f"search_events allowlists {sorted(unscoped)}, which are not "
+        f"migration-defined views scoped by current_setting('app.session_id'). "
+        f"Allowlisting a non-session-scoped relation re-opens the cross-tenant "
+        f"leak this guard exists to prevent."
+    )

--- a/tests/unit/test_search_events_handler.py
+++ b/tests/unit/test_search_events_handler.py
@@ -19,7 +19,16 @@ from aios.tools.search_events import (
 
 
 class TestValidateSql:
-    """Tests for _validate_sql pure function."""
+    """Tests for ``_validate_sql`` — the sqlglot AST walk that gates the tool.
+
+    The guarantee: the model's SQL surface is exactly the per-session
+    ``events_search`` view. Validation parses the query and walks the AST,
+    so it enforces the boundary structurally rather than by pattern-matching
+    text — closing the regex-era bypasses (comma cross-join, in-string comment
+    tricks, ``UNION TABLE``, ``pg_*`` in SELECT position).
+    """
+
+    # ── Legitimate queries pass ──────────────────────────────────────────────
 
     def test_valid_select(self) -> None:
         assert _validate_sql("SELECT * FROM events_search") is None
@@ -30,147 +39,202 @@ class TestValidateSql:
     def test_valid_select_with_where(self) -> None:
         assert _validate_sql("SELECT id FROM events_search WHERE role = 'user' LIMIT 10") is None
 
-    def test_valid_select_with_subquery(self) -> None:
-        assert _validate_sql("SELECT * FROM (SELECT id FROM events_search) sub") is None
-
-    def test_valid_select_ilike(self) -> None:
-        assert (
-            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE '%hello%'") is None
-        )
-
-    def test_valid_select_case_insensitive_keyword(self) -> None:
+    def test_valid_select_case_insensitive(self) -> None:
         assert _validate_sql("select * from events_search") is None
 
-    def test_rejects_insert(self) -> None:
-        err = _validate_sql("INSERT INTO foo VALUES (1)")
-        assert err is not None
-        assert "SELECT" in err
+    def test_allows_leading_whitespace(self) -> None:
+        assert _validate_sql("  SELECT 1") is None
 
-    def test_rejects_update(self) -> None:
-        err = _validate_sql("UPDATE foo SET x = 1")
+    def test_allows_no_from(self) -> None:
+        """A query with no relation target touches no table and is allowed."""
+        assert _validate_sql("SELECT 1") is None
+        assert _validate_sql("SELECT now()") is None
+
+    def test_allows_schema_qualified_public(self) -> None:
+        """Explicit ``public.`` qualification is fine — that's where the view
+        lives on the default search path. (The regex era rejected any schema
+        qualification; the AST distinguishes ``public`` from ``pg_catalog``.)"""
+        assert _validate_sql("SELECT * FROM public.events_search") is None
+
+    def test_allows_cte(self) -> None:
+        """CTEs are genuinely supported now: the CTE name is a local relation,
+        and its body is walked so a CTE reading a forbidden table is still
+        caught (see ``test_rejects_forbidden_table_inside_cte_body``)."""
+        assert _validate_sql("WITH x AS (SELECT * FROM events_search) SELECT * FROM x") is None
+
+    def test_allows_subquery(self) -> None:
+        assert _validate_sql("SELECT * FROM (SELECT * FROM events_search) s") is None
+
+    def test_allows_window_function(self) -> None:
+        assert (
+            _validate_sql("SELECT seq, row_number() OVER (ORDER BY seq) FROM events_search") is None
+        )
+
+    def test_allows_from_keyword_inside_string_literal(self) -> None:
+        """A ``FROM`` inside a string literal is not a relation target — the
+        parser sees it as a string, so this legitimate query passes."""
+        assert (
+            _validate_sql("SELECT count(*) FROM events_search WHERE body ILIKE '%FROM secret%'")
+            is None
+        )
+
+    def test_allows_current_setting(self) -> None:
+        """``current_setting`` is not ``pg_*`` / ``set_config`` — it only reads
+        the (already session-scoped) GUC and is harmless."""
+        assert _validate_sql("SELECT current_setting('app.session_id')") is None
+
+    # ── The four confirmed regex-era cross-tenant bypasses now REJECT ────────
+
+    def test_rejects_comma_cross_join(self) -> None:
+        """``FROM events_search, events`` — a comma cross-join. The regex only
+        scanned the token right after FROM/JOIN; the AST surfaces every table."""
+        err = _validate_sql("SELECT * FROM events_search, events")
+        assert err is not None
+        assert "events" in err
+
+    def test_rejects_in_string_comment_union_tricks(self) -> None:
+        """A comment opened inside a string literal used to fool the regex's
+        strip-comments-before-strings ordering, hiding a trailing ``UNION``.
+        The parser reads the literal correctly and surfaces the ``events`` arm."""
+        for q in (
+            "SELECT * FROM events_search WHERE x='a -- ' UNION SELECT * FROM events",
+            "SELECT * FROM events_search WHERE x='a /* ' UNION SELECT * FROM events",
+        ):
+            err = _validate_sql(q)
+            assert err is not None, f"in-string comment bypass allowed: {q!r}"
+            assert "events" in err
+
+    def test_rejects_union_table_primary(self) -> None:
+        """``UNION TABLE accounts`` — the ``TABLE`` primary form reaches a
+        relation without a FROM/JOIN keyword. sqlglot rejects it as unparseable
+        for our read path, so it fails closed."""
+        err = _validate_sql("SELECT * FROM events_search UNION TABLE accounts")
         assert err is not None
 
-    def test_rejects_delete(self) -> None:
-        err = _validate_sql("DELETE FROM foo")
+    def test_rejects_pg_function_in_select_position(self) -> None:
+        """``pg_read_file`` reads host files with no table reference at all —
+        the regex only looked at FROM/JOIN. The function scan blocks all
+        ``pg_*`` functions wherever they appear."""
+        err = _validate_sql("SELECT pg_read_file('/etc/passwd')")
+        assert err is not None
+        assert "pg_read_file" in err
+
+    # ── Forbidden relations ──────────────────────────────────────────────────
+
+    def test_rejects_direct_events_table(self) -> None:
+        """The underlying ``events`` table holds every account's rows; reading
+        it directly bypasses the view's ``app.session_id`` scoping."""
+        err = _validate_sql("SELECT data FROM events")
+        assert err is not None
+        assert "events" in err
+
+    def test_rejects_other_tables(self) -> None:
+        for table in ("vault_credentials", "accounts", "sessions", "connections"):
+            err = _validate_sql(f"SELECT * FROM {table}")
+            assert err is not None, f"validator allowed access to {table!r}"
+
+    def test_rejects_forgotten_tables_the_old_denylist_missed(self) -> None:
+        """The regression this fix closes: the old hand-maintained denylist
+        never listed these, so ``SELECT * FROM <them>`` ran on the privileged
+        pool and returned every account's rows. An allowlist blocks them by
+        default (fail-closed)."""
+        for table in ("runtime_tokens", "oauth_flows", "wf_run_events", "chat_sessions"):
+            err = _validate_sql(f"SELECT * FROM {table}")
+            assert err is not None, f"validator allowed access to {table!r}"
+            assert "not allowed" in err
+
+    def test_rejects_memories_search_view(self) -> None:
+        """Deliberate narrowing: ``memories_search`` is owned by the separate
+        ``memory_search`` tool (a fixed parameterised query), not part of
+        search_events' raw-SQL surface, so it is not allowlisted."""
+        err = _validate_sql("SELECT * FROM memories_search")
+        assert err is not None
+        assert "memories_search" in err
+        assert "events_search" in err
+
+    def test_rejects_quoted_forbidden_identifier(self) -> None:
+        err = _validate_sql("SELECT * FROM \"events\" WHERE session_id = 'sess_OTHER'")
         assert err is not None
 
-    def test_rejects_drop_in_subquery(self) -> None:
-        err = _validate_sql("SELECT * FROM events_search WHERE id IN (DROP TABLE events)")
+    def test_rejects_forbidden_table_inside_cte_body(self) -> None:
+        """A CTE whose body reads a forbidden table is caught on that table,
+        not waved through because the outer query only names the CTE."""
+        err = _validate_sql("WITH x AS (SELECT * FROM accounts) SELECT * FROM x")
+        assert err is not None
+        assert "accounts" in err
+
+    def test_rejects_forbidden_table_in_join(self) -> None:
+        err = _validate_sql("SELECT * FROM events_search e JOIN accounts a ON e.id = a.id")
+        assert err is not None
+        assert "accounts" in err
+
+    def test_rejects_table_function_fail_closed(self) -> None:
+        """A table-valued function in FROM (``generate_series``) parses to a
+        relation with an off name that isn't allowlisted — rejected."""
+        err = _validate_sql("SELECT * FROM generate_series(1, 10)")
         assert err is not None
 
-    def test_rejects_create(self) -> None:
-        err = _validate_sql("SELECT * FROM events_search; CREATE TABLE evil (id int)")
-        assert err is not None
-        # Caught by semicolon check first
-        assert "semicolon" in err.lower() or "multiple" in err.lower()
+    def test_rejects_schema_introspection(self) -> None:
+        """``pg_catalog`` / ``information_schema`` enumerate the whole catalogue
+        and are rejected as inaccessible schemas."""
+        for q in (
+            "SELECT * FROM pg_catalog.pg_tables",
+            "SELECT * FROM information_schema.tables",
+        ):
+            err = _validate_sql(q)
+            assert err is not None, f"validator allowed {q!r}"
 
-    def test_rejects_truncate(self) -> None:
-        err = _validate_sql("SELECT * FROM events_search WHERE TRUNCATE = 1")
+    def test_rejection_message_names_the_allowed_relation(self) -> None:
+        err = _validate_sql("SELECT * FROM runtime_tokens")
         assert err is not None
-        assert "TRUNCATE" in err
+        assert "runtime_tokens" in err
+        assert "search_events may only read events_search" in err
+
+    # ── Read-only enforcement ────────────────────────────────────────────────
+
+    def test_rejects_write_and_ddl_statements(self) -> None:
+        """DML/DDL and command statements (``COPY``/``CALL`` parse to
+        ``exp.Command``) are all rejected — none is a read."""
+        for q in (
+            "INSERT INTO foo VALUES (1)",
+            "UPDATE foo SET x = 1",
+            "DELETE FROM foo",
+            "DROP TABLE events",
+            "COPY events TO '/tmp/x'",
+            "CALL do_thing()",
+        ):
+            err = _validate_sql(q)
+            assert err is not None, f"validator allowed non-read statement: {q!r}"
+
+    def test_rejects_set_config(self) -> None:
+        """``set_config`` could rewrite ``app.session_id`` (widening the view to
+        another session) even inside a read-only transaction, so it is blocked
+        wherever it appears."""
+        err = _validate_sql("SELECT set_config('app.session_id', 'sess_OTHER', true)")
+        assert err is not None
+        assert "set_config" in err
+
+    def test_rejects_data_modifying_cte(self) -> None:
+        """A data-modifying CTE (``WITH x AS (DELETE ... RETURNING ...)``) is a
+        write hiding behind a SELECT root — the write-node walk rejects it."""
+        err = _validate_sql("WITH x AS (DELETE FROM events RETURNING id) SELECT * FROM x")
+        assert err is not None
+
+    # ── Malformed / multi-statement ──────────────────────────────────────────
 
     def test_rejects_semicolon(self) -> None:
         err = _validate_sql("SELECT 1; DROP TABLE events")
         assert err is not None
         assert "semicolon" in err.lower() or "multiple" in err.lower()
 
-    def test_rejects_semicolon_case_insensitive(self) -> None:
-        err = _validate_sql("select * from events_search; delete from x")
-        assert err is not None
-
-    def test_rejects_non_select_start(self) -> None:
-        err = _validate_sql("WITH cte AS (DELETE FROM events) SELECT 1")
-        assert err is not None
-        assert "SELECT" in err
-
-    def test_rejects_direct_events_table_query(self) -> None:
-        """The agent's SQL surface is the per-session ``events_search`` view.
-
-        Allowing direct access to the ``events`` table bypasses the view's
-        ``session_id = current_setting('app.session_id', true)`` filter and
-        returns events from any session in the database (cross-tenant leak,
-        since the table holds rows for every account).
-        """
-        err = _validate_sql("SELECT data FROM events")
-        assert err is not None
-
-    def test_rejects_query_against_other_table(self) -> None:
-        """Tables other than ``events_search`` are out of scope for the agent.
-
-        A read-only SELECT against ``vault_credentials`` / ``accounts`` /
-        ``sessions`` / etc. still leaks cross-tenant rows; the view scoping
-        only works when the agent is forced to use the view.
-        """
-        for table in ("vault_credentials", "accounts", "sessions", "connections"):
-            err = _validate_sql(f"SELECT * FROM {table}")
-            assert err is not None, f"validator allowed access to {table!r}"
-
-    def test_rejects_events_table_via_cte(self) -> None:
-        """CTEs that reference ``events`` directly are the same defect class."""
-        err = _validate_sql(
-            "WITH peek AS (SELECT data FROM events WHERE session_id = 'sess_OTHER') "
-            "SELECT * FROM peek"
-        )
-        assert err is not None
-
-    def test_rejects_events_via_quoted_identifier(self) -> None:
-        """Postgres double-quoted identifiers must not bypass the check."""
-        err = _validate_sql("SELECT * FROM \"events\" WHERE session_id = 'sess_OTHER'")
-        assert err is not None
-
-    def test_rejects_pg_catalog_introspection(self) -> None:
-        """Postgres catalog tables enumerate the whole schema and must be blocked."""
-        for q in (
-            "SELECT * FROM pg_catalog.pg_tables",
-            "SELECT * FROM pg_class",
-            "SELECT * FROM information_schema.tables",
-        ):
-            err = _validate_sql(q)
-            assert err is not None, f"validator allowed {q!r}"
-
-    def test_allows_ilike_substring_with_table_name(self) -> None:
-        """ILIKE patterns containing a forbidden token must not false-positive.
-
-        ``content_text ILIKE '%events%'`` is a legitimate substring search
-        on the agent's own messages; the literal-stripping pass strips
-        the quoted string so the structural regex doesn't see it.
-        """
-        assert (
-            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE '%events%'") is None
-        )
-        assert (
-            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE '%sessions%'")
-            is None
-        )
-
-    def test_rejects_events_via_dollar_quoted_evasion(self) -> None:
-        """Dollar-quoted strings (Postgres-specific) must be stripped before the check.
-
-        Without dollar-quote stripping, a model could write
-        ``'%' || $$evil events$$ || '%'`` to confuse a naïve scanner; we want
-        to make sure the dollar-quoted body doesn't seed false positives
-        (i.e. that legitimate dollar-quoted strings containing forbidden
-        words still validate cleanly).
-        """
-        # Dollar-quoted string with forbidden word inside the literal — legit.
-        assert (
-            _validate_sql("SELECT * FROM events_search WHERE content_text ILIKE $$%events table%$$")
-            is None
-        )
-        # Dollar-quoted around a real FROM events bypass attempt — must reject.
-        err = _validate_sql("SELECT * FROM events_search UNION SELECT * FROM events")
-        assert err is not None
-
     def test_rejects_empty_string(self) -> None:
-        err = _validate_sql("")
-        assert err is not None
+        assert _validate_sql("") is not None
 
     def test_rejects_whitespace_only(self) -> None:
-        err = _validate_sql("   ")
-        assert err is not None
+        assert _validate_sql("   ") is not None
 
-    def test_allows_leading_whitespace(self) -> None:
-        assert _validate_sql("  SELECT 1") is None
+    def test_rejects_unparseable(self) -> None:
+        assert _validate_sql("SELECT FROM WHERE ORDER") is not None
 
 
 # ─── Format Results ──────────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,7 @@ dependencies = [
     { name = "python-ulid" },
     { name = "pytz" },
     { name = "sqlalchemy" },
+    { name = "sqlglot" },
     { name = "sse-starlette" },
     { name = "structlog" },
     { name = "typer" },
@@ -186,6 +187,7 @@ requires-dist = [
     { name = "python-ulid", specifier = ">=3.0" },
     { name = "pytz", specifier = ">=2024.1" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "sqlglot", specifier = ">=30.12.0" },
     { name = "sse-starlette", specifier = ">=2.1" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "typer", specifier = ">=0.12" },
@@ -2458,6 +2460,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
     { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
     { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "30.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/ed/a6c45aec29353b6392ea34548c40af3ac6ffd6bc5572cf23b2ce250876fc/sqlglot-30.12.0.tar.gz", hash = "sha256:6b8369704662d4f654bc934cea4dd31c916c2a571b389210cb9e951a275e5fd9", size = 5905110, upload-time = "2026-06-26T14:09:40.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/9e/82a390ecc85f066ff80affa01d195f744e3de60ad4d695b8de31c9a66da3/sqlglot-30.12.0-py3-none-any.whl", hash = "sha256:86cccc610073c645c03e72b55b60ae0518aa3253a7fc3bd56551370d003c6554", size = 707583, upload-time = "2026-06-26T14:09:38.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Three independent security/correctness fixes from an `/improve` audit, each implemented in an isolated worktree, reviewed, then hardened through an xhigh `/code-review` pass. All three are disjoint in the files they touch and rebase cleanly onto current `master`.

## `fix(security): search_events gates SQL with a sqlglot AST allowlist`
`search_events` runs model-authored SQL on the privileged app pool with only `SET LOCAL app.session_id` and **no RLS backstop** — the sole tenant guard was a text scan. Code review found four confirmed cross-tenant bypasses:
- comma cross-join: `SELECT * FROM events_search, events`
- in-string comment tricks hiding a UNION: `... WHERE x = 'a -- ' UNION SELECT * FROM events`
- `SELECT * FROM events_search UNION TABLE accounts`
- `SELECT pg_read_file('/etc/passwd')`

Replaced the regex/denylist with a **sqlglot AST** validator: parse (fail-closed on ParseError), require a read-only SELECT, and require every `exp.Table` to be `events_search` (or a CTE name) in the `public`/default schema; reject `pg_*`/`set_config` functions and non-default schemas. Verified against a 28-case adversarial matrix (0 mismatches). CTEs/subqueries/window functions/schema-qualified `public.events_search` now validate correctly. Adds a `sqlglot>=30.12.0` dependency.

## `fix(triggers): enforce the per-account enabled-trigger cap in clone_session`
`clone_session` copied every parent trigger with `enabled`/`next_fire` preserved, with no cap check — a tenant at the cap could multiply armed triggers without bound by cloning. Now enforces `triggers_per_account_max` under the same advisory lock the sibling paths use, counting enabled triggers **under** the lock (TOCTOU-safe), atomic with the copy. The advisory lock is acquired **before** the parent `FOR UPDATE` to match the sibling lock order (avoids an AB/BA deadlock vs. concurrent `add_trigger`).

## `fix(security): redact the per-trigger ingest bearer token from request logs`
`POST /v1/triggers/ingest/{ingest_token}` carries a live bearer secret in the path. Both the request-logging middleware and the error handler logged it verbatim, **and** uvicorn's own access log logged it again. Adds a leaf-module path redactor called at both structlog sites and sets `access_log=False` on the uvicorn server (aios already logs each request, redacted). 

> **Operator follow-up on deploy:** existing `external_event` ingest tokens were logged in cleartext pre-fix — treat them as burned and rotate via `update_trigger` re-mint.

## Verification
`mypy`, `ruff check`/`format`, and `pytest tests/unit` (4163 passed) all green on the combined branch; the new `clone_session` cap tests pass against a Postgres testcontainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
