### PR TITLE
Anthropic 32MB request-BODY cap bricks byte-heavy sessions (request_too_large) — harness budgets by tokens, not bytes; window-trim doesn't reliably clear it

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -33,6 +33,11 @@ import litellm
 
 from aios.config import get_settings
 from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT, EPHEMERAL_TAIL_KEY
+from aios.harness.request_body_budget import (
+    body_budget_for_model,
+    enforce_request_body_budget,
+    is_request_too_large_error,
+)
 from aios.models.attenuation import api_base_of
 from aios.models.model_providers import ProviderAuth
 
@@ -750,9 +755,18 @@ async def call_litellm(
         session_id=request.session_id,
         stream=False,
     )
+    enforce_request_body_budget(kwargs, byte_budget=body_budget_for_model(model))
     deadline_s = get_settings().model_call_deadline_s
     try:
-        response = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=deadline_s)
+        try:
+            response = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=deadline_s)
+        except Exception as exc:
+            if not is_request_too_large_error(exc):
+                raise
+            trimmed = enforce_request_body_budget(kwargs, strip_all_media=True)
+            if trimmed.media_removed == 0:
+                raise
+            response = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=deadline_s)
     except TimeoutError as exc:
         raise ModelCallDeadlineError(
             f"model call exceeded its {deadline_s:.0f}s total deadline before returning",
@@ -805,10 +819,25 @@ async def stream_litellm(
         session_id=session_id,
         stream=True,
     )
+    # Enforce aggregate media and the provider's serialized body ceiling only
+    # after cache hints, tools and passthrough params have reached their final
+    # outbound shape. This is the same payload LiteLLM receives.
+    enforce_request_body_budget(kwargs, byte_budget=body_budget_for_model(model))
     deadline_s = get_settings().model_call_deadline_s
     loop = asyncio.get_running_loop()
     deadline_at = loop.time() + deadline_s
-    response = await litellm.acompletion(**kwargs)
+    try:
+        response = await litellm.acompletion(**kwargs)
+    except Exception as exc:
+        # One guarded reactive retry protects against provider serialization
+        # overhead or a provider cap stricter than our proactive safety margin.
+        # Strip historical media, but retain text and signed thinking blocks.
+        if not is_request_too_large_error(exc):
+            raise
+        trimmed = enforce_request_body_budget(kwargs, strip_all_media=True)
+        if trimmed.media_removed == 0:
+            raise
+        response = await litellm.acompletion(**kwargs)
 
     # Per-chunk inactivity guard. The ``stream_timeout`` kwarg above is
     # LiteLLM's own per-chunk bound, but its behavior varies by provider

--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -34,7 +34,7 @@ import litellm
 from aios.config import get_settings
 from aios.harness.context import _USER_MESSAGE_SEPARATOR_CONTENT, EPHEMERAL_TAIL_KEY
 from aios.harness.request_body_budget import (
-    body_budget_for_model,
+    body_limits_for_model,
     enforce_request_body_budget,
     is_request_too_large_error,
 )
@@ -755,7 +755,12 @@ async def call_litellm(
         session_id=request.session_id,
         stream=False,
     )
-    enforce_request_body_budget(kwargs, byte_budget=body_budget_for_model(model))
+    # Last gate before the wire: enforce the bound provider's request-body
+    # ceilings only after cache hints, tools and passthrough params have
+    # reached their final outbound shape. This is the same payload LiteLLM
+    # receives. Limits are provider-scoped (``body_limits_for_model``) — a
+    # provider that publishes no such cap is left untouched.
+    enforce_request_body_budget(kwargs, limits=body_limits_for_model(model))
     deadline_s = get_settings().model_call_deadline_s
     try:
         try:
@@ -819,10 +824,12 @@ async def stream_litellm(
         session_id=session_id,
         stream=True,
     )
-    # Enforce aggregate media and the provider's serialized body ceiling only
-    # after cache hints, tools and passthrough params have reached their final
-    # outbound shape. This is the same payload LiteLLM receives.
-    enforce_request_body_budget(kwargs, byte_budget=body_budget_for_model(model))
+    # Enforce the bound provider's aggregate-media and serialized-body
+    # ceilings only after cache hints, tools and passthrough params have
+    # reached their final outbound shape. This is the same payload LiteLLM
+    # receives. Limits are provider-scoped (``body_limits_for_model``) — a
+    # provider that publishes no such cap is left untouched.
+    enforce_request_body_budget(kwargs, limits=body_limits_for_model(model))
     deadline_s = get_settings().model_call_deadline_s
     loop = asyncio.get_running_loop()
     deadline_at = loop.time() + deadline_s

--- a/src/aios/harness/request_body_budget.py
+++ b/src/aios/harness/request_body_budget.py
@@ -1,4 +1,29 @@
-"""Serialized request-body and aggregate-media limits for model calls."""
+"""Serialized request-body and aggregate-media limits for model calls.
+
+Anthropic's Messages API rejects any request whose **serialized body** exceeds
+32 MB with ``request_too_large`` (HTTP 413). The harness budgets context by
+*tokens*, which is uncorrelated with body bytes once base64 media is in the
+window: a session can sit comfortably inside its token window and still emit a
+40 MB body. Window trimming does not reliably clear it either — trimming drops
+whole events by token cost, so a single retained image-heavy event can keep the
+body over the ceiling indefinitely. That is the #1999 brick: every wake rebuilds
+the same oversize body, the provider 413s before a token is generated, and the
+session cannot make progress on its own.
+
+This module is the last gate before the wire. It measures the payload LiteLLM
+will actually serialize and evicts **oldest media first**, replacing each
+``image_url`` part with a short text marker so the model still sees that
+something was there. Text and signed thinking blocks are never removed.
+
+**Limits are provider-scoped.** Both the byte ceiling and the aggregate
+media-count cap are Anthropic's, and neither is universal — OpenAI-compatible
+endpoints have their own (much larger, or absent) limits. Applying Anthropic's
+caps to every provider would silently destroy history on providers that were
+never going to reject the request. :func:`body_limits_for_model` resolves both
+numbers together from one provider verdict, so there is a single place where
+"which provider are we talking to" is decided and no path can pick up one limit
+without the other.
+"""
 
 from __future__ import annotations
 
@@ -6,15 +31,65 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
+# Anthropic's documented request-body ceiling is 32 MB. We budget to 26 MB so
+# there is headroom for provider-side serialization overhead (LiteLLM's
+# Anthropic adapter re-encodes content blocks, and HTTP framing/JSON escaping
+# both inflate the on-wire size relative to our compact local measurement).
 ANTHROPIC_BODY_BUDGET_BYTES = 26 * 1024 * 1024
-API_MAX_MEDIA_PER_REQUEST = 100
+
+# Anthropic caps a single request at 100 images. This is an Anthropic API
+# limit, NOT a universal one — see ``body_limits_for_model``.
+ANTHROPIC_MAX_MEDIA_PER_REQUEST = 100
+
 MEDIA_OMITTED_TEXT = "[image omitted: request media budget exceeded]"
+
+# Provider strings that route to Anthropic's Messages API and therefore inherit
+# its body/media ceilings. aios reaches Claude through several providers whose
+# model strings all still carry ``claude`` or ``anthropic`` (direct Anthropic,
+# ``openrouter/anthropic/*``, ``bedrock/anthropic.*``, ``vertex_ai/claude-*``),
+# which is the same substring test
+# :func:`~aios.harness.completion.model_descriptor` and
+# :func:`~aios.harness.vision.supports_vision` use. Kept as a local substring
+# check rather than a ``litellm.get_llm_provider`` sniff so this module stays
+# import-light and usable from the hot path without pulling in litellm.
+_ANTHROPIC_MODEL_MARKERS = ("anthropic", "claude")
+
+
+@dataclass(frozen=True, slots=True)
+class BodyLimits:
+    """The provider's request-body ceilings.
+
+    ``None`` on either field means "this provider publishes no such limit we
+    need to enforce" — the corresponding trimming pass is skipped entirely
+    rather than falling back to some other provider's number.
+    """
+
+    byte_budget: int | None = None
+    max_media: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class BodyBudgetResult:
     request_bytes: int
     media_removed: int
+
+
+def body_limits_for_model(model: str) -> BodyLimits:
+    """Resolve the request-body limits that apply to ``model``.
+
+    Both limits come from one provider verdict so a caller cannot apply the
+    byte ceiling while silently inheriting another provider's media cap (or
+    vice versa). Non-Anthropic models get :class:`BodyLimits` with both fields
+    ``None`` — no proactive trimming at all, because we have no evidence the
+    provider would reject the request and dropping history is destructive.
+    """
+    lowered = model.lower()
+    if any(marker in lowered for marker in _ANTHROPIC_MODEL_MARKERS):
+        return BodyLimits(
+            byte_budget=ANTHROPIC_BODY_BUDGET_BYTES,
+            max_media=ANTHROPIC_MAX_MEDIA_PER_REQUEST,
+        )
+    return BodyLimits()
 
 
 def serialized_request_bytes(payload: dict[str, Any]) -> int:
@@ -60,40 +135,52 @@ def _omit(messages: list[dict[str, Any]], location: tuple[int, int, int]) -> Non
 
 
 def enforce_request_body_budget(
-    payload: dict[str, Any], *, byte_budget: int | None = None, strip_all_media: bool = False
+    payload: dict[str, Any],
+    *,
+    limits: BodyLimits | None = None,
+    strip_all_media: bool = False,
 ) -> BodyBudgetResult:
-    """Evict oldest media until count and serialized-byte limits are satisfied.
+    """Evict oldest media until ``limits`` are satisfied.
 
     The payload is the post-cache-mutation LiteLLM kwargs and is mutated in
     place. Text and signed thinking blocks are never removed.
+
+    ``limits`` scopes the enforcement to the bound provider (see
+    :func:`body_limits_for_model`); a limit left ``None`` disables that pass, so
+    a provider with no published media cap keeps every image and a provider with
+    no published byte ceiling is never byte-trimmed. ``limits=None`` means "no
+    proactive limits at all" and is the correct default for an unknown provider.
+
+    ``strip_all_media=True`` is the reactive path: the provider already rejected
+    the request as too large, so every image is evicted regardless of provider
+    scoping. That is not a cross-provider assumption — it is a response to that
+    provider's own explicit ``request_too_large``/413 verdict.
     """
     messages = payload.get("messages")
     if not isinstance(messages, list):
         return BodyBudgetResult(serialized_request_bytes(payload), 0)
+    effective = limits or BodyLimits()
     locations = _media_locations(messages)
     removed = 0
 
-    excess = (
-        len(locations) if strip_all_media else max(0, len(locations) - API_MAX_MEDIA_PER_REQUEST)
-    )
+    if strip_all_media:
+        excess = len(locations)
+    elif effective.max_media is not None:
+        excess = max(0, len(locations) - effective.max_media)
+    else:
+        excess = 0
     for location in locations[:excess]:
         _omit(messages, location)
         removed += 1
 
     request_bytes = serialized_request_bytes(payload)
+    byte_budget = effective.byte_budget
     remaining = locations[excess:]
     while remaining and byte_budget is not None and request_bytes > byte_budget:
         _omit(messages, remaining.pop(0))
         removed += 1
         request_bytes = serialized_request_bytes(payload)
     return BodyBudgetResult(request_bytes, removed)
-
-
-def body_budget_for_model(model: str) -> int | None:
-    lowered = model.lower()
-    if "anthropic" in lowered or "claude" in lowered:
-        return ANTHROPIC_BODY_BUDGET_BYTES
-    return None
 
 
 def is_request_too_large_error(exc: BaseException) -> bool:

--- a/src/aios/harness/request_body_budget.py
+++ b/src/aios/harness/request_body_budget.py
@@ -1,0 +1,108 @@
+"""Serialized request-body and aggregate-media limits for model calls."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+ANTHROPIC_BODY_BUDGET_BYTES = 26 * 1024 * 1024
+API_MAX_MEDIA_PER_REQUEST = 100
+MEDIA_OMITTED_TEXT = "[image omitted: request media budget exceeded]"
+
+
+@dataclass(frozen=True, slots=True)
+class BodyBudgetResult:
+    request_bytes: int
+    media_removed: int
+
+
+def serialized_request_bytes(payload: dict[str, Any]) -> int:
+    """Measure the compact UTF-8 JSON body sent to the provider.
+
+    Transport-only LiteLLM arguments and credentials are deliberately excluded;
+    messages, tools and provider passthrough parameters remain included.
+    """
+    body = {
+        key: value
+        for key, value in payload.items()
+        if key
+        not in {
+            "api_key",
+            "api_base",
+            "base_url",
+            "timeout",
+            "stream_timeout",
+        }
+    }
+    return len(json.dumps(body, ensure_ascii=False, separators=(",", ":"), default=str).encode())
+
+
+def _media_locations(messages: list[dict[str, Any]]) -> list[tuple[int, int, int]]:
+    locations: list[tuple[int, int, int]] = []
+    for message_index, message in enumerate(messages):
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part_index, part in enumerate(content):
+            if not isinstance(part, dict) or part.get("type") != "image_url":
+                continue
+            image_url = part.get("image_url")
+            url = image_url.get("url") if isinstance(image_url, dict) else ""
+            locations.append((message_index, part_index, len(url) if isinstance(url, str) else 0))
+    return locations
+
+
+def _omit(messages: list[dict[str, Any]], location: tuple[int, int, int]) -> None:
+    message_index, part_index, _ = location
+    content = messages[message_index]["content"]
+    content[part_index] = {"type": "text", "text": MEDIA_OMITTED_TEXT}
+
+
+def enforce_request_body_budget(
+    payload: dict[str, Any], *, byte_budget: int | None = None, strip_all_media: bool = False
+) -> BodyBudgetResult:
+    """Evict oldest media until count and serialized-byte limits are satisfied.
+
+    The payload is the post-cache-mutation LiteLLM kwargs and is mutated in
+    place. Text and signed thinking blocks are never removed.
+    """
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return BodyBudgetResult(serialized_request_bytes(payload), 0)
+    locations = _media_locations(messages)
+    removed = 0
+
+    excess = (
+        len(locations) if strip_all_media else max(0, len(locations) - API_MAX_MEDIA_PER_REQUEST)
+    )
+    for location in locations[:excess]:
+        _omit(messages, location)
+        removed += 1
+
+    request_bytes = serialized_request_bytes(payload)
+    remaining = locations[excess:]
+    while remaining and byte_budget is not None and request_bytes > byte_budget:
+        _omit(messages, remaining.pop(0))
+        removed += 1
+        request_bytes = serialized_request_bytes(payload)
+    return BodyBudgetResult(request_bytes, removed)
+
+
+def body_budget_for_model(model: str) -> int | None:
+    lowered = model.lower()
+    if "anthropic" in lowered or "claude" in lowered:
+        return ANTHROPIC_BODY_BUDGET_BYTES
+    return None
+
+
+def is_request_too_large_error(exc: BaseException) -> bool:
+    status = getattr(exc, "status_code", None)
+    response = getattr(exc, "response", None)
+    status = status or getattr(response, "status_code", None)
+    message = str(exc).lower()
+    return (
+        status == 413
+        or "request_too_large" in message
+        or "request exceeds the maximum size" in message
+    )

--- a/tests/unit/test_request_body_budget.py
+++ b/tests/unit/test_request_body_budget.py
@@ -4,10 +4,15 @@ import json
 
 from aios.harness.request_body_budget import (
     ANTHROPIC_BODY_BUDGET_BYTES,
+    ANTHROPIC_MAX_MEDIA_PER_REQUEST,
     MEDIA_OMITTED_TEXT,
+    BodyLimits,
+    body_limits_for_model,
     enforce_request_body_budget,
     is_request_too_large_error,
 )
+
+ANTHROPIC_LIMITS = body_limits_for_model("anthropic/claude-test")
 
 
 def _image(payload: str) -> dict[str, object]:
@@ -29,7 +34,8 @@ def test_evicts_oldest_media_before_text_and_preserves_thinking() -> None:
     ]
 
     result = enforce_request_body_budget(
-        {"model": "anthropic/claude-test", "messages": messages}, byte_budget=500
+        {"model": "anthropic/claude-test", "messages": messages},
+        limits=BodyLimits(byte_budget=500, max_media=ANTHROPIC_MAX_MEDIA_PER_REQUEST),
     )
 
     assert result.media_removed >= 1
