### PR TITLE
refactor(tools): tavily_request leaks raw httpx so web_fetch + web_search each re-implement the identical httpx→ToolBail (#1697 no-evict) ladder — pull the error contract down into the shared client

### DIFF
--- a/src/aios/tools/tavily.py
+++ b/src/aios/tools/tavily.py
@@ -8,6 +8,7 @@ import httpx
 
 from aios.config import get_settings
 from aios.errors import AiosError
+from aios.tools.invoke import ToolBail
 
 
 class WebToolError(AiosError):
@@ -23,12 +24,21 @@ async def tavily_request(endpoint: str, payload: dict[str, Any]) -> dict[str, An
     if not api_key:
         raise WebToolError("TAVILY_API_KEY not set. Get a free key at https://app.tavily.com")
     payload["api_key"] = api_key
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            f"https://api.tavily.com/{endpoint.lstrip('/')}",
-            json=payload,
-            timeout=60,
-        )
-        resp.raise_for_status()
-        result: dict[str, Any] = resp.json()
-        return result
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"https://api.tavily.com/{endpoint.lstrip('/')}",
+                json=payload,
+                timeout=60,
+            )
+            resp.raise_for_status()
+            result: dict[str, Any] = resp.json()
+            return result
+    except httpx.HTTPStatusError as exc:
+        raise ToolBail(f"HTTP {exc.response.status_code}: {exc.response.text[:200]}") from exc
+    except httpx.TimeoutException as exc:
+        raise ToolBail(f"Tavily {endpoint} request timed out") from exc
+    except httpx.HTTPError as exc:
+        raise ToolBail(
+            f"HTTP transport error during Tavily {endpoint}: {type(exc).__name__}: {exc}"
+        ) from exc

--- a/src/aios/tools/web_fetch.py
+++ b/src/aios/tools/web_fetch.py
@@ -28,12 +28,10 @@ import asyncio
 import re
 from typing import Any
 
-import httpx
-
 from aios.errors import AiosError
 from aios.tools.invoke import ToolBail
 from aios.tools.registry import registry
-from aios.tools.tavily import WebToolError, tavily_request
+from aios.tools.tavily import tavily_request
 from aios.tools.url_safety import is_safe_url
 
 
@@ -105,26 +103,6 @@ async def web_fetch_handler(session_id: str, arguments: dict[str, Any]) -> dict[
         if len(raw) > _MAX_CONTENT_CHARS:
             out["truncated"] = True
         return out
-    except WebToolError:
-        # Already a client-class AiosError (status 400): re-raise so the single
-        # writer classifies it as a clean refusal, not a sandbox-evicting failure.
-        raise
-    except httpx.HTTPStatusError as exc:
-        # A non-2xx from Tavily/upstream is an EXPECTED failure the model reads and
-        # retries — raise ToolBail (a benign refusal), NOT the raw httpx error, which
-        # _classify_tool_error would treat as an internal failure and evict the sandbox.
-        raise ToolBail(f"HTTP {exc.response.status_code}: {exc.response.text[:200]}") from exc
-    except httpx.TimeoutException as exc:
-        raise ToolBail("Request timed out fetching URL") from exc
-    except httpx.HTTPError as exc:
-        # The broader transport-error family — ConnectError / ReadError /
-        # RemoteProtocolError / PoolTimeout — is an EXPECTED benign network blip,
-        # not an internal fault. Catch it as broadly as ``http_request`` does
-        # (``httpx.HTTPError`` is the base of every httpx transport/protocol error)
-        # so a transient Tavily/upstream connection fault becomes a ToolBail the
-        # model reads, NOT a raw httpx error that _classify_tool_error would treat
-        # as internal → evict the sandbox on a benign failure (aios#1697).
-        raise ToolBail(f"HTTP transport error fetching URL: {type(exc).__name__}: {exc}") from exc
     except (KeyError, IndexError) as exc:
         raise ToolBail("No content returned for URL") from exc
 

--- a/src/aios/tools/web_search.py
+++ b/src/aios/tools/web_search.py
@@ -19,12 +19,10 @@ from __future__ import annotations
 
 from typing import Any
 
-import httpx
-
 from aios.errors import AiosError
 from aios.tools.invoke import ToolBail
 from aios.tools.registry import registry
-from aios.tools.tavily import WebToolError, tavily_request
+from aios.tools.tavily import tavily_request
 
 _DEFAULT_LIMIT = 5
 _MAX_LIMIT = 20
@@ -84,25 +82,6 @@ async def web_search_handler(session_id: str, arguments: dict[str, Any]) -> dict
             for r in response["results"]
         ]
         return {"results": normalized}
