### PR TITLE
Bash memory-mount reconcile hashes every file per call — stat-diff prefilter + to_thread

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -416,6 +416,27 @@ class Settings(BaseSettings):
         "reaper sweep (an immediate first sweep runs at worker startup, then "
         "repeats at this cadence).",
     )
+    # ── uncorrelated memory-reconcile audit (#1748 §Uncorrelated detector) ────
+    memory_reconcile_audit_enabled: bool = Field(
+        default=True,
+        description="Kill-switch for the low-rate out-of-band full-hash "
+        "memory-store audit (disk-vs-DB content_sha256 divergence check). "
+        "Ships armed: this is the uncorrelated backstop for the bash "
+        "memory-reconcile stat-prefilter (#1748) and MUST be live before the "
+        "prefilter is trusted as the steady state — disabling it removes the "
+        "only detector for a prefilter false-negative silently dropping "
+        "durable memory.",
+    )
+    memory_reconcile_audit_interval_seconds: float = Field(
+        default=21_600.0,
+        gt=0.0,
+        description="Interval for the periodic uncorrelated memory-reconcile "
+        "audit sweep (default 6h — deliberately low-rate: a full content hash "
+        "of every memory-store file is exactly the on-loop-hash cost #1733 "
+        "forbids per bash call; this runs occasionally, off the hot path, as "
+        "a correctness backstop, not a real-time gate).",
+    )
+
     tool_broker_socket_path: Path | None = Field(
         default=None,
         description="Host path for the tool broker's Unix-domain socket. "

--- a/src/aios/harness/memory_reconcile_audit.py
+++ b/src/aios/harness/memory_reconcile_audit.py
@@ -41,7 +41,7 @@ from typing import Any
 
 import asyncpg
 
-from aios.db import queries
+from aios.db import queries as queries
 from aios.logging import get_logger
 from aios.sandbox.memory_mounts import MATERIALIZED_MARKER
 from aios.sandbox.volumes import memory_store_host_dir, memory_stores_root

--- a/src/aios/harness/memory_reconcile_audit.py
+++ b/src/aios/harness/memory_reconcile_audit.py
@@ -1,0 +1,246 @@
+"""Uncorrelated out-of-band full-hash memory audit (#1748 §Uncorrelated detector).
+
+The bash memory-mount reconcile's stat-prefilter (:mod:`aios.tools.bash_memory_reconcile`)
+trades content hashing for a cheap ``os.stat`` signature comparison. Its soundness
+rests on kernel ctime semantics and filesystem properties that ops can change
+underfoot (the memory-store mount is slated to potentially move off the shared
+postgres volume — see the runtime probe in that module). A verdict read from
+the SAME substrate that produced it (i.e. another stat-based check) is
+unfalsifiable from the inside — "substrate-different-verdict".
+
+This module is the falsifying, uncorrelated arm: a low-rate, full-content-hash
+sweep that walks every writable memory-store's host directory, hashes every
+file's ON-DISK bytes unconditionally (no stat prefilter, no candidate
+skipping — the whole point is to NOT reuse the prefilter's code path), and
+compares against the DB's ``content_sha256``. Any divergence is alarmed
+loudly: this is the external, independent detector that would have caught the
+2026-07-04 ultron-memory-rollback class by the machine instead of the
+chairman.
+
+Deliberately NOT wired into ``bash_memory_reconcile`` in any way — no shared
+helper functions, no shared walk routine beyond the unavoidable
+``rglob``/``read_bytes``/``sha256`` primitives every file-hashing sweep must
+use. If the prefilter walk logic ever silently regresses (e.g. someone
+"optimizes" the symlink-rejection check), this audit's independent walk still
+catches divergence because it never trusted the prefilter's candidate set in
+the first place.
+
+Cadence: intended to run as a low-rate periodic worker job (mirroring the
+other reapers in this package) or an ops-agent cron. Low rate is deliberate —
+a full content hash of every memory-store file is exactly the on-loop-hash
+cost #1733 forbids doing PER BASH CALL; doing it occasionally, off the hot
+path, as a correctness backstop is the intended shape.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+from aios.db import queries
+from aios.logging import get_logger
+from aios.sandbox.memory_mounts import MATERIALIZED_MARKER
+from aios.sandbox.volumes import memory_store_host_dir, memory_stores_root
+
+log = get_logger("aios.harness.memory_reconcile_audit")
+
+
+@dataclass(frozen=True, slots=True)
+class Divergence:
+    """One on-disk-vs-DB content mismatch found by the audit."""
+
+    store_id: str
+    store_path: str
+    reason: str  # "content_mismatch" | "missing_on_disk" | "missing_in_db" | "unreadable"
+    disk_sha256: str | None = None
+    db_sha256: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AuditResult:
+    stores_checked: int
+    files_hashed: int
+    divergences: list[Divergence] = field(default_factory=list)
+
+    @property
+    def clean(self) -> bool:
+        return not self.divergences
+
+
+def _hash_file_unconditionally(fpath: Path) -> str | None:
+    """Read and sha256-hash ``fpath``'s full bytes. Returns ``None`` on read failure.
+
+    Deliberately independent of :mod:`aios.tools.bash_memory_reconcile` — no
+    stat comparison, no candidate classification, no shared sentinel types.
+    Every file this audit walks gets its bytes read and hashed, unconditionally.
+    """
+    try:
+        raw = fpath.read_bytes()
+    except OSError:
+        return None
+    try:
+        content = raw.decode("utf-8")
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+    except UnicodeDecodeError:
+        return hashlib.sha256(raw).hexdigest()
+
+
+def _walk_all_files(host_dir: Path) -> list[tuple[Path, str]]:
+    """Enumerate every real file under ``host_dir`` (independent walk).
+
+    Skips only structural non-content entries (the ``.materialized`` marker,
+    in-flight ``.tmp.`` write scratch, symlinks — the same confused-deputy
+    threat the reconcile walk guards against, since this audit also runs
+    host-side against the same shared directory). This is intentionally the
+    ONLY overlap with the reconcile module's walk semantics: both must reject
+    symlinks for the same security reason, but neither imports the other's
+    walk function.
+    """
+    results: list[tuple[Path, str]] = []
+    for fpath in host_dir.rglob("*"):
+        if fpath.is_symlink():
+            continue
+        if fpath.is_dir():
+            continue
+        name = fpath.name
+        if name == MATERIALIZED_MARKER:
+            continue
+        if name.startswith(".tmp."):
+            continue
+        rel = fpath.relative_to(host_dir)
+        store_path = "/" + str(rel).replace("\\", "/")
+        results.append((fpath, store_path))
+    return results
+
+
+async def _list_all_writable_store_ids(
+    conn: asyncpg.Connection[Any],
+) -> list[tuple[str, str]]:
+    """Return ``(store_id, account_id)`` for every non-archived memory store.
+
+    Cross-account (unscoped) by necessity — this is a worker-level backstop
+    audit, not a tenant-facing read; SQL enforces nothing account-specific
+    here because the whole point is to check every store this worker's host
+    might have materialized, regardless of tenant.
+    """
+    rows = await conn.fetch(
+        "SELECT id, account_id FROM memory_stores WHERE archived_at IS NULL",
+    )
+    return [(row["id"], row["account_id"]) for row in rows]
+
+
+async def run_memory_reconcile_audit(pool: asyncpg.Pool[Any]) -> AuditResult:
+    """Full-hash disk-vs-DB audit across every materialized, writable memory store.
+
+    For each non-archived memory store whose host directory has been
+    materialized on THIS worker: walk every file, hash its on-disk content
+    unconditionally, and compare against the DB's live ``content_sha256`` for
+    that path. Divergences (content mismatch, present-on-disk-absent-in-DB,
+    present-in-DB-absent-on-disk, or unreadable) are collected and logged
+    loudly — this function does not raise on divergence (an audit finding is
+    not a crash), but every divergence is a structured warning log line the
+    ops-agent cron / alerting surface can watch.
+    """
+    divergences: list[Divergence] = []
+    stores_checked = 0
+    files_hashed = 0
+
+    async with pool.acquire() as conn:
+        store_ids = await _list_all_writable_store_ids(conn)
+
+        for store_id, account_id in store_ids:
+            host_dir = memory_store_host_dir(store_id)
+            if not host_dir.exists():
+                continue  # never materialized on this worker — nothing to audit here
+            marker = host_dir / MATERIALIZED_MARKER
+            if not marker.exists():
+                continue
+            stores_checked += 1
+
+            disk_paths = _walk_all_files(host_dir)
+            disk_shas: dict[str, str | None] = {}
+            for fpath, store_path in disk_paths:
+                disk_shas[store_path] = _hash_file_unconditionally(fpath)
+                files_hashed += 1
+
+            db_rows = await queries.list_active_memory_paths_and_content(
+                conn, store_id, account_id=account_id
+            )
+            db_shas: dict[str, str] = {
+                path: hashlib.sha256(content.encode("utf-8")).hexdigest()
+                for path, content in db_rows
+            }
+
+            all_paths = set(disk_shas) | set(db_shas)
+            for path in all_paths:
+                disk_sha = disk_shas.get(path)
+                db_sha = db_shas.get(path)
+                if path in disk_shas and path not in db_shas:
+                    divergences.append(
+                        Divergence(
+                            store_id=store_id,
+                            store_path=path,
+                            reason="missing_in_db",
+                            disk_sha256=disk_sha,
+                        )
+                    )
+                elif path not in disk_shas and path in db_shas:
+                    divergences.append(
+                        Divergence(
+                            store_id=store_id,
+                            store_path=path,
+                            reason="missing_on_disk",
+                            db_sha256=db_sha,
+                        )
+                    )
+                elif disk_sha is None:
+                    divergences.append(
+                        Divergence(
+                            store_id=store_id,
+                            store_path=path,
+                            reason="unreadable",
+                            db_sha256=db_sha,
+                        )
+                    )
+                elif disk_sha != db_sha:
+                    divergences.append(
+                        Divergence(
+                            store_id=store_id,
+                            store_path=path,
+                            reason="content_mismatch",
+                            disk_sha256=disk_sha,
+                            db_sha256=db_sha,
+                        )
+                    )
+
+    for d in divergences:
+        log.warning(
+            "memory_reconcile_audit.divergence",
+            store_id=d.store_id,
+            store_path=d.store_path,
+            reason=d.reason,
+            disk_sha256=d.disk_sha256,
+            db_sha256=d.db_sha256,
+        )
+
+    log.info(
+        "memory_reconcile_audit.swept",
+        stores_checked=stores_checked,
+        files_hashed=files_hashed,
+        divergences=len(divergences),
+    )
+
+    return AuditResult(
+        stores_checked=stores_checked,
+        files_hashed=files_hashed,
+        divergences=divergences,
+    )
+
+
+def memory_reconcile_audit_probe_root() -> Path:
+    """Return the root the audit scans stores under (test seam / documentation)."""
+    return memory_stores_root()

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -385,6 +385,31 @@ async def worker_main() -> None:
         if repaired:
             log.info("worker.workspace_ownership_repaired", count=repaired)
 
+        # Probe the actual memory-store mount's ctime granularity (#1748 §6):
+        # the bash memory-reconcile stat-prefilter's soundness rests on
+        # sub-hot-window ctime granularity. That FS is slated to potentially
+        # move off the shared postgres volume onto something coarser
+        # (overlayfs/tmpfs/NFS), so this is a runtime probe, not a build-time
+        # human check. Cached for the process lifetime; fails closed (forces
+        # every reconcile candidate to be hashed) if the mount reports no
+        # ctime or a granule at/above the hot window. to_thread: two
+        # synchronous writes + stats must not block the event loop.
+        from aios.sandbox.volumes import memory_stores_root
+        from aios.tools.bash_memory_reconcile import (
+            probe_mount_ctime_granularity,
+            set_prefilter_state,
+        )
+
+        prefilter_state = await asyncio.to_thread(
+            probe_mount_ctime_granularity, memory_stores_root()
+        )
+        set_prefilter_state(prefilter_state)
+        if not prefilter_state.enabled:
+            log.warning(
+                "worker.memory_reconcile_prefilter_disabled",
+                observed_granule_ns=prefilter_state.observed_granule_ns,
+            )
+
         # Fail-closed boot-admission gate (#1575): before this worker does ANY
         # work — before it opens procrastinate, sweeps, or touches the liveness
         # heartbeat that the container HEALTHCHECK watches — prove the live DB
@@ -472,6 +497,17 @@ async def worker_main() -> None:
             name="host_dir_reaper",
         )
         _supervise(host_dir_reaper_task, latch=supervised_latch, fatal=supervised_failure)
+
+        # Start the uncorrelated memory-reconcile audit (#1748 §Uncorrelated
+        # detector): a low-rate, out-of-band full-hash disk-vs-DB divergence
+        # check that is the falsifying backstop for the bash memory-reconcile
+        # stat-prefilter. Immediate first sweep at boot so the detector is
+        # proven ringing early; honours ``memory_reconcile_audit_enabled``.
+        memory_reconcile_audit_task = asyncio.create_task(
+            _memory_reconcile_audit_loop(pool),
+            name="memory_reconcile_audit",
+        )
+        _supervise(memory_reconcile_audit_task, latch=supervised_latch, fatal=supervised_failure)
 
         # Start the archived-session workspace reaper (#40 — the 45G hole): GC
         # the per-session ``/workspace`` host dir of archived sessions, which
@@ -788,6 +824,42 @@ async def _workspace_reaper_loop(pool: asyncpg.Pool[Any]) -> None:
                 )
         except Exception:
             log.exception("workspace_reaper.tick_failed")
+
+
+async def _memory_reconcile_audit_loop(pool: asyncpg.Pool[Any]) -> None:
+    """Background loop for the uncorrelated memory-reconcile audit (#1748).
+
+    Same shape as the other reaper loops: try/except INSIDE the loop so one
+    DB/FS hiccup never silently disables the audit for the worker's
+    lifetime, immediate first sweep at boot (so the detector is proven
+    ringing early), then every ``memory_reconcile_audit_interval_seconds``.
+    Honours ``memory_reconcile_audit_enabled`` (default ON — this is the
+    uncorrelated backstop for the bash memory-reconcile stat-prefilter and
+    must be live before that prefilter is trusted as the steady state).
+    """
+    log = get_logger("aios.worker.memory_reconcile_audit")
+    settings = get_settings()
+    if not settings.memory_reconcile_audit_enabled:
+        log.warning("memory_reconcile_audit.disabled")
+        return
+    from aios.harness.memory_reconcile_audit import run_memory_reconcile_audit
+
+    interval = settings.memory_reconcile_audit_interval_seconds
+    first = True
+    while True:
+        try:
+            if not first:
+                await asyncio.sleep(interval)
+            first = False
+            result = await run_memory_reconcile_audit(pool)
+            log.info(
+                "memory_reconcile_audit.tick",
+                stores_checked=result.stores_checked,
+                files_hashed=result.files_hashed,
+                divergences=len(result.divergences),
+            )
+        except Exception:
+            log.exception("memory_reconcile_audit.tick_failed")
 
 
 async def _reclaimable_prune_loop(pool: asyncpg.Pool[Any]) -> None:

--- a/src/aios/tools/bash.py
+++ b/src/aios/tools/bash.py
@@ -48,13 +48,18 @@ use absolute paths.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from aios.config import get_settings
 from aios.errors import AiosError
 from aios.harness import runtime
 from aios.sandbox.spec import resolve_bash_timeout_ceiling
-from aios.tools.bash_memory_reconcile import reconcile_memory_mounts, snapshot_memory_mounts
+from aios.tools.bash_memory_reconcile import (
+    has_writable_memory_mount,
+    reconcile_memory_mounts,
+    snapshot_memory_mounts,
+)
 from aios.tools.registry import registry
 
 
@@ -138,7 +143,16 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     sandbox = runtime.require_sandbox_registry()
     handle = await sandbox.get_or_provision(session_id, pool=runtime.require_pool())
 
-    before = snapshot_memory_mounts(session_id)
+    # Fast path (#1748 step 5): a session with no writable memory mount skips
+    # both the before-snapshot and the reconcile's off-loop hops entirely —
+    # no to_thread dispatch, no stat walk, nothing. There is nothing for the
+    # hot-window to protect (no mount means no candidate can ever exist), so
+    # ``snapshot_ns`` is a dummy placeholder here, not a real pre-exec sample.
+    if not has_writable_memory_mount(session_id):
+        before: dict[tuple[str, str], Any] = {}
+        snapshot_ns = 0
+    else:
+        before, snapshot_ns = await asyncio.to_thread(snapshot_memory_mounts, session_id)
     reconcile_warnings: list[str] = []
     exec_raised = False
 
@@ -155,12 +169,12 @@ async def bash_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, 
     finally:
         # Reconcile unconditionally — even when exec raises (e.g. container death)
         # so that partial writes made before the crash are captured in the DB.
-        # reconcile_memory_mounts returns [] immediately when there are no mounts,
-        # so this is a cheap no-op in the common case.
+        # reconcile_memory_mounts's own fast path (#1748 step 5) makes this a
+        # cheap no-op when there is nothing to reconcile.
         # When exec succeeded, reconcile errors propagate; when exec already raised,
         # we suppress them so the original exception is not shadowed.
         try:
-            reconcile_warnings = await reconcile_memory_mounts(session_id, before)
+            reconcile_warnings = await reconcile_memory_mounts(session_id, before, snapshot_ns)
         except Exception:
             if not exec_raised:
                 raise  # fail hard when exec succeeded

--- a/src/aios/tools/bash_memory_reconcile.py
+++ b/src/aios/tools/bash_memory_reconcile.py
@@ -8,19 +8,77 @@ visible cross-session via the shared FS but did not produce durable version
 history.
 
 Design constraints:
-- Snapshot is synchronous (no DB I/O) — taken before ``sandbox.exec``.
-- Reconcile is async — runs after ``sandbox.exec`` returns.
+- Snapshot is a cheap ``os.stat`` walk (no bytes read, no hash) — taken before
+  ``sandbox.exec``, off the event loop via ``asyncio.to_thread``.
+- Reconcile is async — runs after ``sandbox.exec`` returns; its walk/stat/read
+  phase also runs off the loop via ``asyncio.to_thread``, only the DB calls
+  stay on the loop.
 - read_only mounts are never written; we skip them in both directions.
 - Binary files and oversized files emit warnings instead of failing loudly
   (the command already ran; we just can't record what it wrote).
 - sha256 is over UTF-8 encoded bytes of the content string, matching the
   convention in :mod:`aios.services.memory_stores._sha256_hex`.
+
+Stat-signature prefilter (#1748)
+---------------------------------
+Master (pre-#1748) read + sha256-hashed every file in every writable memory
+store, TWICE per bash call, synchronously on the event loop. That is exactly
+the on-loop-hash pattern #1733 (zero-inference-gap) forbids, and it scales
+with total memory-store bytes rather than with what the command actually
+touched.
+
+The fix replaces content hashing with a cheap ``os.stat`` 4-tuple signature
+``(st_size, st_mtime_ns, st_ctime_ns, st_ino)`` for the before/after walks.
+**``st_ctime_ns`` is the ONLY correctness anchor** in that tuple — the kernel
+bumps it on every inode data change and unprivileged code cannot backdate it
+(no ``CAP_SYS_TIME``, no raw-device access inside the sandbox). ``st_size``,
+``st_mtime_ns``, and ``st_ino`` are free redundancy riding the same
+``stat()`` syscall: they can only ever ADD candidates (the safe direction),
+never remove one that ctime alone would have caught. Do not "optimize" this
+later by trusting size+mtime instead of ctime — a `touch -r`/`cp -p` mtime
+backdate would then silently miss a real content change.
+
+Hot-window (why it is load-bearing, not belt-and-suspenders): ctime is
+*stored* at nanosecond granularity on ext4/xfs, but it is *sourced* from the
+kernel's COARSE realtime clock (``ktime_get_coarse_real_ts64``), which ticks
+only once per timer granule (~1-10ms on stock kernels). Two writes inside the
+same tick can therefore observe an IDENTICAL ``st_ctime_ns`` even on an
+ns-granular filesystem. Any file whose before-observed ctime falls within
+``HOT_WINDOW_NS`` of the pre-exec snapshot timestamp is unconditionally
+treated as a candidate regardless of what the after-stat says — this is what
+actually closes the same-tick collision, not filesystem storage granularity.
+Never shrink ``HOT_WINDOW_NS`` toward "the ns granule": that reopens exactly
+the silent-loss hole it exists to close.
+
+Fail-closed coarse/absent-ctime guard: a file whose ``stat()`` raises, or
+whose ``st_ctime_ns == 0`` (a filesystem without ctime), gets a sentinel sig
+that never compares equal to anything (including itself across calls) — so
+it is always a candidate. A per-mount runtime probe (see
+:func:`probe_mount_ctime_granularity`) additionally disables the whole
+prefilter (forcing every candidate to be hashed) if the observed ctime
+granule on the actual memory-store mount is at or above ``HOT_WINDOW_NS``,
+because that mount is slated to potentially move onto overlayfs/tmpfs/NFS
+underfoot.
+
+Accepted residual: a detached process writing via a shared ``mmap`` can defer
+its timestamp update to writeback. If that writeback lands strictly BETWEEN
+two bash calls (no call's [before, after] window straddles it), the next
+call's before-snapshot already reflects the post-writeback state and, if that
+call doesn't otherwise touch the file, the write may be PERMANENTLY
+unreconciled (not merely deferred) — identical to master's blind spot for a
+single command's before/after window, and outside the supported
+memory-write pattern (mmap'd background writers), so this is a bounded,
+documented, non-regressing residual, not a new hole.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import os
+import time
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 
 from aios.harness import runtime
@@ -31,59 +89,89 @@ from aios.sandbox.volumes import memory_store_host_dir
 from aios.services import memory_stores as memory_service
 from aios.services import sessions as sessions_service
 from aios.services.memory_stores import SessionActor
+from aios.tools import bash_memory_telemetry as telemetry
 
 log = get_logger("aios.tools.bash_memory_reconcile")
 
-# Snapshot type: (store_id, store_path) -> sha256_hex
-_Snapshot = dict[tuple[str, str], str]
+# Hot-window: any file whose before-ctime is within this many nanoseconds of
+# the pre-exec snapshot timestamp is ALWAYS a candidate, regardless of the
+# after-stat comparison. See module docstring — this is the load-bearing
+# catch for same-coarse-tick ctime collisions, not a redundant belt.
+HOT_WINDOW_NS = 2_000_000_000  # 2 seconds
+
+
+@dataclass(frozen=True, slots=True)
+class _Sig:
+    """A stat-derived change-detection signature for one file.
+
+    ``ctime_ns`` is the only field this module's correctness argument rests
+    on. ``size``, ``mtime_ns``, and ``ino`` are free redundancy from the same
+    ``stat()`` call: including them in the equality check can only ever make
+    MORE files candidates than ctime alone would (the safe direction), never
+    fewer. Do not remove ctime in favor of the other three — see module
+    docstring.
+    """
+
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+    ino: int
+
+
+# A sentinel signature that never compares equal to anything, including
+# another instance of itself (via NaN-like identity semantics using a
+# monotonically-unique marker). Used for stat-failures and absent-ctime
+# filesystems so such paths are ALWAYS treated as candidates — the fail-safe
+# direction on the axis where a false negative loses memory.
+class _NeverEqualSig(_Sig):
+    __slots__ = ()
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+    def __hash__(self) -> int:  # pragma: no cover - dict usage doesn't rely on this
+        return id(self)
+
+
+_SENTINEL_SIG = _NeverEqualSig(size=-1, mtime_ns=-1, ctime_ns=-1, ino=-1)
+
+# Snapshot type: (store_id, store_path) -> stat signature.
+_Snapshot = dict[tuple[str, str], _Sig]
 
 
 class _Unreadable:
     """Zero-field sentinel marking a walked file whose ``read_bytes()`` raised.
 
-    Stored in the bytes map in place of bytes so the path stays PRESENT in the
-    snapshot.  This keeps the diff from mistaking "unreadable" for "absent" and
-    reconciling it as a deletion (which would wipe the file's version history
-    while it is still on disk).
+    Stored in the candidate-bytes map in place of bytes so the path stays
+    PRESENT in the after-scan. This keeps the diff from mistaking "unreadable"
+    for "absent" and reconciling it as a deletion (which would wipe the
+    file's version history while it is still on disk).
     """
 
 
 # Module-singleton sentinel for unreadable files.
 UNREADABLE = _Unreadable()
 
-# Type of a bytes-map value: real bytes, or the unreadable sentinel.
+# Type of the candidate-bytes map value: real bytes, or the unreadable sentinel.
 _BytesMap = dict[tuple[str, str], "bytes | _Unreadable"]
 
-# Fixed, content-independent digest for unreadable entries.  Stable across both
-# the before and after snapshots so an unchanged-but-unreadable file (unreadable
-# in both) compares equal and triggers no DB call.
-_UNREADABLE_SHA = hashlib.sha256(b"\x00aios:unreadable").hexdigest()
 
+def _stat_sig(fpath: Path) -> _Sig:
+    """Return the stat-signature for ``fpath``, or the never-equal sentinel.
 
-def _bytes_map_to_sha_map(
-    bytes_map: _BytesMap,
-) -> _Snapshot:
-    """Convert a raw-bytes map to a sha256-hex map.
-
-    For UTF-8 decodable bytes, sha is over the decoded string (matching the
-    memory_stores convention).  For binary blobs, sha is over the raw bytes —
-    this allows change detection even though binary files cannot be stored.
-    For the ``UNREADABLE`` sentinel, a fixed content-independent digest is
-    emitted so the path stays comparable without bytes.
+    Fail-closed: any ``OSError`` from ``stat()`` (permission, race with an
+    in-flight delete, transient FS hiccup) or an absent-ctime filesystem
+    (``st_ctime_ns == 0``) routes to the sentinel so the path is unconditionally
+    a candidate rather than silently compared as "unchanged".
     """
-    result: _Snapshot = {}
-    for (store_id, store_path), raw in bytes_map.items():
-        if isinstance(raw, _Unreadable):
-            result[(store_id, store_path)] = _UNREADABLE_SHA
-            continue
-        try:
-            content = raw.decode("utf-8")
-            # sha256 over UTF-8 bytes of content — mirrors memory_stores._sha256_hex
-            sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
-        except UnicodeDecodeError:
-            sha = hashlib.sha256(raw).hexdigest()
-        result[(store_id, store_path)] = sha
-    return result
+    try:
+        st = os.lstat(fpath)
+    except OSError:
+        return _SENTINEL_SIG
+    ctime_ns = st.st_ctime_ns
+    if ctime_ns == 0:
+        return _SENTINEL_SIG
+    return _Sig(size=st.st_size, mtime_ns=st.st_mtime_ns, ctime_ns=ctime_ns, ino=st.st_ino)
 
 
 def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
@@ -94,11 +182,14 @@ def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
     in-flight writes), and any symlinks. The symlink rejection mirrors
     PR #497's policy for ``walk_skill_dir``: bash inside the sandbox can
     ``ln -s <worker-side-path> /mnt/memory/<store>/leak``, and the
-    subsequent host-side ``read_bytes`` would resolve the symlink
-    against the worker's filesystem — exfiltrating any worker-readable
-    file (vault key material on disk, neighbour tenants' state, /etc,
-    OAuth refresh tokens, …) into a memory store that then persists
-    the bytes to DB and renders them to the model on every wake.
+    subsequent host-side read would resolve the symlink against the
+    worker's filesystem — exfiltrating any worker-readable file (vault key
+    material on disk, neighbour tenants' state, /etc, OAuth refresh
+    tokens, …) into a memory store that then persists the bytes to DB and
+    renders them to the model on every wake.
+
+    LOAD-BEARING — preserved verbatim from pre-#1748 (#1705 depends on this
+    walk's exact skip semantics).
     """
     results: list[tuple[Path, str]] = []
     for fpath in host_dir.rglob("*"):
@@ -117,32 +208,30 @@ def _walk_store_files(host_dir: Path) -> list[tuple[Path, str]]:
     return results
 
 
-def _snapshot_with_bytes(
+def has_writable_memory_mount(session_id: str) -> bool:
+    """True if the session has at least one non-``read_only`` memory-store echo.
+
+    Cheap: ``runtime.get_session_memory_mounts`` is a plain in-process dict
+    read, no I/O. Used by both ``bash.py`` (to decide whether to even
+    dispatch the before-snapshot ``to_thread`` hop) and this module's own
+    fast path (to skip the after-scan ``to_thread`` hop) — #1748 step 5.
+    A session with only read_only mounts (or none at all) can never produce
+    a create/modify/delete, so both hops are pure overhead for it.
+    """
+    return any(echo.access != "read_only" for echo in runtime.get_session_memory_mounts(session_id))
+
+
+def _iter_scannable_stores(
     session_id: str,
-) -> tuple[_BytesMap, set[str]]:
-    """Return raw bytes and the set of successfully-scanned stores.
+) -> list[tuple[str, Path]]:
+    """Yield ``(store_id, host_dir)`` for every writable, materialized mount.
 
-    Called internally by both ``snapshot_memory_mounts`` (which only needs
-    sha digests) and ``reconcile_memory_mounts`` (which needs bytes to avoid
-    a second scan).
-
-    Returns ``(bytes_map, scanned_store_ids)``:
-
-    - ``bytes_map``: ``(store_id, store_path) -> raw_bytes``.  A file that is
-      enumerated but whose ``read_bytes()`` raises ``OSError`` is recorded under
-      the ``UNREADABLE`` sentinel instead of being dropped, so the path stays
-      present in the snapshot and is never mistaken for a deletion.
-    - ``scanned_store_ids``: every writable store that passed the echo-cache +
-      ``host_dir.exists()`` + ``.materialized`` marker gates, INCLUDING stores
-      that scanned to zero files.  This is the store-level analog of the
-      ``UNREADABLE`` file sentinel: a store that is NOT in this set was not
-      actually observed in the after-pass, so its ``before`` paths are UNKNOWN
-      (not deleted) and must never be reconciled as deletions (#1705).
+    Shared gate logic between the before-snapshot and the after-scan: a
+    writable echo whose host dir exists and carries the ``.materialized``
+    marker. LOAD-BEARING — preserved verbatim from pre-#1748.
     """
     echoes = runtime.get_session_memory_mounts(session_id)
