### PR TITLE
Onboarding blocker: .env.example missing required AIOS_EGRESS_CA_KEY, plus CLAUDE.md / run-checks.sh drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ AIOS_API_KEY=
 # Generate with: openssl rand -base64 32
 AIOS_VAULT_KEY=replace-me
 
+# Required: 32 random bytes, base64-encoded, key for the sandbox egress CA.
+# Deliberately SEPARATE from AIOS_VAULT_KEY: keeping the CA key distinct means a
+# vault-key holder can't also mint sandbox-trusted TLS certs. Use a fresh value.
+# Generate with: openssl rand -base64 32
+AIOS_EGRESS_CA_KEY=replace-me
+
 # Required: Postgres connection URL.
 AIOS_DB_URL=postgresql://aios:aios@localhost:5432/aios
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ uv sync --dev
 # Run checks (do all three before every commit)
 uv run mypy src tests
 uv run ruff check src tests && uv run ruff format --check src tests
-uv run pytest tests/unit -q                    # ~160 test files, fast, no Docker needed (CI runs -n 4)
+uv run pytest tests/unit -q                    # hundreds of test files, fast, no Docker needed (CI runs -n 4)
 
 # E2E tests (need Docker for testcontainer Postgres + sandbox)
 DOCKER_HOST=unix:///Users/tom/.docker/run/docker.sock uv run pytest tests/e2e -q
@@ -25,7 +25,7 @@ set -a && source .env && set +a
 uv run aios migrate
 
 # Start the system (two processes)
-uv run python -m aios api      # API server on :8090
+uv run python -m aios api      # API server on :8080 (AIOS_API_PORT)
 uv run python -m aios worker   # procrastinate worker
 ```
 

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -36,13 +36,14 @@ OVERALL=0
 fail() { OVERALL=1; [[ $FAIL_FAST -eq 1 ]] && exit 1; }
 
 # Lint/type targets, kept in lock-step with code-validation.yml's lint job:
-# the harness (src/tests), the hand-written aios-sdk surface, the three
-# connector source trees (signal/telegram/whatsapp — echo-http has no src/),
-# and the connector-http package (which lives at the package root, not src/).
+# the harness (src/tests), the hand-written aios-sdk surface, the four
+# connector source trees (signal/slack/telegram/whatsapp — echo-http has no
+# src/), and the connector-http package (which lives at the package root, not
+# src/).
 LINT_TARGETS=(
     src tests
     packages/aios-sdk/aios_sdk
-    connectors/signal/src connectors/telegram/src connectors/whatsapp/src
+    connectors/signal/src connectors/slack/src connectors/telegram/src connectors/whatsapp/src
     packages/aios-connector-http/aios_connector_http
 )
 
@@ -91,9 +92,11 @@ if ! should_skip tests; then
     # Postgres/Docker/network.
     echo "── pytest (connectors) ──"
     uv run pytest connectors/signal/tests -q || fail
+    uv run pytest connectors/slack/tests -q || fail
     uv run pytest connectors/telegram/tests -q || fail
     uv run pytest connectors/whatsapp/tests -q || fail
     uv run pytest packages/aios-connector-http/tests -q || fail
+    uv run pytest packages/aios-sdk/tests -q || fail
 fi
 
 echo ""

--- a/tests/unit/test_onboarding_docs_drift.py
+++ b/tests/unit/test_onboarding_docs_drift.py
@@ -41,7 +41,9 @@ def test_env_example_declares_required_egress_ca_key() -> None:
 def test_claude_md_has_no_stale_port_or_test_count() -> None:
     """CLAUDE.md must not carry the stale :8090 port or a hardcoded test count."""
     claude = _read("CLAUDE.md")
-    assert ":8090" not in claude, "CLAUDE.md still references the stale :8090 port; api_port default is 8080."
+    assert ":8090" not in claude, (
+        "CLAUDE.md still references the stale :8090 port; api_port default is 8080."
+    )
     assert "160 test" not in claude, (
         "CLAUDE.md hardcodes a test-file count that re-rots; use an "
         "order-of-magnitude phrase instead."

--- a/tests/unit/test_onboarding_docs_drift.py
+++ b/tests/unit/test_onboarding_docs_drift.py
@@ -1,0 +1,65 @@
+"""Guard onboarding docs / local check-runner against known drift (issue #1712).
+
+These files are the fresh-contributor onramp; when they drift from the runtime
+config or from ``.github/workflows/code-validation.yml`` they silently mislead:
+
+* ``.env.example`` must declare every *required* (no-default) setting, or a
+  contributor who copies it still hits a pydantic ``ValidationError`` on first
+  run. ``egress_ca_key`` is required and deliberately separate from
+  ``vault_key``, so it must be present.
+* ``CLAUDE.md`` must not carry the stale ``:8090`` port or a hardcoded test-file
+  count that re-rots.
+* ``scripts/run-checks.sh`` claims lock-step with the CI lint job, so its lint
+  targets and connector test suites must cover the same slack / aios-sdk trees
+  CI does.
+
+Modeled on the other ``*_drift.py`` guards: read the source-of-truth files and
+assert structural coverage, no network / DB / Docker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_env_example_declares_required_egress_ca_key() -> None:
+    """.env.example must declare the required, no-default AIOS_EGRESS_CA_KEY."""
+    env_example = _read(".env.example")
+    assert "AIOS_EGRESS_CA_KEY=" in env_example, (
+        "config.py declares egress_ca_key as required (no default), but "
+        ".env.example omits AIOS_EGRESS_CA_KEY — a contributor copying it hits "
+        "a pydantic ValidationError on first run. Add it near AIOS_VAULT_KEY."
+    )
+
+
+def test_claude_md_has_no_stale_port_or_test_count() -> None:
+    """CLAUDE.md must not carry the stale :8090 port or a hardcoded test count."""
+    claude = _read("CLAUDE.md")
+    assert ":8090" not in claude, "CLAUDE.md still references the stale :8090 port; api_port default is 8080."
+    assert "160 test" not in claude, (
+        "CLAUDE.md hardcodes a test-file count that re-rots; use an "
+        "order-of-magnitude phrase instead."
+    )
+
+
+def test_run_checks_matches_ci_lint_and_test_targets() -> None:
+    """run-checks.sh must cover the same slack/aios-sdk trees CI's lint+test jobs do."""
+    checks = _read("scripts/run-checks.sh")
+    # Lint targets: CI lints connectors/slack/src.
+    assert "connectors/slack/src" in checks, (
+        "run-checks.sh LINT_TARGETS omit connectors/slack/src, but "
+        "code-validation.yml lints it — the 'lock-step' comment misleads."
+    )
+    # Test suites: CI runs the slack and aios-sdk suites.
+    assert "connectors/slack/tests" in checks, (
+        "run-checks.sh omits the connectors/slack/tests suite that CI runs."
+    )
+    assert "packages/aios-sdk/tests" in checks, (
+        "run-checks.sh omits the packages/aios-sdk/tests suite that CI runs."
+    )


### PR DESCRIPTION
Automated dev-pipeline build for issue #1712.