### PR TITLE
update_agent over-attenuates: orthogonal edits (window/model/prompt) require the editor to hold the target's ENTIRE existing MCP+HTTP surface — CEO seat can't manage its lieutenants

### DIFF
--- a/src/aios/models/attenuation.py
+++ b/src/aios/models/attenuation.py
@@ -620,17 +620,24 @@ def surface_diff(expected: Surface, actual: Surface) -> dict[str, list[str]]:
     """
     out: dict[str, list[str]] = {}
 
-    actual_tools = {_tool_key(t): t for t in actual.tools}
     bad_tools = [
         t.name or t.mcp_server_name or t.type
         for t in expected.tools
-        if actual_tools.get(_tool_key(t)) != t
+        if not any(
+            _tool_key(candidate) == _tool_key(t) and candidate == t for candidate in actual.tools
+        )
     ]
     if bad_tools:
         out["tools"] = bad_tools
 
-    actual_mcp = {(s.name, s.url): s for s in actual.mcp_servers}
-    bad_mcp = [s.name for s in expected.mcp_servers if actual_mcp.get((s.name, s.url)) != s]
+    bad_mcp = [
+        s.name
+        for s in expected.mcp_servers
+        if not any(
+            (candidate.name, candidate.url) == (s.name, s.url) and candidate == s
+            for candidate in actual.mcp_servers
+        )
+    ]
     if bad_mcp:
         out["mcp_servers"] = bad_mcp
 

--- a/src/aios/services/agents.py
+++ b/src/aios/services/agents.py
@@ -42,20 +42,21 @@ async def _enforce_surface_attenuation(
     tools: list[ToolSpec],
     mcp_servers: list[McpServerSpec],
     http_servers: list[HttpServerSpec],
+    prior_surface: Surface | None = None,
 ) -> None:
     """Raise ``ForbiddenError`` unless the declared agent surface is admissible against
     the acting (creator/editor) session's agent surface.
 
-    The create-time clamp the issue (T1) calls for: ``create_agent`` authored from
-    inside a session may only declare a surface ⊆ the creating agent's own — an agent
-    cannot grant a child agent a tool, MCP server, or HTTP server it does not itself
-    hold. ``update_agent`` runs the same check on the merged final surface against the
-    editing agent. This is the model-tool plane's analog of the ``create_workflow``
-    surface clamp (``services.workflows._enforce_surface_attenuation``); the HTTP/operator
-    path passes no actor and skips this entirely (declares verbatim, account-scoped).
+    At create time, an agent authored from inside a session may only declare a surface
+    ⊆ the creating agent's own. At update time, ``prior_surface`` admits capabilities
+    already held by the target as well: each resulting capability must be dominated by
+    either the editor or the target's prior surface. Preservation and shrinking therefore
+    pass without requiring the editor to hold the target's connectors, while additions
+    remain bounded by the editor. The HTTP/operator path passes no actor and skips this.
 
-    The predicate is the lattice fixpoint: ``clamp(declared, actor) == normalize(declared)``
-    iff the meet narrowed nothing, i.e. ``declared ≤ actor`` on tool membership +
+    Without ``prior_surface``, the predicate is the lattice fixpoint:
+    ``clamp(declared, actor) == normalize(declared)`` iff the meet narrowed nothing,
+    i.e. ``declared ≤ actor`` on tool membership +
     per-tool permission/transport, MCP server identity, and HTTP server identity
     (name + base_url). A breach raises ``ForbiddenError`` with ``detail=surface_diff``.
 
