### PR TITLE
Context image re-read/re-decode/re-downsample every build — LRU cache + persist-once + to_thread

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -903,6 +903,7 @@ async def get_context(
         prelude=prelude,
         events=windowed.events,
         omission=windowed.omission,
+        persist_image_rewrites=False,
     )
     return ContextResponse(
         session_id=session_id,

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -509,6 +509,7 @@ from .events import (  # noqa: E402
     read_windowed_context_events,
     read_windowed_events,
     recompute_session_channels,
+    replace_event_data,
 )
 from .files import (  # noqa: E402
     insert_file,
@@ -974,6 +975,7 @@ __all__ = [
     "release_trigger_claim",
     "remove_trigger",
     "reparent_connection",
+    "replace_event_data",
     "resolve_account_by_path",
     "resolve_effective_inbound_policy",
     "resolve_effective_sandbox_snapshot_bytes",

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -2039,6 +2039,41 @@ async def get_event(
     return _row_to_event(row)
 
 
+async def replace_event_data(
+    conn: asyncpg.Connection[Any],
+    session_id: str,
+    event_id: str,
+    data: dict[str, Any],
+    *,
+    account_id: str,
+) -> None:
+    """Overwrite ``events.data`` for a single row (issue #1745 Part C).
+
+    The ONLY in-place event mutation in the codebase — every other write
+    path is an append. It exists for exactly one caller,
+    :func:`aios.harness.context_persist.persist_clamped_image_parts`: a
+    deterministic, idempotent, account-scoped self-heal that shrinks an
+    oversize persisted image part once so the render-time clamp pass
+    (:func:`aios.harness.context._clamp_oversize_image_data_urls`) doesn't
+    have to re-decode + re-downsample it on every future build. ``seq``,
+    ``created_at``, and ``kind`` are never touched, so rendered-context
+    monotonicity holds — only the JSONB payload changes, and only to bytes
+    that are byte-equal to what the in-memory clamp pass already produces.
+
+    Account-scoping mirrors :func:`get_event`. Silently no-ops if the row
+    doesn't match (id/session/account mismatch) — same posture as an
+    ``UPDATE`` affecting zero rows; the caller logs the affected-row count
+    if it cares.
+    """
+    await conn.execute(
+        "UPDATE events SET data = $1::jsonb WHERE id = $2 AND session_id = $3 AND account_id = $4",
+        json.dumps(data),
+        event_id,
+        session_id,
+        account_id,
+    )
+
+
 async def get_session_event_stats(
     conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
 ) -> tuple[int, datetime | None]:

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -35,6 +35,9 @@ from __future__ import annotations
 
 import base64
 import json
+import os
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -62,6 +65,123 @@ from aios.models.events import MODEL_VISIBLE_LIFECYCLE_EVENTS, Event
 from aios.sandbox.volumes import resolve_to_host_path
 
 log = get_logger("aios.harness.context")
+
+# ── Attachment render cache (issue #1745 Part A) ─────────────────────────
+#
+# ``_apply_attachments`` re-reads + re-sniffs + re-base64-encodes every
+# inlinable staged image on EVERY ``build_messages`` call (every wake), even
+# though ``/mnt/attachments/`` staged bytes are immutable in steady state.
+# This module-level LRU memoizes the read+sniff+encode verdict keyed on full
+# file identity (path, mtime, size) so a steady-state replay over a window
+# of previously-seen attachments performs zero file reads.
+#
+# Value shapes:
+#   ("inline", content_type, data_b64)  — the file inlines cleanly.
+#   ("marker",)                          — undecodable / unsupported-format
+#                                           verdict (the model degrades to a
+#                                           text marker either way).
+# A "marker" entry does NOT record the size for the byte-cap accounting
+# below since it holds no encoded payload.
+_ATTACHMENT_CACHE_LOCK = threading.Lock()
+_ATTACHMENT_CACHE: OrderedDict[tuple[str, int, int], tuple[Any, ...]] = OrderedDict()
+_ATTACHMENT_CACHE_BYTES = 0
+_ATTACHMENT_CACHE_MAX_ENTRIES = 256
+
+
+def _attachment_cache_max_bytes() -> int:
+    """Read the byte-cap env override lazily (not at import time) so tests
+    can monkeypatch ``os.environ`` per-case without needing a process
+    restart."""
+    raw = os.environ.get("AIOS_CONTEXT_IMAGE_CACHE_MAX_BYTES")
+    if raw is not None:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    return 64 * 1024 * 1024
+
+
+def _attachment_cache_entry_bytes(value: tuple[Any, ...]) -> int:
+    if value and value[0] == "inline":
+        return len(value[2])
+    return 0
+
+
+def _attachment_cache_get(key: tuple[str, int, int]) -> tuple[Any, ...] | None:
+    with _ATTACHMENT_CACHE_LOCK:
+        value = _ATTACHMENT_CACHE.get(key)
+        if value is not None:
+            _ATTACHMENT_CACHE.move_to_end(key)
+        return value
+
+
+def _attachment_cache_put(key: tuple[str, int, int], value: tuple[Any, ...]) -> None:
+    global _ATTACHMENT_CACHE_BYTES
+    with _ATTACHMENT_CACHE_LOCK:
+        # A concurrent racer may have inserted the same key already —
+        # duplicate compute under a race is harmless (deterministic), so
+        # just overwrite and re-account.
+        existing = _ATTACHMENT_CACHE.pop(key, None)
+        if existing is not None:
+            _ATTACHMENT_CACHE_BYTES -= _attachment_cache_entry_bytes(existing)
+        _ATTACHMENT_CACHE[key] = value
+        _ATTACHMENT_CACHE_BYTES += _attachment_cache_entry_bytes(value)
+        max_bytes = _attachment_cache_max_bytes()
+        while _ATTACHMENT_CACHE and (
+            len(_ATTACHMENT_CACHE) > _ATTACHMENT_CACHE_MAX_ENTRIES
+            or max_bytes < _ATTACHMENT_CACHE_BYTES
+        ):
+            _, evicted = _ATTACHMENT_CACHE.popitem(last=False)
+            _ATTACHMENT_CACHE_BYTES -= _attachment_cache_entry_bytes(evicted)
+
+
+def _clear_attachment_cache() -> None:
+    """Test-only: reset the module-level LRU between cases."""
+    global _ATTACHMENT_CACHE_BYTES
+    with _ATTACHMENT_CACHE_LOCK:
+        _ATTACHMENT_CACHE.clear()
+        _ATTACHMENT_CACHE_BYTES = 0
+
+
+# ── Clamp-pass fit-verdict cache (issue #1745 Part B) ────────────────────
+#
+# ``_clamp_oversize_image_data_urls`` full-``base64.b64decode``s EVERY
+# persisted ``image_url`` data-url part on every build to check whether it
+# needs downsampling. This LRU memoizes the FITS/DEGRADE verdict keyed on
+# ``(len(data_b64), hash(data_b64))`` so steady state is a dict lookup, not
+# a decode + Pillow header parse.
+_CLAMP_VERDICT_FITS = "FITS"
+_CLAMP_VERDICT_DEGRADE = "DEGRADE"
+_CLAMP_CACHE_LOCK = threading.Lock()
+_CLAMP_CACHE: OrderedDict[tuple[int, int], str] = OrderedDict()
+_CLAMP_CACHE_MAX_ENTRIES = 8192
+
+
+def _clamp_cache_key(data_b64: str) -> tuple[int, int]:
+    return (len(data_b64), hash(data_b64))
+
+
+def _clamp_cache_get(key: tuple[int, int]) -> str | None:
+    with _CLAMP_CACHE_LOCK:
+        value = _CLAMP_CACHE.get(key)
+        if value is not None:
+            _CLAMP_CACHE.move_to_end(key)
+        return value
+
+
+def _clamp_cache_put(key: tuple[int, int], value: str) -> None:
+    with _CLAMP_CACHE_LOCK:
+        _CLAMP_CACHE[key] = value
+        _CLAMP_CACHE.move_to_end(key)
+        while len(_CLAMP_CACHE) > _CLAMP_CACHE_MAX_ENTRIES:
+            _CLAMP_CACHE.popitem(last=False)
+
+
+def _clear_clamp_cache() -> None:
+    """Test-only: reset the module-level LRU between cases."""
+    with _CLAMP_CACHE_LOCK:
+        _CLAMP_CACHE.clear()
+
 
 # Chat-completions spec fields per role.  Provider-specific extensions
 # (reasoning, reasoning_details, internal reacting_to, etc.) stay in the
@@ -633,12 +753,44 @@ def _apply_attachments(
         ):
             marker_lines.append(text_marker(record))
             continue
-        # v1 deliberately re-reads + re-base64-encodes per render: the
-        # staged bytes are typically immutable (`/mnt/attachments/` is
-        # read-only) so an LRU cache on (host_path, mtime, size) would
-        # be a clean follow-up if profiling shows pressure.  See
-        # PR #216 §14 for the discussion of cache vs. encode-at-staging
-        # alternatives we deferred for v1.
+        # Attachment render cache (#1745 Part A): staged bytes under
+        # ``/mnt/attachments/`` are immutable in steady state, so a cache
+        # keyed on full file identity (path, mtime, size) lets a re-render
+        # of a previously-seen attachment skip the read+sniff+encode
+        # entirely. One ``stat()`` call resolves the key; an ``OSError``
+        # here (file vanished) falls through to the SAME marker fallback
+        # the old direct-read OSError guard used, so behavior is unchanged
+        # for a missing file.
+        try:
+            st = host_path.stat()
+        except OSError as err:
+            log.warning(
+                "context.attachment_read_failed",
+                path=str(host_path),
+                error=str(err),
+            )
+            marker_lines.append(text_marker(record))
+            continue
+        cache_key = (str(host_path), st.st_mtime_ns, st.st_size)
+        cached = _attachment_cache_get(cache_key)
+        if cached is not None:
+            if cached[0] == "inline":
+                _, cached_content_type, cached_data_b64 = cached
+                # Never share the cached dict — each hit rebuilds the part
+                # fresh via make_image_url_part.
+                image_parts.append(
+                    make_image_url_part(
+                        content_type=cached_content_type,
+                        data_b64=cached_data_b64,
+                    )
+                )
+            else:
+                marker_lines.append(text_marker(record))
+            continue
+        # Cache miss: compute (read + sniff + encode) OUTSIDE the lock —
+        # only the insert is lock-guarded (see the cache helpers above).
+        # A duplicate compute under a concurrent-render race is harmless:
+        # the result is a deterministic function of the immutable bytes.
         try:
             payload = host_path.read_bytes()
         except OSError as err:
@@ -667,6 +819,7 @@ def _apply_attachments(
                 path=str(host_path),
                 filename=record.get("filename"),
             )
+            _attachment_cache_put(cache_key, ("marker",))
             marker_lines.append(text_marker(record))
             continue
         if image_format not in PROVIDER_INLINE_IMAGE_FORMATS:
@@ -681,12 +834,15 @@ def _apply_attachments(
                 path=str(host_path),
                 filename=record.get("filename"),
             )
+            _attachment_cache_put(cache_key, ("marker",))
             marker_lines.append(text_marker(record))
             continue
+        data_b64 = base64.b64encode(payload).decode("ascii")
+        _attachment_cache_put(cache_key, ("inline", content_type, data_b64))
         image_parts.append(
             make_image_url_part(
                 content_type=content_type,
-                data_b64=base64.b64encode(payload).decode("ascii"),
+                data_b64=data_b64,
             )
         )
 
@@ -853,18 +1009,45 @@ def _clamp_oversize_image_data_urls(messages: list[dict[str, Any]]) -> None:
             head, sep, data_b64 = url.partition(",")
             if not sep or ";base64" not in head:
                 continue
+            # Fit-verdict cache (#1745 Part B): keyed on the encoded string
+            # itself (length + hash), consulted BEFORE any decode. A hit
+            # means this exact part was already classified on a prior
+            # build — steady state is a dict lookup, zero decode.
+            cache_key = _clamp_cache_key(data_b64)
+            cached_verdict = _clamp_cache_get(cache_key)
+            if cached_verdict == _CLAMP_VERDICT_FITS:
+                continue
+            if cached_verdict == _CLAMP_VERDICT_DEGRADE:
+                if new_content is None:
+                    new_content = list(content)
+                new_content[i] = {
+                    "type": "text",
+                    "text": "[image omitted: too large to display inline]",
+                }
+                continue
+            # Cache miss. O(1) size-gate on the ENCODED length classifies
+            # byte-oversize with zero decode — base64 expands 4 bytes for
+            # every 3 raw bytes, so ``len(data_b64) * 3 // 4`` approximates
+            # the raw size without decoding a single byte. When this alone
+            # already proves oversize, skip the redundant Pillow header
+            # check below (``is_oversize_image``) — we already know the
+            # verdict; decoding still happens once, right before, because
+            # downsampling needs the actual bytes regardless.
+            byte_oversize = (len(data_b64) * 3 // 4) > INLINE_SIZE_CAP_BYTES
             try:
                 raw = base64.b64decode(data_b64, validate=True)
             except Exception:
                 # Malformed base64 — leave it; the mime corrector and the
-                # provider's own decode handle that orthogonal failure.
+                # provider's own decode handle that orthogonal failure. Not
+                # cached: this is a data defect, not a fit verdict.
                 continue
-            # Header-only oversize check first: this pass is scoped to the
-            # DIMENSION wedge only. A part that already fits both caps is left
-            # exactly as the mime corrector produced it (an undecodable-but-
-            # small part is the mime corrector's / provider's concern, not a
-            # dimension wedge — degrading it here would clobber that contract).
-            if not is_oversize_image(raw):
+            # Header-only oversize check: this pass is scoped to the DIMENSION
+            # wedge only. A part that already fits both caps is left exactly
+            # as the mime corrector produced it (an undecodable-but-small part
+            # is the mime corrector's / provider's concern, not a dimension
+            # wedge — degrading it here would clobber that contract).
+            if not byte_oversize and not is_oversize_image(raw):
+                _clamp_cache_put(cache_key, _CLAMP_VERDICT_FITS)
                 continue
             try:
                 # Blocking (not awaited): build_messages is sync. We only
@@ -877,6 +1060,7 @@ def _clamp_oversize_image_data_urls(messages: list[dict[str, Any]]) -> None:
                 # ladder): a part we cannot bound is a wedge if left in place.
                 # Replace it with an inert text placeholder, preserving list
                 # shape rather than dropping the message.
+                _clamp_cache_put(cache_key, _CLAMP_VERDICT_DEGRADE)
                 if new_content is None:
                     new_content = list(content)
                 new_content[i] = {
@@ -887,8 +1071,18 @@ def _clamp_oversize_image_data_urls(messages: list[dict[str, Any]]) -> None:
             if resized is None:
                 # Header check said oversize but the downsample disagreed
                 # (e.g. a race on the cap boundary) — nothing to rewrite.
+                # Not cached: this part's own persisted bytes are the same
+                # every render, so re-deriving this (rare) race each time is
+                # cheap and safer than caching a same-key/different-outcome
+                # verdict.
                 continue
             encoded = base64.b64encode(resized.data).decode("ascii")
+            # NOT cached as FITS: this render successfully shrank the part in
+            # MEMORY only — the persisted bytes are still oversize, so the
+            # NEXT render (absent Part C's persist) must redo this same work.
+            # Once Part C persists the shrunk bytes, the next build sees a
+            # different (smaller) ``data_b64`` — a fresh cache key that hits
+            # the byte-size-gate / header-check FITS path directly.
             if new_content is None:
                 new_content = list(content)
             new_content[i] = {

--- a/src/aios/harness/context_persist.py
+++ b/src/aios/harness/context_persist.py
@@ -1,0 +1,175 @@
+"""Async companion to :mod:`aios.harness.context`'s render-time image clamp.
+
+:func:`aios.harness.context._clamp_oversize_image_data_urls` runs on EVERY
+``build_messages`` call and, for a persisted ``tool_result``/message event
+that still carries a pre-#1616 oversize ``image_url`` data-url part,
+downsamples it IN MEMORY so the current render fits the provider's caps.
+Because that result is never written back, every future build re-decodes
+and re-downsamples the same backlog part forever (issue #1745 Part B/C).
+
+:func:`persist_clamped_image_parts` closes the loop: called once per step
+BEFORE ``build_messages`` (worker path only — see ``persist_image_rewrites``
+at the call site in :func:`aios.harness.step_context.compose_step_context`),
+it performs the identical downsample, writes the shrunk part back to
+``events.data`` via :func:`aios.db.queries.replace_event_data`, and updates
+the in-memory :class:`~aios.models.events.Event` so THIS step's render
+already sees the persisted (small) bytes. Once persisted, the render-time
+clamp pass's fit-verdict cache converges to a steady-state dict lookup —
+the whole point of this module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import TYPE_CHECKING, Any
+
+from aios.harness.image_resize import (
+    ImageDownsampleError,
+    _blocking_downsample,
+    is_oversize_image,
+)
+from aios.harness.vision import INLINE_MAX_DIMENSION, INLINE_SIZE_CAP_BYTES
+from aios.logging import get_logger
+
+if TYPE_CHECKING:
+    import asyncpg
+
+    from aios.models.events import Event
+
+log = get_logger("aios.harness.context_persist")
+
+
+async def persist_clamped_image_parts(
+    pool: asyncpg.Pool[Any],
+    events: list[Event],
+    *,
+    session_id: str,
+    account_id: str,
+) -> None:
+    """Downsample + persist any oversize persisted ``image_url`` part once.
+
+    Mirrors :func:`aios.harness.context._clamp_oversize_image_data_urls`'s
+    per-part decode/downsample logic exactly, sharing its module-level
+    fit-verdict cache (function-local import below avoids a module-load
+    cycle: ``context.py`` stays free of any DB/async import). For each
+    ``kind == "message"`` event whose ``data["content"]`` is a list of
+    parts, an oversize ``image_url`` part is downsampled via
+    :func:`asyncio.to_thread` (off the event loop) and the shrunk part is
+    written back with :func:`aios.db.queries.replace_event_data` — a
+    single-row, account-scoped ``UPDATE`` — then ``e.data`` is replaced
+    (copy-on-write; never mutated in place) so this step's subsequent
+    ``build_messages`` call renders the persisted bytes directly.
+
+    An :class:`~aios.harness.image_resize.ImageDownsampleError` (the part
+    is un-shrinkable — above the pre-resize ceiling, or the byte cap is
+    unreachable even at the bottom of the quality ladder) is NEVER
+    persisted: the render-time placeholder stays render-only so the
+    original log bytes are never destroyed. The DEGRADE verdict is cached
+    so neither this pass nor the render pass re-attempts the decode.
+
+    Crash-safe idempotency: ``_blocking_downsample`` is a deterministic
+    function of the immutable persisted bytes, so a crash before the
+    ``UPDATE`` commits just means the next call re-derives byte-identical
+    output and retries; a crash after means the persisted part already
+    fits, so this pass no-ops on it next time (cached FITS or the size/
+    dimension gate short-circuits before any decode). Concurrent writers
+    hitting the same event compute byte-equal output (determinism), so
+    last-writer-wins on the ``UPDATE`` is safe.
+    """
+    # Function-local import: these are context.py's module-level caches and
+    # verdict constants. Importing them here (not at context_persist.py's
+    # module top) means context.py itself never has to import anything
+    # DB/async-shaped, preserving its "no DB access, no async" contract
+    # (module docstring) — context_persist.py is the async composer-side
+    # half of this feature, context.py stays the pure sync renderer.
+    from aios.db import queries
+    from aios.harness.context import (
+        _CLAMP_VERDICT_DEGRADE,
+        _CLAMP_VERDICT_FITS,
+        _clamp_cache_get,
+        _clamp_cache_key,
+        _clamp_cache_put,
+    )
+
+    async with pool.acquire() as conn:
+        for e in events:
+            if e.kind != "message":
+                continue
+            content = e.data.get("content")
+            if not isinstance(content, list):
+                continue
+            new_content: list[Any] | None = None
+            for i, part in enumerate(content):
+                if not isinstance(part, dict) or part.get("type") != "image_url":
+                    continue
+                image_url = part.get("image_url")
+                if not isinstance(image_url, dict):
+                    continue
+                url = image_url.get("url")
+                if not isinstance(url, str) or not url.startswith("data:"):
+                    continue
+                head, sep, data_b64 = url.partition(",")
+                if not sep or ";base64" not in head:
+                    continue
+                # Same fit-verdict cache the render pass consults — a hit
+                # here means either a prior render or a prior persist call
+                # already classified this exact part: FITS needs no write,
+                # DEGRADE must never be written.
+                cache_key = _clamp_cache_key(data_b64)
+                cached_verdict = _clamp_cache_get(cache_key)
+                if cached_verdict in (_CLAMP_VERDICT_FITS, _CLAMP_VERDICT_DEGRADE):
+                    continue
+                byte_oversize = (len(data_b64) * 3 // 4) > INLINE_SIZE_CAP_BYTES
+                try:
+                    raw = base64.b64decode(data_b64, validate=True)
+                except Exception:
+                    # Malformed base64 — not this pass's concern (mirrors
+                    # the render pass's stance); leave it for the provider.
+                    continue
+                if not byte_oversize and not is_oversize_image(raw):
+                    _clamp_cache_put(cache_key, _CLAMP_VERDICT_FITS)
+                    continue
+                try:
+                    resized = await asyncio.to_thread(
+                        _blocking_downsample,
+                        raw,
+                        INLINE_SIZE_CAP_BYTES,
+                        INLINE_MAX_DIMENSION,
+                    )
+                except ImageDownsampleError:
+                    _clamp_cache_put(cache_key, _CLAMP_VERDICT_DEGRADE)
+                    continue
+                if resized is None:
+                    # Header check said oversize but the downsample
+                    # disagreed (race on the cap boundary) — nothing to
+                    # persist this round.
+                    continue
+                encoded = base64.b64encode(resized.data).decode("ascii")
+                if new_content is None:
+                    new_content = list(content)
+                old_size = len(data_b64)
+                new_content[i] = {
+                    **part,
+                    "image_url": {
+                        **image_url,
+                        "url": f"data:{resized.content_type};base64,{encoded}",
+                    },
+                }
+                log.info(
+                    "context.image_part_persisted_clamp",
+                    event_id=e.id,
+                    part_idx=i,
+                    old_size=old_size,
+                    new_size=len(encoded),
+                )
+            if new_content is not None:
+                # Copy-on-write: never mutate ``e.data`` (or the original
+                # part dicts) in place — mirrors the render pass's contract
+                # that the source-of-truth event is immutable except
+                # through this single, deliberate self-heal write.
+                new_data = {**e.data, "content": new_content}
+                await queries.replace_event_data(
+                    conn, session_id, e.id, new_data, account_id=account_id
+                )
+                e.data = new_data

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1052,6 +1052,7 @@ async def _run_session_step_body(
             ),
             omission=windowed.omission,
             capability_model=capability_model,
+            persist_image_rewrites=True,
         )
     except Exception:
         await sessions_service.append_event(

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -25,6 +25,7 @@ work to honor the "byte-identical" promise.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -36,6 +37,7 @@ from aios.harness.context import (
     message_is_notification_marker,
     stub_missing_reasoning_content,
 )
+from aios.harness.context_persist import persist_clamped_image_parts
 from aios.harness.tokens import approx_tokens
 from aios.harness.window import WindowOmission
 from aios.logging import get_logger
@@ -490,11 +492,21 @@ async def compose_step_context(
     in_flight_tool_call_ids: frozenset[str] = frozenset(),
     omission: WindowOmission | None = None,
     capability_model: str | None = None,
+    persist_image_rewrites: bool = False,
 ) -> StepContext:
     """Compose the chat-completions payload for a step.
 
     Takes a prelude built by :func:`compute_step_prelude` and the
     windowed events slate; glues them into the final message list.
+
+    ``persist_image_rewrites`` (#1745 Part C): when ``True``, an oversize
+    persisted ``image_url`` part (the pre-#1616 backlog) is downsampled
+    ONCE and written back to its event row before ``build_messages`` runs,
+    so this step (and every subsequent one) renders the already-shrunk
+    bytes instead of re-deriving them from the oversize original on every
+    build. The worker step path passes ``True``; the read-only
+    ``GET /v1/sessions/:id/context`` preview passes ``False`` (a dry-run
+    must never write).
 
     ``capability_model`` is the model string the capability gates (vision
     inlining, extended-thinking continuity) key on (#1637): for a ``workflow:``
@@ -540,7 +552,25 @@ async def compose_step_context(
     # renderer change).
     tz_name = await accounts_service.resolve_effective_timezone(pool, account_id)
 
-    ctx = build_messages(
+    # Persist-once self-heal (#1745 Part C): BEFORE build_messages, so this
+    # step (and every subsequent one) renders the already-shrunk bytes
+    # instead of re-decoding + re-downsampling the oversize original on
+    # every build. Gated on the worker-only flag — the read-only
+    # ``GET /v1/sessions/:id/context`` preview leaves this ``False``: a
+    # dry-run must never write.
+    if persist_image_rewrites:
+        await persist_clamped_image_parts(
+            pool, events, session_id=session.id, account_id=account_id
+        )
+
+    # Off the event loop (#1745 Part D): build_messages is pure CPU + file
+    # I/O (no DB, no async — see its module docstring), so running it
+    # inline on the loop thread blocks every other session's step for the
+    # duration. The attachment-render and clamp-fit-verdict LRUs (Parts A/B)
+    # are the only shared state it touches; both are lock-guarded, so
+    # running this on a worker thread is safe under concurrent steps.
+    ctx = await asyncio.to_thread(
+        build_messages,
         events,
         system_prompt=prelude.system_prompt,
         model=gate_model,

--- a/tests/unit/test_context_image_cache.py
+++ b/tests/unit/test_context_image_cache.py
@@ -1,0 +1,630 @@
+"""Unit coverage for issue #1745: attachment render cache (A), clamp-pass
+fit-verdict cache (B), persist-once (C), and the loop-thread offload (D).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+from aios.config import get_settings
+from aios.harness import context, image_resize, vision
+from aios.harness.context import (
+    _ATTACHMENT_CACHE,
+    _CLAMP_CACHE,
+    _apply_attachments,
+    _clamp_cache_key,
+    _clear_attachment_cache,
+    _clear_clamp_cache,
+    build_messages,
+)
+from aios.harness.context_persist import persist_clamped_image_parts
+from aios.harness.image_resize import ImageDownsampleError
+from aios.models.events import Event
+from aios.sandbox.volumes import session_attachments_dir
+from tests.helpers.images import valid_jpeg_bytes
+
+_CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+_VALID_JPEG = valid_jpeg_bytes()
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Any:
+    _clear_attachment_cache()
+    _clear_clamp_cache()
+    yield
+    _clear_attachment_cache()
+    _clear_clamp_cache()
+
+
+@pytest.fixture
+def temp_workspace_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "workspace_root", tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _stub_supports_vision(monkeypatch: pytest.MonkeyPatch) -> Any:
+    saved = dict(vision._VISION_OVERRIDES)
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES["model/vision"] = True
+    yield
+    vision._VISION_OVERRIDES.clear()
+    vision._VISION_OVERRIDES.update(saved)
+
+
+def _stage_image(
+    workspace_root: Path, session_id: str, connector: str, name: str, payload: bytes
+) -> tuple[str, Path]:
+    session_dir = session_attachments_dir(session_id) / connector
+    session_dir.mkdir(parents=True, exist_ok=True)
+    file_path = session_dir / name
+    file_path.write_bytes(payload)
+    return f"/mnt/attachments/{connector}/{name}", file_path
+
+
+def _user_event(*, content: str = "hi", attachments: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "role": "user",
+        "content": content,
+        "metadata": {"channel": "echo/acct/chat-1", "attachments": attachments},
+    }
+
+
+class TestAttachmentRenderCache:
+    def test_second_render_same_identity_zero_read_bytes(
+        self, temp_workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sandbox_path, _host_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "photo.jpg", _VALID_JPEG
+        )
+        record = {
+            "filename": "photo.jpg",
+            "content_type": "image/jpeg",
+            "size": len(_VALID_JPEG),
+            "in_sandbox_path": sandbox_path,
+        }
+
+        read_calls = {"n": 0}
+        orig_read_bytes = Path.read_bytes
+
+        def counting_read_bytes(self: Path) -> bytes:
+            read_calls["n"] += 1
+            return orig_read_bytes(self)
+
+        monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+        msg1: dict[str, Any] = {"content": ""}
+        _apply_attachments(msg1, [record], model="model/vision", session_id="sess-1")
+        assert read_calls["n"] == 1
+        part1 = msg1["content"][0]
+
+        msg2: dict[str, Any] = {"content": ""}
+        _apply_attachments(msg2, [record], model="model/vision", session_id="sess-1")
+        # Zero additional read_bytes calls on the cache hit.
+        assert read_calls["n"] == 1
+        part2 = msg2["content"][0]
+
+        assert part1 == part2
+        # Never share the cached dict — each hit rebuilds the part.
+        assert part1 is not part2
+        assert part1["image_url"] is not part2["image_url"]
+
+    def test_mtime_bump_triggers_reread(
+        self, temp_workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sandbox_path, host_path = _stage_image(
+            temp_workspace_root, "sess-1", "echo", "photo.jpg", _VALID_JPEG
+        )
+        record = {
+            "filename": "photo.jpg",
+            "content_type": "image/jpeg",
+            "size": len(_VALID_JPEG),
+            "in_sandbox_path": sandbox_path,
+        }
+        read_calls = {"n": 0}
+        orig_read_bytes = Path.read_bytes
+
+        def counting_read_bytes(self: Path) -> bytes:
+            read_calls["n"] += 1
+            return orig_read_bytes(self)
+
+        monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+        msg: dict[str, Any] = {"content": ""}
+        _apply_attachments(msg, [record], model="model/vision", session_id="sess-1")
+        assert read_calls["n"] == 1
+
+        # Bump mtime by rewriting with different bytes (same size class ok).
+        import os
+        import time
+
+        time.sleep(0.01)
+        host_path.write_bytes(_VALID_JPEG)
+        os.utime(host_path, None)
+
+        msg2: dict[str, Any] = {"content": ""}
+        _apply_attachments(msg2, [record], model="model/vision", session_id="sess-1")
+        assert read_calls["n"] == 2
+
+    def test_byte_cap_eviction(
+        self, temp_workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AIOS_CONTEXT_IMAGE_CACHE_MAX_BYTES", str(len(_VALID_JPEG) * 2 + 10))
+        paths = []
+        for i in range(5):
+            sandbox_path, _ = _stage_image(
+                temp_workspace_root, "sess-1", "echo", f"photo{i}.jpg", _VALID_JPEG
+            )
+            paths.append(sandbox_path)
+
+        for i, sandbox_path in enumerate(paths):
+            record = {
+                "filename": f"photo{i}.jpg",
+                "content_type": "image/jpeg",
+                "size": len(_VALID_JPEG),
+                "in_sandbox_path": sandbox_path,
+            }
+            msg: dict[str, Any] = {"content": ""}
+            _apply_attachments(msg, [record], model="model/vision", session_id="sess-1")
+
+        # Cache stayed bounded — not all 5 entries retained.
+        assert len(_ATTACHMENT_CACHE) < 5
+
+    def test_marker_verdict_cached(
+        self, temp_workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        corrupt = b"\xff\xd8\xff" + b"\x00" * 20  # JPEG magic, undecodable body
+        sandbox_path, _ = _stage_image(temp_workspace_root, "sess-1", "echo", "bad.jpg", corrupt)
+        record = {
+            "filename": "bad.jpg",
+            "content_type": "image/jpeg",
+            "size": len(corrupt),
+            "in_sandbox_path": sandbox_path,
+        }
+        read_calls = {"n": 0}
+        orig_read_bytes = Path.read_bytes
+
+        def counting_read_bytes(self: Path) -> bytes:
+            read_calls["n"] += 1
+            return orig_read_bytes(self)
+
+        monkeypatch.setattr(Path, "read_bytes", counting_read_bytes)
+
+        msg1: dict[str, Any] = {"content": ""}
+        _apply_attachments(msg1, [record], model="model/vision", session_id="sess-1")
+        assert read_calls["n"] == 1
+        assert isinstance(msg1["content"], str)
+        assert "[image: bad.jpg" in msg1["content"]
+
+        msg2: dict[str, Any] = {"content": ""}
+        _apply_attachments(msg2, [record], model="model/vision", session_id="sess-1")
+        # Marker verdict cached: no second read.
+        assert read_calls["n"] == 1
+        assert "[image: bad.jpg" in msg2["content"]
+
+
+def _big_png_data_url() -> tuple[str, bytes]:
+    buf = io.BytesIO()
+    Image.new("RGB", (4000, 4000), (10, 20, 30)).save(buf, format="PNG")
+    raw = buf.getvalue()
+    b64 = base64.b64encode(raw).decode("ascii")
+    return f"data:image/png;base64,{b64}", raw
+
+
+def _tool_event_with_image(url: str) -> Event:
+    return Event(
+        id="evt_img",
+        session_id="sess_01TEST",
+        seq=3,
+        kind="message",
+        data={
+            "role": "tool",
+            "tool_call_id": "a",
+            "content": [
+                {"type": "text", "text": "Image: huge.png"},
+                {"type": "image_url", "image_url": {"url": url}},
+            ],
+        },
+        created_at=_CREATED_AT,
+        orig_channel=None,
+        focal_channel_at_arrival=None,
+    )
+
+
+def _preceding_events() -> list[Event]:
+    return [
+        Event(
+            id="evt_1",
+            session_id="sess_01TEST",
+            seq=1,
+            kind="message",
+            data={"role": "user", "content": "show photo"},
+            created_at=_CREATED_AT,
+            orig_channel=None,
+            focal_channel_at_arrival=None,
+        ),
+        Event(
+            id="evt_2",
+            session_id="sess_01TEST",
+            seq=2,
+            kind="message",
+            data={
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "a", "type": "function", "function": {"name": "read", "arguments": "{}"}}
+                ],
+            },
+            created_at=_CREATED_AT,
+            orig_channel=None,
+            focal_channel_at_arrival=None,
+        ),
+    ]
+
+
+class TestClampFitVerdictCache:
+    def test_second_build_zero_full_decode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Second build over the SAME (unpersisted, still-oversize) window
+        # re-derives the same result but must not re-decode: the fit
+        # verdict for a DEGRADE-shrunk-in-memory part isn't cached as FITS
+        # (spec: only persisted-fit or DEGRADE verdicts are cached), but a
+        # part that already FITS IS a cache hit. Exercise that directly:
+        # build twice over a window whose part already fits, counting only
+        # FULL-payload decodes (the mime-corrector's own unconditional
+        # 24-char header sniff is orthogonal and out of scope — #1745
+        # explicitly leaves it unchanged).
+        small_buf = io.BytesIO()
+        Image.new("RGB", (64, 64), (1, 2, 3)).save(small_buf, format="PNG")
+        small_b64 = base64.b64encode(small_buf.getvalue()).decode("ascii")
+        small_url = f"data:image/png;base64,{small_b64}"
+        small_events = [*_preceding_events(), _tool_event_with_image(small_url)]
+
+        full_decode_calls = {"n": 0}
+        orig_decode = base64.b64decode
+
+        def counting_decode(data: Any, *args: Any, **kwargs: Any) -> bytes:
+            if isinstance(data, str) and len(data) == len(small_b64):
+                full_decode_calls["n"] += 1
+            return orig_decode(data, *args, **kwargs)
+
+        monkeypatch.setattr(base64, "b64decode", counting_decode)
+
+        is_oversize_calls = {"n": 0}
+        orig_is_oversize = image_resize.is_oversize_image
+
+        def counting_is_oversize(*args: Any, **kwargs: Any) -> bool:
+            is_oversize_calls["n"] += 1
+            return orig_is_oversize(*args, **kwargs)
+
+        monkeypatch.setattr(context, "is_oversize_image", counting_is_oversize)
+
+        build_messages(small_events, system_prompt=None)
+        assert full_decode_calls["n"] == 1
+        assert is_oversize_calls["n"] == 1
+
+        full_decode_calls["n"] = 0
+        is_oversize_calls["n"] = 0
+        build_messages(small_events, system_prompt=None)
+        # Cache hit: zero FULL decode, zero is_oversize_image call.
+        assert full_decode_calls["n"] == 0
+        assert is_oversize_calls["n"] == 0
+
+    def test_degrade_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        url, _raw = _big_png_data_url()
+        events = [*_preceding_events(), _tool_event_with_image(url)]
+
+        def raise_downsample(*args: Any, **kwargs: Any) -> Any:
+            raise ImageDownsampleError("boom")
+
+        monkeypatch.setattr(context, "_blocking_downsample", raise_downsample)
+
+        msgs1 = build_messages(events, system_prompt=None).messages
+        tool_msg1 = msgs1[2]
+        assert tool_msg1["content"][1] == {
+            "type": "text",
+            "text": "[image omitted: too large to display inline]",
+        }
+
+        cache_key = _clamp_cache_key(url.partition(",")[2])
+        assert cache_key in _CLAMP_CACHE
+
+        # Second build: cached DEGRADE, no re-attempt at downsample.
+        calls = {"n": 0}
+
+        def raise_again(*args: Any, **kwargs: Any) -> Any:
+            calls["n"] += 1
+            raise ImageDownsampleError("boom")
+
+        monkeypatch.setattr(context, "_blocking_downsample", raise_again)
+        msgs2 = build_messages(events, system_prompt=None).messages
+        assert calls["n"] == 0
+        assert msgs2[2]["content"][1] == {
+            "type": "text",
+            "text": "[image omitted: too large to display inline]",
+        }
+
+    def test_size_gate_short_circuits_byte_oversize_no_decode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A part whose base64 length alone proves byte-oversize skips the
+        redundant Pillow header check (``is_oversize_image``)."""
+        import random
+
+        from aios.harness.vision import INLINE_SIZE_CAP_BYTES
+
+        # A noisy (incompressible) 2000x2000 RGB PNG lands well over the
+        # 3.75 MiB byte cap while still being <=2000px/side — genuine
+        # BYTE-oversize (not dimension-oversize), the case the size-gate
+        # exists for.
+        data = random.Random("byte-oversize-seed").randbytes(2000 * 2000 * 3)
+        img = Image.frombytes("RGB", (2000, 2000), data)
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        raw = buf.getvalue()
+        assert len(raw) > INLINE_SIZE_CAP_BYTES
+        b64 = base64.b64encode(raw).decode("ascii")
+        url = f"data:image/png;base64,{b64}"
+        events = [*_preceding_events(), _tool_event_with_image(url)]
+
+        is_oversize_calls = {"n": 0}
+        orig_is_oversize = image_resize.is_oversize_image
+
+        def counting_is_oversize(*args: Any, **kwargs: Any) -> bool:
+            is_oversize_calls["n"] += 1
+            return orig_is_oversize(*args, **kwargs)
+
+        monkeypatch.setattr(context, "is_oversize_image", counting_is_oversize)
+        build_messages(events, system_prompt=None)
+        # Byte-oversize proven from length alone — size-gate short-circuits
+        # without calling is_oversize_image at all.
+        assert is_oversize_calls["n"] == 0
+
+
+class TestPersistClampedImageParts:
+    @staticmethod
+    def _fake_pool_and_conn() -> tuple[Any, Any, list[tuple[str, str, dict[str, Any]]]]:
+        updates: list[tuple[str, str, dict[str, Any]]] = []
+
+        class _Conn:
+            pass
+
+        conn = _Conn()
+
+        class _Cm:
+            async def __aenter__(self) -> _Conn:
+                return conn
+
+            async def __aexit__(self, *exc: object) -> None:
+                return None
+
+        class _Pool:
+            def acquire(self) -> _Cm:
+                return _Cm()
+
+        return _Pool(), conn, updates
+
+    @pytest.mark.asyncio
+    async def test_oversize_event_persists_exactly_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        url, _raw = _big_png_data_url()
+        events = [*_preceding_events(), _tool_event_with_image(url)]
+        pool, _conn, _ = self._fake_pool_and_conn()
+
+        update_calls: list[dict[str, Any]] = []
+
+        async def fake_replace(
+            conn_arg: Any, session_id: str, event_id: str, data: Any, *, account_id: str
+        ) -> None:
+            update_calls.append({"event_id": event_id, "data": data, "account_id": account_id})
+
+        monkeypatch.setattr(
+            "aios.db.queries.replace_event_data", AsyncMock(side_effect=fake_replace)
+        )
+
+        await persist_clamped_image_parts(
+            pool, events, session_id="sess_01TEST", account_id="acct_1"
+        )
+        assert len(update_calls) == 1
+        stored_part = update_calls[0]["data"]["content"][1]
+        rendered = build_messages(events, system_prompt=None).messages[2]["content"][1]
+        assert stored_part == rendered
+
+        # In-memory event updated so THIS step renders persisted bytes.
+        assert events[2].data["content"][1] == stored_part
+
+        # Next compose: zero UPDATE, zero downsample (already fits).
+        update_calls.clear()
+        downsample_calls = {"n": 0}
+        orig = image_resize._blocking_downsample
+
+        def counting(*args: Any, **kwargs: Any) -> Any:
+            downsample_calls["n"] += 1
+            return orig(*args, **kwargs)
+
+        monkeypatch.setattr("aios.harness.context_persist._blocking_downsample", counting)
+        await persist_clamped_image_parts(
+            pool, events, session_id="sess_01TEST", account_id="acct_1"
+        )
+        assert len(update_calls) == 0
+        assert downsample_calls["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_undownsampleable_never_persisted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        url, _raw = _big_png_data_url()
+        events = [*_preceding_events(), _tool_event_with_image(url)]
+        pool, _conn, _ = self._fake_pool_and_conn()
+
+        def raise_downsample(*args: Any, **kwargs: Any) -> Any:
+            raise ImageDownsampleError("boom")
+
+        monkeypatch.setattr("aios.harness.context_persist._blocking_downsample", raise_downsample)
+        update_mock = AsyncMock()
+        monkeypatch.setattr("aios.db.queries.replace_event_data", update_mock)
+
+        await persist_clamped_image_parts(
+            pool, events, session_id="sess_01TEST", account_id="acct_1"
+        )
+        update_mock.assert_not_called()
+        # Original bytes untouched in memory.
+        assert events[2].data["content"][1]["image_url"]["url"] == url
+
+    @pytest.mark.asyncio
+    async def test_persist_image_rewrites_false_skips_persist_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``compose_step_context``'s ``persist_image_rewrites`` gate lives
+        at the call site (not inside ``persist_clamped_image_parts``
+        itself): when ``False``, the composer must not call this function
+        at all. Pinned via the composer's own wiring."""
+        from aios.harness.step_context import compose_step_context
+
+        persist_spy = AsyncMock()
+        monkeypatch.setattr("aios.harness.step_context.persist_clamped_image_parts", persist_spy)
+
+        from aios.models.agents import AgentBinding, StepSurface
+
+        agent = StepSurface(
+            model="model/vision",
+            system="sys",
+            tools=[],
+            skills=[],
+            mcp_servers=[],
+            http_servers=[],
+            litellm_extra={},
+            window_min=1,
+            window_max=10,
+            preempt_policy="wait",
+            binding=AgentBinding(agent_id="agt_1", version=1),
+        )
+
+        class _Prelude:
+            system_prompt = "sys"
+            tools: ClassVar[list[Any]] = []
+            skill_versions: ClassVar[list[Any]] = []
+            obligations: ClassVar[list[Any]] = []
+
+        class _Session:
+            id = "sess_gate"
+            focal_channel = None
+
+        pool = MagicMock()
+
+        monkeypatch.setattr(
+            "aios.services.sessions.load_session_workspace_path",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(
+            "aios.services.accounts.resolve_effective_timezone",
+            AsyncMock(return_value="UTC"),
+        )
+
+        await compose_step_context(
+            pool=pool,
+            session=_Session(),  # type: ignore[arg-type]
+            account_id="acct_1",
+            agent=agent,
+            channels=[],
+            prelude=_Prelude(),  # type: ignore[arg-type]
+            events=[],
+            persist_image_rewrites=False,
+        )
+        persist_spy.assert_not_called()
+
+        await compose_step_context(
+            pool=pool,
+            session=_Session(),  # type: ignore[arg-type]
+            account_id="acct_1",
+            agent=agent,
+            channels=[],
+            prelude=_Prelude(),  # type: ignore[arg-type]
+            events=[],
+            persist_image_rewrites=True,
+        )
+        persist_spy.assert_called_once()
+
+
+class TestBuildMessagesOffloadedFromLoop:
+    @pytest.mark.asyncio
+    async def test_build_messages_runs_in_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``compose_step_context`` runs ``build_messages`` via
+        ``asyncio.to_thread`` — assert the sync function executes on a
+        different thread than the event loop's."""
+        import threading
+
+        from aios.harness.step_context import compose_step_context
+
+        loop_thread_id = threading.get_ident()
+        seen_thread_id: dict[str, int] = {}
+
+        orig_build_messages = context.build_messages
+
+        def spy_build_messages(*args: Any, **kwargs: Any) -> Any:
+            seen_thread_id["id"] = threading.get_ident()
+            return orig_build_messages(*args, **kwargs)
+
+        monkeypatch.setattr("aios.harness.step_context.build_messages", spy_build_messages)
+
+        from aios.models.agents import AgentBinding, StepSurface
+
+        agent = StepSurface(
+            model="model/vision",
+            system="sys",
+            tools=[],
+            skills=[],
+            mcp_servers=[],
+            http_servers=[],
+            litellm_extra={},
+            window_min=1,
+            window_max=10,
+            preempt_policy="wait",
+            binding=AgentBinding(agent_id="agt_1", version=1),
+        )
+
+        class _Prelude:
+            system_prompt = "sys"
+            tools: ClassVar[list[Any]] = []
+            skill_versions: ClassVar[list[Any]] = []
+            obligations: ClassVar[list[Any]] = []
+
+        class _Session:
+            id = "sess_thread"
+            focal_channel = None
+
+        pool = MagicMock()
+
+        async def fake_load_workspace(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        async def fake_tz(*args: Any, **kwargs: Any) -> str:
+            return "UTC"
+
+        monkeypatch.setattr(
+            "aios.services.sessions.load_session_workspace_path",
+            AsyncMock(side_effect=fake_load_workspace),
+        )
+        monkeypatch.setattr(
+            "aios.services.accounts.resolve_effective_timezone",
+            AsyncMock(side_effect=fake_tz),
+        )
+
+        await compose_step_context(
+            pool=pool,
+            session=_Session(),  # type: ignore[arg-type]
+            account_id="acct_1",
+            agent=agent,
+            channels=[],
+            prelude=_Prelude(),  # type: ignore[arg-type]
+            events=[],
+            persist_image_rewrites=False,
+        )
+        assert seen_thread_id["id"] != loop_thread_id


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1745.