-    except WebToolError:
-        # Already a client-class AiosError (status 400): re-raise so the single
-        # writer classifies it as a clean refusal, not a sandbox-evicting failure.
-        raise
-    except httpx.HTTPStatusError as exc:
-        # An EXPECTED non-2xx — raise ToolBail (benign refusal), NOT the raw httpx
-        # error, which _classify_tool_error would treat as internal + evict the sandbox.
-        raise ToolBail(f"HTTP {exc.response.status_code}: {exc.response.text[:200]}") from exc
-    except httpx.TimeoutException as exc:
-        raise ToolBail("Search request timed out") from exc
-    except httpx.HTTPError as exc:
-        # The broader transport-error family — ConnectError / ReadError /
-        # RemoteProtocolError / PoolTimeout — is an EXPECTED benign network blip,
-        # not an internal fault. Catch it as broadly as ``http_request`` does
-        # (``httpx.HTTPError`` is the base of every httpx transport/protocol error)
-        # so a transient Tavily/upstream connection fault becomes a ToolBail the
-        # model reads, NOT a raw httpx error that _classify_tool_error would treat
-        # as internal → evict the sandbox on a benign failure (aios#1697).
-        raise ToolBail(f"HTTP transport error during search: {type(exc).__name__}: {exc}") from exc
     except (KeyError, IndexError) as exc:
         # A 200 response missing the 'results' key — surface a legible tool
         # error instead of letting the KeyError escape and evict the sandbox.

