### PR TITLE
Sweep batch-filter fetches a session's ENTIRE assistant/tool-result history (126MB observed) on every full sweep — 12-17s pre-model stall per step

### DIFF
--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -248,21 +248,70 @@ UNREACTED_ROWS_SQL = """
        AND e.seq > s.last_reacted_seq
 """
 
+# ─── batch filter: bounded, payload-stripped fetches (#1729) ─────────────────
+#
+# ``_filter_incomplete_batches`` decides, per candidate session, whether the
+# session's ONLY unreacted events are tool results from a batch whose sibling
+# tools are still in-flight (→ not yet ready). Its actual need is tiny: the
+# unreacted tool_call_ids (already fetched, seq-bounded by
+# ``UNREACTED_ROWS_SQL``) → their OWNING assistant batches → whether each such
+# batch's ids are fully covered by tool results.
+#
+# The pre-#1729 queries fetched the session's ENTIRE lifetime history — every
+# ``role='tool'`` message ever (``ALL_RESULT_ROWS_SQL``) and every assistant
+# message with tool_calls ever, WITH FULL ``data`` PAYLOAD (``ALL_ASST_ROWS_SQL``:
+# 126 MB of JSONB observed on the largest session). All of it was pulled over
+# the wire and JSON-decoded row-by-row on the worker event loop on EVERY full
+# sweep (~2/min), a 16.6s-median pre-model tax that grows linearly and forever
+# with session size. Neither query was seq-bounded or LIMITed.
+#
+# The two replacements below bound the scan to exactly what the filter inspects
+# and strip the payload to the only field it reads (``tool_calls[].id``):
+#
+# * ``REFERENCED_ASST_BATCH_SQL`` — assistant batches OWNING an unreacted tcid.
+#   The ``@>`` containment (``data->'tool_calls' @> $2``, one probe per unreacted
+#   tcid, built as ``[{"id": tcid}]``) restricts to the handful of assistant
+#   rows the unreacted results belong to — not the whole history. It projects
+#   ``jsonb_path_query_array(data->'tool_calls', '$[*].id')`` (the id array)
+#   rather than ``data``, so the 126 MB decode is gone even before bounding.
+#
+# * ``BATCH_RESULT_ROWS_SQL`` — tool results whose ``tool_call_id`` is one of the
+#   ids belonging to those referenced batches (``= ANY($2)``), not every
+#   ``role='tool'`` row the session has ever produced.
+#
+# Rows drop from ~65k (34k results + 30k assistants) to ~dozens, and the decoded
+# bytes from 126 MB to a few id strings.
+REFERENCED_ASST_BATCH_SQL = """
+    SELECT e.session_id,
+           jsonb_path_query_array(e.data->'tool_calls', '$[*].id') AS tool_call_ids
+      FROM events e
+     WHERE e.session_id = $1
+       AND e.kind = 'message'
+       AND e.role = 'assistant'
+       AND e.data->'tool_calls' @> ANY($2::jsonb[])
+"""
+
+BATCH_RESULT_ROWS_SQL = """
+    SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
+      FROM events e
+     WHERE e.session_id = $1
+       AND e.kind = 'message'
+       AND e.role = 'tool'
+       AND e.data->>'tool_call_id' = ANY($2::text[])
+"""
+
+# ``ALL_RESULT_ROWS_SQL`` — every ``role='tool'`` result across a session set.
+# Retained for GHOST REPAIR (``find_and_repair_ghosts``), where the session set
+# is already bounded upstream by ``GHOST_ASST_SQL``'s ``open_tool_call_count > 0``
+# gate (migration 0066) — a fully-resolved session contributes zero rows. The
+# batch filter (#1729) no longer uses this: it fetches results per session and
+# bounded to specific batch ids via ``BATCH_RESULT_ROWS_SQL``.
 ALL_RESULT_ROWS_SQL = """
     SELECT e.session_id, e.data->>'tool_call_id' AS tool_call_id
       FROM events e
      WHERE e.session_id = ANY($1::text[])
        AND e.kind = 'message'
        AND e.role = 'tool'
-"""
-
-ALL_ASST_ROWS_SQL = """
-    SELECT e.session_id, e.data
-      FROM events e
-     WHERE e.session_id = ANY($1::text[])
-       AND e.kind = 'message'
-       AND e.role = 'assistant'
-       AND jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls', 'null'::jsonb), '[]'::jsonb)) > 0
 """
 
 # Sessions currently in the terminal "errored" state, derived from the
