### PR TITLE
fix(worker): AIOS_MEMORY_RECONCILE_AUDIT_ENABLED=false crashloops the worker — its kill-switch early-returns from a _supervise'd while-True loop, read as a fatal 'returned cleanly' (move the gate into the sweep_fn like the 3 sibling reapers)

### DIFF
--- a/src/aios/harness/memory_reconcile_audit.py
+++ b/src/aios/harness/memory_reconcile_audit.py
@@ -41,6 +41,7 @@ from typing import Any
 
 import asyncpg
 
+from aios.config import get_settings
 from aios.db import queries as queries
 from aios.logging import get_logger
 from aios.sandbox.memory_mounts import MATERIALIZED_MARKER
@@ -145,6 +146,9 @@ async def run_memory_reconcile_audit(pool: asyncpg.Pool[Any]) -> AuditResult:
     not a crash), but every divergence is a structured warning log line the
     ops-agent cron / alerting surface can watch.
     """
+    if not get_settings().memory_reconcile_audit_enabled:
+        return AuditResult(stores_checked=0, files_hashed=0)
+
     divergences: list[Divergence] = []
     stores_checked = 0
     files_hashed = 0

--- a/src/aios/harness/worker.py
+++ b/src/aios/harness/worker.py
@@ -910,9 +910,6 @@ async def _memory_reconcile_audit_loop(pool: asyncpg.Pool[Any]) -> None:
     """
     log = get_logger("aios.worker.memory_reconcile_audit")
     settings = get_settings()
-    if not settings.memory_reconcile_audit_enabled:
-        log.warning("memory_reconcile_audit.disabled")
-        return
     from aios.harness.memory_reconcile_audit import run_memory_reconcile_audit
 
     interval = settings.memory_reconcile_audit_interval_seconds

--- a/tests/unit/test_memory_reconcile_audit.py
+++ b/tests/unit/test_memory_reconcile_audit.py
@@ -93,6 +93,20 @@ def _seed_store(
     return host_dir
 
 
+class TestKillSwitch:
+    async def test_disabled_returns_empty_result_without_acquiring_db(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        settings = MagicMock(memory_reconcile_audit_enabled=False)
+        monkeypatch.setattr(audit, "get_settings", lambda: settings)
+        pool = MagicMock()
+
+        result = await audit.run_memory_reconcile_audit(pool)
+
+        assert result == audit.AuditResult(stores_checked=0, files_hashed=0)
+        pool.acquire.assert_not_called()
+
+
 class TestCleanAudit:
     async def test_matching_disk_and_db_produce_no_divergence(
         self,


### PR DESCRIPTION
Automated dev-pipeline build for issue #1873.