### PR TITLE
model_token_class_ratios scans every calibration span ever logged, every 60s on the step hot path

### DIFF
--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -185,6 +185,16 @@ async def _latest_cumulative_state(
 
 
 _MODEL_TOKEN_RATIO_MIN_SAMPLES = 5
+# Hard cap on the number of calibration spans the per-model ridge fit pulls
+# per query.  Without it the fetch had no ORDER BY / LIMIT / time bound and
+# scanned *every* successful calibration span ever logged for the model — a
+# row count that grows linearly and forever — on the step hot path
+# (``read_windowed_events``), eventually tripping the pool's 30 s
+# ``statement_timeout`` inside the session step and JSON-decoding all N rows
+# on the event loop.  1000 is large enough for a stable ridge fit while
+# riding migration 0024's ``((data->>'model'), seq DESC)`` partial index as a
+# bounded seek (``ORDER BY seq DESC LIMIT $2``).  See issue #1711.
+_MODEL_TOKEN_RATIO_SAMPLE_LIMIT = 1000
 _MODEL_TOKEN_RATIO_MIN = 0.5
 _MODEL_TOKEN_RATIO_BUCKET_FLOOR = 0.001
 _MODEL_TOKEN_RATIO_CACHE_TTL_SECONDS = 60.0
@@ -373,6 +383,23 @@ async def model_token_class_ratios(
     cached portions included — do NOT add ``cache_*`` breakdowns).  Uses
     the ``events_model_request_end_calibration_idx`` partial index
     (migration 0024).
+
+    **``account_id`` is intentionally not a query predicate — by design.**
+    These coefficients are model-intrinsic: the provider ``input_tokens``
+    is regressed on model-neutral, account-neutral local class counts, so
+    the fit is a deliberate *global-per-model* aggregate, not a
+    per-tenant one.  This is NOT a tenant leak.  Do **not** add an
+    ``account_id`` predicate: it would fragment the sample (slowing
+    calibration convergence) and require a new index without buying any
+    correctness.  The param is kept for signature/cache-key compatibility
+    with the scalar contract.
+
+    The fetch is bounded to the most recent
+    :data:`_MODEL_TOKEN_RATIO_SAMPLE_LIMIT` spans via ``ORDER BY seq DESC
+    LIMIT`` (issue #1711).  This rides the 0024 index as a bounded index
+    seek rather than an unbounded lifetime scan on the step hot path; the
+    limit is large enough that the ridge fit is stable while capping both
+    the SQL scan and the per-row JSON decode done on the event loop.
     """
     if k_bucket <= 0:
         raise ValueError("k_bucket must be positive")
@@ -403,8 +430,15 @@ async def model_token_class_ratios(
           AND (data->'model_usage') ? 'input_tokens'
           AND (data->'model_usage'->>'input_tokens') IS NOT NULL
           AND (data->>'local_tokens')::bigint > 0
+        -- Bound the scan to the most recent N spans (issue #1711): rides
+        -- migration 0024's ``((data->>'model'), seq DESC)`` partial index
+        -- as a bounded seek instead of a full lifetime scan on the step
+        -- hot path.  MIN_SAMPLES is still checked below the fetch.
+        ORDER BY seq DESC
+        LIMIT $2
         """,
         model,
+        _MODEL_TOKEN_RATIO_SAMPLE_LIMIT,
     )
 
     if len(rows) < _MODEL_TOKEN_RATIO_MIN_SAMPLES:

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -19,6 +19,7 @@ import uuid
 import pytest
 
 from aios.db import queries
+from aios.db.queries.events import _MODEL_TOKEN_RATIO_SAMPLE_LIMIT
 from aios.harness.tokens import CONTENT_CLASSES
 from aios.services import sessions as sessions_service
 from tests.e2e.harness import Harness
@@ -236,8 +237,10 @@ class TestModelTokenRatioSQL:
         assert ratio == pytest.approx(2.0, abs=0.01)
 
     async def test_lifetime_aggregate_retains_old_samples(self, harness: Harness) -> None:
-        """All historical calibration samples for the model contribute to
-        the aggregate; older samples do not fall out of a LIMIT-N window."""
+        """Below the sample limit, all historical calibration samples for the
+        model contribute to the aggregate (60 spans << the 1000-span bound of
+        issue #1711, so the ORDER BY seq DESC LIMIT is a no-op here); older
+        samples do not fall out of the window."""
         account_id = "acc_test_stub"  # PR 3 scaffolding
         model = f"test-model-{uuid.uuid4().hex[:8]}"
         session = await harness.start("seed")
@@ -305,3 +308,30 @@ class TestModelTokenRatioSQL:
         async with harness._pool.acquire() as conn:
             ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
         assert ratio == pytest.approx(1.5, abs=0.005)
+
+    async def test_recency_bound_honors_recent_spans(self, harness: Harness) -> None:
+        """Recency honored (issue #1711): seed MORE than the sample limit,
+        with a deliberately skewed OLD tail (ratio 4.0) below the newest
+        ``_MODEL_TOKEN_RATIO_SAMPLE_LIMIT`` spans (ratio 1.5).  The
+        ``ORDER BY seq DESC LIMIT $2`` bound must select only the recent
+        window, so the fit reflects the recent regime, not the old tail."""
+        account_id = "acc_test_stub"  # PR 3 scaffolding
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        # Old, skewed tail (ratio 4.0): seeded FIRST, so lowest seq.
+        for _ in range(20):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=400
+            )
+        # Recent regime (ratio 1.5): fills the entire bounded window.
+        for _ in range(_MODEL_TOKEN_RATIO_SAMPLE_LIMIT):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(
+                conn, model, k_bucket=0.001, account_id=account_id
+            )
+        # Only the recent (1.5) spans are in-window; the 4.0 tail is excluded
+        # by the LIMIT, so the fit lands at the recent regime, not a blend.
+        assert ratio == pytest.approx(1.5, abs=0.02)

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -28,6 +28,7 @@ from aios.db.queries import (
     model_token_class_ratios,
     model_token_ratio,
 )
