### PR TITLE
Permanently-failing repo clone puts session in an infinite per-step sandbox provision/release storm (~13s tax on every step)

### DIFF
--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -393,20 +393,36 @@ async def _materialize_github_clones(
     session_id: str,
     *,
     account_id: str,
-) -> tuple[list[GithubRepositoryResourceEcho], GitProxy | None]:
+) -> tuple[
+    list[GithubRepositoryResourceEcho],
+    list[GithubRepositoryResourceEcho],
+    GitProxy | None,
+]:
     """Decrypt tokens, start a per-session :class:`GitProxy`, then run
     the host-side clone for each attached github_repository — rewriting
     each working tree's ``origin`` to the proxy URL so the bind-mounted
     ``.git/config`` inside the sandbox carries no credential.
 
-    Returns the materialized echo list and the proxy (or ``None`` when
-    the session has no github_repository attachments).
+    Returns ``(materialized, attempted, proxy)`` (proxy is ``None`` when
+    the session has no github_repository attachments):
+
+    - ``materialized`` is the subset whose clone succeeded — these drive
+      the actual bind mounts.
+    - ``attempted`` is EVERY attached github_repository echo (whether or
+      not its clone succeeded). This is what the mount snapshot / drift
+      key is stamped from, so that a clone failure does not change the
+      drift key (issue #1725). If it did, the provision-time snapshot
+      (materialized-only) would be structurally unequal to the step-time
+      DB echo set (all-attached) forever, churning provision↔release on
+      every step for a *permanently* failing clone (e.g. a dead embedded
+      token).
 
     Per-repo clone failures are non-fatal — they log + append a
     lifecycle event and drop the repo from the materialized list (its
-    working tree won't be bind-mounted). The proxy stays alive for
-    sibling repos. Per-clone wall-clock is bounded by
-    ``Settings.github_clone_session_timeout_seconds`` (issue #697).
+    working tree won't be bind-mounted) while STAYING in the attempted
+    list. The proxy stays alive for sibling repos. Per-clone wall-clock
+    is bounded by ``Settings.github_clone_session_timeout_seconds``
+    (issue #697).
     """
     from aios.sandbox.git_proxy import repo_key
     from aios.services import github_repositories as github_repo_service
@@ -421,7 +437,7 @@ async def _materialize_github_clones(
             conn, session_id, account_id=account_id
         )
         if not echoes:
-            return [], None
+            return [], [], None
         echo_tokens: list[tuple[GithubRepositoryResourceEcho, str]] = []
         repos_map: dict[str, str] = {}
         for echo in echoes:
@@ -486,7 +502,12 @@ async def _materialize_github_clones(
                     },
                     account_id=account_id,
                 )
-        return materialized, proxy
+        # ``attempted`` is every attached echo regardless of clone outcome
+        # — the drift key is stamped from THIS, not ``materialized``, so a
+        # failed clone can't skew the provision-time snapshot below the
+        # step-time DB echo set (issue #1725).
+        attempted = [echo for echo, _ in echo_tokens]
+        return materialized, attempted, proxy
     except BaseException:
         try:
             await proxy.stop()
@@ -639,7 +660,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
     secret_proxy: SecretEgressProxy | None = None
     broker_registered = False
     try:
