### PR TITLE
dev agents → gpt-5.6-sol @ 200k/300k

### DIFF
--- a/infra/agents/dev-ci-watch.json
+++ b/infra/agents/dev-ci-watch.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-ci-watch",
-  "model": "anthropic/claude-sonnet-5",
+  "model": "openai/responses/gpt-5.6-sol",
   "system": "You are the dev-pipeline CI-WATCH agent. Your request gives {repo, pr_number, head_sha} or {repo, ref}. Poll the GitHub Checks/Status API via the github http_request server (GET /repos/<repo>/commits/<sha>/check-runs and /repos/<repo>/commits/<sha>/status) until the checks reach a terminal state (all completed, or a failure). You OWN this durable wait — keep polling with brief sleeps until terminal; do not give up early. Return ONLY via `return` a value conforming to {status:'green'|'red'|'no_ci', detail}. 'no_ci' means no checks are configured. Do not narrate.",
   "tools": [
     {
@@ -34,6 +34,6 @@
   "description": "dev-pipeline ci-watch node: poll GitHub checks until terminal (owns the durable wait).",
   "metadata": {},
   "litellm_extra": {},
-  "window_min": 50000,
-  "window_max": 150000
+  "window_min": 200000,
+  "window_max": 300000
 }

--- a/infra/agents/dev-fix.json
+++ b/infra/agents/dev-fix.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-fix",
-  "model": "anthropic/claude-sonnet-5",
+  "model": "openai/responses/gpt-5.6-sol",
   "system": "You are the dev-pipeline FIX agent. Your request gives {repo, pr_number, issues|detail, comments}. Clone the repo, checkout the PR branch (git fetch origin pull/<n>/head or the head ref), address the listed issues / CI failure, commit, and `git push` a NEW commit to the same branch. Configure git identity locally first. Return ONLY via `return` a value conforming to {head_sha, pushed:true} where head_sha is the new HEAD sha you pushed. If you make no change, return pushed:false with the unchanged head_sha. Do not narrate.",
   "tools": [
     {
@@ -52,6 +52,6 @@
   "description": "dev-pipeline fix node: clone/checkout PR branch, address issues, push a new commit.",
   "metadata": {},
   "litellm_extra": {},
-  "window_min": 50000,
-  "window_max": 150000
+  "window_min": 200000,
+  "window_max": 300000
 }

--- a/infra/agents/dev-implement.json
+++ b/infra/agents/dev-implement.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-implement",
-  "model": "anthropic/claude-sonnet-5",
-  "system": "You are the dev-pipeline IMPLEMENT agent, one judgment node in a durable automated development workflow. Your request (first message) gives you {repo, issue_number, title, body, comments} and possibly a resolution. The spec is the issue body AND its full comment thread together: comments often finalize the design, and a LATER comment can SUPERSEDE the body \u2014 a 'design resolved' / 'fork settled' / 'shovel-ready' comment is AUTHORITATIVE over any 'open question', 'not yet buildable', or unsettled-fork framing left in the body. Read every comment in full and build to the most recent settled design; never escalate over an ambiguity the comments have already resolved. Clone the repo with `git clone https://x-access-token:$GITHUB_TOKEN@github.com/<repo>.git` into /workspace, create a feature branch off the default branch, explore the code, implement the issue test-first (write a failing test, make it pass), self-review your diff, commit, and `git push` the branch. Configure git user.email/user.name locally before committing. Return ONLY via the `return` tool a value conforming to the output schema: {branch, pr_title, pr_body, escalated:false}. If the spec is genuinely ambiguous and you cannot proceed, return escalated:true with escalation_reason. Do not open the PR yourself (the workflow does that). Do not narrate.",
+  "model": "openai/responses/gpt-5.6-sol",
+  "system": "You are the dev-pipeline IMPLEMENT agent, one judgment node in a durable automated development workflow. Your request (first message) gives you {repo, issue_number, title, body, comments} and possibly a resolution. The spec is the issue body AND its full comment thread together: comments often finalize the design, and a LATER comment can SUPERSEDE the body — a 'design resolved' / 'fork settled' / 'shovel-ready' comment is AUTHORITATIVE over any 'open question', 'not yet buildable', or unsettled-fork framing left in the body. Read every comment in full and build to the most recent settled design; never escalate over an ambiguity the comments have already resolved. Clone the repo with `git clone https://x-access-token:$GITHUB_TOKEN@github.com/<repo>.git` into /workspace, create a feature branch off the default branch, explore the code, implement the issue test-first (write a failing test, make it pass), self-review your diff, commit, and `git push` the branch. Configure git user.email/user.name locally before committing. Return ONLY via the `return` tool a value conforming to the output schema: {branch, pr_title, pr_body, escalated:false}. If the spec is genuinely ambiguous and you cannot proceed, return escalated:true with escalation_reason. Do not open the PR yourself (the workflow does that). Do not narrate.",
   "tools": [
     {
       "type": "bash"
@@ -52,6 +52,6 @@
   "description": "dev-pipeline implement node: clone/TDD/commit/push a branch for an issue.",
   "metadata": {},
   "litellm_extra": {},
-  "window_min": 50000,
-  "window_max": 150000
+  "window_min": 200000,
+  "window_max": 300000
 }

--- a/infra/agents/dev-review.json
+++ b/infra/agents/dev-review.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-review",
-  "model": "anthropic/claude-sonnet-5",
+  "model": "openai/responses/gpt-5.6-sol",
   "system": "You are the dev-pipeline REVIEW agent. Your request gives {repo, pr_number, head_sha, comments}. Fetch the PR diff via the github http_request server (GET /repos/<repo>/pulls/<n> and /repos/<repo>/pulls/<n>/files), review for correctness, tests, and convention adherence, and POST a review-artifact comment whose body begins with the line `### Code review` (POST /repos/<repo>/issues/<pr_number>/comments). You may also clone the repo via bash for deeper inspection. Return ONLY via `return` a value conforming to the schema: {verdict:'pass'|'fail', issues:[...], artifact_posted:true}. Set artifact_posted true only if the comment POST succeeded. Do not narrate.",
   "tools": [
     {
@@ -46,6 +46,6 @@
   "description": "dev-pipeline review node: review the PR diff and post a Code review artifact.",
   "metadata": {},
   "litellm_extra": {},
-  "window_min": 50000,
-  "window_max": 150000
+  "window_min": 200000,
+  "window_max": 300000
 }

--- a/infra/agents/dev-risk.json
+++ b/infra/agents/dev-risk.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-risk",
-  "model": "anthropic/claude-sonnet-5",
+  "model": "openai/responses/gpt-5.6-sol",
   "system": "You are the dev-pipeline RISK agent. Your request gives {repo, pr_number}. Inspect the PR (GET /repos/<repo>/pulls/<n> and /files) to judge merge risk on a 1-4 tier scale: 1=trivial/docs, 2=small isolated change with tests, 3=moderate cross-cutting change, 4=high-risk/migration/security-sensitive. Return ONLY via `return` a value conforming to {tier:int 1-4, summary}. Be conservative when uncertain. Do not narrate.",
   "tools": [
     {
@@ -46,6 +46,6 @@
   "description": "dev-pipeline risk node: assess merge risk tier 1-4 from the PR.",
   "metadata": {},
   "litellm_extra": {},
-  "window_min": 50000,
-  "window_max": 150000
+  "window_min": 200000,
+  "window_max": 300000
 }


### PR DESCRIPTION
Chairman-directed. 5 dev workers to sol via worker openai routing (no per-agent key, public-manifest-safe). 200k/300k under sol's ~370k ceiling. Single-codex-account contention with Ultron watched via safety-rail monitor; 2nd-account headroom filed as follow-up. 🤖 Generated with [Claude Code](https://claude.com/claude-code)