@@ -914,11 +963,45 @@ async def find_sessions_needing_inference(
     candidates -= errored
     confirmed_sessions -= errored
     to_filter = candidates - confirmed_sessions
-    filtered = (
-        await _filter_incomplete_batches(pool, inflight_tool_registry, to_filter)
-        if to_filter
-        else set()
-    )
+    if not to_filter:
+        return confirmed_sessions | cancel_marked
+
+    # Span the batch filter (#1729): ``sweep.batch_filter_start/end``. Before
+    # #1729 this region fetched the session's entire assistant/tool-result
+    # lifetime (126 MB observed) and decoded it on the event loop — a
+    # multi-second pre-model stall that was invisible to every existing span
+    # (``sweep.query_exec`` measured only the scalar-gate SQL, ~0.01s). Bracket
+    # it so the next residual on this path is a query, not an archaeology dig
+    # (same lesson as #1658/#1725). Only spanned on the per-step scoped path
+    # (``session_id`` set), where an ``account_id`` is resolvable; the
+    # cross-session sweep has no single session to stamp.
+    if session_id is not None:
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
+        bf_start = await sessions_service.append_event(
+            pool,
+            session_id,
+            "span",
+            {"event": "sweep.batch_filter_start", "candidate_count": len(to_filter)},
+            account_id=account_id,
+        )
+        try:
+            filtered = await _filter_incomplete_batches(
+                pool, inflight_tool_registry, to_filter
+            )
+        finally:
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "span",
+                {
+                    "event": "sweep.batch_filter_end",
+                    "start_id": bf_start.id,
+                },
+                account_id=account_id,
+            )
+    else:
+        filtered = await _filter_incomplete_batches(pool, inflight_tool_registry, to_filter)
+
     return filtered | confirmed_sessions | cancel_marked
 
 
