### PR TITLE
Closed-request burn-loop stop uses un-eval-validated message (defect-2 rejection ≠ defect-1 validated wording) — gates window restore

### DIFF
--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -46,6 +46,11 @@ from aios.models.agents import McpServerSpec
 from aios.services import sessions as sessions_service
 from aios.tools.invoke import ToolBail, invoke_builtin, parse_arguments
 from aios.tools.registry import ToolResult
+from aios.tools.workflow_completion import (
+    ERROR_TOOL_NAME,
+    RETURN_TOOL_NAME,
+    _closed_request_message,
+)
 
 if TYPE_CHECKING:
     from aios.services.tasks import ServicerKind
@@ -289,7 +294,12 @@ def reject_unoffered_tool_calls(
             account_id=account_id,
             log_prefix="tool_reject",
         ) as tc:
-            raise ToolBail(_unoffered_tool_message(tc.name, offered_names))
+            message = (
+                _closed_request_message()
+                if tc.name in {RETURN_TOOL_NAME, ERROR_TOOL_NAME}
+                else _unoffered_tool_message(tc.name, offered_names)
+            )
+            raise ToolBail(message)
         # _append_tool_result_event is only reachable via the ToolBail branch inside
         # _tool_lifecycle's except clause above — no success path exists here.
 

--- a/src/aios/harness/tool_dispatch.py
+++ b/src/aios/harness/tool_dispatch.py
@@ -49,7 +49,7 @@ from aios.tools.registry import ToolResult
 from aios.tools.workflow_completion import (
     ERROR_TOOL_NAME,
     RETURN_TOOL_NAME,
-    _closed_request_message,
+    closed_request_stop_message,
 )
 
 if TYPE_CHECKING:
@@ -261,6 +261,30 @@ def _unoffered_tool_message(name: str, offered_names: list[str]) -> str:
     )
 
 
