### PR TITLE
fix(harness): remove no_reaction special-casing — every tool result is a stimulus

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ A connection binds one platform account to a routing target — a single long-li
 | POST | `/v1/connections/{id}/reparent` | Atomically move a connection (id-preserving) to another account. |
 | POST | `/v1/connectors/runtime/inbound` | Connector posts an inbound user message (multipart; idempotent on `event_id`). |
 | GET | `/v1/connectors/runtime/calls` | SSE of pending custom tool calls for the connector type. |
-| POST | `/v1/connectors/runtime/tool-results` | Submit an outbound tool result (carries `no_reaction` for fire-and-forget). |
+| POST | `/v1/connectors/runtime/tool-results` | Submit an outbound tool result (always a stimulus — the session wakes to react). |
 | GET | `/v1/connectors/runtime/secrets` | The only decryption path for a connection's secrets. |
 | PUT | `/v1/connectors/{connector}/tools_schema` \| `/capabilities` | Connector publishes its derived tool catalog / typed capability descriptor (root-only). |
 | POST | `/v1/connectors/signal/register\|verify\|profile` | Operator-facing Signal provisioning. |

--- a/connectors/signal/tests/test_signal_send.py
+++ b/connectors/signal/tests/test_signal_send.py
@@ -151,12 +151,11 @@ async def test_signal_send_dispatch_resolves_sandbox_path(
 
     sent_params = connector._daemon.rpc.call.call_args.args[1]  # type: ignore[union-attr]
     assert sent_params["attachments"] == [str(ws / "cat.jpg")]
-    # ``signal_send`` is fire-and-forget: a successful dispatch flags
-    # ``no_reaction`` so the delivery ack doesn't wake the session. The
-    # success path leaves ``is_error`` at its default (not passed), so only
-    # ``no_reaction`` is asserted here.
+    # ``signal_send`` posts its delivery ack like any other result (#1919):
+    # there is no ``no_reaction`` suppression flag on the wire, and the success
+    # path leaves ``is_error`` at its default (not passed).
     assert len(captured) == 1
-    assert captured[0]["no_reaction"] is True
+    assert "no_reaction" not in captured[0]
 
 
 async def test_signal_send_dispatch_traversal_returns_error_result(
@@ -181,7 +180,6 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
         tool_call_id: str,
         content: Any,
         is_error: bool = False,
-        no_reaction: bool = False,
     ) -> None:
         del client
         captured.append(
@@ -191,7 +189,6 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
                 "tool_call_id": tool_call_id,
                 "content": content,
                 "is_error": is_error,
-                "no_reaction": no_reaction,
             }
         )
 
@@ -212,9 +209,6 @@ async def test_signal_send_dispatch_traversal_returns_error_result(
     connector._daemon.rpc.call.assert_not_awaited()  # type: ignore[union-attr]
     assert len(captured) == 1
     assert captured[0]["is_error"] is True
-    # A FAILED fire-and-forget send must still wake — the error branch never
-    # sets ``no_reaction`` (it AND-gates with ``not is_error`` at the intake).
-    assert captured[0]["no_reaction"] is False
 
 
 # ── quote / reply ─────────────────────────────────────────────────────

--- a/openapi.json
+++ b/openapi.json
@@ -15820,11 +15820,6 @@
             "type": "boolean",
             "title": "Is Error",
             "default": false
-          },
-          "no_reaction": {
-            "type": "boolean",
-            "title": "No Reaction",
-            "default": false
           }
         },
         "type": "object",

