### PR TITLE
Session-repo clone failures need a circuit breaker + persistent prelude health surface (2,100 auth-failed clones/day on one session)

### DIFF
--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -870,10 +870,18 @@ async def get_context(
         memory_echoes = await _queries.list_session_memory_store_echoes(
             _conn, session_id, account_id=account_id
         )
-        github_repo_echoes = await _queries.list_session_github_repo_echoes(
-            _conn, session_id, account_id=account_id
-        )
 
+    # The resource-health prelude block (#1720) is deliberately NOT threaded
+    # here: it's a projection of the WORKER process's in-memory
+    # ``GithubCloneBreaker`` state, which this API process never initializes.
+    # Passing the repo echoes would make ``compute_step_prelude`` render the
+    # block from a breaker that is always ``None`` here → an unconditional
+    # "healthy" line that silently diverges from the prompt the agent actually
+    # received (a degraded repo would show AUTH-FAILED/CLONE-FAILING in the
+    # worker, healthy here). Rather than ship an observability surface that
+    # lies by omission, the ``/context`` preview omits resource-health
+    # entirely — it is a worker-only surface. Cross-process breaker state is
+    # explicitly out of scope.
     prelude = await compute_step_prelude(
         pool,
         session_id,
@@ -882,7 +890,6 @@ async def get_context(
         agent=agent,
         channels=channels,
         memory_store_echoes=memory_echoes,
-        github_repo_echoes=github_repo_echoes,
     )
     windowed = await service.read_windowed_events(
         pool,

--- a/src/aios/api/routers/sessions.py
+++ b/src/aios/api/routers/sessions.py
@@ -870,6 +870,9 @@ async def get_context(
         memory_echoes = await _queries.list_session_memory_store_echoes(
             _conn, session_id, account_id=account_id
         )
+        github_repo_echoes = await _queries.list_session_github_repo_echoes(
+            _conn, session_id, account_id=account_id
+        )
 
     prelude = await compute_step_prelude(
         pool,
@@ -879,6 +882,7 @@ async def get_context(
         agent=agent,
         channels=channels,
         memory_store_echoes=memory_echoes,
+        github_repo_echoes=github_repo_echoes,
     )
     windowed = await service.read_windowed_events(
         pool,

--- a/src/aios/db/listen.py
+++ b/src/aios/db/listen.py
@@ -601,6 +601,56 @@ async def listen_for_mcp_evict_vault(
         conn.terminate()
 
 
+GITHUB_CLONE_BREAKER_CLEAR_CHANNEL = "aios_github_clone_breaker_clear"
+
+
+@asynccontextmanager
+async def listen_for_github_clone_breaker_clear(
+    db_url: str,
+) -> AsyncIterator[asyncio.Queue[str]]:
+    """Yield ``resource_id`` payloads from the github-clone-breaker clear channel.
+
+    A token rotation (``PUT /v1/sessions/{id}/resources/{resource_id}``, which
+    calls :func:`aios.services.github_repositories.rotate_token`) runs in the
+    API process and fires a NOTIFY on this channel with the ``ghrepo_...``
+    resource id; the worker — which owns the in-memory
+    :class:`aios.sandbox.github_clone_breaker.GithubCloneBreaker` — LISTENs
+    here and clears that resource's breaker state so a fixed credential
+    re-probes on the very next provision instead of serving out a cooldown
+    opened under the old secret (#1720, re-probe path (a)).
+
+    Delivery is fire-and-forget, exactly like
+    :func:`listen_for_mcp_evict_vault`: a clear-signal emitted while this
+    dedicated LISTEN connection is reconnecting is lost, but the breaker's
+    own cooldown-then-half-open-probe re-probe (path (c)) is the safety net,
+    and a subsequent rotation re-fires.
+    """
+    conn = await _connect_listener(db_url)
+    try:
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=1024)
+
+        def _callback(
+            _conn: asyncpg.Connection[object],
+            _pid: int,
+            _channel: str,
+            payload: str,
+        ) -> None:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                log.warning("listen.github_clone_breaker_clear_queue_full")
+
+        def _termination_callback(_conn: asyncpg.Connection[object]) -> None:
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait("")
+
+        conn.add_termination_listener(_termination_callback)
+        await conn.add_listener(GITHUB_CLONE_BREAKER_CLEAR_CHANNEL, _callback)
+        yield queue
+    finally:
+        conn.terminate()
+
+
 # Channel VALUE is byte-identical across the #818 rename (the underlying
 # Postgres NOTIFY trigger function ``notify_scheduled_tasks_due`` and its
 # channel string stay put — renaming buys nothing and opens a deploy window

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
     import asyncpg
 
     from aios.harness.inflight_tool_registry import InflightToolRegistry
+    from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
 
 log = get_logger("aios.harness.loop")
@@ -310,6 +311,25 @@ class _StepResult(NamedTuple):
     autoerror_caller_run_id: str | None = None
     autoerror_caller_session_ids: tuple[str, ...] = ()
     archive_when_idle: bool = False
+
+
+async def _list_session_github_repo_echoes(
+    pool: asyncpg.Pool[Any], session_id: str, *, account_id: str
+) -> list[GithubRepositoryResourceEcho]:
+    """The session's attached github repo echoes, for the resource-health prelude scope.
+
+    A thin pool.acquire() wrapper — kept separate from
+    ``refresh_session_mount_state`` (which already fetches github echoes for
+    the drift check) so the two concerns stay independently callable; the
+    extra query is one indexed lookup, not worth threading a second return
+    value through that function's existing callers/mocks.
+    """
+    from aios.db import queries
+
+    async with pool.acquire() as conn:
+        return await queries.list_session_github_repo_echoes(
+            conn, session_id, account_id=account_id
+        )
 
 
 async def refresh_session_mount_state(
@@ -842,10 +862,11 @@ async def _run_session_step_body(
 
     from aios.services.channels import list_session_channels
 
-    agent, channels, memory_echoes = await asyncio.gather(
+    agent, channels, memory_echoes, github_repo_echoes = await asyncio.gather(
         agents_service.load_for_session(pool, session, account_id=account_id),
         list_session_channels(pool, session_id, account_id=account_id),
         refresh_session_mount_state(pool, session_id, account_id=account_id),
+        _list_session_github_repo_echoes(pool, session_id, account_id=account_id),
     )
 
     mcp_server_map: dict[str, McpServerSpec] = {s.name: s for s in agent.mcp_servers}
@@ -896,6 +917,7 @@ async def _run_session_step_body(
             agent=agent,
             channels=channels,
             memory_store_echoes=memory_echoes,
+            github_repo_echoes=github_repo_echoes,
         )
     except Exception:
         await sessions_service.append_event(

--- a/src/aios/harness/resource_health.py
+++ b/src/aios/harness/resource_health.py
@@ -1,0 +1,69 @@
+"""Prelude health surface for degraded session resources (#1720).
+
+A dead/expired GitHub credential or a down MCP server used to be a per-turn
+rediscovery: the harness silently skipped (or slow-retried) the resource and
+the only trace was a transient ``github_clone_failed``/``mcp_server_unavailable``
+event the model would never see again next turn. Production evidence (#1720):
+one session re-diagnosed the same dead token as a *novel* problem across ~174
+turns because there was no persistent "repo X: AUTH-FAILED since <ts>" fact
+anywhere in its context.
+
+This module renders that fact as a compact, always-visible system-prompt
+block — one line per degraded resource, e.g.::
+
+    ━━━ Resource health ━━━
+    repos: davenant-theme AUTH-FAILED since 2026-07-07T19:53:06Z
+    mcp: github DEGRADED
+
+— built fresh every step from the two in-memory breakers
+(:class:`aios.sandbox.github_clone_breaker.GithubCloneBreaker` and
+:class:`aios.mcp.pool.McpSessionPool`), so it disappears the step after the
+resource heals (no separate "clear" bookkeeping needed here — the block is
+just a projection of current breaker state, never persisted itself).
+"""
+
+from __future__ import annotations
+
+from aios.harness._text import join_blocks
+
+_HEADER = "━━━ Resource health ━━━"
+
+
+def build_resource_health_block(
+    *,
+    degraded_repos: list[tuple[str, str]],
+    degraded_mcp_server_names: list[str],
+) -> str:
+    """Render the standing degraded-resource block.
+
+    ``degraded_repos`` is a list of ``(mount_path, since_iso)`` pairs — already
+    formatted by the caller so this module has no dependency on the breaker's
+    dataclass shape. ``degraded_mcp_server_names`` is the agent-declared
+    server ``name`` (not URL) for each MCP server whose breaker is currently
+    open. Returns ``""`` when nothing is degraded, so the augmenter leaves the
+    system prompt unchanged in the common (healthy) case.
+    """
+    if not degraded_repos and not degraded_mcp_server_names:
+        return ""
+    lines = [_HEADER]
+    for mount_path, since_iso in degraded_repos:
+        lines.append(f"repos: {mount_path} AUTH-FAILED since {since_iso}")
+    for name in degraded_mcp_server_names:
+        lines.append(f"mcp: {name} DEGRADED")
+    return "\n".join(lines)
+
+
+def augment_with_resource_health(
+    base_system: str,
+    *,
+    degraded_repos: list[tuple[str, str]],
+    degraded_mcp_server_names: list[str],
+) -> str:
+    """Append the resource-health block to ``base_system`` if anything is degraded."""
+    return join_blocks(
+        base_system,
+        build_resource_health_block(
+            degraded_repos=degraded_repos,
+            degraded_mcp_server_names=degraded_mcp_server_names,
+        ),
+    )

--- a/src/aios/harness/resource_health.py
+++ b/src/aios/harness/resource_health.py
@@ -13,6 +13,7 @@ block — one line per degraded resource, e.g.::
 
     ━━━ Resource health ━━━
     repos: davenant-theme AUTH-FAILED since 2026-07-07T19:53:06Z
+    repos: acme-api CLONE-FAILING since 2026-07-08T01:00:00Z (last: git clone timed out after 30.0s)
     mcp: github DEGRADED
 
 — built fresh every step from the two in-memory breakers
@@ -31,23 +32,34 @@ _HEADER = "━━━ Resource health ━━━"
 
 def build_resource_health_block(
     *,
-    degraded_repos: list[tuple[str, str]],
+    degraded_repos: list[tuple[str, str, bool, str]],
     degraded_mcp_server_names: list[str],
 ) -> str:
     """Render the standing degraded-resource block.
 
-    ``degraded_repos`` is a list of ``(mount_path, since_iso)`` pairs — already
-    formatted by the caller so this module has no dependency on the breaker's
-    dataclass shape. ``degraded_mcp_server_names`` is the agent-declared
-    server ``name`` (not URL) for each MCP server whose breaker is currently
-    open. Returns ``""`` when nothing is degraded, so the augmenter leaves the
-    system prompt unchanged in the common (healthy) case.
+    ``degraded_repos`` is a list of ``(mount_path, since_iso, auth_failure,
+    last_error)`` tuples — already formatted by the caller so this module has
+    no dependency on the breaker's dataclass shape. The rendered cause is
+    honest (issue #1720 seat-gate fix): ``AUTH-FAILED`` ONLY for a classified
+    auth failure (``auth_failure`` True), else ``CLONE-FAILING ... (last:
+    <err>)`` with the real (token-redacted) git error — never a hardcoded
+    cause. ``degraded_mcp_server_names`` is the agent-declared server ``name``
+    (not URL) for each MCP server whose breaker is currently open. Returns
+    ``""`` when nothing is degraded, so the augmenter leaves the system prompt
+    unchanged in the common (healthy) case.
     """
     if not degraded_repos and not degraded_mcp_server_names:
         return ""
     lines = [_HEADER]
-    for mount_path, since_iso in degraded_repos:
-        lines.append(f"repos: {mount_path} AUTH-FAILED since {since_iso}")
+    for mount_path, since_iso, auth_failure, last_error in degraded_repos:
+        if auth_failure:
+            lines.append(f"repos: {mount_path} AUTH-FAILED since {since_iso}")
+        elif last_error:
+            lines.append(
+                f"repos: {mount_path} CLONE-FAILING since {since_iso} (last: {last_error})"
+            )
+        else:
+            lines.append(f"repos: {mount_path} CLONE-FAILING since {since_iso}")
     for name in degraded_mcp_server_names:
         lines.append(f"mcp: {name} DEGRADED")
     return "\n".join(lines)
@@ -56,7 +68,7 @@ def build_resource_health_block(
 def augment_with_resource_health(
     base_system: str,
     *,
-    degraded_repos: list[tuple[str, str]],
+    degraded_repos: list[tuple[str, str, bool, str]],
     degraded_mcp_server_names: list[str],
 ) -> str:
     """Append the resource-health block to ``base_system`` if anything is degraded."""

--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from aios.harness.inflight_tool_registry import InflightToolRegistry
     from aios.mcp.pool import McpSessionPool
     from aios.models.memory_stores import MemoryStoreResourceEcho
+    from aios.sandbox.github_clone_breaker import GithubCloneBreaker
     from aios.sandbox.registry import SandboxRegistry
     from aios.sandbox.tool_broker import ToolBroker
     from aios.tools.providers import ToolProvider
@@ -37,6 +38,7 @@ worker_id: str | None = None
 sandbox_registry: SandboxRegistry | None = None
 inflight_tool_registry: InflightToolRegistry | None = None
 mcp_session_pool: McpSessionPool | None = None
+github_clone_breaker: GithubCloneBreaker | None = None
 tool_broker: ToolBroker | None = None
 tool_provider: ToolProvider | None = None
 
@@ -113,6 +115,10 @@ def require_crypto_box() -> CryptoBox:
 
 def require_sandbox_registry() -> SandboxRegistry:
     return _require("sandbox_registry", sandbox_registry)
+
+
+def require_github_clone_breaker() -> GithubCloneBreaker:
+    return _require("github_clone_breaker", github_clone_breaker)
 
 
 def require_inflight_tool_registry() -> InflightToolRegistry:

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
         ToolSpec,
     )
     from aios.models.events import Event
+    from aios.models.github_repositories import GithubRepositoryResourceEcho
     from aios.models.memory_stores import MemoryStoreResourceEcho
     from aios.models.sessions import Obligation, Session
     from aios.models.skills import SkillVersion
@@ -265,6 +266,7 @@ async def compute_step_prelude(
     agent: StepSurface,
     channels: list[str],
     memory_store_echoes: list[MemoryStoreResourceEcho],
+    github_repo_echoes: list[GithubRepositoryResourceEcho] | None = None,
 ) -> StepPrelude:
     """Build the events-independent parts of the step payload.
 
@@ -284,6 +286,7 @@ async def compute_step_prelude(
     )
     from aios.harness.memory_stores import augment_with_memory_stores
     from aios.harness.obligations import max_obligations_block_local
+    from aios.harness.resource_health import augment_with_resource_health
     from aios.harness.skills import augment_system_prompt
     from aios.services import skills as skills_service
 
@@ -367,6 +370,11 @@ async def compute_step_prelude(
     system_prompt = augment_with_focal_paradigm(system_prompt, channels)
     system_prompt = join_blocks(system_prompt, instructions_block)
     system_prompt = augment_with_memory_stores(system_prompt, memory_store_echoes)
+    system_prompt = augment_with_resource_health(
+        system_prompt,
+        degraded_repos=_session_degraded_repos(github_repo_echoes),
+        degraded_mcp_server_names=_session_degraded_mcp_server_names(agent.mcp_servers),
+    )
 
     return StepPrelude(
         system_prompt=system_prompt,
@@ -376,6 +384,49 @@ async def compute_step_prelude(
         obligations=obligations,
         obligations_block_upper_bound_local=max_obligations_block_local(obligations),
     )
+
+
+def _session_degraded_repos(
+    github_repo_echoes: list[GithubRepositoryResourceEcho] | None,
+) -> list[tuple[str, str]]:
+    """``(mount_path, since_iso)`` for each attached repo whose clone breaker is open.
+
+    Scoped to THIS session's attached echoes so a repo degraded for a
+    different session (same worker, different attachment) never leaks into
+    this session's prelude. No breaker (API process, or a worker that never
+    initialized one) or no attached repos both render nothing — fail-open,
+    matching the breaker's own fail-open default.
+    """
+    from aios.harness import runtime as harness_runtime
+
+    breaker = harness_runtime.github_clone_breaker
+    if breaker is None or not github_repo_echoes:
+        return []
+    attached_ids = {echo.id for echo in github_repo_echoes}
+    mount_path_by_id = {echo.id: echo.mount_path for echo in github_repo_echoes}
+    out: list[tuple[str, str]] = []
+    for degraded in breaker.degraded_repos():
+        if degraded.resource_id not in attached_ids:
+            continue
+        mount_path = mount_path_by_id.get(degraded.resource_id, degraded.mount_path)
+        out.append((mount_path, degraded.since.isoformat()))
+    return out
+
+
+def _session_degraded_mcp_server_names(mcp_servers: list[McpServerSpec]) -> list[str]:
+    """Agent-declared ``name`` for each MCP server whose connect breaker is open.
+
+    Scoped to THIS agent's declared servers (by URL) — a different agent's
+    down server never leaks into this prelude. No pool (API process) or no
+    declared servers both render nothing.
+    """
+    from aios.harness import runtime as harness_runtime
+
+    pool = harness_runtime.mcp_session_pool
+    if pool is None or not mcp_servers:
+        return []
+    degraded_urls = set(pool.degraded_servers())
+    return [s.name for s in mcp_servers if s.url in degraded_urls]
 
 
 def _build_instructions_block(

--- a/src/aios/harness/step_context.py
+++ b/src/aios/harness/step_context.py
@@ -386,16 +386,32 @@ async def compute_step_prelude(
     )
 
 
+_MAX_CLONE_ERROR_CHARS = 200
+
+
+def _summarize_clone_error(message: str) -> str:
+    """Collapse a (token-redacted) git error to a single length-capped line for
+    the prelude health surface — raw git stderr can be multi-line and long,
+    and this renders inline into the always-visible system prompt."""
+    collapsed = " ".join(message.split())
+    if len(collapsed) > _MAX_CLONE_ERROR_CHARS:
+        collapsed = collapsed[: _MAX_CLONE_ERROR_CHARS - 1].rstrip() + "…"
+    return collapsed
+
+
 def _session_degraded_repos(
     github_repo_echoes: list[GithubRepositoryResourceEcho] | None,
-) -> list[tuple[str, str]]:
-    """``(mount_path, since_iso)`` for each attached repo whose clone breaker is open.
+) -> list[tuple[str, str, bool, str]]:
+    """``(mount_path, since_iso, auth_failure, last_error)`` for each attached
+    repo whose clone breaker is open.
 
     Scoped to THIS session's attached echoes so a repo degraded for a
     different session (same worker, different attachment) never leaks into
     this session's prelude. No breaker (API process, or a worker that never
     initialized one) or no attached repos both render nothing — fail-open,
-    matching the breaker's own fail-open default.
+    matching the breaker's own fail-open default. ``auth_failure`` +
+    ``last_error`` carry the real cause so the renderer shows ``AUTH-FAILED``
+    only for a classified auth failure (#1720 seat-gate fix).
     """
     from aios.harness import runtime as harness_runtime
 
@@ -404,12 +420,19 @@ def _session_degraded_repos(
         return []
     attached_ids = {echo.id for echo in github_repo_echoes}
     mount_path_by_id = {echo.id: echo.mount_path for echo in github_repo_echoes}
-    out: list[tuple[str, str]] = []
+    out: list[tuple[str, str, bool, str]] = []
     for degraded in breaker.degraded_repos():
         if degraded.resource_id not in attached_ids:
             continue
         mount_path = mount_path_by_id.get(degraded.resource_id, degraded.mount_path)
-        out.append((mount_path, degraded.since.isoformat()))
+        out.append(
+            (
+                mount_path,
+                degraded.since.isoformat(),
+                degraded.auth_failure,
+                _summarize_clone_error(degraded.last_error),
+            )
+        )
     return out
 
 

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -37,7 +37,11 @@ import aios.harness.tasks
 import aios.tools  # noqa: F401  — side-effect: register built-in tools
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
-from aios.db.listen import listen_for_mcp_evict_vault, listen_for_session_interrupts
+from aios.db.listen import (
+    listen_for_github_clone_breaker_clear,
+    listen_for_mcp_evict_vault,
+    listen_for_session_interrupts,
+)
 from aios.db.pool import LISTENER_TCP_KEEPALIVE_SETTINGS, create_pool, normalize_dsn
 from aios.harness import runtime
 from aios.harness.attachment_gc import sweep_orphan_attachments
@@ -61,6 +65,7 @@ from aios.retirements.boot_gate import (
     assert_retirements_admissible,
 )
 from aios.sandbox.backends import select_sandbox_backend
+from aios.sandbox.github_clone_breaker import GithubCloneBreaker
 from aios.sandbox.network import ensure_sandbox_network, is_running_in_container
 from aios.sandbox.registry import SandboxRegistry
 from aios.sandbox.tool_broker import ToolBroker
@@ -333,11 +338,13 @@ async def worker_main() -> None:
     sandbox_registry: SandboxRegistry | None = None
     inflight_tool_registry: InflightToolRegistry | None = None
     mcp_session_pool: McpSessionPool | None = None
+    github_clone_breaker: GithubCloneBreaker | None = None
     tool_broker: ToolBroker | None = None
     procrastinate_opened = False
     sweep_task: asyncio.Task[None] | None = None
     interrupt_task: asyncio.Task[None] | None = None
     mcp_evict_task: asyncio.Task[None] | None = None
+    github_clone_breaker_clear_task: asyncio.Task[None] | None = None
     heartbeat_task: asyncio.Task[None] | None = None
     scheduler_task: asyncio.Task[None] | None = None
     supervised_latch = asyncio.Event()
@@ -355,6 +362,7 @@ async def worker_main() -> None:
         sandbox_registry = SandboxRegistry(backend=select_sandbox_backend(settings))
         inflight_tool_registry = InflightToolRegistry()
         mcp_session_pool = McpSessionPool()
+        github_clone_breaker = GithubCloneBreaker()
         await ensure_sandbox_network()
         tool_broker = ToolBroker(socket_path=settings.tool_broker_socket_path)
         await tool_broker.start()
@@ -375,6 +383,7 @@ async def worker_main() -> None:
         runtime.sandbox_registry = sandbox_registry
         runtime.inflight_tool_registry = inflight_tool_registry
         runtime.mcp_session_pool = mcp_session_pool
+        runtime.github_clone_breaker = github_clone_breaker
         runtime.tool_broker = tool_broker
         runtime.tool_provider = SubsystemToolProvider()
 
@@ -555,6 +564,17 @@ async def worker_main() -> None:
         )
         _supervise(mcp_evict_task, latch=supervised_latch, fatal=supervised_failure)
 
+        # Listen for github-repo token-rotation NOTIFYs and clear the
+        # rotated attachment's clone-breaker state so the fixed credential
+        # re-probes on the very next provision (#1720).
+        github_clone_breaker_clear_task = asyncio.create_task(
+            _run_github_clone_breaker_clear_listener(settings.db_url),
+            name="github_clone_breaker_clear_listener",
+        )
+        _supervise(
+            github_clone_breaker_clear_task, latch=supervised_latch, fatal=supervised_failure
+        )
+
         # Start event-driven scheduler. Sleeps until the next due
         # ``next_fire``, woken early by NOTIFY on
         # ``aios_scheduled_tasks_due`` (insert/delete or
@@ -632,6 +652,8 @@ async def worker_main() -> None:
             await _cancel_and_drain(interrupt_task)
         if mcp_evict_task is not None:
             await _cancel_and_drain(mcp_evict_task)
+        if github_clone_breaker_clear_task is not None:
+            await _cancel_and_drain(github_clone_breaker_clear_task)
         if scheduler_task is not None:
             await _cancel_and_drain(scheduler_task)
         if sandbox_registry is not None:
@@ -1047,4 +1069,55 @@ async def _run_mcp_evict_listener(db_url: str) -> None:
             raise
         except Exception:
             log.exception("mcp_evict_listener.listen_failed_will_retry")
+            await asyncio.sleep(_LISTEN_RECONNECT_BACKOFF_SECONDS)
+
+
+async def _run_github_clone_breaker_clear_listener(db_url: str) -> None:
+    """Drain pg_notify on the github-clone-breaker clear channel and clear
+    the rotated resource's breaker state (#1720).
+
+    :func:`aios.services.github_repositories.rotate_token` runs in the API
+    process and NOTIFYs ``aios_github_clone_breaker_clear`` with the
+    ``ghrepo_...`` resource id after a token/identity UPDATE commits. The
+    worker owns ``runtime.github_clone_breaker``, so it LISTENs here and
+    calls :meth:`GithubCloneBreaker.clear` — a fixed credential re-probes on
+    the very next provision instead of serving out a cooldown opened under
+    the old secret.
+
+    Mirrors :func:`_run_mcp_evict_listener`'s survivability contract: the
+    dispatch try/except is nested INSIDE ``while True`` so a transient clear
+    failure doesn't disable the listener for the worker's lifetime;
+    LISTEN-connection failures escape to the outer reconnect loop.
+    ``CancelledError`` propagates so worker shutdown stays clean.
+    """
+    log = get_logger("aios.worker.github_clone_breaker_clear_listener")
+    while True:
+        try:
+            async with listen_for_github_clone_breaker_clear(db_url) as queue:
+                while True:
+                    try:
+                        resource_id = await queue.get()
+                        if resource_id == "":
+                            raise ConnectionError(
+                                "github clone breaker clear LISTEN connection terminated"
+                            )
+                        breaker = runtime.github_clone_breaker
+                        if breaker is None:
+                            # Not yet initialized (startup race) or already
+                            # torn down — nothing to clear; the breaker's own
+                            # cooldown/half-open re-probe covers the gap.
+                            continue
+                        breaker.clear(resource_id)
+                        log.info(
+                            "github_clone_breaker_clear_listener.dispatch",
+                            resource_id=resource_id,
+                        )
+                    except ConnectionError:
+                        raise
+                    except Exception:
+                        log.exception("github_clone_breaker_clear_listener.dispatch_failed")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("github_clone_breaker_clear_listener.listen_failed_will_retry")
             await asyncio.sleep(_LISTEN_RECONNECT_BACKOFF_SECONDS)

--- a/src/aios/sandbox/github_clone.py
+++ b/src/aios/sandbox/github_clone.py
@@ -49,12 +49,57 @@ from aios.sandbox.volumes import (
 log = get_logger("aios.sandbox.github_clone")
 
 
+# Case-insensitive substrings that mark a git clone/fetch failure as
+# AUTH-SHAPED — a dead/expired/invalid credential — rather than a transient
+# timeout / network / GitHub-5xx blip. Only auth-shaped failures earn the
+# breaker's long (1h) cooldown and the ``AUTH-FAILED`` prelude label; a
+# transient class must re-probe fast (issue #1720 seat-gate fix — the 1h
+# lockout after a recovered GitHub outage was a regression). Matched against
+# git's stderr, which is already token-redacted at the raise sites. Kept
+# CONSERVATIVE on purpose: mis-labeling a transient failure as auth is the
+# harmful direction (wrong 1h lockout + wrong "rotate your token" prompt),
+# so only unambiguous auth-rejection signatures are listed.
+_AUTH_FAILURE_SIGNATURES = (
+    "invalid username or token",
+    "authentication failed",
+    "error: 401",
+    "error: 403",
+    "http 401",
+    "http 403",
+    "401 unauthorized",
+    "403 forbidden",
+)
+
+
+def is_auth_failure_message(message: str) -> bool:
+    """True if ``message`` (a git stderr / error string) looks like an auth
+    failure (dead/expired/invalid token) as opposed to a transient
+    timeout/network/5xx failure. Case-insensitive substring match against the
+    known git auth-rejection signatures (issue #1720)."""
+    low = message.lower()
+    return any(sig in low for sig in _AUTH_FAILURE_SIGNATURES)
+
+
 class GithubCloneError(Exception):
     """Raised when a clone or fetch fails in a way the agent can't recover
     from (e.g. invalid token, repo missing). The provisioner catches this,
     logs a lifecycle event, and continues so the agent sees the failure
     context without the session halting.
+
+    Carries ``auth_failure`` (issue #1720): whether this failure is
+    auth-shaped (dead/expired token) vs transient (timeout/network/5xx). The
+    circuit breaker keys its cooldown length + AUTH label on this so a
+    transient GitHub blip doesn't earn a 1h lockout or a false ``AUTH-FAILED``
+    prelude line. When not passed explicitly it is auto-derived from the
+    message text — every raise site's message already carries the (redacted)
+    git stderr the signatures live in.
     """
+
+    def __init__(self, message: str, *, auth_failure: bool | None = None) -> None:
+        super().__init__(message)
+        self.auth_failure: bool = (
+            auth_failure if auth_failure is not None else is_auth_failure_message(message)
+        )
 
 
 def url_hash(repo_url: str) -> str:
@@ -360,6 +405,7 @@ __all__ = [
     "GithubCloneError",
     "ensure_cache_clone",
     "ensure_session_working_tree",
+    "is_auth_failure_message",
     "remove_session_working_tree",
     "url_hash",
 ]

--- a/src/aios/sandbox/github_clone_breaker.py
+++ b/src/aios/sandbox/github_clone_breaker.py
@@ -1,0 +1,205 @@
+"""Per-repo circuit breaker for host-side github clone attempts (#1720).
+
+Production evidence: a session with a dead/expired token on an attached
+``github_repository`` retried the clone on EVERY turn, forever — 2,100
+``github_clone_failed`` events in 24h on one session, each turn paying the
+failed-clone latency in its prelude, plus needless auth-failure traffic
+against GitHub from our egress IP.
+
+This module is the worker-process, in-memory breaker that stops that churn:
+after ``_BREAKER_FAILURE_THRESHOLD`` (K) consecutive clone failures for one
+attachment (keyed on the ``ghrepo_...`` resource id — unique per session
+attachment, so breaker state never crosses sessions, and stable across a
+token rotation on the SAME attachment — see :func:`aios.services.
+github_repositories.rotate_token`), the breaker opens for
+``_BREAKER_UNHEALTHY_BACKOFF_S`` and :func:`aios.sandbox.spec.
+_materialize_github_clones` skips the clone attempt entirely rather than
+re-hitting a dead credential every step.
+
+Deliberately mirrors :mod:`aios.mcp.pool`'s per-key breaker (#1698) — same
+threshold, same cooldown/half-open re-probe shape — so the two breakers
+read as one shared pattern across the codebase. This one is simpler: the
+caller (``_materialize_github_clones``) already runs WITH the session/
+account context the failure needs to log, so there's no pool-level
+"record now, drain-and-emit later from a session-aware caller" indirection
+to bridge — :meth:`record_failure`'s return value tells the caller directly
+whether this is the DOWN edge to emit ``github_clone_degraded`` for.
+
+Half-open re-probe (issue #1720's proposed fix, path (c) "slow timer"):
+when the cooldown window lapses, :meth:`is_open` allows exactly ONE probe
+attempt through ("half-open"). If that probe fails, the breaker reopens
+immediately with a fresh cooldown (no need to accumulate K failures again,
+and no duplicate DOWN event — the resource was already marked degraded).
+If it succeeds, :meth:`record_success` fully closes the breaker.
+
+The other two re-probe paths from the issue:
+
+(a) **Credential row update** — :func:`aios.services.github_repositories.
+    rotate_token` calls :meth:`GithubCloneBreaker.clear` after a successful
+    UPDATE, so a fixed token re-probes on the very next provision instead of
+    serving out a cooldown opened under the old secret.
+(b) **repo_url update** — url/mount_path are immutable on an existing
+    attachment (the API only rotates the token/identity); changing the repo
+    means detach + a fresh attach, which mints a brand-new resource id and
+    therefore a fresh (closed) breaker key automatically.
+(d) **Explicit agent/API request** — :meth:`clear` is also the primitive an
+    explicit re-probe request would call (e.g. a future "retry now" tool/
+    endpoint); not wired to a caller yet.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from aios.logging import get_logger
+
+log = get_logger("aios.sandbox.github_clone_breaker")
+
+# Consecutive clone failures for one resource id before the breaker opens.
+# Mirrors ``aios.mcp.pool._BREAKER_FAILURE_THRESHOLD`` (#1698) — same K
+# across both breaker implementations by design.
+_BREAKER_FAILURE_THRESHOLD = 3
+
+# Cooldown applied when the breaker opens. An hour, per issue #1720's
+# proposed "(c) slow timer (e.g. hourly)" re-probe — long enough that a
+# dead credential doesn't hammer GitHub's auth endpoint, short enough that
+# a same-day credential fix is picked up without an explicit re-probe.
+_BREAKER_UNHEALTHY_BACKOFF_S = 3600.0
+
+
+@dataclass(slots=True)
+class DegradedRepo:
+    """One breaker-open repo attachment, for the prelude/agent-visible surface.
+
+    ``since`` is a wall-clock UTC timestamp (not ``time.monotonic()``) —
+    it's rendered directly into the prelude health line
+    (``repos: <mount_path> AUTH-FAILED since <since>``), so it needs to
+    mean something to a human/agent reading it, not just order events
+    within one process's uptime.
+    """
+
+    resource_id: str
+    repo_url: str
+    mount_path: str
+    since: datetime
+
+
+@dataclass(slots=True)
+class GithubCloneBreaker:
+    """Worker-process, in-memory circuit breaker keyed on github repo resource id.
+
+    Not persisted across worker restarts — a fresh worker starts every
+    breaker closed, which is the correct fail-open default (a dead
+    credential is re-discovered within K failures, not silently muted
+    forever by a stale in-memory flag from a previous process).
+    """
+
+    _failure_count: dict[str, int] = field(default_factory=dict)
+    _unhealthy_until: dict[str, float] = field(default_factory=dict)
+    _half_open: set[str] = field(default_factory=set)
+    _degraded: dict[str, DegradedRepo] = field(default_factory=dict)
+
+    def is_open(self, resource_id: str, *, now: float | None = None) -> bool:
+        """True if this resource id is in a clone backoff window.
+
+        Callers consult this BEFORE attempting a clone so a dead credential
+        is skipped fast instead of re-stalling every step. On expiry the
+        window clears and the resource enters "half-open": this call
+        returns ``False`` (the caller should attempt exactly one probe
+        clone) but the resource stays in :meth:`degraded_repos` until that
+        probe actually succeeds — a cooldown lapse alone doesn't heal the
+        prelude surface.
+        """
+        effective_now = now if now is not None else time.monotonic()
+        until = self._unhealthy_until.get(resource_id)
+        if until is None:
+            return False
+        if effective_now >= until:
+            del self._unhealthy_until[resource_id]
+            self._half_open.add(resource_id)
+            return False
+        return True
+
+    def record_failure(self, resource_id: str, repo_url: str, mount_path: str = "") -> bool:
+        """Count one consecutive clone failure; open the breaker at K.
+
+        Returns ``True`` on the DOWN transition (the failure that first
+        opens the circuit) so the caller — which already has session
+        context in hand — can emit exactly one ``github_clone_degraded``
+        lifecycle event. A half-open probe failure reopens the breaker
+        immediately (fresh cooldown) but returns ``False``: the resource
+        was already degraded, so no duplicate event.
+        """
+        if resource_id in self._half_open:
+            self._half_open.discard(resource_id)
+            self._unhealthy_until[resource_id] = time.monotonic() + _BREAKER_UNHEALTHY_BACKOFF_S
+            log.warning(
+                "github_clone_breaker.reopened",
+                resource_id=resource_id,
+                repo_url=repo_url,
+                backoff_s=_BREAKER_UNHEALTHY_BACKOFF_S,
+            )
+            return False
+
+        count = self._failure_count.get(resource_id, 0) + 1
+        self._failure_count[resource_id] = count
+        if count < _BREAKER_FAILURE_THRESHOLD:
+            return False
+
+        self._unhealthy_until[resource_id] = time.monotonic() + _BREAKER_UNHEALTHY_BACKOFF_S
+        transitioned_down = resource_id not in self._degraded
+        if transitioned_down:
+            self._degraded[resource_id] = DegradedRepo(
+                resource_id=resource_id,
+                repo_url=repo_url,
+                mount_path=mount_path or repo_url,
+                since=datetime.now(UTC),
+            )
+            log.warning(
+                "github_clone_breaker.opened",
+                resource_id=resource_id,
+                repo_url=repo_url,
+                failures=count,
+                backoff_s=_BREAKER_UNHEALTHY_BACKOFF_S,
+            )
+        return transitioned_down
+
+    def record_success(self, resource_id: str) -> None:
+        """Clear breaker state for a successful clone — re-closes the circuit."""
+        self._failure_count.pop(resource_id, None)
+        self._unhealthy_until.pop(resource_id, None)
+        self._half_open.discard(resource_id)
+        self._degraded.pop(resource_id, None)
+
+    def clear(self, resource_id: str) -> None:
+        """Explicitly reset all breaker state for ``resource_id``.
+
+        Called on a credential row update (rotate_token) and available for
+        an explicit agent/API re-probe request (issue #1720 (a)/(d)) — the
+        next clone attempt re-probes immediately regardless of any open
+        cooldown window, and (unlike the half-open path) is treated as a
+        brand-new failure series if it fails again (full K threshold, not
+        an instant reopen) since the credential actually changed.
+        """
+        self._failure_count.pop(resource_id, None)
+        self._unhealthy_until.pop(resource_id, None)
+        self._half_open.discard(resource_id)
+        self._degraded.pop(resource_id, None)
+
+    def degraded_repos(self) -> list[DegradedRepo]:
+        """Return every resource id whose breaker is currently OPEN or half-open.
+
+        In-memory, per-worker accessor for tests/introspection and the
+        prelude health surface — reflects only this worker's breaker state.
+        """
+        return list(self._degraded.values())
+
+
+__all__ = [
+    "_BREAKER_FAILURE_THRESHOLD",
+    "_BREAKER_UNHEALTHY_BACKOFF_S",
+    "DegradedRepo",
+    "GithubCloneBreaker",
+]

--- a/src/aios/sandbox/github_clone_breaker.py
+++ b/src/aios/sandbox/github_clone_breaker.py
@@ -11,8 +11,11 @@ after ``_BREAKER_FAILURE_THRESHOLD`` (K) consecutive clone failures for one
 attachment (keyed on the ``ghrepo_...`` resource id — unique per session
 attachment, so breaker state never crosses sessions, and stable across a
 token rotation on the SAME attachment — see :func:`aios.services.
-github_repositories.rotate_token`), the breaker opens for
-``_BREAKER_UNHEALTHY_BACKOFF_S`` and :func:`aios.sandbox.spec.
+github_repositories.rotate_token`), the breaker opens for a cooldown whose
+length depends on the failure CLASS — ``_BREAKER_AUTH_BACKOFF_S`` (1h) for an
+auth-shaped failure (dead/expired token, which won't fix itself) vs
+``_BREAKER_TRANSIENT_BACKOFF_S`` (60s) for a timeout/network/GitHub-5xx blip
+that should re-probe fast — and :func:`aios.sandbox.spec.
 _materialize_github_clones` skips the clone attempt entirely rather than
 re-hitting a dead credential every step.
 
@@ -62,11 +65,21 @@ log = get_logger("aios.sandbox.github_clone_breaker")
 # across both breaker implementations by design.
 _BREAKER_FAILURE_THRESHOLD = 3
 
-# Cooldown applied when the breaker opens. An hour, per issue #1720's
-# proposed "(c) slow timer (e.g. hourly)" re-probe — long enough that a
-# dead credential doesn't hammer GitHub's auth endpoint, short enough that
-# a same-day credential fix is picked up without an explicit re-probe.
-_BREAKER_UNHEALTHY_BACKOFF_S = 3600.0
+# Cooldown for an AUTH-SHAPED failure (dead/expired/invalid token). An hour,
+# per issue #1720's proposed "(c) slow timer (e.g. hourly)" re-probe — long
+# enough that a dead credential doesn't hammer GitHub's auth endpoint, short
+# enough that a same-day credential fix is picked up without an explicit
+# re-probe.
+_BREAKER_AUTH_BACKOFF_S = 3600.0
+
+# Cooldown for a TRANSIENT failure (timeout / network / GitHub 5xx). Short —
+# mirrors the MCP breaker this one is modeled on
+# (``aios.mcp.pool._BREAKER_UNHEALTHY_BACKOFF_S`` = 60s) — so a GitHub blip or
+# a provision-time network hiccup re-probes within a minute instead of
+# sitting out a full hour AFTER the outage clears. The 1h lockout on a
+# recovered-transient failure was the regression the #1720 seat gate caught:
+# pre-PR the next step retried instantly.
+_BREAKER_TRANSIENT_BACKOFF_S = 60.0
 
 
 @dataclass(slots=True)
@@ -78,12 +91,20 @@ class DegradedRepo:
     (``repos: <mount_path> AUTH-FAILED since <since>``), so it needs to
     mean something to a human/agent reading it, not just order events
     within one process's uptime.
+
+    ``auth_failure`` + ``last_error`` (issue #1720 seat-gate fix) carry the
+    real cause so the prelude renders the TRUTH — ``AUTH-FAILED`` only for a
+    classified auth failure, else ``CLONE-FAILING ... (last: <err>)`` with the
+    (already token-redacted) git error — instead of hardcoding ``AUTH-FAILED``
+    for every degraded repo.
     """
 
     resource_id: str
     repo_url: str
     mount_path: str
     since: datetime
+    auth_failure: bool = False
+    last_error: str = ""
 
 
 @dataclass(slots=True)
@@ -122,7 +143,15 @@ class GithubCloneBreaker:
             return False
         return True
 
-    def record_failure(self, resource_id: str, repo_url: str, mount_path: str = "") -> bool:
+    def record_failure(
+        self,
+        resource_id: str,
+        repo_url: str,
+        mount_path: str = "",
+        *,
+        auth_failure: bool = False,
+        last_error: str = "",
+    ) -> bool:
         """Count one consecutive clone failure; open the breaker at K.
 
         Returns ``True`` on the DOWN transition (the failure that first
@@ -131,15 +160,32 @@ class GithubCloneBreaker:
         lifecycle event. A half-open probe failure reopens the breaker
         immediately (fresh cooldown) but returns ``False``: the resource
         was already degraded, so no duplicate event.
+
+        ``auth_failure`` classifies THIS failure (issue #1720 seat-gate fix):
+        an auth-shaped failure (dead/expired token) opens the long
+        ``_BREAKER_AUTH_BACKOFF_S`` cooldown; a transient one (timeout /
+        network / 5xx) the short ``_BREAKER_TRANSIENT_BACKOFF_S`` so it
+        re-probes fast instead of eating a full-hour lockout after the outage
+        clears. ``last_error`` is the (already token-redacted) git message
+        carried into :class:`DegradedRepo` so the prelude renders the real
+        cause rather than a hardcoded ``AUTH-FAILED``.
         """
+        backoff_s = _BREAKER_AUTH_BACKOFF_S if auth_failure else _BREAKER_TRANSIENT_BACKOFF_S
         if resource_id in self._half_open:
             self._half_open.discard(resource_id)
-            self._unhealthy_until[resource_id] = time.monotonic() + _BREAKER_UNHEALTHY_BACKOFF_S
+            self._unhealthy_until[resource_id] = time.monotonic() + backoff_s
+            # Refresh the degraded record's cause with this probe's failure so
+            # the prelude line reflects the latest reason (keep original since).
+            existing = self._degraded.get(resource_id)
+            if existing is not None:
+                existing.auth_failure = auth_failure
+                existing.last_error = last_error
             log.warning(
                 "github_clone_breaker.reopened",
                 resource_id=resource_id,
                 repo_url=repo_url,
-                backoff_s=_BREAKER_UNHEALTHY_BACKOFF_S,
+                backoff_s=backoff_s,
+                auth_failure=auth_failure,
             )
             return False
 
@@ -148,7 +194,7 @@ class GithubCloneBreaker:
         if count < _BREAKER_FAILURE_THRESHOLD:
             return False
 
-        self._unhealthy_until[resource_id] = time.monotonic() + _BREAKER_UNHEALTHY_BACKOFF_S
+        self._unhealthy_until[resource_id] = time.monotonic() + backoff_s
         transitioned_down = resource_id not in self._degraded
         if transitioned_down:
             self._degraded[resource_id] = DegradedRepo(
@@ -156,13 +202,16 @@ class GithubCloneBreaker:
                 repo_url=repo_url,
                 mount_path=mount_path or repo_url,
                 since=datetime.now(UTC),
+                auth_failure=auth_failure,
+                last_error=last_error,
             )
             log.warning(
                 "github_clone_breaker.opened",
                 resource_id=resource_id,
                 repo_url=repo_url,
                 failures=count,
-                backoff_s=_BREAKER_UNHEALTHY_BACKOFF_S,
+                backoff_s=backoff_s,
+                auth_failure=auth_failure,
             )
         return transitioned_down
 
@@ -198,8 +247,9 @@ class GithubCloneBreaker:
 
 
 __all__ = [
+    "_BREAKER_AUTH_BACKOFF_S",
     "_BREAKER_FAILURE_THRESHOLD",
-    "_BREAKER_UNHEALTHY_BACKOFF_S",
+    "_BREAKER_TRANSIENT_BACKOFF_S",
     "DegradedRepo",
     "GithubCloneBreaker",
 ]

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -423,6 +423,17 @@ async def _materialize_github_clones(
     list. The proxy stays alive for sibling repos. Per-clone wall-clock
     is bounded by ``Settings.github_clone_session_timeout_seconds``
     (issue #697).
+
+    Circuit breaker (#1720): each repo's clone outcome feeds
+    ``runtime.github_clone_breaker`` (worker-process, in-memory, keyed on
+    resource id). A repo with an open breaker is skipped BEFORE any clone
+    subprocess runs — it still lands in ``failures``/``attempted`` (so
+    the drift key and the ``github_clone_failed`` event are unaffected)
+    but costs none of the actual clone latency. The K-th consecutive
+    failure that opens the breaker also appends exactly one
+    ``github_clone_degraded`` session event (the DOWN-edge signal a
+    caller/ops-agent can alert on instead of rediscovering the same dead
+    credential every turn).
     """
     from aios.sandbox.git_proxy import repo_key
     from aios.services import github_repositories as github_repo_service
@@ -458,10 +469,22 @@ async def _materialize_github_clones(
     # uvicorn server, httpx client, bound TCP port, and in-memory
     # token map leak for the worker's lifetime. Mirrors the cleanup
     # pattern at build_spec_from_session below.
+    breaker = runtime.github_clone_breaker
     try:
         materialized: list[GithubRepositoryResourceEcho] = []
         failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError]] = []
+        degraded_down_edges: list[GithubRepositoryResourceEcho] = []
         for echo, token in echo_tokens:
+            # Circuit breaker (#1720): a repo whose clone has failed
+            # ``_BREAKER_FAILURE_THRESHOLD`` times in a row is skipped
+            # fast — no clone attempt, no wall-clock tax on this step's
+            # prelude — until the cooldown window lapses and lets exactly
+            # one probe through. Without this, a dead/expired token
+            # retries on EVERY step forever (issue #1720's 2,100
+            # failures/24h production evidence).
+            if breaker is not None and breaker.is_open(echo.id):
+                failures.append((echo, GithubCloneError("clone breaker open; skipping attempt")))
+                continue
             try:
                 cache_dir = await ensure_cache_clone(echo.url, token)
                 await ensure_session_working_tree(
@@ -476,7 +499,13 @@ async def _materialize_github_clones(
                 )
             except GithubCloneError as err:
                 failures.append((echo, err))
+                if breaker is not None and breaker.record_failure(
+                    echo.id, echo.url, echo.mount_path
+                ):
+                    degraded_down_edges.append(echo)
                 continue
+            if breaker is not None:
+                breaker.record_success(echo.id)
             materialized.append(echo)
 
         # Log + append failure events outside the conn block so we don't
@@ -502,6 +531,23 @@ async def _materialize_github_clones(
                     },
                     account_id=account_id,
                 )
+        # Exactly one durable ``github_clone_degraded`` event per breaker
+        # DOWN transition (#1720) — dedup lives in the breaker (only the
+        # K-th consecutive failure returns True from ``record_failure``),
+        # this just stamps the session-visible artifact for it.
+        for degraded_echo in degraded_down_edges:
+            await sessions_service.append_event(
+                pool,
+                session_id,
+                "span",
+                {
+                    "event": "github_clone_degraded",
+                    "resource_id": degraded_echo.id,
+                    "repo_url": degraded_echo.url,
+                    "is_error": False,
+                },
+                account_id=account_id,
+            )
         # ``attempted`` is every attached echo regardless of clone outcome
         # — the drift key is stamped from THIS, not ``materialized``, so a
         # failed clone can't skew the provision-time snapshot below the

--- a/src/aios/sandbox/spec.py
+++ b/src/aios/sandbox/spec.py
@@ -472,7 +472,11 @@ async def _materialize_github_clones(
     breaker = runtime.github_clone_breaker
     try:
         materialized: list[GithubRepositoryResourceEcho] = []
-        failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError]] = []
+        # (echo, error, breaker_was_open) — ``breaker_was_open`` distinguishes a
+        # per-turn skip (breaker already OPEN) from a real clone attempt that
+        # failed, so the event-append loop can suppress the former's
+        # ``github_clone_failed`` churn (#1720 item 3).
+        failures: list[tuple[GithubRepositoryResourceEcho, GithubCloneError, bool]] = []
         degraded_down_edges: list[GithubRepositoryResourceEcho] = []
         for echo, token in echo_tokens:
             # Circuit breaker (#1720): a repo whose clone has failed
@@ -483,7 +487,9 @@ async def _materialize_github_clones(
             # retries on EVERY step forever (issue #1720's 2,100
             # failures/24h production evidence).
             if breaker is not None and breaker.is_open(echo.id):
-                failures.append((echo, GithubCloneError("clone breaker open; skipping attempt")))
+                failures.append(
+                    (echo, GithubCloneError("clone breaker open; skipping attempt"), True)
+                )
                 continue
             try:
                 cache_dir = await ensure_cache_clone(echo.url, token)
@@ -498,9 +504,13 @@ async def _materialize_github_clones(
                     git_user_email=echo.git_user_email,
                 )
             except GithubCloneError as err:
-                failures.append((echo, err))
+                failures.append((echo, err, False))
                 if breaker is not None and breaker.record_failure(
-                    echo.id, echo.url, echo.mount_path
+                    echo.id,
+                    echo.url,
+                    echo.mount_path,
+                    auth_failure=err.auth_failure,
+                    last_error=str(err),
                 ):
                     degraded_down_edges.append(echo)
                 continue
@@ -511,7 +521,22 @@ async def _materialize_github_clones(
         # Log + append failure events outside the conn block so we don't
         # hold one connection while acquiring a second from the same pool.
         if failures:
-            for failed_echo, failure in failures:
+            for failed_echo, failure, breaker_was_open in failures:
+                if breaker_was_open:
+                    # Breaker already OPEN — we skipped the clone entirely this
+                    # turn. The standing prelude health line + the one-shot
+                    # ``github_clone_degraded`` DOWN edge already carry this
+                    # signal, so appending a ``github_clone_failed`` event every
+                    # step is pure churn (the 2,100-rows/day pathology #1720 set
+                    # out to kill). Demote to a debug log; the ``failures`` /
+                    # ``attempted`` bookkeeping (drift key) stays intact.
+                    log.debug(
+                        "sandbox.github_clone_skipped_breaker_open",
+                        session_id=session_id,
+                        resource_id=failed_echo.id,
+                        repo_url=failed_echo.url,
+                    )
+                    continue
                 log.warning(
                     "sandbox.github_clone_failed",
                     session_id=session_id,

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -20,6 +20,7 @@ import asyncpg
 
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
+from aios.db.listen import GITHUB_CLONE_BREAKER_CLEAR_CHANNEL
 from aios.errors import ConflictError, RateLimitedError
 from aios.models.github_repositories import (
     MAX_REPOS_PER_SESSION,
@@ -27,6 +28,22 @@ from aios.models.github_repositories import (
     GithubRepositoryResourceEcho,
 )
 from aios.sandbox.github_clone import remove_session_working_tree
+
+
+async def _notify_clear_clone_breaker(pool: asyncpg.Pool[Any], resource_id: str) -> None:
+    """Signal the worker's github-clone circuit breaker to clear ``resource_id``
+    after a token rotation (#1720, re-probe path (a)).
+
+    The rotation runs in the API process; the breaker lives in the worker.
+    This fires a ``pg_notify`` on ``GITHUB_CLONE_BREAKER_CLEAR_CHANNEL`` which
+    the worker's clear-listener drains and dispatches to
+    :meth:`aios.sandbox.github_clone_breaker.GithubCloneBreaker.clear` — so a
+    fixed credential re-probes on the very next provision instead of serving
+    out a cooldown opened under the old secret. Fire-and-forget, like the MCP
+    vault-eviction NOTIFY (#1030): a notification lost during a listener
+    reconnect falls back to the breaker's own cooldown/half-open re-probe.
+    """
+    await pool.execute("SELECT pg_notify($1, $2)", GITHUB_CLONE_BREAKER_CLEAR_CHANNEL, resource_id)
 
 
 def _encrypt_token(crypto_box: CryptoBox, token: str, *, account_id: str) -> Any:
@@ -193,10 +210,14 @@ async def rotate_token(
     :func:`aios.sandbox.spec.mount_snapshot_from_echoes`), so the
     per-step :meth:`SandboxRegistry.release_if_mounts_changed` already
     recycles the sandbox on the next step.
+
+    Also fires the github-clone-breaker clear NOTIFY (#1720) after commit
+    so a rotated token re-probes on the very next provision instead of
+    serving out a cooldown opened under the old secret.
     """
     blob = _encrypt_token(crypto_box, new_token, account_id=account_id)
     async with pool.acquire() as conn, conn.transaction():
-        return await queries.update_session_github_repo_blob(
+        result = await queries.update_session_github_repo_blob(
             conn,
             session_id,
             resource_id,
@@ -204,6 +225,8 @@ async def rotate_token(
             identity=identity,
             account_id=account_id,
         )
+    await _notify_clear_clone_breaker(pool, resource_id)
+    return result
 
 
 async def get_session_token(

--- a/src/aios/services/github_repositories.py
+++ b/src/aios/services/github_repositories.py
@@ -22,12 +22,15 @@ from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.db.listen import GITHUB_CLONE_BREAKER_CLEAR_CHANNEL
 from aios.errors import ConflictError, RateLimitedError
+from aios.logging import get_logger
 from aios.models.github_repositories import (
     MAX_REPOS_PER_SESSION,
     GithubRepositoryResource,
     GithubRepositoryResourceEcho,
 )
 from aios.sandbox.github_clone import remove_session_working_tree
+
+log = get_logger("aios.services.github_repositories")
 
 
 async def _notify_clear_clone_breaker(pool: asyncpg.Pool[Any], resource_id: str) -> None:
@@ -225,7 +228,22 @@ async def rotate_token(
             identity=identity,
             account_id=account_id,
         )
-    await _notify_clear_clone_breaker(pool, resource_id)
+    # Best-effort, fire-and-forget (#1720 seat-gate): the token rotation has
+    # already COMMITTED above — a failed advisory NOTIFY (e.g. a transient
+    # connection error on ``pool.execute``) must not turn a SUCCESSFUL rotation
+    # into a 500. If the signal is lost the breaker's own cooldown/half-open
+    # re-probe still picks up the fixed credential (just after the cooldown
+    # instead of immediately). Mirrors the MCP vault-eviction NOTIFY's
+    # fire-and-forget contract.
+    try:
+        await _notify_clear_clone_breaker(pool, resource_id)
+    except Exception:
+        log.warning(
+            "github_repositories.breaker_clear_notify_failed",
+            resource_id=resource_id,
+            session_id=session_id,
+            exc_info=True,
+        )
     return result
 
 

--- a/tests/unit/sandbox/test_github_clone_breaker.py
+++ b/tests/unit/sandbox/test_github_clone_breaker.py
@@ -14,9 +14,12 @@ Pins the breaker contract issue #1720 specifies:
 
 from __future__ import annotations
 
+import time
+
 from aios.sandbox.github_clone_breaker import (
+    _BREAKER_AUTH_BACKOFF_S,
     _BREAKER_FAILURE_THRESHOLD,
-    _BREAKER_UNHEALTHY_BACKOFF_S,
+    _BREAKER_TRANSIENT_BACKOFF_S,
     GithubCloneBreaker,
 )
 
@@ -153,8 +156,65 @@ def test_independent_resource_ids_have_independent_breaker_state() -> None:
     assert len(breaker.degraded_repos()) == 1
 
 
-def test_backoff_constant_is_positive_and_threshold_is_at_least_two() -> None:
+def test_backoff_constants_positive_and_threshold_is_at_least_two() -> None:
     # Sanity guard against an accidental K=1 (breaker on first failure,
     # useless for transient blips) or a zero/negative cooldown.
     assert _BREAKER_FAILURE_THRESHOLD >= 2
-    assert _BREAKER_UNHEALTHY_BACKOFF_S > 0
+    assert _BREAKER_AUTH_BACKOFF_S > 0
+    assert _BREAKER_TRANSIENT_BACKOFF_S > 0
+    # A transient blip must re-probe faster than a dead credential, else the
+    # #1720 regression (1h lockout after a recovered outage) returns.
+    assert _BREAKER_TRANSIENT_BACKOFF_S < _BREAKER_AUTH_BACKOFF_S
+
+
+def test_auth_failure_opens_long_cooldown_and_records_cause() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO, _URL, auth_failure=True, last_error="Authentication failed")
+    # Auth failures earn the long (1h) cooldown.
+    remaining = breaker._unhealthy_until[_REPO] - time.monotonic()
+    assert remaining > _BREAKER_TRANSIENT_BACKOFF_S
+    assert remaining <= _BREAKER_AUTH_BACKOFF_S + 1.0
+    degraded = breaker.degraded_repos()[0]
+    assert degraded.auth_failure is True
+    assert degraded.last_error == "Authentication failed"
+
+
+def test_transient_failure_opens_short_cooldown_not_the_hour_lockout() -> None:
+    """The seat-gate regression fix: a transient (timeout/network/5xx) failure
+    must NOT sit out the 1h lockout — it gets the short cooldown."""
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(
+            _REPO, _URL, auth_failure=False, last_error="git clone timed out after 30.0s"
+        )
+    remaining = breaker._unhealthy_until[_REPO] - time.monotonic()
+    assert remaining <= _BREAKER_TRANSIENT_BACKOFF_S + 1.0
+    degraded = breaker.degraded_repos()[0]
+    assert degraded.auth_failure is False
+    assert degraded.last_error == "git clone timed out after 30.0s"
+
+
+def test_half_open_reopen_refreshes_cause_and_backoff_class() -> None:
+    """A half-open probe that fails for a NEW reason refreshes the recorded
+    cause/backoff-class while keeping the original ``since``."""
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(
+            _REPO, _URL, auth_failure=False, last_error="git clone timed out after 30.0s"
+        )
+    original_since = breaker.degraded_repos()[0].since
+    opened_at = breaker._unhealthy_until[_REPO]
+    assert breaker.is_open(_REPO, now=opened_at + 1.0) is False  # enters half-open
+
+    # The probe now fails with an auth error — reopen with the long cooldown.
+    assert (
+        breaker.record_failure(_REPO, _URL, auth_failure=True, last_error="Authentication failed")
+        is False
+    )
+    degraded = breaker.degraded_repos()[0]
+    assert degraded.auth_failure is True
+    assert degraded.last_error == "Authentication failed"
+    assert degraded.since == original_since  # degradation start is preserved
+    remaining = breaker._unhealthy_until[_REPO] - time.monotonic()
+    assert remaining > _BREAKER_TRANSIENT_BACKOFF_S

--- a/tests/unit/sandbox/test_github_clone_breaker.py
+++ b/tests/unit/sandbox/test_github_clone_breaker.py
@@ -1,0 +1,160 @@
+"""Unit coverage for :class:`aios.sandbox.github_clone_breaker.GithubCloneBreaker`.
+
+Pins the breaker contract issue #1720 specifies:
+
+- Opens at K consecutive failures (not before).
+- Exactly one DOWN-edge signal per degradation episode (dedup until recovery).
+- ``is_open`` gates further attempts while the cooldown window is live.
+- The cooldown lapsing allows exactly one half-open probe; success fully
+  recovers, failure reopens with a fresh window and no duplicate DOWN edge.
+- ``clear`` (the credential-rotation re-probe lever) resets state immediately
+  regardless of any open window.
+- Healthy repos (never failing) never enter the degraded set.
+"""
+
+from __future__ import annotations
+
+from aios.sandbox.github_clone_breaker import (
+    _BREAKER_FAILURE_THRESHOLD,
+    _BREAKER_UNHEALTHY_BACKOFF_S,
+    GithubCloneBreaker,
+)
+
+_REPO = "ghrepo_01TEST"
+_URL = "https://github.com/acme/foo.git"
+
+
+def test_breaker_stays_closed_below_threshold() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD - 1):
+        down = breaker.record_failure(_REPO, _URL)
+        assert down is False
+        assert breaker.is_open(_REPO) is False
+    assert breaker.degraded_repos() == []
+
+
+def test_breaker_opens_at_threshold_with_single_down_edge() -> None:
+    breaker = GithubCloneBreaker()
+    down_edges = [breaker.record_failure(_REPO, _URL) for _ in range(_BREAKER_FAILURE_THRESHOLD)]
+    # Only the K-th failure is the DOWN transition.
+    assert down_edges == [False] * (_BREAKER_FAILURE_THRESHOLD - 1) + [True]
+    assert breaker.is_open(_REPO) is True
+    degraded = breaker.degraded_repos()
+    assert len(degraded) == 1
+    assert degraded[0].resource_id == _REPO
+    assert degraded[0].repo_url == _URL
+
+
+def test_further_failures_while_open_do_not_re_signal_down() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO, _URL)
+    assert breaker.is_open(_REPO) is True
+    # One more failure while already open (shouldn't normally be recorded
+    # since is_open gates the attempt, but the breaker itself must still
+    # dedup if a caller calls it anyway).
+    assert breaker.record_failure(_REPO, _URL) is False
+
+
+def test_healthy_repo_never_degrades() -> None:
+    breaker = GithubCloneBreaker()
+    breaker.record_success(_REPO)
+    assert breaker.is_open(_REPO) is False
+    assert breaker.degraded_repos() == []
+
+
+def test_record_success_closes_breaker() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO, _URL)
+    assert breaker.is_open(_REPO) is True
+
+    breaker.record_success(_REPO)
+
+    assert breaker.is_open(_REPO) is False
+    assert breaker.degraded_repos() == []
+
+
+def test_cooldown_lapse_allows_half_open_probe() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO, _URL)
+    opened_at = breaker._unhealthy_until[_REPO]
+
+    # Before the cooldown elapses: still open, no probe allowed.
+    assert breaker.is_open(_REPO, now=opened_at - 1.0) is True
+    # Still shows as degraded for the prelude surface throughout the window.
+    assert len(breaker.degraded_repos()) == 1
+
+    # After the cooldown elapses: is_open returns False (probe allowed) but
+    # the resource stays in the degraded set until the probe actually
+    # succeeds.
+    assert breaker.is_open(_REPO, now=opened_at + 1.0) is False
+    assert len(breaker.degraded_repos()) == 1
+
+
+def test_half_open_probe_failure_reopens_without_duplicate_down_edge() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO, _URL)
+    opened_at = breaker._unhealthy_until[_REPO]
+    assert breaker.is_open(_REPO, now=opened_at + 1.0) is False  # enters half-open
+
+    # The probe clone fails again — reopens immediately (no need to
+    # accumulate K failures again), and this is NOT a new DOWN edge (the
+    # resource was already degraded).
+    down_edge = breaker.record_failure(_REPO, _URL)
+    assert down_edge is False
+    assert breaker.is_open(_REPO) is True
+    assert len(breaker.degraded_repos()) == 1
+
+
+def test_half_open_probe_success_fully_recovers() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO, _URL)
+    opened_at = breaker._unhealthy_until[_REPO]
+    assert breaker.is_open(_REPO, now=opened_at + 1.0) is False  # enters half-open
+
+    breaker.record_success(_REPO)
+
+    assert breaker.is_open(_REPO) is False
+    assert breaker.degraded_repos() == []
+    # A subsequent failure series starts fresh from zero (not still half-open).
+    for _ in range(_BREAKER_FAILURE_THRESHOLD - 1):
+        assert breaker.record_failure(_REPO, _URL) is False
+    assert breaker.is_open(_REPO) is False
+
+
+def test_clear_resets_state_regardless_of_open_window() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO, _URL)
+    assert breaker.is_open(_REPO) is True
+
+    breaker.clear(_REPO)
+
+    assert breaker.is_open(_REPO) is False
+    assert breaker.degraded_repos() == []
+    # A fresh failure series requires the full K again (not an instant
+    # reopen the way a half-open probe failure is) since the credential
+    # actually changed.
+    for _ in range(_BREAKER_FAILURE_THRESHOLD - 1):
+        assert breaker.record_failure(_REPO, _URL) is False
+    assert breaker.is_open(_REPO) is False
+
+
+def test_independent_resource_ids_have_independent_breaker_state() -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure("ghrepo_dead", _URL)
+    assert breaker.is_open("ghrepo_dead") is True
+    assert breaker.is_open("ghrepo_healthy") is False
+    assert len(breaker.degraded_repos()) == 1
+
+
+def test_backoff_constant_is_positive_and_threshold_is_at_least_two() -> None:
+    # Sanity guard against an accidental K=1 (breaker on first failure,
+    # useless for transient blips) or a zero/negative cooldown.
+    assert _BREAKER_FAILURE_THRESHOLD >= 2
+    assert _BREAKER_UNHEALTHY_BACKOFF_S > 0

--- a/tests/unit/sandbox/test_spec_clone_breaker_wiring.py
+++ b/tests/unit/sandbox/test_spec_clone_breaker_wiring.py
@@ -153,6 +153,64 @@ async def test_open_breaker_skips_clone_subprocess() -> None:
     assert {e.id for e in attempted} == {"ghr_dead2"}
 
 
+async def test_open_breaker_does_not_append_clone_failed_event_per_turn() -> None:
+    """Item 3 (#1720): while the breaker is OPEN, the per-turn skip must NOT
+    append a ``github_clone_failed`` event (the 2,100-rows/day churn). The
+    prelude line + the one-shot ``github_clone_degraded`` edge carry the signal.
+    """
+    breaker = GithubCloneBreaker()
+    echo = _make_echo("ghr_open")
+
+    # Drive it OPEN (records the degraded DOWN edge on the K-th failure).
+    open_append = AsyncMock()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        await _run_once(breaker=breaker, echo=echo, append_event_mock=open_append)
+    assert breaker.is_open("ghr_open") is True
+
+    # Now a further turn hits the skip path (is_open True) — fresh mock.
+    skip_append = AsyncMock()
+    mock_proxy = MagicMock()
+    mock_proxy.start = AsyncMock()
+    mock_proxy.stop = AsyncMock()
+    mock_proxy.proxy_url = MagicMock(return_value="http://stub/proxy")
+    with (
+        patch("aios.sandbox.spec.GitProxy", return_value=mock_proxy),
+        patch(
+            "aios.sandbox.spec.queries.list_session_github_repo_echoes",
+            AsyncMock(return_value=[echo]),
+        ),
+        patch(
+            "aios.services.github_repositories.get_session_token",
+            AsyncMock(return_value="ghp_TEST"),
+        ),
+        patch("aios.sandbox.spec.ensure_cache_clone", AsyncMock(return_value=Path("/tmp/cache"))),
+        patch("aios.sandbox.spec.ensure_session_working_tree", AsyncMock()),
+        patch("aios.sandbox.spec.runtime.require_pool", return_value=_make_pool_with_conn()),
+        patch("aios.sandbox.spec.runtime.require_crypto_box", return_value=MagicMock()),
+        patch("aios.sandbox.spec.runtime.github_clone_breaker", breaker),
+        patch("aios.sandbox.spec.sessions_service.append_event", skip_append),
+    ):
+        await _materialize_github_clones("sess_x", account_id="acct_x")
+
+    events = [c.args[3]["event"] for c in skip_append.await_args_list]
+    assert "github_clone_failed" not in events
+
+
+async def test_transient_failure_records_auth_false_and_error_on_breaker() -> None:
+    """The classification (#1720 item 1) is threaded from the error into the
+    breaker: a non-auth ``GithubCloneError`` opens with ``auth_failure=False``
+    and carries the (redacted) message as ``last_error``."""
+    breaker = GithubCloneBreaker()
+    echo = _make_echo("ghr_transient")
+    append = AsyncMock()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        await _run_once(breaker=breaker, echo=echo, append_event_mock=append)
+
+    degraded = breaker.degraded_repos()[0]
+    assert degraded.auth_failure is False  # "boom" is not auth-shaped
+    assert "boom" in degraded.last_error
+
+
 async def test_breaker_recovers_on_successful_clone() -> None:
     breaker = GithubCloneBreaker()
     echo = _make_echo("ghr_recovers")

--- a/tests/unit/sandbox/test_spec_clone_breaker_wiring.py
+++ b/tests/unit/sandbox/test_spec_clone_breaker_wiring.py
@@ -1,0 +1,204 @@
+"""``_materialize_github_clones`` wiring to ``runtime.github_clone_breaker`` (#1720).
+
+Separate from ``tests/unit/test_sandbox_spec.py`` (which pins the proxy
+cleanup/sibling-continuation contract with no breaker present) — these pin
+that repeated clone failures for the SAME resource id open the breaker,
+skip the clone subprocess on subsequent attempts, and emit exactly one
+``github_clone_degraded`` event on the DOWN transition.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aios.models.github_repositories import GithubRepositoryResourceEcho
+from aios.sandbox.github_clone import GithubCloneError
+from aios.sandbox.github_clone_breaker import _BREAKER_FAILURE_THRESHOLD, GithubCloneBreaker
+from aios.sandbox.spec import _materialize_github_clones
+
+
+def _make_echo(repo_id: str = "ghr_test") -> GithubRepositoryResourceEcho:
+    now = datetime.now(tz=UTC)
+    return GithubRepositoryResourceEcho(
+        id=repo_id,
+        url="https://github.com/acme/foo.git",
+        mount_path="/workspace/foo",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_pool_with_conn() -> MagicMock:
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    return pool
+
+
+async def _run_once(
+    *, breaker: GithubCloneBreaker, echo: GithubRepositoryResourceEcho, append_event_mock: AsyncMock
+) -> tuple[list[GithubRepositoryResourceEcho], list[GithubRepositoryResourceEcho]]:
+    mock_proxy = MagicMock()
+    mock_proxy.start = AsyncMock()
+    mock_proxy.stop = AsyncMock()
+    mock_proxy.proxy_url = MagicMock(return_value="http://stub/proxy")
+
+    with (
+        patch("aios.sandbox.spec.GitProxy", return_value=mock_proxy),
+        patch(
+            "aios.sandbox.spec.queries.list_session_github_repo_echoes",
+            AsyncMock(return_value=[echo]),
+        ),
+        patch(
+            "aios.services.github_repositories.get_session_token",
+            AsyncMock(return_value="ghp_TEST"),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_cache_clone",
+            AsyncMock(return_value=Path("/tmp/cache")),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_session_working_tree",
+            AsyncMock(side_effect=GithubCloneError("boom")),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_pool",
+            return_value=_make_pool_with_conn(),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_crypto_box",
+            return_value=MagicMock(),
+        ),
+        patch("aios.sandbox.spec.runtime.github_clone_breaker", breaker),
+        patch(
+            "aios.sandbox.spec.sessions_service.append_event",
+            append_event_mock,
+        ),
+    ):
+        materialized, attempted, _proxy = await _materialize_github_clones(
+            "sess_x", account_id="acct_x"
+        )
+    return materialized, attempted
+
+
+async def test_breaker_opens_after_threshold_and_emits_degraded_event() -> None:
+    breaker = GithubCloneBreaker()
+    echo = _make_echo("ghr_dead")
+    append_event_mock = AsyncMock()
+
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        await _run_once(breaker=breaker, echo=echo, append_event_mock=append_event_mock)
+
+    assert breaker.is_open("ghr_dead") is True
+    events = [c.args[3] for c in append_event_mock.await_args_list]
+    degraded_events = [e for e in events if e["event"] == "github_clone_degraded"]
+    assert len(degraded_events) == 1
+    assert degraded_events[0]["resource_id"] == "ghr_dead"
+
+
+async def test_open_breaker_skips_clone_subprocess() -> None:
+    breaker = GithubCloneBreaker()
+    echo = _make_echo("ghr_dead2")
+    append_event_mock = AsyncMock()
+
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        await _run_once(breaker=breaker, echo=echo, append_event_mock=append_event_mock)
+    assert breaker.is_open("ghr_dead2") is True
+
+    ensure_working_tree_mock = AsyncMock(side_effect=GithubCloneError("boom"))
+    mock_proxy = MagicMock()
+    mock_proxy.start = AsyncMock()
+    mock_proxy.stop = AsyncMock()
+    mock_proxy.proxy_url = MagicMock(return_value="http://stub/proxy")
+
+    with (
+        patch("aios.sandbox.spec.GitProxy", return_value=mock_proxy),
+        patch(
+            "aios.sandbox.spec.queries.list_session_github_repo_echoes",
+            AsyncMock(return_value=[echo]),
+        ),
+        patch(
+            "aios.services.github_repositories.get_session_token",
+            AsyncMock(return_value="ghp_TEST"),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_cache_clone",
+            AsyncMock(return_value=Path("/tmp/cache")),
+        ),
+        patch("aios.sandbox.spec.ensure_session_working_tree", ensure_working_tree_mock),
+        patch(
+            "aios.sandbox.spec.runtime.require_pool",
+            return_value=_make_pool_with_conn(),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_crypto_box",
+            return_value=MagicMock(),
+        ),
+        patch("aios.sandbox.spec.runtime.github_clone_breaker", breaker),
+        patch(
+            "aios.sandbox.spec.sessions_service.append_event",
+            AsyncMock(),
+        ),
+    ):
+        materialized, attempted, _proxy = await _materialize_github_clones(
+            "sess_x", account_id="acct_x"
+        )
+
+    ensure_working_tree_mock.assert_not_awaited()
+    assert materialized == []
+    assert {e.id for e in attempted} == {"ghr_dead2"}
+
+
+async def test_breaker_recovers_on_successful_clone() -> None:
+    breaker = GithubCloneBreaker()
+    echo = _make_echo("ghr_recovers")
+    append_event_mock = AsyncMock()
+
+    mock_proxy = MagicMock()
+    mock_proxy.start = AsyncMock()
+    mock_proxy.stop = AsyncMock()
+    mock_proxy.proxy_url = MagicMock(return_value="http://stub/proxy")
+
+    with (
+        patch("aios.sandbox.spec.GitProxy", return_value=mock_proxy),
+        patch(
+            "aios.sandbox.spec.queries.list_session_github_repo_echoes",
+            AsyncMock(return_value=[echo]),
+        ),
+        patch(
+            "aios.services.github_repositories.get_session_token",
+            AsyncMock(return_value="ghp_TEST"),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_cache_clone",
+            AsyncMock(return_value=Path("/tmp/cache")),
+        ),
+        patch(
+            "aios.sandbox.spec.ensure_session_working_tree",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_pool",
+            return_value=_make_pool_with_conn(),
+        ),
+        patch(
+            "aios.sandbox.spec.runtime.require_crypto_box",
+            return_value=MagicMock(),
+        ),
+        patch("aios.sandbox.spec.runtime.github_clone_breaker", breaker),
+        patch(
+            "aios.sandbox.spec.sessions_service.append_event",
+            append_event_mock,
+        ),
+    ):
+        materialized, _attempted, _proxy = await _materialize_github_clones(
+            "sess_x", account_id="acct_x"
+        )
+
+    assert [e.id for e in materialized] == ["ghr_recovers"]
+    assert breaker.is_open("ghr_recovers") is False
+    append_event_mock.assert_not_awaited()

--- a/tests/unit/test_github_clone_breaker_clear_listener.py
+++ b/tests/unit/test_github_clone_breaker_clear_listener.py
@@ -1,0 +1,180 @@
+"""Unit coverage for
+:func:`aios.harness.worker._run_github_clone_breaker_clear_listener` (#1720).
+
+A token rotation runs in the API process and NOTIFYs
+``aios_github_clone_breaker_clear`` with the ``ghrepo_...`` resource id; the
+worker owns ``runtime.github_clone_breaker`` so it LISTENs here and calls
+:meth:`GithubCloneBreaker.clear` — a fixed credential re-probes on the next
+provision instead of serving out a cooldown opened under the old secret.
+
+Mirrors ``test_mcp_evict_listener.py``: it pins the same survivability
+contract (a per-payload dispatch exception is isolated INSIDE ``while True``;
+an empty-string termination sentinel escapes to the outer reconnect loop).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from aios.harness import runtime
+from aios.harness.worker import _run_github_clone_breaker_clear_listener
+from aios.sandbox.github_clone_breaker import GithubCloneBreaker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def _restore_runtime_breaker() -> Iterator[None]:
+    saved = runtime.github_clone_breaker
+    yield
+    runtime.github_clone_breaker = saved
+
+
+async def test_listener_clears_breaker_on_notify(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_breaker: None
+) -> None:
+    """A resource_id payload drives ``clear(resource_id)`` on the breaker."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_github_clone_breaker_clear", fake_listen)
+
+    breaker = MagicMock(spec=GithubCloneBreaker)
+    cleared = asyncio.Event()
+
+    def clear(_resource_id: str) -> None:
+        cleared.set()
+
+    breaker.clear.side_effect = clear
+    runtime.github_clone_breaker = breaker
+
+    task = asyncio.create_task(_run_github_clone_breaker_clear_listener("postgresql://stub"))
+    try:
+        await queue.put("ghrepo_rotated")
+        await asyncio.wait_for(cleared.wait(), timeout=1.0)
+        breaker.clear.assert_called_with("ghrepo_rotated")
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_listener_noop_when_breaker_unset(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_breaker: None
+) -> None:
+    """If the breaker global isn't set yet (startup race), a NOTIFY is a
+    harmless no-op and the listener survives to process the next one."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_github_clone_breaker_clear", fake_listen)
+    runtime.github_clone_breaker = None
+
+    breaker = MagicMock(spec=GithubCloneBreaker)
+    second_cleared = asyncio.Event()
+    breaker.clear.side_effect = lambda _rid: second_cleared.set()
+
+    task = asyncio.create_task(_run_github_clone_breaker_clear_listener("postgresql://stub"))
+    try:
+        # First NOTIFY arrives while the breaker is None — must not crash.
+        await queue.put("ghrepo_early")
+        await asyncio.sleep(0)
+        # Now the breaker is up; the next NOTIFY dispatches.
+        runtime.github_clone_breaker = breaker
+        await queue.put("ghrepo_later")
+        await asyncio.wait_for(second_cleared.wait(), timeout=1.0)
+        breaker.clear.assert_called_with("ghrepo_later")
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_listener_survives_dispatch_exception(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_breaker: None
+) -> None:
+    """One exception in dispatch must not disable the listener."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_github_clone_breaker_clear", fake_listen)
+
+    breaker = MagicMock(spec=GithubCloneBreaker)
+    first = asyncio.Event()
+    second = asyncio.Event()
+    calls = 0
+
+    def clear(_resource_id: str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first.set()
+            raise RuntimeError("simulated transient clear failure")
+        second.set()
+
+    breaker.clear.side_effect = clear
+    runtime.github_clone_breaker = breaker
+
+    task = asyncio.create_task(_run_github_clone_breaker_clear_listener("postgresql://stub"))
+    try:
+        await queue.put("ghrepo_one")
+        await asyncio.wait_for(first.wait(), timeout=1.0)
+        await queue.put("ghrepo_two")
+        try:
+            await asyncio.wait_for(second.wait(), timeout=1.0)
+        except TimeoutError as exc:
+            raise AssertionError(
+                "listener did not process second clear — it died on the first"
+            ) from exc
+        assert calls == 2
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_listener_reconnects_after_termination(
+    monkeypatch: pytest.MonkeyPatch, _restore_runtime_breaker: None
+) -> None:
+    """An empty-string payload (termination sentinel) tears down the inner loop
+    and the outer loop re-enters LISTEN."""
+    queue: asyncio.Queue[str] = asyncio.Queue()
+    attempts = 0
+    second_entered = asyncio.Event()
+
+    @asynccontextmanager
+    async def fake_listen(_db_url: str) -> AsyncIterator[asyncio.Queue[str]]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 2:
+            second_entered.set()
+        yield queue
+
+    monkeypatch.setattr("aios.harness.worker.listen_for_github_clone_breaker_clear", fake_listen)
+    monkeypatch.setattr("aios.harness.worker._LISTEN_RECONNECT_BACKOFF_SECONDS", 0)
+    runtime.github_clone_breaker = MagicMock(spec=GithubCloneBreaker)
+
+    task = asyncio.create_task(_run_github_clone_breaker_clear_listener("postgresql://stub"))
+    try:
+        await queue.put("")  # termination sentinel
+        await asyncio.wait_for(second_entered.wait(), timeout=1.0)
+        assert attempts == 2
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/unit/test_github_clone_breaker_notify.py
+++ b/tests/unit/test_github_clone_breaker_notify.py
@@ -75,3 +75,30 @@ async def test_rotate_token_fires_breaker_clear_notify() -> None:
     assert args[0] == "SELECT pg_notify($1, $2)"
     assert args[1] == GITHUB_CLONE_BREAKER_CLEAR_CHANNEL
     assert args[2] == "ghr_1"
+
+
+async def test_rotate_token_survives_failed_breaker_clear_notify() -> None:
+    """Item 5b (#1720 seat-gate): the rotation UPDATE already committed, so a
+    failed advisory NOTIFY must NOT 500 — rotate_token swallows it and returns
+    the rotated echo. The breaker's own cooldown/half-open re-probe still
+    recovers the fixed credential."""
+    pool = _fake_pool_with_conn()
+    pool.execute = AsyncMock(side_effect=RuntimeError("pg_notify connection reset"))
+    crypto_box = MagicMock()
+    crypto_box.derive_account_subkey = MagicMock(return_value=MagicMock(encrypt=MagicMock()))
+
+    with patch.object(
+        queries, "update_session_github_repo_blob", AsyncMock(return_value=_echo("ghr_1"))
+    ):
+        result = await github_repo_service.rotate_token(
+            pool,
+            crypto_box,
+            account_id="acc_1",
+            session_id="sess_1",
+            resource_id="ghr_1",
+            new_token="new-token",
+        )
+
+    # The rotation succeeded despite the NOTIFY failure.
+    assert result.id == "ghr_1"
+    pool.execute.assert_awaited_once()

--- a/tests/unit/test_github_clone_breaker_notify.py
+++ b/tests/unit/test_github_clone_breaker_notify.py
@@ -1,0 +1,77 @@
+"""``rotate_token`` fires the github-clone-breaker clear NOTIFY (#1720).
+
+A token rotation runs in the API process, but the live
+``GithubCloneBreaker`` state for that resource lives in the worker's
+in-memory breaker. This test pins that ``rotate_token`` emits a
+``pg_notify`` on ``aios_github_clone_breaker_clear`` with the resource id
+after the UPDATE commits, so a fixed credential re-probes on the next
+provision instead of serving out a stale cooldown.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aios.db import queries
+from aios.db.listen import GITHUB_CLONE_BREAKER_CLEAR_CHANNEL
+from aios.models.github_repositories import GithubRepositoryResourceEcho
+from aios.services import github_repositories as github_repo_service
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fake_pool_with_conn() -> Any:
+    conn = MagicMock()
+    txn_cm = MagicMock()
+    txn_cm.__aenter__ = AsyncMock(return_value=None)
+    txn_cm.__aexit__ = AsyncMock(return_value=None)
+    conn.transaction = MagicMock(return_value=txn_cm)
+
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+    pool.execute = AsyncMock()
+    return pool
+
+
+def _echo(resource_id: str = "ghr_1") -> GithubRepositoryResourceEcho:
+    now = datetime.now(UTC)
+    return GithubRepositoryResourceEcho(
+        id=resource_id,
+        url="https://github.com/acme/foo.git",
+        mount_path="/workspace/foo",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def test_rotate_token_fires_breaker_clear_notify() -> None:
+    pool = _fake_pool_with_conn()
+    crypto_box = MagicMock()
+    crypto_box.derive_account_subkey = MagicMock(return_value=MagicMock(encrypt=MagicMock()))
+
+    with patch.object(
+        queries, "update_session_github_repo_blob", AsyncMock(return_value=_echo("ghr_1"))
+    ):
+        result = await github_repo_service.rotate_token(
+            pool,
+            crypto_box,
+            account_id="acc_1",
+            session_id="sess_1",
+            resource_id="ghr_1",
+            new_token="new-token",
+        )
+
+    assert result.id == "ghr_1"
+    pool.execute.assert_awaited_once()
+    args = pool.execute.await_args.args
+    assert args[0] == "SELECT pg_notify($1, $2)"
+    assert args[1] == GITHUB_CLONE_BREAKER_CLEAR_CHANNEL
+    assert args[2] == "ghr_1"

--- a/tests/unit/test_github_clone_helpers.py
+++ b/tests/unit/test_github_clone_helpers.py
@@ -203,3 +203,54 @@ async def test_cache_clone_uses_cache_timeout_not_session_timeout(
         assert call.kwargs["timeout_s"] == 99.0, (
             f"expected cache budget (99.0) for {call.args[0]!r}, got {call.kwargs['timeout_s']}"
         )
+
+
+class TestAuthFailureClassification:
+    """`GithubCloneError.auth_failure` / `is_auth_failure_message` — auth-shaped
+    (dead/expired token) vs transient (timeout/network/5xx) classification
+    (#1720 seat-gate fix). Auth-shaped is the ONLY class that earns the 1h
+    breaker lockout + the AUTH-FAILED prelude label."""
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "remote: Invalid username or token. Password authentication is not supported",
+            "fatal: Authentication failed for 'https://github.com/acme/foo.git/'",
+            "The requested URL returned error: 403",
+            "The requested URL returned error: 401",
+            "error: RPC failed; HTTP 403 curl 22",
+            "error: RPC failed; HTTP 401",
+            "remote: 403 Forbidden",
+            "401 Unauthorized",
+        ],
+    )
+    def test_auth_shaped_messages_classified_auth(self, stderr: str) -> None:
+        from aios.sandbox.github_clone import is_auth_failure_message
+
+        assert is_auth_failure_message(stderr) is True
+        assert GithubCloneError(f"git clone --reference failed: {stderr}").auth_failure is True
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "git clone --reference timed out after 30.0s",
+            "fatal: unable to access 'https://github.com/acme/foo.git/': "
+            "Could not resolve host: github.com",
+            "error: RPC failed; HTTP 500 curl 22",
+            "error: RPC failed; HTTP 502",
+            "fatal: the remote end hung up unexpectedly",
+            "clone breaker open; skipping attempt",
+        ],
+    )
+    def test_transient_messages_not_classified_auth(self, stderr: str) -> None:
+        from aios.sandbox.github_clone import is_auth_failure_message
+
+        assert is_auth_failure_message(stderr) is False
+        assert GithubCloneError(stderr).auth_failure is False
+
+    def test_explicit_auth_failure_overrides_message_autoderive(self) -> None:
+        # An explicit verdict wins over the auto-derived one.
+        err = GithubCloneError("some opaque failure", auth_failure=True)
+        assert err.auth_failure is True
+        err2 = GithubCloneError("Authentication failed", auth_failure=False)
+        assert err2.auth_failure is False

--- a/tests/unit/test_loop_spend_gate_real_collaborator.py
+++ b/tests/unit/test_loop_spend_gate_real_collaborator.py
@@ -128,6 +128,7 @@ async def test_real_gate_trips_when_subtree_over_finite_limit() -> None:
         patch("aios.harness.loop.agents_service.load_for_session", AsyncMock(return_value=agent)),
         patch("aios.services.channels.list_session_channels", AsyncMock(return_value=[])),
         patch("aios.harness.loop.refresh_session_mount_state", AsyncMock(return_value=[])),
+        patch("aios.harness.loop._list_session_github_repo_echoes", AsyncMock(return_value=[])),
         patch("aios.harness.loop.compute_step_prelude", AsyncMock(return_value=SimpleNamespace())),
         patch("aios.harness.loop.prelude_overhead_local", return_value=0),
         patch(

--- a/tests/unit/test_resource_health_block.py
+++ b/tests/unit/test_resource_health_block.py
@@ -1,0 +1,73 @@
+"""Unit coverage for :mod:`aios.harness.resource_health` (issue #1720).
+
+Pins the prelude "resource health" surface: a persistent, always-visible
+system-prompt line for a resource whose circuit breaker is open, so the
+model doesn't silently re-diagnose the same dead credential/down MCP server
+turn after turn with no memory of having already tried.
+"""
+
+from __future__ import annotations
+
+from aios.harness.resource_health import (
+    augment_with_resource_health,
+    build_resource_health_block,
+)
+
+
+def test_empty_when_nothing_degraded() -> None:
+    assert build_resource_health_block(degraded_repos=[], degraded_mcp_server_names=[]) == ""
+
+
+def test_augment_leaves_system_prompt_unchanged_when_healthy() -> None:
+    base = "you are a helpful agent"
+    assert (
+        augment_with_resource_health(base, degraded_repos=[], degraded_mcp_server_names=[]) == base
+    )
+
+
+def test_renders_one_line_per_degraded_repo() -> None:
+    block = build_resource_health_block(
+        degraded_repos=[
+            ("/workspace/theme", "2026-07-07T19:53:06+00:00"),
+            ("/workspace/api", "2026-07-08T01:00:00+00:00"),
+        ],
+        degraded_mcp_server_names=[],
+    )
+    lines = block.splitlines()
+    assert lines[0] == "━━━ Resource health ━━━"
+    assert "repos: /workspace/theme AUTH-FAILED since 2026-07-07T19:53:06+00:00" in lines
+    assert "repos: /workspace/api AUTH-FAILED since 2026-07-08T01:00:00+00:00" in lines
+
+
+def test_renders_one_line_per_degraded_mcp_server() -> None:
+    block = build_resource_health_block(
+        degraded_repos=[], degraded_mcp_server_names=["github", "linear"]
+    )
+    lines = block.splitlines()
+    assert lines[0] == "━━━ Resource health ━━━"
+    assert "mcp: github DEGRADED" in lines
+    assert "mcp: linear DEGRADED" in lines
+
+
+def test_mixed_repo_and_mcp_degradation() -> None:
+    block = build_resource_health_block(
+        degraded_repos=[("/workspace/theme", "2026-07-07T19:53:06+00:00")],
+        degraded_mcp_server_names=["github"],
+    )
+    assert block == (
+        "━━━ Resource health ━━━\n"
+        "repos: /workspace/theme AUTH-FAILED since 2026-07-07T19:53:06+00:00\n"
+        "mcp: github DEGRADED"
+    )
+
+
+def test_augment_appends_block_when_degraded() -> None:
+    base = "you are a helpful agent"
+    out = augment_with_resource_health(
+        base,
+        degraded_repos=[("/workspace/theme", "2026-07-07T19:53:06+00:00")],
+        degraded_mcp_server_names=[],
+    )
+    assert out.startswith(base)
+    assert "━━━ Resource health ━━━" in out
+    assert "repos: /workspace/theme AUTH-FAILED since 2026-07-07T19:53:06+00:00" in out

--- a/tests/unit/test_resource_health_block.py
+++ b/tests/unit/test_resource_health_block.py
@@ -25,11 +25,11 @@ def test_augment_leaves_system_prompt_unchanged_when_healthy() -> None:
     )
 
 
-def test_renders_one_line_per_degraded_repo() -> None:
+def test_renders_auth_failed_only_for_classified_auth_failures() -> None:
     block = build_resource_health_block(
         degraded_repos=[
-            ("/workspace/theme", "2026-07-07T19:53:06+00:00"),
-            ("/workspace/api", "2026-07-08T01:00:00+00:00"),
+            ("/workspace/theme", "2026-07-07T19:53:06+00:00", True, "Authentication failed"),
+            ("/workspace/api", "2026-07-08T01:00:00+00:00", True, "remote: Invalid username"),
         ],
         degraded_mcp_server_names=[],
     )
@@ -37,6 +37,40 @@ def test_renders_one_line_per_degraded_repo() -> None:
     assert lines[0] == "━━━ Resource health ━━━"
     assert "repos: /workspace/theme AUTH-FAILED since 2026-07-07T19:53:06+00:00" in lines
     assert "repos: /workspace/api AUTH-FAILED since 2026-07-08T01:00:00+00:00" in lines
+
+
+def test_transient_failure_renders_clone_failing_with_real_cause_not_auth() -> None:
+    """A non-auth (transient) failure must NOT be mislabeled AUTH-FAILED — it
+    renders CLONE-FAILING with the real, token-redacted git error (#1720)."""
+    block = build_resource_health_block(
+        degraded_repos=[
+            (
+                "/workspace/api",
+                "2026-07-08T01:00:00+00:00",
+                False,
+                "git clone timed out after 30.0s",
+            ),
+        ],
+        degraded_mcp_server_names=[],
+    )
+    lines = block.splitlines()
+    assert lines[0] == "━━━ Resource health ━━━"
+    assert (
+        "repos: /workspace/api CLONE-FAILING since 2026-07-08T01:00:00+00:00 "
+        "(last: git clone timed out after 30.0s)" in lines
+    )
+    assert "AUTH-FAILED" not in block
+
+
+def test_transient_failure_without_error_text_omits_last_clause() -> None:
+    block = build_resource_health_block(
+        degraded_repos=[("/workspace/api", "2026-07-08T01:00:00+00:00", False, "")],
+        degraded_mcp_server_names=[],
+    )
+    assert (
+        "repos: /workspace/api CLONE-FAILING since 2026-07-08T01:00:00+00:00" in block.splitlines()
+    )
+    assert "(last:" not in block
 
 
 def test_renders_one_line_per_degraded_mcp_server() -> None:
@@ -51,7 +85,7 @@ def test_renders_one_line_per_degraded_mcp_server() -> None:
 
 def test_mixed_repo_and_mcp_degradation() -> None:
     block = build_resource_health_block(
-        degraded_repos=[("/workspace/theme", "2026-07-07T19:53:06+00:00")],
+        degraded_repos=[("/workspace/theme", "2026-07-07T19:53:06+00:00", True, "auth failed")],
         degraded_mcp_server_names=["github"],
     )
     assert block == (
@@ -65,7 +99,7 @@ def test_augment_appends_block_when_degraded() -> None:
     base = "you are a helpful agent"
     out = augment_with_resource_health(
         base,
-        degraded_repos=[("/workspace/theme", "2026-07-07T19:53:06+00:00")],
+        degraded_repos=[("/workspace/theme", "2026-07-07T19:53:06+00:00", True, "auth failed")],
         degraded_mcp_server_names=[],
     )
     assert out.startswith(base)

--- a/tests/unit/test_step_context_resource_health.py
+++ b/tests/unit/test_step_context_resource_health.py
@@ -122,12 +122,39 @@ async def test_healthy_session_has_no_resource_health_block() -> None:
 async def test_degraded_repo_renders_auth_failed_line(monkeypatch: Any) -> None:
     breaker = GithubCloneBreaker()
     for _ in range(_BREAKER_FAILURE_THRESHOLD):
-        breaker.record_failure(_REPO_ID, _REPO_URL, _MOUNT_PATH)
+        breaker.record_failure(
+            _REPO_ID,
+            _REPO_URL,
+            _MOUNT_PATH,
+            auth_failure=True,
+            last_error="Authentication failed",
+        )
     monkeypatch.setattr(runtime, "github_clone_breaker", breaker)
 
     system = await _prelude_system(_agent(), github_repo_echoes=[_repo_echo()])
     assert "━━━ Resource health ━━━" in system
     assert f"repos: {_MOUNT_PATH} AUTH-FAILED since" in system
+
+
+async def test_degraded_repo_transient_renders_clone_failing_not_auth(monkeypatch: Any) -> None:
+    """A transient (non-auth) breaker-open repo renders CLONE-FAILING with the
+    real git cause, never a hardcoded AUTH-FAILED (#1720 seat-gate fix)."""
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(
+            _REPO_ID,
+            _REPO_URL,
+            _MOUNT_PATH,
+            auth_failure=False,
+            last_error="git clone timed out after 30.0s",
+        )
+    monkeypatch.setattr(runtime, "github_clone_breaker", breaker)
+
+    system = await _prelude_system(_agent(), github_repo_echoes=[_repo_echo()])
+    assert "━━━ Resource health ━━━" in system
+    assert f"repos: {_MOUNT_PATH} CLONE-FAILING since" in system
+    assert "git clone timed out after 30.0s" in system
+    assert "AUTH-FAILED" not in system
 
 
 async def test_degraded_repo_not_attached_to_this_session_is_not_leaked(monkeypatch: Any) -> None:

--- a/tests/unit/test_step_context_resource_health.py
+++ b/tests/unit/test_step_context_resource_health.py
@@ -1,0 +1,172 @@
+"""``compute_step_prelude`` wires breaker state into the resource-health block (#1720).
+
+Unit-level: no Postgres. Stubs the pool (only ``get_open_obligations`` is
+touched) and the ``ToolProvider`` seam, same pattern as
+``test_step_context_provider_clamp.py``. The two cases nail the wiring:
+
+* an attached repo whose ``GithubCloneBreaker`` is open renders
+  ``repos: <mount_path> AUTH-FAILED since <since>`` in the system prompt;
+* an agent-declared MCP server whose ``McpSessionPool`` breaker is open
+  renders ``mcp: <name> DEGRADED``.
+
+A healthy session (no open breakers) gets neither line — the system prompt
+is unchanged from the pre-#1720 baseline.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.harness import runtime
+from aios.harness.step_context import compute_step_prelude
+from aios.mcp.pool import McpSessionPool
+from aios.models.agents import AgentBinding, McpServerSpec, StepSurface, ToolSpec
+from aios.models.github_repositories import GithubRepositoryResourceEcho
+from aios.sandbox.github_clone_breaker import _BREAKER_FAILURE_THRESHOLD, GithubCloneBreaker
+
+pytestmark = pytest.mark.asyncio
+
+_ACCOUNT = "acc_1720"
+_SESSION = "sess_1720"
+_REPO_ID = "ghrepo_01HEALTH"
+_REPO_URL = "https://github.com/acme/theme.git"
+_MOUNT_PATH = "/workspace/theme"
+_MCP_URL = "https://mcp.example.com/github"
+
+
+def _agent(*, mcp_servers: list[McpServerSpec] | None = None) -> StepSurface:
+    return StepSurface(
+        model="gpt-test",
+        system="you are a test agent",
+        tools=[ToolSpec(type="bash")],
+        skills=[],
+        mcp_servers=mcp_servers or [],
+        http_servers=[],
+        litellm_extra={},
+        window_min=1,
+        window_max=10,
+        binding=AgentBinding(agent_id="agt_1720", version=1),
+        preempt_policy="wait",
+    )
+
+
+def _session() -> Any:
+    return mock.Mock(id=_SESSION, parent_run_id=None)
+
+
+def _repo_echo() -> GithubRepositoryResourceEcho:
+    now = datetime.now(UTC)
+    return GithubRepositoryResourceEcho(
+        id=_REPO_ID,
+        url=_REPO_URL,
+        mount_path=_MOUNT_PATH,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class _StubConn:
+    async def __aenter__(self) -> _StubConn:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class _StubPool:
+    def acquire(self) -> _StubConn:
+        return _StubConn()
+
+
+def _stub_tool_provider() -> Any:
+    tp = mock.Mock()
+    tp.list_tools_for_session = AsyncMock(return_value=[])
+    return tp
+
+
+async def _prelude_system(
+    agent: StepSurface,
+    *,
+    github_repo_echoes: list[GithubRepositoryResourceEcho] | None = None,
+) -> str:
+    with mock.patch("aios.db.queries.get_open_obligations", new=AsyncMock(return_value=[])):
+        prelude = await compute_step_prelude(
+            _StubPool(),
+            _SESSION,
+            account_id=_ACCOUNT,
+            session=_session(),
+            agent=agent,
+            channels=[],
+            memory_store_echoes=[],
+            github_repo_echoes=github_repo_echoes,
+        )
+    return prelude.system_prompt
+
+
+@pytest.fixture(autouse=True)
+def _stub_tool_provider_runtime(monkeypatch: Any) -> None:
+    monkeypatch.setattr(runtime, "tool_provider", _stub_tool_provider())
+
+
+async def test_healthy_session_has_no_resource_health_block() -> None:
+    agent = _agent()
+    system = await _prelude_system(agent, github_repo_echoes=[_repo_echo()])
+    assert "Resource health" not in system
+
+
+async def test_degraded_repo_renders_auth_failed_line(monkeypatch: Any) -> None:
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(_REPO_ID, _REPO_URL, _MOUNT_PATH)
+    monkeypatch.setattr(runtime, "github_clone_breaker", breaker)
+
+    system = await _prelude_system(_agent(), github_repo_echoes=[_repo_echo()])
+    assert "━━━ Resource health ━━━" in system
+    assert f"repos: {_MOUNT_PATH} AUTH-FAILED since" in system
+
+
+async def test_degraded_repo_not_attached_to_this_session_is_not_leaked(monkeypatch: Any) -> None:
+    """A different session's degraded repo id doesn't leak into this one's prelude."""
+    breaker = GithubCloneBreaker()
+    for _ in range(_BREAKER_FAILURE_THRESHOLD):
+        breaker.record_failure(
+            "ghrepo_other", "https://github.com/acme/other.git", "/workspace/other"
+        )
+    monkeypatch.setattr(runtime, "github_clone_breaker", breaker)
+
+    system = await _prelude_system(_agent(), github_repo_echoes=[_repo_echo()])
+    assert "Resource health" not in system
+
+
+def _mcp_key(url: str) -> tuple[str, str | None, str]:
+    return (url, None, "")
+
+
+async def test_degraded_mcp_server_renders_degraded_line(monkeypatch: Any) -> None:
+    pool = McpSessionPool()
+    key = _mcp_key(_MCP_URL)
+    for _ in range(3):
+        pool._record_connect_failure(key, _MCP_URL)
+    monkeypatch.setattr(runtime, "mcp_session_pool", pool)
+
+    agent = _agent(mcp_servers=[McpServerSpec(name="github", url=_MCP_URL)])
+    system = await _prelude_system(agent)
+    assert "━━━ Resource health ━━━" in system
+    assert "mcp: github DEGRADED" in system
+
+
+async def test_degraded_mcp_server_not_declared_by_agent_is_not_leaked(monkeypatch: Any) -> None:
+    pool = McpSessionPool()
+    key = _mcp_key(_MCP_URL)
+    for _ in range(3):
+        pool._record_connect_failure(key, _MCP_URL)
+    monkeypatch.setattr(runtime, "mcp_session_pool", pool)
+
+    agent = _agent(mcp_servers=[])
+    system = await _prelude_system(agent)
+    assert "Resource health" not in system


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/eumemic-ops#323.