### PR TITLE
External-account BYOK readiness: make platform root credentialless and fail closed instead of using worker-global paid inference keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,14 +91,14 @@ ECHO_HTTP_CONNECTOR_TOKEN=
 TELEGRAM_CONNECTOR_TOKEN=
 SIGNAL_CONNECTOR_TOKEN=
 
-# Model provider keys.  At least one is required for any real session;
-# LiteLLM picks based on the agent's mind URL.
-ANTHROPIC_API_KEY=
-# Optional Anthropic-API-compatible proxy (e.g. ant-proxy).  Both compose
-# and lean modes pass this through to the api + worker.
-ANTHROPIC_API_BASE=
-OPENROUTER_API_KEY=
-OPENAI_API_KEY=
+# Inference credentials belong in encrypted model-provider rows on non-root
+# accounts (`aios model-providers create`). The platform root is credentialless.
+# Migration only: explicitly set legacy_env before supplying process env keys.
+# AIOS_INFERENCE_CREDENTIAL_POLICY=legacy_env
+# ANTHROPIC_API_KEY=
+# ANTHROPIC_API_BASE=
+# OPENROUTER_API_KEY=
+# OPENAI_API_KEY=
 
 # Optional: Tavily key for web_fetch / web_search built-in tools.
 AIOS_TAVILY_API_KEY=

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -278,7 +278,21 @@ jobs:
         # startups time out. Retry only pytest's recorded failures once so a
         # transient testcontainer startup cannot fail the entire suite; a real
         # regression fails both attempts and remains blocking.
-        run: uv run pytest tests/integration -q || uv run pytest tests/integration -q --lf
+        run: |
+          if ! uv run pytest tests/integration -q; then
+            echo "::warning::FLAKE_RETRY integration"
+            echo "FLAKE_RETRY integration" >> "$GITHUB_STEP_SUMMARY"
+            echo "FLAKE_RETRY integration" >> flake-retry-integration.txt
+            uv run pytest tests/integration -q --lf
+          fi
+
+      - name: Upload integration flake-retry marker
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake-retry-integration
+          path: flake-retry-integration.txt
+          if-no-files-found: ignore
 
   # E2E runs as a two-shard matrix.  Tests carrying ``pytest.mark.docker``
   # (added at module scope on the 31 files that use the sandbox image)
@@ -421,7 +435,20 @@ jobs:
         # preserving a second failure as a blocking signal.
         if: needs.detect.outputs.run_checks == 'true' && matrix.shard == 'non-docker'
         run: |
-          uv run pytest tests/e2e -q -m "not docker" -n 4 || uv run pytest tests/e2e -q -m "not docker" -n 4 --lf
+          if ! uv run pytest tests/e2e -q -m "not docker" -n 4; then
+            echo "::warning::FLAKE_RETRY e2e-non-docker"
+            echo "FLAKE_RETRY e2e-non-docker" >> "$GITHUB_STEP_SUMMARY"
+            echo "FLAKE_RETRY e2e-non-docker" >> flake-retry-e2e-non-docker.txt
+            uv run pytest tests/e2e -q -m "not docker" -n 4 --lf
+          fi
+
+      - name: Upload non-docker E2E flake-retry marker
+        if: always() && needs.detect.outputs.run_checks == 'true' && matrix.shard == 'non-docker'
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake-retry-e2e-non-docker
+          path: flake-retry-e2e-non-docker.txt
+          if-no-files-found: ignore
 
       - name: E2E tests (docker shard)
         # ``-n 4 --dist=loadfile`` runs the docker shard in four parallel

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -416,10 +416,12 @@ jobs:
         # tests/e2e lives in docker-marked test_memory_cross_session_sync.
         # Each worker spins its own session-scoped testcontainer Postgres,
         # so there is no cross-worker DB state at all.  Measured locally:
-        # 141 s serial → 44 s at ``-n 4``.
+        # 141 s serial → 44 s at ``-n 4``. Retry pytest's recorded failures
+        # once to tolerate a transient testcontainer startup failure while
+        # preserving a second failure as a blocking signal.
         if: needs.detect.outputs.run_checks == 'true' && matrix.shard == 'non-docker'
         run: |
-          uv run pytest tests/e2e -q -m "not docker" -n 4
+          uv run pytest tests/e2e -q -m "not docker" -n 4 || uv run pytest tests/e2e -q -m "not docker" -n 4 --lf
 
       - name: E2E tests (docker shard)
         # ``-n 4 --dist=loadfile`` runs the docker shard in four parallel

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -272,10 +272,10 @@ jobs:
         run: uv sync --dev
 
       - name: Integration tests
-        # Default ``load`` dist: the suite has no shared module-scoped
-        # fixtures (the migration tests boot their own per-test
-        # containers).  Measured locally: 87 s serial → 43 s at ``-n 4``.
-        run: uv run pytest tests/integration -q -n 4
+        # Keep container concurrency below the hosted runner's practical
+        # Postgres startup limit. Four simultaneous testcontainers can starve
+        # Docker and turn healthy tests into multi-minute startup failures.
+        run: uv run pytest tests/integration -q -n 2
 
   # E2E runs as a two-shard matrix.  Tests carrying ``pytest.mark.docker``
   # (added at module scope on the 31 files that use the sandbox image)

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -272,10 +272,11 @@ jobs:
         run: uv sync --dev
 
       - name: Integration tests
-        # Keep container concurrency below the hosted runner's practical
-        # Postgres startup limit. Four simultaneous testcontainers can starve
-        # Docker and turn healthy tests into multi-minute startup failures.
-        run: uv run pytest tests/integration -q -n 2
+        # Run serially: each xdist worker owns a session Postgres container,
+        # while migration tests start additional containers. Even two workers
+        # can exhaust hosted-runner Docker resources and make healthy container
+        # startups time out.
+        run: uv run pytest tests/integration -q
 
   # E2E runs as a two-shard matrix.  Tests carrying ``pytest.mark.docker``
   # (added at module scope on the 31 files that use the sandbox image)

--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -275,8 +275,10 @@ jobs:
         # Run serially: each xdist worker owns a session Postgres container,
         # while migration tests start additional containers. Even two workers
         # can exhaust hosted-runner Docker resources and make healthy container
-        # startups time out.
-        run: uv run pytest tests/integration -q
+        # startups time out. Retry only pytest's recorded failures once so a
+        # transient testcontainer startup cannot fail the entire suite; a real
+        # regression fails both attempts and remains blocking.
+        run: uv run pytest tests/integration -q || uv run pytest tests/integration -q --lf
 
   # E2E runs as a two-shard matrix.  Tests carrying ``pytest.mark.docker``
   # (added at module scope on the 31 files that use the sandbox image)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ uv sync --dev
 
 # Configure (see Environment variables below) — minimally:
 #   AIOS_DB_URL, AIOS_VAULT_KEY, AIOS_EGRESS_CA_KEY, AIOS_BOOTSTRAP_TOKEN
-#   and a provider key (ANTHROPIC_API_KEY / OPENROUTER_API_KEY / ...)
+# Provider credentials are encrypted model-provider rows on non-root accounts.
+# Use `aios model-providers create`; the platform root is credentialless.
+# Env keys are migration-only: AIOS_INFERENCE_CREDENTIAL_POLICY=legacy_env.
 set -a && source .env && set +a
 
 # Run migrations (also applies the procrastinate schema + lock-release trigger;

