### PR TITLE
Token-ratio calibration hardening (follow-on to #1794): blend floor, ridge scaling, two-way margin, absent≠0 usage, recency fix, cast-defensive query, discriminating e2e test

### DIFF
--- a/migrations/versions/0142_events_model_calibration_recency_index.py
+++ b/migrations/versions/0142_events_model_calibration_recency_index.py
@@ -1,0 +1,75 @@
+"""Add the ``events_model_calibration_recency_idx`` partial index behind the
+recency-ordered per-model token-ratio calibration fetch (#1798 / #1711).
+
+``model_token_class_ratios`` (``src/aios/db/queries/events.py``) fetches the
+globally most-recent N successful ``model_request_end`` spans for one model to
+fit the per-class token-count coefficients.  It is read on the step-hot window
+path (``read_windowed_events`` ← ``harness/loop.py``), so its access cost is
+paid synchronously before a model request whenever the 60 s ratio cache misses.
+
+Issue #1798 changed the recency key from ``seq DESC`` to
+``ORDER BY created_at DESC, session_id DESC, seq DESC`` because ``seq`` is
+session-local and cannot rank spans pooled across sessions.  Migration 0024's
+``events_model_request_end_calibration_idx`` is keyed ``((data->>'model'),
+seq DESC)``, so it can seek to the model but no longer satisfies the new sort:
+the planner has to read **every** qualifying lifetime row for the model and
+Sort it before ``LIMIT 1000`` applies.  The limit therefore no longer bounds
+the scan, regressing the #1711 timeout protection — and the cost grows without
+bound as calibration history accumulates.
+
+This migration adds the composite partial index whose column order matches the
+query's access path exactly:
+
+* Leading ``(data->>'model')`` — the sole equality predicate — gives the
+  planner an equality seek into the matching rows.
+* Trailing ``created_at DESC, session_id DESC, seq DESC`` reproduces the
+  ``ORDER BY`` verbatim (matching DESC directions so a forward index scan
+  yields rows already in order), so ``LIMIT 1000`` bounds the scan to an index
+  seek instead of a full-model scan + Sort.  ``seq`` is the deterministic
+  tie-breaker.
+* The partial predicate mirrors migration 0024's predicate verbatim — it is a
+  strict subset of the query's ``WHERE`` (which adds
+  ``data ? 'local_tokens_by_class'`` and the input/local token gates), so the
+  planner can prove the partial index applicable while keeping the index to
+  exactly the calibration-bearing spans (a small fraction of ``events``).
+
+Purely additive — a single ``CREATE INDEX CONCURRENTLY`` built inside
+``op.get_context().autocommit_block()`` so it never takes an ACCESS EXCLUSIVE
+lock on the live-written ``events`` table (same pattern as 0024 / 0128).  Safe
+in the post-deploy new-code/old-schema window: the index only speeds the read;
+the running container works against the old schema until it completes, and the
+index is invisible while building.  The now-redundant ``seq``-ordered 0024
+index is left in place (never-delete; additive change only).
+
+Revision ID: 0142
+Revises: 0141
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0142"
+down_revision: str = "0141"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_model_calibration_recency_idx "
+            "ON events ((data->>'model'), created_at DESC, session_id DESC, seq DESC) "
+            "WHERE kind = 'span' "
+            "AND data->>'event' = 'model_request_end' "
+            "AND (data->>'is_error')::boolean = false "
+            "AND data ? 'local_tokens' "
+            "AND data ? 'model'"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS events_model_calibration_recency_idx")

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -192,8 +192,8 @@ _MODEL_TOKEN_RATIO_MIN_SAMPLES = 5
 # (``read_windowed_events``), eventually tripping the pool's 30 s
 # ``statement_timeout`` inside the session step and JSON-decoding all N rows
 # on the event loop.  1000 is large enough for a stable ridge fit while
-# riding migration 0024's ``((data->>'model'), seq DESC)`` partial index as a
-# bounded seek (``ORDER BY seq DESC LIMIT $2``).  See issue #1711.
+# bounding the fit to the newest rows (``ORDER BY created_at DESC LIMIT $2``).
+# See issue #1711.  ``seq`` is session-local and cannot express global recency.
 _MODEL_TOKEN_RATIO_SAMPLE_LIMIT = 1000
 _MODEL_TOKEN_RATIO_MIN = 0.5
 _MODEL_TOKEN_RATIO_BUCKET_FLOOR = 0.001
@@ -239,7 +239,7 @@ _MODEL_TOKEN_CLASS_PRIOR = 1.0
 # prices a class below 0 tok/local-tok, and the windower divides by the
 # blend so a near-zero blend must be guarded.  Mirrors the scalar's
 # ``_MODEL_TOKEN_RATIO_MIN`` lower bound and adds a generous upper bound.
-_MODEL_TOKEN_CLASS_MIN = 0.0
+_MODEL_TOKEN_CLASS_MIN = 0.05
 _MODEL_TOKEN_CLASS_MAX = 8.0
 
 # Safety-margin slack between the budgeted window and the provider hard cap
@@ -291,10 +291,22 @@ def _solve_ridge(
     class-by-class meaning.
     """
     p = n_features
+    # Normalize the whole least-squares system to token-scale units before
+    # forming XᵀX.  Without this, ~1e10 normal-matrix entries make λ=1e-2
+    # numerically equivalent to unregularized OLS.  A single global scale
+    # preserves coefficient units and the neutral 1.0 prior.
+    # Keep typical normalized normal-matrix entries around 1e2 rather than
+    # 1e10.  This leaves data dominant while making λ representable and
+    # consequential for weak/collinear directions.
+    scale = math.sqrt(sum(sum(v * v for v in x) for x, _ in rows) / max(len(rows), 1)) / 10.0
+    if not math.isfinite(scale) or scale <= 0:
+        return None
+    normalized_rows = [([v / scale for v in x], y / scale) for x, y in rows]
+
     # Normal equations: (XᵀX + λI) β = Xᵀy + λ·prior·1
     ata = [[0.0] * p for _ in range(p)]
     aty = [0.0] * p
-    for x, y in rows:
+    for x, y in normalized_rows:
         for j in range(p):
             aty[j] += x[j] * y
             xj = x[j]
@@ -395,11 +407,10 @@ async def model_token_class_ratios(
     with the scalar contract.
 
     The fetch is bounded to the most recent
-    :data:`_MODEL_TOKEN_RATIO_SAMPLE_LIMIT` spans via ``ORDER BY seq DESC
-    LIMIT`` (issue #1711).  This rides the 0024 index as a bounded index
-    seek rather than an unbounded lifetime scan on the step hot path; the
-    limit is large enough that the ridge fit is stable while capping both
-    the SQL scan and the per-row JSON decode done on the event loop.
+    :data:`_MODEL_TOKEN_RATIO_SAMPLE_LIMIT` spans via ``ORDER BY created_at
+    DESC LIMIT`` (issue #1711).  ``seq`` is only session-local, so it cannot
+    rank spans pooled across sessions.  The limit caps both the SQL result
+    and the per-row JSON decode done on the event loop.
     """
     if k_bucket <= 0:
         raise ValueError("k_bucket must be positive")
@@ -455,9 +466,16 @@ async def model_token_class_ratio_fit(
           AND data ? 'model'
           AND (data->'model_usage') ? 'input_tokens'
           AND (data->'model_usage'->>'input_tokens') IS NOT NULL
-          AND (data->'model_usage'->>'input_tokens')::bigint > 0
-          AND (data->>'local_tokens')::bigint > 0
-        ORDER BY seq DESC
+          -- Regex gates make the casts defensive against future malformed or
+          -- non-integral JSON values (e.g. "150.5").
+          AND (data->'model_usage'->>'input_tokens') ~ '^[0-9]+$'
+          AND (data->'model_usage'->>'input_tokens')::numeric > 0
+          AND (data->>'local_tokens') ~ '^[0-9]+$'
+          AND (data->>'local_tokens')::numeric > 0
+        -- Bound the scan to the globally most recent N spans (issue #1711).
+        -- seq is session-local, so created_at must lead across sessions.
+        -- MIN_SAMPLES is still checked below the fetch.
+        ORDER BY created_at DESC, session_id DESC, seq DESC
         LIMIT $2
         """,
         model,
@@ -627,8 +645,10 @@ def blended_r_eff(ratios: dict[str, float], local_by_class: dict[str, float]) ->
     """
     total = sum(local_by_class.get(c, 0.0) for c in ratios)
     if total <= 0:
-        return sum(ratios.values()) / len(ratios)
-    return sum(ratios[c] * float(local_by_class.get(c, 0.0)) for c in ratios) / total
+        blend = sum(ratios.values()) / len(ratios)
+    else:
+        blend = sum(ratios[c] * float(local_by_class.get(c, 0.0)) for c in ratios) / total
+    return max(blend, _MODEL_TOKEN_RATIO_MIN)
 
 
 def _derive_tool_name(kind: str, data: dict[str, Any]) -> str | None:
@@ -2484,11 +2504,14 @@ async def read_windowed_events(
     # together with the Layer-2 calibrated coefficients it protects.
     calibrated = any(c != 1.0 for c in coefs.values())
     margin = (1.0 + _WINDOW_SAFETY_MARGIN) if calibrated else 1.0
+    # Two-way guard: calibration may make the conversion larger, never
+    # smaller than neutral.  A low fitted ratio must not inflate retention.
+    effective_ratio = max(1.0, ratio * margin)
 
     # Shrink the effective window by the caller's overhead contribution.
     # Apply R_eff (x margin) to the overhead up-front so the subtraction
     # happens in the same effective space tokens_to_drop operates in.
-    overhead_effective = round(overhead.total * ratio * margin)
+    overhead_effective = round(overhead.total * effective_ratio)
     events_window_max = window_max - overhead_effective
     events_window_min = max(0, window_min - overhead_effective)
     if events_window_max <= 0:
@@ -2497,7 +2520,7 @@ async def read_windowed_events(
             f"exceeds window_max ({window_max}); no budget remains for events"
         )
 
-    total_effective = round(total * ratio * margin)
+    total_effective = round(total * effective_ratio)
     if total_effective <= events_window_max:
         return WindowedEvents(
             events=await queries.read_windowed_context_events(
@@ -2524,7 +2547,7 @@ async def read_windowed_events(
             omission=None,
         )
 
-    drop = math.ceil(drop_effective / (ratio * margin))
+    drop = math.ceil(drop_effective / effective_ratio)
 
     # Never drop the entire window: the window must keep a non-empty tail.
     # Here ``events_window_min`` can clamp to 0 when overhead exceeds

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -393,8 +393,10 @@ async def model_token_class_ratios(
     NORMALIZATION; the same string must appear at stamp and query time.
     "actual" is the provider's ``input_tokens`` (the full prompt count,
     cached portions included — do NOT add ``cache_*`` breakdowns).  Uses
-    the ``events_model_request_end_calibration_idx`` partial index
-    (migration 0024).
+    the ``events_model_calibration_recency_idx`` partial index (migration
+    0142), keyed ``((data->>'model'), created_at DESC, session_id DESC,
+    seq DESC)`` so the ``ORDER BY … LIMIT`` recency fetch is a bounded
+    index seek rather than a full-model scan + sort (issue #1711).
 
     **``account_id`` is intentionally not a query predicate — by design.**
     These coefficients are model-intrinsic: the provider ``input_tokens``

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -847,7 +847,9 @@ async def stream_litellm(
                     usage: dict[str, int] = {}
                     cost: float | None = None
                     if chunks:
-                        partial_assembled: Any = litellm.stream_chunk_builder(chunks=chunks, messages=messages)
+                        partial_assembled: Any = litellm.stream_chunk_builder(
+                            chunks=chunks, messages=messages
+                        )
                         if partial_assembled is not None:
                             _, usage, cost, _ = _unpack_litellm_response(
                                 partial_assembled, source="stream_chunk_builder"

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -617,13 +617,28 @@ def _normalize_usage(raw: dict[str, Any]) -> dict[str, int]:
     ``prompt_tokens_details.cached_tokens``.
     """
     prompt_details = raw.get("prompt_tokens_details") or {}
-    cache_read = raw.get("cache_read_input_tokens") or prompt_details.get("cached_tokens") or 0
-    return {
-        "input_tokens": raw.get("prompt_tokens") or 0,
-        "output_tokens": raw.get("completion_tokens") or 0,
-        "cache_read_input_tokens": cache_read,
-        "cache_creation_input_tokens": raw.get("cache_creation_input_tokens") or 0,
-    }
+    usage: dict[str, int] = {}
+    # Missing usage is unknown, not zero.  In particular, streaming providers
+    # may omit the terminal usage trailer; persisting a fabricated zero makes
+    # that success span look calibration-eligible.
+    if raw.get("prompt_tokens") is not None:
+        usage["input_tokens"] = int(raw["prompt_tokens"])
+    if raw.get("completion_tokens") is not None:
+        usage["output_tokens"] = int(raw["completion_tokens"])
+    cache_read = raw.get("cache_read_input_tokens")
+    if cache_read is None:
+        cache_read = prompt_details.get("cached_tokens")
+    if cache_read is not None:
+        usage["cache_read_input_tokens"] = int(cache_read)
+    cache_creation = raw.get("cache_creation_input_tokens")
+    if cache_creation is not None:
+        usage["cache_creation_input_tokens"] = int(cache_creation)
+    # Once a real usage object contains token totals, absent optional cache
+    # breakdowns are genuine zeroes.  An entirely absent trailer remains {}.
+    if usage:
+        usage.setdefault("cache_read_input_tokens", 0)
+        usage.setdefault("cache_creation_input_tokens", 0)
+    return usage
 
 
 def _build_litellm_kwargs(
@@ -645,6 +660,9 @@ def _build_litellm_kwargs(
     if stream:
         kwargs["stream"] = True
         kwargs["stream_timeout"] = _STREAM_INTER_CHUNK_TIMEOUT_S
+        # LiteLLM translates this for providers which expose streaming usage
+        # and drops it for adapters which do not.
+        kwargs["stream_options"] = {"include_usage": True}
     if tools:
         kwargs["tools"] = tools
     if auth is not None:
@@ -829,7 +847,7 @@ async def stream_litellm(
                     usage: dict[str, int] = {}
                     cost: float | None = None
                     if chunks:
-                        partial_assembled: Any = litellm.stream_chunk_builder(chunks=chunks)
+                        partial_assembled: Any = litellm.stream_chunk_builder(chunks=chunks, messages=messages)
                         if partial_assembled is not None:
                             _, usage, cost, _ = _unpack_litellm_response(
                                 partial_assembled, source="stream_chunk_builder"
@@ -869,7 +887,7 @@ async def stream_litellm(
         with contextlib.suppress(Exception):
             await response.aclose()
 
-    assembled: Any = litellm.stream_chunk_builder(chunks=chunks)
+    assembled: Any = litellm.stream_chunk_builder(chunks=chunks, messages=messages)
     # ``litellm.stream_chunk_builder(chunks=[])`` returns ``None`` rather
     # than raising, so a provider that closes the connection without
     # emitting any chunks (Bedrock cold start, OpenRouter mid-handshake

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -309,6 +309,28 @@ class TestModelTokenRatioSQL:
             ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
         assert ratio == pytest.approx(1.5, abs=0.005)
 
+    async def test_zero_input_usage_and_decimal_values_are_excluded(self, harness: Harness) -> None:
+        """Real-Postgres discriminator: zero usage is poison, while a future
+        non-integral value must be ignored rather than crashing the cast."""
+        account_id = "acc_test_stub"
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(20):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100_000, input_tokens=0
+            )
+        for _ in range(5):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+        # JSON permits this future hostile shape despite today's int-typed provider model.
+        await _seed_valid_span(
+            harness, session.id, model=model, local_tokens=100, input_tokens=150.5  # type: ignore[arg-type]
+        )
+        async with harness._pool.acquire() as conn:
+            ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
+        assert ratio == pytest.approx(1.5, abs=0.01)
+
     async def test_recency_bound_honors_recent_spans(self, harness: Harness) -> None:
         """Recency honored (issue #1711): seed MORE than the sample limit,
         with a deliberately skewed OLD tail (ratio 4.0) below the newest

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -15,7 +15,9 @@ table persists across cases within the module-scoped pool fixture.
 from __future__ import annotations
 
 import uuid
+from typing import Any, cast
 
+import asyncpg
 import pytest
 
 from aios.db import queries
@@ -361,3 +363,73 @@ class TestModelTokenRatioSQL:
         # Only the recent (1.5) spans are in-window; the 4.0 tail is excluded
         # by the LIMIT, so the fit lands at the recent regime, not a blend.
         assert ratio == pytest.approx(1.5, abs=0.02)
+
+    async def test_recency_fetch_is_a_bounded_index_scan(self, harness: Harness) -> None:
+        """Perf guard (issue #1711 / #1798): the ``ORDER BY created_at DESC,
+        session_id DESC, seq DESC LIMIT`` recency fetch must be a bounded index
+        seek, not a full-model scan + Sort.
+
+        The query orders by global recency; migration 0024's
+        ``((data->>'model'), seq DESC)`` index can seek the model but cannot
+        satisfy that order, so without a matching covering index the planner
+        must read *every* lifetime row for the model and Sort it before the
+        ``LIMIT`` applies — the limit stops bounding the scan and the cost
+        grows without bound as calibration history accumulates.  Migration
+        0142 adds ``events_model_calibration_recency_idx`` keyed
+        ``((data->>'model'), created_at DESC, session_id DESC, seq DESC)`` so
+        the plan is an ordered index scan whose ``LIMIT`` bounds the read.
+
+        This EXPLAINs the *actual* SQL the query issues (captured, not
+        duplicated) so a future ORDER-BY change that the index no longer
+        covers reintroduces a ``Sort`` node and fails here.
+        """
+        account_id = "acc_test_stub"
+        model = f"test-model-{uuid.uuid4().hex[:8]}"
+        session = await harness.start("seed")
+        for _ in range(30):
+            await _seed_valid_span(
+                harness, session.id, model=model, local_tokens=100, input_tokens=150
+            )
+
+        class _CapturingConn:
+            """Delegates to a real connection while recording the one SQL the
+            ratio query issues, so the plan is checked against the live query."""
+
+            def __init__(self, real: asyncpg.Connection[Any]) -> None:
+                self._real = real
+                self.sql: str | None = None
+                self.args: tuple[Any, ...] = ()
+
+            async def fetch(self, query: str, *args: Any, **kwargs: Any) -> list[asyncpg.Record]:
+                self.sql = query
+                self.args = args
+                rows: list[asyncpg.Record] = await self._real.fetch(query, *args, **kwargs)
+                return rows
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self._real, name)
+
+        async with harness._pool.acquire() as conn:
+            capturing = _CapturingConn(conn)
+            # Fresh model name ⇒ cache miss ⇒ a real DB fetch we can capture.
+            await queries.model_token_class_ratios(
+                cast("asyncpg.Connection[Any]", capturing), model, account_id=account_id
+            )
+            assert capturing.sql is not None, "the ratio query issued no fetch to EXPLAIN"
+
+            await conn.execute("ANALYZE events")
+            # Nudge the planner off a whole-table seq scan so the plan reveals
+            # whether an ordered index path exists that satisfies the ORDER BY
+            # without a Sort.  If none does (the regression), a Sort node
+            # survives and the assertion below fails.
+            async with conn.transaction():
+                await conn.execute("SET LOCAL enable_seqscan = off")
+                plan_rows = await conn.fetch(f"EXPLAIN {capturing.sql}", *capturing.args)
+            plan = "\n".join(row[0] for row in plan_rows)
+
+        assert "events_model_calibration_recency_idx" in plan, (
+            f"recency fetch did not use the covering index:\n{plan}"
+        )
+        assert "Sort" not in plan, (
+            f"recency fetch still sorts — the LIMIT no longer bounds the scan:\n{plan}"
+        )

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -325,7 +325,11 @@ class TestModelTokenRatioSQL:
             )
         # JSON permits this future hostile shape despite today's int-typed provider model.
         await _seed_valid_span(
-            harness, session.id, model=model, local_tokens=100, input_tokens=150.5  # type: ignore[arg-type]
+            harness,
+            session.id,
+            model=model,
+            local_tokens=100,
+            input_tokens=150.5,  # type: ignore[arg-type]
         )
         async with harness._pool.acquire() as conn:
             ratio = await queries.model_token_ratio(conn, model, account_id=account_id)

--- a/tests/unit/test_completion_finish_reason.py
+++ b/tests/unit/test_completion_finish_reason.py
@@ -98,7 +98,7 @@ class _FakeStream:
 def _clobbered_builder(finish_reason: str) -> Any:
     """A ``stream_chunk_builder`` stand-in returning a given assembled
     ``finish_reason`` — used to simulate litellm's last-wins clobber."""
-    return lambda chunks: {
+    return lambda chunks, **_kwargs: {
         "usage": {},
         "choices": [
             {"message": {"role": "assistant", "content": ""}, "finish_reason": finish_reason}

--- a/tests/unit/test_completion_prompt_cache_key.py
+++ b/tests/unit/test_completion_prompt_cache_key.py
@@ -104,7 +104,7 @@ async def test_stream_litellm_openai_path_sends_prompt_cache_key(
     monkeypatch.setattr(
         litellm,
         "stream_chunk_builder",
-        lambda chunks: {
+        lambda chunks, **_kwargs: {
             "usage": {},
             "choices": [{"message": {"role": "assistant", "content": ""}}],
         },

--- a/tests/unit/test_completion_provider_auth.py
+++ b/tests/unit/test_completion_provider_auth.py
@@ -169,7 +169,7 @@ async def test_stream_litellm_also_injects_auth(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(
         litellm,
         "stream_chunk_builder",
-        lambda chunks: {
+        lambda chunks, **_kwargs: {
             "usage": {},
             "choices": [{"message": {"role": "assistant", "content": ""}}],
         },

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -232,7 +232,7 @@ async def test_stream_litellm_long_ttft_succeeds_when_inter_chunk_is_fast(
     monkeypatch.setattr(
         litellm,
         "stream_chunk_builder",
-        lambda chunks: {
+        lambda chunks, **_kwargs: {
             "usage": {},
             "choices": [{"message": {"role": "assistant", "content": "hello"}}],
         },
@@ -274,7 +274,7 @@ async def test_stream_litellm_passes_timeout_kwargs(
     monkeypatch.setattr(
         litellm,
         "stream_chunk_builder",
-        lambda chunks: {
+        lambda chunks, **_kwargs: {
             "usage": {},
             "choices": [{"message": {"role": "assistant", "content": ""}}],
         },
@@ -496,7 +496,7 @@ async def test_stream_litellm_closes_stream_on_normal_drain(
     monkeypatch.setattr(
         litellm,
         "stream_chunk_builder",
-        lambda chunks: {
+        lambda chunks, **_kwargs: {
             "usage": {},
             "choices": [{"message": {"role": "assistant", "content": "hello"}}],
         },

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -135,9 +135,8 @@ class TestModelTokenClassRatios:
         * Excludes rows lacking ``local_tokens_by_class`` (zero backfill;
           self-heals as new spans accumulate).
         * Bounds the scan to the most recent N spans via
-          ``ORDER BY seq DESC LIMIT $2`` (issue #1711), riding migration
-          0024's ``seq DESC`` partial index instead of an unbounded
-          lifetime scan on the step hot path.
+          ``ORDER BY created_at DESC LIMIT $2`` (issue #1711); ``seq`` is
+          session-local and cannot rank rows across sessions.
         """
         conn = _mock_conn([])
         await model_token_class_ratios(conn, "model-x", account_id="acc_test_stub")
@@ -146,7 +145,7 @@ class TestModelTokenClassRatios:
         assert "cache_read_input_tokens" not in sql
         assert "cache_creation_input_tokens" not in sql
         assert "data ? 'local_tokens_by_class'" in sql
-        assert "ORDER BY seq DESC" in sql
+        assert "ORDER BY created_at DESC" in sql
         assert "LIMIT $2" in sql
 
     @pytest.mark.asyncio
@@ -162,7 +161,7 @@ class TestModelTokenClassRatios:
         conn = _mock_conn([])
         await model_token_class_ratios(conn, "model-x", account_id="acc_test_stub")
         sql = conn.fetch.await_args.args[0]
-        assert "(data->'model_usage'->>'input_tokens')::bigint > 0" in sql
+        assert "input_tokens') ~ '^[0-9]+$'" in sql
 
     @pytest.mark.asyncio
     async def test_fetch_bound_to_sample_limit_constant(self) -> None:
@@ -197,11 +196,11 @@ class TestModelTokenClassRatios:
 
     @pytest.mark.asyncio
     async def test_recency_honored_recent_rows_drive_fit(self) -> None:
-        """Recency: the DB returns the most recent N (``ORDER BY seq DESC
+        """Recency: the DB returns the most recent N (``ORDER BY created_at DESC
         LIMIT``); a deliberately skewed *old* tail beyond N is never fetched,
         so the fit reflects only the recent regime.
 
-        The mock stands in for the DB's ``ORDER BY seq DESC LIMIT $2`` seek:
+        The mock stands in for the DB's ``ORDER BY created_at DESC LIMIT $2``:
         it returns exactly the recent-N slice, and the assertion proves the
         old tail (a wildly different coefficient regime) does not move the
         fit — i.e. the bound is honored, not silently ignored."""
@@ -209,7 +208,7 @@ class TestModelTokenClassRatios:
         old_skew = {"text": 8.0, "tool_result": 8.0, "thinking": 8.0}
         recent_rows = _linear_rows(recent, n=_MODEL_TOKEN_RATIO_SAMPLE_LIMIT)
         old_rows = _linear_rows(old_skew, n=500)
-        # The DB, honoring ORDER BY seq DESC LIMIT, hands back only the recent N.
+        # The DB, honoring global created_at recency, hands back only the recent N.
         conn = _mock_conn(recent_rows)
         recent_only_fit = await model_token_class_ratios(
             conn, "model-recent", account_id="acc_test_stub"
@@ -360,6 +359,9 @@ class TestBlendedREff:
     def test_empty_composition_falls_back_to_mean(self) -> None:
         coefs = {"text": 2.0, "tool_result": 1.0, "thinking": 3.0}
         assert blended_r_eff(coefs, {}) == pytest.approx(2.0)
+
+    def test_blend_has_scalar_floor(self) -> None:
+        assert blended_r_eff({"text": 0.1}, {"text": 100.0}) == 0.5
 
     def test_neutral_coefs_blend_to_one(self) -> None:
         # The acceptance-#5 fence: all-1.0 coefficients ⇒ R_eff == 1.0 for any

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -93,12 +93,7 @@ class TestNormalizeUsage:
 
     def test_empty_dict(self) -> None:
         result = _normalize_usage({})
-        assert result == {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-        }
+        assert result == {}
 
     def test_none_values_treated_as_zero(self) -> None:
         raw = {
@@ -107,12 +102,7 @@ class TestNormalizeUsage:
             "prompt_tokens_details": None,
         }
         result = _normalize_usage(raw)
-        assert result == {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-        }
+        assert result == {}
 
     def test_model_dump_flattened_prompt_tokens_details(self) -> None:
         """Regression: model_dump() flattens Pydantic objects to dicts with extra keys."""

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -225,9 +225,8 @@ async def test_ratio_above_1_drops_more(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.mark.asyncio
-async def test_ratio_below_1_drops_fewer(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A calibrated R_eff=0.5 deflates total_effective below window_max -> no
-    drop, even after the x1.3 calibrated safety margin (0.5*1.3=0.65)."""
+async def test_ratio_below_1_never_inflates_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sub-neutral calibration cannot enlarge the retained window."""
     account_id = "acc_test_stub"
     monkeypatch.setattr(
         queries,
@@ -248,10 +247,10 @@ async def test_ratio_below_1_drops_fewer(monkeypatch: pytest.MonkeyPatch) -> Non
         overhead_local=0,
         account_id=account_id,
     )
-    # total_effective = round(3000*0.5*1.3) = 1950 < 2000 -> no drop -> fallback.
-    assert result.events == _FALLBACK_SENTINEL
-    assert result.omission is None
-    assert not conn.fetch_calls
+    # The two-way margin clamps the conversion to neutral, so a low fit can
+    # never inflate retention; this 3000-token slate must still be windowed.
+    assert result.events != _FALLBACK_SENTINEL
+    assert conn.fetch_calls
 
 
 # ─── omission metadata (#738) ────────────────────────────────────────────────


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1798.