### PR TITLE
P0: salvage docker-commit gets the blanket 30s CLI timeout (not the size-derived snapshot budget) — every deploy bricks large live sandboxes; breaker-open has no recovery path

### DIFF
--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -74,6 +74,16 @@ _CONTAINER_TIMEOUT_EXIT_CODE = 137
 # an unbounded chain. NOT a hard-wall dodge on the prod store.
 _FLATTEN_DEPTH_CEILING = 200
 
+# Snapshot operations legitimately scale with the corpse writable layer. Keep
+# metadata/management calls on the blanket Docker CLI bound, but budget the
+# data-moving commit/export/import work by SizeRw so large corpses converge.
+_SNAPSHOT_TIMEOUT_FLOOR_S = 60.0
+_SNAPSHOT_TIMEOUT_NS_PER_BYTE = 20e-9
+
+
+def _snapshot_timeout_s(size_rw: int | None) -> float:
+    return max(_SNAPSHOT_TIMEOUT_FLOOR_S, (size_rw or 0) * _SNAPSHOT_TIMEOUT_NS_PER_BYTE)
+
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
     """Decode ``raw`` as UTF-8 (with replacement) and truncate to ``max_bytes``.
@@ -584,10 +594,12 @@ class DockerBackend:
                 raise SandboxBackendError(
                     f"flatten deferred: {free} free bytes, {required} required"
                 )
-            return await self._flatten(sandbox_id, tag, labels)
-        # Commit remains on the management-call bound; only flatten needs the
-        # long-running progress-aware pipeline.
-        return await self._commit(sandbox_id, tag, env_keys, base_ref, timeout_s=30.0)
+            return await self._flatten(
+                sandbox_id, tag, labels, timeout_s=_snapshot_timeout_s(size_rw)
+            )
+        return await self._commit(
+            sandbox_id, tag, env_keys, base_ref, timeout_s=_snapshot_timeout_s(size_rw)
+        )
 
     async def _commit(
         self,
@@ -632,6 +644,8 @@ class DockerBackend:
         sandbox_id: str,
         tag: str,
         labels: dict[str, str],
+        *,
+        timeout_s: float,
     ) -> SnapshotOutcome:
         """``docker export | docker import`` — collapse the chain to one layer.
 
