### PR TITLE
API: unknown query params are silently ignored — a typo'd param name returns confidently-wrong pages

### DIFF
--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -19,7 +19,6 @@ from fastapi.routing import APIRoute
 
 from aios.api.deps import require_bearer_auth
 from aios.api.middleware import RequestLoggingMiddleware
-from aios.api.strict_query_params import reject_unknown_query_params
 from aios.api.routers import (
     accounts,
     agents,
@@ -38,6 +37,7 @@ from aios.api.routers import (
     vaults,
     workflows,
 )
+from aios.api.strict_query_params import reject_unknown_query_params
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db.pool import create_pool

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -19,6 +19,7 @@ from fastapi.routing import APIRoute
 
 from aios.api.deps import require_bearer_auth
 from aios.api.middleware import RequestLoggingMiddleware
+from aios.api.strict_query_params import reject_unknown_query_params
 from aios.api.routers import (
     accounts,
     agents,
@@ -155,6 +156,7 @@ def create_app() -> FastAPI:
         description="Open-source agent runtime: Postgres-backed sessions, "
         "Docker sandbox, any LiteLLM model.",
         lifespan=lifespan,
+        dependencies=[Depends(reject_unknown_query_params)],
         # One schema per Pydantic model (not a Foo-Input / Foo-Output pair).
         # We use distinct ``Foo`` / ``FooCreate`` / ``FooUpdate`` types instead
         # of the read-only-field split, and the hyphenated split-schema names

--- a/src/aios/api/strict_query_params.py
+++ b/src/aios/api/strict_query_params.py
@@ -1,0 +1,43 @@
+"""Fail closed when API callers send undeclared query parameters."""
+
+from fastapi import HTTPException, Request
+from fastapi.routing import APIRoute
+
+# Webhook providers commonly append their own query parameters. The opaque token
+# authenticates this raw ingest surface, so rejecting those parameters could drop
+# otherwise valid external events.
+_EXEMPT_PATH_PREFIX = "/v1/triggers/ingest/"
+
+
+def _declared_query_aliases(route: APIRoute) -> set[str]:
+    """Collect public query names, including parameters from dependencies."""
+    aliases: set[str] = set()
+    pending = [route.dependant]
+    while pending:
+        dependant = pending.pop()
+        aliases.update(param.alias for param in dependant.query_params)
+        pending.extend(dependant.dependencies)
+    return aliases
+
+
+async def reject_unknown_query_params(request: Request) -> None:
+    """Reject query keys absent from the matched operation's declaration."""
+    if request.url.path.startswith(_EXEMPT_PATH_PREFIX):
+        return
+    route = request.scope.get("route")
+    if not isinstance(route, APIRoute):
+        return
+    unknown = sorted(set(request.query_params) - _declared_query_aliases(route))
+    if unknown:
+        raise HTTPException(
+            status_code=422,
+            detail=[
+                {
+                    "type": "extra_forbidden",
+                    "loc": ["query", name],
+                    "msg": "Unknown query parameter",
+                    "input": request.query_params.getlist(name),
+                }
+                for name in unknown
+            ],
+        )

--- a/tests/unit/test_strict_query_params.py
+++ b/tests/unit/test_strict_query_params.py
@@ -1,0 +1,40 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Query, Request
+from fastapi.testclient import TestClient
+
+from aios.api.strict_query_params import reject_unknown_query_params
+
+
+def _client() -> TestClient:
+    app = FastAPI(dependencies=[Depends(reject_unknown_query_params)])
+
+    @app.get("/items")
+    async def items(
+        direction: Annotated[str, Query(alias="dir")] = "forward",
+        channel: Annotated[list[str] | None, Query()] = None,
+    ) -> dict:
+        return {"direction": direction, "channel": channel}
+
+    @app.post("/v1/triggers/ingest/{token}")
+    async def ingest(token: str, request: Request) -> dict:
+        return {"token": token}
+
+    return TestClient(app)
+
+
+def test_unknown_query_parameter_is_rejected_and_named() -> None:
+    response = _client().get("/items?seq=123")
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["query", "seq"]
+
+
+def test_aliases_and_repeatable_parameters_are_accepted() -> None:
+    response = _client().get("/items?dir=backward&channel=a&channel=b")
+    assert response.status_code == 200
+    assert response.json() == {"direction": "backward", "channel": ["a", "b"]}
+
+
+def test_raw_ingest_route_allows_provider_query_parameters() -> None:
+    response = _client().post("/v1/triggers/ingest/secret?provider_retry=1")
+    assert response.status_code == 200

--- a/tests/unit/test_strict_query_params.py
+++ b/tests/unit/test_strict_query_params.py
@@ -13,11 +13,11 @@ def _client() -> TestClient:
     async def items(
         direction: Annotated[str, Query(alias="dir")] = "forward",
         channel: Annotated[list[str] | None, Query()] = None,
-    ) -> dict:
+    ) -> dict[str, object]:
         return {"direction": direction, "channel": channel}
 
     @app.post("/v1/triggers/ingest/{token}")
-    async def ingest(token: str, request: Request) -> dict:
+    async def ingest(token: str, request: Request) -> dict[str, str]:
         return {"token": token}
 
     return TestClient(app)


### PR DESCRIPTION
Automated dev-pipeline build for issue #1839.