### PR TITLE
Calibration observability: expose per-model fitted R_eff + rolling measured server/local token ratio (item 9 of #1798)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -29,6 +29,27 @@
         }
       }
     },
+    "/telemetry/calibration": {
+      "get": {
+        "summary": "Calibration",
+        "description": "On-demand calibration observability for models active in the last 24h.",
+        "operationId": "get_calibration_telemetry",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Calibration Telemetry"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ready": {
       "get": {
         "summary": "Ready",

--- a/packages/aios-sdk/aios_sdk/_generated/api/default/get_calibration_telemetry.py
+++ b/packages/aios-sdk/aios_sdk/_generated/api/default/get_calibration_telemetry.py
@@ -1,0 +1,140 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.get_calibration_telemetry_response_get_calibration_telemetry import (
+    GetCalibrationTelemetryResponseGetCalibrationTelemetry,
+)
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/telemetry/calibration",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> GetCalibrationTelemetryResponseGetCalibrationTelemetry | None:
+    if response.status_code == 200:
+        response_200 = GetCalibrationTelemetryResponseGetCalibrationTelemetry.from_dict(
+            response.json()
+        )
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[GetCalibrationTelemetryResponseGetCalibrationTelemetry]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetCalibrationTelemetryResponseGetCalibrationTelemetry]:
+    """Calibration
+
+     On-demand calibration observability for models active in the last 24h.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetCalibrationTelemetryResponseGetCalibrationTelemetry]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetCalibrationTelemetryResponseGetCalibrationTelemetry | None:
+    """Calibration
+
+     On-demand calibration observability for models active in the last 24h.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetCalibrationTelemetryResponseGetCalibrationTelemetry
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[GetCalibrationTelemetryResponseGetCalibrationTelemetry]:
+    """Calibration
+
+     On-demand calibration observability for models active in the last 24h.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GetCalibrationTelemetryResponseGetCalibrationTelemetry]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> GetCalibrationTelemetryResponseGetCalibrationTelemetry | None:
+    """Calibration
+
+     On-demand calibration observability for models active in the last 24h.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GetCalibrationTelemetryResponseGetCalibrationTelemetry
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/__init__.py
@@ -69,6 +69,9 @@ from .event_kind import EventKind
 from .external_event_source import ExternalEventSource
 from .file_upload_response import FileUploadResponse
 from .gate_resume import GateResume
+from .get_calibration_telemetry_response_get_calibration_telemetry import (
+    GetCalibrationTelemetryResponseGetCalibrationTelemetry,
+)
 from .get_health_response_get_health import GetHealthResponseGetHealth
 from .github_repository_resource import GithubRepositoryResource
 from .github_repository_resource_echo import GithubRepositoryResourceEcho
@@ -409,6 +412,7 @@ __all__ = (
     "ExternalEventSource",
     "FileUploadResponse",
     "GateResume",
+    "GetCalibrationTelemetryResponseGetCalibrationTelemetry",
     "GetHealthResponseGetHealth",
     "GithubRepositoryResource",
     "GithubRepositoryResourceEcho",

--- a/packages/aios-sdk/aios_sdk/_generated/models/get_calibration_telemetry_response_get_calibration_telemetry.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/get_calibration_telemetry_response_get_calibration_telemetry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="GetCalibrationTelemetryResponseGetCalibrationTelemetry")
+
+
+@_attrs_define
+class GetCalibrationTelemetryResponseGetCalibrationTelemetry:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        get_calibration_telemetry_response_get_calibration_telemetry = cls()
+
+        get_calibration_telemetry_response_get_calibration_telemetry.additional_properties = d
+        return get_calibration_telemetry_response_get_calibration_telemetry
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/aios/api/routers/health.py
+++ b/src/aios/api/routers/health.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
 from aios import __version__
+from aios.db.queries.events import calibration_telemetry
 
 router = APIRouter()
 
@@ -40,6 +41,14 @@ async def health() -> dict[str, str]:
         "version": __version__,
         "source_commit": os.environ.get("SOURCE_COMMIT") or "unknown",
     }
+
+
+@router.get("/telemetry/calibration", operation_id="get_calibration_telemetry")
+async def calibration(request: Request) -> dict[str, object]:
+    """On-demand calibration observability for models active in the last 24h."""
+    async with request.app.state.pool.acquire() as conn:
+        models = await calibration_telemetry(conn)
+    return {"models": models, "window_hours": 24}
 
 
 @router.get("/ready", operation_id="get_ready")

--- a/src/aios/cli/allowlist.py
+++ b/src/aios/cli/allowlist.py
@@ -70,6 +70,10 @@ NOT_CLI_OPERATIONS: dict[str, str] = {
         "its typed capability descriptor at startup; operators don't hand-write it."
     ),
     # ── Infra/orchestrator probe ─────────────────────────────────────
+    "get_calibration_telemetry": (
+        "Machine-polled observability endpoint consumed by the off-substrate ops-agent; "
+        "not an interactive operator workflow."
+    ),
     "get_ready": (
         "Readiness probe (SELECT 1 under a short timeout) consumed by the "
         "Docker/compose healthcheck and load balancers, not operators. "

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -467,16 +467,39 @@ async def model_token_class_ratio_fit(
 
 
 async def calibration_telemetry(conn: asyncpg.Connection[Any]) -> dict[str, dict[str, Any]]:
-    """Compute fit-vs-measured token ratios for models active in the last 24h."""
+    """Compute fit-vs-measured token ratios for models active in the last 24h.
+
+    ``fitted_r_eff`` is the *composition-weighted* blended ratio the windower
+    actually consumes (:func:`blended_r_eff`: ``Σ_c coef_c·local_c / Σ_c
+    local_c``), evaluated over a representative composition — the summed
+    ``local_tokens_by_class`` mass over the same 24h window as
+    ``measured_ratio``.  It is NOT the unweighted arithmetic mean of the
+    per-class coefficients: for a skewed class mix the two diverge
+    substantially, so the mean would put ``fitted_r_eff`` on a different scale
+    than ``measured_ratio`` and make the ops-agent's ``|fitted - measured|``
+    divergence check miss or falsely fire — the exact failure this endpoint
+    exists to detect.  ``fitted_coefficients`` still carries the raw per-class
+    fit for finer diagnosis.
+    """
+    # Aggregate the recent class composition alongside the measured ratio.  The
+    # per-class mass columns are built from the trusted ``CONTENT_CLASSES``
+    # constant (never user input — no injection surface), and ``coalesce``
+    # keeps a class absent from every span at 0.0 mass rather than NULL.
+    class_mass_cols = ",\n".join(
+        f"               coalesce(sum((data->'local_tokens_by_class'->>'{c}')::float), 0.0) "
+        f"AS mass_{c}"
+        for c in CONTENT_CLASSES
+    )
     measured = await conn.fetch(
-        """
+        f"""
         SELECT data->>'model' AS model,
                avg((data->'model_usage'->>'input_tokens')::float /
                    (data->>'local_tokens')::float) AS mean_ratio,
                percentile_cont(0.5) WITHIN GROUP (ORDER BY
                    (data->'model_usage'->>'input_tokens')::float /
                    (data->>'local_tokens')::float) AS p50_ratio,
-               count(*) AS n_samples
+               count(*) AS n_samples,
+{class_mass_cols}
         FROM events
         WHERE kind = 'span'
           AND data->>'event' = 'model_request_end'
@@ -500,8 +523,9 @@ async def calibration_telemetry(conn: asyncpg.Connection[Any]) -> dict[str, dict
             conn, model, account_id="telemetry"
         )
         effective = coefficients or _neutral_class_ratios()
+        composition = {c: float(row[f"mass_{c}"]) for c in CONTENT_CLASSES}
         result[model] = {
-            "fitted_r_eff": sum(effective.values()) / len(effective),
+            "fitted_r_eff": blended_r_eff(effective, composition),
             "fitted_coefficients": effective,
             "measured_ratio": {
                 "mean": float(row["mean_ratio"]),

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -413,47 +413,11 @@ async def model_token_class_ratios(
             return dict(ratios)
         del _model_token_ratio_cache[cache_key]
 
-    rows = await conn.fetch(
-        """
-        SELECT
-            (data->'model_usage'->>'input_tokens')::float AS it,
-            data->'local_tokens_by_class'                 AS by_class
-        FROM events
-        WHERE kind = 'span'
-          AND data->>'event' = 'model_request_end'
-          AND (data->>'is_error')::boolean = false
-          AND data->>'model' = $1
-          AND data ? 'local_tokens'
-          AND data ? 'local_tokens_by_class'
-          AND data ? 'model'
-          -- Exclude old/malformed success spans before casting.
-          AND (data->'model_usage') ? 'input_tokens'
-          AND (data->'model_usage'->>'input_tokens') IS NOT NULL
-          AND (data->'model_usage'->>'input_tokens')::bigint > 0
-          AND (data->>'local_tokens')::bigint > 0
-        -- Bound the scan to the most recent N spans (issue #1711): rides
-        -- migration 0024's ``((data->>'model'), seq DESC)`` partial index
-        -- as a bounded seek instead of a full lifetime scan on the step
-        -- hot path.  MIN_SAMPLES is still checked below the fetch.
-        ORDER BY seq DESC
-        LIMIT $2
-        """,
-        model,
-        _MODEL_TOKEN_RATIO_SAMPLE_LIMIT,
+    fitted, n_samples = await model_token_class_ratio_fit(
+        conn, model, account_id=account_id
     )
 
-    if len(rows) < _MODEL_TOKEN_RATIO_MIN_SAMPLES:
-        neutral = _neutral_class_ratios()
-        _model_token_ratio_cache[cache_key] = (
-            now + _MODEL_TOKEN_RATIO_BELOW_THRESHOLD_CACHE_TTL_SECONDS,
-            neutral,
-        )
-        return dict(neutral)
-
-    fitted = _fit_class_ratios(rows)
-    if fitted is None:
-        # Degenerate / singular system → fold back to neutral but cache
-        # briefly (the data may settle as more varied spans arrive).
+    if n_samples < _MODEL_TOKEN_RATIO_MIN_SAMPLES or fitted is None:
         neutral = _neutral_class_ratios()
         _model_token_ratio_cache[cache_key] = (
             now + _MODEL_TOKEN_RATIO_BELOW_THRESHOLD_CACHE_TTL_SECONDS,
@@ -467,6 +431,88 @@ async def model_token_class_ratios(
     )
     return dict(fitted)
 
+
+
+async def model_token_class_ratio_fit(
+    conn: asyncpg.Connection[Any], model: str, *, account_id: str
+) -> tuple[dict[str, float] | None, int]:
+    """Return a fresh bounded calibration fit and its usable sample count.
+
+    This is the uncached calibration reader shared by the hot-path cached
+    wrapper and the on-demand observability surface. ``account_id`` remains
+    intentionally unused because calibration is global per model.
+    """
+    del account_id
+    rows = await conn.fetch(
+        """
+        SELECT
+            (data->'model_usage'->>'input_tokens')::float AS it,
+            data->'local_tokens_by_class'                 AS by_class
+        FROM events
+        WHERE kind = 'span'
+          AND data->>'event' = 'model_request_end'
+          AND (data->>'is_error')::boolean = false
+          AND data->>'model' = $1
+          AND data ? 'local_tokens'
+          AND data ? 'local_tokens_by_class'
+          AND data ? 'model'
+          AND (data->'model_usage') ? 'input_tokens'
+          AND (data->'model_usage'->>'input_tokens') IS NOT NULL
+          AND (data->'model_usage'->>'input_tokens')::bigint > 0
+          AND (data->>'local_tokens')::bigint > 0
+        ORDER BY seq DESC
+        LIMIT $2
+        """,
+        model,
+        _MODEL_TOKEN_RATIO_SAMPLE_LIMIT,
+    )
+    return _fit_class_ratios(rows), len(rows)
+
+
+async def calibration_telemetry(conn: asyncpg.Connection[Any]) -> dict[str, dict[str, Any]]:
+    """Compute fit-vs-measured token ratios for models active in the last 24h."""
+    measured = await conn.fetch(
+        """
+        SELECT data->>'model' AS model,
+               avg((data->'model_usage'->>'input_tokens')::float /
+                   (data->>'local_tokens')::float) AS mean_ratio,
+               percentile_cont(0.5) WITHIN GROUP (ORDER BY
+                   (data->'model_usage'->>'input_tokens')::float /
+                   (data->>'local_tokens')::float) AS p50_ratio,
+               count(*) AS n_samples
+        FROM events
+        WHERE kind = 'span'
+          AND data->>'event' = 'model_request_end'
+          AND (data->>'is_error')::boolean = false
+          AND created_at >= now() - interval '24 hours'
+          AND data ? 'local_tokens'
+          AND data ? 'local_tokens_by_class'
+          AND data ? 'model'
+          AND (data->'model_usage') ? 'input_tokens'
+          AND (data->'model_usage'->>'input_tokens') IS NOT NULL
+          AND (data->'model_usage'->>'input_tokens')::bigint > 0
+          AND (data->>'local_tokens')::bigint > 0
+        GROUP BY data->>'model'
+        ORDER BY data->>'model'
+        """
+    )
+    result: dict[str, dict[str, Any]] = {}
+    for row in measured:
+        model = str(row["model"])
+        coefficients, fitted_n = await model_token_class_ratio_fit(
+            conn, model, account_id="telemetry"
+        )
+        effective = coefficients or _neutral_class_ratios()
+        result[model] = {
+            "fitted_r_eff": sum(effective.values()) / len(effective),
+            "fitted_coefficients": effective,
+            "measured_ratio": {
+                "mean": float(row["mean_ratio"]),
+                "p50": float(row["p50_ratio"]),
+            },
+            "n_samples": {"fitted": fitted_n, "measured": int(row["n_samples"])},
+        }
+    return result
 
 def _fit_class_ratios(rows: list[Any]) -> dict[str, float] | None:
     """Ridge-fit the per-class coefficient dict from calibration rows.

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -413,9 +413,7 @@ async def model_token_class_ratios(
             return dict(ratios)
         del _model_token_ratio_cache[cache_key]
 
-    fitted, n_samples = await model_token_class_ratio_fit(
-        conn, model, account_id=account_id
-    )
+    fitted, n_samples = await model_token_class_ratio_fit(conn, model, account_id=account_id)
 
     if n_samples < _MODEL_TOKEN_RATIO_MIN_SAMPLES or fitted is None:
         neutral = _neutral_class_ratios()
@@ -430,7 +428,6 @@ async def model_token_class_ratios(
         fitted,
     )
     return dict(fitted)
-
 
 
 async def model_token_class_ratio_fit(
@@ -513,6 +510,7 @@ async def calibration_telemetry(conn: asyncpg.Connection[Any]) -> dict[str, dict
             "n_samples": {"fitted": fitted_n, "measured": int(row["n_samples"])},
         }
     return result
+
 
 def _fit_class_ratios(rows: list[Any]) -> dict[str, float] | None:
     """Ridge-fit the per-class coefficient dict from calibration rows.

--- a/tests/unit/test_calibration_telemetry.py
+++ b/tests/unit/test_calibration_telemetry.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aios.api.routers import health
+from aios.db.queries.events import calibration_telemetry
+
+
+class _Conn:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.query = ""
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        self.query = query
+        return self.rows
+
+
+async def test_calibration_telemetry_aggregates_recent_successes(monkeypatch: Any) -> None:
+    conn = _Conn([
+        {"model": "model-a", "mean_ratio": 1.2, "p50_ratio": 1.1, "n_samples": 7},
+    ])
+
+    async def _fit(_conn: Any, model: str, *, account_id: str) -> tuple[dict[str, float], int]:
+        assert model == "model-a"
+        return {"message": 0.9, "tool_result": 1.1}, 19
+
+    monkeypatch.setattr("aios.db.queries.events.model_token_class_ratio_fit", _fit)
+    result = await calibration_telemetry(conn)
+
+    assert "created_at >= now() - interval '24 hours'" in conn.query
+    assert "input_tokens')::bigint > 0" in conn.query
+    assert result == {"model-a": {
+        "fitted_r_eff": 1.0,
+        "fitted_coefficients": {"message": 0.9, "tool_result": 1.1},
+        "measured_ratio": {"mean": 1.2, "p50": 1.1},
+        "n_samples": {"fitted": 19, "measured": 7},
+    }}
+
+
+def test_calibration_telemetry_route_uses_pool(monkeypatch: Any) -> None:
+    expected = {"model-a": {"fitted_r_eff": 1.0}}
+
+    async def _telemetry(_conn: Any) -> dict[str, Any]:
+        return expected
+
+    monkeypatch.setattr("aios.api.routers.health.calibration_telemetry", _telemetry)
+
+    class _Acquire:
+        async def __aenter__(self) -> object:
+            return object()
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+    class _Pool:
+        def acquire(self) -> _Acquire:
+            return _Acquire()
+
+    app = FastAPI()
+    app.state.pool = _Pool()
+    app.include_router(health.router)
+    response = TestClient(app).get("/telemetry/calibration")
+    assert response.status_code == 200
+    assert response.json() == {"models": expected, "window_hours": 24}

--- a/tests/unit/test_calibration_telemetry.py
+++ b/tests/unit/test_calibration_telemetry.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from aios.api.routers import health
 from aios.db.queries.events import calibration_telemetry
+from aios.harness.tokens import CONTENT_CLASSES
 
 
 class _Conn:
@@ -19,30 +21,85 @@ class _Conn:
         return self.rows
 
 
-async def test_calibration_telemetry_aggregates_recent_successes(monkeypatch: Any) -> None:
-    conn = _Conn(
-        [
-            {"model": "model-a", "mean_ratio": 1.2, "p50_ratio": 1.1, "n_samples": 7},
-        ]
-    )
+async def test_calibration_telemetry_fitted_r_eff_is_composition_weighted(
+    monkeypatch: Any,
+) -> None:
+    """``fitted_r_eff`` must be the composition-weighted blend the windower
+    consumes, NOT the unweighted mean of the per-class coefficients.
+
+    Uses NONUNIFORM coefficients AND a skewed composition so the two values
+    diverge sharply — the arithmetic-mean bug (invisible under the prior
+    symmetric-coefficient test) would fail this assertion.
+    """
+    # Skewed mix: ~all local mass in "text", a little in "tool_result".
+    mass = {c: 0.0 for c in CONTENT_CLASSES}
+    mass["text"] = 900.0
+    mass["tool_result"] = 100.0
+    row: dict[str, Any] = {
+        "model": "model-a",
+        "mean_ratio": 1.8,
+        "p50_ratio": 1.75,
+        "n_samples": 42,
+    }
+    row.update({f"mass_{c}": m for c, m in mass.items()})
+    conn = _Conn([row])
+
+    # Nonuniform coefficients. Unweighted mean = 6.5 / 6 ≈ 1.0833; the correct
+    # composition-weighted blend over the skewed mix
+    # = (2.0*900 + 0.5*100) / 1000 = 1.85 — close to the measured 1.8, whereas
+    # the old mean (1.0833) would falsely trip the ops-agent's divergence band.
+    coefficients = {
+        "system": 1.0,
+        "tools": 1.0,
+        "text": 2.0,
+        "tool_result": 0.5,
+        "thinking": 1.0,
+        "tool_use": 1.0,
+    }
 
     async def _fit(_conn: Any, model: str, *, account_id: str) -> tuple[dict[str, float], int]:
         assert model == "model-a"
-        return {"message": 0.9, "tool_result": 1.1}, 19
+        return dict(coefficients), 19
 
     monkeypatch.setattr("aios.db.queries.events.model_token_class_ratio_fit", _fit)
     result = await calibration_telemetry(conn)
 
     assert "created_at >= now() - interval '24 hours'" in conn.query
     assert "input_tokens')::bigint > 0" in conn.query
-    assert result == {
-        "model-a": {
-            "fitted_r_eff": 1.0,
-            "fitted_coefficients": {"message": 0.9, "tool_result": 1.1},
-            "measured_ratio": {"mean": 1.2, "p50": 1.1},
-            "n_samples": {"fitted": 19, "measured": 7},
-        }
+
+    entry = result["model-a"]
+    assert entry["fitted_r_eff"] == pytest.approx(1.85)
+    # Regression guard: reject a relapse to the unweighted arithmetic mean.
+    unweighted_mean = sum(coefficients.values()) / len(coefficients)
+    assert entry["fitted_r_eff"] != pytest.approx(unweighted_mean)
+    assert entry["fitted_coefficients"] == coefficients
+    assert entry["measured_ratio"] == {"mean": 1.8, "p50": 1.75}
+    assert entry["n_samples"] == {"fitted": 19, "measured": 42}
+
+
+async def test_calibration_telemetry_neutral_fit_is_scale_stable(monkeypatch: Any) -> None:
+    """Below-threshold / degenerate fits fold to all-1.0 coefficients, whose
+    blend is 1.0 for any composition — no divergence introduced by the fix."""
+    mass = {c: 0.0 for c in CONTENT_CLASSES}
+    mass["text"] = 500.0
+    mass["tool_use"] = 500.0
+    row: dict[str, Any] = {
+        "model": "model-b",
+        "mean_ratio": 1.05,
+        "p50_ratio": 1.0,
+        "n_samples": 3,
     }
+    row.update({f"mass_{c}": m for c, m in mass.items()})
+    conn = _Conn([row])
+
+    async def _fit(_conn: Any, model: str, *, account_id: str) -> tuple[None, int]:
+        return None, 3
+
+    monkeypatch.setattr("aios.db.queries.events.model_token_class_ratio_fit", _fit)
+    result = await calibration_telemetry(conn)
+
+    assert result["model-b"]["fitted_r_eff"] == pytest.approx(1.0)
+    assert result["model-b"]["fitted_coefficients"] == {c: 1.0 for c in CONTENT_CLASSES}
 
 
 def test_calibration_telemetry_route_uses_pool(monkeypatch: Any) -> None:

--- a/tests/unit/test_calibration_telemetry.py
+++ b/tests/unit/test_calibration_telemetry.py
@@ -20,9 +20,11 @@ class _Conn:
 
 
 async def test_calibration_telemetry_aggregates_recent_successes(monkeypatch: Any) -> None:
-    conn = _Conn([
-        {"model": "model-a", "mean_ratio": 1.2, "p50_ratio": 1.1, "n_samples": 7},
-    ])
+    conn = _Conn(
+        [
+            {"model": "model-a", "mean_ratio": 1.2, "p50_ratio": 1.1, "n_samples": 7},
+        ]
+    )
 
     async def _fit(_conn: Any, model: str, *, account_id: str) -> tuple[dict[str, float], int]:
         assert model == "model-a"
@@ -33,12 +35,14 @@ async def test_calibration_telemetry_aggregates_recent_successes(monkeypatch: An
 
     assert "created_at >= now() - interval '24 hours'" in conn.query
     assert "input_tokens')::bigint > 0" in conn.query
-    assert result == {"model-a": {
-        "fitted_r_eff": 1.0,
-        "fitted_coefficients": {"message": 0.9, "tool_result": 1.1},
-        "measured_ratio": {"mean": 1.2, "p50": 1.1},
-        "n_samples": {"fitted": 19, "measured": 7},
-    }}
+    assert result == {
+        "model-a": {
+            "fitted_r_eff": 1.0,
+            "fitted_coefficients": {"message": 0.9, "tool_result": 1.1},
+            "measured_ratio": {"mean": 1.2, "p50": 1.1},
+            "n_samples": {"fitted": 19, "measured": 7},
+        }
+    }
 
 
 def test_calibration_telemetry_route_uses_pool(monkeypatch: Any) -> None:
@@ -52,6 +56,7 @@ def test_calibration_telemetry_route_uses_pool(monkeypatch: Any) -> None:
     class _Acquire:
         async def __aenter__(self) -> object:
             return object()
+
         async def __aexit__(self, *args: Any) -> None:
             return None
 


### PR DESCRIPTION
Automated dev-pipeline build for issue #1801.