### PR TITLE
Sandbox salvage: derive commit timeout from measured throughput + escalate deterministic failures instead of looping fail-closed

### DIFF
--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -87,8 +87,29 @@ _SNAPSHOT_TIMEOUT_FLOOR_S = 60.0
 _SNAPSHOT_WALK_SAFETY_FACTOR = 10.0
 
 
-def _snapshot_timeout_s(size_walk_seconds: float) -> float:
-    return max(_SNAPSHOT_TIMEOUT_FLOOR_S, size_walk_seconds * _SNAPSHOT_WALK_SAFETY_FACTOR)
+def _snapshot_timeout_s(
+    size_rw: int | None,
+    *,
+    throughput_bytes_per_second: float | None = None,
+    retry_attempt: int = 0,
+    size_walk_seconds: float | None = None,
+) -> float:
+    settings = get_settings()
+    if size_walk_seconds is not None:
+        base = max(_SNAPSHOT_TIMEOUT_FLOOR_S, size_walk_seconds * _SNAPSHOT_WALK_SAFETY_FACTOR)
+    else:
+        seconds = (
+            (size_rw or 0) * settings.sandbox_snapshot_timeout_ns_per_byte
+            if throughput_bytes_per_second is None
+            else (size_rw or 0) / throughput_bytes_per_second
+        )
+        base = max(settings.sandbox_snapshot_timeout_floor_seconds, seconds)
+        base *= settings.sandbox_snapshot_timeout_safety_margin
+    retry_scale = min(
+        settings.sandbox_snapshot_timeout_retry_cap,
+        settings.sandbox_snapshot_timeout_retry_multiplier**retry_attempt,
+    )
+    return base * retry_scale
 
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
@@ -615,7 +636,7 @@ class DockerBackend:
         # reflects this daemon, filesystem, and corpse rather than a fixed rate.
         inspect_started = monotonic()
         parent_image, size_rw, labels = await self._inspect_container_for_snapshot(sandbox_id)
-        snapshot_timeout_s = _snapshot_timeout_s(monotonic() - inspect_started)
+        size_walk_seconds = monotonic() - inspect_started
         env_keys = _split_label_list(labels.get(ENV_KEYS_LABEL_KEY))
         base_ref = labels.get(BASE_IMAGE_LABEL_KEY)
 
@@ -664,10 +685,8 @@ class DockerBackend:
             and projected_unique > flatten_if_unique_bytes_over
         )
         retry_attempt = self._snapshot_timeout_attempts.get(sandbox_id, 0)