-    bytes_map: _BytesMap = {}
-    scanned_store_ids: set[str] = set()
-
+    result: list[tuple[str, Path]] = []
     for echo in echoes:
         if echo.access == "read_only":
             continue
@@ -153,32 +242,40 @@ def _snapshot_with_bytes(
         marker = host_dir / MATERIALIZED_MARKER
         if not marker.exists():
             continue
+        result.append((store_id, host_dir))
+    return result
 
-        # Store passed every gate — record it as scanned even if it has zero
-        # files, so the deleted-files diff can tell "scanned, now empty"
-        # (a genuine delete-all) apart from "dropped out of the scan"
-        # (an untrustworthy view that must suppress deletes).
-        scanned_store_ids.add(store_id)
 
+def _snapshot_sigs(session_id: str) -> _Snapshot:
+    """Stat-only walk of every writable, materialized memory mount.
+
+    No bytes read, no hashing — one ``os.stat`` per file. Sync/cheap enough
+    to run inline in the caller's thread (callers off the event loop via
+    ``asyncio.to_thread``).
+    """
+    snapshot: _Snapshot = {}
+    for store_id, host_dir in _iter_scannable_stores(session_id):
         for fpath, store_path in _walk_store_files(host_dir):
-            try:
-                raw: bytes | _Unreadable = fpath.read_bytes()
-            except OSError:
-                # Record the path as seen-but-unreadable rather than dropping it.
-                # Keeping it present (under UNREADABLE) means the diff cannot
-                # mistake it for an absent file and reconcile it as a deletion.
-                raw = UNREADABLE
-            bytes_map[(store_id, store_path)] = raw
-
-    return bytes_map, scanned_store_ids
+            snapshot[(store_id, store_path)] = _stat_sig(fpath)
+    return snapshot
 
 
-def snapshot_memory_mounts(session_id: str) -> _Snapshot:
-    """Return a sha256 snapshot of all writable, materialized memory mount files.
+def snapshot_memory_mounts(session_id: str) -> tuple[_Snapshot, int]:
+    """Return a stat-signature snapshot plus the pre-exec timestamp.
 
-    Called synchronously before ``sandbox.exec``.  No DB I/O.  Returns a dict
-    mapping ``(store_id, store_path)`` to the sha256 hex digest of the file's
-    content at that point.
+    Called before ``sandbox.exec`` (via ``asyncio.to_thread`` from
+    ``bash.py`` — this function itself is plain sync code, safe to run in a
+    worker thread). Returns ``(before_sigs, snapshot_ns)``:
+
+    - ``before_sigs``: ``(store_id, store_path) -> _Sig`` for every eligible
+      file, no bytes read, no hash.
+    - ``snapshot_ns``: ``time.time_ns()`` sampled HERE, pre-exec. This is a
+      hard contract (Lens 0 #2): the after-scan MUST be given this same
+      value, never re-sample it. Sampling post-exec would make every file
+      whose ctime predates ``snapshot_ns`` by less than one hot-window look
+      "not hot" even if it was modified moments before a long-running exec —
+      silently disabling the hot-window net for any command that runs longer
+      than ``HOT_WINDOW_NS`` (routine: default bash timeout is 120s).
 
     Skips:
     - Sessions with no attached stores.
@@ -186,8 +283,127 @@ def snapshot_memory_mounts(session_id: str) -> _Snapshot:
     - Stores whose host directory does not exist yet.
     - Stores that have not been materialized (marker file absent).
     """
-    by_bytes, _scanned = _snapshot_with_bytes(session_id)
-    return _bytes_map_to_sha_map(by_bytes)
+    snapshot_ns = time.time_ns()
+    sigs = _snapshot_sigs(session_id)
+    return sigs, snapshot_ns
+
+
+def _is_hot(sig: _Sig, snapshot_ns: int) -> bool:
+    """True if ``sig``'s ctime falls within ``HOT_WINDOW_NS`` of the snapshot.
+
+    The sentinel sig (ctime_ns=-1) is never "hot" by this check alone — it's
+    already a candidate unconditionally via the sentinel's never-equal
+    semantics, so hot-window membership is moot for it.
+    """
+    if sig is _SENTINEL_SIG:
+        return False
+    return sig.ctime_ns >= snapshot_ns - HOT_WINDOW_NS
+
+
+def _is_candidate(
+    before_sig: _Sig | None,
+    after_sig: _Sig,
+    snapshot_ns: int,
+    *,
+    force_hash: bool,
+) -> bool:
+    """True if this path must be read+hashed rather than trusted as unchanged.
+
+    A path is skipped (NOT a candidate) only if: it existed in ``before``
+    AND both sigs are non-sentinel AND they compare equal AND it is not hot.
+    Everything else — new path, missing before entry, sentinel on either
+    side, sig-differs, hot, or the coarse-ctime force-hash escape armed —
+    is a candidate.
+    """
+    if force_hash:
+        return True
+    if before_sig is None:
+        return True  # new path
+    if before_sig is _SENTINEL_SIG or after_sig is _SENTINEL_SIG:
+        return True
+    if before_sig != after_sig:
+        return True
+    return _is_hot(before_sig, snapshot_ns)
+
+
+def _read_candidate(fpath: Path) -> bytes | _Unreadable:
+    """Read a candidate file's bytes, immediately after the symlink check.
+
+    Mirrors the pre-#1748 ``_snapshot_with_bytes`` read: happens in the SAME
+    walk iteration as the symlink rejection, never via a later re-open by
+    reconstructed path (which could race a symlink planted by a peer
+    session between the walk and a deferred read).
+    """
+    try:
+        return fpath.read_bytes()
+    except OSError:
+        return UNREADABLE
+
+
+@dataclass(frozen=True, slots=True)
+class _ScanResult:
+    after_sigs: _Snapshot
+    candidate_bytes: _BytesMap
+    scanned_store_ids: set[str]
+    candidate_read_count: int
+
+
+def _scan_after(
+    session_id: str,
+    before: _Snapshot,
+    snapshot_ns: int,
+    *,
+    force_hash: bool,
+) -> _ScanResult:
+    """Re-walk every store; stat every file; read bytes for candidates only.
+
+    Hard invariant: ``after_sigs`` contains EVERY walked path, including
+    paths whose ``os.stat`` raised (recorded under the sentinel sig) and
+    paths whose candidate read later fails. The delete-diff in
+    :func:`reconcile_memory_mounts` keys off ``after_sigs`` presence, NEVER
+    off the (smaller) candidate-bytes set — a builder who populated
+    ``after_sigs`` only for "valid, comparable" sigs would let a transient
+    ``os.stat`` failure on an untouched, unrelated file read as "absent" and
+    reconcile it as a delete (the #1705 mass-delete class).
+
+    Runs entirely off the event loop (call via ``asyncio.to_thread``).
+    """
+    after_sigs: _Snapshot = {}
+    candidate_bytes: _BytesMap = {}
+    scanned_store_ids: set[str] = set()
+    candidate_read_count = 0
+
+    for store_id, host_dir in _iter_scannable_stores(session_id):
+        scanned_store_ids.add(store_id)
+        for fpath, store_path in _walk_store_files(host_dir):
+            after_sig = _stat_sig(fpath)
+            after_sigs[(store_id, store_path)] = after_sig
+
+            before_sig = before.get((store_id, store_path))
+            if _is_candidate(before_sig, after_sig, snapshot_ns, force_hash=force_hash):
+                candidate_read_count += 1
+                candidate_bytes[(store_id, store_path)] = _read_candidate(fpath)
+
+    return _ScanResult(
+        after_sigs=after_sigs,
+        candidate_bytes=candidate_bytes,
+        scanned_store_ids=scanned_store_ids,
+        candidate_read_count=candidate_read_count,
+    )
+
+
+def _content_sha256(raw: bytes) -> str:
+    """sha256 over UTF-8-decoded content when possible, else over raw bytes.
+
+    Mirrors :mod:`aios.services.memory_stores`' ``_sha256_hex`` convention
+    (sha over the decoded string), falling back to raw bytes for binary
+    blobs so a change can still be detected even though it can't be stored.
+    """
+    try:
+        content = raw.decode("utf-8")
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()
+    except UnicodeDecodeError:
+        return hashlib.sha256(raw).hexdigest()
 
 
 def _read_utf8_content(
@@ -200,7 +416,7 @@ def _read_utf8_content(
     """Decode ``raw`` as UTF-8 and enforce the size limit.
 
     Returns the decoded string on success, or ``None`` if the bytes cannot be
-    decoded or exceed ``MAX_CONTENT_BYTES``.  In the rejection case a human-
+    decoded or exceed ``MAX_CONTENT_BYTES``. In the rejection case a human-
     readable entry is appended to ``warnings`` and a structured warning is
     emitted via the logger.
     """
@@ -264,15 +480,19 @@ def _warn_store_unscannable(
 ) -> None:
     """Surface a store that dropped out of the after-scan; suppress its deletes.
 
-    The store-level twin of :func:`_warn_unreadable` (#1705).  A store present
+    The store-level twin of :func:`_warn_unreadable` (#1705). A store present
     in ``before`` but absent from the after-pass ``scanned_store_ids`` was not
     actually observed after ``sandbox.exec`` — its mount echo-cache was cleared
     mid-bash (``SandboxRegistry.release``/``evict``/idle-reaper), or its host dir
-    or ``.materialized`` marker vanished.  Its ``before`` paths therefore read as
+    or ``.materialized`` marker vanished. Its ``before`` paths therefore read as
     "deleted" only because the after-view is UNKNOWN, not because the files were
-    removed (they are still on disk and in the DB).  Deleting on that view is the
+    removed (they are still on disk and in the DB). Deleting on that view is the
     mass-delete data-loss path, so every delete for the store is suppressed and
     the store is surfaced instead — emitted once per store, not once per file.
+
+    LOAD-BEARING — must run regardless of whether ``account_id`` has been
+    loaded (it needs none); see the ordering hazard note in
+    :func:`reconcile_memory_mounts`.
     """
     warnings.append(
         f"store {store_id}: not scannable after exec (mount cache cleared or "
@@ -287,55 +507,131 @@ def _warn_store_unscannable(
     )
 
 
-async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[str]:
+async def reconcile_memory_mounts(
+    session_id: str, before: _Snapshot, snapshot_ns: int
+) -> list[str]:
     """Diff memory mount state against ``before``; write DB changes.
 
-    Called after ``sandbox.exec`` returns.  For each writable mount:
+    Called after ``sandbox.exec`` returns. For each writable mount:
 
     - New files (in after, not in before): ``create_memory``
-    - Modified files (sha changed): ``update_memory`` with precondition
-    - Deleted files (in before, not in after): ``delete_memory``
-    - Unchanged files: no DB call
+    - Modified candidates (sig differs from a valid DB sha comparison):
+      ``update_memory`` with precondition
+    - Deleted files (in before, not in after_sigs): ``delete_memory``
+    - Unchanged files (not a candidate): no read, no DB call
+
+    The walk/stat/candidate-read phase runs off the event loop via
+    ``asyncio.to_thread``; only the DB phase below stays on the loop.
+
+    Fast path (#1748 step 5): if there is nothing to reconcile — zero
+    candidates AND zero real deletes — ``load_session_account_id`` is never
+    called. "Zero real deletes" is evaluated AFTER the #1705 unscannable-store
+    suppression classification: an unscannable store's suppressed deletes are
+    NOT "real" deletes for this purpose (nothing gets written to the DB for
+    them), so a no-op call against an otherwise-unscannable store still hits
+    the fast path — but the suppression warning is emitted regardless,
+    UNCONDITIONALLY on whether the fast path fires, because it needs no
+    ``account_id`` and is the #1705 regression guard's whole point.
 
     Binary files and files exceeding ``MAX_CONTENT_BYTES`` are skipped with a
-    warning string (collected and returned).  DB errors propagate — they are
+    warning string (collected and returned). DB errors propagate — they are
     the session's problem to recover from through the normal error channel.
     """
+    # Fast path (#1748 step 5, bash.py-mirrored): a session with no attached
+    # memory-store echoes at all (not even read_only ones) cannot have
+    # anything to scan — ``_iter_scannable_stores`` would yield nothing for
+    # either pass. Skip the ``to_thread`` dispatch entirely rather than
+    # paying a thread-pool round trip just to discover an empty result.
+    # ``runtime.get_session_memory_mounts`` is a plain dict read (no I/O), so
+    # this check is free.
+    if not before and not has_writable_memory_mount(session_id):
+        telemetry.record_candidate_reads(0)
+        return []
+
+    force_hash = not get_prefilter_state().enabled
+
+    with telemetry.timed_phase("memory_reconcile"):
+        with telemetry.timed_phase("after_scan"):
+            scan = await asyncio.to_thread(
+                _scan_after, session_id, before, snapshot_ns, force_hash=force_hash
+            )
+
+        after_sigs = scan.after_sigs
+        candidate_bytes = scan.candidate_bytes
+        after_scanned_stores = scan.scanned_store_ids
+        telemetry.record_candidate_reads(scan.candidate_read_count)
+
+        warnings: list[str] = []
+
+        # ── Deleted files: classify FIRST (no account_id needed) ────────────
+        # Count before-paths per store so an unscannable store can report how
+        # many deletions it suppressed (the #1705 incident wrote 159 durable
+        # deletes in 1.79s from a read-only bash while the mount cache was
+        # cleared under it).
+        before_path_counts = Counter(store_id for store_id, _store_path in before)
+        unscannable_warned: set[str] = set()
+        # (store_id, store_path) pairs that are genuinely deleted (store WAS
+        # scanned, path is absent from after_sigs) — these are the only
+        # deletes that will actually hit the DB.
+        real_deletes: list[tuple[str, str]] = []
+        for store_id, store_path in before:
+            if (store_id, store_path) in after_sigs:
+                continue  # still present
+            if store_id not in after_scanned_stores:
+                # Store not observed in the after-pass — before-paths are
+                # UNKNOWN, not deleted. Warn once per store; suppress the
+                # delete. Runs regardless of the fast-path / account_id state.
+                if store_id not in unscannable_warned:
+                    unscannable_warned.add(store_id)
+                    _warn_store_unscannable(
+                        store_id, before_path_counts[store_id], warnings, session_id
+                    )
+                continue
+            real_deletes.append((store_id, store_path))
+
+        # ── Fast path: nothing to do ─────────────────────────────────────────
+        if not candidate_bytes and not real_deletes:
+            return warnings
+
+        with telemetry.timed_phase("db_phase"):
+            warnings = await _reconcile_db_phase(
+                session_id, before, candidate_bytes, real_deletes, warnings
+            )
+        return warnings
+
+
+async def _reconcile_db_phase(
+    session_id: str,
+    before: _Snapshot,
+    candidate_bytes: _BytesMap,
+    real_deletes: list[tuple[str, str]],
+    warnings: list[str],
+) -> list[str]:
+    """The on-loop DB phase: create/update/delete calls for real work only.
+
+    Split out of :func:`reconcile_memory_mounts` purely so the ``db_phase``
+    telemetry span brackets exactly this work (walk/stat/candidate-read is
+    already off-loop in :func:`_scan_after`).
+    """
     account_id = await sessions_service.load_session_account_id(runtime.require_pool(), session_id)
-    # Build after snapshot as (store_id, store_path) -> bytes in one pass.
-    # Using bytes avoids re-reading files during the create/modify loops.
-    # ``after_scanned_stores`` is the set of stores actually observed in this
-    # after-pass; a ``before`` store missing from it is UNKNOWN, not empty, and
-    # its deletes must be suppressed (#1705).
-    after_bytes, after_scanned_stores = _snapshot_with_bytes(session_id)
     pool = runtime.require_pool()
     actor = SessionActor(session_id=session_id)
-    warnings: list[str] = []
 
-    # Compute sha for after entries (needed for equality checks).
-    after: _Snapshot = _bytes_map_to_sha_map(after_bytes)
-
-    # ── New files (created by bash) ─────────────────────────────────────────
-    for (store_id, store_path), _sha in after.items():
+    # ── New files (created by bash) ─────────────────────────────────────
+    for (store_id, store_path), raw in candidate_bytes.items():
         if (store_id, store_path) in before:
-            continue  # will be handled as modify or unchanged
-        raw = after_bytes[(store_id, store_path)]
+            continue  # handled as modify below
         if isinstance(raw, _Unreadable):
             _warn_unreadable(store_id, store_path, warnings, session_id)
             continue
-        maybe_content = _read_utf8_content(
-            store_id,
-            store_path,
-            warnings,
-            session_id,
-            raw,
-        )
+        maybe_content = _read_utf8_content(store_id, store_path, warnings, session_id, raw)
         if maybe_content is None:
             continue
         content = maybe_content
-        # create_memory calls _mirror_to_host internally, which rewrites the same
-        # bytes bash just wrote. This is redundant I/O but harmless and unavoidable
-        # without adding a skip_mirror parameter to the service layer.
+        # create_memory calls _mirror_to_host internally, which rewrites
+        # the same bytes bash just wrote. This is redundant I/O but
+        # harmless and unavoidable without adding a skip_mirror
+        # parameter to the service layer.
         memory = await memory_service.create_memory(
             pool,
             store_id=store_id,
@@ -352,24 +648,22 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             store_path=store_path,
         )
 
-    # ── Modified files (sha changed) ────────────────────────────────────────
-    for (store_id, store_path), before_sha in before.items():
-        after_sha = after.get((store_id, store_path))
-        if after_sha is None:
-            continue  # deleted — handled below
-        if after_sha == before_sha:
-            continue  # unchanged
-        raw = after_bytes[(store_id, store_path)]
+    # ── Modified candidates (DB-sha anchor) ─────────────────────────────
+    # Once the before-pass stops reading bytes, the DB row's
+    # content_sha256 is the only available baseline for a modify
+    # candidate. Baseline semantics shift honestly here: this diffs
+    # DB-state -> disk-after, not disk-before -> disk-after (see module
+    # docstring / issue #1748 Behavioral deltas). They coincide for
+    # single-session stores and diverge only under shared-store peer-write
+    # races, where the DB baseline is the more accurate "state we are
+    # updating".
+    for (store_id, store_path), raw in candidate_bytes.items():
+        if (store_id, store_path) not in before:
+            continue  # handled as create above
         if isinstance(raw, _Unreadable):
             _warn_unreadable(store_id, store_path, warnings, session_id)
             continue
-        maybe_content = _read_utf8_content(
-            store_id,
-            store_path,
-            warnings,
-            session_id,
-            raw,
-        )
+        maybe_content = _read_utf8_content(store_id, store_path, warnings, session_id, raw)
         if maybe_content is None:
             continue
         content = maybe_content
@@ -377,11 +671,8 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             pool, store_id, store_path, include_content=False, account_id=account_id
         )
         if existing is None:
-            # Race: was in before snapshot but no DB record (e.g. previously skipped binary).
-            # Treat as a new create.
-            # create_memory calls _mirror_to_host internally, which rewrites the same
-            # bytes bash just wrote. This is redundant I/O but harmless and unavoidable
-            # without adding a skip_mirror parameter to the service layer.
+            # Race: was in before snapshot but no DB record (e.g.
+            # previously skipped binary). Treat as a new create.
             memory = await memory_service.create_memory(
                 pool,
                 store_id=store_id,
@@ -392,13 +683,25 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             )
             runtime.set_read_sha(session_id, store_id, store_path, memory.content_sha256)
         else:
-            # update_memory calls _mirror_to_host internally, which rewrites the same
-            # bytes bash just wrote. This is redundant I/O but harmless and unavoidable
-            # without adding a skip_mirror parameter to the service layer.
-            # Passing existing.content_sha256 as precondition guards against concurrent writes
-            # from another session: if a peer session wrote between our get_memory_by_path and
-            # this update, the precondition fails and MemoryPreconditionFailedError propagates
-            # as a tool-result error, which the model can handle.
+            candidate_sha = _content_sha256(raw)
+            if candidate_sha == existing.content_sha256:
+                # Content is unchanged vs DB (a peer session's write beat
+                # us to the same content, or a hot/sig-changed candidate
+                # turned out byte-identical). No DB write; stamp the read
+                # cache so a subsequent tool write in this session isn't
+                # spuriously treated as unread.
+                runtime.set_read_sha(session_id, store_id, store_path, candidate_sha)
+                continue
+            # update_memory calls _mirror_to_host internally, which
+            # rewrites the same bytes bash just wrote. This is redundant
+            # I/O but harmless and unavoidable without adding a
+            # skip_mirror parameter to the service layer.
+            # Passing existing.content_sha256 as precondition guards
+            # against concurrent writes from another session: if a peer
+            # session wrote between our get_memory_by_path and this
+            # update, the precondition fails and
+            # MemoryPreconditionFailedError propagates as a tool-result
+            # error, which the model can handle.
             memory = await memory_service.update_memory(
                 pool,
                 store_id=store_id,
@@ -416,34 +719,16 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
             store_path=store_path,
         )
 
-    # ── Deleted files ────────────────────────────────────────────────────────
-    # Count before-paths per store so an unscannable store can report how many
-    # deletions it suppressed (the #1705 incident wrote 159 durable deletes in
-    # 1.79s from a read-only bash while the mount cache was cleared under it).
-    before_path_counts = Counter(store_id for store_id, _store_path in before)
-    unscannable_warned: set[str] = set()
-    for store_id, store_path in before:
-        if (store_id, store_path) in after:
-            continue  # still exists
-        if store_id not in after_scanned_stores:
-            # The store was NOT observed in the after-pass (mount echo-cache
-            # cleared mid-bash, host dir/marker vanished, or materialization
-            # incomplete). Its before paths are UNKNOWN, not deleted — never
-            # delete on an untrustworthy view. Store-level twin of the
-            # per-file UNREADABLE sentinel (#1571 → #1705). Warn once per store.
-            if store_id not in unscannable_warned:
-                unscannable_warned.add(store_id)
-                _warn_store_unscannable(
-                    store_id, before_path_counts[store_id], warnings, session_id
-                )
-            continue
+    # ── Deleted files ────────────────────────────────────────────────────
+    for store_id, store_path in real_deletes:
         existing = await memory_service.get_memory_by_path(
             pool, store_id, store_path, include_content=False, account_id=account_id
         )
         if existing is None:
             continue  # already gone from DB; nothing to do
-        # delete_memory calls _mirror_delete_from_host internally, which tries to unlink
-        # a file bash already deleted. Since missing_ok=True it is harmless.
+        # delete_memory calls _mirror_delete_from_host internally, which
+        # tries to unlink a file bash already deleted. Since
+        # missing_ok=True it is harmless.
         await memory_service.delete_memory(
             pool,
             store_id=store_id,
@@ -459,3 +744,70 @@ async def reconcile_memory_mounts(session_id: str, before: _Snapshot) -> list[st
         )
 
     return warnings
+
+
+# ── Coarse/absent-ctime runtime guard (#1748 step 6) ─────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class PrefilterState:
+    """Result of the mount-ctime-granularity probe, cached at worker boot."""
+
+    enabled: bool
+    observed_granule_ns: int | None
+
+
+_prefilter_state: PrefilterState | None = None
+
+
+def probe_mount_ctime_granularity(probe_dir: Path) -> PrefilterState:
+    """Probe the actual memory-store mount for ctime support/granularity.
+
+    Writes a temp file twice in quick succession on ``probe_dir`` and
+    measures the smallest observed non-zero ctime delta. If ``st_ctime_ns``
+    reads back as 0 (no ctime) or the smallest observed delta between two
+    back-to-back writes is >= ``HOT_WINDOW_NS`` (a coarser-than-window
+    granule), the prefilter is disabled and every candidate is force-hashed —
+    the fail-safe direction on the memory-loss axis.
+
+    The common case (stock kernels, coarse-but-sub-window ctime, ~ms tick)
+    needs no force-hash: the hot-window already covers it (see module
+    docstring). This probe only fires for the exotic case of a granule at or
+    above the window itself, or a filesystem with no ctime at all.
+    """
+    probe_dir.mkdir(parents=True, exist_ok=True)
+    probe_path = probe_dir / ".ctime_probe"
+    try:
+        probe_path.write_bytes(b"a")
+        first = os.lstat(probe_path).st_ctime_ns
+        probe_path.write_bytes(b"b")
+        second = os.lstat(probe_path).st_ctime_ns
+    finally:
+        probe_path.unlink(missing_ok=True)
+
+    if first == 0 or second == 0:
+        return PrefilterState(enabled=False, observed_granule_ns=None)
+
+    delta = abs(second - first)
+    if delta >= HOT_WINDOW_NS:
+        return PrefilterState(enabled=False, observed_granule_ns=delta)
+    return PrefilterState(enabled=True, observed_granule_ns=delta)
+
+
+def set_prefilter_state(state: PrefilterState) -> None:
+    """Install the cached probe result (called once at worker boot)."""
+    global _prefilter_state
+    _prefilter_state = state
+
+
+def get_prefilter_state() -> PrefilterState:
+    """Return the cached probe result, defaulting to enabled if never probed.
+
+    Never-probed (e.g. unit tests, or a worker that hasn't run boot-time
+    probing yet) defaults to the sound-and-common case: prefilter enabled.
+    Production boot MUST call :func:`set_prefilter_state` with a real probe
+    result before serving bash calls with real memory mounts, per #1748 §6.
+    """
+    if _prefilter_state is None:
+        return PrefilterState(enabled=True, observed_granule_ns=None)
+    return _prefilter_state

--- a/src/aios/tools/bash_memory_telemetry.py
+++ b/src/aios/tools/bash_memory_telemetry.py
@@ -1,0 +1,139 @@
+"""Telemetry for the bash memory-mount reconcile phase (#1748).
+
+The #1733 zero-inference-gap profiler measures the event-loop gap directly
+and will see the on-loop hash vanish once the stat-prefilter ships — but
+nothing in that profile tells you whether a LATER edit re-introduced an
+on-loop read/hash, nor whether the ``asyncio.to_thread`` offload is
+saturating the default thread pool under concurrent load. This module is the
+corroboration layer for both:
+
+* A per-call **candidate-read counter** — the number of files actually read
+  and hashed by one ``reconcile_memory_mounts`` call. The all-unchanged path
+  MUST report 0; a regression that silently reverts to "hash everything"
+  shows up here as a counter spike, ideally caught before it ever shows up as
+  an inference-gap regression.
+* Per-phase duration samples (``before_scan``, ``after_scan``, ``db_phase``)
+  so the "moved off the event loop" claim is a gated, measured property, not
+  an eyeballed one.
+
+Nothing here is load-bearing for correctness — this module NEVER gates
+reconcile behavior, only observes it. A metrics-sink failure must never wedge
+a bash call, matching the pattern in
+:mod:`aios.retirements.telemetry`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+# ── Optional Prometheus sink (the #1324 metrics surface) ──────────────────────
+try:  # pragma: no cover - exercised only where prometheus_client is installed
+    from prometheus_client import Counter as _PromCounter
+    from prometheus_client import Histogram as _PromHistogram
+
+    _CANDIDATE_READS = _PromCounter(
+        "bash_memory_reconcile_candidate_reads_total",
+        "Candidate file reads/hashes performed across all bash memory-reconcile calls.",
+    )
+    _PHASE_SECONDS = _PromHistogram(
+        "bash_memory_reconcile_phase_seconds",
+        "Duration of a named bash memory-reconcile phase.",
+        ["phase"],
+    )
+except Exception:  # pragma: no cover - the common path in this repo today
+    _CANDIDATE_READS = None
+    _PHASE_SECONDS = None
+
+
+# ── In-process tallies (always maintained) ────────────────────────────────────
+
+_lock = threading.Lock()
+_candidate_read_total = 0
+_last_candidate_read_count = 0
+_phase_totals: dict[str, float] = {}
+_phase_counts: dict[str, int] = {}
+
+
+def record_candidate_reads(count: int) -> None:
+    """Record the number of candidate reads/hashes performed by one reconcile call.
+
+    The all-unchanged path MUST report 0 — a regression that re-hashes
+    everything shows up as a counter spike before it shows up as an
+    event-loop-gap regression in the #1733 profiler.
+    """
+    global _candidate_read_total, _last_candidate_read_count
+    with _lock:
+        _candidate_read_total += count
+        _last_candidate_read_count = count
+    if _CANDIDATE_READS is not None:  # pragma: no cover
+        with contextlib.suppress(Exception):
+            _CANDIDATE_READS.inc(count)
+
+
+def last_candidate_read_count() -> int:
+    """The candidate-read count from the most recent :func:`record_candidate_reads` call."""
+    with _lock:
+        return _last_candidate_read_count
+
+
+def total_candidate_reads() -> int:
+    """Cumulative candidate reads across the process lifetime."""
+    with _lock:
+        return _candidate_read_total
+
+
+def record_phase_duration(phase: str, duration_s: float) -> None:
+    """Record one duration sample for a named reconcile phase.
+
+    Phases: ``before_scan`` (the pre-exec stat walk), ``after_scan`` (the
+    post-exec stat walk + candidate reads, run via ``asyncio.to_thread``),
+    ``db_phase`` (the on-loop create/update/delete calls). Corroboration
+    only — never gates behavior.
+    """
+    with _lock:
+        _phase_totals[phase] = _phase_totals.get(phase, 0.0) + duration_s
+        _phase_counts[phase] = _phase_counts.get(phase, 0) + 1
+    if _PHASE_SECONDS is not None:  # pragma: no cover
+        with contextlib.suppress(Exception):
+            _PHASE_SECONDS.labels(phase=phase).observe(duration_s)
+
+
+def phase_totals() -> dict[str, float]:
+    """Cumulative duration per phase across the process lifetime."""
+    with _lock:
+        return dict(_phase_totals)
+
+
+def phase_counts() -> dict[str, int]:
+    """Cumulative sample count per phase across the process lifetime."""
+    with _lock:
+        return dict(_phase_counts)
+
+
+@contextmanager
+def timed_phase(phase: str) -> Iterator[None]:
+    """Context manager that records one duration sample for ``phase`` on exit.
+
+    Wraps the body in a monotonic-clock timer; never raises on its own (a
+    metrics failure inside :func:`record_phase_duration`'s Prometheus sink is
+    already swallowed there), and re-raises whatever the body raised.
+    """
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        record_phase_duration(phase, time.monotonic() - start)
+
+
+def reset() -> None:
+    """Test-only: clear all in-process tallies."""
+    global _candidate_read_total, _last_candidate_read_count
+    with _lock:
+        _candidate_read_total = 0
+        _last_candidate_read_count = 0
+        _phase_totals.clear()
+        _phase_counts.clear()

--- a/tests/unit/test_bash_handler.py
+++ b/tests/unit/test_bash_handler.py
@@ -233,6 +233,71 @@ class TestPerEnvTimeoutCeiling:
         assert kwargs["timeout_seconds"] == 600
 
 
+class TestMemoryReconcileFastPath:
+    """#1748 step 5: a session with no writable memory mounts skips the
+    snapshot's to_thread dispatch entirely, but reconcile is still invoked
+    (with an empty before + snapshot_ns=0) so its own fast path can run and
+    any warnings channel stays wired."""
+
+    async def test_no_writable_mounts_skips_snapshot_to_thread(
+        self, stub_registry: _StubRegistry
+    ) -> None:
+        with (
+            patch(
+                "aios.tools.bash.snapshot_memory_mounts",
+            ) as mock_snapshot,
+            patch(
+                "aios.tools.bash.reconcile_memory_mounts",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_reconcile,
+        ):
+            await bash_handler("sess_01TEST", {"command": "true"})
+
+        mock_snapshot.assert_not_called()
+        mock_reconcile.assert_awaited_once()
+        args = mock_reconcile.await_args.args
+        assert args[1] == {}
+        assert args[2] == 0
+
+    async def test_writable_mount_dispatches_snapshot_via_to_thread(
+        self, stub_registry: _StubRegistry
+    ) -> None:
+        from aios.harness import runtime
+        from aios.models.memory_stores import MemoryStoreResourceEcho
+
+        echo = MemoryStoreResourceEcho(
+            memory_store_id="memstore_01FAKE00000000000000000001",
+            access="read_write",
+            instructions="",
+            name="notes",
+            description="",
+            mount_path="/mnt/memory/notes",
+        )
+        runtime.set_session_memory_mounts("sess_01TEST", [echo])
+        try:
+            with (
+                patch(
+                    "aios.tools.bash.snapshot_memory_mounts",
+                    return_value=({}, 12345),
+                ) as mock_snapshot,
+                patch(
+                    "aios.tools.bash.reconcile_memory_mounts",
+                    new_callable=AsyncMock,
+                    return_value=[],
+                ) as mock_reconcile,
+            ):
+                await bash_handler("sess_01TEST", {"command": "true"})
+
+            mock_snapshot.assert_called_once_with("sess_01TEST")
+            mock_reconcile.assert_awaited_once()
+            args = mock_reconcile.await_args.args
+            assert args[1] == {}
+            assert args[2] == 12345
+        finally:
+            runtime.clear_session_memory_mounts("sess_01TEST")
+
+
 class TestExecRaisedReconcileSuppression:
     """When exec raises, reconcile exceptions are suppressed so the original propagates."""
 

--- a/tests/unit/test_bash_handler.py
+++ b/tests/unit/test_bash_handler.py
@@ -256,6 +256,7 @@ class TestMemoryReconcileFastPath:
 
         mock_snapshot.assert_not_called()
         mock_reconcile.assert_awaited_once()
+        assert mock_reconcile.await_args is not None
         args = mock_reconcile.await_args.args
         assert args[1] == {}
         assert args[2] == 0
@@ -291,6 +292,7 @@ class TestMemoryReconcileFastPath:
 
             mock_snapshot.assert_called_once_with("sess_01TEST")
             mock_reconcile.assert_awaited_once()
+            assert mock_reconcile.await_args is not None
             args = mock_reconcile.await_args.args
             assert args[1] == {}
             assert args[2] == 12345

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -1,13 +1,17 @@
-"""Unit tests for bash_memory_reconcile — snapshot + reconcile helpers.
+"""Unit tests for bash_memory_reconcile — stat-signature snapshot + reconcile (#1748).
 
-All tests are pure in-memory: no Docker, no Postgres.  The file system
+All tests are pure in-memory: no Docker, no Postgres. The file system
 operations use pytest's ``tmp_path`` fixture; DB calls are mocked via
 ``unittest.mock``.
 """
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import os
+import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -16,6 +20,7 @@ import pytest
 
 from aios.harness import runtime
 from aios.models.memory_stores import MemoryStoreResourceEcho
+from aios.tools import bash_memory_telemetry as telemetry
 
 SESSION_ID = "sesn_01RECONCILETEST00000000001"
 STORE_A = "memstore_01STOREA000000000000000001"
@@ -48,35 +53,63 @@ def _sha256_bytes(data: bytes) -> str:
 def _clear_runtime() -> Any:
     runtime.clear_session_memory_mounts(SESSION_ID)
     runtime.clear_session_read_shas(SESSION_ID)
+    telemetry.reset()
     yield
     runtime.clear_session_memory_mounts(SESSION_ID)
     runtime.clear_session_read_shas(SESSION_ID)
+    telemetry.reset()
+
+
+@pytest.fixture(autouse=True)
+def _prefilter_enabled() -> Any:
+    """Default every test to the "prefilter enabled" state unless overridden."""
+    from aios.tools.bash_memory_reconcile import PrefilterState, set_prefilter_state
+
+    set_prefilter_state(PrefilterState(enabled=True, observed_granule_ns=1_000_000))
+    yield
+    set_prefilter_state(PrefilterState(enabled=True, observed_granule_ns=1_000_000))
+
+
+def _far_past_ns() -> int:
+    """A snapshot_ns far enough in the future that any real file's ctime is 'cold'."""
+    return time.time_ns() + 10_000_000_000  # +10s
+
+
+@contextlib.contextmanager
+def _patch_all(mocks: dict[str, Any]) -> Iterator[None]:
+    """Apply every ``target -> mock`` pair in ``mocks`` for the block's duration."""
+    with contextlib.ExitStack() as stack:
+        for target, mock in mocks.items():
+            stack.enter_context(patch(target, mock))
+        yield
 
 
 # ── TestSnapshot ─────────────────────────────────────────────────────────────
 
 
 class TestSnapshot:
-    def test_empty_when_no_mounts(self, tmp_path: Path) -> None:
-        """Session has no mounts attached; snapshot returns {}."""
+    async def test_empty_when_no_mounts(self, tmp_path: Path) -> None:
+        """Session has no mounts attached; snapshot returns ({}, ns)."""
         from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
 
         runtime.set_session_memory_mounts(SESSION_ID, [])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=tmp_path):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, snapshot_ns = snapshot_memory_mounts(SESSION_ID)
         assert result == {}
+        assert isinstance(snapshot_ns, int)
+        assert snapshot_ns > 0
 
-    def test_empty_when_host_dir_missing(self, tmp_path: Path) -> None:
+    async def test_empty_when_host_dir_missing(self, tmp_path: Path) -> None:
         """Mount in cache but host dir doesn't exist; snapshot returns {}."""
         from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
         missing = tmp_path / "nonexistent_store"
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=missing):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
         assert result == {}
 
-    def test_empty_when_not_materialized(self, tmp_path: Path) -> None:
+    async def test_empty_when_not_materialized(self, tmp_path: Path) -> None:
         """Host dir exists but .materialized marker absent; returns {}."""
         from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
 
@@ -87,28 +120,55 @@ class TestSnapshot:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
         assert result == {}
 
-    def test_includes_file_sha(self, tmp_path: Path) -> None:
-        """Host dir has foo.md with known content; snapshot returns correct sha."""
-        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+    async def test_includes_file_sig(self, tmp_path: Path) -> None:
+        """Host dir has foo.md; snapshot returns a stat _Sig (no bytes read)."""
+        from aios.tools.bash_memory_reconcile import _Sig, snapshot_memory_mounts
 
         host_dir = tmp_path / STORE_A
         host_dir.mkdir()
         (host_dir / ".materialized").touch()
         content = "hello world\n"
-        (host_dir / "foo.md").write_text(content)
+        fpath = host_dir / "foo.md"
+        fpath.write_text(content)
+        st = os.stat(fpath, follow_symlinks=False)
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
 
-        expected_sha = _sha256(content)
         assert (STORE_A, "/foo.md") in result
-        assert result[(STORE_A, "/foo.md")] == expected_sha
+        sig = result[(STORE_A, "/foo.md")]
+        assert isinstance(sig, _Sig)
+        assert sig.size == st.st_size
+        assert sig.ino == st.st_ino
 
-    def test_nested_path(self, tmp_path: Path) -> None:
+    async def test_snapshot_does_not_read_bytes(self, tmp_path: Path) -> None:
+        """The stat-only snapshot must never call Path.read_bytes."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        (host_dir / "foo.md").write_text("hello world\n")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        real_read_bytes = Path.read_bytes
+
+        def _spy_read_bytes(self: Path) -> bytes:
+            raise AssertionError(f"snapshot_memory_mounts must not read bytes of {self}")
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch.object(Path, "read_bytes", _spy_read_bytes),
+        ):
+            snapshot_memory_mounts(SESSION_ID)
+        assert real_read_bytes  # sanity: original still bound elsewhere
+
+    async def test_nested_path(self, tmp_path: Path) -> None:
         """File at a/b/c.md resolves to store path /a/b/c.md."""
         from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
 
@@ -121,11 +181,11 @@ class TestSnapshot:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
 
         assert (STORE_A, "/a/b/c.md") in result
 
-    def test_skips_read_only_mounts(self, tmp_path: Path) -> None:
+    async def test_skips_read_only_mounts(self, tmp_path: Path) -> None:
         """read_only mount is present; its files are not included."""
         from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
 
@@ -136,11 +196,11 @@ class TestSnapshot:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo(access="read_only")])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
 
         assert result == {}
 
-    def test_materialized_marker_itself_excluded(self, tmp_path: Path) -> None:
+    async def test_materialized_marker_itself_excluded(self, tmp_path: Path) -> None:
         """.materialized file not treated as a memory file."""
         from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
 
@@ -150,14 +210,14 @@ class TestSnapshot:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
 
         assert result == {}
 
 
 class TestSymlinkRejection:
     """Bash inside the sandbox can ``ln -s <worker-side-path> /mnt/memory/<store>/leak``.
-    The host_dir read happens on the WORKER side, so ``read_bytes`` on the
+    The host_dir read happens on the WORKER side, so a stat/read on the
     symlinked file resolves the link against the worker's filesystem — which
     exposes any file the worker process can read (vault key material on disk,
     other tenants' state, /etc, etc.) to a memory store that subsequently
@@ -180,14 +240,11 @@ class TestSymlinkRejection:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
 
         assert (STORE_A, "/leak.txt") not in result, (
             f"snapshot must skip symlinks; got entries for symlinked paths: "
-            f"{[k for k in result if k[1] == '/leak.txt']!r}. Pre-fix the "
-            f"file_sha would be the sha256 of the symlink target's bytes "
-            f"(HOST-ONLY SECRET) — confused-deputy exfiltration through the "
-            f"reconcile path."
+            f"{[k for k in result if k[1] == '/leak.txt']!r}"
         )
 
     def test_snapshot_skips_symlinks_to_in_tree_files(self, tmp_path: Path) -> None:
@@ -203,7 +260,7 @@ class TestSymlinkRejection:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            result = snapshot_memory_mounts(SESSION_ID)
+            result, _ = snapshot_memory_mounts(SESSION_ID)
 
         assert (STORE_A, "/real.md") in result
         assert (STORE_A, "/alias.md") not in result
@@ -233,6 +290,21 @@ class TestReconcile:
         (host_dir / ".materialized").touch()
         return host_dir
 
+    def _mocks(self, **overrides: Any) -> dict[str, Any]:
+        defaults = {
+            "aios.tools.bash_memory_reconcile.memory_service.create_memory": AsyncMock(),
+            "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                return_value=None
+            ),
+            "aios.tools.bash_memory_reconcile.memory_service.update_memory": AsyncMock(),
+            "aios.tools.bash_memory_reconcile.memory_service.delete_memory": AsyncMock(),
+            "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id": AsyncMock(
+                return_value="acct_01FAKE"
+            ),
+        }
+        defaults.update(overrides)
+        return defaults
+
     async def test_new_file_calls_create_memory(self, tmp_path: Path) -> None:
         """before={}, after has one file; create_memory called with correct args."""
         from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
@@ -242,163 +314,157 @@ class TestReconcile:
         (host_dir / "new.md").write_text(content)
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory": AsyncMock(
+                    return_value=MagicMock(content_sha256=_sha256(content))
+                )
+            }
+        )
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ),
+            _patch_all(mocks),
         ):
-            mock_create.return_value = MagicMock(content_sha256=_sha256(content))
-            warnings = await reconcile_memory_mounts(SESSION_ID, before={})
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before={}, snapshot_ns=_far_past_ns()
+            )
 
+        mock_create = mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"]
         assert warnings == []
         mock_create.assert_awaited_once()
-        assert mock_create.await_args is not None
         call_kwargs = mock_create.await_args.kwargs
         assert call_kwargs["store_id"] == STORE_A
         assert call_kwargs["path"] == "/new.md"
         assert call_kwargs["content"] == content
 
     async def test_modified_file_calls_update_memory(self, tmp_path: Path) -> None:
-        """before has sha A, after sha B; update_memory called with precondition_sha256=existing.content_sha256."""
+        """before has a sentinel sig guaranteed to differ, after content differs
+        from the DB sha; update_memory called with precondition_sha256=existing.content_sha256."""
         from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)
