### PR TITLE
Post-model tokenizer: 3 full-slate passes on the event loop per step — memoize per-message + to_thread

### DIFF
--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1115,8 +1115,18 @@ async def _run_session_step_body(
     # more than once and must NOT be used as the baseline (it would skew the
     # stored ``local_tokens`` away from ``cumulative_tokens`` and from what
     # callers recompute via ``approx_tokens``).
-    local_tokens = approx_tokens(messages, tools=tools)
-    by_class = approx_tokens_by_class(messages, tools=tools)
+    # Both counters re-tokenize the full slate every step; run the pair off
+    # the event loop (issue #1744) — ``Encoding.encode`` is a stateless,
+    # GIL-releasing call, and the per-message/per-payload memoization in
+    # ``tokens.py`` makes the steady-state cost O(new tail) rather than
+    # O(slate). Stamp order/content below is unchanged.
+    def _compute_token_counts() -> tuple[int, dict[str, int]]:
+        return (
+            approx_tokens(messages, tools=tools),
+            approx_tokens_by_class(messages, tools=tools),
+        )
+
+    local_tokens, by_class = await asyncio.to_thread(_compute_token_counts)
     cost_microusd = _resolve_cost_microusd(agent.model, usage, cost_usd, session_id=session_id)
     await sessions_service.append_event(
         pool,

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -8,12 +8,126 @@
 
 * :func:`tokens_to_drop` — snap boundary math for the DB-level windowed
   reader (:func:`~aios.db.queries.events.read_windowed_events`).
+
+Performance (issue #1744): ``approx_tokens`` / ``approx_tokens_by_class``
+are called once per step on the full message slate, but only the tail
+changes step to step. Both are built from two memoized primitives —
+``_message_body_tokens`` (per-message body cost) and ``_extra_tokens``
+(payload-level system/tools framing overhead) — cached in
+``_BODY_CACHE`` / ``_EXTRA_CACHE`` keyed by a content digest, so repeat
+calls on an (almost) unchanged slate cost ~0 after the first warm pass.
+The call site (``loop.py``) additionally runs the pair off the event
+loop via ``asyncio.to_thread`` since ``Encoding.encode`` releases the
+GIL and is stateless (safe to call concurrently from threads).
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import threading
+from collections import OrderedDict
 from collections.abc import Iterable, Mapping
 from typing import Any
+
+# ─── memoization primitives ────────────────────────────────────────────────
+
+# A stub system message used to measure payload-level "extra" overhead
+# (tools schema + the chat-framing tokens litellm adds when a system
+# message is present) in isolation from any real message's body cost.
+_STUB_SYSTEM_MESSAGE: dict[str, Any] = {"role": "system", "content": ""}
+
+_BODY_CACHE_MAX = 65536
+_BODY_CACHE: OrderedDict[bytes, int] = OrderedDict()
+_EXTRA_CACHE: OrderedDict[bytes, int] = OrderedDict()
+_CACHE_LOCK = threading.Lock()
+
+
+def _payload_digest(obj: Any) -> bytes | None:
+    """Stable content digest for cache keys.
+
+    Returns ``None`` (cache-bypass sentinel) if ``obj`` can't be
+    serialized deterministically — callers must fall back to counting
+    directly rather than raising.
+    """
+    try:
+        blob = json.dumps(
+            obj,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            default=repr,
+        ).encode()
+    except Exception:
+        return None
+    return hashlib.blake2b(blob, digest_size=16).digest()
+
+
+def _cache_get(cache: OrderedDict[bytes, int], key: bytes) -> int | None:
+    with _CACHE_LOCK:
+        if key in cache:
+            cache.move_to_end(key)
+            return cache[key]
+        return None
+
+
+def _cache_put(cache: OrderedDict[bytes, int], key: bytes, value: int) -> None:
+    with _CACHE_LOCK:
+        cache[key] = value
+        cache.move_to_end(key)
+        while len(cache) > _BODY_CACHE_MAX:
+            cache.popitem(last=False)
+
+
+def _message_body_tokens(msg: Mapping[str, Any]) -> int:
+    """The pure per-message body cost of ``msg`` (no payload-level framing).
+
+    Memoized by content digest; digest failures bypass the cache and
+    count directly (never raise).
+    """
+    from litellm import token_counter
+
+    key = _payload_digest(msg)
+    if key is not None:
+        cached = _cache_get(_BODY_CACHE, key)
+        if cached is not None:
+            return cached
+
+    value = int(token_counter(messages=[msg], count_response_tokens=True))
+
+    if key is not None:
+        _cache_put(_BODY_CACHE, key, value)
+    return value
+
+
+def _extra_tokens(tools: Any, system_present: bool) -> int:
+    """Payload-level overhead: tool-schema cost plus (when a system
+    message is present) the chat-framing tokens litellm adds for it.
+
+    Computed as ``token_counter(messages=[STUB] if system_present else [],
+    tools=tools) - (body(STUB) if system_present else 0)`` — i.e. the
+    total minus the stub's own body cost, isolating the framing/tools
+    overhead. Memoized by (tools digest, system_present).
+    """
+    from litellm import token_counter
+
+    tool_list = list(tools) if tools else None
+    digest_key = _payload_digest((tool_list, system_present))
+    if digest_key is not None:
+        cached = _cache_get(_EXTRA_CACHE, digest_key)
+        if cached is not None:
+            return cached
+
+    if system_present:
+        total = int(token_counter(messages=[_STUB_SYSTEM_MESSAGE], tools=tool_list))
+        value = total - _message_body_tokens(_STUB_SYSTEM_MESSAGE)
+    else:
+        value = int(token_counter(messages=[], tools=tool_list))
+
+    if digest_key is not None:
+        _cache_put(_EXTRA_CACHE, digest_key, value)
+    return value
+
 
 # ─── estimator (delegates to litellm's local tokenizers) ──────────────────
 
@@ -49,18 +163,18 @@ def approx_tokens(
     implementation changes (e.g. a different tokenizer, passing
     ``model=...``), re-run the backfill script to keep stored values
     honest.
-    """
-    # Defer the heavy ``litellm`` import: every consumer of this module
-    # pays ~1.18s of bootstrap otherwise, and many CLI / test code paths
-    # never call into this helper.
-    from litellm import token_counter
 
-    return int(
-        token_counter(
-            messages=list(messages),
-            tools=list(tools) if tools else None,
-        )
-    )
+    Internally built from memoized per-message + per-payload
+    primitives (issue #1744): returns byte-identical results to a
+    direct ``litellm.token_counter(messages=..., tools=...)`` call,
+    but repeat calls on an (almost) unchanged slate cost ~0 after the
+    cache warms.
+    """
+    msgs = list(messages)
+    total = sum(_message_body_tokens(m) for m in msgs)
+    system_present = any(m.get("role") == "system" for m in msgs)
+    total += _extra_tokens(tools, system_present)
+    return total
 
 
 # ─── per-content-class estimator (issue #1609) ────────────────────────────
@@ -111,16 +225,26 @@ def content_class(role: str | None, data: Mapping[str, Any]) -> str:
 
 
 def _count(messages: list[Mapping[str, Any]], *, tools: Any = None) -> int:
-    from litellm import token_counter
+    """Single-payload count, sourced from the same memoized primitives as
+    :func:`approx_tokens` (issue #1744).
 
+    ``_count([m])`` == ``_message_body_tokens(m) + _extra_tokens(None, m.role
+    == "system")``; ``_count([], tools)`` == ``_extra_tokens(tools, False)``.
+    """
     if not messages and not tools:
         return 0
-    return int(
-        token_counter(
-            messages=list(messages),
-            tools=list(tools) if tools else None,
-        )
-    )
+    if len(messages) == 1:
+        msg = messages[0]
+        system_present = msg.get("role") == "system"
+        return _message_body_tokens(msg) + _extra_tokens(tools, system_present)
+    if not messages:
+        return _extra_tokens(tools, False)
+    # General fallback (not used by the current call sites, which only ever
+    # pass 0 or 1 messages here, but keep correct for any future caller).
+    total = sum(_message_body_tokens(m) for m in messages)
+    system_present = any(m.get("role") == "system" for m in messages)
+    total += _extra_tokens(tools, system_present)
+    return total
 
 
 def approx_tokens_by_class(

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -128,6 +128,189 @@ class TestApproxTokensWithTools:
         assert approx_tokens(self._MSGS, tools=[]) == approx_tokens(self._MSGS)
 
 
+class TestApproxTokensEquivalenceMatrix:
+    """Issue #1744: the memoized primitives must not change what
+    ``approx_tokens`` returns.  Every slate here is checked against a
+    direct, unmemoized ``litellm.token_counter(messages=..., tools=...)``
+    call — the ground truth the old implementation delegated to directly.
+    """
+
+    _TOOL: ClassVar[dict[str, Any]] = {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    }
+
+    _SYSTEM: ClassVar[dict[str, Any]] = {"role": "system", "content": "you are a helpful agent"}
+    _USER: ClassVar[dict[str, Any]] = {"role": "user", "content": "what files are here"}
+    _TOOL_CALL_MSG: ClassVar[dict[str, Any]] = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "tc_1",
+                "type": "function",
+                "function": {"name": "bash", "arguments": '{"command": "ls"}'},
+            }
+        ],
+    }
+    _REASONING_MSG: ClassVar[dict[str, Any]] = {
+        "role": "assistant",
+        "content": "the answer",
+        "reasoning_content": "a long internal chain of deliberation",
+    }
+    _NAME_KEY_MSG: ClassVar[dict[str, Any]] = {
+        "role": "user",
+        "name": "alice",
+        "content": "hi there",
+    }
+    _LIST_CONTENT_MSG: ClassVar[dict[str, Any]] = {
+        "role": "user",
+        "content": [{"type": "text", "text": "hello from a list"}],
+    }
+    _TOOL_RESULT_MSG: ClassVar[dict[str, Any]] = {
+        "role": "tool",
+        "tool_call_id": "tc_1",
+        "content": "result payload text",
+    }
+
+    def _slates(self) -> list[list[dict[str, Any]]]:
+        return [
+            [],
+            [self._USER],
+            [self._SYSTEM, self._USER],
+            [self._SYSTEM, self._USER, self._TOOL_CALL_MSG],
+            [self._REASONING_MSG],
+            [self._NAME_KEY_MSG],
+            [self._LIST_CONTENT_MSG],
+            [self._TOOL_RESULT_MSG],
+            [
+                self._SYSTEM,
+                self._USER,
+                self._REASONING_MSG,
+                self._TOOL_CALL_MSG,
+                self._TOOL_RESULT_MSG,
+                self._NAME_KEY_MSG,
+                self._LIST_CONTENT_MSG,
+            ],
+        ]
+
+    def test_matches_direct_token_counter(self) -> None:
+        from litellm import token_counter
+
+        for tools in (None, [self._TOOL]):
+            for msgs in self._slates():
+                got = approx_tokens(msgs, tools=tools)
+                want = int(
+                    token_counter(
+                        messages=list(msgs),
+                        tools=list(tools) if tools else None,
+                    )
+                )
+                assert got == want, (msgs, tools, got, want)
+
+
+class TestApproxTokensCache:
+    """Issue #1744: memoization must be transparent — same results, but
+    the underlying ``token_counter`` isn't re-invoked on a repeat call
+    with fresh-but-equal dicts.
+    """
+
+    def test_repeat_call_makes_zero_token_counter_calls(self, monkeypatch: Any) -> None:
+        msgs = [
+            {"role": "user", "content": "warm the cache please, this is unique-9182"},
+            {"role": "assistant", "content": "sure thing"},
+        ]
+        # Warm the cache first (fresh dicts).
+        first = approx_tokens([dict(m) for m in msgs])
+
+        calls = {"n": 0}
+        real_token_counter = None
+        import litellm
+
+        real_token_counter = litellm.token_counter
+
+        def _counting(*args: Any, **kwargs: Any) -> int:
+            calls["n"] += 1
+            return real_token_counter(*args, **kwargs)
+
+        monkeypatch.setattr(litellm, "token_counter", _counting)
+
+        # Fresh-but-equal dicts (new objects, same content) must hit cache.
+        second = approx_tokens([dict(m) for m in msgs])
+
+        assert second == first
+        assert calls["n"] == 0
+
+    def test_changed_message_is_recounted(self) -> None:
+        a = [{"role": "user", "content": "version A of the message"}]
+        b = [{"role": "user", "content": "version B of the message, different"}]
+        assert approx_tokens(a) != approx_tokens(b)
+
+    def test_unserializable_payload_still_counted(self) -> None:
+        class Weird:
+            def __repr__(self) -> str:
+                return "Weird()"
+
+        # A message value that json.dumps can't natively serialize (falls
+        # back to `default=repr`, or fails outright) must still be counted,
+        # not raise.
+        msg = {"role": "user", "content": "hello", "_marker": Weird()}
+        result = approx_tokens([msg])
+        assert result >= 1
+
+    def test_cache_bound_enforced(self) -> None:
+        from aios.harness.tokens import _BODY_CACHE, _BODY_CACHE_MAX
+
+        # Blow well past the cache bound with unique messages; the cache
+        # must never exceed its max size.
+        for i in range(200):
+            approx_tokens([{"role": "user", "content": f"unique message body {i}"}])
+        assert len(_BODY_CACHE) <= _BODY_CACHE_MAX
+
+
+class TestApproxTokensThreaded:
+    """Issue #1744: concurrent calls (as the loop.py ``to_thread`` call
+    site will make) must return identical, correct results — no shared
+    mutable state races.
+    """
+
+    def test_concurrent_calls_agree(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        msgs = [
+            {"role": "system", "content": "you are a helpful agent"},
+            {"role": "user", "content": "what is the weather like today in paris"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_1",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": '{"city": "paris"}'},
+                    }
+                ],
+            },
+        ]
+        expected = approx_tokens(msgs)
+
+        def _call(_: int) -> int:
+            return approx_tokens([dict(m) for m in msgs])
+
+        with ThreadPoolExecutor(max_workers=16) as ex:
+            results = list(ex.map(_call, range(64)))
+
+        assert all(r == expected for r in results)
+
+
 class TestEventTokenDelta:
     """``_event_token_delta`` is the pure per-event token contribution that
     ``append_event`` now computes BEFORE the row lock (issue #862).

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -239,7 +239,7 @@ class TestApproxTokensCache:
 
         def _counting(*args: Any, **kwargs: Any) -> int:
             calls["n"] += 1
-            return real_token_counter(*args, **kwargs)
+            return int(real_token_counter(*args, **kwargs))
 
         monkeypatch.setattr(litellm, "token_counter", _counting)
 
@@ -285,7 +285,7 @@ class TestApproxTokensThreaded:
     def test_concurrent_calls_agree(self) -> None:
         from concurrent.futures import ThreadPoolExecutor
 
-        msgs = [
+        msgs: list[dict[str, Any]] = [
             {"role": "system", "content": "you are a helpful agent"},
             {"role": "user", "content": "what is the weather like today in paris"},
             {

--- a/tests/unit/test_tokens_by_class.py
+++ b/tests/unit/test_tokens_by_class.py
@@ -142,7 +142,9 @@ class TestApproxTokensByClass:
         assert approx_tokens(msgs) > 0
 
 
-def _reference_count(messages: list[dict], *, tools: object = None) -> int:
+def _reference_count(
+    messages: list[dict[str, Any]], *, tools: list[dict[str, Any]] | None = None
+) -> int:
     """Inline reference copy of the pre-#1744 ``_count`` (unmemoized,
     calls ``litellm.token_counter`` directly every time) — the
     equivalence baseline for the memoized ``approx_tokens_by_class``.