--- a/docs/ops/inference-credentials.md
+++ b/docs/ops/inference-credentials.md
@@ -1,0 +1,15 @@
+# Inference credential posture
+
+Paid inference credentials are tenant secrets. Store each provider's API key and proxy base URL together in an account-scoped `model_providers` row. Platform infrastructure secrets (`AIOS_VAULT_KEY`, database credentials, bootstrap/control-plane tokens, and egress CA keys) remain deployment settings and must not be placed in provider rows.
+
+`AIOS_INFERENCE_CREDENTIAL_POLICY` controls whether LiteLLM may use paid-provider process environment variables:
+
+- `account_only` (default): a call without a resolvable account/ancestor provider row fails with `model_provider_not_configured` before LiteLLM is invoked.
+- `observe_legacy_env`: temporary single-operator migration mode; missing rows may use process environment credentials.
+- `legacy_env`: explicit legacy single-operator fallback.
+
+`AIOS_TENANCY_POSTURE=external_byok` is valid only with `account_only`; startup rejects either legacy mode. Never admit external accounts while a legacy mode is configured.
+
+The platform root must have no active paid-provider rows. Eumemic and external customers are sibling children of that root. Descendant inheritance is appropriate only inside an intentional shared billing/trust domain.
+
+Before external admission, remove paid-provider variables such as `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` from every API/worker deployment, restart all processes, and verify unconfigured session and workflow calls emit `model_provider_not_configured`. Rollback must restore verified account-scoped rows or stop inference; it must never restore worker-global paid keys.

--- a/src/aios/api/app.py
+++ b/src/aios/api/app.py
@@ -40,6 +40,7 @@ from aios.api.routers import (
 from aios.api.strict_query_params import reject_unknown_query_params
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
+from aios.db import queries
 from aios.db.pool import create_pool
 from aios.errors import install_exception_handlers
 from aios.harness import runtime
@@ -88,6 +89,8 @@ def create_app() -> FastAPI:
         log.info("api.startup", db_url=_redact_dsn(settings.db_url))
         pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
         crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+        async with pool.acquire() as conn:
+            await queries.audit_credentialless_root(conn)
         await procrastinate_app.open_async()
         app.state.pool = pool
         app.state.crypto_box = crypto_box

--- a/src/aios/cli/commands/dev.py
+++ b/src/aios/cli/commands/dev.py
@@ -549,7 +549,12 @@ def bootstrap() -> None:
         print_note("Required contents (generate values yourself):")
         print_note("  AIOS_BOOTSTRAP_TOKEN=<openssl rand -hex 32>")
         print_note("  AIOS_VAULT_KEY=<openssl rand -base64 32>")
-        print_note("Plus any provider keys (OPENROUTER_API_KEY, ANTHROPIC_API_KEY, ...).")
+        print_note(
+            "Provision provider credentials on a non-root account with `aios model-providers create`."
+        )
+        print_note(
+            "For migration only, env keys require AIOS_INFERENCE_CREDENTIAL_POLICY=legacy_env."
+        )
         raise typer.Exit(1)
 
     admin_url = _resolve_admin_url(secrets)

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -77,6 +77,18 @@ class Settings(BaseSettings):
         "``openssl rand -base64 32``.",
     )
 
