### PR TITLE
Sandbox snapshot-pool GC retains archived-session snapshots + corpses (no archived_at fast-path) → recurring disk-fill

### DIFF
--- a/docs/design/durable-session-sandboxes.md
+++ b/docs/design/durable-session-sandboxes.md
@@ -359,8 +359,8 @@ deterministic local tag — today's behavior exactly. Rules:
   against the old tag and discard live post-drift work as `skipped_stale`) — a
   model-visible `sandbox_fs_reset {reason: "environment_image_changed"}` lifecycle event
   is appended, and the session cold-starts on the new image. (Content changes under the *same* ref — base rebuilds, `:stable`
-  promotes — do not trigger this; parked chains keep their pinned base until the session is reset or archived and
-  its archive grace has elapsed.) Keep-the-FS-instead is a defensible alternative semantic; the event is the
+  promotes — do not trigger this; parked chains keep their pinned base until the session is
+  reset or archived.) Keep-the-FS-instead is a defensible alternative semantic; the event is the
   non-negotiable part — sign-off item §11.
 - **First-commit crash heal**: the salvage preamble (§5.4), already under the per-session
   lock, also reconciles the pointer against local truth — a crash after the first-ever
@@ -413,14 +413,14 @@ crash windows content-equal no-ops.
 `start_gc(pool, ...)` — background loop, hourly tick, immediate first tick at boot:
 
 1. **Corpse pass** — per corpse, under `_lock_for(session_id)`: re-read the
-   session lifecycle. Deleted sessions and sessions archived at or beyond
-   `sandbox_archive_gc_grace_seconds` are bare-destroyed; all other session
-   corpses are salvaged before removal. Ephemeral workflow-run corpses are
+   session lifecycle. Deleted and archived sessions are bare-destroyed immediately;
+   non-archived session corpses are salvaged before removal. Ephemeral workflow-run
+   corpses are
    always bare-destroyed because they have no durable rootfs.
 2. **Image pass** — enumerate all managed images, including untagged residue.
    Canonical images for existing non-archived sessions are protected. Archived
-   canonical images become collectible only once archive grace has elapsed;
-   deleted-session images and non-canonical leaf residue are collectible.
+   canonical images, deleted-session images, and non-canonical leaf residue are
+   collectible immediately.
    Live-chain interiors are skipped structurally by parent relationship.
 3. **Pressure passes** — host-pool and per-account snapshot limits are
    observational: they never delete lifecycle-protected filesystems. Pressure
@@ -429,7 +429,7 @@ crash windows content-equal no-ops.
    never ephemeral run sandboxes. A later clear report restores admission.
 4. **Pointer reconciliation** — local store truth heals missing/stale pointers.
    Destructive archive cleanup requires a fresh, exact archive timestamp,
-   elapsed grace, matching pointer, and positive ownership
+   matching pointer and positive ownership
    (`snapshot_host == instance_id`) under the per-session lock; an unarchive,
    rearchive, pointer move, or ambiguous host fails closed.
 
@@ -668,8 +668,7 @@ All four new columns are nullable with NULL = no snapshot — zero backfill, met
 DDL. They are internal (excluded from the session wire shape), so no openapi/SDK churn
 from this migration itself.
 