@@ -154,12 +156,14 @@ def _reference_count(messages: list[dict], *, tools: object = None) -> int:
     return int(
         token_counter(
             messages=list(messages),
-            tools=list(tools) if tools else None,  # type: ignore[arg-type]
+            tools=list(tools) if tools else None,
         )
     )
 
 
-def _reference_split_assistant(msg: dict, by_class: dict[str, int], *, primary: str) -> None:
+def _reference_split_assistant(
+    msg: dict[str, Any], by_class: dict[str, int], *, primary: str
+) -> None:
     full = _reference_count([msg])
 
     text_content = msg.get("content")
@@ -180,7 +184,9 @@ def _reference_split_assistant(msg: dict, by_class: dict[str, int], *, primary: 
     by_class[primary] += residual
 
 
-def _reference_by_class(messages: list[dict], *, tools: list[dict] | None = None) -> dict[str, int]:
+def _reference_by_class(
+    messages: list[dict[str, Any]], *, tools: list[dict[str, Any]] | None = None
+) -> dict[str, int]:
     """Inline reference copy of the pre-#1744 ``approx_tokens_by_class``
     (unmemoized): the equivalence-matrix ground truth.
     """
@@ -265,7 +271,7 @@ class TestApproxTokensByClassEquivalenceMatrix:
         "content": "result payload text",
     }
 
