### PR TITLE
Sandbox flatten-salvage can never finish inside its size-derived timeout for corpses ≳5GB → permanent provision brick (session loses all sandbox tools until operator intervenes)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -198,6 +198,26 @@ class Settings(BaseSettings):
         "applies). Per-environment overridable via "
         "``EnvironmentConfig.snapshot_budget_bytes``.",
     )
+    sandbox_pipeline_stall_seconds: float = Field(
+        default=120.0,
+        gt=0,
+        description="Maximum interval without bytes moving through a Docker flatten pipeline.",
+    )
+    sandbox_pipeline_max_seconds: float = Field(
+        default=3600.0,
+        gt=0,
+        description="Absolute backstop for a Docker flatten pipeline.",
+    )
+    sandbox_salvage_breaker_threshold: int = Field(
+        default=3,
+        ge=1,
+        description="Consecutive failures of one corpse before salvage retries are suppressed.",
+    )
+    sandbox_flatten_disk_floor_bytes: int = Field(
+        default=15 * 1024 * 1024 * 1024,
+        ge=0,
+        description="Free disk retained in addition to the estimated transient flatten cost.",
+    )
     sandbox_snapshot_ttl_seconds: int = Field(
         default=2_592_000,  # 30 days
         ge=60,

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 
 from aios.sandbox.backends.base import SandboxBackendError
 
@@ -118,11 +117,13 @@ async def run_docker_pipeline(
     consumer: asyncio.subprocess.Process | None = None
     started = asyncio.get_running_loop().time()
 
-    async def _kill_all() -> None:
+    async def _kill_all(*, close_transports: bool = False) -> None:
         for proc in (producer, consumer):
             if proc is not None:
                 with contextlib.suppress(ProcessLookupError):
                     proc.kill()
+                if close_transports:
+                    proc._transport.close()  # type: ignore[attr-defined]
 
     try:
         try:
@@ -130,8 +131,10 @@ async def run_docker_pipeline(
                 *producer_argv, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
             )
             consumer = await asyncio.create_subprocess_exec(
-                *consumer_argv, stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                *consumer_argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
         except (OSError, FileNotFoundError) as host_err:
             raise SandboxBackendError(f"failed to launch docker pipeline: {host_err}") from host_err
@@ -183,5 +186,7 @@ async def run_docker_pipeline(
             )
         return consumer.returncode if consumer.returncode is not None else -1, cons_out, cons_err
     except BaseException:
-        await _kill_all()
+        # Outer cancellation returns immediately, so close both transports
+        # after killing to release their parent-side pipe descriptors.
+        await _kill_all(close_transports=True)
         raise

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -140,7 +140,9 @@ async def run_docker_pipeline(
             raise SandboxBackendError(f"failed to launch docker pipeline: {host_err}") from host_err
         assert producer.stdout is not None and consumer.stdin is not None
 
-        async def _pump() -> int:
+        async def _pump(
+            producer_stdout: asyncio.StreamReader, consumer_stdin: asyncio.StreamWriter
+        ) -> int:
             moved = 0
             while True:
                 remaining = max_timeout_s - (asyncio.get_running_loop().time() - started)
@@ -148,24 +150,24 @@ async def run_docker_pipeline(
                     raise TimeoutError("absolute ceiling")
                 try:
                     chunk = await asyncio.wait_for(
-                        producer.stdout.read(1024 * 1024), timeout=min(stall_timeout_s, remaining)
+                        producer_stdout.read(1024 * 1024), timeout=min(stall_timeout_s, remaining)
                     )
                 except TimeoutError as err:
                     raise TimeoutError("stream stalled") from err
                 if not chunk:
-                    consumer.stdin.close()
+                    consumer_stdin.close()
                     with contextlib.suppress(BrokenPipeError, ConnectionResetError):
-                        await consumer.stdin.wait_closed()
+                        await consumer_stdin.wait_closed()
                     return moved
-                consumer.stdin.write(chunk)
-                await consumer.stdin.drain()
+                consumer_stdin.write(chunk)
+                await consumer_stdin.drain()
                 moved += len(chunk)
 
         prod_err_task = asyncio.create_task(producer.stderr.read())  # type: ignore[union-attr]
         cons_out_task = asyncio.create_task(consumer.stdout.read())  # type: ignore[union-attr]
         cons_err_task = asyncio.create_task(consumer.stderr.read())  # type: ignore[union-attr]
         try:
-            moved = await _pump()
+            moved = await _pump(producer.stdout, consumer.stdin)
             remaining = max_timeout_s - (asyncio.get_running_loop().time() - started)
             if remaining <= 0:
                 raise TimeoutError("absolute ceiling")

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -105,104 +105,83 @@ async def run_docker_pipeline(
     producer_argv: list[str],
     consumer_argv: list[str],
     *,
-    timeout_s: float,
+    stall_timeout_s: float,
+    max_timeout_s: float,
 ) -> tuple[int, bytes, bytes]:
-    """Run ``producer_argv | consumer_argv`` joined by an ``os.pipe()`` fd pair.
+    """Run a Docker producer/consumer pipeline with progress-based deadlines.
 
-    Used for the flatten path ``docker export <id> | docker import - <tag>``
-    without a host shell: both argvs go straight to ``execve`` and are
-    connected at the OS level, so no shell metacharacter interpretation
-    happens on the host (same security posture as
-    :func:`run_subprocess_with_timeout`). Returns the **consumer's**
-    ``(returncode, stdout, stderr)`` — ``docker import`` prints the new
-    image id to stdout — so the caller can read the flattened image id.
-
-    Raises :class:`SandboxBackendError` on launch failure, on timeout
-    (both children are SIGKILLed), or when the **producer** exits nonzero
-    (a failed ``export`` would otherwise feed the consumer a truncated
-    stream that imports as a silently-corrupt image). The consumer's own
-    nonzero exit is returned for the caller to interpret, mirroring
-    :func:`run_docker_cli`.
+    The relay makes stream progress observable. A lack of bytes before EOF is
+    a stall; after EOF the consumer may legitimately spend substantial time
+    finalizing, so only the absolute ceiling applies then.
     """
-    rd, wr = os.pipe()
     producer: asyncio.subprocess.Process | None = None
     consumer: asyncio.subprocess.Process | None = None
+    started = asyncio.get_running_loop().time()
+
+    async def _kill_all() -> None:
+        for proc in (producer, consumer):
+            if proc is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+
     try:
         try:
             producer = await asyncio.create_subprocess_exec(
-                *producer_argv, stdout=wr, stderr=asyncio.subprocess.PIPE
+                *producer_argv, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
             )
-        except (OSError, FileNotFoundError) as host_err:
-            raise SandboxBackendError(
-                f"failed to launch {producer_argv[0]}: {host_err}"
-            ) from host_err
-        # The producer now holds the only writer; the parent must drop its
-        # copy so the consumer sees EOF when the producer exits.
-        os.close(wr)
-        wr = -1
-        try:
             consumer = await asyncio.create_subprocess_exec(
-                *consumer_argv,
-                stdin=rd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+                *consumer_argv, stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
             )
         except (OSError, FileNotFoundError) as host_err:
-            raise SandboxBackendError(
-                f"failed to launch {consumer_argv[0]}: {host_err}"
-            ) from host_err
-        os.close(rd)
-        rd = -1
+            raise SandboxBackendError(f"failed to launch docker pipeline: {host_err}") from host_err
+        assert producer.stdout is not None and consumer.stdin is not None
 
-        async def _drain() -> tuple[tuple[bytes, bytes], tuple[bytes, bytes]]:
-            # Drive both concurrently so neither stderr/stdout pipe can
-            # fill and deadlock the other. Both are non-None here (assigned
-            # above before _drain is ever awaited).
-            return await asyncio.gather(consumer.communicate(), producer.communicate())
+        async def _pump() -> int:
+            moved = 0
+            while True:
+                remaining = max_timeout_s - (asyncio.get_running_loop().time() - started)
+                if remaining <= 0:
+                    raise TimeoutError("absolute ceiling")
+                try:
+                    chunk = await asyncio.wait_for(
+                        producer.stdout.read(1024 * 1024), timeout=min(stall_timeout_s, remaining)
+                    )
+                except TimeoutError as err:
+                    raise TimeoutError("stream stalled") from err
+                if not chunk:
+                    consumer.stdin.close()
+                    with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                        await consumer.stdin.wait_closed()
+                    return moved
+                consumer.stdin.write(chunk)
+                await consumer.stdin.drain()
+                moved += len(chunk)
 
+        prod_err_task = asyncio.create_task(producer.stderr.read())  # type: ignore[union-attr]
+        cons_out_task = asyncio.create_task(consumer.stdout.read())  # type: ignore[union-attr]
+        cons_err_task = asyncio.create_task(consumer.stderr.read())  # type: ignore[union-attr]
         try:
-            (cons_out, cons_err), (_prod_out, prod_err) = await asyncio.wait_for(
-                _drain(), timeout=timeout_s
+            moved = await _pump()
+            remaining = max_timeout_s - (asyncio.get_running_loop().time() - started)
+            if remaining <= 0:
+                raise TimeoutError("absolute ceiling")
+            await asyncio.wait_for(asyncio.gather(producer.wait(), consumer.wait()), remaining)
+            prod_err, cons_out, cons_err = await asyncio.gather(
+                prod_err_task, cons_out_task, cons_err_task
             )
         except TimeoutError as timeout_err:
-            for proc in (producer, consumer):
-                if proc is not None:
-                    with contextlib.suppress(ProcessLookupError):
-                        proc.kill()
+            await _kill_all()
             raise SandboxBackendError(
-                f"docker pipeline timed out after {timeout_s}s: "
+                f"docker pipeline timed out ({timeout_err}; {moved if 'moved' in locals() else 0} bytes moved): "
                 f"{' '.join(producer_argv)} | {' '.join(consumer_argv)}"
             ) from timeout_err
-        except BaseException:
-            # CancelledError is a BaseException, not a TimeoutError, so an
-            # outer cancel (caller's job deadline, worker SIGTERM mid
-            # multi-GB export) skips the timeout branch above — both
-            # children keep running and their parent-side pipe FDs leak.
-            # Mirror run_subprocess_with_timeout: SIGKILL both and close
-            # their transports before propagating. (The timeout branch
-            # needs no close — the loop reclaims each transport on the
-            # killed child's pipe EOF — but a propagating cancel returns
-            # immediately, so it must release them here.)
-            for proc in (producer, consumer):
-                if proc is not None:
-                    with contextlib.suppress(ProcessLookupError):
-                        proc.kill()
-                    proc._transport.close()  # type: ignore[attr-defined]  # typeshed omits Process._transport
-            raise
-
         if producer.returncode != 0:
             raise SandboxBackendError(
                 f"{producer_argv[0]} export failed (exit {producer.returncode}): "
                 f"{prod_err.decode('utf-8', errors='replace').strip()}"
             )
-        return (
-            consumer.returncode if consumer.returncode is not None else -1,
-            cons_out,
-            cons_err,
-        )
-    finally:
-        # Close any fd we still own (launch-failure / early-raise paths).
-        for fd in (rd, wr):
-            if fd != -1:
-                with contextlib.suppress(OSError):
-                    os.close(fd)
+        return consumer.returncode if consumer.returncode is not None else -1, cons_out, cons_err
+    except BaseException:
+        await _kill_all()
+        raise

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -140,27 +140,58 @@ async def run_docker_pipeline(
             raise SandboxBackendError(f"failed to launch docker pipeline: {host_err}") from host_err
         assert producer.stdout is not None and consumer.stdin is not None
 
+        def _stall_deadline() -> float:
+            """Per-operation timeout: the stall bound, tightened so a single
+            wait can never overshoot the absolute ceiling. Raises the
+            absolute-ceiling ``TimeoutError`` when the ceiling has already
+            passed (evaluated *outside* the per-op ``wait_for`` so the two
+            deadline classes stay distinguishable in the surfaced error)."""
+            remaining = max_timeout_s - (asyncio.get_running_loop().time() - started)
+            if remaining <= 0:
+                raise TimeoutError("absolute ceiling")
+            return min(stall_timeout_s, remaining)
+
         async def _pump(
             producer_stdout: asyncio.StreamReader, consumer_stdin: asyncio.StreamWriter
         ) -> int:
+            # Every await that can block on a peer — the producer withholding
+            # bytes (read) OR the consumer refusing to accept them (write /
+            # drain / final flush) — is bounded by the SAME stall+absolute
+            # pair. A read or drain that completes is progress and opens a
+            # fresh stall window for the next op; the absolute ceiling caps the
+            # whole relay. Bounding only the read side leaves the brick
+            # half-fixed: a consumer that stops draining (a wedged
+            # ``docker import``) fills the OS pipe, the writer's buffer grows
+            # past its high-water mark, and ``drain()`` blocks forever with
+            # neither deadline able to fire.
             moved = 0
             while True:
-                remaining = max_timeout_s - (asyncio.get_running_loop().time() - started)
-                if remaining <= 0:
-                    raise TimeoutError("absolute ceiling")
+                read_timeout = _stall_deadline()
                 try:
                     chunk = await asyncio.wait_for(
-                        producer_stdout.read(1024 * 1024), timeout=min(stall_timeout_s, remaining)
+                        producer_stdout.read(1024 * 1024), timeout=read_timeout
                     )
                 except TimeoutError as err:
-                    raise TimeoutError("stream stalled") from err
+                    raise TimeoutError("read stalled") from err
                 if not chunk:
+                    # EOF: flush and close the write side under the same
+                    # deadlines, so a consumer that stops reading during the
+                    # final flush can't wedge here either.
                     consumer_stdin.close()
-                    with contextlib.suppress(BrokenPipeError, ConnectionResetError):
-                        await consumer_stdin.wait_closed()
+                    close_timeout = _stall_deadline()
+                    try:
+                        await asyncio.wait_for(consumer_stdin.wait_closed(), timeout=close_timeout)
+                    except (BrokenPipeError, ConnectionResetError):
+                        pass
+                    except TimeoutError as err:
+                        raise TimeoutError("close stalled") from err
                     return moved
                 consumer_stdin.write(chunk)
-                await consumer_stdin.drain()
+                drain_timeout = _stall_deadline()
+                try:
+                    await asyncio.wait_for(consumer_stdin.drain(), timeout=drain_timeout)
+                except TimeoutError as err:
+                    raise TimeoutError("write stalled") from err
                 moved += len(chunk)
 
         prod_err_task = asyncio.create_task(producer.stderr.read())  # type: ignore[union-attr]

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -23,13 +23,13 @@ from __future__ import annotations
 import json
 import shutil
 
+from aios.config import get_settings
 from aios.logging import get_logger
 from aios.sandbox._subprocess import (
     run_docker_cli,
     run_docker_pipeline,
     run_subprocess_with_timeout,
 )
-from aios.config import get_settings
 from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
     ENV_KEYS_LABEL_KEY,
@@ -73,6 +73,7 @@ _CONTAINER_TIMEOUT_EXIT_CODE = 137
 # the kernel overlayfs lower-layer max so a budget-less session can't grow
 # an unbounded chain. NOT a hard-wall dodge on the prod store.
 _FLATTEN_DEPTH_CEILING = 200
+
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
     """Decode ``raw`` as UTF-8 (with replacement) and truncate to ``max_bytes``.

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -21,6 +21,7 @@ expected to run arbitrary shell inside the sandbox.
 from __future__ import annotations
 
 import json
+import shutil
 
 from aios.logging import get_logger
 from aios.sandbox._subprocess import (
@@ -28,6 +29,7 @@ from aios.sandbox._subprocess import (
     run_docker_pipeline,
     run_subprocess_with_timeout,
 )
+from aios.config import get_settings
 from aios.sandbox.backends.base import (
     BASE_IMAGE_LABEL_KEY,
     ENV_KEYS_LABEL_KEY,
@@ -71,17 +73,6 @@ _CONTAINER_TIMEOUT_EXIT_CODE = 137
 # the kernel overlayfs lower-layer max so a budget-less session can't grow
 # an unbounded chain. NOT a hard-wall dodge on the prod store.
 _FLATTEN_DEPTH_CEILING = 200
-
-# Constant floor + per-byte budget for the commit/flatten/export timeout,
-# derived from the writable-layer ``SizeRw`` already read in the snapshot
-# sequence. A fixed timeout would turn a genuinely huge writable layer into
-# a permanent-brick retry loop (commit times out -> corpse retained ->
-# salvage times out -> forever); a size-derived bound fires only on a
-# genuinely hung daemon, never merely on size. ~10x a conservative
-# 50 MB/s measured commit throughput => 20 ns/byte.
-_SNAPSHOT_TIMEOUT_FLOOR_S = 60.0
-_SNAPSHOT_TIMEOUT_NS_PER_BYTE = 20e-9
-
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
     """Decode ``raw`` as UTF-8 (with replacement) and truncate to ``max_bytes``.
@@ -576,14 +567,26 @@ class DockerBackend:
             flatten_if_unique_bytes_over is not None
             and projected_unique > flatten_if_unique_bytes_over
         )
-        # Timeout scales with the bytes the daemon must move (resulting image
-        # for commit; whole rootfs for export) so a huge layer never wedges
-        # the worker in a permanent retry loop, while a hung daemon still trips.
-        timeout_s = _SNAPSHOT_TIMEOUT_FLOOR_S + (parent_size + rw) * _SNAPSHOT_TIMEOUT_NS_PER_BYTE
-
         if parent_depth + 1 >= _FLATTEN_DEPTH_CEILING or over_budget:
-            return await self._flatten(sandbox_id, tag, labels, timeout_s=timeout_s)
-        return await self._commit(sandbox_id, tag, env_keys, base_ref, timeout_s=timeout_s)
+            estimate = parent_size + rw
+            settings = get_settings()
+            free = shutil.disk_usage("/").free
+            required = int(estimate * 1.75) + settings.sandbox_flatten_disk_floor_bytes
+            if free < required:
+                log.warning(
+                    "sandbox.flatten_deferred_disk",
+                    container_id=sandbox_id[:12],
+                    free_disk=free,
+                    required_disk=required,
+                    tar_estimate=estimate,
+                )
+                raise SandboxBackendError(
+                    f"flatten deferred: {free} free bytes, {required} required"
+                )
+            return await self._flatten(sandbox_id, tag, labels)
+        # Commit remains on the management-call bound; only flatten needs the
+        # long-running progress-aware pipeline.
+        return await self._commit(sandbox_id, tag, env_keys, base_ref, timeout_s=30.0)
 
     async def _commit(
         self,
@@ -628,8 +631,6 @@ class DockerBackend:
         sandbox_id: str,
         tag: str,
         labels: dict[str, str],
-        *,
-        timeout_s: float,
     ) -> SnapshotOutcome:
         """``docker export | docker import`` — collapse the chain to one layer.
 
@@ -664,7 +665,13 @@ class DockerBackend:
         for change in changes:
             consumer.extend(["--change", change])
         consumer.extend(["-", tag])
-        await run_docker_pipeline(["docker", "export", sandbox_id], consumer, timeout_s=timeout_s)
+        settings = get_settings()
+        await run_docker_pipeline(
+            ["docker", "export", sandbox_id],
+            consumer,
+            stall_timeout_s=settings.sandbox_pipeline_stall_seconds,
+            max_timeout_s=settings.sandbox_pipeline_max_seconds,
+        )
         new = await self._inspect_image_fields(tag)
         if new is None:
             raise SandboxBackendError(f"flattened image {tag} not found after import")

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -232,6 +232,9 @@ class SandboxRegistry:
         self._locks: dict[str, asyncio.Lock] = {}
         self._reaper_task: asyncio.Task[None] | None = None
         self._gc_task: asyncio.Task[None] | None = None
+        # Consecutive failures keyed by full corpse id; value also records
+        # whether the one-shot operator alarm has been emitted.
+        self._salvage_failures: dict[str, tuple[int, bool]] = {}
         # Strong refs for evict()'s fire-and-forget proxy-stop tasks.
         # asyncio only weak-refs tasks, so without this the task can be
         # GC'd before stop() unwinds the proxy's uvicorn server, httpx
@@ -952,18 +955,53 @@ class SandboxRegistry:
         refs = await self._backend.list_managed(
             instance_id=settings.instance_id, session_id=session_id
         )
+        present = {ref.sandbox_id for ref in refs}
+        for corpse_id in list(self._salvage_failures):
+            if corpse_id not in present:
+                self._salvage_failures.pop(corpse_id, None)
         for ref in refs:
+            failures, alarmed = self._salvage_failures.get(ref.sandbox_id, (0, False))
+            if failures >= settings.sandbox_salvage_breaker_threshold:
+                log.warning(
+                    "sandbox.salvage_breaker_open",
+                    session_id=session_id,
+                    container_id=ref.sandbox_id[:12],
+                    failures=failures,
+                )
+                raise SandboxBackendError(
+                    f"salvage breaker open for corpse {ref.sandbox_id[:12]}; "
+                    "refusing to provision over unrecovered state"
+                )
             removable = await self._snapshot_and_record(
                 session_id,
                 ref.sandbox_id,
                 disk_limit_bytes=settings.sandbox_snapshot_budget_bytes,
             )
             if not removable:
+                failures += 1
+                opened = failures >= settings.sandbox_salvage_breaker_threshold
+                self._salvage_failures[ref.sandbox_id] = (failures, alarmed or opened)
+                if opened and not alarmed:
+                    log.error(
+                        "sandbox.salvage_breaker_open",
+                        session_id=session_id,
+                        container_id=ref.sandbox_id[:12],
+                        failures=failures,
+                    )
+                    try:
+                        await self._append_fs_event(
+                            session_id,
+                            "sandbox.salvage_breaker_open",
+                            {"container_id": ref.sandbox_id[:12], "failures": failures},
+                        )
+                    except Exception as err:
+                        log.warning("sandbox.salvage_breaker_alert_failed", error=str(err))
                 raise SandboxBackendError(
                     f"salvage of corpse {ref.sandbox_id[:12]} for session {session_id} "
                     "failed (snapshot or pointer write); refusing to provision over "
                     "unrecovered state"
                 )
+            self._salvage_failures.pop(ref.sandbox_id, None)
             await self._backend.force_remove(ref.sandbox_id)
 
     async def _reconcile_pointer_from_local(self, session_id: str) -> None:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -962,12 +962,13 @@ class SandboxRegistry:
         for ref in refs:
             failures, alarmed = self._salvage_failures.get(ref.sandbox_id, (0, False))
             if failures >= settings.sandbox_salvage_breaker_threshold:
-                log.warning(
-                    "sandbox.salvage_breaker_open",
-                    session_id=session_id,
-                    container_id=ref.sandbox_id[:12],
-                    failures=failures,
+                # Already tripped by a prior attempt — suppress the salvage
+                # retry entirely. Still (re)fire the one-shot alert if a prior
+                # transition failed to write it, so a lost wake is recovered.
+                alarmed = await self._alarm_salvage_breaker_once(
+                    session_id, ref.sandbox_id, failures, alarmed
                 )
+                self._salvage_failures[ref.sandbox_id] = (failures, alarmed)
                 raise SandboxBackendError(
                     f"salvage breaker open for corpse {ref.sandbox_id[:12]}; "
                     "refusing to provision over unrecovered state"
@@ -979,23 +980,11 @@ class SandboxRegistry:
             )
             if not removable:
                 failures += 1
-                opened = failures >= settings.sandbox_salvage_breaker_threshold
-                self._salvage_failures[ref.sandbox_id] = (failures, alarmed or opened)
-                if opened and not alarmed:
-                    log.error(
-                        "sandbox.salvage_breaker_open",
-                        session_id=session_id,
-                        container_id=ref.sandbox_id[:12],
-                        failures=failures,
+                if failures >= settings.sandbox_salvage_breaker_threshold:
+                    alarmed = await self._alarm_salvage_breaker_once(
+                        session_id, ref.sandbox_id, failures, alarmed
                     )
-                    try:
-                        await self._append_fs_event(
-                            session_id,
-                            "sandbox.salvage_breaker_open",
-                            {"container_id": ref.sandbox_id[:12], "failures": failures},
-                        )
-                    except Exception as err:
-                        log.warning("sandbox.salvage_breaker_alert_failed", error=str(err))
+                self._salvage_failures[ref.sandbox_id] = (failures, alarmed)
                 raise SandboxBackendError(
                     f"salvage of corpse {ref.sandbox_id[:12]} for session {session_id} "
                     "failed (snapshot or pointer write); refusing to provision over "
@@ -1003,6 +992,37 @@ class SandboxRegistry:
                 )
             self._salvage_failures.pop(ref.sandbox_id, None)
             await self._backend.force_remove(ref.sandbox_id)
+
+    async def _alarm_salvage_breaker_once(
+        self, session_id: str, corpse_id: str, failures: int, alarmed: bool
+    ) -> bool:
+        """Emit the one-shot operator wake for an open salvage breaker.
+
+        Returns the (possibly newly-``True``) ``alarmed`` flag. It only flips
+        to ``True`` after the channel-less wake write lands, so a failed write
+        stays ``False`` and is retried on the next provision attempt of this
+        still-present corpse rather than being silently dropped.
+        """
+        if alarmed:
+            return True
+        log.error(
+            "sandbox.salvage_breaker_open",
+            session_id=session_id,
+            container_id=corpse_id[:12],
+            failures=failures,
+        )
+        try:
+            await self._alert_operator(
+                session_id,
+                f"Sandbox salvage breaker OPEN for corpse {corpse_id[:12]}: "
+                f"{failures} consecutive salvage failures. Provisioning for this "
+                "session is fail-closed until the corpse is recovered or cleared.",
+                cause="sandbox.salvage_breaker_open",
+            )
+        except Exception as err:
+            log.warning("sandbox.salvage_breaker_alert_failed", error=str(err))
+            return False
+        return True
 
     async def _reconcile_pointer_from_local(self, session_id: str) -> None:
         """First-commit crash heal (§5.3): if the canonical tag exists locally,
@@ -1128,6 +1148,31 @@ class SandboxRegistry:
             session_id,
             "lifecycle",
             {"event": event, **payload},
+            account_id=account_id,
+        )
+
+    async def _alert_operator(self, session_id: str, content: str, *, cause: str) -> None:
+        """Surface a channel-less operator alert that ACTIVELY wakes the session.
+
+        Unlike :meth:`_append_fs_event` — a non-stimulus ``lifecycle`` notice
+        that advances no stimulus seq and so is read only on some *future*
+        wake — this uses the platform's ``Tell(ExistingSession)`` writer: a
+        user-role message plus a deferred wake, opening no response obligation.
+        Used for detection-hole alerts (e.g. the salvage breaker opening) that
+        must reach an operator promptly rather than sit unread until an
+        unrelated wake. Raises on write failure so the caller can leave the
+        one-shot un-alarmed and retry on the next occurrence.
+        """
+        from aios.harness import runtime
+        from aios.services import sessions as sessions_service
+
+        pool = runtime.require_pool()
+        account_id = await sessions_service.load_session_account_id(pool, session_id)
+        await sessions_service.tell_existing_session(
+            pool,
+            session_id,
+            content=content,
+            cause=cause,
             account_id=account_id,
         )
 

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -232,9 +232,13 @@ class SandboxRegistry:
         self._locks: dict[str, asyncio.Lock] = {}
         self._reaper_task: asyncio.Task[None] | None = None
         self._gc_task: asyncio.Task[None] | None = None
-        # Consecutive failures keyed by full corpse id; value also records
-        # whether the one-shot operator alarm has been emitted.
-        self._salvage_failures: dict[str, tuple[int, bool]] = {}
+        # Consecutive salvage failures keyed by full corpse id. The value is
+        # ``(owning_session_id, failures, alarmed)`` — the owning session is
+        # stored so a salvage pass for one session only reconciles/clears its
+        # OWN entries (``list_managed`` is session-filtered, so a session-A
+        # pass must never GC session-B's open-breaker entry). ``alarmed``
+        # records whether the one-shot operator wake has been emitted.
+        self._salvage_failures: dict[str, tuple[str, int, bool]] = {}
         # Strong refs for evict()'s fire-and-forget proxy-stop tasks.
         # asyncio only weak-refs tasks, so without this the task can be
         # GC'd before stop() unwinds the proxy's uvicorn server, httpx
@@ -955,12 +959,19 @@ class SandboxRegistry:
         refs = await self._backend.list_managed(
             instance_id=settings.instance_id, session_id=session_id
         )
+        # GC only THIS session's stale counters. ``present`` is session-local
+        # (``list_managed`` was filtered to ``session_id``), so we must never
+        # reconcile it against other sessions' entries — doing so would clear a
+        # different session's open breaker and let it retry the expensive
+        # flatten and re-emit its "one-shot" alert.
         present = {ref.sandbox_id for ref in refs}
-        for corpse_id in list(self._salvage_failures):
-            if corpse_id not in present:
+        for corpse_id, (owner, _failures, _alarmed) in list(self._salvage_failures.items()):
+            if owner == session_id and corpse_id not in present:
                 self._salvage_failures.pop(corpse_id, None)
         for ref in refs:
-            failures, alarmed = self._salvage_failures.get(ref.sandbox_id, (0, False))
+            _owner, failures, alarmed = self._salvage_failures.get(
+                ref.sandbox_id, (session_id, 0, False)
+            )
             if failures >= settings.sandbox_salvage_breaker_threshold:
                 # Already tripped by a prior attempt — suppress the salvage
                 # retry entirely. Still (re)fire the one-shot alert if a prior
@@ -968,7 +979,7 @@ class SandboxRegistry:
                 alarmed = await self._alarm_salvage_breaker_once(
                     session_id, ref.sandbox_id, failures, alarmed
                 )
-                self._salvage_failures[ref.sandbox_id] = (failures, alarmed)
+                self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
                 raise SandboxBackendError(
                     f"salvage breaker open for corpse {ref.sandbox_id[:12]}; "
                     "refusing to provision over unrecovered state"
@@ -984,7 +995,7 @@ class SandboxRegistry:
                     alarmed = await self._alarm_salvage_breaker_once(
                         session_id, ref.sandbox_id, failures, alarmed
                     )
-                self._salvage_failures[ref.sandbox_id] = (failures, alarmed)
+                self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
                 raise SandboxBackendError(
                     f"salvage of corpse {ref.sandbox_id[:12]} for session {session_id} "
                     "failed (snapshot or pointer write); refusing to provision over "

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -356,14 +356,19 @@ class TestFlattenDiskGate:
         assert not fake_docker.pipelines, "a deferred flatten must never start the pipeline"
 
     @pytest.mark.asyncio
-    async def test_over_5gb_flattens_via_progress_pipeline(
-        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("size_rw", [6_000_000_000, 200_000_000_000])
+    async def test_large_corpse_flatten_deadlines_are_size_independent(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch, size_rw: int
     ) -> None:
-        """A >5 GB writable layer — arithmetically impossible for the retired
-        size-scaled timeout — flattens through the pipeline with the
-        config-driven stall + absolute deadlines (independent of size)."""
-        fake_docker.size_rw = 6_000_000_000  # 6 GB
-        _set_free_disk(monkeypatch, 100 * 1024**3)  # 100 GiB — well over required
+        """The layer that USED to compute the timeout (``DockerBackend.snapshot``)
+        must no longer derive it from size. A >5 GB corpse — and a 200 GB one —
+        both flatten with the SAME config-driven stall/absolute deadlines; the
+        retired ``floor + bytes*ns_per_byte`` formula is gone, so there is no
+        size-scaled kill for a large corpse (the arithmetic that bricked
+        salvage). Byte-stream relay through the real pump is proven separately
+        in ``test_subprocess.py`` (large-progressing-stream test)."""
+        fake_docker.size_rw = size_rw
+        _set_free_disk(monkeypatch, 2 * 1024**5)  # 2 PiB — over required for any size here
         out = await DockerBackend().snapshot(
             "cid",
             "tag:latest",
@@ -371,9 +376,10 @@ class TestFlattenDiskGate:
             flatten_if_unique_bytes_over=4 * 1024 * 1024 * 1024,
         )
         assert out.kind == "flattened"
-        assert fake_docker.pipelines, "the >5 GB corpse must flatten via the pipeline"
+        assert fake_docker.pipelines, "a large corpse must flatten via the pipeline"
         settings = get_settings()
-        # Progress-based deadlines, NOT a per-byte size-scaled timeout.
+        # Deadlines are the CONSTANT config values, identical across the 6 GB and
+        # 200 GB cases — i.e. not derived from size (the killed regression).
         assert fake_docker.pipeline_timeouts == [
             (settings.sandbox_pipeline_stall_seconds, settings.sandbox_pipeline_max_seconds)
         ]

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -62,7 +62,12 @@ class _FakeDocker:
         raise AssertionError(f"unexpected docker cli: {argv}")
 
     async def pipeline(
-        self, producer: list[str], consumer: list[str], *, timeout_s: float
+        self,
+        producer: list[str],
+        consumer: list[str],
+        *,
+        stall_timeout_s: float,
+        max_timeout_s: float,
     ) -> tuple[int, bytes, bytes]:
         self.pipelines.append((producer, consumer))
         tag = consumer[-1]

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -9,11 +9,25 @@ and the env-keys scrub are all exercised without a real daemon.
 from __future__ import annotations
 
 import json
+from collections import namedtuple
 from typing import Any
 
 import pytest
 
+from aios.config import get_settings
+from aios.sandbox.backends.base import SandboxBackendError
 from aios.sandbox.backends.docker import _FLATTEN_DEPTH_CEILING, DockerBackend
+
+_Usage = namedtuple("_Usage", ["total", "used", "free"])
+
+
+def _set_free_disk(monkeypatch: pytest.MonkeyPatch, free_bytes: int) -> None:
+    """Pin ``shutil.disk_usage(...).free`` the flatten disk-gate reads, so the
+    gate is deterministic instead of depending on the host/runner's real disk."""
+    monkeypatch.setattr(
+        "aios.sandbox.backends.docker.shutil.disk_usage",
+        lambda _path: _Usage(total=free_bytes * 2, used=free_bytes, free=free_bytes),
+    )
 
 
 class _FakeDocker:
@@ -31,6 +45,10 @@ class _FakeDocker:
         self.images: dict[str, dict[str, Any]] = {}
         self.calls: list[list[str]] = []
         self.pipelines: list[tuple[list[str], list[str]]] = []
+        # (stall_timeout_s, max_timeout_s) each flatten ran with — lets a test
+        # assert the pipeline uses the config-driven progress deadlines, not a
+        # size-scaled timeout.
+        self.pipeline_timeouts: list[tuple[float, float]] = []
 
     async def cli(self, argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
         self.calls.append(argv)
@@ -70,6 +88,7 @@ class _FakeDocker:
         max_timeout_s: float,
     ) -> tuple[int, bytes, bytes]:
         self.pipelines.append((producer, consumer))
+        self.pipeline_timeouts.append((stall_timeout_s, max_timeout_s))
         tag = consumer[-1]
         self.images[tag] = {
             "id": "flattened",
@@ -85,6 +104,9 @@ def fake_docker(monkeypatch: pytest.MonkeyPatch) -> _FakeDocker:
     fd = _FakeDocker()
     monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", fd.cli)
     monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_pipeline", fd.pipeline)
+    # Default to abundant free disk so flatten-path tests are deterministic;
+    # the disk-gate tests override this explicitly.
+    _set_free_disk(monkeypatch, 1024**4)  # 1 TiB
     return fd
 
 
@@ -305,3 +327,53 @@ class TestFlattenConfigRestore:
         assert "aios.base_image=ghcr.io/eumemic/aios-sandbox:latest" in joined
         # PATH is NOT restored.
         assert "ENV PATH=" not in joined
+
+
+# ── flatten disk-admission gate + the >5 GB salvage regime ───────────────────
+
+
+class TestFlattenDiskGate:
+    """The flatten path first checks free disk against the estimated transient
+    ``docker export`` tar cost plus a floor, and DEFERS (raises, corpse
+    retained) rather than fail mid-write into a half-baked image. The deferral
+    is what the salvage breaker counts. With sufficient disk the flatten runs
+    on the progress-aware pipeline — the fix for the size regime the old
+    size-scaled timeout could never satisfy."""
+
+    @pytest.mark.asyncio
+    async def test_flatten_deferred_when_disk_below_required(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_docker.size_rw = 6_000_000_000  # 6 GB writable layer → over budget
+        _set_free_disk(monkeypatch, 1_000_000_000)  # only 1 GB free
+        with pytest.raises(SandboxBackendError, match="flatten deferred"):
+            await DockerBackend().snapshot(
+                "cid",
+                "tag:latest",
+                empty_floor_bytes=8192,
+                flatten_if_unique_bytes_over=4 * 1024 * 1024 * 1024,
+            )
+        assert not fake_docker.pipelines, "a deferred flatten must never start the pipeline"
+
+    @pytest.mark.asyncio
+    async def test_over_5gb_flattens_via_progress_pipeline(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A >5 GB writable layer — arithmetically impossible for the retired
+        size-scaled timeout — flattens through the pipeline with the
+        config-driven stall + absolute deadlines (independent of size)."""
+        fake_docker.size_rw = 6_000_000_000  # 6 GB
+        _set_free_disk(monkeypatch, 100 * 1024**3)  # 100 GiB — well over required
+        out = await DockerBackend().snapshot(
+            "cid",
+            "tag:latest",
+            empty_floor_bytes=8192,
+            flatten_if_unique_bytes_over=4 * 1024 * 1024 * 1024,
+        )
+        assert out.kind == "flattened"
+        assert fake_docker.pipelines, "the >5 GB corpse must flatten via the pipeline"
+        settings = get_settings()
+        # Progress-based deadlines, NOT a per-byte size-scaled timeout.
+        assert fake_docker.pipeline_timeouts == [
+            (settings.sandbox_pipeline_stall_seconds, settings.sandbox_pipeline_max_seconds)
+        ]

--- a/tests/unit/sandbox/test_subprocess.py
+++ b/tests/unit/sandbox/test_subprocess.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -110,23 +109,38 @@ async def test_pipeline_outer_cancel_kills_and_closes_both(
     SIGTERM or job-deadline cancel mid ``docker export | docker import``
     leaves both children running and strands their parent-side pipe
     FDs."""
+
+    async def _hang(*_args: Any) -> bytes:
+        await asyncio.sleep(3600)
+        raise AssertionError("unreachable")
+
     producer = _WedgedProc()
+    producer.stdout = MagicMock()
+    producer.stdout.read = AsyncMock(side_effect=_hang)
+    producer.stderr = MagicMock()
+    producer.stderr.read = AsyncMock(side_effect=_hang)
     consumer = _WedgedProc()
+    consumer.stdin = MagicMock()
+    consumer.stdin.drain = AsyncMock()
+    consumer.stdout = MagicMock()
+    consumer.stdout.read = AsyncMock(side_effect=_hang)
+    consumer.stderr = MagicMock()
+    consumer.stderr.read = AsyncMock(side_effect=_hang)
     spawned = iter((producer, consumer))
 
     async def _fake_spawn(*_argv: Any, **_kwargs: Any) -> _WedgedProc:
         return next(spawned)
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
-    # Keep the pipe plumbing hermetic — no real host FDs are created or closed.
-    monkeypatch.setattr(os, "pipe", lambda: (100, 101))
-    monkeypatch.setattr(os, "close", lambda _fd: None)
 
-    # Generous timeout so the wait_for itself never fires — outer
-    # cancellation is what we're testing.
+    # Generous deadlines so neither timeout fires — outer cancellation is
+    # what we're testing.
     task = asyncio.create_task(
         run_docker_pipeline(
-            ["docker", "export", "x"], ["docker", "import", "-", "tag"], timeout_s=60.0
+            ["docker", "export", "x"],
+            ["docker", "import", "-", "tag"],
+            stall_timeout_s=60.0,
+            max_timeout_s=60.0,
         )
     )
     # Let the task reach `await asyncio.wait_for(_drain(), ...)`.

--- a/tests/unit/sandbox/test_subprocess.py
+++ b/tests/unit/sandbox/test_subprocess.py
@@ -23,6 +23,7 @@ import pytest
 
 from aios.sandbox import _subprocess
 from aios.sandbox._subprocess import run_docker_pipeline, run_subprocess_with_timeout
+from aios.sandbox.backends.base import SandboxBackendError
 
 
 class _WedgedProc:
@@ -156,3 +157,177 @@ async def test_pipeline_outer_cancel_kills_and_closes_both(
     assert consumer._transport.kill.called
     producer._transport.close.assert_called_once()
     consumer._transport.close.assert_called_once()
+
+
+# ── progress-based deadlines (the flatten-brick fix) ─────────────────────────
+#
+# The flatten pipeline (``docker export | docker import``) replaced a single
+# size-scaled timeout — which a genuinely large writable layer could never
+# beat, permanently bricking salvage — with two progress-based deadlines: a
+# per-op *stall* bound (no bytes moving) and an *absolute* ceiling on the whole
+# relay. BOTH the read side (producer withholding bytes) AND the write side
+# (consumer refusing to drain them) must be under those deadlines, or a wedged
+# ``docker import`` fills the pipe and the relay hangs forever with neither
+# deadline able to fire.
+
+
+def _pipe_proc() -> _WedgedProc:
+    """A pipeline child stub: real ``_transport``/``kill`` coupling (reused
+    from ``_WedgedProc``) plus per-stream mocks the caller fills in."""
+    proc = _WedgedProc()
+    proc.returncode = 0
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.close = MagicMock()
+    proc.stdin.drain = AsyncMock()
+    proc.stdin.wait_closed = AsyncMock()
+    proc.stdout = MagicMock()
+    proc.stdout.read = AsyncMock(return_value=b"")
+    proc.stderr = MagicMock()
+    proc.stderr.read = AsyncMock(return_value=b"")
+    proc.wait = AsyncMock(return_value=0)  # type: ignore[attr-defined]
+    return proc
+
+
+def _spawn_pair(
+    monkeypatch: pytest.MonkeyPatch, producer: _WedgedProc, consumer: _WedgedProc
+) -> None:
+    spawned = iter((producer, consumer))
+
+    async def _fake_spawn(*_argv: Any, **_kwargs: Any) -> _WedgedProc:
+        return next(spawned)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_spawn)
+
+
+async def test_pipeline_consumer_backpressure_trips_write_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A consumer that stops draining must trip the stall deadline on the
+    WRITE side, not hang.
+
+    This is the regression that exposes the half-fixed brick: the producer
+    keeps yielding bytes (reads succeed), but ``docker import`` stops
+    consuming stdin, so ``drain()`` blocks on backpressure. If only the read
+    side is bounded, the whole pipeline wedges forever. The outer
+    ``wait_for`` guard turns a re-introduced unbounded ``drain()`` into a
+    loud failure instead of a suite hang."""
+    producer = _pipe_proc()
+    producer.stdout.read = AsyncMock(return_value=b"x" * (1024 * 1024))  # never EOF
+    consumer = _pipe_proc()
+
+    async def _never_drains() -> None:
+        await asyncio.sleep(3600)
+
+    consumer.stdin.drain = AsyncMock(side_effect=_never_drains)
+    _spawn_pair(monkeypatch, producer, consumer)
+
+    with pytest.raises(SandboxBackendError) as excinfo:
+        await asyncio.wait_for(
+            run_docker_pipeline(
+                ["docker", "export", "x"],
+                ["docker", "import", "-", "tag"],
+                stall_timeout_s=0.05,
+                max_timeout_s=5.0,
+            ),
+            timeout=5.0,
+        )
+
+    assert "write stalled" in str(excinfo.value)
+    # Both children SIGKILLed on the timeout unwind.
+    assert producer._transport.kill.called
+    assert consumer._transport.kill.called
+
+
+async def test_pipeline_slow_but_moving_data_completes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Data that moves in small increments — each read/drain under the stall
+    bound but their sum well over it — must NOT trip the stall deadline:
+    every completed op resets the stall clock. Total relay time (~0.15s) far
+    exceeds the 0.05s stall bound, yet the pipeline completes."""
+    chunks = iter([b"a" * 1000, b"b" * 1000, b"c" * 1000, b"d" * 1000, b""])
+
+    async def _slow_read(_n: int) -> bytes:
+        await asyncio.sleep(0.03)  # < stall bound; genuine progress each time
+        return next(chunks)
+
+    producer = _pipe_proc()
+    producer.stdout.read = _slow_read
+    consumer = _pipe_proc()
+    consumer.stdout.read = AsyncMock(return_value=b"sha256:imported\n")
+    _spawn_pair(monkeypatch, producer, consumer)
+
+    rc, out, _err = await run_docker_pipeline(
+        ["docker", "export", "x"],
+        ["docker", "import", "-", "tag"],
+        stall_timeout_s=0.05,
+        max_timeout_s=5.0,
+    )
+
+    assert rc == 0
+    assert out == b"sha256:imported\n"
+    assert consumer.stdin.write.call_count == 4  # four non-empty chunks relayed
+    consumer.stdin.close.assert_called_once()  # write side closed on EOF
+
+
+async def test_pipeline_post_eof_finalization_exempt_from_stall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After EOF the consumer may legitimately spend a long time finalizing
+    the import; only the ABSOLUTE ceiling applies then, never the (short)
+    stall bound. A finalize that outlasts the stall bound but beats the
+    ceiling must still succeed."""
+    producer = _pipe_proc()  # immediate EOF (default read → b"")
+    consumer = _pipe_proc()
+
+    async def _slow_finalize() -> int:
+        await asyncio.sleep(0.15)  # > stall bound (0.05), < ceiling (5.0)
+        return 0
+
+    producer.wait = _slow_finalize  # type: ignore[attr-defined]
+    consumer.wait = _slow_finalize  # type: ignore[attr-defined]
+    consumer.stdout.read = AsyncMock(return_value=b"sha256:imported\n")
+    _spawn_pair(monkeypatch, producer, consumer)
+
+    rc, out, _err = await run_docker_pipeline(
+        ["docker", "export", "x"],
+        ["docker", "import", "-", "tag"],
+        stall_timeout_s=0.05,
+        max_timeout_s=5.0,
+    )
+
+    assert rc == 0
+    assert out == b"sha256:imported\n"
+
+
+async def test_pipeline_finalization_bounded_by_absolute_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The post-EOF finalize is stall-exempt but NOT unbounded: a consumer
+    that never exits must still trip the absolute ceiling."""
+    producer = _pipe_proc()  # immediate EOF
+
+    async def _never_exits() -> int:
+        await asyncio.sleep(3600)  # outlives the (tiny) absolute ceiling
+        return 0  # unreachable; satisfies the return type
+
+    consumer = _pipe_proc()
+    consumer.wait = _never_exits  # type: ignore[attr-defined]
+    producer.wait = _never_exits  # type: ignore[attr-defined]
+    _spawn_pair(monkeypatch, producer, consumer)
+
+    with pytest.raises(SandboxBackendError) as excinfo:
+        await asyncio.wait_for(
+            run_docker_pipeline(
+                ["docker", "export", "x"],
+                ["docker", "import", "-", "tag"],
+                stall_timeout_s=5.0,
+                max_timeout_s=0.1,
+            ),
+            timeout=5.0,
+        )
+
+    assert "timed out" in str(excinfo.value)
+    assert producer._transport.kill.called
+    assert consumer._transport.kill.called

--- a/tests/unit/sandbox/test_subprocess.py
+++ b/tests/unit/sandbox/test_subprocess.py
@@ -36,6 +36,9 @@ class _WedgedProc:
         # transport, so route kill through the same mock — the fake
         # can't drift from Process's real kill/_transport coupling.
         self._transport = MagicMock(name="transport")
+        self.stdin: Any = None
+        self.stdout: Any = None
+        self.stderr: Any = None
 
     def kill(self) -> None:
         self._transport.kill()

--- a/tests/unit/sandbox/test_subprocess.py
+++ b/tests/unit/sandbox/test_subprocess.py
@@ -331,3 +331,59 @@ async def test_pipeline_finalization_bounded_by_absolute_ceiling(
     assert "timed out" in str(excinfo.value)
     assert producer._transport.kill.called
     assert consumer._transport.kill.called
+
+
+async def test_pipeline_relays_large_progressing_stream_without_size_derived_kill(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A large corpse that keeps making progress must salvage to completion.
+
+    The retired design put a SINGLE size-derived wall-clock timeout on the whole
+    ``docker export | docker import`` — a corpse whose flatten legitimately ran
+    longer than that estimate was killed, retained, and retried forever (the
+    brick). The progress-based deadlines replace it: as long as bytes keep
+    MOVING within the stall window, an arbitrarily large stream completes,
+    bounded only by the (generous) absolute ceiling.
+
+    This drives the REAL ``run_docker_pipeline`` and relays a substantial stream
+    (256 MiB across 256 chunks) whose aggregate wall-time far exceeds the stall
+    bound — a single stall/size-sized wall-clock cap would have killed it — yet
+    it finishes with every byte relayed."""
+    chunk = b"x" * (1024 * 1024)  # one reused 1 MiB buffer → low resident memory
+    n_chunks = 256
+    remaining = {"n": n_chunks}
+
+    async def _read(_n: int) -> bytes:
+        if remaining["n"] == 0:
+            return b""  # EOF
+        remaining["n"] -= 1
+        await asyncio.sleep(0.002)  # each chunk arrives within the stall window
+        return chunk
+
+    producer = _pipe_proc()
+    producer.stdout.read = _read
+    consumer = _pipe_proc()
+    consumer.stdout.read = AsyncMock(return_value=b"sha256:flattened\n")
+    _spawn_pair(monkeypatch, producer, consumer)
+
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    rc, out, _err = await run_docker_pipeline(
+        ["docker", "export", "big-corpse"],
+        ["docker", "import", "-", "tag"],
+        stall_timeout_s=0.05,  # << aggregate relay time (~0.5s)
+        max_timeout_s=30.0,
+    )
+    elapsed = loop.time() - start
+
+    assert rc == 0
+    assert out == b"sha256:flattened\n"
+    # The full stream was relayed chunk-by-chunk through the real pump.
+    assert consumer.stdin.write.call_count == n_chunks
+    moved = sum(len(call.args[0]) for call in consumer.stdin.write.call_args_list)
+    assert moved == n_chunks * len(chunk)  # 256 MiB relayed end-to-end
+    consumer.stdin.close.assert_called_once()  # write side closed on EOF
+    # Aggregate wall-time outran the per-op stall bound ~10x: a single
+    # size/stall-sized wall-clock cap would have killed this large corpse;
+    # progress-based deadlines let it finish.
+    assert elapsed > 0.05

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aios.config import get_settings
 from aios.db.queries import EnvVarCredentialEcho
 from aios.harness import runtime
 from aios.ids import VAULT_CREDENTIAL
@@ -31,7 +32,9 @@ from aios.models.environments import UnrestrictedNetworking
 from aios.models.memory_stores import Access, MemoryStoreResourceEcho
 from aios.sandbox.backends.base import (
     CommandResult,
+    ManagedSandboxRef,
     Mount,
+    SandboxBackendError,
     SandboxHandle,
     SandboxSpec,
 )
@@ -1403,3 +1406,184 @@ class TestRunSandboxLifecycle:
 
         registry.release.assert_awaited_once_with("sess_01TEST")
         registry.release_run.assert_not_awaited()
+
+
+class TestSalvageBreaker:
+    """The salvage circuit breaker (flatten-brick fix): consecutive salvage
+    failures of one corpse suppress further retries, and the transition to
+    open fires a ONE-SHOT channel-less operator wake — persisted alarmed only
+    after the wake write lands, so a lost wake is retried, not dropped.
+    """
+
+    def _corpse_ref(
+        self, session_id: str, sandbox_id: str = "corpse0123456789"
+    ) -> ManagedSandboxRef:
+        return ManagedSandboxRef(sandbox_id=sandbox_id, session_id=session_id, running=False)
+
+    def _snapshot_count(self, backend: FakeBackend) -> int:
+        return sum(1 for verb, _ in backend.calls if verb == "snapshot")
+
+    async def test_breaker_opens_after_threshold_and_alerts_once(self) -> None:
+        backend = FakeBackend()
+        session_id = "sess_brk"
+        ref = self._corpse_ref(session_id)
+        backend.managed = [ref]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        alert = AsyncMock()
+        registry._alert_operator = alert  # type: ignore[method-assign]
+        threshold = get_settings().sandbox_salvage_breaker_threshold
+
+        # Sub-threshold failures keep retrying the salvage (a snapshot attempt
+        # each) and never alert.
+        for _ in range(threshold - 1):
+            with pytest.raises(SandboxBackendError, match="failed"):
+                await registry._salvage_session_corpses(session_id)
+        assert alert.await_count == 0
+        assert self._snapshot_count(backend) == threshold - 1
+
+        # The threshold-th failure opens the breaker and fires the one-shot.
+        with pytest.raises(SandboxBackendError, match="failed"):
+            await registry._salvage_session_corpses(session_id)
+        assert alert.await_count == 1
+        assert self._snapshot_count(backend) == threshold
+
+        # Once open, provisioning is suppressed: NO further snapshot attempt
+        # and NO re-alert.
+        with pytest.raises(SandboxBackendError, match="breaker open"):
+            await registry._salvage_session_corpses(session_id)
+        assert alert.await_count == 1
+        assert self._snapshot_count(backend) == threshold  # unchanged
+
+    async def test_breaker_alert_retries_when_wake_write_fails(self) -> None:
+        """A failed wake write must leave the one-shot un-alarmed so the next
+        provision retries it — the ``alarmed``-after-success ordering."""
+        backend = FakeBackend()
+        session_id = "sess_retry"
+        backend.managed = [self._corpse_ref(session_id)]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        threshold = get_settings().sandbox_salvage_breaker_threshold
+
+        attempts: list[str] = []
+
+        async def _flaky_alert(session_id: str, content: str, *, cause: str) -> None:
+            attempts.append(cause)
+            if len(attempts) == 1:
+                raise RuntimeError("wake write failed")
+
+        registry._alert_operator = _flaky_alert  # type: ignore[method-assign]
+
+        # Drive to the transition; the alert is attempted once and fails.
+        for _ in range(threshold):
+            with pytest.raises(SandboxBackendError):
+                await registry._salvage_session_corpses(session_id)
+        assert len(attempts) == 1
+
+        # Breaker now open: the suppressed pass retries the lost wake, which
+        # lands this time.
+        with pytest.raises(SandboxBackendError, match="breaker open"):
+            await registry._salvage_session_corpses(session_id)
+        assert len(attempts) == 2
+
+        # Alarmed now persisted → no further re-fire.
+        with pytest.raises(SandboxBackendError, match="breaker open"):
+            await registry._salvage_session_corpses(session_id)
+        assert len(attempts) == 2
+
+    async def test_successful_salvage_resets_failure_counter(self) -> None:
+        backend = FakeBackend()
+        session_id = "sess_reset"
+        ref = self._corpse_ref(session_id)
+        backend.managed = [ref]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        registry._alert_operator = AsyncMock()  # type: ignore[method-assign]
+
+        with pytest.raises(SandboxBackendError):
+            await registry._salvage_session_corpses(session_id)
+        assert registry._salvage_failures[ref.sandbox_id][0] == 1
+
+        # A subsequent SUCCESSFUL salvage clears the counter and removes the corpse.
+        backend.snapshot_raises = False
+        await registry._salvage_session_corpses(session_id)
+        assert ref.sandbox_id not in registry._salvage_failures
+        assert ("force_remove", {"sandbox_id": ref.sandbox_id}) in backend.calls
+
+    async def test_counter_cleared_when_corpse_disappears(self) -> None:
+        backend = FakeBackend()
+        session_id = "sess_gone"
+        ref = self._corpse_ref(session_id)
+        backend.managed = [ref]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        registry._alert_operator = AsyncMock()  # type: ignore[method-assign]
+
+        with pytest.raises(SandboxBackendError):
+            await registry._salvage_session_corpses(session_id)
+        assert ref.sandbox_id in registry._salvage_failures
+
+        # Corpse removed out of band → the stale counter is GC'd on the next pass.
+        backend.managed = []
+        await registry._salvage_session_corpses(session_id)
+        assert ref.sandbox_id not in registry._salvage_failures
+
+    async def test_disk_deferral_counts_toward_breaker(self) -> None:
+        """A flatten deferred for insufficient disk surfaces as a snapshot
+        ``SandboxBackendError`` → ``removable=False`` → increments the breaker
+        exactly like any other salvage failure (no silent bypass)."""
+
+        class _DiskDeferBackend(FakeBackend):
+            async def snapshot(
+                self,
+                sandbox_id: str,
+                tag: str,
+                *,
+                empty_floor_bytes: int,
+                flatten_if_unique_bytes_over: int | None,
+            ) -> Any:
+                self.calls.append(("snapshot", {"sandbox_id": sandbox_id, "tag": tag}))
+                raise SandboxBackendError("flatten deferred: 1000 free bytes, 999999999 required")
+
+        backend = _DiskDeferBackend()
+        session_id = "sess_disk"
+        backend.managed = [self._corpse_ref(session_id)]
+        registry = SandboxRegistry(backend=backend)
+        alert = AsyncMock()
+        registry._alert_operator = alert  # type: ignore[method-assign]
+        threshold = get_settings().sandbox_salvage_breaker_threshold
+
+        for _ in range(threshold):
+            with pytest.raises(SandboxBackendError):
+                await registry._salvage_session_corpses(session_id)
+        assert alert.await_count == 1
+        assert self._snapshot_count(backend) == threshold
+        with pytest.raises(SandboxBackendError, match="breaker open"):
+            await registry._salvage_session_corpses(session_id)
+
+    async def test_alert_operator_uses_tell_existing_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The operator alert must go through the platform's channel-less
+        ``Tell(ExistingSession)`` writer (user message + deferred wake), NOT
+        a non-stimulus lifecycle event that only surfaces on some future wake."""
+        backend = FakeBackend()
+        registry = SandboxRegistry(backend=backend)
+        tell = AsyncMock()
+        monkeypatch.setattr("aios.services.sessions.tell_existing_session", tell)
+        monkeypatch.setattr(
+            "aios.services.sessions.load_session_account_id",
+            AsyncMock(return_value="acct_x"),
+        )
+
+        await registry._alert_operator(
+            "sess_1", "salvage breaker OPEN", cause="sandbox.salvage_breaker_open"
+        )
+
+        tell.assert_awaited_once()
+        call = tell.await_args
+        assert call is not None
+        assert call.args[1] == "sess_1"
+        assert call.kwargs["content"] == "salvage breaker OPEN"
+        assert call.kwargs["cause"] == "sandbox.salvage_breaker_open"
+        assert call.kwargs["account_id"] == "acct_x"

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -1502,7 +1502,8 @@ class TestSalvageBreaker:
 
         with pytest.raises(SandboxBackendError):
             await registry._salvage_session_corpses(session_id)
-        assert registry._salvage_failures[ref.sandbox_id][0] == 1
+        # value = (owning_session_id, failures, alarmed)
+        assert registry._salvage_failures[ref.sandbox_id] == (session_id, 1, False)
 
         # A subsequent SUCCESSFUL salvage clears the counter and removes the corpse.
         backend.snapshot_raises = False
@@ -1587,3 +1588,39 @@ class TestSalvageBreaker:
         assert call.kwargs["content"] == "salvage breaker OPEN"
         assert call.kwargs["cause"] == "sandbox.salvage_breaker_open"
         assert call.kwargs["account_id"] == "acct_x"
+
+    async def test_pass_for_one_session_does_not_reset_another_sessions_breaker(self) -> None:
+        """A salvage pass for session A must NOT clear session B's open-breaker
+        state. ``list_managed`` is session-filtered, so the stale-counter GC must
+        be scoped to the CURRENT session's entries; otherwise A's pass GCs B's
+        entry (B's corpse isn't in A's present set), B retries the expensive
+        flatten and re-emits its 'one-shot' alert — the breaker is defeated in
+        normal multi-session operation."""
+        backend = FakeBackend()
+        corpse_a = self._corpse_ref("sess_A", sandbox_id="corpseAAAAAAAAAA")
+        corpse_b = self._corpse_ref("sess_B", sandbox_id="corpseBBBBBBBBBB")
+        backend.managed = [corpse_a, corpse_b]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        registry._alert_operator = AsyncMock()  # type: ignore[method-assign]
+        threshold = get_settings().sandbox_salvage_breaker_threshold
+
+        # Drive session B's corpse to an OPEN breaker.
+        for _ in range(threshold):
+            with pytest.raises(SandboxBackendError):
+                await registry._salvage_session_corpses("sess_B")
+        assert registry._salvage_failures[corpse_b.sandbox_id] == ("sess_B", threshold, True)
+
+        # A salvage pass for session A (its own corpse also fails) must leave
+        # B's entry fully intact — this is the fail-before/pass-after.
+        with pytest.raises(SandboxBackendError, match="failed"):
+            await registry._salvage_session_corpses("sess_A")
+        assert corpse_b.sandbox_id in registry._salvage_failures
+        assert registry._salvage_failures[corpse_b.sandbox_id] == ("sess_B", threshold, True)
+
+        # B's breaker is still OPEN: a fresh B pass is suppressed (no new
+        # snapshot attempt, no re-alert) rather than retrying the flatten.
+        snaps_before = self._snapshot_count(backend)
+        with pytest.raises(SandboxBackendError, match="breaker open"):
+            await registry._salvage_session_corpses("sess_B")
+        assert self._snapshot_count(backend) == snaps_before


### PR DESCRIPTION
Automated dev-pipeline build for issue #1820.