-        old_content = "old\n"
         new_content = "new\n"
         (host_dir / "mod.md").write_text(new_content)
 
-        old_sha = _sha256(old_content)
-        db_sha = _sha256("db-current\n")  # DB's sha may differ from before_sha
-        before = {(STORE_A, "/mod.md"): old_sha}
+        db_sha = _sha256("db-current\n")  # DB's sha differs from new content
+        # Build a before dict with a fabricated old sig for the SAME path so
+        # it counts as "existing" (in ``before``), but stat-differs from
+        # whatever the after-scan observes — guaranteeing the modify branch
+        # (not the "unchanged" skip) fires.
+        from aios.tools.bash_memory_reconcile import _Sig
+
+        before = {(STORE_A, "/mod.md"): _Sig(size=0, mtime_ns=0, ctime_ns=1, ino=0)}
+
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
 
         fake_memory = MagicMock()
         fake_memory.id = "mem_01FAKE0000000000000000001"
         fake_memory.content_sha256 = db_sha
 
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                    return_value=fake_memory
+                ),
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory": AsyncMock(
+                    return_value=fake_memory
+                ),
+            }
+        )
+
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=fake_memory,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-                return_value=fake_memory,
-            ) as mock_update,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ),
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
 
+        mock_update = mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"]
         assert warnings == []
         mock_update.assert_awaited_once()
