### PR TITLE
fix(security): harden worker-originated HTTP — pin connect IP + refuse plaintext-http credentials

### DIFF
--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -28,6 +28,7 @@ from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import InitializeResult
 
+from aios.config import get_settings
 from aios.crypto.vault import CryptoBox, EncryptedBlob
 from aios.db import queries
 from aios.logging import get_logger
@@ -35,6 +36,7 @@ from aios.mcp._constants import _MCP_HTTPX_TIMEOUT as _MCP_HTTPX_TIMEOUT_SHARED
 from aios.mcp.pool import HttpErrorSink
 from aios.mcp.schema import make_function_tool
 from aios.models.vaults import AuthType
+from aios.pinned_transport import PinnedTransport
 from aios.services.vaults import is_expiring, refresh_credential
 
 log = get_logger("aios.mcp.client")
@@ -135,8 +137,16 @@ async def _open_session(
     Returns the session along with the ``InitializeResult`` so callers can
     read server-supplied metadata (notably ``instructions``).
     """
+    # PinnedTransport resolves-validates-pins the connect IP per request: a
+    # tenant-supplied MCP URL (or a later DNS rebind of it) that resolves to a
+    # private/internal address is refused at the transport. The operator dev
+    # bypass set is the same one the OAuth connect flow honors.
     http_client = await stack.enter_async_context(
-        httpx.AsyncClient(headers=headers, timeout=_MCP_HTTPX_TIMEOUT)
+        httpx.AsyncClient(
+            headers=headers,
+            timeout=_MCP_HTTPX_TIMEOUT,
+            transport=PinnedTransport(allow_hosts=get_settings().oauth_allow_insecure_host_set),
+        )
     )
     read_stream, write_stream, _ = await stack.enter_async_context(
         streamable_http_client(url, http_client=http_client)

--- a/src/aios/mcp/client.py
+++ b/src/aios/mcp/client.py
@@ -39,6 +39,14 @@ from aios.models.vaults import AuthType
 from aios.pinned_transport import PinnedTransport
 from aios.services.vaults import is_expiring, refresh_credential
 
+# NOTE: ``aios.tools.url_safety`` is imported lazily inside the two credential
+# guards below — NOT at module top. This module is imported by
+# ``aios.tools.http_request`` (via ``resolve_auth_for_target_url``), so a
+# module-level ``from aios.tools...`` forces the ``aios.tools`` package
+# ``__init__`` to run mid-import and re-enters this partially-initialized module
+# (circular import). Deferring to call time keeps the import graph acyclic —
+# the same precedent as ``pinned_transport``/``secret_egress_proxy``.
+
 log = get_logger("aios.mcp.client")
 
 
@@ -393,10 +401,19 @@ async def discover_mcp_tools(
     into a 502 response because the sandboxed model DID initiate the call.
     """
     from aios.harness import runtime
+    from aios.tools.url_safety import is_cleartext_credential_target  # lazy — see module note
 
     _pool = runtime.mcp_session_pool
     merged = _merge_headers(spec_headers, headers)
     hkey = _headers_key(spec_headers)
+
+    if vault_id is not None and is_cleartext_credential_target(
+        url, allow_hosts=get_settings().oauth_allow_insecure_host_set
+    ):
+        raise ValueError(
+            f"refusing to send MCP credential over plaintext http: {url} — "
+            "use https or add the host to AIOS_OAUTH_ALLOW_INSECURE_HOSTS"
+        )
 
     if _pool is not None and binding_id is not None:
         cached = _pool.get_cached_tools(url, vault_id, hkey, binding_id)
@@ -531,10 +548,22 @@ async def call_mcp_tool(
     """
     try:
         from aios.harness import runtime
+        from aios.tools.url_safety import is_cleartext_credential_target  # lazy — see module note
 
         _pool = runtime.mcp_session_pool
         merged = _merge_headers(spec_headers, headers)
         hkey = _headers_key(spec_headers)
+
+        if vault_id is not None and is_cleartext_credential_target(
+            url, allow_hosts=get_settings().oauth_allow_insecure_host_set
+        ):
+            return {
+                "error": (
+                    f"refusing to send MCP credential over plaintext http: {url} — "
+                    "use https or allow-list the host"
+                ),
+                "code": "transport_error",
+            }
 
         if _pool is not None:
             # Circuit breaker (#1698 (d)): if this transport key is in a backoff

--- a/src/aios/mcp/pool.py
+++ b/src/aios/mcp/pool.py
@@ -55,8 +55,10 @@ from mcp.client.session import ClientSession, MessageHandlerFnT
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import InitializeResult
 
+from aios.config import get_settings
 from aios.logging import get_logger
 from aios.mcp._constants import _MCP_HTTPX_TIMEOUT as _MCP_HTTPX_TIMEOUT_SHARED
+from aios.pinned_transport import PinnedTransport
 
 log = get_logger("aios.mcp.pool")
 
@@ -361,11 +363,19 @@ class McpSessionPool:
         async def _own() -> None:
             try:
                 async with AsyncExitStack() as stack:
+                    # PinnedTransport resolves-validates-pins the connect IP per
+                    # request: a tenant-supplied MCP URL (or a later DNS rebind
+                    # of it) that resolves to a private/internal address is
+                    # refused at the transport. The operator dev bypass set is
+                    # the same one the OAuth connect flow honors.
                     http_client: Any = await stack.enter_async_context(
                         httpx.AsyncClient(
                             headers=headers,
                             timeout=_MCP_HTTPX_TIMEOUT,
                             event_hooks={"response": [_make_error_hook(sink)]},
+                            transport=PinnedTransport(
+                                allow_hosts=get_settings().oauth_allow_insecure_host_set
+                            ),
                         )
                     )
                     read_stream, write_stream, _ = await stack.enter_async_context(

--- a/src/aios/pinned_transport.py
+++ b/src/aios/pinned_transport.py
@@ -1,0 +1,119 @@
+"""Connect-time IP pinning for worker-originated HTTP — the DNS-rebinding SSRF fix.
+
+``is_safe_url`` pre-flight checks resolve a hostname, validate the IPs, then hand
+the *hostname* back to httpx, which re-resolves it at connect time. That is a
+resolve-then-connect TOCTOU: an attacker-controlled DNS server with TTL=0 can
+return a public IP for the check and a private IP for the connection.
+:class:`PinnedTransport` closes it at the transport layer: resolve ONCE, validate
+every returned IP, pin the connection to one of them, and keep SNI + certificate
+verification on the original hostname. Because the transport runs on every
+request — including each redirect hop — the guarantee holds by construction
+rather than by each call site remembering to pre-flight a URL string.
+
+:func:`resolve_pinned_ip` is the promoted primitive from the sandbox secret
+egress proxy (:mod:`aios.sandbox.secret_egress_proxy`), which re-imports it —
+the egress proxy remains the security-critical consumer, so its fail-closed /
+IPv4-preferred semantics are authoritative.
+
+NOTE: ``aios.tools.url_safety`` is imported lazily inside ``resolve_pinned_ip``
+(the only user) — not here. This module is imported by both ``aios.tools`` and
+``aios.mcp``; a module-level import of the ``aios.tools`` package would make its
+eager ``__init__`` part of this module's import graph and cycle. Deferring to
+call time keeps the import graph acyclic (same precedent as the egress proxy).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any
+
+import httpx
+
+
+async def _resolve_addrinfos(host: str, port: int) -> list[tuple[Any, ...]]:
+    """Async DNS resolution seam (monkeypatched in tests)."""
+    loop = asyncio.get_running_loop()
+    return list(await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM))
+
+
+async def resolve_pinned_ip(host: str, port: int) -> str | None:
+    """Re-resolve ``host`` at connect time and return ONE safe IP to pin the
+    connection to, or ``None`` if it must not be reached.
+
+    Fail-closed: a known-internal name, a resolution failure, an empty
+    result, or ANY resolved IP in a blocked range (loopback / link-local /
+    RFC-1918 / ULA / reserved / multicast / unspecified / CGNAT / metadata)
+    returns ``None``. This is the runtime, rebinding-resistant complement to
+    #872's create-time IP-literal rejection. Prefers an IPv4 address (the
+    worker is IPv4-only; a first-returned global IPv6 with no route would
+    502 a reachable host otherwise).
+    """
+    from aios.tools import url_safety  # deferred — see the import-graph note at module top
+
+    if url_safety.is_blocked_hostname(host):
+        return None
+    try:
+        infos = await _resolve_addrinfos(host, port)
+    except OSError:
+        return None
+    ips = [str(info[4][0]) for info in infos]
+    if not ips or any(url_safety.is_blocked_ip(ip) for ip in ips):
+        return None
+    return next((ip for ip in ips if ":" not in ip), ips[0])
+
+
+class PinnedTransport(httpx.AsyncBaseTransport):
+    """An httpx transport that pins each request's connection to a safe resolved IP.
+
+    Wraps an inner transport (composition, not subclassing): every request's host
+    is resolved-and-validated via :func:`resolve_pinned_ip`, the URL is rewritten
+    to the pinned IP, and for https the ``sni_hostname`` extension keeps SNI +
+    certificate verification on the real hostname. A host that resolves to any
+    blocked IP raises :class:`httpx.ConnectError` (an ``httpx.HTTPError``, so it
+    flows into callers' existing transport-error handling) without the inner
+    transport ever being reached.
+
+    ``allow_hosts`` (operator-controlled, e.g.
+    ``Settings.oauth_allow_insecure_host_set``) bypasses pinning entirely for
+    dev-internal hosts; entries match the bare host or ``host:port`` form,
+    mirroring ``_guard_url``.
+
+    The default inner transport disables keepalive
+    (``max_keepalive_connections=0``): pooled connections key on IP-origin only
+    and silently ignore a later request's ``sni_hostname`` on reuse, so two
+    hosts sharing a pinned IP could ride one another's verified TLS session.
+    """
+
+    def __init__(
+        self,
+        *,
+        allow_hosts: frozenset[str] = frozenset(),
+        inner: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._allow_hosts = allow_hosts
+        self._inner = (
+            inner
+            if inner is not None
+            else httpx.AsyncHTTPTransport(limits=httpx.Limits(max_keepalive_connections=0))
+        )
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        host = request.url.host
+        port = request.url.port or (443 if request.url.scheme == "https" else 80)
+        if host in self._allow_hosts or f"{host}:{port}" in self._allow_hosts:
+            return await self._inner.handle_async_request(request)
+        pinned = await resolve_pinned_ip(host, port)
+        if pinned is None:
+            raise httpx.ConnectError(f"blocked: {host} resolves to a private/internal address")
+        # Rewrite only the connect target; httpx brackets an IPv6 literal itself,
+        # and the Host header was frozen from the original URL at Request
+        # construction, so it still names the real host.
+        request.url = request.url.copy_with(host=pinned)
+        if request.url.scheme == "https":
+            # SNI + certificate verification stay on the real hostname.
+            request.extensions = {**request.extensions, "sni_hostname": host}
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()

--- a/src/aios/sandbox/secret_egress_proxy.py
+++ b/src/aios/sandbox/secret_egress_proxy.py
@@ -62,12 +62,10 @@ import contextlib
 import os
 import re
 import secrets
-import socket
 import ssl
 import tempfile
 import weakref
 from collections.abc import Iterable
-from typing import Any
 
 import h11
 import httpx
@@ -76,15 +74,9 @@ from cryptography.hazmat.primitives import serialization
 from aios.config import get_settings
 from aios.logging import get_logger
 from aios.models.vaults import parse_allowed_host_entry
+from aios.pinned_transport import resolve_pinned_ip
 from aios.sandbox.egress_ca import EgressCA, get_egress_ca, mint_server_leaf
 from aios.services.vaults import ResolvedEnvVarCredential
-
-# NOTE: ``aios.tools.url_safety`` is imported lazily inside ``_resolve_pinned_ip``
-# (the only user) — not here. A module-level ``from aios.tools import ...`` makes
-# the ``aios.tools`` package (whose ``__init__`` imports ``bash`` → ``sandbox.spec``,
-# which binds ``SecretEgressProxy`` back from this module) part of this module's
-# import graph, so a standalone ``import aios.sandbox.secret_egress_proxy`` cycles
-# and ImportErrors. Deferring to call time keeps the import graph acyclic.
 
 log = get_logger("aios.sandbox.secret_egress_proxy")
 
@@ -247,36 +239,11 @@ def _decode_basic_credential(value: str) -> str | None:
         return None
 
 
-async def _resolve_addrinfos(host: str, port: int) -> list[tuple[Any, ...]]:
-    """Async DNS resolution seam (monkeypatched in tests)."""
-    loop = asyncio.get_running_loop()
-    return list(await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM))
-
-
-async def _resolve_pinned_ip(host: str, port: int) -> str | None:
-    """Re-resolve ``host`` at connect time and return ONE safe IP to pin the
-    upstream connection to, or ``None`` if it must not be reached.
-
-    Fail-closed: a known-internal name, a resolution failure, an empty
-    result, or ANY resolved IP in a blocked range (loopback / link-local /
-    RFC-1918 / ULA / reserved / multicast / unspecified / CGNAT / metadata)
-    returns ``None``. This is the runtime, rebinding-resistant complement to
-    #872's create-time IP-literal rejection. Prefers an IPv4 address (the
-    worker is IPv4-only; a first-returned global IPv6 with no route would
-    502 a reachable host otherwise).
-    """
-    from aios.tools import url_safety  # deferred — see the import-graph note at module top
-
-    if url_safety.is_blocked_hostname(host):
-        return None
-    try:
-        infos = await _resolve_addrinfos(host, port)
-    except OSError:
-        return None
-    ips = [str(info[4][0]) for info in infos]
-    if not ips or any(url_safety.is_blocked_ip(ip) for ip in ips):
-        return None
-    return next((ip for ip in ips if ":" not in ip), ips[0])
+# Promoted to :mod:`aios.pinned_transport` (now shared with ``PinnedTransport``);
+# the egress proxy remains the security-critical consumer of its fail-closed /
+# IPv4-preferred semantics. The module-scope alias is load-bearing: the connect
+# path below and the tests' ``sep._resolve_pinned_ip`` monkeypatch resolve it here.
+_resolve_pinned_ip = resolve_pinned_ip
 
 
 def _h11_send(conn: h11.Connection, event: h11.Event) -> bytes:

--- a/src/aios/services/vault_oauth.py
+++ b/src/aios/services/vault_oauth.py
@@ -69,6 +69,7 @@ from aios.models.vaults import (
     VaultCredentialCreate,
     VaultCredentialUpdate,
 )
+from aios.pinned_transport import PinnedTransport
 from aios.services.vaults import (
     build_token_endpoint_post,
     create_vault_credential,
@@ -259,9 +260,13 @@ async def start_oauth_flow(
     # follow_redirects is OFF: is_safe_url validates the literal host, but a 3xx
     # to an internal host would bypass it (the redirect target is never guarded).
     # RFC 9728/8414 discovery hits well-known paths directly, so no redirect is
-    # needed for a spec-compliant provider.
+    # needed for a spec-compliant provider. PinnedTransport pins each request's
+    # connect IP at resolve time, closing the DNS-rebinding TOCTOU that the
+    # _guard_url pre-flights alone cannot.
     async with httpx.AsyncClient(
-        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS, follow_redirects=False
+        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS,
+        follow_redirects=False,
+        transport=PinnedTransport(allow_hosts=allow_insecure),
     ) as client:
         prm = await _discover_protected_resource(client, body.target_url)
         auth_server_url = (
@@ -466,8 +471,12 @@ async def _exchange_code(
     # follow_redirects OFF: the token_endpoint was SSRF-guarded at start and is
     # stored encrypted, but a token-exchange POST should never be redirected
     # anyway — a 3xx here can only point somewhere we didn't validate.
+    # PinnedTransport re-validates and pins the connect IP at request time, so a
+    # rebind of the stored endpoint's host cannot reach an internal address.
     async with httpx.AsyncClient(
-        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS, follow_redirects=False
+        timeout=_OAUTH_HTTP_TIMEOUT_SECONDS,
+        follow_redirects=False,
+        transport=PinnedTransport(allow_hosts=get_settings().oauth_allow_insecure_host_set),
     ) as client:
         try:
             resp = await client.post(token_endpoint, **post_kwargs)

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -45,6 +45,7 @@ from typing import Any, assert_never, cast
 import asyncpg
 import httpx
 
+from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.db.listen import MCP_EVICT_VAULT_CHANNEL
@@ -61,6 +62,7 @@ from aios.models.vaults import (
     VaultCredentialUpdate,
     parse_allowed_host_entry,
 )
+from aios.pinned_transport import PinnedTransport
 
 MAX_CREDENTIALS_PER_VAULT = 20
 
@@ -269,7 +271,14 @@ async def refresh_credential(
         )
 
         try:
-            async with httpx.AsyncClient(timeout=_REFRESH_HTTP_TIMEOUT_SECONDS) as client:
+            # The stored token_endpoint was SSRF-guarded once at flow start,
+            # possibly long ago; PinnedTransport re-validates and pins its
+            # connect IP now, so a since-rebound host can't pull the refresh
+            # credential onto an internal address.
+            async with httpx.AsyncClient(
+                timeout=_REFRESH_HTTP_TIMEOUT_SECONDS,
+                transport=PinnedTransport(allow_hosts=get_settings().oauth_allow_insecure_host_set),
+            ) as client:
                 resp = await client.post(token_endpoint, **post_kwargs)
                 resp.raise_for_status()
                 token_data = resp.json()

--- a/src/aios/services/vaults.py
+++ b/src/aios/services/vaults.py
@@ -270,6 +270,21 @@ async def refresh_credential(
             body, client_id=client_id, endpoint_auth=payload.get("token_endpoint_auth")
         )
 
+        # Lazy import: a module-level ``from aios.tools...`` would run the
+        # ``aios.tools`` package __init__ mid-import and re-enter this
+        # partially-initialized module (``aios.tools`` → ``bash``/``http_request``
+        # → ``sandbox.spec``/``mcp.client`` → ``services.vaults``). Same acyclic
+        # precedent as ``pinned_transport``/``mcp.client``.
+        from aios.tools.url_safety import is_cleartext_credential_target
+
+        if is_cleartext_credential_target(
+            token_endpoint, allow_hosts=get_settings().oauth_allow_insecure_host_set
+        ):
+            raise OAuthRefreshError(
+                "refusing to send refresh credential over plaintext http",
+                detail={"token_endpoint": token_endpoint, "vault_id": vault_id},
+            )
+
         try:
             # The stored token_endpoint was SSRF-guarded once at flow start,
             # possibly long ago; PinnedTransport re-validates and pins its

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -20,7 +20,6 @@ path the raise is translated back to a value-shaped ``{"error": ...}`` dict at t
 
 from __future__ import annotations
 
-import asyncio
 import os
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -36,13 +35,13 @@ from aios.models.agents import (
     StepSurface,
     http_route_suppressed,
 )
+from aios.pinned_transport import PinnedTransport
 from aios.services import agents as agents_service
 from aios.services import outbound_suppression as outbound_suppression_service
 from aios.services import sessions as sessions_service
 from aios.tools._glob_match import match_glob
 from aios.tools.invoke import ToolBail
 from aios.tools.registry import registry
-from aios.tools.url_safety import is_safe_url
 
 # The response-body character cap. Bodies longer than this are truncated — but
 # NEVER silently: the result dict carries ``"truncated": True`` so the caller can
@@ -374,10 +373,6 @@ async def _do_http_request(
             return synthesized
 
     full_url = server.base_url.rstrip("/") + "/" + path.lstrip("/")
-    # is_safe_url does a blocking getaddrinfo; offload it so the SSRF pre-flight
-    # never stalls the event loop (matches services/vault_oauth._guard_url).
-    if not await asyncio.to_thread(is_safe_url, full_url):
-        raise ToolBail(f"Blocked: URL targets a private/internal address: {full_url}")
 
     _vault_id, auth_headers = await resolve_auth(server.base_url)
 
@@ -393,7 +388,11 @@ async def _do_http_request(
     request_headers.update(auth_headers)
 
     try:
-        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        # PinnedTransport resolves-validates-pins the connect IP per request (every
+        # redirect hop included), closing the DNS-rebinding TOCTOU a hostname-level
+        # pre-flight can't. A blocked host surfaces as httpx.ConnectError → the
+        # HTTPError arm below → ToolBail.
+        async with httpx.AsyncClient(timeout=_TIMEOUT, transport=PinnedTransport()) as client:
             kwargs: dict[str, Any] = {"headers": request_headers}
             if body:
                 kwargs["content"] = body

--- a/src/aios/tools/http_request.py
+++ b/src/aios/tools/http_request.py
@@ -42,6 +42,7 @@ from aios.services import sessions as sessions_service
 from aios.tools._glob_match import match_glob
 from aios.tools.invoke import ToolBail
 from aios.tools.registry import registry
+from aios.tools.url_safety import is_cleartext_credential_target
 
 # The response-body character cap. Bodies longer than this are truncated — but
 # NEVER silently: the result dict carries ``"truncated": True`` so the caller can
@@ -375,6 +376,12 @@ async def _do_http_request(
     full_url = server.base_url.rstrip("/") + "/" + path.lstrip("/")
 
     _vault_id, auth_headers = await resolve_auth(server.base_url)
+
+    if auth_headers and is_cleartext_credential_target(full_url):
+        raise ToolBail(
+            f"refusing to attach a vault credential over plaintext http: {full_url} — "
+            "use https for this http_server's base_url"
+        )
 
     # Strip headers the worker manages on the caller's behalf. ``Authorization``
     # is rendered from the bound vault by ``resolve_auth``. ``Host`` is derived

--- a/src/aios/tools/url_safety.py
+++ b/src/aios/tools/url_safety.py
@@ -114,3 +114,20 @@ def is_safe_url(url: str) -> bool:
         # become SSRF bypass vectors
         log.warning("blocked_url_safety_error", url=url, error=str(exc))
         return False
+
+
+def is_cleartext_credential_target(url: str, *, allow_hosts: frozenset[str] = frozenset()) -> bool:
+    """True when sending a credential to ``url`` would expose it in cleartext:
+    the scheme is not https and the host is not operator-allow-listed.
+
+    Pure scheme+allowlist check — no DNS (connection-time IP validation is
+    ``PinnedTransport``'s job). Host matching mirrors ``_guard_url`` and
+    ``PinnedTransport``: the bare host or the ``host:port`` netloc form may
+    appear in ``allow_hosts`` (the dev-only ``Settings.oauth_allow_insecure_host_set``).
+    Callers AND this with "a credential is actually being attached".
+    """
+    parsed = urlparse(url)
+    if parsed.scheme == "https":
+        return False
+    host = (parsed.hostname or "").lower()
+    return host not in allow_hosts and parsed.netloc.lower() not in allow_hosts

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -4672,7 +4672,6 @@ async def test_tool_http_request_credential_e2e(wf_runtime: asyncpg.Pool[Any]) -
         captured: dict[str, Any] = {}
         with (
             mock.patch("aios.tools.http_request.httpx.AsyncClient", _capturing_client(captured)),
-            mock.patch("aios.tools.http_request.is_safe_url", return_value=True),
         ):
             await run_workflow_step(run_id)  # park at the tool
             await (

--- a/tests/unit/sandbox/test_secret_egress_proxy.py
+++ b/tests/unit/sandbox/test_secret_egress_proxy.py
@@ -25,15 +25,16 @@ import httpx
 import pytest
 from structlog.testing import capture_logs
 
+from aios import pinned_transport
 from aios.crypto.vault import CryptoBox
 from aios.harness import runtime
+from aios.pinned_transport import resolve_pinned_ip
 from aios.sandbox import secret_egress_proxy as sep
 from aios.sandbox.egress_ca import get_egress_ca
 from aios.sandbox.secret_egress_proxy import (
     SecretEgressProxy,
     _path_within_prefix,
     _request_path,
-    _resolve_pinned_ip,
 )
 from aios.services.vaults import SECRET_PLACEHOLDER_PREFIX, ResolvedEnvVarCredential
 
@@ -495,20 +496,24 @@ class TestResolvePinnedIp:
         return _resolve
 
     async def test_public_ip_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sep, "_resolve_addrinfos", self._addrinfos("93.184.216.34"))
-        assert await _resolve_pinned_ip("api.example.com", 443) == "93.184.216.34"
+        monkeypatch.setattr(
+            pinned_transport, "_resolve_addrinfos", self._addrinfos("93.184.216.34")
+        )
+        assert await resolve_pinned_ip("api.example.com", 443) == "93.184.216.34"
 
     @pytest.mark.parametrize(
         "ip", ["127.0.0.1", "169.254.169.254", "10.0.0.1", "192.168.1.1", "fd00::1", "100.64.0.1"]
     )
     async def test_blocked_ip_returns_none(self, ip: str, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sep, "_resolve_addrinfos", self._addrinfos(ip))
-        assert await _resolve_pinned_ip("api.example.com", 443) is None
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", self._addrinfos(ip))
+        assert await resolve_pinned_ip("api.example.com", 443) is None
 
     async def test_any_blocked_ip_in_set_blocks(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A good public IP alongside an internal one still fails closed.
-        monkeypatch.setattr(sep, "_resolve_addrinfos", self._addrinfos("93.184.216.34", "10.0.0.1"))
-        assert await _resolve_pinned_ip("api.example.com", 443) is None
+        monkeypatch.setattr(
+            pinned_transport, "_resolve_addrinfos", self._addrinfos("93.184.216.34", "10.0.0.1")
+        )
+        assert await resolve_pinned_ip("api.example.com", 443) is None
 
     async def test_blocked_hostname_returns_none_without_resolving(
         self, monkeypatch: pytest.MonkeyPatch
@@ -516,15 +521,17 @@ class TestResolvePinnedIp:
         def _boom(host: str, port: int) -> object:
             raise AssertionError("must not resolve a blocked hostname")
 
-        monkeypatch.setattr(sep, "_resolve_addrinfos", _boom)
-        assert await _resolve_pinned_ip("metadata.google.internal", 443) is None
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _boom)
+        assert await resolve_pinned_ip("metadata.google.internal", 443) is None
 
     async def test_prefers_ipv4(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # F11: AAAA first, A second → pin the reachable IPv4 (worker is v4-only).
         monkeypatch.setattr(
-            sep, "_resolve_addrinfos", self._addrinfos("2606:2800:220::1", "93.184.216.34")
+            pinned_transport,
+            "_resolve_addrinfos",
+            self._addrinfos("2606:2800:220::1", "93.184.216.34"),
         )
-        assert await _resolve_pinned_ip("api.example.com", 443) == "93.184.216.34"
+        assert await resolve_pinned_ip("api.example.com", 443) == "93.184.216.34"
 
     @pytest.mark.parametrize("exc", [socket.gaierror("nope"), OSError("EAI_SYSTEM")])
     async def test_resolution_failure_returns_none(
@@ -534,8 +541,8 @@ class TestResolvePinnedIp:
         async def _raise(host: str, port: int) -> list[tuple[object, ...]]:
             raise exc
 
-        monkeypatch.setattr(sep, "_resolve_addrinfos", _raise)
-        assert await _resolve_pinned_ip("api.example.com", 443) is None
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _raise)
+        assert await resolve_pinned_ip("api.example.com", 443) is None
 
 
 class TestLifecycle:

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -387,6 +387,70 @@ class TestHttpRequestHandler:
             )
         assert isinstance(captured["init_kwargs"]["transport"], PinnedTransport)
 
+    async def test_plaintext_http_with_credential_is_refused(self, _stub_runtime: Any) -> None:
+        """SECURITY-02: a vault credential must not travel cleartext. A server
+        whose base_url is plain http + an attached Authorization header is
+        refused before any dispatch."""
+        agent = _agent(
+            http_servers=[
+                _server(base_url="http://api.example.com/v1", routes=[_route("/lights/*")])
+            ]
+        )
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth({"Authorization": "Bearer x"}),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+            pytest.raises(ToolBail) as excinfo,
+        ):
+            await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        assert "plaintext" in excinfo.value.message
+        assert "url" not in captured  # refused before any upstream dispatch
+
+    async def test_https_with_credential_is_not_refused_by_scheme_rule(
+        self, _stub_runtime: Any
+    ) -> None:
+        """The same credentialed request over https is not refused by this rule
+        — it dispatches like any other happy path."""
+        agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth({"Authorization": "Bearer x"}),
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        assert result["status"] == 200
+
+    async def test_plaintext_http_without_credential_is_allowed(self, _stub_runtime: Any) -> None:
+        """A non-credentialed plaintext call is allowed — the rule gates on a
+        credential actually being attached, not on the scheme alone."""
+        agent = _agent(
+            http_servers=[
+                _server(base_url="http://api.example.com/v1", routes=[_route("/lights/*")])
+            ]
+        )
+        captured: dict[str, Any] = {}
+        stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
+        with (
+            _patch_load_agent(agent),
+            _patch_resolve_auth(),  # ("vlt_x", {}) — no auth header attached
+            patch("aios.tools.http_request.httpx.AsyncClient", stub),
+        ):
+            result = await http_request_handler(
+                "sess_x",
+                {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
+            )
+        assert result["status"] == 200
+
     async def test_method_not_allowed_returns_error(self, _stub_runtime: Any) -> None:
         # A route scoped to GET refuses a POST at the gate (no upstream dispatch).
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*", methods=["GET"])])])

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -18,6 +18,7 @@ from aios.models.agents import (
     StepSurface,
     ToolSpec,
 )
+from aios.pinned_transport import PinnedTransport
 from aios.tools.http_request import (
     _classify_permission,
     _decode_body,
@@ -305,10 +306,6 @@ def _patch_resolve_auth(headers: dict[str, str] | None = None) -> Any:
     )
 
 
-def _patch_safe_url(safe: bool = True) -> Any:
-    return patch("aios.tools.http_request.is_safe_url", return_value=safe)
-
-
 def _make_stub_client(
     *,
     response: httpx.Response | None = None,
@@ -320,7 +317,9 @@ def _make_stub_client(
     captured at import time so the patch doesn't recurse into itself."""
 
     class _Stub:
-        def __init__(self, **_: Any) -> None:
+        def __init__(self, **kw: Any) -> None:
+            if capture is not None:
+                capture["init_kwargs"] = kw
             if response is not None:
                 self._inner: httpx.AsyncClient | None = _REAL_ASYNC_CLIENT(
                     transport=httpx.MockTransport(lambda _req: response)
@@ -367,26 +366,26 @@ class TestHttpRequestHandler:
             )
         assert "does not match any enabled route" in excinfo.value.message
 
-    async def test_ssrf_blocked_url_returns_error(self, _stub_runtime: Any) -> None:
-        """The SSRF pre-flight blocks a private/internal target after the route
-        matches but before any upstream dispatch — coverage parity with
-        web_fetch's guard test (the offload to a worker thread doesn't change
-        this functional contract)."""
+    async def test_client_is_mounted_with_pinned_transport(self, _stub_runtime: Any) -> None:
+        """The SSRF guard lives in ``PinnedTransport`` (resolve-validate-pin at
+        connect time — see ``tests/unit/test_pinned_transport.py`` for the
+        behavioral rebinding assertions). The stub client swallows the transport,
+        so what this test can honestly pin down is *construction*: the dispatch
+        client must be mounted with ``PinnedTransport``, catching any future
+        refactor that silently drops the guard."""
         agent = _agent(http_servers=[_server(routes=[_route("/lights/*")])])
         captured: dict[str, Any] = {}
         stub = _make_stub_client(response=httpx.Response(200, content=b""), capture=captured)
         with (
             _patch_load_agent(agent),
-            _patch_safe_url(False),
+            _patch_resolve_auth(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
-            pytest.raises(ToolBail) as excinfo,
         ):
             await http_request_handler(
                 "sess_x",
                 {"server_ref": "hue", "path": "/lights/1", "method": "GET"},
             )
-        assert "private/internal" in excinfo.value.message
-        assert "url" not in captured  # blocked before any upstream dispatch
+        assert isinstance(captured["init_kwargs"]["transport"], PinnedTransport)
 
     async def test_method_not_allowed_returns_error(self, _stub_runtime: Any) -> None:
         # A route scoped to GET refuses a POST at the gate (no upstream dispatch).
@@ -396,7 +395,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             pytest.raises(ToolBail) as excinfo,
         ):
@@ -417,7 +415,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth({"Authorization": "Bearer xyz"}),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             result = await http_request_handler(
@@ -447,7 +444,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             pytest.raises(ToolBail),
         ):
@@ -488,7 +484,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             result = await http_request_handler(
@@ -515,7 +510,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             pytest.raises(ToolBail),
         ):
@@ -558,7 +552,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth({"Authorization": "Bearer xyz"}),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             result = await http_request_handler(
@@ -593,7 +586,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             result = await http_request_handler(
@@ -622,7 +614,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth({"Authorization": "Bearer xyz"}),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             result = await http_request_handler(
@@ -644,7 +635,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             result = await http_request_handler(
@@ -665,7 +655,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth({"Authorization": "Bearer broker-token"}),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             await http_request_handler(
@@ -705,7 +694,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth({"Authorization": "Bearer broker-token"}),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
         ):
             await http_request_handler(
@@ -736,7 +724,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             pytest.raises(ToolBail) as excinfo,
         ):
@@ -772,7 +759,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             pytest.raises(ToolBail),
         ):
@@ -809,7 +795,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             pytest.raises(ToolBail),
         ):
@@ -842,7 +827,6 @@ class TestHttpRequestHandler:
         with (
             _patch_load_agent(agent),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             pytest.raises(ToolBail),
         ):
@@ -878,7 +862,6 @@ class TestDoHttpRequest:
             return ("vlt", {"Authorization": "Bearer RUNTOKEN"})
 
         with (
-            _patch_safe_url(True),
             patch(
                 "aios.tools.http_request.httpx.AsyncClient",
                 _make_stub_client(response=httpx.Response(200, json={"ok": True}), capture=capture),
@@ -925,7 +908,6 @@ class TestOutboundSuppressionHttp:
         with (
             _patch_load_agent(agent, outbound_suppression="on"),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             patch(
                 "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
@@ -964,7 +946,6 @@ class TestOutboundSuppressionHttp:
         with (
             _patch_load_agent(agent, outbound_suppression="on"),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             patch(
                 "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
@@ -989,7 +970,6 @@ class TestOutboundSuppressionHttp:
         with (
             _patch_load_agent(agent, outbound_suppression="on"),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             patch(
                 "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
@@ -1013,7 +993,6 @@ class TestOutboundSuppressionHttp:
         with (
             _patch_load_agent(agent, outbound_suppression="on"),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             patch(
                 "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
@@ -1036,7 +1015,6 @@ class TestOutboundSuppressionHttp:
         with (
             _patch_load_agent(agent, outbound_suppression="on"),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch(
                 "aios.tools.http_request.outbound_suppression_service.record_http_suppression",
                 record,
@@ -1059,7 +1037,6 @@ class TestOutboundSuppressionHttp:
         with (
             _patch_load_agent(agent, outbound_suppression="off"),
             _patch_resolve_auth(),
-            _patch_safe_url(),
             patch("aios.tools.http_request.httpx.AsyncClient", stub),
             patch(
                 "aios.tools.http_request.outbound_suppression_service.record_http_suppression",

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -749,3 +749,46 @@ class TestSpecHeadersOutbound:
             )
 
         assert captured[0].get("X-MCP-Toolsets") == "issues"
+
+
+# ── SECURITY-02: refuse a vault credential over plaintext http ─────────────────
+
+
+class TestPlaintextCredentialGuard:
+    """A vault-bound MCP server (``vault_id is not None``) reached over plain
+    http must be refused before the transport is entered — the credential would
+    otherwise ride cleartext. A non-vault server (``vault_id is None``) or an
+    allow-listed host is not refused."""
+
+    async def test_discover_refuses_plaintext_credentialed(self) -> None:
+        with patch("aios.mcp.client.streamable_http_client") as transport:
+            with pytest.raises(ValueError, match="plaintext"):
+                await discover_mcp_tools("http://mcp.example.com/", "vlt_x", {}, "srv")
+            transport.assert_not_called()
+
+    async def test_call_refuses_plaintext_credentialed(self) -> None:
+        with patch("aios.mcp.client.streamable_http_client") as transport:
+            result = await call_mcp_tool("http://mcp.example.com/", "vlt_x", {}, "tool", {})
+            transport.assert_not_called()
+        assert result["code"] == "transport_error"
+        assert "plaintext" in result["error"]
+
+    async def test_discover_allowlisted_plaintext_proceeds(self) -> None:
+        from aios.config import Settings
+
+        settings = Settings(oauth_allow_insecure_hosts="mcp.internal:8080")
+        with (
+            patch("aios.mcp.client.get_settings", lambda: settings),
+            patch("aios.mcp.client.streamable_http_client", return_value=_transport()),
+            patch("aios.mcp.client.ClientSession", _session_ctx(_ok_session())),
+        ):
+            tools, _ = await discover_mcp_tools("http://mcp.internal:8080/", "vlt_x", {}, "srv")
+        assert tools == []  # proceeded past the guard into a (mocked) discovery
+
+    async def test_call_plaintext_without_vault_is_allowed(self) -> None:
+        with (
+            patch("aios.mcp.client.streamable_http_client", return_value=_transport()),
+            patch("aios.mcp.client.ClientSession", _session_ctx(_ok_session())),
+        ):
+            result = await call_mcp_tool("http://mcp.example.com/", None, {}, "tool", {})
+        assert result == {"content": "ok"}  # credential-gated: no vault_id, not refused

--- a/tests/unit/test_pinned_transport.py
+++ b/tests/unit/test_pinned_transport.py
@@ -1,0 +1,137 @@
+"""Unit tests for :class:`PinnedTransport` — the connect-time IP-pinning SSRF guard.
+
+The DNS seam (``pinned_transport._resolve_addrinfos``) is monkeypatched so no
+real lookups happen, and the inner transport is an ``httpx.MockTransport`` so no
+real sockets are opened. The resolver primitive itself
+(:func:`aios.pinned_transport.resolve_pinned_ip`) is covered by
+``TestResolvePinnedIp`` in ``tests/unit/sandbox/test_secret_egress_proxy.py``;
+these tests cover the transport behavior built on it.
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Awaitable, Callable
+
+import httpx
+import pytest
+
+from aios import pinned_transport
+from aios.pinned_transport import PinnedTransport
+
+
+def _addrinfos(*ips: str) -> Callable[[str, int], Awaitable[list[tuple[object, ...]]]]:
+    """A fake ``_resolve_addrinfos`` returning the given IPs (v6 detected by colon)."""
+
+    async def _resolve(host: str, port: int) -> list[tuple[object, ...]]:
+        out: list[tuple[object, ...]] = []
+        for ip in ips:
+            fam = socket.AF_INET6 if ":" in ip else socket.AF_INET
+            out.append((fam, socket.SOCK_STREAM, 0, "", (ip, port)))
+        return out
+
+    return _resolve
+
+
+def _inner(seen: list[httpx.Request]) -> httpx.MockTransport:
+    """An inner transport recording every request it is handed."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    return httpx.MockTransport(handler)
+
+
+class TestPinnedTransport:
+    async def test_rebind_to_private_ip_is_blocked_before_inner(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fix: a host that (re)resolves to a private IP at connect time is
+        refused at the transport — the inner transport is NEVER reached, so no
+        connection (and no request) can leak to the rebound address."""
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _addrinfos("10.0.0.1"))
+        seen: list[httpx.Request] = []
+        transport = PinnedTransport(inner=_inner(seen))
+        request = httpx.Request("GET", "https://api.example.com/secret")
+        with pytest.raises(httpx.ConnectError, match="private/internal"):
+            await transport.handle_async_request(request)
+        assert seen == []
+
+    async def test_public_ip_is_pinned_with_sni_and_original_host_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _addrinfos("93.184.216.34"))
+        seen: list[httpx.Request] = []
+        transport = PinnedTransport(inner=_inner(seen))
+        request = httpx.Request("GET", "https://api.example.com:8443/path?q=1")
+        response = await transport.handle_async_request(request)
+        assert response.status_code == 200
+        (inner_req,) = seen
+        # Connect target is the pinned IP; the port and request-target survive.
+        assert inner_req.url.host == "93.184.216.34"
+        assert inner_req.url.port == 8443
+        assert inner_req.url.raw_path == b"/path?q=1"
+        # SNI + cert verification stay on the real hostname, and the Host header
+        # (frozen at Request construction) still names it — never the IP.
+        assert inner_req.extensions["sni_hostname"] == "api.example.com"
+        assert inner_req.headers["host"] == "api.example.com:8443"
+
+    @pytest.mark.parametrize(
+        "ip", ["127.0.0.1", "169.254.169.254", "10.0.0.1", "192.168.1.1", "fd00::1", "100.64.0.1"]
+    )
+    async def test_blocked_ip_raises_connect_error(
+        self, ip: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _addrinfos(ip))
+        seen: list[httpx.Request] = []
+        transport = PinnedTransport(inner=_inner(seen))
+        with pytest.raises(httpx.ConnectError):
+            await transport.handle_async_request(httpx.Request("GET", "https://api.example.com/x"))
+        assert seen == []
+
+    async def test_ipv6_pin_renders_bracketed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        v6 = "2606:2800:220:1:248:1893:25c8:1946"
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _addrinfos(v6))
+        seen: list[httpx.Request] = []
+        transport = PinnedTransport(inner=_inner(seen))
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://api.example.com/x")
+        )
+        assert response.status_code == 200
+        (inner_req,) = seen
+        assert inner_req.url.host == v6
+        assert f"[{v6}]" in str(inner_req.url)  # httpx brackets the literal itself
+
+    @pytest.mark.parametrize("entry", ["workspace-mcp", "workspace-mcp:8000"])
+    async def test_allow_hosts_bypasses_pinning(
+        self, entry: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both forms _guard_url accepts — bare host and host:port — delegate to
+        the inner transport unpinned (no resolution, no sni_hostname)."""
+
+        async def _boom(host: str, port: int) -> list[tuple[object, ...]]:
+            raise AssertionError("an allow-listed host must not be resolved")
+
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _boom)
+        seen: list[httpx.Request] = []
+        transport = PinnedTransport(allow_hosts=frozenset({entry}), inner=_inner(seen))
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "http://workspace-mcp:8000/mcp")
+        )
+        assert response.status_code == 200
+        (inner_req,) = seen
+        assert inner_req.url.host == "workspace-mcp"  # original host, unpinned
+        assert "sni_hostname" not in inner_req.extensions
+
+    async def test_plain_http_pins_without_sni(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(pinned_transport, "_resolve_addrinfos", _addrinfos("93.184.216.34"))
+        seen: list[httpx.Request] = []
+        transport = PinnedTransport(inner=_inner(seen))
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "http://api.example.com/x")
+        )
+        assert response.status_code == 200
+        (inner_req,) = seen
+        assert inner_req.url.host == "93.184.216.34"
+        assert "sni_hostname" not in inner_req.extensions  # no cert to pin on http

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -1,0 +1,60 @@
+"""Unit tests for ``is_cleartext_credential_target`` (SECURITY-02).
+
+Pure scheme+allowlist predicate — no DNS. Callers AND it with "a credential is
+actually being attached"; here we test the predicate in isolation.
+"""
+
+from __future__ import annotations
+
+from aios.tools.url_safety import is_cleartext_credential_target
+
+
+class TestIsCleartextCredentialTarget:
+    def test_https_is_never_cleartext(self) -> None:
+        assert is_cleartext_credential_target("https://api.example.com/token") is False
+
+    def test_https_ignores_allow_hosts(self) -> None:
+        # https is safe regardless of the allow-list membership.
+        assert (
+            is_cleartext_credential_target(
+                "https://api.example.com", allow_hosts=frozenset({"api.example.com"})
+            )
+            is False
+        )
+
+    def test_plain_http_is_cleartext(self) -> None:
+        assert is_cleartext_credential_target("http://api.example.com/token") is True
+
+    def test_allow_listed_bare_host_bypasses(self) -> None:
+        assert (
+            is_cleartext_credential_target(
+                "http://api.example.com", allow_hosts=frozenset({"api.example.com"})
+            )
+            is False
+        )
+
+    def test_allow_listed_host_port_form_bypasses(self) -> None:
+        assert (
+            is_cleartext_credential_target(
+                "http://workspace-mcp:8000/mcp", allow_hosts=frozenset({"workspace-mcp:8000"})
+            )
+            is False
+        )
+
+    def test_allow_listed_bare_host_matches_host_with_port(self) -> None:
+        # A bare-host allow-list entry matches the hostname even when the URL
+        # carries an explicit port (mirrors _guard_url / PinnedTransport).
+        assert (
+            is_cleartext_credential_target(
+                "http://workspace-mcp:8000/mcp", allow_hosts=frozenset({"workspace-mcp"})
+            )
+            is False
+        )
+
+    def test_plain_http_with_unrelated_allow_hosts_is_cleartext(self) -> None:
+        assert (
+            is_cleartext_credential_target(
+                "http://api.example.com", allow_hosts=frozenset({"other-host"})
+            )
+            is True
+        )

--- a/tests/unit/test_vault.py
+++ b/tests/unit/test_vault.py
@@ -652,6 +652,37 @@ class TestRefreshCredential:
         conn.execute.assert_not_awaited()  # row not updated
 
     @pytest.mark.asyncio
+    async def test_refuses_plaintext_token_endpoint(self, crypto_box: CryptoBox) -> None:
+        """SECURITY-02: an expiring credential whose stored ``token_endpoint`` is
+        plain http is refused before the POST — the refresh_token/client_secret
+        must not travel cleartext even though the endpoint was https-guarded at
+        flow start."""
+        account_id = "acc_test_stub"
+        payload = _expiring_oauth_payload(token_endpoint="http://issuer.example/token")
+        blob = crypto_box.derive_account_subkey(account_id).encrypt(json.dumps(payload))
+        conn = _conn_with_transaction()
+        client = _async_client_returning(_http_response(body={"access_token": "new"}))
+
+        with (
+            patch.object(
+                queries,
+                "lock_oauth_credential_for_refresh",
+                AsyncMock(return_value=("vc_1", blob)),
+            ),
+            patch.object(httpx, "AsyncClient", MagicMock(return_value=client)),
+            pytest.raises(OAuthRefreshError, match="plaintext"),
+        ):
+            await refresh_credential(
+                crypto_box,
+                conn,
+                vault_id="vlt_1",
+                target_url="http://issuer.example",
+                account_id=account_id,
+            )
+
+        client.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_basic_method_uses_basic_auth(self, crypto_box: CryptoBox) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
         import httpx as _httpx


### PR DESCRIPTION
Hardens the confidentiality and destination-integrity of every worker-originated HTTP client. Two related, independently-reviewed commits.

## 1. Pin the resolved IP at connect time (`361866d9`)

`is_safe_url()` validates a hostname's IPs at pre-flight, then hands the *hostname* to httpx, which re-resolves at connect time — a resolve-then-connect TOCTOU that `url_safety`'s own module docstring already documents as "not fixable at pre-flight level" and points at connection-level validation to close.

This promotes the sandbox egress proxy's proven resolve-validate-pin primitive into a small shared `PinnedTransport` (`src/aios/pinned_transport.py`) and mounts it on every worker-originated httpx client: `http_request`, both OAuth clients, the credential-refresh POST, and both MCP clients (the last previously had no guard at all). Pinning happens **at the transport layer**, so it applies by construction on every request — including each redirect hop — rather than by each call site remembering to pre-flight a URL. SNI and certificate verification stay on the real hostname (`sni_hostname` extension); TLS verification is never weakened.

## 2. Refuse to send a vault credential over plaintext `http://` (`17bbf4d5`)

A vault-resolved credential (auth header, OAuth access token, or refresh token + client secret) attached to a plaintext `http://` target travels the wire in cleartext. A shared `is_cleartext_credential_target()` predicate now guards the four credential-attachment sites (`http_request` when a credential is attached, both MCP entry points when a vault is bound, and the OAuth refresh POST), refusing before dispatch. The operator dev-only allowlist (`AIOS_OAUTH_ALLOW_INSECURE_HOSTS`) preserves the self-hosted-http-fleet flow; production (https) is unaffected.

## Scope & safety

- No TLS verification is ever disabled.
- The connection-keepalive-off setting on the shared transport mirrors the egress proxy's documented cross-host SNI-reuse fix.
- The OAuth interactive discovery/exchange path was already https-enforced (`_guard_url`) and is untouched.

## Verification

- `mypy src tests` — clean
- `ruff check` + `ruff format --check` — clean
- `pytest tests/unit -q` — **4170 passed**

New tests assert the honest properties: on a rebind-to-private-IP the inner transport is never reached, and a credential is never dispatched over plaintext (`test_pinned_transport.py`, `test_url_safety.py`, plus additions to `test_http_request.py` / `test_mcp_client.py` / `test_vault.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)