### PR TITLE
[invoke-edge] P1 cancel-cascade: run-terminal revokes children; leaf teardown (revoked⇒forceful/fulfilled⇒graceful); atomic timeout-revocation; 4-clause invariant sweep; archive_session outbound pass

### DIFF
--- a/migrations/versions/0141_edge_owned_lifetime_indexes.py
+++ b/migrations/versions/0141_edge_owned_lifetime_indexes.py
@@ -1,0 +1,26 @@
+"""Reverse indexes for edge-owned lifetime cascade. Revision ID: 0141."""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0141"
+down_revision: str = "0140"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS wf_runs_parent_run_idx ON wf_runs (parent_run_id) WHERE parent_run_id IS NOT NULL"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS sessions_live_parent_run_idx ON sessions (parent_run_id) WHERE archived_at IS NULL AND parent_run_id IS NOT NULL"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS sessions_live_parent_run_idx")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS wf_runs_parent_run_idx")

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -605,6 +605,20 @@ class Settings(BaseSettings):
         "single run's standing agent() fan-out. The re-drive uses the existing "
         "child-completion re-wake — no new machinery.",
     )
+    cancel_cascade_enabled: bool = Field(
+        default=True,
+        description="Kill switch for seeding edge-owned lifetime cancellation carriers.",
+    )
+    api_lease_deadline_seconds: float = Field(
+        default=6 * 60 * 60,
+        gt=0,
+        description="Dry-run API lease abandonment horizon (separate from workflow deadlines).",
+    )
+    lease_ceiling_seconds: float = Field(
+        default=60 * 60,
+        gt=0,
+        description="Maximum zero-lease lifetime for ephemeral sessions.",
+    )
     workflow_agent_deadline_seconds: float = Field(
         default=60 * 60,  # 1 hour
         gt=0,

--- a/src/aios/db/queries/clone_policy.py
+++ b/src/aios/db/queries/clone_policy.py
@@ -240,7 +240,8 @@ SESSIONS_POLICY: dict[str, Arm] = {
     "last_error_seq": Arm.COPY,
     "last_user_seq": Arm.COPY,
     "last_stimulus_seq": Arm.COPY,
-    "archive_when_idle": Arm.COPY,
+    # A clone is an operator/forensic artifact, not the ephemeral servicer it copies.
+    "archive_when_idle": Arm.RESET_DEFAULT,
     "spec_version": Arm.RESET_DEFAULT,
     "tools": Arm.COPY,
     "mcp_servers": Arm.COPY,

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1534,6 +1534,43 @@ async def _open_awaited_children(
     return result
 
 
+async def _session_owned(
+    conn: asyncpg.Connection[Any], session_id: str, *, account_id: str
+) -> bool:
+    """Is this session **lease-bound (owned)** — legitimately reachable by teardown?
+
+    owned ⟺ the CREATION edge is awaited, or the session is flag-declared ephemeral
+    (``archive_when_idle=TRUE``, the API/``call_agent`` servicer class). The creation
+    edge is the ``request_opened`` row written by the caller that created this session
+    — for a workflow child that is ``caller.kind='run' AND caller.id=parent_run_id``
+    (oldest such edge; a later re-invoke never re-classifies). An edgeless legacy FK
+    child (``parent_run_id`` set, no creation edge — pre-#1123) counts owned, the
+    conservative cut matching ``trace.py``'s documented default.
+
+    NEVER a bare any-inbound-edge EXISTS: a self-owned root (lieutenant, operator
+    session) that once received an awaited Ask must not classify as owned — that
+    any-edge join is the wrong-kill class (spec §1 FATAL-1 / §2.3 FATAL-2).
+    """
+    return bool(
+        await conn.fetchval(
+            "SELECT s.archive_when_idle OR ("
+            "  s.parent_run_id IS NOT NULL"
+            "  AND COALESCE("
+            "    (SELECT COALESCE((e.data->>'awaited')::bool, TRUE)"
+            "     FROM events e"
+            "     WHERE e.session_id = s.id AND e.account_id = $2"
+            "       AND e.kind = 'lifecycle' AND e.data->>'event' = 'request_opened'"
+            "       AND e.data->'caller'->>'kind' = 'run'"
+            "       AND e.data->'caller'->>'id' = s.parent_run_id"
+            "     ORDER BY e.seq ASC LIMIT 1),"
+            "    TRUE))"  # no creation edge found → edgeless legacy → owned
+            " FROM sessions s WHERE s.id = $1 AND s.account_id = $2",
+            session_id,
+            account_id,
+        )
+    )
+
+
 async def seed_outbound_cancel_conn(
     conn: asyncpg.Connection[Any], *, caller_kind: str, caller_id: str, account_id: str
 ) -> list[queries.ChildNode]:
@@ -1570,20 +1607,23 @@ async def harvest_session_cancel_markers(
     the open set AND latches first-writer-wins, so a late ``return(R)`` no-ops; the caller is
     woken (run / session) so it re-resolves ``cancelled`` promptly.
 
-    **Recursive propagation (§2.3):** once the session owes NO remaining open inbound awaited
-    request — the dominant owned/fresh-node case (a ``call_agent`` spawn serving only the
-    cancelled request) — its outbound awaited children are orphaned, so the leaf seeds a
-    cancel-marker on each (a run via the ``wf_run_signals`` cancel, a session via a
-    ``session_cancel_markers`` row) in the SAME transaction, and each child's own step repeats.
-    A still-multiply-inbound **shared** session does NOT propagate (it still owes a surviving
-    request — over-cancelling its work would be unsound).
+    **Recursive propagation (§2.3), ownership- and revocation-gated:** the leaf seeds a
+    cancel-marker on each outbound awaited *open-edge* child (a run via the ``wf_run_signals``
+    cancel, a session via a ``session_cancel_markers`` row) in the SAME transaction — but ONLY
+    when this node is itself tearing down: **zero surviving open inbound awaited requests ∧
+    owned (**:func:`_session_owned` — the creation edge or the ephemeral flag, never a bare
+    any-inbound-edge EXISTS**) ∧ revocation-context (at least one marked edge was REVOKED —
+    closed by this leaf's ``cancelled`` write or by an already-written outcome whose
+    ``error.kind ∈ REVOCATION_KINDS``)**. A purely-fulfilled marker set never propagates (the
+    busy servicer that honored its ask keeps its Tell-work); a still-multiply-inbound shared
+    session does NOT propagate (it still owes a surviving request); a self-owned session
+    (lieutenant) NEVER auto-propagates on obligation withdrawal — mandatory down ownership
+    lines, advisory across message lines.
 
-    The "no open inbound ⇒ orphaned" heuristic is **slightly over-broad until §7**: the
-    ``call_session(existing)`` path lets a session close its sole inbound (an early ``return``)
-    while an outbound child stays legitimately live, and that child is cancelled here. The
-    over-cancel is **bounded — intent only, never state**: an already-answered child is a
-    first-writer-wins no-op (no outcome corruption); only a genuinely-live child is reclaimed
-    early. The precise per-edge ``attributed_to`` reclaim (§7) is a later slice.
+    The over-cancel of a legitimately-live outbound child (the ``call_session(existing)``
+    early-``return`` shape) stays **bounded — intent only, never state**: an already-answered
+    child is a first-writer-wins no-op (no outcome corruption). The precise per-edge
+    ``attributed_to`` reclaim (§7) is a later slice.
 
     Minimal cut: the owned-session teardown (request-scoped interrupt + drain + archive +
     sandbox release, §4/C1) and the §9 quiescence counter are deferred residuals — the cancelled
@@ -1597,6 +1637,7 @@ async def harvest_session_cancel_markers(
         markers = await queries.list_unharvested_session_cancel_markers(conn, session_id)
         if not markers:
             return False
+        revocation_context = False
         for marker in markers:
             write = await respond_to_request_conn(
                 conn,
@@ -1605,27 +1646,35 @@ async def harvest_session_cancel_markers(
                 outcome=Err(error={"kind": "cancelled"}),
             )
             wakes.append(write)
+            # Revoked/fulfilled asymmetry (§1): this edge counts as REVOKED iff this
+            # leaf wrote the ``cancelled`` answer itself, or the already-written closing
+            # outcome carries a revocation kind. ``respond_to_request_conn``'s return
+            # value carries no kind, so an already-closed request's outcome is read
+            # explicitly via ``read_request_response``. Unknown/absent kinds classify
+            # FULFILLED — under-cancel is strictly safer, the lease ceiling backstops.
+            if write.outcome == "responded":
+                revocation_context = True
+            else:
+                closed = await queries.read_request_response(
+                    conn, session_id, account_id=account_id, request_id=marker.request_id
+                )
+                if isinstance(closed, Err) and closed.error.get("kind") in REVOCATION_KINDS:
+                    revocation_context = True
             await queries.mark_session_cancel_marker_harvested(
                 conn, session_id=session_id, request_id=marker.request_id
             )
-        # Propagation is ownership-gated: only edge-created or explicitly ephemeral
-        # sessions may tear down a subtree. Bare parent_run_id is not ownership.
-        if not await queries.get_open_request_ids(conn, session_id, account_id=account_id):
-            owned = bool(
-                await conn.fetchval(
-                    "SELECT archive_when_idle OR EXISTS ("
-                    "SELECT 1 FROM events e WHERE e.session_id=sessions.id "
-                    "AND e.kind='lifecycle' AND e.data->>'event'='request_opened' "
-                    "AND COALESCE((e.data->>'awaited')::bool, true)) "
-                    "FROM sessions WHERE id=$1 AND account_id=$2",
-                    session_id,
-                    account_id,
-                )
+        # §2.3 propagation gate: fires only when this node is itself tearing down —
+        # revocation-context ∧ zero surviving open inbound ∧ owned. A purely-fulfilled
+        # marker set never propagates; ownership is the creation edge or the ephemeral
+        # flag (never bare parent_run_id, never any-inbound-edge EXISTS).
+        if (
+            revocation_context
+            and not await queries.get_open_request_ids(conn, session_id, account_id=account_id)
+            and await _session_owned(conn, session_id, account_id=account_id)
+        ):
+            propagated = await seed_outbound_cancel_conn(
+                conn, caller_kind="session", caller_id=session_id, account_id=account_id
             )
-            if owned:
-                propagated = await seed_outbound_cancel_conn(
-                    conn, caller_kind="session", caller_id=session_id, account_id=account_id
-                )
     # AFTER commit: re-resolve each cancelled caller, and prompt each marked child to run its
     # own leaf (the C2 sweep / the run cancel-signal clause is the durable backstop).
     for write in wakes:

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1492,6 +1492,71 @@ async def respond_to_request_conn(
     )
 
 
+# Outcomes written by a party withdrawing an edge rather than by its servicer.
+# Unknown future error kinds intentionally classify as fulfilled/graceful.
+REVOCATION_KINDS: frozenset[str] = frozenset(
+    {"cancelled", "timeout", "child_gone", "engine_semantics_changed", "nondeterministic_replay"}
+)
+
+
+async def _open_awaited_children(
+    conn: asyncpg.Connection[Any], *, caller_kind: str, caller_id: str, account_id: str
+) -> list[queries.ChildNode]:
+    """Return live children backed by a still-open awaited edge (never FK-only rows)."""
+    result: list[queries.ChildNode] = []
+    for child in await queries.children_of(
+        conn, caller_kind=caller_kind, caller_id=caller_id, account_id=account_id
+    ):
+        if not child.awaited or child.request_id is None:
+            continue
+        if child.kind == "session":
+            row = await conn.fetchrow(
+                "SELECT archived_at FROM sessions WHERE id=$1 AND account_id=$2",
+                child.id,
+                account_id,
+            )
+            if row is None or row["archived_at"] is not None:
+                continue
+            if (
+                await queries.read_request_response(
+                    conn, child.id, account_id=account_id, request_id=child.request_id
+                )
+                is not None
+            ):
+                continue
+        else:
+            status = await conn.fetchval(
+                "SELECT status FROM wf_runs WHERE id=$1 AND account_id=$2", child.id, account_id
+            )
+            if status is None or status in {"completed", "errored", "cancelled"}:
+                continue
+        result.append(child)
+    return result
+
+
+async def seed_outbound_cancel_conn(
+    conn: asyncpg.Connection[Any], *, caller_kind: str, caller_id: str, account_id: str
+) -> list[queries.ChildNode]:
+    """Seed cancellation carriers for the caller's open owned edges."""
+    if not get_settings().cancel_cascade_enabled:
+        return []
+    seeded: list[queries.ChildNode] = []
+    for child in await _open_awaited_children(
+        conn, caller_kind=caller_kind, caller_id=caller_id, account_id=account_id
+    ):
+        if child.kind == "run":
+            await wf_queries.insert_run_signal(
+                conn, run_id=child.id, call_key=wf_queries.CANCEL_SIGNAL_CALL_KEY, kind="cancel"
+            )
+        else:
+            assert child.request_id is not None
+            await queries.insert_session_cancel_marker(
+                conn, session_id=child.id, request_id=child.request_id, account_id=account_id
+            )
+        seeded.append(child)
+    return seeded
+
+
 async def harvest_session_cancel_markers(
     pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
 ) -> bool:
@@ -1543,30 +1608,24 @@ async def harvest_session_cancel_markers(
             await queries.mark_session_cancel_marker_harvested(
                 conn, session_id=session_id, request_id=marker.request_id
             )
-        # §2.3: propagate ONLY when no awaited inbound survives (over-cancel-safe). A child
-        # marker is a side-table write keyed by the CHILD id — never its log — so the child
-        # harvests its own exit under its own lock (the single-writer invariant).
+        # Propagation is ownership-gated: only edge-created or explicitly ephemeral
+        # sessions may tear down a subtree. Bare parent_run_id is not ownership.
         if not await queries.get_open_request_ids(conn, session_id, account_id=account_id):
-            for child in await queries.children_of(
-                conn, caller_kind="session", caller_id=session_id, account_id=account_id
-            ):
-                if not child.awaited:
-                    continue  # a Tell child is detached — an exit never crosses
-                if child.kind == "run":
-                    await wf_queries.insert_run_signal(
-                        conn,
-                        run_id=child.id,
-                        call_key=wf_queries.CANCEL_SIGNAL_CALL_KEY,
-                        kind="cancel",
-                    )
-                elif child.request_id is not None:
-                    await queries.insert_session_cancel_marker(
-                        conn,
-                        session_id=child.id,
-                        request_id=child.request_id,
-                        account_id=account_id,
-                    )
-                propagated.append(child)
+            owned = bool(
+                await conn.fetchval(
+                    "SELECT archive_when_idle OR EXISTS ("
+                    "SELECT 1 FROM events e WHERE e.session_id=sessions.id "
+                    "AND e.kind='lifecycle' AND e.data->>'event'='request_opened' "
+                    "AND COALESCE((e.data->>'awaited')::bool, true)) "
+                    "FROM sessions WHERE id=$1 AND account_id=$2",
+                    session_id,
+                    account_id,
+                )
+            )
+            if owned:
+                propagated = await seed_outbound_cancel_conn(
+                    conn, caller_kind="session", caller_id=session_id, account_id=account_id
+                )
     # AFTER commit: re-resolve each cancelled caller, and prompt each marked child to run its
     # own leaf (the C2 sweep / the run cancel-signal clause is the durable backstop).
     for write in wakes:
@@ -2072,7 +2131,11 @@ async def archive_session(
     # of waiting out the 1h agent deadline. Enrich vault_ids / resources / triggers
     # so the API response shape matches GET /sessions/{id}; the lists are read
     # post-update to surface any concurrent mutation that committed before archive.
+    propagated: list[queries.ChildNode] = []
     async with pool.acquire() as conn, conn.transaction():
+        propagated = await seed_outbound_cancel_conn(
+            conn, caller_kind="session", caller_id=session_id, account_id=account_id
+        )
         parent_run_id = await fail_open_child_requests_conn(
             conn, session_id, account_id=account_id, error={"kind": "child_gone"}
         )
@@ -2092,6 +2155,11 @@ async def archive_session(
     await pool.execute("SELECT pg_notify($1, $2)", f"events_{session_id}", EVENTS_ARCHIVED_NOTIFY)
     if parent_run_id is not None:
         await defer_run_wake(parent_run_id, batch=True)
+    for child in propagated:
+        if child.kind == "run":
+            await defer_run_wake(child.id, batch=True)
+        else:
+            await defer_wake(pool, child.id, cause="cancel", account_id=account_id)
     return session
 
 

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -1448,20 +1448,45 @@ async def _cancel_run(conn: asyncpg.Connection[Any], run: WfRun, *, reason: Any 
 
 async def _fail_child_requests_for_terminal_error(
     conn: asyncpg.Connection[Any], run: WfRun, *, error_kind: str
-) -> None:
+) -> list[str]:
+    """Close each live child's open requests with ``error_kind`` AND seed the cancel
+    marker those closures would otherwise orphan (event-path parity, spec §5).
+
+    This runs BEFORE ``seed_outbound_cancel_conn``'s open-edge enumeration in the same
+    terminal transaction, so the edges it closes are invisible to the C1 seeder — each
+    child must get its cancel-marker HERE, in the SAME transaction, or the
+    ``engine_semantics_changed`` / ``nondeterministic_replay`` cohort never runs its
+    lifecycle leaf until the durable sweep (the backstop silently becoming the primary
+    path). The marker is the wake carrier only; the child's own leaf classifies the
+    already-written ``error_kind`` (∈ ``REVOCATION_KINDS``) under its own lock. Returns
+    the marked session ids so the post-commit loop can prompt each child's leaf.
+    """
+    marked: list[str] = []
     rows = await conn.fetch(
         "SELECT id FROM sessions "
         "WHERE parent_run_id = $1 AND account_id = $2 AND archived_at IS NULL",
         run.id,
         run.account_id,
     )
+    cascade_enabled = get_settings().cancel_cascade_enabled
     for row in rows:
+        # Snapshot the open set BEFORE the closures — these are exactly the requests
+        # ``fail_open_child_requests_conn`` answers (same conn, same transaction).
+        open_ids = await db_queries.get_open_request_ids(conn, row["id"], account_id=run.account_id)
         await fail_open_child_requests_conn(
             conn,
             row["id"],
             account_id=run.account_id,
             error={"kind": error_kind},
         )
+        if not cascade_enabled or not open_ids:
+            continue
+        for request_id in open_ids:
+            await db_queries.insert_session_cancel_marker(
+                conn, session_id=row["id"], request_id=request_id, account_id=run.account_id
+            )
+        marked.append(row["id"])
+    return marked
 
 
 async def _commit_terminal_and_dispatch(
@@ -1487,6 +1512,7 @@ async def _commit_terminal_and_dispatch(
     """
     fires: list[db_queries.TriggerFireRef] = []
     cascade_children: list[db_queries.ChildNode] = []
+    terminal_marked: list[str] = []
     # The CALLER run to answer, or None — a run servicing a RUN caller (single-sourced so
     # the durable signal-write and the prompt wake below can never desync on the gate).
     run_caller_id = (
@@ -1506,7 +1532,9 @@ async def _commit_terminal_and_dispatch(
         if status == "errored" and (error := payload.get("error")) is not None:
             kind = error.get("kind")
             if kind in {"engine_semantics_changed", "nondeterministic_replay"}:
-                await _fail_child_requests_for_terminal_error(conn, run, error_kind=kind)
+                terminal_marked = await _fail_child_requests_for_terminal_error(
+                    conn, run, error_kind=kind
+                )
         # A run in service of a request answers via its terminal record itself (#1126):
         # the ``run_completed`` bookend (above) + the ``status`` flip (below) ARE the
         # answer, read back by ``derive_run_response``. No separate ``request_response``
@@ -1559,12 +1587,22 @@ async def _commit_terminal_and_dispatch(
     if inserted is not None and run_caller_id is not None:
         with contextlib.suppress(Exception):
             await defer_run_wake(run_caller_id, batch=True)
+    # Prompt each seeded child to run its cancel leaf now instead of waiting out the
+    # durable backstops (the C2 marker sweep / the run cancel-signal sweep clause).
+    # Session children use the same pool/deferred-wake plumbing ``archive_session``
+    # rides after its own outbound pass; the worker's runtime pool is always set here
+    # (``run_workflow_step`` required it at step entry).
     for child in cascade_children:
         if child.kind == "run":
             await defer_run_wake(child.id, batch=True)
         else:
-            # Durable marker sweep is the backstop; session prompt wake needs a pool.
-            pass
+            await defer_wake(
+                runtime.require_pool(), child.id, cause="cancel", account_id=run.account_id
+            )
+    for marked_session_id in terminal_marked:
+        await defer_wake(
+            runtime.require_pool(), marked_session_id, cause="cancel", account_id=run.account_id
+        )
     for fire in fires:
         try:
             await defer_trigger_fire(fire.trigger_id, fire.trigger_run_id)

--- a/src/aios/workflows/step.py
+++ b/src/aios/workflows/step.py
@@ -56,6 +56,7 @@ from aios.services.sessions import (
     AskNewSession,
     create_child_session,
     fail_open_child_requests_conn,
+    seed_outbound_cancel_conn,
     write_gate_opened,
 )
 from aios.tools.registry import tool_executes_class
@@ -237,13 +238,18 @@ async def _resolve_agent_call(
     if now - started_at < deadline:
         return None  # pending, within deadline
     with contextlib.suppress(NotFoundError):
-        await db_queries.write_response_if_absent(
-            conn,
-            child_id,
-            account_id=account_id,
-            request_id=request_id,
-            outcome=Err(error={"kind": "timeout"}),
-        )
+        async with conn.transaction():
+            wrote = await db_queries.write_response_if_absent(
+                conn,
+                child_id,
+                account_id=account_id,
+                request_id=request_id,
+                outcome=Err(error={"kind": "timeout"}),
+            )
+            if wrote and get_settings().cancel_cascade_enabled:
+                await db_queries.insert_session_cancel_marker(
+                    conn, session_id=child_id, request_id=request_id, account_id=account_id
+                )
     resolved = await db_queries.derive_response(
         conn, child_id, account_id=account_id, request_id=request_id
     )
@@ -1480,6 +1486,7 @@ async def _commit_terminal_and_dispatch(
     rows the periodic sweep re-defers; never a silently dropped event fire.
     """
     fires: list[db_queries.TriggerFireRef] = []
+    cascade_children: list[db_queries.ChildNode] = []
     # The CALLER run to answer, or None — a run servicing a RUN caller (single-sourced so
     # the durable signal-write and the prompt wake below can never desync on the gate).
     run_caller_id = (
@@ -1508,6 +1515,13 @@ async def _commit_terminal_and_dispatch(
         # ``cancelled`` rather than the ``child_gone`` a gated-off response implied.
         await wf_queries.set_run_terminal(
             conn, run.id, status=status, output=output, account_id=run.account_id
+        )
+        cascade_children = (
+            await seed_outbound_cancel_conn(
+                conn, caller_kind="run", caller_id=run.id, account_id=run.account_id
+            )
+            if inserted is not None
+            else []
         )
         # Durable run-caller wake (C4/C5): a run answering a RUN caller writes a
         # ``child_done`` signal into the CALLER's signal side-table (never its journal —
@@ -1545,6 +1559,12 @@ async def _commit_terminal_and_dispatch(
     if inserted is not None and run_caller_id is not None:
         with contextlib.suppress(Exception):
             await defer_run_wake(run_caller_id, batch=True)
+    for child in cascade_children:
+        if child.kind == "run":
+            await defer_run_wake(child.id, batch=True)
+        else:
+            # Durable marker sweep is the backstop; session prompt wake needs a pool.
+            pass
     for fire in fires:
         try:
             await defer_trigger_fire(fire.trigger_id, fire.trigger_run_id)

--- a/tests/integration/test_cancel_cascade_seeding.py
+++ b/tests/integration/test_cancel_cascade_seeding.py
@@ -1,0 +1,311 @@
+"""#1152 stage 1 — C1 caller-terminal cancel-cascade seeding, end to end on Postgres.
+
+Drives REAL run terminals through ``run_workflow_step`` and asserts the durable DB
+state the seeding path leaves behind (the markers/signals ARE the surface under
+test — no mocks of the queries):
+
+* §6(g) — a Tell (unawaited-edge) child of a terminal run is NEVER seeded a cancel
+  marker nor archived by the seeding path: the ``awaited`` bit IS the ownership bit;
+* §6(i) — FK-only children (``parent_run_id``/launcher FK, no request edge — the
+  trigger-fired / ``create_run`` / WaM model-dispatch shapes) get NO cancel
+  signal/marker: the trace-display ``awaited=True`` default is never load-bearing
+  for a kill;
+* the positive control — an open awaited Ask child IS seeded in the terminal's own
+  transaction and promptly woken (``defer_wake(cause="cancel")``, the restored
+  session-child prompt wake);
+* §6(x) event-path parity — an ``engine_semantics_changed`` terminal closes the
+  children's edges BEFORE the open-edge seeder runs, so
+  ``_fail_child_requests_for_terminal_error`` must seed the markers itself; the
+  child's own leaf then classifies the closed edge as REVOKED (kind ∈
+  ``REVOCATION_KINDS``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+
+from aios.db import queries as db_queries
+from aios.db.pool import create_pool
+from aios.db.queries import workflows as wf_queries
+from aios.harness import runtime
+from aios.models.attenuation import Surface
+from aios.models.sessions import Err
+from aios.services import agents as agents_service
+from aios.services import sessions as sessions_service
+from aios.services.sessions import AskNewSession, TellNewSession
+from aios.workflows import run_tools, service
+from aios.workflows.child_id import child_session_id
+from aios.workflows.step import run_workflow_step
+
+pytestmark = pytest.mark.integration
+
+_ACCOUNT = "acc_cascade_seed"
+_ENV = "env_cascade_seed"
+
+
+@pytest.fixture
+async def cascade_runtime(
+    migrated_db_url: str, _reset_db_state: None
+) -> AsyncIterator[tuple[asyncpg.Pool[Any], AsyncMock]]:
+    """A pool installed on ``runtime.pool`` + a seeded tenant; every procrastinate
+    deferral patched out. Yields the pool and the STEP module's ``defer_wake`` mock
+    so tests can assert the post-commit session-child prompt wake."""
+    pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
+    prev = runtime.pool
+    runtime.pool = pool
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
+                "VALUES ($1, NULL, TRUE, 'cascade-seed')",
+                _ACCOUNT,
+            )
+            await conn.execute(
+                "INSERT INTO environments (id, name, config, account_id) "
+                "VALUES ($1, 'cascade-env', '{}'::jsonb, $2)",
+                _ENV,
+                _ACCOUNT,
+            )
+        run_tools._INFLIGHT.clear()
+        step_wake = AsyncMock()
+        with (
+            mock.patch("aios.workflows.service.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.workflows.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.workflows.step.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.workflows.step.defer_wake", new=step_wake),
+            mock.patch("aios.workflows.run_tools.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.sessions.defer_run_wake", new=AsyncMock()),
+            mock.patch("aios.services.sessions.defer_wake", new=AsyncMock()),
+        ):
+            yield pool, step_wake
+    finally:
+        run_tools._INFLIGHT.clear()
+        runtime.pool = prev
+        await pool.close()
+
+
+async def _make_run(pool: asyncpg.Pool[Any], script: str, *, name: str = "w") -> str:
+    async with pool.acquire() as conn:
+        wf = await wf_queries.insert_workflow(conn, account_id=_ACCOUNT, name=name, script=script)
+    run = await service.create_run(
+        pool, account_id=_ACCOUNT, workflow_id=wf.id, environment_id=_ENV, input=None
+    )
+    return run.id
+
+
+@pytest.fixture
+async def child_agent_id(cascade_runtime: tuple[asyncpg.Pool[Any], AsyncMock]) -> str:
+    pool, _ = cascade_runtime
+    agent = await agents_service.create_agent(
+        pool,
+        account_id=_ACCOUNT,
+        name="cascade-child-agent",
+        model="test/dummy",
+        system="",
+        tools=[],
+        description=None,
+        metadata={},
+        window_min=1000,
+        window_max=100000,
+    )
+    return agent.id
+
+
+async def _spawn_edge_child(
+    pool: asyncpg.Pool[Any],
+    agent_id: str,
+    run_id: str,
+    *,
+    request_id: str,
+    awaited: bool,
+) -> str:
+    """Spawn a real Ask/Tell child of ``run_id`` through the public NewSession writer
+    (which stamps ``parent_run_id`` + ``archive_when_idle=TRUE`` for BOTH arms and
+    writes the ``request_opened`` edge with the given ``awaited`` bit)."""
+    cid = child_session_id(run_id, request_id)
+    stim: AskNewSession | TellNewSession
+    if awaited:
+        stim = AskNewSession(
+            session_id=cid,
+            agent_id=agent_id,
+            environment_id=_ENV,
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id=request_id,
+            input="hi",
+        )
+    else:
+        stim = TellNewSession(
+            session_id=cid,
+            agent_id=agent_id,
+            environment_id=_ENV,
+            agent_version=1,
+            model=None,
+            parent_run_id=run_id,
+            surface=Surface([], [], []),
+            vault_ids=[],
+            request_id=request_id,
+            input="hi",
+        )
+    await sessions_service.create_child_session(pool, stim, account_id=_ACCOUNT)
+    return cid
+
+
+async def _run_status(pool: asyncpg.Pool[Any], run_id: str) -> str | None:
+    async with pool.acquire() as conn:
+        status = await conn.fetchval("SELECT status FROM wf_runs WHERE id = $1", run_id)
+    return str(status) if status is not None else None
+
+
+async def test_tell_child_not_seeded_ask_child_seeded_and_woken(
+    cascade_runtime: tuple[asyncpg.Pool[Any], AsyncMock], child_agent_id: str
+) -> None:
+    """§6(g) + positive control: a terminal parent seeds ONLY the open awaited edge —
+    the Tell child gets no marker and stays unarchived; the Ask child's marker commits
+    with the terminal and the child is promptly woken with ``cause='cancel'``."""
+    pool, step_wake = cascade_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1\n")
+    tell_id = await _spawn_edge_child(
+        pool, child_agent_id, run_id, request_id="tell1", awaited=False
+    )
+    ask_id = await _spawn_edge_child(pool, child_agent_id, run_id, request_id="ask1", awaited=True)
+
+    await run_workflow_step(run_id)
+    assert await _run_status(pool, run_id) == "completed"
+
+    async with pool.acquire() as conn:
+        # the Ask child was seeded in the terminal transaction, unharvested
+        ask_marker = await db_queries.get_session_cancel_marker(
+            conn, session_id=ask_id, request_id="ask1"
+        )
+        assert ask_marker is not None and ask_marker.harvested_at is None
+        # the Tell child: no marker at all, and NOT archived by the seeding path
+        assert (
+            await db_queries.get_session_cancel_marker(conn, session_id=tell_id, request_id="tell1")
+            is None
+        )
+        tell_row = await conn.fetchrow("SELECT archived_at FROM sessions WHERE id = $1", tell_id)
+        assert tell_row is not None and tell_row["archived_at"] is None
+
+    # the restored session-child prompt wake: the Ask child only
+    woken = {c.args[1] for c in step_wake.await_args_list}
+    assert ask_id in woken
+    assert tell_id not in woken
+    for c in step_wake.await_args_list:
+        if c.args[1] == ask_id:
+            assert c.kwargs["cause"] == "cancel"
+
+
+async def test_fk_only_children_get_no_cancel_signal(
+    cascade_runtime: tuple[asyncpg.Pool[Any], AsyncMock], child_agent_id: str
+) -> None:
+    """§6(i): FK-only children — a run child with a bare ``parent_run_id`` and a
+    session child with a bare ``parent_run_id`` (no request edge) — get no cancel
+    signal/marker from a terminal parent: ``children_of``'s ``awaited=True`` display
+    default is never load-bearing for a kill."""
+    pool, step_wake = cascade_runtime
+    parent_id = await _make_run(pool, "async def main(input):\n    return 1\n")
+    # FK-only RUN child (the create_run / trigger-fired / WaM shape: FK, no edge).
+    fk_run_id = await _make_run(pool, "async def main(input):\n    return 2\n", name="w-child")
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE wf_runs SET parent_run_id = $1 WHERE id = $2", parent_id, fk_run_id
+        )
+        # FK-only SESSION child (edgeless pre-#1123 legacy shape).
+        fk_session = await db_queries.insert_session(
+            conn,
+            account_id=_ACCOUNT,
+            agent_id=child_agent_id,
+            environment_id=_ENV,
+            agent_version=1,
+            title=None,
+            metadata={},
+        )
+        await conn.execute(
+            "UPDATE sessions SET parent_run_id = $1 WHERE id = $2", parent_id, fk_session.id
+        )
+
+    await run_workflow_step(parent_id)
+    assert await _run_status(pool, parent_id) == "completed"
+
+    async with pool.acquire() as conn:
+        # no cancel signal on the FK-only run child; it is untouched (still pending)
+        signals = await wf_queries.list_run_signals(conn, fk_run_id)
+        assert not any(s.kind == "cancel" for s in signals)
+        assert (
+            await conn.fetchval("SELECT status FROM wf_runs WHERE id = $1", fk_run_id) == "pending"
+        )
+        # no marker rows at all for the FK-only session child, and not archived
+        assert (
+            await conn.fetchval(
+                "SELECT count(*) FROM session_cancel_markers WHERE session_id = $1",
+                fk_session.id,
+            )
+            == 0
+        )
+        assert (
+            await conn.fetchval("SELECT archived_at FROM sessions WHERE id = $1", fk_session.id)
+            is None
+        )
+    step_wake.assert_not_awaited()  # nothing was seeded → nothing to wake
+
+
+async def test_engine_semantics_terminal_seeds_marker_in_same_transaction(
+    cascade_runtime: tuple[asyncpg.Pool[Any], AsyncMock], child_agent_id: str
+) -> None:
+    """§6(x) event-path parity: an ``engine_semantics_changed`` terminal closes the
+    child's edge BEFORE the open-edge seeder runs, so the closing path itself must
+    seed the marker (same transaction) and the child is promptly woken; the child's
+    leaf then classifies the closed edge REVOKED (kind ∈ REVOCATION_KINDS) and
+    harvests."""
+    pool, step_wake = cascade_runtime
+    run_id = await _make_run(pool, "async def main(input):\n    return 1\n")
+    child_id = await _spawn_edge_child(
+        pool, child_agent_id, run_id, request_id="ask_es", awaited=True
+    )
+    async with pool.acquire() as conn:
+        # age the run's engine epoch so the next wake takes the terminal-error path
+        await conn.execute(
+            "UPDATE wf_runs SET host_semantics_epoch = host_semantics_epoch - 1 WHERE id = $1",
+            run_id,
+        )
+
+    await run_workflow_step(run_id)
+    assert await _run_status(pool, run_id) == "errored"
+
+    async with pool.acquire() as conn:
+        # the child's edge was closed with the terminal kind…
+        resolved = await db_queries.derive_response(
+            conn, child_id, account_id=_ACCOUNT, request_id="ask_es"
+        )
+        assert isinstance(resolved, Err)
+        assert resolved.error.get("kind") == "engine_semantics_changed"
+        # …AND the cancel marker was seeded in the same transaction (not left to
+        # the sweep): the open-edge seeder can no longer see this child.
+        marker = await db_queries.get_session_cancel_marker(
+            conn, session_id=child_id, request_id="ask_es"
+        )
+        assert marker is not None and marker.harvested_at is None
+    # the prompt wake reached the marked child
+    assert child_id in {c.args[1] for c in step_wake.await_args_list}
+
+    # the child's own leaf harvests the marker: the already-closed edge classifies
+    # REVOKED (engine_semantics_changed ∈ REVOCATION_KINDS) — the leaf applies it
+    # (returns True) and the marker is consumed.
+    assert await sessions_service.harvest_session_cancel_markers(
+        pool, child_id, account_id=_ACCOUNT
+    )
+    async with pool.acquire() as conn:
+        marker = await db_queries.get_session_cancel_marker(
+            conn, session_id=child_id, request_id="ask_es"
+        )
+        assert marker is not None and marker.harvested_at is not None

--- a/tests/integration/test_clone_policy_arms.py
+++ b/tests/integration/test_clone_policy_arms.py
@@ -89,11 +89,12 @@ async def test_clone_copies_authority_and_class_mass_and_resets_run_child(
                 workspace_volume_path, env, focal_channel, focal_locked, account_id,
                 last_event_seq, input_tokens, output_tokens, cost_microusd,
                 parent_run_id, origin, surface_frozen, model, litellm_extra,
-                tools, mcp_servers, http_servers, snapshot_ref, outbound_suppression)
+                tools, mcp_servers, http_servers, snapshot_ref, outbound_suppression,
+                archive_when_idle)
             VALUES ($1, $2, $3, 1, 't', '{}'::jsonb, '/w/p', '{}'::jsonb, 'tg/c1',
                 TRUE, $4, 2, 100, 50, 4242, 'run_p', 'background', TRUE,
                 'anthropic/claude', '{"api_base":"x"}'::jsonb, '[]'::jsonb, '[]'::jsonb,
-                '[]'::jsonb, 'snap_p', 'on')
+                '[]'::jsonb, 'snap_p', 'on', TRUE)
             """,
             parent,
             agent_id,
@@ -136,6 +137,10 @@ async def test_clone_copies_authority_and_class_mass_and_resets_run_child(
         # run-lineage arms — RESET (no phantom run-child membership)
         assert srow["parent_run_id"] is None
         assert srow["origin"] == "foreground"
+
+        # cascade-immunity arm (#1152 §6(m)) — RESET: a forensic clone of an ephemeral
+        # servicer is an operator artifact, never flag-owned by the cancel cascade
+        assert srow["archive_when_idle"] is False
 
         # usage arms — RESET (paid on the parent)
         assert srow["input_tokens"] == 0

--- a/tests/integration/test_session_cancel_leaf.py
+++ b/tests/integration/test_session_cancel_leaf.py
@@ -24,7 +24,7 @@ from aios.db.pool import create_pool
 from aios.errors import NotFoundError
 from aios.harness.inflight_tool_registry import InflightToolRegistry
 from aios.harness.sweep import find_sessions_needing_inference
-from aios.models.sessions import Err
+from aios.models.sessions import Err, Ok
 from aios.services import sessions as service
 from aios.services import tasks as tasks_service
 from tests.integration.conftest import seed_agent_env_session
@@ -255,9 +255,13 @@ async def _open_child_session_edge(
 async def test_owned_session_cancel_propagates_to_awaited_children(
     pool_and_session: tuple[asyncpg.Pool[Any], str, str],
 ) -> None:
-    """§2.3: when the cancelled request was the session's SOLE inbound, the leaf seeds a
-    cancel-marker on each outbound awaited child — the recursive cascade hop."""
+    """§2.3: when the cancelled request was an OWNED session's SOLE inbound, the leaf seeds
+    a cancel-marker on each outbound awaited child — the recursive cascade hop. Ownership
+    here is flag-declared (``archive_when_idle=TRUE``, the servicer class every edge-created
+    child carries); a bare inbound Ask no longer classifies a session as owned."""
     pool, parent_id, env_id = pool_and_session
+    async with pool.acquire() as conn:
+        await conn.execute("UPDATE sessions SET archive_when_idle = TRUE WHERE id = $1", parent_id)
     await _open_request(pool, parent_id, env_id, request_id="req_root")  # the parent's sole inbound
     _a, _e, child = await seed_agent_env_session(
         pool, account_id=_ACCOUNT, prefix="cancel-leaf-child"
@@ -275,6 +279,84 @@ async def test_owned_session_cancel_propagates_to_awaited_children(
             conn, session_id=child.id, request_id="req_child"
         )
         assert child_marker is not None and child_marker.harvested_at is None  # cascade reached it
+
+
+async def test_self_owned_session_never_propagates(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """FATAL-2 wrong-kill immunity: a SELF-OWNED session (no creation edge, no
+    ``archive_when_idle`` flag — the lieutenant/root shape) never auto-propagates on
+    obligation withdrawal, even when its sole inbound was revoked. Receiving an
+    awaited Ask must NOT classify a session as owned (the any-edge join defect)."""
+    pool, parent_id, env_id = pool_and_session
+    await _open_request(pool, parent_id, env_id, request_id="req_root")  # sole inbound
+    _a, _e, child = await seed_agent_env_session(pool, account_id=_ACCOUNT, prefix="cancel-leaf-lt")
+    await _open_child_session_edge(pool, child.id, parent_id, env_id, request_id="req_child")
+    async with pool.acquire() as conn:
+        await queries.insert_session_cancel_marker(
+            conn, session_id=parent_id, request_id="req_root", account_id=_ACCOUNT
+        )
+
+    # The leaf answers req_root cancelled (revocation-context) and harvests…
+    assert await service.harvest_session_cancel_markers(pool, parent_id, account_id=_ACCOUNT)
+    async with pool.acquire() as conn:
+        resolved = await queries.derive_response(
+            conn, parent_id, account_id=_ACCOUNT, request_id="req_root"
+        )
+        assert resolved == Err(error={"kind": "cancelled"})
+        # …but the live subtree is untouched: not owned ⇒ zero propagation.
+        assert (
+            await queries.get_session_cancel_marker(
+                conn, session_id=child.id, request_id="req_child"
+            )
+            is None
+        )
+
+
+async def test_fulfilled_marker_set_does_not_propagate(
+    pool_and_session: tuple[asyncpg.Pool[Any], str, str],
+) -> None:
+    """§1 revoked/fulfilled asymmetry: a marker whose request the SERVICER already
+    answered (``Ok``) classifies FULFILLED — an owned session with a purely-fulfilled
+    marker set and zero surviving inbound must NOT propagate cancellation."""
+    pool, parent_id, env_id = pool_and_session
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE sessions SET archive_when_idle = TRUE WHERE id = $1", parent_id
+        )  # owned via the flag — isolates the revocation-context gate
+    await _open_request(pool, parent_id, env_id, request_id="req_done")  # sole inbound
+    _a, _e, child = await seed_agent_env_session(
+        pool, account_id=_ACCOUNT, prefix="cancel-leaf-fulfilled"
+    )
+    await _open_child_session_edge(pool, child.id, parent_id, env_id, request_id="req_child")
+    async with pool.acquire() as conn:
+        # the servicer answers FIRST (first-writer-wins latches the Ok)…
+        assert await queries.write_response_if_absent(
+            conn, parent_id, account_id=_ACCOUNT, request_id="req_done", outcome=Ok(result="done")
+        )
+        # …then a stray marker lands on the already-fulfilled edge
+        await queries.insert_session_cancel_marker(
+            conn, session_id=parent_id, request_id="req_done", account_id=_ACCOUNT
+        )
+
+    # The leaf applies the marker (harvests it; the cancelled write no-ops)…
+    assert await service.harvest_session_cancel_markers(pool, parent_id, account_id=_ACCOUNT)
+    async with pool.acquire() as conn:
+        marker = await queries.get_session_cancel_marker(
+            conn, session_id=parent_id, request_id="req_done"
+        )
+        assert marker is not None and marker.harvested_at is not None
+        resolved = await queries.derive_response(
+            conn, parent_id, account_id=_ACCOUNT, request_id="req_done"
+        )
+        assert resolved == Ok(result="done")  # the servicer's answer survived
+        # …and does NOT cascade: fulfilled ⇒ no revocation-context ⇒ zero propagation.
+        assert (
+            await queries.get_session_cancel_marker(
+                conn, session_id=child.id, request_id="req_child"
+            )
+            is None
+        )
 
 
 async def test_shared_session_cancel_does_not_over_cancel_children(

--- a/tests/unit/test_revocation_kinds_coverage.py
+++ b/tests/unit/test_revocation_kinds_coverage.py
@@ -1,0 +1,157 @@
+"""#1152 §6(w) — writer-coverage over the revoked/fulfilled kind taxonomy.
+
+The cancel leaf (``harvest_session_cancel_markers``) classifies an already-closed
+edge by its written ``error.kind``: ``kind ∈ REVOCATION_KINDS`` ⇒ REVOKED (counts as
+revocation-context for §2.3 propagation), anything else — including unknown/absent —
+⇒ FULFILLED (graceful; under-cancel is strictly safer and the lease ceiling
+backstops). That default makes NEW kinds silently graceful, so every kind an ``Err``
+writer can actually produce must be a *conscious* classification: this test
+enumerates the writer call sites by AST scan and fails when a kind appears that is
+in neither ``REVOCATION_KINDS`` nor the fulfilled ledger below — the anti-drift
+guard the spec demands (§1: "a test asserting every Err-writing call site's kind is
+classified").
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import aios
+from aios.services.sessions import REVOCATION_KINDS
+
+SRC_ROOT = Path(aios.__file__).parent
+
+# Kinds an Err writer can produce that classify FULFILLED (graceful): written by the
+# servicer itself — its own ``error`` tool, its harness-erroring path (the model
+# failed past its retry budget and the session's own step latches + answers), or the
+# run's own script/host failure answering its caller through its terminal record.
+# A REVOCATION is a closure by someone OTHER than the servicer (stop/timeout/caller
+# terminal/caller archived) — keep this ledger in lockstep with spec §1.
+FULFILLED_KINDS: frozenset[str] = frozenset(
+    {
+        # the servicer quiesced owing its answer (the totality backstop)
+        "no_return",
+        # the run answered but its output failed the request's acceptance contract
+        "output_schema_violation",
+        # session harness-erroring: the servicer's own step latches its death
+        "model_terminal_error",
+        "model_call_deadline",
+        "model_refusal",
+        "model_workflow_run_errored",
+        "model_workflow_invalid_shape",
+        "child_errored",
+        "spend_cap_exceeded",
+        "provider_auth_conflict",
+        # run-side script/host failures (HostErrorKind + step dispatch arms): the
+        # run answers its caller via its own terminal record
+        "author_exception",
+        "too_wide_fanout",
+        "script_host_crash",
+        "script_host_timeout",
+        "script_host_spawn_failed",
+        "too_many_agents",
+        "bad_tool_call",
+        "not_implemented",
+    }
+)
+
+
+def _kind_from_dict(node: ast.expr) -> str | None:
+    """The ``"kind"`` value of a dict literal, when both key and value are constants."""
+    if not isinstance(node, ast.Dict):
+        return None
+    for key, value in zip(node.keys, node.values, strict=True):
+        if (
+            isinstance(key, ast.Constant)
+            and key.value == "kind"
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+        ):
+            return value.value
+    return None
+
+
+def _kind_value_constants(node: ast.expr) -> list[str]:
+    """String constants in KIND-VALUE position: a bare literal, or the literal
+    operand(s) of an ``x or "<lit>"`` fallback (the ``terminal.get("kind") or
+    "author_exception"`` shape). Deliberately does NOT walk into calls/subscripts —
+    a ``.get("kind")`` lookup is a dict KEY, not a kind value (the read-side
+    ``error_kind=(data.get("error") or {}).get("kind")`` shape must not count)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.BoolOp):
+        return [
+            v.value for v in node.values if isinstance(v, ast.Constant) and isinstance(v.value, str)
+        ]
+    return []
+
+
+def _collect_writer_kinds() -> dict[str, list[str]]:
+    """kind → call sites, from the three origination shapes an Err writer takes:
+
+    * an ``error={"kind": <lit>}`` kwarg (``Err(...)``, ``fail_open_child_requests_conn``,
+      ``fail_all_open_requests`` and friends);
+    * an ``error_kind=<lit>`` kwarg (``_complete_run`` / ``_latch_errored_turn`` /
+      ``HostOutcome`` origination sites), including the ``x or "<lit>"`` fallback shape;
+    * an ``error_kind = "<lit>"`` assignment (the schema-violation arm).
+    """
+    kinds: dict[str, list[str]] = {}
+
+    def record(kind: str, path: Path, lineno: int) -> None:
+        kinds.setdefault(kind, []).append(f"{path.relative_to(SRC_ROOT)}:{lineno}")
+
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                for kw in node.keywords:
+                    if kw.arg == "error" and (kind := _kind_from_dict(kw.value)) is not None:
+                        record(kind, path, node.lineno)
+                    elif kw.arg == "error_kind":
+                        for lit in _kind_value_constants(kw.value):
+                            record(lit, path, node.lineno)
+            elif (
+                isinstance(node, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == "error_kind" for t in node.targets)
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+            ):
+                record(node.value.value, path, node.lineno)
+    return kinds
+
+
+def test_scanner_sees_the_known_writers() -> None:
+    """Non-vacuity: the scan must surface the kinds we KNOW the tree writes — if a
+    refactor changes the writer shapes, this fails before the coverage assert goes
+    silently green on an empty set."""
+    kinds = set(_collect_writer_kinds())
+    assert {
+        "cancelled",
+        "timeout",
+        "child_gone",
+        "engine_semantics_changed",
+        "nondeterministic_replay",
+        "no_return",
+    } <= kinds, f"writer scan lost known kinds; saw only {sorted(kinds)}"
+
+
+def test_every_err_writer_kind_is_classified() -> None:
+    kinds = _collect_writer_kinds()
+    unclassified = {
+        kind: sites
+        for kind, sites in kinds.items()
+        if kind not in REVOCATION_KINDS and kind not in FULFILLED_KINDS
+    }
+    assert not unclassified, (
+        "Err-writer kinds with no revoked/fulfilled classification (they would "
+        "silently default to FULFILLED at the cancel leaf). Categorize each in "
+        "aios.services.sessions.REVOCATION_KINDS (a withdrawal by someone other "
+        "than the servicer) or in this test's FULFILLED_KINDS ledger (the "
+        f"servicer's own answer/erroring): {unclassified}"
+    )
+
+
+def test_ledgers_are_disjoint() -> None:
+    overlap = REVOCATION_KINDS & FULFILLED_KINDS
+    assert not overlap, f"a kind cannot be both revoked and fulfilled: {sorted(overlap)}"


### PR DESCRIPTION
Automated dev-pipeline build for issue #1152.