-        assert mock_update.await_args is not None
         call_kwargs = mock_update.await_args.kwargs
         assert call_kwargs["precondition_sha256"] == db_sha
         assert call_kwargs["new_content"] == new_content
 
     async def test_deleted_file_calls_delete_memory(self, tmp_path: Path) -> None:
         """path in before but not after; delete_memory called."""
-        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+        from aios.tools.bash_memory_reconcile import _Sig, reconcile_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)
         # No file written — before has it, after won't
-        before = {(STORE_A, "/gone.md"): _sha256("old content\n")}
+        before = {(STORE_A, "/gone.md"): _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1)}
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
 
         fake_memory = MagicMock()
         fake_memory.id = "mem_01FAKE0000000000000000002"
 
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                    return_value=fake_memory
+                ),
+            }
+        )
+
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=fake_memory,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ) as mock_delete,
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
 
+        mock_delete = mocks["aios.tools.bash_memory_reconcile.memory_service.delete_memory"]
         assert warnings == []
         mock_delete.assert_awaited_once()
-        assert mock_delete.await_args is not None
         call_kwargs = mock_delete.await_args.kwargs
         assert call_kwargs["store_id"] == STORE_A
         assert call_kwargs["memory_id"] == fake_memory.id
 
     async def test_unchanged_file_no_db_call(self, tmp_path: Path) -> None:
