### PR TITLE
fix(tokens): tokens_to_drop divide-by-zero on collapsed window band

### DIFF
--- a/src/aios/db/queries/agents.py
+++ b/src/aios/db/queries/agents.py
@@ -287,8 +287,12 @@ async def update_agent(
         # alone, set at-or-below the current ``window_min``) only
         # produces an invalid pair AFTER the merge, so the check has to
         # live on the resolved values rather than the input kwargs.
-        # Without this, the row commits and the next session step
-        # ``ZeroDivisionError``s in :func:`aios.harness.tokens.tokens_to_drop`.
+        # A stored band must have positive width (``window_min == window_max``
+        # is zero snap hysteresis — every overflow trims to exactly
+        # ``window_max`` with no chunking). :func:`aios.harness.tokens.tokens_to_drop`
+        # itself tolerates a collapsed band at runtime (the overflow shrink
+        # ladder can derive one from a valid config), so this is a
+        # config-quality constraint, not crash-prevention.
         raise ValidationError(
             "window_min must be strictly less than window_max",
             detail={"window_min": new_wmin, "window_max": new_wmax},

--- a/src/aios/harness/tokens.py
+++ b/src/aios/harness/tokens.py
@@ -358,5 +358,14 @@ def tokens_to_drop(total: int, *, window_min: int, window_max: int) -> int:
         return 0
     overshoot = total - window_max
     chunk = window_max - window_min
+    if chunk == 0:
+        # Degenerate band ``window_min == window_max``: no chunk to snap within,
+        # so drop exactly the overshoot and retain ``window_max``. This band is
+        # reachable from a VALID config — the context-overflow shrink ladder
+        # collapses the effective band to a point once the shrunk request ceiling
+        # falls to or below ``agent.window_min`` (see the ``min()`` in ``loop.py``
+        # feeding ``read_windowed_events``). Dividing by zero here would crash the
+        # very step meant to shrink the prompt, wedging overflow recovery.
+        return overshoot
     snaps = (overshoot + chunk - 1) // chunk  # ceil division
     return snaps * chunk

--- a/tests/integration/test_agent_window_validation.py
+++ b/tests/integration/test_agent_window_validation.py
@@ -76,9 +76,10 @@ class TestUpdateAgentWindowValidation:
     ) -> None:
         """PUT setting only ``window_max`` equal to current ``window_min`` must raise.
 
-        After the queries-level merge, this produces
-        ``new_wmin == new_wmax`` — a downstream session step would
-        ``ZeroDivisionError`` in ``tokens_to_drop`` without this guard.
+        After the queries-level merge this produces ``new_wmin == new_wmax`` — a
+        zero-width band. ``tokens_to_drop`` itself tolerates a collapsed band at
+        runtime, so this guard is a config-quality constraint (a stored window
+        band must have positive snap hysteresis), not crash-prevention.
         """
         pool, account_id = pool_and_account
         agent = await _seed_valid_agent(pool, account_id, "bound-test")

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import Any, ClassVar
 
 from aios.harness.context import render_user_event
-from aios.harness.tokens import approx_tokens
+from aios.harness.tokens import approx_tokens, tokens_to_drop
 
 _CREATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
 
@@ -430,3 +430,42 @@ class TestPrecomputeEventAppend:
         )
         assert result.token_delta == 0
         assert result.resolved_tool_channel is None
+
+
+class TestTokensToDrop:
+    """``tokens_to_drop`` is the pure snap-boundary math that decides how many
+    front-of-window tokens ``read_windowed_events`` sheds.  Its precondition is a
+    valid window band ``window_min <= window_max``; ``==`` is a legal band the
+    runtime can produce, so the function must be total over it (no crash).
+    """
+
+    def test_fits_within_max_drops_nothing(self) -> None:
+        assert tokens_to_drop(120_000, window_min=100_000, window_max=150_000) == 0
+        # Boundary: total exactly at window_max still fits.
+        assert tokens_to_drop(150_000, window_min=100_000, window_max=150_000) == 0
+
+    def test_normal_band_snaps_to_chunk_multiples(self) -> None:
+        # chunk = 50k; a 1-token overshoot snaps a whole chunk so the cutoff
+        # advances in cache-stable steps, leaving the retained window in
+        # (window_min, window_max].
+        assert tokens_to_drop(150_001, window_min=100_000, window_max=150_000) == 50_000
+        # A 2-chunk overshoot drops exactly two chunks.
+        assert tokens_to_drop(250_000, window_min=100_000, window_max=150_000) == 100_000
+
+    def test_collapsed_band_does_not_divide_by_zero(self) -> None:
+        """Degenerate band (``window_min == window_max``) with an overflowing
+        total.  Before the fix this raised ``ZeroDivisionError`` at the ceil
+        division (``chunk == 0``); the correct degenerate behavior is to drop
+        exactly the overshoot, retaining ``window_max``.
+
+        This band is REACHABLE from a valid stored config: the context-overflow
+        shrink ladder collapses the effective band to a point once the shrunk
+        request ceiling falls to or below ``agent.window_min`` (``loop.py`` passes
+        ``window_min=min(agent.window_min, request_window_max)``). The crash lands
+        on the very path meant to shrink the prompt, so the session can never
+        build a smaller request and never converges.
+        """
+        drop = tokens_to_drop(200_000, window_min=120_000, window_max=120_000)
+        assert drop == 80_000  # overshoot; remaining = 200_000 - 80_000 == window_max
+        # A collapsed band that still fits takes the early return, never the divide.
+        assert tokens_to_drop(120_000, window_min=120_000, window_max=120_000) == 0


### PR DESCRIPTION
## Summary

- `tokens_to_drop` divides by `chunk = window_max - window_min`, which is **zero when the window band collapses to a point** (`window_min == window_max`) — raising `ZeroDivisionError` on the overflow path (`total > window_max`).
- The band collapse is **reachable from a valid stored config**: the create-time guard in `db/queries/agents.py` only enforces `window_min < window_max` on the *stored* config, never the runtime band. On a context-overflow retry, `loop.py` passes `window_min=min(agent.window_min, request_window_max)` with `window_max=request_window_max`; once the shrink ladder drops the request ceiling to or below the configured floor, the two collapse to equal, and `read_windowed_events` calls `tokens_to_drop` with equal bounds.
- Impact: the crash lands on the **very step meant to shrink the prompt**, so the session re-enters overflow, re-crashes, and never converges — burning the retry ladder toward a terminal errored state. Narrow-band configs (e.g. `window_min=100k`, `window_max=150k`) are exposed; the default `50k/150k` is immune (deepest shrink `0.4096` keeps the ceiling above `50k`).
- **Fix**: make `tokens_to_drop` *total* over its valid domain (`window_min <= window_max`, `==` included) — when `chunk == 0` there is no chunk to snap within, so drop exactly the overshoot and retain `window_max`. This fixes the crash at the site where the invariant is actually violated, covering every feeder. The config guard stays as a config-quality constraint; its now-stale "prevents a `ZeroDivisionError`" rationale (comment + integration-test docstring) is corrected.

Found by a hypothesis-driven bug audit; proven by a red→green regression test (`ZeroDivisionError` today → returns `80_000` after fix).

## Test plan

- [x] Type-checker (mypy) — clean
- [x] Linter + format-check (ruff) — clean
- [x] Unit suite — 4539 passed (`TestTokensToDrop`: red test `test_collapsed_band_does_not_divide_by_zero` fails with `ZeroDivisionError` before the fix, green after)
- [ ] CI runs the integration/e2e suites (incl. `tests/integration/test_agent_window_validation.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)