--- a/tests/unit/test_tavily.py
+++ b/tests/unit/test_tavily.py
@@ -1,0 +1,48 @@
+"""Unit tests for the shared Tavily client."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from aios.tools.invoke import ToolBail
+from aios.tools.tavily import tavily_request
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("connection refused"),
+        httpx.TimeoutException("timed out"),
+    ],
+)
+async def test_transport_faults_are_tool_bails(exc: httpx.HTTPError) -> None:
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    client.post.side_effect = exc
+    settings = MagicMock(tavily_api_key="key")
+    with (
+        patch("aios.tools.tavily.get_settings", return_value=settings),
+        patch("aios.tools.tavily.httpx.AsyncClient", return_value=client),
+        pytest.raises(ToolBail) as raised,
+    ):
+        await tavily_request("search", {"query": "x"})
+    assert "search" in raised.value.message
+
+
+async def test_http_status_is_a_tool_bail() -> None:
+    request = httpx.Request("POST", "https://api.tavily.com/extract")
+    response = httpx.Response(503, text="upstream down", request=request)
+    client = AsyncMock()
+    client.__aenter__.return_value = client
+    client.post.return_value = response
+    settings = MagicMock(tavily_api_key="key")
+    with (
+        patch("aios.tools.tavily.get_settings", return_value=settings),
+        patch("aios.tools.tavily.httpx.AsyncClient", return_value=client),
+        pytest.raises(ToolBail) as raised,
+    ):
+        await tavily_request("extract", {"urls": ["https://example.com"]})
+    assert "503" in raised.value.message

--- a/tests/unit/test_web_fetch_handler.py
+++ b/tests/unit/test_web_fetch_handler.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
 
 from aios.tools.invoke import ToolBail
@@ -126,39 +125,3 @@ class TestWebFetchHandler:
         result = await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
         assert result["content"] == ""
         assert result["title"] == ""
-
-    @pytest.mark.parametrize(
-        "exc",
-        [
-            httpx.ConnectError("connection refused"),
-            httpx.ReadError("read failed"),
-            httpx.RemoteProtocolError("protocol error"),
-            httpx.PoolTimeout("pool exhausted"),
-            httpx.TimeoutException("timed out"),
-        ],
-    )
-    async def test_transport_faults_raise_toolbail_not_raw_httpx(
-        self, mock_tavily: AsyncMock, mock_safe_url: Any, exc: httpx.HTTPError
-    ) -> None:
-        """A benign upstream transport blip (ConnectError/ReadError/… — the whole
-        ``httpx.TransportError`` family, plus timeouts) must convert to ``ToolBail``,
-        NOT propagate raw. A raw httpx error reaches ``_classify_tool_error`` →
-        ``evict=True`` → the sandbox is torn down on a transient network failure
-        (aios#1697). Mirrors ``http_request``'s broad ``httpx.HTTPError`` catch."""
-        mock_tavily.side_effect = exc
-        with pytest.raises(ToolBail):
-            await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
-
-    async def test_http_status_error_raises_toolbail(
-        self, mock_tavily: AsyncMock, mock_safe_url: Any
-    ) -> None:
-        """A non-2xx from Tavily/upstream is an expected failure → ``ToolBail``
-        carrying the status, never the raw httpx error (which would evict)."""
-        request = httpx.Request("GET", "https://example.com")
-        response = httpx.Response(503, text="upstream down", request=request)
-        mock_tavily.side_effect = httpx.HTTPStatusError(
-            "server error", request=request, response=response
-        )
-        with pytest.raises(ToolBail) as excinfo:
-            await web_fetch_handler("sess_01TEST", {"url": "https://example.com"})
-        assert "503" in excinfo.value.message

--- a/tests/unit/test_web_search_handler.py
+++ b/tests/unit/test_web_search_handler.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
-import httpx
 import pytest
 
 from aios.tools.invoke import ToolBail
@@ -91,37 +90,3 @@ class TestWebSearchHandler:
         mock_tavily.return_value = {}
         with pytest.raises(ToolBail):
             await web_search_handler("sess_01TEST", {"query": "x"})
-
-    @pytest.mark.parametrize(
-        "exc",
-        [
-            httpx.ConnectError("connection refused"),
-            httpx.ReadError("read failed"),
-            httpx.RemoteProtocolError("protocol error"),
-            httpx.PoolTimeout("pool exhausted"),
-            httpx.TimeoutException("timed out"),
-        ],
-    )
-    async def test_transport_faults_raise_toolbail_not_raw_httpx(
-        self, mock_tavily: AsyncMock, exc: httpx.HTTPError
-    ) -> None:
-        """A benign upstream transport blip (ConnectError/ReadError/… — the whole
-        ``httpx.TransportError`` family, plus timeouts) must convert to ``ToolBail``,
-        NOT propagate raw. A raw httpx error reaches ``_classify_tool_error`` →
-        ``evict=True`` → the sandbox is torn down on a transient network failure
-        (aios#1697). Mirrors ``http_request``'s broad ``httpx.HTTPError`` catch."""
-        mock_tavily.side_effect = exc
-        with pytest.raises(ToolBail):
-            await web_search_handler("sess_01TEST", {"query": "x"})
-
-    async def test_http_status_error_raises_toolbail(self, mock_tavily: AsyncMock) -> None:
-        """A non-2xx from Tavily/upstream is an expected failure → ``ToolBail``
-        carrying the status, never the raw httpx error (which would evict)."""
-        request = httpx.Request("GET", "https://example.com")
-        response = httpx.Response(503, text="upstream down", request=request)
-        mock_tavily.side_effect = httpx.HTTPStatusError(
-            "server error", request=request, response=response
-        )
-        with pytest.raises(ToolBail) as excinfo:
-            await web_search_handler("sess_01TEST", {"query": "x"})
-        assert "503" in excinfo.value.message


### PR DESCRIPTION
Automated dev-pipeline build for issue #1866.