-        timeout_s = _snapshot_timeout_s(
-            size_rw,
-            throughput_bytes_per_second=self._throughput_bytes_per_second,
-            retry_attempt=retry_attempt,
+        snapshot_timeout_s = _snapshot_timeout_s(
+            size_rw, retry_attempt=retry_attempt, size_walk_seconds=size_walk_seconds
         )
         if parent_depth + 1 >= _FLATTEN_DEPTH_CEILING or over_budget:
             estimate = parent_size + rw

--- a/src/aios/sandbox/backends/docker.py
+++ b/src/aios/sandbox/backends/docker.py
@@ -78,24 +78,17 @@ _FLATTEN_DEPTH_CEILING = 200
 
 
 # Snapshot operations legitimately scale with the corpse writable layer. Keep
-# metadata/management calls on the blanket Docker CLI bound, but budget the
-# data-scaling work so large corpses converge: commit/export/import by SizeRw,
-# and the ``inspect --size`` writable-layer walk (whose size is not yet known)
-# by the fixed ``sandbox_inspect_size_timeout_seconds`` bound.
-def _snapshot_timeout_s(
-    size_rw: int | None, *, throughput_bytes_per_second: float | None, retry_attempt: int = 0
-) -> float:
-    settings = get_settings()
-    if throughput_bytes_per_second is None:
-        seconds = (size_rw or 0) * settings.sandbox_snapshot_timeout_ns_per_byte
-    else:
-        seconds = (size_rw or 0) / throughput_bytes_per_second
-    base = max(settings.sandbox_snapshot_timeout_floor_seconds, seconds)
-    retry_scale = min(
-        settings.sandbox_snapshot_timeout_retry_cap,
-        settings.sandbox_snapshot_timeout_retry_multiplier**retry_attempt,
-    )
-    return base * settings.sandbox_snapshot_timeout_safety_margin * retry_scale
+# metadata calls on the blanket Docker CLI bound, but calibrate data work from
+# the immediately preceding ``inspect --size`` stat-walk. Commit must walk the
+# same paths and additionally read and compress their contents, so ten walk
+# durations is a deliberately generous measured-hardware budget. The floor
+# covers tiny layers and clocks with coarse resolution.
+_SNAPSHOT_TIMEOUT_FLOOR_S = 60.0
+_SNAPSHOT_WALK_SAFETY_FACTOR = 10.0
+
+
+def _snapshot_timeout_s(size_walk_seconds: float) -> float:
+    return max(_SNAPSHOT_TIMEOUT_FLOOR_S, size_walk_seconds * _SNAPSHOT_WALK_SAFETY_FACTOR)
 
 
 def _decode_and_truncate(raw: bytes, max_bytes: int) -> tuple[str, bool]:
@@ -618,7 +611,11 @@ class DockerBackend:
         await self.stop(sandbox_id)
 
         # 2. Inspect the corpse: parent image, writable-layer bytes, labels.
+        # Time the data-scaling stat walk so the subsequent operation's budget
+        # reflects this daemon, filesystem, and corpse rather than a fixed rate.
+        inspect_started = monotonic()
         parent_image, size_rw, labels = await self._inspect_container_for_snapshot(sandbox_id)
+        snapshot_timeout_s = _snapshot_timeout_s(monotonic() - inspect_started)
         env_keys = _split_label_list(labels.get(ENV_KEYS_LABEL_KEY))
         base_ref = labels.get(BASE_IMAGE_LABEL_KEY)
 
@@ -688,10 +685,12 @@ class DockerBackend:
                 raise SandboxBackendError(
                     f"flatten deferred: {free} free bytes, {required} required"
                 )
-            operation = self._flatten(sandbox_id, tag, labels, timeout_s=timeout_s, size_rw=rw)
+            operation = self._flatten(
+                sandbox_id, tag, labels, timeout_s=snapshot_timeout_s, size_rw=rw
+            )
         else:
             operation = self._commit(
-                sandbox_id, tag, env_keys, base_ref, timeout_s=timeout_s, size_rw=rw
+                sandbox_id, tag, env_keys, base_ref, timeout_s=snapshot_timeout_s, size_rw=rw
             )
         return await operation
 

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -225,6 +225,59 @@ def _classify_images(
 
 _SALVAGE_BREAKER_COOLDOWN_S = 300.0
 
+# In-band recovery lever for an escalated (deterministic) salvage breaker.
+#
+# The escalated state must name an action the operator/agent can actually
+# take **in this build**. The session-scoped self-recycle route
+# (``POST /v1/sessions/{id}/sandbox/recycle``, #2022) lands separately in
+# #2031; naming it unconditionally would hand a wedged caller a 404 — a
+# confidently wrong instruction is worse than a vague one, because it looks
+# actionable. So the hint is *probed*, not assumed: we name the endpoint only
+# when it is actually registered on the sessions router in this revision, and
+# otherwise fall back to the recovery that is always available (removing the
+# corpse, which self-clears the in-memory breaker on the next provision —
+# exactly the manual fix used to end the 22 h outage).
+_recycle_route_available: bool | None = None
+
+
+def _recycle_route_registered() -> bool:
+    """Is the self-recycle route actually served by this build?
+
+    Probed once from the sessions router's own route table (the source of
+    truth FastAPI serves from), then cached. Any import/introspection problem
+    is treated as "not available" so the surfaced guidance degrades to the
+    always-true fallback rather than to a 404.
+    """
+    global _recycle_route_available
+    if _recycle_route_available is None:
+        try:
+            from aios.api.routers.sessions import router as sessions_router
+
+            _recycle_route_available = any(
+                getattr(route, "path", "").endswith("/sandbox/recycle")
+                for route in sessions_router.routes
+            )
+        except Exception:  # pragma: no cover - defensive: never fail salvage on a probe
+            _recycle_route_available = False
+    return _recycle_route_available
+
+
+def _salvage_recovery_hint(session_id: str) -> str:
+    """The in-band recovery action to advertise, guaranteed to exist here."""
+    if _recycle_route_registered():
+        return (
+            f"recover in-band via POST /v1/sessions/{session_id}/sandbox/recycle "
+            'with body {"discard_unsalvaged": true} (self-recycle, #2022) — durable '
+            "workspace, repositories, memory stores and uploads are bind mounts and survive"
+        )
+    return (
+        "this build exposes no in-band recycle route, so recovery is out-of-band: remove the "
+        "corpse (``docker rm -f <corpse_id>``) — the breaker state is in-memory and keyed on "
+        "the corpse, so it self-clears on the next provision. Durable workspace, repositories, "
+        "memory stores and uploads are bind mounts and survive; only writable-layer packages, "
+        "caches and dotfiles are lost"
+    )
+
 
 class SandboxRegistry:
     """Maps session_id to a live :class:`SandboxHandle` with idle-TTL.
@@ -1401,9 +1454,10 @@ class SandboxRegistry:
                     )
                     self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
                     raise SandboxBackendError(
-                        f"salvage breaker open: deterministic salvage failure for corpse {ref.sandbox_id[:12]}: "
-                        f"{cause}; refusing to provision over unrecovered state; recover via "
-                        f"POST /v1/sessions/{session_id}/sandbox/recycle"
+                        "salvage breaker open (escalated): deterministic salvage failure "
+                        "for corpse "
+                        f"{ref.sandbox_id[:12]}: {cause}; refusing to provision over "
+                        f"unrecovered state; {_salvage_recovery_hint(session_id)}"
                     )
                 opened_at = self._salvage_breaker_opened_at.setdefault(
                     ref.sandbox_id, time.monotonic()
@@ -1480,8 +1534,8 @@ class SandboxRegistry:
                 session_id,
                 f"Sandbox salvage breaker OPEN for corpse {corpse_id[:12]}: "
                 f"{failures} consecutive salvage failures with cause: {cause}. "
-                "Provisioning remains fail-closed over unrecovered state. Recover in-band "
-                f"via POST /v1/sessions/{session_id}/sandbox/recycle (self-recycle, #2022).",
+                "Provisioning remains fail-closed over unrecovered state. To recover, "
+                f"{_salvage_recovery_hint(session_id)}.",
                 cause="sandbox.salvage_breaker_open",
             )
         except Exception as err:

--- a/src/aios/sandbox/registry.py
+++ b/src/aios/sandbox/registry.py
@@ -261,6 +261,11 @@ class SandboxRegistry:
         self._salvage_failures: dict[str, tuple[str, int, bool]] = {}
         self._snapshot_timeout_failures: dict[str, int] = {}
         self._snapshot_timeout_alarmed: set[str] = set()
+        # Exact failure text and its consecutive repetition count. Once one
+        # cause alone reaches the breaker threshold, cooldown cannot make the
+        # identical operation transient; it remains escalated until recovery.
+        self._salvage_failure_causes: dict[str, tuple[str, int]] = {}
+        self._last_snapshot_failure: dict[str, str] = {}
         self._salvage_breaker_opened_at: dict[str, float] = {}
         # Strong refs for evict()'s fire-and-forget proxy-stop tasks.
         # asyncio only weak-refs tasks, so without this the task can be
@@ -1252,6 +1257,8 @@ class SandboxRegistry:
                 flatten_if_unique_bytes_over=disk_limit_bytes,
             )
         except Exception as err:
+            cause = str(err)
+            self._last_snapshot_failure[sandbox_id] = cause
             is_timeout = isinstance(err, SandboxSnapshotTimeoutError)
             timeout_failures = 0
             if is_timeout:
@@ -1264,7 +1271,7 @@ class SandboxRegistry:
                 container_id=sandbox_id[:12],
                 cause="TIMEOUT" if is_timeout else "ERROR",
                 timeout_failures=timeout_failures,
-                error=str(err),
+                error=cause,
             )
             if (
                 is_timeout
@@ -1313,6 +1320,8 @@ class SandboxRegistry:
             try:
                 await self._write_snapshot_pointer(session_id, tag, outcome.unique_bytes)
             except Exception as err:
+                cause = f"snapshot pointer write failed: {err}"
+                self._last_snapshot_failure[sandbox_id] = cause
                 log.warning(
                     "sandbox.snapshot_pointer_write_failed_corpse_retained",
                     session_id=session_id,
@@ -1341,6 +1350,7 @@ class SandboxRegistry:
 
         self._snapshot_timeout_failures.pop(sandbox_id, None)
         self._snapshot_timeout_alarmed.discard(sandbox_id)
+        self._last_snapshot_failure.pop(sandbox_id, None)
         log.info(
             "sandbox.snapshot",
             session_id=session_id,
@@ -1374,12 +1384,27 @@ class SandboxRegistry:
         for corpse_id, (owner, _failures, _alarmed) in list(self._salvage_failures.items()):
             if owner == session_id and corpse_id not in present:
                 self._salvage_failures.pop(corpse_id, None)
+                self._salvage_failure_causes.pop(corpse_id, None)
+                self._last_snapshot_failure.pop(corpse_id, None)
                 self._salvage_breaker_opened_at.pop(corpse_id, None)
         for ref in refs:
             _owner, failures, alarmed = self._salvage_failures.get(
                 ref.sandbox_id, (session_id, 0, False)
             )
             if failures >= settings.sandbox_salvage_breaker_threshold:
+                cause, same_cause_count = self._salvage_failure_causes.get(
+                    ref.sandbox_id, ("unknown salvage failure", 0)
+                )
+                if same_cause_count >= settings.sandbox_salvage_breaker_threshold:
+                    alarmed = await self._alarm_salvage_breaker_once(
+                        session_id, ref.sandbox_id, failures, alarmed, cause=cause
+                    )
+                    self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
+                    raise SandboxBackendError(
+                        f"salvage breaker open: deterministic salvage failure for corpse {ref.sandbox_id[:12]}: "
+                        f"{cause}; refusing to provision over unrecovered state; recover via "
+                        f"POST /v1/sessions/{session_id}/sandbox/recycle"
+                    )
                 opened_at = self._salvage_breaker_opened_at.setdefault(
                     ref.sandbox_id, time.monotonic()
                 )
@@ -1401,9 +1426,17 @@ class SandboxRegistry:
             )
             if not removable:
                 failures += 1
+                cause = self._last_snapshot_failure.get(
+                    ref.sandbox_id, "snapshot or pointer write failed"
+                )
+                previous_cause, previous_count = self._salvage_failure_causes.get(
+                    ref.sandbox_id, ("", 0)
+                )
+                same_cause_count = previous_count + 1 if cause == previous_cause else 1
+                self._salvage_failure_causes[ref.sandbox_id] = (cause, same_cause_count)
                 if failures >= settings.sandbox_salvage_breaker_threshold:
                     alarmed = await self._alarm_salvage_breaker_once(
-                        session_id, ref.sandbox_id, failures, alarmed
+                        session_id, ref.sandbox_id, failures, alarmed, cause=cause
                     )
                 self._salvage_failures[ref.sandbox_id] = (session_id, failures, alarmed)
                 self._salvage_breaker_opened_at[ref.sandbox_id] = time.monotonic()
@@ -1413,11 +1446,19 @@ class SandboxRegistry:
                     "unrecovered state"
                 )
             self._salvage_failures.pop(ref.sandbox_id, None)
+            self._salvage_failure_causes.pop(ref.sandbox_id, None)
+            self._last_snapshot_failure.pop(ref.sandbox_id, None)
             self._salvage_breaker_opened_at.pop(ref.sandbox_id, None)
             await self._backend.force_remove(ref.sandbox_id)
 
     async def _alarm_salvage_breaker_once(
-        self, session_id: str, corpse_id: str, failures: int, alarmed: bool
+        self,
+        session_id: str,
+        corpse_id: str,
+        failures: int,
+        alarmed: bool,
+        *,
+        cause: str = "unknown salvage failure",
     ) -> bool:
         """Emit the one-shot operator wake for an open salvage breaker.
 
@@ -1438,8 +1479,9 @@ class SandboxRegistry:
             await self._alert_operator(
                 session_id,
                 f"Sandbox salvage breaker OPEN for corpse {corpse_id[:12]}: "
-                f"{failures} consecutive salvage failures. Provisioning for this "
-                "session is fail-closed until the corpse is recovered or cleared.",
+                f"{failures} consecutive salvage failures with cause: {cause}. "
+                "Provisioning remains fail-closed over unrecovered state. Recover in-band "
+                f"via POST /v1/sessions/{session_id}/sandbox/recycle (self-recycle, #2022).",
                 cause="sandbox.salvage_breaker_open",
             )
         except Exception as err:

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -236,15 +236,26 @@ class TestLineageGate:
 
 class TestSnapshotTimeoutBudget:
     @pytest.mark.asyncio
-    async def test_large_commit_uses_size_derived_budget(self, fake_docker: _FakeDocker) -> None:
-        fake_docker.size_rw = 12_000_000_000
+    async def test_commit_budget_is_calibrated_from_size_walk_throughput(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_docker.size_rw = 3_370_000_000
+        ticks = iter((100.0, 164.02))
+        monkeypatch.setattr("aios.sandbox.backends.docker.monotonic", lambda: next(ticks))
+
         await DockerBackend().snapshot(
             "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
         )
+
         commit_timeout = next(
             timeout for argv, timeout in fake_docker.cli_timeouts if argv[1] == "commit"
         )
-        assert commit_timeout == 480.0
+
+        # The old fixed 50 MB/s coefficient allowed only 67.4s. Calibrating
+        # from the observed 64.02s stat walk, with room for read+compression,
+        # must allow this real corpse several minutes.
+        assert commit_timeout == pytest.approx(640.2)
+
 
     @pytest.mark.asyncio
     async def test_inspect_size_walk_gets_generous_timeout(self, fake_docker: _FakeDocker) -> None:
@@ -418,11 +429,13 @@ class TestFlattenDiskGate:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("size_rw", [6_000_000_000, 200_000_000_000])
-    async def test_large_corpse_flatten_uses_size_derived_deadline(
+    async def test_large_corpse_flatten_uses_measured_walk_deadline(
         self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch, size_rw: int
     ) -> None:
-        """Flatten receives the same SizeRw-derived snapshot budget as commit."""
+        """Flatten receives the same measured-hardware budget as commit."""
         fake_docker.size_rw = size_rw
+        ticks = iter((100.0, 125.0))
+        monkeypatch.setattr("aios.sandbox.backends.docker.monotonic", lambda: next(ticks))
         _set_free_disk(monkeypatch, 2 * 1024**5)  # 2 PiB — over required for any size here
         out = await DockerBackend().snapshot(
             "cid",
@@ -433,7 +446,9 @@ class TestFlattenDiskGate:
         assert out.kind == "flattened"
         assert fake_docker.pipelines, "a large corpse must flatten via the pipeline"
         settings = get_settings()
-        budget = max(60.0, size_rw * 20e-9) * 2.0
+
+        budget = 250.0  # 25s observed walk * 10x safety factor
+
         assert fake_docker.pipeline_timeouts == [
             (min(settings.sandbox_pipeline_stall_seconds, budget), budget)
         ]

--- a/tests/unit/sandbox/test_snapshot_verb.py
+++ b/tests/unit/sandbox/test_snapshot_verb.py
@@ -240,7 +240,7 @@ class TestSnapshotTimeoutBudget:
         self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         fake_docker.size_rw = 3_370_000_000
-        ticks = iter((100.0, 164.02))
+        ticks = iter((100.0, 164.02, 200.0, 500.0))
         monkeypatch.setattr("aios.sandbox.backends.docker.monotonic", lambda: next(ticks))
 
         await DockerBackend().snapshot(
@@ -256,6 +256,50 @@ class TestSnapshotTimeoutBudget:
         # must allow this real corpse several minutes.
         assert commit_timeout == pytest.approx(640.2)
 
+    @pytest.mark.asyncio
+    async def test_incident_scale_corpse_salvages_within_its_computed_budget(
+        self, fake_docker: _FakeDocker, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reviewer's verification bar for Defect A: a corpse whose commit
+        legitimately needs minutes must SALVAGE, not time out.
+
+        Replays the 2026-07-23 outage corpse (3.37 GB writable layer, 64.02 s
+        stat walk) and drives commit against a clock that consumes 300 s of
+        wall time — far past the old fixed-coefficient budget of 67.44 s, which
+        is what produced the 22 h fail-closed outage. The commit must be
+        allowed to finish under the measured-throughput budget.
+        """
+        fake_docker.size_rw = 3_370_000_000
+        walk_seconds = 64.02
+        legacy_budget = fake_docker.size_rw * 20e-9  # the unachievable 67.44 s
+        commit_seconds = 300.0  # what this corpse really costs on prod hardware
+
+        ticks = iter((100.0, 100.0 + walk_seconds, 200.0, 200.0 + commit_seconds))
+        monkeypatch.setattr("aios.sandbox.backends.docker.monotonic", lambda: next(ticks))
+
+        real_cli = fake_docker.cli
+
+        async def _cli(
+            argv: list[str], *, timeout_s: float = 30.0, snapshot_timeout: bool = False
+        ) -> tuple[int, bytes, bytes]:
+            if argv[1] == "commit" and commit_seconds > timeout_s:
+                raise SandboxBackendError(
+                    f"docker cli timed out after {timeout_s}s: {' '.join(argv)}"
+                )
+            return await real_cli(argv, timeout_s=timeout_s, snapshot_timeout=snapshot_timeout)
+
+        monkeypatch.setattr("aios.sandbox.backends.docker.run_docker_cli", _cli)
+
+        out = await DockerBackend().snapshot(
+            "cid", "tag:latest", empty_floor_bytes=8192, flatten_if_unique_bytes_over=None
+        )
+
+        assert out.kind == "committed"
+        commit_timeout = next(
+            timeout for argv, timeout in fake_docker.cli_timeouts if argv[1] == "commit"
+        )
+        assert commit_timeout > commit_seconds
+        assert commit_timeout > legacy_budget  # the old constant could never have passed
 
     @pytest.mark.asyncio
     async def test_inspect_size_walk_gets_generous_timeout(self, fake_docker: _FakeDocker) -> None:
@@ -434,7 +478,7 @@ class TestFlattenDiskGate:
     ) -> None:
         """Flatten receives the same measured-hardware budget as commit."""
         fake_docker.size_rw = size_rw
-        ticks = iter((100.0, 125.0))
+        ticks = iter((100.0, 125.0, 200.0, 300.0))
         monkeypatch.setattr("aios.sandbox.backends.docker.monotonic", lambda: next(ticks))
         _set_free_disk(monkeypatch, 2 * 1024**5)  # 2 PiB — over required for any size here
         out = await DockerBackend().snapshot(

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -1484,7 +1484,91 @@ class TestSalvageBreaker:
         assert call is not None
         content = call.args[1]
         assert "fake snapshot failure" in content
-        assert f"POST /v1/sessions/{session_id}/sandbox/recycle" in content
+        # The surfaced recovery action must EXIST in this build. The route is
+        # only named when it is actually registered on the sessions router;
+        # otherwise the always-true corpse-removal fallback is surfaced.
+        from aios.sandbox import registry as registry_mod
+
+        if registry_mod._recycle_route_registered():
+            assert f"POST /v1/sessions/{session_id}/sandbox/recycle" in content
+        else:
+            assert "/sandbox/recycle" not in content
+            assert "docker rm -f" in content
+
+    async def test_escalation_never_advertises_an_unregistered_route(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The escalated state must never name an endpoint this build does not
+        serve: a 404'ing instruction is worse than a vague one because it looks
+        actionable (the exact failure mode the review blocked on).
+
+        Both branches are asserted against the router's OWN route table, so the
+        hint tracks reality whether or not the self-recycle route (#2031) has
+        landed in this revision.
+        """
+        from aios.api.routers.sessions import router as sessions_router
+        from aios.sandbox import registry as registry_mod
+
+        served = {getattr(route, "path", "") for route in sessions_router.routes}
+
+        monkeypatch.setattr(registry_mod, "_recycle_route_available", None)
+        registered = registry_mod._recycle_route_registered()
+        assert registered == any(path.endswith("/sandbox/recycle") for path in served)
+
+        hint = registry_mod._salvage_recovery_hint("sess_x")
+        if registered:
+            assert "POST /v1/sessions/sess_x/sandbox/recycle" in hint
+            assert "discard_unsalvaged" in hint  # the route's required ack
+        else:
+            # No endpoint may be named when the route is not served.
+            assert "/v1/sessions/" not in hint
+            assert "POST " not in hint
+            assert "docker rm -f" in hint
+
+        # Force the not-available branch: no endpoint may be named at all.
+        monkeypatch.setattr(registry_mod, "_recycle_route_available", False)
+        fallback = registry_mod._salvage_recovery_hint("sess_x")
+        assert "/v1/sessions/" not in fallback
+        assert "docker rm -f" in fallback
+
+    async def test_advertised_recovery_clears_breaker_and_allows_provisioning(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The advertised recovery must actually work: once the corpse is gone
+        (what every branch of the hint achieves — the route force-removes it,
+        the fallback tells you to), the breaker clears and salvage stops
+        raising, so provisioning is permitted again.
+        """
+        backend = FakeBackend()
+        session_id = "sess_recovered"
+        ref = self._corpse_ref(session_id)
+        backend.managed = [ref]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        registry._alert_operator = AsyncMock()  # type: ignore[method-assign]
+        threshold = get_settings().sandbox_salvage_breaker_threshold
+        now = 1000.0
+        monkeypatch.setattr("aios.sandbox.registry.time.monotonic", lambda: now)
+
+        for _ in range(threshold):
+            with pytest.raises(SandboxBackendError):
+                await registry._salvage_session_corpses(session_id)
+        # Escalated: fail-closed, and no further snapshot attempts.
+        with pytest.raises(SandboxBackendError, match="deterministic salvage failure"):
+            await registry._salvage_session_corpses(session_id)
+        assert self._snapshot_count(backend) == threshold
+
+        # Perform the advertised recovery: the corpse is discarded.
+        backend.managed = []
+
+        # Salvage now succeeds (nothing to salvage) and every scrap of breaker
+        # state for that corpse is gone — a fresh sandbox can be provisioned.
+        await registry._salvage_session_corpses(session_id)
+        assert ref.sandbox_id not in registry._salvage_failures
+        assert ref.sandbox_id not in registry._salvage_failure_causes
+        assert ref.sandbox_id not in registry._last_snapshot_failure
+        assert ref.sandbox_id not in registry._salvage_breaker_opened_at
+        assert self._snapshot_count(backend) == threshold  # no extra attempt
 
     async def test_breaker_half_open_recovers_after_cooldown_when_causes_differ(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_sandbox_registry.py
+++ b/tests/unit/test_sandbox_registry.py
@@ -1455,7 +1455,38 @@ class TestSalvageBreaker:
         assert alert.await_count == 1
         assert self._snapshot_count(backend) == threshold  # unchanged
 
-    async def test_breaker_half_open_recovers_after_cooldown(
+    async def test_repeated_same_cause_escalates_without_half_open_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        backend = FakeBackend()
+        session_id = "sess_deterministic"
+        ref = self._corpse_ref(session_id)
+        backend.managed = [ref]
+        backend.snapshot_raises = True
+        registry = SandboxRegistry(backend=backend)
+        alert = AsyncMock()
+        registry._alert_operator = alert  # type: ignore[method-assign]
+        threshold = get_settings().sandbox_salvage_breaker_threshold
+        now = 1000.0
+        monkeypatch.setattr("aios.sandbox.registry.time.monotonic", lambda: now)
+
+        for _ in range(threshold):
+            with pytest.raises(SandboxBackendError):
+                await registry._salvage_session_corpses(session_id)
+
+        now += 300.0
+        with pytest.raises(SandboxBackendError, match="deterministic salvage failure") as excinfo:
+            await registry._salvage_session_corpses(session_id)
+
+        assert self._snapshot_count(backend) == threshold
+        assert "fake snapshot failure" in str(excinfo.value)
+        call = alert.await_args
+        assert call is not None
+        content = call.args[1]
+        assert "fake snapshot failure" in content
+        assert f"POST /v1/sessions/{session_id}/sandbox/recycle" in content
+
+    async def test_breaker_half_open_recovers_after_cooldown_when_causes_differ(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         backend = FakeBackend()
@@ -1472,6 +1503,8 @@ class TestSalvageBreaker:
         for _ in range(threshold):
             with pytest.raises(SandboxBackendError):
                 await registry._salvage_session_corpses(session_id)
+        # Model distinct transient causes: no single cause reached threshold.
+        registry._salvage_failure_causes[ref.sandbox_id] = ("latest transient", 1)
         with pytest.raises(SandboxBackendError, match="breaker open"):
             await registry._salvage_session_corpses(session_id)
 


### PR DESCRIPTION
Automated dev-pipeline build for issue #2028.