### PR TITLE
feat(harness): auto-preempt in-flight model phase on new wake-eligible event (#253)

### DIFF
--- a/migrations/versions/0136_agent_preempt_policy.py
+++ b/migrations/versions/0136_agent_preempt_policy.py
@@ -29,9 +29,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     op.execute("ALTER TABLE agents ADD COLUMN preempt_policy text NOT NULL DEFAULT 'wait';")
-    op.execute(
-        "ALTER TABLE agent_versions ADD COLUMN preempt_policy text NOT NULL DEFAULT 'wait';"
-    )
+    op.execute("ALTER TABLE agent_versions ADD COLUMN preempt_policy text NOT NULL DEFAULT 'wait';")
 
 
 def downgrade() -> None:

--- a/migrations/versions/0136_agent_preempt_policy.py
+++ b/migrations/versions/0136_agent_preempt_policy.py
@@ -1,0 +1,39 @@
+"""Add ``preempt_policy`` column to agents + agent_versions (#253).
+
+Per-agent policy for what happens to an in-flight model call when a new
+wake-eligible event (e.g. a user message) arrives mid-step: ``'wait'``
+(default — the step finishes, the queued wake handles the event next
+step) or ``'preempt'`` (the model phase is cancelled and the step
+restarts against context that includes the event).  Default ``'wait'``
+so every existing agent keeps current behavior; chat-facing agents opt
+in per agent.  No CHECK constraint — the ``PreemptPolicy`` Literal on
+the pydantic models is the single validation point (0111 precedent).
+Purely additive, safe in the new-code/old-schema deploy window.
+
+Revision ID: 0136
+Revises: 0135
+Create Date: 2026-07-09
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0136"
+down_revision: str = "0135"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agents ADD COLUMN preempt_policy text NOT NULL DEFAULT 'wait';")
+    op.execute(
+        "ALTER TABLE agent_versions ADD COLUMN preempt_policy text NOT NULL DEFAULT 'wait';"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS preempt_policy;")
+    op.execute("ALTER TABLE agent_versions DROP COLUMN IF EXISTS preempt_policy;")

--- a/migrations/versions/0139_agent_preempt_policy.py
+++ b/migrations/versions/0139_agent_preempt_policy.py
@@ -10,8 +10,8 @@ in per agent.  No CHECK constraint — the ``PreemptPolicy`` Literal on
 the pydantic models is the single validation point (0111 precedent).
 Purely additive, safe in the new-code/old-schema deploy window.
 
-Revision ID: 0136
-Revises: 0135
+Revision ID: 0139
+Revises: 0138
 Create Date: 2026-07-09
 """
 
@@ -21,8 +21,8 @@ from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "0136"
-down_revision: str = "0135"
+revision: str = "0139"
+down_revision: str = "0138"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/openapi.json
+++ b/openapi.json
@@ -11043,6 +11043,15 @@
             "type": "integer",
             "title": "Window Max"
           },
+          "preempt_policy": {
+            "type": "string",
+            "enum": [
+              "preempt",
+              "wait"
+            ],
+            "title": "Preempt Policy",
+            "default": "wait"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -11166,6 +11175,16 @@
             "minimum": 1.0,
             "title": "Window Max",
             "default": 150000
+          },
+          "preempt_policy": {
+            "type": "string",
+            "enum": [
+              "preempt",
+              "wait"
+            ],
+            "title": "Preempt Policy",
+            "description": "Whether a new wake-eligible event (e.g. a user message) arriving mid-step cancels the in-flight model call so the step restarts against fresh context ('preempt'), or waits for the step to finish ('wait', default).",
+            "default": "wait"
           }
         },
         "additionalProperties": false,
@@ -11361,6 +11380,21 @@
               }
             ],
             "title": "Window Max"
+          },
+          "preempt_policy": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "preempt",
+                  "wait"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preempt Policy"
           }
         },
         "additionalProperties": false,
@@ -11429,6 +11463,15 @@
           "window_max": {
             "type": "integer",
             "title": "Window Max"
+          },
+          "preempt_policy": {
+            "type": "string",
+            "enum": [
+              "preempt",
+              "wait"
+            ],
+            "title": "Preempt Policy",
+            "default": "wait"
           },
           "created_at": {
             "type": "string",

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -11,14 +11,18 @@ from .agent import Agent
 from .agent_create import AgentCreate
 from .agent_create_litellm_extra import AgentCreateLitellmExtra
 from .agent_create_metadata import AgentCreateMetadata
+from .agent_create_preempt_policy import AgentCreatePreemptPolicy
 from .agent_litellm_extra import AgentLitellmExtra
 from .agent_metadata import AgentMetadata
+from .agent_preempt_policy import AgentPreemptPolicy
 from .agent_skill_ref import AgentSkillRef
 from .agent_update import AgentUpdate
 from .agent_update_litellm_extra_type_0 import AgentUpdateLitellmExtraType0
 from .agent_update_metadata_type_0 import AgentUpdateMetadataType0
+from .agent_update_preempt_policy_type_0 import AgentUpdatePreemptPolicyType0
 from .agent_version import AgentVersion
 from .agent_version_litellm_extra import AgentVersionLitellmExtra
+from .agent_version_preempt_policy import AgentVersionPreemptPolicy
 from .allow_all import AllowAll
 from .allow_list import AllowList
 from .await_response import AwaitResponse
@@ -343,14 +347,18 @@ __all__ = (
     "AgentCreate",
     "AgentCreateLitellmExtra",
     "AgentCreateMetadata",
+    "AgentCreatePreemptPolicy",
     "AgentLitellmExtra",
     "AgentMetadata",
+    "AgentPreemptPolicy",
     "AgentSkillRef",
     "AgentUpdate",
     "AgentUpdateLitellmExtraType0",
     "AgentUpdateMetadataType0",
+    "AgentUpdatePreemptPolicyType0",
     "AgentVersion",
     "AgentVersionLitellmExtra",
+    "AgentVersionPreemptPolicy",
     "AllowAll",
     "AllowList",
     "AwaitingToolCall",

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent.py
@@ -8,6 +8,7 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..models.agent_preempt_policy import AgentPreemptPolicy
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -43,6 +44,7 @@ class Agent:
         skills (list[AgentSkillRef] | Unset):
         http_servers (list[HttpServerSpec] | Unset):
         litellm_extra (AgentLitellmExtra | Unset):
+        preempt_policy (AgentPreemptPolicy | Unset):  Default: AgentPreemptPolicy.WAIT.
         archived_at (datetime.datetime | None | Unset):
     """
 
@@ -62,6 +64,7 @@ class Agent:
     skills: list[AgentSkillRef] | Unset = UNSET
     http_servers: list[HttpServerSpec] | Unset = UNSET
     litellm_extra: AgentLitellmExtra | Unset = UNSET
+    preempt_policy: AgentPreemptPolicy | Unset = AgentPreemptPolicy.WAIT
     archived_at: datetime.datetime | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -117,6 +120,10 @@ class Agent:
         if not isinstance(self.litellm_extra, Unset):
             litellm_extra = self.litellm_extra.to_dict()
 
+        preempt_policy: str | Unset = UNSET
+        if not isinstance(self.preempt_policy, Unset):
+            preempt_policy = self.preempt_policy.value
+
         archived_at: None | str | Unset
         if isinstance(self.archived_at, Unset):
             archived_at = UNSET
@@ -150,6 +157,8 @@ class Agent:
             field_dict["http_servers"] = http_servers
         if litellm_extra is not UNSET:
             field_dict["litellm_extra"] = litellm_extra
+        if preempt_policy is not UNSET:
+            field_dict["preempt_policy"] = preempt_policy
         if archived_at is not UNSET:
             field_dict["archived_at"] = archived_at
 
@@ -231,6 +240,13 @@ class Agent:
         else:
             litellm_extra = AgentLitellmExtra.from_dict(_litellm_extra)
 
+        _preempt_policy = d.pop("preempt_policy", UNSET)
+        preempt_policy: AgentPreemptPolicy | Unset
+        if isinstance(_preempt_policy, Unset):
+            preempt_policy = UNSET
+        else:
+            preempt_policy = AgentPreemptPolicy(_preempt_policy)
+
         def _parse_archived_at(data: object) -> datetime.datetime | None | Unset:
             if data is None:
                 return data
@@ -265,6 +281,7 @@ class Agent:
             skills=skills,
             http_servers=http_servers,
             litellm_extra=litellm_extra,
+            preempt_policy=preempt_policy,
             archived_at=archived_at,
         )
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent_create.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent_create.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
+from ..models.agent_create_preempt_policy import AgentCreatePreemptPolicy
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -41,6 +42,9 @@ class AgentCreate:
             accept this field from untrusted principals.
         window_min (int | Unset):  Default: 50000.
         window_max (int | Unset):  Default: 150000.
+        preempt_policy (AgentCreatePreemptPolicy | Unset): Whether a new wake-eligible event (e.g. a user message)
+            arriving mid-step cancels the in-flight model call so the step restarts against fresh context ('preempt'), or
+            waits for the step to finish ('wait', default). Default: AgentCreatePreemptPolicy.WAIT.
     """
 
     name: str
@@ -55,6 +59,7 @@ class AgentCreate:
     litellm_extra: AgentCreateLitellmExtra | Unset = UNSET
     window_min: int | Unset = 50000
     window_max: int | Unset = 150000
+    preempt_policy: AgentCreatePreemptPolicy | Unset = AgentCreatePreemptPolicy.WAIT
 
     def to_dict(self) -> dict[str, Any]:
         name = self.name
@@ -109,6 +114,10 @@ class AgentCreate:
 
         window_max = self.window_max
 
+        preempt_policy: str | Unset = UNSET
+        if not isinstance(self.preempt_policy, Unset):
+            preempt_policy = self.preempt_policy.value
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -137,6 +146,8 @@ class AgentCreate:
             field_dict["window_min"] = window_min
         if window_max is not UNSET:
             field_dict["window_max"] = window_max
+        if preempt_policy is not UNSET:
+            field_dict["preempt_policy"] = preempt_policy
 
         return field_dict
 
@@ -219,6 +230,13 @@ class AgentCreate:
 
         window_max = d.pop("window_max", UNSET)
 
+        _preempt_policy = d.pop("preempt_policy", UNSET)
+        preempt_policy: AgentCreatePreemptPolicy | Unset
+        if isinstance(_preempt_policy, Unset):
+            preempt_policy = UNSET
+        else:
+            preempt_policy = AgentCreatePreemptPolicy(_preempt_policy)
+
         agent_create = cls(
             name=name,
             model=model,
@@ -232,6 +250,7 @@ class AgentCreate:
             litellm_extra=litellm_extra,
             window_min=window_min,
             window_max=window_max,
+            preempt_policy=preempt_policy,
         )
 
         return agent_create

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent_create_preempt_policy.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent_create_preempt_policy.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class AgentCreatePreemptPolicy(str, Enum):
+    PREEMPT = "preempt"
+    WAIT = "wait"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent_preempt_policy.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent_preempt_policy.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class AgentPreemptPolicy(str, Enum):
+    PREEMPT = "preempt"
+    WAIT = "wait"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent_update.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent_update.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 
+from ..models.agent_update_preempt_policy_type_0 import AgentUpdatePreemptPolicyType0
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -42,6 +43,7 @@ class AgentUpdate:
             litellm_extra (AgentUpdateLitellmExtraType0 | None | Unset):
             window_min (int | None | Unset):
             window_max (int | None | Unset):
+            preempt_policy (AgentUpdatePreemptPolicyType0 | None | Unset):
     """
 
     version: int
@@ -57,6 +59,7 @@ class AgentUpdate:
     litellm_extra: AgentUpdateLitellmExtraType0 | None | Unset = UNSET
     window_min: int | None | Unset = UNSET
     window_max: int | None | Unset = UNSET
+    preempt_policy: AgentUpdatePreemptPolicyType0 | None | Unset = UNSET
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.agent_update_litellm_extra_type_0 import (
@@ -166,6 +169,14 @@ class AgentUpdate:
         else:
             window_max = self.window_max
 
+        preempt_policy: None | str | Unset
+        if isinstance(self.preempt_policy, Unset):
+            preempt_policy = UNSET
+        elif isinstance(self.preempt_policy, AgentUpdatePreemptPolicyType0):
+            preempt_policy = self.preempt_policy.value
+        else:
+            preempt_policy = self.preempt_policy
+
         field_dict: dict[str, Any] = {}
 
         field_dict.update(
@@ -197,6 +208,8 @@ class AgentUpdate:
             field_dict["window_min"] = window_min
         if window_max is not UNSET:
             field_dict["window_max"] = window_max
+        if preempt_policy is not UNSET:
+            field_dict["preempt_policy"] = preempt_policy
 
         return field_dict
 
@@ -398,6 +411,25 @@ class AgentUpdate:
 
         window_max = _parse_window_max(d.pop("window_max", UNSET))
 
+        def _parse_preempt_policy(
+            data: object,
+        ) -> AgentUpdatePreemptPolicyType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                preempt_policy_type_0 = AgentUpdatePreemptPolicyType0(data)
+
+                return preempt_policy_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(AgentUpdatePreemptPolicyType0 | None | Unset, data)
+
+        preempt_policy = _parse_preempt_policy(d.pop("preempt_policy", UNSET))
+
         agent_update = cls(
             version=version,
             name=name,
@@ -412,6 +444,7 @@ class AgentUpdate:
             litellm_extra=litellm_extra,
             window_min=window_min,
             window_max=window_max,
+            preempt_policy=preempt_policy,
         )
 
         return agent_update

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent_update_preempt_policy_type_0.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent_update_preempt_policy_type_0.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class AgentUpdatePreemptPolicyType0(str, Enum):
+    PREEMPT = "preempt"
+    WAIT = "wait"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent_version.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent_version.py
@@ -8,6 +8,7 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
+from ..models.agent_version_preempt_policy import AgentVersionPreemptPolicy
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ class AgentVersion:
         skills (list[AgentSkillRef] | Unset):
         http_servers (list[HttpServerSpec] | Unset):
         litellm_extra (AgentVersionLitellmExtra | Unset):
+        preempt_policy (AgentVersionPreemptPolicy | Unset):  Default: AgentVersionPreemptPolicy.WAIT.
     """
 
     agent_id: str
@@ -52,6 +54,7 @@ class AgentVersion:
     skills: list[AgentSkillRef] | Unset = UNSET
     http_servers: list[HttpServerSpec] | Unset = UNSET
     litellm_extra: AgentVersionLitellmExtra | Unset = UNSET
+    preempt_policy: AgentVersionPreemptPolicy | Unset = AgentVersionPreemptPolicy.WAIT
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -97,6 +100,10 @@ class AgentVersion:
         if not isinstance(self.litellm_extra, Unset):
             litellm_extra = self.litellm_extra.to_dict()
 
+        preempt_policy: str | Unset = UNSET
+        if not isinstance(self.preempt_policy, Unset):
+            preempt_policy = self.preempt_policy.value
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -118,6 +125,8 @@ class AgentVersion:
             field_dict["http_servers"] = http_servers
         if litellm_extra is not UNSET:
             field_dict["litellm_extra"] = litellm_extra
+        if preempt_policy is not UNSET:
+            field_dict["preempt_policy"] = preempt_policy
 
         return field_dict
 
@@ -183,6 +192,13 @@ class AgentVersion:
         else:
             litellm_extra = AgentVersionLitellmExtra.from_dict(_litellm_extra)
 
+        _preempt_policy = d.pop("preempt_policy", UNSET)
+        preempt_policy: AgentVersionPreemptPolicy | Unset
+        if isinstance(_preempt_policy, Unset):
+            preempt_policy = UNSET
+        else:
+            preempt_policy = AgentVersionPreemptPolicy(_preempt_policy)
+
         agent_version = cls(
             agent_id=agent_id,
             version=version,
@@ -196,6 +212,7 @@ class AgentVersion:
             skills=skills,
             http_servers=http_servers,
             litellm_extra=litellm_extra,
+            preempt_policy=preempt_policy,
         )
 
         agent_version.additional_properties = d

--- a/packages/aios-sdk/aios_sdk/_generated/models/agent_version_preempt_policy.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/agent_version_preempt_policy.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class AgentVersionPreemptPolicy(str, Enum):
+    PREEMPT = "preempt"
+    WAIT = "wait"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/src/aios/api/routers/agents.py
+++ b/src/aios/api/routers/agents.py
@@ -34,6 +34,7 @@ async def create(body: AgentCreate, pool: PoolDep, account_id: AccountIdDep) -> 
         litellm_extra=body.litellm_extra,
         window_min=body.window_min,
         window_max=body.window_max,
+        preempt_policy=body.preempt_policy,
         account_id=account_id,
     )
 
@@ -99,6 +100,7 @@ async def update(
         litellm_extra=body.litellm_extra,
         window_min=body.window_min,
         window_max=body.window_max,
+        preempt_policy=body.preempt_policy,
         account_id=account_id,
     )
 

--- a/src/aios/db/queries/agents.py
+++ b/src/aios/db/queries/agents.py
@@ -32,6 +32,7 @@ from aios.models.agents import (
     AgentVersion,
     HttpServerSpec,
     McpServerSpec,
+    PreemptPolicy,
     ToolSpec,
     load_tool_specs,
 )
@@ -63,6 +64,7 @@ def _row_to_agent(row: asyncpg.Record) -> Agent:
         litellm_extra=litellm_extra or {},
         window_min=row["window_min"],
         window_max=row["window_max"],
+        preempt_policy=row["preempt_policy"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
         archived_at=row["archived_at"],
@@ -87,6 +89,7 @@ def _row_to_agent_version(row: asyncpg.Record) -> AgentVersion:
         litellm_extra=litellm_extra or {},
         window_min=row["window_min"],
         window_max=row["window_max"],
+        preempt_policy=row["preempt_policy"],
         created_at=row["created_at"],
     )
 
@@ -107,6 +110,7 @@ async def insert_agent(
     litellm_extra: dict[str, Any],
     window_min: int,
     window_max: int,
+    preempt_policy: PreemptPolicy,
 ) -> Agent:
     if window_min >= window_max:
         raise ValidationError(
@@ -126,10 +130,11 @@ async def insert_agent(
                 INSERT INTO agents (
                     id, name, model, system, tools, skills, mcp_servers, http_servers,
                     description, metadata, litellm_extra,
-                    window_min, window_max, version, account_id, tools_vocab_epoch
+                    window_min, window_max, preempt_policy,
+                    version, account_id, tools_vocab_epoch
                 )
                 VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb,
-                        $9, $10::jsonb, $11::jsonb, $12, $13, 1, $14, $15)
+                        $9, $10::jsonb, $11::jsonb, $12, $13, $14, 1, $15, $16)
                 RETURNING *
                 """,
                 new_id,
@@ -145,6 +150,7 @@ async def insert_agent(
                 extra_json,
                 window_min,
                 window_max,
+                preempt_policy,
                 account_id,
                 TOOLS_VOCAB_EPOCH,
             )
@@ -154,10 +160,11 @@ async def insert_agent(
                 """
                 INSERT INTO agent_versions (
                     agent_id, version, model, system, tools, skills, mcp_servers, http_servers,
-                    litellm_extra, window_min, window_max, account_id, tools_vocab_epoch
+                    litellm_extra, window_min, window_max, preempt_policy,
+                    account_id, tools_vocab_epoch
                 )
                 VALUES ($1, 1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7::jsonb,
-                        $8::jsonb, $9, $10, $11, $12)
+                        $8::jsonb, $9, $10, $11, $12, $13)
                 """,
                 new_id,
                 model,
@@ -169,6 +176,7 @@ async def insert_agent(
                 extra_json,
                 window_min,
                 window_max,
+                preempt_policy,
                 account_id,
                 TOOLS_VOCAB_EPOCH,
             )
@@ -238,6 +246,7 @@ async def update_agent(
     litellm_extra: dict[str, Any] | None = None,
     window_min: int | None = None,
     window_max: int | None = None,
+    preempt_policy: PreemptPolicy | None = None,
 ) -> Agent:
     """Update an agent, creating a new version.
 