-        """Same sha in before and after; no create/update/delete called."""
-        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+        """Same sig in before and after, not hot; no create/update/delete called,
+        zero candidate reads, zero account_id load."""
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)
         content = "unchanged\n"
         (host_dir / "same.md").write_text(content)
-        sha = _sha256(content)
-        before = {(STORE_A, "/same.md"): sha}
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            before, _snapshot_ns = snapshot_memory_mounts(SESSION_ID)
+
+        # snapshot_ns far in the past relative to "now" so the file is not hot.
+        cold_snapshot_ns = _far_past_ns()  # far enough ahead that real ctimes are "cold"
+
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        mocks = self._mocks()
+        real_read_bytes = Path.read_bytes
+
+        def _spy_read_bytes(self: Path) -> bytes:
+            raise AssertionError(f"unchanged file must not be read: {self}")
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ) as mock_update,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ) as mock_delete,
+            patch.object(Path, "read_bytes", _spy_read_bytes),
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=cold_snapshot_ns
+            )
 
+        assert real_read_bytes
         assert warnings == []
-        mock_create.assert_not_awaited()
-        mock_update.assert_not_awaited()
-        mock_delete.assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.delete_memory"].assert_not_awaited()
+        mocks[
+            "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id"
+        ].assert_not_awaited()
+        assert telemetry.last_candidate_read_count() == 0
 
     async def test_binary_file_skipped_with_warning(self, tmp_path: Path) -> None:
         """Non-UTF-8 bytes; create not called; warning returned."""
