### PR TITLE
Sandbox salvage fail-closed PERMANENTLY for large corpses: snapshot timeout formula assumes ~50MB/s commit throughput the host can't deliver

### DIFF
--- a/src/aios/config.py
+++ b/src/aios/config.py
@@ -222,6 +222,32 @@ class Settings(BaseSettings):
         "walk during salvage; it scales with the corpse, so it gets this "
         "generous bound rather than the blanket ``DOCKER_CLI_TIMEOUT_S``.",
     )
+    sandbox_snapshot_timeout_floor_seconds: float = Field(
+        default=60.0, gt=0, description="Minimum Docker snapshot operation timeout."
+    )
+    sandbox_snapshot_timeout_ns_per_byte: float = Field(
+        default=20e-9,
+        gt=0,
+        description="Fallback snapshot time per byte until measured throughput is available.",
+    )
+    sandbox_snapshot_timeout_safety_margin: float = Field(
+        default=2.0,
+        ge=1.0,
+        description="Multiplier applied to throughput-derived snapshot budgets.",
+    )
+    sandbox_snapshot_timeout_retry_multiplier: float = Field(
+        default=2.0, ge=1.0, description="Budget multiplier for each prior timeout of a corpse."
+    )
+    sandbox_snapshot_timeout_retry_cap: float = Field(
+        default=16.0, ge=1.0, description="Maximum cumulative timeout retry multiplier."
+    )
+    sandbox_snapshot_throughput_ewma_alpha: float = Field(
+        default=0.25, gt=0, le=1, description="Weight of the latest successful snapshot throughput."
+    )
+    sandbox_snapshot_throughput_state_path: Path = Field(
+        default=Path("/var/lib/aios/snapshot-throughput.json"),
+        description="Host-local persisted snapshot throughput calibration.",
+    )
     sandbox_salvage_breaker_threshold: int = Field(
         default=3,
         ge=1,

--- a/src/aios/sandbox/_subprocess.py
+++ b/src/aios/sandbox/_subprocess.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 
-from aios.sandbox.backends.base import SandboxBackendError
+from aios.sandbox.backends.base import SandboxBackendError, SandboxSnapshotTimeoutError
 
 # Bound on the post-kill drain so a CLI stuck in an uninterruptible
 # state can't hold the worker indefinitely past the wait_for timeout.
@@ -84,7 +84,7 @@ async def run_subprocess_with_timeout(
 
 
 async def run_docker_cli(
-    argv: list[str], *, timeout_s: float = DOCKER_CLI_TIMEOUT_S
+    argv: list[str], *, timeout_s: float = DOCKER_CLI_TIMEOUT_S, snapshot_timeout: bool = False
 ) -> tuple[int, bytes, bytes]:
     """Run a ``docker`` CLI call. Returns ``(exit_code, stdout, stderr)``.
 
@@ -96,7 +96,8 @@ async def run_docker_cli(
         argv, timeout_s=timeout_s
     )
     if timed_out:
-        raise SandboxBackendError(f"docker cli timed out after {timeout_s}s: {' '.join(argv)}")
+        error_type = SandboxSnapshotTimeoutError if snapshot_timeout else SandboxBackendError
+        raise error_type(f"docker cli timed out after {timeout_s}s: {' '.join(argv)}")
     return rc, stdout_bytes, stderr_bytes
 
 

--- a/src/aios/sandbox/backends/base.py
+++ b/src/aios/sandbox/backends/base.py
@@ -284,6 +284,10 @@ class SandboxBackendError(Exception):
     """
 
 
+class SandboxSnapshotTimeoutError(SandboxBackendError):
+    """Size-dependent snapshot work exceeded its deadline."""
+
+
 @runtime_checkable
 class SandboxBackend(Protocol):
     """The five-verb surface every backend implements."""

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from time import monotonic
 
 from aios.config import get_settings
 from aios.logging import get_logger
@@ -44,6 +45,7 @@ from aios.sandbox.backends.base import (
     ManagedSandboxRef,
     SandboxBackendError,
     SandboxHandle,
+    SandboxSnapshotTimeoutError,
     SandboxSpec,
     SnapshotOutcome,
 )
@@ -74,17 +76,26 @@ _CONTAINER_TIMEOUT_EXIT_CODE = 137
 # an unbounded chain. NOT a hard-wall dodge on the prod store.
 _FLATTEN_DEPTH_CEILING = 200
 
+
 # Snapshot operations legitimately scale with the corpse writable layer. Keep
 # metadata/management calls on the blanket Docker CLI bound, but budget the
 # data-scaling work so large corpses converge: commit/export/import by SizeRw,
 # and the ``inspect --size`` writable-layer walk (whose size is not yet known)
 # by the fixed ``sandbox_inspect_size_timeout_seconds`` bound.
-_SNAPSHOT_TIMEOUT_FLOOR_S = 60.0
-_SNAPSHOT_TIMEOUT_NS_PER_BYTE = 20e-9
-
-
-def _snapshot_timeout_s(size_rw: int | None) -> float:
-    return max(_SNAPSHOT_TIMEOUT_FLOOR_S, (size_rw or 0) * _SNAPSHOT_TIMEOUT_NS_PER_BYTE)
+def _snapshot_timeout_s(
+    size_rw: int | None, *, throughput_bytes_per_second: float | None, retry_attempt: int = 0
+) -> float:
+    settings = get_settings()
+    if throughput_bytes_per_second is None:
+        seconds = (size_rw or 0) * settings.sandbox_snapshot_timeout_ns_per_byte
+    else:
+        seconds = (size_rw or 0) / throughput_bytes_per_second
+    base = max(settings.sandbox_snapshot_timeout_floor_seconds, seconds)
+    retry_scale = min(
+        settings.sandbox_snapshot_timeout_retry_cap,
+        settings.sandbox_snapshot_timeout_retry_multiplier**retry_attempt,
+    )
+    return base * settings.sandbox_snapshot_timeout_safety_margin * retry_scale
 
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
@@ -104,6 +115,40 @@ class DockerBackend:
     """Sandbox backend backed by the host's Docker daemon."""
 
     name = "docker"
+
+    def __init__(self) -> None:
+        self._throughput_bytes_per_second = self._load_throughput()
+        self._snapshot_timeout_attempts: dict[str, int] = {}
+
+    @staticmethod
+    def _load_throughput() -> float | None:
+        path = get_settings().sandbox_snapshot_throughput_state_path
+        try:
+            value = json.loads(path.read_text()).get("bytes_per_second")
+            return float(value) if float(value) > 0 else None
+        except (OSError, ValueError, TypeError, AttributeError, json.JSONDecodeError):
+            return None
+
+    def _record_throughput(self, bytes_processed: int, elapsed_s: float) -> None:
+        if bytes_processed <= 0 or elapsed_s <= 0:
+            return
+        settings = get_settings()
+        measured = bytes_processed / elapsed_s
+        previous = self._throughput_bytes_per_second
+        alpha = settings.sandbox_snapshot_throughput_ewma_alpha
+        self._throughput_bytes_per_second = (
+            measured if previous is None else alpha * measured + (1 - alpha) * previous
+        )
+        path = settings.sandbox_snapshot_throughput_state_path
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = path.with_suffix(path.suffix + ".tmp")
+            temporary.write_text(
+                json.dumps({"bytes_per_second": self._throughput_bytes_per_second})
+            )
+            temporary.replace(path)
+        except OSError as err:
+            log.warning("sandbox.snapshot_throughput_persist_failed", error=str(err))
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         """Run ``docker run`` per ``spec`` and return a handle to the started container."""
@@ -580,6 +625,12 @@ class DockerBackend:
             flatten_if_unique_bytes_over is not None
             and projected_unique > flatten_if_unique_bytes_over
         )
+        retry_attempt = self._snapshot_timeout_attempts.get(sandbox_id, 0)
+        timeout_s = _snapshot_timeout_s(
+            size_rw,
+            throughput_bytes_per_second=self._throughput_bytes_per_second,
+            retry_attempt=retry_attempt,
+        )
         if parent_depth + 1 >= _FLATTEN_DEPTH_CEILING or over_budget:
             estimate = parent_size + rw
             settings = get_settings()
@@ -596,12 +647,18 @@ class DockerBackend:
                 raise SandboxBackendError(
                     f"flatten deferred: {free} free bytes, {required} required"
                 )
-            return await self._flatten(
-                sandbox_id, tag, labels, timeout_s=_snapshot_timeout_s(size_rw)
+            operation = self._flatten(sandbox_id, tag, labels, timeout_s=timeout_s, size_rw=rw)
+        else:
+            operation = self._commit(
+                sandbox_id, tag, env_keys, base_ref, timeout_s=timeout_s, size_rw=rw
             )
-        return await self._commit(
-            sandbox_id, tag, env_keys, base_ref, timeout_s=_snapshot_timeout_s(size_rw)
-        )
+        try:
+            outcome = await operation
+        except SandboxSnapshotTimeoutError:
+            self._snapshot_timeout_attempts[sandbox_id] = retry_attempt + 1
+            raise
+        self._snapshot_timeout_attempts.pop(sandbox_id, None)
+        return outcome
 
     async def _commit(
         self,
@@ -611,6 +668,7 @@ class DockerBackend:
         base_ref: str | None,
         *,
         timeout_s: float,
+        size_rw: int,
     ) -> SnapshotOutcome:
         """``docker commit`` one layer, scrubbing exactly the run-injected env keys.
 
@@ -625,7 +683,11 @@ class DockerBackend:
         for key in env_keys:
             argv.extend(["--change", f"ENV {key}="])
         argv.extend([sandbox_id, tag])
-        rc, _stdout, stderr_bytes = await run_docker_cli(argv, timeout_s=timeout_s)
+        started = monotonic()
+        rc, _stdout, stderr_bytes = await run_docker_cli(
+            argv, timeout_s=timeout_s, snapshot_timeout=True
+        )
+        elapsed = monotonic() - started
         if rc != 0:
             raise SandboxBackendError(
                 f"docker commit failed (exit {rc}) for {tag}: "
@@ -634,6 +696,7 @@ class DockerBackend:
         new = await self._inspect_image_fields(tag)
         if new is None:
             raise SandboxBackendError(f"committed image {tag} not found after commit")
+        self._record_throughput(size_rw, elapsed)
         return SnapshotOutcome(
             kind="committed",
             image_id=new[0],
@@ -648,6 +711,7 @@ class DockerBackend:
         labels: dict[str, str],
         *,
         timeout_s: float,
+        size_rw: int,
     ) -> SnapshotOutcome:
         """``docker export | docker import`` — collapse the chain to one layer.
 
@@ -683,15 +747,23 @@ class DockerBackend:
             consumer.extend(["--change", change])
         consumer.extend(["-", tag])
         settings = get_settings()
-        await run_docker_pipeline(
-            ["docker", "export", sandbox_id],
-            consumer,
-            stall_timeout_s=min(settings.sandbox_pipeline_stall_seconds, timeout_s),
-            max_timeout_s=timeout_s,
-        )
+        started = monotonic()
+        try:
+            await run_docker_pipeline(
+                ["docker", "export", sandbox_id],
+                consumer,
+                stall_timeout_s=min(settings.sandbox_pipeline_stall_seconds, timeout_s),
+                max_timeout_s=timeout_s,
+            )
+        except SandboxBackendError as err:
+            if "timed out" in str(err).lower():
+                raise SandboxSnapshotTimeoutError(str(err)) from err
+            raise
+        elapsed = monotonic() - started
         new = await self._inspect_image_fields(tag)
         if new is None:
             raise SandboxBackendError(f"flattened image {tag} not found after import")
+        self._record_throughput(size_rw, elapsed)
         # A flattened image is standalone — it shares no layers with the base,
         # so it is charged its FULL size (subtracting a base it doesn't share
         # would hide ~hundreds of MB from the accounting that must see the host

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -572,7 +572,48 @@ class DockerBackend:
         empty_floor_bytes: int,
         flatten_if_unique_bytes_over: int | None,
     ) -> SnapshotOutcome:
-        """Commit (or flatten) ``sandbox_id``'s rootfs to ``tag`` (§5.2)."""
+        """Commit (or flatten) ``sandbox_id``'s rootfs to ``tag`` (§5.2).
+
+        Owns the per-corpse timeout-retry state for the WHOLE verb, so every
+        terminal outcome settles it exactly once:
+
+        * any successful outcome — including the early ``skipped_stale`` /
+          ``skipped_empty`` returns — clears the entry. The common timeout
+          recovery is ``docker commit`` finishing server-side while the client
+          gave up: the retry then sees the advanced tag and returns
+          ``skipped_stale``, and the corpse is removed right after. Clearing
+          only on the commit/flatten path would strand that entry forever
+          (the container is gone, so nothing can ever clear it), leaking a
+          dict entry per successfully-salvaged timeout corpse for the life of
+          the worker.
+        * a typed snapshot timeout escalates the next attempt's budget.
+        * any other failure leaves the entry untouched — the corpse is
+          retained fail-closed and salvage converges on a later attempt.
+        """
+        try:
+            outcome = await self._snapshot_uncounted(
+                sandbox_id,
+                tag,
+                empty_floor_bytes=empty_floor_bytes,
+                flatten_if_unique_bytes_over=flatten_if_unique_bytes_over,
+            )
+        except SandboxSnapshotTimeoutError:
+            self._snapshot_timeout_attempts[sandbox_id] = (
+                self._snapshot_timeout_attempts.get(sandbox_id, 0) + 1
+            )
+            raise
+        self._snapshot_timeout_attempts.pop(sandbox_id, None)
+        return outcome
+
+    async def _snapshot_uncounted(
+        self,
+        sandbox_id: str,
+        tag: str,
+        *,
+        empty_floor_bytes: int,
+        flatten_if_unique_bytes_over: int | None,
+    ) -> SnapshotOutcome:
+        """``snapshot()`` minus the retry-state bookkeeping its caller owns."""
         # 1. Stop (idempotent — the corpse may already be stopped).
         await self.stop(sandbox_id)
 
@@ -652,13 +693,7 @@ class DockerBackend:
             operation = self._commit(
                 sandbox_id, tag, env_keys, base_ref, timeout_s=timeout_s, size_rw=rw
             )
-        try:
-            outcome = await operation
-        except SandboxSnapshotTimeoutError:
-            self._snapshot_timeout_attempts[sandbox_id] = retry_attempt + 1
-            raise
-        self._snapshot_timeout_attempts.pop(sandbox_id, None)
-        return outcome
+        return await operation
 
     async def _commit(
         self,

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -54,6 +54,7 @@ from aios.sandbox.backends.base import (
     SandboxBackend,
     SandboxBackendError,
     SandboxHandle,
+    SandboxSnapshotTimeoutError,
     SandboxSpec,
 )
 from aios.sandbox.git_proxy import GitProxy
@@ -258,6 +259,8 @@ class SandboxRegistry:
         # pass must never GC session-B's open-breaker entry). ``alarmed``
         # records whether the one-shot operator wake has been emitted.
         self._salvage_failures: dict[str, tuple[str, int, bool]] = {}
+        self._snapshot_timeout_failures: dict[str, int] = {}
+        self._snapshot_timeout_alarmed: set[str] = set()
         self._salvage_breaker_opened_at: dict[str, float] = {}
         # Strong refs for evict()'s fire-and-forget proxy-stop tasks.
         # asyncio only weak-refs tasks, so without this the task can be
@@ -1249,12 +1252,36 @@ class SandboxRegistry:
                 flatten_if_unique_bytes_over=disk_limit_bytes,
             )
         except Exception as err:
-            log.warning(
+            is_timeout = isinstance(err, SandboxSnapshotTimeoutError)
+            timeout_failures = 0
+            if is_timeout:
+                timeout_failures = self._snapshot_timeout_failures.get(sandbox_id, 0) + 1
+                self._snapshot_timeout_failures[sandbox_id] = timeout_failures
+            logger = log.error if is_timeout else log.warning
+            logger(
                 "sandbox.snapshot_failed_corpse_retained",
                 session_id=session_id,
                 container_id=sandbox_id[:12],
+                cause="TIMEOUT" if is_timeout else "ERROR",
+                timeout_failures=timeout_failures,
                 error=str(err),
             )
+            if (
+                is_timeout
+                and timeout_failures >= settings.sandbox_salvage_breaker_threshold
+                and sandbox_id not in self._snapshot_timeout_alarmed
+            ):
+                try:
+                    await self._alert_operator(
+                        session_id,
+                        f"Sandbox snapshot TIMEOUT repeated {timeout_failures} times for corpse "
+                        f"{sandbox_id[:12]}; corpse retained and provisioning remains fail-closed.",
+                        cause="sandbox.snapshot_failed_corpse_retained.TIMEOUT",
+                    )
+                except Exception as alert_err:
+                    log.warning("sandbox.snapshot_timeout_alert_failed", error=str(alert_err))
+                else:
+                    self._snapshot_timeout_alarmed.add(sandbox_id)
             return False
 
         # ``image_id is None`` ⇒ skipped_empty with no prior tag (a session
@@ -1312,6 +1339,8 @@ class SandboxRegistry:
                         error=str(err),
                     )
 
+        self._snapshot_timeout_failures.pop(sandbox_id, None)
+        self._snapshot_timeout_alarmed.discard(sandbox_id)
         log.info(
             "sandbox.snapshot",
             session_id=session_id,

--- a/tests/unit/sandbox/test_docker_runtime_argv.py
+++ b/tests/unit/sandbox/test_docker_runtime_argv.py
@@ -45,7 +45,9 @@ def _runtime_values(argv: list[str]) -> list[str]:
 async def test_create_omits_runtime_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[list[str]] = []
 
-    async def fake_run(argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+    async def fake_run(
+        argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+    ) -> tuple[int, bytes, bytes]:
         del timeout_s
         calls.append(list(argv))
         return 0, b"deadbeefcafe\n", b""
@@ -60,7 +62,9 @@ async def test_create_omits_runtime_by_default(monkeypatch: pytest.MonkeyPatch) 
 async def test_create_emits_configured_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[list[str]] = []
 
-    async def fake_run(argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+    async def fake_run(
+        argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+    ) -> tuple[int, bytes, bytes]:
         del timeout_s
         calls.append(list(argv))
         return 0, b"deadbeefcafe\n", b""

--- a/tests/unit/sandbox/test_docker_seccomp_argv.py
+++ b/tests/unit/sandbox/test_docker_seccomp_argv.py
@@ -31,7 +31,9 @@ def _install_capture(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
     """Patch ``run_docker_cli`` to record argv and return a fake container id."""
     calls: list[list[str]] = []
 
-    async def fake_run(argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+    async def fake_run(
+        argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+    ) -> tuple[int, bytes, bytes]:
         del timeout_s
         calls.append(list(argv))
         return 0, b"deadbeefcafe\n", b""

--- a/tests/unit/sandbox/test_sandbox_network.py
+++ b/tests/unit/sandbox/test_sandbox_network.py
@@ -29,7 +29,9 @@ def install_docker_responder(
     """
     calls: list[list[str]] = []
 
-    async def fake_run(argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+    async def fake_run(
+        argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+    ) -> tuple[int, bytes, bytes]:
         del timeout_s
         calls.append(list(argv))
         return responder(argv)

--- a/tests/unit/sandbox/test_snapshot_timeout_calibration.py
+++ b/tests/unit/sandbox/test_snapshot_timeout_calibration.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aios.config import get_settings
+from aios.sandbox.backends import docker as docker_backend
+from aios.sandbox.backends.docker import DockerBackend, _snapshot_timeout_s
+
+
+def test_timeout_budget_uses_configured_floor_throughput_and_retry_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "sandbox_snapshot_timeout_floor_seconds", 10.0)
+    monkeypatch.setattr(settings, "sandbox_snapshot_timeout_ns_per_byte", 100e-9)
+    monkeypatch.setattr(settings, "sandbox_snapshot_timeout_safety_margin", 2.0)
+    monkeypatch.setattr(settings, "sandbox_snapshot_timeout_retry_multiplier", 2.0)
+    monkeypatch.setattr(settings, "sandbox_snapshot_timeout_retry_cap", 4.0)
+
+    assert (
+        _snapshot_timeout_s(100_000_000, throughput_bytes_per_second=None, retry_attempt=0) == 20.0
+    )
+    assert (
+        _snapshot_timeout_s(100_000_000, throughput_bytes_per_second=None, retry_attempt=1) == 40.0
+    )
+    assert (
+        _snapshot_timeout_s(100_000_000, throughput_bytes_per_second=None, retry_attempt=9) == 80.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_commit_updates_and_persists_throughput(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    settings = get_settings()
+    state_path = tmp_path / "throughput.json"
+    monkeypatch.setattr(settings, "sandbox_snapshot_throughput_state_path", state_path)
+    monkeypatch.setattr(settings, "sandbox_snapshot_throughput_ewma_alpha", 0.5)
+    times = iter((10.0, 12.0))
+    monkeypatch.setattr(docker_backend, "monotonic", lambda: next(times))
+
+    async def cli(
+        argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+    ) -> tuple[int, bytes, bytes]:
+        return 0, b"", b""
+
+    monkeypatch.setattr(docker_backend, "run_docker_cli", cli)
+    backend = DockerBackend()
+    backend._throughput_bytes_per_second = 50.0
+    monkeypatch.setattr(
+        backend, "_inspect_image_fields", lambda tag: _async_value(("id", 100, 2, {}))
+    )
+    monkeypatch.setattr(backend, "_unique_bytes", lambda fields, base: _async_value(100))
+
+    await backend._commit("cid", "tag", [], None, timeout_s=60.0, size_rw=200)
+
+    assert backend._throughput_bytes_per_second == 75.0
+    assert '"bytes_per_second": 75.0' in state_path.read_text()
+
+
+async def _async_value(value: Any) -> Any:
+    return value

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 
 from aios.config import get_settings
-from aios.sandbox.backends.base import SandboxBackendError
+from aios.sandbox.backends.base import SandboxBackendError, SandboxSnapshotTimeoutError
 from aios.sandbox.backends.docker import _FLATTEN_DEPTH_CEILING, DockerBackend
 
 _Usage = namedtuple("_Usage", ["total", "used", "free"])
@@ -437,3 +437,165 @@ class TestFlattenDiskGate:
         assert fake_docker.pipeline_timeouts == [
             (min(settings.sandbox_pipeline_stall_seconds, budget), budget)
         ]
+
+
+# ── timeout retry-state lifecycle (#2009 review) ─────────────────────────────
+
+
+class TestTimeoutRetryStateCleared:
+    """Every SUCCESSFUL snapshot outcome must clear the corpse's timeout-retry
+    entry — not just the commit/flatten paths.
+
+    The normal timeout recovery is ``docker commit`` completing server-side
+    while the client's deadline fires: the retry then observes the advanced
+    tag and returns ``skipped_stale`` (or ``skipped_empty``) from an early
+    return, and the corpse is removed immediately after. If those paths didn't
+    clear the entry, nothing ever could — the container is gone — so
+    ``_snapshot_timeout_attempts`` would grow one stranded entry per
+    successfully-salvaged timeout corpse for the lifetime of the worker.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_then_skipped_stale_clears_retry_state(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        backend = DockerBackend()
+        fake_docker.size_rw = 12_000_000_000
+        fake_docker.parent_image = "img_S1"
+
+        real_cli = fake_docker.cli
+
+        async def timing_out_commit(
+            argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+        ) -> tuple[int, bytes, bytes]:
+            if argv[1] == "commit":
+                raise SandboxSnapshotTimeoutError(f"docker cli timed out after {timeout_s}s")
+            return await real_cli(argv, timeout_s=timeout_s, snapshot_timeout=snapshot_timeout)
+
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", timing_out_commit)
+
+        with pytest.raises(SandboxSnapshotTimeoutError):
+            await backend.snapshot(
+                "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+            )
+        assert backend._snapshot_timeout_attempts["cid"] == 1, "a timeout must escalate the budget"
+
+        # The commit actually landed daemon-side: the tag has moved past the
+        # corpse's parent, so the retry takes the lineage-gate early return.
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", real_cli)
+        fake_docker.images["tag:latest"] = {
+            "id": "img_S2",
+            "size": 700_000,
+            "depth": 3,
+            "labels": {},
+        }
+
+        out = await backend.snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+
+        assert out.kind == "skipped_stale"
+        assert "cid" not in backend._snapshot_timeout_attempts, (
+            "skipped_stale is a successful salvage — it must not strand retry state"
+        )
+        assert backend._snapshot_timeout_attempts == {}
+
+    @pytest.mark.asyncio
+    async def test_timeout_then_skipped_empty_clears_retry_state(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        backend = DockerBackend()
+        fake_docker.size_rw = 12_000_000_000
+
+        real_cli = fake_docker.cli
+
+        async def timing_out_commit(
+            argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+        ) -> tuple[int, bytes, bytes]:
+            if argv[1] == "commit":
+                raise SandboxSnapshotTimeoutError(f"docker cli timed out after {timeout_s}s")
+            return await real_cli(argv, timeout_s=timeout_s, snapshot_timeout=snapshot_timeout)
+
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", timing_out_commit)
+
+        with pytest.raises(SandboxSnapshotTimeoutError):
+            await backend.snapshot(
+                "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+            )
+        assert backend._snapshot_timeout_attempts["cid"] == 1
+
+        # Retry against a corpse whose writable layer is at/below the floor →
+        # the identity short-circuit early return.
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", real_cli)
+        fake_docker.size_rw = 4096
+
+        out = await backend.snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+
+        assert out.kind == "skipped_empty"
+        assert not _committed(fake_docker)
+        assert "cid" not in backend._snapshot_timeout_attempts, (
+            "skipped_empty is a successful salvage — it must not strand retry state"
+        )
+
+    @pytest.mark.asyncio
+    async def test_repeated_timeouts_escalate_then_success_clears(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Consecutive timeouts accumulate (escalating the budget); the first
+        successful outcome settles the entry back to empty."""
+        backend = DockerBackend()
+        fake_docker.size_rw = 12_000_000_000
+        real_cli = fake_docker.cli
+        commit_timeouts: list[float] = []
+
+        async def timing_out_commit(
+            argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+        ) -> tuple[int, bytes, bytes]:
+            if argv[1] == "commit":
+                commit_timeouts.append(timeout_s)
+                raise SandboxSnapshotTimeoutError(f"docker cli timed out after {timeout_s}s")
+            return await real_cli(argv, timeout_s=timeout_s, snapshot_timeout=snapshot_timeout)
+
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", timing_out_commit)
+        for expected_attempts in (1, 2, 3):
+            with pytest.raises(SandboxSnapshotTimeoutError):
+                await backend.snapshot(
+                    "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+                )
+            assert backend._snapshot_timeout_attempts["cid"] == expected_attempts
+
+        assert commit_timeouts == sorted(commit_timeouts), "each retry must get a larger budget"
+        assert commit_timeouts[1] > commit_timeouts[0]
+
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", real_cli)
+        out = await backend.snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+        assert out.kind == "committed"
+        assert backend._snapshot_timeout_attempts == {}
+
+    @pytest.mark.asyncio
+    async def test_non_timeout_failure_leaves_retry_state_untouched(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only typed snapshot timeouts escalate. A generic backend error is a
+        retained-corpse failure that must neither escalate nor clear."""
+        backend = DockerBackend()
+        fake_docker.size_rw = 12_000_000_000
+        real_cli = fake_docker.cli
+
+        async def failing_commit(
+            argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+        ) -> tuple[int, bytes, bytes]:
+            if argv[1] == "commit":
+                return 1, b"", b"no space left on device"
+            return await real_cli(argv, timeout_s=timeout_s, snapshot_timeout=snapshot_timeout)
+
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", failing_commit)
+        with pytest.raises(SandboxBackendError):
+            await backend.snapshot(
+                "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+            )
+        assert "cid" not in backend._snapshot_timeout_attempts

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from collections import namedtuple
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -51,7 +52,9 @@ class _FakeDocker:
         # size-scaled timeout.
         self.pipeline_timeouts: list[tuple[float, float]] = []
 
-    async def cli(self, argv: list[str], *, timeout_s: float = 30.0) -> tuple[int, bytes, bytes]:
+    async def cli(
+        self, argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+    ) -> tuple[int, bytes, bytes]:
         self.calls.append(argv)
         self.cli_timeouts.append((argv, timeout_s))
         sub = argv[1]
@@ -106,8 +109,11 @@ class _FakeDocker:
 
 
 @pytest.fixture
-def fake_docker(monkeypatch: pytest.MonkeyPatch) -> _FakeDocker:
+def fake_docker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> _FakeDocker:
     fd = _FakeDocker()
+    monkeypatch.setattr(
+        get_settings(), "sandbox_snapshot_throughput_state_path", tmp_path / "throughput.json"
+    )
     monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", fd.cli)
     monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_pipeline", fd.pipeline)
     # Default to abundant free disk so flatten-path tests are deterministic;
@@ -238,7 +244,7 @@ class TestSnapshotTimeoutBudget:
         commit_timeout = next(
             timeout for argv, timeout in fake_docker.cli_timeouts if argv[1] == "commit"
         )
-        assert commit_timeout == 240.0
+        assert commit_timeout == 480.0
 
     @pytest.mark.asyncio
     async def test_inspect_size_walk_gets_generous_timeout(self, fake_docker: _FakeDocker) -> None:
@@ -427,7 +433,7 @@ class TestFlattenDiskGate:
         assert out.kind == "flattened"
         assert fake_docker.pipelines, "a large corpse must flatten via the pipeline"
         settings = get_settings()
-        budget = max(60.0, size_rw * 20e-9)
+        budget = max(60.0, size_rw * 20e-9) * 2.0
         assert fake_docker.pipeline_timeouts == [
             (min(settings.sandbox_pipeline_stall_seconds, budget), budget)
         ]


### PR DESCRIPTION
Automated dev-pipeline build for issue #1996.