### PR TITLE
fix(sandbox): budget the inspect --size walk (#1838 sibling)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -208,6 +208,13 @@ class Settings(BaseSettings):
         gt=0,
         description="Absolute backstop for a Docker flatten pipeline.",
     )
+    sandbox_inspect_size_timeout_seconds: float = Field(
+        default=300.0,
+        gt=0,
+        description="Timeout for the ``docker inspect --size`` writable-layer "
+        "walk during salvage; it scales with the corpse, so it gets this "
+        "generous bound rather than the blanket ``DOCKER_CLI_TIMEOUT_S``.",
+    )
     sandbox_salvage_breaker_threshold: int = Field(
         default=3,
         ge=1,

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -76,7 +76,9 @@ _FLATTEN_DEPTH_CEILING = 200
 
 # Snapshot operations legitimately scale with the corpse writable layer. Keep
 # metadata/management calls on the blanket Docker CLI bound, but budget the
-# data-moving commit/export/import work by SizeRw so large corpses converge.
+# data-scaling work so large corpses converge: commit/export/import by SizeRw,
+# and the ``inspect --size`` writable-layer walk (whose size is not yet known)
+# by the fixed ``sandbox_inspect_size_timeout_seconds`` bound.
 _SNAPSHOT_TIMEOUT_FLOOR_S = 60.0
 _SNAPSHOT_TIMEOUT_NS_PER_BYTE = 20e-9
 
@@ -845,25 +847,51 @@ class DockerBackend:
     ) -> tuple[str, int | None, dict[str, str]]:
         """Return ``(parent_image_id, size_rw, labels)`` for a container.
 
-        ``size_rw`` is ``None`` only when the daemon reports an unparseable
-        value — the snapshot path then declines the empty short-circuit
-        (commit rather than risk losing data).
+        Split into two calls, each on the bound its cost warrants. The parent
+        image and labels (needed for the lineage gate) are cheap metadata on the
+        blanket ``DOCKER_CLI_TIMEOUT_S``; the writable-layer size is a separate
+        ``--size`` stat-walk that scales with the corpse, so it gets the generous
+        ``sandbox_inspect_size_timeout_seconds`` bound (see
+        :meth:`_inspect_container_size_rw`). Folding ``--size`` into a single
+        blanket-bounded call was the one size-scaling step #1838 left on the 30s
+        CLI timeout, so a large corpse timed out here before commit and wedged
+        salvage (the breaker's half-open re-probe then re-hit the same wall).
         """
-        fmt = "{{.Image}}\t{{.SizeRw}}\t{{json .Config.Labels}}"
+        meta_fmt = "{{.Image}}\t{{json .Config.Labels}}"
         rc, stdout_bytes, stderr_bytes = await run_docker_cli(
-            ["docker", "inspect", "--size", "--format", fmt, sandbox_id]
+            ["docker", "inspect", "--format", meta_fmt, sandbox_id]
         )
         if rc != 0:
             raise SandboxBackendError(
                 f"docker inspect (container) failed (exit {rc}) for {sandbox_id[:12]}: "
                 f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
             )
-        parts = stdout_bytes.decode("utf-8").rstrip("\n").split("\t", 2)
+        parts = stdout_bytes.decode("utf-8").rstrip("\n").split("\t", 1)
         parent_image = parts[0].strip()
-        raw_rw = parts[1].strip() if len(parts) > 1 else ""
-        size_rw = int(raw_rw) if raw_rw.isdigit() else None
-        labels = _parse_json_labels(parts[2]) if len(parts) > 2 else {}
+        labels = _parse_json_labels(parts[1]) if len(parts) > 1 else {}
+        size_rw = await self._inspect_container_size_rw(sandbox_id)
         return parent_image, size_rw, labels
