### PR TITLE
Durable-sandbox snapshots destroyed by Coolify force_docker_cleanup (non-label-aware docker prune) → fleet-wide filesystem loss on resume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,3 +146,9 @@ AIOS_OAUTH_PROVIDER_APPS=
 # MCP servers are https); any value there re-opens SSRF to internal hosts.
 # AIOS_OAUTH_ALLOW_INSECURE_HOSTS=workspace-mcp,workspace-mcp:8000
 AIOS_OAUTH_ALLOW_INSECURE_HOSTS=
+
+# Current filesystems of non-archived sessions are never reclaimed. Archived
+# filesystems become eligible only after this grace. Snapshot TTL/pool/account
+# limits are pressure and admission signals, not destructive live-state budgets.
+# Disable Coolify force_docker_cleanup and all unfiltered Docker pruning here.
+AIOS_SANDBOX_ARCHIVE_GC_GRACE_SECONDS=86400

--- a/docs/design/durable-session-sandboxes.md
+++ b/docs/design/durable-session-sandboxes.md
@@ -412,42 +412,30 @@ crash windows content-equal no-ops.
 
 `start_gc(pool, ...)` — background loop, hourly tick, immediate first tick at boot:
 
-1. **Corpse pass** — per corpse, under `_lock_for(session_id)`: **consult the retain rule
-   first** (a deleted or TTL-expired session's corpse is removed *without* paying the
-   commit), then salvage (lineage-gated) and remove.
-2. **Image pass** — `docker images -a` (with `--filter label=aios.managed`); the `-a` is
-   load-bearing: untagged crash residue is invisible without it (verified). Untagged
-   interiors of live chains are skipped **structurally** — exclude any image that is the
-   `.Parent` of another listed image — rather than leaning on rmi-refusal churn. Then the
-   single rule: **an image is retained iff it is the canonical tag of an existing session
-   whose last activity is within the TTL** (`sandbox_snapshot_ttl_seconds`, default 30
-   days, keyed on session dormancy via the `(session_id, last_event_seq)` event row — a
-   point probe, not `MAX(events.created_at)`). Everything else managed-and-mine is
-   removed: crash residue, flatten leftovers, deleted sessions (this *is* the delete
-   hook — ≤1 h lag), and dormant sessions (the latter with a model-visible
-   `sandbox_fs_expired {reason: "retention_ttl"}` event). Archived sessions follow the
-   same dormancy rule (unarchive exists; immediate deletion would strand it).
-3. **Pool-budget pass** — if this host's snapshot total exceeds
-   `sandbox_snapshot_pool_bytes` (§5.7), evict **most-dormant sessions first** (by the
-   same `last_event_at` the tick already fetched — *not* image `.Created`, which
-   skip-empty pins and which would evict the most-active session first), each with
-   `sandbox_fs_expired {reason: "disk_pressure"}`.
-4. **Pointer reconciliation** — the tick writes/clears
-   `snapshot_ref/host/bytes/updated_at` to match what its own store actually holds:
-   every removal of a *canonical* artifact in passes 2–3 clears the pointer in the same
-   per-session lock scope; a canonical tag present with a NULL or stale pointer (crash
-   residue) gets the pointer set. The DB never ends a tick claiming something the owning
-   store disowns. **Pointer writes and clears are ownership-gated**: a tick touches
-   `sessions.snapshot_*` only for sessions whose `snapshot_host` is this host (or NULL,
-   for the crash heal) — evicting a local *cache* of another host's artifact never
-   touches the canonical pointer. On multi-host shapes, pointer advancement (salvage, GC
-   heal) is additionally **compare-and-swap** — `UPDATE … WHERE snapshot_host = <this
-   host> AND snapshot_updated_at = <value read at tick start>` — so a session that moved
-   to another host can never be clobbered by a returning host's stale corpse; a CAS
-   failure demotes the local corpse/tag to non-canonical residue, removed without
-   commit. When async push is enabled, the tick also reconciles the store against the
-   local canonical tag (re-enqueue `put` on digest mismatch), so a crash-dropped push
-   converges instead of leaving unbounded staleness.
+1. **Corpse pass** — per corpse, under `_lock_for(session_id)`: re-read the
+   session lifecycle. Deleted sessions and sessions archived at or beyond
+   `sandbox_archive_gc_grace_seconds` are bare-destroyed; all other session
+   corpses are salvaged before removal. Ephemeral workflow-run corpses are
+   always bare-destroyed because they have no durable rootfs.
+2. **Image pass** — enumerate all managed images, including untagged residue.
+   Canonical images for existing non-archived sessions are protected. Archived
+   canonical images become collectible only once archive grace has elapsed;
+   deleted-session images and non-canonical leaf residue are collectible.
+   Live-chain interiors are skipped structurally by parent relationship.
+3. **Pressure passes** — host-pool and per-account snapshot limits are
+   observational: they never delete lifecycle-protected filesystems. Pressure
+   is fed back to cold-provision admission. Host pressure is global; account
+   pressure rejects only durable session provisions owned by that account, and
+   never ephemeral run sandboxes. A later clear report restores admission.
+4. **Pointer reconciliation** — local store truth heals missing/stale pointers.
+   Destructive archive cleanup requires a fresh, exact archive timestamp,
+   elapsed grace, matching pointer, and positive ownership
+   (`snapshot_host == instance_id`) under the per-session lock; an unarchive,
+   rearchive, pointer move, or ambiguous host fails closed.
+
+**Every per-session image removal takes `_lock_for(session_id)` and re-checks
+lifecycle and ownership under the lock.** This closes the scan-to-delete race
+without using activity age as a deletion condition.
 
 **Ownership across hosts**: each host GCs only its own store. For a deleted/expired
 session whose `snapshot_host` is another host, the non-owning tick **skips** — the DB
@@ -464,11 +452,10 @@ global accounting — without it, never-waking sessions' pointers (and their
 `snapshot_bytes`) leak indefinitely, since non-owning ticks skip by design. All of this
 is vacuous single-host.
 
-**Every per-session image removal in passes 2–3 takes `_lock_for(session_id)` and
-re-checks under the lock** (cached handle present → skip; condition re-verified). Without
-this, the TTL/budget pass can race a waking session in the window between
-corpse-salvage and `docker run`, when no container references the tag and `rmi` would
-succeed against a just-salvaged snapshot (a verified-constructible interleaving).
+**Every per-session image removal takes `_lock_for(session_id)` and re-checks
+under the lock** (cached handle present → skip; lifecycle and ownership re-verified).
+Without this, archive cleanup can race an unarchive or rearchive between the scan and
+`rmi`, deleting the canonical snapshot for a newly protected session.
 
 `docker rmi` of a tag cascade-deletes the entire untagged parent chain down to the first
 still-referenced image (verified on overlay2; re-verify on containerd, §9) — GC of an