-    def _slates(self) -> list[list[dict]]:
+    def _slates(self) -> list[list[dict[str, Any]]]:
         return [
             [],
             [self._USER],

--- a/tests/unit/test_tokens_by_class.py
+++ b/tests/unit/test_tokens_by_class.py
@@ -7,6 +7,8 @@ classes without touching the neutral baseline counter itself.
 
 from __future__ import annotations
 
+from typing import Any, ClassVar
+
 from aios.harness.tokens import (
     CONTENT_CLASSES,
     approx_tokens,
@@ -138,3 +140,155 @@ class TestApproxTokensByClass:
         msgs = [{"role": "user", "content": "hello there"}]
         # Sanity: still returns the plain neutral count.
         assert approx_tokens(msgs) > 0
+
+
+def _reference_count(messages: list[dict], *, tools: object = None) -> int:
+    """Inline reference copy of the pre-#1744 ``_count`` (unmemoized,
+    calls ``litellm.token_counter`` directly every time) — the
+    equivalence baseline for the memoized ``approx_tokens_by_class``.
+    """
+    from litellm import token_counter
+
+    if not messages and not tools:
+        return 0
+    return int(
+        token_counter(
+            messages=list(messages),
+            tools=list(tools) if tools else None,  # type: ignore[arg-type]
+        )
+    )
+
+
+def _reference_split_assistant(msg: dict, by_class: dict[str, int], *, primary: str) -> None:
+    full = _reference_count([msg])
+
+    text_content = msg.get("content")
+    text_tokens = 0
+    if text_content:
+        text_tokens = _reference_count([{"role": "assistant", "content": text_content}])
+
+    thinking_tokens = 0
+    reasoning = msg.get("reasoning_content")
+    if reasoning:
+        thinking_tokens = _reference_count([{"role": "assistant", "content": reasoning}])
+
+    by_class["text"] += text_tokens
+    by_class["thinking"] += thinking_tokens
+    residual = full - text_tokens - thinking_tokens
+    if residual < 0:
+        residual = 0
+    by_class[primary] += residual
+
+
+def _reference_by_class(messages: list[dict], *, tools: list[dict] | None = None) -> dict[str, int]:
+    """Inline reference copy of the pre-#1744 ``approx_tokens_by_class``
+    (unmemoized): the equivalence-matrix ground truth.
+    """
+    msgs = list(messages)
+    tool_list = list(tools) if tools else None
+
+    by_class: dict[str, int] = {c: 0 for c in CONTENT_CLASSES}
+
+    if tool_list:
+        by_class["tools"] = _reference_count([], tools=tool_list)
+
+    for msg in msgs:
+        role = msg.get("role")
+        cls = content_class(role, msg)
+        if cls == "system":
+            by_class["system"] += _reference_count([msg])
+            continue
+        if cls == "tool_result":
+            by_class["tool_result"] += _reference_count([msg])
+            continue
+        if cls == "tool_use":
+            _reference_split_assistant(msg, by_class, primary="tool_use")
+            continue
+        if cls == "thinking":
+            _reference_split_assistant(msg, by_class, primary="thinking")
+            continue
+        by_class["text"] += _reference_count([msg])
+
+    return by_class
+
+
+class TestApproxTokensByClassEquivalenceMatrix:
+    """Issue #1744: the memoized ``approx_tokens_by_class`` must return
+    byte-identical results to the (unmemoized) reference implementation
+    above, across a slates x {system?, tools?, tool_calls,
+    reasoning_content, name key, list-content, empty list, [msg]} matrix.
+    """
+
+    _TOOL: ClassVar[dict[str, Any]] = {
+        "type": "function",
+        "function": {
+            "name": "bash",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+        },
+    }
+
+    _SYSTEM: ClassVar[dict[str, Any]] = {"role": "system", "content": "you are a helpful agent"}
+    _USER: ClassVar[dict[str, Any]] = {"role": "user", "content": "what files are here"}
+    _TOOL_CALL_MSG: ClassVar[dict[str, Any]] = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "tc_1",
+                "type": "function",
+                "function": {"name": "bash", "arguments": '{"command": "ls"}'},
+            }
+        ],
+    }
+    _REASONING_MSG: ClassVar[dict[str, Any]] = {
+        "role": "assistant",
+        "content": "the answer",
+        "reasoning_content": "a long internal chain of deliberation",
+    }
+    _NAME_KEY_MSG: ClassVar[dict[str, Any]] = {
+        "role": "user",
+        "name": "alice",
+        "content": "hi there",
+    }
+    _LIST_CONTENT_MSG: ClassVar[dict[str, Any]] = {
+        "role": "user",
+        "content": [{"type": "text", "text": "hello from a list"}],
+    }
+    _TOOL_RESULT_MSG: ClassVar[dict[str, Any]] = {
+        "role": "tool",
+        "tool_call_id": "tc_1",
+        "content": "result payload text",
+    }
+
+    def _slates(self) -> list[list[dict]]:
+        return [
+            [],
+            [self._USER],
+            [self._SYSTEM, self._USER],
+            [self._SYSTEM, self._USER, self._TOOL_CALL_MSG],
+            [self._REASONING_MSG],
+            [self._NAME_KEY_MSG],
+            [self._LIST_CONTENT_MSG],
+            [self._TOOL_RESULT_MSG],
+            [
+                self._SYSTEM,
+                self._USER,
+                self._REASONING_MSG,
+                self._TOOL_CALL_MSG,
+                self._TOOL_RESULT_MSG,
+                self._NAME_KEY_MSG,
+                self._LIST_CONTENT_MSG,
+            ],
+        ]
+
+    def test_matches_reference_implementation(self) -> None:
+        for tools in (None, [self._TOOL]):
+            for msgs in self._slates():
+                got = approx_tokens_by_class(msgs, tools=tools)
+                want = _reference_by_class(msgs, tools=tools)
+                assert got == want, (msgs, tools, got, want)


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1744.