+
+    async def _inspect_container_size_rw(self, sandbox_id: str) -> int | None:
+        """Return the container's writable-layer bytes (``.SizeRw``), or ``None``
+        when the daemon reports an unparseable value — the snapshot path then
+        declines the empty short-circuit (commit rather than risk losing data).
+
+        The ``--size`` walk is budgeted by ``sandbox_inspect_size_timeout_seconds``
+        rather than the blanket CLI bound; see :meth:`_inspect_container_for_snapshot`
+        for why.
+        """
+        rc, stdout_bytes, stderr_bytes = await run_docker_cli(
+            ["docker", "inspect", "--size", "--format", "{{.SizeRw}}", sandbox_id],
+            timeout_s=get_settings().sandbox_inspect_size_timeout_seconds,
+        )
+        if rc != 0:
+            raise SandboxBackendError(
+                f"docker inspect --size failed (exit {rc}) for {sandbox_id[:12]}: "
+                f"{stderr_bytes.decode('utf-8', errors='replace').strip()}"
+            )
+        raw_rw = stdout_bytes.decode("utf-8").strip()
+        return int(raw_rw) if raw_rw.isdigit() else None
 
     async def _inspect_image_fields(self, ref: str) -> tuple[str, int, int, dict[str, str]] | None:
         """Return ``(image_id, size_bytes, layer_depth, labels)`` or ``None`` if absent.

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -58,7 +58,11 @@ class _FakeDocker:
         if sub == "stop":
             return 0, b"cid\n", b""
         if sub == "inspect" and "--size" in argv:
-            out = f"{self.parent_image}\t{self.size_rw}\t{json.dumps(self.container_labels)}"
+            # The budgeted writable-layer size-walk: `{{.SizeRw}}` only.
+            return 0, f"{self.size_rw}".encode(), b""
+        if sub == "inspect":
+            # The cheap metadata probe: `{{.Image}}\t{{json .Config.Labels}}`.
+            out = f"{self.parent_image}\t{json.dumps(self.container_labels)}"
             return 0, out.encode(), b""
         if sub == "image" and len(argv) > 2 and argv[2] == "inspect":
             ref = argv[-1]
@@ -235,6 +239,42 @@ class TestSnapshotTimeoutBudget:
             timeout for argv, timeout in fake_docker.cli_timeouts if argv[1] == "commit"
         )
         assert commit_timeout == 240.0
+
+    @pytest.mark.asyncio
+    async def test_inspect_size_walk_gets_generous_timeout(self, fake_docker: _FakeDocker) -> None:
+        """The ``docker inspect --size`` writable-layer walk must NOT run on the
+        blanket 30s CLI bound. ``--size`` stat-walks the corpse's RW layer, so a
+        large corpse would time out here before commit is even reached — the one
+        size-scaling call #1838 left unbudgeted — wedging salvage (the breaker's
+        half-open re-probe then re-hits the same 30s wall forever).
+        """
+        fake_docker.size_rw = 12_000_000_000  # large, slow-to-walk corpse
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        size_walk_timeout = next(
+            t for argv, t in fake_docker.cli_timeouts if argv[1] == "inspect" and "--size" in argv
+        )
+        assert size_walk_timeout == get_settings().sandbox_inspect_size_timeout_seconds
+
+    @pytest.mark.asyncio
+    async def test_inspect_metadata_stays_on_blanket_timeout(
+        self, fake_docker: _FakeDocker
+    ) -> None:
+        """The cheap metadata inspect (parent image + labels, no ``--size``) is a
+        management call and stays on the blanket bound — only the data-walking
+        ``--size`` probe is budgeted. This is the split that makes the module
+        comment's 'metadata on the blanket bound, data-walk budgeted' literally true.
+        """
+        await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        meta_timeout = next(
+            t
+            for argv, t in fake_docker.cli_timeouts
+            if argv[1] == "inspect" and "--size" not in argv
+        )
+        assert meta_timeout == 30.0
 
 
 class TestFlattenTriggers:


### PR DESCRIPTION
## Summary

- **Sibling of #1838.** That PR budgeted the data-moving salvage steps (commit/export/import) by `SizeRw` so large corpses converge, but left `docker inspect --size` on the blanket 30s `DOCKER_CLI_TIMEOUT_S`.
- `docker inspect --size` computes `.SizeRw` by **stat-walking the corpse's writable layer** — a cost that scales with the corpse — and it's the **first** size-scaling step in `snapshot()` (its output feeds the empty short-circuit, the flatten/commit decision, and the size-derived budgets for every later step).
- **Impact (same P0 class as #1838):** a large/many-inode corpse times out at the inspect step before commit is reached → salvage fails → the per-session salvage breaker opens → its 300s half-open re-probe re-hits the same 30s wall **forever**. This is the exact "every deploy bricks large live sandboxes" symptom #1838 fixed, at the one call it missed — defeating #1838's own recovery path.
- **Why a fixed/config bound:** the size is unknowable before this call returns (chicken-and-egg), and a single-shot `inspect` emits no progress signal, so a size-derived or stall-aware bound is impossible.

## Fix

- New `sandbox_inspect_size_timeout_seconds` (default **300s**, operator-tunable).
- **Split** `_inspect_container_for_snapshot` into a cheap metadata `docker inspect` (parent image + labels, keeps the blanket 30s) + a separate `docker inspect --size` walk budgeted by the new setting. This makes the module comment's "metadata on the blanket bound, data-walk budgeted" categorization literally true.
- The split also **preserves fast failure detection**: a fully-wedged daemon still trips the salvage breaker in 30s via the liveness-probe metadata call, while a daemon merely slow-walking a huge corpse gets its full budget. Collapsing to one 300s call would give a wedged daemon 270 extra seconds before the breaker learns.

Found by the same hypothesis-driven audit that surfaced #1846; proven by a red→green test (`--size` walk on 30s today → the config bound after).

## Test plan

- [x] mypy — clean
- [x] ruff check + format — clean
- [x] Unit suite — 4541 passed (`test_inspect_size_walk_gets_generous_timeout` red on 30s → green; `test_inspect_metadata_stays_on_blanket_timeout` pins the split; all 17 existing snapshot-verb tests still pass through the two-call fake)
- [ ] CI runs integration + docker-e2e (`test_sandbox_persistence.py` drives real `docker inspect` on both calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)