### PR TITLE
kaizen: de-duplicate get_session_github_repo via delegation to the with-blob variant

### DIFF
--- a/src/aios/db/queries/memory_stores.py
+++ b/src/aios/db/queries/memory_stores.py
@@ -991,19 +991,10 @@ async def get_session_github_repo(
     *,
     account_id: str,
 ) -> GithubRepositoryResourceEcho:
-    row = await conn.fetchrow(
-        "SELECT * FROM session_github_repositories "
-        "WHERE session_id = $1 AND id = $2 AND account_id = $3",
-        session_id,
-        resource_id,
-        account_id,
+    echo, _ = await get_session_github_repo_with_blob(
+        conn, session_id, resource_id, account_id=account_id
     )
-    if row is None:
-        raise NotFoundError(
-            f"github_repository resource {resource_id} not found on session {session_id}",
-            detail={"session_id": session_id, "resource_id": resource_id},
-        )
-    return _row_to_github_repo_echo(row)
+    return echo
 
 
 async def get_session_github_repo_with_blob(

--- a/tests/unit/test_memory_store_queries.py
+++ b/tests/unit/test_memory_store_queries.py
@@ -1,0 +1,26 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aios.db.queries import memory_stores
+from aios.models.github_repositories import GithubRepositoryResourceEcho
+
+
+@pytest.mark.asyncio
+async def test_get_session_github_repo_delegates_to_with_blob(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    echo = AsyncMock(spec=GithubRepositoryResourceEcho)
+    get_with_blob = AsyncMock(return_value=(echo, AsyncMock()))
+    monkeypatch.setattr(memory_stores, "get_session_github_repo_with_blob", get_with_blob)
+    conn = AsyncMock()
+
+    result = await memory_stores.get_session_github_repo(
+        conn, "session-id", "resource-id", account_id="account-id"
+    )
+
+    assert result is echo
+    get_with_blob.assert_awaited_once_with(
+        conn, "session-id", "resource-id", account_id="account-id"
+    )
+    conn.fetchrow.assert_not_awaited()


### PR DESCRIPTION
Automated dev-pipeline build for issue #1872.