### PR TITLE
kaizen: delete the deprecated scalar model_token_ratio shim (#1609 migration complete)

### DIFF
--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -471,7 +471,6 @@ from .environments import (  # noqa: E402
     update_environment,
 )
 from .events import (  # noqa: E402
-    _clear_model_token_class_ratios_cache,
     _clear_model_token_ratio_cache,
     _derive_is_error,
     _derive_sender_name,
@@ -502,7 +501,6 @@ from .events import (  # noqa: E402
     list_unresolved_tool_calls_batch,
     lookup_tool_name_by_call_id,
     model_token_class_ratios,
-    model_token_ratio,
     precompute_event_append,
     read_events,
     read_message_events,
@@ -741,7 +739,6 @@ __all__ = [
     "_allocate_version_seq",
     "_archive_scoped",
     "_build_set_assignments",
-    "_clear_model_token_class_ratios_cache",
     "_clear_model_token_ratio_cache",
     "_derive_is_error",
     "_derive_sender_name",
@@ -958,7 +955,6 @@ __all__ = [
     "mark_management_call_resolved",
     "mark_session_cancel_marker_harvested",
     "model_token_class_ratios",
-    "model_token_ratio",
     "notify_connection_change",
     "notify_management_call_dispatch",
     "notify_management_call_result",

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -259,12 +259,6 @@ def _clear_model_token_ratio_cache() -> None:
     _model_token_ratio_cache.clear()
 
 
-# Back-compat alias: the package re-exports the per-class names, but keep the
-# old private clearer name working for any in-tree caller / test that imported
-# it directly.
-_clear_model_token_class_ratios_cache = _clear_model_token_ratio_cache
-
-
 def _neutral_class_ratios() -> dict[str, float]:
     """The all-1.0 coefficient dict — reduces the windower to today's
     byte-identical model-neutral behavior (issue #1609 acceptance #5)."""
@@ -610,31 +604,6 @@ def _fit_class_ratios(rows: list[Any]) -> dict[str, float] | None:
         c = max(_MODEL_TOKEN_CLASS_MIN, min(_MODEL_TOKEN_CLASS_MAX, c))
         out[classes[j]] = c
     return out
-
-
-# Back-compat scalar wrapper: a few call sites / tests still want a single
-# blended R.  Re-derive it from the per-class dict against a uniform class
-# mix (every class weighted equally) so the contract is "the average of the
-# fitted coefficients".  Real windowing weights by the actual composition
-# (see ``blended_r_eff``); this uniform default is only for the legacy
-# scalar shape.
-async def model_token_ratio(
-    conn: asyncpg.Connection[Any],
-    model: str,
-    *,
-    account_id: str,
-    k_bucket: float = 2.0,
-) -> float:
-    """Deprecated scalar shim over :func:`model_token_class_ratios`.
-
-    Returns the unweighted mean of the fitted per-class coefficients,
-    clamped to the scalar's historical ``0.5`` lower bound.  Prefer
-    :func:`model_token_class_ratios` + :func:`blended_r_eff`; this exists
-    so legacy scalar call sites keep compiling during the #1609 rollout.
-    """
-    ratios = await model_token_class_ratios(conn, model, account_id=account_id, k_bucket=k_bucket)
-    mean = sum(ratios.values()) / len(ratios)
-    return max(mean, _MODEL_TOKEN_RATIO_MIN)
 
 
 def blended_r_eff(ratios: dict[str, float], local_by_class: dict[str, float]) -> float:
@@ -1309,7 +1278,7 @@ async def append_event(
     counted against the focal read BEFORE the lock, so if a ``switch_channel``
     commits between that pre-read and the lock, the token count MAY reflect
     the pre-switch focal — an acceptable, bounded drift in the same class as
-    the documented vision/tz drifts below (absorbed by ``model_token_ratio``
+    the documented vision/tz drifts below (absorbed by ``model_token_class_ratios``
     calibration).  The STORED ``focal_channel_at_arrival`` is always the
     locked RETURNING value, never the pre-read.
     """
@@ -1474,7 +1443,7 @@ async def append_event(
         # ``model``/``session_id`` and in the default UTC zone, so inlined
         # images undercount by ~55 LiteLLM tokens each and a non-UTC account's
         # envelope is a few tokens narrower than build time.  Both drifts are
-        # bounded and absorbed by ``model_token_ratio`` calibration in
+        # bounded and absorbed by ``model_token_class_ratios`` calibration in
         # :func:`read_windowed_events` (see PR #218); exact matching is
         # impossible anyway, since a later tz/vision change re-renders history.
         # cumulative_messages / cumulative_*_mass extend the SAME append-time
@@ -2419,9 +2388,9 @@ async def read_windowed_events(
     ~18 % low on Sonnet 4.6, ~34 % low on Opus 4.7.  This function
     corrects for that at read time: ``window_min`` / ``window_max`` are
     interpreted as provider tokens, ``total_effective = total_local * R``
-    where ``R = model_token_ratio(model)``, and the drop boundary is
+    where ``R`` is the composition-weighted class ratio, and the drop boundary is
     translated back to local units for the ``cumulative_tokens`` index
-    scan.  When the model has fewer than ``model_token_ratio``'s sample
+    scan.  When the model has fewer than ``model_token_class_ratios``' sample
     threshold, ``R`` is ``1.0`` and the math reduces to the plain
     chunked-snap algorithm.
 
@@ -2442,7 +2411,7 @@ async def read_windowed_events(
     Prefix-cache invariant: the plain chunked-snap algorithm gave a
     *strict* guarantee of byte-identical prompt prefix within a snap
     chunk.  With the ratio correction this remains stable in practice
-    because :func:`model_token_ratio` uses a lifetime aggregate and
+    because :func:`model_token_class_ratios` uses a lifetime aggregate and
     standard-error bucketing, so mature calibrations do not drift on every
     new sample.  Early calibrations are coarse by design and converge as
     the sample count grows.

--- a/src/aios/harness/context.py
+++ b/src/aios/harness/context.py
@@ -620,7 +620,7 @@ def render_user_event(
     the optional vision policy inputs ``model`` / ``session_id``.
     ``build_messages`` threads vision policy through; the append-time
     token counter in ``queries.append_event`` does not (and pays a small
-    under-count per inlined image, absorbed by ``model_token_ratio``
+    under-count per inlined image, absorbed by ``model_token_class_ratios``
     calibration).
 
     Every user message carries a ``received`` envelope field (the absolute

--- a/tests/e2e/test_model_token_ratio_sql.py
+++ b/tests/e2e/test_model_token_ratio_sql.py
@@ -1,4 +1,4 @@
-"""E2E tests for :func:`aios.db.queries.model_token_ratio` against a real
+"""E2E tests for :func:`aios.db.queries.model_token_class_ratios` against a real
 Postgres with migration 0024's partial index applied.
 
 Unlike the mock-based unit tests in ``tests/unit/test_model_token_ratio.py``
@@ -27,6 +27,11 @@ from aios.services import sessions as sessions_service
 from tests.e2e.harness import Harness
 
 
+def _mean_ratio(ratios: dict[str, float]) -> float:
+    """Return the unweighted coefficient mean for uniform compositions."""
+    return sum(ratios.values()) / len(ratios)
+
+
 def _by_class(local_tokens: int) -> dict[str, float]:
     """Spread a model-neutral ``local_tokens`` total evenly across every
     content class, as a stand-in for the ``local_tokens_by_class`` vector that
@@ -37,8 +42,7 @@ def _by_class(local_tokens: int) -> dict[str, float]:
     ``litellm`` calls, so in production the per-class slices each carry their
     own framing overhead and ``sum(by_class.values()) >= local_tokens`` (the
     implementation deliberately does NOT enforce equality). The even spread
-    used here happens to sum back to ``local_tokens`` only so the scalar
-    shim's unweighted mean reproduces ``input/local`` for these SQL-path
+    used here happens to sum back to ``local_tokens`` only so the class-ratio reader's unweighted coefficient mean reproduces ``input/local`` for these SQL-path
     assertions; the per-class ridge fit (#1609) does not depend on that.
     """
     per = local_tokens / len(CONTENT_CLASSES)
@@ -112,7 +116,11 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            assert await queries.model_token_ratio(conn, model, account_id=account_id) == 1.0
+            assert set(
+                (
+                    await queries.model_token_class_ratios(conn, model, account_id=account_id)
+                ).values()
+            ) == {1.0}
 
     async def test_min_samples_returns_mean_ratio(self, harness: Harness) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
@@ -123,8 +131,8 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
-        assert ratio == pytest.approx(1.5, abs=0.005)
+            ratio = await queries.model_token_class_ratios(conn, model, account_id=account_id)
+        assert _mean_ratio(ratio) == pytest.approx(1.5, abs=0.005)
 
     async def test_ignores_cache_breakdown_fields(self, harness: Harness) -> None:
         """LiteLLM normalizes Anthropic's usage to the OpenAI convention:
@@ -149,10 +157,10 @@ class TestModelTokenRatioSQL:
                 cache_creation=40,
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
+            ratio = await queries.model_token_class_ratios(conn, model, account_id=account_id)
         # per-span ratio = input_tokens/local_tokens = 150/100 (cache_* ignored).
         # ratio = 150/100 = 1.5.
-        assert ratio == pytest.approx(1.5, abs=0.005)
+        assert _mean_ratio(ratio) == pytest.approx(1.5, abs=0.005)
 
     async def test_excludes_error_spans(self, harness: Harness) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
@@ -165,8 +173,8 @@ class TestModelTokenRatioSQL:
         for _ in range(30):
             await _seed_error_span(harness, session.id)
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
-        assert ratio == pytest.approx(1.5, abs=0.005)
+            ratio = await queries.model_token_class_ratios(conn, model, account_id=account_id)
+        assert _mean_ratio(ratio) == pytest.approx(1.5, abs=0.005)
 
     async def test_partitions_by_model_string(self, harness: Harness) -> None:
         account_id = "acc_test_stub"  # PR 3 scaffolding
@@ -182,10 +190,10 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model_b, local_tokens=100, input_tokens=120
             )
         async with harness._pool.acquire() as conn:
-            ratio_a = await queries.model_token_ratio(conn, model_a, account_id=account_id)
-            ratio_b = await queries.model_token_ratio(conn, model_b, account_id=account_id)
-        assert ratio_a == pytest.approx(1.5, abs=0.005)
-        assert ratio_b == pytest.approx(1.2, abs=0.005)
+            ratio_a = await queries.model_token_class_ratios(conn, model_a, account_id=account_id)
+            ratio_b = await queries.model_token_class_ratios(conn, model_b, account_id=account_id)
+        assert _mean_ratio(ratio_a) == pytest.approx(1.5, abs=0.005)
+        assert _mean_ratio(ratio_b) == pytest.approx(1.2, abs=0.005)
 
     async def test_cross_session_aggregation(self, harness: Harness) -> None:
         """Ratio pools spans across every session in the DB for a given
@@ -204,8 +212,8 @@ class TestModelTokenRatioSQL:
                 harness, session_b.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
-        assert ratio == pytest.approx(1.5, abs=0.005)
+            ratio = await queries.model_token_class_ratios(conn, model, account_id=account_id)
+        assert _mean_ratio(ratio) == pytest.approx(1.5, abs=0.005)
 
     async def test_ridge_fit_is_magnitude_weighted(self, harness: Harness) -> None:
         """The per-class ridge fit (#1609) is a least-squares regression of
@@ -228,15 +236,15 @@ class TestModelTokenRatioSQL:
         )
 
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(
+            ratio = await queries.model_token_class_ratios(
                 conn, model, k_bucket=0.001, account_id=account_id
             )
 
         # The 10k-local span (ratio 2.0) swamps the four 100-local spans
         # (ratio 1.0) in the least-squares fit, so the coefficient — and
-        # hence the scalar shim's mean — sits at ~2.0, NOT the old
+        # hence the coefficients' mean — sits at ~2.0, NOT the old
         # unweighted 1.2.
-        assert ratio == pytest.approx(2.0, abs=0.01)
+        assert _mean_ratio(ratio) == pytest.approx(2.0, abs=0.01)
 
     async def test_lifetime_aggregate_retains_old_samples(self, harness: Harness) -> None:
         """Below the sample limit, all historical calibration samples for the
@@ -259,9 +267,10 @@ class TestModelTokenRatioSQL:
         async with harness._pool.acquire() as conn:
             # Use a narrow bucket here to isolate lifetime aggregation:
             # mean_ratio = mean([2.0] * 30 + [1.5] * 30) = 1.75.
-            assert await queries.model_token_ratio(
+            ratios = await queries.model_token_class_ratios(
                 conn, model, k_bucket=0.001, account_id=account_id
-            ) == pytest.approx(1.75)
+            )
+            assert _mean_ratio(ratios) == pytest.approx(1.75)
 
     async def test_bucket_shrinks_as_sample_count_grows(self, harness: Harness) -> None:
         """With the same underlying ratio distribution, standard-error
@@ -274,7 +283,9 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model, local_tokens=100, input_tokens=input_tokens
             )
         async with harness._pool.acquire() as conn:
-            coarse_ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
+            coarse_ratio = await queries.model_token_class_ratios(
+                conn, model, account_id=account_id
+            )
 
         for _ in range(3):
             await _seed_valid_span(
@@ -286,9 +297,11 @@ class TestModelTokenRatioSQL:
 
         queries._clear_model_token_ratio_cache()
         async with harness._pool.acquire() as conn:
-            tighter_ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
+            tighter_ratio = await queries.model_token_class_ratios(
+                conn, model, account_id=account_id
+            )
 
-        assert abs(tighter_ratio - 1.5) < abs(coarse_ratio - 1.5)
+        assert abs(_mean_ratio(tighter_ratio) - 1.5) < abs(_mean_ratio(coarse_ratio) - 1.5)
 
     async def test_zero_local_tokens_excluded(self, harness: Harness) -> None:
         """The WHERE clause filters ``(data->>'local_tokens')::bigint > 0``
@@ -308,8 +321,8 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
-        assert ratio == pytest.approx(1.5, abs=0.005)
+            ratio = await queries.model_token_class_ratios(conn, model, account_id=account_id)
+        assert _mean_ratio(ratio) == pytest.approx(1.5, abs=0.005)
 
     async def test_zero_input_usage_and_decimal_values_are_excluded(self, harness: Harness) -> None:
         """Real-Postgres discriminator: zero usage is poison, while a future
@@ -334,8 +347,8 @@ class TestModelTokenRatioSQL:
             input_tokens=150.5,  # type: ignore[arg-type]
         )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(conn, model, account_id=account_id)
-        assert ratio == pytest.approx(1.5, abs=0.01)
+            ratio = await queries.model_token_class_ratios(conn, model, account_id=account_id)
+        assert _mean_ratio(ratio) == pytest.approx(1.5, abs=0.01)
 
     async def test_recency_bound_honors_recent_spans(self, harness: Harness) -> None:
         """Recency honored (issue #1711): seed MORE than the sample limit,
@@ -357,12 +370,12 @@ class TestModelTokenRatioSQL:
                 harness, session.id, model=model, local_tokens=100, input_tokens=150
             )
         async with harness._pool.acquire() as conn:
-            ratio = await queries.model_token_ratio(
+            ratio = await queries.model_token_class_ratios(
                 conn, model, k_bucket=0.001, account_id=account_id
             )
         # Only the recent (1.5) spans are in-window; the 4.0 tail is excluded
         # by the LIMIT, so the fit lands at the recent regime, not a blend.
-        assert ratio == pytest.approx(1.5, abs=0.02)
+        assert _mean_ratio(ratio) == pytest.approx(1.5, abs=0.02)
 
     async def test_recency_fetch_is_a_bounded_index_scan(self, harness: Harness) -> None:
         """Perf guard (issue #1711 / #1798): the ``ORDER BY created_at DESC,

--- a/tests/unit/test_model_token_ratio.py
+++ b/tests/unit/test_model_token_ratio.py
@@ -3,9 +3,7 @@
 ``model_token_class_ratios`` generalizes the old single lifetime scalar
 ``R`` into a ridge-fit coefficient dict over
 :data:`aios.harness.tokens.CONTENT_CLASSES`; ``blended_r_eff`` collapses
-that dict to the one composition-weighted number the windower consumes;
-``model_token_ratio`` survives as a deprecated scalar shim (unweighted
-mean of the coefficients) for legacy call sites.
+that dict to the one composition-weighted number the windower consumes.
 
 The SQL itself — partial-index coverage, JSON extraction, is_error
 filter, model-string partitioning — is exercised against a real Postgres
@@ -26,7 +24,6 @@ from aios.db.queries import (
     _clear_model_token_ratio_cache,
     blended_r_eff,
     model_token_class_ratios,
-    model_token_ratio,
 )
 from aios.db.queries.events import _MODEL_TOKEN_RATIO_SAMPLE_LIMIT, _fit_class_ratios
 from aios.harness.tokens import CONTENT_CLASSES
@@ -375,31 +372,3 @@ class TestBlendedREff:
         light = {"text": 900.0, "thinking": 100.0}
         heavy = {"text": 100.0, "thinking": 900.0}
         assert blended_r_eff(coefs, heavy) > blended_r_eff(coefs, light)
-
-
-class TestScalarShim:
-    @pytest.mark.asyncio
-    async def test_shim_returns_mean_of_coefficients(self) -> None:
-        true = {"text": 2.0, "tool_result": 1.4, "thinking": 3.0}
-        conn = _mock_conn(_linear_rows(true, n=40))
-        ratios = await model_token_class_ratios(conn, "model-x", account_id="acc_test_stub")
-        _clear_model_token_ratio_cache()
-        conn2 = _mock_conn(_linear_rows(true, n=40))
-        scalar = await model_token_ratio(conn2, "model-x", account_id="acc_test_stub")
-        expected = sum(ratios.values()) / len(ratios)
-        assert scalar == pytest.approx(max(expected, 0.5))
-
-    @pytest.mark.asyncio
-    async def test_shim_neutral_below_threshold(self) -> None:
-        conn = _mock_conn(_linear_rows({"text": 2.0, "tool_result": 1.4, "thinking": 3.0}, n=3))
-        # All-neutral coefs ⇒ mean 1.0 (above the 0.5 clamp).
-        assert await model_token_ratio(
-            conn, "model-x", account_id="acc_test_stub"
-        ) == pytest.approx(1.0)
-
-    @pytest.mark.asyncio
-    async def test_shim_min_clamp(self) -> None:
-        # Coefs fit near zero ⇒ mean below 0.5 ⇒ clamped up to the historical
-        # scalar floor (a degenerate, near-empty-prompt relationship).
-        conn = _mock_conn(_linear_rows({"text": 0.01, "tool_result": 0.01, "thinking": 0.01}, n=20))
-        assert await model_token_ratio(conn, "model-x", account_id="acc_test_stub") >= 0.5

--- a/tests/unit/test_queries_package_split.py
+++ b/tests/unit/test_queries_package_split.py
@@ -78,7 +78,6 @@ def test_underscore_and_nonfunc_names_reexported() -> None:
         "_derive_is_error",
         "_derive_sender_name",
         "_clear_model_token_ratio_cache",
-        "model_token_ratio",
         "reparent_connection",
         "get_session_bare",
         "get_session_vault_ids",
@@ -121,7 +120,7 @@ def test_internal_callers_route_patched_fns_through_package() -> None:
     # retained-window range scan calls ``read_windowed_context_events`` bare on
     # purpose, so the fallback stub does not intercept it — that bare call is not
     # asserted here.)  Since #1609 the per-content-class calibration replaced the
-    # legacy scalar ``model_token_ratio``; the windowing path now routes through
+    # removed scalar reader; the windowing path now routes through
     # ``model_token_class_ratios`` (which the windowed-ratio tests patch).
     windowed_src = inspect.getsource(events.read_windowed_events)
     assert "queries.read_windowed_context_events(" in windowed_src

--- a/tests/unit/test_windowed_ratio.py
+++ b/tests/unit/test_windowed_ratio.py
@@ -161,7 +161,7 @@ async def test_no_cumulative_falls_back_to_full_read() -> None:
 async def test_insufficient_ratio_1_matches_today() -> None:
     """Load-bearing backward-compatibility fence.  Do not delete.
 
-    While model_token_ratio has too few samples (or on a model the
+    While calibration has too few samples (or on a model the
     DB has never seen), it returns 1.0 and ``read_windowed_events`` must behave
     byte-identically to the pre-ratio chunked-snap algorithm — otherwise
     the "gradual rollout" rollout property breaks.  This test pins that.


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1868.