### PR TITLE
Cure the #1975 freeze at the source: completion.py holds pooled 'notify_conn' across the pg_notify non-DB await (2 sites flagged by #1979's PCA001 lint)

### DIFF
--- a/src/aios/harness/completion.py
+++ b/src/aios/harness/completion.py
@@ -836,51 +836,54 @@ async def stream_litellm(
     # Make it sticky: once seen on the wire, override the assembled value.
     saw_content_filter = False
     try:
-        # Hold one pool connection for the streaming step instead of acquiring
-        # and releasing once per content chunk.
-        async with pool.acquire() as notify_conn:
-            while True:
-                guard_timeout = _STREAM_TTFT_TIMEOUT_S if first else _STREAM_INTER_CHUNK_TIMEOUT_S
-                remaining_deadline_s = deadline_at - loop.time()
-                timeout = min(guard_timeout, remaining_deadline_s)
-                try:
-                    chunk = await asyncio.wait_for(aiter.__anext__(), timeout=timeout)
-                except TimeoutError as exc:
-                    if loop.time() >= deadline_at:
-                        usage: dict[str, int] = {}
-                        cost: float | None = None
-                        if chunks:
-                            partial_assembled: Any = litellm.stream_chunk_builder(
-                                chunks=chunks, messages=messages
+        while True:
+            guard_timeout = _STREAM_TTFT_TIMEOUT_S if first else _STREAM_INTER_CHUNK_TIMEOUT_S
+            remaining_deadline_s = deadline_at - loop.time()
+            timeout = min(guard_timeout, remaining_deadline_s)
+            try:
+                chunk = await asyncio.wait_for(aiter.__anext__(), timeout=timeout)
+            except TimeoutError as exc:
+                if loop.time() >= deadline_at:
+                    usage: dict[str, int] = {}
+                    cost: float | None = None
+                    if chunks:
+                        partial_assembled: Any = litellm.stream_chunk_builder(
+                            chunks=chunks, messages=messages
+                        )
+                        if partial_assembled is not None:
+                            _, usage, cost, _ = _unpack_litellm_response(
+                                partial_assembled, source="stream_chunk_builder"
                             )
-                            if partial_assembled is not None:
-                                _, usage, cost, _ = _unpack_litellm_response(
-                                    partial_assembled, source="stream_chunk_builder"
-                                )
-                        raise ModelCallDeadlineError(
-                            f"model call exceeded its {deadline_s:.0f}s total deadline while still streaming",
-                            usage=usage,
-                            cost_usd=cost,
-                            chunks_seen=len(chunks),
-                        ) from exc
-                    raise
-                except StopAsyncIteration:
-                    break
-                first = False
-                chunks.append(chunk)
-                # Some providers (OpenRouter, Grok, vLLM, OpenAI with stream_options.
-                # include_usage) emit a terminal usage-summary chunk with empty choices.
-                if not chunk.choices:
-                    continue
-                # ``"content_filter"`` == ``loop.REFUSAL_FINISH_REASON`` (literal here
-                # to avoid a loop<->completion import cycle). ``getattr`` guard: real
-                # litellm chunks always carry ``finish_reason`` (defaults None/""), but
-                # a partial/edge chunk that omits it must not crash the stream loop.
-                if getattr(chunk.choices[0], "finish_reason", None) == "content_filter":
-                    saw_content_filter = True
-                content = chunk.choices[0].delta.content
-                if content:
-                    await _notify_delta(notify_conn, session_id, content)
+                    raise ModelCallDeadlineError(
+                        f"model call exceeded its {deadline_s:.0f}s total deadline while still streaming",
+                        usage=usage,
+                        cost_usd=cost,
+                        chunks_seen=len(chunks),
+                    ) from exc
+                raise
+            except StopAsyncIteration:
+                break
+            first = False
+            chunks.append(chunk)
+            # Some providers (OpenRouter, Grok, vLLM, OpenAI with stream_options.
+            # include_usage) emit a terminal usage-summary chunk with empty choices.
+            if not chunk.choices:
+                continue
+            # ``"content_filter"`` == ``loop.REFUSAL_FINISH_REASON`` (literal here
+            # to avoid a loop<->completion import cycle). ``getattr`` guard: real
+            # litellm chunks always carry ``finish_reason`` (defaults None/""), but
+            # a partial/edge chunk that omits it must not crash the stream loop.
+            if getattr(chunk.choices[0], "finish_reason", None) == "content_filter":
+                saw_content_filter = True
+            content = chunk.choices[0].delta.content
+            if content:
+                payload = json.dumps({"delta": content})
+                async with pool.acquire() as notify_conn:
+                    await notify_conn.execute(
+                        "SELECT pg_notify($1, $2)",
+                        f"events_{session_id}",
+                        payload,
+                    )
     finally:
         # Close the litellm CustomStreamWrapper on every exit path — normal
         # full drain (no-op), TTFT/inter-chunk TimeoutError, or any in-loop
@@ -917,22 +920,3 @@ async def stream_litellm(
     if saw_content_filter and finish_reason != "content_filter":
         finish_reason = "content_filter"
     return LlmResponse.from_message(message, usage=usage, cost=cost, finish_reason=finish_reason)
-
-
-async def _notify_delta(
-    conn: asyncpg.Connection[Any],
-    session_id: str,
-    content: str,
-) -> None:
-    """Send a transient content delta via pg_notify.
-
-    Uses the same ``events_{session_id}`` channel as persisted events.
-    The JSON payload is distinguishable from event-id payloads because
-    it starts with ``{``.
-    """
-    payload = json.dumps({"delta": content})
-    await conn.execute(
-        "SELECT pg_notify($1, $2)",
-        f"events_{session_id}",
-        payload,
-    )

--- a/tests/unit/test_completion_timeouts.py
+++ b/tests/unit/test_completion_timeouts.py
@@ -86,27 +86,36 @@ def _make_chunk(text: str | None) -> object:
 
 
 class _StubPool:
-    """No-op pool that records streaming-step connection acquisitions."""
+    """No-op pool that records connection acquisitions and checkouts."""
 
     def __init__(self) -> None:
         self.acquire_count = 0
+        self.checked_out = 0
+        self.executions: list[tuple[object, ...]] = []
 
     def acquire(self) -> _StubPoolAcquire:
         self.acquire_count += 1
-        return _StubPoolAcquire()
+        return _StubPoolAcquire(self)
 
 
 class _StubPoolAcquire:
+    def __init__(self, pool: _StubPool) -> None:
+        self.pool = pool
+
     async def __aenter__(self) -> _StubConnection:
-        return _StubConnection()
+        self.pool.checked_out += 1
+        return _StubConnection(self.pool)
 
     async def __aexit__(self, *args: object) -> None:
-        pass
+        self.pool.checked_out -= 1
 
 
 class _StubConnection:
+    def __init__(self, pool: _StubPool) -> None:
+        self.pool = pool
+
     async def execute(self, *args: object) -> None:
-        pass
+        self.pool.executions.append(args)
 
 
 @pytest.mark.asyncio
@@ -481,6 +490,43 @@ async def test_stream_litellm_closes_stream_on_mid_stream_exception(
 
 
 @pytest.mark.asyncio
+async def test_stream_litellm_releases_notify_connection_before_stream_await(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation while waiting for a chunk cannot strand a notify checkout."""
+    pool = _StubPool()
+
+    class _CancelWhileStreaming:
+        def __aiter__(self) -> _CancelWhileStreaming:
+            return self
+
+        async def __anext__(self) -> object:
+            assert pool.checked_out == 0
+            raise asyncio.CancelledError
+
+        async def aclose(self) -> None:
+            pass
+
+    async def fake_acompletion(**kwargs: object) -> _CancelWhileStreaming:
+        return _CancelWhileStreaming()
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+    with pytest.raises(asyncio.CancelledError):
+        await completion.stream_litellm(
+            completion.LlmRequest(
+                messages=[{"role": "user", "content": "ping"}],
+                session_id="sess_test",
+            ),
+            model="anthropic/claude-sonnet-4-6",
+            pool=pool,
+        )
+
+    assert pool.checked_out == 0
+    assert pool.acquire_count == 0
+
+
+@pytest.mark.asyncio
 async def test_stream_litellm_closes_stream_on_normal_drain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -514,5 +560,10 @@ async def test_stream_litellm_closes_stream_on_normal_drain(
     message = response.message
 
     assert message["content"] == "hello"
-    assert pool.acquire_count == 1
+    assert pool.acquire_count == 2
+    assert pool.checked_out == 0
+    assert pool.executions == [
+        ("SELECT pg_notify($1, $2)", "events_sess_test", '{"delta": "hel"}'),
+        ("SELECT pg_notify($1, $2)", "events_sess_test", '{"delta": "lo"}'),
+    ]
     assert resp.aclose_count == 1


### PR DESCRIPTION
Automated dev-pipeline build for issue #2005.