@@ -670,8 +684,8 @@ class DockerBackend:
         await run_docker_pipeline(
             ["docker", "export", sandbox_id],
             consumer,
-            stall_timeout_s=settings.sandbox_pipeline_stall_seconds,
-            max_timeout_s=settings.sandbox_pipeline_max_seconds,
+            stall_timeout_s=min(settings.sandbox_pipeline_stall_seconds, timeout_s),
+            max_timeout_s=timeout_s,
         )
         new = await self._inspect_image_fields(tag)
         if new is None:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -209,6 +209,9 @@ def _classify_images(
     return verdicts
 
 
+_SALVAGE_BREAKER_COOLDOWN_S = 300.0
+
+
 class SandboxRegistry:
     """Maps session_id to a live :class:`SandboxHandle` with idle-TTL.
 
@@ -239,6 +242,7 @@ class SandboxRegistry:
         # pass must never GC session-B's open-breaker entry). ``alarmed``
         # records whether the one-shot operator wake has been emitted.
         self._salvage_failures: dict[str, tuple[str, int, bool]] = {}
+        self._salvage_breaker_opened_at: dict[str, float] = {}
         # Strong refs for evict()'s fire-and-forget proxy-stop tasks.
         # asyncio only weak-refs tasks, so without this the task can be
         # GC'd before stop() unwinds the proxy's uvicorn server, httpx
@@ -968,22 +972,26 @@ class SandboxRegistry:
         for corpse_id, (owner, _failures, _alarmed) in list(self._salvage_failures.items()):
             if owner == session_id and corpse_id not in present:
                 self._salvage_failures.pop(corpse_id, None)
+                self._salvage_breaker_opened_at.pop(corpse_id, None)
         for ref in refs:
             _owner, failures, alarmed = self._salvage_failures.get(
                 ref.sandbox_id, (session_id, 0, False)
             )
             if failures >= settings.sandbox_salvage_breaker_threshold:
-                # Already tripped by a prior attempt — suppress the salvage
-                # retry entirely. Still (re)fire the one-shot alert if a prior
-                # transition failed to write it, so a lost wake is recovered.
-                alarmed = await self._alarm_salvage_breaker_once(
-                    session_id, ref.sandbox_id, failures, alarmed
+                opened_at = self._salvage_breaker_opened_at.setdefault(
+                    ref.sandbox_id, time.monotonic()
                 )
-                self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
-                raise SandboxBackendError(
-                    f"salvage breaker open for corpse {ref.sandbox_id[:12]}; "
-                    "refusing to provision over unrecovered state"
-                )
+                if time.monotonic() - opened_at < _SALVAGE_BREAKER_COOLDOWN_S:
+                    # Suppress retries until the cooldown expires, then permit
+                    # one half-open attempt under the backend snapshot budget.
+                    alarmed = await self._alarm_salvage_breaker_once(
+                        session_id, ref.sandbox_id, failures, alarmed
+                    )
+                    self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
+                    raise SandboxBackendError(
+                        f"salvage breaker open for corpse {ref.sandbox_id[:12]}; "
+                        "refusing to provision over unrecovered state"
+                    )
             removable = await self._snapshot_and_record(
                 session_id,
                 ref.sandbox_id,
@@ -996,12 +1004,14 @@ class SandboxRegistry:
                         session_id, ref.sandbox_id, failures, alarmed
                     )
                 self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
+                self._salvage_breaker_opened_at[ref.sandbox_id] = time.monotonic()
                 raise SandboxBackendError(
                     f"salvage of corpse {ref.sandbox_id[:12]} for session {session_id} "
                     "failed (snapshot or pointer write); refusing to provision over "
                     "unrecovered state"
                 )
             self._salvage_failures.pop(ref.sandbox_id, None)
+            self._salvage_breaker_opened_at.pop(ref.sandbox_id, None)
             await self._backend.force_remove(ref.sandbox_id)
 
     async def _alarm_salvage_breaker_once(

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -44,6 +44,7 @@ class _FakeDocker:
         self.container_labels: dict[str, str] = {}
         self.images: dict[str, dict[str, Any]] = {}
         self.calls: list[list[str]] = []
+        self.cli_timeouts: list[tuple[list[str], float]] = []
         self.pipelines: list[tuple[list[str], list[str]]] = []
         # (stall_timeout_s, max_timeout_s) each flatten ran with — lets a test
         # assert the pipeline uses the config-driven progress deadlines, not a
@@ -52,6 +53,7 @@ class _FakeDocker:
 
     async def cli(self, argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
         self.calls.append(argv)
+        self.cli_timeouts.append((argv, timeout_s))
         sub = argv[1]
         if sub == "stop":
             return 0, b"cid\n", b""
@@ -222,6 +224,19 @@ class TestLineageGate:
 # ── flatten triggers ─────────────────────────────────────────────────────────
 
 
+class TestSnapshotTimeoutBudget:
+    @pytest.mark.asyncio
+    async def test_large_commit_uses_size_derived_budget(self, fake_docker: _FakeDocker) -> None:
+        fake_docker.size_rw = 12_000_000_000
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        commit_timeout = next(
+            timeout for argv, timeout in fake_docker.cli_timeouts if argv[1] == "commit"
+        )
+        assert commit_timeout == 240.0
+
+
 class TestFlattenTriggers:
     @pytest.mark.asyncio
     async def test_over_budget_flattens_not_commits(self, fake_docker: _FakeDocker) -> None:
@@ -357,16 +372,10 @@ class TestFlattenDiskGate:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("size_rw", [6_000_000_000, 200_000_000_000])
-    async def test_large_corpse_flatten_deadlines_are_size_independent(
+    async def test_large_corpse_flatten_uses_size_derived_deadline(
         self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch, size_rw: int
     ) -> None:
-        """The layer that USED to compute the timeout (``DockerBackend.snapshot``)
-        must no longer derive it from size. A >5 GB corpse — and a 200 GB one —
-        both flatten with the SAME config-driven stall/absolute deadlines; the
-        retired ``floor + bytes*ns_per_byte`` formula is gone, so there is no
-        size-scaled kill for a large corpse (the arithmetic that bricked
-        salvage). Byte-stream relay through the real pump is proven separately
-        in ``test_subprocess.py`` (large-progressing-stream test)."""
+        """Flatten receives the same SizeRw-derived snapshot budget as commit."""
         fake_docker.size_rw = size_rw
         _set_free_disk(monkeypatch, 2 * 1024**5)  # 2 PiB — over required for any size here
         out = await DockerBackend().snapshot(
@@ -378,8 +387,7 @@ class TestFlattenDiskGate:
         assert out.kind == "flattened"
         assert fake_docker.pipelines, "a large corpse must flatten via the pipeline"
         settings = get_settings()
-        # Deadlines are the CONSTANT config values, identical across the 6 GB and
-        # 200 GB cases — i.e. not derived from size (the killed regression).
+        budget = max(60.0, size_rw * 20e-9)
         assert fake_docker.pipeline_timeouts == [
-            (settings.sandbox_pipeline_stall_seconds, settings.sandbox_pipeline_max_seconds)
+            (min(settings.sandbox_pipeline_stall_seconds, budget), budget)
         ]

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -1455,6 +1455,32 @@ class TestSalvageBreaker:
         assert alert.await_count == 1
         assert self._snapshot_count(backend) == threshold  # unchanged
 
+    async def test_breaker_half_open_recovers_after_cooldown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        backend = FakeBackend()
+        session_id = "sess_half_open"
+        ref = self._corpse_ref(session_id)
+        backend.managed = [ref]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        registry._alert_operator = AsyncMock()  # type: ignore[method-assign]
+        threshold = get_settings().sandbox_salvage_breaker_threshold
+        now = 1000.0
+        monkeypatch.setattr("aios.sandbox.registry.time.monotonic", lambda: now)
+
+        for _ in range(threshold):
+            with pytest.raises(SandboxBackendError):
+                await registry._salvage_session_corpses(session_id)
+        with pytest.raises(SandboxBackendError, match="breaker open"):
+            await registry._salvage_session_corpses(session_id)
+
+        now += 300.0
+        backend.snapshot_raises = False
+        await registry._salvage_session_corpses(session_id)
+        assert ref.sandbox_id not in registry._salvage_failures
+        assert ("force_remove", {"sandbox_id": ref.sandbox_id}) in backend.calls
+
     async def test_breaker_alert_retries_when_wake_write_fails(self) -> None:
         """A failed wake write must leave the one-shot un-alarmed so the next
         provision retries it — the ``alarmed``-after-success ordering."""


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/eumemic-ops#327.