### PR TITLE
test(evals): add reasoning headroom/discriminating/extra-hard corpora for WaM fusion eval

### DIFF
--- a/evals/wam_fusion/tasks/reasoning_discriminating.json
+++ b/evals/wam_fusion/tasks/reasoning_discriminating.json
@@ -1,0 +1,154 @@
+{
+  "items": [
+    {
+      "id": "x013",
+      "prompt": "Five processes take these durations: 2 hours 37 minutes 48 seconds; 1 hour 55 minutes 22 seconds; 3 hours 9 minutes 59 seconds; 48 minutes 35 seconds; and 4 hours 12 minutes 6 seconds. What is the total duration, expressed as a whole number of SECONDS?",
+      "answer": "45830"
+    },
+    {
+      "id": "x025",
+      "prompt": "A path goes from (0,0) to (7,6), moving only one unit right (+1 in x) or one unit up (+1 in y) at each step. How many such paths avoid BOTH of the points (2,3) and (5,2)?",
+      "answer": "841"
+    },
+    {
+      "id": "x027",
+      "prompt": "How many ordered 5-tuples of integers (x1, x2, x3, x4, x5) satisfy x1 + x2 + x3 + x4 + x5 = 30 with each xi in the range 0 <= xi <= 9?",
+      "answer": "3246"
+    },
+    {
+      "id": "x001",
+      "prompt": "You deposit $12,500.00 into an account. Interest is credited once at the end of each year and the balance is then rounded to the nearest cent (round half up). After the interest is credited and rounded each year, a flat $35.00 annual fee is subtracted. The annual interest rates for years 1 through 5 are 4.3%, 5.75%, 3.85%, 6.25%, and 4.90% respectively. What is the exact balance in dollars at the end of year 5? Give the answer as a number with two decimals.",
+      "answer": "15764.18"
+    },
+    {
+      "id": "x002",
+      "prompt": "A quantity starts at 480. It is then changed by the following sequence of percentage changes, applied one after another to the running value: increase by 37.5%, decrease by 22%, increase by 15%, decrease by 8%, increase by 64%, decrease by 55%. What is the exact final value? Express it as a reduced fraction a/b (or an integer if it is whole).",
+      "answer": "251223687/625000"
+    },
+    {
+      "id": "x003",
+      "prompt": "A person has gross income of $187,400 and a standard deduction of $14,600, giving taxable income. Tax is computed on the taxable income using these marginal brackets: 10% on the portion from $0 to $11,600; 12% on the portion from $11,600 to $47,150; 22% on the portion from $47,150 to $100,525; 24% on the portion from $100,525 to $191,950; 32% on the portion from $191,950 to $243,725. What is the exact total tax owed, in dollars? Give the answer as a reduced fraction a/b or an integer.",
+      "answer": "69029/2"
+    },
+    {
+      "id": "x004",
+      "prompt": "A machine produces 4,750 widgets per hour. It runs 6.5 hours per day for 5 days. Of all widgets produced, exactly 12% are defective and discarded. Each good widget weighs 37 grams. Good widgets are packed into crates that hold exactly 25 kilograms each. How many completely FULL crates can be filled? (Answer with an integer.)",
+      "answer": "201"
+    },
+    {
+      "id": "x005",
+      "prompt": "An item lists at $899.99. In this exact order: a 15% discount is applied, then a flat $50.00 coupon is subtracted, then an 8% loyalty discount is applied to that result, and finally 7.25% sales tax is added. Round only the final amount to the nearest cent (round half up). What is the final price in dollars, with two decimals?",
+      "answer": "705.48"
+    },
+    {
+      "id": "x006",
+      "prompt": "Compute the following expression exactly, step by step, evaluating left to right: take 87,654, multiply by 23, add 998,877, multiply the result by 7, subtract 4,567,890, then divide by 3. The final division is exact. What integer results?",
+      "answer": "5512181"
+    },
+    {
+      "id": "x007",
+      "prompt": "Three workers are paid weekly. Regular hours (up to 40) are paid at the base rate; hours beyond 40 are paid at 1.5x the base rate. Worker A worked 46 hours at $28.50/hour. Worker B worked 52 hours at $21.40/hour. Worker C worked 38 hours at $31.75/hour. What is the exact total weekly payroll in dollars? Give a reduced fraction a/b or a number.",
+      "answer": "19221/5"
+    },
+    {
+      "id": "x008",
+      "prompt": "You mix 350 mL of an 18% (by volume) salt solution, 200 mL of a 42% solution, and 150 mL of a 6% solution. You then evaporate 100 mL of pure water from the mixture (removing only water, no salt). What is the exact final salt concentration as a reduced fraction (a/b, a fraction between 0 and 1)?",
+      "answer": "13/50"
+    },
+    {
+      "id": "x009",
+      "prompt": "Start with the integer 1,000,000. Apply these seven multipliers in order, and after EACH multiplication take the floor (round down to the nearest integer) before applying the next: 1.03, 0.97, 1.11, 0.89, 1.27, 0.94, 1.08. What is the final integer?",
+      "answer": "1272554"
+    },
+    {
+      "id": "x010",
+      "prompt": "A road trip has three legs: 247 miles at 31 miles per gallon, 388 miles at 27 miles per gallon, and 176 miles at 34 miles per gallon. Gasoline costs $4.29 per gallon. Compute the exact total gallons used, then the total fuel cost, and round the final cost to the nearest cent (round half up). What is the total fuel cost in dollars, with two decimals?",
+      "answer": "118.04"
+    },
+    {
+      "id": "x011",
+      "prompt": "A course grade weights: Homework 20%, Midterm 30%, Project 25%, Final 25%. The homework score is the average of 91, 84, 77, 88, 95. The project score is the average of 90 and 86. The midterm is 82 and the final is 79. What is the exact weighted course grade? Give a reduced fraction a/b or a number.",
+      "answer": "335/4"
+    },
+    {
+      "id": "x012",
+      "prompt": "You start with 10,000 USD. You convert USD to EUR at a rate of 0.9180 EUR per USD, then a 1.5% conversion fee is deducted from the resulting EUR amount. You convert that EUR to GBP at 0.8620 GBP per EUR, then a 1.2% fee is deducted from the GBP. You convert that GBP back to USD at 1.2650 USD per GBP, then a 0.9% fee is deducted from the USD. Round only the final USD amount to the nearest cent (round half up). How many USD do you end with, with two decimals?",
+      "answer": "9654.00"
+    },
+    {
+      "id": "x014",
+      "prompt": "An item costs the store $240. The price is set by a 65% markup on cost. Then it is marked down 30%, then marked down a further 15% off the current price, then marked up 20% off the current price. Round the final price to the nearest cent (round half up). What is the final price in dollars, with two decimals?",
+      "answer": "282.74"
+    },
+    {
+      "id": "x015",
+      "prompt": "An account starts at $5,000.00. Interest compounds monthly at an annual nominal rate of 6% (so 0.5% per month), and the balance is rounded to the nearest cent (round half up) at the end of EACH month. At the end of each 12-month year (after that year's 12 monthly compoundings), exactly $800.00 is withdrawn. What is the exact balance after 3 full years (3 withdrawals total), in dollars with two decimals?",
+      "answer": "3432.33"
+    },
+    {
+      "id": "x016",
+      "prompt": "Let N = 999,983. Compute N squared, then subtract 123,456,789, then add 987,654,321. What are the last six digits of the resulting number? (Answer as an integer from 0 to 999999; drop leading zeros.)",
+      "answer": "197821"
+    },
+    {
+      "id": "x017",
+      "prompt": "Seven distinct people are to be seated in a row of 7 seats. The following pairs refuse to sit in adjacent seats: (A and B), (C and D), and (E and F). The seventh person, G, has no restriction. In how many distinct arrangements can all seven be seated so that none of those three pairs sit next to each other?",
+      "answer": "1968"
+    },
+    {
+      "id": "x018",
+      "prompt": "How many integers n with 1 <= n <= 10000 are divisible by NONE of 6, 10, 15, and 14?",
+      "answer": "6953"
+    },
+    {
+      "id": "x019",
+      "prompt": "How many ordered integer solutions (a, b, c, d) are there to a + b + c + d = 25 where each of a, b, c, d satisfies 1 <= value <= 10?",
+      "answer": "592"
+    },
+    {
+      "id": "x020",
+      "prompt": "How many integers n with 1 <= n <= 2000 are divisible by AT LEAST ONE of 2, 3, 5, and 7?",
+      "answer": "1542"
+    },
+    {
+      "id": "x021",
+      "prompt": "A row of 6 cells is colored, each cell one of 3 colors. No two ADJACENT cells may share a color, AND the first cell and the last cell must also be different colors from each other. How many colorings are possible?",
+      "answer": "66"
+    },
+    {
+      "id": "x022",
+      "prompt": "From a standard 52-card deck, 5 cards are drawn at random (all 5-card hands equally likely). What is the probability that the hand contains EXACTLY 2 aces AND AT LEAST 1 king? Give the answer as a reduced fraction a/b.",
+      "answer": "1013/108290"
+    },
+    {
+      "id": "x023",
+      "prompt": "A 2-by-10 rectangular board (2 rows, 10 columns) is to be completely tiled using two kinds of tiles: 1-by-2 dominoes (which may be placed horizontally or vertically) and 2-by-2 square tiles. Tiles may not overlap and must cover the whole board exactly. How many distinct tilings are there?",
+      "answer": "683"
+    },
+    {
+      "id": "x024",
+      "prompt": "Consider all permutations of the 8 numbers 1 through 8. How many of these permutations have EXACTLY 2 fixed points (positions i where the number in position i equals i)?",
+      "answer": "7420"
+    },
+    {
+      "id": "x026",
+      "prompt": "How many distinct arrangements are there of all the letters in the word BOOKKEEPER? (The word has letters B, O, O, K, K, E, E, P, E, R.)",
+      "answer": "151200"
+    },
+    {
+      "id": "x028",
+      "prompt": "Seven distinct people are seated around a round table. Two seatings are considered the same if one is a rotation of the other (but reflections are considered different). Two particular people, call them A and B, must NOT be seated in adjacent chairs. How many distinct seatings are possible?",
+      "answer": "480"
+    },
+    {
+      "id": "x029",
+      "prompt": "Four fair six-sided dice are rolled. What is the probability that their sum is exactly 15? Give the answer as a reduced fraction a/b.",
+      "answer": "35/324"
+    },
+    {
+      "id": "x030",
+      "prompt": "How many three-digit numbers (from 100 to 999) have digits that are strictly increasing from left to right AND have a digit sum that is divisible by 5?",
+      "answer": "16"
+    }
+  ]
+}