@@ -930,43 +1013,75 @@ async def _filter_incomplete_batches(
     """Remove sessions whose only unreacted events are tool results from
     in-progress batches (where sibling tools are still in-flight).
 
-    Uses three batched queries across all candidates (no N+1).
+    The unreacted set is fetched in ONE seq-bounded batched query
+    (``UNREACTED_ROWS_SQL``, gated by ``seq > last_reacted_seq``). The assistant
+    batches and their tool results are then fetched per session, but ONLY the
+    batches that OWN an unreacted tool_call_id and ONLY the tool results for
+    those batches' ids — via ``@>`` containment and ``= ANY`` rather than the
+    pre-#1729 unbounded lifetime scans (which pulled every ``role='tool'`` row
+    plus every assistant ``tool_calls`` payload — 126 MB observed — and decoded
+    it on the event loop on every full sweep). See the query docstrings above.
+    Sessions with no unreacted events (or whose unreacted set contains a user
+    message) are decided without touching ``events`` at all.
     """
     session_list = list(candidates)
 
     async with pool.acquire() as conn:
         unreacted_rows = await conn.fetch(UNREACTED_ROWS_SQL, session_list)
-        all_result_rows = await conn.fetch(ALL_RESULT_ROWS_SQL, session_list)
-        all_asst_rows = await conn.fetch(ALL_ASST_ROWS_SQL, session_list)
+        unreacted_by_sid = _group_event_data(unreacted_rows)
 
-    unreacted_by_sid = _group_event_data(unreacted_rows)
-    results_by_sid = _group_tool_call_ids(all_result_rows)
-    asst_by_sid = _group_event_data(all_asst_rows)
+        result: set[str] = set()
+        for sid in candidates:
+            in_flight = inflight_tool_registry.in_flight_tool_call_ids(sid)
+            unreacted = unreacted_by_sid.get(sid, [])
 
-    result: set[str] = set()
-    for sid in candidates:
-        in_flight = inflight_tool_registry.in_flight_tool_call_ids(sid)
-        unreacted = unreacted_by_sid.get(sid, [])
-
-        if not unreacted:
-            if not in_flight:
-                result.add(sid)
-            continue
-
-        if any(evt.get("role") == "user" for evt in unreacted):
-            result.add(sid)
-            continue
-
-        unreacted_tcids = {evt.get("tool_call_id") for evt in unreacted if evt.get("tool_call_id")}
-        all_result_ids = results_by_sid.get(sid, set())
-
-        for asst_data in asst_by_sid.get(sid, []):
-            batch_ids = {tc["id"] for tc in (asst_data.get("tool_calls") or []) if tc.get("id")}
-            if not (batch_ids & unreacted_tcids):
+            if not unreacted:
+                if not in_flight:
+                    result.add(sid)
                 continue
-            if batch_ids <= all_result_ids:
+
+            if any(evt.get("role") == "user" for evt in unreacted):
                 result.add(sid)
-                break
+                continue
+
+            unreacted_tcids = {
+                evt.get("tool_call_id") for evt in unreacted if evt.get("tool_call_id")
+            }
+            if not unreacted_tcids:
+                # Unreacted non-user events with no tool_call_id: pre-#1729 the
+                # assistant loop ran but no batch intersected the (empty)
+                # unreacted-tcid set, so the session was NOT admitted. Preserve
+                # that — skip the (now pointless) bounded fetch and drop it.
+                continue
+
+            # Bounded fetch (#1729): only the assistant batches that OWN one of
+            # this session's unreacted tool_call_ids, projected to their id
+            # arrays (no payload). One containment probe per unreacted tcid.
+            probes = [json.dumps([{"id": tcid}]) for tcid in unreacted_tcids]
+            asst_rows = await conn.fetch(REFERENCED_ASST_BATCH_SQL, sid, probes)
+
+            referenced_batches: list[set[str]] = []
+            all_batch_ids: set[str] = set()
+            for r in asst_rows:
+                batch_ids = {tcid for tcid in (r["tool_call_ids"] or []) if tcid}
+                if batch_ids & unreacted_tcids:
+                    referenced_batches.append(batch_ids)
+                    all_batch_ids |= batch_ids
+
+            if not referenced_batches:
+                continue
+
+            # Bounded fetch (#1729): only the tool results for THESE batches'
+            # ids, not the session's entire ``role='tool'`` history.
+            result_rows = await conn.fetch(
+                BATCH_RESULT_ROWS_SQL, sid, list(all_batch_ids)
+            )
+            result_ids = {r["tool_call_id"] for r in result_rows if r["tool_call_id"]}
+
+            for batch_ids in referenced_batches:
+                if batch_ids <= result_ids:
+                    result.add(sid)
+                    break
 
     return result
 
@@ -976,13 +1091,6 @@ def _group_event_data(rows: list[Any]) -> dict[str, list[dict[str, Any]]]:
     for r in rows:
         data = r["data"]
         grouped.setdefault(r["session_id"], []).append(data)
-    return grouped
-
-
-def _group_tool_call_ids(rows: list[Any]) -> dict[str, set[str]]:
-    grouped: dict[str, set[str]] = {}
-    for r in rows:
-        grouped.setdefault(r["session_id"], set()).add(r["tool_call_id"])
     return grouped
 
 

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -985,9 +985,7 @@ async def find_sessions_needing_inference(
             account_id=account_id,
         )
         try:
-            filtered = await _filter_incomplete_batches(
-                pool, inflight_tool_registry, to_filter
-            )
+            filtered = await _filter_incomplete_batches(pool, inflight_tool_registry, to_filter)
         finally:
             await sessions_service.append_event(
                 pool,
@@ -1073,9 +1071,7 @@ async def _filter_incomplete_batches(
 
             # Bounded fetch (#1729): only the tool results for THESE batches'
             # ids, not the session's entire ``role='tool'`` history.
-            result_rows = await conn.fetch(
-                BATCH_RESULT_ROWS_SQL, sid, list(all_batch_ids)
-            )
+            result_rows = await conn.fetch(BATCH_RESULT_ROWS_SQL, sid, list(all_batch_ids))
             result_ids = {r["tool_call_id"] for r in result_rows if r["tool_call_id"]}
 
             for batch_ids in referenced_batches:

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -30,11 +30,13 @@ import pytest
 
 from aios.db.queries import _SESSION_STATUS_EXPR
 from aios.harness.sweep import (
+    BATCH_RESULT_ROWS_SQL,
     CANDIDATE_ROWS_SQL,
     ERRORED_SESSIONS_SQL,
     FAST_PATH_PENDING_WORK_SQL,
     GHOST_ASST_SQL,
     GHOST_SPAN_START_SQL,
+    REFERENCED_ASST_BATCH_SQL,
     UNREACTED_ROWS_SQL,
 )
 from tests.conftest import needs_docker
@@ -592,6 +594,59 @@ class TestGhostAsstSweepBounded:
         assert returned == {"sess_tc_open"}, (
             f"GHOST_ASST_SQL must return rows ONLY for sessions with "
             f"open_tool_call_count > 0; expected {{'sess_tc_open'}}, got {returned} (#840)."
+        )
+
+
+@needs_docker
+class TestBatchFilterBounded:
+    """#1729: the batch filter's assistant/result fetches are BOUNDED to the
+    batches referenced by the session's *unreacted* tool_call_ids — not the
+    session's entire lifetime.
+
+    The pre-#1729 filter ran two unbounded lifetime scans (every ``role='tool'``
+    row + every assistant ``tool_calls`` payload, 126 MB observed) and decoded
+    them on the worker event loop on every full sweep. The deep, fully-resolved
+    ``sess_tc_deep`` (500 turns x 4 tool_calls) is the fixture that would blow up
+    such a scan; here the bounded queries must return only the handful of rows
+    tied to a referenced batch id, no matter how deep the resolved history is.
+
+    Structural (row-set) assertions, not wall-clock — deterministic on any CI.
+    """
+
+    async def test_referenced_asst_scoped_to_containment_probe(
+        self, seeded_pool: asyncpg.Pool[Any]
+    ) -> None:
+        # Probe for a single tool_call id belonging to ONE assistant turn deep in
+        # sess_tc_deep. The containment-bounded query must return exactly that
+        # one owning batch row, not the 500 assistant turns in the session.
+        probe_tcid = "tc_sess_tc_deep_250_0"
+        probes = [json.dumps([{"id": probe_tcid}])]
+        async with seeded_pool.acquire() as conn:
+            rows = await conn.fetch(REFERENCED_ASST_BATCH_SQL, "sess_tc_deep", probes)
+
+        assert len(rows) == 1, (
+            f"REFERENCED_ASST_BATCH_SQL must return ONLY the batch owning the "
+            f"probed tcid, got {len(rows)} rows — an unbounded scan leaked the "
+            f"deep resolved history (#1729)."
+        )
+        ids = {tcid for tcid in rows[0]["tool_call_ids"]}
+        assert probe_tcid in ids
+        # Payload-stripped: the row carries the id array, not the full ``data``.
+        assert "data" not in dict(rows[0])
+
+    async def test_batch_result_scoped_to_batch_ids(
+        self, seeded_pool: asyncpg.Pool[Any]
+    ) -> None:
+        # Results are fetched ONLY for the specific batch ids, not every
+        # ``role='tool'`` row the deep session ever produced (2000 of them).
+        batch_ids = [f"tc_sess_tc_deep_250_{k}" for k in range(_N_TC_PER_ASST)]
+        async with seeded_pool.acquire() as conn:
+            rows = await conn.fetch(BATCH_RESULT_ROWS_SQL, "sess_tc_deep", batch_ids)
+
+        returned = {r["tool_call_id"] for r in rows}
+        assert returned == set(batch_ids), (
+            f"BATCH_RESULT_ROWS_SQL must return results ONLY for the requested "
+            f"batch ids; expected {set(batch_ids)}, got {returned} (#1729)."
         )
 
 

--- a/tests/e2e/test_sweep_perf.py
+++ b/tests/e2e/test_sweep_perf.py
@@ -634,9 +634,7 @@ class TestBatchFilterBounded:
         # Payload-stripped: the row carries the id array, not the full ``data``.
         assert "data" not in dict(rows[0])
 
-    async def test_batch_result_scoped_to_batch_ids(
-        self, seeded_pool: asyncpg.Pool[Any]
-    ) -> None:
+    async def test_batch_result_scoped_to_batch_ids(self, seeded_pool: asyncpg.Pool[Any]) -> None:
         # Results are fetched ONLY for the specific batch ids, not every
         # ``role='tool'`` row the deep session ever produced (2000 of them).
         batch_ids = [f"tc_sess_tc_deep_250_{k}" for k in range(_N_TC_PER_ASST)]

--- a/tests/unit/test_sweep_batch_filter_bounded.py
+++ b/tests/unit/test_sweep_batch_filter_bounded.py
@@ -92,7 +92,10 @@ async def test_filter_never_issues_unbounded_lifetime_scans() -> None:
     assert "e.data->>'tool_call_id' = ANY" in joined
     # None of the fetches is the removed unbounded lifetime scan (session set
     # only, no tcid/containment bound).
-    assert "e.session_id = ANY($1::text[])\n       AND e.kind = 'message'\n       AND e.role = 'tool'\n\"" not in joined
+    assert (
+        "e.session_id = ANY($1::text[])\n       AND e.kind = 'message'\n       AND e.role = 'tool'\n\""
+        not in joined
+    )
 
 
 async def test_no_unreacted_events_touches_no_history() -> None:

--- a/tests/unit/test_sweep_batch_filter_bounded.py
+++ b/tests/unit/test_sweep_batch_filter_bounded.py
@@ -1,0 +1,160 @@
+"""``_filter_incomplete_batches`` must fetch ONLY what it inspects (#1729).
+
+Before #1729 the batch filter ran two unbounded lifetime scans per full sweep:
+``ALL_RESULT_ROWS_SQL`` (every ``role='tool'`` message ever) and
+``ALL_ASST_ROWS_SQL`` (every assistant-with-tool_calls message ever, with the
+FULL ``data`` payload — 126 MB of JSONB observed on the largest production
+session). Both were pulled over the wire and JSON-decoded row-by-row on the
+worker event loop on every step, a 12-17s pre-model stall that grows linearly
+and forever with session size.
+
+These tests encode the fix as a **structural** contract on the SQL the filter
+issues, driven through a fake connection (no docker):
+
+  * it NEVER issues the two unbounded lifetime scans;
+  * its assistant fetch is bounded by tool_call_id containment (``@>``) and
+    projects only ``tool_calls[].id`` (no ``data`` payload);
+  * its result fetch is bounded to the referenced batch ids (``= ANY``);
+  * a session with no unreacted events never touches ``events`` for
+    assistant/result rows at all.
+
+Behaviour parity (a session is/ isn't admitted for the same reasons as before)
+is covered by the docker-backed sweep e2e suite; these are the perf-shape
+guards that a well-meaning refactor back to a lifetime scan would trip.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from aios.harness import sweep
+from aios.harness.inflight_tool_registry import InflightToolRegistry
+from tests.unit.conftest import fake_pool_yielding_conn
+
+
+def _dispatching_conn(handlers: list[tuple[str, list[dict[str, Any]]]]) -> Any:
+    """Build a fake ``conn`` whose ``fetch`` returns rows based on the SQL text.
+
+    ``handlers`` is a list of ``(needle, rows)``: the first needle found as a
+    substring of the SQL passed to ``conn.fetch`` wins. Records the SQL of every
+    call on ``conn.fetched_sql`` for assertions.
+    """
+    conn = MagicMock()
+    conn.fetched_sql = []
+
+    async def _fetch(sql: str, *args: Any) -> list[dict[str, Any]]:
+        conn.fetched_sql.append(sql)
+        for needle, rows in handlers:
+            if needle in sql:
+                return rows
+        raise AssertionError(f"unexpected SQL fetched by batch filter:\n{sql}")
+
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    return conn
+
+
+async def test_filter_never_issues_unbounded_lifetime_scans() -> None:
+    """The batch filter must not run the removed whole-history queries — the
+    projected assistant/result select and the ``@>`` containment bound are the
+    load-bearing fix (#1729)."""
+    unreacted = [{"session_id": "sess_a", "data": {"role": "tool", "tool_call_id": "tc_1"}}]
+    asst = [{"session_id": "sess_a", "tool_call_ids": ["tc_1"]}]
+    results = [{"session_id": "sess_a", "tool_call_id": "tc_1"}]
+
+    conn = _dispatching_conn(
+        [
+            ("s.last_reacted_seq", unreacted),  # UNREACTED_ROWS_SQL
+            ("jsonb_path_query_array", asst),  # REFERENCED_ASST_BATCH_SQL
+            ("data->>'tool_call_id' = ANY", results),  # BATCH_RESULT_ROWS_SQL
+        ]
+    )
+    pool = fake_pool_yielding_conn(conn)
+
+    out = await sweep._filter_incomplete_batches(pool, InflightToolRegistry(), {"sess_a"})
+
+    # Fully-resolved single batch → session is ready.
+    assert out == {"sess_a"}
+
+    joined = "\n".join(conn.fetched_sql)
+    # The projected assistant fetch selects ONLY the id array. The removed
+    # ``ALL_ASST_ROWS_SQL`` selected the full ``data`` payload gated only by
+    # ``jsonb_array_length(... 'tool_calls') > 0`` — assert that whole-payload
+    # unbounded shape is gone (the seq-bounded ``UNREACTED_ROWS_SQL`` also selects
+    # ``e.data`` but carries a ``last_reacted_seq`` bound, so key on the removed
+    # query's distinguishing predicate).
+    assert "jsonb_path_query_array(e.data->'tool_calls'" in joined
+    assert "jsonb_array_length(COALESCE(NULLIF(e.data->'tool_calls'" not in joined
+    # The assistant fetch is bounded by tool_call_id containment, not a scan of
+    # every assistant-with-tool_calls row.
+    assert "e.data->'tool_calls' @> ANY" in joined
+    # The result fetch is bounded to the referenced batch ids.
+    assert "e.data->>'tool_call_id' = ANY" in joined
+    # None of the fetches is the removed unbounded lifetime scan (session set
+    # only, no tcid/containment bound).
+    assert "e.session_id = ANY($1::text[])\n       AND e.kind = 'message'\n       AND e.role = 'tool'\n\"" not in joined
+
+
+async def test_no_unreacted_events_touches_no_history() -> None:
+    """A candidate with an empty unreacted set is decided from the unreacted
+    query alone — no assistant/result fetch fires (it can't need bounding what
+    it never reads)."""
+    conn = _dispatching_conn([("s.last_reacted_seq", [])])
+    pool = fake_pool_yielding_conn(conn)
+
+    out = await sweep._filter_incomplete_batches(pool, InflightToolRegistry(), {"sess_idle"})
+
+    # No unreacted events and nothing in-flight → ready.
+    assert out == {"sess_idle"}
+    # Exactly one fetch: the seq-bounded unreacted query.
+    assert conn.fetch.await_count == 1
+    assert "s.last_reacted_seq" in conn.fetched_sql[0]
+
+
+async def test_incomplete_batch_not_admitted() -> None:
+    """A referenced batch whose sibling ids lack results is NOT admitted — the
+    session is still waiting on in-flight tools (parity with pre-#1729)."""
+    unreacted = [{"session_id": "sess_a", "data": {"role": "tool", "tool_call_id": "tc_1"}}]
+    # Batch owns tc_1 and tc_2, but only tc_1 has a result.
+    asst = [{"session_id": "sess_a", "tool_call_ids": ["tc_1", "tc_2"]}]
+    results = [{"session_id": "sess_a", "tool_call_id": "tc_1"}]
+
+    conn = _dispatching_conn(
+        [
+            ("s.last_reacted_seq", unreacted),
+            ("jsonb_path_query_array", asst),
+            ("data->>'tool_call_id' = ANY", results),
+        ]
+    )
+    pool = fake_pool_yielding_conn(conn)
+
+    out = await sweep._filter_incomplete_batches(pool, InflightToolRegistry(), {"sess_a"})
+    assert out == set()
+
+
+async def test_user_message_bypasses_batch_fetch() -> None:
+    """An unreacted user message admits immediately, without any batch fetch."""
+    unreacted = [{"session_id": "sess_u", "data": {"role": "user", "content": "hi"}}]
+    conn = _dispatching_conn([("s.last_reacted_seq", unreacted)])
+    pool = fake_pool_yielding_conn(conn)
+
+    out = await sweep._filter_incomplete_batches(pool, InflightToolRegistry(), {"sess_u"})
+    assert out == {"sess_u"}
+    # Only the unreacted query — the user branch short-circuits before any
+    # assistant/result fetch.
+    assert conn.fetch.await_count == 1
+
+
+async def test_removed_unbounded_constants_are_gone() -> None:
+    """The two unbounded lifetime scans the batch filter used are removed from
+    its query surface. ``ALL_RESULT_ROWS_SQL`` survives ONLY for ghost repair
+    (bounded upstream by ``open_tool_call_count > 0``); ``ALL_ASST_ROWS_SQL`` —
+    the 126 MB payload fetch — is deleted outright."""
+    assert not hasattr(sweep, "ALL_ASST_ROWS_SQL")
+    # New bounded queries exist and carry their bounds.
+    assert "@> ANY" in sweep.REFERENCED_ASST_BATCH_SQL
+    assert "jsonb_path_query_array" in sweep.REFERENCED_ASST_BATCH_SQL
+    assert "e.data" not in sweep.REFERENCED_ASST_BATCH_SQL.split("FROM")[0].replace(
+        "e.data->'tool_calls'", ""
+    )
+    assert "= ANY($2::text[])" in sweep.BATCH_RESULT_ROWS_SQL


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1729.