@@ -41,16 +47,87 @@ def test_evicts_oldest_media_before_text_and_preserves_thinking() -> None:
     assert result.request_bytes <= 500
 
 
-def test_caps_media_count_at_100_evicting_oldest() -> None:
+def test_caps_media_count_for_anthropic_evicting_oldest() -> None:
     messages = [{"role": "user", "content": [_image(str(i)) for i in range(101)]}]
     result = enforce_request_body_budget(
-        {"model": "openai/test", "messages": messages}, byte_budget=1_000_000
+        {"model": "anthropic/claude-test", "messages": messages}, limits=ANTHROPIC_LIMITS
     )
     assert result.media_removed == 1
     content = messages[0].get("content")
     assert isinstance(content, list)
     assert len(content) == 101
     assert content[0]["type"] == "text"
+    assert content[1]["type"] == "image_url"
+
+
+def test_media_count_cap_is_not_applied_to_non_anthropic_providers() -> None:
+    """#2007 review: the 100-image cap is Anthropic's, not universal.
+
+    An OpenAI-compatible model does not share Anthropic's per-request media
+    limit, so a payload with more than 100 images must reach the provider
+    untouched rather than silently losing history.
+    """
+    messages = [{"role": "user", "content": [_image(str(i)) for i in range(150)]}]
+    result = enforce_request_body_budget(
+        {"model": "openai/test", "messages": messages}, limits=body_limits_for_model("openai/test")
+    )
+    assert result.media_removed == 0
+    content = messages[0].get("content")
+    assert isinstance(content, list)
+    assert all(part["type"] == "image_url" for part in content)
+    assert MEDIA_OMITTED_TEXT not in json.dumps(messages)
+
+
+def test_non_anthropic_models_get_no_proactive_limits() -> None:
+    for model in ("openai/test", "gpt-5", "openrouter/openai/gpt-5", "qwen2.5-coder"):
+        limits = body_limits_for_model(model)
+        assert limits.byte_budget is None, model
+        assert limits.max_media is None, model
+
+
+def test_anthropic_routes_get_both_limits() -> None:
+    for model in (
+        "anthropic/claude-opus-5",
+        "claude-fable-5",
+        "openrouter/anthropic/claude-opus-5",
+        "bedrock/anthropic.claude-v2",
+        "vertex_ai/claude-opus-5",
+    ):
+        limits = body_limits_for_model(model)
+        assert limits.byte_budget == ANTHROPIC_BODY_BUDGET_BYTES, model
+        assert limits.max_media == ANTHROPIC_MAX_MEDIA_PER_REQUEST, model
+
+
+def test_no_limits_means_no_trimming_even_for_a_huge_body() -> None:
+    """Absent limits, a large body is left alone (no byte-budget fallback)."""
+    messages = [{"role": "user", "content": [_image("a" * 5000) for _ in range(20)]}]
+    payload = {"model": "openai/test", "messages": messages}
+    result = enforce_request_body_budget(payload, limits=None)
+    assert result.media_removed == 0
+    assert MEDIA_OMITTED_TEXT not in json.dumps(messages)
+
+
+def test_byte_budget_alone_trims_without_a_media_cap() -> None:
+    """A provider with a byte ceiling but no media cap still gets byte-trimmed."""
+    messages = [{"role": "user", "content": [_image("a" * 200) for _ in range(5)]}]
+    result = enforce_request_body_budget(
+        {"model": "x/y", "messages": messages}, limits=BodyLimits(byte_budget=600, max_media=None)
+    )
+    assert result.media_removed >= 1
+    assert result.request_bytes <= 600
+
+
+def test_strip_all_media_is_provider_agnostic_reactive_path() -> None:
+    """The reactive retry answers the provider's own 413 — it ignores scoping."""
+    messages = [{"role": "user", "content": [{"type": "text", "text": "t"}, _image("a" * 50)]}]
+    result = enforce_request_body_budget(
+        {"model": "openai/test", "messages": messages}, strip_all_media=True
+    )
+    assert result.media_removed == 1
+    content = messages[0].get("content")
+    assert isinstance(content, list)
+    assert content[0] == {"type": "text", "text": "t"}
+    assert content[1]["text"] == MEDIA_OMITTED_TEXT
 
 
 def test_anthropic_budget_has_margin_under_32mb() -> None:

