### PR TITLE
kaizen: delete dead config sandbox_pipeline_max_seconds (silent no-op operator footgun)

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -203,11 +203,6 @@ class Settings(BaseSettings):
         gt=0,
         description="Maximum interval without bytes moving through a Docker flatten pipeline.",
     )
-    sandbox_pipeline_max_seconds: float = Field(
-        default=3600.0,
-        gt=0,
-        description="Absolute backstop for a Docker flatten pipeline.",
-    )
     sandbox_inspect_size_timeout_seconds: float = Field(
         default=300.0,
         gt=0,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,6 +12,12 @@ from pathlib import Path
 import pytest
 
 
+def test_dead_pipeline_max_setting_is_not_exposed() -> None:
+    from aios.config import Settings
+
+    assert "sandbox_pipeline_max_seconds" not in Settings.model_fields
+
+
 def test_workspace_root_must_be_absolute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``AIOS_WORKSPACE_ROOT=./relative`` fails fast at process load.
 


### PR DESCRIPTION
Automated dev-pipeline build for issue #1869.