@@ -272,6 +281,7 @@ async def update_agent(
     new_extra = litellm_extra if litellm_extra is not None else current.litellm_extra
     new_wmin = window_min if window_min is not None else current.window_min
     new_wmax = window_max if window_max is not None else current.window_max
+    new_preempt = preempt_policy if preempt_policy is not None else current.preempt_policy
     if new_wmin >= new_wmax:
         # Partial-merge semantics: a one-sided update (e.g. ``window_max``
         # alone, set at-or-below the current ``window_min``) only
@@ -298,6 +308,7 @@ async def update_agent(
         and new_extra == current.litellm_extra
         and new_wmin == current.window_min
         and new_wmax == current.window_max
+        and new_preempt == current.preempt_policy
     ):
         return current
 
@@ -328,8 +339,9 @@ async def update_agent(
                    description = $10, metadata = $11::jsonb,
                    litellm_extra = $12::jsonb,
                    window_min = $13, window_max = $14,
+                   preempt_policy = $15,
                    updated_at = now()
-             WHERE id = $1 AND account_id = $15 AND version = $16
+             WHERE id = $1 AND account_id = $16 AND version = $17
                AND archived_at IS NULL
             RETURNING *
             """,
@@ -347,6 +359,7 @@ async def update_agent(
             extra_json,
             new_wmin,
             new_wmax,
+            new_preempt,
             account_id,
             expected_version,
         )
@@ -371,10 +384,11 @@ async def update_agent(
             """
             INSERT INTO agent_versions (
                 agent_id, version, model, system, tools, skills, mcp_servers, http_servers,
-                litellm_extra, window_min, window_max, account_id, tools_vocab_epoch
+                litellm_extra, window_min, window_max, preempt_policy,
+                account_id, tools_vocab_epoch
             )
             VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb,
-                    $9::jsonb, $10, $11, $12, $13)
+                    $9::jsonb, $10, $11, $12, $13, $14)
             """,
             agent_id,
             new_version,
@@ -387,6 +401,7 @@ async def update_agent(
             extra_json,
             new_wmin,
             new_wmax,
+            new_preempt,
             account_id,
             TOOLS_VOCAB_EPOCH,
         )

--- a/src/aios/db/queries/sessions.py
+++ b/src/aios/db/queries/sessions.py
@@ -100,16 +100,28 @@ def session_errored_predicate(alias: str) -> str:
     return f"({alias}.last_error_seq > 0 AND {alias}.last_error_seq > {alias}.last_user_seq)"
 
 
-def session_active_predicate(alias: str) -> str:
+def session_active_predicate(alias: str, *, stimulus_floor_param: str | None = None) -> str:
     """SQL boolean fragment: does the session have work the model must react to?
 
     One source for the active predicate, alias-parameterized so the read-path
     status derivation (``sessions`` alias) and the sweep's wake candidate filter
     (``CANDIDATE_ROWS_SQL``, ``s`` alias) compose the IDENTICAL boolean — they
     MUST agree or the worker wakes with no progress (#155) / skips inference.
+
+    ``stimulus_floor_param`` (a positional placeholder like ``"$2"``) raises the
+    reacted watermark to ``GREATEST(last_reacted_seq, <param>)`` — the #253
+    preemption trigger's re-parameterization against the in-flight step's
+    context watermark (``sweep.CANDIDATE_ROWS_FLOORED_SQL``): during a step the
+    last-appended assistant's watermark is the *previous* step's, so the
+    committed column would re-admit the very stimuli the in-flight step is
+    already reacting to. The default emits the byte-identical committed
+    predicate.
     """
+    reacted = f"{alias}.last_reacted_seq"
+    if stimulus_floor_param is not None:
+        reacted = f"GREATEST({alias}.last_reacted_seq, {stimulus_floor_param})"
     return (
-        f"(({alias}.last_stimulus_seq > {alias}.last_reacted_seq"
+        f"(({alias}.last_stimulus_seq > {reacted}"
         f" OR {alias}.open_tool_call_count > 0)"
         f" AND NOT {session_errored_predicate(alias)})"
     )

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -442,6 +442,10 @@ async def _wait_for_preempt(
     iterations poll the one-row gate and re-run the full predicate only when
     ``last_event_seq`` has advanced past the value captured BEFORE the previous
     full evaluation (so rows appended mid-evaluation are never skipped).
+
+    ``cancelled_by`` is the gate read's ``last_stimulus_seq`` when it lies past
+    the floor — the stimulus whose append tripped the gate. A confirmed-dispatch
+    or cancel-marker admission carries no stimulus past the floor → ``None``.
     """
     baseline: int | None = None
     while True:
@@ -456,10 +460,7 @@ async def _wait_for_preempt(
                 reacted_floor=reacted_floor,
             )
             if eligible:
-                async with pool.acquire() as conn:
-                    last_stimulus = await conn.fetchval(
-                        "SELECT last_stimulus_seq FROM sessions WHERE id = $1", session_id
-                    )
+                last_stimulus = gate["last_stimulus_seq"]
                 if last_stimulus is not None and last_stimulus > reacted_floor:
                     return int(last_stimulus)
                 return None

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import os as _os
+from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import litellm.exceptions as litellm_exceptions
@@ -35,6 +36,7 @@ from aios.db.sse_lock import has_subscriber
 from aios.harness import runtime
 from aios.harness.completion import (
     LlmRequest,
+    LlmResponse,
     ModelCallDeadlineError,
     call_litellm,
     estimate_cost_usd,
@@ -338,6 +340,211 @@ async def refresh_session_mount_state(
             session_id, memory_echoes, github_echoes, env_var_echoes
         )
     return memory_echoes
+
+
+# ─── #253 auto-preemption ─────────────────────────────────────────────────────
+#
+# When ``agent.preempt_policy == "preempt"``, the inline model call is raced
+# against a watcher that resolves the moment the session becomes wake-eligible
+# past the in-flight step's context watermark — the wake predicate
+# (``find_sessions_needing_inference``) re-parameterized with
+# ``reacted_floor=step_ctx.reacting_to``, NOT an enumerated event-kind list, so
+# the trigger can never drift from wake semantics. The model phase is
+# side-effect-free by construction (no DB writes between ``model_request_start``
+# and the assistant append; streaming deltas are transient pg_notify only), so
+# cancelling the model child task discards nothing durable; the event append
+# that made the session eligible already deferred a wake, and the preempted
+# step's normal early return releases the procrastinate lock for it. Once the
+# model call returns, the watcher is torn down before the append/dispatch tail
+# — un-preemptibility after the model phase is structural, not checked.
+
+# Poll cadence of the watcher's cheap gate. Worst case adds one interval to
+# preemption latency — negligible against the 20-50s model calls preemption
+# targets (the wake-tail p90/p99 this feature exists to cut is 15s/51s).
+_PREEMPT_POLL_INTERVAL_S = 1.0
+
+# Starvation cap: consecutive preemptions (no completed assistant turn) before
+# the step runs un-preemptible so a sustained inbound burst gets SOME reply.
+_PREEMPT_STARVATION_CAP = 3
+
+# One PK-scoped read per poll tick. ``last_event_seq`` advances on EVERY event
+# append, and every wake-eligible transition appends a row — the stimulus
+# itself, or the ``wake_deferred`` span ``defer_wake`` writes even when
+# procrastinate dedups the job — so "unchanged" proves the full floored
+# predicate would return what it returned last time.
+_PREEMPT_GATE_SQL = "SELECT last_event_seq, last_stimulus_seq FROM sessions WHERE id = $1"
+
+# Trailing ``step_preempted`` spans since the last completed assistant turn.
+# The floor is the last assistant message's own seq, NOT ``last_reacted_seq``:
+# a preempt span is sequenced after the stimulus that triggered it, so it can
+# lie above the eventual assistant's ``reacting_to`` while still belonging to
+# the completed turn.
+_PREEMPT_STARVATION_COUNT_SQL = """
+    SELECT count(*)
+      FROM events
+     WHERE session_id = $1
+       AND account_id = $2
+       AND kind = 'span'
+       AND data->>'event' = 'step_preempted'
+       AND seq > COALESCE((
+           SELECT max(a.seq)
+             FROM events a
+            WHERE a.session_id = $1
+              AND a.account_id = $2
+              AND a.kind = 'message'
+              AND a.role = 'assistant'
+       ), 0)
+"""
+
+
+class _Preempted(NamedTuple):
+    """Race outcome: the watcher won — the model phase was cancelled.
+
+    ``cancelled_by`` is the preempting stimulus seq (``last_stimulus_seq`` at
+    detection), or ``None`` when the admission carried no stimulus seq (a
+    confirmed-dispatch or cancel-marker admission).
+    """
+
+    cancelled_by: int | None
+
+
+async def _preempt_allowed(pool: Any, session_id: str, *, account_id: str) -> bool:
+    """Starvation guard: cap consecutive preemptions at ``_PREEMPT_STARVATION_CAP``.
+
+    A sustained inbound burst faster than the model responds would otherwise
+    cancel-and-restart the step forever, deferring the reply indefinitely (the
+    livelock the #253 decision comment required a cap for). The count is
+    derived from the event log — trailing ``step_preempted`` spans past the
+    last assistant message — so it is correct across workers and resets on any
+    completed assistant turn. An errored turn deliberately does not reset it.
+    """
+    async with pool.acquire() as conn:
+        count = await conn.fetchval(_PREEMPT_STARVATION_COUNT_SQL, session_id, account_id)
+    if count is not None and count >= _PREEMPT_STARVATION_CAP:
+        log.info("step.preempt_starved", session_id=session_id, consecutive_preempts=count)
+        return False
+    return True
+
+
+async def _wait_for_preempt(
+    pool: Any,
+    inflight_tool_registry: InflightToolRegistry,
+    session_id: str,
+    *,
+    reacted_floor: int,
+) -> int | None:
+    """Resolve when the session becomes wake-eligible past ``reacted_floor``.
+
+    Runs as a child task raced against the model call; cancelled when the
+    model wins. The FIRST iteration always runs the full floored predicate —
+    events may have landed between context build and this task starting, and
+    confirms are not stimuli so the watermark alone cannot see them. Later
+    iterations poll the one-row gate and re-run the full predicate only when
+    ``last_event_seq`` has advanced past the value captured BEFORE the previous
+    full evaluation (so rows appended mid-evaluation are never skipped).
+    """
+    baseline: int | None = None
+    while True:
+        async with pool.acquire() as conn:
+            gate = await conn.fetchrow(_PREEMPT_GATE_SQL, session_id)
+        if gate is not None and gate["last_event_seq"] != baseline:
+            baseline = gate["last_event_seq"]
+            eligible = await find_sessions_needing_inference(
+                pool,
+                inflight_tool_registry,
+                session_id=session_id,
+                reacted_floor=reacted_floor,
+            )
+            if eligible:
+                async with pool.acquire() as conn:
+                    last_stimulus = await conn.fetchval(
+                        "SELECT last_stimulus_seq FROM sessions WHERE id = $1", session_id
+                    )
+                if last_stimulus is not None and last_stimulus > reacted_floor:
+                    return int(last_stimulus)
+                return None
+        await asyncio.sleep(_PREEMPT_POLL_INTERVAL_S)
+
+
+async def _race_model_against_preempt(
+    call_model: Callable[[], Coroutine[Any, Any, LlmResponse]],
+    pool: Any,
+    inflight_tool_registry: InflightToolRegistry,
+    session_id: str,
+    *,
+    reacted_floor: int,
+) -> LlmResponse | _Preempted:
+    """Race the model call against the preempt watcher.
+
+    Model-first on ties: a completed inference is never discarded. A watcher
+    failure degrades to "wait" semantics — preemption plumbing must never
+    break inference. Cancellation of the step task itself (operator interrupt,
+    the job-level ``wait_for`` timeout, worker shutdown) tears down both
+    children and propagates, preserving today's semantics exactly. Raises the
+    model call's exception (into the caller's existing handler arms) when the
+    model errored.
+    """
+    model_task = asyncio.create_task(call_model())
+    watch_task = asyncio.create_task(
+        _wait_for_preempt(pool, inflight_tool_registry, session_id, reacted_floor=reacted_floor)
+    )
+    try:
+        await asyncio.wait({model_task, watch_task}, return_when=asyncio.FIRST_COMPLETED)
+    except asyncio.CancelledError:
+        model_task.cancel()
+        watch_task.cancel()
+        await asyncio.gather(model_task, watch_task, return_exceptions=True)
+        raise
+    if model_task.done():
+        watch_task.cancel()
+        await asyncio.gather(watch_task, return_exceptions=True)
+        return model_task.result()
+    if watch_task.exception() is not None:
+        log.warning(
+            "step.preempt_watcher_failed",
+            session_id=session_id,
+            error=repr(watch_task.exception()),
+        )
+        return await model_task
+    # Watcher won: cancel the model phase. The stream teardown
+    # (``response.aclose()``) runs in ``stream_litellm``'s own finally on
+    # cancellation; already-streamed deltas were transient pg_notify only.
+    model_task.cancel()
+    await asyncio.gather(model_task, return_exceptions=True)
+    return _Preempted(cancelled_by=watch_task.result())
+
+
+async def _append_preempted_spans(
+    pool: Any,
+    session_id: str,
+    *,
+    start_event_id: str,
+    cancelled_by: int | None,
+    account_id: str,
+) -> None:
+    """Close the cancelled ``model_request`` span pair and record the preemption.
+
+    The cancelled ``model_request_end`` deliberately omits ``local_tokens`` /
+    ``local_tokens_by_class`` / ``model`` / ``model_usage``: the token-
+    calibration reader keys on those fields' presence, so their absence keeps
+    the cancelled request structurally out of calibration (and out of the 0024
+    partial index) — no usage was observed, so none is stamped.
+    """
+    end_payload: dict[str, Any] = {
+        "event": "model_request_end",
+        "model_request_start_id": start_event_id,
+        "is_error": False,
+    }
+    preempted_payload: dict[str, Any] = {"event": "step_preempted"}
+    if cancelled_by is not None:
+        end_payload["cancelled_by"] = cancelled_by
+        preempted_payload["cancelled_by"] = cancelled_by
+    await sessions_service.append_event(
+        pool, session_id, "span", end_payload, account_id=account_id
+    )
+    await sessions_service.append_event(
+        pool, session_id, "span", preempted_payload, account_id=account_id
+    )
 
 
 async def run_session_step(
@@ -1031,18 +1238,58 @@ async def _run_session_step_body(
             account_id=account_id,
         )
         subscribed = await has_subscriber(pool, session_id)
-        try:
+
+        async def _call_model() -> LlmResponse:
             if subscribed:
-                llm_response = await stream_litellm(
+                return await stream_litellm(
                     llm_request,
                     model=agent.model,
                     pool=pool,
                 )
-            else:
-                llm_response = await call_litellm(
-                    llm_request,
-                    model=agent.model,
+            return await call_litellm(
+                llm_request,
+                model=agent.model,
+            )
+
+        # #253 arm decision: policy is agent-level ("wait" default keeps the
+        # exact pre-preemption await), gated by the starvation cap. Both are
+        # only evaluated for opted-in agents — zero extra reads on the default
+        # path.
+        preempt_armed = agent.preempt_policy == "preempt" and await _preempt_allowed(
+            pool, session_id, account_id=account_id
+        )
+        try:
+            if preempt_armed:
+                outcome = await _race_model_against_preempt(
+                    _call_model,
+                    pool,
+                    inflight_tool_registry,
+                    session_id,
+                    reacted_floor=step_ctx.reacting_to,
                 )
+                if isinstance(outcome, _Preempted):
+                    # No assistant message, no charge (charge is post-persist),
+                    # no turn_ended: the step exits owing nothing. The append
+                    # that made the session eligible already deferred a wake;
+                    # the lock releases on return and that wake re-steps with
+                    # context including the new event(s).
+                    await _append_preempted_spans(
+                        pool,
+                        session_id,
+                        start_event_id=start_event.id,
+                        cancelled_by=outcome.cancelled_by,
+                        account_id=account_id,
+                    )
+                    log.info(
+                        "step.preempted",
+                        session_id=session_id,
+                        cancelled_by=outcome.cancelled_by,
+                        reacted_floor=step_ctx.reacting_to,
+                    )
+                    return _StepResult()
+                llm_response = outcome
+            else:
+                llm_response = await _call_model()
         except ModelCallDeadlineError as exc:
             log.exception(
                 "step.model_call_deadline", session_id=session_id, chunks_seen=exc.chunks_seen

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -420,7 +420,7 @@ async def _preempt_allowed(pool: Any, session_id: str, *, account_id: str) -> bo
     """
     async with pool.acquire() as conn:
         count = await conn.fetchval(_PREEMPT_STARVATION_COUNT_SQL, session_id, account_id)
-    if count is not None and count >= _PREEMPT_STARVATION_CAP:
+    if count >= _PREEMPT_STARVATION_CAP:
         log.info("step.preempt_starved", session_id=session_id, consecutive_preempts=count)
         return False
     return True
@@ -443,9 +443,12 @@ async def _wait_for_preempt(
     ``last_event_seq`` has advanced past the value captured BEFORE the previous
     full evaluation (so rows appended mid-evaluation are never skipped).
 
-    ``cancelled_by`` is the gate read's ``last_stimulus_seq`` when it lies past
-    the floor — the stimulus whose append tripped the gate. A confirmed-dispatch
-    or cancel-marker admission carries no stimulus past the floor → ``None``.
+    ``cancelled_by`` is ``last_stimulus_seq`` re-read AFTER the eligible
+    evaluation (a stimulus admitted by the predicate committed before its
+    snapshot, so the re-read always covers it — the pre-evaluation gate row can
+    be older than the admitting stimulus and would misattribute or drop it). A
+    confirmed-dispatch or cancel-marker admission carries no stimulus past the
+    floor → ``None``.
     """
     baseline: int | None = None
     while True:
@@ -460,7 +463,9 @@ async def _wait_for_preempt(
                 reacted_floor=reacted_floor,
             )
             if eligible:
-                last_stimulus = gate["last_stimulus_seq"]
+                async with pool.acquire() as conn:
+                    row = await conn.fetchrow(_PREEMPT_GATE_SQL, session_id)
+                last_stimulus = None if row is None else row["last_stimulus_seq"]
                 if last_stimulus is not None and last_stimulus > reacted_floor:
                     return int(last_stimulus)
                 return None
@@ -506,7 +511,14 @@ async def _race_model_against_preempt(
             session_id=session_id,
             error=repr(watch_task.exception()),
         )
-        return await model_task
+        try:
+            return await model_task
+        except asyncio.CancelledError:
+            # Step-task cancellation while degraded: the model child must not
+            # outlive the step (same teardown as the asyncio.wait arm above).
+            model_task.cancel()
+            await asyncio.gather(model_task, return_exceptions=True)
+            raise
     # Watcher won: cancel the model phase. The stream teardown
     # (``response.aclose()``) runs in ``stream_litellm``'s own finally on
     # cancellation; already-streamed deltas were transient pg_notify only.

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -301,6 +301,20 @@ CANDIDATE_ROWS_SQL = f"""
        {{scope_clause}}
 """
 
+# Floored variant for the #253 preemption trigger — the SAME single-source
+# predicate re-parameterized against the in-flight step's context watermark
+# (``$2``): during a step, the committed ``last_reacted_seq`` is the *previous*
+# step's watermark, so the unfloored form would re-admit the very stimuli the
+# in-flight step is already reacting to. Always single-session (``$1``) — the
+# preempt check runs from inside a step, never cross-session.
+CANDIDATE_ROWS_FLOORED_SQL = f"""
+    SELECT s.id AS session_id
+      FROM sessions s
+     WHERE s.archived_at IS NULL
+       AND {session_active_predicate("s", stimulus_floor_param="$2")}
+       AND s.id = $1
+"""
+
 # Cross-session detection of confirmed-but-unresolved tools, for the wake
 # decision (case (c)).  The dispatch-side counterpart that resolves these same
 # confirmed-allow, result-less tool_calls into the actual tool_call dicts to
@@ -332,6 +346,27 @@ CONFIRMED_ROWS_SQL = f"""
        {{scope_clause}}
 """
 
+# Floored variant for the #253 preemption trigger. ``lc.seq > $3`` bounds the
+# confirmed arm to confirms the in-flight step could NOT have consumed: a step
+# that reaches the model phase already resolved every confirm it saw at its
+# confirmed-dispatch check (``_dispatch_confirmed_tools`` early-returns when it
+# dispatches), so only a confirm sequenced past the step's context watermark
+# represents new dispatchable work. Projects ``tool_call_id`` (not DISTINCT
+# session_id) so the caller can additionally subtract already-dispatched calls
+# — in-flight in the registry or bearing a ``tool_execute_start`` span — which
+# the registry-blind predicate cannot see; without that subtraction a confirmed
+# tool dispatched by a PRIOR step but still running would re-admit on every
+# evaluation and thrash the preempt loop.
+CONFIRMED_ROWS_FLOORED_SQL = f"""
+    SELECT lc.session_id, lc.data->>'tool_call_id' AS tool_call_id
+      FROM events lc
+      JOIN sessions s ON s.id = lc.session_id
+     WHERE s.archived_at IS NULL
+       AND {confirmed_unresolved_predicate("lc", "$2")}
+       AND lc.seq > $3
+       AND lc.session_id = $1
+"""
+
 # The reaction watermark — ``MAX(COALESCE(reacting_to, seq))`` over assistant
 # messages — lives in exactly ONE writable place: the ``last_reacted_seq``
 # UPDATE in ``append_event`` (db/queries/events.py), seeded once by migration
@@ -347,7 +382,7 @@ CONFIRMED_ROWS_SQL = f"""
 # ``is_stimulus``). ``IS DISTINCT FROM 'true'`` is NULL-safe: a missing key →
 # NULL → TRUE → the row still counts (every historical/unmarked result wakes
 # exactly as before); only the literal JSON ``true`` is excluded.
-UNREACTED_ROWS_SQL = """
+_UNREACTED_ROWS_TEMPLATE = """
     SELECT e.session_id, e.role, e.data->>'tool_call_id' AS tool_call_id
       FROM events e
       JOIN sessions s ON s.id = e.session_id
@@ -355,8 +390,20 @@ UNREACTED_ROWS_SQL = """
        AND e.kind = 'message'
        AND e.role <> 'assistant'
        AND e.data->>'no_reaction' IS DISTINCT FROM 'true'
-       AND e.seq > s.last_reacted_seq
+       AND e.seq > {watermark_expr}
 """
+
+UNREACTED_ROWS_SQL = _UNREACTED_ROWS_TEMPLATE.format(watermark_expr="s.last_reacted_seq")
+
+# Floored variant for the #253 preemption trigger — same rows, with the
+# watermark raised to the in-flight step's context watermark (``$2``).
+# ``GREATEST`` rather than a bare ``$2`` is belt-free self-documentation: the
+# step's watermark is ≥ ``last_reacted_seq`` by construction (its context
+# includes everything the previous assistant reacted to), so the two forms are
+# equivalent; GREATEST states the invariant in the query text.
+UNREACTED_ROWS_FLOORED_SQL = _UNREACTED_ROWS_TEMPLATE.format(
+    watermark_expr="GREATEST(s.last_reacted_seq, $2)"
+)
 
 # ─── batch filter: bounded, payload-stripped fetches (#1729) ─────────────────
 #
@@ -1189,6 +1236,7 @@ async def find_sessions_needing_inference(
     inflight_tool_registry: InflightToolRegistry,
     *,
     session_id: str | None = None,
+    reacted_floor: int | None = None,
 ) -> set[str]:
     """Return session IDs that need an inference step.
 
@@ -1205,7 +1253,20 @@ async def find_sessions_needing_inference(
     Sessions from (a)/(b) are filtered: if the only unreacted events are
     tool results from a batch with in-flight tasks, the session is not
     yet ready. Case (c) sessions bypass this filter.
+
+    ``reacted_floor`` (requires ``session_id``) is the #253 preemption
+    trigger: the SAME predicate evaluated against the in-flight step's
+    context watermark instead of the committed ``last_reacted_seq`` —
+    "would this session be wake-eligible immediately after the current
+    step finished?". See :func:`_find_needing_inference_floored` for the
+    two floored-only restrictions.
     """
+    if reacted_floor is not None:
+        if session_id is None:
+            raise ValueError("reacted_floor requires session_id")
+        return await _find_needing_inference_floored(
+            pool, inflight_tool_registry, session_id, reacted_floor
+        )
     scope_clause = "AND s.id = $1" if session_id else ""
     scope_params: list[Any] = [session_id] if session_id else []
 
@@ -1288,10 +1349,81 @@ async def find_sessions_needing_inference(
     return filtered | confirmed_sessions | cancel_marked
 
 
+async def _find_needing_inference_floored(
+    pool: asyncpg.Pool[Any],
+    inflight_tool_registry: InflightToolRegistry,
+    session_id: str,
+    reacted_floor: int,
+) -> set[str]:
+    """The #253 preemption-trigger variant of the wake predicate.
+
+    Same arms as :func:`find_sessions_needing_inference` — candidate gate,
+    unreacted batch filter, confirmed-dispatch union, errored subtraction,
+    cancel-marker union — with every seq-anchored comparison raised to the
+    in-flight step's context watermark (the ``*_FLOORED_SQL`` constants, each
+    composed from the same single-source fragment as its committed twin).
+    Cancel markers need no floor: the step harvests them before building
+    context, so any unharvested marker post-dates the watermark.
+
+    Two floored-only restrictions, both erring toward NOT preempting (the
+    inverse of the sweep's wedge-safety doctrine — a missed wake wedges a
+    session forever, a missed preempt costs one stale model call that the
+    already-queued wake supersedes next step):
+
+    * The #1710 empty-unreacted dispatch-narrowing pass is skipped
+      (``preempt_floor`` on :func:`_filter_incomplete_batches`): its
+      wedge-safety argument assumes :func:`find_and_repair_ghosts` ran first,
+      which only the composed sweep guarantees — and anything it admits was
+      already true when the step's entry guard ran this predicate unfloored,
+      so it cannot represent an *arriving* event.
+    * The confirmed arm subtracts already-dispatched calls (in-flight in the
+      registry, or bearing a durable ``tool_execute_start`` span) — see
+      ``CONFIRMED_ROWS_FLOORED_SQL``.
+
+    No span bracketing around the batch filter: this runs from the preempt
+    watcher (potentially once per poll tick), and span appends here would
+    both spam the log and re-trip the watcher's own ``last_event_seq`` gate.
+    """
+    confirmed_max_age_seconds = get_settings().confirmed_dispatch_max_age_seconds
+    async with pool.acquire() as conn:
+        candidate_rows = await conn.fetch(CANDIDATE_ROWS_FLOORED_SQL, session_id, reacted_floor)
+        candidates = {r["session_id"] for r in candidate_rows}
+
+        confirmed_rows = await conn.fetch(
+            CONFIRMED_ROWS_FLOORED_SQL,
+            session_id,
+            confirmed_max_age_seconds,
+            reacted_floor,
+        )
+        confirmed_tcids = {r["tool_call_id"] for r in confirmed_rows if r["tool_call_id"]}
+        confirmed_tcids -= inflight_tool_registry.in_flight_tool_call_ids(session_id)
+        if confirmed_tcids:
+            span_rows = await conn.fetch(GHOST_SPAN_START_SQL, [session_id], list(confirmed_tcids))
+            confirmed_tcids -= {r["tool_call_id"] for r in span_rows}
+        confirmed_sessions = {session_id} if confirmed_tcids else set()
+
+        errored = await _errored_session_ids(conn, session_id=session_id)
+        cancel_marked = await list_session_ids_with_unharvested_cancel_marker(
+            conn, session_id=session_id
+        )
+
+    candidates -= errored
+    confirmed_sessions -= errored
+    to_filter = candidates - confirmed_sessions
+    if not to_filter:
+        return confirmed_sessions | cancel_marked
+    filtered = await _filter_incomplete_batches(
+        pool, inflight_tool_registry, to_filter, preempt_floor=reacted_floor
+    )
+    return filtered | confirmed_sessions | cancel_marked
+
+
 async def _filter_incomplete_batches(
     pool: asyncpg.Pool[Any],
     inflight_tool_registry: InflightToolRegistry,
     candidates: set[str],
+    *,
+    preempt_floor: int | None = None,
 ) -> set[str]:
     """Remove sessions whose only unreacted events are tool results from
     in-progress batches (where sibling tools are still in-flight).
@@ -1339,7 +1471,12 @@ async def _filter_incomplete_batches(
     session_list = list(candidates)
 
     async with pool.acquire() as conn:
-        unreacted_rows = await conn.fetch(UNREACTED_ROWS_SQL, session_list)
+        if preempt_floor is not None:
+            unreacted_rows = await conn.fetch(
+                UNREACTED_ROWS_FLOORED_SQL, session_list, preempt_floor
+            )
+        else:
+            unreacted_rows = await conn.fetch(UNREACTED_ROWS_SQL, session_list)
         unreacted_by_sid = _group_unreacted_rows(unreacted_rows)
 
         result: set[str] = set()
@@ -1401,7 +1538,16 @@ async def _filter_incomplete_batches(
         # candidate set — so the common (has-unreacted) path never pays for
         # it. ``OPEN_CANDIDATES_ASST_SQL`` mirrors ``GHOST_ASST_SQL``'s
         # ``open_tool_call_count > 0`` bound.
-        if empty_no_inflight:
+        #
+        # Skipped on the #253 floored path (``preempt_floor``): this branch's
+        # wedge-safety argument assumes ghost repair ran first (true only in
+        # the composed sweep), and anything it admits — a dispatched-but-
+        # taskless open call — was already true when the step's entry guard
+        # ran this predicate unfloored, so it cannot represent an *arriving*
+        # event. Admitting it would preempt-loop on state the restarted step
+        # cannot progress. False-negative-safe: no preempt → the step
+        # completes → the composed sweep handles the ghost as today.
+        if empty_no_inflight and preempt_floor is None:
             all_result_rows = await conn.fetch(ALL_RESULT_ROWS_SQL, empty_no_inflight)
             results_by_sid: dict[str, set[str]] = {}
             for r in all_result_rows:

--- a/src/aios/models/agents.py
+++ b/src/aios/models/agents.py
@@ -88,6 +88,15 @@ ToolTransport = Literal["cli", "agent_tool", "both"]
 # ``_ALLOWED_METHODS`` tuple in ``tools/http_request.py``.
 HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
 
+# What happens to an in-flight model call when a new wake-eligible event (e.g.
+# a user message) arrives mid-step. "wait" (default): the step finishes and the
+# queued wake handles the event next step. "preempt": the model phase is
+# cancelled and the step restarts against context that includes the event.
+# Deliberately not named "interrupt" — that vocabulary is the broad operator
+# cancel-everything mechanism (``POST /sessions/:id/interrupt``); this is the
+# narrow, automatic, model-phase-only policy.
+PreemptPolicy = Literal["preempt", "wait"]
+
 _BUILTIN_NAMES: frozenset[str] = frozenset(get_args(BuiltinToolType))
 
 # Read-tolerance for the builtin tool renames (#1419 invoke*→call_*, #1428 cancel_run→stop_task).
@@ -676,6 +685,15 @@ class AgentCreate(BaseModel):
     )
     window_min: int = Field(default=50_000, ge=1)
     window_max: int = Field(default=150_000, ge=1)
+    preempt_policy: PreemptPolicy = Field(
+        default="wait",
+        description=(
+            "Whether a new wake-eligible event (e.g. a user message) arriving "
+            "mid-step cancels the in-flight model call so the step restarts "
+            "against fresh context ('preempt'), or waits for the step to "
+            "finish ('wait', default)."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_http_servers(self) -> AgentCreate:
@@ -709,6 +727,7 @@ class AgentUpdate(BaseModel):
     litellm_extra: dict[str, Any] | None = None
     window_min: int | None = Field(default=None, ge=1)
     window_max: int | None = Field(default=None, ge=1)
+    preempt_policy: PreemptPolicy | None = None
 
     @model_validator(mode="after")
     def _validate_http_servers(self) -> AgentUpdate:
@@ -738,6 +757,7 @@ class Agent(BaseModel):
     litellm_extra: dict[str, Any] = Field(default_factory=dict)
     window_min: int
     window_max: int
+    preempt_policy: PreemptPolicy = "wait"
     created_at: datetime
     updated_at: datetime
     archived_at: datetime | None = None
@@ -757,6 +777,7 @@ class AgentVersion(BaseModel):
     litellm_extra: dict[str, Any] = Field(default_factory=dict)
     window_min: int
     window_max: int
+    preempt_policy: PreemptPolicy = "wait"
     created_at: datetime
 
 
@@ -806,7 +827,7 @@ class StepSurface(BaseModel):
 
     Nominal replacement for the ``Agent | AgentVersion`` structural union (the
     two wire read-models) plus the ``agent_id=""``/``version=0`` sentinel that
-    encoded "no agent at all". Carries **exactly** the nine config fields the
+    encoded "no agent at all". Carries **exactly** the ten config fields the
     harness consumes off the loaded surface (verified by grep over every
     caller — nothing reads ``name``/``metadata``/``description``/``created_at``
     off it) plus a discriminated :data:`StepBinding` identity.
@@ -828,6 +849,7 @@ class StepSurface(BaseModel):
     litellm_extra: dict[str, Any] = Field(default_factory=dict)
     window_min: int
     window_max: int
+    preempt_policy: PreemptPolicy
     binding: StepBinding
 
 

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -22,6 +22,7 @@ from aios.models.agents import (
     HttpServerSpec,
     McpServerSpec,
     PermissionPolicy,
+    PreemptPolicy,
     StepSurface,
     ToolSpec,
     resolve_mcp_permission,
@@ -108,6 +109,7 @@ async def create_agent(
     litellm_extra: dict[str, Any] | None = None,
     window_min: int,
     window_max: int,
+    preempt_policy: PreemptPolicy = "wait",
     creator_session_id: str | None = None,
 ) -> Agent:
     """Create a new agent at version 1.
@@ -153,6 +155,7 @@ async def create_agent(
             litellm_extra=litellm_extra or {},
             window_min=window_min,
             window_max=window_max,
+            preempt_policy=preempt_policy,
             account_id=account_id,
         )
 
@@ -199,6 +202,7 @@ async def update_agent(
     litellm_extra: dict[str, Any] | None = None,
     window_min: int | None = None,
     window_max: int | None = None,
+    preempt_policy: PreemptPolicy | None = None,
     editor_session_id: str | None = None,
 ) -> Agent:
     """Update an agent in place, creating a new immutable version (optimistic
@@ -248,6 +252,7 @@ async def update_agent(
             litellm_extra=litellm_extra,
             window_min=window_min,
             window_max=window_max,
+            preempt_policy=preempt_policy,
             account_id=account_id,
         )
 
@@ -291,7 +296,7 @@ async def validate_pinned_agent_version(
 
 def _surface_from_agent(agent: Agent | AgentVersion, binding: AgentBinding) -> StepSurface:
     """Project a wire read-model (``Agent``/``AgentVersion``) onto the nominal
-    :class:`StepSurface`, carrying exactly the nine harness-consumed fields.
+    :class:`StepSurface`, carrying exactly the ten harness-consumed fields.
 
     A missing field here is a compile-loud ``StepSurface`` construction error,
     not a silent structural-overlap drift — the projection's drift surface is
@@ -307,6 +312,7 @@ def _surface_from_agent(agent: Agent | AgentVersion, binding: AgentBinding) -> S
         litellm_extra=agent.litellm_extra,
         window_min=agent.window_min,
         window_max=agent.window_max,
+        preempt_policy=agent.preempt_policy,
         binding=binding,
     )
 
@@ -345,6 +351,7 @@ async def _load_for_session_conn(
                 litellm_extra={},
                 window_min=defaults["window_min"].default,
                 window_max=defaults["window_max"].default,
+                preempt_policy=defaults["preempt_policy"].default,
                 binding=GenericChildBinding(session_id=session.id),
             )
         version = await queries.get_agent_version(

--- a/src/aios/tools/agent_management.py
+++ b/src/aios/tools/agent_management.py
@@ -183,6 +183,7 @@ async def create_agent_handler(session_id: str, arguments: dict[str, Any]) -> di
         litellm_extra=body.litellm_extra,
         window_min=body.window_min,
         window_max=body.window_max,
+        preempt_policy=body.preempt_policy,
         creator_session_id=session_id,
     )
     return agent.model_dump(mode="json")
@@ -209,6 +210,7 @@ async def update_agent_handler(session_id: str, arguments: dict[str, Any]) -> di
         litellm_extra=args.litellm_extra,
         window_min=args.window_min,
         window_max=args.window_max,
+        preempt_policy=args.preempt_policy,
         editor_session_id=session_id,
     )
     return agent.model_dump(mode="json")

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -29,6 +29,7 @@ import asyncpg
 
 from aios.harness.inflight_tool_registry import InflightToolRegistry
 from aios.harness.loop import run_session_step
+from aios.models.agents import PreemptPolicy
 from aios.models.events import Event
 from aios.models.sessions import Session
 from aios.services import agents as agents_service
@@ -383,6 +384,7 @@ class Harness:
         tool_specs: list[Any] | None = None,
         system: str = "You are a test assistant.",
         environment_config: Any | None = None,
+        preempt_policy: PreemptPolicy = "wait",
     ) -> Session:
         """Create an agent + session and append the initial user message.
 
@@ -448,6 +450,7 @@ class Harness:
             metadata={},
             window_min=50_000,
             window_max=150_000,
+            preempt_policy=preempt_policy,
             account_id=account_id,
         )
         session = await sessions_service.create_session(

--- a/tests/e2e/test_preempt_predicate.py
+++ b/tests/e2e/test_preempt_predicate.py
@@ -1,0 +1,215 @@
+"""Direct tests of the #253 floored wake predicate against real Postgres.
+
+``find_sessions_needing_inference(session_id=..., reacted_floor=...)`` is the
+preemption trigger: "would this session be wake-eligible immediately after the
+in-flight step (whose context watermark is the floor) finished?". These tests
+pin each arm's floored behavior by constructing event-log states manually
+(the ``test_confirmed_always_ask_ghost`` idiom) and calling the predicate
+directly — no step machinery involved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from aios.harness.sweep import find_sessions_needing_inference
+from aios.models.agents import ToolSpec
+from aios.models.events import EventKind
+from aios.services import sessions as sessions_service
+from tests.conftest import needs_docker
+from tests.e2e.harness import Harness, assistant
+
+pytestmark = pytest.mark.docker
+
+_ACCOUNT_ID = "acc_test_stub"  # PR 3 scaffolding
+
+
+async def _floored(harness: Harness, session_id: str, floor: int) -> set[str]:
+    return await find_sessions_needing_inference(
+        harness._pool,
+        harness._inflight_tool_registry,
+        session_id=session_id,
+        reacted_floor=floor,
+    )
+
+
+async def _append(harness: Harness, session_id: str, kind: EventKind, data: dict[str, Any]) -> int:
+    event = await sessions_service.append_event(
+        harness._pool, session_id, kind, data, account_id=_ACCOUNT_ID
+    )
+    return event.seq
+
+
+def _batch_turn(tool_call_ids: list[str], *, reacting_to: int) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": tcid, "type": "function", "function": {"name": "glob", "arguments": "{}"}}
+            for tcid in tool_call_ids
+        ],
+        "reacting_to": reacting_to,
+    }
+
+
+@needs_docker
+class TestStimulusArm:
+    async def test_user_message_above_floor_admits_at_floor_does_not(
+        self, harness: Harness
+    ) -> None:
+        harness.script_model([assistant("hi")])
+        session = await harness.start("hello")
+        events = await harness.all_events(session.id)
+        msg_seq = max(e.seq for e in events)
+
+        assert await _floored(harness, session.id, msg_seq - 1) == {session.id}
+        # Floor at the message: the in-flight step is already reacting to it.
+        assert await _floored(harness, session.id, msg_seq) == set()
+
+
+@needs_docker
+class TestBatchFilterArm:
+    async def test_partial_batch_held_completing_result_admits(self, harness: Harness) -> None:
+        """Partial-batch tool result does NOT admit at the floor; the
+        batch-completing result does (no restart-thrash on tool fan-outs)."""
+        harness.script_model([assistant("unused")])
+        session = await harness.start("run tools", tools=["glob"])
+        msg_seq = 1
+        await _append(
+            harness, session.id, "message", _batch_turn(["c1", "c2"], reacting_to=msg_seq)
+        )
+
+        # The in-flight step's context saw the batch but no results: floor = msg_seq.
+        await _append(
+            harness,
+            session.id,
+            "message",
+            {"role": "tool", "tool_call_id": "c1", "content": "r1"},
+        )
+        assert await _floored(harness, session.id, msg_seq) == set()
+
+        await _append(
+            harness,
+            session.id,
+            "message",
+            {"role": "tool", "tool_call_id": "c2", "content": "r2"},
+        )
+        assert await _floored(harness, session.id, msg_seq) == {session.id}
+
+
+@needs_docker
+class TestConfirmedArm:
+    async def _session_with_confirmed_call(self, harness: Harness) -> tuple[str, int]:
+        harness.script_model([assistant("unused")])
+        session = await harness.start(
+            "find files", tool_specs=[ToolSpec(type="glob", permission="always_ask")]
+        )
+        await _append(harness, session.id, "message", _batch_turn(["call_g"], reacting_to=1))
+        confirm_seq = await _append(
+            harness,
+            session.id,
+            "lifecycle",
+            {"event": "tool_confirmed", "tool_call_id": "call_g", "result": "allow"},
+        )
+        return session.id, confirm_seq
+
+    async def test_confirm_above_floor_undispatched_admits(self, harness: Harness) -> None:
+        sid, confirm_seq = await self._session_with_confirmed_call(harness)
+        assert await _floored(harness, sid, confirm_seq - 1) == {sid}
+
+    async def test_confirm_at_floor_not_admitted(self, harness: Harness) -> None:
+        """A confirm the in-flight step already consumed (dispatched at its
+        confirmed-dispatch check) must not re-admit. This also pins the
+        skipped #1710 dispatch-narrowing pass: the open, undispatched
+        always_ask call alone admits nothing at the floor."""
+        sid, confirm_seq = await self._session_with_confirmed_call(harness)
+        assert await _floored(harness, sid, confirm_seq) == set()
+
+    async def test_confirm_with_execute_start_span_not_admitted(self, harness: Harness) -> None:
+        """The durable dispatch marker (``tool_execute_start``) excludes a
+        still-running confirmed tool — without it, a confirmed tool dispatched
+        by a PRIOR step would re-admit on every evaluation (preempt thrash)."""
+        sid, confirm_seq = await self._session_with_confirmed_call(harness)
+        await _append(
+            harness,
+            sid,
+            "span",
+            {"event": "tool_execute_start", "tool_call_id": "call_g", "tool_name": "glob"},
+        )
+        assert await _floored(harness, sid, confirm_seq - 1) == set()
+
+    async def test_confirm_with_inflight_task_not_admitted(self, harness: Harness) -> None:
+        """The registry arm of the same exclusion: an in-flight task for the
+        confirmed call means it needs no dispatch — no preempt."""
+        sid, confirm_seq = await self._session_with_confirmed_call(harness)
+        blocker = asyncio.Event()
+
+        async def _running() -> None:
+            await blocker.wait()
+
+        task = asyncio.create_task(_running())
+        harness._inflight_tool_registry.add(sid, "call_g", task)
+        try:
+            assert await _floored(harness, sid, confirm_seq - 1) == set()
+        finally:
+            blocker.set()
+            await task
+            harness._inflight_tool_registry.remove(sid, "call_g")
+
+
+@needs_docker
+class TestFlooredOnlyRestrictions:
+    async def test_dispatched_ghost_admitted_committed_but_not_floored(
+        self, harness: Harness
+    ) -> None:
+        """The F1 restriction, pinned as a committed-vs-floored difference: a
+        dispatched-but-taskless open call (crashed-worker ghost shape) is
+        admitted by the COMMITTED predicate's #1710 dispatch-narrowing pass
+        (wedge-safety: composed sweep repairs it first) but must NOT preempt —
+        it was already true when the step's entry guard admitted the step, so
+        it cannot represent an arriving event."""
+        harness.script_model([assistant("unused")])
+        session = await harness.start("run tools", tools=["glob"])
+        await _append(harness, session.id, "message", _batch_turn(["c_ghost"], reacting_to=1))
+        span_seq = await _append(
+            harness,
+            session.id,
+            "span",
+            {"event": "tool_execute_start", "tool_call_id": "c_ghost", "tool_name": "glob"},
+        )
+
+        committed = await find_sessions_needing_inference(
+            harness._pool, harness._inflight_tool_registry, session_id=session.id
+        )
+        assert committed == {session.id}
+        assert await _floored(harness, session.id, span_seq) == set()
+
+
+@needs_docker
+class TestErroredArm:
+    async def test_errored_parked_session_not_admitted(self, harness: Harness) -> None:
+        """The errored subtraction is inherited unchanged: a parked session is
+        not preempt-eligible even with a fresh stimulus above the floor."""
+        harness.script_model([assistant("unused")])
+        session = await harness.start("hello")
+        floor = 1
+        # Latch errored (the ``last_error_seq`` bump keys on this lifecycle
+        # shape), then land a tool stimulus above the floor. A USER message
+        # would lift the park (last_user_seq > last_error_seq) — the errored
+        # arm only holds back non-user stimuli, matching wake semantics.
+        await _append(
+            harness,
+            session.id,
+            "lifecycle",
+            {"event": "turn_errored", "status": "errored", "stop_reason": "error"},
+        )
+        await _append(
+            harness,
+            session.id,
+            "message",
+            {"role": "tool", "tool_call_id": "c_x", "content": "late result"},
+        )
+        assert await _floored(harness, session.id, floor) == set()

--- a/tests/e2e/test_read_path_complexity.py
+++ b/tests/e2e/test_read_path_complexity.py
@@ -80,6 +80,7 @@ from typing import Any, cast
 import asyncpg
 import pytest
 
+from aios.harness.loop import _PREEMPT_STARVATION_COUNT_SQL
 from aios.harness.sweep import (
     ALL_RESULT_ROWS_SQL,
     CANDIDATE_ROWS_FLOORED_SQL,
@@ -550,10 +551,12 @@ _SQL_CONFIRMED_ROWS_SCOPED = CONFIRMED_ROWS_SQL.format(scope_clause="AND s.id = 
 # parameterized in their module constants (no ``.format`` composition). These
 # run from inside an in-flight step's preempt watcher (up to ~1/s per armed
 # step), so their plan shapes are held to the same gates as the per-step
-# scoped sweep reads they mirror.
+# scoped sweep reads they mirror. The starvation-count read runs once per
+# step of every opted-in agent (the arm decision, before the watcher exists).
 _SQL_CANDIDATE_ROWS_FLOORED = CANDIDATE_ROWS_FLOORED_SQL
 _SQL_UNREACTED_ROWS_FLOORED = UNREACTED_ROWS_FLOORED_SQL
 _SQL_CONFIRMED_ROWS_FLOORED = CONFIRMED_ROWS_FLOORED_SQL
+_SQL_PREEMPT_STARVATION_COUNT = _PREEMPT_STARVATION_COUNT_SQL
 
 
 HOT_PATH_READS: list[HotRead] = [
@@ -648,6 +651,13 @@ HOT_PATH_READS: list[HotRead] = [
         declared_complexity="O(confirmed-allow)",
         sql=_SQL_CONFIRMED_ROWS_FLOORED,
         args=lambda: (_SESSION_ID, 3600, 10),
+        max_rows=_O1_ROW_CEIL,
+    ),
+    HotRead(
+        name="preempt_starvation_count",
+        declared_complexity="O(post-assistant tail)",
+        sql=_SQL_PREEMPT_STARVATION_COUNT,
+        args=lambda: (_SESSION_ID, _ACCOUNT_ID),
         max_rows=_O1_ROW_CEIL,
     ),
 ]

--- a/tests/e2e/test_read_path_complexity.py
+++ b/tests/e2e/test_read_path_complexity.py
@@ -82,8 +82,11 @@ import pytest
 
 from aios.harness.sweep import (
     ALL_RESULT_ROWS_SQL,
+    CANDIDATE_ROWS_FLOORED_SQL,
+    CONFIRMED_ROWS_FLOORED_SQL,
     CONFIRMED_ROWS_SQL,
     GHOST_ASST_SQL,
+    UNREACTED_ROWS_FLOORED_SQL,
     UNREACTED_ROWS_SQL,
 )
 from tests.conftest import needs_docker
@@ -542,6 +545,16 @@ _SQL_ALL_RESULT_ROWS = ALL_RESULT_ROWS_SQL
 _SQL_UNREACTED_ROWS = UNREACTED_ROWS_SQL
 _SQL_CONFIRMED_ROWS_SCOPED = CONFIRMED_ROWS_SQL.format(scope_clause="AND s.id = $1", age_param="$2")
 
+# The #253 preempt-watcher reads (``_find_needing_inference_floored``) — the
+# floored twins of the three sweep arms above, already single-session
+# parameterized in their module constants (no ``.format`` composition). These
+# run from inside an in-flight step's preempt watcher (up to ~1/s per armed
+# step), so their plan shapes are held to the same gates as the per-step
+# scoped sweep reads they mirror.
+_SQL_CANDIDATE_ROWS_FLOORED = CANDIDATE_ROWS_FLOORED_SQL
+_SQL_UNREACTED_ROWS_FLOORED = UNREACTED_ROWS_FLOORED_SQL
+_SQL_CONFIRMED_ROWS_FLOORED = CONFIRMED_ROWS_FLOORED_SQL
+
 
 HOT_PATH_READS: list[HotRead] = [
     HotRead(
@@ -613,6 +626,28 @@ HOT_PATH_READS: list[HotRead] = [
         declared_complexity="O(confirmed-allow)",
         sql=_SQL_CONFIRMED_ROWS_SCOPED,
         args=lambda: (_SESSION_ID, 3600),
+        max_rows=_O1_ROW_CEIL,
+    ),
+    # ─── preempt-watcher phase (issue #253) ───────────────────────────────
+    HotRead(
+        name="candidate_rows_floored_seek",
+        declared_complexity="O(1)",
+        sql=_SQL_CANDIDATE_ROWS_FLOORED,
+        args=lambda: (_SESSION_ID, 10),
+        max_rows=_O1_ROW_CEIL,
+    ),
+    HotRead(
+        name="unreacted_rows_floored_scan",
+        declared_complexity="O(unreacted-tail)",
+        sql=_SQL_UNREACTED_ROWS_FLOORED,
+        args=lambda: ([_SESSION_ID], 10),
+        max_rows=_OW_ROW_CEIL,
+    ),
+    HotRead(
+        name="confirmed_rows_floored_scan",
+        declared_complexity="O(confirmed-allow)",
+        sql=_SQL_CONFIRMED_ROWS_FLOORED,
+        args=lambda: (_SESSION_ID, 3600, 10),
         max_rows=_O1_ROW_CEIL,
     ),
 ]

--- a/tests/e2e/test_step_preempt.py
+++ b/tests/e2e/test_step_preempt.py
@@ -41,12 +41,15 @@ class _GatedModel:
     def __init__(self, harness: Harness) -> None:
         self._harness = harness
         self.release = asyncio.Event()
+        self.returned = asyncio.Event()
         self._entered: asyncio.Queue[None] = asyncio.Queue()
 
     async def acompletion(self, **kwargs: Any) -> Any:
         self._entered.put_nowait(None)
         await self.release.wait()
-        return self._harness._pop_response(**kwargs)
+        response = self._harness._pop_response(**kwargs)
+        self.returned.set()
+        return response
 
     async def wait_entered(self) -> None:
         await asyncio.wait_for(self._entered.get(), timeout=10.0)
@@ -138,6 +141,11 @@ class TestPreemptOnUserMessage:
         step = asyncio.create_task(harness.run_step(session.id))
         await gated_model.wait_entered()
         await harness.inject_message(session.id, "wait, actually...")
+        # Hold the gate through ~30 watcher ticks: a wrongly-armed watcher
+        # would preempt well within this window — releasing immediately would
+        # let model-first-on-ties mask the regression.
+        await asyncio.sleep(0.3)
+        assert not step.done()
         gated_model.release.set()
         await asyncio.wait_for(step, timeout=10.0)
 
@@ -148,6 +156,40 @@ class TestPreemptOnUserMessage:
         assert reply.data["reacting_to"] < injected_seq
         assert _spans(events, "step_preempted") == []
         # The injected message is the next step's work.
+        assert await harness.sessions_needing_inference(session.id) == {session.id}
+
+
+@needs_docker
+class TestScopeModelPhaseOnly:
+    async def test_message_after_model_returns_does_not_cancel_the_tail(
+        self, harness: Harness, gated_model: _GatedModel
+    ) -> None:
+        """Once the model call returns, the step runs to completion
+        un-preemptible (the watcher is torn down before the append/dispatch
+        tail). A message racing the tail is next step's work.
+
+        The inject waits for the model's return signal, so it lands in the
+        tail window (a few ms of appends) or just after the step — the
+        assertions hold in both cases; the structural guarantee (no watcher
+        survives the model's completion) is pinned deterministically by the
+        race unit tests. Injecting any earlier would race the still-running
+        model call, where preemption would be correct.
+        """
+        harness.script_model([assistant("committed reply")])
+        session = await harness.start("hello", preempt_policy="preempt")
+
+        step = asyncio.create_task(harness.run_step(session.id))
+        await gated_model.wait_entered()
+        gated_model.release.set()
+        await asyncio.wait_for(gated_model.returned.wait(), timeout=10.0)
+        await harness.inject_message(session.id, "too late for this turn")
+        await asyncio.wait_for(step, timeout=10.0)
+
+        events = await harness.all_events(session.id)
+        (reply,) = _assistants(events)
+        assert reply.data["content"] == "committed reply"
+        assert _spans(events, "step_preempted") == []
+        # The late message is unreacted — the next step's work.
         assert await harness.sessions_needing_inference(session.id) == {session.id}
 
 

--- a/tests/e2e/test_step_preempt.py
+++ b/tests/e2e/test_step_preempt.py
@@ -1,0 +1,287 @@
+"""E2E tests for #253 auto-preemption of the in-flight model phase.
+
+Real Postgres, real step function, scripted model — the model call is
+additionally gated on an ``asyncio.Event`` so a step can be held mid-model-
+phase while events arrive. ``_PREEMPT_POLL_INTERVAL_S`` is patched down so the
+watcher's poll gate ticks fast.
+
+The re-wake assertions use ``harness.sessions_needing_inference`` (the
+committed-watermark predicate) rather than a queued procrastinate job because
+the e2e fixture noops ``defer_wake`` — the harness drives steps manually.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from aios.models.events import Event
+from tests.conftest import needs_docker
+from tests.e2e.conftest import wait_for_predicate
+from tests.e2e.harness import Harness, assistant, tool_call
+
+pytestmark = pytest.mark.docker
+
+
+class _GatedModel:
+    """Gate the fixture's scripted model behind an ``asyncio.Event``.
+
+    Each model call signals ``entered`` and then blocks on ``release`` before
+    popping the harness's next scripted response — so a cancelled (preempted)
+    call never consumes a script entry. EVERY model call pushes an entered
+    marker, including release-set (non-blocking) runs — a test that runs a
+    step with the gate open must consume that marker too, or the next
+    ``wait_entered`` returns stale and races the following step's context
+    build (the injected message lands under the floor and correctly never
+    preempts).
+    """
+
+    def __init__(self, harness: Harness) -> None:
+        self._harness = harness
+        self.release = asyncio.Event()
+        self._entered: asyncio.Queue[None] = asyncio.Queue()
+
+    async def acompletion(self, **kwargs: Any) -> Any:
+        self._entered.put_nowait(None)
+        await self.release.wait()
+        return self._harness._pop_response(**kwargs)
+
+    async def wait_entered(self) -> None:
+        await asyncio.wait_for(self._entered.get(), timeout=10.0)
+
+    async def run_released_step(self, session_id: str) -> None:
+        """Run one step with the gate held open, consuming its entered marker."""
+        self.release.set()
+        await self._harness.run_step(session_id)
+        await self.wait_entered()
+        self.release.clear()
+
+
+@pytest.fixture
+def gated_model(harness: Harness, monkeypatch: pytest.MonkeyPatch) -> _GatedModel:
+    monkeypatch.setattr("aios.harness.loop._PREEMPT_POLL_INTERVAL_S", 0.01)
+    gated = _GatedModel(harness)
+    monkeypatch.setattr("aios.harness.completion.litellm.acompletion", gated.acompletion)
+    return gated
+
+
+def _spans(events: list[Event], name: str) -> list[Event]:
+    return [e for e in events if e.kind == "span" and e.data.get("event") == name]
+
+
+def _assistants(events: list[Event]) -> list[Event]:
+    return [e for e in events if e.kind == "message" and e.data.get("role") == "assistant"]
+
+
+def _user_seq(events: list[Event], content: str) -> int:
+    return next(
+        e.seq
+        for e in events
+        if e.kind == "message" and e.data.get("role") == "user" and e.data.get("content") == content
+    )
+
+
+@needs_docker
+class TestPreemptOnUserMessage:
+    async def test_mid_step_message_preempts_and_next_step_reads_it(
+        self, harness: Harness, gated_model: _GatedModel
+    ) -> None:
+        """The issue's headline scenario: a user message lands while the model
+        is mid-flight → the model phase is cancelled with no assistant append,
+        the session stays wake-eligible, and the re-run's assistant reacts to
+        the new message."""
+        harness.script_model([assistant("answered both")])
+        session = await harness.start("hello", preempt_policy="preempt")
+
+        step = asyncio.create_task(harness.run_step(session.id))
+        await gated_model.wait_entered()
+        await harness.inject_message(session.id, "wait, actually...")
+        await asyncio.wait_for(step, timeout=10.0)
+
+        events = await harness.all_events(session.id)
+        injected_seq = _user_seq(events, "wait, actually...")
+        assert _assistants(events) == []
+
+        # Span trace: the cancelled model_request pair closes with cancelled_by
+        # and, per the calibration contract, carries no usage/token fields.
+        (preempted,) = _spans(events, "step_preempted")
+        assert preempted.data["cancelled_by"] == injected_seq
+        end_spans = _spans(events, "model_request_end")
+        (cancelled_end,) = [s for s in end_spans if "cancelled_by" in s.data]
+        assert cancelled_end.data["cancelled_by"] == injected_seq
+        assert cancelled_end.data["is_error"] is False
+        for poisoned in ("local_tokens", "local_tokens_by_class", "model", "model_usage"):
+            assert poisoned not in cancelled_end.data
+        start_span = _spans(events, "model_request_start")[0]
+        assert cancelled_end.data["model_request_start_id"] == start_span.id
+
+        # Resume: still wake-eligible at the committed watermark; the re-run
+        # reacts to the injected message.
+        assert await harness.sessions_needing_inference(session.id) == {session.id}
+        gated_model.release.set()
+        await harness.run_step(session.id)
+        events = await harness.all_events(session.id)
+        (reply,) = _assistants(events)
+        assert reply.data["reacting_to"] >= injected_seq
+
+    async def test_wait_policy_message_mid_step_does_not_preempt(
+        self, harness: Harness, gated_model: _GatedModel
+    ) -> None:
+        """Default-policy regression: same interleaving, ``preempt_policy``
+        unset — the step runs to completion on stale context and the queued
+        wake handles the message next step (today's behavior, unchanged)."""
+        harness.script_model([assistant("stale reply")])
+        session = await harness.start("hello")
+
+        step = asyncio.create_task(harness.run_step(session.id))
+        await gated_model.wait_entered()
+        await harness.inject_message(session.id, "wait, actually...")
+        gated_model.release.set()
+        await asyncio.wait_for(step, timeout=10.0)
+
+        events = await harness.all_events(session.id)
+        injected_seq = _user_seq(events, "wait, actually...")
+        (reply,) = _assistants(events)
+        assert reply.data["content"] == "stale reply"
+        assert reply.data["reacting_to"] < injected_seq
+        assert _spans(events, "step_preempted") == []
+        # The injected message is the next step's work.
+        assert await harness.sessions_needing_inference(session.id) == {session.id}
+
+
+@needs_docker
+class TestTriggerCriterion:
+    async def test_partial_batch_result_holds_completing_result_preempts(
+        self, harness: Harness, gated_model: _GatedModel
+    ) -> None:
+        """The load-bearing trigger consequence: a tool result from a
+        partially in-flight batch does NOT preempt; the result that completes
+        the outstanding set DOES — the wake predicate's batch filter evaluated
+        at the in-flight step's watermark."""
+        a_proceed = asyncio.Event()
+        b_proceed = asyncio.Event()
+
+        async def handler_a(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            await a_proceed.wait()
+            return {"result": "a_done"}
+
+        async def handler_b(session_id: str, arguments: dict[str, Any]) -> dict[str, Any]:
+            await b_proceed.wait()
+            return {"result": "b_done"}
+
+        harness.register_tool("tool_a", handler_a)
+        harness.register_tool("tool_b", handler_b)
+        harness.script_model(
+            [assistant(tool_calls=[tool_call("tool_a", {}), tool_call("tool_b", {})])]
+        )
+        session = await harness.start("run both tools", preempt_policy="preempt")
+
+        # Step 1: dispatch the two gated tools. The scripted tool-call turn
+        # must pass the gate too.
+        await gated_model.run_released_step(session.id)
+
+        # Step 2: held mid-model-phase (a user message makes it wake-eligible).
+        await harness.inject_message(session.id, "status?")
+        step = asyncio.create_task(harness.run_step(session.id))
+        await gated_model.wait_entered()
+
+        # Partial batch: tool_a's result lands, tool_b still in flight → held.
+        a_proceed.set()
+        await wait_for_predicate(
+            lambda: _has_tool_result(harness, session.id, "a_done"), max_wait_s=10.0
+        )
+        await asyncio.sleep(0.3)  # ~30 watcher ticks at the patched interval
+        assert not step.done()
+
+        # Completing result → preempt.
+        b_proceed.set()
+        await asyncio.wait_for(step, timeout=10.0)
+
+        events = await harness.all_events(session.id)
+        (preempted,) = _spans(events, "step_preempted")
+        b_result_seq = max(
+            e.seq for e in events if e.kind == "message" and e.data.get("role") == "tool"
+        )
+        assert preempted.data["cancelled_by"] == b_result_seq
+        # Only step 1's tool-call turn exists; the preempted step appended none.
+        assert len(_assistants(events)) == 1
+
+
+async def _has_tool_result(harness: Harness, session_id: str, needle: str) -> bool:
+    events = await harness.all_events(session_id)
+    return any(
+        e.kind == "message"
+        and e.data.get("role") == "tool"
+        and needle in str(e.data.get("content"))
+        for e in events
+    )
+
+
+@needs_docker
+class TestStarvationGuard:
+    async def test_fourth_step_runs_unpreemptible_after_three_preempts(
+        self, harness: Harness, gated_model: _GatedModel
+    ) -> None:
+        """The #253 decision comment's required deferral cap: after 3
+        consecutive preemptions with no completed assistant turn, the next
+        step ignores new arrivals and runs to completion."""
+        harness.script_model([assistant("finally answered")])
+        session = await harness.start("hello", preempt_policy="preempt")
+
+        for i in range(3):
+            step = asyncio.create_task(harness.run_step(session.id))
+            await gated_model.wait_entered()
+            await harness.inject_message(session.id, f"more input {i}")
+            await asyncio.wait_for(step, timeout=10.0)
+
+        events = await harness.all_events(session.id)
+        assert len(_spans(events, "step_preempted")) == 3
+        assert _assistants(events) == []
+
+        # Fourth step: a new arrival must NOT preempt it.
+        step = asyncio.create_task(harness.run_step(session.id))
+        await gated_model.wait_entered()
+        await harness.inject_message(session.id, "yet more input")
+        await asyncio.sleep(
+            0.3
+        )  # ~30 watcher ticks — a wrongly-armed watcher fires well within this
+        assert not step.done()
+        gated_model.release.set()
+        await asyncio.wait_for(step, timeout=10.0)
+
+        events = await harness.all_events(session.id)
+        assert len(_spans(events, "step_preempted")) == 3
+        (reply,) = _assistants(events)
+        assert reply.data["content"] == "finally answered"
+
+    async def test_completed_turn_resets_the_cap(
+        self, harness: Harness, gated_model: _GatedModel
+    ) -> None:
+        """A completed assistant turn resets the consecutive-preempt count:
+        preemption arms again on the next turn."""
+        harness.script_model([assistant("turn one"), assistant("turn two")])
+        session = await harness.start("hello", preempt_policy="preempt")
+
+        for i in range(3):
+            step = asyncio.create_task(harness.run_step(session.id))
+            await gated_model.wait_entered()
+            await harness.inject_message(session.id, f"more input {i}")
+            await asyncio.wait_for(step, timeout=10.0)
+
+        # Cap reached — run the turn to completion.
+        await gated_model.run_released_step(session.id)
+        events = await harness.all_events(session.id)
+        assert len(_assistants(events)) == 1
+
+        # Next turn: preemption is armed again.
+        await harness.inject_message(session.id, "new turn")
+        step = asyncio.create_task(harness.run_step(session.id))
+        await gated_model.wait_entered()
+        await harness.inject_message(session.id, "changed my mind")
+        await asyncio.wait_for(step, timeout=10.0)
+
+        events = await harness.all_events(session.id)
+        assert len(_spans(events, "step_preempted")) == 4
+        assert len(_assistants(events)) == 1

--- a/tests/unit/sandbox/test_tool_broker.py
+++ b/tests/unit/sandbox/test_tool_broker.py
@@ -50,6 +50,7 @@ def _agent(
         litellm_extra={},
         window_min=1000,
         window_max=100000,
+        preempt_policy="wait",
         binding=AgentBinding(agent_id="agt_1", version=3),
     )
 

--- a/tests/unit/test_classify_awaiting.py
+++ b/tests/unit/test_classify_awaiting.py
@@ -35,6 +35,7 @@ def _make_agent(tools: list[ToolSpec]) -> StepSurface:
         litellm_extra={},
         window_min=1,
         window_max=10,
+        preempt_policy="wait",
         binding=AgentBinding(agent_id="agt_test", version=1),
     )
 

--- a/tests/unit/test_discover_session_mcp_tools.py
+++ b/tests/unit/test_discover_session_mcp_tools.py
@@ -42,6 +42,7 @@ def _agent(
         litellm_extra={},
         window_min=1000,
         window_max=100000,
+        preempt_policy="wait",
         binding=AgentBinding(agent_id="agt_1", version=3),
     )
 

--- a/tests/unit/test_http_request.py
+++ b/tests/unit/test_http_request.py
@@ -49,6 +49,7 @@ def _agent(
         litellm_extra={},
         window_min=1000,
         window_max=100000,
+        preempt_policy="wait",
         binding=GenericChildBinding(session_id="ses_test"),
     )
 

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -177,6 +177,7 @@ def mock_step_dependencies() -> Any:
         litellm_extra={},
         window_min=1000,
         window_max=10000,
+        preempt_policy="wait",
     )
     start_event = SimpleNamespace(id="ev_start")
 

--- a/tests/unit/test_loop_spend_gate.py
+++ b/tests/unit/test_loop_spend_gate.py
@@ -52,6 +52,7 @@ async def test_spend_gate_trips_before_context_build() -> None:
         litellm_extra={},
         window_min=1000,
         window_max=10000,
+        preempt_policy="wait",
     )
     append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
     with (
@@ -129,6 +130,7 @@ async def test_preflight_gate_trips_on_subtree_rollup() -> None:
         litellm_extra={},
         window_min=1000,
         window_max=10000,
+        preempt_policy="wait",
     )
     append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
     # Flat per-account meter is well under the cap; only the subtree rollup trips.
@@ -208,6 +210,7 @@ async def test_preflight_gate_admits_when_subtree_under_limit() -> None:
         litellm_extra={},
         window_min=1000,
         window_max=10000,
+        preempt_policy="wait",
     )
     compose = AsyncMock(side_effect=RuntimeError("stop after admission"))
     with (
@@ -275,6 +278,7 @@ async def test_usage_charged_only_after_assistant_persists() -> None:
         litellm_extra={},
         window_min=1000,
         window_max=10000,
+        preempt_policy="wait",
     )
     step_ctx = SimpleNamespace(
         messages=[{"role": "user", "content": "hi"}], tools=[], skill_versions=[], reacting_to=0

--- a/tests/unit/test_loop_spend_gate_real_collaborator.py
+++ b/tests/unit/test_loop_spend_gate_real_collaborator.py
@@ -112,6 +112,7 @@ async def test_real_gate_trips_when_subtree_over_finite_limit() -> None:
         litellm_extra={},
         window_min=1000,
         window_max=10000,
+        preempt_policy="wait",
     )
     append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
     with (

--- a/tests/unit/test_mcp_discovery_cache.py
+++ b/tests/unit/test_mcp_discovery_cache.py
@@ -174,6 +174,7 @@ def _agent_surface(*, agent_id: str, version: int, tools: list[ToolSpec]) -> Ste
         litellm_extra={},
         window_min=1000,
         window_max=100000,
+        preempt_policy="wait",
         binding=AgentBinding(agent_id=agent_id, version=version),
     )
 
@@ -191,6 +192,7 @@ def _generic_child_surface(*, session_id: str, tools: list[ToolSpec]) -> StepSur
         litellm_extra={},
         window_min=1000,
         window_max=100000,
+        preempt_policy="wait",
         binding=GenericChildBinding(session_id=session_id),
     )
 

--- a/tests/unit/test_retired_goal_tool_tolerance.py
+++ b/tests/unit/test_retired_goal_tool_tolerance.py
@@ -87,6 +87,7 @@ def test_agent_row_with_retired_builtin_hydrates_clean() -> None:
         "litellm_extra": {},
         "window_min": 1,
         "window_max": 10,
+        "preempt_policy": "wait",
         "created_at": now,
         "updated_at": now,
         "archived_at": None,

--- a/tests/unit/test_step_context_provider_clamp.py
+++ b/tests/unit/test_step_context_provider_clamp.py
@@ -49,6 +49,7 @@ def _agent(tools: list[ToolSpec]) -> StepSurface:
         litellm_extra={},
         window_min=1,
         window_max=10,
+        preempt_policy="wait",
         binding=AgentBinding(agent_id="agt_1627", version=1),
     )
 

--- a/tests/unit/test_step_preempt.py
+++ b/tests/unit/test_step_preempt.py
@@ -123,6 +123,42 @@ class TestRace:
             )
         assert result is response
 
+    async def test_degraded_branch_cancellation_tears_down_model_task(self) -> None:
+        """Step-task cancellation while degraded (watcher already failed) must
+        still cancel the model child — it must not outlive the step (the
+        20-50s litellm HTTP call would otherwise run detached)."""
+        model_cancelled = asyncio.Event()
+        model_running = asyncio.Event()
+
+        async def model() -> Any:
+            model_running.set()
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                model_cancelled.set()
+                raise
+
+        async def watcher(*args: Any, **kwargs: Any) -> int | None:
+            await model_running.wait()
+            raise RuntimeError("watcher exploded")
+
+        with patch.object(loop_mod, "_wait_for_preempt", watcher):
+            race = asyncio.create_task(
+                _race_model_against_preempt(
+                    model, MagicMock(), InflightToolRegistry(), SID, reacted_floor=0
+                )
+            )
+            await asyncio.wait_for(model_running.wait(), timeout=5)
+            # Let the watcher's failure propagate through asyncio.wait so the
+            # race reaches the degraded ``await model_task`` before the cancel.
+            # (If the cancel lands earlier, the asyncio.wait arm tears the
+            # model down instead — the asserted invariant holds either way.)
+            await asyncio.sleep(0.05)
+            race.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await race
+        assert model_cancelled.is_set()
+
     async def test_outer_cancellation_tears_down_both_and_propagates(self) -> None:
         """Operator interrupt / step timeout / shutdown cancel the STEP task;
         the race must cancel both children and re-raise — today's semantics."""
@@ -170,7 +206,6 @@ class TestWaitForPreempt:
         stimuli and invisible to the watermark)."""
         conn = MagicMock()
         conn.fetchrow = AsyncMock(return_value={"last_event_seq": 5, "last_stimulus_seq": 9})
-        conn.fetchval = AsyncMock(return_value=9)
         predicate = AsyncMock(return_value={SID})
         registry = InflightToolRegistry()
 
@@ -187,7 +222,6 @@ class TestWaitForPreempt:
         seq past the floor — ``cancelled_by`` is omitted, not fabricated."""
         conn = MagicMock()
         conn.fetchrow = AsyncMock(return_value={"last_event_seq": 5, "last_stimulus_seq": 7})
-        conn.fetchval = AsyncMock(return_value=7)
         predicate = AsyncMock(return_value={SID})
 
         with patch.object(loop_mod, "find_sessions_needing_inference", predicate):
@@ -208,7 +242,6 @@ class TestWaitForPreempt:
         ] * 10
         conn = MagicMock()
         conn.fetchrow = AsyncMock(side_effect=rows)
-        conn.fetchval = AsyncMock(return_value=11)
         predicate = AsyncMock(side_effect=[set(), {SID}])
 
         with patch.object(loop_mod, "find_sessions_needing_inference", predicate):
@@ -217,9 +250,10 @@ class TestWaitForPreempt:
             )
         assert result == 11
         # Exactly two full evaluations: first tick + the gate advance; the 9
-        # unchanged reads in between ran no predicate.
+        # unchanged reads in between ran no predicate. 12 fetchrows: 11 gate
+        # ticks + the post-eligibility cancelled_by re-read.
         assert predicate.await_count == 2
-        assert conn.fetchrow.await_count == 11
+        assert conn.fetchrow.await_count == 12
 
 
 # ─── _preempt_allowed (starvation guard) ──────────────────────────────────────

--- a/tests/unit/test_step_preempt.py
+++ b/tests/unit/test_step_preempt.py
@@ -1,0 +1,246 @@
+"""Unit tests for the #253 preemption plumbing in ``harness/loop.py``.
+
+Pure asyncio + fake pool — the floored predicate's SQL behavior is pinned
+against real Postgres in ``tests/e2e/test_preempt_predicate.py``; here we pin
+the race orchestration (``_race_model_against_preempt``), the watcher's poll
+gate (``_wait_for_preempt``), and the starvation guard (``_preempt_allowed``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.harness import loop as loop_mod
+from aios.harness.inflight_tool_registry import InflightToolRegistry
+from aios.harness.loop import (
+    _preempt_allowed,
+    _Preempted,
+    _race_model_against_preempt,
+    _wait_for_preempt,
+)
+from aios.harness.sweep import find_sessions_needing_inference
+
+SID = "sess_preempt"
+
+
+def _fake_pool(conn: Any) -> Any:
+    pool = MagicMock()
+
+    @asynccontextmanager
+    async def _acquire() -> Any:
+        yield conn
+
+    pool.acquire = _acquire
+    return pool
+
+
+# ─── _race_model_against_preempt ──────────────────────────────────────────────
+
+
+class TestRace:
+    async def test_model_wins_returns_response_and_cancels_watcher(self) -> None:
+        response = object()
+
+        async def model() -> Any:
+            return response
+
+        watcher_cancelled = asyncio.Event()
+
+        async def watcher(*args: Any, **kwargs: Any) -> int | None:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                watcher_cancelled.set()
+                raise
+            return None
+
+        with patch.object(loop_mod, "_wait_for_preempt", watcher):
+            result = await _race_model_against_preempt(
+                model, MagicMock(), InflightToolRegistry(), SID, reacted_floor=0
+            )
+        assert result is response
+        assert watcher_cancelled.is_set()
+
+    async def test_model_error_propagates_after_watcher_teardown(self) -> None:
+        async def model() -> Any:
+            raise RuntimeError("provider exploded")
+
+        async def watcher(*args: Any, **kwargs: Any) -> int | None:
+            await asyncio.sleep(3600)
+            return None
+
+        with (
+            patch.object(loop_mod, "_wait_for_preempt", watcher),
+            pytest.raises(RuntimeError, match="provider exploded"),
+        ):
+            await _race_model_against_preempt(
+                model, MagicMock(), InflightToolRegistry(), SID, reacted_floor=0
+            )
+
+    async def test_watcher_wins_cancels_model_and_returns_preempted(self) -> None:
+        model_cancelled = asyncio.Event()
+
+        async def model() -> Any:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                model_cancelled.set()
+                raise
+
+        async def watcher(*args: Any, **kwargs: Any) -> int | None:
+            return 42
+
+        with patch.object(loop_mod, "_wait_for_preempt", watcher):
+            result = await _race_model_against_preempt(
+                model, MagicMock(), InflightToolRegistry(), SID, reacted_floor=0
+            )
+        assert result == _Preempted(cancelled_by=42)
+        assert model_cancelled.is_set()
+
+    async def test_watcher_failure_degrades_to_wait(self) -> None:
+        """Preemption plumbing must never break inference: a dead watcher
+        means the step just awaits the model as if policy were wait."""
+        response = object()
+        model_started = asyncio.Event()
+
+        async def model() -> Any:
+            model_started.set()
+            await asyncio.sleep(0.01)
+            return response
+
+        async def watcher(*args: Any, **kwargs: Any) -> int | None:
+            await model_started.wait()
+            raise RuntimeError("watcher exploded")
+
+        with patch.object(loop_mod, "_wait_for_preempt", watcher):
+            result = await _race_model_against_preempt(
+                model, MagicMock(), InflightToolRegistry(), SID, reacted_floor=0
+            )
+        assert result is response
+
+    async def test_outer_cancellation_tears_down_both_and_propagates(self) -> None:
+        """Operator interrupt / step timeout / shutdown cancel the STEP task;
+        the race must cancel both children and re-raise — today's semantics."""
+        model_cancelled = asyncio.Event()
+        watcher_cancelled = asyncio.Event()
+        race_running = asyncio.Event()
+
+        async def model() -> Any:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                model_cancelled.set()
+                raise
+
+        async def watcher(*args: Any, **kwargs: Any) -> int | None:
+            race_running.set()
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                watcher_cancelled.set()
+                raise
+            return None
+
+        with patch.object(loop_mod, "_wait_for_preempt", watcher):
+            race = asyncio.create_task(
+                _race_model_against_preempt(
+                    model, MagicMock(), InflightToolRegistry(), SID, reacted_floor=0
+                )
+            )
+            await asyncio.wait_for(race_running.wait(), timeout=5)
+            race.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await race
+        assert model_cancelled.is_set()
+        assert watcher_cancelled.is_set()
+
+
+# ─── _wait_for_preempt ────────────────────────────────────────────────────────
+
+
+class TestWaitForPreempt:
+    async def test_first_tick_runs_full_predicate_and_returns_stimulus_seq(self) -> None:
+        """The first iteration always runs the full floored predicate — it
+        closes the context-build→arm gap (including confirms, which are not
+        stimuli and invisible to the watermark)."""
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value={"last_event_seq": 5, "last_stimulus_seq": 9})
+        conn.fetchval = AsyncMock(return_value=9)
+        predicate = AsyncMock(return_value={SID})
+        registry = InflightToolRegistry()
+
+        with patch.object(loop_mod, "find_sessions_needing_inference", predicate):
+            result = await _wait_for_preempt(_fake_pool(conn), registry, SID, reacted_floor=7)
+        assert result == 9
+        assert predicate.await_count == 1
+        assert predicate.await_args is not None
+        assert predicate.await_args.kwargs["session_id"] == SID
+        assert predicate.await_args.kwargs["reacted_floor"] == 7
+
+    async def test_returns_none_when_admission_has_no_stimulus_past_floor(self) -> None:
+        """A confirmed-dispatch or cancel-marker admission carries no stimulus
+        seq past the floor — ``cancelled_by`` is omitted, not fabricated."""
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value={"last_event_seq": 5, "last_stimulus_seq": 7})
+        conn.fetchval = AsyncMock(return_value=7)
+        predicate = AsyncMock(return_value={SID})
+
+        with patch.object(loop_mod, "find_sessions_needing_inference", predicate):
+            result = await _wait_for_preempt(
+                _fake_pool(conn), InflightToolRegistry(), SID, reacted_floor=7
+            )
+        assert result is None
+
+    async def test_gate_suppresses_reevaluation_until_last_event_seq_advances(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Steady state is one PK read per tick: the full predicate re-runs
+        only when ``last_event_seq`` advances past the value captured BEFORE
+        the previous evaluation."""
+        monkeypatch.setattr(loop_mod, "_PREEMPT_POLL_INTERVAL_S", 0)
+        rows = [{"last_event_seq": 5, "last_stimulus_seq": 3}] * 10 + [
+            {"last_event_seq": 6, "last_stimulus_seq": 11}
+        ] * 10
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(side_effect=rows)
+        conn.fetchval = AsyncMock(return_value=11)
+        predicate = AsyncMock(side_effect=[set(), {SID}])
+
+        with patch.object(loop_mod, "find_sessions_needing_inference", predicate):
+            result = await _wait_for_preempt(
+                _fake_pool(conn), InflightToolRegistry(), SID, reacted_floor=3
+            )
+        assert result == 11
+        # Exactly two full evaluations: first tick + the gate advance; the 9
+        # unchanged reads in between ran no predicate.
+        assert predicate.await_count == 2
+        assert conn.fetchrow.await_count == 11
+
+
+# ─── _preempt_allowed (starvation guard) ──────────────────────────────────────
+
+
+class TestPreemptAllowed:
+    async def _allowed_with_count(self, count: int) -> bool:
+        conn = MagicMock()
+        conn.fetchval = AsyncMock(return_value=count)
+        return await _preempt_allowed(_fake_pool(conn), SID, account_id="acc_x")
+
+    async def test_under_cap_allows(self) -> None:
+        assert await self._allowed_with_count(loop_mod._PREEMPT_STARVATION_CAP - 1) is True
+
+    async def test_at_cap_blocks(self) -> None:
+        assert await self._allowed_with_count(loop_mod._PREEMPT_STARVATION_CAP) is False
+
+
+# ─── floored-predicate argument contract ──────────────────────────────────────
+
+
+async def test_reacted_floor_requires_session_id() -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        await find_sessions_needing_inference(MagicMock(), MagicMock(), reacted_floor=5)

--- a/tests/unit/test_sweep_instrumentation.py
+++ b/tests/unit/test_sweep_instrumentation.py
@@ -248,6 +248,7 @@ class TestEntrySweepSpan:
             litellm_extra={},
             window_min=1000,
             window_max=10000,
+            preempt_policy="wait",
         )
         start_event = SimpleNamespace(id="ev_sweep")
 

--- a/tests/unit/test_tool_disposition.py
+++ b/tests/unit/test_tool_disposition.py
@@ -61,6 +61,7 @@ def _agent(
         litellm_extra={},
         window_min=1,
         window_max=10,
+        preempt_policy="wait",
         binding=AgentBinding(agent_id="agt_test", version=1),
     )
 

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -240,6 +240,7 @@ class TestStepStartEndSpans:
             litellm_extra={},
             window_min=1000,
             window_max=10000,
+            preempt_policy="wait",
         )
         start_event = SimpleNamespace(id="ev_step")
 
@@ -357,6 +358,7 @@ class TestStepStartEndSpans:
             litellm_extra={},
             window_min=1000,
             window_max=10000,
+            preempt_policy="wait",
         )
         start_event = SimpleNamespace(id="ev_step")
 
@@ -479,6 +481,7 @@ class TestStepStartEndSpans:
             litellm_extra={},
             window_min=1000,
             window_max=10000,
+            preempt_policy="wait",
         )
         start_event = SimpleNamespace(id="ev_step")
 
@@ -583,6 +586,7 @@ class TestStepStartEndSpans:
             litellm_extra={},
             window_min=1000,
             window_max=10000,
+            preempt_policy="wait",
         )
         start_event = SimpleNamespace(id="ev_step")
 
@@ -687,6 +691,7 @@ class TestStepStartEndSpans:
             litellm_extra={},
             window_min=1000,
             window_max=10000,
+            preempt_policy="wait",
         )
         append_event = AsyncMock(return_value=SimpleNamespace(id="ev_step"))
 
@@ -788,6 +793,7 @@ async def _harness_with_guard(
         litellm_extra={},
         window_min=1000,
         window_max=10000,
+        preempt_policy="wait",
     )
     manager = MagicMock()
     append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))

--- a/tests/unit/test_wake_predicate_single_source.py
+++ b/tests/unit/test_wake_predicate_single_source.py
@@ -131,3 +131,49 @@ def test_confirmed_predicate_age_param_is_caller_supplied() -> None:
     sharing one boolean body."""
     assert "$3" in queries.confirmed_unresolved_predicate("lc", "$3")
     assert "{age_param}" in queries.confirmed_unresolved_predicate("lc", "{age_param}")
+
+
+# ─── instance 3: the #253 floored (preempt-trigger) twins — same sources ──────
+
+
+def test_floor_param_default_is_byte_identical() -> None:
+    """``stimulus_floor_param=None`` (the default) emits the exact pre-#253
+    text — the committed wake predicate, the read-path status derivation, and
+    every existing composition are untouched by the parameter's existence."""
+    assert queries.session_active_predicate("s") == queries.session_active_predicate(
+        "s", stimulus_floor_param=None
+    )
+
+
+def test_floored_candidate_sql_generated_from_session_active_predicate() -> None:
+    """``CANDIDATE_ROWS_FLOORED_SQL`` (the preempt trigger's candidate arm) is
+    composed FROM the SAME ``session_active_predicate`` generator as the
+    committed detector — the floor raises the reacted watermark inside the one
+    shared boolean rather than forking a hand-kept re-encode."""
+    floored = _norm(sweep.CANDIDATE_ROWS_FLOORED_SQL)
+    assert _norm(queries.session_active_predicate("s", stimulus_floor_param="$2")) in floored
+    assert "GREATEST(s.last_reacted_seq, $2)" in _norm(
+        queries.session_active_predicate("s", stimulus_floor_param="$2")
+    )
+
+
+def test_unreacted_sql_twins_share_the_template() -> None:
+    """Committed and floored unreacted queries are the SAME template rendered
+    at two watermark expressions — they cannot drift row-shape or filters."""
+    assert (
+        sweep._UNREACTED_ROWS_TEMPLATE.format(watermark_expr="s.last_reacted_seq")
+        == sweep.UNREACTED_ROWS_SQL
+    )
+    assert (
+        sweep._UNREACTED_ROWS_TEMPLATE.format(watermark_expr="GREATEST(s.last_reacted_seq, $2)")
+        == sweep.UNREACTED_ROWS_FLOORED_SQL
+    )
+
+
+def test_floored_confirmed_sql_generated_from_confirmed_unresolved_predicate() -> None:
+    """``CONFIRMED_ROWS_FLOORED_SQL`` composes the SAME confirmed-dispatch
+    boolean as the committed detector and the dispatch resolver, plus the seq
+    floor — one source, three consumers."""
+    floored = _norm(sweep.CONFIRMED_ROWS_FLOORED_SQL)
+    assert _norm(queries.confirmed_unresolved_predicate("lc", "$2")) in floored
+    assert "lc.seq > $3" in floored


### PR DESCRIPTION
Closes eumemic/aios#253.

## What

Per-agent `preempt_policy: Literal["preempt","wait"]`, default `"wait"` (every existing agent keeps current behavior — the default path's awaits are byte-identical). When `"preempt"`, the inline model call runs as a child task raced against a preempt watcher; the moment the session becomes wake-eligible past the in-flight step's context watermark, the model phase is cancelled and the step exits early so the already-queued wake re-steps against context that includes the new event(s). This targets the dominant remaining wake-tail latency: post-#243 wake p50 is 17ms but p90/p99 = 15s/51s, almost entirely "user message arrived during a 20–50s Opus extended-thinking step" — the model finishing a reply to stale context.

## Design (per the issue's Settled design, 2026-07-07)

- **Trigger criterion is the wake predicate itself, re-parameterized** — `find_sessions_needing_inference(session_id=…, reacted_floor=step_ctx.reacting_to)` — never an enumerated event-kind or call-site list, so the trigger cannot drift from wake semantics. Every seq-anchored arm is floored through the same single-source fragments as its committed twin (`session_active_predicate` grows a `stimulus_floor_param`; UNREACTED/CANDIDATE/CONFIRMED get `*_FLOORED_SQL` constants; single-source composition pinned by `test_wake_predicate_single_source.py`). Falls out for free: a user message always preempts; a partial-batch tool result does not, the batch-completing one does; errored-park filters inherited.
- **Two floored-only restrictions**, both erring toward *not* preempting (the inverse of the sweep's wedge-safety doctrine — a missed preempt costs one stale model call that the queued wake supersedes): the eumemic/aios#1710 empty-unreacted dispatch-narrowing pass is skipped (its wedge-safety argument requires ghost repair to have run first, and anything it admits predates the step's own entry guard), and the confirmed arm subtracts already-dispatched calls (registry in-flight or durable `tool_execute_start` span) so a still-running confirmed tool can't preempt-thrash.
- **Delivery: in-step race + poll gate** (the issue's viable shape (2); it delegated the choice as "simplest correct-by-construction shape wins"). The watcher's first tick runs the full floored predicate (closing the context-build→arm gap, including confirms — which are not stimuli and invisible to the watermark); its steady state is one PK read per second (`last_event_seq` gate — sound because every wake-eligible transition appends a row: the stimulus itself, or `defer_wake`'s `wake_deferred` span even when procrastinate dedups). No new channel, no listener, no registry changes, no `defer_wake` changes; the step task is never cancelled by preemption, so the operator-interrupt path is untouched. Worst case adds ≤1s to preemption latency — noise against the 20–50s calls this targets.
- **Scope: model phase only, structurally.** The model call is side-effect-free by construction (no DB writes between `model_request_start` and the assistant append; streaming deltas are transient pg_notify). Model-first on ties — a completed inference is never discarded; the watcher is torn down before the append/dispatch tail, so post-model un-preemptibility is not a checked condition. Watcher failure degrades to `"wait"` loudly (`step.preempt_watcher_failed`). Step-task cancellation (operator interrupt, step timeout, shutdown) tears down both children — including on the degraded path — and propagates unchanged.
- **Resume: no special path.** The eligible-making append already deferred a wake (`queueing_lock` dedups only `todo` jobs); the preempted step returns normally (no assistant append, no charge, no `turn_ended`), the lock releases, the queued wake re-steps.
- **Starvation guard** (required by the issue's decision comment): after 3 consecutive preemptions with no completed assistant turn, the next step runs un-preemptible so a sustained burst gets *some* reply. Counted from trailing `step_preempted` spans past the last assistant message seq — derived from the event log, so cross-worker correct with no new state; resets on any completed turn.
- **Telemetry**: the cancelled `model_request_end` closes its span pair with `cancelled_by` (the preempting stimulus seq) and deliberately omits `local_tokens`/`model`/`model_usage` so the token-calibration reader (key-presence-gated) never sees it; a `step_preempted` span records each preemption (underscore name per the `step_start`/`step_end` family — the issue's dotted "step.preempted" is the sub-phase-span idiom).

## Config plumbing

All five pydantic structures (`StepSurface` deliberately has **no** default so a missed projection is a mypy error, per its compile-loud contract), both `agents`/`agent_versions` tables (migration 0136 — purely additive, safe in the deploy window; no CHECK constraint per the 0111 precedent), queries (incl. `update_agent` no-op detection), services, routers, model tools, `openapi.json` + SDK regen. Version-pinned sessions freeze the policy with the version; agented workflow children inherit the pinned version's policy (their inline model calls are legitimate targets); generic children get `"wait"` from the `AgentCreate` defaults.

## Adversarial review

Pre-PR review workflow: 5 specialized lenses over the diff, every finding independently verified by 2 adversarial refuters (39 agents). 7 confirmed findings — 1 major (the watcher-failed degrade branch could leak the running model call on step cancellation) and 6 minor (stale-gate `cancelled_by` attribution, a probabilistic e2e assertion, an unregistered hot-read, dead mocks, a dead guard, a missing scope test) — all fixed in the third commit. By-design residuals it surfaced (no change): provider spend on a cancelled stream is unobservable (litellm yields usage only at completion) and bounded by the starvation cap; multi-worker registry blindness in the confirmed-arm exclusion is mitigated by the durable `tool_execute_start` marker and bounded by the cap; SSE consumers of a preempted stream see partial deltas superseded by the re-run (transient, no rows, no protocol break).

## Tests

- **e2e behavioral** (gated scripted model, 10ms poll): mid-step user message preempts with a clean span trace and the re-run's assistant covers it; default policy byte-identical (gate held through ~30 watcher ticks so a wrongly-armed watcher can't hide behind model-first-on-ties); post-model-return message does not cancel the tail; partial-batch holds / completing result preempts (integrated); starvation cap trips on the 4th step and resets after a completed turn.
- **e2e floored-predicate matrix** (direct calls, manually constructed logs): stimulus above/at floor; batch coverage; confirmed-arm floor + both dispatched exclusions; the committed-vs-floored dispatch-narrowing difference pinned on a ghost shape; errored-park inherited.
- **unit**: full race matrix (incl. degraded-path teardown and outer-cancellation propagation), watcher gate logic, cap boundary, floored-SQL single-source composition.
- **Perf guards**: the three floored reads + the per-step starvation count registered as HotReads in the read-path complexity harness; eumemic/aios#1734 predicate-mismatch oracle clean.
- Full gating suite green: mypy, ruff, 4331 unit, 341 e2e (`-m "docker and not perf"`); the one local `perf`-advisory failure (`test_retained_window_read_scales_sublinearly`, 9.2x ratio) is on an untouched pre-existing query and that mark is explicitly non-gating/jitter-prone (also fails on this machine without the diff).

## Post-deploy checklist (not CI)

- Rerun the issue's per-step profile harness; success = wake p90/p99 drop from 15s/51s.
- Opt in chat-facing agents per agent (`preempt_policy: "preempt"`); nothing changes until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)