### PR TITLE
Perf headroom: GIN jsonb_path_ops index on (data->'tool_calls') to skip detoast in the sweep batch-filter containment (#1729 follow-up)

### DIFF
--- a/migrations/versions/0143_events_asst_tool_calls_gin_index.py
+++ b/migrations/versions/0143_events_asst_tool_calls_gin_index.py
@@ -1,0 +1,51 @@
+"""Add the assistant tool-call containment GIN index (#1737).
+
+The sweep batch filter probes ``data->'tool_calls' @> ANY($::jsonb[])`` while
+scoped to assistant messages.  Previously PostgreSQL used the session/message
+btree and filter-detoasted every message in a large session.  This expression
+GIN index lets PostgreSQL answer the containment condition directly without an
+application query change.
+
+The partial predicate intentionally does *not* include ``data ? 'tool_calls'``.
+Although rows without that key add no GIN keys, the extra predicate would make
+the index unusable: PostgreSQL cannot prove that the unmodified containment
+probe implies the key-existence predicate.
+
+Built concurrently in an autocommit block because ``events`` is hot and live
+written.  If a concurrent build is interrupted, it can leave an INVALID index
+that ``IF NOT EXISTS`` will silently retain.  Before retrying, operators must
+remove that remnant with::
+
+    DROP INDEX CONCURRENTLY IF EXISTS events_asst_tool_calls_gin_idx;
+
+Revision ID: 0143
+Revises: 0142
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0143"
+down_revision: str = "0142"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INDEX_NAME = "events_asst_tool_calls_gin_idx"
+CREATE_INDEX = (
+    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} "
+    "ON events USING gin ((data->'tool_calls') jsonb_path_ops) "
+    "WHERE kind = 'message' AND role = 'assistant'"
+)
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(CREATE_INDEX)
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")

--- a/tests/unit/test_migration_0143_asst_tool_calls_gin.py
+++ b/tests/unit/test_migration_0143_asst_tool_calls_gin.py
@@ -1,0 +1,40 @@
+"""Guard migration 0143's assistant tool-call containment GIN index (#1737)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "migrations" / "versions"
+
+
+def _load() -> ModuleType:
+    path = next(_VERSIONS_DIR.glob("0143_*.py"))
+    spec = importlib.util.spec_from_file_location("_mig_0143", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_revision_extends_the_single_head() -> None:
+    migration = _load()
+    assert migration.revision == "0143"
+    assert migration.down_revision == "0142"
+
+
+def test_index_supports_the_unmodified_containment_probe() -> None:
+    ddl = _load().CREATE_INDEX
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS events_asst_tool_calls_gin_idx" in ddl
+    assert "ON events USING gin ((data->'tool_calls') jsonb_path_ops)" in ddl
+    assert "WHERE kind = 'message' AND role = 'assistant'" in ddl
+    # This term prevents PostgreSQL from proving the unmodified query implies
+    # the partial predicate, making the index unusable.
+    assert "data ? 'tool_calls'" not in ddl
+
+
+def test_upgrade_and_downgrade_use_autocommit() -> None:
+    source = next(_VERSIONS_DIR.glob("0143_*.py")).read_text()
+    assert source.count("autocommit_block()") >= 2
+    assert "DROP INDEX CONCURRENTLY IF EXISTS events_asst_tool_calls_gin_idx" in source


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1737.