### PR TITLE
fix(sandbox): include non-terminal shared-workspace runs in archived-workspace reaper keep-set (#1970)

### DIFF
--- a/src/aios/db/queries/sandboxes.py
+++ b/src/aios/db/queries/sandboxes.py
@@ -166,7 +166,13 @@ async def unscoped_reapable_archived_workspaces(
 async def unscoped_live_workspace_volume_paths(
     conn: asyncpg.Connection[Any],
 ) -> list[str]:
-    """Return every NON-archived (live) session's stored ``workspace_volume_path``.
+    """Return paths currently borrowed by live sessions or shared workflow runs.
+
+    The keep-set includes every non-archived session's ``workspace_volume_path``
+    and every non-terminal shared ``wf_runs.workspace_path``. A shared workflow
+    run keeps executing against its launcher's session workspace even after the
+    launcher is archived, so omitting those run pointers can delete a live run's
+    filesystem.
 
     The keep-set for the archived-workspace reaper's live-clone cross-check
     (aios#40, same never-delete class as the confinement gate). ``clone_session``
@@ -188,6 +194,13 @@ async def unscoped_live_workspace_volume_paths(
          WHERE archived_at IS NULL
            AND workspace_volume_path IS NOT NULL
            AND workspace_volume_path <> ''
+        UNION
+        SELECT workspace_path AS workspace_volume_path
+          FROM wf_runs
+         WHERE workspace_mode = 'shared'
+           AND status IN ('pending', 'running', 'suspended')
+           AND workspace_path IS NOT NULL
+           AND workspace_path <> ''
         """,
     )
     return [row["workspace_volume_path"] for row in rows]

--- a/src/aios/harness/workspace_reaper.py
+++ b/src/aios/harness/workspace_reaper.py
@@ -384,10 +384,19 @@ async def sweep_archived_workspaces(pool: asyncpg.Pool[Any]) -> ReapResult:
             )
             continue
         try:
+            # Revalidate immediately before the destructive operation. A shared
+            # run can become non-terminal after the sweep's initial keep-set read;
+            # never treat that stale absence as permission to delete its workspace.
+            async with pool.acquire() as conn:
+                current_live_paths = await queries.unscoped_live_workspace_volume_paths(conn)
+            if str(target.resolve()) in _live_workspace_realpath_keepset(current_live_paths):
+                skip_conf += 1
+                continue
+
             # Off the event loop: a multi-GB tree's rmtree would otherwise block
             # every concurrent session sharing the worker loop for its duration.
             await asyncio.to_thread(shutil.rmtree, target)
-        except OSError:
+        except (asyncpg.PostgresError, OSError):
             # One un-removable dir (perm drift, read-only FS) must not abort the
             # rest of the sweep; the next sweep retries it.
             log.exception("workspace_reaper.rmtree_failed", path=str(target))

--- a/tests/unit/test_workspace_reaper.py
+++ b/tests/unit/test_workspace_reaper.py
@@ -372,6 +372,85 @@ async def test_live_clone_sharing_archived_parents_canonical_dir_is_skipped(
     assert (parent_dir / "scratch.txt").exists()
 
 
+async def test_nonterminal_shared_run_keeps_archived_launcher_workspace(
+    env: dict[str, Any],
+) -> None:
+    """A pending/running/suspended shared run protects its archived launcher's path."""
+    launcher_dir = _mk_workspace(env["root"], "acct1", "sess_launcher")
+    pool = _fake_pool(
+        [_row("acct1", "sess_launcher", str(launcher_dir))],
+        live_paths=[str(launcher_dir)],
+    )
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert launcher_dir.exists(), "a non-terminal shared run still uses this workspace"
+    sql = " ".join(call.args[0] for call in pool._conn.fetch.await_args_list)
+    assert "workspace_mode = 'shared'" in sql
+    assert "status IN ('pending', 'running', 'suspended')" in sql
+
+
+async def test_terminal_shared_run_allows_archive_grace_reclamation(
+    env: dict[str, Any],
+) -> None:
+    """Terminal shared runs are absent from the keep-set, so normal reaping proceeds."""
+    launcher_dir = _mk_workspace(env["root"], "acct1", "sess_launcher_terminal")
+    pool = _fake_pool([_row("acct1", "sess_launcher_terminal", str(launcher_dir))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 1
+    assert not launcher_dir.exists()
+
+
+async def test_nonterminal_fresh_run_does_not_keep_archived_workspace(
+    env: dict[str, Any],
+) -> None:
+    """Fresh-workspace runs remain outside this shared-workspace keep-set."""
+    launcher_dir = _mk_workspace(env["root"], "acct1", "sess_launcher_fresh")
+    pool = _fake_pool([_row("acct1", "sess_launcher_fresh", str(launcher_dir))])
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 1
+    assert not launcher_dir.exists()
+
+
+async def test_shared_run_created_after_scan_is_caught_by_pre_delete_revalidation(
+    env: dict[str, Any],
+) -> None:
+    """A shared run appearing after the initial scan is caught before ``rmtree``."""
+    launcher_dir = _mk_workspace(env["root"], "acct1", "sess_launcher_race")
+    conn = MagicMock()
+    keep_reads = 0
+
+    async def _route_fetch(sql: str, *_a: Any, **_k: Any) -> list[Any]:
+        nonlocal keep_reads
+        if "archived_at IS NOT NULL" in sql:
+            return [_row("acct1", "sess_launcher_race", str(launcher_dir))]
+        keep_reads += 1
+        return [] if keep_reads == 1 else [{"workspace_volume_path": str(launcher_dir)}]
+
+    conn.fetch = AsyncMock(side_effect=_route_fetch)
+
+    class _Cm:
+        async def __aenter__(self) -> Any:
+            return conn
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+    pool = MagicMock()
+    pool.acquire.return_value = _Cm()
+
+    result = await sweep_archived_workspaces(pool)
+
+    assert result.reaped == 0
+    assert launcher_dir.exists()
+    assert keep_reads == 2
+
+
 async def test_off_shape_ids_are_never_reaped(env: dict[str, Any]) -> None:
     """An account/session id carrying a path separator or ``..`` is skipped.
 


### PR DESCRIPTION
## Problem

The archived-workspace reaper built its keep-set only from non-archived session workspace pointers. A workflow launched with `workspace_mode='shared'` persists the launcher's host workspace in `wf_runs.workspace_path`, so archiving the launcher while that run is pending, running, or suspended could let the reaper delete the workspace underneath the live run.

## Approach

- Extend the archived-workspace reaper keep-set query with non-empty `workspace_path` values from shared workflow runs in non-terminal states (`pending`, `running`, and `suspended`).
- Re-read and normalize the keep-set immediately before each destructive `rmtree`, failing closed on a database or filesystem error, so a shared run that becomes live after the initial sweep scan is protected.
- Keep terminal shared runs and all fresh-workspace runs outside this additional keep-set, preserving normal archive-grace reclamation.
- Add focused tests covering non-terminal shared-run retention, terminal-run reclamation, fresh-workspace behavior, and the pre-delete revalidation race.

No other reclamation path is changed.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src tests`
- `uv run pytest tests/unit -q -n 4` (4611 passed, 1 skipped)

Fixes #1970
