### PR TITLE
fix(ci): retirement-aging-sla bash syntax — apostrophe in "re-SLA'd" broke the issue-filing step

### DIFF
--- a/.github/workflows/retirement-aging-sla.yml
+++ b/.github/workflows/retirement-aging-sla.yml
@@ -115,7 +115,7 @@ jobs:
           lines += [
               "",
               "---",
-              "Detected by `.github/workflows/retirement-aging-sla.yml` via the offline aging core `src/aios/retirements/aging.py`. NOT auto-closed — close it yourself once the descriptor(s) are torn down or re-SLA'd.",
+              "Detected by `.github/workflows/retirement-aging-sla.yml` via the offline aging core `src/aios/retirements/aging.py`. NOT auto-closed — close it yourself once the descriptor(s) are torn down or re-SLA-ed.",
           ]
           print("\n".join(lines))
           ')


### PR DESCRIPTION
The scheduled `Retirement aging-SLA check` has failed since 2026-07-22 08:10 with `syntax error near unexpected token 'else'`. Root cause: the apostrophe in `re-SLA'd` inside the `python -c '...'` heredoc terminates the single-quoted block early, so the remainder parses as shell. One-word fix (`re-SLA-ed`); step body now passes `bash -n` (verified locally by extracting the step).

Blast radius: `.github/workflows` only — a scheduled governance canary; cannot touch runtime. Tier-1. The step only runs when there IS an SLA breach to file, which is why it first fired (and failed) today.