### PR TITLE
Follow-up to #1886: bin/aios-retire --help still describes the deleted retirement_ledger arm; guard-ordering test weakened to a tautology

### DIFF
--- a/bin/aios-retire
+++ b/bin/aios-retire
@@ -7,7 +7,7 @@ migrations. Given the name of a descriptor declared as data in
 ``aios.retirements.registry`` (#1573), it emits the three lifecycle migrations in
 chain order on top of the current migration head:
 
-  * **expand**   (rev N)   — no-op while the read-tolerance shim remains active,
+  * **expand**   (rev N)   — genuine no-op (the read-tolerance shim does the work),
   * **backfill** (rev N+1) — EXISTS-pre-checked, batched, epoch-stamping rewrite,
   * **contract** (rev N+2) — in-transaction residue abort-guard.
 

--- a/tests/unit/test_retirement_migration_gen.py
+++ b/tests/unit/test_retirement_migration_gen.py
@@ -222,6 +222,16 @@ def test_contract_has_in_transaction_abort_on_nonzero_guard() -> None:
     # contract rev on abort).
     assert "RAISE EXCEPTION" in src
     assert "residue > 0" in src
+    # The guard remains the only and therefore final operation in upgrade().
+    module = _module(src)
+    (upgrade,) = [
+        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "upgrade"
+    ]
+    assert len(upgrade.body) == 1
+    assert isinstance(upgrade.body[-1], ast.Expr)
+    assert isinstance(upgrade.body[-1].value, ast.Call)
+    assert ast.unparse(upgrade.body[-1].value.func) == "op.execute"
+    assert "RAISE EXCEPTION" in ast.literal_eval(upgrade.body[-1].value.args[0])
 
 
 def test_contract_guard_references_the_backfill_revision() -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue #1920.