-        github_echoes, git_proxy = await _materialize_github_clones(
+        github_echoes, attempted_github_echoes, git_proxy = await _materialize_github_clones(
             session_id, account_id=account_id
         )
         # Start the per-session secret-egress proxy when the session has
@@ -697,6 +718,7 @@ async def build_spec_from_session(session_id: str) -> ProvisioningPlan:
             session_env=session_env,
             memory_echoes=memory_echoes,
             github_echoes=github_echoes,
+            snapshot_github_echoes=attempted_github_echoes,
             git_proxy=git_proxy,
             tool_broker_url=tool_broker_url,
             tool_broker_secret=tool_broker_secret,
@@ -842,6 +864,7 @@ def _assemble_plan(
     git_proxy: GitProxy | None,
     tool_broker_url: str,
     tool_broker_secret: str,
+    snapshot_github_echoes: list[GithubRepositoryResourceEcho] | None = None,
     tool_socket_host_path: Path | None = None,
     snapshot_ref: str | None = None,
     snapshot_budget_bytes: int | None = None,
@@ -855,6 +878,14 @@ def _assemble_plan(
     the broker socket file is appended at
     ``TOOL_BROKER_SOCKET_SANDBOX_PATH``; the caller is expected to have
     set ``tool_broker_url`` to the matching ``unix://`` URL.
+
+    ``github_echoes`` drives the actual bind mounts (only successfully
+    cloned repos). ``snapshot_github_echoes`` — the set folded into the
+    ``mount_snapshot`` drift key — defaults to ``github_echoes`` but the
+    session path passes the ATTEMPTED (all-attached) set so a failed
+    clone does not shift the drift key below the step-time DB echo set
+    (issue #1725). The run path has no github attachments, so the
+    default keeps the two sets identical there.
     """
     from aios.sandbox.volumes import (
         ensure_session_attachments_dir,
@@ -1000,7 +1031,15 @@ def _assemble_plan(
         BASE_IMAGE_LABEL_KEY: image,
     }
 
-    snapshot = mount_snapshot_from_echoes(memory_echoes, github_echoes, env_var_credentials)
+    # Drift key is stamped from the ATTEMPTED github set (issue #1725):
+    # a repo whose clone failed still counts toward the snapshot so the
+    # provision-time key matches the step-time DB echo set (all attached
+    # repos), instead of dropping below it and churning provision↔release
+    # on every step forever for a permanently-failing clone.
+    snapshot_github = (
+        snapshot_github_echoes if snapshot_github_echoes is not None else github_echoes
+    )
+    snapshot = mount_snapshot_from_echoes(memory_echoes, snapshot_github, env_var_credentials)
     settings = get_settings()
     spec = SandboxSpec(
         session_id=session_id,

--- a/tests/helpers/sandbox.py
+++ b/tests/helpers/sandbox.py
@@ -427,7 +427,7 @@ def patch_build_spec_deps(
         ),
         patch(
             "aios.sandbox.spec._materialize_github_clones",
-            github_clones or AsyncMock(return_value=([], None)),
+            github_clones or AsyncMock(return_value=([], [], None)),
         ),
         patch("aios.sandbox.spec.runtime.require_pool", MagicMock()),
         patch(

--- a/tests/unit/sandbox/test_spec_clone_failure_drift.py
+++ b/tests/unit/sandbox/test_spec_clone_failure_drift.py
@@ -45,7 +45,9 @@ def _echo(repo_id: str, mount_path: str) -> GithubRepositoryResourceEcho:
 
 
 async def _build_snapshot(
-    *, materialized: list[GithubRepositoryResourceEcho], attempted: list[GithubRepositoryResourceEcho]
+    *,
+    materialized: list[GithubRepositoryResourceEcho],
+    attempted: list[GithubRepositoryResourceEcho],
 ) -> frozenset[tuple[str, ...]]:
     clones = AsyncMock(return_value=(materialized, attempted, None))
     with contextlib.ExitStack() as stack:

--- a/tests/unit/sandbox/test_spec_clone_failure_drift.py
+++ b/tests/unit/sandbox/test_spec_clone_failure_drift.py
@@ -1,0 +1,103 @@
+"""Regression: a failed github clone must NOT shift the mount-snapshot
+drift key (issue #1725).
+
+Mechanism of the bug this pins:
+
+- ``_materialize_github_clones`` drops any repo whose clone fails from the
+  ``materialized`` list, and ``build_spec_from_session`` used to stamp the
+  provision-time ``mount_snapshot`` from that *filtered* list.
+- Every step, ``refresh_session_mount_state`` recomputes the snapshot from
+  the FULL DB echo set (``list_session_github_repo_echoes`` knows nothing
+  about clone outcomes) and releases the sandbox if the snapshot drifted.
+- A *permanent* clone failure (e.g. a dead embedded token) makes
+  ``frozenset(materialized-only) != frozenset(all-attached)`` FOREVER, so
+  the session churns provision↔release on every step indefinitely
+  (~13s/step tax, all day).
+
+The fix stamps the provision-time snapshot from the ATTEMPTED (all-attached)
+echo set, so a failed clone leaves the drift key untouched. The mount list
+still only carries successfully-cloned repos.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+from aios.db.queries import EnvVarCredentialEcho
+from aios.models.github_repositories import GithubRepositoryResourceEcho
+from aios.sandbox.registry import mount_snapshot_from_echoes
+from aios.sandbox.spec import build_spec_from_session
+from tests.helpers.sandbox import patch_build_spec_deps
+
+_NOW = datetime(2026, 7, 7, tzinfo=UTC)
+
+
+def _echo(repo_id: str, mount_path: str) -> GithubRepositoryResourceEcho:
+    return GithubRepositoryResourceEcho(
+        id=repo_id,
+        url=f"https://github.com/acme/{repo_id}.git",
+        mount_path=mount_path,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+async def _build_snapshot(
+    *, materialized: list[GithubRepositoryResourceEcho], attempted: list[GithubRepositoryResourceEcho]
+) -> frozenset[tuple[str, ...]]:
+    clones = AsyncMock(return_value=(materialized, attempted, None))
+    with contextlib.ExitStack() as stack:
+        for ctx in patch_build_spec_deps(github_clones=clones):
+            stack.enter_context(ctx)
+        plan = await build_spec_from_session("sess_01TEST")
+    return plan.spec.mount_snapshot
+
+
+async def test_failed_clone_does_not_shrink_drift_key() -> None:
+    """The provision-time snapshot must fold EVERY attached repo, even one
+    whose clone failed — so it equals the step-time DB echo set and the
+    drift detector doesn't release on every step (#1725)."""
+    ok = _echo("ok", "/workspace/ok")
+    dead = _echo("dead", "/workspace/dead")  # permanently-failing clone
+
+    # Provision: only ``ok`` materialized; both were attempted.
+    provision_snapshot = await _build_snapshot(materialized=[ok], attempted=[ok, dead])
+
+    # Step-time: ``refresh_session_mount_state`` folds the FULL DB echo set
+    # (all attached repos — it can't see clone outcomes).
+    step_snapshot = mount_snapshot_from_echoes([], [ok, dead], [])
+
+    assert provision_snapshot == step_snapshot
+
+
+async def test_all_clones_succeed_snapshot_unchanged() -> None:
+    """When every clone succeeds, attempted == materialized and the snapshot
+    is exactly the DB echo set — the fix is a no-op for the happy path."""
+    ok = _echo("ok", "/workspace/ok")
+    provision_snapshot = await _build_snapshot(materialized=[ok], attempted=[ok])
+    step_snapshot = mount_snapshot_from_echoes([], [ok], [])
+    assert provision_snapshot == step_snapshot
+
+
+async def test_failed_clone_snapshot_folds_dead_repo_element() -> None:
+    """Concretely: the dead repo's ``(GITHUB_REPOSITORY, id, mount, ts)``
+    element is present in the provision snapshot despite the clone failing."""
+    from aios.ids import GITHUB_REPOSITORY
+
+    ok = _echo("ok", "/workspace/ok")
+    dead = _echo("dead", "/workspace/dead")
+    provision_snapshot = await _build_snapshot(materialized=[ok], attempted=[ok, dead])
+    assert (
+        GITHUB_REPOSITORY,
+        dead.id,
+        dead.mount_path,
+        dead.updated_at.isoformat(),
+    ) in provision_snapshot
+
+
+def test_env_var_echo_import_smoke() -> None:
+    """Guard: the step-side fold takes ``EnvVarCredentialEcho`` — ensure the
+    import path used by the drift probe stays valid alongside this fix."""
+    assert EnvVarCredentialEcho is not None

--- a/tests/unit/sandbox/test_spec_clone_failure_drift.py
+++ b/tests/unit/sandbox/test_spec_clone_failure_drift.py
@@ -27,8 +27,7 @@ from unittest.mock import AsyncMock
 
 from aios.db.queries import EnvVarCredentialEcho
 from aios.models.github_repositories import GithubRepositoryResourceEcho
-from aios.sandbox.registry import mount_snapshot_from_echoes
-from aios.sandbox.spec import build_spec_from_session
+from aios.sandbox.spec import build_spec_from_session, mount_snapshot_from_echoes
 from tests.helpers.sandbox import patch_build_spec_deps
 
 _NOW = datetime(2026, 7, 7, tzinfo=UTC)

--- a/tests/unit/sandbox/test_spec_env_var_credentials.py
+++ b/tests/unit/sandbox/test_spec_env_var_credentials.py
@@ -152,7 +152,7 @@ async def test_no_creds_leaves_env_untouched() -> None:
 
 
 async def test_resolve_failure_aborts_before_git_proxy_or_broker_exist() -> None:
-    clones = AsyncMock(return_value=([], None))
+    clones = AsyncMock(return_value=([], [], None))
     broker = MagicMock()
     broker.port = 54321
     with contextlib.ExitStack() as stack:
@@ -382,7 +382,7 @@ async def test_failure_after_proxy_starts_stops_both_proxies() -> None:
         for ctx in patch_build_spec_deps(
             env_config=env_config,
             env_var_credentials=AsyncMock(return_value=(_CRED,)),
-            github_clones=AsyncMock(return_value=([], git_proxy)),
+            github_clones=AsyncMock(return_value=([], [], git_proxy)),
             tool_broker=broker,
         ):
             stack.enter_context(ctx)
@@ -427,7 +427,7 @@ async def test_secret_proxy_start_failure_does_not_double_stop() -> None:
             # Containing Limited env: required by the #879 gate.
             env_config=_LIMITED_GITHUB,
             env_var_credentials=AsyncMock(return_value=(_CRED,)),
-            github_clones=AsyncMock(return_value=([], None)),
+            github_clones=AsyncMock(return_value=([], [], None)),
             tool_broker=broker,
         ):
             stack.enter_context(ctx)
@@ -481,7 +481,7 @@ async def test_session_and_run_cleanup_share_one_envelope() -> None:
         for ctx in patch_build_spec_deps(
             env_config=env_config,
             env_var_credentials=AsyncMock(return_value=(_CRED,)),
-            github_clones=AsyncMock(return_value=([], git_proxy)),
+            github_clones=AsyncMock(return_value=([], [], git_proxy)),
             tool_broker=broker,
         ):
             stack.enter_context(ctx)

--- a/tests/unit/test_sandbox_spec.py
+++ b/tests/unit/test_sandbox_spec.py
@@ -106,11 +106,15 @@ async def test_session_clone_timeout_does_not_abort_sibling_clones() -> None:
             append_event_mock,
         ),
     ):
-        materialized, returned_proxy = await _materialize_github_clones(
+        materialized, attempted, returned_proxy = await _materialize_github_clones(
             "sess_x", account_id="acct_x"
         )
 
     assert [e.id for e in materialized] == [ok_echo.id]
+    # The failed clone is dropped from ``materialized`` (no bind mount) but
+    # STAYS in ``attempted`` — that's the set the drift key is stamped from,
+    # so a permanently-failing clone can't churn provision↔release (#1725).
+    assert {e.id for e in attempted} == {failed_echo.id, ok_echo.id}
     assert returned_proxy is mock_proxy
     append_event_mock.assert_awaited_once()
     call_args = append_event_mock.await_args


### PR DESCRIPTION
Automated dev-pipeline build for issue #1725.