+from aios.db.queries.events import _MODEL_TOKEN_RATIO_SAMPLE_LIMIT
 from aios.harness.tokens import CONTENT_CLASSES
 
 # The three classes the synthetic calibration data exercises; the rest stay
@@ -133,7 +134,10 @@ class TestModelTokenClassRatios:
           (regression for the pre-#163 double-count).
         * Excludes rows lacking ``local_tokens_by_class`` (zero backfill;
           self-heals as new spans accumulate).
-        * No ``LIMIT`` window — lifetime calibration.
+        * Bounds the scan to the most recent N spans via
+          ``ORDER BY seq DESC LIMIT $2`` (issue #1711), riding migration
+          0024's ``seq DESC`` partial index instead of an unbounded
+          lifetime scan on the step hot path.
         """
         conn = _mock_conn([])
         await model_token_class_ratios(conn, "model-x", account_id="acc_test_stub")
@@ -142,7 +146,69 @@ class TestModelTokenClassRatios:
         assert "cache_read_input_tokens" not in sql
         assert "cache_creation_input_tokens" not in sql
         assert "data ? 'local_tokens_by_class'" in sql
-        assert "LIMIT" not in sql
+        assert "ORDER BY seq DESC" in sql
+        assert "LIMIT $2" in sql
+
+    @pytest.mark.asyncio
+    async def test_fetch_bound_to_sample_limit_constant(self) -> None:
+        """The LIMIT is bound to the module constant (locked at 1000, issue
+        #1711), passed as ``$2`` alongside the model — not inlined — so the
+        scan is a bounded seek rather than a full lifetime scan."""
+        conn = _mock_conn([])
+        await model_token_class_ratios(conn, "model-x", account_id="acc_test_stub")
+        args = conn.fetch.await_args
+        assert args is not None
+        # $1 = model, $2 = the sample limit.
+        assert args.args[1] == "model-x"
+        assert args.args[2] == _MODEL_TOKEN_RATIO_SAMPLE_LIMIT
+        assert _MODEL_TOKEN_RATIO_SAMPLE_LIMIT == 1000
+
+    @pytest.mark.asyncio
+    async def test_sub_limit_sample_fits_identically_to_lifetime(self) -> None:
+        """No-op below the limit: with fewer than the limit spans, every row
+        the pre-#1711 unbounded query would have returned is still selected,
+        so the fit is byte-identical (same rows in, same coefficients out)."""
+        true = {"text": 2.0, "tool_result": 1.4, "thinking": 3.0}
+        rows = _linear_rows(true, n=_MODEL_TOKEN_RATIO_SAMPLE_LIMIT - 1)
+        conn = _mock_conn(rows)
+        bounded = await model_token_class_ratios(conn, "model-sub", account_id="acc_test_stub")
+        # The unbounded lifetime fit over the identical row set: _fit_class_ratios
+        # is deterministic in its input rows, so equal rows ⇒ equal fit.
+        from aios.db.queries.events import _fit_class_ratios
+
+        lifetime = _fit_class_ratios(rows)
+        assert lifetime is not None
+        assert bounded == lifetime
+
+    @pytest.mark.asyncio
+    async def test_recency_honored_recent_rows_drive_fit(self) -> None:
+        """Recency: the DB returns the most recent N (``ORDER BY seq DESC
+        LIMIT``); a deliberately skewed *old* tail beyond N is never fetched,
+        so the fit reflects only the recent regime.
+
+        The mock stands in for the DB's ``ORDER BY seq DESC LIMIT $2`` seek:
+        it returns exactly the recent-N slice, and the assertion proves the
+        old tail (a wildly different coefficient regime) does not move the
+        fit — i.e. the bound is honored, not silently ignored."""
+        recent = {"text": 2.0, "tool_result": 1.4, "thinking": 3.0}
+        old_skew = {"text": 8.0, "tool_result": 8.0, "thinking": 8.0}
+        recent_rows = _linear_rows(recent, n=_MODEL_TOKEN_RATIO_SAMPLE_LIMIT)
+        old_rows = _linear_rows(old_skew, n=500)
+        # The DB, honoring ORDER BY seq DESC LIMIT, hands back only the recent N.
+        conn = _mock_conn(recent_rows)
+        recent_only_fit = await model_token_class_ratios(
+            conn, "model-recent", account_id="acc_test_stub"
+        )
+        # If the bound were dropped, the fit would train on recent + old tail.
+        from aios.db.queries.events import _fit_class_ratios
+
+        contaminated = _fit_class_ratios(recent_rows + old_rows)
+        assert contaminated is not None
+        # The recent-only fit must NOT equal the contaminated lifetime fit,
+        # and must track the recent regime.
+        assert recent_only_fit != contaminated
+        for c, v in recent.items():
+            assert recent_only_fit[c] == pytest.approx(v, abs=0.25)
 
     @pytest.mark.asyncio
     async def test_invalid_bucket_rejected(self) -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1711.