### PR TITLE
fix(front): /health route (FRONT-reported 404)

### DIFF
--- a/infra/agents/ceo-front.json
+++ b/infra/agents/ceo-front.json
@@ -255,7 +255,7 @@
           "description": "read"
         },
         {
-          "path_pattern": "/v1/health",
+          "path_pattern": "/health",
           "methods": [
             "GET"
           ],


### PR DESCRIPTION
FRONT's Increment-2 arm-test found /v1/health 404s — health is unversioned (/health = 200). One route path fix. 🤖 Generated with [Claude Code](https://claude.com/claude-code)