-**Settings** (config.py): `sandbox_archive_gc_grace_seconds` controls the explicit
-archive-to-destruction delay; `sandbox_snapshot_budget_bytes: int = 4 GiB` (per-session; per-env override via a **new**
+**Settings** (config.py): `sandbox_snapshot_budget_bytes: int = 4 GiB` (per-session; per-env override via a **new**
 `EnvironmentConfig` field replacing `disk_bytes` — never a silent semantic rename of the
 existing field, per §5.7's own no-repurposing rule); `sandbox_snapshot_pool_bytes: int | None = None` with the eumemic-ops
 deploy setting it (§9); **delete** `sandbox_disk_bytes`; raise
@@ -815,7 +814,7 @@ E2E (`docker_harness`, gated by the existing `needs_docker` marker; force idle v
   `evict()` → next tool call sees the pre-crash marker; stale-corpse variant never
   regresses tag content.
 - **GC** (`test_sandbox_snapshot_gc.py`): session delete → `_gc_once` → image gone;
-  archive grace boundary and zero-grace cases → image gone; unarchive/rearchive races
+  archive boundary → image gone; unarchive/rearchive races
   fail closed; orphaned-chain residue is collected; pressure is signalled without
   deleting lifecycle-protected snapshots.
 - **Lockdown sidecar** (`test_networking.py` extension): Limited env on a *resumed*
@@ -875,7 +874,7 @@ Docker availability: e2e requires real Docker (`DOCKER_HOST` per conftest); CI a
    **`--read-only` closed as incompatible** rather than re-deferred; **`--cap-drop=ALL`
    stays deferred** (NET_ADMIN removal ships now via the lockdown sidecar).
 9. **Rollback posture**: disable new snapshot creation while retaining lifecycle-
-   protected artifacts; destructive cleanup remains tied to archive plus grace.
+   protected artifacts; destructive cleanup remains tied to archive.
 
 ---
 

--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -232,11 +232,6 @@ class Settings(BaseSettings):
         ge=0,
         description="Free disk retained in addition to the estimated transient flatten cost.",
     )
-    sandbox_archive_gc_grace_seconds: int = Field(
-        default=86400,
-        ge=0,
-        description="Grace after archived_at before canonical filesystem reclamation.",
-    )
     sandbox_snapshot_ttl_seconds: int = Field(
         default=2_592_000,  # 30 days
         ge=60,

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -36,7 +36,7 @@ import re
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from aios.config import get_settings
@@ -144,9 +144,8 @@ class SessionSnapshotState:
 
     A session *absent* from the GC's state map is **deleted** — its snapshot
     is collectible without an event (the model is gone). Canonical filesystem
-    state for an existing session is protected until the session is archived
-    and its archive grace interval has elapsed. ``last_event_at`` remains in
-    the query shape for accounting compatibility; it is not a lifecycle gate.
+    state for an existing session is protected until the session is archived.
+    ``last_event_at`` remains in the query shape for accounting compatibility; it is not a lifecycle gate.
     """
 
     session_id: str
@@ -159,7 +158,7 @@ class SessionSnapshotState:
 
 
 _GcVerdict = Literal["retain", "remove"]
-_GcReason = Literal["protected_live", "archive_grace", "archived", "deleted", "residue"]
+_GcReason = Literal["protected_live", "archived", "deleted", "residue"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,21 +191,10 @@ class GcPressureResult:
 PressureCallback = Callable[[GcPressureResult], Awaitable[None] | None]
 
 
-def _archive_eligible(
-    state: SessionSnapshotState, now: datetime, archive_grace_seconds: int
-) -> bool:
-    """Whether current state crossed the sole destructive lifecycle boundary."""
-    return state.archived_at is not None and now >= state.archived_at + timedelta(
-        seconds=archive_grace_seconds
-    )
-
-
 def _classify_images(
     images: list[ManagedImage],
     states: dict[str, SessionSnapshotState],
     *,
-    now: datetime,
-    archive_grace_seconds: int,
     this_host: str,
 ) -> list[GcImageVerdict]:
     """Classify canonical state by archive lifecycle; residue stays collectible."""
@@ -224,10 +212,8 @@ def _classify_images(
             if state.archived_at is None:
                 verdict: _GcVerdict = "retain"
                 reason: _GcReason = "protected_live"
-            elif _archive_eligible(state, now, archive_grace_seconds):
-                verdict, reason = "remove", "archived"
             else:
-                verdict, reason = "retain", "archive_grace"
+                verdict, reason = "remove", "archived"
         elif is_canonical:
             verdict, reason = "remove", "deleted"
         else:
@@ -2005,13 +1991,9 @@ class SandboxRegistry:
         verdicts = _classify_images(
             images,
             image_states,
-            now=now,
-            archive_grace_seconds=settings.sandbox_archive_gc_grace_seconds,
             this_host=instance_id,
         )
-        retained = await self._gc_image_pass(
-            verdicts, image_states, now, settings.sandbox_archive_gc_grace_seconds, instance_id
-        )
+        retained = await self._gc_image_pass(verdicts, image_states, instance_id)
 
         # Pass 3 — per-host pool budget.
         pool_pressure = await self._gc_pool_budget_pass(
@@ -2065,7 +2047,7 @@ class SandboxRegistry:
 
         The tick-start ``states`` snapshot can be stale across archive,
         unarchive, or rearchive. Re-reading under the lock proves the lifecycle
-        timestamp, grace boundary, pointer, and ownership used by a destructive
+        timestamp, pointer, and ownership used by a destructive
         decision. ``None`` means deleted and is collectible only on paths whose
         contract explicitly permits deleted-session cleanup.
         """
@@ -2084,8 +2066,8 @@ class SandboxRegistry:
     ) -> None:
         """Salvage (or drop) every managed container that isn't a live cached handle.
 
-        Retain rule first: a deleted or archived-past-grace session's corpse is
-        removed WITHOUT paying a commit; every other existing session is
+        Retain rule first: a deleted or archived session's corpse is removed
+        WITHOUT paying a commit; every non-archived existing session is
         salvaged (committed) and then removed. Best-effort — a snapshot failure leaves the corpse for
         the next tick (the GC never raises). Each corpse is handled under the
         per-session lock with the cached-handle re-check.
@@ -2116,10 +2098,8 @@ class SandboxRegistry:
                 # ── session corpse: lifecycle rule + under-lock re-verify ──
                 state = states.get(sid)
                 fresh = await self._fresh_session_state(sid)
-                keep_fs = fresh is not None and not _archive_eligible(
-                    fresh, now, settings.sandbox_archive_gc_grace_seconds
-                )
-                # Archived-past-grace destruction requires the exact timestamp
+                keep_fs = fresh is not None and fresh.archived_at is None
+                # Archived destruction requires the exact timestamp
                 # seen by the scan. Any lifecycle race fails closed.
                 if (
                     not keep_fs
@@ -2135,15 +2115,13 @@ class SandboxRegistry:
                         await self._backend.force_remove(ref.sandbox_id)
                     # else: snapshot failed — leave the corpse for the next tick.
                 else:
-                    # Deleted/dormant: remove without paying a commit.
+                    # Deleted/archived: remove without paying a commit.
                     await self._backend.force_remove(ref.sandbox_id)
 
     async def _gc_image_pass(
         self,
         verdicts: list[GcImageVerdict],
         states: dict[str, SessionSnapshotState],
-        now: datetime,
-        archive_grace_seconds: int,
         instance_id: str,
     ) -> list[GcImageVerdict]:
         """Remove every non-retained image (under per-session locks); return the retained."""
@@ -2173,7 +2151,7 @@ class SandboxRegistry:
                         candidate is None
                         or fresh is None
                         or fresh.archived_at != candidate.archived_at
-                        or not _archive_eligible(fresh, now, archive_grace_seconds)
+                        or fresh.archived_at is None
                         or fresh.snapshot_ref != v.removal_ref
                         or fresh.snapshot_host != instance_id
                     ):

--- a/tests/unit/sandbox/test_gc_classify.py
+++ b/tests/unit/sandbox/test_gc_classify.py
@@ -1,13 +1,11 @@
 """Table-driven coverage for lifecycle-based snapshot GC classification.
 
 Canonical snapshots of existing, non-archived sessions are protected regardless
-of activity. Archived snapshots become collectible only when archive grace has
-elapsed; deleted sessions and non-canonical residue are collectible immediately.
+of activity. Archived snapshots become collectible immediately; deleted sessions and non-canonical residue are collectible immediately.
 """
 
 from __future__ import annotations
 
-from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 from aios.sandbox.backends.base import SESSION_LABEL_KEY, ManagedImage
@@ -57,9 +55,7 @@ def _state(session_id: str, *, dormant: bool) -> SessionSnapshotState:
 def _classify(
     images: list[ManagedImage], states: dict[str, SessionSnapshotState]
 ) -> dict[str, tuple[str, str]]:
-    verdicts = _classify_images(
-        images, states, now=_NOW, archive_grace_seconds=86400, this_host=_HOST
-    )
+    verdicts = _classify_images(images, states, this_host=_HOST)
     return {v.image.image_id: (v.verdict, v.reason) for v in verdicts}
 
 
@@ -103,8 +99,8 @@ def test_structural_parent_skip_excludes_live_chain_interior() -> None:
     assert out["img_leaf"] == ("retain", "protected_live")
 
 
-def test_archived_session_within_grace_is_retained() -> None:
-    """An archived session remains protected until archive grace elapses."""
+def test_archived_session_is_removed_immediately() -> None:
+    """An archived session bypasses retention regardless of archive age."""
     img = _image(image_id="img_a", session_id="sess_a", canonical=True)
     state = SessionSnapshotState(
         session_id="sess_a",
@@ -116,7 +112,7 @@ def test_archived_session_within_grace_is_retained() -> None:
         snapshot_bytes=1,
     )
     out = _classify([img], {"sess_a": state})
-    assert out["img_a"] == ("retain", "archive_grace")
+    assert out["img_a"] == ("remove", "archived")
 
 
 def test_missing_dormancy_probe_is_not_dormant() -> None:
@@ -141,43 +137,3 @@ def test_arbitrarily_dormant_non_archived_canonical_is_protected() -> None:
     state = _state("sess_a", dormant=True)
     out = _classify([img], {"sess_a": state})
     assert out["img_a"] == ("retain", "protected_live")
-
-
-def test_archived_current_observes_grace_boundary() -> None:
-    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
-    state = _state("sess_a", dormant=True)
-    grace = 86400
-    before = replace(state, archived_at=_NOW - timedelta(seconds=grace - 1))
-    at = replace(state, archived_at=_NOW - timedelta(seconds=grace))
-    assert (
-        _classify_images(
-            [img], {"sess_a": before}, now=_NOW, archive_grace_seconds=grace, this_host=_HOST
-        )[0].verdict
-        == "retain"
-    )
-    verdict = _classify_images(
-        [img], {"sess_a": at}, now=_NOW, archive_grace_seconds=grace, this_host=_HOST
-    )[0]
-    assert (verdict.verdict, verdict.reason) == ("remove", "archived")
-
-
-def test_zero_archive_grace_is_immediately_eligible() -> None:
-    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
-    state = replace(_state("sess_a", dormant=False), archived_at=_NOW)
-    verdict = _classify_images(
-        [img], {"sess_a": state}, now=_NOW, archive_grace_seconds=0, this_host=_HOST
-    )[0]
-    assert (verdict.verdict, verdict.reason) == ("remove", "archived")
-
-
-def test_nondefault_archive_grace_boundary() -> None:
-    img = _image(image_id="img_a", session_id="sess_a", canonical=True)
-    state = replace(_state("sess_a", dormant=False), archived_at=_NOW - timedelta(seconds=17))
-    before = _classify_images(
-        [img], {"sess_a": state}, now=_NOW, archive_grace_seconds=18, this_host=_HOST
-    )[0]
-    at = _classify_images(
-        [img], {"sess_a": state}, now=_NOW, archive_grace_seconds=17, this_host=_HOST
-    )[0]
-    assert before.verdict == "retain"
-    assert at.verdict == "remove"

--- a/tests/unit/sandbox/test_gc_passes.py
+++ b/tests/unit/sandbox/test_gc_passes.py
@@ -24,7 +24,6 @@ from aios.sandbox.spec import snapshot_tag
 from tests.helpers.sandbox import FakeBackend, FakePool
 
 _NOW = datetime(2026, 6, 10, tzinfo=UTC)
-_ARCHIVE_GRACE = 30 * 24 * 3600
 
 
 @pytest.fixture
@@ -188,8 +187,6 @@ async def test_image_pass_retains_archived_removal_after_unarchive(
     retained = await registry._gc_image_pass(
         [verdict],
         {"sess_x": _state("sess_x", dormant=True)},
-        _NOW,
-        _ARCHIVE_GRACE,
         get_settings().instance_id,
     )
 
@@ -417,7 +414,7 @@ async def test_archived_current_positive_ownership_is_removed() -> None:
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
     tag = snapshot_tag(get_settings().instance_id, "sess_x")
-    archived_at = _NOW - timedelta(days=2)
+    archived_at = _NOW
     state = SessionSnapshotState(
         "sess_x", "acct", archived_at, _NOW, tag, get_settings().instance_id, 1
     )
@@ -429,7 +426,7 @@ async def test_archived_current_positive_ownership_is_removed() -> None:
     registry._clear_pointer_if_owned = AsyncMock()  # type: ignore[method-assign]
 
     retained = await registry._gc_image_pass(
-        [verdict], {"sess_x": state}, _NOW, 86400, get_settings().instance_id
+        [verdict], {"sess_x": state}, get_settings().instance_id
     )
 
     assert retained == []
@@ -437,9 +434,7 @@ async def test_archived_current_positive_ownership_is_removed() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "failure", ["null_host", "stale_grace", "pointer_moved", "unarchived", "rearchived"]
-)
+@pytest.mark.parametrize("failure", ["null_host", "pointer_moved", "unarchived", "rearchived"])
 async def test_archived_current_destructive_path_fails_closed(failure: str) -> None:
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
@@ -450,8 +445,6 @@ async def test_archived_current_destructive_path_fails_closed(failure: str) -> N
     fresh = candidate
     if failure == "null_host":
         fresh = replace(candidate, snapshot_host=None)
-    elif failure == "stale_grace":
-        fresh = replace(candidate, archived_at=_NOW - timedelta(seconds=86399))
     elif failure == "pointer_moved":
         fresh = replace(candidate, snapshot_ref="other")
     elif failure == "unarchived":
@@ -463,82 +456,24 @@ async def test_archived_current_destructive_path_fails_closed(failure: str) -> N
     )
     registry._fresh_session_state = AsyncMock(return_value=fresh)  # type: ignore[method-assign]
 
-    retained = await registry._gc_image_pass([verdict], {"sess_x": candidate}, _NOW, 86400, host)
+    retained = await registry._gc_image_pass([verdict], {"sess_x": candidate}, host)
 
     assert retained == [verdict]
     assert tag not in backend.removed_image_refs
 
 
 @pytest.mark.asyncio
-async def test_archived_within_grace_corpse_is_salvaged() -> None:
+async def test_archived_corpse_is_removed_without_salvage() -> None:
     backend = FakeBackend()
     registry = SandboxRegistry(backend=backend)
     state = replace(_state("sess_x", dormant=False), archived_at=_NOW - timedelta(seconds=16))
     registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
     registry._snapshot_and_record = AsyncMock(return_value=True)  # type: ignore[method-assign]
     container = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
-    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 17})
+    settings = get_settings()
 
     await registry._gc_corpse_pass(
         [container], {"sess_x": state}, _NOW, settings, get_settings().instance_id
-    )
-
-    registry._snapshot_and_record.assert_awaited_once()
-    assert any(call[0] == "force_remove" for call in backend.calls)
-
-
-@pytest.mark.asyncio
-async def test_snapshot_failure_retains_archived_grace_corpse() -> None:
-    backend = FakeBackend()
-    registry = SandboxRegistry(backend=backend)
-    state = replace(_state("sess_x", dormant=False), archived_at=_NOW)
-    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
-    registry._snapshot_and_record = AsyncMock(return_value=False)  # type: ignore[method-assign]
-    container = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
-    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 17})
-
-    await registry._gc_corpse_pass(
-        [container], {"sess_x": state}, _NOW, settings, get_settings().instance_id
-    )
-
-    registry._snapshot_and_record.assert_awaited_once()
-    assert not any(call[0] == "force_remove" for call in backend.calls)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("grace_seconds, age_seconds", [(17, 17), (0, 0)])
-async def test_archived_corpse_at_boundary_is_bare_destroyed(
-    grace_seconds: int, age_seconds: int
-) -> None:
-    backend = FakeBackend()
-    registry = SandboxRegistry(backend=backend)
-    archived_at = _NOW - timedelta(seconds=age_seconds)
-    state = replace(_state("sess_x", dormant=False), archived_at=archived_at)
-    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
-    registry._snapshot_and_record = AsyncMock()  # type: ignore[method-assign]
-    corpse = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
-    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": grace_seconds})
-
-    await registry._gc_corpse_pass(
-        [corpse], {"sess_x": state}, _NOW, settings, get_settings().instance_id
-    )
-
-    registry._snapshot_and_record.assert_not_awaited()
-    assert ("force_remove", {"sandbox_id": "cid"}) in backend.calls
-
-
-@pytest.mark.asyncio
-async def test_archived_past_grace_corpse_is_bare_destroyed() -> None:
-    backend = FakeBackend()
-    registry = SandboxRegistry(backend=backend)
-    state = replace(_state("sess_x", dormant=False), archived_at=_NOW - timedelta(days=2))
-    registry._fresh_session_state = AsyncMock(return_value=state)  # type: ignore[method-assign]
-    registry._snapshot_and_record = AsyncMock()  # type: ignore[method-assign]
-    corpse = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
-    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 86400})
-
-    await registry._gc_corpse_pass(
-        [corpse], {"sess_x": state}, _NOW, settings, get_settings().instance_id
     )
 
     registry._snapshot_and_record.assert_not_awaited()
@@ -554,7 +489,7 @@ async def test_corpse_rearchive_race_fails_closed_and_salvages() -> None:
     registry._fresh_session_state = AsyncMock(return_value=fresh)  # type: ignore[method-assign]
     registry._snapshot_and_record = AsyncMock(return_value=True)  # type: ignore[method-assign]
     corpse = ManagedSandboxRef(sandbox_id="cid", session_id="sess_x", running=False)
-    settings = get_settings().model_copy(update={"sandbox_archive_gc_grace_seconds": 86400})
+    settings = get_settings()
 
     await registry._gc_corpse_pass(
         [corpse], {"sess_x": scanned}, _NOW, settings, get_settings().instance_id


### PR DESCRIPTION
Automated dev-pipeline build for issue #1889.