@@ -409,31 +475,19 @@ class TestReconcile:
         (host_dir / "binary.bin").write_bytes(b"\xff\xfe\x00\x01")
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        mocks = self._mocks()
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ),
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before={})
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before={}, snapshot_ns=_far_past_ns()
+            )
 
         assert len(warnings) == 1
         assert "binary.bin" in warnings[0] or "binary" in warnings[0].lower()
-        mock_create.assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
 
     async def test_oversized_file_skipped_with_warning(self, tmp_path: Path) -> None:
         """File > MAX_CONTENT_BYTES; warning returned, no create."""
@@ -445,27 +499,15 @@ class TestReconcile:
         (host_dir / "big.md").write_text(big_content)
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        mocks = self._mocks()
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ),
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before={})
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before={}, snapshot_ns=_far_past_ns()
+            )
 
         assert len(warnings) == 1
         assert (
@@ -473,10 +515,10 @@ class TestReconcile:
             or "size" in warnings[0].lower()
             or "exceeds" in warnings[0].lower()
         )
-        mock_create.assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
 
     async def test_unreadable_after_file_not_deleted(self, tmp_path: Path) -> None:
-        """File readable at before but unreadable at after: warned, not deleted."""
+        """File readable at before-snapshot-time but unreadable at after: warned, not deleted."""
         from aios.tools.bash_memory_reconcile import (
             reconcile_memory_mounts,
             snapshot_memory_mounts,
@@ -488,13 +530,15 @@ class TestReconcile:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
 
-        # Build before from a real snapshot while the file is still readable.
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            before = snapshot_memory_mounts(SESSION_ID)
+            before, _ = snapshot_memory_mounts(SESSION_ID)
         assert (STORE_A, "/notes.md") in before
 
         # Make the file unreadable at after-time by patching Path.read_bytes to
         # raise OSError for this specific path (deterministic across platforms).
+        # Also mutate its mtime/content so it becomes a candidate even though
+        # read fails.
+        os.utime(notes, ns=(time.time_ns(), time.time_ns()))
         real_read_bytes = Path.read_bytes
 
         def _fake_read_bytes(self: Path) -> bytes:
@@ -505,48 +549,32 @@ class TestReconcile:
         fake_memory = MagicMock()
         fake_memory.id = "mem_01FAKE0000000000000000003"
 
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                    return_value=fake_memory
+                ),
+            }
+        )
+
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
             patch.object(Path, "read_bytes", _fake_read_bytes),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=fake_memory,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ) as mock_update,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ) as mock_delete,
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
 