--- a/evals/wam_fusion/tasks/reasoning_extrahard.json
+++ b/evals/wam_fusion/tasks/reasoning_extrahard.json
@@ -1,0 +1,406 @@
+{
+ "_comment": "Extra-hard checkable-answer reasoning problems designed to defeat a frontier LLM reasoner (Opus-4.8 / GPT-5.5 class). Built for the WaM fusion benchmark to provide difficulty headroom above reasoning_hard/reasoning_headroom. Every canonical answer was computed and independently re-verified with Python (brute force / exact simulation / fractions). Categories: long-exact-arithmetic (x001-x016), deep-combinatorics (x017-x032), number-theory-traps (x033-x048), logic-scheduling-calendar (x049-x064), iterated-process (x065-x080).",
+ "answer_format_instruction": "Work carefully step by step, then end your reply with a line of the exact form 'ANSWER: <value>' where <value> is a single number (integer, reduced fraction a/b, or decimal) or a single word. Do not include units, commas, currency symbols, or extra text on that line.",
+ "items": [
+  {
+   "id": "x001",
+   "prompt": "You deposit $12,500.00 into an account. Interest is credited once at the end of each year and the balance is then rounded to the nearest cent (round half up). After the interest is credited and rounded each year, a flat $35.00 annual fee is subtracted. The annual interest rates for years 1 through 5 are 4.3%, 5.75%, 3.85%, 6.25%, and 4.90% respectively. What is the exact balance in dollars at the end of year 5? Give the answer as a number with two decimals.",
+   "answer": "15764.18"
+  },
+  {
+   "id": "x002",
+   "prompt": "A quantity starts at 480. It is then changed by the following sequence of percentage changes, applied one after another to the running value: increase by 37.5%, decrease by 22%, increase by 15%, decrease by 8%, increase by 64%, decrease by 55%. What is the exact final value? Express it as a reduced fraction a/b (or an integer if it is whole).",
+   "answer": "251223687/625000"
+  },
+  {
+   "id": "x003",
+   "prompt": "A person has gross income of $187,400 and a standard deduction of $14,600, giving taxable income. Tax is computed on the taxable income using these marginal brackets: 10% on the portion from $0 to $11,600; 12% on the portion from $11,600 to $47,150; 22% on the portion from $47,150 to $100,525; 24% on the portion from $100,525 to $191,950; 32% on the portion from $191,950 to $243,725. What is the exact total tax owed, in dollars? Give the answer as a reduced fraction a/b or an integer.",
+   "answer": "69029/2"
+  },
+  {
+   "id": "x004",
+   "prompt": "A machine produces 4,750 widgets per hour. It runs 6.5 hours per day for 5 days. Of all widgets produced, exactly 12% are defective and discarded. Each good widget weighs 37 grams. Good widgets are packed into crates that hold exactly 25 kilograms each. How many completely FULL crates can be filled? (Answer with an integer.)",
+   "answer": "201"
+  },
+  {
+   "id": "x005",
+   "prompt": "An item lists at $899.99. In this exact order: a 15% discount is applied, then a flat $50.00 coupon is subtracted, then an 8% loyalty discount is applied to that result, and finally 7.25% sales tax is added. Round only the final amount to the nearest cent (round half up). What is the final price in dollars, with two decimals?",
+   "answer": "705.48"
+  },
+  {
+   "id": "x006",
+   "prompt": "Compute the following expression exactly, step by step, evaluating left to right: take 87,654, multiply by 23, add 998,877, multiply the result by 7, subtract 4,567,890, then divide by 3. The final division is exact. What integer results?",
+   "answer": "5512181"
+  },
+  {
+   "id": "x007",
+   "prompt": "Three workers are paid weekly. Regular hours (up to 40) are paid at the base rate; hours beyond 40 are paid at 1.5x the base rate. Worker A worked 46 hours at $28.50/hour. Worker B worked 52 hours at $21.40/hour. Worker C worked 38 hours at $31.75/hour. What is the exact total weekly payroll in dollars? Give a reduced fraction a/b or a number.",
+   "answer": "19221/5"
+  },
+  {
+   "id": "x008",
+   "prompt": "You mix 350 mL of an 18% (by volume) salt solution, 200 mL of a 42% solution, and 150 mL of a 6% solution. You then evaporate 100 mL of pure water from the mixture (removing only water, no salt). What is the exact final salt concentration as a reduced fraction (a/b, a fraction between 0 and 1)?",
+   "answer": "13/50"
+  },
+  {
+   "id": "x009",
+   "prompt": "Start with the integer 1,000,000. Apply these seven multipliers in order, and after EACH multiplication take the floor (round down to the nearest integer) before applying the next: 1.03, 0.97, 1.11, 0.89, 1.27, 0.94, 1.08. What is the final integer?",
+   "answer": "1272554"
+  },
+  {
+   "id": "x010",
+   "prompt": "A road trip has three legs: 247 miles at 31 miles per gallon, 388 miles at 27 miles per gallon, and 176 miles at 34 miles per gallon. Gasoline costs $4.29 per gallon. Compute the exact total gallons used, then the total fuel cost, and round the final cost to the nearest cent (round half up). What is the total fuel cost in dollars, with two decimals?",
+   "answer": "118.04"
+  },
+  {
+   "id": "x011",
+   "prompt": "A course grade weights: Homework 20%, Midterm 30%, Project 25%, Final 25%. The homework score is the average of 91, 84, 77, 88, 95. The project score is the average of 90 and 86. The midterm is 82 and the final is 79. What is the exact weighted course grade? Give a reduced fraction a/b or a number.",
+   "answer": "335/4"
+  },
+  {
+   "id": "x012",
+   "prompt": "You start with 10,000 USD. You convert USD to EUR at a rate of 0.9180 EUR per USD, then a 1.5% conversion fee is deducted from the resulting EUR amount. You convert that EUR to GBP at 0.8620 GBP per EUR, then a 1.2% fee is deducted from the GBP. You convert that GBP back to USD at 1.2650 USD per GBP, then a 0.9% fee is deducted from the USD. Round only the final USD amount to the nearest cent (round half up). How many USD do you end with, with two decimals?",
+   "answer": "9654.00"
+  },
+  {
+   "id": "x013",
+   "prompt": "Five processes take these durations: 2 hours 37 minutes 48 seconds; 1 hour 55 minutes 22 seconds; 3 hours 9 minutes 59 seconds; 48 minutes 35 seconds; and 4 hours 12 minutes 6 seconds. What is the total duration, expressed as a whole number of SECONDS?",
+   "answer": "45830"
+  },
+  {
+   "id": "x014",
+   "prompt": "An item costs the store $240. The price is set by a 65% markup on cost. Then it is marked down 30%, then marked down a further 15% off the current price, then marked up 20% off the current price. Round the final price to the nearest cent (round half up). What is the final price in dollars, with two decimals?",
+   "answer": "282.74"
+  },
+  {
+   "id": "x015",
+   "prompt": "An account starts at $5,000.00. Interest compounds monthly at an annual nominal rate of 6% (so 0.5% per month), and the balance is rounded to the nearest cent (round half up) at the end of EACH month. At the end of each 12-month year (after that year's 12 monthly compoundings), exactly $800.00 is withdrawn. What is the exact balance after 3 full years (3 withdrawals total), in dollars with two decimals?",
+   "answer": "3432.33"
+  },
+  {
+   "id": "x016",
+   "prompt": "Let N = 999,983. Compute N squared, then subtract 123,456,789, then add 987,654,321. What are the last six digits of the resulting number? (Answer as an integer from 0 to 999999; drop leading zeros.)",
+   "answer": "197821"
+  },
+  {
+   "id": "x017",
+   "prompt": "Seven distinct people are to be seated in a row of 7 seats. The following pairs refuse to sit in adjacent seats: (A and B), (C and D), and (E and F). The seventh person, G, has no restriction. In how many distinct arrangements can all seven be seated so that none of those three pairs sit next to each other?",
+   "answer": "1968"
+  },
+  {
+   "id": "x018",
+   "prompt": "How many integers n with 1 <= n <= 10000 are divisible by NONE of 6, 10, 15, and 14?",
+   "answer": "6953"
+  },
+  {
+   "id": "x019",
+   "prompt": "How many ordered integer solutions (a, b, c, d) are there to a + b + c + d = 25 where each of a, b, c, d satisfies 1 <= value <= 10?",
+   "answer": "592"
+  },
+  {
+   "id": "x020",
+   "prompt": "How many integers n with 1 <= n <= 2000 are divisible by AT LEAST ONE of 2, 3, 5, and 7?",
+   "answer": "1542"
+  },
+  {
+   "id": "x021",
+   "prompt": "A row of 6 cells is colored, each cell one of 3 colors. No two ADJACENT cells may share a color, AND the first cell and the last cell must also be different colors from each other. How many colorings are possible?",
+   "answer": "66"
+  },
+  {
+   "id": "x022",
+   "prompt": "From a standard 52-card deck, 5 cards are drawn at random (all 5-card hands equally likely). What is the probability that the hand contains EXACTLY 2 aces AND AT LEAST 1 king? Give the answer as a reduced fraction a/b.",
+   "answer": "1013/108290"
+  },
+  {
+   "id": "x023",
+   "prompt": "A 2-by-10 rectangular board (2 rows, 10 columns) is to be completely tiled using two kinds of tiles: 1-by-2 dominoes (which may be placed horizontally or vertically) and 2-by-2 square tiles. Tiles may not overlap and must cover the whole board exactly. How many distinct tilings are there?",
+   "answer": "683"
+  },
+  {
+   "id": "x024",
+   "prompt": "Consider all permutations of the 8 numbers 1 through 8. How many of these permutations have EXACTLY 2 fixed points (positions i where the number in position i equals i)?",
+   "answer": "7420"
+  },
+  {
+   "id": "x025",
+   "prompt": "A path goes from (0,0) to (7,6), moving only one unit right (+1 in x) or one unit up (+1 in y) at each step. How many such paths avoid BOTH of the points (2,3) and (5,2)?",
+   "answer": "841"
+  },
+  {
+   "id": "x026",
+   "prompt": "How many distinct arrangements are there of all the letters in the word BOOKKEEPER? (The word has letters B, O, O, K, K, E, E, P, E, R.)",
+   "answer": "151200"
+  },
+  {
+   "id": "x027",
+   "prompt": "How many ordered 5-tuples of integers (x1, x2, x3, x4, x5) satisfy x1 + x2 + x3 + x4 + x5 = 30 with each xi in the range 0 <= xi <= 9?",
+   "answer": "3246"
+  },
+  {
+   "id": "x028",
+   "prompt": "Seven distinct people are seated around a round table. Two seatings are considered the same if one is a rotation of the other (but reflections are considered different). Two particular people, call them A and B, must NOT be seated in adjacent chairs. How many distinct seatings are possible?",
+   "answer": "480"
+  },
+  {
+   "id": "x029",
+   "prompt": "Four fair six-sided dice are rolled. What is the probability that their sum is exactly 15? Give the answer as a reduced fraction a/b.",
+   "answer": "35/324"
+  },
+  {
+   "id": "x030",
+   "prompt": "How many three-digit numbers (from 100 to 999) have digits that are strictly increasing from left to right AND have a digit sum that is divisible by 5?",
+   "answer": "16"
+  },
+  {
+   "id": "x031",
+   "prompt": "A committee of 5 people is chosen from a group of 6 men and 5 women. The committee must contain at least 2 men and at least 2 women. In how many ways can the committee be formed?",
+   "answer": "350"
+  },
+  {
+   "id": "x032",
+   "prompt": "An urn contains 4 red, 5 blue, and 3 green balls (12 total, all distinguishable by position). Four balls are drawn at random without replacement. What is the probability that all three colors appear among the 4 drawn? Give the answer as a reduced fraction a/b.",
+   "answer": "6/11"
+  },
+  {
+   "id": "x033",
+   "prompt": "Compute 7^(7^7), that is, 7 raised to the power (7 raised to the 7th power). What are its last three digits? (Answer as an integer 0-999; drop leading zeros.)",
+   "answer": "343"
+  },
+  {
+   "id": "x034",
+   "prompt": "What are the last four digits of 2^1000 (2 raised to the 1000th power)? Answer as an integer (drop any leading zeros).",
+   "answer": "9376"
+  },
+  {
+   "id": "x035",
+   "prompt": "How many integers n with 1 <= n <= 100000 are divisible by 7 but NOT divisible by 11 and NOT divisible by 13?",
+   "answer": "11988"
+  },
+  {
+   "id": "x036",
+   "prompt": "What is the multiplicative order of 3 modulo 1000? (That is, the smallest positive integer k such that 3^k leaves remainder 1 when divided by 1000.)",
+   "answer": "100"
+  },
+  {
+   "id": "x037",
+   "prompt": "Compute 2^100 (2 raised to the 100th power) as an ordinary base-10 integer, then add up all of its decimal digits. What is the digit sum?",
+   "answer": "115"
+  },
+  {
+   "id": "x038",
+   "prompt": "Let A be the hexadecimal (base 16) number 2F3B7, B be the base-7 number 6540123, and C be the base-5 number 4302114. Convert all three to base 10 and compute A + B - C. What is the result in base 10?",
+   "answer": "920903"
+  },
+  {
+   "id": "x039",
+   "prompt": "What are the last three digits of 13^100 (13 raised to the 100th power)? Answer as an integer 0-999 (drop leading zeros).",
+   "answer": "1"
+  },
+  {
+   "id": "x040",
+   "prompt": "How many positive divisors does 360360 have (including 1 and 360360 itself)?",
+   "answer": "192"
+  },
+  {
+   "id": "x041",
+   "prompt": "Compute (123^45 + 67^89) modulo 100. Answer with an integer from 0 to 99.",
+   "answer": "90"
+  },
+  {
+   "id": "x042",
+   "prompt": "How many integers n with 1 <= n <= 10000 have a decimal digit sum exactly equal to 13?",
+   "answer": "480"
+  },
+  {
+   "id": "x043",
+   "prompt": "Compute 3^(3^(3^3)), i.e. 3 raised to the power (3 raised to the power (3 raised to the 3rd power)). What are its last two digits? Answer as an integer 0-99 (drop leading zeros).",
+   "answer": "87"
+  },
+  {
+   "id": "x044",
+   "prompt": "What is the least common multiple (LCM) of the eight numbers 12, 18, 21, 28, 33, 44, 50, and 63?",
+   "answer": "69300"
+  },
+  {
+   "id": "x045",
+   "prompt": "How many four-digit numbers (from 1000 to 9999) are palindromes (read the same forwards and backwards) AND divisible by 7?",
+   "answer": "18"
+  },
+  {
+   "id": "x046",
+   "prompt": "How many integers n with 1 <= n <= 10000 are relatively prime to 210 (i.e. share no common factor greater than 1 with 210)? Note 210 = 2 * 3 * 5 * 7.",
+   "answer": "2285"
+  },
+  {
+   "id": "x047",
+   "prompt": "Compute the sum 1! + 2! + 3! + ... + 20! (sum of factorials from 1 to 20). What are the last three digits of this sum? Answer as an integer 0-999 (drop leading zeros).",
+   "answer": "313"
+  },
+  {
+   "id": "x048",
+   "prompt": "How many integers n with 1 <= n <= 10000 satisfy ALL THREE of n mod 7 = 3, n mod 9 = 4, and n mod 11 = 5 (where 'mod' is the nonnegative remainder)?",
+   "answer": "14"
+  },
+  {
+   "id": "x049",
+   "prompt": "How many days are there from March 15, 2019 to November 8, 2027 (counting the end date but not the start date, i.e. the difference b - a in days)? Note that 2020 and 2024 are leap years.",
+   "answer": "3160"
+  },
+  {
+   "id": "x050",
+   "prompt": "Starting from July 1, 2026, add exactly 1000 days. On what day-of-the-year number does the resulting date fall? (Day-of-year: January 1 is day 1; account for leap years. Answer as an integer.)",
+   "answer": "86"
+  },
+  {
+   "id": "x051",
+   "prompt": "A flight departs New York on March 7, 2026 at 22:30 local New York time (America/New_York) and is in the air for exactly 11 hours and 40 minutes of real elapsed time. Using correct time-zone and daylight-saving rules (note: US daylight saving time begins at 02:00 local on Sunday March 8, 2026, springing clocks forward one hour; the UK is still on GMT in early March), at what LOCAL London time (Europe/London) does the flight arrive? Express the answer as the arrival's minute-of-day: hour*60 + minute (an integer 0 to 1439).",
+   "answer": "910"
+  },
+  {
+   "id": "x052",
+   "prompt": "A tank has capacity 200 gallons and starts empty. Pipe A adds 3 gallons per minute starting at minute 0. Pipe B adds 5 gallons per minute starting at the beginning of minute 4 (i.e., it is active during minute 4 onward). Drain C removes 2 gallons per minute starting at the beginning of minute 9. Rates are constant within each whole minute. After how many whole minutes does the tank first contain at least 200 gallons?",
+   "answer": "34"
+  },
+  {
+   "id": "x053",
+   "prompt": "Five people A, B, C, D, E each occupy a distinct position numbered 1 to 5 in a row. Constraints: A is somewhere to the left of B (smaller position number); C is exactly at position 3; D is immediately to the right of A (D's position = A's position + 1); E is not at position 1 and not at position 5. How many distinct arrangements satisfy all of these constraints?",
+   "answer": "1"
+  },
+  {
+   "id": "x054",
+   "prompt": "A job is done by three workers whose individual rates are 1/6, 1/8, and 1/12 of the job per hour. Worker 1 starts at time 0 and works continuously. Worker 2 joins at time t = 2 hours. Worker 3 joins at time t = 3 hours. All continue until the job is complete. What is the exact total time in hours to finish the whole job? Give a reduced fraction a/b or a number.",
+   "answer": "4"
+  },
+  {
+   "id": "x055",
+   "prompt": "Two trains travel a straight 385-mile route between city A and city B. Train X leaves A heading toward B at 9:00, going 60 mph. Train Y leaves B heading toward A at 9:45, going 80 mph. At what clock time do they meet, expressed as minutes-after-midnight? (9:00 is 540 minutes after midnight.) Give the exact value as a reduced fraction a/b or a number.",
+   "answer": "5115/7"
+  },
+  {
+   "id": "x056",
+   "prompt": "Counting every date from January 1, 2000 through December 31, 2030 (inclusive), how many of them are a Friday that falls on the 13th of a month?",
+   "answer": "53"
+  },
+  {
+   "id": "x057",
+   "prompt": "Three lighthouses flash at regular intervals of 42, 54, and 66 seconds respectively. At time t = 0 seconds all three flash together. Over the next 24 hours (86400 seconds, from t = 0 up to and including t = 86400), how many times do all three flash at the same instant (count the flash at t = 0)?",
+   "answer": "21"
+  },
+  {
+   "id": "x058",
+   "prompt": "Six people (numbered 0 to 5) are each assigned exactly one of six tasks (numbered 0 to 5), one task per person, all tasks used. Person i is forbidden from doing task i (for every i from 0 to 5). Additionally, person 0 cannot do task 5, and person 5 cannot do task 0. How many valid assignments are there?",
+   "answer": "168"
+  },
+  {
+   "id": "x059",
+   "prompt": "The product of the ages of three brothers is 2450 and the sum of their ages is 76. Each age is a positive integer. What is the age of the OLDEST brother? (There is a unique set of three ages fitting these facts.)",
+   "answer": "49"
+  },
+  {
+   "id": "x060",
+   "prompt": "How many weekdays (Monday through Friday, ignoring holidays) are there from January 1, 2026 to June 30, 2026, inclusive of both endpoints?",
+   "answer": "129"
+  },
+  {
+   "id": "x061",
+   "prompt": "Two clocks are set to exactly the correct time at noon. Clock A gains 3 seconds every hour; Clock B loses 5 seconds every hour (both at constant rates). After how many whole hours will the two clocks first show times that differ by at least 10 minutes (600 seconds) from each other?",
+   "answer": "75"
+  },
+  {
+   "id": "x062",
+   "prompt": "A pump runs in a repeating 10-minute cycle: it is ON for the first 7 minutes of each cycle (adding 12 gallons per minute) and OFF for the last 3 minutes (adding nothing). It starts at the beginning of an ON phase at minute 0. Exactly how many gallons have been added after 100 minutes?",
+   "answer": "840"
+  },
+  {
+   "id": "x063",
+   "prompt": "Three runners start together at the start line of a 400-meter circular track, all running the same direction at constant speeds 5, 6, and 8 meters per second. After how many seconds do all three simultaneously return to the start line together for the first time? Give the exact answer as a reduced fraction a/b or an integer.",
+   "answer": "400"
+  },
+  {
+   "id": "x064",
+   "prompt": "During the 60 minutes numbered 0 through 59 of one hour, three machines each run maintenance on certain minutes: Machine 1 on every minute m where m is divisible by 4; Machine 2 on every minute where m is divisible by 6; Machine 3 on every minute where m is divisible by 9. On how many of the 60 minutes is NO machine running maintenance?",
+   "answer": "37"
+  },
+  {
+   "id": "x065",
+   "prompt": "Start with n = 27. Repeat this rule: if n is even, replace n with n/2; if n is odd, replace n with 3n+1. Count how many steps it takes to first reach 1. How many steps?",
+   "answer": "111"
+  },
+  {
+   "id": "x066",
+   "prompt": "Start with the number 999999999999 (twelve 9's). Repeatedly replace the current number by the sum of the squares of its decimal digits. Apply this operation exactly 20 times. What is the resulting number?",
+   "answer": "4"
+  },
+  {
+   "id": "x067",
+   "prompt": "A sequence is defined by a(0) = 2, a(1) = 5, and for n >= 2, a(n) = 3*a(n-1) - 2*a(n-2) + n. What is a(20)?",
+   "answer": "6291202"
+  },
+  {
+   "id": "x068",
+   "prompt": "Start with the string \"1\". At each step, simultaneously replace every '1' with the two characters '10' and every '0' with the single character '1'. (All replacements in a step use the string as it was at the start of that step.) After 15 steps, how many '1' characters does the string contain?",
+   "answer": "987"
+  },
+  {
+   "id": "x069",
+   "prompt": "There are 41 people standing in a circle, numbered 1 to 41 clockwise. Starting the count at person 1, every 3rd person is eliminated going clockwise (so persons 3, 6, 9, ... are removed first), and counting continues around the circle over the remaining people until only one remains. What is the number of the last remaining person?",
+   "answer": "31"
+  },
+  {
+   "id": "x070",
+   "prompt": "A population has three age classes: juveniles (J), adults (A), and elders (E). Each time step, the counts update simultaneously by these rules: new J = 2*A + E; new A = old J; new E = old A. Initially J = 1, A = 0, E = 0. After 20 time steps, what is the total population J + A + E?",
+   "answer": "13531"
+  },
+  {
+   "id": "x071",
+   "prompt": "Define a sequence by x(0) = 7 and x(n+1) = (x(n)^2 + 1) mod 1000. What is x(50)?",
+   "answer": "901"
+  },
+  {
+   "id": "x072",
+   "prompt": "A deck of 52 cards undergoes repeated perfect out-shuffles. Under an out-shuffle, the card in position i (positions numbered 0 to 51) moves to position (2*i) mod 51, except the last card (position 51) stays fixed. How many out-shuffles are needed to return the deck to its original order?",
+   "answer": "8"
+  },
+  {
+   "id": "x073",
+   "prompt": "Start with n = 1. Repeat 30 times: replace n with n plus the sum of the decimal digits of n. What is the final value of n after 30 repetitions?",
+   "answer": "271"
+  },
+  {
+   "id": "x074",
+   "prompt": "A ball starts at corner (0,0) of a rectangular billiard table with corners (0,0), (7,0), (0,5), (7,5). It moves diagonally, initially in direction (+1,+1), one unit in x and one unit in y per step. When it hits a vertical wall (x=0 or x=7) the x-direction flips; when it hits a horizontal wall (y=0 or y=5) the y-direction flips (a corner flips both). It stops the moment it arrives at any of the four corners. How many unit diagonal steps does it take to reach a corner?",
+   "answer": "35"
+  },
+  {
+   "id": "x075",
+   "prompt": "Start with the 4-tuple (0, 653, 1854, 4063). Repeat this operation: replace (a, b, c, d) with (|a-b|, |b-c|, |c-d|, |d-a|) (absolute differences of adjacent entries, cyclically). How many steps does it take to first reach (0, 0, 0, 0)?",
+   "answer": "23"
+  },
+  {
+   "id": "x076",
+   "prompt": "A Tribonacci-like sequence is defined mod 100: s(0)=s(1)=s(2)=1, and for n>=3, s(n) = (s(n-1) + s(n-2) + s(n-3)) mod 100. What is s(100)?",
+   "answer": "81"
+  },
+  {
+   "id": "x077",
+   "prompt": "Start with n = 500. Repeat this operation exactly 4 times: write n in binary (base 2), then read that same string of digits as if it were a base-3 numeral, and let that value be the new n. What is the final value?",
+   "answer": "1883617943244157"
+  },
+  {
+   "id": "x078",
+   "prompt": "Define f(i) = (i*i + 7) mod 1000. Start with x(0) = 8 and generate the sequence x(1) = f(x(0)), x(2) = f(x(1)), x(3) = f(x(2)), and so on. Counting applications of f, at which step number k (k >= 1) does x(k) first equal a value that already appeared earlier in the sequence (i.e. x(k) = x(j) for some j with 0 <= j < k)? Give the integer k.",
+   "answer": "8"
+  },
+  {
+   "id": "x079",
+   "prompt": "Consider a 1-dimensional row of 21 cells (positions 0 to 20), each either 0 or 1. Initially only the center cell (position 10) is 1. At each step, every cell's new value is the XOR of its left and right neighbors' current values (cells outside the row count as 0); this is 'Rule 90'. After 10 steps, how many cells contain a 1?",
+   "answer": "4"
+  },
+  {
+   "id": "x080",
+   "prompt": "Start with n = 1000000. Repeatedly replace n with d(n), the number of positive divisors of n (for example d(12) = 6). Continue until n first equals 2. How many replacement steps does this take?",
+   "answer": "3"
+  }
+ ]
+}