+async def _rejection_message(session_id: str, tc: _ToolCall, offered_names: list[str]) -> str:
+    """The model-visible rejection wording for one unoffered tool call.
+
+    ``return``/``error`` are de-offered once the request that opened them has
+    closed (#1773) — so a de-offered ``return`` answering a genuinely-closed request
+    must get defect-1's eval-validated "already answered … end your turn" stop
+    (#1789 the gate: route the validated framing to the de-offered path). But those
+    names are ALSO unoffered for an ordinary session that never owned a request, so a
+    hallucinated ``return``/``error`` there must NOT be told the factual falsehood that
+    its request was already answered. The distinction is made from durable request state,
+    NOT the tool name: :func:`closed_request_stop_message` resolves the call's
+    ``request_id`` exactly as the ``return``/``error`` handler does, and only a real
+    closed request yields the closed-request stop. Absent one (pure name hallucination),
+    the generic unoffered-tool rejection stands.
+    """
+    if tc.name in {RETURN_TOOL_NAME, ERROR_TOOL_NAME}:
+        parsed = parse_arguments(tc.raw_args)
+        request_id = parsed.get("request_id") if parsed else None
+        stop_message = await closed_request_stop_message(session_id, request_id)
+        if stop_message is not None:
+            return stop_message
+    return _unoffered_tool_message(tc.name, offered_names)
+
+
 def reject_unoffered_tool_calls(
     pool: asyncpg.Pool[Any],
     session_id: str,
@@ -294,12 +318,7 @@ def reject_unoffered_tool_calls(
             account_id=account_id,
             log_prefix="tool_reject",
         ) as tc:
-            message = (
-                _closed_request_message()
-                if tc.name in {RETURN_TOOL_NAME, ERROR_TOOL_NAME}
-                else _unoffered_tool_message(tc.name, offered_names)
-            )
-            raise ToolBail(message)
+            raise ToolBail(await _rejection_message(session_id, tc, offered_names))
         # _append_tool_result_event is only reachable via the ToolBail branch inside
         # _tool_lifecycle's except clause above — no success path exists here.
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -225,23 +225,27 @@ async def _enforce_output_schema(session_id: str, request_id: Any, value: Any) -
     return None if schema is None else _validate_value(value, schema)
 
 
-def _closed_request_message(outcome: Outcome, closed_at: Any) -> str:
-    """The terminal stop message for a `return`/`error` call that targets an
-    ALREADY-answered request (#1773 defect 1).
+def _closed_request_message(
+    outcome: Outcome | None = None, closed_at: Any | None = None
+) -> str:
+    """The terminal stop message for a `return`/`error` call after all requests
+    are ALREADY answered (#1773 defect 1).
 
     The ``deadline timeout`` wording is the exact string the incident's replay
     eval (Arm D, 24/24 real trap points → 24/24 clean stops) validated as
-    actually stopping the model — use it verbatim for that case. Any other
-    closing (a duplicate self-answer, `no_return`, the child going away) still
-    gets a truthful, equally terminal message; it just isn't the specific
-    wording the eval pinned, since claiming "deadline timeout" for a close the
-    request itself caused would be false.
+    actually stopping the model — use it verbatim when the closing event is
+    available. The dispatch rejection path only knows that no obligation remains;
+    omitting the unavailable close detail keeps the same validated terminal
+    framing without inventing a timeout or timestamp.
     """
-    ts = closed_at.isoformat() if hasattr(closed_at, "isoformat") else str(closed_at)
-    is_timeout = isinstance(outcome, Err) and outcome.error.get("kind") == "timeout"
-    qualifier = f"deadline timeout at {ts}" if is_timeout else f"at {ts}"
+    qualifier = ""
+    if outcome is not None and closed_at is not None:
+        ts = closed_at.isoformat() if hasattr(closed_at, "isoformat") else str(closed_at)
+        is_timeout = isinstance(outcome, Err) and outcome.error.get("kind") == "timeout"
+        detail = f"deadline timeout at {ts}" if is_timeout else f"at {ts}"
+        qualifier = f" ({detail})"
     return (
-        f"this request was already answered ({qualifier}); "
+        f"this request was already answered{qualifier}; "
         "do not call return again — end your turn."
     )
 

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -247,6 +247,35 @@ def _closed_request_message(outcome: Outcome | None = None, closed_at: Any | Non
     )
 
 
+async def closed_request_stop_message(session_id: str, request_id: Any) -> str | None:
+    """The terminal stop message for a `return`/`error` naming an ALREADY-CLOSED
+    request, or ``None`` when the request is still open OR ``request_id`` resolves to
+    no request at all (a non-``str`` id included — the existing ``unknown_request``
+    path downstream owns that).
+
+    The single liveness-first state resolution (#1773 defect 1) shared by BOTH the
+    ``return``/``error`` handlers (via :func:`_closed_request_error`) and the harness
+    de-offered-tool rejection path (:func:`aios.harness.tool_dispatch.reject_unoffered_tool_calls`).
+    Sharing it is load-bearing for #1789: the rejection path must select the closed-request
+    framing from *durable request state*, never from the tool NAME alone — a session that
+    never owned a request but hallucinates the literal name ``return``/``error`` resolves
+    here to ``None`` and gets the generic unoffered rejection, NOT a false "your request
+    was already answered".
+
+    Emits defect-1's eval-validated wording (Arm D, 24/24) verbatim when the closing
+    event is available, quoting the outcome/timestamp the ``_closed_request_message``
+    detail arm renders.
+    """
+    if not isinstance(request_id, str):
+        return None
+    async with runtime.require_pool().acquire() as conn:
+        closed = await queries.get_closed_request(conn, session_id, request_id=request_id)
+    if closed is None:
+        return None
+    outcome, closed_at = closed
+    return _closed_request_message(outcome, closed_at)
+
+
 async def _closed_request_error(session_id: str, request_id: Any) -> ToolResult | None:
     """If ``request_id`` names a request that's ALREADY closed, the terminal
     :class:`ToolResult` error `return`/`error` must surface BEFORE anything else
@@ -260,15 +289,12 @@ async def _closed_request_error(session_id: str, request_id: Any) -> ToolResult 
     caller's await deadline wrote a timeout response before the child's first
     `return` landed — gets ONE clear stop signal instead of an endless
     ``output_schema_violation`` bounce that never mentions the request is dead.
+
+    The handler-path wrapper over :func:`closed_request_stop_message` — the same
+    resolution the rejection path mirrors (#1789).
     """
-    if not isinstance(request_id, str):
-        return None
-    async with runtime.require_pool().acquire() as conn:
-        closed = await queries.get_closed_request(conn, session_id, request_id=request_id)
-    if closed is None:
-        return None
-    outcome, closed_at = closed
-    return ToolResult(content=_closed_request_message(outcome, closed_at), is_error=True)
+    message = await closed_request_stop_message(session_id, request_id)
+    return None if message is None else ToolResult(content=message, is_error=True)
 
 
 async def return_handler(session_id: str, arguments: dict[str, Any]) -> dict[str, Any] | ToolResult:

--- a/src/aios/tools/workflow_completion.py
+++ b/src/aios/tools/workflow_completion.py
@@ -225,9 +225,7 @@ async def _enforce_output_schema(session_id: str, request_id: Any, value: Any) -
     return None if schema is None else _validate_value(value, schema)
 
 
-def _closed_request_message(
-    outcome: Outcome | None = None, closed_at: Any | None = None
-) -> str:
+def _closed_request_message(outcome: Outcome | None = None, closed_at: Any | None = None) -> str:
     """The terminal stop message for a `return`/`error` call after all requests
     are ALREADY answered (#1773 defect 1).
 
@@ -245,8 +243,7 @@ def _closed_request_message(
         detail = f"deadline timeout at {ts}" if is_timeout else f"at {ts}"
         qualifier = f" ({detail})"
     return (
-        f"this request was already answered{qualifier}; "
-        "do not call return again — end your turn."
+        f"this request was already answered{qualifier}; do not call return again — end your turn."
     )
 
 

--- a/tests/unit/test_closed_request_liveness.py
+++ b/tests/unit/test_closed_request_liveness.py
@@ -33,6 +33,13 @@ _CLOSED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
 
 
 class TestClosedRequestMessage:
+    def test_close_without_event_detail_keeps_terminal_framing(self) -> None:
+        msg = _closed_request_message()
+        assert msg == (
+            "this request was already answered; "
+            "do not call return again — end your turn."
+        )
+
     def test_timeout_close_names_deadline_timeout(self) -> None:
         msg = _closed_request_message(Err(error={"kind": "timeout"}), _CLOSED_AT)
         assert "deadline timeout" in msg

--- a/tests/unit/test_closed_request_liveness.py
+++ b/tests/unit/test_closed_request_liveness.py
@@ -36,8 +36,7 @@ class TestClosedRequestMessage:
     def test_close_without_event_detail_keeps_terminal_framing(self) -> None:
         msg = _closed_request_message()
         assert msg == (
-            "this request was already answered; "
-            "do not call return again — end your turn."
+            "this request was already answered; do not call return again — end your turn."
         )
 
     def test_timeout_close_names_deadline_timeout(self) -> None:

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -10,11 +10,13 @@ or a genuine failure (also evicts the sandbox).
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from aios.db import queries
 from aios.errors import (
     AiosError,
     ConflictError,
@@ -31,6 +33,7 @@ from aios.harness.tool_dispatch import (
     _unoffered_tool_message,
     reject_unoffered_tool_calls,
 )
+from aios.models.sessions import Err
 from aios.services import sessions as sessions_service
 from aios.tools.bash import BashArgumentError
 from aios.tools.invoke import ToolBail, validate_arguments
@@ -243,7 +246,12 @@ class TestRejectUnofferedToolCalls:
     """
 
     async def _drive(
-        self, monkeypatch: Any, tool_calls: list[dict[str, Any]], offered_names: list[str]
+        self,
+        monkeypatch: Any,
+        tool_calls: list[dict[str, Any]],
+        offered_names: list[str],
+        *,
+        closed: tuple[Any, Any] | None = None,
     ) -> Any:
         monkeypatch.setattr(
             sessions_service,
@@ -256,6 +264,20 @@ class TestRejectUnofferedToolCalls:
         from aios.harness.inflight_tool_registry import InflightToolRegistry
 
         monkeypatch.setattr(runtime, "require_inflight_tool_registry", InflightToolRegistry)
+
+        # A de-offered `return`/`error` classifies by DURABLE request state (#1789),
+        # exactly like the return/error handler: it resolves the request_id via
+        # ``get_closed_request`` over a pooled connection. Mock both so the rejection
+        # path can distinguish a genuinely-closed request (``closed`` is a tuple) from a
+        # session that never owned one (``closed=None`` → the generic rejection).
+        conn = MagicMock()
+        acquire = MagicMock()
+        acquire.__aenter__ = AsyncMock(return_value=conn)
+        acquire.__aexit__ = AsyncMock(return_value=False)
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire)
+        monkeypatch.setattr(runtime, "require_pool", lambda: pool)
+        monkeypatch.setattr(queries, "get_closed_request", AsyncMock(return_value=closed))
 
         reject_unoffered_tool_calls(
             MagicMock(),
@@ -270,8 +292,14 @@ class TestRejectUnofferedToolCalls:
         return append_result
 
     async def test_closed_control_call_gets_terminal_stop_message(self, monkeypatch: Any) -> None:
-        call = {"id": "tc_1", "function": {"name": "return", "arguments": "{}"}}
-        append_result = await self._drive(monkeypatch, [call], ["bash", "read"])
+        # A de-offered `return` answering a GENUINELY-CLOSED request (durable state
+        # resolves a real closed request) → defect-1's eval-validated terminal stop.
+        call = {
+            "id": "tc_1",
+            "function": {"name": "return", "arguments": '{"request_id": "req_1", "value": 1}'},
+        }
+        closed = (Err(error={"kind": "timeout"}), datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC))
+        append_result = await self._drive(monkeypatch, [call], ["bash", "read"], closed=closed)
         assert append_result.await_count == 1
         args = append_result.await_args.args
         kwargs = append_result.await_args.kwargs
@@ -280,7 +308,46 @@ class TestRejectUnofferedToolCalls:
         error = kwargs["error"]
         assert "already answered" in error
         assert "end your turn" in error
+        assert "deadline timeout" in error  # the eval-validated handler wording, verbatim
         assert "tool not offered" not in error
+
+    async def test_hallucinated_control_name_without_closed_request_gets_generic(
+        self, monkeypatch: Any
+    ) -> None:
+        """#1789 regression: the state-classification the seat gate demanded.
+
+        A session that never owned a request can also hallucinate the literal name
+        ``return``/``error`` — those names are unoffered for it too. With no closed
+        request resolving (``get_closed_request`` → ``None``), it must get the GENERIC
+        unoffered rejection, NOT the factual falsehood ``this request was already
+        answered``. The pre-fix name-only branch failed exactly here.
+        """
+        call = {
+            "id": "tc_1",
+            "function": {"name": "return", "arguments": '{"request_id": "req_ghost", "value": 1}'},
+        }
+        append_result = await self._drive(monkeypatch, [call], ["bash", "read"], closed=None)
+        error = append_result.await_args.kwargs["error"]
+        assert "tool not offered" in error
+        assert "return" in error
+        assert "bash" in error and "read" in error
+        assert "already answered" not in error
+        assert "end your turn" not in error
+
+    async def test_de_offered_error_name_with_no_request_id_gets_generic(
+        self, monkeypatch: Any
+    ) -> None:
+        # Pure name hallucination with no request_id at all — resolved to the generic
+        # rejection (never the closed-request lie), and without even a state lookup.
+        call = {"id": "tc_1", "function": {"name": "error", "arguments": "{}"}}
+        append_result = await self._drive(monkeypatch, [call], ["bash"])
+        error = append_result.await_args.kwargs["error"]
+        assert "tool not offered" in error
+        assert "error" in error
+        assert "already answered" not in error
+        # No request_id → short-circuits before the DB read: the get_closed_request
+        # mock ``_drive`` installed is never called.
+        queries.get_closed_request.assert_not_called()
 
     async def test_hallucinated_name_keeps_generic_unoffered_message(
         self, monkeypatch: Any

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -252,6 +252,7 @@ class TestRejectUnofferedToolCalls:
         offered_names: list[str],
         *,
         closed: tuple[Any, Any] | None = None,
+        get_closed_request: AsyncMock | None = None,
     ) -> Any:
         monkeypatch.setattr(
             sessions_service,
@@ -277,7 +278,10 @@ class TestRejectUnofferedToolCalls:
         pool = MagicMock()
         pool.acquire = MagicMock(return_value=acquire)
         monkeypatch.setattr(runtime, "require_pool", lambda: pool)
-        monkeypatch.setattr(queries, "get_closed_request", AsyncMock(return_value=closed))
+        gcr = (
+            get_closed_request if get_closed_request is not None else AsyncMock(return_value=closed)
+        )
+        monkeypatch.setattr(queries, "get_closed_request", gcr)
 
         reject_unoffered_tool_calls(
             MagicMock(),
@@ -340,14 +344,15 @@ class TestRejectUnofferedToolCalls:
         # Pure name hallucination with no request_id at all — resolved to the generic
         # rejection (never the closed-request lie), and without even a state lookup.
         call = {"id": "tc_1", "function": {"name": "error", "arguments": "{}"}}
-        append_result = await self._drive(monkeypatch, [call], ["bash"])
+        gcr = AsyncMock(return_value=None)
+        append_result = await self._drive(monkeypatch, [call], ["bash"], get_closed_request=gcr)
         error = append_result.await_args.kwargs["error"]
         assert "tool not offered" in error
         assert "error" in error
         assert "already answered" not in error
-        # No request_id → short-circuits before the DB read: the get_closed_request
-        # mock ``_drive`` installed is never called.
-        queries.get_closed_request.assert_not_called()
+        # No request_id → short-circuits before the DB read: get_closed_request is
+        # never called (the whole point — no state lookup for a nameless hallucination).
+        gcr.assert_not_called()
 
     async def test_hallucinated_name_keeps_generic_unoffered_message(
         self, monkeypatch: Any

--- a/tests/unit/test_tool_dispatch.py
+++ b/tests/unit/test_tool_dispatch.py
@@ -269,7 +269,7 @@ class TestRejectUnofferedToolCalls:
         await asyncio.sleep(0)
         return append_result
 
-    async def test_rejects_with_is_error_and_names_offered_set(self, monkeypatch: Any) -> None:
+    async def test_closed_control_call_gets_terminal_stop_message(self, monkeypatch: Any) -> None:
         call = {"id": "tc_1", "function": {"name": "return", "arguments": "{}"}}
         append_result = await self._drive(monkeypatch, [call], ["bash", "read"])
         assert append_result.await_count == 1
@@ -278,9 +278,20 @@ class TestRejectUnofferedToolCalls:
         assert args[1] == "ses_1"  # session_id
         assert args[3] == "return"  # tool name
         error = kwargs["error"]
-        assert "return" in error
-        assert "not offered" in error
+        assert "already answered" in error
+        assert "end your turn" in error
+        assert "tool not offered" not in error
+
+    async def test_hallucinated_name_keeps_generic_unoffered_message(
+        self, monkeypatch: Any
+    ) -> None:
+        call = {"id": "tc_1", "function": {"name": "hallucinated", "arguments": "{}"}}
+        append_result = await self._drive(monkeypatch, [call], ["bash", "read"])
+        error = append_result.await_args.kwargs["error"]
+        assert "tool not offered" in error
+        assert "hallucinated" in error
         assert "bash" in error and "read" in error
+        assert "end your turn" not in error
 
     async def test_never_reaches_a_handler(self, monkeypatch: Any) -> None:
         """The tool's own handler must not run — only the rejection path does."""


### PR DESCRIPTION
Automated dev-pipeline build for issue #1789.