-        mock_delete.assert_not_awaited()
-        mock_create.assert_not_awaited()
-        mock_update.assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.delete_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()
         assert any("/notes.md" in w for w in warnings)
 
     async def test_store_unscannable_after_not_deleted(self, tmp_path: Path) -> None:
         """Whole store drops out of the after-scan (echo-cache cleared mid-bash):
         every delete is suppressed and the store is warned — the direct #1705
-        regression guard and the store-level analog of
-        ``test_unreadable_after_file_not_deleted``.
-
-        Reproduces the production incident: a real ``before`` snapshot is taken
-        while the mount is materialized, then ``clear_session_memory_mounts``
-        (what ``SandboxRegistry.release``/``evict``/idle-reaper actually call)
-        fires before the reconcile. The files are STILL on disk and in the DB
-        (``get_memory_by_path`` returns a row), yet every ``before`` path reads
-        as "deleted". Pre-fix this issued one ``delete_memory`` per path (159 in
-        the incident); post-fix zero deletes and one per-store warning.
-        """
+        regression guard. No account_id load, no DB call at all (pure fast path)."""
         from aios.tools.bash_memory_reconcile import (
             reconcile_memory_mounts,
             snapshot_memory_mounts,
@@ -558,58 +586,51 @@ class TestReconcile:
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
 
-        # before: a real snapshot while the mount is present + materialized.
         with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
-            before = snapshot_memory_mounts(SESSION_ID)
+            before, _ = snapshot_memory_mounts(SESSION_ID)
         assert (STORE_A, "/notes.md") in before
         assert (STORE_A, "/log.md") in before
 
-        # Simulate the mount echo-cache clearing between before and reconcile
-        # (SandboxRegistry.release/evict/idle-reaper). The store now drops out
-        # of the after-scan entirely even though its files remain on disk + DB.
+        # Simulate the mount echo-cache clearing between before and reconcile.
         runtime.clear_session_memory_mounts(SESSION_ID)
 
-        # get_memory_by_path returns a live row: the files are genuinely present
-        # in the DB, so the only thing standing between the incident and 159
-        # deletes is the store-unscannable guard (not the existing-is-None one).
         fake_memory = MagicMock()
         fake_memory.id = "mem_01FAKE0000000000000000004"
 
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                    return_value=fake_memory
+                ),
+            }
+        )
+
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=fake_memory,
-            ) as mock_get,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ) as mock_update,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ) as mock_delete,
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
 
-        mock_delete.assert_not_awaited()
-        mock_create.assert_not_awaited()
-        mock_update.assert_not_awaited()
-        # Guard short-circuits before the DB lookup — no read attempted either.
-        mock_get.assert_not_awaited()
-        # One warning for the store (not one per file), naming the store and the
-        # suppressed-delete count.
+        mocks["aios.tools.bash_memory_reconcile.memory_service.delete_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()
+        mocks[
+            "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path"
+        ].assert_not_awaited()
+        mocks[
+            "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id"
+        ].assert_not_awaited()
         assert len(warnings) == 1
         assert STORE_A in warnings[0]
         assert "2" in warnings[0]
 
     async def test_unreadable_in_both_snapshots_is_unchanged(self, tmp_path: Path) -> None:
-        """Path unreadable in both before and after: no DB call, no warning."""
+        """A path unreadable in the before snapshot has the sentinel sig — it is
+        ALWAYS a candidate (sentinel never compares equal), so it's re-read at
+        after time. If it's STILL unreadable, it's warned once (not silently
+        dropped)."""
         from aios.tools.bash_memory_reconcile import (
             reconcile_memory_mounts,
             snapshot_memory_mounts,
@@ -628,41 +649,38 @@ class TestReconcile:
                 raise OSError("permission denied")
             return real_read_bytes(self)
 
-        # before is built while the file is ALREADY unreadable, so it carries
-        # the sentinel sha — identical to the after sha → unchanged.
+        # Sentinel sig doesn't come from read failure anymore (stat-only), so
+        # simulate a stat failure at before-time via a patched os.stat.
+        real_stat = os.lstat
+
+        def _fake_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+            if Path(path) == notes:
+                raise OSError("permission denied (stat)")
+            return real_stat(path, *args, **kwargs)
+
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch.object(Path, "read_bytes", _fake_read_bytes),
+            patch("aios.tools.bash_memory_reconcile.os.lstat", _fake_stat),
         ):
-            before = snapshot_memory_mounts(SESSION_ID)
+            before, _ = snapshot_memory_mounts(SESSION_ID)
         assert (STORE_A, "/notes.md") in before
 
+        mocks = self._mocks()
+
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch("aios.tools.bash_memory_reconcile.os.lstat", _fake_stat),
             patch.object(Path, "read_bytes", _fake_read_bytes),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ) as mock_update,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ) as mock_delete,
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
 
-        mock_create.assert_not_awaited()
-        mock_update.assert_not_awaited()
-        mock_delete.assert_not_awaited()
-        assert warnings == []
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.delete_memory"].assert_not_awaited()
+        assert any("/notes.md" in w for w in warnings)
 
     async def test_skips_read_only_mounts_in_reconcile(self, tmp_path: Path) -> None:
         """read_only mount; no DB call — files from read_only mounts never appear in before or after."""
@@ -671,36 +689,25 @@ class TestReconcile:
         host_dir = self._make_host_dir(tmp_path)
         (host_dir / "file.md").write_text("content\n")
 
-        # read_only mount: snapshot_memory_mounts also skips read_only mounts, so
-        # before is empty; after will also be empty (read_only skipped in scan).
-        before: dict[tuple[str, str], str] = {}
+        before: dict[tuple[str, str], Any] = {}
         runtime.set_session_memory_mounts(SESSION_ID, [_echo(access="read_only")])
+        mocks = self._mocks()
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ) as mock_update,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ) as mock_delete,
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
 
         assert warnings == []
-        mock_create.assert_not_awaited()
-        mock_update.assert_not_awaited()
-        mock_delete.assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.delete_memory"].assert_not_awaited()
+        mocks[
+            "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id"
+        ].assert_not_awaited()
 
     async def test_read_sha_updated_after_create(self, tmp_path: Path) -> None:
         """runtime.set_read_sha called after create_memory."""
@@ -712,116 +719,662 @@ class TestReconcile:
         expected_sha = _sha256(content)
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory": AsyncMock(
+                    return_value=MagicMock(content_sha256=expected_sha)
+                ),
+            }
+        )
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-                return_value=MagicMock(content_sha256=expected_sha),
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ),
+            _patch_all(mocks),
         ):
-            await reconcile_memory_mounts(SESSION_ID, before={})
+            await reconcile_memory_mounts(SESSION_ID, before={}, snapshot_ns=_far_past_ns())
 
         cached_sha = runtime.get_read_sha(SESSION_ID, STORE_A, "/fresh.md")
         assert cached_sha == expected_sha
 
     async def test_modified_file_no_db_record_falls_back_to_create(self, tmp_path: Path) -> None:
-        """before has sha A, after sha B, but get_memory_by_path returns None (race); falls back to create_memory."""
-        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+        """before has the path, after content differs, get_memory_by_path returns
+        None (race); falls back to create_memory."""
+        from aios.tools.bash_memory_reconcile import _Sig, reconcile_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)
         new_content = "new content after race\n"
         (host_dir / "race.md").write_text(new_content)
 
-        old_sha = _sha256("old content\n")
-        before = {(STORE_A, "/race.md"): old_sha}
+        before = {(STORE_A, "/race.md"): _Sig(size=0, mtime_ns=0, ctime_ns=1, ino=0)}
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
 
         fake_created = MagicMock()
         fake_created.content_sha256 = _sha256(new_content)
 
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.create_memory": AsyncMock(
+                    return_value=fake_created
+                ),
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                    return_value=None
+                ),
+            }
+        )
+
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-                return_value=fake_created,
-            ) as mock_create,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-            ) as mock_update,
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ),
+            _patch_all(mocks),
         ):
-            warnings = await reconcile_memory_mounts(SESSION_ID, before=before)
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
 
-        # No crash; update_memory is not called (create_memory is used instead)
-        mock_update.assert_not_awaited()
-        mock_create.assert_awaited_once()
-        # No warning for this path — it is handled gracefully as a create
+        mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_awaited_once()
         assert warnings == []
 
     async def test_read_sha_updated_after_update(self, tmp_path: Path) -> None:
         """runtime.set_read_sha called after update_memory."""
-        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+        from aios.tools.bash_memory_reconcile import _Sig, reconcile_memory_mounts
 
         host_dir = self._make_host_dir(tmp_path)
         new_content = "updated\n"
         (host_dir / "upd.md").write_text(new_content)
-        old_sha = _sha256("old\n")
         new_sha = _sha256(new_content)
-        before = {(STORE_A, "/upd.md"): old_sha}
+        db_sha = _sha256("old\n")
+        before = {(STORE_A, "/upd.md"): _Sig(size=0, mtime_ns=0, ctime_ns=1, ino=0)}
 
         runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
 
         fake_memory = MagicMock()
         fake_memory.id = "mem_01FAKEUPDATETEST0000000001"
         fake_memory.content_sha256 = new_sha
+        fake_existing = MagicMock()
+        fake_existing.id = "mem_01FAKEUPDATETEST0000000001"
+        fake_existing.content_sha256 = db_sha
+
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                    return_value=fake_existing
+                ),
+                "aios.tools.bash_memory_reconcile.memory_service.update_memory": AsyncMock(
+                    return_value=fake_memory
+                ),
+            }
+        )
 
         with (
             patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.create_memory",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
-                new_callable=AsyncMock,
-                return_value=fake_memory,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.update_memory",
-                new_callable=AsyncMock,
-                return_value=fake_memory,
-            ),
-            patch(
-                "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
-                new_callable=AsyncMock,
-            ),
+            _patch_all(mocks),
         ):
-            await reconcile_memory_mounts(SESSION_ID, before=before)
+            await reconcile_memory_mounts(SESSION_ID, before=before, snapshot_ns=_far_past_ns())
 
         cached_sha = runtime.get_read_sha(SESSION_ID, STORE_A, "/upd.md")
         assert cached_sha == new_sha
+
+    async def test_touch_unchanged_content_no_db_write(self, tmp_path: Path) -> None:
+        """`touch` (mtime bump, content unchanged): candidate (sig differs) but
+        NO DB write, because the candidate's content sha matches the DB sha."""
+        from aios.tools.bash_memory_reconcile import _Sig, reconcile_memory_mounts
+
+        host_dir = self._make_host_dir(tmp_path)
+        content = "same content\n"
+        fpath = host_dir / "touched.md"
+        fpath.write_text(content)
+        # Force a stat-differing before-sig (simulate `touch` having changed
+        # mtime/ctime from some prior state) while content is identical.
+        before = {(STORE_A, "/touched.md"): _Sig(size=999, mtime_ns=1, ctime_ns=1, ino=999)}
+        db_sha = _sha256(content)
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        fake_existing = MagicMock()
+        fake_existing.content_sha256 = db_sha
+
+        mocks = self._mocks(
+            **{
+                "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path": AsyncMock(
+                    return_value=fake_existing
+                ),
+            }
+        )
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            _patch_all(mocks),
+        ):
+            warnings = await reconcile_memory_mounts(
+                SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+            )
+
+        mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()
+        mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
+        assert warnings == []
+        # Candidate read DID happen (it's a candidate), but no DB write.
+        assert telemetry.last_candidate_read_count() == 1
+        # read-sha cache still stamped so a later session write isn't
+        # spuriously treated as unread.
+        assert runtime.get_read_sha(SESSION_ID, STORE_A, "/touched.md") == db_sha
+
+
+class TestSoundPrefilter:
+    """Direct unit tests of the change-detection predicate + hot window,
+    independent of the full async reconcile plumbing."""
+
+    def test_new_path_is_always_candidate(self) -> None:
+        from aios.tools.bash_memory_reconcile import _is_candidate, _Sig
+
+        after = _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1)
+        assert _is_candidate(None, after, snapshot_ns=0, force_hash=False) is True
+
+    def test_sig_equal_not_hot_is_not_candidate(self) -> None:
+        from aios.tools.bash_memory_reconcile import _is_candidate, _Sig
+
+        sig = _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1)
+        # snapshot_ns far bigger than ctime_ns + HOT_WINDOW_NS -> not hot
+        assert _is_candidate(sig, sig, snapshot_ns=10_000_000_000, force_hash=False) is False
+
+    def test_sig_equal_but_hot_is_candidate(self) -> None:
+        from aios.tools.bash_memory_reconcile import HOT_WINDOW_NS, _is_candidate, _Sig
+
+        ctime_ns = 5_000_000_000
+        sig = _Sig(size=1, mtime_ns=1, ctime_ns=ctime_ns, ino=1)
+        # snapshot_ns within HOT_WINDOW_NS of ctime_ns -> hot
+        snapshot_ns = ctime_ns + HOT_WINDOW_NS - 1
+        assert _is_candidate(sig, sig, snapshot_ns=snapshot_ns, force_hash=False) is True
+
+    def test_sentinel_before_is_always_candidate(self) -> None:
+        from aios.tools.bash_memory_reconcile import _SENTINEL_SIG, _is_candidate, _Sig
+
+        after = _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1)
+        assert _is_candidate(_SENTINEL_SIG, after, snapshot_ns=0, force_hash=False) is True
+
+    def test_sentinel_after_is_always_candidate(self) -> None:
+        from aios.tools.bash_memory_reconcile import _SENTINEL_SIG, _is_candidate, _Sig
+
+        before = _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1)
+        assert _is_candidate(before, _SENTINEL_SIG, snapshot_ns=0, force_hash=False) is True
+
+    def test_sig_differs_is_candidate(self) -> None:
+        from aios.tools.bash_memory_reconcile import _is_candidate, _Sig
+
+        before = _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1)
+        after = _Sig(
+            size=2, mtime_ns=1, ctime_ns=1, ino=1
+        )  # touch -r style: mtime same, ctime same, size differs
+        assert _is_candidate(before, after, snapshot_ns=10_000_000_000, force_hash=False) is True
+
+    def test_ctime_bump_same_size_mtime_is_candidate(self) -> None:
+        """same-size in-place edit (dd conv=notrunc): ctime bumps -> candidate."""
+        from aios.tools.bash_memory_reconcile import _is_candidate, _Sig
+
+        before = _Sig(size=10, mtime_ns=100, ctime_ns=100, ino=1)
+        after = _Sig(size=10, mtime_ns=100, ctime_ns=200, ino=1)
+        assert _is_candidate(before, after, snapshot_ns=10_000_000_000, force_hash=False) is True
+
+    def test_atomic_replace_new_inode_is_candidate(self) -> None:
+        """os.replace / atomic_mirror: new inode + ctime -> candidate."""
+        from aios.tools.bash_memory_reconcile import _is_candidate, _Sig
+
+        before = _Sig(size=10, mtime_ns=100, ctime_ns=100, ino=1)
+        after = _Sig(size=10, mtime_ns=300, ctime_ns=300, ino=2)
+        assert _is_candidate(before, after, snapshot_ns=10_000_000_000, force_hash=False) is True
+
+    def test_force_hash_makes_everything_a_candidate(self) -> None:
+        from aios.tools.bash_memory_reconcile import _is_candidate, _Sig
+
+        sig = _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1)
+        assert _is_candidate(sig, sig, snapshot_ns=10_000_000_000, force_hash=True) is True
+
+
+class TestSnapshotNsContract:
+    """Lens 0 #2: snapshot_ns must be captured pre-exec, not re-sampled in the
+    after-scan — a post-exec sample would silently disable the hot-window net
+    for any exec longer than HOT_WINDOW_NS."""
+
+    async def test_snapshot_ns_captured_before_scan_after_call(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import snapshot_memory_mounts
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+
+        before_call_ns = time.time_ns()
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            _, snapshot_ns = snapshot_memory_mounts(SESSION_ID)
+        after_call_ns = time.time_ns()
+
+        assert before_call_ns <= snapshot_ns <= after_call_ns
+
+    async def test_long_running_exec_still_marks_recent_write_hot(self, tmp_path: Path) -> None:
+        """Model a bash call that runs longer than HOT_WINDOW_NS: a file
+        modified just before snapshot_ns (pre-exec) must still be 'hot' at
+        after-scan time, i.e. always a candidate regardless of the after
+        stat — proving snapshot_ns is NOT re-sampled post-exec."""
+        from aios.tools.bash_memory_reconcile import (
+            HOT_WINDOW_NS,
+            _is_candidate,
+            _Sig,
+        )
+
+        # File modified 0.5s before the (pre-exec) snapshot.
+        ctime_ns = 10_000_000_000
+        snapshot_ns = ctime_ns + 500_000_000  # snapshot taken 0.5s after write
+        sig = _Sig(size=1, mtime_ns=ctime_ns, ctime_ns=ctime_ns, ino=1)
+
+        # Even though "now" (post a long exec) is way later, the candidate
+        # decision uses the ORIGINAL pre-exec snapshot_ns, so this file
+        # (modified 0.5s before it) is still within HOT_WINDOW_NS and hot.
+        assert snapshot_ns - ctime_ns < HOT_WINDOW_NS
+        assert _is_candidate(sig, sig, snapshot_ns=snapshot_ns, force_hash=False) is True
+
+
+class TestAfterSigsCompleteness:
+    """Lens 0 #3: after_sigs must contain EVERY walked path, including stat
+    failures, so the delete-diff never keys off the (smaller) candidate set."""
+
+    async def test_unchanged_sibling_survives_transient_stat_failure(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import _scan_after
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        changed = host_dir / "changed.md"
+        changed.write_text("new\n")
+        sibling = host_dir / "sibling.md"
+        sibling.write_text("sibling content\n")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        real_stat = os.lstat
+
+        def _flaky_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+            if Path(path) == sibling:
+                raise OSError("transient stat failure")
+            return real_stat(path, *args, **kwargs)
+
+        before: dict[tuple[str, str], Any] = {}
+
+        with (
+            patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir),
+            patch("aios.tools.bash_memory_reconcile.os.lstat", _flaky_stat),
+        ):
+            scan = _scan_after(SESSION_ID, before, snapshot_ns=0, force_hash=False)
+
+        # sibling.md is present in after_sigs (under the sentinel), NOT absent.
+        assert (STORE_A, "/sibling.md") in scan.after_sigs
+        assert (STORE_A, "/changed.md") in scan.after_sigs
+
+    async def test_sibling_not_deleted_end_to_end(self, tmp_path: Path) -> None:
+        """Full reconcile: a store with one genuinely-changed file and one
+        unchanged sibling that transiently fails os.stat in the after-pass —
+        the sibling must NOT be deleted."""
+        from aios.tools.bash_memory_reconcile import _Sig, reconcile_memory_mounts
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        changed = host_dir / "changed.md"
+        changed.write_text("new content\n")
+        sibling = host_dir / "sibling.md"
+        sibling.write_text("sibling content\n")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        # before has both paths with sentinel-ish sigs guaranteed to differ,
+        # AND the sibling is genuinely unchanged on disk (we just want to
+        # simulate the transient stat failure independent of change status).
+        before = {
+            (STORE_A, "/changed.md"): _Sig(size=0, mtime_ns=0, ctime_ns=1, ino=0),
+            (STORE_A, "/sibling.md"): _Sig(size=0, mtime_ns=0, ctime_ns=1, ino=0),
+        }
+
+        real_stat = os.lstat
+
+        def _flaky_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+            if Path(path) == sibling:
+                raise OSError("transient stat failure")
+            return real_stat(path, *args, **kwargs)
+
+        pool = MagicMock()
+        prev_pool = runtime.pool
+        runtime.pool = pool
+
+        fake_created = MagicMock()
+        fake_created.content_sha256 = _sha256("new content\n")
+
+        try:
+            with (
+                patch(
+                    "aios.tools.bash_memory_reconcile.memory_store_host_dir",
+                    return_value=host_dir,
+                ),
+                patch("aios.tools.bash_memory_reconcile.os.lstat", _flaky_stat),
+                patch(
+                    "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                    new_callable=AsyncMock,
+                    return_value=fake_created,
+                ),
+                patch(
+                    "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                    new_callable=AsyncMock,
+                    return_value=None,
+                ),
+                patch(
+                    "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                    new_callable=AsyncMock,
+                ) as mock_delete,
+                patch(
+                    "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id",
+                    new_callable=AsyncMock,
+                    return_value="acct_01FAKE",
+                ),
+            ):
+                await reconcile_memory_mounts(SESSION_ID, before=before, snapshot_ns=_far_past_ns())
+        finally:
+            runtime.pool = prev_pool
+
+        # sibling.md must NOT be deleted — it's present in after_sigs (under
+        # the stat-failure sentinel), so the delete-diff never fires for it.
+        mock_delete.assert_not_awaited()
+
+
+class TestUnscannableStoreOnNoOpCall:
+    """Lens 2 #5: the #1705 warn must survive the no-op fast-path."""
+
+    async def test_unscannable_store_warns_and_makes_no_db_call_on_no_op(
+        self, tmp_path: Path
+    ) -> None:
+        from aios.tools.bash_memory_reconcile import (
+            _Sig,
+            reconcile_memory_mounts,
+        )
+
+        # before has entries for a store that will NOT be scannable in the
+        # after-pass (mount cache cleared) — the whole call is otherwise a
+        # no-op (no other stores, no writes).
+        before = {
+            (STORE_A, "/a.md"): _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1),
+            (STORE_A, "/b.md"): _Sig(size=1, mtime_ns=1, ctime_ns=1, ino=1),
+        }
+        # No mounts attached at reconcile time -> store not in scanned set.
+        runtime.set_session_memory_mounts(SESSION_ID, [])
+
+        pool = MagicMock()
+        prev_pool = runtime.pool
+        runtime.pool = pool
+        try:
+            with patch(
+                "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id",
+                new_callable=AsyncMock,
+            ) as mock_load_account:
+                warnings = await reconcile_memory_mounts(
+                    SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+                )
+        finally:
+            runtime.pool = prev_pool
+
+        mock_load_account.assert_not_awaited()
+        assert len(warnings) == 1
+        assert STORE_A in warnings[0]
+        assert "2" in warnings[0]
+
+
+class TestCoarseAbsentCtimeGuard:
+    """#1748 §6: fail-closed force-hash on absent/coarse ctime."""
+
+    def test_zero_ctime_sig_is_sentinel(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import _SENTINEL_SIG, _stat_sig
+
+        fpath = tmp_path / "f.md"
+        fpath.write_text("x")
+
+        class _FakeStatResult:
+            st_size = 1
+            st_mtime_ns = 123
+            st_ctime_ns = 0
+            st_ino = 1
+
+        with patch("aios.tools.bash_memory_reconcile.os.lstat", return_value=_FakeStatResult()):
+            sig = _stat_sig(fpath)
+        assert sig is _SENTINEL_SIG
+
+    def test_stat_oserror_is_sentinel(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import _SENTINEL_SIG, _stat_sig
+
+        fpath = tmp_path / "missing.md"
+
+        with patch("aios.tools.bash_memory_reconcile.os.lstat", side_effect=OSError("boom")):
+            sig = _stat_sig(fpath)
+        assert sig is _SENTINEL_SIG
+
+    def test_probe_disables_prefilter_on_absent_ctime(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import probe_mount_ctime_granularity
+
+        real_stat = os.lstat
+
+        def _fake_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+            st = real_stat(path, *args, **kwargs)
+
+            class _Wrapped:
+                st_size = st.st_size
+                st_mtime_ns = st.st_mtime_ns
+                st_ctime_ns = 0
+                st_ino = st.st_ino
+
+            return _Wrapped()
+
+        with patch("aios.tools.bash_memory_reconcile.os.lstat", _fake_stat):
+            state = probe_mount_ctime_granularity(tmp_path)
+
+        assert state.enabled is False
+
+    def test_probe_disables_prefilter_on_coarse_granule(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import (
+            HOT_WINDOW_NS,
+            probe_mount_ctime_granularity,
+        )
+
+        calls = {"n": 0}
+        real_stat = os.lstat
+
+        def _fake_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+            st = real_stat(path, *args, **kwargs)
+            calls["n"] += 1
+
+            class _Wrapped:
+                st_size = st.st_size
+                st_mtime_ns = st.st_mtime_ns
+                # First call (post-first-write) returns a fixed value; second
+                # call (post-second-write) returns a value >= HOT_WINDOW_NS
+                # later, simulating a coarse-granule FS.
+                st_ctime_ns = 1_000_000_000 if calls["n"] == 1 else 1_000_000_000 + HOT_WINDOW_NS
+                st_ino = st.st_ino
+
+            return _Wrapped()
+
+        with patch("aios.tools.bash_memory_reconcile.os.lstat", _fake_stat):
+            state = probe_mount_ctime_granularity(tmp_path)
+
+        assert state.enabled is False
+        assert state.observed_granule_ns is not None
+        assert state.observed_granule_ns >= HOT_WINDOW_NS
+
+    def test_probe_enables_prefilter_on_fine_granule(self, tmp_path: Path) -> None:
+        from aios.tools.bash_memory_reconcile import probe_mount_ctime_granularity
+
+        calls = {"n": 0}
+        real_stat = os.lstat
+
+        def _fake_stat(path: Any, *args: Any, **kwargs: Any) -> Any:
+            st = real_stat(path, *args, **kwargs)
+            calls["n"] += 1
+
+            class _Wrapped:
+                st_size = st.st_size
+                st_mtime_ns = st.st_mtime_ns
+                st_ctime_ns = 1_000_000_000 if calls["n"] == 1 else 1_000_001_000
+                st_ino = st.st_ino
+
+            return _Wrapped()
+
+        with patch("aios.tools.bash_memory_reconcile.os.lstat", _fake_stat):
+            state = probe_mount_ctime_granularity(tmp_path)
+
+        assert state.enabled is True
+
+    async def test_force_hash_path_taken_when_prefilter_disabled(self, tmp_path: Path) -> None:
+        """When the cached prefilter state is disabled, an unchanged file
+        (sig-equal, not hot) is STILL read/hashed (force_hash escape)."""
+        from aios.tools.bash_memory_reconcile import (
+            PrefilterState,
+            reconcile_memory_mounts,
+            set_prefilter_state,
+            snapshot_memory_mounts,
+        )
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        content = "same\n"
+        (host_dir / "same.md").write_text(content)
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            before, _ = snapshot_memory_mounts(SESSION_ID)
+
+        set_prefilter_state(PrefilterState(enabled=False, observed_granule_ns=5_000_000_000))
+        try:
+            pool = MagicMock()
+            prev_pool = runtime.pool
+            runtime.pool = pool
+            db_sha = _sha256(content)
+            fake_existing = MagicMock()
+            fake_existing.content_sha256 = db_sha
+            try:
+                with (
+                    patch(
+                        "aios.tools.bash_memory_reconcile.memory_store_host_dir",
+                        return_value=host_dir,
+                    ),
+                    patch(
+                        "aios.tools.bash_memory_reconcile.memory_service.get_memory_by_path",
+                        new_callable=AsyncMock,
+                        return_value=fake_existing,
+                    ),
+                    patch(
+                        "aios.tools.bash_memory_reconcile.memory_service.create_memory",
+                        new_callable=AsyncMock,
+                    ),
+                    patch(
+                        "aios.tools.bash_memory_reconcile.memory_service.update_memory",
+                        new_callable=AsyncMock,
+                    ),
+                    patch(
+                        "aios.tools.bash_memory_reconcile.memory_service.delete_memory",
+                        new_callable=AsyncMock,
+                    ),
+                    patch(
+                        "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id",
+                        new_callable=AsyncMock,
+                        return_value="acct_01FAKE",
+                    ),
+                ):
+                    await reconcile_memory_mounts(
+                        SESSION_ID, before=before, snapshot_ns=_far_past_ns()
+                    )
+            finally:
+                runtime.pool = prev_pool
+        finally:
+            set_prefilter_state(PrefilterState(enabled=True, observed_granule_ns=1_000_000))
+
+        # force_hash means it WAS read even though sig-equal/not-hot.
+        assert telemetry.last_candidate_read_count() == 1
+
+
+class TestUnreadableUnchanged:
+    """Lens 0 #6: a file that's read-failing but STAT-succeeding has a stable
+    valid sig -> skipped entirely, no read attempt, no per-call warning (an
+    improvement over master, which re-read it every call)."""
+
+    async def test_stat_succeeding_read_failing_file_is_skipped_no_warning(
+        self, tmp_path: Path
+    ) -> None:
+        from aios.tools.bash_memory_reconcile import (
+            reconcile_memory_mounts,
+            snapshot_memory_mounts,
+        )
+
+        host_dir = tmp_path / STORE_A
+        host_dir.mkdir()
+        (host_dir / ".materialized").touch()
+        notes = host_dir / "notes.md"
+        notes.write_text("notes content\n")
+
+        runtime.set_session_memory_mounts(SESSION_ID, [_echo()])
+
+        with patch("aios.tools.bash_memory_reconcile.memory_store_host_dir", return_value=host_dir):
+            before, _ = snapshot_memory_mounts(SESSION_ID)
+
+        # stat still succeeds (sig stable across before/after); read fails,
+        # but since sig doesn't change and isn't hot, read is never attempted.
+        cold_snapshot_ns = _far_past_ns()
+
+        def _spy_read_bytes(self: Path) -> bytes:
+            raise AssertionError(f"unchanged-sig file must not be read: {self}")
+
+        pool = MagicMock()
+        prev_pool = runtime.pool
+        runtime.pool = pool
+        try:
+            with (
+                patch(
+                    "aios.tools.bash_memory_reconcile.memory_store_host_dir",
+                    return_value=host_dir,
+                ),
+                patch.object(Path, "read_bytes", _spy_read_bytes),
+                patch(
+                    "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id",
+                    new_callable=AsyncMock,
+                ) as mock_load_account,
+            ):
+                warnings = await reconcile_memory_mounts(
+                    SESSION_ID, before=before, snapshot_ns=cold_snapshot_ns
+                )
+        finally:
+            runtime.pool = prev_pool
+
+        assert warnings == []
+        mock_load_account.assert_not_awaited()
+
+
+class TestFastPath:
+    """No writable mounts at all -> reconcile is a pure no-op, no to_thread work
+    observable via telemetry, no account load."""
+
+    async def test_no_mounts_skips_account_load(self) -> None:
+        from aios.tools.bash_memory_reconcile import reconcile_memory_mounts
+
+        runtime.set_session_memory_mounts(SESSION_ID, [])
+        pool = MagicMock()
+        prev_pool = runtime.pool
+        runtime.pool = pool
+        try:
+            with patch(
+                "aios.tools.bash_memory_reconcile.sessions_service.load_session_account_id",
+                new_callable=AsyncMock,
+            ) as mock_load_account:
+                warnings = await reconcile_memory_mounts(SESSION_ID, before={}, snapshot_ns=0)
+        finally:
+            runtime.pool = prev_pool
+
+        assert warnings == []
+        mock_load_account.assert_not_awaited()
+        assert telemetry.last_candidate_read_count() == 0

--- a/tests/unit/test_bash_memory_reconcile.py
+++ b/tests/unit/test_bash_memory_reconcile.py
@@ -166,7 +166,7 @@ class TestSnapshot:
             patch.object(Path, "read_bytes", _spy_read_bytes),
         ):
             snapshot_memory_mounts(SESSION_ID)
-        assert real_read_bytes  # sanity: original still bound elsewhere
+        assert real_read_bytes is not None  # sanity: original still bound elsewhere
 
     async def test_nested_path(self, tmp_path: Path) -> None:
         """File at a/b/c.md resolves to store path /a/b/c.md."""
@@ -456,7 +456,7 @@ class TestReconcile:
                 SESSION_ID, before=before, snapshot_ns=cold_snapshot_ns
             )
 
-        assert real_read_bytes
+        assert real_read_bytes is not None
         assert warnings == []
         mocks["aios.tools.bash_memory_reconcile.memory_service.create_memory"].assert_not_awaited()
         mocks["aios.tools.bash_memory_reconcile.memory_service.update_memory"].assert_not_awaited()

--- a/tests/unit/test_bash_memory_telemetry.py
+++ b/tests/unit/test_bash_memory_telemetry.py
@@ -1,0 +1,88 @@
+"""Unit tests for the bash memory-reconcile telemetry surface (#1748).
+
+Corroboration-only: verifies the counters/timers record what they claim to,
+never that they gate anything (they must not).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aios.tools import bash_memory_telemetry as telemetry
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Any:
+    telemetry.reset()
+    yield
+    telemetry.reset()
+
+
+class TestCandidateReadCounter:
+    def test_zero_reads_reported_for_all_unchanged(self) -> None:
+        telemetry.record_candidate_reads(0)
+        assert telemetry.last_candidate_read_count() == 0
+        assert telemetry.total_candidate_reads() == 0
+
+    def test_records_nonzero_count(self) -> None:
+        telemetry.record_candidate_reads(3)
+        assert telemetry.last_candidate_read_count() == 3
+        assert telemetry.total_candidate_reads() == 3
+
+    def test_accumulates_across_calls(self) -> None:
+        telemetry.record_candidate_reads(2)
+        telemetry.record_candidate_reads(5)
+        # last reflects only the most recent call...
+        assert telemetry.last_candidate_read_count() == 5
+        # ...but the cumulative total across the process lifetime sums both.
+        assert telemetry.total_candidate_reads() == 7
+
+    def test_never_raises_even_if_prometheus_sink_errors(self) -> None:
+        """A metrics-sink failure must never propagate — corroboration only."""
+        import aios.tools.bash_memory_telemetry as mod
+
+        class _BoomCounter:
+            def inc(self, *_args: Any, **_kwargs: Any) -> None:
+                raise RuntimeError("sink exploded")
+
+        prev = mod._CANDIDATE_READS
+        mod._CANDIDATE_READS = _BoomCounter()  # type: ignore[assignment]
+        try:
+            telemetry.record_candidate_reads(1)  # must not raise
+        finally:
+            mod._CANDIDATE_READS = prev
+        assert telemetry.last_candidate_read_count() == 1
+
+
+class TestPhaseDurations:
+    def test_timed_phase_records_a_sample(self) -> None:
+        with telemetry.timed_phase("after_scan"):
+            pass
+        assert telemetry.phase_counts().get("after_scan") == 1
+        assert telemetry.phase_totals().get("after_scan", 0.0) >= 0.0
+
+    def test_timed_phase_reraises_body_exception(self) -> None:
+        with pytest.raises(ValueError), telemetry.timed_phase("db_phase"):
+            raise ValueError("boom")
+        # Still recorded a sample despite the exception.
+        assert telemetry.phase_counts().get("db_phase") == 1
+
+    def test_nested_phases_both_recorded(self) -> None:
+        with telemetry.timed_phase("memory_reconcile"), telemetry.timed_phase("after_scan"):
+            pass
+        assert telemetry.phase_counts().get("memory_reconcile") == 1
+        assert telemetry.phase_counts().get("after_scan") == 1
+
+
+class TestReset:
+    def test_reset_clears_everything(self) -> None:
+        telemetry.record_candidate_reads(4)
+        with telemetry.timed_phase("after_scan"):
+            pass
+        telemetry.reset()
+        assert telemetry.total_candidate_reads() == 0
+        assert telemetry.last_candidate_read_count() == 0
+        assert telemetry.phase_counts() == {}
+        assert telemetry.phase_totals() == {}

--- a/tests/unit/test_bash_memory_telemetry.py
+++ b/tests/unit/test_bash_memory_telemetry.py
@@ -48,7 +48,7 @@ class TestCandidateReadCounter:
                 raise RuntimeError("sink exploded")
 
         prev = mod._CANDIDATE_READS
-        mod._CANDIDATE_READS = _BoomCounter()  # type: ignore[assignment]
+        mod._CANDIDATE_READS = _BoomCounter()
         try:
             telemetry.record_candidate_reads(1)  # must not raise
         finally:

--- a/tests/unit/test_memory_reconcile_audit.py
+++ b/tests/unit/test_memory_reconcile_audit.py
@@ -1,0 +1,327 @@
+"""Unit tests for the uncorrelated memory-reconcile audit (#1748 §Uncorrelated detector).
+
+Pure in-memory: the DB pool/connection are mocked directly (no Postgres), the
+host directories live under ``tmp_path``. These tests exercise the audit's
+independent walk + unconditional hash + DB-comparison logic — never the
+prefilter's candidate classification, by design (the whole point of this
+detector is that it does NOT reuse that code path).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aios.harness import memory_reconcile_audit as audit
+
+STORE_A = "memstore_01AUDITSTOREA00000000000001"
+ACCOUNT_A = "acct_01AUDITACCOUNT0000000000001"
+
+
+def _sha256(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _fake_conn(
+    *,
+    store_rows: list[tuple[str, str]],
+    db_content: dict[str, str],
+) -> MagicMock:
+    conn = MagicMock()
+
+    async def _fetch(sql: str, *args: Any) -> list[dict[str, Any]]:
+        assert "memory_stores" in sql
+        return [{"id": sid, "account_id": aid} for sid, aid in store_rows]
+
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    return conn
+
+
+def _fake_pool(conn: MagicMock) -> MagicMock:
+    pool = MagicMock()
+
+    class _Cm:
+        async def __aenter__(self) -> Any:
+            return conn
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+    pool.acquire.return_value = _Cm()
+    return pool
+
+
+@pytest.fixture(autouse=True)
+def _patch_list_active(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[tuple[str, str]]]:
+    """Patch ``list_active_memory_paths_and_content`` per-store via a mutable dict."""
+    db_state: dict[str, list[tuple[str, str]]] = {}
+
+    async def _fake_list_active(
+        conn: Any, store_id: str, *, account_id: str
+    ) -> list[tuple[str, str]]:
+        return db_state.get(store_id, [])
+
+    monkeypatch.setattr(audit.queries, "list_active_memory_paths_and_content", _fake_list_active)
+    return db_state
+
+
+def _seed_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    db_state: dict[str, list[tuple[str, str]]],
+    *,
+    store_id: str = STORE_A,
+    disk_files: dict[str, str] | None = None,
+    db_files: dict[str, str] | None = None,
+    materialized: bool = True,
+) -> Path:
+    host_dir = tmp_path / store_id
+    host_dir.mkdir(parents=True, exist_ok=True)
+    if materialized:
+        (host_dir / ".materialized").touch()
+    for path, content in (disk_files or {}).items():
+        target = host_dir / path.lstrip("/")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    db_state[store_id] = list((db_files or {}).items())
+
+    monkeypatch.setattr(audit, "memory_store_host_dir", lambda sid, _host_dir=host_dir: _host_dir)
+    return host_dir
+
+
+class TestCleanAudit:
+    async def test_matching_disk_and_db_produce_no_divergence(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        content = "hello world\n"
+        _seed_store(
+            tmp_path,
+            monkeypatch,
+            _patch_list_active,
+            disk_files={"/foo.md": content},
+            db_files={"/foo.md": content},
+        )
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert result.clean
+        assert result.stores_checked == 1
+        assert result.files_hashed == 1
+
+
+class TestDivergenceDetection:
+    async def test_content_mismatch_detected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        """The core scenario this detector exists for: on-disk content differs
+        from the DB's row — a prefilter false-negative would produce exactly
+        this divergence, undetectably from inside the prefilter's own
+        substrate. This audit's independent hash must catch it."""
+        _seed_store(
+            tmp_path,
+            monkeypatch,
+            _patch_list_active,
+            disk_files={"/foo.md": "disk content\n"},
+            db_files={"/foo.md": "stale db content\n"},
+        )
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert not result.clean
+        assert len(result.divergences) == 1
+        d = result.divergences[0]
+        assert d.reason == "content_mismatch"
+        assert d.store_id == STORE_A
+        assert d.store_path == "/foo.md"
+        assert d.disk_sha256 == _sha256("disk content\n")
+        assert d.db_sha256 == _sha256("stale db content\n")
+
+    async def test_missing_in_db_detected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        """A file present on disk but absent from the DB (e.g. a create that
+        never durably landed) is a divergence, not silently ignored."""
+        _seed_store(
+            tmp_path,
+            monkeypatch,
+            _patch_list_active,
+            disk_files={"/orphan.md": "orphaned content\n"},
+            db_files={},
+        )
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert not result.clean
+        assert result.divergences[0].reason == "missing_in_db"
+
+    async def test_missing_on_disk_detected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        """A file the DB believes is live but which vanished from disk (e.g. a
+        prefilter false-negative on a delete) is a divergence."""
+        _seed_store(
+            tmp_path,
+            monkeypatch,
+            _patch_list_active,
+            disk_files={},
+            db_files={"/ghost.md": "ghost content\n"},
+        )
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert not result.clean
+        assert result.divergences[0].reason == "missing_on_disk"
+
+    async def test_unreadable_file_detected(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        host_dir = _seed_store(
+            tmp_path,
+            monkeypatch,
+            _patch_list_active,
+            disk_files={"/locked.md": "content\n"},
+            db_files={"/locked.md": "content\n"},
+        )
+        real_read_bytes = Path.read_bytes
+        target = host_dir / "locked.md"
+
+        def _fake_read_bytes(self: Path) -> bytes:
+            if self == target:
+                raise OSError("permission denied")
+            return real_read_bytes(self)
+
+        monkeypatch.setattr(Path, "read_bytes", _fake_read_bytes)
+
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert not result.clean
+        assert result.divergences[0].reason == "unreadable"
+
+
+class TestSkipsUnmaterializedOrMissingStores:
+    async def test_store_without_host_dir_is_skipped(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        missing_dir = tmp_path / "does_not_exist"
+        monkeypatch.setattr(audit, "memory_store_host_dir", lambda sid: missing_dir)
+
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert result.stores_checked == 0
+        assert result.clean
+
+    async def test_store_without_materialized_marker_is_skipped(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        _seed_store(
+            tmp_path,
+            monkeypatch,
+            _patch_list_active,
+            disk_files={"/foo.md": "content\n"},
+            db_files={},
+            materialized=False,
+        )
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert result.stores_checked == 0
+        assert result.clean
+
+
+class TestSymlinkRejection:
+    """The audit walks the same shared host directory bash writes into and
+    must reject the same confused-deputy symlink pattern the reconcile
+    prefilter rejects — even though the two walks are independent code."""
+
+    async def test_symlink_never_hashed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        _patch_list_active: dict[str, list[tuple[str, str]]],
+    ) -> None:
+        sensitive = tmp_path / "host_secret.txt"
+        sensitive.write_text("HOST-ONLY SECRET")
+
+        host_dir = _seed_store(
+            tmp_path,
+            monkeypatch,
+            _patch_list_active,
+            disk_files={},
+            db_files={},
+        )
+        (host_dir / "leak.txt").symlink_to(sensitive)
+
+        conn = _fake_conn(store_rows=[(STORE_A, ACCOUNT_A)], db_content={})
+        pool = _fake_pool(conn)
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        # The symlink is invisible to the audit entirely (not even a
+        # divergence) — it must never be walked or hashed.
+        assert result.files_hashed == 0
+        assert result.clean
+
+
+class TestIndependenceFromPrefilter:
+    """The audit module must not import or call into
+    ``aios.tools.bash_memory_reconcile`` at all — a same-substrate verdict is
+    worthless as a backstop (per the issue's design constraint)."""
+
+    def test_module_does_not_import_bash_memory_reconcile(self) -> None:
+        import ast
+        import inspect
+
+        source = inspect.getsource(audit)
+        tree = ast.parse(source)
+        imported_modules: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_modules.add(node.module)
+
+        assert not any("bash_memory_reconcile" in m for m in imported_modules), (
+            f"the uncorrelated audit must never import the prefilter module "
+            f"it's meant to independently verify; found imports: {imported_modules!r}"
+        )


### PR DESCRIPTION
Automated dev-pipeline build for issue #1748.