--- a/tests/unit/test_request_body_budget.py
+++ b/tests/unit/test_request_body_budget.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+from aios.harness.request_body_budget import (
+    ANTHROPIC_BODY_BUDGET_BYTES,
+    MEDIA_OMITTED_TEXT,
+    enforce_request_body_budget,
+    is_request_too_large_error,
+)
+
+
+def _image(payload: str) -> dict[str, object]:
+    return {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,{payload}"},
+    }
+
+
+def test_evicts_oldest_media_before_text_and_preserves_thinking() -> None:
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "keep-old"}, _image("a" * 80)]},
+        {
+            "role": "assistant",
+            "content": "keep-new",
+            "thinking_blocks": [{"thinking": "reason", "signature": "signed"}],
+        },
+        {"role": "user", "content": [_image("b" * 80)]},
+    ]
+
+    result = enforce_request_body_budget(
+        {"model": "anthropic/claude-test", "messages": messages}, byte_budget=500
+    )
+
+    assert result.media_removed >= 1
+    assert json.dumps(messages).find(MEDIA_OMITTED_TEXT) >= 0
+    assert "keep-old" in json.dumps(messages)
+    assistant = messages[1]
+    assert isinstance(assistant, dict)
+    assert assistant.get("thinking_blocks") == [{"thinking": "reason", "signature": "signed"}]
+    assert result.request_bytes <= 500
+
+
+def test_caps_media_count_at_100_evicting_oldest() -> None:
+    messages = [{"role": "user", "content": [_image(str(i)) for i in range(101)]}]
+    result = enforce_request_body_budget(
+        {"model": "openai/test", "messages": messages}, byte_budget=1_000_000
+    )
+    assert result.media_removed == 1
+    content = messages[0].get("content")
+    assert isinstance(content, list)
+    assert len(content) == 101
+    assert content[0]["type"] == "text"
+
+
+def test_anthropic_budget_has_margin_under_32mb() -> None:
+    assert 24 * 1024 * 1024 <= ANTHROPIC_BODY_BUDGET_BYTES <= 27 * 1024 * 1024
+
+
+def test_recognizes_provider_size_signatures() -> None:
+    assert is_request_too_large_error(
+        Exception("request_too_large: Request exceeds the maximum size")
+    )
+    exc = Exception("payload rejected")
+    exc.status_code = 413  # type: ignore[attr-defined]
+    assert is_request_too_large_error(exc)
+    assert not is_request_too_large_error(Exception("invalid api key"))


### PR DESCRIPTION
Automated dev-pipeline build for issue #1999.