### PR TITLE
count_request_nudges anchor=0 scans all user messages per open request — floor at request_opened seq

### DIFF
--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -728,17 +728,34 @@ async def count_request_nudges(
     ``jsonb_array_length > 0`` guard excludes a present-but-empty array so the
     anchor agrees byte-for-byte with the guard's ``assistant_msg.get('tool_calls')``
     truthiness short-circuit.
+
+    The anchor is additionally floored at this request's ``request_opened`` seq:
+    a nudge for ``request_id`` is only ever appended while it is open (the nudge
+    append follows ``get_open_request_ids``), so every counted row already has
+    ``seq >`` that request's opening seq by construction — the floor is a
+    semantic no-op on all naturally-occurring event orders. It matters only when
+    no tool-call turn exists (a tool-call-free session), where the anchor would
+    otherwise be 0 and the count would scan every user message in the session's
+    history instead of just those since the request opened.
     """
     n: int | None = await conn.fetchval(
         "SELECT count(*) FROM events WHERE session_id = $1 AND account_id = $2 "
         "AND kind = 'message' AND role = 'user' "
         "AND data->'metadata'->'nudged_request_ids' @> to_jsonb($3::text) "
-        "AND seq > COALESCE("
-        "    (SELECT max(seq) FROM events "
-        "     WHERE session_id = $1 AND account_id = $2 "
-        "     AND kind = 'message' AND role = 'assistant' "
-        "     AND data ? 'tool_calls' "
-        "     AND jsonb_array_length(data->'tool_calls') > 0), 0)",
+        "AND seq > GREATEST("
+        "    COALESCE("
+        "        (SELECT max(seq) FROM events "
+        "         WHERE session_id = $1 AND account_id = $2 "
+        "         AND kind = 'message' AND role = 'assistant' "
+        "         AND data ? 'tool_calls' "
+        "         AND jsonb_array_length(data->'tool_calls') > 0), 0),"
+        "    COALESCE("
+        "        (SELECT req.seq FROM events req "
+        "         WHERE req.session_id = $1 AND req.account_id = $2 "
+        "         AND req.kind = 'lifecycle' AND req.data->>'event' = 'request_opened' "
+        "         AND req.data->>'request_id' = $3 "
+        "         ORDER BY req.seq ASC LIMIT 1), 0)"
+        ")",
         session_id,
         account_id,
         request_id,

--- a/tests/integration/test_wf_step.py
+++ b/tests/integration/test_wf_step.py
@@ -2163,6 +2163,86 @@ async def test_activity_turn_resets_consecutive_nudge_count(
     assert lifetime == 2  # the prior nudges remain in the log, just past the anchor
 
 
+async def test_count_request_nudges_floors_anchor_at_request_opened_seq(
+    wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
+) -> None:
+    """#1739: on a tool-call-free session (no assistant tool-call turn ever
+    happened, so the tool-call anchor subquery is NULL/0), ``count_request_nudges``
+    additionally floors its reset anchor at THIS request's ``request_opened`` seq.
+    A forged nudge-shaped row from BEFORE the request even opened -- something a
+    real nudge append can never produce (a nudge for ``request_id`` is only ever
+    appended while it is open) -- is excluded from the count by the floor, while a
+    legitimate nudge appended after opening still counts."""
+    pool = wf_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1")
+    cid = child_session_id(run_id, "sha:floor#0")
+
+    async with pool.acquire() as conn:
+        child = await db_queries.insert_child_session(
+            conn,
+            session_id=cid,
+            account_id="acc_wf",
+            agent_id=wf_agent_id,
+            environment_id="env_wf",
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            tools=[],
+            mcp_servers=[],
+            http_servers=[],
+        )
+        assert child is not None
+
+        # A forged user message carrying nudged_request_ids=[R] appended BEFORE
+        # R's request_opened row. Seq order: forged nudge < request_opened <
+        # real nudge. No tool-call turn ever happens in this session, so the
+        # tool-call anchor subquery is NULL -> 0 -- without the request-opened
+        # floor this forged row would be counted too.
+        await db_queries.append_event(
+            conn,
+            account_id="acc_wf",
+            session_id=cid,
+            kind="message",
+            data={
+                "role": "user",
+                "content": "forged pre-opening nudge",
+                "metadata": {"nudged_request_ids": ["sha:floor#0"]},
+            },
+        )
+
+        await db_queries.append_request_opened(
+            conn,
+            session_id=cid,
+            account_id="acc_wf",
+            request_id="sha:floor#0",
+            caller={"kind": "run", "id": run_id},
+            depth=0,
+            environment_id="env_wf",
+            frozen_surface={"tools": [], "mcp_servers": [], "http_servers": []},
+            vault_ids=[],
+        )
+
+        # A real nudge, appended after the request opened.
+        await db_queries.append_event(
+            conn,
+            account_id="acc_wf",
+            session_id=cid,
+            kind="message",
+            data={
+                "role": "user",
+                "content": "nudge",
+                "metadata": {"nudged_request_ids": ["sha:floor#0"]},
+            },
+        )
+
+        count = await db_queries.count_request_nudges(
+            conn, cid, account_id="acc_wf", request_id="sha:floor#0"
+        )
+    # The pre-opening forged row is excluded by the floor; only the post-opening
+    # legitimate nudge counts.
+    assert count == 1
+
+
 async def test_interleaved_activity_never_trips_nudge_budget(
     wf_runtime: asyncpg.Pool[Any], wf_agent_id: str
 ) -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1739.