### PR TITLE
kaizen: dead-code sweep — remove 4 unreferenced symbols

### DIFF
--- a/src/aios/db/pool.py
+++ b/src/aios/db/pool.py
@@ -100,10 +100,6 @@ async def register_jsonb_codec(conn: asyncpg.Connection[Any]) -> None:
     )
 
 
-# Back-compat alias: the original private name used as the pool ``init``.
-_register_jsonb_codec = register_jsonb_codec
-
-
 async def create_pool(db_url: str, *, min_size: int = 1, max_size: int = 8) -> asyncpg.Pool[Any]:
     """Create a new asyncpg pool against ``db_url``."""
     # asyncpg exposes no client-side keepalive kwarg, so the statement/idle

--- a/src/aios/harness/model_workflow.py
+++ b/src/aios/harness/model_workflow.py
@@ -79,11 +79,6 @@ def reset_inflight_harvests() -> None:
     _INFLIGHT_HARVESTS.clear()
 
 
-def inflight_harvest_keys() -> frozenset[tuple[str, str]]:
-    """The ``(session_id, run_id)`` keys of harvest tasks live in THIS worker (#1635)."""
-    return frozenset(_INFLIGHT_HARVESTS)
-
-
 # Event ``kind`` is ``"span"`` (excluded from the message-replay window like the
 # other harness bookkeeping events); the ``event`` discriminator names the role.
 PARK_EVENT = "model_workflow_park"

--- a/src/aios/harness/runtime.py
+++ b/src/aios/harness/runtime.py
@@ -117,10 +117,6 @@ def require_sandbox_registry() -> SandboxRegistry:
     return _require("sandbox_registry", sandbox_registry)
 
 
-def require_github_clone_breaker() -> GithubCloneBreaker:
-    return _require("github_clone_breaker", github_clone_breaker)
-
-
 def require_inflight_tool_registry() -> InflightToolRegistry:
     return _require("inflight_tool_registry", inflight_tool_registry)
 

--- a/src/aios/sandbox/volumes.py
+++ b/src/aios/sandbox/volumes.py
@@ -110,20 +110,9 @@ def workspace_dir_for(session_id: str) -> Path:
     path (e.g. ``./workspaces`` in a dev ``.env``), it is resolved
     against the current working directory at call time.
 
-    Pure — does not touch the filesystem. Use :func:`ensure_workspace_dir`
-    to both compute and create.
+    Pure — does not touch the filesystem.
     """
     return (get_settings().workspace_root / session_id).resolve()
-
-
-def ensure_workspace_dir(session_id: str) -> Path:
-    """Return the absolute host directory for ``session_id``, creating it if needed.
-
-    Also ensures the parent ``workspace_root`` exists. ``parents=True,
-    exist_ok=True`` semantics — safe to call repeatedly.
-    """
-    path = workspace_dir_for(session_id)
-    return ensure_owned_dir(path)
 
 
 def ensure_workspace_path(raw_path: str) -> Path:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1871.