+    inference_credential_policy: Literal["account_only", "observe_legacy_env", "legacy_env"] = (
+        Field(
+            default="account_only",
+            description="Admission policy for paid inference credentials. account_only fails closed; "
+            "legacy modes explicitly permit LiteLLM process-environment fallback during migration.",
+        )
+    )
+    tenancy_posture: Literal["single_operator", "external_byok"] = Field(
+        default="single_operator",
+        description="Deployment tenancy posture. external_byok forbids every process-env inference fallback.",
+    )
+
     default_spend_limit_usd: float | None = Field(
         default=None,
         ge=0,
@@ -878,6 +890,15 @@ class Settings(BaseSettings):
     def oauth_allow_insecure_host_set(self) -> frozenset[str]:
         """Parsed ``oauth_allow_insecure_hosts`` as a set of host[:port] entries."""
         return frozenset(h.strip() for h in self.oauth_allow_insecure_hosts.split(",") if h.strip())
+
+    @model_validator(mode="after")
+    def _external_byok_requires_account_only(self) -> Settings:
+        if (
+            self.tenancy_posture == "external_byok"
+            and self.inference_credential_policy != "account_only"
+        ):
+            raise ValueError("external_byok requires account_only inference credentials")
+        return self
 
     @model_validator(mode="after")
     def _require_absolute_workspace_root(self) -> Settings:

--- a/src/aios/db/queries/__init__.py
+++ b/src/aios/db/queries/__init__.py
@@ -551,6 +551,7 @@ from .memory_stores import (  # noqa: E402
 from .model_providers import (  # noqa: E402
     ResolvedModelProvider,
     archive_model_provider,
+    audit_credentialless_root,
     get_model_provider,
     insert_model_provider,
     list_model_providers,
@@ -770,6 +771,7 @@ __all__ = [
     "archive_vault_credential",
     "attach_github_repos_to_session",
     "attach_memory_stores_to_session",
+    "audit_credentialless_root",
     "batch_get_session_vault_ids",
     "batch_list_session_github_repo_echoes",
     "batch_list_session_memory_store_echoes",

--- a/src/aios/db/queries/model_providers.py
+++ b/src/aios/db/queries/model_providers.py
@@ -43,6 +43,37 @@ def _row_to_model_provider(row: asyncpg.Record) -> ModelProvider:
     )
 
 
+async def assert_account_accepts_model_provider(
+    conn: asyncpg.Connection[Any], *, account_id: str
+) -> None:
+    """Reject provider credentials on the credentialless platform root."""
+    is_root = await conn.fetchval(
+        "SELECT parent_account_id IS NULL FROM accounts WHERE id = $1 AND archived_at IS NULL",
+        account_id,
+    )
+    if is_root is None:
+        raise NotFoundError(f"account {account_id} not found", detail={"id": account_id})
+    if is_root:
+        raise ConflictError(
+            "the platform-root account must remain credentialless",
+            detail={"account_id": account_id},
+        )
+
+
+async def audit_credentialless_root(conn: asyncpg.Connection[Any]) -> None:
+    """Fail startup if legacy/manual writes left an active root-owned row."""
+    count = await conn.fetchval(
+        "SELECT count(*) FROM model_providers mp "
+        "JOIN accounts a ON a.id = mp.account_id "
+        "WHERE a.parent_account_id IS NULL AND a.archived_at IS NULL "
+        "AND mp.archived_at IS NULL"
+    )
+    if count:
+        raise RuntimeError(
+            f"credentialless-root invariant violated: {count} active root model-provider row(s)"
+        )
+
+
 async def insert_model_provider(
     conn: asyncpg.Connection[Any],
     *,
@@ -51,6 +82,7 @@ async def insert_model_provider(
     api_base: str | None,
     blob: EncryptedBlob,
 ) -> ModelProvider:
+    await assert_account_accepts_model_provider(conn, account_id=account_id)
     new_id = make_id(MODEL_PROVIDER)
     try:
         row = await conn.fetchrow(
@@ -126,6 +158,7 @@ async def update_model_provider(
     model-provider row holds a live provider credential, so this path is
     guarded from the start.
     """
+    await assert_account_accepts_model_provider(conn, account_id=account_id)
     current = await get_model_provider(conn, model_provider_id, account_id=account_id)
     if current.archived_at is not None:
         raise ConflictError(

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -665,18 +665,18 @@ def _build_litellm_kwargs(
         kwargs["stream_options"] = {"include_usage": True}
     if tools:
         kwargs["tools"] = tools
+    effective_extra = dict(extra or {})
+    if auth is not None and get_settings().inference_credential_policy != "legacy_env":
+        # Account rows are authoritative under non-legacy policies. Inline auth
+        # fields are agent metadata, not account configuration.
+        for key in ("api_key", "api_base", "base_url"):
+            effective_extra.pop(key, None)
     if auth is not None:
         kwargs["api_key"] = auth.api_key
-        # Only inject auth.api_base when `extra` doesn't already redirect —
-        # otherwise both `api_base` and its `base_url` alias could end up in
-        # kwargs (one from here, one from extra), and litellm's api_base-over-
-        # base_url precedence would silently invert "extra wins". `extra`
-        # itself needs no such guard: kwargs.update(extra) below overwrites
-        # a same-key api_base naturally.
-        if auth.api_base is not None and api_base_of(extra) is None:
+        if auth.api_base is not None and api_base_of(effective_extra) is None:
             kwargs["api_base"] = auth.api_base
-    if extra:
-        kwargs.update(extra)
+    if effective_extra:
+        kwargs.update(effective_extra)
     _apply_provider_cache_hints(kwargs, model, session_id)
     return kwargs
 

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1328,8 +1328,21 @@ async def _run_session_step_body(
             has_subscriber(pool, session_id),
         )
         if conflict is not None:
-            await _handle_provider_auth_conflict(
-                pool, session_id, message=conflict, account_id=account_id
+            await _handle_provider_configuration_error(
+                pool,
+                session_id,
+                error_kind="provider_auth_conflict",
+                message=conflict,
+                account_id=account_id,
+            )
+            return _StepResult()
+        if auth is None and get_settings().inference_credential_policy == "account_only":
+            await _handle_provider_configuration_error(
+                pool,
+                session_id,
+                error_kind="model_provider_not_configured",
+                message=model_providers_service.PROVIDER_NOT_CONFIGURED_MESSAGE,
+                account_id=account_id,
             )
             return _StepResult()
 
@@ -2345,27 +2358,26 @@ async def _handle_spend_cap(
     )
 
 
-async def _handle_provider_auth_conflict(
-    pool: Any, session_id: str, *, message: str, account_id: str
+async def _handle_provider_configuration_error(
+    pool: Any,
+    session_id: str,
+    *,
+    error_kind: str,
+    message: str,
+    account_id: str,
 ) -> None:
-    """Latch a session whose litellm_extra would send an above-owned api_key to a redirect.
-
-    Mirrors ``_handle_spend_cap``: a deterministic config error, not a transient
-    provider failure, so it lands here — before any inference leaves the worker —
-    rather than through the model-call try/except (which would misclassify it as
-    retryable and burn the backoff ladder).
-    """
+    """Latch a deterministic provider configuration error before inference."""
     await sessions_service.append_event(
         pool,
         session_id,
         "span",
-        {"event": "provider_auth_conflict", "is_error": True},
+        {"event": error_kind, "is_error": True},
         account_id=account_id,
     )
     await _latch_errored_turn(
         pool,
         session_id,
-        error_kind="provider_auth_conflict",
+        error_kind=error_kind,
         stop_message=message,
         account_id=account_id,
     )

--- a/src/aios/harness/loop.py
+++ b/src/aios/harness/loop.py
@@ -1336,7 +1336,10 @@ async def _run_session_step_body(
                 account_id=account_id,
             )
             return _StepResult()
-        if auth is None and get_settings().inference_credential_policy == "account_only":
+        if auth is None and (
+            get_settings().inference_credential_policy == "account_only"
+            or get_settings().tenancy_posture == "external_byok"
+        ):
             await _handle_provider_configuration_error(
                 pool,
                 session_id,

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -37,6 +37,7 @@ import aios.harness.tasks
 import aios.tools  # noqa: F401  — side-effect: register built-in tools
 from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
+from aios.db import queries
 from aios.db.listen import (
     listen_for_github_clone_breaker_clear,
     listen_for_mcp_evict_vault,
@@ -373,6 +374,8 @@ async def worker_main() -> None:
     try:
         pool = await create_pool(settings.db_url, max_size=settings.db_pool_max_size)
         crypto_box = CryptoBox.from_base64(settings.vault_key.get_secret_value())
+        async with pool.acquire() as conn:
+            await queries.audit_credentialless_root(conn)
         sandbox_registry = SandboxRegistry(backend=select_sandbox_backend(settings))
         inflight_tool_registry = InflightToolRegistry()
         mcp_session_pool = McpSessionPool()

--- a/src/aios/models/model_providers.py
+++ b/src/aios/models/model_providers.py
@@ -110,18 +110,9 @@ def provider_auth_conflict(
     ``base_url`` alias). If it does, the effective ``api_key`` LiteLLM will
     actually send must be traceable to something the account holds itself:
 
-    * an explicit ``litellm_extra["api_key"]`` that is a **non-empty string
-      after stripping whitespace** — the account supplied its own key
-      alongside the redirect, so nothing "above" it rides along. This is a
-      value check, not a presence check: ``{"api_key": None}`` or
-      ``{"api_key": ""}`` are indistinguishable from omitting the key to
-      every LiteLLM provider branch (each falls back to its provider env var
-      via an ``or``-chain), so treating mere key *presence* as exemption
-      would let an attacker who knows no real credential fully bypass this
-      guard with a null value. A whitespace-only or non-``str`` value is
-      treated the same way (not an exemption) so the guard's correctness
-      doesn't depend on un-contracted LiteLLM/httpx handling of a
-      degenerate key string.
+    * Inline ``litellm_extra["api_key"]`` never exempts this guard: inline
+      credentials are agent metadata, not account configuration, and are not
+      authoritative under non-legacy credential policies.
     * a ``model_providers`` row **owned by this account itself**
       (``resolved.owner_account_id == account_id``) — the account's own key,
       redirected by the account's own agent, is not privilege escalation.
@@ -148,9 +139,6 @@ def provider_auth_conflict(
     """
     redirect = api_base_of(litellm_extra)
     if redirect is None:
-        return False
-    extra_key = litellm_extra.get("api_key") if litellm_extra else None
-    if isinstance(extra_key, str) and extra_key.strip():
         return False
     if resolved is not None:
         return resolved.owner_account_id != account_id

--- a/src/aios/services/inference_credential_telemetry.py
+++ b/src/aios/services/inference_credential_telemetry.py
@@ -1,0 +1,43 @@
+"""Observation surface for explicit migration-policy environment fallback."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+
+from aios.logging import get_logger
+
+log = get_logger(__name__)
+_lock = threading.Lock()
+_observed_total = 0
+try:  # pragma: no cover
+    from prometheus_client import Counter
+
+    _FALLBACKS = Counter(
+        "aios_inference_legacy_env_fallback_total",
+        "Inference calls that fell back to process-environment credentials.",
+        ["provider"],
+    )
+except Exception:  # pragma: no cover
+    _FALLBACKS = None
+
+
+def observe_env_fallback(*, account_id: str, provider: str) -> None:
+    """Log and count every fallback admitted by ``observe_legacy_env``."""
+    global _observed_total
+    with _lock:
+        _observed_total += 1
+    log.warning(
+        "inference_credentials.legacy_env_fallback",
+        account_id=account_id,
+        provider=provider,
+        policy="observe_legacy_env",
+    )
+    if _FALLBACKS is not None:  # pragma: no cover
+        with contextlib.suppress(Exception):
+            _FALLBACKS.labels(provider=provider).inc()
+
+
+def observed_total() -> int:
+    with _lock:
+        return _observed_total

--- a/src/aios/services/model_providers.py
+++ b/src/aios/services/model_providers.py
@@ -28,10 +28,12 @@ from typing import Any
 import asyncpg
 import litellm
 
+from aios.config import get_settings
 from aios.crypto.vault import CryptoBox
 from aios.db import queries
 from aios.models.attenuation import api_base_of
 from aios.models.model_providers import ModelProvider, ProviderAuth, provider_auth_conflict
+from aios.services.inference_credential_telemetry import observe_env_fallback
 
 # Surfaced as a session's stop_reason.message (session-visible) and, on the
 # workflow call_llm path, as a journaled {"error": ...} value — both are read
@@ -45,8 +47,7 @@ PROVIDER_NOT_CONFIGURED_MESSAGE = (
 
 PROVIDER_AUTH_CONFLICT_MESSAGE = (
     "This session's effective model-provider key is owned by an account above "
-    "this one; supply your own api_key in litellm_extra or configure a "
-    "model_providers row for this account."
+    "this one; configure a model_providers row for this account."
 )
 
 
@@ -202,7 +203,20 @@ async def _resolve_provider_auth(
             conn, account_id=account_id, provider=provider
         )
     if resolved is None:
+        if get_settings().inference_credential_policy == "observe_legacy_env":
+            observe_env_fallback(account_id=account_id, provider=provider)
         return None
+    settings = get_settings()
+    if resolved.owner_account_id != account_id and (
+        settings.inference_credential_policy == "account_only"
+        or settings.tenancy_posture == "external_byok"
+    ):
+        async with pool.acquire() as conn:
+            owner = await queries.get_account(conn, resolved.owner_account_id)
+        if owner is not None and owner.parent_account_id is None:
+            # Defense in depth for legacy/manual rows: platform-root credentials
+            # are never inherited by a descendant under a non-legacy policy.
+            return None
     subkey = crypto_box.derive_account_subkey(resolved.owner_account_id)
     return ProviderAuth(
         api_key=subkey.decrypt(resolved.blob),

--- a/src/aios/services/model_providers.py
+++ b/src/aios/services/model_providers.py
@@ -39,6 +39,10 @@ from aios.models.model_providers import ModelProvider, ProviderAuth, provider_au
 # and generic, matching every other stop_message constant in harness/loop.py
 # (_SPEND_CAP_STOP_REASON_MESSAGE, _REFUSAL_STOP_REASON_MESSAGE): no dynamic
 # data embedded.
+PROVIDER_NOT_CONFIGURED_MESSAGE = (
+    "No account-scoped credentials are configured for this model provider."
+)
+
 PROVIDER_AUTH_CONFLICT_MESSAGE = (
     "This session's effective model-provider key is owned by an account above "
     "this one; supply your own api_key in litellm_extra or configure a "

--- a/src/aios/workflows/run_llm.py
+++ b/src/aios/workflows/run_llm.py
@@ -238,7 +238,10 @@ async def invoke_call_llm(*, run: WfRun, spec: dict[str, Any]) -> tuple[dict[str
         }, 0
     if conflict is not None:
         return {"error": f"call_llm refused: {conflict}"}, 0
-    if auth is None and get_settings().inference_credential_policy == "account_only":
+    if auth is None and (
+        get_settings().inference_credential_policy == "account_only"
+        or get_settings().tenancy_posture == "external_byok"
+    ):
         return {
             "error": model_providers_service.PROVIDER_NOT_CONFIGURED_MESSAGE,
             "error_kind": "model_provider_not_configured",

--- a/src/aios/workflows/run_llm.py
+++ b/src/aios/workflows/run_llm.py
@@ -57,6 +57,7 @@ from typing import Any
 
 import asyncpg
 
+from aios.config import get_settings
 from aios.db.queries import workflows as wf_queries
 from aios.harness import runtime
 from aios.harness.completion import (
@@ -237,6 +238,11 @@ async def invoke_call_llm(*, run: WfRun, spec: dict[str, Any]) -> tuple[dict[str
         }, 0
     if conflict is not None:
         return {"error": f"call_llm refused: {conflict}"}, 0
+    if auth is None and get_settings().inference_credential_policy == "account_only":
+        return {
+            "error": model_providers_service.PROVIDER_NOT_CONFIGURED_MESSAGE,
+            "error_kind": "model_provider_not_configured",
+        }, 0
 
     tools = spec.get("tools") if isinstance(spec.get("tools"), list) else None
     session_id = spec.get("session_id") if isinstance(spec.get("session_id"), str) else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,6 +257,9 @@ def aios_env_minimal(
         "AIOS_EGRESS_CA_KEY": base64.b64encode(secrets.token_bytes(32)).decode("ascii"),
         "AIOS_DB_URL": migrated_db_url,
         "AIOS_WORKSPACE_ROOT": str(tmp_path / "workspaces"),
+        # Existing integration/e2e tests stub inference without provisioning an
+        # account provider. Provider-admission tests exercise the fail-closed default.
+        "AIOS_INFERENCE_CREDENTIAL_POLICY": "legacy_env",
         # Issue #807: point the docker_harness-driven e2e provisions at the
         # repo's authored seccomp profile. The config default resolves to the
         # baked /app/docker path, which doesn't exist on the host running the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,9 +257,8 @@ def aios_env_minimal(
         "AIOS_EGRESS_CA_KEY": base64.b64encode(secrets.token_bytes(32)).decode("ascii"),
         "AIOS_DB_URL": migrated_db_url,
         "AIOS_WORKSPACE_ROOT": str(tmp_path / "workspaces"),
-        # Existing integration/e2e tests stub inference without provisioning an
-        # account provider. Provider-admission tests exercise the fail-closed default.
-        "AIOS_INFERENCE_CREDENTIAL_POLICY": "legacy_env",
+        # Tests exercise the production default. Legacy env-key behavior is opt-in.
+        "AIOS_INFERENCE_CREDENTIAL_POLICY": "account_only",
         # Issue #807: point the docker_harness-driven e2e provisions at the
         # repo's authored seccomp profile. The config default resolves to the
         # baked /app/docker path, which doesn't exist on the host running the

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -369,7 +369,21 @@ def crypto_box(aios_env: dict[str, str]) -> Any:
 
 
 @pytest.fixture
-async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
+async def legacy_inference_env(
+    aios_env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[None]:
+    """Explicitly opt scripted-model harnesses into legacy credential behavior."""
+    from aios.config import get_settings
+
+    monkeypatch.setenv("AIOS_INFERENCE_CREDENTIAL_POLICY", "legacy_env")
+    aios_env["AIOS_INFERENCE_CREDENTIAL_POLICY"] = "legacy_env"
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def harness(aios_env: dict[str, str], legacy_inference_env: None) -> AsyncIterator[Harness]:
     """Function-scoped harness: real Postgres, scripted model, no Docker."""
     import aios.tools  # noqa: F401  — register built-in tools
     from aios.config import get_settings
@@ -448,7 +462,9 @@ async def harness(aios_env: dict[str, str]) -> AsyncIterator[Harness]:
 
 @pytest.fixture
 async def docker_harness(
-    aios_env: dict[str, str], open_procrastinate_app: None
+    aios_env: dict[str, str],
+    open_procrastinate_app: None,
+    legacy_inference_env: None,
 ) -> AsyncIterator[Harness]:
     """Like ``harness`` but with a real SandboxRegistry for Docker tests.
 

--- a/tests/integration/test_model_provider_resolution.py
+++ b/tests/integration/test_model_provider_resolution.py
@@ -177,3 +177,109 @@ async def test_different_provider_does_not_match(
         chain_conn, account_id="acc_customer", provider="anthropic"
     )
     assert resolved is None
+
+
+async def test_startup_audit_rejects_preexisting_active_root_row(
+    chain_conn: asyncpg.Connection[Any], crypto_box: CryptoBox
+) -> None:
+    blob = crypto_box.derive_account_subkey("platform_root").encrypt("sentinel-root")
+    await chain_conn.execute(
+        "INSERT INTO model_providers (id, account_id, provider, ciphertext, nonce) VALUES ($1,$2,$3,$4,$5)",
+        "mp_root_audit",
+        "platform_root",
+        "anthropic",
+        blob.ciphertext,
+        blob.nonce,
+    )
+    with pytest.raises(RuntimeError, match="credentialless-root invariant violated"):
+        await queries.audit_credentialless_root(chain_conn)
+
+
+async def test_root_row_update_is_rejected(
+    chain_conn: asyncpg.Connection[Any], crypto_box: CryptoBox
+) -> None:
+    from aios.errors import ConflictError
+
+    blob = crypto_box.derive_account_subkey("platform_root").encrypt("sentinel-root")
+    await chain_conn.execute(
+        "INSERT INTO model_providers (id, account_id, provider, ciphertext, nonce) VALUES ($1,$2,$3,$4,$5)",
+        "mp_root_update",
+        "platform_root",
+        "anthropic",
+        blob.ciphertext,
+        blob.nonce,
+    )
+    replacement = crypto_box.derive_account_subkey("platform_root").encrypt("replacement")
+    with pytest.raises(ConflictError, match="must remain credentialless"):
+        await queries.update_model_provider(
+            chain_conn, "mp_root_update", account_id="platform_root", blob=replacement
+        )
+
+
+@pytest.mark.parametrize(
+    ("policy", "posture"),
+    [("account_only", "internal"), ("account_only", "external_byok")],
+)
+async def test_root_credentials_never_reach_descendant_harness(
+    chain_conn: asyncpg.Connection[Any],
+    crypto_box: CryptoBox,
+    monkeypatch: pytest.MonkeyPatch,
+    policy: str,
+    posture: str,
+) -> None:
+    """Real topology: a legacy ACTIVE root row cannot fund/call for a leaf."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from aios.services import model_providers
+    from aios.workflows.run_llm import invoke_call_llm
+
+    sentinel_env = "SENTINEL_ENV_MUST_NOT_EGRESS"
+    sentinel_row = "SENTINEL_ROOT_ROW_MUST_NOT_EGRESS"
+    monkeypatch.setenv("ANTHROPIC_API_KEY", sentinel_env)
+    blob = crypto_box.derive_account_subkey("platform_root").encrypt(sentinel_row)
+    await chain_conn.execute(
+        "INSERT INTO model_providers (id, account_id, provider, ciphertext, nonce) VALUES ($1,$2,$3,$4,$5)",
+        f"mp_root_{posture}",
+        "platform_root",
+        "anthropic",
+        blob.ciphertext,
+        blob.nonce,
+    )
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=chain_conn)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire.return_value = cm
+    settings = SimpleNamespace(inference_credential_policy=policy, tenancy_posture=posture)
+    request_capture = AsyncMock()
+    run = SimpleNamespace(
+        id="wfr_root_regression",
+        account_id="acc_customer",
+        default_child_model="anthropic/claude-x",
+    )
+    spec = {
+        "model": "anthropic/claude-x",
+        "messages": [{"role": "user", "content": "do not egress credentials"}],
+        "tools": None,
+        "params": None,
+        "session_id": None,
+    }
+    with (
+        patch.object(model_providers, "get_settings", return_value=settings),
+        patch("aios.workflows.run_llm.runtime.require_pool", return_value=pool),
+        patch("aios.workflows.run_llm.runtime.require_crypto_box", return_value=crypto_box),
+        patch("aios.workflows.run_llm.call_litellm", request_capture),
+    ):
+        result, cost = await invoke_call_llm(
+            run=run,  # type: ignore[arg-type]
+            spec=spec,
+        )
+
+    assert result["error_kind"] == "model_provider_not_configured"
+    assert cost == 0
+    request_capture.assert_not_awaited()
+    assert sentinel_env not in repr(request_capture.await_args_list)
+    assert sentinel_row not in repr(request_capture.await_args_list)
+    assert "FUNDED_BY_ROOT" not in repr(result)

--- a/tests/integration/test_model_provider_resolution.py
+++ b/tests/integration/test_model_provider_resolution.py
@@ -27,15 +27,15 @@ pytestmark = pytest.mark.integration
 async def chain_conn(
     migrated_db_url: str, _reset_db_state: None
 ) -> AsyncIterator[asyncpg.Connection[Any]]:
-    """A 3-level account chain: acc_root -> acc_mid -> acc_leaf."""
+    """Real topology: platform_root -> eumemic -> customer."""
     conn = await asyncpg.connect(migrated_db_url)
     try:
         await conn.execute(
             """
             INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
-            VALUES ('acc_root', NULL,       TRUE,  'root'),
-                   ('acc_mid',  'acc_root', TRUE,  'mid'),
-                   ('acc_leaf', 'acc_mid',  FALSE, 'leaf')
+            VALUES ('platform_root', NULL,            TRUE,  'platform-root'),
+                   ('acc_eumemic',  'platform_root', TRUE,  'Eumemic'),
+                   ('acc_customer', 'acc_eumemic',   FALSE, 'customer')
             """
         )
         yield conn
@@ -67,31 +67,29 @@ async def _insert(
 async def test_leaf_row_wins_over_ancestors(
     chain_conn: asyncpg.Connection[Any], crypto_box: CryptoBox
 ) -> None:
-    await _insert(chain_conn, crypto_box, account_id="acc_root", api_key="sk-root")
-    await _insert(chain_conn, crypto_box, account_id="acc_mid", api_key="sk-mid")
-    await _insert(chain_conn, crypto_box, account_id="acc_leaf", api_key="sk-leaf")
+    await _insert(chain_conn, crypto_box, account_id="acc_eumemic", api_key="sk-eumemic")
+    await _insert(chain_conn, crypto_box, account_id="acc_customer", api_key="sk-customer")
 
     resolved = await queries.resolve_model_provider(
-        chain_conn, account_id="acc_leaf", provider="anthropic"
+        chain_conn, account_id="acc_customer", provider="anthropic"
     )
     assert resolved is not None
-    assert resolved.owner_account_id == "acc_leaf"
-    assert crypto_box.derive_account_subkey("acc_leaf").decrypt(resolved.blob) == "sk-leaf"
+    assert resolved.owner_account_id == "acc_customer"
+    assert crypto_box.derive_account_subkey("acc_customer").decrypt(resolved.blob) == "sk-customer"
 
 
 async def test_no_leaf_row_resolves_nearest_ancestor(
     chain_conn: asyncpg.Connection[Any], crypto_box: CryptoBox
 ) -> None:
-    await _insert(chain_conn, crypto_box, account_id="acc_root", api_key="sk-root")
-    await _insert(chain_conn, crypto_box, account_id="acc_mid", api_key="sk-mid")
-    # acc_leaf has no row of its own.
+    await _insert(chain_conn, crypto_box, account_id="acc_eumemic", api_key="sk-eumemic")
+    # acc_customer has no row of its own.
 
     resolved = await queries.resolve_model_provider(
-        chain_conn, account_id="acc_leaf", provider="anthropic"
+        chain_conn, account_id="acc_customer", provider="anthropic"
     )
     assert resolved is not None
-    assert resolved.owner_account_id == "acc_mid"  # nearest, not root
-    assert crypto_box.derive_account_subkey("acc_mid").decrypt(resolved.blob) == "sk-mid"
+    assert resolved.owner_account_id == "acc_eumemic"  # nearest, not root
+    assert crypto_box.derive_account_subkey("acc_eumemic").decrypt(resolved.blob) == "sk-eumemic"
 
 
 async def test_row_atomicity_no_field_merge_across_levels(
@@ -103,34 +101,38 @@ async def test_row_atomicity_no_field_merge_across_levels(
     await _insert(
         chain_conn,
         crypto_box,
-        account_id="acc_root",
-        api_key="sk-root",
-        api_base="https://root-proxy.example",
+        account_id="acc_eumemic",
+        api_key="sk-eumemic",
+        api_base="https://eumemic-proxy.example",
     )
-    await _insert(chain_conn, crypto_box, account_id="acc_mid", api_key="sk-mid", api_base=None)
+    await _insert(
+        chain_conn, crypto_box, account_id="acc_customer", api_key="sk-customer", api_base=None
+    )
 
     resolved = await queries.resolve_model_provider(
-        chain_conn, account_id="acc_leaf", provider="anthropic"
+        chain_conn, account_id="acc_customer", provider="anthropic"
     )
     assert resolved is not None
-    assert resolved.owner_account_id == "acc_mid"
-    # NOT the root's api_base — the winning row's own (unset) value.
+    assert resolved.owner_account_id == "acc_customer"
+    # NOT the Eumemic's api_base — the winning row's own (unset) value.
     assert resolved.api_base is None
-    assert crypto_box.derive_account_subkey("acc_mid").decrypt(resolved.blob) == "sk-mid"
+    assert crypto_box.derive_account_subkey("acc_customer").decrypt(resolved.blob) == "sk-customer"
 
 
 async def test_archived_row_falls_through_to_next_ancestor(
     chain_conn: asyncpg.Connection[Any], crypto_box: CryptoBox
 ) -> None:
-    await _insert(chain_conn, crypto_box, account_id="acc_root", api_key="sk-root")
-    mid_row_id = await _insert(chain_conn, crypto_box, account_id="acc_mid", api_key="sk-mid")
-    await queries.archive_model_provider(chain_conn, mid_row_id, account_id="acc_mid")
+    await _insert(chain_conn, crypto_box, account_id="acc_eumemic", api_key="sk-eumemic")
+    customer_row_id = await _insert(
+        chain_conn, crypto_box, account_id="acc_customer", api_key="sk-customer"
+    )
+    await queries.archive_model_provider(chain_conn, customer_row_id, account_id="acc_customer")
 
     resolved = await queries.resolve_model_provider(
-        chain_conn, account_id="acc_leaf", provider="anthropic"
+        chain_conn, account_id="acc_customer", provider="anthropic"
     )
     assert resolved is not None
-    assert resolved.owner_account_id == "acc_root"  # mid's archived row is skipped, not selected
+    assert resolved.owner_account_id == "acc_eumemic"  # customer's archived row falls through
 
 
 async def test_archived_account_severs_the_chain(
@@ -139,21 +141,30 @@ async def test_archived_account_severs_the_chain(
     """An archived ACCOUNT (not just an archived row) must sever the walk —
     a grandparent becomes invisible even though it still has an active row,
     and even though the archived account itself never had one."""
-    await _insert(chain_conn, crypto_box, account_id="acc_root", api_key="sk-root")
-    # acc_mid never gets a provider row — only its ACCOUNT is archived.
-    await chain_conn.execute("UPDATE accounts SET archived_at = now() WHERE id = 'acc_mid'")
+    blob = crypto_box.derive_account_subkey("platform_root").encrypt("sentinel-root")
+    await chain_conn.execute(
+        "INSERT INTO model_providers "
+        "(id, account_id, provider, ciphertext, nonce) VALUES ($1, $2, $3, $4, $5)",
+        "mp_legacy_root",
+        "platform_root",
+        "anthropic",
+        blob.ciphertext,
+        blob.nonce,
+    )
+    # Eumemic has no provider row; archiving it severs customer from root.
+    await chain_conn.execute("UPDATE accounts SET archived_at = now() WHERE id = 'acc_eumemic'")
 
     resolved = await queries.resolve_model_provider(
-        chain_conn, account_id="acc_leaf", provider="anthropic"
+        chain_conn, account_id="acc_customer", provider="anthropic"
     )
-    assert resolved is None  # root's row is invisible — the archived mid account cut it off
+    assert resolved is None  # root's legacy row is invisible — archived Eumemic cut it off
 
 
 async def test_no_row_anywhere_returns_none(
     chain_conn: asyncpg.Connection[Any], crypto_box: CryptoBox
 ) -> None:
     resolved = await queries.resolve_model_provider(
-        chain_conn, account_id="acc_leaf", provider="anthropic"
+        chain_conn, account_id="acc_customer", provider="anthropic"
     )
     assert resolved is None
 
@@ -161,8 +172,8 @@ async def test_no_row_anywhere_returns_none(
 async def test_different_provider_does_not_match(
     chain_conn: asyncpg.Connection[Any], crypto_box: CryptoBox
 ) -> None:
-    await _insert(chain_conn, crypto_box, account_id="acc_root", provider="openai")
+    await _insert(chain_conn, crypto_box, account_id="acc_eumemic", provider="openai")
     resolved = await queries.resolve_model_provider(
-        chain_conn, account_id="acc_leaf", provider="anthropic"
+        chain_conn, account_id="acc_customer", provider="anthropic"
     )
     assert resolved is None

--- a/tests/integration/test_model_provider_resolution.py
+++ b/tests/integration/test_model_provider_resolution.py
@@ -19,6 +19,7 @@ import pytest
 
 from aios.crypto.vault import KEY_BYTES, CryptoBox
 from aios.db import queries
+from aios.db.pool import register_jsonb_codec
 
 pytestmark = pytest.mark.integration
 
@@ -29,6 +30,7 @@ async def chain_conn(
 ) -> AsyncIterator[asyncpg.Connection[Any]]:
     """Real topology: platform_root -> eumemic -> customer."""
     conn = await asyncpg.connect(migrated_db_url)
+    await register_jsonb_codec(conn)
     try:
         await conn.execute(
             """

--- a/tests/integration/test_model_provider_resolution.py
+++ b/tests/integration/test_model_provider_resolution.py
@@ -29,6 +29,8 @@ async def chain_conn(
 ) -> AsyncIterator[asyncpg.Connection[Any]]:
     """Real topology: platform_root -> eumemic -> customer."""
     conn = await asyncpg.connect(migrated_db_url)
+    transaction = conn.transaction()
+    await transaction.start()
     try:
         await conn.execute(
             """
@@ -40,6 +42,9 @@ async def chain_conn(
         )
         yield conn
     finally:
+        # This fixture deliberately seeds invalid legacy root rows. Roll back so
+        # xdist test teardown cannot expose one to a concurrent startup audit.
+        await transaction.rollback()
         await conn.close()
 
 

--- a/tests/integration/test_model_provider_resolution.py
+++ b/tests/integration/test_model_provider_resolution.py
@@ -29,8 +29,6 @@ async def chain_conn(
 ) -> AsyncIterator[asyncpg.Connection[Any]]:
     """Real topology: platform_root -> eumemic -> customer."""
     conn = await asyncpg.connect(migrated_db_url)
-    transaction = conn.transaction()
-    await transaction.start()
     try:
         await conn.execute(
             """
@@ -42,9 +40,6 @@ async def chain_conn(
         )
         yield conn
     finally:
-        # This fixture deliberately seeds invalid legacy root rows. Roll back so
-        # xdist test teardown cannot expose one to a concurrent startup audit.
-        await transaction.rollback()
         await conn.close()
 
 

--- a/tests/integration/test_model_providers_crud.py
+++ b/tests/integration/test_model_providers_crud.py
@@ -33,7 +33,8 @@ async def pool_with_account(
             await conn.execute(
                 """
                 INSERT INTO accounts (id, parent_account_id, can_mint_children, display_name)
-                VALUES ('acc_mp_test', NULL, TRUE, 'model-providers-test')
+                VALUES ('platform_root', NULL, TRUE, 'platform-root'),
+                       ('acc_mp_test', 'platform_root', TRUE, 'model-providers-test')
                 """
             )
         yield pool, "acc_mp_test"
@@ -66,6 +67,22 @@ async def test_create_get_list(
 
     listed = await service.list_model_providers(pool, account_id=account_id)
     assert [p.id for p in listed] == [created.id]
+
+
+async def test_platform_root_rejects_simultaneous_openai_and_anthropic(
+    pool_with_account: tuple[asyncpg.Pool[Any], str], crypto_box: CryptoBox
+) -> None:
+    pool, _ = pool_with_account
+    for provider in ("openai", "anthropic"):
+        with pytest.raises(ConflictError, match="credentialless"):
+            await service.create_model_provider(
+                pool,
+                crypto_box,
+                account_id="platform_root",
+                provider=provider,
+                api_key=f"sentinel-{provider}",
+                api_base=None,
+            )
 
 
 async def test_duplicate_active_provider_conflicts(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,9 +28,7 @@ def _unit_env() -> Iterator[None]:
         "AIOS_VAULT_KEY": base64.b64encode(secrets.token_bytes(32)).decode(),
         "AIOS_EGRESS_CA_KEY": base64.b64encode(secrets.token_bytes(32)).decode(),
         "AIOS_DB_URL": "postgresql://test:test@localhost:5432/test",
-        # Most existing tests predate account-scoped provider rows and stub no auth.
-        # Dedicated provider-admission tests override this migration escape hatch.
-        "AIOS_INFERENCE_CREDENTIAL_POLICY": "legacy_env",
+        "AIOS_INFERENCE_CREDENTIAL_POLICY": "account_only",
     }
     with mock.patch.dict(os.environ, env):
         from aios.config import get_settings
@@ -38,6 +36,26 @@ def _unit_env() -> Iterator[None]:
         get_settings.cache_clear()
         yield
         get_settings.cache_clear()
+
+
+@pytest.fixture
+def legacy_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Opt one legacy-dependent test into process-environment credentials."""
+    monkeypatch.setenv("AIOS_INFERENCE_CREDENTIAL_POLICY", "legacy_env")
+    from aios.config import get_settings
+
+    get_settings.cache_clear()
+    settings = get_settings()
+    # Patch references imported into credential/harness modules as well as config.
+    for target in (
+        "aios.harness.loop.get_settings",
+        "aios.harness.completion.get_settings",
+        "aios.services.model_providers.get_settings",
+    ):
+        monkeypatch.setattr(target, lambda: settings)
+    yield
+    # Never leak a cached legacy Settings object into the next account-only test.
+    get_settings.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,6 +28,9 @@ def _unit_env() -> Iterator[None]:
         "AIOS_VAULT_KEY": base64.b64encode(secrets.token_bytes(32)).decode(),
         "AIOS_EGRESS_CA_KEY": base64.b64encode(secrets.token_bytes(32)).decode(),
         "AIOS_DB_URL": "postgresql://test:test@localhost:5432/test",
+        # Most existing tests predate account-scoped provider rows and stub no auth.
+        # Dedicated provider-admission tests override this migration escape hatch.
+        "AIOS_INFERENCE_CREDENTIAL_POLICY": "legacy_env",
     }
     with mock.patch.dict(os.environ, env):
         from aios.config import get_settings

--- a/tests/unit/test_completion_provider_auth.py
+++ b/tests/unit/test_completion_provider_auth.py
@@ -25,6 +25,15 @@ class _DictResponse(dict[str, object]):
         self._hidden_params: dict[str, object] = {}
 
 
+@pytest.fixture(autouse=True)
+def _nonlegacy_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Settings:
+        inference_credential_policy = "account_only"
+        model_call_deadline_s = 300.0
+
+    monkeypatch.setattr(completion, "get_settings", lambda: _Settings())
+
+
 def _ok_response() -> _DictResponse:
     return _DictResponse(
         choices=[{"message": {"role": "assistant", "content": ""}}],
@@ -71,7 +80,7 @@ async def test_auth_none_injects_neither_key(monkeypatch: pytest.MonkeyPatch) ->
     assert "api_base" not in captured
 
 
-async def test_extra_api_base_overrides_auth_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_resolved_api_base_overrides_extra_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _capture(monkeypatch)
     auth = ProviderAuth(
         api_key="sk-resolved", api_base="https://account.example", owner_account_id="acc_x"
@@ -86,13 +95,13 @@ async def test_extra_api_base_overrides_auth_api_base(monkeypatch: pytest.Monkey
         auth=auth,
     )
 
-    assert captured["api_base"] == "https://agent.example"
+    assert captured["api_base"] == "https://account.example"
     assert (
         captured["api_key"] == "sk-resolved"
     )  # extra doesn't carry a key here — auth's still lands
 
 
-async def test_extra_base_url_alias_suppresses_auth_api_base(
+async def test_resolved_api_base_suppresses_extra_base_url_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A redirect via the base_url alias must ALSO suppress auth.api_base —
@@ -114,11 +123,11 @@ async def test_extra_base_url_alias_suppresses_auth_api_base(
         auth=auth,
     )
 
-    assert "api_base" not in captured  # auth's api_base was suppressed
-    assert captured["base_url"] == "https://agent.example"  # extra's redirect lands unmodified
+    assert captured["api_base"] == "https://account.example"
+    assert "base_url" not in captured
 
 
-async def test_extra_api_key_overrides_auth_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_resolved_api_key_overrides_extra_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _capture(monkeypatch)
     auth = ProviderAuth(api_key="sk-resolved", api_base=None, owner_account_id="acc_x")
 
@@ -131,7 +140,7 @@ async def test_extra_api_key_overrides_auth_api_key(monkeypatch: pytest.MonkeyPa
         auth=auth,
     )
 
-    assert captured["api_key"] == "sk-agent-supplied"
+    assert captured["api_key"] == "sk-resolved"
 
 
 async def test_cache_hints_unaffected_by_auth(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_completion_provider_auth.py
+++ b/tests/unit/test_completion_provider_auth.py
@@ -200,3 +200,23 @@ async def test_stream_litellm_also_injects_auth(monkeypatch: pytest.MonkeyPatch)
 
     assert captured["api_key"] == "sk-resolved"
     assert captured["api_base"] == "https://proxy.example"
+
+
+async def test_legacy_env_preserves_inline_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _LegacySettings:
+        inference_credential_policy = "legacy_env"
+        model_call_deadline_s = 300.0
+
+    monkeypatch.setattr(completion, "get_settings", lambda: _LegacySettings())
+    captured = _capture(monkeypatch)
+    auth = ProviderAuth(api_key="sk-row", api_base="https://row.example", owner_account_id="acc_x")
+    await completion.call_litellm(
+        completion.LlmRequest(
+            messages=[{"role": "user", "content": "hi"}],
+            params={"api_key": "sk-inline", "api_base": "https://inline.example"},
+        ),
+        model="anthropic/claude-x",
+        auth=auth,
+    )
+    assert captured["api_key"] == "sk-inline"
+    assert captured["api_base"] == "https://inline.example"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,6 +12,34 @@ from pathlib import Path
 import pytest
 
 
+def test_external_byok_rejects_legacy_inference_env_policy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from pydantic import ValidationError
+
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_EGRESS_CA_KEY=e\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.setenv("AIOS_TENANCY_POSTURE", "external_byok")
+    monkeypatch.setenv("AIOS_INFERENCE_CREDENTIAL_POLICY", "legacy_env")
+
+    with pytest.raises(ValidationError, match="external_byok requires account_only"):
+        Settings(_env_file=(str(secrets),))
+
+
+def test_inference_credential_policy_defaults_account_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from aios.config import Settings
+
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("AIOS_VAULT_KEY=v\nAIOS_EGRESS_CA_KEY=e\nAIOS_DB_URL=postgresql://x/y\n")
+    monkeypatch.delenv("AIOS_INFERENCE_CREDENTIAL_POLICY", raising=False)
+    settings = Settings(_env_file=(str(secrets),))
+    assert settings.inference_credential_policy == "account_only"
+
+
 def test_dead_pipeline_max_setting_is_not_exposed() -> None:
     from aios.config import Settings
 

--- a/tests/unit/test_inference_credential_telemetry.py
+++ b/tests/unit/test_inference_credential_telemetry.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aios.crypto.vault import CryptoBox
+from aios.db import queries
+from aios.services import inference_credential_telemetry as telemetry
+from aios.services import model_providers
+from tests.unit.conftest import fake_pool_yielding_conn
+
+
+async def test_observe_legacy_env_emits_log_and_metric() -> None:
+    pool = fake_pool_yielding_conn(MagicMock())
+    before = telemetry.observed_total()
+    with (
+        patch.object(
+            model_providers,
+            "get_settings",
+            return_value=SimpleNamespace(
+                inference_credential_policy="observe_legacy_env", tenancy_posture="internal"
+            ),
+        ),
+        patch.object(queries, "resolve_model_provider", AsyncMock(return_value=None)),
+        patch.object(telemetry.log, "warning") as warning,
+    ):
+        auth = await model_providers._resolve_provider_auth(
+            pool,
+            CryptoBox(os.urandom(32)),
+            account_id="acc_child",
+            model="anthropic/claude-x",
+            litellm_extra=None,
+        )
+    assert auth is None
+    assert telemetry.observed_total() == before + 1
+    warning.assert_called_once_with(
+        "inference_credentials.legacy_env_fallback",
+        account_id="acc_child",
+        provider="anthropic",
+        policy="observe_legacy_env",
+    )

--- a/tests/unit/test_loop_provider_guard.py
+++ b/tests/unit/test_loop_provider_guard.py
@@ -74,6 +74,43 @@ def _enter_base_patches(
     stack.enter_context(patch("aios.harness.loop.prelude_overhead_local", return_value=0))
 
 
+async def test_unconfigured_provider_latches_before_model_call() -> None:
+    pool = MagicMock()
+    inflight_tool_registry = MagicMock()
+    inflight_tool_registry.in_flight_tool_call_ids.return_value = set()
+    append_event = AsyncMock(return_value=SimpleNamespace(id="ev"))
+    with ExitStack() as stack:
+        _enter_base_patches(stack, resolved=None, conflict=None)
+        stack.enter_context(patch("aios.harness.loop.sessions_service.append_event", append_event))
+        fail_open = stack.enter_context(
+            patch("aios.harness.loop.fail_all_open_requests", AsyncMock())
+        )
+        stack.enter_context(
+            patch("aios.harness.loop.sessions_service.set_session_stop_reason", AsyncMock())
+        )
+        call_litellm = stack.enter_context(patch("aios.harness.loop.call_litellm", AsyncMock()))
+        stack.enter_context(
+            patch(
+                "aios.harness.loop.get_settings",
+                return_value=SimpleNamespace(inference_credential_policy="account_only"),
+            )
+        )
+        result = await _run_session_step_body(
+            pool, inflight_tool_registry, "sess_x", cause="message", account_id="acc_x"
+        )
+
+    assert result == _StepResult()
+    call_litellm.assert_not_awaited()
+    fail_open.assert_awaited_once_with(
+        ANY, "sess_x", account_id="acc_x", error={"kind": "model_provider_not_configured"}
+    )
+    assert any(
+        call.args[3].get("event") == "model_provider_not_configured"
+        for call in append_event.call_args_list
+        if call.args[2] == "span"
+    )
+
+
 async def test_conflict_latches_errored_before_model_call() -> None:
     pool = MagicMock()
     inflight_tool_registry = MagicMock()

--- a/tests/unit/test_loop_retry.py
+++ b/tests/unit/test_loop_retry.py
@@ -31,6 +31,13 @@ from aios.harness.loop import (
 )
 from aios.harness.window import WindowedEvents
 
+# These tests deliberately exercise downstream provider retry semantics.
+
+
+@pytest.fixture(autouse=True)
+def _legacy_inference_policy(legacy_env: None) -> None:
+    """This suite intentionally reaches model behavior beyond credential admission."""
+
 
 def _make_litellm_error(cls: type[Exception]) -> Exception:
     """Construct a litellm exception instance, supplying per-class required args.

--- a/tests/unit/test_loop_spend_gate.py
+++ b/tests/unit/test_loop_spend_gate.py
@@ -15,6 +15,11 @@ from aios.harness.loop import (
 from aios.harness.window import WindowedEvents
 
 
+@pytest.fixture(autouse=True)
+def _legacy_inference_policy(legacy_env: None) -> None:
+    """This suite intentionally reaches model behavior beyond credential admission."""
+
+
 def test_limit_to_microusd_allows_none_zero_and_rounding() -> None:
     assert _limit_to_microusd(None) is None
     assert _limit_to_microusd(0) == 0

--- a/tests/unit/test_model_providers_service.py
+++ b/tests/unit/test_model_providers_service.py
@@ -144,7 +144,7 @@ class TestProviderAuthConflict:
             is True
         )
 
-    def test_truthy_self_supplied_key_exempts(self) -> None:
+    def test_truthy_inline_key_does_not_exempt_redirect_guard(self) -> None:
         resolved = ProviderAuth(api_key="k", api_base=None, owner_account_id="acc_parent")
         assert (
             provider_auth_conflict(
@@ -153,7 +153,7 @@ class TestProviderAuthConflict:
                 account_id="acc_child",
                 account_is_root=False,
             )
-            is False
+            is True
         )
 
     @pytest.mark.parametrize("falsy_key", [None, ""])

--- a/tests/unit/test_model_providers_service.py
+++ b/tests/unit/test_model_providers_service.py
@@ -32,6 +32,11 @@ from tests.unit.conftest import fake_pool_yielding_conn
 
 
 @pytest.fixture(autouse=True)
+def _legacy_inference_policy(legacy_env: None) -> None:
+    """This suite intentionally reaches model behavior beyond credential admission."""
+
+
+@pytest.fixture(autouse=True)
 def _unit_provider_auth_ungated() -> None:
     """Shadow (by name) the conftest-level autouse stub of the same name.
 

--- a/tests/unit/test_revocation_kinds_coverage.py
+++ b/tests/unit/test_revocation_kinds_coverage.py
@@ -43,6 +43,7 @@ FULFILLED_KINDS: frozenset[str] = frozenset(
         "child_errored",
         "spend_cap_exceeded",
         "provider_auth_conflict",
+        "model_provider_not_configured",
         # the session errored its OWN turn: its context didn't fit and it
         # exhausted the shrink-on-retry ladder (#1792) — servicer's own erroring
         "context_overflow",

--- a/tests/unit/test_run_llm.py
+++ b/tests/unit/test_run_llm.py
@@ -184,6 +184,25 @@ async def test_trusted_api_base_admitted() -> None:
 # ─── guard 3: provider-auth conflict ──────────────────────────────────────────
 
 
+async def test_unconfigured_provider_fails_closed() -> None:
+    with (
+        patch(
+            "aios.services.model_providers.resolve_provider_auth_or_conflict",
+            AsyncMock(return_value=(None, None)),
+        ),
+        patch("aios.workflows.run_llm.call_litellm", AsyncMock()) as model_call,
+        patch(
+            "aios.workflows.run_llm.get_settings",
+            return_value=SimpleNamespace(inference_credential_policy="account_only"),
+        ),
+    ):
+        result, cost = await invoke_call_llm(run=_run(), spec=_spec())
+
+    assert result["error_kind"] == "model_provider_not_configured"
+    assert cost == 0
+    model_call.assert_not_awaited()
+
+
 async def test_provider_auth_conflict_rejected() -> None:
     with (
         patch(

--- a/tests/unit/test_run_llm.py
+++ b/tests/unit/test_run_llm.py
@@ -25,6 +25,11 @@ from aios.workflows.wf_script_host import call_llm
 
 
 @pytest.fixture(autouse=True)
+def _legacy_inference_policy(legacy_env: None) -> None:
+    """This suite intentionally reaches model behavior beyond credential admission."""
+
+
+@pytest.fixture(autouse=True)
 def _stub_provider_auth_guard(monkeypatch: pytest.MonkeyPatch) -> None:
     """Guard 3 (provider-auth conflict) needs a worker context (pool/crypto_box)
     and hits the DB. Stub it to a clean pass — no resolved row, no conflict —

--- a/tests/unit/test_wake_instrumentation.py
+++ b/tests/unit/test_wake_instrumentation.py
@@ -24,6 +24,11 @@ from aios.harness.window import WindowedEvents
 from aios.services.sessions import AssistantAppendResult
 
 
+@pytest.fixture(autouse=True)
+def _legacy_inference_policy(legacy_env: None) -> None:
+    """This suite intentionally reaches model behavior beyond credential admission."""
+
+
 def _llm_response(
     message: dict[str, object],
     *,


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/aios#1960.

## Fix-round changelog (9427d50e)
- Enforced the structural credentialless platform-root invariant at provider create/update, startup audit, and non-legacy descendant resolution.
- Added per-use log and metric observation for `observe_legacy_env`.
- Made resolved account-provider rows authoritative over inline key/base fields under non-legacy policy; inline keys no longer exempt redirect guards.
- Added real platform-root → Eumemic → customer topology coverage, simultaneous OpenAI/Anthropic root rejection, and updated account-row migration documentation.
- Validation: ruff check/format, mypy src tests, full unit (4611 passed, 1 skipped), credential/provider suites (integration unavailable locally: Docker not available).

### Fixer round 2 changelog
- Added real-topology regression coverage for ACTIVE platform-root rows under `account_only` and `external_byok`, exercising the workflow inference guard end-to-end: `model_provider_not_configured`, zero invocation/cost, no `FUNDED_BY_ROOT`, and request capture proving sentinel env/root-row credentials do not egress.
- Changed shared integration and unit credential policy fixtures to default to `account_only`; legacy-dependent downstream harness suites now opt into `legacy_env` explicitly.
- Added direct regression tests for startup audit of a pre-existing root row, root-row UPDATE rejection, `observe_legacy_env` log+metric emission, and legacy inline precedence.
- Test-only change; no production files modified in this round.
- Validation: ruff check + format-check pass; mypy `src tests` pass; full unit 4617 passed/1 skipped; credential suites 66 passed/33 Docker-only skipped locally.

### Fixer round 3 changelog (46f9eed7)
- Replaced blanket integration and non-docker E2E `cmd || cmd --lf` retries with one explicitly scoped `--lf` retry.
- Each retry now emits a `::warning::FLAKE_RETRY <shard>` annotation, records the marker in `$GITHUB_STEP_SUMMARY`, and uploads a shard-specific flake-retry marker artifact.
- Integration remains serial. No files outside `.github/workflows/code-validation.yml` changed.
- Validation: `uv run ruff check` passed; `python3 -c yaml.safe_load` passed; workflow lint N/A.