--- a/evals/wam_fusion/tasks/reasoning_headroom.json
+++ b/evals/wam_fusion/tasks/reasoning_headroom.json
@@ -1,0 +1,706 @@
+{
+  "_comment": "Phase A REASONING-HEADROOM tier — 140 checkable-answer items engineered to BREAK the ceiling effect that nulled prior trick-riddle corpora (which hit 100% single-model accuracy). These are genuinely hard multi-step problems drawn from six categories that reliably trip frontier LLMs: (1) multi-step arithmetic word problems with large numbers / compound rates / multi-stage percentages, (2) combinatorics & careful case-counting (permutations-with-restrictions, inclusion-exclusion, lattice paths, derangements, make-change, constrained seating), (3) number theory (modular exponentiation, last-k-digits, divisor counts, CRT, Legendre valuations, base conversion, digit sums), (4) multi-constraint logic / age / calendar-date arithmetic with a unique numeric answer, (5) sequences / recurrences / finite & infinite series, (6) probability with EXACT reduced-fraction answers. EVERY canonical answer was produced AND independently re-verified by from-scratch Python computation (brute-force / exact formula) — 140/140 verified, 0 mismatches. Answers are single integers (107), reduced fractions (25), short decimals (5), or a single weekday/month word (3), chosen for robust programmatic scoring (ANSWER: <value>; the scorer bridges fraction<->decimal, strips $/,/% and units, and normalizes word case). Calibrated to leave real headroom: a strong single frontier model is expected to miss a meaningful fraction, so fusion has room to help.",
+  "answer_format_instruction": "Solve the problem carefully, step by step. Give exact answers: integers as integers, fractions in lowest terms (like 5/18), decimals rounded as the problem asks. Then end your reply with a final line of EXACTLY the form:  ANSWER: <value>   (just the value — no units, no words, no extra text).",
+  "items": [
+    {
+      "id": "r001",
+      "prompt": "In how many ways can 8 letters, each addressed to a different one of 8 people, be placed into 8 addressed envelopes so that NO letter goes into its correct envelope?",
+      "answer": "14833"
+    },
+    {
+      "id": "r002",
+      "prompt": "In how many ways can 6 distinct people be arranged in a row so that two specific people (call them A and B) are never seated next to each other?",
+      "answer": "480"
+    },
+    {
+      "id": "r003",
+      "prompt": "A grid path goes from (0,0) to (6,5), moving only one unit right (+1 in x) or one unit up (+1 in y) at each step. How many such paths do NOT pass through the point (3,2)?",
+      "answer": "262"
+    },
+    {
+      "id": "r004",
+      "prompt": "How many ways are there to make 63 cents using any number of pennies (1c), nickels (5c), dimes (10c), and quarters (25c)?",
+      "answer": "73"
+    },
+    {
+      "id": "r005",
+      "prompt": "How many strings of length 5 can be formed from the letters A, B, C (repetition allowed) such that no two adjacent letters are the same?",
+      "answer": "48"
+    },
+    {
+      "id": "r006",
+      "prompt": "A committee of 4 people is chosen from 7 men and 5 women. How many committees contain at least 2 women?",
+      "answer": "285"
+    },
+    {
+      "id": "r007",
+      "prompt": "How many distinct arrangements are there of all the letters of the word MISSISSIPPI?",
+      "answer": "34650"
+    },
+    {
+      "id": "r008",
+      "prompt": "How many subsets of the set {1, 2, 3, ..., 12} (including the empty set) have a sum of elements that is divisible by 4?",
+      "answer": "1024"
+    },
+    {
+      "id": "r009",
+      "prompt": "In how many ways can 8 distinct people be seated around a circular table (arrangements that differ only by rotation are considered the same) if two specific people must sit next to each other?",
+      "answer": "1440"
+    },
+    {
+      "id": "r010",
+      "prompt": "In how many ways can 10 identical balls be distributed into 4 distinct boxes so that each box contains at least one ball?",
+      "answer": "84"
+    },
+    {
+      "id": "r011",
+      "prompt": "How many 4-digit positive integers have their digits strictly increasing from left to right (e.g., 1258 qualifies, 1225 does not)?",
+      "answer": "126"
+    },
+    {
+      "id": "r012",
+      "prompt": "A path goes from (0,0) to (4,4) using only unit steps right (R) or up (U). How many such paths never rise above the line y = x (i.e., after every step, y <= x)?",
+      "answer": "14"
+    },
+    {
+      "id": "r013",
+      "prompt": "In how many ways can 3 numbers be chosen from {1, 2, ..., 20} such that no two of the chosen numbers are consecutive integers?",
+      "answer": "816"
+    },
+    {
+      "id": "r014",
+      "prompt": "How many binary strings of length 10 contain no occurrence of three consecutive 1s?",
+      "answer": "504"
+    },
+    {
+      "id": "r015",
+      "prompt": "How many functions from a set of 5 elements onto a set of 3 elements are surjective (i.e., every element of the 3-element codomain is hit)?",
+      "answer": "150"
+    },
+    {
+      "id": "r016",
+      "prompt": "What are the last two digits of 7^2023? (Give the two-digit number, e.g. 07 would be written as 7.)",
+      "answer": "43"
+    },
+    {
+      "id": "r017",
+      "prompt": "What is the remainder when 3^1000 is divided by 1000?",
+      "answer": "1"
+    },
+    {
+      "id": "r018",
+      "prompt": "How many positive divisors does 720 have?",
+      "answer": "30"
+    },
+    {
+      "id": "r019",
+      "prompt": "Find the smallest positive integer x such that x leaves remainder 2 when divided by 3, remainder 3 when divided by 5, and remainder 2 when divided by 7.",
+      "answer": "23"
+    },
+    {
+      "id": "r020",
+      "prompt": "What is the sum of all positive divisors of 360 (including 1 and 360 itself)?",
+      "answer": "1170"
+    },
+    {
+      "id": "r021",
+      "prompt": "What is the greatest common divisor (GCD) of 1274 and 1029?",
+      "answer": "49"
+    },
+    {
+      "id": "r022",
+      "prompt": "What is the least common multiple (LCM) of 12, 18, 30, and 45?",
+      "answer": "180"
+    },
+    {
+      "id": "r023",
+      "prompt": "What is the units (last) digit of 2^100 + 3^100?",
+      "answer": "7"
+    },
+    {
+      "id": "r024",
+      "prompt": "What is the sum of the digits of 2^50?",
+      "answer": "76"
+    },
+    {
+      "id": "r025",
+      "prompt": "How many integers from 1 to 1000 inclusive are divisible by neither 6 nor 10?",
+      "answer": "767"
+    },
+    {
+      "id": "r026",
+      "prompt": "Convert the decimal number 1729 to base 7. Give the answer as the resulting digit string (a number in base 7).",
+      "answer": "5020"
+    },
+    {
+      "id": "r027",
+      "prompt": "How many trailing zeros does 100! (100 factorial) have?",
+      "answer": "24"
+    },
+    {
+      "id": "r028",
+      "prompt": "What is the remainder when 15^15 is divided by 13?",
+      "answer": "8"
+    },
+    {
+      "id": "r029",
+      "prompt": "How many positive integers from 1 to 100 inclusive are relatively prime to 100 (share no common factor greater than 1 with 100)?",
+      "answer": "40"
+    },
+    {
+      "id": "r030",
+      "prompt": "What is the largest integer k such that 3^k divides 50! (50 factorial) exactly?",
+      "answer": "22"
+    },
+    {
+      "id": "r031",
+      "prompt": "What is the smallest positive integer that is divisible by every integer from 1 to 10 inclusive?",
+      "answer": "2520"
+    },
+    {
+      "id": "r032",
+      "prompt": "What are the last two digits of 13^99? (Give the two-digit result as a number.)",
+      "answer": "77"
+    },
+    {
+      "id": "r033",
+      "prompt": "Among the integers from 1 to 200 inclusive, how many are a perfect square, a perfect cube, or both?",
+      "answer": "17"
+    },
+    {
+      "id": "r034",
+      "prompt": "Find the smallest 3-digit number the product of whose digits is 24 and the sum of whose digits is 11.",
+      "answer": "146"
+    },
+    {
+      "id": "r035",
+      "prompt": "What is the units digit of 7^(7^7) (that is, 7 raised to the power 7^7)?",
+      "answer": "3"
+    },
+    {
+      "id": "r036",
+      "prompt": "Pipe A alone fills a tank in 12 hours, pipe B alone fills it in 18 hours, and a drain C alone empties a full tank in 24 hours. If the empty tank has all three opened at once, how many hours does it take to fill the tank? Give your answer as a reduced fraction.",
+      "answer": "72/7"
+    },
+    {
+      "id": "r037",
+      "prompt": "An item originally priced at $650 has its price increased by 20%, then the new price is discounted by 15%, and finally an 8% sales tax is added to that. What is the final price in dollars? Round to the nearest cent.",
+      "answer": "716.04"
+    },
+    {
+      "id": "r038",
+      "prompt": "A container has 40 liters of a solution that is 30% acid. How many liters of PURE acid must be added so that the resulting mixture is 50% acid?",
+      "answer": "16"
+    },
+    {
+      "id": "r039",
+      "prompt": "A factory makes 1,375 widgets per day, operating 6 days a week for 48 weeks. Exactly 12% of all widgets produced are defective and scrapped with no revenue. Each non-defective widget sells for $23. What is the total revenue in dollars?",
+      "answer": "8015040"
+    },
+    {
+      "id": "r040",
+      "prompt": "A school has 1200 students. 55% of them are girls. Of the girls, 40% play a sport. Of the girls who play a sport, 25% play soccer. How many girls play soccer?",
+      "answer": "66"
+    },
+    {
+      "id": "r041",
+      "prompt": "A train travels 342 km at a constant 76 km/h, then stops for 35 minutes, then travels a further 285 km at a constant 95 km/h. What is the total elapsed time for the journey in minutes?",
+      "answer": "485"
+    },
+    {
+      "id": "r042",
+      "prompt": "$8000 is invested at 6% interest compounded annually. What is the value of the investment in dollars after 3 years? Round to the nearest cent.",
+      "answer": "9528.13"
+    },
+    {
+      "id": "r043",
+      "prompt": "A merchant buys 240 items at $18 each. She sells 60% of them at $30 each and the remaining items at $22 each. What is her total profit in dollars?",
+      "answer": "2112"
+    },
+    {
+      "id": "r044",
+      "prompt": "The average of 15 numbers is 42. If the number 30 is removed from the set, what is the average of the remaining 14 numbers? Give your answer as a reduced fraction.",
+      "answer": "300/7"
+    },
+    {
+      "id": "r045",
+      "prompt": "Two cars start 480 km apart and drive directly toward each other. One travels at 65 km/h and the other at 55 km/h. After how many hours do they meet?",
+      "answer": "4"
+    },
+    {
+      "id": "r046",
+      "prompt": "A car gets 32 miles per gallon. Gas costs $3.85 per gallon. What is the total cost of gas, in dollars, for a 1,472-mile trip? Round to the nearest cent.",
+      "answer": "177.1"
+    },
+    {
+      "id": "r047",
+      "prompt": "Compute the exact product 6789 × 4321.",
+      "answer": "29335269"
+    },
+    {
+      "id": "r048",
+      "prompt": "350 tickets are sold: 200 adult tickets at $45 each and 150 child tickets at $28 each. A 12% group discount is then applied to the combined total. How much money is collected in dollars? Round to the nearest cent.",
+      "answer": "11616"
+    },
+    {
+      "id": "r049",
+      "prompt": "A tank holds 6,300 liters. It leaks at 45 liters per hour for the first 8 hours, after which the leak is reduced to 18 liters per hour. How many liters remain in the tank after 20 total hours (assuming it doesn't run empty)?",
+      "answer": "5724"
+    },
+    {
+      "id": "r050",
+      "prompt": "After receiving a 25% raise, an employee's salary is $52,500. What was the original salary in dollars?",
+      "answer": "42000"
+    },
+    {
+      "id": "r051",
+      "prompt": "12 workers can build a wall in 15 days working 8 hours per day. Working at the same rate, how many days will it take 9 workers working 10 hours per day to build an identical wall?",
+      "answer": "16"
+    },
+    {
+      "id": "r052",
+      "prompt": "A stadium has 40 rows of seats. The first row has 22 seats, and each subsequent row has 4 more seats than the row before it. What is the total number of seats in the stadium?",
+      "answer": "4000"
+    },
+    {
+      "id": "r053",
+      "prompt": "1000 apples are packed into boxes holding 24 apples each. Any apples that don't fill a complete box are then packed into bags of 5. Any apples remaining after that are eaten. How many apples are eaten?",
+      "answer": "1"
+    },
+    {
+      "id": "r054",
+      "prompt": "A stock price rises 10%, then falls 20%, then rises 25%, in that order. What is the net percentage change in the stock price over the three moves? Give the answer as a percentage (a number; positive for a gain).",
+      "answer": "10"
+    },
+    {
+      "id": "r055",
+      "prompt": "A charity raises $284,760 and divides it equally among 8 shelters. Each shelter then spends 35% of its share on food. How much does a single shelter spend on food, in dollars? Round to the nearest cent.",
+      "answer": "12458.25"
+    },
+    {
+      "id": "r056",
+      "prompt": "Two fair six-sided dice are rolled. What is the probability that the sum of the two dice is 7 or 11? Give your answer as a reduced fraction.",
+      "answer": "2/9"
+    },
+    {
+      "id": "r057",
+      "prompt": "Two cards are drawn without replacement from a standard 52-card deck. What is the probability that both cards are hearts? Give your answer as a reduced fraction.",
+      "answer": "1/17"
+    },
+    {
+      "id": "r058",
+      "prompt": "A fair coin is flipped 5 times. What is the probability of getting exactly 3 heads? Give your answer as a reduced fraction.",
+      "answer": "5/16"
+    },
+    {
+      "id": "r059",
+      "prompt": "An urn contains 4 red and 6 blue balls. Three balls are drawn without replacement. What is the probability that exactly 2 of them are red? Give your answer as a reduced fraction.",
+      "answer": "3/10"
+    },
+    {
+      "id": "r060",
+      "prompt": "Three people each independently pick a random day of the week (each of the 7 days equally likely). What is the probability that all three pick different days? Give your answer as a reduced fraction.",
+      "answer": "30/49"
+    },
+    {
+      "id": "r061",
+      "prompt": "A fair six-sided die is rolled repeatedly until a 6 appears. What is the probability that the first 6 appears on exactly the third roll? Give your answer as a reduced fraction.",
+      "answer": "25/216"
+    },
+    {
+      "id": "r062",
+      "prompt": "Two fair six-sided dice are rolled. What is the probability that the product of the two numbers is even? Give your answer as a reduced fraction.",
+      "answer": "3/4"
+    },
+    {
+      "id": "r063",
+      "prompt": "Three distinct numbers are chosen at random from {1, 2, ..., 10}. What is the probability that their sum is even? Give your answer as a reduced fraction.",
+      "answer": "1/2"
+    },
+    {
+      "id": "r064",
+      "prompt": "A family has two children. Given that at least one of them is a boy, what is the probability that both children are boys? (Assume each child is independently a boy or girl with equal probability.) Give your answer as a reduced fraction.",
+      "answer": "1/3"
+    },
+    {
+      "id": "r065",
+      "prompt": "Two cards are drawn without replacement from a standard 52-card deck (which has 4 aces). What is the probability that at least one of the two cards is an ace? Give your answer as a reduced fraction.",
+      "answer": "33/221"
+    },
+    {
+      "id": "r066",
+      "prompt": "A fair coin is flipped 4 times. What is the probability that no two consecutive flips are both heads? Give your answer as a reduced fraction.",
+      "answer": "1/2"
+    },
+    {
+      "id": "r067",
+      "prompt": "A spinner has 4 equal sections numbered 1 to 4. It is spun twice. What is the probability that the first spin shows a smaller number than the second? Give your answer as a reduced fraction.",
+      "answer": "3/8"
+    },
+    {
+      "id": "r068",
+      "prompt": "Three fair six-sided dice are rolled. What is the probability that all three dice show different values? Give your answer as a reduced fraction.",
+      "answer": "5/9"
+    },
+    {
+      "id": "r069",
+      "prompt": "A bag contains 5 white and 3 black marbles. Two marbles are drawn at random without replacement. What is the probability that both marbles are the same color? Give your answer as a reduced fraction.",
+      "answer": "13/28"
+    },
+    {
+      "id": "r070",
+      "prompt": "5 people are seated in a random order in a row of 5 chairs. What is the probability that two specific people end up sitting next to each other? Give your answer as a reduced fraction.",
+      "answer": "2/5"
+    },
+    {
+      "id": "r071",
+      "prompt": "A father is currently 4 times as old as his son. In 20 years, the father will be twice as old as his son. How old is the son now?",
+      "answer": "10"
+    },
+    {
+      "id": "r072",
+      "prompt": "A two-digit number is 18 greater than the number formed by reversing its digits, and its digits sum to 12. What is the two-digit number?",
+      "answer": "75"
+    },
+    {
+      "id": "r073",
+      "prompt": "On an island, knights always tell the truth and knaves always lie. You meet three inhabitants A, B, and C. A says: 'Exactly one of us three is a knave.' B says: 'Exactly two of us three are knaves.' C says: 'All three of us are knaves.' How many of the three are knaves?",
+      "answer": "2"
+    },
+    {
+      "id": "r074",
+      "prompt": "January 1, 2025 falls on a Wednesday. What day of the week is March 15, 2025? Give the full name of the day.",
+      "answer": "Saturday"
+    },
+    {
+      "id": "r075",
+      "prompt": "How many days are there strictly between February 10, 2024 and May 3, 2024 (counting neither endpoint)? Note that 2024 is a leap year.",
+      "answer": "82"
+    },
+    {
+      "id": "r076",
+      "prompt": "Three numbers have a sum of 60. The second number is twice the first, and the third is three times the first. What is the value of the largest of the three numbers?",
+      "answer": "30"
+    },
+    {
+      "id": "r077",
+      "prompt": "A piggy bank contains only dimes (10 cents) and quarters (25 cents). There are 32 coins in all, worth a total of $5.15. How many quarters are in the bank?",
+      "answer": "13"
+    },
+    {
+      "id": "r078",
+      "prompt": "If today is Monday, what day of the week will it be 100 days from now? Give the full name of the day.",
+      "answer": "Wednesday"
+    },
+    {
+      "id": "r079",
+      "prompt": "Alice is 3 years older than Bob. In 5 years, the sum of their ages will be 45. How old is Alice now?",
+      "answer": "19"
+    },
+    {
+      "id": "r080",
+      "prompt": "Four runners A, B, C, D finish a race in distinct positions (1st through 4th). A finished before B. C finished last. D finished before A. B did not finish 2nd. In which position (1, 2, 3, or 4) did A finish?",
+      "answer": "2"
+    },
+    {
+      "id": "r081",
+      "prompt": "2024 is a leap year. What is the ordinal day number of December 31, 2024 within that year (January 1 = day 1)?",
+      "answer": "366"
+    },
+    {
+      "id": "r082",
+      "prompt": "The sum of 5 consecutive integers is 155. What is the largest of these 5 integers?",
+      "answer": "33"
+    },
+    {
+      "id": "r083",
+      "prompt": "What is the measure, in degrees, of the smaller angle between the hour hand and the minute hand of a clock at exactly 3:40?",
+      "answer": "130"
+    },
+    {
+      "id": "r084",
+      "prompt": "A two-digit number has digits that sum to 11. When its digits are reversed, the resulting number is 45 greater than the original. What is the original two-digit number?",
+      "answer": "38"
+    },
+    {
+      "id": "r085",
+      "prompt": "Counting January as month 1, February as month 2, and so on (wrapping around after December back to January), which month is the 30th month? Give the month name.",
+      "answer": "June"
+    },
+    {
+      "id": "r086",
+      "prompt": "A sequence is defined by a(1) = 2 and a(n) = 3*a(n-1) - 1 for n > 1. What is a(6)?",
+      "answer": "365"
+    },
+    {
+      "id": "r087",
+      "prompt": "A sequence is defined by b(1) = 3, b(2) = 5, and b(n) = b(n-1) + b(n-2) for n > 2. What is b(10)?",
+      "answer": "233"
+    },
+    {
+      "id": "r088",
+      "prompt": "Compute the exact sum 1/(1·2) + 1/(2·3) + 1/(3·4) + ... + 1/(49·50). Give your answer as a reduced fraction.",
+      "answer": "49/50"
+    },
+    {
+      "id": "r089",
+      "prompt": "What is the sum of the first 30 positive odd numbers (1 + 3 + 5 + ... )?",
+      "answer": "900"
+    },
+    {
+      "id": "r090",
+      "prompt": "Compute the sum of the first 12 terms of the geometric series 3 + 6 + 12 + 24 + ... (each term is double the previous).",
+      "answer": "12285"
+    },
+    {
+      "id": "r091",
+      "prompt": "A sequence is defined by c(1) = 1 and c(n) = c(n-1) + (2n - 1) for n > 1. What is c(15)?",
+      "answer": "225"
+    },
+    {
+      "id": "r092",
+      "prompt": "In an arithmetic sequence, the first term is 7 and the common difference is 4. What is the 25th term?",
+      "answer": "103"
+    },
+    {
+      "id": "r093",
+      "prompt": "Compute the value of the alternating sum 1 - 2 + 3 - 4 + 5 - 6 + ... + 99 - 100.",
+      "answer": "-50"
+    },
+    {
+      "id": "r094",
+      "prompt": "What is the sum of the squares of the integers from 1 to 20 (that is, 1² + 2² + ... + 20²)?",
+      "answer": "2870"
+    },
+    {
+      "id": "r095",
+      "prompt": "Let d(n) denote the number of positive divisors of n. Compute d(1) + d(2) + d(3) + ... + d(12).",
+      "answer": "35"
+    },
+    {
+      "id": "r096",
+      "prompt": "A sequence is defined by t(1) = 5 and t(n) = (7*t(n-1) + 3) mod 100 for n > 1. What is t(5)?",
+      "answer": "5"
+    },
+    {
+      "id": "r097",
+      "prompt": "What is the sum of all positive multiples of 7 that are less than or equal to 500?",
+      "answer": "17892"
+    },
+    {
+      "id": "r098",
+      "prompt": "The nth triangular number is 1 + 2 + ... + n. What is the 20th triangular number?",
+      "answer": "210"
+    },
+    {
+      "id": "r099",
+      "prompt": "A sequence is defined by a(1) = 1, a(2) = 1, and a(n) = 2*a(n-1) + a(n-2) for n > 2. What is a(8)?",
+      "answer": "239"
+    },
+    {
+      "id": "r100",
+      "prompt": "Compute the sum 1 + 2 + 4 + 8 + 16 + ... + 512 (all powers of 2 from 2^0 through 2^9).",
+      "answer": "1023"
+    },
+    {
+      "id": "r101",
+      "prompt": "How many distinct arrangements of all the letters of the word BOOKKEEPER have no two E's adjacent to each other?",
+      "answer": "70560"
+    },
+    {
+      "id": "r102",
+      "prompt": "In how many ways can 10 distinct people be split into two teams of 5, where the two teams are not labeled (i.e., swapping the two teams gives the same division)?",
+      "answer": "126"
+    },
+    {
+      "id": "r103",
+      "prompt": "Consider all 720 arrangements of the digits 1,2,3,4,5,6 into a 6-digit number (each digit used once). In how many of them is NO digit in its natural position — that is, the digit in position 1 is not 1, the digit in position 2 is not 2, and so on?",
+      "answer": "265"
+    },
+    {
+      "id": "r104",
+      "prompt": "A monotonic lattice path goes from (0,0) to (5,5), each step moving one unit right or one unit up. How many such paths avoid BOTH of the points (2,2) and (3,1)?",
+      "answer": "72"
+    },
+    {
+      "id": "r105",
+      "prompt": "How many solutions in non-negative integers does x1 + x2 + x3 + x4 = 20 have, subject to the constraint that each xi is at most 8?",
+      "answer": "375"
+    },
+    {
+      "id": "r106",
+      "prompt": "Three married couples (6 people total) sit in a row of 6 seats. In how many arrangements does every couple sit together (each pair of spouses occupies adjacent seats)?",
+      "answer": "48"
+    },
+    {
+      "id": "r107",
+      "prompt": "In how many ways can a 2×10 rectangular board be completely tiled by 1×2 dominoes (each domino covers two adjacent squares, placed either horizontally or vertically)?",
+      "answer": "89"
+    },
+    {
+      "id": "r108",
+      "prompt": "What are the last three digits of 7^999? Give the three-digit result as a number.",
+      "answer": "143"
+    },
+    {
+      "id": "r109",
+      "prompt": "What is the sum of the decimal digits of 100! (100 factorial)?",
+      "answer": "648"
+    },
+    {
+      "id": "r110",
+      "prompt": "How many integers from 1 to 10000 inclusive are divisible by 3 or by 5 (or both), but are NOT divisible by 7?",
+      "answer": "4001"
+    },
+    {
+      "id": "r111",
+      "prompt": "What is the remainder when 2^1000 is divided by 1000?",
+      "answer": "376"
+    },
+    {
+      "id": "r112",
+      "prompt": "What is the smallest positive integer n such that n! (n factorial) is divisible by 1,000,000?",
+      "answer": "25"
+    },
+    {
+      "id": "r113",
+      "prompt": "How many trailing zeros does 50! (50 factorial) have when written in base 12?",
+      "answer": "22"
+    },
+    {
+      "id": "r114",
+      "prompt": "Find the smallest positive integer x satisfying all three: x ≡ 1 (mod 4), x ≡ 2 (mod 9), and x ≡ 3 (mod 25).",
+      "answer": "353"
+    },
+    {
+      "id": "r115",
+      "prompt": "What is the sum of all the positive divisors of 10,000 that are perfect squares?",
+      "answer": "13671"
+    },
+    {
+      "id": "r116",
+      "prompt": "Three fair six-sided dice are rolled. What is the probability that their sum is exactly 10? Give your answer as a reduced fraction.",
+      "answer": "1/8"
+    },
+    {
+      "id": "r117",
+      "prompt": "A 5-card hand is dealt from a standard 52-card deck. What is the probability that all 5 cards are of the same suit? Give your answer as a reduced fraction.",
+      "answer": "33/16660"
+    },
+    {
+      "id": "r118",
+      "prompt": "A bag contains 3 gold and 5 silver coins. Three coins are drawn at random without replacement. What is the probability that at least one gold coin is drawn? Give your answer as a reduced fraction.",
+      "answer": "23/28"
+    },
+    {
+      "id": "r119",
+      "prompt": "Box A contains 2 red and 3 blue balls; Box B contains 4 red and 1 blue ball. A box is chosen at random (each equally likely) and one ball is drawn from it. Given that the drawn ball is red, what is the probability it came from Box B? Give your answer as a reduced fraction.",
+      "answer": "2/3"
+    },
+    {
+      "id": "r120",
+      "prompt": "Four fair six-sided dice are rolled. What is the probability that at least two of them show the same value? Give your answer as a reduced fraction.",
+      "answer": "13/18"
+    },
+    {
+      "id": "r121",
+      "prompt": "A worker earns $18/hour for the first 40 hours in a week, 1.5 times that rate for the next 8 hours, and 2 times the base rate for any hours beyond 48. She works 52 hours. Then 22% of her gross pay is withheld. What is her take-home pay in dollars? Round to the nearest cent.",
+      "answer": "842.4"
+    },
+    {
+      "id": "r122",
+      "prompt": "A recipe for 6 servings requires 450 grams of flour. A baker wants to make 15 servings and buys 20% extra flour to allow for spillage. How many grams of flour does the baker need in total?",
+      "answer": "1350"
+    },
+    {
+      "id": "r123",
+      "prompt": "A town's population is 25,000 and grows by 8% each year. What is the population after 4 years? Round to the nearest whole person.",
+      "answer": "34012"
+    },
+    {
+      "id": "r124",
+      "prompt": "A 9,000-liter tank is filled at 250 liters per minute for the first 12 minutes, after which the rate drops to 150 liters per minute. How many total minutes does it take to completely fill the tank?",
+      "answer": "52"
+    },
+    {
+      "id": "r125",
+      "prompt": "A car travels at a constant 90 kilometers per hour. What is its speed in meters per second?",
+      "answer": "25"
+    },
+    {
+      "id": "r126",
+      "prompt": "A sequence is defined by a(1)=1, a(2)=2, a(3)=3, and a(n) = a(n-1) + a(n-2) - a(n-3) for n > 3. What is a(20)?",
+      "answer": "20"
+    },
+    {
+      "id": "r127",
+      "prompt": "Start with the number 27. Repeatedly apply the rule: if the number is even, divide it by 2; if it is odd, multiply by 3 and add 1. How many steps does it take to first reach 1?",
+      "answer": "111"
+    },
+    {
+      "id": "r128",
+      "prompt": "A 3-digit number is called an Armstrong number if it equals the sum of the cubes of its digits (for example, 153 = 1³ + 5³ + 3³). What is the sum of ALL 3-digit Armstrong numbers?",
+      "answer": "1301"
+    },
+    {
+      "id": "r129",
+      "prompt": "Convert the binary number 11011010 to decimal (base 10).",
+      "answer": "218"
+    },
+    {
+      "id": "r130",
+      "prompt": "What is the units (last) digit of the sum 1! + 2! + 3! + ... + 100! ?",
+      "answer": "3"
+    },
+    {
+      "id": "r131",
+      "prompt": "How many integers from 1 to 1000 inclusive have a digit sum (sum of their decimal digits) equal to 10?",
+      "answer": "63"
+    },
+    {
+      "id": "r132",
+      "prompt": "A fair coin is flipped 6 times. What is the probability of getting strictly more heads than tails? Give your answer as a reduced fraction.",
+      "answer": "11/32"
+    },
+    {
+      "id": "r133",
+      "prompt": "Alice can complete a job in 6 hours, Bob in 8 hours, and Carol in 12 hours. Working together at their individual rates, how many hours does it take them to complete the job? Give your answer as a reduced fraction.",
+      "answer": "8/3"
+    },
+    {
+      "id": "r134",
+      "prompt": "Alloy 1 is 40% copper and Alloy 2 is 70% copper. They are mixed to produce 30 kg of an alloy that is 50% copper. How many kilograms of Alloy 1 are used?",
+      "answer": "20"
+    },
+    {
+      "id": "r135",
+      "prompt": "What is the 100th prime number (with 2 being the 1st prime)?",
+      "answer": "541"
+    },
+    {
+      "id": "r136",
+      "prompt": "How many 4-digit codes (each position a digit 0-9) have all four digits distinct and arranged in strictly increasing order from left to right (e.g., 0247)?",
+      "answer": "210"
+    },
+    {
+      "id": "r137",
+      "prompt": "What is the sum of the infinite geometric series 8 + 8/3 + 8/9 + 8/27 + ... ? Give your answer as a reduced fraction.",
+      "answer": "12"
+    },
+    {
+      "id": "r138",
+      "prompt": "A shirt's price is first marked up by 60% from its original cost, and then a 60% discount is applied to the marked-up price. The final price is what percent of the original cost? Give the answer as a number (percent).",
+      "answer": "64"
+    },
+    {
+      "id": "r139",
+      "prompt": "Two distinguishable dice (a red one and a blue one) are rolled. In how many of the 36 equally likely outcomes is the red die's value strictly greater than the blue die's value?",
+      "answer": "15"
+    },
+    {
+      "id": "r140",
+      "prompt": "A store buys 500 units at $12 each. It sells 70% of them at a 45% markup on cost, and clears the remaining 30% at a 20% loss on cost. What is the store's total profit in dollars? Round to the nearest cent.",
+      "answer": "1530"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds three reasoning-tier task corpora for the workflows-as-models (WaM) fusion eval harness:

| File | Items | Tier |
|------|-------|------|
| `reasoning_headroom.json` | 140 | headroom |
| `reasoning_extrahard.json` | 80 | extra-hard |
| `reasoning_discriminating.json` | 30 | discriminating |

## Why

These were produced during the WaM fusion eval work (`[workflows-as-models]` Phases A/B) but never committed. They match the exact schema (`{items: [{id, prompt, answer}]}`) of the already-tracked sibling corpora `reasoning_hard.json` / `reasoning_checkable.json`, and slot into the existing harness — `run_fusion.py --tasks <file>` selects a corpus at runtime.

Per the dir's `.gitignore` convention, **inputs are version-controlled; only per-run output artifacts** (`results.json`, `fusion_results.json`, `coding_results.json`) **are ignored.** Tracking these makes the headroom/discriminating/extra-hard eval tiers reproducible.

## Scope

Eval-only. No code, no runtime surface, no code-gen invariants (openapi/SDK) touched. All three validated as parseable JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)