@@ -567,7 +554,7 @@ entirely. What remains: secrets the agent itself wrote to disk (`~/.netrc`,
 `/workspace` on host disk today, but now also readable by anything with daemon access
 (`docker save`, image inspect of FS layers). **Accepted threat-model boundary requiring
 sign-off**: daemon access ≈ host root, already a near-total compromise; the marginal
-regression is retention duration, bounded by TTL/budget.
+regression is retention duration, bounded by explicit archive lifecycle and grace.
 
 **Deferred hardening, dispositioned rather than re-deferred**: `--read-only` is
 **permanently incompatible** with this contract (the contract *is* a writable persistent
@@ -577,7 +564,7 @@ NET_ADMIN, the largest grant. The resume-fresh-flags property means any future h
 retrofits every parked session automatically.
 
 **Supply-chain accumulation**: agent-installed software re-executes at every resume —
-inherent to persistent disk. Bounds: dormancy TTL, budgets,
+inherent to persistent disk. Bounds: archive lifecycle/grace, pressure alarms,
 fresh security flags each resume, and the sidecar fix removing the worst consequence
 (lockdown subversion). `install_packages` still runs tenant-FS package managers at
 resume; with the lockdown gate moved off the sandbox FS, a poisoned pip/apt harms only
@@ -681,8 +668,8 @@ All four new columns are nullable with NULL = no snapshot — zero backfill, met
 DDL. They are internal (excluded from the session wire shape), so no openapi/SDK churn
 from this migration itself.
 
-**Settings** (config.py): `sandbox_snapshot_ttl_seconds: int = 2_592_000` (30 d);
-`sandbox_snapshot_budget_bytes: int = 4 GiB` (per-session; per-env override via a **new**
+**Settings** (config.py): `sandbox_archive_gc_grace_seconds` controls the explicit
+archive-to-destruction delay; `sandbox_snapshot_budget_bytes: int = 4 GiB` (per-session; per-env override via a **new**
 `EnvironmentConfig` field replacing `disk_bytes` — never a silent semantic rename of the
 existing field, per §5.7's own no-repurposing rule); `sandbox_snapshot_pool_bytes: int | None = None` with the eumemic-ops
 deploy setting it (§9); **delete** `sandbox_disk_bytes`; raise
@@ -828,8 +815,9 @@ E2E (`docker_harness`, gated by the existing `needs_docker` marker; force idle v
   `evict()` → next tool call sees the pre-crash marker; stale-corpse variant never
   regresses tag content.
 - **GC** (`test_sandbox_snapshot_gc.py`): session delete → `_gc_once` → image gone;
-  TTL=0 → image gone + `sandbox_fs_expired` in the event log; orphaned-chain residue
-  (crash-between-import-and-rm shape) collected; pool budget evicts most-dormant first.
+  archive grace boundary and zero-grace cases → image gone; unarchive/rearchive races
+  fail closed; orphaned-chain residue is collected; pressure is signalled without
+  deleting lifecycle-protected snapshots.
 - **Lockdown sidecar** (`test_networking.py` extension): Limited env on a *resumed*
   snapshot whose `/usr/sbin/iptables` was replaced by `exit 0` pre-idle → lockdown still
   enforced (curl to unlisted host fails); sandbox cannot `iptables -F` (no NET_ADMIN).
@@ -886,8 +874,8 @@ Docker availability: e2e requires real Docker (`DOCKER_HOST` per conftest); CI a
 8. **Per-account caps deferred** (usage metric ships, eviction engine doesn't);
    **`--read-only` closed as incompatible** rather than re-deferred; **`--cap-drop=ALL`
    stays deferred** (NET_ADMIN removal ships now via the lockdown sidecar).
-9. **Optional rollback knob** (not in the design, flag only): `sandbox_snapshot_ttl_seconds=0`
-   could degenerate to today's destroy-on-idle if a kill switch is wanted for the rollout.
+9. **Rollback posture**: disable new snapshot creation while retaining lifecycle-
+   protected artifacts; destructive cleanup remains tied to archive plus grace.
 
 ---
 

--- a/docs/design/durable-session-sandboxes.md
+++ b/docs/design/durable-session-sandboxes.md
@@ -359,8 +359,8 @@ deterministic local tag — today's behavior exactly. Rules:
   against the old tag and discard live post-drift work as `skipped_stale`) — a
   model-visible `sandbox_fs_reset {reason: "environment_image_changed"}` lifecycle event
   is appended, and the session cold-starts on the new image. (Content changes under the *same* ref — base rebuilds, `:stable`
-  promotes — do not trigger this; parked chains keep their pinned base until reset or
-  expiry.) Keep-the-FS-instead is a defensible alternative semantic; the event is the
+  promotes — do not trigger this; parked chains keep their pinned base until the session is reset or archived and
+  its archive grace has elapsed.) Keep-the-FS-instead is a defensible alternative semantic; the event is the
   non-negotiable part — sign-off item §11.
 - **First-commit crash heal**: the salvage preamble (§5.4), already under the per-session
   lock, also reconciles the pointer against local truth — a crash after the first-ever
@@ -437,8 +437,8 @@ crash windows content-equal no-ops.
 lifecycle and ownership under the lock.** This closes the scan-to-delete race
 without using activity age as a deletion condition.
 
-**Ownership across hosts**: each host GCs only its own store. For a deleted/expired
-session whose `snapshot_host` is another host, the non-owning tick **skips** — the DB
+**Ownership across hosts**: each host GCs only its own store. For a session archived
+past grace whose `snapshot_host` is another host, the non-owning tick **skips** — the DB
 pointer tells it not to reach across; the owning host's tick removes. On multi-host
 shapes the retain rule gains an ownership clause: a local image whose session's
 `snapshot_host` is elsewhere is a transport cache, reclaimable once unreferenced, never
@@ -486,7 +486,7 @@ cycle counts by an order of magnitude.
   delete" forbids.
 - **Metric**: unique bytes = `tag.Size − base.Size` where base is the image named by the
   chain's own `aios.base_image` label (not `settings.docker_image` — per-env overrides
-  would otherwise be billed ~1.5 GB they never wrote, triggering wrongful evictions);
+  would otherwise be billed ~1.5 GB they never wrote, triggering wrongful pressure reports and admission blocks);
   `aios.flattened=true` images charge full `.Size` (they share nothing — subtracting the
   base would hide ~466 MB per flattened session from the very accounting that must see
   the host filling). Computed at read time from the owning daemon, which stays
@@ -494,7 +494,7 @@ cycle counts by an order of magnitude.
   at each commit so cross-host reporting needs no daemon round-trips.
   **`snapshot_bytes` is reporting-only — never an enforcement input**: enforcement
   always derives from the owning store's live enumeration (the column can be one
-  generation stale in a crash window; a future bytes-based eviction reading it would
+  generation stale in a crash window; a future bytes-based destructive cleanup reading it would
   silently break this).
 - **Per-session enforcement**: commit-and-flag, never refuse (refusal destroys the
   agent's work as punishment for a state it wasn't awake to prevent). Over budget →
@@ -509,7 +509,7 @@ cycle counts by an order of magnitude.
   computed by summing `sessions.snapshot_bytes` pointers. v1 enforces per-host and
   reports global.
 - **Per-account caps** (`accounts.config.sandbox_snapshot_bytes`): **deferred to a
-  follow-up.** The eviction engine is the most intricate code in the design and would
+  follow-up.** A destructive quota engine is the most intricate code in the design and would
   ship dead (no account will have a cap set); v1 ships per-account *usage* as a read-time
   ops metric only. (Ethos review; consistent with the no-belt-and-suspenders rule.)
 - **Stated residual**: nothing bounds the *live* writable layer between commits on ext4 —
@@ -573,7 +573,7 @@ the tenant's own sandbox — unchanged from the agent running them directly.
 ### 5.9 Agent observability
 
 `build_messages` skips all non-`message` events today, so loss events need a render path:
-a minimal allowlist in context.py (`sandbox_fs_expired`, `sandbox_fs_over_limit`,
+a minimal allowlist in context.py (`sandbox_fs_expired` for legacy records, `sandbox_fs_over_limit`,
 `sandbox_fs_reset`) rendered as bracketed user-role notices at their seq position —
 append-only in, append-only out (monotonicity holds), **not** stimulus-bearing
 (`find_sessions_needing_inference` ignores them, so a GC append never wakes a session or
@@ -736,7 +736,7 @@ through FastAPI introspection → run `./scripts/regen-openapi.sh && ./scripts/r
 | Host loss | Detected at resume via the pointer (reset event), but the data is unrecoverable until a host-independent store exists — the §9.3 argument for the async `put`. With async push enabled: the replacement host's `store.get` falls back to the **last successful push** (a crash-dropped push is re-enqueued by the GC's push reconciliation, §5.5, so the lag is bounded by one tick in steady state). Elastic shape: the store is authoritative; loss bounded to unpushed deltas. |
 | Env image ref changed while parked | Detected via `aios.base_image` label → snapshot discarded (`store.remove` + pointer cleared) + `sandbox_fs_reset` event + cold start (§5.3). |
 | Mid-commit wake | Waking step blocks on the per-session lock ≤ commit duration (+ `put` duration in the elastic shape — both size-bounded), then provisions from the fresh tag. |
-| Giant layer (100 GB) | Size-derived timeout admits it; budget enforcement flattens/evicts via GC; never an infinite retry loop. |
+| Giant layer (100 GB) | Size-derived timeout admits it; budget enforcement flattens and pressure blocks new durable provisions; never an infinite retry loop. |
 | Session deleted while corpse/image exist | API can't touch Docker; GC removes both within ≤1 h (corpse pass checks retain rule before salvaging — no wasted commit). |
 
 ## 9. Deployment prerequisites (eumemic-ops, lockstep)
@@ -871,7 +871,7 @@ Docker availability: e2e requires real Docker (`DOCKER_HOST` per conftest); CI a
    Deliberate near-redundancy across different writer sets.
 7. **Idle-TTL default 300 s → 1800 s**: operator-visible behavior change shipped inside
    this feature because the feature inverts the constant's economics.
-8. **Per-account caps deferred** (usage metric ships, eviction engine doesn't);
+8. **Per-account caps deferred** (usage metric ships, destructive quota enforcement doesn't);
    **`--read-only` closed as incompatible** rather than re-deferred; **`--cap-drop=ALL`
    stays deferred** (NET_ADMIN removal ships now via the lockdown sidecar).
 9. **Rollback posture**: disable new snapshot creation while retaining lifecycle-

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -220,23 +220,24 @@ class Settings(BaseSettings):
         ge=0,
         description="Free disk retained in addition to the estimated transient flatten cost.",
     )
+    sandbox_archive_gc_grace_seconds: int = Field(
+        default=86400,
+        ge=0,
+        description="Grace after archived_at before canonical filesystem reclamation.",
+    )
     sandbox_snapshot_ttl_seconds: int = Field(
         default=2_592_000,  # 30 days
         ge=60,
-        description="Dormancy TTL for a persisted session snapshot. The GC "
-        "reconciler removes a snapshot whose session's last activity is older "
-        "than this (appending a model-visible ``sandbox_fs_expired`` notice), "
+        description="Dormancy threshold for non-destructive maintenance and pressure reporting. "
         "keyed on the session's ``(session_id, last_event_seq)`` event row. "
-        "Bounds supply-chain accumulation (agent-installed software re-executes "
-        "at every resume) and unbounded snapshot retention.",
+        "It never authorizes deletion of canonical non-archived state.",
     )
     sandbox_snapshot_pool_bytes: int | None = Field(
         default=None,
         ge=0,
-        description="Per-host snapshot disk budget in bytes (durable session "
-        "sandboxes, §5.7) — the load-bearing pool bound. When this host's "
-        "total snapshot bytes exceed it, the GC evicts the MOST-DORMANT "
-        "sessions first (``sandbox_fs_expired {disk_pressure}``). Required in "
+        description="Per-host snapshot pressure threshold in bytes (durable session "
+        "sandboxes, §5.7). Crossing it emits an operator diagnostic but never "
+        "authorizes deletion of canonical session state. Required in "
         "production once the eumemic-ops prune-cron exemption lands (that "
         "exemption removes the only existing disk control). ``None`` ⇒ "
         "unbounded retention (dev default); operators MUST set real host "

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -67,7 +67,7 @@ from aios.retirements.boot_gate import (
 from aios.sandbox.backends import select_sandbox_backend
 from aios.sandbox.github_clone_breaker import GithubCloneBreaker
 from aios.sandbox.network import ensure_sandbox_network, is_running_in_container
-from aios.sandbox.registry import SandboxRegistry
+from aios.sandbox.registry import GcPressureResult, SandboxRegistry
 from aios.sandbox.tool_broker import ToolBroker
 from aios.sandbox.workspace_ownership import repair_workspace_ownership
 
@@ -484,7 +484,19 @@ async def worker_main() -> None:
         # pointers against store truth, then repeats hourly. Boot is not
         # blocked — a session waking mid-reconcile salvages its own corpse
         # inline under its own lock.
-        sandbox_gc_task = sandbox_registry.start_gc(pool)
+        def _consume_snapshot_pressure(pressure: GcPressureResult) -> None:
+            sandbox_registry.set_provisioning_pressure(pressure)
+            if pressure.pressured:
+                log.error(
+                    "worker.sandbox_capacity_pressure_alarm",
+                    pool_used_bytes=pressure.pool_used_bytes,
+                    pool_budget_bytes=pressure.pool_budget_bytes,
+                    pressured_accounts=sorted(pressure.pressured_accounts),
+                )
+
+        sandbox_gc_task = sandbox_registry.start_gc(
+            pool, pressure_callback=_consume_snapshot_pressure
+        )
         _supervise(sandbox_gc_task, latch=supervised_latch, fatal=supervised_failure)
 
         # Start container + MCP-pool idle-TTL reapers.

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -71,6 +71,19 @@ from aios.sandbox.registry import GcPressureResult, SandboxRegistry
 from aios.sandbox.tool_broker import ToolBroker
 from aios.sandbox.workspace_ownership import repair_workspace_ownership
 
+
+def _consume_snapshot_pressure(registry: SandboxRegistry, pressure: GcPressureResult) -> None:
+    """Apply one GC pressure report to subsequent provisioning admission."""
+    registry.set_provisioning_pressure(pressure)
+    if pressure.pressured:
+        get_logger("aios.worker").error(
+            "worker.sandbox_capacity_pressure_alarm",
+            pool_used_bytes=pressure.pool_used_bytes,
+            pool_budget_bytes=pressure.pool_budget_bytes,
+            pressured_accounts=sorted(pressure.pressured_accounts),
+        )
+
+
 # Hashed (via Postgres ``hashtextextended($1, 0)``) into the 64-bit
 # advisory-lock key enforcing the worker-process singleton. The string
 # is a historical magic value, preserved verbatim so a rolling deploy
@@ -484,18 +497,11 @@ async def worker_main() -> None:
         # pointers against store truth, then repeats hourly. Boot is not
         # blocked — a session waking mid-reconcile salvages its own corpse
         # inline under its own lock.
-        def _consume_snapshot_pressure(pressure: GcPressureResult) -> None:
-            sandbox_registry.set_provisioning_pressure(pressure)
-            if pressure.pressured:
-                log.error(
-                    "worker.sandbox_capacity_pressure_alarm",
-                    pool_used_bytes=pressure.pool_used_bytes,
-                    pool_budget_bytes=pressure.pool_budget_bytes,
-                    pressured_accounts=sorted(pressure.pressured_accounts),
-                )
-
         sandbox_gc_task = sandbox_registry.start_gc(
-            pool, pressure_callback=_consume_snapshot_pressure
+            pool,
+            pressure_callback=lambda pressure: _consume_snapshot_pressure(
+                sandbox_registry, pressure
+            ),
         )
         _supervise(sandbox_gc_task, latch=supervised_latch, fatal=supervised_failure)
 

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -283,16 +283,32 @@ class SandboxRegistry:
         """Install the worker's latest GC-derived cold-provision admission state."""
         self._provisioning_pressure = pressure
 
-    def _admit_capacity_provision(self, owner_id: str) -> None:
-        """Reject a cold, capacity-consuming provision while GC reports pressure."""
-        if not self._provisioning_pressure.pressured:
+    def _admit_capacity_provision(
+        self, owner_id: str, *, account_id: str | None, durable: bool = True
+    ) -> None:
+        """Reject only provisions affected by the latest capacity pressure.
+
+        Host-pool pressure applies to every cold provision. Account pressure is
+        scoped to durable session sandboxes owned by that account; ephemeral run
+        sandboxes never add snapshots and therefore do not consume account cap.
+        """
+        pressure = self._provisioning_pressure
+        host_pressured = (
+            pressure.pool_budget_bytes is not None
+            and pressure.pool_used_bytes > pressure.pool_budget_bytes
+        )
+        account_pressured = (
+            durable and account_id is not None and account_id in pressure.pressured_accounts
+        )
+        if not (host_pressured or account_pressured):
             return
         log.error(
             "sandbox.provisioning_pressure_alarm",
             owner_id=owner_id,
-            pool_used_bytes=self._provisioning_pressure.pool_used_bytes,
-            pool_budget_bytes=self._provisioning_pressure.pool_budget_bytes,
-            pressured_accounts=sorted(self._provisioning_pressure.pressured_accounts),
+            account_id=account_id,
+            pool_used_bytes=pressure.pool_used_bytes,
+            pool_budget_bytes=pressure.pool_budget_bytes,
+            pressured_accounts=sorted(pressure.pressured_accounts),
         )
         raise RuntimeError(
             "sandbox provisioning temporarily unavailable: snapshot capacity pressure"
@@ -408,8 +424,13 @@ class SandboxRegistry:
                     # the before/after diff empty and silently drop the step's
                     # memory writes.
                     self.evict(session_id, unload_session_caches=False)
-            self._admit_capacity_provision(session_id)
-            handle = await self._provision_with_span(session_id, pool=pool)
+            account_id: str | None = None
+            if pool is not None:
+                from aios.services import sessions as sessions_service
+
+                account_id = await sessions_service.load_session_account_id(pool, session_id)
+            self._admit_capacity_provision(session_id, account_id=account_id)
+            handle = await self._provision_with_span(session_id, pool=pool, account_id=account_id)
             self._handles[session_id] = handle
             self._last_used[session_id] = time.monotonic()
             return handle
@@ -438,14 +459,19 @@ class SandboxRegistry:
         return current != handle.spec_version
 
     async def _provision_with_span(
-        self, session_id: str, *, pool: asyncpg.Pool[Any] | None
+        self,
+        session_id: str,
+        *,
+        pool: asyncpg.Pool[Any] | None,
+        account_id: str | None = None,
     ) -> SandboxHandle:
         if pool is None:
             return await self._provision(session_id)
 
         from aios.services import sessions as sessions_service
 
-        account_id = await sessions_service.load_session_account_id(pool, session_id)
+        if account_id is None:
+            account_id = await sessions_service.load_session_account_id(pool, session_id)
         span_start = await sessions_service.append_event(
             pool, session_id, "span", {"event": "sandbox_provision_start"}, account_id=account_id
         )
@@ -617,7 +643,7 @@ class SandboxRegistry:
                 # snapshot: a run sandbox has no durable rootfs to preserve) and
                 # cold-reprovision.
                 await self._destroy_run_quietly(run_id, current)
-            self._admit_capacity_provision(run_id)
+            self._admit_capacity_provision(run_id, account_id=None, durable=False)
             handle = await self._provision_run(run_id)
             self._handles[run_id] = handle
             self._last_used[run_id] = time.monotonic()

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -34,6 +34,7 @@ import asyncio
 import dataclasses
 import re
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
@@ -142,10 +143,10 @@ class SessionSnapshotState:
     """The GC's per-session decision inputs (one existing session row).
 
     A session *absent* from the GC's state map is **deleted** — its snapshot
-    is collectible without an event (the model is gone). ``last_event_at`` is
-    the dormancy probe (the ``created_at`` of the event at ``last_event_seq``);
-    ``None`` only on the should-not-happen no-events edge, treated as *not*
-    dormant (conservative — never wipe on a missing probe).
+    is collectible without an event (the model is gone). Canonical filesystem
+    state for an existing session is protected until the session is archived
+    and its archive grace interval has elapsed. ``last_event_at`` remains in
+    the query shape for accounting compatibility; it is not a lifecycle gate.
     """
 
     session_id: str
@@ -171,6 +172,24 @@ class GcImageVerdict:
     removal_ref: str  # the tag for a canonical image (cascade-deletes the chain), else the image id
     verdict: _GcVerdict
     reason: _GcReason
+
+
+@dataclass(frozen=True, slots=True)
+class GcPressureResult:
+    """Capacity pressure observed without widening lifecycle deletion rules."""
+
+    pool_used_bytes: int = 0
+    pool_budget_bytes: int | None = None
+    pressured_accounts: frozenset[str] = frozenset()
+
+    @property
+    def pressured(self) -> bool:
+        return (
+            self.pool_budget_bytes is not None and self.pool_used_bytes > self.pool_budget_bytes
+        ) or bool(self.pressured_accounts)
+
+
+PressureCallback = Callable[[GcPressureResult], Awaitable[None] | None]
 
 
 def _archive_eligible(
@@ -245,6 +264,7 @@ class SandboxRegistry:
         self._gc_task: asyncio.Task[None] | None = None
         self._egress_refresh_task: asyncio.Task[None] | None = None
         self._egress_states: dict[str, EgressRefreshState] = {}
+        self._provisioning_pressure = GcPressureResult()
         # Consecutive salvage failures keyed by full corpse id. The value is
         # ``(owning_session_id, failures, alarmed)`` — the owning session is
         # stored so a salvage pass for one session only reconciles/clears its
@@ -258,6 +278,25 @@ class SandboxRegistry:
         # GC'd before stop() unwinds the proxy's uvicorn server, httpx
         # client and bound TCP port.
         self._evict_proxy_stop_tasks: set[asyncio.Task[None]] = set()
+
+    def set_provisioning_pressure(self, pressure: GcPressureResult) -> None:
+        """Install the worker's latest GC-derived cold-provision admission state."""
+        self._provisioning_pressure = pressure
+
+    def _admit_capacity_provision(self, owner_id: str) -> None:
+        """Reject a cold, capacity-consuming provision while GC reports pressure."""
+        if not self._provisioning_pressure.pressured:
+            return
+        log.error(
+            "sandbox.provisioning_pressure_alarm",
+            owner_id=owner_id,
+            pool_used_bytes=self._provisioning_pressure.pool_used_bytes,
+            pool_budget_bytes=self._provisioning_pressure.pool_budget_bytes,
+            pressured_accounts=sorted(self._provisioning_pressure.pressured_accounts),
+        )
+        raise RuntimeError(
+            "sandbox provisioning temporarily unavailable: snapshot capacity pressure"
+        )
 
     def _lock_for(self, session_id: str) -> asyncio.Lock:
         lock = self._locks.get(session_id)
@@ -369,6 +408,7 @@ class SandboxRegistry:
                     # the before/after diff empty and silently drop the step's
                     # memory writes.
                     self.evict(session_id, unload_session_caches=False)
+            self._admit_capacity_provision(session_id)
             handle = await self._provision_with_span(session_id, pool=pool)
             self._handles[session_id] = handle
             self._last_used[session_id] = time.monotonic()
@@ -577,6 +617,7 @@ class SandboxRegistry:
                 # snapshot: a run sandbox has no durable rootfs to preserve) and
                 # cold-reprovision.
                 await self._destroy_run_quietly(run_id, current)
+            self._admit_capacity_provision(run_id)
             handle = await self._provision_run(run_id)
             self._handles[run_id] = handle
             self._last_used[run_id] = time.monotonic()
@@ -1868,7 +1909,9 @@ class SandboxRegistry:
 
     # ── GC: one retain-rule reconciler (§5.5) ───────────────────────────────
 
-    def start_gc(self, pool: asyncpg.Pool[Any]) -> asyncio.Task[None]:
+    def start_gc(
+        self, pool: asyncpg.Pool[Any], *, pressure_callback: PressureCallback | None = None
+    ) -> asyncio.Task[None]:
         """Start the snapshot GC reconciler (hourly, immediate first tick).
 
         Replaces the old boot-time ``reap_orphans``: instead of removing every
@@ -1879,7 +1922,9 @@ class SandboxRegistry:
         """
         if self._gc_task is not None:
             return self._gc_task
-        self._gc_task = asyncio.create_task(self._gc_loop(pool), name="sandbox-snapshot-gc")
+        self._gc_task = asyncio.create_task(
+            self._gc_loop(pool, pressure_callback), name="sandbox-snapshot-gc"
+        )
         return self._gc_task
 
     def stop_gc(self) -> None:
@@ -1888,7 +1933,9 @@ class SandboxRegistry:
             self._gc_task.cancel()
             self._gc_task = None
 
-    async def _gc_loop(self, pool: asyncpg.Pool[Any]) -> None:
+    async def _gc_loop(
+        self, pool: asyncpg.Pool[Any], pressure_callback: PressureCallback | None
+    ) -> None:
         """Background loop: immediate first tick, then hourly.
 
         The try/except is nested INSIDE the loop (mirroring the idle reaper):
@@ -1902,11 +1949,15 @@ class SandboxRegistry:
                 if not first:
                     await asyncio.sleep(_GC_INTERVAL_SECONDS)
                 first = False
-                await self._gc_once(pool)
+                pressure = await self._gc_once(pool)
+                if pressure_callback is not None:
+                    callback_result = pressure_callback(pressure)
+                    if callback_result is not None:
+                        await callback_result
             except Exception:
                 log.exception("sandbox.gc_tick_failed")
 
-    async def _gc_once(self, pool: asyncpg.Pool[Any]) -> None:
+    async def _gc_once(self, pool: asyncpg.Pool[Any]) -> GcPressureResult:
         """One GC tick: corpse pass, image pass, pool-budget pass, pointer reconcile."""
         settings = get_settings()
         instance_id = settings.instance_id
@@ -1937,24 +1988,16 @@ class SandboxRegistry:
         )
 
         # Pass 3 — per-host pool budget.
-        pool_evicted = await self._gc_pool_budget_pass(
+        pool_pressure = await self._gc_pool_budget_pass(
             retained, image_states, settings.sandbox_snapshot_pool_bytes, instance_id
         )
 
         # Pass 3b — per-account snapshot cap (quota tiers / plan limits, §5.7).
-        # Skip artifacts the pool-budget pass already evicted this tick.
-        cap_evicted = await self._gc_account_cap_pass(
-            retained, image_states, instance_id, already_evicted=pool_evicted
-        )
+        account_pressure = await self._gc_account_cap_pass(retained, image_states, instance_id)
 
-        # Pass 4 — pointer reconciliation against local store truth. Skip every
-        # snapshot evicted this tick (passes 3 + 3b): its image is gone, but the
-        # tick-start state still shows the pre-eviction pointer, so reconciling
-        # would resurrect a pointer to a now-removed image (a dangling pointer →
-        # unresumable session).
-        await self._gc_reconcile_pointers(
-            retained, image_states, instance_id, already_evicted=pool_evicted | cap_evicted
-        )
+        # Pass 4 — pointer reconciliation against local store truth. Pressure
+        # passes are observational and never remove lifecycle-protected images.
+        await self._gc_reconcile_pointers(retained, image_states, instance_id)
 
         log.info(
             "sandbox.gc_tick",
@@ -1962,6 +2005,11 @@ class SandboxRegistry:
             images=len(images),
             retained=len(retained),
             removed=len(verdicts) - len(retained),
+        )
+        return GcPressureResult(
+            pool_used_bytes=pool_pressure.pool_used_bytes,
+            pool_budget_bytes=pool_pressure.pool_budget_bytes,
+            pressured_accounts=account_pressure.pressured_accounts,
         )
 
     async def _load_gc_states(
@@ -1989,12 +2037,11 @@ class SandboxRegistry:
         """Re-read one session's GC state — the **condition re-verify** the
         retain rule needs under the per-session lock (§5.5).
 
-        The tick-start ``states`` snapshot can be stale for a session that woke
-        (or crossed back under the TTL) between the load and a drop decision;
-        re-deriving dormancy from a fresh single-row read under the lock is what
-        keeps the GC from force-removing a just-woke session's corpse without
-        salvage, or removing its canonical snapshot a tick too early. ``None``
-        ⇒ the session is genuinely gone (deleted), still collectible.
+        The tick-start ``states`` snapshot can be stale across archive,
+        unarchive, or rearchive. Re-reading under the lock proves the lifecycle
+        timestamp, grace boundary, pointer, and ownership used by a destructive
+        decision. ``None`` means deleted and is collectible only on paths whose
+        contract explicitly permits deleted-session cleanup.
         """
         from aios.harness import runtime
 
@@ -2011,9 +2058,9 @@ class SandboxRegistry:
     ) -> None:
         """Salvage (or drop) every managed container that isn't a live cached handle.
 
-        Retain rule first: a deleted/dormant session's corpse is removed
-        WITHOUT paying a commit; a live-within-TTL corpse is salvaged (commit)
-        then removed. Best-effort — a snapshot failure leaves the corpse for
+        Retain rule first: a deleted or archived-past-grace session's corpse is
+        removed WITHOUT paying a commit; every other existing session is
+        salvaged (committed) and then removed. Best-effort — a snapshot failure leaves the corpse for
         the next tick (the GC never raises). Each corpse is handled under the
         per-session lock with the cached-handle re-check.
 
@@ -2040,7 +2087,7 @@ class SandboxRegistry:
                     # destroy, no DB lookup.
                     await self._backend.force_remove(ref.sandbox_id)
                     continue
-                # ── session corpse: retain rule + under-lock dormancy re-verify ──
+                # ── session corpse: lifecycle rule + under-lock re-verify ──
                 state = states.get(sid)
                 fresh = await self._fresh_session_state(sid)
                 keep_fs = fresh is not None and not _archive_eligible(
@@ -2091,11 +2138,8 @@ class SandboxRegistry:
                 if self._handles.get(sid) is not None:
                     retained.append(v)
                     continue
-                # Condition re-verify (§5.5): a TTL-expiry removal is decided
-                # from the tick-start snapshot — re-read dormancy under the lock
-                # so a session that woke since the load keeps its canonical
-                # snapshot instead of being expired a tick early. (Deleted /
-                # residue verdicts can't flip back within a tick.)
+                # Condition re-verify: destructive archive cleanup requires a
+                # fresh proof of lifecycle, pointer, grace, and host ownership.
                 fresh = await self._fresh_session_state(sid)
                 if v.reason == "archived":
                     candidate = states.get(sid)
@@ -2105,7 +2149,7 @@ class SandboxRegistry:
                         or fresh.archived_at != candidate.archived_at
                         or not _archive_eligible(fresh, now, archive_grace_seconds)
                         or fresh.snapshot_ref != v.removal_ref
-                        or fresh.snapshot_host not in (None, instance_id)
+                        or fresh.snapshot_host != instance_id
                     ):
                         retained.append(v)
                         continue
@@ -2140,10 +2184,10 @@ class SandboxRegistry:
         states: dict[str, SessionSnapshotState],
         pool_bytes: int | None,
         instance_id: str,
-    ) -> set[str]:
-        """Report host pressure; lifecycle eligibility is never widened by it."""
+    ) -> GcPressureResult:
+        """Return host pressure; lifecycle eligibility is never widened by it."""
         if pool_bytes is None:
-            return set()
+            return GcPressureResult()
         base_sizes: dict[str, int] = {}
         total = sum(
             [
@@ -2154,7 +2198,7 @@ class SandboxRegistry:
         )
         if total > pool_bytes:
             log.error("sandbox.snapshot_pool_pressure", used_bytes=total, budget_bytes=pool_bytes)
-        return set()
+        return GcPressureResult(pool_used_bytes=total, pool_budget_bytes=pool_bytes)
 
     async def _gc_account_cap_pass(
         self,
@@ -2163,7 +2207,7 @@ class SandboxRegistry:
         instance_id: str,
         *,
         already_evicted: set[str] | None = None,
-    ) -> set[str]:
+    ) -> GcPressureResult:
         """Report account pressure without deleting canonical session state."""
         from aios.harness import runtime
 
@@ -2175,17 +2219,19 @@ class SandboxRegistry:
                 size = await self._unique_bytes_for_image(v.image, base_sizes)
                 totals[account] = totals.get(account, 0) + size
         pool = runtime.require_pool()
+        pressured: set[str] = set()
         for account, total in totals.items():
             async with pool.acquire() as conn:
                 cap = await queries.resolve_effective_sandbox_snapshot_bytes(conn, account)
             if cap is not None and total > cap:
+                pressured.add(account)
                 log.error(
                     "sandbox.snapshot_account_pressure",
                     account_id=account,
                     used_bytes=total,
                     budget_bytes=cap,
                 )
-        return set()
+        return GcPressureResult(pressured_accounts=frozenset(pressured))
 
     async def _gc_reconcile_pointers(
         self,

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -35,7 +35,7 @@ import dataclasses
 import re
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 
 from aios.config import get_settings
@@ -150,7 +150,7 @@ class SessionSnapshotState:
 
     session_id: str
     account_id: str
-    archived: bool
+    archived_at: datetime | None
     last_event_at: datetime | None
     snapshot_ref: str | None
     snapshot_host: str | None
@@ -158,7 +158,7 @@ class SessionSnapshotState:
 
 
 _GcVerdict = Literal["retain", "remove"]
-_GcReason = Literal["live", "retention_ttl", "deleted", "residue"]
+_GcReason = Literal["protected_live", "archive_grace", "archived", "deleted", "residue"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,15 +173,13 @@ class GcImageVerdict:
     reason: _GcReason
 
 
-def _is_session_dormant(state: SessionSnapshotState, now: datetime, ttl_seconds: int) -> bool:
-    """A session is dormant iff its last activity is older than the TTL.
-
-    Archived sessions follow the same rule (unarchive exists; immediate
-    deletion would strand it). A missing dormancy probe reads as *not* dormant.
-    """
-    if state.last_event_at is None:
-        return False
-    return (now - state.last_event_at).total_seconds() > ttl_seconds
+def _archive_eligible(
+    state: SessionSnapshotState, now: datetime, archive_grace_seconds: int
+) -> bool:
+    """Whether current state crossed the sole destructive lifecycle boundary."""
+    return state.archived_at is not None and now >= state.archived_at + timedelta(
+        seconds=archive_grace_seconds
+    )
 
 
 def _classify_images(
@@ -189,28 +187,13 @@ def _classify_images(
     states: dict[str, SessionSnapshotState],
     *,
     now: datetime,
-    ttl_seconds: int,
+    archive_grace_seconds: int,
     this_host: str,
 ) -> list[GcImageVerdict]:
-    """Pure retain-rule classifier for the GC image pass (§5.5), table-driven.
-
-    The single rule: **an image is retained iff it is the canonical tag of an
-    existing session whose last activity is within the TTL.** Everything else
-    managed-and-mine is removed — crash residue, flatten leftovers, deleted
-    sessions (the delete hook), and dormant sessions (the latter flagged
-    ``retention_ttl`` so the caller emits ``sandbox_fs_expired``).
-
-    Untagged interiors of *live* chains are skipped **structurally** — any
-    image that is the ``.Parent`` of another listed image is excluded (the
-    leaf's removal cascade-deletes the chain; removing an interior directly
-    would be refused anyway). On the containerd store ``.Parent`` may be empty;
-    the structural skip then no-ops and the ``remove_image`` refusal is the
-    safety net.
-    """
+    """Classify canonical state by archive lifecycle; residue stays collectible."""
     parent_ids = {img.parent_id for img in images if img.parent_id}
     verdicts: list[GcImageVerdict] = []
     for img in images:
-        # Structural skip: interior of a (possibly live) chain.
         if img.image_id in parent_ids:
             continue
         sid = img.labels.get(SESSION_LABEL_KEY)
@@ -218,26 +201,19 @@ def _classify_images(
         is_canonical = canonical_tag is not None and canonical_tag in img.repo_tags
         removal_ref = canonical_tag if (is_canonical and canonical_tag) else img.image_id
         state = states.get(sid) if sid else None
-
-        if is_canonical and state is not None and not _is_session_dormant(state, now, ttl_seconds):
-            verdict: _GcVerdict = "retain"
-            reason: _GcReason = "live"
-        elif is_canonical and state is not None:
-            verdict, reason = "remove", "retention_ttl"  # dormant → emit expired event
-        elif is_canonical and state is None:
-            verdict, reason = "remove", "deleted"  # session deleted → no event
+        if is_canonical and state is not None:
+            if state.archived_at is None:
+                verdict: _GcVerdict = "retain"
+                reason: _GcReason = "protected_live"
+            elif _archive_eligible(state, now, archive_grace_seconds):
+                verdict, reason = "remove", "archived"
+            else:
+                verdict, reason = "retain", "archive_grace"
+        elif is_canonical:
+            verdict, reason = "remove", "deleted"
         else:
-            verdict, reason = "remove", "residue"  # crash/flatten leftover, non-canonical
-        verdicts.append(
-            GcImageVerdict(
-                image=img,
-                session_id=sid,
-                is_canonical=is_canonical,
-                removal_ref=removal_ref,
-                verdict=verdict,
-                reason=reason,
-            )
-        )
+            verdict, reason = "remove", "residue"
+        verdicts.append(GcImageVerdict(img, sid, is_canonical, removal_ref, verdict, reason))
     return verdicts
 
 
@@ -1953,11 +1929,11 @@ class SandboxRegistry:
             images,
             image_states,
             now=now,
-            ttl_seconds=settings.sandbox_snapshot_ttl_seconds,
+            archive_grace_seconds=settings.sandbox_archive_gc_grace_seconds,
             this_host=instance_id,
         )
         retained = await self._gc_image_pass(
-            verdicts, image_states, now, settings.sandbox_snapshot_ttl_seconds, instance_id
+            verdicts, image_states, now, settings.sandbox_archive_gc_grace_seconds, instance_id
         )
 
         # Pass 3 — per-host pool budget.
@@ -2000,7 +1976,7 @@ class SandboxRegistry:
             row["id"]: SessionSnapshotState(
                 session_id=row["id"],
                 account_id=row["account_id"],
-                archived=row["archived_at"] is not None,
+                archived_at=row["archived_at"],
                 last_event_at=row["last_event_at"],
                 snapshot_ref=row["snapshot_ref"],
                 snapshot_host=row["snapshot_host"],
@@ -2065,17 +2041,19 @@ class SandboxRegistry:
                     await self._backend.force_remove(ref.sandbox_id)
                     continue
                 # ── session corpse: retain rule + under-lock dormancy re-verify ──
-                ttl = settings.sandbox_snapshot_ttl_seconds
                 state = states.get(sid)
-                keep_fs = state is not None and not _is_session_dormant(state, now, ttl)
-                if not keep_fs:
-                    # Drop candidate (deleted/dormant per the tick-start snapshot)
-                    # — re-verify dormancy under the lock (§5.5). A session that
-                    # woke since the load must be salvaged, not dropped without a
-                    # commit. (Only the drop direction can be wrong: a session
-                    # can't grow MORE dormant within one tick.)
-                    fresh = await self._fresh_session_state(sid)
-                    keep_fs = fresh is not None and not _is_session_dormant(fresh, now, ttl)
+                fresh = await self._fresh_session_state(sid)
+                keep_fs = fresh is not None and not _archive_eligible(
+                    fresh, now, settings.sandbox_archive_gc_grace_seconds
+                )
+                # Archived-past-grace destruction requires the exact timestamp
+                # seen by the scan. Any lifecycle race fails closed.
+                if (
+                    not keep_fs
+                    and fresh is not None
+                    and (state is None or fresh.archived_at != state.archived_at)
+                ):
+                    keep_fs = True
                 if keep_fs:
                     removable = await self._snapshot_and_record(
                         sid, ref.sandbox_id, disk_limit_bytes=settings.sandbox_snapshot_budget_bytes
@@ -2092,7 +2070,7 @@ class SandboxRegistry:
         verdicts: list[GcImageVerdict],
         states: dict[str, SessionSnapshotState],
         now: datetime,
-        ttl_seconds: int,
+        archive_grace_seconds: int,
         instance_id: str,
     ) -> list[GcImageVerdict]:
         """Remove every non-retained image (under per-session locks); return the retained."""
@@ -2118,19 +2096,39 @@ class SandboxRegistry:
                 # so a session that woke since the load keeps its canonical
                 # snapshot instead of being expired a tick early. (Deleted /
                 # residue verdicts can't flip back within a tick.)
-                if v.reason == "retention_ttl":
-                    fresh = await self._fresh_session_state(sid)
-                    if fresh is not None and not _is_session_dormant(fresh, now, ttl_seconds):
+                fresh = await self._fresh_session_state(sid)
+                if v.reason == "archived":
+                    candidate = states.get(sid)
+                    if (
+                        candidate is None
+                        or fresh is None
+                        or fresh.archived_at != candidate.archived_at
+                        or not _archive_eligible(fresh, now, archive_grace_seconds)
+                        or fresh.snapshot_ref != v.removal_ref
+                        or fresh.snapshot_host not in (None, instance_id)
+                    ):
                         retained.append(v)
                         continue
+                elif (
+                    v.reason == "residue"
+                    and fresh is not None
+                    and fresh.snapshot_ref
+                    in (
+                        v.removal_ref,
+                        *v.image.repo_tags,
+                    )
+                ):
+                    # Publication raced the scan: it is current now, not residue.
+                    retained.append(v)
+                    continue
                 removed = await self._backend.remove_image(v.removal_ref)
                 if not removed:
                     # Refused (a child still references it) — retain this tick.
                     retained.append(v)
                     continue
-                if v.reason == "retention_ttl":
+                if v.reason == "archived":
                     await self._append_fs_event(
-                        sid, SANDBOX_FS_EXPIRED_EVENT, {"reason": "retention_ttl"}
+                        sid, SANDBOX_FS_EXPIRED_EVENT, {"reason": "archived"}
                     )
                 if v.is_canonical:
                     await self._clear_pointer_if_owned(sid, instance_id, states)
@@ -2143,27 +2141,20 @@ class SandboxRegistry:
         pool_bytes: int | None,
         instance_id: str,
     ) -> set[str]:
-        """Evict most-dormant sessions first while this host is over its pool budget.
-
-        Returns the session_ids it evicted, so a downstream cap pass can skip
-        artifacts already gone this tick (and not double-count their bytes).
-        """
+        """Report host pressure; lifecycle eligibility is never widened by it."""
         if pool_bytes is None:
             return set()
         base_sizes: dict[str, int] = {}
-        sized: list[tuple[GcImageVerdict, int]] = []
-        total = 0
-        for v in retained:
-            if not v.is_canonical:
-                continue
-            ub = await self._unique_bytes_for_image(v.image, base_sizes)
-            total += ub
-            sized.append((v, ub))
-        if total <= pool_bytes:
-            return set()
-        return await self._evict_most_dormant(
-            sized, states, instance_id, total=total, budget=pool_bytes, reason="disk_pressure"
+        total = sum(
+            [
+                await self._unique_bytes_for_image(v.image, base_sizes)
+                for v in retained
+                if v.is_canonical
+            ]
         )
+        if total > pool_bytes:
+            log.error("sandbox.snapshot_pool_pressure", used_bytes=total, budget_bytes=pool_bytes)
+        return set()
 
     async def _gc_account_cap_pass(
         self,
@@ -2173,94 +2164,28 @@ class SandboxRegistry:
         *,
         already_evicted: set[str] | None = None,
     ) -> set[str]:
-        """Enforce per-account snapshot caps (``config.sandbox_snapshot_bytes``, §5.7).
-
-        Mirrors the per-host pool-budget pass, but partitioned by account: each
-        over-cap account's MOST-DORMANT snapshots are evicted first (each with a
-        model-visible ``sandbox_fs_expired {account_cap}`` event) until the
-        account is back under cap. An account with no configured cap (none up its
-        parent chain) is never enforced; under-cap accounts are untouched.
-
-        Returns the session_ids it evicted, so the pointer-reconcile pass can
-        skip them — their image is gone this tick but the tick-start state still
-        shows the pre-eviction pointer.
-        """
+        """Report account pressure without deleting canonical session state."""
         from aios.harness import runtime
 
-        skip = already_evicted or set()
-        base_sizes: dict[str, int] = {}  # shared across accounts (sessions share a base)
-        # Group retained canonical snapshots by owning account, summing bytes.
-        by_account: dict[str, list[tuple[GcImageVerdict, int]]] = {}
         totals: dict[str, int] = {}
+        base_sizes: dict[str, int] = {}
         for v in retained:
-            sid = v.session_id
-            if not v.is_canonical or sid is None or sid in skip:
-                continue
-            st = states.get(sid)
-            if st is None:
-                continue  # deleted since tick start — collected elsewhere
-            ub = await self._unique_bytes_for_image(v.image, base_sizes)
-            by_account.setdefault(st.account_id, []).append((v, ub))
-            totals[st.account_id] = totals.get(st.account_id, 0) + ub
-
+            if v.is_canonical and v.session_id in states:
+                account = states[v.session_id].account_id
+                size = await self._unique_bytes_for_image(v.image, base_sizes)
+                totals[account] = totals.get(account, 0) + size
         pool = runtime.require_pool()
-        evicted: set[str] = set()
-        for account_id, sized in by_account.items():
+        for account, total in totals.items():
             async with pool.acquire() as conn:
-                cap = await queries.resolve_effective_sandbox_snapshot_bytes(conn, account_id)
-            if cap is None or totals[account_id] <= cap:
-                continue
-            evicted |= await self._evict_most_dormant(
-                sized,
-                states,
-                instance_id,
-                total=totals[account_id],
-                budget=cap,
-                reason="account_cap",
-            )
-        return evicted
-
-    async def _evict_most_dormant(
-        self,
-        sized: list[tuple[GcImageVerdict, int]],
-        states: dict[str, SessionSnapshotState],
-        instance_id: str,
-        *,
-        total: int,
-        budget: int,
-        reason: str,
-    ) -> set[str]:
-        """Evict the most-dormant snapshots from ``sized`` until ``total`` ≤ ``budget``.
-
-        Shared by the per-host pool-budget and per-account cap passes (§5.5/§5.7).
-        Each removal takes the per-session lock and re-checks the cached handle
-        (a waking session is skipped, never evicted out from under itself),
-        appends a model-visible ``sandbox_fs_expired {reason}`` event, and clears
-        the ownership-gated pointer. Returns the evicted session_ids.
-        """
-
-        def _dormancy_key(item: tuple[GcImageVerdict, int]) -> datetime:
-            st = item[0].session_id and states.get(item[0].session_id)
-            if st and st.last_event_at is not None:
-                return st.last_event_at
-            return datetime.min.replace(tzinfo=UTC)  # unknown dormancy ⇒ evict first
-
-        evicted: set[str] = set()
-        for v, ub in sorted(sized, key=_dormancy_key):
-            if total <= budget:
-                break
-            sid = v.session_id
-            if sid is None:
-                continue
-            async with self._lock_for(sid):
-                if self._handles.get(sid) is not None:
-                    continue  # waking — skip
-                if await self._backend.remove_image(v.removal_ref):
-                    total -= ub
-                    evicted.add(sid)
-                    await self._append_fs_event(sid, SANDBOX_FS_EXPIRED_EVENT, {"reason": reason})
-                    await self._clear_pointer_if_owned(sid, instance_id, states)
-        return evicted
+                cap = await queries.resolve_effective_sandbox_snapshot_bytes(conn, account)
+            if cap is not None and total > cap:
+                log.error(
+                    "sandbox.snapshot_account_pressure",
+                    account_id=account,
+                    used_bytes=total,
+                    budget_bytes=cap,
+                )
+        return set()
 
     async def _gc_reconcile_pointers(
         self,

--- a/tests/unit/sandbox/test_gc_classify.py
+++ b/tests/unit/sandbox/test_gc_classify.py
@@ -163,3 +163,25 @@ def test_archived_current_observes_grace_boundary() -> None:
         [img], {"sess_a": at}, now=_NOW, archive_grace_seconds=grace, this_host=_HOST
     )[0]
     assert (verdict.verdict, verdict.reason) == ("remove", "archived")
+
+
+def test_zero_archive_grace_is_immediately_eligible() -> None:
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    state = replace(_state("sess_a", dormant=False), archived_at=_NOW)
+    verdict = _classify_images(
+        [img], {"sess_a": state}, now=_NOW, archive_grace_seconds=0, this_host=_HOST
+    )[0]
+    assert (verdict.verdict, verdict.reason) == ("remove", "archived")
+
+
+def test_nondefault_archive_grace_boundary() -> None:
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    state = replace(_state("sess_a", dormant=False), archived_at=_NOW - timedelta(seconds=17))
+    before = _classify_images(
+        [img], {"sess_a": state}, now=_NOW, archive_grace_seconds=18, this_host=_HOST
+    )[0]
+    at = _classify_images(
+        [img], {"sess_a": state}, now=_NOW, archive_grace_seconds=17, this_host=_HOST
+    )[0]
+    assert before.verdict == "retain"
+    assert at.verdict == "remove"

--- a/tests/unit/sandbox/test_gc_classify.py
+++ b/tests/unit/sandbox/test_gc_classify.py
@@ -1,11 +1,8 @@
-"""Table-driven coverage for the GC retain-rule classifier (durable session
-sandboxes, §5.5). ``_classify_images`` is pure, so it needs no Docker or DB.
+"""Table-driven coverage for lifecycle-based snapshot GC classification.
 
-The single rule: an image is RETAINED iff it is the canonical tag of an
-existing session whose last activity is within the TTL. Everything else
-managed-and-mine is removed — crash/flatten residue, deleted sessions (the
-delete hook), and dormant sessions (flagged ``retention_ttl``). Untagged
-interiors of live chains are skipped structurally.
+Canonical snapshots of existing, non-archived sessions are protected regardless
+of activity. Archived snapshots become collectible only when archive grace has
+elapsed; deleted sessions and non-canonical residue are collectible immediately.
 """
 
 from __future__ import annotations
@@ -18,7 +15,6 @@ from aios.sandbox.registry import SessionSnapshotState, _classify_images
 from aios.sandbox.spec import snapshot_tag
 
 _HOST = "default"
-_TTL = 30 * 24 * 3600
 _NOW = datetime(2026, 6, 10, tzinfo=UTC)
 
 
@@ -107,8 +103,8 @@ def test_structural_parent_skip_excludes_live_chain_interior() -> None:
     assert out["img_leaf"] == ("retain", "protected_live")
 
 
-def test_archived_session_within_ttl_is_retained() -> None:
-    """Archived sessions follow the same dormancy rule (unarchive exists)."""
+def test_archived_session_within_grace_is_retained() -> None:
+    """An archived session remains protected until archive grace elapses."""
     img = _image(image_id="img_a", session_id="sess_a", canonical=True)
     state = SessionSnapshotState(
         session_id="sess_a",

--- a/tests/unit/sandbox/test_gc_classify.py
+++ b/tests/unit/sandbox/test_gc_classify.py
@@ -10,6 +10,7 @@ interiors of live chains are skipped structurally.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 from aios.sandbox.backends.base import SESSION_LABEL_KEY, ManagedImage
@@ -49,7 +50,7 @@ def _state(session_id: str, *, dormant: bool) -> SessionSnapshotState:
     return SessionSnapshotState(
         session_id=session_id,
         account_id="acct",
-        archived=False,
+        archived_at=None,
         last_event_at=last,
         snapshot_ref=snapshot_tag(_HOST, session_id),
         snapshot_host=_HOST,
@@ -60,20 +61,22 @@ def _state(session_id: str, *, dormant: bool) -> SessionSnapshotState:
 def _classify(
     images: list[ManagedImage], states: dict[str, SessionSnapshotState]
 ) -> dict[str, tuple[str, str]]:
-    verdicts = _classify_images(images, states, now=_NOW, ttl_seconds=_TTL, this_host=_HOST)
+    verdicts = _classify_images(
+        images, states, now=_NOW, archive_grace_seconds=86400, this_host=_HOST
+    )
     return {v.image.image_id: (v.verdict, v.reason) for v in verdicts}
 
 
 def test_live_canonical_is_retained() -> None:
     img = _image(image_id="img_a", session_id="sess_a", canonical=True)
     out = _classify([img], {"sess_a": _state("sess_a", dormant=False)})
-    assert out["img_a"] == ("retain", "live")
+    assert out["img_a"] == ("retain", "protected_live")
 
 
-def test_dormant_canonical_is_removed_with_ttl_reason() -> None:
+def test_dormant_canonical_is_protected() -> None:
     img = _image(image_id="img_a", session_id="sess_a", canonical=True)
     out = _classify([img], {"sess_a": _state("sess_a", dormant=True)})
-    assert out["img_a"] == ("remove", "retention_ttl")
+    assert out["img_a"] == ("retain", "protected_live")
 
 
 def test_deleted_session_canonical_is_removed_no_event() -> None:
@@ -101,7 +104,7 @@ def test_structural_parent_skip_excludes_live_chain_interior() -> None:
     interior = _image(image_id="img_interior", session_id="sess_a", canonical=False)
     out = _classify([leaf, interior], {"sess_a": _state("sess_a", dormant=False)})
     assert "img_interior" not in out, "live-chain interior must be skipped, not classified"
-    assert out["img_leaf"] == ("retain", "live")
+    assert out["img_leaf"] == ("retain", "protected_live")
 
 
 def test_archived_session_within_ttl_is_retained() -> None:
@@ -110,14 +113,14 @@ def test_archived_session_within_ttl_is_retained() -> None:
     state = SessionSnapshotState(
         session_id="sess_a",
         account_id="acct",
-        archived=True,
+        archived_at=_NOW - timedelta(hours=12),
         last_event_at=_NOW - timedelta(days=1),
         snapshot_ref=snapshot_tag(_HOST, "sess_a"),
         snapshot_host=_HOST,
         snapshot_bytes=1,
     )
     out = _classify([img], {"sess_a": state})
-    assert out["img_a"] == ("retain", "live")
+    assert out["img_a"] == ("retain", "archive_grace")
 
 
 def test_missing_dormancy_probe_is_not_dormant() -> None:
@@ -127,11 +130,36 @@ def test_missing_dormancy_probe_is_not_dormant() -> None:
     state = SessionSnapshotState(
         session_id="sess_a",
         account_id="acct",
-        archived=False,
+        archived_at=None,
         last_event_at=None,
         snapshot_ref=snapshot_tag(_HOST, "sess_a"),
         snapshot_host=_HOST,
         snapshot_bytes=1,
     )
     out = _classify([img], {"sess_a": state})
-    assert out["img_a"] == ("retain", "live")
+    assert out["img_a"] == ("retain", "protected_live")
+
+
+def test_arbitrarily_dormant_non_archived_canonical_is_protected() -> None:
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    state = _state("sess_a", dormant=True)
+    out = _classify([img], {"sess_a": state})
+    assert out["img_a"] == ("retain", "protected_live")
+
+
+def test_archived_current_observes_grace_boundary() -> None:
+    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
+    state = _state("sess_a", dormant=True)
+    grace = 86400
+    before = replace(state, archived_at=_NOW - timedelta(seconds=grace - 1))
+    at = replace(state, archived_at=_NOW - timedelta(seconds=grace))
+    assert (
+        _classify_images(
+            [img], {"sess_a": before}, now=_NOW, archive_grace_seconds=grace, this_host=_HOST
+        )[0].verdict
+        == "retain"
+    )
+    verdict = _classify_images(
+        [img], {"sess_a": at}, now=_NOW, archive_grace_seconds=grace, this_host=_HOST
+    )[0]
+    assert (verdict.verdict, verdict.reason) == ("remove", "archived")

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -43,7 +43,7 @@ def _state(session_id: str, *, dormant: bool) -> SessionSnapshotState:
     return SessionSnapshotState(
         session_id=session_id,
         account_id="acct",
-        archived=False,
+        archived_at=None,
         last_event_at=_NOW - timedelta(days=40 if dormant else 1),
         snapshot_ref=snapshot_tag(get_settings().instance_id, session_id),
         snapshot_host=get_settings().instance_id,
@@ -116,9 +116,7 @@ async def test_corpse_pass_drops_still_dormant_session_without_commit(
         get_settings().instance_id,
     )
 
-    assert not any(c[0] == "snapshot" for c in backend.calls), (
-        "a still-dormant corpse must be dropped without paying a commit"
-    )
+    assert any(c[0] == "snapshot" for c in backend.calls)
     assert any(c[0] == "force_remove" for c in backend.calls)
 
 
@@ -187,7 +185,7 @@ async def test_image_pass_retains_ttl_removal_for_session_that_woke(
         is_canonical=True,
         removal_ref=tag,
         verdict="remove",
-        reason="retention_ttl",
+        reason="archived",
     )
 
     retained = await registry._gc_image_pass(
@@ -209,7 +207,7 @@ def _acct_state(session_id: str, *, account_id: str, days_dormant: float) -> Ses
     return SessionSnapshotState(
         session_id=session_id,
         account_id=account_id,
-        archived=False,
+        archived_at=None,
         last_event_at=_NOW - timedelta(days=days_dormant),
         snapshot_ref=snapshot_tag(get_settings().instance_id, session_id),
         snapshot_host=get_settings().instance_id,
@@ -233,7 +231,7 @@ def _canonical_verdict(session_id: str, *, size_bytes: int) -> GcImageVerdict:
         is_canonical=True,
         removal_ref=tag,
         verdict="retain",
-        reason="live",
+        reason="protected_live",
     )
 
 
@@ -280,13 +278,9 @@ async def test_account_cap_pass_evicts_most_dormant_first(
     await registry._gc_account_cap_pass([fresh, mid, old], states, get_settings().instance_id)
 
     removed = [c[1]["ref"] for c in backend.calls if c[0] == "remove_image"]
-    assert removed == [old.removal_ref], (
-        "only the single most-dormant snapshot should be evicted to drop under cap"
-    )
+    assert removed == []
     # The eviction emits a model-visible sandbox_fs_expired {account_cap} event.
-    registry._append_fs_event.assert_awaited_once_with(  # type: ignore[attr-defined]
-        "sess_old", "sandbox_fs_expired", {"reason": "account_cap"}
-    )
+    registry._append_fs_event.assert_not_awaited()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio
@@ -351,7 +345,7 @@ async def test_account_cap_pass_is_per_account(
     )
 
     removed = [c[1]["ref"] for c in backend.calls if c[0] == "remove_image"]
-    assert removed == [over_old.removal_ref]
+    assert removed == []
 
 
 @pytest.mark.asyncio
@@ -378,7 +372,7 @@ async def test_account_cap_pass_skips_waking_session(
     removed = [c[1]["ref"] for c in backend.calls if c[0] == "remove_image"]
     # The waking session is skipped; the next-most-dormant is evicted instead.
     assert old.removal_ref not in removed
-    assert removed == [new.removal_ref]
+    assert removed == []
 
 
 @pytest.mark.asyncio
@@ -404,7 +398,7 @@ async def test_reconcile_skips_snapshot_evicted_this_tick(
         "sess_x": SessionSnapshotState(
             session_id="sess_x",
             account_id="acct",
-            archived=False,
+            archived_at=None,
             last_event_at=_NOW - timedelta(days=1),
             snapshot_ref=None,  # live canonical image on disk, but NULL DB pointer
             snapshot_host=instance_id,
@@ -422,9 +416,9 @@ async def test_reconcile_skips_snapshot_evicted_this_tick(
 
     # Pass 3 evicts sess_x under disk pressure (2 MB snapshot vs 1 MB pool budget).
     evicted = await registry._gc_pool_budget_pass([verdict], states, 1_000_000, instance_id)
-    assert evicted == {"sess_x"}
-    assert verdict.removal_ref in backend.removed_image_refs
+    assert evicted == set()
+    assert verdict.removal_ref not in backend.removed_image_refs
 
     # Pass 4, told what was evicted this tick, must NOT re-point the removed image.
     await registry._gc_reconcile_pointers([verdict], states, instance_id, already_evicted=evicted)
-    set_pointer.assert_not_awaited()
+    set_pointer.assert_awaited_once()

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -11,6 +11,7 @@ says active, and assert the woke session is salvaged / retained — not dropped.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -415,10 +416,100 @@ async def test_reconcile_skips_snapshot_evicted_this_tick(
     set_pointer.reset_mock()
 
     # Pass 3 evicts sess_x under disk pressure (2 MB snapshot vs 1 MB pool budget).
-    evicted = await registry._gc_pool_budget_pass([verdict], states, 1_000_000, instance_id)
-    assert evicted == set()
+    pressure = await registry._gc_pool_budget_pass([verdict], states, 1_000_000, instance_id)
+    assert pressure.pressured
+    assert pressure.pool_used_bytes == 2_000_000
     assert verdict.removal_ref not in backend.removed_image_refs
 
-    # Pass 4, told what was evicted this tick, must NOT re-point the removed image.
-    await registry._gc_reconcile_pointers([verdict], states, instance_id, already_evicted=evicted)
-    set_pointer.assert_awaited_once()
+    # Pressure reports capacity state without deleting or suppressing reconciliation.
+    await registry._gc_reconcile_pointers([verdict], states, instance_id)
+    assert set_pointer.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_archived_current_positive_ownership_is_removed() -> None:
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    tag = snapshot_tag(get_settings().instance_id, "sess_x")
+    archived_at = _NOW - timedelta(days=2)
+    state = SessionSnapshotState(
+        "sess_x", "acct", archived_at, _NOW, tag, get_settings().instance_id, 1
+    )
+    verdict = GcImageVerdict(
+        ManagedImage("img", (tag,), None, 1, {}), "sess_x", True, tag, "remove", "archived"
+    )
+    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
+    registry._append_fs_event = AsyncMock()  # type: ignore[method-assign]
+    registry._clear_pointer_if_owned = AsyncMock()  # type: ignore[method-assign]
+
+    retained = await registry._gc_image_pass(
+        [verdict], {"sess_x": state}, _NOW, 86400, get_settings().instance_id
+    )
+
+    assert retained == []
+    assert tag in backend.removed_image_refs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["null_host", "stale_grace", "pointer_moved", "rearchived"])
+async def test_archived_current_destructive_path_fails_closed(failure: str) -> None:
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    host = get_settings().instance_id
+    tag = snapshot_tag(host, "sess_x")
+    archived_at = _NOW - timedelta(days=2)
+    candidate = SessionSnapshotState("sess_x", "acct", archived_at, _NOW, tag, host, 1)
+    fresh = candidate
+    if failure == "null_host":
+        fresh = replace(candidate, snapshot_host=None)
+    elif failure == "stale_grace":
+        fresh = replace(candidate, archived_at=_NOW - timedelta(seconds=86399))
+    elif failure == "pointer_moved":
+        fresh = replace(candidate, snapshot_ref="other")
+    else:
+        fresh = replace(candidate, archived_at=archived_at + timedelta(seconds=1))
+    verdict = GcImageVerdict(
+        ManagedImage("img", (tag,), None, 1, {}), "sess_x", True, tag, "remove", "archived"
+    )
+    registry._fresh_session_state = AsyncMock(return_value=fresh)  # type: ignore[method-assign]
+
+    retained = await registry._gc_image_pass([verdict], {"sess_x": candidate}, _NOW, 86400, host)
+
+    assert retained == [verdict]
+    assert tag not in backend.removed_image_refs
+
+
+@pytest.mark.asyncio
+async def test_archived_within_grace_corpse_is_salvaged() -> None:
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    state = replace(_state("sess_x", dormant=False), archived_at=_NOW - timedelta(seconds=16))
+    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
+    registry._snapshot_and_record = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    container = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 17})
+
+    await registry._gc_corpse_pass(
+        [container], {"sess_x": state}, _NOW, settings, get_settings().instance_id
+    )
+
+    registry._snapshot_and_record.assert_awaited_once()
+    assert any(call[0] == "force_remove" for call in backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_failure_retains_archived_grace_corpse() -> None:
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    state = replace(_state("sess_x", dormant=False), archived_at=_NOW)
+    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
+    registry._snapshot_and_record = AsyncMock(return_value=False)  # type: ignore[method-assign]
+    container = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 17})
+
+    await registry._gc_corpse_pass(
+        [container], {"sess_x": state}, _NOW, settings, get_settings().instance_id
+    )
+
+    registry._snapshot_and_record.assert_awaited_once()
+    assert not any(call[0] == "force_remove" for call in backend.calls)

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -197,7 +197,7 @@ async def test_image_pass_retains_archived_removal_after_unarchive(
     assert not any(c[0] == "remove_image" for c in backend.calls)
 
 
-# ─── account-cap eviction pass (per-account snapshot quota, §5.7) ──────────────
+# ─── observational account-cap pass (per-account snapshot quota, §5.7) ────────
 
 
 def _acct_state(session_id: str, *, account_id: str, days_dormant: float) -> SessionSnapshotState:
@@ -243,9 +243,8 @@ def _patch_caps(monkeypatch: pytest.MonkeyPatch, caps: dict[str, int | None]) ->
 
 
 def _stub_event_and_pointer(registry: SandboxRegistry) -> None:
-    """Stub the DB-touching side effects of an eviction so the pass can run on
-    the FakePool (which has no real ``transaction``). The event text itself is
-    asserted in ``tests/unit/test_context_fs_lifecycle.py``."""
+    """Stub DB-touching methods so observational-pass tests can assert that
+    neither lifecycle events nor pointer changes occur on the transaction-less FakePool."""
     registry._append_fs_event = AsyncMock()  # type: ignore[method-assign]
     registry._clear_pointer_if_owned = AsyncMock()  # type: ignore[method-assign]
 
@@ -254,15 +253,15 @@ def _stub_event_and_pointer(registry: SandboxRegistry) -> None:
 async def test_account_cap_pass_evicts_most_dormant_first(
     fake_pool: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An over-cap account's MOST-DORMANT snapshots are evicted first until the
-    account is back under cap, each with ``sandbox_fs_expired {account_cap}``."""
+    """An over-cap account is reported without removing snapshots or emitting
+    filesystem lifecycle events."""
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
     _stub_event_and_pointer(registry)
     _patch_caps(monkeypatch, {"acct_a": 2_500_000})
 
-    # Three sessions of acct_a, 1MB each (3MB > 2.5MB cap). Evicting the single
-    # most-dormant (sess_old, 6 days) brings the account to 2MB ≤ cap.
+    # Three sessions of acct_a, 1MB each (3MB > 2.5MB cap). The pass observes
+    # the overage while retaining every lifecycle-protected snapshot.
     fresh = _canonical_verdict("sess_new", size_bytes=1_000_000)
     mid = _canonical_verdict("sess_mid", size_bytes=1_000_000)
     old = _canonical_verdict("sess_old", size_bytes=1_000_000)
@@ -276,7 +275,7 @@ async def test_account_cap_pass_evicts_most_dormant_first(
 
     removed = [c[1]["ref"] for c in backend.calls if c[0] == "remove_image"]
     assert removed == []
-    # The eviction emits a model-visible sandbox_fs_expired {account_cap} event.
+    # Observing account pressure emits no filesystem lifecycle event.
     registry._append_fs_event.assert_not_awaited()  # type: ignore[attr-defined]
 
 
@@ -306,7 +305,7 @@ async def test_account_cap_pass_leaves_under_cap_account_untouched(
 async def test_account_cap_pass_skips_accounts_with_no_cap(
     fake_pool: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """An account with no configured cap is never enforced, however large."""
+    """An account with no configured cap remains untouched, however large."""
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
     _patch_caps(monkeypatch, {"acct_a": None})
@@ -322,8 +321,8 @@ async def test_account_cap_pass_skips_accounts_with_no_cap(
 async def test_account_cap_pass_is_per_account(
     fake_pool: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Each account is enforced against its own cap independently: an over-cap
-    account is trimmed while an under-cap one is left alone."""
+    """Account-cap observation is independent per account and retains snapshots
+    for both over-cap and under-cap accounts."""
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
     _stub_event_and_pointer(registry)
@@ -349,8 +348,8 @@ async def test_account_cap_pass_is_per_account(
 async def test_account_cap_pass_skips_waking_session(
     fake_pool: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A session that holds a live cached handle (waking) is never evicted out
-    from under itself, even when it is the most-dormant over-cap candidate."""
+    """Account pressure remains observational when a session has a live cached
+    handle; no snapshot is removed."""
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
     _stub_event_and_pointer(registry)
@@ -367,7 +366,7 @@ async def test_account_cap_pass_skips_waking_session(
     await registry._gc_account_cap_pass([old, new], states, get_settings().instance_id)
 
     removed = [c[1]["ref"] for c in backend.calls if c[0] == "remove_image"]
-    # The waking session is skipped; the next-most-dormant is evicted instead.
+    # Pressure accounting does not remove either the waking or dormant snapshot.
     assert old.removal_ref not in removed
     assert removed == []
 
@@ -376,20 +375,12 @@ async def test_account_cap_pass_skips_waking_session(
 async def test_reconcile_skips_snapshot_evicted_this_tick(
     fake_pool: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Pass 4 must not re-point a session whose canonical image an earlier pass
-    removed this tick.
-
-    The eviction passes leave the verdict in ``retained`` and don't mutate the
-    tick-start ``states``, so an evicted session still presents its pre-eviction
-    pointer (here NULL — the first-commit-crash-heal window: a committed tag
-    whose pointer write was lost). Without the ``already_evicted`` skip, pass 4
-    heals that NULL pointer by writing a pointer to the image pass 3 just
-    removed — a dangling pointer that makes the session unresumable.
-    """
+    """An observational pressure pass retains the canonical image and allows
+    pointer reconciliation to heal a missing pointer in the same tick."""
     instance_id = get_settings().instance_id
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
-    _stub_event_and_pointer(registry)  # stub eviction's event + pointer-clear side effects
+    _stub_event_and_pointer(registry)  # verify pressure causes no lifecycle side effects
     verdict = _canonical_verdict("sess_x", size_bytes=2_000_000)
     states = {
         "sess_x": SessionSnapshotState(
@@ -405,13 +396,12 @@ async def test_reconcile_skips_snapshot_evicted_this_tick(
     set_pointer = AsyncMock()
     monkeypatch.setattr("aios.sandbox.registry.queries.unscoped_set_session_snapshot", set_pointer)
 
-    # Baseline: with nothing evicted, pass 4 legitimately heals the NULL pointer.
-    # This proves the resurrection path is live, so the skip below is not vacuous.
+    # Pointer reconciliation legitimately heals the NULL pointer.
     await registry._gc_reconcile_pointers([verdict], states, instance_id, already_evicted=set())
     set_pointer.assert_awaited_once()
     set_pointer.reset_mock()
 
-    # Pass 3 evicts sess_x under disk pressure (2 MB snapshot vs 1 MB pool budget).
+    # Pass 3 reports disk pressure (2 MB snapshot vs 1 MB pool budget) without removal.
     pressure = await registry._gc_pool_budget_pass([verdict], states, 1_000_000, instance_id)
     assert pressure.pressured
     assert pressure.pool_used_bytes == 2_000_000

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -1,11 +1,8 @@
-"""The GC passes' under-lock dormancy RE-VERIFY (durable session sandboxes, §5.5).
+"""Impure snapshot-GC pass tests for under-lock lifecycle re-verification.
 
-The retain rule is decided from a ``states`` snapshot loaded once per tick, but
-the design requires the condition to be **re-verified under the per-session
-lock**: a session that wakes (or crosses back under the TTL) between the load
-and a drop decision must keep its filesystem. These tests drive the impure
-corpse/image passes with a stale-dormant tick-start state and a fresh-read that
-says active, and assert the woke session is salvaged / retained — not dropped.
+Destructive archive cleanup must re-read archive state, grace, pointer, and host
+ownership while holding the session lock. Lifecycle races fail closed; deleted
+sessions and ephemeral run corpses may be destroyed without snapshotting.
 """
 
 from __future__ import annotations
@@ -27,7 +24,7 @@ from aios.sandbox.spec import snapshot_tag
 from tests.helpers.sandbox import FakeBackend, FakePool
 
 _NOW = datetime(2026, 6, 10, tzinfo=UTC)
-_TTL = 30 * 24 * 3600
+_ARCHIVE_GRACE = 30 * 24 * 3600
 
 
 @pytest.fixture
@@ -169,11 +166,10 @@ async def test_corpse_pass_run_owner_dropped_without_db_lookup_or_snapshot(
 
 
 @pytest.mark.asyncio
-async def test_image_pass_retains_ttl_removal_for_session_that_woke(
+async def test_image_pass_retains_archived_removal_after_unarchive(
     fake_pool: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A retention_ttl removal verdict is re-verified under the lock — a session
-    that woke since the tick-start load keeps its canonical snapshot image."""
+    """An explicit unarchive in the fresh read fails closed."""
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
     _patch_fresh_read(monkeypatch, dormant=False)  # woke
@@ -193,11 +189,11 @@ async def test_image_pass_retains_ttl_removal_for_session_that_woke(
         [verdict],
         {"sess_x": _state("sess_x", dormant=True)},
         _NOW,
-        _TTL,
+        _ARCHIVE_GRACE,
         get_settings().instance_id,
     )
 
-    assert retained == [verdict], "a woke session's snapshot must not be expired a tick early"
+    assert retained == [verdict], "an explicitly unarchived session must retain its snapshot"
     assert not any(c[0] == "remove_image" for c in backend.calls)
 
 
@@ -451,7 +447,9 @@ async def test_archived_current_positive_ownership_is_removed() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failure", ["null_host", "stale_grace", "pointer_moved", "rearchived"])
+@pytest.mark.parametrize(
+    "failure", ["null_host", "stale_grace", "pointer_moved", "unarchived", "rearchived"]
+)
 async def test_archived_current_destructive_path_fails_closed(failure: str) -> None:
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
@@ -466,6 +464,8 @@ async def test_archived_current_destructive_path_fails_closed(failure: str) -> N
         fresh = replace(candidate, archived_at=_NOW - timedelta(seconds=86399))
     elif failure == "pointer_moved":
         fresh = replace(candidate, snapshot_ref="other")
+    elif failure == "unarchived":
+        fresh = replace(candidate, archived_at=None)
     else:
         fresh = replace(candidate, archived_at=archived_at + timedelta(seconds=1))
     verdict = GcImageVerdict(
@@ -513,3 +513,62 @@ async def test_snapshot_failure_retains_archived_grace_corpse() -> None:
 
     registry._snapshot_and_record.assert_awaited_once()
     assert not any(call[0] == "force_remove" for call in backend.calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("grace_seconds, age_seconds", [(17, 17), (0, 0)])
+async def test_archived_corpse_at_boundary_is_bare_destroyed(
+    grace_seconds: int, age_seconds: int
+) -> None:
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    archived_at = _NOW - timedelta(seconds=age_seconds)
+    state = replace(_state("sess_x", dormant=False), archived_at=archived_at)
+    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
+    registry._snapshot_and_record = AsyncMock()  # type: ignore[method-assign]
+    corpse = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": grace_seconds})
+
+    await registry._gc_corpse_pass(
+        [corpse], {"sess_x": state}, _NOW, settings, get_settings().instance_id
+    )
+
+    registry._snapshot_and_record.assert_not_awaited()
+    assert ("force_remove", {"sandbox_id": "cid"}) in backend.calls
+
+
+@pytest.mark.asyncio
+async def test_archived_past_grace_corpse_is_bare_destroyed() -> None:
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    state = replace(_state("sess_x", dormant=False), archived_at=_NOW - timedelta(days=2))
+    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
+    registry._snapshot_and_record = AsyncMock()  # type: ignore[method-assign]
+    corpse = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 86400})
+
+    await registry._gc_corpse_pass(
+        [corpse], {"sess_x": state}, _NOW, settings, get_settings().instance_id
+    )
+
+    registry._snapshot_and_record.assert_not_awaited()
+    assert any(call[0] == "force_remove" for call in backend.calls)
+
+
+@pytest.mark.asyncio
+async def test_corpse_rearchive_race_fails_closed_and_salvages() -> None:
+    backend = FakeBackend()
+    registry = SandboxRegistry(backend=backend)
+    scanned = replace(_state("sess_x", dormant=False), archived_at=_NOW - timedelta(days=2))
+    fresh = replace(scanned, archived_at=_NOW - timedelta(days=2) + timedelta(seconds=1))
+    registry._fresh_session_state = AsyncMock(return_value=fresh)  # type: ignore[method-assign]
+    registry._snapshot_and_record = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    corpse = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
+    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 86400})
+
+    await registry._gc_corpse_pass(
+        [corpse], {"sess_x": scanned}, _NOW, settings, get_settings().instance_id
+    )
+
+    registry._snapshot_and_record.assert_awaited_once()
+    assert any(call[0] == "force_remove" for call in backend.calls)

--- a/tests/unit/sandbox/test_gc_pressure_admission.py
+++ b/tests/unit/sandbox/test_gc_pressure_admission.py
@@ -1,0 +1,62 @@
+"""GC pressure is applied only to provisioning that can worsen that pressure."""
+
+import importlib
+from unittest.mock import Mock
+
+import pytest
+
+from aios.harness.worker import _consume_snapshot_pressure
+from aios.sandbox.registry import GcPressureResult, SandboxRegistry
+from tests.helpers.sandbox import FakeBackend
+
+
+def test_account_pressure_is_scoped_and_alarm_clears(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = SandboxRegistry(backend=FakeBackend())
+    alarm = Mock()
+    monkeypatch.setattr("aios.sandbox.registry.log.error", alarm)
+    registry.set_provisioning_pressure(GcPressureResult(pressured_accounts=frozenset({"acct_hot"})))
+
+    with pytest.raises(RuntimeError, match="snapshot capacity pressure"):
+        registry._admit_capacity_provision("sess_hot", account_id="acct_hot")
+    registry._admit_capacity_provision("sess_other", account_id="acct_other")
+    registry._admit_capacity_provision("wfr_run", account_id=None, durable=False)
+    alarm.assert_called_once()
+
+    registry.set_provisioning_pressure(GcPressureResult())
+    registry._admit_capacity_provision("sess_hot", account_id="acct_hot")
+
+
+def test_host_pool_pressure_remains_global() -> None:
+    registry = SandboxRegistry(backend=FakeBackend())
+    registry.set_provisioning_pressure(GcPressureResult(pool_used_bytes=11, pool_budget_bytes=10))
+
+    with pytest.raises(RuntimeError, match="snapshot capacity pressure"):
+        registry._admit_capacity_provision("sess_any", account_id="acct_other")
+    with pytest.raises(RuntimeError, match="snapshot capacity pressure"):
+        registry._admit_capacity_provision("wfr_run", account_id=None, durable=False)
+
+
+def test_worker_gc_callback_drives_and_clears_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SandboxRegistry(backend=FakeBackend())
+    worker_alarm = Mock()
+    worker_module = importlib.import_module("aios.harness.worker")
+    logger = Mock()
+    logger.error = worker_alarm
+    monkeypatch.setattr(worker_module, "get_logger", Mock(return_value=logger))
+
+    _consume_snapshot_pressure(
+        registry, GcPressureResult(pressured_accounts=frozenset({"acct_hot"}))
+    )
+    with pytest.raises(RuntimeError):
+        registry._admit_capacity_provision("sess_hot", account_id="acct_hot")
+    worker_alarm.assert_called_once_with(
+        "worker.sandbox_capacity_pressure_alarm",
+        pool_used_bytes=0,
+        pool_budget_bytes=None,
+        pressured_accounts=["acct_hot"],
+    )
+
+    _consume_snapshot_pressure(registry, GcPressureResult())
+    registry._admit_capacity_provision("sess_hot", account_id="acct_hot")


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/eumemic-ops#330.