--- a/packages/aios-connector-http/aios_connector_http/runner.py
+++ b/packages/aios-connector-http/aios_connector_http/runner.py
@@ -154,21 +154,15 @@ def tool(
     at startup via ``PUT /v1/connectors/{connector}/tools_schema``;
     individual connections inherit it from the type catalog.
 
-    ``fire_and_forget`` declares the tool's result a *delivery
-    confirmation* the model has nothing to react to — a message send or
-    reaction whose only output is a ``{"sent_at_ms": N}`` ack.  A
-    *successful* result for such a tool is POSTed with ``no_reaction=true``
-    so aios appends it to the log (the model still sees it) but does NOT
-    wake the session to react to its own send (the duplicate-send loop).
-    A *failed* result always wakes regardless — the runner only sets
-    ``no_reaction`` on the post-success path.  Leave it ``False`` for
-    list/create/get/edit/delete tools whose results carry data the model
-    must consume — and, crucially, for any *precursor* action the model
-    calls before doing more work, such as a "typing…"/presence indicator.
-    Its result is benign, but it is the only thing that would wake the
-    follow-up step; suppressing it strands a typing-only turn idle, never
-    sending (#1121).  Rule of thumb: fire-and-forget iff the turn is *over*
-    after this tool — not merely "the result is uninteresting."
+    ``fire_and_forget`` declares the tool a *delivery* action — a message
+    send or reaction whose only output is a ``{"sent_at_ms": N}`` ack.  It
+    types a mid-dispatch failure as ``delivery_failed`` (#1722) so the model
+    can tell "my send attempt itself errored" from an ordinary tool
+    exception.  It no longer affects the wake decision: every tool result —
+    including a delivery ack — is a stimulus the session wakes to react to,
+    so the standard agentic loop (tool call → result → continue) holds for
+    connector sends too (#1919).  Leave it ``False`` for ordinary
+    list/create/get/edit/delete tools.
     """
 
     def _wrap(f: ToolFn) -> ToolFn:
@@ -1375,10 +1369,9 @@ class HttpConnector:
                 # (or was about to believe) the message was on its way. Typed
                 # ``delivery_failed`` so the model can distinguish "my send
                 # attempt itself errored" from an ordinary tool exception and
-                # decide whether to retry or re-target — it is NEVER silently
-                # dropped: this exception branch always sets ``is_error=True``
-                # below, and fire-and-forget's ``no_reaction`` suppression only
-                # ever applies to the SUCCESS path (see the completion branch).
+                # decide whether to retry or re-target — this exception branch
+                # always sets ``is_error=True`` below, so a failed send is a
+                # clear, typed result the session wakes to react to.
                 error_payload = {"error": str(exc), "code": "delivery_failed"}
                 reason = "delivery_failed"
             else:
@@ -1410,18 +1403,15 @@ class HttpConnector:
         # POSTed in its native list shape below.
         serialized_result = result if isinstance(result, str) else json.dumps(result)
         await self._mark_answered(tool_call_id, serialized_result)
-        # Post-success path only: a fire-and-forget tool's successful result
-        # is a delivery ack the model has nothing to react to, so flag it
-        # ``no_reaction`` to keep aios from waking the session to react to its
-        # own send (the duplicate-send loop).  The error branches above NEVER
-        # set this — a failed send always wakes.
+        # Every tool result is a stimulus (#1919): POST the successful result and
+        # let aios wake the session to react to the completion — including a bare
+        # delivery ack, which the model may simply acknowledge and end the turn.
         await self._post_tool_result(
             client,
             connection_id=connection_id,
             session_id=session_id,
             tool_call_id=tool_call_id,
             content=result,
-            no_reaction=meta.fire_and_forget,
         )
         log.info(
             "connector.tool_call.completed",
@@ -1588,14 +1578,8 @@ class HttpConnector:
         tool_call_id: str,
         content: str | list[dict[str, Any]],
         is_error: bool = False,
-        no_reaction: bool = False,
     ) -> None:
-        """POST one tool result via the generated runtime op.
-
-        ``no_reaction`` marks a successful fire-and-forget result so the
-        intake appends it without waking the session to react.  Only the
-        post-success caller sets it; the error callers leave it False.
-        """
+        """POST one tool result via the generated runtime op."""
         # The generated model's list branch is typed as
         # ``list[RuntimeToolResultRequestContentType1Item]``; that item type is
         # a thin ``additional_properties`` bag whose ``from_dict``/``to_dict``
@@ -1612,7 +1596,6 @@ class HttpConnector:
             tool_call_id=tool_call_id,
             content=body_content,
             is_error=is_error,
-            no_reaction=no_reaction,
         )
         response = await _post_runtime_tool_result(client=client, body=body)
         if response.status_code >= 400:

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -206,9 +206,7 @@ class TestFireAndForget:
         assert probe._tools["shout"].fire_and_forget is False
         assert probe._tools["say_struct"].fire_and_forget is False
 
-    async def test_successful_fire_and_forget_posts_result(
-        self, probe: _ProbeConnector
-    ) -> None:
+    async def test_successful_fire_and_forget_posts_result(self, probe: _ProbeConnector) -> None:
         # #1919: the delivery ack is posted like any other result — no
         # wake-suppression flag on the wire; the session wakes to react.
         await probe.dispatch_call(
@@ -1142,6 +1140,7 @@ class TestPostToolResultSerialization:
         )
         assert len(captured) == 1
         assert captured[0]["content"] == "hello"
+
 
 class TestWaitConnectionServed:
     async def test_times_out_if_connection_never_added(self) -> None:

--- a/packages/aios-connector-http/tests/test_runner.py
+++ b/packages/aios-connector-http/tests/test_runner.py
@@ -95,7 +95,6 @@ class _ProbeConnector(HttpConnector):
         tool_call_id: str,
         content: str | list[dict[str, Any]],
         is_error: bool = False,
-        no_reaction: bool = False,
     ) -> None:
         del client
         self.results.append(
@@ -105,7 +104,6 @@ class _ProbeConnector(HttpConnector):
                 tool_call_id=tool_call_id,
                 content=content,
                 is_error=is_error,
-                no_reaction=no_reaction,
             )
         )
 
@@ -195,7 +193,10 @@ class TestDispatch:
 
 
 class TestFireAndForget:
-    """``@tool(fire_and_forget=True)`` → ``no_reaction`` on the SUCCESS POST."""
+    """``@tool(fire_and_forget=True)`` marks a delivery action. Its result is
+    posted like any other — every tool result is a stimulus (#1919), so there
+    is no wake-suppression flag on the wire. The flag only types a mid-dispatch
+    failure as ``delivery_failed`` (see ``TestFireAndForgetDeliveryFailure``)."""
 
     async def test_meta_records_fire_and_forget(self, probe: _ProbeConnector) -> None:
         # The decorator freezes the flag onto the per-tool meta; a plain
@@ -205,9 +206,11 @@ class TestFireAndForget:
         assert probe._tools["shout"].fire_and_forget is False
         assert probe._tools["say_struct"].fire_and_forget is False
 
-    async def test_successful_fire_and_forget_sets_no_reaction(
+    async def test_successful_fire_and_forget_posts_result(
         self, probe: _ProbeConnector
     ) -> None:
+        # #1919: the delivery ack is posted like any other result — no
+        # wake-suppression flag on the wire; the session wakes to react.
         await probe.dispatch_call(
             {
                 "connection_id": "conn_1",
@@ -219,43 +222,9 @@ class TestFireAndForget:
         )
         r = probe.results[0]
         assert r.kwargs["is_error"] is False
-        assert r.kwargs["no_reaction"] is True
-        # The result content (the delivery ack) is still posted — the model sees it.
+        assert "no_reaction" not in r.kwargs
+        # The result content (the delivery ack) is posted — the model sees it.
         assert json.loads(r.kwargs["content"]) == {"sent_at_ms": 123}
-
-    async def test_failed_fire_and_forget_does_not_set_no_reaction(
-        self, probe: _ProbeConnector
-    ) -> None:
-        # A failure goes through the error branch, which never passes
-        # ``no_reaction`` — so a failed send still wakes.
-        await probe.dispatch_call(
-            {
-                "connection_id": "conn_1",
-                "tool_call_id": "call_db",
-                "session_id": "sess_db",
-                "name": "deliver_boom",
-                "arguments": "{}",
-            }
-        )
-        r = probe.results[0]
-        assert r.kwargs["is_error"] is True
-        assert r.kwargs["no_reaction"] is False
-
-    async def test_non_fire_and_forget_success_does_not_set_no_reaction(
-        self, probe: _ProbeConnector
-    ) -> None:
-        await probe.dispatch_call(
-            {
-                "connection_id": "conn_1",
-                "tool_call_id": "call_s",
-                "session_id": "sess_s",
-                "name": "shout",
-                "arguments": json.dumps({"text": "hi"}),
-            }
-        )
-        r = probe.results[0]
-        assert r.kwargs["is_error"] is False
-        assert r.kwargs["no_reaction"] is False
 
 
 class TestToolCollection:
@@ -346,7 +315,6 @@ class _IdempotencyConnector(_ProbeConnector):
         tool_call_id: str,
         content: str | list[dict[str, Any]],
         is_error: bool = False,
-        no_reaction: bool = False,
     ) -> None:
         self.post_attempts += 1
         if self.fail_posts > 0:
@@ -359,7 +327,6 @@ class _IdempotencyConnector(_ProbeConnector):
             tool_call_id=tool_call_id,
             content=content,
             is_error=is_error,
-            no_reaction=no_reaction,
         )
 
 
@@ -676,7 +643,7 @@ class TestChannelUnresolved:
 class TestFireAndForgetDeliveryFailure:
     """#1722: a fire-and-forget tool (send/react) whose body raises is a
     connector-side delivery failure — typed ``delivery_failed``, and it
-    always wakes (no_reaction is never set on the error path)."""
+    always wakes (every tool result is a stimulus, #1919)."""
 
     async def test_fire_and_forget_exception_is_typed_delivery_failed(
         self, probe: _ProbeConnector
@@ -692,7 +659,6 @@ class TestFireAndForgetDeliveryFailure:
         )
         r = probe.results[0]
         assert r.kwargs["is_error"] is True
-        assert r.kwargs["no_reaction"] is False
         body = json.loads(r.kwargs["content"])
         assert body["code"] == "delivery_failed"
         assert body["error"] == "delivery failed"
@@ -1176,33 +1142,6 @@ class TestPostToolResultSerialization:
         )
         assert len(captured) == 1
         assert captured[0]["content"] == "hello"
-
-    async def test_no_reaction_serializes_on_the_wire(self) -> None:
-        """``no_reaction=True`` reaches the POST body via the generated model."""
-        client, captured = self._client_capturing_body()
-        await HttpConnector._post_tool_result(
-            client,
-            connection_id="conn_1",
-            session_id="sess_1",
-            tool_call_id="call_1",
-            content="hello",
-            no_reaction=True,
-        )
-        assert len(captured) == 1
-        assert captured[0]["no_reaction"] is True
-
-    async def test_no_reaction_default_false_on_the_wire(self) -> None:
-        client, captured = self._client_capturing_body()
-        await HttpConnector._post_tool_result(
-            client,
-            connection_id="conn_1",
-            session_id="sess_1",
-            tool_call_id="call_1",
-            content="hello",
-        )
-        assert len(captured) == 1
-        assert captured[0]["no_reaction"] is False
-
 
 class TestWaitConnectionServed:
     async def test_times_out_if_connection_never_added(self) -> None:

--- a/packages/aios-connector-http/tests/test_sandbox.py
+++ b/packages/aios-connector-http/tests/test_sandbox.py
@@ -243,7 +243,6 @@ class _PathConsumer(HttpConnector):
         tool_call_id: str,
         content: Any,
         is_error: bool = False,
-        no_reaction: bool = False,
     ) -> None:
         del client
         self.tool_results.append(
@@ -253,7 +252,6 @@ class _PathConsumer(HttpConnector):
                 "tool_call_id": tool_call_id,
                 "content": content,
                 "is_error": is_error,
-                "no_reaction": no_reaction,
             }
         )
 

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
@@ -96,8 +96,10 @@ class RuntimeToolResultRequest:
                 content_type_1 = []
                 _content_type_1 = data
                 for content_type_1_item_data in _content_type_1:
-                    content_type_1_item = RuntimeToolResultRequestContentType1Item.from_dict(
-                        content_type_1_item_data
+                    content_type_1_item = (
+                        RuntimeToolResultRequestContentType1Item.from_dict(
+                            content_type_1_item_data
+                        )
                     )
 
                     content_type_1.append(content_type_1_item)

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
@@ -96,10 +96,8 @@ class RuntimeToolResultRequest:
                 content_type_1 = []
                 _content_type_1 = data
                 for content_type_1_item_data in _content_type_1:
-                    content_type_1_item = (
-                        RuntimeToolResultRequestContentType1Item.from_dict(
-                            content_type_1_item_data
-                        )
+                    content_type_1_item = RuntimeToolResultRequestContentType1Item.from_dict(
+                        content_type_1_item_data
                     )
 
                     content_type_1.append(content_type_1_item)

--- a/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
+++ b/packages/aios-sdk/aios_sdk/_generated/models/runtime_tool_result_request.py
@@ -31,7 +31,6 @@ class RuntimeToolResultRequest:
             tool_call_id (str):
             content (list[RuntimeToolResultRequestContentType1Item] | str):
             is_error (bool | Unset):  Default: False.
-            no_reaction (bool | Unset):  Default: False.
     """
 
     connection_id: str
@@ -39,7 +38,6 @@ class RuntimeToolResultRequest:
     tool_call_id: str
     content: list[RuntimeToolResultRequestContentType1Item] | str
     is_error: bool | Unset = False
-    no_reaction: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -61,8 +59,6 @@ class RuntimeToolResultRequest:
 
         is_error = self.is_error
 
-        no_reaction = self.no_reaction
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -75,8 +71,6 @@ class RuntimeToolResultRequest:
         )
         if is_error is not UNSET:
             field_dict["is_error"] = is_error
-        if no_reaction is not UNSET:
-            field_dict["no_reaction"] = no_reaction
 
         return field_dict
 
@@ -119,15 +113,12 @@ class RuntimeToolResultRequest:
 
         is_error = d.pop("is_error", UNSET)
 
-        no_reaction = d.pop("no_reaction", UNSET)
-
         runtime_tool_result_request = cls(
             connection_id=connection_id,
             session_id=session_id,
             tool_call_id=tool_call_id,
             content=content,
             is_error=is_error,
-            no_reaction=no_reaction,
         )
 
         runtime_tool_result_request.additional_properties = d

--- a/src/aios/api/routers/connectors.py
+++ b/src/aios/api/routers/connectors.py
@@ -266,16 +266,6 @@ class RuntimeToolResultRequest(BaseModel):
     tool_call_id: str
     content: str | list[dict[str, Any]]
     is_error: bool = False
-    # The connector declares (via ``@tool(fire_and_forget=True)``) that a
-    # *successful* result for this tool is a delivery confirmation the model
-    # has nothing to react to (a message send/reaction ack).  When set, the
-    # result is still appended to the log — the model sees it — but the
-    # session is NOT woken to react to its own send (closes the duplicate-send
-    # loop).  A failed result NEVER carries this (the runner only sets it
-    # on the post-success path); the intake also AND-gates it with
-    # ``not is_error`` so a failure always wakes.  Default False keeps a
-    # not-yet-redeployed connector's omitted field behaving exactly as before.
-    no_reaction: bool = False
 
 
 class RuntimeLifecycleRequest(BaseModel):
@@ -980,25 +970,17 @@ async def post_runtime_tool_result(
                     "connection_id": body.connection_id,
                 },
             )
-        # ``no_reaction`` stamps the row so the wake GATE excludes it: a successful
-        # fire-and-forget result is not itself a stimulus to react to. A failure must
-        # react (so the model can recover), hence AND-gate with ``not is_error``.
-        no_reaction = body.no_reaction and not body.is_error
         event = await sessions_service.append_tool_result(
             conn,
             session_id=body.session_id,
             tool_call_id=body.tool_call_id,
             content=body.content,
             is_error=body.is_error,
-            no_reaction=no_reaction,
             account_id=account_id,
         )
-    # Always append (tool-always-appends-result) and always wake: the wake GATE — not
-    # this intake — decides whether to infer. The gate excludes the ``no_reaction`` row,
-    # so a LONE delivery confirmation makes the woken step re-gate and no-op (settles, no
-    # re-inference on its own ack); but a ``no_reaction`` result COMPLETING a mixed batch
-    # still surfaces the unreacted real sibling, which must run. This intake can't see the
-    # worker's in-flight sibling tasks, so it cannot make that call itself.
+    # Always append (tool-always-appends-result) and always wake: every tool result
+    # is a stimulus, so the woken step runs and the model gets a turn to react to the
+    # completion — including a lone delivery confirmation (it may simply end the turn).
     await defer_wake(pool, body.session_id, cause="connector_tool_result", account_id=account_id)
     return event
 

--- a/src/aios/db/queries/events.py
+++ b/src/aios/db/queries/events.py
@@ -1304,15 +1304,10 @@ async def append_event(
     # (the error latch) — an unreacted tool result keeps the session active, but
     # must NOT clear an error. See ``_SESSION_ACTIVE_EXPR``.
     #
-    # A fire-and-forget tool result (``data['no_reaction'] == True``, stamped by
-    # ``append_tool_result`` for a connector that declared the tool
-    # fire-and-forget) is a delivery confirmation the model has nothing to react
-    # to — it is NOT a stimulus, so it must not bump ``last_stimulus_seq`` and
-    # make the session a wake candidate (the duplicate-send loop). The result is
-    # still appended (the model sees it); only the wake decision excludes it.
-    # ``data.get`` is missing → falsy on every historical/unmarked result, so
-    # those keep counting as stimulus exactly as before (backward-compat).
-    is_stimulus = kind == "message" and role != "assistant" and not data.get("no_reaction")
+    # Every tool result is a stimulus: the session wakes and the model gets a
+    # turn to react to any tool completion (including a ``signal_send`` delivery
+    # ack), restoring the standard agentic loop (tool call → result → continue).
+    is_stimulus = kind == "message" and role != "assistant"
     # ``is_errored_lifecycle_event`` reads the SAME constant the error latch
     # writes (``harness/loop.py:_latch_errored_turn``). The read is off the JSONB
     # ``data`` (type ``Any``), which cannot bind to the write literal — see the

--- a/src/aios/harness/sweep.py
+++ b/src/aios/harness/sweep.py
@@ -374,14 +374,9 @@ CONFIRMED_ROWS_FLOORED_SQL = f"""
 # JOIN; it does NOT recompute the watermark. Re-deriving the formula here (the
 # pre-#1080 ``session_max_reacting`` CTE) re-introduces the #155-class drift
 # the deletion in #1080 foreclosed — keep this an equality JOIN, not a CTE.
-# The ``no_reaction`` clause excludes fire-and-forget delivery confirmations (a
-# connector ``signal_send``/``telegram_react``/… success, stamped
-# ``data['no_reaction']=true`` by ``append_tool_result``) from the unreacted-
-# stimulus set the batch filter inspects — matching the scalar gate, where such
-# a result does not bump ``last_stimulus_seq`` (``append_event``'s
-# ``is_stimulus``). ``IS DISTINCT FROM 'true'`` is NULL-safe: a missing key →
-# NULL → TRUE → the row still counts (every historical/unmarked result wakes
-# exactly as before); only the literal JSON ``true`` is excluded.
+# Every unreacted tool result counts (matching the scalar gate's ``is_stimulus``
+# in ``append_event``): a session with any tool result past its reaction
+# watermark is a wake candidate.
 _UNREACTED_ROWS_TEMPLATE = """
     SELECT e.session_id, e.role, e.data->>'tool_call_id' AS tool_call_id
       FROM events e
@@ -389,7 +384,6 @@ _UNREACTED_ROWS_TEMPLATE = """
      WHERE e.session_id = ANY($1::text[])
        AND e.kind = 'message'
        AND e.role <> 'assistant'
-       AND e.data->>'no_reaction' IS DISTINCT FROM 'true'
        AND e.seq > {watermark_expr}
 """
 

--- a/src/aios/services/sessions.py
+++ b/src/aios/services/sessions.py
@@ -1901,7 +1901,6 @@ async def append_tool_result(
     tool_call_id: str,
     content: str | list[dict[str, Any]],
     is_error: bool = False,
-    no_reaction: bool = False,
 ) -> Event:
     """Append a tool-role event for a custom tool call (#133).
 
@@ -1960,12 +1959,6 @@ async def append_tool_result(
     # GC's referenced-set sees it as live (#1093).  Done before the precompute
     # so the stored event and its token estimate reflect the same shape.
     record_spill_attachment(data, spill_attachment)
-    # Fire-and-forget delivery confirmation: stamp the marker so the wake gate
-    # (``CANDIDATE_ROWS_SQL`` via the scalar ``last_stimulus_seq``, and
-    # ``UNREACTED_ROWS_SQL``) excludes this row.  The model still sees the
-    # result in its context — only the WAKE decision skips it.
-    if no_reaction:
-        data["no_reaction"] = True
     precomputed = await queries.precompute_event_append(
         conn,
         account_id=account_id,

--- a/tests/e2e/test_signal_connector.py
+++ b/tests/e2e/test_signal_connector.py
@@ -434,14 +434,14 @@ class TestSignalMultiConnection:
                     raise AssertionError("tool_result event never persisted")
                 await asyncio.sleep(0.1)
 
-            # ``signal_send`` is fire-and-forget: the successful delivery
-            # confirmation is appended to the session log (the model still
-            # sees it) but must NOT re-wake the session to react to its own
-            # send.  That re-wake was the duplicate-send loop ("same DM
-            # delivered 4x").  Drain any in-flight tool tasks, then assert
-            # the sweep does not consider session A ready for inference.
+            # Every tool result is a stimulus (#1919): the successful
+            # delivery confirmation re-wakes the session so the model gets
+            # its continuation turn (ending the turn is the fixpoint that
+            # terminates the old duplicate-send loop).  Drain any in-flight
+            # tool tasks, then assert the sweep considers session A ready
+            # for inference.
             await harness.wait_for_tools(session_a.id)
-            assert session_a.id not in await harness.sessions_needing_inference(session_a.id)
+            assert session_a.id in await harness.sessions_needing_inference(session_a.id)
         finally:
             connector_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/e2e/test_telegram_connector.py
+++ b/tests/e2e/test_telegram_connector.py
@@ -283,14 +283,14 @@ class TestTelegramMultiConnection:
                     raise AssertionError("tool_result event never persisted")
                 await asyncio.sleep(0.1)
 
-            # ``telegram_send`` is fire-and-forget: the successful delivery
-            # confirmation is appended to the session log (the model still
-            # sees it) but must NOT re-wake the session to react to its own
-            # send.  That re-wake was the duplicate-send loop ("same DM
-            # delivered 4x").  Drain any in-flight tool tasks, then assert
-            # the sweep does not consider session A ready for inference.
+            # Every tool result is a stimulus (#1919): the successful
+            # delivery confirmation re-wakes the session so the model gets
+            # its continuation turn (ending the turn is the fixpoint that
+            # terminates the old duplicate-send loop).  Drain any in-flight
+            # tool tasks, then assert the sweep considers session A ready
+            # for inference.
             await harness.wait_for_tools(session_a.id)
-            assert session_a.id not in await harness.sessions_needing_inference(session_a.id)
+            assert session_a.id in await harness.sessions_needing_inference(session_a.id)
         finally:
             connector_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/integration/test_session_status_scalars.py
+++ b/tests/integration/test_session_status_scalars.py
@@ -488,14 +488,14 @@ class TestDerivedStatus:
             )
             assert row is not None and row["last_stimulus_seq"] == 3
 
-    async def test_no_reaction_tool_result_is_not_a_stimulus(
+    async def test_delivery_ack_tool_result_is_a_stimulus(
         self,
         pool_and_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
-        """A fire-and-forget tool result (``data['no_reaction']=true``) is a
-        delivery confirmation the model has nothing to react to: it must NOT
-        bump ``last_stimulus_seq``, so the session settles idle instead of
-        re-inferring to react to its own send (the duplicate-send loop)."""
+        """Every tool result is a stimulus (#1919): a ``signal_send`` delivery
+        ack — even one carrying a legacy ``data['no_reaction']=true`` marker from
+        before the removal — bumps ``last_stimulus_seq`` and leaves the session
+        ACTIVE, so it wakes and the model gets a turn to react."""
         pool, account_id, session_id = pool_and_session
         async with pool.acquire() as conn:
             # user (seq 1)
@@ -514,7 +514,8 @@ class TestDerivedStatus:
                 kind="message",
                 data={"role": "assistant", "content": "on it", "reacting_to": 1},
             )
-            # fire-and-forget delivery ack (seq 3) — NOT a stimulus
+            # delivery ack (seq 3) — a stimulus. The legacy ``no_reaction`` marker
+            # is inert: ``is_stimulus`` no longer reads it.
             await queries.append_event(
                 conn,
                 account_id=account_id,
@@ -529,10 +530,10 @@ class TestDerivedStatus:
             )
             s = await _scalars(conn, session_id)
             session = await queries.get_session(conn, session_id, account_id=account_id)
-        # last_stimulus_seq stays at 1 (the user) — the ack did not advance it.
-        assert s["last_stimulus_seq"] == 1
+        # last_stimulus_seq advances to 3 (the ack) — an unreacted stimulus.
+        assert s["last_stimulus_seq"] == 3
         assert s["last_reacted_seq"] == 1
-        assert session.status == "idle"
+        assert session.status == "active"
 
     async def test_status_active_rescheduling_after_failed_step(
         self,

--- a/tests/integration/test_tool_result_wakes_stimulus.py
+++ b/tests/integration/test_tool_result_wakes_stimulus.py
@@ -1,40 +1,34 @@
-"""Integration suite for the fire-and-forget (``no_reaction``) tool-result wake fix.
+"""Integration suite for the every-tool-result-is-a-stimulus wake behavior (#1919).
 
-The bug
--------
+Background
+----------
 A session runs one agent across connector channels. When the model calls a
 message-delivery tool (``signal_send`` / ``signal_react`` and the telegram /
 whatsapp equivalents), the connector runtime executes it and POSTs the result
 (``{"sent_at_ms": N}``) to ``POST /v1/connectors/runtime/tool-results``. The
 intake unconditionally ``defer_wake``\\ s, and the wake gate counts the
-``role='tool'`` result as new unreacted stimulus — so the session RE-INFERS to
-react to its own delivery confirmation. There is nothing to react to; a
-less-disciplined model RE-SENDS the same message (the duplicate-send loop).
+``role='tool'`` result as new unreacted stimulus — so the session wakes and the
+model gets a turn to react to the completion.
 
-The fix
--------
-The connector declares the tool fire-and-forget; on a *successful* result the
-runner sets ``no_reaction=true`` on the POST. The intake computes
-``no_reaction = body.no_reaction AND NOT body.is_error`` and, when true, appends
-the result WITH ``data['no_reaction']=true`` (so the model still sees it) but
-SKIPS ``defer_wake``. ``append_event`` then treats a ``no_reaction`` tool result
-as a NON-stimulus (it does not bump ``last_stimulus_seq``), and the sweep's
-``UNREACTED_ROWS_SQL`` excludes the marked row. Both layers agree, so the
-session settles instead of re-inferring.
+#1398/#1121/#1489 briefly special-cased this: a connector declared the tool
+fire-and-forget, the runner POSTed ``no_reaction=true`` on success, and both the
+scalar gate (``last_stimulus_seq``) and the sweep excluded the marked row so the
+session settled idle. That suppression existed to placate a dumber model that
+re-sent on a bare delivery ack. #1919 removed it: **every tool result is a
+stimulus.** The loop is the model's responsibility to avoid; the cost of a
+spurious "anything else?" wake is cheap, silent idle is not.
 
 What this suite pins
 --------------------
-- ``append_tool_result(no_reaction=True)`` stamps ``data['no_reaction']=true``
-  and does NOT advance ``last_stimulus_seq`` → the session is NOT a wake
-  candidate (loop closed).
-- A FAILED send (``is_error=True``) still wakes — the marker is never stamped
-  on the error path (the intake AND-gates with ``not is_error``).
-- A non-fire-and-forget result (``no_reaction=False``) still wakes.
-- An UNMARKED result (historical / not-yet-redeployed connector) still wakes
-  exactly as before (backward-compat: missing key → counts as stimulus).
-- A co-pending REAL user message still wakes even when a fire-and-forget result
-  is also unreacted (no false negative).
-- The model still SEES the result in the log (it stays appended).
+- A lone successful ``signal_send`` delivery result IS a stimulus: it advances
+  ``last_stimulus_seq``, leaves the session ACTIVE, and the sweep wakes it.
+- A FAILED send wakes (as every result does), so the model can recover.
+- A non-delivery result (``bash`` etc.) wakes.
+- A historical row carrying an inert ``data['no_reaction']=true`` marker (from
+  before the removal) now wakes too — ``is_stimulus`` no longer reads the key.
+- A fire-and-forget send completing a MIXED batch wakes: the intake always
+  ``defer_wake``\\ s and the gate sees the unreacted real sibling.
+- The model SEES every result in the log (it stays appended).
 """
 
 from __future__ import annotations
@@ -94,7 +88,11 @@ async def _status(pool: asyncpg.Pool[Any], session_id: str, account_id: str) -> 
 
 
 async def _result_marker(pool: asyncpg.Pool[Any], session_id: str, tool_call_id: str) -> Any:
-    """Return ``data->>'no_reaction'`` for the tool-result row, or None."""
+    """Return ``data->>'no_reaction'`` for the tool-result row, or None.
+
+    ``no_reaction`` is no longer written by any code path; this reads the raw
+    JSONB only so the legacy-inert-marker test can prove a historical value is
+    present-but-ignored."""
     async with pool.acquire() as conn:
         return await conn.fetchval(
             "SELECT data->>'no_reaction' FROM events "
@@ -113,18 +111,18 @@ async def pool_account_session(
     declares a tool the parent ``tool_calls`` entry can resolve a name from."""
     pool = await create_pool(migrated_db_url, min_size=1, max_size=4)
     try:
-        account_id = "acc_no_reaction"
+        account_id = "acc_tool_stimulus"
         async with pool.acquire() as conn:
             await conn.execute(
                 "INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name) "
                 "VALUES ($1, NULL, TRUE, $2)",
                 account_id,
-                "no-reaction",
+                "tool-stimulus",
             )
         _agent, _env, session = await seed_agent_env_session(
             pool,
             account_id=account_id,
-            prefix="no-reaction",
+            prefix="tool-stimulus",
             tools=[ToolSpec(type="bash")],
         )
         yield pool, account_id, session.id
@@ -138,7 +136,6 @@ async def _drive_one_send_turn(
     session_id: str,
     *,
     tool_call_id: str,
-    no_reaction: bool,
     is_error: bool = False,
 ) -> None:
     """User → assistant(tool_call) → reacted → tool result. Mirrors the live
@@ -160,9 +157,7 @@ async def _drive_one_send_turn(
             kind="message",
             data=_assistant([tool_call_id], reacting_to=1),
         )
-    # The connector POSTs the result. ``append_tool_result`` is the shared
-    # intake target; ``no_reaction`` is what the API handler computes
-    # (``body.no_reaction AND NOT body.is_error``).
+    # The connector POSTs the result. ``append_tool_result`` is the shared intake.
     async with pool.acquire() as conn:
         await sessions_service.append_tool_result(
             conn,
@@ -171,84 +166,80 @@ async def _drive_one_send_turn(
             tool_call_id=tool_call_id,
             content='{"sent_at_ms": 123}',
             is_error=is_error,
-            no_reaction=no_reaction,
         )
 
 
-class TestFireAndForgetSettles:
-    async def test_successful_fire_and_forget_does_not_wake(
+class TestEveryToolResultWakes:
+    async def test_lone_successful_send_wakes(
         self,
         pool_account_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
+        """A lone ``signal_send`` delivery ack IS a stimulus (#1919): it advances
+        the scalar gate past the reacted watermark, leaves the session ACTIVE,
+        and the sweep wakes it so the model gets a turn to react."""
         pool, account_id, session_id = pool_account_session
         await _drive_one_send_turn(
-            pool, account_id, session_id, tool_call_id="tc_send", no_reaction=True
+            pool, account_id, session_id, tool_call_id="tc_send"
         )
 
-        # The result is appended WITH the marker — the model still sees it.
-        assert await _result_marker(pool, session_id, "tc_send") == "true"
+        # The result is appended (the model sees it) with no suppression marker.
+        assert await _result_marker(pool, session_id, "tc_send") is None
 
-        # The marker keeps the result from counting as a stimulus: the scalar
-        # gate (last_stimulus_seq) does not advance past the reacted watermark.
+        # The result counts as a stimulus: the scalar gate advances past the
+        # reacted watermark (seq 1), so there is unreacted work.
         scalars = await _scalars(pool, session_id)
-        assert scalars["last_stimulus_seq"] <= scalars["last_reacted_seq"]
-        assert await _status(pool, session_id, account_id) == "idle"
+        assert scalars["last_stimulus_seq"] > scalars["last_reacted_seq"]
+        assert await _status(pool, session_id, account_id) == "active"
 
         registry = InflightToolRegistry()
         needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
-        assert session_id not in needs, (
-            "a successful fire-and-forget delivery confirmation must NOT wake the "
-            "session — that is the duplicate-send loop"
+        assert session_id in needs, (
+            "a lone signal_send delivery result must wake the session — every "
+            "tool result is a stimulus (#1919)"
         )
 
-    async def test_failed_send_still_wakes(
+    async def test_failed_send_wakes(
         self,
         pool_account_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
         pool, account_id, session_id = pool_account_session
-        # The intake AND-gates ``no_reaction`` with ``not is_error``; a failure
-        # arrives with no_reaction already False (the runner's error branches
-        # never set it). Pass no_reaction=False to model that.
         await _drive_one_send_turn(
             pool,
             account_id,
             session_id,
             tool_call_id="tc_fail",
-            no_reaction=False,
             is_error=True,
         )
 
-        assert await _result_marker(pool, session_id, "tc_fail") is None
         assert await _status(pool, session_id, account_id) == "active"
 
         registry = InflightToolRegistry()
         needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
         assert session_id in needs, "a FAILED send must wake so the model can recover"
 
-    async def test_non_fire_and_forget_result_still_wakes(
+    async def test_non_delivery_result_wakes(
         self,
         pool_account_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
         pool, account_id, session_id = pool_account_session
         # A list/get/edit-style tool result carries data the model must consume.
         await _drive_one_send_turn(
-            pool, account_id, session_id, tool_call_id="tc_list", no_reaction=False
+            pool, account_id, session_id, tool_call_id="tc_list"
         )
 
-        assert await _result_marker(pool, session_id, "tc_list") is None
         assert await _status(pool, session_id, account_id) == "active"
 
         registry = InflightToolRegistry()
         needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
         assert session_id in needs
 
-    async def test_unmarked_result_wakes_backward_compat(
+    async def test_legacy_no_reaction_marker_is_inert_and_wakes(
         self,
         pool_account_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
-        """A historical event / not-yet-redeployed connector omits the field.
-        ``append_event`` sees no ``no_reaction`` key → stimulus → wakes; the
-        sweep's ``IS DISTINCT FROM 'true'`` is NULL-safe → row still counts."""
+        """A historical row still carrying ``data['no_reaction']=true`` (written
+        before #1919) now wakes exactly like any other result: ``is_stimulus``
+        no longer reads the key and the sweep no longer excludes the row."""
         pool, account_id, session_id = pool_account_session
         async with pool.acquire() as conn:
             await queries.append_event(
@@ -263,10 +254,10 @@ class TestFireAndForgetSettles:
                 account_id=account_id,
                 session_id=session_id,
                 kind="message",
-                data=_assistant(["tc_old"], reacting_to=1),
+                data=_assistant(["tc_legacy"], reacting_to=1),
             )
-            # Append the tool-result event directly with NO no_reaction key —
-            # exactly what a pre-fix / historical row looks like.
+            # Append the tool-result event directly WITH a legacy no_reaction
+            # marker — exactly what a pre-#1919 row on disk looks like.
             await queries.append_event(
                 conn,
                 account_id=account_id,
@@ -274,31 +265,34 @@ class TestFireAndForgetSettles:
                 kind="message",
                 data={
                     "role": "tool",
-                    "tool_call_id": "tc_old",
-                    "content": "ok",
+                    "tool_call_id": "tc_legacy",
+                    "content": '{"sent_at_ms": 1}',
                     "name": "signal_send",
+                    "no_reaction": True,
                 },
             )
 
-        assert await _result_marker(pool, session_id, "tc_old") is None
+        # The marker is still on the row (we never rewrite history) …
+        assert await _result_marker(pool, session_id, "tc_legacy") == "true"
+        # … but it is inert: the row counts as a stimulus and the session wakes.
         assert await _status(pool, session_id, account_id) == "active"
 
         registry = InflightToolRegistry()
         needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
-        assert session_id in needs
+        assert session_id in needs, (
+            "a historical no_reaction-marked row must now count as a stimulus — "
+            "the marker is inert after #1919"
+        )
 
-    async def test_copending_user_message_still_wakes(
+    async def test_copending_user_message_wakes(
         self,
         pool_account_session: tuple[asyncpg.Pool[Any], str, str],
     ) -> None:
-        """A real user message landing alongside the fire-and-forget result
-        must still wake — the user stimulus is independent of the ack."""
+        """A real user message landing alongside a delivery result still wakes."""
         pool, account_id, session_id = pool_account_session
         await _drive_one_send_turn(
-            pool, account_id, session_id, tool_call_id="tc_send", no_reaction=True
+            pool, account_id, session_id, tool_call_id="tc_send"
         )
-        # The fire-and-forget result alone settled the session; now a real user
-        # message arrives.
         async with pool.acquire() as conn:
             await queries.append_event(
                 conn,
@@ -339,19 +333,17 @@ async def _bind_connection(pool: asyncpg.Pool[Any], account_id: str, session_id:
 
 
 class TestMixedBatchWake:
-    async def test_no_reaction_completing_mixed_batch_still_wakes(
+    async def test_send_completing_mixed_batch_wakes(
         self,
         pool_account_session: tuple[asyncpg.Pool[Any], str, str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A turn emits BOTH a real builtin (``bash``) AND a fire-and-forget connector
-        send. The real result lands first (unreacted; batch still incomplete), then the
-        ``no_reaction`` send result lands LAST via the connector-runtime intake, COMPLETING
-        the batch. The session now has an unreacted real result and must be woken — but the
-        intake's ``no_reaction`` wake-skip drops the wake, stranding the real result until
-        the 30s periodic sweep (~30s of dead air). The wake decision belongs to the gate
-        (which excludes the ``no_reaction`` row), not this intake site, which cannot see the
-        in-flight real sibling."""
+        """A turn emits BOTH a real builtin (``bash``) AND a connector send. The
+        real result lands first (unreacted; batch still incomplete), then the
+        send result lands LAST via the connector-runtime intake, COMPLETING the
+        batch. The intake always ``defer_wake``\\ s and the gate sees the
+        unreacted real sibling, so the session wakes immediately — never stranded
+        until the 30s periodic sweep."""
         pool, account_id, session_id = pool_account_session
         connection_id = await _bind_connection(pool, account_id, session_id)
 
@@ -396,11 +388,10 @@ class TestMixedBatchWake:
                 tool_call_id="tc_real",
                 content="file1\nfile2",
                 is_error=False,
-                no_reaction=False,
             )
 
-        # The fire-and-forget send result lands LAST, through the connector-runtime
-        # intake — the site whose wake decision is under test.
+        # The send result lands LAST, through the connector-runtime intake — the
+        # site whose wake decision is under test.
         defer_wake_mock = AsyncMock()
         monkeypatch.setattr(connectors_router, "defer_wake", defer_wake_mock)
         auth = ("runtime-token", _CONNECTOR, account_id, None)
@@ -411,22 +402,19 @@ class TestMixedBatchWake:
                 tool_call_id="tc_send",
                 content='{"sent_at_ms": 1}',
                 is_error=False,
-                no_reaction=True,
             ),
             pool,
             auth,
         )
 
         # The gate agrees there is work: the real bash result is unreacted and the
-        # batch is now complete (this assertion holds on buggy code too — the gate is
-        # correct; the bug is the missing wake to act on it).
+        # batch is now complete.
         registry = InflightToolRegistry()
         needs = await find_sessions_needing_inference(pool, registry, session_id=session_id)
         assert session_id in needs
 
-        # The intake MUST enqueue a wake. Skipping it on no_reaction stranded the real
-        # sibling until the periodic sweep — the bug.
+        # The intake always enqueues a wake now — nothing is stranded.
         assert defer_wake_mock.called, (
-            "a no_reaction result completing a mixed batch with an unreacted real "
-            "sibling must wake the session, not strand it until the 30s periodic sweep"
+            "a result completing a mixed batch with an unreacted real sibling must "
+            "wake the session, not strand it until the 30s periodic sweep"
         )

--- a/tests/integration/test_tool_result_wakes_stimulus.py
+++ b/tests/integration/test_tool_result_wakes_stimulus.py
@@ -178,9 +178,7 @@ class TestEveryToolResultWakes:
         the scalar gate past the reacted watermark, leaves the session ACTIVE,
         and the sweep wakes it so the model gets a turn to react."""
         pool, account_id, session_id = pool_account_session
-        await _drive_one_send_turn(
-            pool, account_id, session_id, tool_call_id="tc_send"
-        )
+        await _drive_one_send_turn(pool, account_id, session_id, tool_call_id="tc_send")
 
         # The result is appended (the model sees it) with no suppression marker.
         assert await _result_marker(pool, session_id, "tc_send") is None
@@ -223,9 +221,7 @@ class TestEveryToolResultWakes:
     ) -> None:
         pool, account_id, session_id = pool_account_session
         # A list/get/edit-style tool result carries data the model must consume.
-        await _drive_one_send_turn(
-            pool, account_id, session_id, tool_call_id="tc_list"
-        )
+        await _drive_one_send_turn(pool, account_id, session_id, tool_call_id="tc_list")
 
         assert await _status(pool, session_id, account_id) == "active"
 
@@ -290,9 +286,7 @@ class TestEveryToolResultWakes:
     ) -> None:
         """A real user message landing alongside a delivery result still wakes."""
         pool, account_id, session_id = pool_account_session
-        await _drive_one_send_turn(
-            pool, account_id, session_id, tool_call_id="tc_send"
-        )
+        await _drive_one_send_turn(pool, account_id, session_id, tool_call_id="tc_send")
         async with pool.acquire() as conn:
             await queries.append_event(
                 conn,

--- a/tests/unit/test_connector_intake_forward_tolerant.py
+++ b/tests/unit/test_connector_intake_forward_tolerant.py
@@ -15,9 +15,9 @@ The fix
 -------
 The connector-runtime intake models are made **forward-tolerant**
 (``extra="ignore"``): an unknown extra field is silently dropped, the known
-fields still validate and process. This is the forward half of the symmetry
-#1398 established backward (a *newer* api defaulting ``no_reaction`` for an
-*older* connector that omits it).
+fields still validate and process. This is the forward half of the connector→api
+deploy-skew symmetry (the backward half: a newer api defaulting an omitted field
+for an older connector).
 
 What this suite pins
 --------------------
@@ -25,8 +25,9 @@ What this suite pins
   field (no ``ValidationError``) and parses the known fields normally.
 - The unknown field is dropped (``extra="ignore"`` semantics) — it does not
   leak onto the model.
-- The existing backward-compat behaviour (``no_reaction`` omitted → default
-  ``False``) is unchanged.
+- A connector still sending a since-retired field (e.g. ``no_reaction``, removed
+  in #1919) is harmless: it is ignored, not retained, exactly like any other
+  unknown field.
 """
 
 from __future__ import annotations
@@ -91,6 +92,9 @@ class TestRuntimeToolResultRequest:
     """The intake that 422'd in the incident — pinned directly."""
 
     def test_tool_result_accepts_unknown_field(self) -> None:
+        # ``no_reaction`` was removed in #1919; a connector still POSTing it
+        # mid-rollout is exactly the forward-skew case — it must be ignored,
+        # not 422'd or retained, alongside any other unknown field.
         parsed = RuntimeToolResultRequest.model_validate(
             {
                 "connection_id": "conn_1",
@@ -104,18 +108,6 @@ class TestRuntimeToolResultRequest:
             }
         )
         assert parsed.connection_id == "conn_1"
-        assert parsed.no_reaction is True
+        assert not hasattr(parsed, "no_reaction")
         assert not hasattr(parsed, "future_field")
-
-    def test_no_reaction_backward_compat_default_unchanged(self) -> None:
-        """An older connector that OMITS ``no_reaction`` still defaults False —
-        the backward half of the symmetry (#1398) is untouched."""
-        parsed = RuntimeToolResultRequest.model_validate(
-            {
-                "connection_id": "conn_1",
-                "session_id": "sess_1",
-                "tool_call_id": "tc_1",
-                "content": "ok",
-            }
-        )
-        assert parsed.no_reaction is False
+        assert "no_reaction" not in parsed.model_dump()


### PR DESCRIPTION
Closes #1919

## Summary

Rips out the `no_reaction` special-casing from the harness. **Every tool result is a stimulus** — a tool result no longer has to opt in to waking its session; it always does.

This reverts the accreted `no_reaction` machinery introduced across #1398, #1121, and #1489. The predicate that decided whether a given tool result should be treated as a wake-worthy stimulus is deleted; the harness now treats all tool results uniformly.

## Risk: TIER-4

This changes the **all-sessions wake predicate** — it alters when *every* session wakes on a tool result, so the blast radius is the entire fleet. It requires:

- **Human merge-approval** (not auto-mergeable).
- **Lockstep api/worker deploy** — the api and worker must ship the same revision together; a split deploy would run mismatched wake semantics across the two planes.

## Adversarial review verdicts

Three independent adversarial reviews were run against the change, grounded in aios source at review commit `ca6faaa2`:

```json
[
  {
    "lens": "Skeptical harness-safety reviewer: does deleting no_reaction reintroduce an infinite self-send/wake loop? Grounded in aios source at the review commit ca6faaa2 (events.py is_stimulus, sweep.py unreacted-rows predicate + #1729 batch filter, jobs/app.py defer_wake), not just the diff summary.",
    "verdict": "SAFE (no STRUCTURAL infinite loop — a fixpoint is reachable on every path; the removed guard is behavioral-not-structural, so termination now rests on model quality rather than code)."
  },
  {
    "lens": "completeness (dangling-reference / runtime-break audit of the no_reaction removal)",
    "verdict": "COMPLETE"
  },
  {
    "lens": "test-correctness (behavior-flip: a lone signal_send tool-result must now BE a stimulus / wake the session; verify suppression tests were flipped not deleted-to-hide, and a positive lone-send-wakes test was added)",
    "verdict": "TESTS-SOUND"
  }
]
```
