### PR TITLE
infra: committed IaC specs for dev-review/fix/ci-watch/risk @150k window — fix the 600k drift doom-loop halting the pipeline (aios#1770)

### DIFF
--- a/infra/agents/dev-ci-watch.json
+++ b/infra/agents/dev-ci-watch.json
@@ -1,0 +1,39 @@
+{
+  "name": "dev-ci-watch",
+  "model": "anthropic/claude-sonnet-5",
+  "system": "You are the dev-pipeline CI-WATCH agent. Your request gives {repo, pr_number, head_sha} or {repo, ref}. Poll the GitHub Checks/Status API via the github http_request server (GET /repos/<repo>/commits/<sha>/check-runs and /repos/<repo>/commits/<sha>/status) until the checks reach a terminal state (all completed, or a failure). You OWN this durable wait — keep polling with brief sleeps until terminal; do not give up early. Return ONLY via `return` a value conforming to {status:'green'|'red'|'no_ci', detail}. 'no_ci' means no checks are configured. Do not narrate.",
+  "tools": [
+    {
+      "type": "http_request"
+    }
+  ],
+  "skills": [],
+  "mcp_servers": [],
+  "http_servers": [
+    {
+      "name": "github",
+      "base_url": "https://api.github.com",
+      "routes": [
+        {
+          "path_pattern": "/repos/**",
+          "methods": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        {
+          "path_pattern": "/graphql",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "description": "dev-pipeline ci-watch node: poll GitHub checks until terminal (owns the durable wait).",
+  "metadata": {},
+  "litellm_extra": {},
+  "window_min": 50000,
+  "window_max": 150000
+}

--- a/infra/agents/dev-fix.json
+++ b/infra/agents/dev-fix.json
@@ -1,0 +1,57 @@
+{
+  "name": "dev-fix",
+  "model": "anthropic/claude-sonnet-5",
+  "system": "You are the dev-pipeline FIX agent. Your request gives {repo, pr_number, issues|detail, comments}. Clone the repo, checkout the PR branch (git fetch origin pull/<n>/head or the head ref), address the listed issues / CI failure, commit, and `git push` a NEW commit to the same branch. Configure git identity locally first. Return ONLY via `return` a value conforming to {head_sha, pushed:true} where head_sha is the new HEAD sha you pushed. If you make no change, return pushed:false with the unchanged head_sha. Do not narrate.",
+  "tools": [
+    {
+      "type": "bash"
+    },
+    {
+      "type": "read"
+    },
+    {
+      "type": "write"
+    },
+    {
+      "type": "edit"
+    },
+    {
+      "type": "glob"
+    },
+    {
+      "type": "grep"
+    },
+    {
+      "type": "http_request"
+    }
+  ],
+  "skills": [],
+  "mcp_servers": [],
+  "http_servers": [
+    {
+      "name": "github",
+      "base_url": "https://api.github.com",
+      "routes": [
+        {
+          "path_pattern": "/repos/**",
+          "methods": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        {
+          "path_pattern": "/graphql",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "description": "dev-pipeline fix node: clone/checkout PR branch, address issues, push a new commit.",
+  "metadata": {},
+  "litellm_extra": {},
+  "window_min": 50000,
+  "window_max": 150000
+}

--- a/infra/agents/dev-review.json
+++ b/infra/agents/dev-review.json
@@ -1,0 +1,51 @@
+{
+  "name": "dev-review",
+  "model": "anthropic/claude-sonnet-5",
+  "system": "You are the dev-pipeline REVIEW agent. Your request gives {repo, pr_number, head_sha, comments}. Fetch the PR diff via the github http_request server (GET /repos/<repo>/pulls/<n> and /repos/<repo>/pulls/<n>/files), review for correctness, tests, and convention adherence, and POST a review-artifact comment whose body begins with the line `### Code review` (POST /repos/<repo>/issues/<pr_number>/comments). You may also clone the repo via bash for deeper inspection. Return ONLY via `return` a value conforming to the schema: {verdict:'pass'|'fail', issues:[...], artifact_posted:true}. Set artifact_posted true only if the comment POST succeeded. Do not narrate.",
+  "tools": [
+    {
+      "type": "bash"
+    },
+    {
+      "type": "read"
+    },
+    {
+      "type": "glob"
+    },
+    {
+      "type": "grep"
+    },
+    {
+      "type": "http_request"
+    }
+  ],
+  "skills": [],
+  "mcp_servers": [],
+  "http_servers": [
+    {
+      "name": "github",
+      "base_url": "https://api.github.com",
+      "routes": [
+        {
+          "path_pattern": "/repos/**",
+          "methods": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        {
+          "path_pattern": "/graphql",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "description": "dev-pipeline review node: review the PR diff and post a Code review artifact.",
+  "metadata": {},
+  "litellm_extra": {},
+  "window_min": 50000,
+  "window_max": 150000
+}

--- a/infra/agents/dev-risk.json
+++ b/infra/agents/dev-risk.json
@@ -1,0 +1,51 @@
+{
+  "name": "dev-risk",
+  "model": "anthropic/claude-sonnet-5",
+  "system": "You are the dev-pipeline RISK agent. Your request gives {repo, pr_number}. Inspect the PR (GET /repos/<repo>/pulls/<n> and /files) to judge merge risk on a 1-4 tier scale: 1=trivial/docs, 2=small isolated change with tests, 3=moderate cross-cutting change, 4=high-risk/migration/security-sensitive. Return ONLY via `return` a value conforming to {tier:int 1-4, summary}. Be conservative when uncertain. Do not narrate.",
+  "tools": [
+    {
+      "type": "bash"
+    },
+    {
+      "type": "read"
+    },
+    {
+      "type": "glob"
+    },
+    {
+      "type": "grep"
+    },
+    {
+      "type": "http_request"
+    }
+  ],
+  "skills": [],
+  "mcp_servers": [],
+  "http_servers": [
+    {
+      "name": "github",
+      "base_url": "https://api.github.com",
+      "routes": [
+        {
+          "path_pattern": "/repos/**",
+          "methods": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        {
+          "path_pattern": "/graphql",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "description": "dev-pipeline risk node: assess merge risk tier 1-4 from the PR.",
+  "metadata": {},
+  "litellm_extra": {},
+  "window_min": 50000,
+  "window_max": 150000
+}


### PR DESCRIPTION
## Incident

The four per-issue dev-pipeline judgment agents — **dev-review, dev-fix, dev-ci-watch, dev-risk** — had drifted live to a **600 000 / 700 000** context window (committed truth is 50 000 / 150 000). On `claude-sonnet-5` this collides with the model's `return`-tool serialization quirk and the agents **doom-loop**, clogging the aios worker (103-job backlog) and halting the dev pipeline.

These four agents had **no committed IaC specs** (only `dev-implement` + `ceo-front` were under `infra/agents/`), so `reconcile-agents` could not correct them — there was nothing to reconcile against. This PR closes that gap.

## What this does

Adds `infra/agents/dev-review.json`, `dev-fix.json`, `dev-ci-watch.json`, `dev-risk.json`, each **mirroring the agent's CURRENT live prod config exactly**, with the **only** intended delta being the window corrected back to `window_min: 50000, window_max: 150000`. Model stays `anthropic/claude-sonnet-5`; system prompt, tools, http_servers, skills, mcp_servers, description, metadata, litellm_extra are all reproduced verbatim from the live rows.

On merge to `master`, the path filter `infra/agents/**` fires `.github/workflows/reconcile-agents.yml` → `scripts/reconcile_agents.py`, which reads each agent **by name**, diffs against the manifest, and `PUT`s a version-bumped `update_agent` — the proper versioned fix, in place (id unchanged, so the dev-pipeline workflow header stays wired).

## How the specs were produced

Captured each agent's live config **read-only** from the aios prod DB (`SELECT to_jsonb(a) FROM agents … WHERE archived_at IS NULL`), stripped the server-only fields (`id`, `version`, `account_id`, `tools_vocab_epoch`, timestamps), forced the window to 50k/150k, and emitted the minimal manifest form via the real `AgentCreate` model (matching `dev-implement.json`'s style). No secrets: agent specs carry only model + system + tools + window; `http_servers` reference `api.github.com` by base_url with the credential resolved from the vault at runtime (the secret-scan unit test confirms).

## Verification

- **Pure window change, proven offline against live**: for each agent, routed both the live subset and the manifest through `AgentCreate(...).model_dump()` and asserted the canonical delta is **exactly `{window_min, window_max}`** — re-checked against the written file bytes. No other field differs.
- `uv run pytest tests/unit/test_reconcile_agents.py -q` → **41 passed** (includes `test_every_committed_manifest_validates_against_agentcreate`, the secret-shaped-literal scan, and `test_main_real_committed_dir_is_default`, all of which now exercise the 4 new manifests).
- Each name resolves to **exactly one** non-archived live row → reconcile takes the clean **UPDATE** path (no duplicate-name fail-loud, no CREATE path that would mint a new id and require a workflow rewire).
- Did **not** run the live reconcile (that is the GitHub Action on merge). The offline canonical diff against the exact DB the API reads is a strictly stronger equivalent of `--check`.

## Per-agent capture confirmation (system + tools verbatim from live)

| agent | model | tools | http_servers | system len |
|---|---|---|---|---|
| dev-review | anthropic/claude-sonnet-5 | bash, read, glob, grep, http_request | github | 663 |
| dev-fix | anthropic/claude-sonnet-5 | bash, read, write, edit, glob, grep, http_request | github | 527 |
| dev-ci-watch | anthropic/claude-sonnet-5 | http_request | github | 567 |
| dev-risk | anthropic/claude-sonnet-5 | bash, read, glob, grep, http_request | github | 418 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)