@@ -80,16 +81,18 @@ async def _enforce_surface_attenuation(
     declared = Surface(tools, mcp_servers, http_servers)
     expected = attenuation_service.normalize(declared)
     effective = attenuation_service.clamp(declared, surface_of(agent))
-    surviving_http = {(s.name, s.base_url) for s in effective.http_servers}
-    exceeds = (
-        effective.tools != expected.tools
-        or effective.mcp_servers != expected.mcp_servers
-        or any((s.name, s.base_url) not in surviving_http for s in expected.http_servers)
-    )
-    if exceeds:
+    if prior_surface is not None:
+        preserved = attenuation_service.clamp(declared, prior_surface)
+        effective = Surface(
+            effective.tools + preserved.tools,
+            effective.mcp_servers + preserved.mcp_servers,
+            effective.http_servers + preserved.http_servers,
+        )
+    diff = surface_diff(expected, effective)
+    if diff:
         raise ForbiddenError(
             "agent surface exceeds the acting agent's permissions",
-            detail={"exceeds": surface_diff(expected, effective)},
+            detail={"exceeds": diff},
         )
 
 
@@ -208,13 +211,11 @@ async def update_agent(
     """Update an agent in place, creating a new immutable version (optimistic
     concurrency on ``expected_version``).
 
-    **Update-time attenuation (T1):** when ``editor_session_id`` is set (an agent
-    editing another agent via the ``update_agent`` model tool), the **merged final
-    surface** must be a subset of the editing agent's own — an agent may only update an
-    agent to a surface it could have declared itself; a breach raises
-    :class:`ForbiddenError`. Omitted surface fields are merged from the current stored
-    version before the check. With no editor (the HTTP/operator path) anything may be
-    updated.
+    **Update-time attenuation:** when ``editor_session_id`` is set, the merged final
+    surface may contain only capabilities held by the editor or already held by the
+    target's current version. Thus preserving or shrinking existing surface is allowed,
+    while additions remain bounded by the editor; a breach raises :class:`ForbiddenError`.
+    With no editor (the HTTP/operator path) anything may be updated.
     """
     if editor_session_id is not None:
         # #1636: the model-binding privilege, keyed on the editor being a
@@ -230,6 +231,7 @@ async def update_agent(
             tools=tools if tools is not None else current.tools,
             mcp_servers=mcp_servers if mcp_servers is not None else current.mcp_servers,
             http_servers=http_servers if http_servers is not None else current.http_servers,
+            prior_surface=surface_of(current),
         )
     skills_json_str: str | None = None
     if skills is not None:

--- a/tests/integration/test_agent_management_attenuation.py
+++ b/tests/integration/test_agent_management_attenuation.py
@@ -28,7 +28,7 @@ from aios.db import queries as db_queries
 from aios.db.pool import create_pool
 from aios.errors import ForbiddenError
 from aios.harness import runtime
-from aios.models.agents import Agent, ToolSpec
+from aios.models.agents import Agent, HttpServerSpec, McpServerSpec, ToolSpec
 from aios.models.attenuation import surface_of
 from aios.services import agents as agents_service
 from aios.services import attenuation as attenuation_service
@@ -212,6 +212,62 @@ async def test_update_rejects_widening_past_editor(pool: asyncpg.Pool[Any]) -> N
     # Unchanged (still at its original version, still read-only).
     after = await agents_service.get_agent(pool, target.id, account_id=ACC)
     assert after.version == target.version and {t.type for t in after.tools} == {"read"}
+
+
+async def test_update_preserves_target_surface_the_editor_lacks(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    editor = await _make_agent(pool, "delta-editor", tools=[ToolSpec(type="read")])
+    session_id = await _make_session(pool, editor)
+    target = await agents_service.create_agent(
+        pool,
+        account_id=ACC,
+        name="delta-target",
+        model="test/dummy",
+        system="x",
+        tools=[ToolSpec(type="write")],
+        mcp_servers=[McpServerSpec(name="target-mcp", url="https://mcp.example.test")],
+        http_servers=[HttpServerSpec(name="target-http", base_url="https://api.example.test")],
+        description=None,
+        metadata={},
+        window_min=1000,
+        window_max=100000,
+    )
+
+    updated = await agents_service.update_agent(
+        pool,
+        target.id,
+        account_id=ACC,
+        expected_version=target.version,
+        window_max=120000,
+        editor_session_id=session_id,
+    )
+
+    assert updated.window_max == 120000
+    assert {t.type for t in updated.tools} == {"write"}
+    assert [server.name for server in updated.mcp_servers] == ["target-mcp"]
+    assert [server.name for server in updated.http_servers] == ["target-http"]
+
+
+async def test_update_allows_shrinking_surface_the_editor_lacks(
+    pool: asyncpg.Pool[Any],
+) -> None:
+    editor = await _make_agent(pool, "shrink-editor", tools=[])
+    session_id = await _make_session(pool, editor)
+    target = await _make_agent(
+        pool, "shrink-target", tools=[ToolSpec(type="read"), ToolSpec(type="write")]
+    )
+
+    updated = await agents_service.update_agent(
+        pool,
+        target.id,
+        account_id=ACC,
+        expected_version=target.version,
+        tools=[ToolSpec(type="read")],
+        editor_session_id=session_id,
+    )
+
+    assert {t.type for t in updated.tools} == {"read"}
 
 
 async def test_update_within_editor_surface_persists(pool: asyncpg.Pool[Any]) -> None:


### PR DESCRIPTION
Automated dev-pipeline build for issue eumemic/eumemic-ops#339.